### PR TITLE
[AI-1709] Dedupe MCP registrations and retire the resident node wrapper for kcap mcp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,16 @@ jobs:
       - name: Build solution
         run: dotnet build Capacitor.slnx
 
+      - name: Run npm wrapper tests
+        # Plain-Node assertion scripts for the npm launcher/refresh/resolve
+        # modules (no test framework, no npm install). `shell: bash` gives
+        # fail-fast -e semantics on both matrix legs.
+        shell: bash
+        run: |
+          node npm/kcap/bin/kcap.test.js
+          node npm/kcap/bin/resolve.test.js
+          node npm/kcap/bin/refresh.test.js
+
       - name: Run unit tests
         # --maximum-parallel-tests 1 serializes the entire unit suite.
         # The codebase has many tests that mutate process-global state

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
         <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
         <PackageVersion Include="NSubstitute" Version="5.3.0" />
         <PackageVersion Include="Spectre.Console" Version="0.55.2" />
+        <PackageVersion Include="System.Threading.AccessControl" Version="10.0.0" />
         <PackageVersion Include="Tomlyn" Version="2.4.0" />
         <PackageVersion Include="TUnit" Version="1.18.37" />
         <PackageVersion Include="WireMock.Net" Version="1.7.0" />

--- a/npm/kcap/bin/kcap.js
+++ b/npm/kcap/bin/kcap.js
@@ -5,28 +5,11 @@
 const { execFileSync, spawnSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
-
-function isMusl() {
-  if (process.platform !== "linux") return false;
-  try {
-    return fs.readFileSync("/usr/bin/ldd", "utf8").includes("musl");
-  } catch {
-    try {
-      return fs.readdirSync("/lib").some((f) => f.startsWith("ld-musl-"));
-    } catch {
-      return false;
-    }
-  }
-}
-
-const PLATFORM_PACKAGES = {
-  "darwin-arm64":      "@kurrent/kcap-darwin-arm64",
-  "linux-x64":         "@kurrent/kcap-linux-x64",
-  "linux-arm64":       "@kurrent/kcap-linux-arm64",
-  "linux-musl-x64":    "@kurrent/kcap-linux-musl-x64",
-  "linux-musl-arm64":  "@kurrent/kcap-linux-musl-arm64",
-  "win32-x64":         "@kurrent/kcap-win-x64",
-};
+// Platform detection + native-binary resolution live in resolve.js — a
+// side-effect-free module shared with refresh.js (which must never require
+// THIS file: during `kcap update`, runUpdate executes before the final
+// module.exports below, so it would see partial exports).
+const { PLATFORM_PACKAGES, platformKey } = require("./resolve");
 
 // Resolves the npm dist-tag to install for `kcap update`, based on the
 // resolved channel reported by `kcap update --check`'s `install_tag` field.
@@ -203,12 +186,11 @@ function printLockedBinaryHelp(globalRoot, onlyIfFound = false) {
 // runs the update flow), so it's guarded to only run when this file is
 // executed directly — not when `require()`d (e.g. by the test).
 if (require.main === module) {
-  const musl = process.platform === "linux" && isMusl() ? "-musl" : "";
-  const platformKey = `${process.platform}${musl}-${process.arch}`;
-  const packageName = PLATFORM_PACKAGES[platformKey];
+  const key = platformKey();
+  const packageName = PLATFORM_PACKAGES[key];
 
   if (!packageName) {
-    console.error(`Unsupported platform: ${platformKey}`);
+    console.error(`Unsupported platform: ${key}`);
     console.error(`Supported: ${Object.keys(PLATFORM_PACKAGES).join(", ")}`);
     process.exit(1);
   }

--- a/npm/kcap/bin/kcap.test.js
+++ b/npm/kcap/bin/kcap.test.js
@@ -24,30 +24,38 @@ assert.deepStrictEqual(probeArgs(["--stable"]), ["update", "--check", "--no-upda
 assert.deepStrictEqual(probeArgs(["--foo", "--beta", "-x"]), ["update", "--check", "--no-update-check", "--beta"]); // only channel flags forwarded
 assert.deepStrictEqual(probeArgs(undefined), ["update", "--check", "--no-update-check"]); // defensive
 
+// Absolute fixture roots must be host-native: trashDirFromLauncher path.resolves
+// its input (a POSIX host treats "C:\…" as relative and cwd-prefixes it) and
+// filterKcapProcesses path.basenames it — so this test runs on every CI leg.
+const NPM_PREFIX = process.platform === "win32" ? "C:\\npm" : "/npm";
+
 // trashDirFor: sibling of node_modules (same volume as the install tree).
 assert.strictEqual(
-  trashDirFor(path.join("C:", "npm", "node_modules")),
-  path.join("C:", "npm", ".kcap-trash"),
+  trashDirFor(path.join(NPM_PREFIX, "node_modules")),
+  path.join(NPM_PREFIX, ".kcap-trash"),
 );
 
 // trashDirFromLauncher: derives the same dir from the launcher's location…
 assert.strictEqual(
-  trashDirFromLauncher(path.join("C:", "npm", "node_modules", "@kurrent", "kcap", "bin")),
-  path.join("C:", "npm", ".kcap-trash"),
+  trashDirFromLauncher(path.join(NPM_PREFIX, "node_modules", "@kurrent", "kcap", "bin")),
+  path.join(NPM_PREFIX, ".kcap-trash"),
 );
 // …and refuses non-node_modules layouts (dev checkout, packed tarball).
-assert.strictEqual(trashDirFromLauncher(path.join("C:", "git", "kcap", "npm", "kcap", "bin")), null);
+assert.strictEqual(trashDirFromLauncher(path.join(NPM_PREFIX, "..", "git", "kcap", "npm", "kcap", "bin")), null);
 
 // filterKcapProcesses: keeps only processes under the install root
 // (case-insensitive), tolerates a bare object (ConvertTo-Json unwraps
 // single-element arrays), null entries, and missing ExecutablePath.
-const installRoot = "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@kurrent";
-const exePath = `${installRoot}\\kcap\\node_modules\\@kurrent\\kcap-win-x64\\bin\\kcap.exe`;
+const installRoot = process.platform === "win32"
+  ? "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@kurrent"
+  : "/home/u/.npm-global/node_modules/@kurrent";
+const exePath = path.join(installRoot, "kcap", "node_modules", "@kurrent", "kcap-win-x64", "bin", "kcap.exe");
+const foreignExePath = process.platform === "win32" ? "C:\\other\\kcap.exe" : "/other/kcap.exe";
 assert.deepStrictEqual(
   filterKcapProcesses(
     [
       { ProcessId: 11, ExecutablePath: exePath.toUpperCase(), CommandLine: `"${exePath}" mcp sessions` },
-      { ProcessId: 22, ExecutablePath: "C:\\other\\kcap.exe", CommandLine: "kcap.exe mcp review" }, // foreign install
+      { ProcessId: 22, ExecutablePath: foreignExePath, CommandLine: "kcap.exe mcp review" }, // foreign install
       { ProcessId: 33 },       // no path (access denied)
       null,                    // defensive
     ],

--- a/npm/kcap/bin/refresh.js
+++ b/npm/kcap/bin/refresh.js
@@ -7,8 +7,14 @@
 //   when the package manager allows install scripts to run.
 // - kcap.js `update` — runs after a user-initiated `kcap update`, which works
 //   even when the package manager blocks postinstall scripts.
+//
+// This file must never require kcap.js: during `kcap update`, runUpdate executes
+// before kcap.js's final module.exports assignment, so it would observe partial
+// exports. Shared platform/binary resolution lives in resolve.js instead.
 
 const { spawnSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
 
 // One entry per agent. Order is independent — each refresh is gated by its own
 // marker via `--if-installed`, which no-ops unless the user has previously
@@ -28,6 +34,11 @@ const REFRESHES = [
 // from one never prevents the others and never throws to the caller — a failed
 // refresh must never break `npm install` or report `kcap update` as failed.
 function runRefreshes(launcherPath) {
+  // Point the shipped Claude plugin's MCP entries at the native binary. Runs
+  // here because runRefreshes fires at exactly the two moments the plugin dir
+  // has just been (re)written by npm: postinstall and `kcap update`.
+  patchPluginMcpConfig(launcherPath);
+
   for (const argv of REFRESHES) {
     try {
       spawnSync(process.execPath, [launcherPath, ...argv], {
@@ -44,4 +55,96 @@ function runRefreshes(launcherPath) {
   }
 }
 
-module.exports = { runRefreshes };
+// ── Claude plugin .mcp.json patch ───────────────────────────────────────────
+//
+// The plugin ships `"command": "kcap"`, which resolves to the node wrapper —
+// one resident Node runtime per MCP server per open Claude session (~25 MB
+// idle each). Rewriting the command to the resolved native binary makes Claude
+// spawn the binary directly. Best-effort: on any failure the shipped value
+// stays in place, which still works via the wrapper.
+
+// The servers shipped in the plugin's .mcp.json, keyed by canonical
+// `["mcp", <suffix>]` args. Only these exact name/args pairs are patched —
+// anything else in the file is preserved verbatim.
+const PLUGIN_MCP_SERVERS = {
+  "kcap-review":    "review",
+  "kcap-sessions":  "sessions",
+  "kcap-flows":     "flows",
+  "kcap-memory":    "memory",
+  "kcap-workitems": "workitems",
+  "kcap-analytics": "analytics",
+};
+
+// A command this patcher may rewrite: the shipped literal "kcap", or an
+// absolute path whose basename is the kcap binary (a previous patch that has
+// gone stale after an npm re-layout). Handles both path flavors so a stale
+// Windows path is still recognized. Anything else is a customization → keep.
+function isPatchableKcapCommand(command) {
+  if (command === "kcap") return true;
+  if (typeof command !== "string") return false;
+  if (!path.posix.isAbsolute(command) && !path.win32.isAbsolute(command)) return false;
+  const base = command.split(/[\\/]/).pop().toLowerCase();
+  return base === "kcap" || base === "kcap.exe";
+}
+
+// Pure: rewrites in place the canonical plugin entries of `cfg` whose command
+// is patchable, returning whether anything changed. Throws on a shape that
+// isn't the plugin config (caller turns that into the single warning).
+function patchPluginMcpServers(cfg, binaryPath) {
+  if (!cfg || typeof cfg !== "object" || Array.isArray(cfg)) {
+    throw new Error("config is not an object");
+  }
+  const servers = cfg.mcpServers;
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
+    throw new Error("mcpServers is not an object");
+  }
+
+  let changed = false;
+  for (const [name, suffix] of Object.entries(PLUGIN_MCP_SERVERS)) {
+    const entry = servers[name];
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    if (!Array.isArray(entry.args) || entry.args.length !== 2 ||
+        entry.args[0] !== "mcp" || entry.args[1] !== suffix) continue; // customized args → keep
+    if (!isPatchableKcapCommand(entry.command)) continue;              // customized command → keep
+    if (entry.command === binaryPath) continue;                        // already current
+    entry.command = binaryPath;
+    changed = true;
+  }
+  return changed;
+}
+
+// Rewrites the plugin's shipped .mcp.json (a sibling `kcap/` dir of the
+// launcher's `bin/`) so Claude spawns the native binary directly. Validates
+// before writing, writes a sibling temp file, then renames atomically — the
+// original survives any pre-rename failure. Never throws; on failure it emits
+// ONE concise warning and leaves the shipped `"command": "kcap"` in place.
+// `binaryPath` is a test seam; real callers let it resolve.
+function patchPluginMcpConfig(launcherPath, binaryPath) {
+  let mcpJsonPath;
+  try {
+    binaryPath = binaryPath || require("./resolve").resolveNativeBinary();
+    if (!binaryPath) return; // unsupported platform / package missing — wrapper keeps working
+
+    mcpJsonPath = path.join(path.dirname(launcherPath), "..", "kcap", ".mcp.json");
+    if (!fs.existsSync(mcpJsonPath)) return; // dev checkout / plugin not shipped
+
+    const cfg = JSON.parse(fs.readFileSync(mcpJsonPath, "utf8"));
+    if (!patchPluginMcpServers(cfg, binaryPath)) return; // already patched / nothing canonical
+
+    const tmp = `${mcpJsonPath}.tmp-${process.pid}-${Date.now()}`;
+    try {
+      fs.writeFileSync(tmp, JSON.stringify(cfg, null, 2) + "\n");
+      fs.renameSync(tmp, mcpJsonPath);
+    } catch (e) {
+      try { fs.unlinkSync(tmp); } catch {}
+      throw e;
+    }
+  } catch (e) {
+    console.warn(
+      `kcap: could not point the Claude plugin MCP entries at the native binary` +
+      ` (${e && e.message ? e.message : e}); they will keep launching via the node wrapper.`,
+    );
+  }
+}
+
+module.exports = { runRefreshes, patchPluginMcpConfig, patchPluginMcpServers, isPatchableKcapCommand };

--- a/npm/kcap/bin/refresh.test.js
+++ b/npm/kcap/bin/refresh.test.js
@@ -1,0 +1,213 @@
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+// ── require-order regression ─────────────────────────────────────────────────
+// refresh.js is required by runUpdate BEFORE kcap.js's final module.exports
+// assignment, so it must never require kcap.js (it would see partial exports).
+// This require runs first in this process; the cache proves the independence.
+const {
+  patchPluginMcpConfig,
+  patchPluginMcpServers,
+  isPatchableKcapCommand,
+} = require("./refresh.js");
+assert(
+  !Object.keys(require.cache).some((k) => k.endsWith(`${path.sep}kcap.js`)),
+  "refresh.js must not (transitively) require kcap.js",
+);
+
+// The REAL shipped plugin config — the release workflow copies the repo's
+// kcap/ dir into the wrapper package verbatim, so testing against this file
+// keeps the fixture honest.
+const shippedMcpJson = path.join(__dirname, "..", "..", "..", "kcap", ".mcp.json");
+assert(fs.existsSync(shippedMcpJson), `expected the shipped plugin config at ${shippedMcpJson}`);
+
+const BINARY = process.platform === "win32"
+  ? "C:\\npm\\node_modules\\@kurrent\\kcap-win-x64\\bin\\kcap.exe"
+  : "/opt/npm/node_modules/@kurrent/kcap-darwin-arm64/bin/kcap";
+
+// Builds the released package layout (bin/ + sibling kcap/ plugin dir) in a
+// temp root — a plain `npm pack` can't produce it, release.yml assembles it.
+// Note the space in the directory name: the patch must survive spaced prefixes.
+function makeFakePackage(mcpJsonContent) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "kcap refresh test-"));
+  const binDir = path.join(root, "node_modules", "@kurrent", "kcap", "bin");
+  const pluginDir = path.join(root, "node_modules", "@kurrent", "kcap", "kcap");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(pluginDir, { recursive: true });
+  const launcher = path.join(binDir, "kcap.js");
+  fs.writeFileSync(launcher, "// fake launcher\n");
+  if (mcpJsonContent !== null) {
+    fs.writeFileSync(path.join(pluginDir, ".mcp.json"), mcpJsonContent);
+  }
+  return { root, launcher, mcpJson: path.join(pluginDir, ".mcp.json") };
+}
+
+function withCapturedWarnings(body) {
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (m) => warnings.push(String(m));
+  try {
+    body();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
+
+// ── isPatchableKcapCommand ───────────────────────────────────────────────────
+assert.strictEqual(isPatchableKcapCommand("kcap"), true);
+assert.strictEqual(isPatchableKcapCommand("/old/prefix/bin/kcap"), true);          // stale POSIX path
+assert.strictEqual(isPatchableKcapCommand("C:\\old\\npm\\bin\\kcap.exe"), true);   // stale Windows path
+assert.strictEqual(isPatchableKcapCommand("/old/prefix/bin/KCAP.EXE"), true);      // case-insensitive exe
+assert.strictEqual(isPatchableKcapCommand("npx"), false);                          // foreign command
+assert.strictEqual(isPatchableKcapCommand("/usr/bin/other-tool"), false);          // foreign path
+assert.strictEqual(isPatchableKcapCommand("relative/kcap"), false);                // not absolute
+assert.strictEqual(isPatchableKcapCommand("/opt/kcap-wrapper"), false);            // basename must BE kcap
+assert.strictEqual(isPatchableKcapCommand(undefined), false);
+assert.strictEqual(isPatchableKcapCommand(["kcap"]), false);
+
+// ── happy path: the real shipped config, all six entries patched ────────────
+{
+  const { root, launcher, mcpJson } = makeFakePackage(fs.readFileSync(shippedMcpJson, "utf8"));
+  try {
+    const before = JSON.parse(fs.readFileSync(mcpJson, "utf8"));
+    const warnings = withCapturedWarnings(() => patchPluginMcpConfig(launcher, BINARY));
+    assert.deepStrictEqual(warnings, []);
+
+    const after = JSON.parse(fs.readFileSync(mcpJson, "utf8"));
+    const names = Object.keys(after.mcpServers);
+    assert.strictEqual(names.length, 6);
+    for (const name of names) {
+      assert.strictEqual(after.mcpServers[name].command, BINARY, `${name} should point at the native binary`);
+      // Everything except command is preserved verbatim.
+      const { command: _a, ...restAfter } = after.mcpServers[name];
+      const { command: _b, ...restBefore } = before.mcpServers[name];
+      assert.deepStrictEqual(restAfter, restBefore, `${name} must only have its command rewritten`);
+    }
+
+    // Idempotence: a second run leaves the file byte-identical.
+    const patched = fs.readFileSync(mcpJson, "utf8");
+    patchPluginMcpConfig(launcher, BINARY);
+    assert.strictEqual(fs.readFileSync(mcpJson, "utf8"), patched);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// ── stale absolute path from a previous install is re-patched ───────────────
+{
+  const stale = process.platform === "win32" ? "C:\\old\\npm\\bin\\kcap.exe" : "/old/prefix/bin/kcap";
+  const cfg = { mcpServers: { "kcap-review": { command: stale, args: ["mcp", "review"] } } };
+  assert.strictEqual(patchPluginMcpServers(cfg, BINARY), true);
+  assert.strictEqual(cfg.mcpServers["kcap-review"].command, BINARY);
+}
+
+// ── customized entries are preserved (command or args diverge) ──────────────
+{
+  const cfg = {
+    mcpServers: {
+      "kcap-review":   { command: "/usr/bin/my-own-tool", args: ["mcp", "review"] }, // foreign command
+      "kcap-sessions": { command: "kcap", args: ["mcp", "sessions", "--extra"] },    // extra arg
+      "kcap-flows":    { command: "kcap", args: ["mcp", "memory"] },                 // wrong args for name
+      "not-kcap":      { command: "kcap", args: ["mcp", "review"] },                 // unknown name
+      "kcap-memory":   { command: "kcap", args: ["mcp", "memory"] },                 // canonical → patched
+    },
+  };
+  assert.strictEqual(patchPluginMcpServers(cfg, BINARY), true);
+  assert.strictEqual(cfg.mcpServers["kcap-review"].command, "/usr/bin/my-own-tool");
+  assert.strictEqual(cfg.mcpServers["kcap-sessions"].command, "kcap");
+  assert.strictEqual(cfg.mcpServers["kcap-flows"].command, "kcap");
+  assert.strictEqual(cfg.mcpServers["not-kcap"].command, "kcap");
+  assert.strictEqual(cfg.mcpServers["kcap-memory"].command, BINARY);
+}
+
+// ── malformed input: ONE warning, file untouched ─────────────────────────────
+{
+  const { root, launcher, mcpJson } = makeFakePackage("{ not json at all");
+  try {
+    const warnings = withCapturedWarnings(() => patchPluginMcpConfig(launcher, BINARY));
+    assert.strictEqual(warnings.length, 1, `expected exactly one warning, got: ${warnings}`);
+    assert(warnings[0].includes("Claude plugin MCP entries"));
+    assert.strictEqual(fs.readFileSync(mcpJson, "utf8"), "{ not json at all");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// ── wrong shape (mcpServers not an object): ONE warning, file untouched ─────
+{
+  const original = JSON.stringify({ mcpServers: [1, 2] });
+  const { root, launcher, mcpJson } = makeFakePackage(original);
+  try {
+    const warnings = withCapturedWarnings(() => patchPluginMcpConfig(launcher, BINARY));
+    assert.strictEqual(warnings.length, 1);
+    assert.strictEqual(fs.readFileSync(mcpJson, "utf8"), original);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// ── missing .mcp.json (dev checkout): silent no-op ───────────────────────────
+{
+  const { root, launcher } = makeFakePackage(null);
+  try {
+    const warnings = withCapturedWarnings(() => patchPluginMcpConfig(launcher, BINARY));
+    assert.deepStrictEqual(warnings, []);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// ── no resolvable binary: silent no-op, file untouched ──────────────────────
+{
+  const original = fs.readFileSync(shippedMcpJson, "utf8");
+  const { root, launcher, mcpJson } = makeFakePackage(original);
+  try {
+    // No platform package exists in this fake layout, and resolve.js's default
+    // resolution (from the repo) finds none either → null → leave the wrapper.
+    const warnings = withCapturedWarnings(() => patchPluginMcpConfig(launcher));
+    assert.deepStrictEqual(warnings, []);
+    assert.strictEqual(fs.readFileSync(mcpJson, "utf8"), original);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// ── unwritable plugin dir: ONE warning, original preserved (POSIX only) ─────
+if (process.platform !== "win32" && typeof process.getuid === "function" && process.getuid() !== 0) {
+  const original = fs.readFileSync(shippedMcpJson, "utf8");
+  const { root, launcher, mcpJson } = makeFakePackage(original);
+  const pluginDir = path.dirname(mcpJson);
+  try {
+    fs.chmodSync(pluginDir, 0o555);
+    const warnings = withCapturedWarnings(() => patchPluginMcpConfig(launcher, BINARY));
+    assert.strictEqual(warnings.length, 1, `expected exactly one warning, got: ${warnings}`);
+    assert.strictEqual(fs.readFileSync(mcpJson, "utf8"), original);
+    // No temp litter left behind next to the config.
+    assert.deepStrictEqual(fs.readdirSync(pluginDir), [".mcp.json"]);
+  } finally {
+    fs.chmodSync(pluginDir, 0o755);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// ── symlinked prefix: patch through a symlink resolves and writes fine ───────
+if (process.platform !== "win32") {
+  const { root, mcpJson } = makeFakePackage(fs.readFileSync(shippedMcpJson, "utf8"));
+  try {
+    const link = path.join(root, "linked-prefix");
+    fs.symlinkSync(path.join(root, "node_modules"), link);
+    const linkedLauncher = path.join(link, "@kurrent", "kcap", "bin", "kcap.js");
+
+    const warnings = withCapturedWarnings(() => patchPluginMcpConfig(linkedLauncher, BINARY));
+    assert.deepStrictEqual(warnings, []);
+    const after = JSON.parse(fs.readFileSync(mcpJson, "utf8"));
+    assert.strictEqual(after.mcpServers["kcap-review"].command, BINARY);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+console.log("ok");

--- a/npm/kcap/bin/resolve.js
+++ b/npm/kcap/bin/resolve.js
@@ -1,0 +1,61 @@
+// Side-effect-free platform/native-binary resolution, shared by kcap.js (the
+// launcher) and refresh.js (postinstall / `kcap update` refresh).
+//
+// This lives in its OWN module — refresh.js must never require kcap.js: during
+// `kcap update`, runUpdate executes BEFORE kcap.js's final module.exports
+// assignment, so a refresh.js → kcap.js require would observe partial exports
+// exactly on that path. Requiring this module has no side effects.
+
+const path = require("path");
+const fs = require("fs");
+
+function isMusl() {
+  if (process.platform !== "linux") return false;
+  try {
+    return fs.readFileSync("/usr/bin/ldd", "utf8").includes("musl");
+  } catch {
+    try {
+      return fs.readdirSync("/lib").some((f) => f.startsWith("ld-musl-"));
+    } catch {
+      return false;
+    }
+  }
+}
+
+const PLATFORM_PACKAGES = {
+  "darwin-arm64":      "@kurrent/kcap-darwin-arm64",
+  "linux-x64":         "@kurrent/kcap-linux-x64",
+  "linux-arm64":       "@kurrent/kcap-linux-arm64",
+  "linux-musl-x64":    "@kurrent/kcap-linux-musl-x64",
+  "linux-musl-arm64":  "@kurrent/kcap-linux-musl-arm64",
+  "win32-x64":         "@kurrent/kcap-win-x64",
+};
+
+function platformKey() {
+  const musl = process.platform === "linux" && isMusl() ? "-musl" : "";
+  return `${process.platform}${musl}-${process.arch}`;
+}
+
+// Absolute path to the native kcap binary for the current platform, or null
+// when the platform is unsupported, the platform package isn't installed, or
+// the binary file is missing. `basedir` (optional) overrides where module
+// resolution starts — tests point it at a fake package layout; callers inside
+// the real install tree omit it (resolution then starts from this file).
+function resolveNativeBinary(basedir) {
+  const packageName = PLATFORM_PACKAGES[platformKey()];
+  if (!packageName) return null;
+
+  let binaryDir;
+  try {
+    const opts = basedir ? { paths: [basedir] } : undefined;
+    binaryDir = path.dirname(require.resolve(`${packageName}/package.json`, opts));
+  } catch {
+    return null;
+  }
+
+  const ext = process.platform === "win32" ? ".exe" : "";
+  const binaryPath = path.join(binaryDir, "bin", `kcap${ext}`);
+  return fs.existsSync(binaryPath) ? binaryPath : null;
+}
+
+module.exports = { PLATFORM_PACKAGES, isMusl, platformKey, resolveNativeBinary };

--- a/npm/kcap/bin/resolve.test.js
+++ b/npm/kcap/bin/resolve.test.js
@@ -1,0 +1,50 @@
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { PLATFORM_PACKAGES, platformKey, resolveNativeBinary } = require("./resolve.js");
+
+// platformKey has the `<platform>[-musl]-<arch>` shape and covers the current
+// process's values.
+assert(platformKey().startsWith(process.platform));
+assert(platformKey().endsWith(`-${process.arch}`));
+
+// The supported-platform table is exactly the six shipped native packages.
+assert.deepStrictEqual(Object.keys(PLATFORM_PACKAGES).sort(), [
+  "darwin-arm64",
+  "linux-arm64",
+  "linux-musl-arm64",
+  "linux-musl-x64",
+  "linux-x64",
+  "win32-x64",
+]);
+
+// resolveNativeBinary against a fake package layout. Only meaningful when the
+// current platform is in the table (dev on an unsupported platform skips).
+const packageName = PLATFORM_PACKAGES[platformKey()];
+if (packageName) {
+  // realpath: require.resolve reports canonical paths, and macOS's tmpdir is a
+  // symlink (/var → /private/var).
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "kcap-resolve-test-")));
+  try {
+    const pkgDir = path.join(root, "node_modules", ...packageName.split("/"));
+    const ext = process.platform === "win32" ? ".exe" : "";
+    const binaryPath = path.join(pkgDir, "bin", `kcap${ext}`);
+
+    // Package not installed → null.
+    assert.strictEqual(resolveNativeBinary(root), null);
+
+    // Package present but the binary file missing → null.
+    fs.mkdirSync(path.join(pkgDir, "bin"), { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, "package.json"), JSON.stringify({ name: packageName, version: "0.0.0" }));
+    assert.strictEqual(resolveNativeBinary(root), null);
+
+    // Binary present → its absolute path.
+    fs.writeFileSync(binaryPath, "native");
+    assert.strictEqual(resolveNativeBinary(root), binaryPath);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+console.log("ok");

--- a/src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj
+++ b/src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj
@@ -31,5 +31,8 @@
         <PackageReference Include="Duende.IdentityModel.OidcClient" />
         <PackageReference Include="Duende.IdentityModel" />
         <PackageReference Include="Tomlyn" />
+        <!-- Windows-only at runtime (guarded by OperatingSystem.IsWindows): user-restricted
+             DACLs on the Global\ cross-process config mutexes (ConfigFileLock). -->
+        <PackageReference Include="System.Threading.AccessControl" />
     </ItemGroup>
 </Project>

--- a/src/Capacitor.Cli.Core/ClaudePluginInstaller.cs
+++ b/src/Capacitor.Cli.Core/ClaudePluginInstaller.cs
@@ -66,6 +66,36 @@ public static class ClaudePluginInstaller {
         enabled[key] is JsonValue v && v.TryGetValue<bool>(out var on) && on;
 
     /// <summary>
+    /// True only when the plugin is CURRENTLY effective: an enabled plugin registration in
+    /// <paramref name="settingsPath"/> AND a resolvable payload — the registered marketplace
+    /// directory still ships the plugin's <c>.mcp.json</c>. Distinct from
+    /// <see cref="IsInstalled"/>, which is the refresh gate ("previously installed → refresh
+    /// it") and accepts the version marker alone: a stale marker (manual removal, failed
+    /// refresh, npm re-layout) must never authorize a DESTRUCTIVE decision — doctor's
+    /// duplicate cleanup and the launcher's merge-skip both assume Claude will actually load
+    /// the plugin's servers in place of the entry being suppressed or removed.
+    /// </summary>
+    public static bool IsEffectivelyInstalled(string settingsPath) {
+        try {
+            if (!File.Exists(settingsPath)) return false;
+            if (JsonNode.Parse(File.ReadAllText(settingsPath)) is not JsonObject root) return false;
+
+            if (root["enabledPlugins"] is not JsonObject enabled ||
+                !(HasEnabledFlag(enabled, "kcap@kcap")           ||
+                  HasEnabledFlag(enabled, "kcap@kurrent")        ||
+                  HasEnabledFlag(enabled, "kapacitor@kapacitor") ||
+                  HasEnabledFlag(enabled, "kapacitor@kurrent"))) {
+                return false;
+            }
+        } catch {
+            return false; // malformed settings → nothing provably enabled
+        }
+
+        var marketplace = RegisteredMarketplacePath(settingsPath);
+        return marketplace is not null && File.Exists(Path.Combine(marketplace, ".mcp.json"));
+    }
+
+    /// <summary>
     /// The directory Claude actually loads the kcap plugin from —
     /// <c>extraKnownMarketplaces.kcap.source.path</c> in <paramref name="settingsPath"/> —
     /// or null when nothing is registered or the file is unreadable. Distinct from where the

--- a/src/Capacitor.Cli.Core/ClaudePluginInstaller.cs
+++ b/src/Capacitor.Cli.Core/ClaudePluginInstaller.cs
@@ -67,32 +67,78 @@ public static class ClaudePluginInstaller {
 
     /// <summary>
     /// True only when the plugin is CURRENTLY effective: an enabled plugin registration in
-    /// <paramref name="settingsPath"/> AND a resolvable payload — the registered marketplace
-    /// directory still ships the plugin's <c>.mcp.json</c>. Distinct from
+    /// <paramref name="settingsPath"/> AND a resolvable INSTALLED payload. Distinct from
     /// <see cref="IsInstalled"/>, which is the refresh gate ("previously installed → refresh
     /// it") and accepts the version marker alone: a stale marker (manual removal, failed
     /// refresh, npm re-layout) must never authorize a DESTRUCTIVE decision — doctor's
     /// duplicate cleanup and the launcher's merge-skip both assume Claude will actually load
     /// the plugin's servers in place of the entry being suppressed or removed.
+    ///
+    /// <para>The payload is resolved the way Claude loads it, not from a marketplace SOURCE
+    /// dir (whose content proves nothing about what is installed/active): the enabled key's
+    /// entry in <c>&lt;claude-home&gt;/plugins/installed_plugins.json</c> names the per-scope
+    /// <c>installPath</c> (the plugin cache). Directory-sourced marketplaces are the one
+    /// exception — Claude resolves those LIVE and their recorded cache path never
+    /// materializes (verified against Claude Code 2.x), so when no cache payload exists the
+    /// marketplace's <c>installLocation</c> in <c>known_marketplaces.json</c> is consulted.
+    /// Anything unresolvable → not effective (fail closed: no destructive action).</para>
     /// </summary>
     public static bool IsEffectivelyInstalled(string settingsPath) {
+        var enabledKey = EnabledKcapPluginKey(settingsPath);
+        if (enabledKey is null) return false;
+
+        var claudeHome = Path.GetDirectoryName(settingsPath);
+        if (string.IsNullOrEmpty(claudeHome)) return false;
+        var pluginsDir = Path.Combine(claudeHome, "plugins");
+
         try {
-            if (!File.Exists(settingsPath)) return false;
-            if (JsonNode.Parse(File.ReadAllText(settingsPath)) is not JsonObject root) return false;
-
-            if (root["enabledPlugins"] is not JsonObject enabled ||
-                !(HasEnabledFlag(enabled, "kcap@kcap")           ||
-                  HasEnabledFlag(enabled, "kcap@kurrent")        ||
-                  HasEnabledFlag(enabled, "kapacitor@kapacitor") ||
-                  HasEnabledFlag(enabled, "kapacitor@kurrent"))) {
+            // No install record for the enabled key → Claude has nothing to load.
+            if (JsonNode.Parse(File.ReadAllText(Path.Combine(pluginsDir, "installed_plugins.json")))
+                    is not JsonObject installedRoot ||
+                installedRoot["plugins"] is not JsonObject plugins ||
+                plugins[enabledKey] is not { } entryNode)
                 return false;
-            }
-        } catch {
-            return false; // malformed settings → nothing provably enabled
-        }
 
-        var marketplace = RegisteredMarketplacePath(settingsPath);
-        return marketplace is not null && File.Exists(Path.Combine(marketplace, ".mcp.json"));
+            // v2 records an array of per-scope installs; tolerate a bare object defensively.
+            IEnumerable<JsonObject> entries = entryNode switch {
+                JsonArray arr    => arr.OfType<JsonObject>(),
+                JsonObject single => [single],
+                _                 => []
+            };
+            foreach (var entry in entries) {
+                if (entry["installPath"] is JsonValue v && v.TryGetValue<string>(out var installPath) &&
+                    !string.IsNullOrWhiteSpace(installPath) &&
+                    File.Exists(Path.Combine(installPath, ".mcp.json")))
+                    return true;
+            }
+
+            // Directory-sourced marketplace: loaded live from installLocation, never cached.
+            var marketplaceName = enabledKey[(enabledKey.IndexOf('@') + 1)..];
+            return JsonNode.Parse(File.ReadAllText(Path.Combine(pluginsDir, "known_marketplaces.json")))
+                       is JsonObject markets &&
+                   markets[marketplaceName]?["installLocation"] is JsonValue loc &&
+                   loc.TryGetValue<string>(out var installLocation) &&
+                   !string.IsNullOrWhiteSpace(installLocation) &&
+                   File.Exists(Path.Combine(installLocation, ".mcp.json"));
+        } catch {
+            return false; // missing/malformed plugin records → fail closed
+        }
+    }
+
+    /// <summary>The first recognized kcap plugin key enabled in settings, else null.</summary>
+    static string? EnabledKcapPluginKey(string settingsPath) {
+        try {
+            if (!File.Exists(settingsPath)) return null;
+            if (JsonNode.Parse(File.ReadAllText(settingsPath)) is not JsonObject root) return null;
+            if (root["enabledPlugins"] is not JsonObject enabled) return null;
+
+            foreach (var key in (string[]) ["kcap@kcap", "kcap@kurrent", "kapacitor@kapacitor", "kapacitor@kurrent"])
+                if (HasEnabledFlag(enabled, key))
+                    return key;
+        } catch {
+            // malformed settings → nothing provably enabled
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Core/ClaudePluginInstaller.cs
+++ b/src/Capacitor.Cli.Core/ClaudePluginInstaller.cs
@@ -99,9 +99,15 @@ public static class ClaudePluginInstaller {
                 plugins[enabledKey] is not { } entryNode)
                 return false;
 
-            // v2 records an array of per-scope installs; tolerate a bare object defensively.
+            // v2 records an array of per-scope installs. Both callers gate on the USER-scope
+            // settings.json enabled flag, so only a "user"-scoped install proves that flag's
+            // payload — a local/project-scoped install belonging to some unrelated repo must
+            // not make the plugin globally "effective". The bare-object shape (pre-v2
+            // compatibility) predates scopes and is accepted as-is.
             IEnumerable<JsonObject> entries = entryNode switch {
-                JsonArray arr    => arr.OfType<JsonObject>(),
+                JsonArray arr => arr.OfType<JsonObject>().Where(e =>
+                    e["scope"] is JsonValue sv && sv.TryGetValue<string>(out var scope) &&
+                    string.Equals(scope, "user", StringComparison.Ordinal)),
                 JsonObject single => [single],
                 _                 => []
             };
@@ -113,10 +119,18 @@ public static class ClaudePluginInstaller {
             }
 
             // Directory-sourced marketplace: loaded live from installLocation, never cached.
+            // The exception applies ONLY when the source type is exactly "directory" — a
+            // git/github marketplace IS cached, so its lingering checkout under
+            // installLocation proves nothing once the installed cache is gone; accepting it
+            // would let doctor delete the only working registrations.
             var marketplaceName = enabledKey[(enabledKey.IndexOf('@') + 1)..];
             return JsonNode.Parse(File.ReadAllText(Path.Combine(pluginsDir, "known_marketplaces.json")))
                        is JsonObject markets &&
-                   markets[marketplaceName]?["installLocation"] is JsonValue loc &&
+                   markets[marketplaceName] is JsonObject market &&
+                   market["source"]?["source"] is JsonValue srcType &&
+                   srcType.TryGetValue<string>(out var sourceType) &&
+                   string.Equals(sourceType, "directory", StringComparison.Ordinal) &&
+                   market["installLocation"] is JsonValue loc &&
                    loc.TryGetValue<string>(out var installLocation) &&
                    !string.IsNullOrWhiteSpace(installLocation) &&
                    File.Exists(Path.Combine(installLocation, ".mcp.json"));

--- a/src/Capacitor.Cli.Core/ClaudePluginInstaller.cs
+++ b/src/Capacitor.Cli.Core/ClaudePluginInstaller.cs
@@ -104,13 +104,18 @@ public static class ClaudePluginInstaller {
             // payload — a local/project-scoped install belonging to some unrelated repo must
             // not make the plugin globally "effective". The bare-object shape (pre-v2
             // compatibility) predates scopes and is accepted as-is.
-            IEnumerable<JsonObject> entries = entryNode switch {
-                JsonArray arr => arr.OfType<JsonObject>().Where(e =>
+            List<JsonObject> entries = entryNode switch {
+                JsonArray arr => [.. arr.OfType<JsonObject>().Where(e =>
                     e["scope"] is JsonValue sv && sv.TryGetValue<string>(out var scope) &&
-                    string.Equals(scope, "user", StringComparison.Ordinal)),
+                    string.Equals(scope, "user", StringComparison.Ordinal))],
                 JsonObject single => [single],
                 _                 => []
             };
+            // No eligible user-scoped record (v2 with only local/project installs, or an
+            // unrecognized shape) → not effective, and the directory-marketplace fallback
+            // below must not run either: it only excuses a PHANTOM cache path on an
+            // otherwise-eligible record, never the absence of an eligible record.
+            if (entries.Count == 0) return false;
             foreach (var entry in entries) {
                 if (entry["installPath"] is JsonValue v && v.TryGetValue<string>(out var installPath) &&
                     !string.IsNullOrWhiteSpace(installPath) &&

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -90,12 +90,18 @@ public static class CodexConfigToml {
     /// Registers the kcap MCP servers (<see cref="KcapMcpServers.ForCodex"/>) under the
     /// top-level <c>[mcp_servers]</c> table of <c>~/.codex/config.toml</c> (or
     /// <paramref name="configPath"/>) so Codex CLI picks them up with no manual TOML edit.
-    /// Idempotent, and non-destructive: an entry that already exists (a prior registration
-    /// or a user customization such as an absolute-path <c>command</c>) is left untouched;
-    /// only missing servers are added. User-defined <c>mcp_servers</c> entries are preserved.
+    /// The <c>command</c> is the resolved native binary path (see
+    /// <see cref="Mcp.KcapBinaryCommand"/>; <paramref name="resolveBinaryPath"/> is the test
+    /// seam). Idempotent, and non-destructive: an entry whose ownership-ledger fingerprint
+    /// still matches is HEALED to the current canonical shape (so an absolute path from a
+    /// previous npm layout is re-pointed), while an unclaimed or user-customized entry is
+    /// left untouched; only missing servers are added. User-defined <c>mcp_servers</c>
+    /// entries are preserved.
     /// </summary>
-    public static Change RegisterKcapMcpServers(string? configPath = null) =>
-        UpdateMcpRegistration(configPath ?? DefaultConfigPath, remove: false);
+    public static Change RegisterKcapMcpServers(string? configPath = null,
+                                                Func<string?>? resolveBinaryPath = null) =>
+        UpdateMcpRegistration(configPath ?? DefaultConfigPath, remove: false,
+                              Mcp.KcapBinaryCommand.Resolve(resolveBinaryPath));
 
     /// <summary>
     /// Removes the kcap-owned MCP server entries (<see cref="KcapMcpServers.ForCodex"/>)
@@ -104,9 +110,9 @@ public static class CodexConfigToml {
     /// entirely when removing them empties it, so uninstall leaves no bare table behind.
     /// </summary>
     public static Change UnregisterKcapMcpServers(string? configPath = null) =>
-        UpdateMcpRegistration(configPath ?? DefaultConfigPath, remove: true);
+        UpdateMcpRegistration(configPath ?? DefaultConfigPath, remove: true, KcapMcpServers.Command);
 
-    static Change UpdateMcpRegistration(string configPath, bool remove) {
+    static Change UpdateMcpRegistration(string configPath, bool remove, string command) {
         lock (_writeLock) {
             try {
                 configPath = CanonicalConfigPath(configPath);
@@ -136,15 +142,28 @@ public static class CodexConfigToml {
                     servers ??= GetOrAddTable(root, "mcp_servers");
                     foreach (var descriptor in KcapMcpServers.ForCodex) {
                         if (servers.TryGetValue(descriptor.Name, out var existingValue)) {
-                            if (claims[descriptor.Name] is JsonObject claim && existingValue is TomlTable existingTable &&
-                                !string.Equals(StringField(claim, "fingerprint"), Fingerprint(existingTable), StringComparison.Ordinal)) {
-                                claims.Remove(descriptor.Name); // user changed an owned entry: relinquish it
-                                ledgerChanged = true;
+                            if (claims[descriptor.Name] is JsonObject claim && existingValue is TomlTable existingTable) {
+                                if (!string.Equals(StringField(claim, "fingerprint"), Fingerprint(existingTable), StringComparison.Ordinal)) {
+                                    claims.Remove(descriptor.Name); // user changed an owned entry: relinquish it
+                                    ledgerChanged = true;
+                                    continue;
+                                }
+                                // Fingerprint still matches → the entry is exactly what kcap wrote,
+                                // so heal it to the current canonical shape (e.g. re-point an
+                                // absolute binary path left stale by an npm re-layout).
+                                var healed = BuildMcpTable(descriptor, command);
+                                if (!string.Equals(Fingerprint(healed), Fingerprint(existingTable), StringComparison.Ordinal)) {
+                                    servers[descriptor.Name] = healed;
+                                    tomlChanged = true;
+                                    claims[descriptor.Name] = BuildClaim(healed);
+                                    ledgerChanged = true;
+                                }
+                                continue;
                             }
-                            continue; // never mutate or claim a pre-existing/manual entry
+                            continue; // never mutate or claim a pre-existing/manual (unclaimed) entry
                         }
 
-                        var table = BuildMcpTable(descriptor);
+                        var table = BuildMcpTable(descriptor, command);
                         servers[descriptor.Name] = table;
                         tomlChanged = true;
                         claims[descriptor.Name] = BuildClaim(table);
@@ -203,9 +222,9 @@ public static class CodexConfigToml {
         }
     }
 
-    static TomlTable BuildMcpTable(KcapMcpServer descriptor) {
+    static TomlTable BuildMcpTable(KcapMcpServer descriptor, string command) {
         var table = new TomlTable {
-            ["command"] = KcapMcpServers.Command,
+            ["command"] = command,
             ["args"] = ToTomlArray(descriptor.Args)
         };
         if (descriptor.ReadOnly) table["default_tools_approval_mode"] = "approve";

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -326,6 +326,32 @@ public static class CodexConfigToml {
     /// (<c>Capacitor.Cli.Daemon.Services.CodexMcpInventory</c>), which reports the fully-composed
     /// effective list (config + plugins).
     /// </summary>
+    /// <summary>
+    /// Reads (name, command) pairs from the top-level <c>[mcp_servers]</c> table — the doctor's
+    /// stale-path scan input. Only string commands are returned (Codex has no argv-array shape).
+    /// Read-only; never throws; empty when the file is missing/unreadable/has no table.
+    /// </summary>
+    public static IReadOnlyList<(string Name, string Command)> ReadMcpServerCommands(string? configPath = null) {
+        var path = configPath ?? DefaultConfigPath;
+
+        if (!File.Exists(path)) return [];
+
+        try {
+            var root = TomlSerializer.Deserialize(File.ReadAllText(path), _tomlTypeInfo.TableInfo);
+
+            if (root is null || !root.TryGetValue("mcp_servers", out var v) || v is not TomlTable servers)
+                return [];
+
+            return servers
+                .Where(kv => kv.Value is TomlTable t && t.TryGetValue("command", out var c) && c is string)
+                .Select(kv => (kv.Key, (string)((TomlTable)kv.Value)["command"]))
+                .OrderBy(x => x.Key, StringComparer.Ordinal)
+                .ToArray();
+        } catch {
+            return [];
+        }
+    }
+
     public static IReadOnlyList<string> ReadMcpServerNames(string? configPath = null) {
         var path = configPath ?? DefaultConfigPath;
 

--- a/src/Capacitor.Cli.Core/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/CodexConfigToml.cs
@@ -606,20 +606,11 @@ public static class CodexConfigToml {
     static IDisposable AcquireConfigLock(string canonicalConfigPath) {
         EnsureParentDirectory(canonicalConfigPath);
         RejectSymlinkComponents(canonicalConfigPath);
-        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonicalConfigPath))).ToLowerInvariant();
-        var mutex = new Mutex(false, "kcap-codex-config-" + hash);
-        try {
-            try {
-                if (!mutex.WaitOne(TimeSpan.FromSeconds(10)))
-                    throw new TimeoutException("Timed out waiting for another kcap Codex configuration update.");
-            } catch (AbandonedMutexException) {
-                // The prior writer died while holding the lock; ownership transfers to us.
-            }
-            return new MutexLease(mutex);
-        } catch {
-            mutex.Dispose();
-            throw;
-        }
+        // Shared cross-process lock helper (Global\ + current-user DACL on Windows). This
+        // replaced a bare "kcap-codex-config-<hash>" mutex, which was session-local on
+        // Windows — a service-session daemon and the login-session CLI never excluded each
+        // other — and open to same-session squatting by other users.
+        return ConfigFileLock.Acquire(canonicalConfigPath);
     }
 
     static void SetOwnerOnly(string path) {
@@ -640,12 +631,6 @@ public static class CodexConfigToml {
             writer.Write(content);
         // Defense in depth for platforms/filesystems that ignore the create mode.
         SetOwnerOnly(path);
-    }
-
-    sealed class MutexLease(Mutex mutex) : IDisposable {
-        public void Dispose() {
-            try { mutex.ReleaseMutex(); } finally { mutex.Dispose(); }
-        }
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Core/ConfigFileLock.cs
+++ b/src/Capacitor.Cli.Core/ConfigFileLock.cs
@@ -1,0 +1,68 @@
+using System.Security.AccessControl;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
+
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// Cross-process mutual exclusion among kcap writers of one shared config file (Claude's
+/// <c>~/.claude.json</c>, Codex's <c>config.toml</c>). EVERY kcap writer of such a file must
+/// acquire this lock for its read-modify-write — an in-process <c>lock</c> serializes only one
+/// process, and a writer outside the lock can commit between another writer's re-read and
+/// rename, losing its update.
+///
+/// <para><b>Naming/security.</b> On Windows a bare mutex name is session-local
+/// (<c>Local\</c>), which misses the real topology here: a service-installed daemon runs in
+/// session 0 while the CLI runs in the login session. The lock therefore uses <c>Global\</c>
+/// explicitly, created with a DACL granting access to the CURRENT USER only, so another local
+/// user cannot squat or hold the name (an existing mutex we cannot open surfaces as an
+/// exception → callers fail closed). On non-Windows, .NET named mutexes are already
+/// machine-wide (per-user shared-memory files), so the plain name suffices. The name hashes
+/// the canonical config path, which itself contains the user's home — distinct users get
+/// distinct names even before the DACL.</para>
+///
+/// <para>Note: kcap versions predating this helper used a bare, differently-prefixed name for
+/// the Codex config lock, so mutual exclusion across a version transition is best-effort —
+/// accepted: the lock guards rare, explicit admin operations.</para>
+/// </summary>
+public static class ConfigFileLock {
+    /// <summary>Acquires the lock for <paramref name="configPath"/>, waiting up to
+    /// <paramref name="timeout"/> (default 10s). Dispose to release. Throws on timeout or an
+    /// unopenable (foreign-owned) mutex — callers treat that as a failed, no-write operation.</summary>
+    public static IDisposable Acquire(string configPath, TimeSpan? timeout = null) {
+        var hash = Convert.ToHexString(SHA256.HashData(
+            Encoding.UTF8.GetBytes(Path.GetFullPath(configPath)))).ToLowerInvariant();
+        var mutex = CreateMutex("kcap-cfg-" + hash);
+        try {
+            try {
+                if (!mutex.WaitOne(timeout ?? TimeSpan.FromSeconds(10)))
+                    throw new TimeoutException($"Timed out waiting for another kcap update of {configPath}.");
+            } catch (AbandonedMutexException) {
+                // The prior writer died while holding the lock; ownership transfers to us.
+            }
+            return new MutexLease(mutex);
+        } catch {
+            mutex.Dispose();
+            throw;
+        }
+    }
+
+    static Mutex CreateMutex(string name) {
+        if (!OperatingSystem.IsWindows()) return new Mutex(false, name);
+
+        // Global\ = cross-session (service daemon in session 0 vs. the login-session CLI);
+        // the current-user-only DACL keeps other local users from squatting the name.
+        var security = new MutexSecurity();
+        security.AddAccessRule(new MutexAccessRule(
+            WindowsIdentity.GetCurrent().User!, MutexRights.FullControl, AccessControlType.Allow));
+        return MutexAcl.Create(initiallyOwned: false, @"Global\" + name, out _, security);
+    }
+
+    sealed class MutexLease(Mutex mutex) : IDisposable {
+        public void Dispose() {
+            try { mutex.ReleaseMutex(); } finally { mutex.Dispose(); }
+        }
+    }
+}

--- a/src/Capacitor.Cli.Core/Mcp/HarnessMcpProjections.cs
+++ b/src/Capacitor.Cli.Core/Mcp/HarnessMcpProjections.cs
@@ -20,8 +20,9 @@ public sealed record HarnessMcpProjection(
     /// <summary>Writes this harness's kcap servers into <paramref name="configPath"/>. The marker name
     /// is derived from the harness rather than passed in, so the two call sites cannot disagree about
     /// which entries kcap owns — a mismatch there would strand entries on uninstall.</summary>
-    public JsonMcpConfigWriter.Change Register(string configPath, string? cwd = null) =>
-        JsonMcpConfigWriter.Register(configPath, Servers, Shape, cwd, new McpMarker(Harness));
+    public JsonMcpConfigWriter.Change Register(string configPath, string? cwd = null,
+                                               Func<string?>? resolveBinaryPath = null) =>
+        JsonMcpConfigWriter.Register(configPath, Servers, Shape, cwd, new McpMarker(Harness), resolveBinaryPath);
 
     public JsonMcpConfigWriter.Change Unregister(string configPath) =>
         JsonMcpConfigWriter.Unregister(configPath, Shape, new McpMarker(Harness));

--- a/src/Capacitor.Cli.Core/Mcp/JsonMcpConfigWriter.cs
+++ b/src/Capacitor.Cli.Core/Mcp/JsonMcpConfigWriter.cs
@@ -20,21 +20,34 @@ public static class JsonMcpConfigWriter {
                                   Func<string?>? resolveBinaryPath = null) {
         var command = KcapBinaryCommand.Resolve(resolveBinaryPath);
         var written = new List<KeyValuePair<string, JsonNode?>>();
+        var adopted = false;
 
         var change = Update(configPath, root => {
             var block   = GetOrAddObject(root, shape.BlockKey); // throws on wrong-type → Failed
             var changed = false;
             written.Clear(); // Update may retry the mutate in principle — never double-record
+            adopted = false;
 
             foreach (var s in servers) {
                 var rendered = RenderEntry(s, shape, cwd, command);
                 if (block[s.Name] is JsonNode existing) {
-                    if (!marker.Owns(configPath, s.Name, existing)) continue;   // user look-alike — never clobber
-                    written.Add(new(s.Name, rendered));                         // kcap-owned → keep recorded
-                    if (JsonNode.DeepEquals(existing, rendered)) continue;      // identical → idempotent no-op
-                    block[s.Name] = rendered;                                   // stale/old shape → heal to canonical
-                    changed = true;
-                    continue;
+                    if (marker.Owns(configPath, s.Name, existing)) {
+                        written.Add(new(s.Name, rendered));                     // kcap-owned → keep recorded
+                        if (JsonNode.DeepEquals(existing, rendered)) continue;  // identical → idempotent no-op
+                        block[s.Name] = rendered;                               // stale/old shape → heal to canonical
+                        changed = true;
+                        continue;
+                    }
+                    // Unowned but EXACTLY the entry this register would write: adopt it. This
+                    // is the recovery lane for config-committed-but-marker-failed (a crash or
+                    // marker-write failure after the config landed): re-claiming a shape
+                    // indistinguishable from our own write strands nothing user-authored —
+                    // uninstall would remove only what registration itself would have written.
+                    if (JsonNode.DeepEquals(existing, rendered)) {
+                        written.Add(new(s.Name, rendered));
+                        adopted = true;
+                    }
+                    continue;                                                   // divergent user look-alike — never clobber
                 }
                 block[s.Name] = rendered;                                       // missing → add
                 written.Add(new(s.Name, rendered));
@@ -48,7 +61,17 @@ public static class JsonMcpConfigWriter {
         // the CodexConfigToml crash ordering): a crash between the two leaks an unowned entry,
         // which registration and uninstall deliberately preserve, whereas the reverse order
         // could claim (fingerprint) a shape that never reached disk and strand healing.
-        if (change == Change.Updated && written.Count > 0) marker.Record(configPath, written);
+        // Adoption records even on an Unchanged config (that IS the marker-only repair).
+        if ((change == Change.Updated || (change == Change.Unchanged && adopted)) && written.Count > 0) {
+            // A marker failure must never fail the caller: the config — the user-visible
+            // artifact — already committed, and setup/plugin install must not report a
+            // registration that IS in place as a hard failure (never-fails-install contract).
+            // Degraded ownership self-heals: the adoption lane above re-records it on the
+            // next register/refresh pass, because the committed entries still match the
+            // canonical shape it renders.
+            try { marker.Record(configPath, written); }
+            catch { /* degraded: ownership heals via adoption on the next pass */ }
+        }
         return change;
     }
 

--- a/src/Capacitor.Cli.Core/Mcp/JsonMcpConfigWriter.cs
+++ b/src/Capacitor.Cli.Core/Mcp/JsonMcpConfigWriter.cs
@@ -16,30 +16,41 @@ public static class JsonMcpConfigWriter {
     public enum Change { Unchanged, Updated, Failed }
 
     public static Change Register(string configPath, IReadOnlyList<KcapMcpServer> servers,
-                                  McpConfigShape shape, string? cwd, IMcpMarker marker) =>
-        Update(configPath, root => {
+                                  McpConfigShape shape, string? cwd, IMcpMarker marker,
+                                  Func<string?>? resolveBinaryPath = null) {
+        var command = KcapBinaryCommand.Resolve(resolveBinaryPath);
+        var written = new List<KeyValuePair<string, JsonNode?>>();
+
+        var change = Update(configPath, root => {
             var block   = GetOrAddObject(root, shape.BlockKey); // throws on wrong-type → Failed
             var changed = false;
-            var written = new List<string>();
+            written.Clear(); // Update may retry the mutate in principle — never double-record
 
             foreach (var s in servers) {
-                var rendered = RenderEntry(s, shape, cwd);
+                var rendered = RenderEntry(s, shape, cwd, command);
                 if (block[s.Name] is JsonNode existing) {
                     if (!marker.Owns(configPath, s.Name, existing)) continue;   // user look-alike — never clobber
-                    written.Add(s.Name);                                        // kcap-owned → keep recorded
+                    written.Add(new(s.Name, rendered));                         // kcap-owned → keep recorded
                     if (JsonNode.DeepEquals(existing, rendered)) continue;      // identical → idempotent no-op
                     block[s.Name] = rendered;                                   // stale/old shape → heal to canonical
                     changed = true;
                     continue;
                 }
                 block[s.Name] = rendered;                                       // missing → add
-                written.Add(s.Name);
+                written.Add(new(s.Name, rendered));
                 changed = true;
             }
 
-            if (changed) marker.Record(configPath, written);
             return changed;
         });
+
+        // Record ownership only AFTER the config write commits (config first, claim second —
+        // the CodexConfigToml crash ordering): a crash between the two leaks an unowned entry,
+        // which registration and uninstall deliberately preserve, whereas the reverse order
+        // could claim (fingerprint) a shape that never reached disk and strand healing.
+        if (change == Change.Updated && written.Count > 0) marker.Record(configPath, written);
+        return change;
+    }
 
     public static Change Unregister(string configPath, McpConfigShape shape, IMcpMarker marker) {
         var change = Update(configPath, root => {
@@ -61,7 +72,7 @@ public static class JsonMcpConfigWriter {
         return change;
     }
 
-    static JsonObject RenderEntry(KcapMcpServer s, McpConfigShape shape, string? cwd) {
+    static JsonObject RenderEntry(KcapMcpServer s, McpConfigShape shape, string? cwd, string command) {
         var o = new JsonObject();
         if (shape.TypeValue is not null) o["type"] = shape.TypeValue;
 
@@ -70,11 +81,11 @@ public static class JsonMcpConfigWriter {
             // than JsonValue.Create / collection expressions, which lower to generic
             // Add<T> and trip NativeAOT (IL3050). Matches ReviewLaunchBuilder's pattern.
             var argv = new JsonArray();
-            argv.Add((JsonNode?)KcapMcpServers.Command);
+            argv.Add((JsonNode?)command);
             foreach (var a in s.Args) argv.Add((JsonNode?)a);
             o["command"] = argv;
         } else {
-            o["command"] = KcapMcpServers.Command;
+            o["command"] = command;
             var args = new JsonArray();
             foreach (var a in s.Args) args.Add((JsonNode?)a);
             o["args"] = args;

--- a/src/Capacitor.Cli.Core/Mcp/KcapBinaryCommand.cs
+++ b/src/Capacitor.Cli.Core/Mcp/KcapBinaryCommand.cs
@@ -25,6 +25,15 @@ public static class KcapBinaryCommand {
     /// must then treat only the literal <c>"kcap"</c> as recognized, never their own
     /// executable: inside <c>kcap-daemon</c>, <see cref="Environment.ProcessPath"/> is the
     /// daemon binary, not the CLI the registrations point at.
+    ///
+    /// <para><b>Accepted limitation (deliberate, no config knob):</b> a hand-rolled layout
+    /// that ships <c>kcap-daemon</c> WITHOUT its sibling <c>kcap</c> resolves null. Every
+    /// official layout (npm platform packages, release archives, the dev build script)
+    /// publishes both binaries into one directory, so such a layout is unsupported rather
+    /// than configurable. The failure direction is safe: an absolute-path registration is
+    /// then merely not recognized as canonical, so the launcher keeps the wrapper duplicate
+    /// in the agent worktree — a wasted resident process, never a lost or suppressed
+    /// registration.</para>
     /// </summary>
     public static string? ResolveCliSibling() {
         var processPath = Environment.ProcessPath;

--- a/src/Capacitor.Cli.Core/Mcp/KcapBinaryCommand.cs
+++ b/src/Capacitor.Cli.Core/Mcp/KcapBinaryCommand.cs
@@ -1,0 +1,20 @@
+namespace Capacitor.Cli.Core.Mcp;
+
+/// <summary>
+/// The command value written into generated harness MCP configs: the absolute path of the
+/// running native binary, so the harness spawns it directly instead of resolving `kcap` to the
+/// npm node wrapper (one resident Node runtime per MCP server per session otherwise). When
+/// `kcap setup` runs via the wrapper the process is ALREADY the native binary — the wrapper
+/// exec's it — so <see cref="Environment.ProcessPath"/> IS the platform binary path.
+/// </summary>
+public static class KcapBinaryCommand {
+    /// <summary>Resolves the command to register. <paramref name="resolveBinaryPath"/> is the
+    /// test seam (null = the real <see cref="Environment.ProcessPath"/>); a null/blank resolution
+    /// falls back to the PATH-resolved literal <c>"kcap"</c>, which keeps working via the wrapper.</summary>
+    public static string Resolve(Func<string?>? resolveBinaryPath = null) {
+        string? path = null;
+        try { path = resolveBinaryPath is null ? Environment.ProcessPath : resolveBinaryPath(); }
+        catch { /* fall back to the PATH-resolved wrapper command */ }
+        return string.IsNullOrWhiteSpace(path) ? KcapMcpServers.Command : path;
+    }
+}

--- a/src/Capacitor.Cli.Core/Mcp/KcapBinaryCommand.cs
+++ b/src/Capacitor.Cli.Core/Mcp/KcapBinaryCommand.cs
@@ -17,4 +17,26 @@ public static class KcapBinaryCommand {
         catch { /* fall back to the PATH-resolved wrapper command */ }
         return string.IsNullOrWhiteSpace(path) ? KcapMcpServers.Command : path;
     }
+
+    /// <summary>
+    /// The native <c>kcap</c> CLI binary as seen from the CURRENT process: the process itself
+    /// when it IS kcap, else a sibling named <c>kcap</c> in the same directory (the daemon
+    /// ships next to the CLI in every install layout). Null when neither resolves — callers
+    /// must then treat only the literal <c>"kcap"</c> as recognized, never their own
+    /// executable: inside <c>kcap-daemon</c>, <see cref="Environment.ProcessPath"/> is the
+    /// daemon binary, not the CLI the registrations point at.
+    /// </summary>
+    public static string? ResolveCliSibling() {
+        var processPath = Environment.ProcessPath;
+        if (string.IsNullOrWhiteSpace(processPath)) return null;
+
+        if (string.Equals(Path.GetFileNameWithoutExtension(processPath), "kcap", StringComparison.OrdinalIgnoreCase))
+            return processPath;
+
+        var dir = Path.GetDirectoryName(processPath);
+        if (string.IsNullOrEmpty(dir)) return null;
+
+        var sibling = Path.Combine(dir, OperatingSystem.IsWindows() ? "kcap.exe" : "kcap");
+        return File.Exists(sibling) ? sibling : null;
+    }
 }

--- a/src/Capacitor.Cli.Core/Mcp/McpFingerprint.cs
+++ b/src/Capacitor.Cli.Core/Mcp/McpFingerprint.cs
@@ -1,0 +1,25 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Core.Mcp;
+
+/// <summary>
+/// Canonical fingerprint of a JSON MCP entry, used by <see cref="McpMarker"/>'s v2 per-entry
+/// ownership claims (the JSON analogue of <c>CodexConfigToml</c>'s ownership-ledger fingerprint):
+/// SHA-256 over a key-sorted, whitespace-free serialization, so cosmetic reformatting of the host
+/// config never changes identity while any value edit does.
+/// </summary>
+public static class McpFingerprint {
+    public static string Compute(JsonNode entry) {
+        var canonical = Normalize(entry)?.ToJsonString() ?? "null";
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical))).ToLowerInvariant();
+    }
+
+    static JsonNode? Normalize(JsonNode? node) => node switch {
+        JsonObject obj => new JsonObject(obj.OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => KeyValuePair.Create(kv.Key, Normalize(kv.Value)))),
+        JsonArray arr => new JsonArray(arr.Select(Normalize).ToArray()),
+        _ => node?.DeepClone()
+    };
+}

--- a/src/Capacitor.Cli.Core/Mcp/McpMarker.cs
+++ b/src/Capacitor.Cli.Core/Mcp/McpMarker.cs
@@ -78,7 +78,32 @@ public sealed class McpMarker(string harness, Func<string, string>? markerPathFo
         };
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-        File.WriteAllText(path, doc.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+        // Atomic sibling-rename, never an in-place truncate-rewrite: the marker is the ownership
+        // record for ABSOLUTE-path entries (v2 fingerprints), so a write interrupted mid-truncate
+        // would strand every such entry as unowned forever — no heal, no uninstall. Owner-only on
+        // create (defense in depth; it holds no secrets but has no business being group-writable).
+        WriteAtomicOwnerOnly(path, doc.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    static void WriteAtomicOwnerOnly(string path, string content) {
+        var options = new FileStreamOptions {
+            Mode   = FileMode.CreateNew,
+            Access = FileAccess.Write,
+            Share  = FileShare.None
+        };
+        if (!OperatingSystem.IsWindows())
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+        var tmp = path + ".tmp-" + Environment.ProcessId + "-" + Guid.NewGuid().ToString("N");
+        try {
+            using (var stream = new FileStream(tmp, options))
+            using (var writer = new StreamWriter(stream))
+                writer.Write(content);
+            File.Move(tmp, path, overwrite: true);
+        } catch {
+            try { File.Delete(tmp); } catch { /* best-effort */ }
+            throw;
+        }
     }
 
     /// <summary>Names-only convenience (legacy v1 semantics: no fingerprint, ownership by the

--- a/src/Capacitor.Cli.Core/Mcp/McpMarker.cs
+++ b/src/Capacitor.Cli.Core/Mcp/McpMarker.cs
@@ -6,10 +6,17 @@ using System.Text.Json.Nodes;
 namespace Capacitor.Cli.Core.Mcp;
 
 public interface IMcpMarker {
-    /// <summary>True if `entry` under `name` is a kcap-owned registration (name recorded in the marker
-    /// AND command == "kcap"), so overwrite/unregister may touch it. A user look-alike returns false.</summary>
+    /// <summary>True if `entry` under `name` is a kcap-owned registration, so overwrite/unregister
+    /// may touch it. A v2 marker owns exactly the recorded per-entry fingerprint (any edit —
+    /// command, args, env — relinquishes ownership); a v1 marker (names only, pre-fingerprint)
+    /// falls back to the legacy command == "kcap" check. A user look-alike returns false.</summary>
     bool Owns(string configPath, string name, JsonNode entry);
-    void Record(string configPath, IReadOnlyList<string> names);
+
+    /// <summary>Records ownership of the given entries (name → the exact JSON just written).
+    /// A null entry records the name with no fingerprint — legacy v1 semantics, kept for
+    /// callers that cannot supply the written JSON.</summary>
+    void Record(string configPath, IReadOnlyList<KeyValuePair<string, JsonNode?>> entries);
+
     IEnumerable<string> Owned(string configPath);
     void Clear(string configPath);
 }
@@ -20,9 +27,16 @@ public interface IMcpMarker {
 ///  - user-scope config → `.kcap-mcp-version` next to the config file;
 ///  - otherwise (project-scope / central) → `~/.kcap/mcp-markers/&lt;harness&gt;-&lt;hash(abs path)&gt;.json`.
 /// The `markerPathFor` override lets tests point both cases at a temp dir.
+///
+/// <para><b>Format v2</b> records a per-entry fingerprint (<see cref="McpFingerprint"/>) so an
+/// absolute-path <c>command</c> (the native binary, AI's Phase-2 registration shape) stays owned
+/// across refresh-healing and uninstall — v1's literal <c>command == "kcap"</c> ownership test
+/// would strand it. Migration is safe and lazy: a v1 marker (JSON array of names) reads as
+/// fingerprint-less entries that keep the legacy command check, and the next
+/// <see cref="Record"/> rewrites the file as v2.</para>
 /// </summary>
 public sealed class McpMarker(string harness, Func<string, string>? markerPathFor = null) : IMcpMarker {
-    const int Version = 1;
+    const int Version = 2;
 
     // Test seam: redirect the CENTRAL marker root (normally the user profile's `.kcap`) so unit tests
     // never read/write the real shared `~/.kcap/mcp-markers` — a single process-global dir that races
@@ -33,36 +47,54 @@ public sealed class McpMarker(string harness, Func<string, string>? markerPathFo
     internal static void OverrideCentralRootForTesting(string? kcapRoot) => _centralRootOverride = kcapRoot;
 
     public bool Owns(string configPath, string name, JsonNode entry) {
-        if (!Owned(configPath).Contains(name)) return false;
+        if (!ReadEntries(MarkerPath(configPath), configPath).TryGetValue(name, out var fingerprint)) return false;
         if (entry is not JsonObject obj) return false; // malformed/non-object entry → not ours; never throw
+
+        // v2: ownership is the exact recorded shape — any edit is the user's and is preserved.
+        if (fingerprint is not null)
+            return string.Equals(McpFingerprint.Compute(obj), fingerprint, StringComparison.Ordinal);
+
+        // v1 marker (no fingerprint recorded): legacy command == "kcap" check.
         var cmd = obj["command"];
         return cmd is JsonValue v && v.TryGetValue(out string? s) && s == KcapMcpServers.Command
             || cmd is JsonArray a && a.Count > 0 && a[0] is JsonValue fv && fv.TryGetValue(out string? fs) && fs == KcapMcpServers.Command;
     }
 
-    public void Record(string configPath, IReadOnlyList<string> names) {
+    public void Record(string configPath, IReadOnlyList<KeyValuePair<string, JsonNode?>> entries) {
         var path = MarkerPath(configPath);
-        var existing = ReadNames(path, configPath);
-        foreach (var n in names) existing.Add(n);
+        var existing = ReadEntries(path, configPath); // merges + migrates a v1 marker in place
+        foreach (var (name, entry) in entries)
+            existing[name] = entry is null ? null : McpFingerprint.Compute(entry);
+
+        var servers = new JsonObject();
+        foreach (var (name, fingerprint) in existing.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+            servers[name] = fingerprint is null ? null : JsonValue.Create(fingerprint);
+
         var doc = new JsonObject {
             ["version"] = Version,
             ["harness"] = harness,
             ["config"]  = Path.GetFullPath(configPath),
-            ["servers"] = new JsonArray(existing.Select(n => (JsonNode)n!).ToArray())
+            ["servers"] = servers
         };
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
         File.WriteAllText(path, doc.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
     }
 
-    public IEnumerable<string> Owned(string configPath) => ReadNames(MarkerPath(configPath), configPath);
+    /// <summary>Names-only convenience (legacy v1 semantics: no fingerprint, ownership by the
+    /// command == "kcap" check). Prefer the entries overload wherever the written JSON is at hand.</summary>
+    public void Record(string configPath, IReadOnlyList<string> names) =>
+        Record(configPath, names.Select(n => KeyValuePair.Create(n, (JsonNode?)null)).ToArray());
+
+    public IEnumerable<string> Owned(string configPath) => ReadEntries(MarkerPath(configPath), configPath).Keys;
 
     public void Clear(string configPath) {
         var p = MarkerPath(configPath);
         try { if (File.Exists(p)) File.Delete(p); } catch { /* best-effort */ }
     }
 
-    HashSet<string> ReadNames(string markerPath, string configPath) {
+    /// <summary>name → fingerprint (null = recorded without one: a v1 marker or a names-only record).</summary>
+    Dictionary<string, string?> ReadEntries(string markerPath, string configPath) {
         try {
             if (!File.Exists(markerPath)) return [];
             if (JsonNode.Parse(File.ReadAllText(markerPath)) is not JsonObject root) return [];
@@ -70,7 +102,19 @@ public sealed class McpMarker(string harness, Func<string, string>? markerPathFo
             // that pertains to THIS harness + config path (else treat as not-ours → preserve).
             if ((string?)root["harness"] != harness) return [];
             if ((string?)root["config"] != Path.GetFullPath(configPath)) return [];
-            return root["servers"] is JsonArray arr ? [.. arr.Select(n => (string)n!)] : [];
+
+            return root["servers"] switch {
+                // v1: a bare array of names — no fingerprints (legacy ownership semantics).
+                JsonArray arr => arr.OfType<JsonValue>()
+                    .Select(n => n.TryGetValue(out string? s) ? s : null)
+                    .Where(s => s is not null)
+                    .ToDictionary(s => s!, _ => (string?)null),
+                // v2: name → fingerprint (null tolerated: recorded without one).
+                JsonObject obj => obj.ToDictionary(
+                    kv => kv.Key,
+                    kv => kv.Value is JsonValue v && v.TryGetValue(out string? fp) ? fp : null),
+                _ => []
+            };
         } catch { return []; }
     }
 

--- a/src/Capacitor.Cli.Core/Mcp/McpRegistrationAudit.cs
+++ b/src/Capacitor.Cli.Core/Mcp/McpRegistrationAudit.cs
@@ -1,0 +1,203 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Core.Mcp;
+
+public enum McpRegistrationIssue {
+    /// <summary>The entry is semantically the canonical kcap registration (recognized kcap
+    /// command, exact canonical args, no customization), so a plugin-shipped entry fully
+    /// shadows it and it is safe to remove.</summary>
+    CanonicalDuplicate,
+
+    /// <summary>Same name as a kcap server but structurally divergent (custom command, args,
+    /// env, or extra fields). Reported so the user can decide; never removed — same name does
+    /// not imply ownership.</summary>
+    Conflict
+}
+
+/// <param name="Scope"><c>user</c> for the top-level <c>mcpServers</c> block, or
+/// <c>projects[&lt;path&gt;]</c> for a per-project block.</param>
+public sealed record McpRegistrationFinding(string Scope, string Name, McpRegistrationIssue Issue);
+
+/// <summary>
+/// Pure audit over Claude Code's user config (<c>~/.claude.json</c>) content: finds user- and
+/// project-scope MCP registrations that duplicate the kcap Claude plugin's shipped servers.
+/// Each duplicate costs one extra resident server process per open Claude session.
+///
+/// Classification is STRUCTURAL, never name-only: an entry is a removable duplicate only when
+/// it is semantically canonical (a recognized kcap command, the exact canonical
+/// <c>["mcp", "&lt;name&gt;"]</c> args, and no custom env/extra fields). A divergent same-name
+/// entry is reported as a <see cref="McpRegistrationIssue.Conflict"/> and preserved — this
+/// repo's standing policy is that same name does not imply ownership (see
+/// <c>JsonMcpConfigWriter</c> / <c>CodexConfigToml</c>).
+///
+/// Callers own the "is the kcap Claude plugin actually present?" gate
+/// (<c>ClaudePluginInstaller.IsInstalled</c>) — without the plugin nothing is shadowed and
+/// nothing here is a duplicate.
+/// </summary>
+public static class McpRegistrationAudit {
+    public const string UserScope = "user";
+
+    /// <summary>
+    /// Finds kcap-named MCP entries in both Claude config scopes: the top-level
+    /// <c>mcpServers</c> block and every <c>projects[&lt;path&gt;].mcpServers</c> block (the
+    /// latter is what <c>ClaudeLauncher.WriteMcpConfig</c> copies into agent worktrees).
+    /// Unreadable/misshapen JSON yields no findings — the audit is diagnostics, never a gate.
+    /// </summary>
+    public static IReadOnlyList<McpRegistrationFinding> FindClaudeDuplicates(
+        string claudeUserConfigJson, string? nativeBinaryPath = null) {
+        var findings = new List<McpRegistrationFinding>();
+
+        try {
+            if (JsonNode.Parse(claudeUserConfigJson) is not JsonObject root) return findings;
+
+            Collect(root["mcpServers"] as JsonObject, UserScope, nativeBinaryPath, findings);
+
+            if (root["projects"] is JsonObject projects)
+                foreach (var (key, project) in projects)
+                    Collect((project as JsonObject)?["mcpServers"] as JsonObject,
+                            $"projects[{key}]", nativeBinaryPath, findings);
+        } catch {
+            // Unreadable config — nothing to report.
+        }
+
+        return findings;
+    }
+
+    /// <summary>
+    /// Returns the config with every <see cref="McpRegistrationIssue.CanonicalDuplicate"/>
+    /// entry removed from both scopes; conflicts and everything else are preserved verbatim.
+    /// Returns the input unchanged when it cannot be parsed (never clobber).
+    /// </summary>
+    public static string RemoveClaudeDuplicates(string claudeUserConfigJson, string? nativeBinaryPath = null) {
+        try {
+            if (JsonNode.Parse(claudeUserConfigJson) is not JsonObject root) return claudeUserConfigJson;
+
+            RemoveCanonical(root["mcpServers"] as JsonObject, nativeBinaryPath);
+
+            if (root["projects"] is JsonObject projects)
+                foreach (var (_, project) in projects)
+                    RemoveCanonical((project as JsonObject)?["mcpServers"] as JsonObject, nativeBinaryPath);
+
+            return root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+        } catch {
+            return claudeUserConfigJson;
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="entry"/> is semantically the canonical registration of the
+    /// kcap server named <paramref name="name"/>: a recognized kcap command (the literal
+    /// <c>kcap</c>, or exactly <paramref name="nativeBinaryPath"/> when provided), the exact
+    /// canonical args, and only cosmetic extra fields (<c>type: "stdio"</c>, <c>cwd</c>,
+    /// <c>description</c>, an EMPTY <c>env</c>). Anything else — including a same-named entry
+    /// pointing at a different binary — is not canonical and must be preserved.
+    /// </summary>
+    public static bool IsCanonicalKcapEntry(string? name, JsonNode? entry, string? nativeBinaryPath) {
+        if (name is null || FindDescriptor(name) is not { } descriptor || entry is not JsonObject obj) return false;
+
+        if (!IsRecognizedKcapCommand(StringValue(obj["command"]), nativeBinaryPath)) return false;
+
+        if (obj["args"] is not JsonArray args || args.Count != descriptor.Args.Length) return false;
+        for (var i = 0; i < descriptor.Args.Length; i++)
+            if (!string.Equals(StringValue(args[i]), descriptor.Args[i], StringComparison.Ordinal))
+                return false;
+
+        foreach (var (key, value) in obj) {
+            switch (key) {
+                case "command" or "args":
+                    break;
+                case "type":
+                    if (!string.Equals(StringValue(value), "stdio", StringComparison.Ordinal)) return false;
+                    break;
+                case "cwd" or "description":
+                    if (StringValue(value) is null) return false;
+                    break;
+                case "env":
+                    if (value is not JsonObject env || env.Count != 0) return false;
+                    break;
+                default:
+                    return false; // custom field → not canonical
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Extracts kcap-named entries under <paramref name="blockKey"/> whose command is an
+    /// absolute path to a kcap binary (string command, or argv-array first element — the
+    /// OpenCode shape). Pure: the caller decides what "stale" means (typically the file no
+    /// longer existing after an npm re-layout) and owns the filesystem check.
+    /// </summary>
+    public static IReadOnlyList<(string Name, string Command)> FindAbsoluteKcapCommands(
+        string configJson, string blockKey = "mcpServers") {
+        var results = new List<(string, string)>();
+
+        try {
+            if (JsonNode.Parse(configJson) is not JsonObject root ||
+                root[blockKey] is not JsonObject block)
+                return results;
+
+            foreach (var (name, entry) in block) {
+                if (FindDescriptor(name) is null || entry is not JsonObject obj) continue;
+
+                var command = StringValue(obj["command"])
+                    ?? (obj["command"] is JsonArray argv && argv.Count > 0 ? StringValue(argv[0]) : null);
+
+                if (command is not null && IsAbsoluteKcapBinaryPath(command))
+                    results.Add((name, command));
+            }
+        } catch {
+            // Unreadable config — nothing to report.
+        }
+
+        return results;
+    }
+
+    /// <summary>The literal <c>kcap</c> (PATH/wrapper resolution) or, when the caller can
+    /// resolve it, exactly the current native binary path. Deliberately NOT any path whose
+    /// basename happens to be <c>kcap</c> — a user pointing a same-named entry at a custom
+    /// build is a conflict to preserve, not a duplicate to remove.</summary>
+    static bool IsRecognizedKcapCommand(string? command, string? nativeBinaryPath) =>
+        command is not null &&
+        (string.Equals(command, KcapMcpServers.Command, StringComparison.Ordinal) ||
+         (nativeBinaryPath is not null && string.Equals(command, nativeBinaryPath, StringComparison.Ordinal)));
+
+    internal static bool IsAbsoluteKcapBinaryPath(string command) {
+        if (!Path.IsPathRooted(command)) return false;
+        var baseName = Path.GetFileNameWithoutExtension(command);
+        return string.Equals(baseName, "kcap", StringComparison.OrdinalIgnoreCase);
+    }
+
+    static void Collect(JsonObject? block, string scope, string? nativeBinaryPath,
+                        List<McpRegistrationFinding> findings) {
+        if (block is null) return;
+
+        foreach (var (name, entry) in block) {
+            if (FindDescriptor(name) is null) continue;
+
+            findings.Add(new McpRegistrationFinding(
+                scope, name,
+                IsCanonicalKcapEntry(name, entry, nativeBinaryPath)
+                    ? McpRegistrationIssue.CanonicalDuplicate
+                    : McpRegistrationIssue.Conflict));
+        }
+    }
+
+    static void RemoveCanonical(JsonObject? block, string? nativeBinaryPath) {
+        if (block is null) return;
+
+        foreach (var name in block
+                     .Where(kv => IsCanonicalKcapEntry(kv.Key, kv.Value, nativeBinaryPath))
+                     .Select(kv => kv.Key)
+                     .ToArray())
+            block.Remove(name);
+    }
+
+    static KcapMcpServer? FindDescriptor(string name) =>
+        KcapMcpServers.All.FirstOrDefault(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+
+    static string? StringValue(JsonNode? node) =>
+        node is JsonValue v && v.TryGetValue(out string? s) ? s : null;
+}

--- a/src/Capacitor.Cli.Core/Mcp/McpRegistrationAudit.cs
+++ b/src/Capacitor.Cli.Core/Mcp/McpRegistrationAudit.cs
@@ -51,12 +51,12 @@ public static class McpRegistrationAudit {
         try {
             if (JsonNode.Parse(claudeUserConfigJson) is not JsonObject root) return findings;
 
-            Collect(root["mcpServers"] as JsonObject, UserScope, nativeBinaryPath, findings);
+            Collect(root["mcpServers"] as JsonObject, UserScope, nativeBinaryPath, projectPath: null, findings);
 
             if (root["projects"] is JsonObject projects)
                 foreach (var (key, project) in projects)
                     Collect((project as JsonObject)?["mcpServers"] as JsonObject,
-                            $"projects[{key}]", nativeBinaryPath, findings);
+                            $"projects[{key}]", nativeBinaryPath, projectPath: key, findings);
         } catch {
             // Unreadable config — nothing to report.
         }
@@ -73,11 +73,12 @@ public static class McpRegistrationAudit {
         try {
             if (JsonNode.Parse(claudeUserConfigJson) is not JsonObject root) return claudeUserConfigJson;
 
-            RemoveCanonical(root["mcpServers"] as JsonObject, nativeBinaryPath);
+            RemoveCanonical(root["mcpServers"] as JsonObject, nativeBinaryPath, projectPath: null);
 
             if (root["projects"] is JsonObject projects)
-                foreach (var (_, project) in projects)
-                    RemoveCanonical((project as JsonObject)?["mcpServers"] as JsonObject, nativeBinaryPath);
+                foreach (var (key, project) in projects)
+                    RemoveCanonical((project as JsonObject)?["mcpServers"] as JsonObject, nativeBinaryPath,
+                                    projectPath: key);
 
             return root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
         } catch {
@@ -85,15 +86,27 @@ public static class McpRegistrationAudit {
         }
     }
 
+    /// <summary>The <c>cwd</c> value the shipped Claude plugin uses for repo-scoped servers —
+    /// Claude expands it to the project dir, so it never customizes execution context.</summary>
+    public const string ClaudeProjectDirPlaceholder = "${CLAUDE_PROJECT_DIR}";
+
     /// <summary>
     /// True when <paramref name="entry"/> is semantically the canonical registration of the
     /// kcap server named <paramref name="name"/>: a recognized kcap command (the literal
     /// <c>kcap</c>, or exactly <paramref name="nativeBinaryPath"/> when provided), the exact
-    /// canonical args, and only cosmetic extra fields (<c>type: "stdio"</c>, <c>cwd</c>,
+    /// canonical args, and only cosmetic extra fields (<c>type: "stdio"</c>,
     /// <c>description</c>, an EMPTY <c>env</c>). Anything else — including a same-named entry
     /// pointing at a different binary — is not canonical and must be preserved.
+    ///
+    /// <para><c>cwd</c> is NOT cosmetic — it changes the server's execution context (repo
+    /// scoping), so an arbitrary value is a customization. It is canonical only on a server
+    /// that requires a project cwd (<see cref="KcapMcpServer.NeedsProjectCwd"/>) and only when
+    /// it is the shipped <see cref="ClaudeProjectDirPlaceholder"/>, or — for a project-scoped
+    /// entry — exactly the project's own path (<paramref name="projectPath"/>), which is what
+    /// the placeholder would expand to anyway.</para>
     /// </summary>
-    public static bool IsCanonicalKcapEntry(string? name, JsonNode? entry, string? nativeBinaryPath) {
+    public static bool IsCanonicalKcapEntry(string? name, JsonNode? entry, string? nativeBinaryPath,
+                                            string? projectPath = null) {
         if (name is null || FindDescriptor(name) is not { } descriptor || entry is not JsonObject obj) return false;
 
         if (!IsRecognizedKcapCommand(StringValue(obj["command"]), nativeBinaryPath)) return false;
@@ -110,7 +123,15 @@ public static class McpRegistrationAudit {
                 case "type":
                     if (!string.Equals(StringValue(value), "stdio", StringComparison.Ordinal)) return false;
                     break;
-                case "cwd" or "description":
+                case "cwd":
+                    if (!descriptor.NeedsProjectCwd) return false; // this server takes no cwd → customization
+                    var cwd = StringValue(value);
+                    if (cwd is null) return false;
+                    if (!string.Equals(cwd, ClaudeProjectDirPlaceholder, StringComparison.Ordinal) &&
+                        !(projectPath is not null && string.Equals(cwd, projectPath, StringComparison.Ordinal)))
+                        return false; // any other cwd redirects execution context → preserved
+                    break;
+                case "description":
                     if (StringValue(value) is null) return false;
                     break;
                 case "env":
@@ -170,7 +191,7 @@ public static class McpRegistrationAudit {
         return string.Equals(baseName, "kcap", StringComparison.OrdinalIgnoreCase);
     }
 
-    static void Collect(JsonObject? block, string scope, string? nativeBinaryPath,
+    static void Collect(JsonObject? block, string scope, string? nativeBinaryPath, string? projectPath,
                         List<McpRegistrationFinding> findings) {
         if (block is null) return;
 
@@ -179,17 +200,17 @@ public static class McpRegistrationAudit {
 
             findings.Add(new McpRegistrationFinding(
                 scope, name,
-                IsCanonicalKcapEntry(name, entry, nativeBinaryPath)
+                IsCanonicalKcapEntry(name, entry, nativeBinaryPath, projectPath)
                     ? McpRegistrationIssue.CanonicalDuplicate
                     : McpRegistrationIssue.Conflict));
         }
     }
 
-    static void RemoveCanonical(JsonObject? block, string? nativeBinaryPath) {
+    static void RemoveCanonical(JsonObject? block, string? nativeBinaryPath, string? projectPath) {
         if (block is null) return;
 
         foreach (var name in block
-                     .Where(kv => IsCanonicalKcapEntry(kv.Key, kv.Value, nativeBinaryPath))
+                     .Where(kv => IsCanonicalKcapEntry(kv.Key, kv.Value, nativeBinaryPath, projectPath))
                      .Select(kv => kv.Key)
                      .ToArray())
             block.Remove(name);

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -9,6 +9,16 @@ public class DaemonConfig {
     public int      MaxConcurrentAgents { get; set; } = 5;
 
     /// <summary>
+    /// Absolute path of the native <c>kcap</c> CLI binary, resolved as the daemon's sibling
+    /// (<see cref="Capacitor.Cli.Core.Mcp.KcapBinaryCommand.ResolveCliSibling"/>) — inside the
+    /// daemon, <see cref="Environment.ProcessPath"/> is <c>kcap-daemon</c>, NOT the binary that
+    /// generated MCP registrations point at. Used to recognize a canonical absolute-path kcap
+    /// entry (e.g. <see cref="Services.ClaudeLauncher"/>'s worktree merge-skip). Null when no
+    /// sibling resolves; consumers then recognize only the literal <c>"kcap"</c>.
+    /// </summary>
+    public string? KcapCliPath { get; set; } = Core.Mcp.KcapBinaryCommand.ResolveCliSibling();
+
+    /// <summary>
     /// Phase B (D3): backstop lifetime/idle bounds for a hosted review-flow reviewer, enforced
     /// in the daemon heartbeat. A reviewer whose run went terminal on the server without the daemon
     /// hearing about it (or whose driver vanished) is reaped here so it can't hold a slot forever.

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -61,7 +61,7 @@ internal sealed partial class ClaudeLauncher(
         }
 
         try {
-            WriteMcpConfig(ctx.SourceRepoPath, ctx.Worktree.Path);
+            WriteMcpConfig(ctx.SourceRepoPath, ctx.Worktree.Path, config.KcapCliPath);
         } catch (Exception ex) {
             LogMcpConfigFailed(ex, ctx.AgentId);
         }
@@ -598,7 +598,8 @@ internal sealed partial class ClaudeLauncher(
         }
     }
 
-    internal static void WriteMcpConfig(string sourceRepoPath, string worktreePath) {
+    internal static void WriteMcpConfig(string sourceRepoPath, string worktreePath,
+                                        string? nativeKcapPath = null) {
         var claudeJsonPath = ClaudePaths.UserConfigJson();
 
         if (!File.Exists(claudeJsonPath)) return;
@@ -610,8 +611,8 @@ internal sealed partial class ClaudeLauncher(
         // the raw path for entries written by older kcap builds or by hand.
         var sourceKey = NormalizeClaudeProjectKey(sourceRepoPath);
 
-        var servers = root?["projects"]?[sourceKey]?["mcpServers"]?.AsObject()
-         ?? root?["projects"]?[sourceRepoPath]?["mcpServers"]?.AsObject();
+        var projectKey = root?["projects"]?[sourceKey]?["mcpServers"] is not null ? sourceKey : sourceRepoPath;
+        var servers = root?["projects"]?[projectKey]?["mcpServers"]?.AsObject();
 
         if (servers is null || servers.Count == 0) return;
 
@@ -632,13 +633,19 @@ internal sealed partial class ClaudeLauncher(
         // in the agent session. Skip those — but STRUCTURALLY, never by name alone: a
         // divergent same-name entry is a user customization and follows the conflict policy
         // (merged like any other server; same name does not imply ownership). Gated on the
-        // plugin actually being installed: without it the copy is the only registration.
-        var pluginInstalled = ClaudePluginInstaller.IsInstalled(ClaudePaths.UserSettings);
+        // plugin being EFFECTIVELY installed (enabled registration + resolvable payload,
+        // never the version marker alone): suppressing an entry is destructive, so a stale
+        // marker must not authorize it — without a loadable plugin the copy is the only
+        // registration.
+        var pluginInstalled = ClaudePluginInstaller.IsEffectivelyInstalled(ClaudePaths.UserSettings);
 
         // Add servers from ~/.claude.json (don't overwrite repo-committed ones)
         foreach (var (name, value) in servers) {
+            // nativeKcapPath comes from DaemonConfig (the CLI binary sibling of this daemon):
+            // Environment.ProcessPath here would be kcap-daemon, misclassifying a canonical
+            // absolute-path entry as divergent and copying the duplicate anyway.
             if (pluginInstalled &&
-                McpRegistrationAudit.IsCanonicalKcapEntry(name, value, Environment.ProcessPath))
+                McpRegistrationAudit.IsCanonicalKcapEntry(name, value, nativeKcapPath, projectKey))
                 continue;
 
             if (!merged.ContainsKey(name) && value is not null) {

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Core.Mcp;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Services;
@@ -626,8 +627,20 @@ internal sealed partial class ClaudeLauncher(
             merged = new JsonObject();
         }
 
+        // The kcap Claude plugin already ships its servers session-wide, so a semantically
+        // canonical project-scope copy would only spawn a duplicate resident server process
+        // in the agent session. Skip those — but STRUCTURALLY, never by name alone: a
+        // divergent same-name entry is a user customization and follows the conflict policy
+        // (merged like any other server; same name does not imply ownership). Gated on the
+        // plugin actually being installed: without it the copy is the only registration.
+        var pluginInstalled = ClaudePluginInstaller.IsInstalled(ClaudePaths.UserSettings);
+
         // Add servers from ~/.claude.json (don't overwrite repo-committed ones)
         foreach (var (name, value) in servers) {
+            if (pluginInstalled &&
+                McpRegistrationAudit.IsCanonicalKcapEntry(name, value, Environment.ProcessPath))
+                continue;
+
             if (!merged.ContainsKey(name) && value is not null) {
                 var clone = value.DeepClone().AsObject();
                 clone.Remove("env");

--- a/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ClaudeLauncher.cs
@@ -353,7 +353,7 @@ internal sealed partial class ClaudeLauncher(
         return OperatingSystem.IsWindows() ? full.Replace('\\', '/') : full;
     }
 
-    static void TrustWorktreeInClaudeConfig(string worktreePath) {
+    internal static void TrustWorktreeInClaudeConfig(string worktreePath) {
         // Serialize against concurrent agent launches. ~/.claude.json is shared
         // across the whole user and {worktree}/.claude/settings.local.json is
         // touched by MergeToolPermissions on the same path; interleaved reads and
@@ -367,7 +367,14 @@ internal sealed partial class ClaudeLauncher(
             // environment, so it reads/writes the same file we resolve here —
             // $CLAUDE_CONFIG_DIR/.claude.json when set, else ~/.claude.json.
             var claudeJsonPath = ClaudePaths.UserConfigJson();
-            var root           = LoadJsonObject(claudeJsonPath);
+
+            // The in-process lock above serializes only THIS daemon; every kcap writer of
+            // ~/.claude.json must also take the shared cross-process lock, or this write can
+            // land between another writer's inside-lock re-read and its rename (e.g. doctor
+            // --clean) and be silently overwritten. See ConfigFileLock.
+            using var _ = ConfigFileLock.Acquire(claudeJsonPath);
+
+            var root = LoadJsonObject(claudeJsonPath);
 
             if (root["projects"] is not JsonObject projects) {
                 projects         = [];

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -603,6 +603,17 @@ public static class DaemonCommands {
     static async Task<int> DoctorAsync(string[] args) {
         var clean = args.Contains("--clean");
 
+        // MCP-registrations audit runs BEFORE the daemon-file early return below — a machine
+        // with no daemon state still has registrations worth checking (duplicate Claude-scope
+        // entries cost one extra server process per session; a stale absolute binary path
+        // breaks the servers outright after an npm re-layout).
+        await McpDoctorSection.RunAsync(Console.Out, clean,
+            ClaudePaths.UserConfigJson(), ClaudePaths.UserSettings,
+            McpDoctorSection.DefaultJsonRegistrations(),
+            Path.Combine(CodexPaths.Home(), "config.toml"),
+            Environment.ProcessPath);
+        await Console.Out.WriteLineAsync();
+
         DaemonLockPaths.EnsureDirectory();
 
         var names = DaemonLockPaths.EnumerateNames();

--- a/src/Capacitor.Cli/Commands/McpDoctorSection.cs
+++ b/src/Capacitor.Cli/Commands/McpDoctorSection.cs
@@ -92,20 +92,108 @@ static class McpDoctorSection {
         }
 
         if (clean && duplicates > 0) {
-            try {
-                var cleaned = McpRegistrationAudit.RemoveClaudeDuplicates(json, nativeBinaryPath);
-                // Atomic sibling-rename so a crash can never truncate Claude's config.
-                var tmp = claudeConfigPath + ".tmp-" + Environment.ProcessId + "-" + Guid.NewGuid().ToString("N");
-                await File.WriteAllTextAsync(tmp, cleaned);
-                try { File.Move(tmp, claudeConfigPath, overwrite: true); }
-                catch { try { File.Delete(tmp); } catch { /* best-effort */ } throw; }
-                await output.WriteLineAsync($"  removed {duplicates} duplicate MCP registration(s) from {claudeConfigPath}");
-            } catch (Exception ex) {
-                await output.WriteLineAsync($"  could not clean {claudeConfigPath}: {ex.Message}");
+            switch (TryCleanClaudeConfig(claudeConfigPath, json, nativeBinaryPath, out var error)) {
+                case CleanOutcome.Cleaned:
+                    await output.WriteLineAsync($"  removed {duplicates} duplicate MCP registration(s) from {claudeConfigPath}");
+                    break;
+                case CleanOutcome.Conflicted:
+                    await output.WriteLineAsync(
+                        $"  {claudeConfigPath} changed while doctor was running — skipped the clean; " +
+                        "re-run `kcap daemon doctor --clean`");
+                    break;
+                case CleanOutcome.Failed:
+                    await output.WriteLineAsync($"  could not clean {claudeConfigPath}: {error}");
+                    break;
             }
         }
 
         return findings.Count;
+    }
+
+    internal enum CleanOutcome { Cleaned, Conflicted, Failed }
+
+    /// <summary>
+    /// Commits the duplicate removal computed from <paramref name="snapshotJson"/>. The config is
+    /// shared: Claude itself and the daemon's trust write both update it, and nothing in this
+    /// codebase offers a cross-process lock for it (the daemon's trust write serializes only
+    /// in-process) — so kcap-side writers serialize under a named mutex keyed on the path, and the
+    /// remaining window against OTHER writers is closed by re-reading INSIDE the lock immediately
+    /// before committing and aborting (<see cref="CleanOutcome.Conflicted"/>, nothing written) when
+    /// the file no longer matches the snapshot the findings were computed from — a blind rewrite
+    /// there would silently drop their update. The write is an atomic sibling-rename that preserves
+    /// the target's Unix mode (a 0600 config must not come back 0644; new files default owner-only).
+    /// </summary>
+    internal static CleanOutcome TryCleanClaudeConfig(string claudeConfigPath, string snapshotJson,
+                                                      string? nativeBinaryPath, out string? error) {
+        error = null;
+        try {
+            using var _ = AcquireClaudeConfigLock(claudeConfigPath);
+
+            if (!string.Equals(File.ReadAllText(claudeConfigPath), snapshotJson, StringComparison.Ordinal))
+                return CleanOutcome.Conflicted;
+
+            var cleaned = McpRegistrationAudit.RemoveClaudeDuplicates(snapshotJson, nativeBinaryPath);
+            WriteAtomicPreservingMode(claudeConfigPath, cleaned);
+            return CleanOutcome.Cleaned;
+        } catch (Exception ex) {
+            error = ex.Message;
+            return CleanOutcome.Failed;
+        }
+    }
+
+    /// <summary>Cross-process serialization among kcap writers of one Claude config file —
+    /// the same named-mutex shape as <c>CodexConfigToml.AcquireConfigLock</c>.</summary>
+    static IDisposable AcquireClaudeConfigLock(string claudeConfigPath) {
+        var hash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(System.IO.Path.GetFullPath(claudeConfigPath)))).ToLowerInvariant();
+        var mutex = new Mutex(false, "kcap-claude-config-" + hash);
+        try {
+            try {
+                if (!mutex.WaitOne(TimeSpan.FromSeconds(10)))
+                    throw new TimeoutException("Timed out waiting for another kcap Claude configuration update.");
+            } catch (AbandonedMutexException) {
+                // The prior writer died while holding the lock; ownership transfers to us.
+            }
+            return new MutexLease(mutex);
+        } catch {
+            mutex.Dispose();
+            throw;
+        }
+    }
+
+    sealed class MutexLease(Mutex mutex) : IDisposable {
+        public void Dispose() {
+            try { mutex.ReleaseMutex(); } finally { mutex.Dispose(); }
+        }
+    }
+
+    static void WriteAtomicPreservingMode(string path, string content) {
+        var options = new FileStreamOptions {
+            Mode   = FileMode.CreateNew,
+            Access = FileAccess.Write,
+            Share  = FileShare.None
+        };
+        if (!OperatingSystem.IsWindows()) {
+            UnixFileMode mode;
+            try {
+                mode = File.Exists(path) ? File.GetUnixFileMode(path)
+                                         : UnixFileMode.UserRead | UnixFileMode.UserWrite;
+            } catch {
+                mode = UnixFileMode.UserRead | UnixFileMode.UserWrite; // unreadable → fail safe to owner-only
+            }
+            options.UnixCreateMode = mode;
+        }
+
+        var tmp = path + ".tmp-" + Environment.ProcessId + "-" + Guid.NewGuid().ToString("N");
+        try {
+            using (var stream = new FileStream(tmp, options))
+            using (var writer = new StreamWriter(stream))
+                writer.Write(content);
+            File.Move(tmp, path, overwrite: true);
+        } catch {
+            try { File.Delete(tmp); } catch { /* best-effort */ }
+            throw;
+        }
     }
 
     static async Task<int> AuditStalePathsAsync(TextWriter output, string claudeConfigPath,

--- a/src/Capacitor.Cli/Commands/McpDoctorSection.cs
+++ b/src/Capacitor.Cli/Commands/McpDoctorSection.cs
@@ -1,0 +1,158 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Antigravity;
+using Capacitor.Cli.Core.Copilot;
+using Capacitor.Cli.Core.Cursor;
+using Capacitor.Cli.Core.Gemini;
+using Capacitor.Cli.Core.Kiro;
+using Capacitor.Cli.Core.Mcp;
+using Capacitor.Cli.Core.OpenCode;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// The MCP-registrations section of <c>kcap daemon doctor</c>. Deliberately runs BEFORE the
+/// daemon-file early return — a machine with no daemon state still has registrations worth
+/// auditing. Two checks:
+///
+/// <list type="number">
+/// <item><b>Duplicate Claude registrations</b> — user/project-scope copies of plugin-shipped
+/// kcap servers in <c>~/.claude.json</c> (each costs one extra resident server process per open
+/// session). Gated on the kcap Claude plugin actually being installed; classification is
+/// structural, never name-only (<see cref="McpRegistrationAudit"/>): only a semantically
+/// canonical copy is removable, a divergent same-name entry is reported and preserved.
+/// Read-only by default; <c>--clean</c> removes only the canonical duplicates.</item>
+/// <item><b>Stale absolute binary paths</b> — Phase-2 registrations point at the native binary,
+/// and an npm re-layout can strand them. "Stale" is two-tier: the registered file no longer
+/// exists (broken — re-run <c>kcap setup</c>) vs. it differs from the current resolution
+/// (outdated — healed by the next <c>kcap setup</c>/<c>kcap update</c>). Only kcap-named
+/// entries are inspected.</item>
+/// </list>
+///
+/// All paths are injected so tests run against fixture files in temp dirs, never the real
+/// <c>~/.claude.json</c> or harness configs.
+/// </summary>
+static class McpDoctorSection {
+    /// <summary>One JSON registration file to scan: a display label, its path, and the MCP
+    /// block key its harness uses ("mcpServers" for most, "mcp" for OpenCode).</summary>
+    internal sealed record RegistrationFile(string Label, string Path, string BlockKey);
+
+    /// <summary>The user-scope registration files kcap writes (Claude's own config is handled
+    /// separately — it carries the duplicate audit too, not just the stale-path scan).</summary>
+    internal static IReadOnlyList<RegistrationFile> DefaultJsonRegistrations() => [
+        new("Cursor",      CursorPaths.UserMcpJson(),        "mcpServers"),
+        new("Copilot",     CopilotPaths.McpConfigJson(),     "mcpServers"),
+        new("Kiro",        KiroPaths.SettingsMcpJson(),      "mcpServers"),
+        new("Gemini",      GeminiPaths.SettingsJson(),       "mcpServers"),
+        new("OpenCode",    OpenCodePaths.McpConfigJson(),    "mcp"),
+        new("Antigravity", AntigravityPaths.McpConfigJson(), "mcpServers"),
+    ];
+
+    /// <summary>Returns the number of issues found (0 = healthy).</summary>
+    public static async Task<int> RunAsync(TextWriter output, bool clean,
+                                           string claudeConfigPath, string claudeSettingsPath,
+                                           IReadOnlyList<RegistrationFile> jsonRegistrations,
+                                           string? codexConfigPath,
+                                           string? nativeBinaryPath) {
+        var issues = 0;
+        issues += await AuditClaudeDuplicatesAsync(output, clean, claudeConfigPath, claudeSettingsPath, nativeBinaryPath);
+        issues += await AuditStalePathsAsync(output, claudeConfigPath, jsonRegistrations, codexConfigPath, nativeBinaryPath);
+
+        if (issues == 0) await output.WriteLineAsync("MCP registrations: no issues found.");
+        return issues;
+    }
+
+    static async Task<int> AuditClaudeDuplicatesAsync(TextWriter output, bool clean,
+                                                      string claudeConfigPath, string claudeSettingsPath,
+                                                      string? nativeBinaryPath) {
+        if (!File.Exists(claudeConfigPath)) return 0;
+        // Without the plugin nothing is shadowed — a user-scope entry is the only registration.
+        if (!ClaudePluginInstaller.IsInstalled(claudeSettingsPath)) return 0;
+
+        string json;
+        try { json = await File.ReadAllTextAsync(claudeConfigPath); } catch { return 0; }
+
+        var findings = McpRegistrationAudit.FindClaudeDuplicates(json, nativeBinaryPath);
+        if (findings.Count == 0) return 0;
+
+        var duplicates = 0;
+        foreach (var f in findings) {
+            if (f.Issue == McpRegistrationIssue.CanonicalDuplicate) {
+                duplicates++;
+                await output.WriteLineAsync(
+                    $"  duplicate MCP registration '{f.Name}' ({f.Scope}) in {claudeConfigPath} shadows the " +
+                    "kcap plugin entry (costs one extra server process per session)" +
+                    (clean ? "" : " — run `kcap daemon doctor --clean` to remove it"));
+            } else {
+                await output.WriteLineAsync(
+                    $"  same-named MCP registration '{f.Name}' ({f.Scope}) in {claudeConfigPath} differs from " +
+                    "the kcap plugin entry — left untouched (remove it manually if unintended)");
+            }
+        }
+
+        if (clean && duplicates > 0) {
+            try {
+                var cleaned = McpRegistrationAudit.RemoveClaudeDuplicates(json, nativeBinaryPath);
+                // Atomic sibling-rename so a crash can never truncate Claude's config.
+                var tmp = claudeConfigPath + ".tmp-" + Environment.ProcessId + "-" + Guid.NewGuid().ToString("N");
+                await File.WriteAllTextAsync(tmp, cleaned);
+                try { File.Move(tmp, claudeConfigPath, overwrite: true); }
+                catch { try { File.Delete(tmp); } catch { /* best-effort */ } throw; }
+                await output.WriteLineAsync($"  removed {duplicates} duplicate MCP registration(s) from {claudeConfigPath}");
+            } catch (Exception ex) {
+                await output.WriteLineAsync($"  could not clean {claudeConfigPath}: {ex.Message}");
+            }
+        }
+
+        return findings.Count;
+    }
+
+    static async Task<int> AuditStalePathsAsync(TextWriter output, string claudeConfigPath,
+                                                IReadOnlyList<RegistrationFile> jsonRegistrations,
+                                                string? codexConfigPath,
+                                                string? nativeBinaryPath) {
+        var issues = 0;
+
+        // Claude's own config participates in the stale scan too (top-level scope).
+        IEnumerable<RegistrationFile> jsonFiles =
+            [.. jsonRegistrations, new("Claude", claudeConfigPath, "mcpServers")];
+
+        foreach (var file in jsonFiles) {
+            if (!File.Exists(file.Path)) continue;
+
+            string json;
+            try { json = await File.ReadAllTextAsync(file.Path); } catch { continue; }
+
+            foreach (var (name, command) in McpRegistrationAudit.FindAbsoluteKcapCommands(json, file.BlockKey))
+                issues += await ReportStaleAsync(output, file.Label, file.Path, name, command, nativeBinaryPath);
+        }
+
+        if (codexConfigPath is not null) {
+            foreach (var (name, command) in CodexConfigToml.ReadMcpServerCommands(codexConfigPath)) {
+                if (!KcapMcpServers.All.Any(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase))) continue;
+                if (!McpRegistrationAudit.IsAbsoluteKcapBinaryPath(command)) continue;
+                issues += await ReportStaleAsync(output, "Codex", codexConfigPath, name, command, nativeBinaryPath);
+            }
+        }
+
+        return issues;
+    }
+
+    static async Task<int> ReportStaleAsync(TextWriter output, string label, string configPath,
+                                            string name, string command, string? nativeBinaryPath) {
+        if (!File.Exists(command)) {
+            await output.WriteLineAsync(
+                $"  stale MCP registration '{name}' ({label}) in {configPath}: {command} no longer exists — re-run `kcap setup`");
+            return 1;
+        }
+
+        if (nativeBinaryPath is not null &&
+            !string.Equals(command, nativeBinaryPath, StringComparison.Ordinal)) {
+            await output.WriteLineAsync(
+                $"  outdated MCP registration '{name}' ({label}) in {configPath}: points at {command}, " +
+                $"current binary is {nativeBinaryPath} (healed by the next `kcap setup` or `kcap update`)");
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/src/Capacitor.Cli/Commands/McpDoctorSection.cs
+++ b/src/Capacitor.Cli/Commands/McpDoctorSection.cs
@@ -65,8 +65,10 @@ static class McpDoctorSection {
                                                       string claudeConfigPath, string claudeSettingsPath,
                                                       string? nativeBinaryPath) {
         if (!File.Exists(claudeConfigPath)) return 0;
-        // Without the plugin nothing is shadowed — a user-scope entry is the only registration.
-        if (!ClaudePluginInstaller.IsInstalled(claudeSettingsPath)) return 0;
+        // Without an EFFECTIVE plugin (enabled registration + resolvable payload — never the
+        // version marker alone) nothing is shadowed: the user-scope entry is the only
+        // registration, and cleanup would delete the servers outright.
+        if (!ClaudePluginInstaller.IsEffectivelyInstalled(claudeSettingsPath)) return 0;
 
         string json;
         try { json = await File.ReadAllTextAsync(claudeConfigPath); } catch { return 0; }

--- a/src/Capacitor.Cli/Commands/McpDoctorSection.cs
+++ b/src/Capacitor.Cli/Commands/McpDoctorSection.cs
@@ -123,14 +123,22 @@ static class McpDoctorSection {
     /// there would silently drop their update. The write is an atomic sibling-rename that preserves
     /// the target's Unix mode (a 0600 config must not come back 0644; new files default owner-only).
     /// </summary>
+    /// <param name="afterReReadForTesting">Test hook, invoked INSIDE the config lock after the
+    /// snapshot re-check passes and before the write — lets a test park the commit while it
+    /// proves a concurrent kcap writer blocks on the same lock. Never set in production.</param>
     internal static CleanOutcome TryCleanClaudeConfig(string claudeConfigPath, string snapshotJson,
-                                                      string? nativeBinaryPath, out string? error) {
+                                                      string? nativeBinaryPath, out string? error,
+                                                      Action? afterReReadForTesting = null) {
         error = null;
         try {
-            using var _ = AcquireClaudeConfigLock(claudeConfigPath);
+            // The shared cross-process lock every kcap writer of this file takes
+            // (ClaudeLauncher's trust write included) — see ConfigFileLock.
+            using var _ = ConfigFileLock.Acquire(claudeConfigPath);
 
             if (!string.Equals(File.ReadAllText(claudeConfigPath), snapshotJson, StringComparison.Ordinal))
                 return CleanOutcome.Conflicted;
+
+            afterReReadForTesting?.Invoke();
 
             var cleaned = McpRegistrationAudit.RemoveClaudeDuplicates(snapshotJson, nativeBinaryPath);
             WriteAtomicPreservingMode(claudeConfigPath, cleaned);
@@ -138,32 +146,6 @@ static class McpDoctorSection {
         } catch (Exception ex) {
             error = ex.Message;
             return CleanOutcome.Failed;
-        }
-    }
-
-    /// <summary>Cross-process serialization among kcap writers of one Claude config file —
-    /// the same named-mutex shape as <c>CodexConfigToml.AcquireConfigLock</c>.</summary>
-    static IDisposable AcquireClaudeConfigLock(string claudeConfigPath) {
-        var hash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
-            System.Text.Encoding.UTF8.GetBytes(System.IO.Path.GetFullPath(claudeConfigPath)))).ToLowerInvariant();
-        var mutex = new Mutex(false, "kcap-claude-config-" + hash);
-        try {
-            try {
-                if (!mutex.WaitOne(TimeSpan.FromSeconds(10)))
-                    throw new TimeoutException("Timed out waiting for another kcap Claude configuration update.");
-            } catch (AbandonedMutexException) {
-                // The prior writer died while holding the lock; ownership transfers to us.
-            }
-            return new MutexLease(mutex);
-        } catch {
-            mutex.Dispose();
-            throw;
-        }
-    }
-
-    sealed class MutexLease(Mutex mutex) : IDisposable {
-        public void Dispose() {
-            try { mutex.ReleaseMutex(); } finally { mutex.Dispose(); }
         }
     }
 
@@ -189,7 +171,14 @@ static class McpDoctorSection {
             using (var stream = new FileStream(tmp, options))
             using (var writer = new StreamWriter(stream))
                 writer.Write(content);
-            File.Move(tmp, path, overwrite: true);
+            if (OperatingSystem.IsWindows()) {
+                // File.Replace (ReplaceFile semantics) preserves the DESTINATION's ACL and
+                // attributes; Move(overwrite) would publish the temp file's inherited DACL
+                // over an explicitly-restricted config ACL.
+                File.Replace(tmp, path, destinationBackupFileName: null);
+            } else {
+                File.Move(tmp, path, overwrite: true);
+            }
         } catch {
             try { File.Delete(tmp); } catch { /* best-effort */ }
             throw;

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -477,7 +477,7 @@ public static class PluginCommand {
     /// Never fails the install: a write error is a warning, not an error code.
     /// </summary>
     static async Task RegisterCodexMcpServersAsync(PluginEnvironment env) {
-        switch (CodexConfigToml.RegisterKcapMcpServers(env.CodexConfigTomlPath)) {
+        switch (CodexConfigToml.RegisterKcapMcpServers(env.CodexConfigTomlPath, env.ResolveMcpBinaryPath)) {
             case CodexConfigToml.Change.Updated:
                 await env.Stdout.WriteLineAsync($"Codex MCP servers registered: {string.Join(", ", KcapMcpServers.ForCodex.Select(s => s.Name))} ({env.CodexConfigTomlPath}).");
                 break;
@@ -723,7 +723,7 @@ public static class PluginCommand {
     /// not an error code.
     /// </summary>
     static async Task RegisterCursorMcpServersAsync(PluginEnvironment env) {
-        var change = HarnessMcpProjections.Cursor.Register(env.CursorMcpJson);
+        var change = HarnessMcpProjections.Cursor.Register(env.CursorMcpJson, resolveBinaryPath: env.ResolveMcpBinaryPath);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1054,7 +1054,7 @@ public static class PluginCommand {
     /// loads them without a manual JSON edit. Never fails the install: a write error is a warning.
     /// </summary>
     static async Task RegisterOpenCodeMcpServersAsync(PluginEnvironment env) {
-        var change = HarnessMcpProjections.OpenCode.Register(env.OpenCodeMcpConfigJson);
+        var change = HarnessMcpProjections.OpenCode.Register(env.OpenCodeMcpConfigJson, resolveBinaryPath: env.ResolveMcpBinaryPath);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1192,7 +1192,7 @@ public static class PluginCommand {
     /// <summary>Registers the kcap MCP servers in Antigravity's own <c>~/.gemini/config/mcp_config.json</c>
     /// (Standard shape). Never fails the install: a write error is a warning.</summary>
     static async Task RegisterAntigravityMcpServersAsync(PluginEnvironment env) {
-        var change = HarnessMcpProjections.Antigravity.Register(env.AntigravityMcpConfigJson);
+        var change = HarnessMcpProjections.Antigravity.Register(env.AntigravityMcpConfigJson, resolveBinaryPath: env.ResolveMcpBinaryPath);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1381,7 +1381,7 @@ public static class PluginCommand {
     /// not an error code.
     /// </summary>
     static async Task RegisterCopilotMcpServersAsync(PluginEnvironment env) {
-        var change = HarnessMcpProjections.Copilot.Register(env.CopilotMcpConfigJson);
+        var change = HarnessMcpProjections.Copilot.Register(env.CopilotMcpConfigJson, resolveBinaryPath: env.ResolveMcpBinaryPath);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1624,7 +1624,7 @@ public static class PluginCommand {
     /// fields (kcap leaves autoApprove unset). Never fails the install: a write error is a warning.
     /// </summary>
     static async Task RegisterKiroMcpServersAsync(PluginEnvironment env, string mcpPath) {
-        var change = HarnessMcpProjections.Kiro.Register(mcpPath);
+        var change = HarnessMcpProjections.Kiro.Register(mcpPath, resolveBinaryPath: env.ResolveMcpBinaryPath);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:
@@ -1970,7 +1970,7 @@ public static class PluginCommand {
     /// Never fails the install: a write error is a warning, not an error code.
     /// </summary>
     static async Task RegisterGeminiMcpServersAsync(PluginEnvironment env, string settingsPath) {
-        var change = HarnessMcpProjections.Gemini.Register(settingsPath);
+        var change = HarnessMcpProjections.Gemini.Register(settingsPath, resolveBinaryPath: env.ResolveMcpBinaryPath);
 
         switch (change) {
             case JsonMcpConfigWriter.Change.Updated:

--- a/src/Capacitor.Cli/Commands/PluginEnvironment.cs
+++ b/src/Capacitor.Cli/Commands/PluginEnvironment.cs
@@ -26,6 +26,13 @@ public sealed record PluginEnvironment(
     TextWriter     Stdout,
     TextWriter     Stderr
 ) {
+    /// <summary>
+    /// Resolves the native binary path written as the <c>command</c> of generated MCP
+    /// registrations. Null → the production default (<see cref="Environment.ProcessPath"/>, see
+    /// <c>KcapBinaryCommand</c>). Tests inject a deterministic path so assertions never bless
+    /// whatever executable happens to be running the test.
+    /// </summary>
+    public Func<string?>? ResolveMcpBinaryPath { get; init; }
     public string ClaudeHome          => ClaudePaths.Home(HomeDirectory);
     public string ClaudeUserSettings  => Path.Combine(ClaudeHome, "settings.json");
     public string CodexHome           => CodexPaths.Home(HomeDirectory);

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteMcpConfigTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteMcpConfigTests.cs
@@ -126,11 +126,19 @@ public class ClaudeLauncherWriteMcpConfigTests {
     }
 
     static void MarkClaudePluginInstalled(string configDir) {
-        // ClaudePluginInstaller.IsInstalled recognises an enabledPlugins["kcap@kcap"] flag in
-        // the settings file — with CLAUDE_CONFIG_DIR set that is $CLAUDE_CONFIG_DIR/settings.json.
+        // The merge-skip gates on ClaudePluginInstaller.IsEffectivelyInstalled: an enabled
+        // registration in settings.json ($CLAUDE_CONFIG_DIR/settings.json here) AND a registered
+        // marketplace dir that still ships the plugin payload (.mcp.json).
+        var marketplace = Path.Combine(configDir, "plugin");
+        Directory.CreateDirectory(marketplace);
+        File.WriteAllText(Path.Combine(marketplace, ".mcp.json"), "{}");
         File.WriteAllText(
             Path.Combine(configDir, "settings.json"),
-            """{ "enabledPlugins": { "kcap@kcap": true } }""");
+            $$"""
+            { "enabledPlugins": { "kcap@kcap": true },
+              "extraKnownMarketplaces": { "kcap": { "source": {
+                  "source": "local", "path": {{JsonValue.Create(marketplace).ToJsonString()}} } } } }
+            """);
     }
 
     static JsonObject KcapEntry(string suffix, string command = "kcap") => new() {
@@ -181,6 +189,51 @@ public class ClaudeLauncherWriteMcpConfigTests {
             var servers = ReadWorktreeMcpServers(worktree);
             await Assert.That(servers).IsNotNull();
             await Assert.That(servers!.ContainsKey("kcap-flows")).IsTrue();
+        });
+    }
+
+    /// <summary>
+    /// A stale <c>.kcap-plugin-version</c> marker (manual removal, failed refresh, npm
+    /// re-layout) satisfies the refresh gate but must NOT authorize the merge-skip: without a
+    /// loadable plugin payload the copy is the user's only registration of the server.
+    /// </summary>
+    [Test]
+    public async Task Version_marker_alone_does_not_authorize_the_merge_skip() {
+        await RunWithRelocatedConfigAsync(async (configDir, sourceRepo, worktree) => {
+            File.WriteAllText(Path.Combine(configDir, ".kcap-plugin-version"), "9.9.9");
+            WriteClaudeJsonWithServers(configDir, ClaudeLauncher.NormalizeClaudeProjectKey(sourceRepo),
+                new JsonObject { ["kcap-flows"] = KcapEntry("flows") });
+
+            ClaudeLauncher.WriteMcpConfig(sourceRepo, worktree);
+
+            var servers = ReadWorktreeMcpServers(worktree);
+            await Assert.That(servers).IsNotNull();
+            await Assert.That(servers!.ContainsKey("kcap-flows")).IsTrue(); // still merged
+        });
+    }
+
+    /// <summary>
+    /// Inside the daemon Environment.ProcessPath is kcap-daemon, so recognizing a canonical
+    /// absolute-path entry needs the CLI path from DaemonConfig — without it, exactly the
+    /// duplicate this skip exists to remove would be copied into the worktree.
+    /// </summary>
+    [Test]
+    public async Task Skips_canonical_absolute_path_entry_when_the_cli_path_is_supplied() {
+        await RunWithRelocatedConfigAsync(async (configDir, sourceRepo, worktree) => {
+            MarkClaudePluginInstalled(configDir);
+            var cliPath = Path.Combine(configDir, "bin", "kcap"); // deterministic, never this test host
+            WriteClaudeJsonWithServers(configDir, ClaudeLauncher.NormalizeClaudeProjectKey(sourceRepo),
+                new JsonObject {
+                    ["kcap-flows"]    = KcapEntry("flows", cliPath),          // canonical at the CLI path → skipped
+                    ["kcap-sessions"] = KcapEntry("sessions", "/other/kcap")  // different binary → conflict, kept
+                });
+
+            ClaudeLauncher.WriteMcpConfig(sourceRepo, worktree, nativeKcapPath: cliPath);
+
+            var servers = ReadWorktreeMcpServers(worktree);
+            await Assert.That(servers).IsNotNull();
+            await Assert.That(servers!.ContainsKey("kcap-flows")).IsFalse();
+            await Assert.That(servers.ContainsKey("kcap-sessions")).IsTrue();
         });
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteMcpConfigTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteMcpConfigTests.cs
@@ -216,6 +216,42 @@ public class ClaudeLauncherWriteMcpConfigTests {
     }
 
     /// <summary>
+    /// ALL kcap writers of ~/.claude.json share one cross-process lock (ConfigFileLock): the
+    /// daemon's trust write must not be able to commit between doctor --clean's inside-lock
+    /// re-read and its rename, where the rename would silently overwrite it. The doctor is
+    /// parked inside its lock via a test hook; the trust write started there must block until
+    /// the clean commits, and then land ON TOP of the cleaned file — both changes survive.
+    /// Without the trust writer taking the lock, it completes inside the parked window and the
+    /// doctor's rename deterministically erases it.
+    /// </summary>
+    [Test]
+    public async Task Trust_write_during_a_parked_doctor_clean_cannot_be_lost() {
+        await RunWithRelocatedConfigAsync(async (configDir, sourceRepo, worktree) => {
+            var cfgPath  = Path.Combine(configDir, ".claude.json");
+            var snapshot = """{ "mcpServers": { "kcap-flows": { "command": "kcap", "args": ["mcp","flows"] } } }""";
+            File.WriteAllText(cfgPath, snapshot);
+
+            Task? trust = null;
+            var outcome = Capacitor.Cli.Commands.McpDoctorSection.TryCleanClaudeConfig(
+                cfgPath, snapshot, null, out _,
+                afterReReadForTesting: () => {
+                    trust = Task.Run(() => ClaudeLauncher.TrustWorktreeInClaudeConfig(worktree));
+                    // With the shared lock the trust writer blocks here (this thread holds the
+                    // lock), so the bounded wait elapses. Without it, the trust write finishes
+                    // NOW, and the doctor's rename below deterministically overwrites it.
+                    trust.Wait(TimeSpan.FromSeconds(2));
+                });
+            await trust!;
+
+            await Assert.That(outcome).IsEqualTo(Capacitor.Cli.Commands.McpDoctorSection.CleanOutcome.Cleaned);
+            var root = (JsonObject)JsonNode.Parse(File.ReadAllText(cfgPath))!;
+            await Assert.That(((JsonObject)root["mcpServers"]!).ContainsKey("kcap-flows")).IsFalse(); // clean applied
+            var trustKey = ClaudeLauncher.NormalizeClaudeProjectKey(worktree);
+            await Assert.That((bool)root["projects"]![trustKey]!["hasTrustDialogAccepted"]!).IsTrue(); // trust survived
+        });
+    }
+
+    /// <summary>
     /// Inside the daemon Environment.ProcessPath is kcap-daemon, so recognizing a canonical
     /// absolute-path entry needs the CLI path from DaemonConfig — without it, exactly the
     /// duplicate this skip exists to remove would be copied into the worktree.

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteMcpConfigTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteMcpConfigTests.cs
@@ -112,4 +112,75 @@ public class ClaudeLauncherWriteMcpConfigTests {
             await Assert.That(File.Exists(Path.Combine(worktree, ".mcp.json"))).IsFalse();
         });
     }
+
+    // ── Phase-1 dedupe: don't propagate plugin-shadowed kcap entries ────────────
+
+    static void WriteClaudeJsonWithServers(string configDir, string projectKey, JsonObject servers) {
+        var json = new JsonObject {
+            ["projects"] = new JsonObject {
+                [projectKey] = new JsonObject { ["mcpServers"] = servers }
+            }
+        };
+
+        File.WriteAllText(Path.Combine(configDir, ".claude.json"), json.ToJsonString());
+    }
+
+    static void MarkClaudePluginInstalled(string configDir) {
+        // ClaudePluginInstaller.IsInstalled recognises an enabledPlugins["kcap@kcap"] flag in
+        // the settings file — with CLAUDE_CONFIG_DIR set that is $CLAUDE_CONFIG_DIR/settings.json.
+        File.WriteAllText(
+            Path.Combine(configDir, "settings.json"),
+            """{ "enabledPlugins": { "kcap@kcap": true } }""");
+    }
+
+    static JsonObject KcapEntry(string suffix, string command = "kcap") => new() {
+        ["command"] = command,
+        ["args"]    = new JsonArray("mcp", suffix)
+    };
+
+    /// <summary>
+    /// The Claude plugin already ships the kcap servers session-wide, so a semantically
+    /// canonical project-scope copy would only spawn a duplicate resident server process in
+    /// the agent session. The skip is STRUCTURAL, never name-only: a divergent same-name
+    /// entry (different command) is a user customization and is still merged, as is any
+    /// non-kcap server.
+    /// </summary>
+    [Test]
+    public async Task Skips_canonical_kcap_duplicate_but_keeps_divergent_and_custom_servers() {
+        await RunWithRelocatedConfigAsync(async (configDir, sourceRepo, worktree) => {
+            MarkClaudePluginInstalled(configDir);
+            WriteClaudeJsonWithServers(configDir, ClaudeLauncher.NormalizeClaudeProjectKey(sourceRepo),
+                new JsonObject {
+                    ["kcap-flows"]    = KcapEntry("flows"),                          // canonical → skipped
+                    ["kcap-sessions"] = KcapEntry("sessions", "/custom/build/kcap"), // divergent → kept
+                    ["my-custom"]     = new JsonObject { ["command"] = "some-mcp" }  // foreign → kept
+                });
+
+            ClaudeLauncher.WriteMcpConfig(sourceRepo, worktree);
+
+            var servers = ReadWorktreeMcpServers(worktree);
+            await Assert.That(servers).IsNotNull();
+            await Assert.That(servers!.ContainsKey("kcap-flows")).IsFalse();
+            await Assert.That(servers.ContainsKey("kcap-sessions")).IsTrue();
+            await Assert.That(servers.ContainsKey("my-custom")).IsTrue();
+        });
+    }
+
+    /// <summary>
+    /// Without the Claude plugin installed nothing shadows the project-scope entry — it is
+    /// the user's only registration of the server and must keep being copied.
+    /// </summary>
+    [Test]
+    public async Task Merges_canonical_kcap_entry_when_plugin_not_installed() {
+        await RunWithRelocatedConfigAsync(async (configDir, sourceRepo, worktree) => {
+            WriteClaudeJsonWithServers(configDir, ClaudeLauncher.NormalizeClaudeProjectKey(sourceRepo),
+                new JsonObject { ["kcap-flows"] = KcapEntry("flows") });
+
+            ClaudeLauncher.WriteMcpConfig(sourceRepo, worktree);
+
+            var servers = ReadWorktreeMcpServers(worktree);
+            await Assert.That(servers).IsNotNull();
+            await Assert.That(servers!.ContainsKey("kcap-flows")).IsTrue();
+        });
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteMcpConfigTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeLauncherWriteMcpConfigTests.cs
@@ -127,18 +127,21 @@ public class ClaudeLauncherWriteMcpConfigTests {
 
     static void MarkClaudePluginInstalled(string configDir) {
         // The merge-skip gates on ClaudePluginInstaller.IsEffectivelyInstalled: an enabled
-        // registration in settings.json ($CLAUDE_CONFIG_DIR/settings.json here) AND a registered
-        // marketplace dir that still ships the plugin payload (.mcp.json).
-        var marketplace = Path.Combine(configDir, "plugin");
-        Directory.CreateDirectory(marketplace);
-        File.WriteAllText(Path.Combine(marketplace, ".mcp.json"), "{}");
+        // registration in settings.json ($CLAUDE_CONFIG_DIR/settings.json here) AND the enabled
+        // plugin's INSTALLED payload — resolved via plugins/installed_plugins.json the way
+        // Claude loads it, never a marketplace source dir.
+        var installPath = Path.Combine(configDir, "plugins", "cache", "kcap", "kcap", "1.0.0");
+        Directory.CreateDirectory(installPath);
+        File.WriteAllText(Path.Combine(installPath, ".mcp.json"), "{}");
+        File.WriteAllText(
+            Path.Combine(configDir, "plugins", "installed_plugins.json"),
+            $$"""
+            { "version": 2, "plugins": { "kcap@kcap": [
+                { "scope": "user", "installPath": {{JsonValue.Create(installPath).ToJsonString()}}, "version": "1.0.0" } ] } }
+            """);
         File.WriteAllText(
             Path.Combine(configDir, "settings.json"),
-            $$"""
-            { "enabledPlugins": { "kcap@kcap": true },
-              "extraKnownMarketplaces": { "kcap": { "source": {
-                  "source": "local", "path": {{JsonValue.Create(marketplace).ToJsonString()}} } } } }
-            """);
+            """{ "enabledPlugins": { "kcap@kcap": true } }""");
     }
 
     static JsonObject KcapEntry(string suffix, string command = "kcap") => new() {

--- a/test/Capacitor.Cli.Tests.Unit/ClaudePluginInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudePluginInstallerTests.cs
@@ -1,8 +1,96 @@
+using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli.Tests.Unit;
 
 public class ClaudePluginInstallerTests {
+    // ── IsEffectivelyInstalled — the destructive-action gate ─────────────────
+    //
+    // Resolves the enabled plugin's INSTALLED payload the way Claude loads it
+    // (plugins/installed_plugins.json → installPath; directory-sourced marketplaces live
+    // via known_marketplaces.json installLocation). A marker, an enabled flag alone, or a
+    // marketplace SOURCE dir prove nothing about what Claude actually loads.
+
+    static string WriteEnabledSettings(string home) {
+        var settingsPath = Path.Combine(home, "settings.json");
+        File.WriteAllText(settingsPath, """{ "enabledPlugins": { "kcap@kcap": true } }""");
+        return settingsPath;
+    }
+
+    static void WriteInstallRecord(string home, string installPath) =>
+        File.WriteAllText(Path.Combine(Directory.CreateDirectory(Path.Combine(home, "plugins")).FullName,
+                                       "installed_plugins.json"), $$"""
+            { "version": 2, "plugins": { "kcap@kcap": [
+                { "scope": "user", "installPath": {{JsonValue.Create(installPath).ToJsonString()}}, "version": "1.0.0" } ] } }
+            """);
+
+    [Test]
+    public async Task IsEffectivelyInstalled_true_when_the_installed_cache_ships_the_payload() {
+        using var tmp = new TempDir();
+        var settingsPath = WriteEnabledSettings(tmp.Path);
+        var install = Directory.CreateDirectory(Path.Combine(tmp.Path, "plugins", "cache", "kcap", "kcap", "1.0.0")).FullName;
+        File.WriteAllText(Path.Combine(install, ".mcp.json"), "{}");
+        WriteInstallRecord(tmp.Path, install);
+
+        await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsTrue();
+    }
+
+    /// <summary>Directory-sourced marketplaces are resolved live: the install record's cache
+    /// path never materializes, and the loadable payload is the marketplace installLocation.</summary>
+    [Test]
+    public async Task IsEffectivelyInstalled_true_for_directory_marketplace_with_phantom_cache_path() {
+        using var tmp = new TempDir();
+        var settingsPath = WriteEnabledSettings(tmp.Path);
+        WriteInstallRecord(tmp.Path, Path.Combine(tmp.Path, "plugins", "cache", "kcap", "kcap", "1.0.0")); // never created
+        var location = Directory.CreateDirectory(Path.Combine(tmp.Path, "npm-kcap", "kcap")).FullName;
+        File.WriteAllText(Path.Combine(location, ".mcp.json"), "{}");
+        File.WriteAllText(Path.Combine(tmp.Path, "plugins", "known_marketplaces.json"), $$"""
+            { "kcap": { "source": { "source": "directory", "path": {{JsonValue.Create(location).ToJsonString()}} },
+                        "installLocation": {{JsonValue.Create(location).ToJsonString()}} } }
+            """);
+
+        await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsTrue();
+    }
+
+    [Test]
+    public async Task IsEffectivelyInstalled_false_when_enabled_but_no_install_record() {
+        using var tmp = new TempDir();
+        var settingsPath = WriteEnabledSettings(tmp.Path);
+        await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsEffectivelyInstalled_false_when_only_the_marker_exists() {
+        using var tmp = new TempDir();
+        var settingsPath = Path.Combine(tmp.Path, "settings.json");
+        File.WriteAllText(Path.Combine(tmp.Path, ClaudePluginInstaller.MarkerFileName), "1.2.3");
+        await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsFalse();
+    }
+
+    /// <summary>The round-1 gap this closes: a marketplace SOURCE dir shipping .mcp.json does
+    /// not prove the installed payload exists — without an install record it is not effective.</summary>
+    [Test]
+    public async Task IsEffectivelyInstalled_false_when_only_a_marketplace_source_dir_has_the_payload() {
+        using var tmp = new TempDir();
+        var source = Directory.CreateDirectory(Path.Combine(tmp.Path, "source-kcap")).FullName;
+        File.WriteAllText(Path.Combine(source, ".mcp.json"), "{}");
+        var settingsPath = Path.Combine(tmp.Path, "settings.json");
+        File.WriteAllText(settingsPath, $$"""
+            { "enabledPlugins": { "kcap@kcap": true },
+              "extraKnownMarketplaces": { "kcap": { "source": {
+                  "source": "directory", "path": {{JsonValue.Create(source).ToJsonString()}} } } } }
+            """);
+
+        await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsEffectivelyInstalled_false_when_the_install_record_points_nowhere() {
+        using var tmp = new TempDir();
+        var settingsPath = WriteEnabledSettings(tmp.Path);
+        WriteInstallRecord(tmp.Path, Path.Combine(tmp.Path, "gone")); // no cache, no marketplace record
+        await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsFalse();
+    }
     [Test]
     public async Task IsInstalled_false_when_dir_missing() {
         using var tmp = new TempDir();

--- a/test/Capacitor.Cli.Tests.Unit/ClaudePluginInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudePluginInstallerTests.cs
@@ -52,6 +52,63 @@ public class ClaudePluginInstallerTests {
         await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsTrue();
     }
 
+    /// <summary>
+    /// The directory-marketplace exception is for LIVE resolution only. A git/github-sourced
+    /// marketplace IS cached: once its installed cache payload is gone, a lingering checkout
+    /// under installLocation proves nothing — accepting it would let doctor --clean delete the
+    /// user's only working registrations.
+    /// </summary>
+    [Test]
+    public async Task IsEffectivelyInstalled_false_for_git_marketplace_with_lingering_checkout_and_no_cache() {
+        using var tmp = new TempDir();
+        var settingsPath = WriteEnabledSettings(tmp.Path);
+        WriteInstallRecord(tmp.Path, Path.Combine(tmp.Path, "plugins", "cache", "kcap", "kcap", "1.0.0")); // cache gone
+        var checkout = Directory.CreateDirectory(Path.Combine(tmp.Path, "plugins", "marketplaces", "kcap")).FullName;
+        File.WriteAllText(Path.Combine(checkout, ".mcp.json"), "{}"); // stale clone still ships the payload
+        File.WriteAllText(Path.Combine(tmp.Path, "plugins", "known_marketplaces.json"), $$"""
+            { "kcap": { "source": { "source": "github", "repo": "kurrent-io/kcap-cli" },
+                        "installLocation": {{JsonValue.Create(checkout).ToJsonString()}} } }
+            """);
+
+        await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsFalse();
+    }
+
+    /// <summary>
+    /// Both callers gate on the USER-scope settings.json enabled flag, so only a user-scoped
+    /// v2 install entry proves that flag's payload — a project/local-scoped install belonging
+    /// to some unrelated repo must not make the plugin globally "effective".
+    /// </summary>
+    [Test]
+    public async Task IsEffectivelyInstalled_false_when_only_a_project_scoped_install_has_the_payload() {
+        using var tmp = new TempDir();
+        var settingsPath = WriteEnabledSettings(tmp.Path);
+        var install = Directory.CreateDirectory(Path.Combine(tmp.Path, "plugins", "cache", "kcap", "kcap", "1.0.0")).FullName;
+        File.WriteAllText(Path.Combine(install, ".mcp.json"), "{}");
+        File.WriteAllText(Path.Combine(Directory.CreateDirectory(Path.Combine(tmp.Path, "plugins")).FullName,
+                                       "installed_plugins.json"), $$"""
+            { "version": 2, "plugins": { "kcap@kcap": [
+                { "scope": "project", "installPath": {{JsonValue.Create(install).ToJsonString()}}, "version": "1.0.0" } ] } }
+            """);
+
+        await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsFalse();
+    }
+
+    /// <summary>Pre-v2 compatibility: a bare-object install record predates scopes and stays accepted.</summary>
+    [Test]
+    public async Task IsEffectivelyInstalled_true_for_bare_object_install_record_with_payload() {
+        using var tmp = new TempDir();
+        var settingsPath = WriteEnabledSettings(tmp.Path);
+        var install = Directory.CreateDirectory(Path.Combine(tmp.Path, "plugins", "cache", "kcap", "kcap", "1.0.0")).FullName;
+        File.WriteAllText(Path.Combine(install, ".mcp.json"), "{}");
+        File.WriteAllText(Path.Combine(Directory.CreateDirectory(Path.Combine(tmp.Path, "plugins")).FullName,
+                                       "installed_plugins.json"), $$"""
+            { "version": 1, "plugins": { "kcap@kcap":
+                { "installPath": {{JsonValue.Create(install).ToJsonString()}}, "version": "1.0.0" } } }
+            """);
+
+        await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsTrue();
+    }
+
     [Test]
     public async Task IsEffectivelyInstalled_false_when_enabled_but_no_install_record() {
         using var tmp = new TempDir();

--- a/test/Capacitor.Cli.Tests.Unit/ClaudePluginInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudePluginInstallerTests.cs
@@ -93,6 +93,33 @@ public class ClaudePluginInstallerTests {
         await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsFalse();
     }
 
+    /// <summary>
+    /// The cross-product of the two round-3 gates: a v2 record with ONLY a project-scoped
+    /// install must not fall through to the directory-marketplace fallback either — that
+    /// fallback only excuses a phantom cache path on an otherwise-eligible (user-scoped)
+    /// record, never the absence of an eligible record.
+    /// </summary>
+    [Test]
+    public async Task IsEffectivelyInstalled_false_for_project_only_record_even_with_directory_marketplace() {
+        using var tmp = new TempDir();
+        var settingsPath = WriteEnabledSettings(tmp.Path);
+        var install = Directory.CreateDirectory(Path.Combine(tmp.Path, "plugins", "cache", "kcap", "kcap", "1.0.0")).FullName;
+        File.WriteAllText(Path.Combine(install, ".mcp.json"), "{}");
+        var checkout = Directory.CreateDirectory(Path.Combine(tmp.Path, "marketplace-src", "kcap")).FullName;
+        File.WriteAllText(Path.Combine(checkout, ".mcp.json"), "{}");
+        var pluginsDir = Directory.CreateDirectory(Path.Combine(tmp.Path, "plugins")).FullName;
+        File.WriteAllText(Path.Combine(pluginsDir, "installed_plugins.json"), $$"""
+            { "version": 2, "plugins": { "kcap@kcap": [
+                { "scope": "project", "installPath": {{JsonValue.Create(install).ToJsonString()}}, "version": "1.0.0" } ] } }
+            """);
+        File.WriteAllText(Path.Combine(pluginsDir, "known_marketplaces.json"), $$"""
+            { "kcap": { "source": { "source": "directory" },
+                        "installLocation": {{JsonValue.Create(checkout).ToJsonString()}} } }
+            """);
+
+        await Assert.That(ClaudePluginInstaller.IsEffectivelyInstalled(settingsPath)).IsFalse();
+    }
+
     /// <summary>Pre-v2 compatibility: a bare-object install record predates scopes and stays accepted.</summary>
     [Test]
     public async Task IsEffectivelyInstalled_true_for_bare_object_install_record_with_payload() {

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -7,6 +7,9 @@ namespace Capacitor.Cli.Tests.Unit.Codex;
 // EnableNetworkAccess/TrustWorktree take an explicit config path, so these tests
 // use a temp file and never touch HOME — safe to run in parallel.
 public class CodexConfigTomlTests {
+    // Injected native-binary path for command assertions - never bless the test runner.
+    const string TestBinaryPath = "/opt/kcap-test/bin/kcap";
+
     static string TempConfig() =>
         Path.Combine(Directory.CreateTempSubdirectory("kcap-codextoml-").FullName, "config.toml");
 
@@ -222,7 +225,7 @@ public class CodexConfigTomlTests {
     public async Task RegisterKcapMcpServers_on_missing_config_writes_all_servers() {
         var path = TempConfig();
 
-        var change = CodexConfigToml.RegisterKcapMcpServers(path);
+        var change = CodexConfigToml.RegisterKcapMcpServers(path, resolveBinaryPath: () => TestBinaryPath);
 
         await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
 
@@ -232,14 +235,14 @@ public class CodexConfigTomlTests {
         var flows    = (TomlTable)servers["kcap-flows"];
         var memory   = (TomlTable)servers["kcap-memory"];
 
-        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
-        await Assert.That((string)review["command"]).IsEqualTo(Environment.ProcessPath!);
+        // Registered command is the resolved native binary (injected seam), not the wrapper-resolved "kcap".
+        await Assert.That((string)review["command"]).IsEqualTo(TestBinaryPath);
         await Assert.That(ArgsOf(review)).IsEquivalentTo(new[] { "mcp", "review" });
-        await Assert.That((string)sessions["command"]).IsEqualTo(Environment.ProcessPath!);
+        await Assert.That((string)sessions["command"]).IsEqualTo(TestBinaryPath);
         await Assert.That(ArgsOf(sessions)).IsEquivalentTo(new[] { "mcp", "sessions" });
         await Assert.That(ArgsOf(flows)).IsEquivalentTo(new[] { "mcp", "flows" });
         // kcap-memory is now auto-registered for Codex too.
-        await Assert.That((string)memory["command"]).IsEqualTo(Environment.ProcessPath!);
+        await Assert.That((string)memory["command"]).IsEqualTo(TestBinaryPath);
         await Assert.That(ArgsOf(memory)).IsEquivalentTo(new[] { "mcp", "memory" });
         await Assert.That(File.Exists(Path.Combine(Path.GetDirectoryName(path)!, "mcp-ownership-v1.json"))).IsTrue();
     }
@@ -448,14 +451,14 @@ public class CodexConfigTomlTests {
             args = ["mcp", "sessions"]
             """);
 
-        var change = CodexConfigToml.RegisterKcapMcpServers(path);
+        var change = CodexConfigToml.RegisterKcapMcpServers(path, resolveBinaryPath: () => TestBinaryPath);
 
         // kcap-review added; kcap-sessions left as-is → overall Updated.
         await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
 
         var servers = (TomlTable)ReadToml(path)["mcp_servers"];
         await Assert.That((string)((TomlTable)servers["kcap-sessions"])["command"]).IsEqualTo("/opt/homebrew/bin/kcap");
-        await Assert.That((string)((TomlTable)servers["kcap-review"])["command"]).IsEqualTo(Environment.ProcessPath!);
+        await Assert.That((string)((TomlTable)servers["kcap-review"])["command"]).IsEqualTo(TestBinaryPath);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexConfigTomlTests.cs
@@ -10,6 +10,17 @@ public class CodexConfigTomlTests {
     static string TempConfig() =>
         Path.Combine(Directory.CreateTempSubdirectory("kcap-codextoml-").FullName, "config.toml");
 
+    // The writer under test rejects symlinked path components (CanonicalConfigPath), and macOS's
+    // default temp root lives under /var and /tmp — both symlinks into /private. Resolving the
+    // prefix lets these tests run on macOS dev machines too (CI's Linux/Windows tmp is real).
+    static string RealTempConfig() {
+        var dir = Directory.CreateTempSubdirectory("kcap-codextoml-real-").FullName;
+        if (OperatingSystem.IsMacOS() && (dir.StartsWith("/var/", StringComparison.Ordinal) ||
+                                          dir.StartsWith("/tmp/", StringComparison.Ordinal)))
+            dir = "/private" + dir;
+        return Path.Combine(dir, "config.toml");
+    }
+
     static TomlTable ReadToml(string path) =>
         TomlSerializer.Deserialize<TomlTable>(File.ReadAllText(path))!;
 
@@ -221,13 +232,14 @@ public class CodexConfigTomlTests {
         var flows    = (TomlTable)servers["kcap-flows"];
         var memory   = (TomlTable)servers["kcap-memory"];
 
-        await Assert.That((string)review["command"]).IsEqualTo("kcap");
+        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
+        await Assert.That((string)review["command"]).IsEqualTo(Environment.ProcessPath!);
         await Assert.That(ArgsOf(review)).IsEquivalentTo(new[] { "mcp", "review" });
-        await Assert.That((string)sessions["command"]).IsEqualTo("kcap");
+        await Assert.That((string)sessions["command"]).IsEqualTo(Environment.ProcessPath!);
         await Assert.That(ArgsOf(sessions)).IsEquivalentTo(new[] { "mcp", "sessions" });
         await Assert.That(ArgsOf(flows)).IsEquivalentTo(new[] { "mcp", "flows" });
         // kcap-memory is now auto-registered for Codex too.
-        await Assert.That((string)memory["command"]).IsEqualTo("kcap");
+        await Assert.That((string)memory["command"]).IsEqualTo(Environment.ProcessPath!);
         await Assert.That(ArgsOf(memory)).IsEquivalentTo(new[] { "mcp", "memory" });
         await Assert.That(File.Exists(Path.Combine(Path.GetDirectoryName(path)!, "mcp-ownership-v1.json"))).IsTrue();
     }
@@ -329,6 +341,65 @@ public class CodexConfigTomlTests {
     }
 
     [Test]
+    public async Task RegisterKcapMcpServers_falls_back_to_kcap_when_binary_path_unresolvable() {
+        var path = RealTempConfig();
+
+        CodexConfigToml.RegisterKcapMcpServers(path, resolveBinaryPath: () => null);
+
+        var servers = (TomlTable)ReadToml(path)["mcp_servers"];
+        await Assert.That((string)((TomlTable)servers["kcap-review"])["command"]).IsEqualTo("kcap");
+    }
+
+    [Test]
+    public async Task RegisterKcapMcpServers_heals_owned_entries_across_binary_relayout() {
+        var path = RealTempConfig();
+
+        // Fresh install at binary A, then an npm re-layout moves the binary to B. The
+        // ownership-ledger fingerprint recorded at A still matches the on-disk entry → heal.
+        CodexConfigToml.RegisterKcapMcpServers(path, resolveBinaryPath: () => "/opt/a/kcap");
+        var change = CodexConfigToml.RegisterKcapMcpServers(path, resolveBinaryPath: () => "/opt/b/kcap");
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+        var servers = (TomlTable)ReadToml(path)["mcp_servers"];
+        await Assert.That((string)((TomlTable)servers["kcap-review"])["command"]).IsEqualTo("/opt/b/kcap");
+        await Assert.That((string)((TomlTable)servers["kcap-sessions"])["command"]).IsEqualTo("/opt/b/kcap");
+
+        // And the heal is idempotent once current.
+        var again = CodexConfigToml.RegisterKcapMcpServers(path, resolveBinaryPath: () => "/opt/b/kcap");
+        await Assert.That(again).IsEqualTo(CodexConfigToml.Change.Unchanged);
+    }
+
+    [Test]
+    public async Task RegisterKcapMcpServers_never_heals_a_customized_owned_entry() {
+        var path = RealTempConfig();
+        CodexConfigToml.RegisterKcapMcpServers(path, resolveBinaryPath: () => "/opt/a/kcap");
+
+        // The user edits the owned entry — fingerprint no longer matches, so the relayout
+        // heal must relinquish the claim and preserve the customization.
+        var root = ReadToml(path);
+        var review = (TomlTable)((TomlTable)root["mcp_servers"])["kcap-review"];
+        review["env"] = new TomlTable { ["KCAP_URL"] = "https://x" };
+        File.WriteAllText(path, TomlSerializer.Serialize(root));
+
+        CodexConfigToml.RegisterKcapMcpServers(path, resolveBinaryPath: () => "/opt/b/kcap");
+
+        var after = (TomlTable)((TomlTable)ReadToml(path)["mcp_servers"])["kcap-review"];
+        await Assert.That((string)after["command"]).IsEqualTo("/opt/a/kcap"); // untouched
+        await Assert.That(after.ContainsKey("env")).IsTrue();                 // customization preserved
+    }
+
+    [Test]
+    public async Task UnregisterKcapMcpServers_removes_absolute_registered_owned_entries() {
+        var path = RealTempConfig();
+        CodexConfigToml.RegisterKcapMcpServers(path, resolveBinaryPath: () => "/opt/a/kcap");
+
+        var change = CodexConfigToml.UnregisterKcapMcpServers(path);
+
+        await Assert.That(change).IsEqualTo(CodexConfigToml.Change.Updated);
+        await Assert.That(ReadToml(path).ContainsKey("mcp_servers")).IsFalse();
+    }
+
+    [Test]
     public async Task RegisterKcapMcpServers_is_idempotent() {
         var path = TempConfig();
 
@@ -384,7 +455,7 @@ public class CodexConfigTomlTests {
 
         var servers = (TomlTable)ReadToml(path)["mcp_servers"];
         await Assert.That((string)((TomlTable)servers["kcap-sessions"])["command"]).IsEqualTo("/opt/homebrew/bin/kcap");
-        await Assert.That((string)((TomlTable)servers["kcap-review"])["command"]).IsEqualTo("kcap");
+        await Assert.That((string)((TomlTable)servers["kcap-review"])["command"]).IsEqualTo(Environment.ProcessPath!);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/FlowsDriverSchemaConformanceTests.cs
@@ -212,9 +212,17 @@ public class FlowsDriverSchemaConformanceTests {
         public void Dispose() => Environment.SetEnvironmentVariable(_key, _prev);
     }
 
+    /// <summary>Deterministic native-binary path injected into every installer arm. Registration
+    /// writes the resolved binary as the command (default: Environment.ProcessPath) — under the
+    /// test host that default would be the test-runner executable, so the suite injects its own
+    /// value and asserts THAT, never blessing whatever happens to be running the tests.</summary>
+    internal const string InjectedBinaryPath = "/opt/conformance/bin/kcap";
+
     static PluginEnvironment TestEnv(string home, string? pluginRoot = null) =>
         new(HomeDirectory: home, ResolvePluginPath: () => pluginRoot,
-            Stdout: TextWriter.Null, Stderr: TextWriter.Null);
+            Stdout: TextWriter.Null, Stderr: TextWriter.Null) {
+            ResolveMcpBinaryPath = () => InjectedBinaryPath
+        };
 
     /// <summary>Codex is the one arm that does not use the `--if-installed` refresh branch (it
     /// installs unconditionally), so it needs a resolvable plugin root carrying the skills source —
@@ -340,7 +348,7 @@ public class FlowsDriverSchemaConformanceTests {
     public async Task Every_installed_driver_launches_the_same_flows_server(Arm arm) {
         var p = await InstallAndRead(arm);
 
-        await Assert.That(p.Command).IsEqualTo(KcapMcpServers.Command)
+        await Assert.That(p.Command).IsEqualTo(InjectedBinaryPath)
             .Because($"{p.Harness} must launch the same executable as every other driver");
         // ORDERED: argv order is semantic. An unordered comparison passes ["flows","mcp"], which
         // launches nothing.

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/JsonMcpConfigWriterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/JsonMcpConfigWriterTests.cs
@@ -313,6 +313,63 @@ public class JsonMcpConfigWriterTests {
         await Assert.That(((JsonObject)JsonNode.Parse(File.ReadAllText(path))!).ContainsKey("mcpServers")).IsFalse();
     }
 
+    // ── marker-failure containment + adoption recovery ──────────────────────────
+
+    sealed class ThrowingMarker : IMcpMarker {
+        public bool Owns(string cfg, string name, JsonNode entry) => false;
+        public void Record(string cfg, IReadOnlyList<KeyValuePair<string, JsonNode?>> entries) =>
+            throw new IOException("marker volume is read-only");
+        public IEnumerable<string> Owned(string cfg) => [];
+        public void Clear(string cfg) { }
+    }
+
+    /// <summary>
+    /// The marker write runs after Update's guarded boundary, so it must never throw through
+    /// the caller: setup/plugin install must not report a registration that IS committed as a
+    /// hard failure (never-fails-install contract). The config result stands; ownership is
+    /// degraded and self-heals via adoption on the next pass.
+    /// </summary>
+    [Test]
+    public async Task Register_swallows_a_marker_write_failure_and_keeps_the_config_result() {
+        var path = TempConfig();
+
+        var change = JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, null,
+                                                  new ThrowingMarker(), resolveBinaryPath: () => "/opt/a/kcap");
+
+        await Assert.That(change).IsEqualTo(JsonMcpConfigWriter.Change.Updated); // no throw, config committed
+        var servers = (JsonObject)Read(path)["mcpServers"]!;
+        await Assert.That(servers.ContainsKey("kcap-review")).IsTrue();
+    }
+
+    /// <summary>
+    /// The recovery story for config-committed-but-marker-failed: a canonical entry left
+    /// unowned (marker lost/never written) is RE-ADOPTED by the next register pass — the
+    /// marker is re-recorded without touching the config — so healing and uninstall work again.
+    /// </summary>
+    [Test]
+    public async Task Register_readopts_a_committed_but_unmarked_canonical_entry() {
+        var dir = Directory.CreateTempSubdirectory("kcap-adopt-").FullName;
+        var path = Path.Combine(dir, "mcp.json");
+        var markerFile = Path.Combine(dir, "marker.json");
+        var marker = new McpMarker("test", _ => markerFile);
+
+        JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, null, marker,
+                                     resolveBinaryPath: () => "/opt/a/kcap");
+        File.Delete(markerFile); // simulate the marker write having failed/crashed post-commit
+        await Assert.That(marker.Owned(path)).IsEmpty();
+
+        var again = JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, null, marker,
+                                                 resolveBinaryPath: () => "/opt/a/kcap");
+
+        await Assert.That(again).IsEqualTo(JsonMcpConfigWriter.Change.Unchanged); // config untouched…
+        await Assert.That(marker.Owned(path)).Contains("kcap-review");            // …ownership re-acquired
+
+        // And the re-acquired ownership is REAL: uninstall removes the absolute-path entries.
+        var removed = JsonMcpConfigWriter.Unregister(path, McpConfigShape.Standard, marker);
+        await Assert.That(removed).IsEqualTo(JsonMcpConfigWriter.Change.Updated);
+        await Assert.That(((JsonObject)JsonNode.Parse(File.ReadAllText(path))!).ContainsKey("mcpServers")).IsFalse();
+    }
+
     [Test]
     public async Task Register_preserves_a_genuine_user_edit_of_a_previously_owned_entry() {
         var dir = Directory.CreateTempSubdirectory("kcap-useredit-").FullName;

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/JsonMcpConfigWriterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/JsonMcpConfigWriterTests.cs
@@ -12,7 +12,7 @@ public class JsonMcpConfigWriterTests {
     sealed class FakeMarker : IMcpMarker {
         readonly HashSet<string> _owned = [];
         public bool Owns(string cfg, string name, JsonNode entry) => name.StartsWith("kcap-");
-        public void Record(string cfg, IReadOnlyList<string> names) { foreach (var n in names) _owned.Add(n); }
+        public void Record(string cfg, IReadOnlyList<KeyValuePair<string, JsonNode?>> entries) { foreach (var (n, _) in entries) _owned.Add(n); }
         public IEnumerable<string> Owned(string cfg) => _owned;
         public void Clear(string cfg) => _owned.Clear();
     }
@@ -22,13 +22,36 @@ public class JsonMcpConfigWriterTests {
     [Test]
     public async Task Register_on_missing_file_writes_all_servers_standard_shape() {
         var path = TempConfig();
-        var change = JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new FakeMarker());
+        var change = JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new FakeMarker(),
+                                                  resolveBinaryPath: () => "/opt/kcap/bin/kcap");
 
         await Assert.That(change).IsEqualTo(JsonMcpConfigWriter.Change.Updated);
         var servers = (JsonObject)Read(path)["mcpServers"]!;
         await Assert.That(servers.Count).IsEqualTo(KcapMcpServers.All.Count);
-        await Assert.That((string)servers["kcap-review"]!["command"]!).IsEqualTo("kcap");
+        // The registered command is the resolved native binary, not the wrapper-resolved "kcap".
+        await Assert.That((string)servers["kcap-review"]!["command"]!).IsEqualTo("/opt/kcap/bin/kcap");
         await Assert.That(servers["kcap-review"]!["args"]!.AsArray().Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Register_falls_back_to_kcap_when_binary_path_unresolvable() {
+        var path = TempConfig();
+        JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new FakeMarker(),
+                                     resolveBinaryPath: () => null);
+
+        var servers = (JsonObject)Read(path)["mcpServers"]!;
+        await Assert.That((string)servers["kcap-review"]!["command"]!).IsEqualTo("kcap");
+    }
+
+    [Test]
+    public async Task Register_default_resolution_is_the_running_process_path() {
+        // kcap setup executes as the native binary even when invoked via the npm wrapper
+        // (the wrapper exec's it), so Environment.ProcessPath IS the platform binary.
+        var path = TempConfig();
+        JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, cwd: null, new FakeMarker());
+
+        var servers = (JsonObject)Read(path)["mcpServers"]!;
+        await Assert.That((string)servers["kcap-review"]!["command"]!).IsEqualTo(Environment.ProcessPath!);
     }
 
     [Test]
@@ -227,11 +250,13 @@ public class JsonMcpConfigWriterTests {
         var again = JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, null, marker);
         await Assert.That(again).IsEqualTo(JsonMcpConfigWriter.Change.Unchanged);
 
-        // Simulate a stale owned entry (still command "kcap", so still kcap-owned).
+        // A stale entry written by an OLDER kcap arrives with a v1 marker (names only, no
+        // fingerprint) — ownership falls back to the legacy command == "kcap" check, so it heals.
         var root = (JsonObject)JsonNode.Parse(File.ReadAllText(path))!;
         ((JsonObject)root["mcpServers"]!)["kcap-review"] =
             new JsonObject { ["command"] = "kcap", ["args"] = new JsonArray { "mcp", "OLD-review" } };
         File.WriteAllText(path, root.ToJsonString());
+        marker.Record(path, ["kcap-review"]); // names-only record = no fingerprint (v1 semantics)
 
         // Re-register heals it back to canonical.
         var change = JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, null, marker);
@@ -239,5 +264,74 @@ public class JsonMcpConfigWriterTests {
         var review = (JsonObject)((JsonObject)JsonNode.Parse(File.ReadAllText(path))!["mcpServers"]!)["kcap-review"]!;
         var args = review["args"]!.AsArray().Select(n => (string)n!).ToArray();
         await Assert.That(args).IsEquivalentTo(new[] { "mcp", "review" }); // healed
+    }
+
+    // ── Marker v2: absolute-path ownership lifecycle ────────────────────────────
+
+    static string CommandOf(string path, string name) =>
+        (string)((JsonObject)((JsonObject)JsonNode.Parse(File.ReadAllText(path))!["mcpServers"]!)[name]!)["command"]!;
+
+    /// <summary>
+    /// The full migration chain: a v1 install (marker without fingerprints, command "kcap")
+    /// heals to absolute path A, and an npm re-layout (A → B) heals again — the v2 fingerprint
+    /// recorded at A still owns the on-disk entry.
+    /// </summary>
+    [Test]
+    public async Task Register_migrates_v1_kcap_entry_to_absolute_and_heals_a_relayout() {
+        var dir = Directory.CreateTempSubdirectory("kcap-migrate-").FullName;
+        var path = Path.Combine(dir, "mcp.json");
+        var marker = new McpMarker("test", _ => Path.Combine(dir, "marker.json"));
+
+        // A pre-fingerprint install: entry command "kcap", marker recorded names-only.
+        File.WriteAllText(path, """{ "mcpServers": { "kcap-review": { "command": "kcap", "args": ["mcp","review"] } } }""");
+        marker.Record(path, ["kcap-review"]);
+
+        var toA = JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, null, marker,
+                                               resolveBinaryPath: () => "/opt/a/kcap");
+        await Assert.That(toA).IsEqualTo(JsonMcpConfigWriter.Change.Updated);
+        await Assert.That(CommandOf(path, "kcap-review")).IsEqualTo("/opt/a/kcap");
+
+        // npm re-layout: the binary moved. The v2 fingerprint recorded at A owns the entry → heal to B.
+        var toB = JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, null, marker,
+                                               resolveBinaryPath: () => "/opt/b/kcap");
+        await Assert.That(toB).IsEqualTo(JsonMcpConfigWriter.Change.Updated);
+        await Assert.That(CommandOf(path, "kcap-review")).IsEqualTo("/opt/b/kcap");
+    }
+
+    [Test]
+    public async Task Unregister_removes_absolute_registered_owned_entries() {
+        var dir = Directory.CreateTempSubdirectory("kcap-absrm-").FullName;
+        var path = Path.Combine(dir, "mcp.json");
+        var marker = new McpMarker("test", _ => Path.Combine(dir, "marker.json"));
+
+        JsonMcpConfigWriter.Register(path, KcapMcpServers.All, McpConfigShape.Standard, null, marker,
+                                     resolveBinaryPath: () => "/opt/a/kcap");
+
+        // v1's Owns (command == "kcap") would strand these absolute-path entries on uninstall.
+        var change = JsonMcpConfigWriter.Unregister(path, McpConfigShape.Standard, marker);
+        await Assert.That(change).IsEqualTo(JsonMcpConfigWriter.Change.Updated);
+        await Assert.That(((JsonObject)JsonNode.Parse(File.ReadAllText(path))!).ContainsKey("mcpServers")).IsFalse();
+    }
+
+    [Test]
+    public async Task Register_preserves_a_genuine_user_edit_of_a_previously_owned_entry() {
+        var dir = Directory.CreateTempSubdirectory("kcap-useredit-").FullName;
+        var path = Path.Combine(dir, "mcp.json");
+        var marker = new McpMarker("test", _ => Path.Combine(dir, "marker.json"));
+        var oneServer = KcapMcpServers.All.Take(1).ToArray(); // kcap-review only, so no sibling heal muddies the change
+
+        JsonMcpConfigWriter.Register(path, oneServer, McpConfigShape.Standard, null, marker,
+                                     resolveBinaryPath: () => "/opt/a/kcap");
+
+        // The user customizes the owned entry (adds env) — the fingerprint no longer matches.
+        var root = (JsonObject)JsonNode.Parse(File.ReadAllText(path))!;
+        ((JsonObject)((JsonObject)root["mcpServers"]!)["kcap-review"]!)["env"] = new JsonObject { ["KCAP_URL"] = "https://x" };
+        File.WriteAllText(path, root.ToJsonString());
+        var edited = File.ReadAllText(path);
+
+        var change = JsonMcpConfigWriter.Register(path, oneServer, McpConfigShape.Standard, null, marker,
+                                                  resolveBinaryPath: () => "/opt/b/kcap");
+        await Assert.That(change).IsEqualTo(JsonMcpConfigWriter.Change.Unchanged);
+        await Assert.That(File.ReadAllText(path)).IsEqualTo(edited); // user edit preserved byte-for-byte
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpDoctorSectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpDoctorSectionTests.cs
@@ -164,6 +164,56 @@ public class McpDoctorSectionTests {
         await Assert.That(output).DoesNotContain("my-tool");                             // non-kcap → never inspected
     }
 
+    /// <summary>
+    /// The clean commits under a lock and re-reads first: a concurrent write to ~/.claude.json
+    /// (Claude itself, the daemon's trust write) between the snapshot and the commit must abort
+    /// the clean rather than be silently overwritten by a rewrite of the stale snapshot.
+    /// </summary>
+    [Test]
+    public async Task Clean_aborts_without_writing_when_the_config_changed_after_the_snapshot() {
+        var f = Fixture.Create();
+        File.WriteAllText(f.ClaudeConfig, DuplicateAndConflictConfig);
+        var snapshot = DuplicateAndConflictConfig;
+
+        // Another writer lands between the findings snapshot and the commit.
+        var concurrent = """{ "mcpServers": { "kcap-flows": { "command": "kcap", "args": ["mcp","flows"] } }, "newTrust": true }""";
+        File.WriteAllText(f.ClaudeConfig, concurrent);
+
+        var outcome = McpDoctorSection.TryCleanClaudeConfig(f.ClaudeConfig, snapshot, null, out _);
+
+        await Assert.That(outcome).IsEqualTo(McpDoctorSection.CleanOutcome.Conflicted);
+        await Assert.That(File.ReadAllText(f.ClaudeConfig)).IsEqualTo(concurrent); // the other writer's update survives
+    }
+
+    [Test]
+    public async Task Clean_commits_when_the_snapshot_is_still_current() {
+        var f = Fixture.Create();
+        File.WriteAllText(f.ClaudeConfig, DuplicateAndConflictConfig);
+
+        var outcome = McpDoctorSection.TryCleanClaudeConfig(f.ClaudeConfig, DuplicateAndConflictConfig, null, out _);
+
+        await Assert.That(outcome).IsEqualTo(McpDoctorSection.CleanOutcome.Cleaned);
+        var servers = (JsonObject)JsonNode.Parse(File.ReadAllText(f.ClaudeConfig))!["mcpServers"]!;
+        await Assert.That(servers.ContainsKey("kcap-flows")).IsFalse();
+        // No temp litter left beside the config.
+        await Assert.That(Directory.GetFiles(f.Dir, ".claude.json.tmp-*")).IsEmpty();
+    }
+
+    /// <summary>A 0600 config must not come back 0644: the rewrite preserves the target's mode.</summary>
+    [Test]
+    public async Task Clean_preserves_the_configs_unix_mode() {
+        if (OperatingSystem.IsWindows()) return;
+        var f = Fixture.Create();
+        File.WriteAllText(f.ClaudeConfig, DuplicateAndConflictConfig);
+        File.SetUnixFileMode(f.ClaudeConfig, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var outcome = McpDoctorSection.TryCleanClaudeConfig(f.ClaudeConfig, DuplicateAndConflictConfig, null, out _);
+
+        await Assert.That(outcome).IsEqualTo(McpDoctorSection.CleanOutcome.Cleaned);
+        await Assert.That(File.GetUnixFileMode(f.ClaudeConfig))
+            .IsEqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
     [Test]
     public async Task Stale_scan_covers_codex_toml_kcap_entries_only() {
         var f = Fixture.Create();

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpDoctorSectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpDoctorSectionTests.cs
@@ -16,17 +16,18 @@ public class McpDoctorSectionTests {
             return new(dir, Path.Combine(dir, ".claude.json"), Path.Combine(dir, "settings.json"));
         }
 
-        /// <summary>An EFFECTIVE plugin install: enabled registration + a marketplace dir that
-        /// ships the payload — what the destructive duplicate audit requires.</summary>
+        /// <summary>An EFFECTIVE plugin install: enabled registration + the plugin's INSTALLED
+        /// payload (installed_plugins.json → installPath cache dir shipping .mcp.json) — what
+        /// the destructive duplicate audit requires.</summary>
         public void InstallPlugin() {
-            var marketplace = Path.Combine(Dir, "plugin");
-            Directory.CreateDirectory(marketplace);
-            File.WriteAllText(Path.Combine(marketplace, ".mcp.json"), "{}");
-            File.WriteAllText(ClaudeSettings, $$"""
-                { "enabledPlugins": { "kcap@kcap": true },
-                  "extraKnownMarketplaces": { "kcap": { "source": {
-                      "source": "local", "path": {{JsonValue.Create(marketplace).ToJsonString()}} } } } }
+            var installPath = Path.Combine(Dir, "plugins", "cache", "kcap", "kcap", "1.0.0");
+            Directory.CreateDirectory(installPath);
+            File.WriteAllText(Path.Combine(installPath, ".mcp.json"), "{}");
+            File.WriteAllText(Path.Combine(Dir, "plugins", "installed_plugins.json"), $$"""
+                { "version": 2, "plugins": { "kcap@kcap": [
+                    { "scope": "user", "installPath": {{JsonValue.Create(installPath).ToJsonString()}}, "version": "1.0.0" } ] } }
                 """);
+            File.WriteAllText(ClaudeSettings, """{ "enabledPlugins": { "kcap@kcap": true } }""");
         }
 
         /// <summary>The refresh gate's weakest signal: a version marker with no enabled
@@ -116,7 +117,7 @@ public class McpDoctorSectionTests {
     public async Task Enabled_registration_without_a_resolvable_payload_never_authorizes_cleanup() {
         var f = Fixture.Create();
         f.InstallPlugin();
-        Directory.Delete(Path.Combine(f.Dir, "plugin"), recursive: true); // npm re-layout: payload gone
+        Directory.Delete(Path.Combine(f.Dir, "plugins", "cache"), recursive: true); // re-layout: installed payload gone
         File.WriteAllText(f.ClaudeConfig, DuplicateAndConflictConfig);
 
         var (issues, _) = await RunAsync(f, clean: true);

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpDoctorSectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpDoctorSectionTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit.Mcp;
+
+/// <summary>
+/// The MCP-registrations doctor section, run entirely against fixture files in temp dirs
+/// (never the real ~/.claude.json or harness configs). Pins: the plugin-installed gate, the
+/// structural duplicate-vs-conflict split, --clean removing only canonical duplicates, and
+/// the two-tier stale-path scan (missing binary vs. differs-from-current-resolution).
+/// </summary>
+public class McpDoctorSectionTests {
+    sealed record Fixture(string Dir, string ClaudeConfig, string ClaudeSettings) {
+        public static Fixture Create() {
+            var dir = Directory.CreateTempSubdirectory("kcap-mcpdoctor-").FullName;
+            return new(dir, Path.Combine(dir, ".claude.json"), Path.Combine(dir, "settings.json"));
+        }
+
+        public void InstallPlugin() =>
+            File.WriteAllText(ClaudeSettings, """{ "enabledPlugins": { "kcap@kcap": true } }""");
+    }
+
+    static async Task<(int Issues, string Output)> RunAsync(Fixture f, bool clean = false,
+            IReadOnlyList<McpDoctorSection.RegistrationFile>? files = null,
+            string? codexConfigPath = null, string? nativeBinaryPath = null) {
+        await using var writer = new StringWriter();
+        var issues = await McpDoctorSection.RunAsync(writer, clean, f.ClaudeConfig, f.ClaudeSettings,
+                                                     files ?? [], codexConfigPath, nativeBinaryPath);
+        return (issues, writer.ToString());
+    }
+
+    const string DuplicateAndConflictConfig = """
+        { "mcpServers": {
+            "kcap-flows":    { "command": "kcap", "args": ["mcp","flows"] },
+            "kcap-sessions": { "command": "kcap", "args": ["mcp","sessions"], "env": { "X": "1" } },
+            "other":         { "command": "npx" } },
+          "projects": { "/w/repo": { "mcpServers": {
+            "kcap-review": { "command": "kcap", "args": ["mcp","review"] } } } } }
+        """;
+
+    [Test]
+    public async Task Reports_duplicates_in_both_scopes_and_conflicts_without_mutating() {
+        var f = Fixture.Create();
+        f.InstallPlugin();
+        File.WriteAllText(f.ClaudeConfig, DuplicateAndConflictConfig);
+
+        var (issues, output) = await RunAsync(f);
+
+        await Assert.That(issues).IsEqualTo(3);
+        await Assert.That(output).Contains("duplicate MCP registration 'kcap-flows' (user)");
+        await Assert.That(output).Contains("duplicate MCP registration 'kcap-review' (projects[/w/repo])");
+        await Assert.That(output).Contains("same-named MCP registration 'kcap-sessions'");
+        // Read-only by default (passive doctor must not mutate).
+        await Assert.That(File.ReadAllText(f.ClaudeConfig)).IsEqualTo(DuplicateAndConflictConfig);
+    }
+
+    [Test]
+    public async Task Clean_removes_only_canonical_duplicates_and_preserves_conflicts() {
+        var f = Fixture.Create();
+        f.InstallPlugin();
+        File.WriteAllText(f.ClaudeConfig, DuplicateAndConflictConfig);
+
+        var (_, output) = await RunAsync(f, clean: true);
+
+        await Assert.That(output).Contains("removed 2 duplicate MCP registration(s)");
+        var root = (JsonObject)JsonNode.Parse(File.ReadAllText(f.ClaudeConfig))!;
+        var servers = (JsonObject)root["mcpServers"]!;
+        await Assert.That(servers.ContainsKey("kcap-flows")).IsFalse();     // canonical → removed
+        await Assert.That(servers.ContainsKey("kcap-sessions")).IsTrue();   // conflict → preserved
+        await Assert.That(servers.ContainsKey("other")).IsTrue();           // foreign → preserved
+        var project = (JsonObject)root["projects"]!["/w/repo"]!["mcpServers"]!;
+        await Assert.That(project.ContainsKey("kcap-review")).IsFalse();    // project scope cleaned too
+    }
+
+    [Test]
+    public async Task Without_the_plugin_installed_nothing_is_flagged_or_removed() {
+        var f = Fixture.Create(); // no settings.json → plugin not installed
+        File.WriteAllText(f.ClaudeConfig, DuplicateAndConflictConfig);
+
+        var (issues, output) = await RunAsync(f, clean: true);
+
+        await Assert.That(issues).IsEqualTo(0);
+        await Assert.That(output).Contains("no issues found");
+        await Assert.That(File.ReadAllText(f.ClaudeConfig)).IsEqualTo(DuplicateAndConflictConfig);
+    }
+
+    [Test]
+    public async Task Missing_claude_config_reports_healthy() {
+        var f = Fixture.Create();
+        var (issues, output) = await RunAsync(f);
+        await Assert.That(issues).IsEqualTo(0);
+        await Assert.That(output).Contains("no issues found");
+    }
+
+    [Test]
+    public async Task Stale_scan_distinguishes_missing_binary_from_outdated_resolution() {
+        var f = Fixture.Create();
+        var current = Path.Combine(f.Dir, "kcap");     // exists = the "current" binary
+        var old     = Path.Combine(f.Dir, "old", "kcap"); // exists but differs from current
+        File.WriteAllText(current, "bin");
+        Directory.CreateDirectory(Path.GetDirectoryName(old)!);
+        File.WriteAllText(old, "bin");
+        var missing = Path.Combine(f.Dir, "gone", "kcap"); // never created
+
+        var cursor = Path.Combine(f.Dir, "cursor-mcp.json");
+        File.WriteAllText(cursor, $$"""
+            { "mcpServers": {
+                "kcap-review":   { "command": {{JsonValue.Create(missing).ToJsonString()}}, "args": ["mcp","review"] },
+                "kcap-sessions": { "command": {{JsonValue.Create(old).ToJsonString()}}, "args": ["mcp","sessions"] },
+                "kcap-flows":    { "command": {{JsonValue.Create(current).ToJsonString()}}, "args": ["mcp","flows"] },
+                "my-tool":       { "command": "/does/not/exist/anywhere" } } }
+            """);
+
+        var (issues, output) = await RunAsync(f,
+            files: [new McpDoctorSection.RegistrationFile("Cursor", cursor, "mcpServers")],
+            nativeBinaryPath: current);
+
+        await Assert.That(issues).IsEqualTo(2);
+        await Assert.That(output).Contains("stale MCP registration 'kcap-review'");     // missing file
+        await Assert.That(output).Contains("re-run `kcap setup`");
+        await Assert.That(output).Contains("outdated MCP registration 'kcap-sessions'"); // differs from current
+        await Assert.That(output).DoesNotContain("kcap-flows");                          // current → healthy
+        await Assert.That(output).DoesNotContain("my-tool");                             // non-kcap → never inspected
+    }
+
+    [Test]
+    public async Task Stale_scan_covers_codex_toml_kcap_entries_only() {
+        var f = Fixture.Create();
+        var missing = Path.Combine(f.Dir, "gone", "kcap");
+        var codex = Path.Combine(f.Dir, "config.toml");
+        File.WriteAllText(codex, $"""
+            [mcp_servers.kcap-review]
+            command = "{missing}"
+            args = ["mcp", "review"]
+
+            [mcp_servers.my-tool]
+            command = "/also/gone/my-tool"
+            """);
+
+        var (issues, output) = await RunAsync(f, codexConfigPath: codex);
+
+        await Assert.That(issues).IsEqualTo(1);
+        await Assert.That(output).Contains("stale MCP registration 'kcap-review' (Codex)");
+        await Assert.That(output).DoesNotContain("my-tool");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpDoctorSectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpDoctorSectionTests.cs
@@ -16,8 +16,23 @@ public class McpDoctorSectionTests {
             return new(dir, Path.Combine(dir, ".claude.json"), Path.Combine(dir, "settings.json"));
         }
 
-        public void InstallPlugin() =>
-            File.WriteAllText(ClaudeSettings, """{ "enabledPlugins": { "kcap@kcap": true } }""");
+        /// <summary>An EFFECTIVE plugin install: enabled registration + a marketplace dir that
+        /// ships the payload — what the destructive duplicate audit requires.</summary>
+        public void InstallPlugin() {
+            var marketplace = Path.Combine(Dir, "plugin");
+            Directory.CreateDirectory(marketplace);
+            File.WriteAllText(Path.Combine(marketplace, ".mcp.json"), "{}");
+            File.WriteAllText(ClaudeSettings, $$"""
+                { "enabledPlugins": { "kcap@kcap": true },
+                  "extraKnownMarketplaces": { "kcap": { "source": {
+                      "source": "local", "path": {{JsonValue.Create(marketplace).ToJsonString()}} } } } }
+                """);
+        }
+
+        /// <summary>The refresh gate's weakest signal: a version marker with no enabled
+        /// registration and no payload — must never authorize the duplicate audit.</summary>
+        public void WriteStaleMarkerOnly() =>
+            File.WriteAllText(Path.Combine(Dir, ".kcap-plugin-version"), "9.9.9");
     }
 
     static async Task<(int Issues, string Output)> RunAsync(Fixture f, bool clean = false,
@@ -81,6 +96,32 @@ public class McpDoctorSectionTests {
 
         await Assert.That(issues).IsEqualTo(0);
         await Assert.That(output).Contains("no issues found");
+        await Assert.That(File.ReadAllText(f.ClaudeConfig)).IsEqualTo(DuplicateAndConflictConfig);
+    }
+
+    [Test]
+    public async Task Stale_version_marker_alone_never_authorizes_flagging_or_cleanup() {
+        var f = Fixture.Create();
+        f.WriteStaleMarkerOnly(); // satisfies the refresh gate (IsInstalled) but is not effective
+        File.WriteAllText(f.ClaudeConfig, DuplicateAndConflictConfig);
+
+        var (issues, output) = await RunAsync(f, clean: true);
+
+        await Assert.That(issues).IsEqualTo(0);
+        await Assert.That(output).Contains("no issues found");
+        await Assert.That(File.ReadAllText(f.ClaudeConfig)).IsEqualTo(DuplicateAndConflictConfig);
+    }
+
+    [Test]
+    public async Task Enabled_registration_without_a_resolvable_payload_never_authorizes_cleanup() {
+        var f = Fixture.Create();
+        f.InstallPlugin();
+        Directory.Delete(Path.Combine(f.Dir, "plugin"), recursive: true); // npm re-layout: payload gone
+        File.WriteAllText(f.ClaudeConfig, DuplicateAndConflictConfig);
+
+        var (issues, _) = await RunAsync(f, clean: true);
+
+        await Assert.That(issues).IsEqualTo(0);
         await Assert.That(File.ReadAllText(f.ClaudeConfig)).IsEqualTo(DuplicateAndConflictConfig);
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpDoctorSectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpDoctorSectionTests.cs
@@ -220,13 +220,19 @@ public class McpDoctorSectionTests {
         var f = Fixture.Create();
         var missing = Path.Combine(f.Dir, "gone", "kcap");
         var codex = Path.Combine(f.Dir, "config.toml");
+        // LITERAL (single-quoted) TOML strings: `\` is an escape introducer in a basic
+        // (double-quoted) string, so interpolating a Windows temp path into one produced
+        // invalid TOML — Tomlyn threw, the never-throws ReadMcpServerCommands returned [],
+        // and this test reported 0 issues on the Windows CI leg. Production is unaffected
+        // (the writer emits properly-escaped TOML via TomlSerializer); a literal string is
+        // the canonical hand-written form for Windows paths and parses on every platform.
         File.WriteAllText(codex, $"""
             [mcp_servers.kcap-review]
-            command = "{missing}"
+            command = '{missing}'
             args = ["mcp", "review"]
 
             [mcp_servers.my-tool]
-            command = "/also/gone/my-tool"
+            command = '/also/gone/my-tool'
             """);
 
         var (issues, output) = await RunAsync(f, codexConfigPath: codex);

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpMarkerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpMarkerTests.cs
@@ -94,6 +94,58 @@ public class McpMarkerTests {
         await Assert.That(m.Owned(equiv)).Contains("kcap-review"); // equivalent path form still recognized
     }
 
+    // ── v2 fingerprints + v1 migration ──────────────────────────────────────────
+
+    static JsonObject CanonicalEntry(string cmd = "kcap") =>
+        new() { ["command"] = cmd, ["args"] = new JsonArray { "mcp", "review" } };
+
+    [Test]
+    public async Task Owns_v2_matches_the_exact_recorded_entry_including_absolute_command() {
+        var (marker, cfg, _) = NewMarker();
+        var entry = CanonicalEntry("/opt/a/kcap");
+        marker.Record(cfg, [KeyValuePair.Create("kcap-review", (JsonNode?)entry)]);
+
+        // Same content, different instance + key order + formatting → still owned.
+        var reparsed = JsonNode.Parse("""{ "args": ["mcp","review"], "command": "/opt/a/kcap" }""")!;
+        await Assert.That(marker.Owns(cfg, "kcap-review", reparsed)).IsTrue();
+    }
+
+    [Test]
+    public async Task Owns_v2_rejects_a_user_edited_entry_even_with_command_kcap() {
+        var (marker, cfg, _) = NewMarker();
+        marker.Record(cfg, [KeyValuePair.Create("kcap-review", (JsonNode?)CanonicalEntry())]);
+
+        var edited = CanonicalEntry(); // command is still the literal "kcap"…
+        edited["env"] = new JsonObject { ["X"] = "1" }; // …but the user customized it
+        await Assert.That(marker.Owns(cfg, "kcap-review", edited)).IsFalse();
+    }
+
+    [Test]
+    public async Task V1_marker_file_reads_with_legacy_command_semantics_and_migrates_on_record() {
+        var dir = Directory.CreateTempSubdirectory("kcap-marker-v1-").FullName;
+        var cfg = Path.Combine(dir, "mcp.json");
+        var markerFile = Path.Combine(dir, "marker.json");
+        var marker = new McpMarker("test", _ => markerFile);
+
+        // The exact on-disk v1 format an older kcap wrote: servers as a bare name array.
+        File.WriteAllText(markerFile, $$"""
+            { "version": 1, "harness": "test", "config": {{JsonValue.Create(Path.GetFullPath(cfg)).ToJsonString()}},
+              "servers": ["kcap-review"] }
+            """);
+
+        // v1 semantics: command "kcap" (string or argv head) is ours; anything else is not.
+        await Assert.That(marker.Owns(cfg, "kcap-review", CanonicalEntry())).IsTrue();
+        await Assert.That(marker.Owns(cfg, "kcap-review", CanonicalEntry("/opt/a/kcap"))).IsFalse();
+
+        // Recording upgrades the file to v2 and keeps the v1 name (fingerprint-less).
+        marker.Record(cfg, [KeyValuePair.Create("kcap-sessions", (JsonNode?)CanonicalEntry("/opt/a/kcap"))]);
+        var root = (JsonObject)JsonNode.Parse(File.ReadAllText(markerFile))!;
+        await Assert.That((int)root["version"]!).IsEqualTo(2);
+        await Assert.That(marker.Owned(cfg)).Contains("kcap-review");   // migrated, still legacy-owned
+        await Assert.That(marker.Owns(cfg, "kcap-review", CanonicalEntry())).IsTrue();
+        await Assert.That(marker.Owns(cfg, "kcap-sessions", CanonicalEntry("/opt/a/kcap"))).IsTrue();
+    }
+
     // Exercises the REAL central-path resolution (no per-config markerPathFor override). The central
     // root is the assembly-pinned throwaway temp dir (McpMarkerGlobalSetup), never the real
     // ~/.kcap/mcp-markers, so this touches no shared real state — no cleanup or serialization needed

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpMarkerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpMarkerTests.cs
@@ -146,6 +146,21 @@ public class McpMarkerTests {
         await Assert.That(marker.Owns(cfg, "kcap-sessions", CanonicalEntry("/opt/a/kcap"))).IsTrue();
     }
 
+    /// <summary>The marker is the ownership record for absolute-path entries: it is written via
+    /// sibling temp + atomic rename (never an in-place truncate), owner-only on Unix.</summary>
+    [Test]
+    public async Task Record_writes_atomically_owner_only_with_no_temp_litter() {
+        var (marker, cfg, markerFile) = NewMarker();
+        marker.Record(cfg, [KeyValuePair.Create("kcap-review", (JsonNode?)CanonicalEntry("/opt/a/kcap"))]);
+        marker.Record(cfg, [KeyValuePair.Create("kcap-sessions", (JsonNode?)CanonicalEntry("/opt/a/kcap"))]); // rewrite path too
+
+        await Assert.That(marker.Owned(cfg)).Contains("kcap-review");
+        await Assert.That(Directory.GetFiles(Path.GetDirectoryName(markerFile)!, "*.tmp-*")).IsEmpty();
+        if (!OperatingSystem.IsWindows())
+            await Assert.That(File.GetUnixFileMode(markerFile))
+                .IsEqualTo(UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
     // Exercises the REAL central-path resolution (no per-config markerPathFor override). The central
     // root is the assembly-pinned throwaway temp dir (McpMarkerGlobalSetup), never the real
     // ~/.kcap/mcp-markers, so this touches no shared real state — no cleanup or serialization needed

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpRegistrationAuditTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpRegistrationAuditTests.cs
@@ -1,0 +1,160 @@
+using System.Linq;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core.Mcp;
+
+namespace Capacitor.Cli.Tests.Unit.Mcp;
+
+/// <summary>
+/// Pins the structural (never name-only) duplicate classification over Claude's user config:
+/// only a semantically canonical user-scope copy of a plugin-shipped kcap server is a removable
+/// duplicate; a divergent same-name entry is a conflict and must be preserved — same name does
+/// not imply ownership.
+/// </summary>
+public class McpRegistrationAuditTests {
+    [Test]
+    public async Task Detects_user_scope_canonical_duplicate_of_a_plugin_server() {
+        var json = """
+        { "mcpServers": { "kcap-flows": { "type": "stdio", "command": "kcap", "args": ["mcp","flows"] } } }
+        """;
+
+        var findings = McpRegistrationAudit.FindClaudeDuplicates(json);
+
+        await Assert.That(findings.Count).IsEqualTo(1);
+        await Assert.That(findings[0].Name).IsEqualTo("kcap-flows");
+        await Assert.That(findings[0].Scope).IsEqualTo(McpRegistrationAudit.UserScope);
+        await Assert.That(findings[0].Issue).IsEqualTo(McpRegistrationIssue.CanonicalDuplicate);
+    }
+
+    [Test]
+    public async Task Detects_project_scope_canonical_duplicate() {
+        var json = """
+        { "projects": { "/w/repo": { "mcpServers": {
+            "kcap-sessions": { "command": "kcap", "args": ["mcp","sessions"], "cwd": "/w/repo" } } } } }
+        """;
+
+        var findings = McpRegistrationAudit.FindClaudeDuplicates(json);
+
+        await Assert.That(findings.Count).IsEqualTo(1);
+        await Assert.That(findings[0].Scope).IsEqualTo("projects[/w/repo]");
+        await Assert.That(findings[0].Issue).IsEqualTo(McpRegistrationIssue.CanonicalDuplicate);
+    }
+
+    [Test]
+    public async Task Cosmetic_fields_do_not_break_canonical_classification() {
+        // description + empty env are what the shipped plugin/older registrations carry.
+        var json = """
+        { "mcpServers": { "kcap-review": {
+            "command": "kcap", "args": ["mcp","review"], "description": "anything", "env": {} } } }
+        """;
+
+        var findings = McpRegistrationAudit.FindClaudeDuplicates(json);
+        await Assert.That(findings[0].Issue).IsEqualTo(McpRegistrationIssue.CanonicalDuplicate);
+    }
+
+    [Test]
+    [Arguments("""{ "command": "kcap", "args": ["mcp","flows"], "env": { "KCAP_URL": "https://x" } }""")] // custom env
+    [Arguments("""{ "command": "/some/other/tool", "args": ["mcp","flows"] }""")]                          // foreign command
+    [Arguments("""{ "command": "kcap", "args": ["mcp","memory"] }""")]                                     // wrong args for name
+    [Arguments("""{ "command": "kcap", "args": ["mcp","flows"], "custom": true }""")]                      // extra field
+    [Arguments("""{ "command": "kcap", "args": ["mcp","flows","--extra"] }""")]                            // extra arg
+    public async Task Divergent_same_name_entry_is_a_conflict_and_never_removed(string entryJson) {
+        var json = $$"""{ "mcpServers": { "kcap-flows": {{entryJson}} } }""";
+
+        var findings = McpRegistrationAudit.FindClaudeDuplicates(json);
+        await Assert.That(findings.Count).IsEqualTo(1);
+        await Assert.That(findings[0].Issue).IsEqualTo(McpRegistrationIssue.Conflict);
+
+        // Conflict preservation: removal must leave the divergent entry byte-identical.
+        var removed = McpRegistrationAudit.RemoveClaudeDuplicates(json);
+        var servers = (JsonObject)JsonNode.Parse(removed)!["mcpServers"]!;
+        await Assert.That(servers.ContainsKey("kcap-flows")).IsTrue();
+        await Assert.That(JsonNode.DeepEquals(servers["kcap-flows"], JsonNode.Parse(entryJson))).IsTrue();
+    }
+
+    [Test]
+    public async Task Ignores_non_kcap_servers_and_absent_block() {
+        await Assert.That(McpRegistrationAudit.FindClaudeDuplicates("""{ "mcpServers": { "other": {} } }""")).IsEmpty();
+        await Assert.That(McpRegistrationAudit.FindClaudeDuplicates("{}")).IsEmpty();
+        await Assert.That(McpRegistrationAudit.FindClaudeDuplicates("not json at all")).IsEmpty();
+        await Assert.That(McpRegistrationAudit.FindClaudeDuplicates("[1,2]")).IsEmpty();
+    }
+
+    [Test]
+    public async Task Resolved_native_path_command_is_canonical_only_when_it_matches_exactly() {
+        var json = """
+        { "mcpServers": {
+            "kcap-review":   { "command": "/opt/kcap/bin/kcap", "args": ["mcp","review"] },
+            "kcap-sessions": { "command": "/somewhere/else/kcap", "args": ["mcp","sessions"] } } }
+        """;
+
+        var findings = McpRegistrationAudit.FindClaudeDuplicates(json, nativeBinaryPath: "/opt/kcap/bin/kcap");
+
+        var review   = findings.Single(f => f.Name == "kcap-review");
+        var sessions = findings.Single(f => f.Name == "kcap-sessions");
+        await Assert.That(review.Issue).IsEqualTo(McpRegistrationIssue.CanonicalDuplicate);
+        await Assert.That(sessions.Issue).IsEqualTo(McpRegistrationIssue.Conflict); // different path → preserved
+    }
+
+    [Test]
+    public async Task Remove_strips_only_canonical_duplicates_and_preserves_the_rest() {
+        var json = """
+        {
+          "keep": 1,
+          "mcpServers": {
+            "kcap-flows": { "command": "kcap", "args": ["mcp","flows"] },
+            "kcap-memory": { "command": "kcap", "args": ["mcp","memory"], "env": { "X": "1" } },
+            "other": { "command": "npx" }
+          },
+          "projects": { "/w/repo": { "mcpServers": {
+            "kcap-review": { "command": "kcap", "args": ["mcp","review"] } } } }
+        }
+        """;
+
+        var result = McpRegistrationAudit.RemoveClaudeDuplicates(json);
+        var root = (JsonObject)JsonNode.Parse(result)!;
+
+        await Assert.That((int)root["keep"]!).IsEqualTo(1);
+        var servers = (JsonObject)root["mcpServers"]!;
+        await Assert.That(servers.ContainsKey("kcap-flows")).IsFalse();   // canonical → removed
+        await Assert.That(servers.ContainsKey("kcap-memory")).IsTrue();   // conflict (custom env) → preserved
+        await Assert.That(servers.ContainsKey("other")).IsTrue();         // foreign → preserved
+
+        var projectServers = (JsonObject)root["projects"]!["/w/repo"]!["mcpServers"]!;
+        await Assert.That(projectServers.ContainsKey("kcap-review")).IsFalse(); // project scope cleaned too
+    }
+
+    [Test]
+    public async Task Remove_returns_input_unchanged_when_unparseable() {
+        await Assert.That(McpRegistrationAudit.RemoveClaudeDuplicates("{ not json")).IsEqualTo("{ not json");
+    }
+
+    [Test]
+    public async Task IsCanonicalKcapEntry_rejects_unknown_names_and_non_objects() {
+        var canonical = JsonNode.Parse("""{ "command": "kcap", "args": ["mcp","flows"] }""");
+        await Assert.That(McpRegistrationAudit.IsCanonicalKcapEntry("my-flows", canonical, null)).IsFalse();
+        await Assert.That(McpRegistrationAudit.IsCanonicalKcapEntry("kcap-flows", JsonNode.Parse("\"str\""), null)).IsFalse();
+        await Assert.That(McpRegistrationAudit.IsCanonicalKcapEntry("kcap-flows", null, null)).IsFalse();
+        await Assert.That(McpRegistrationAudit.IsCanonicalKcapEntry(null, canonical, null)).IsFalse();
+    }
+
+    [Test]
+    public async Task FindAbsoluteKcapCommands_extracts_string_and_argv_shapes_only_for_kcap_names() {
+        var json = """
+        { "mcpServers": {
+            "kcap-review":   { "command": "/opt/kcap/bin/kcap", "args": ["mcp","review"] },
+            "kcap-sessions": { "command": "kcap", "args": ["mcp","sessions"] },
+            "other":         { "command": "/opt/kcap/bin/kcap" } } }
+        """;
+
+        var abs = McpRegistrationAudit.FindAbsoluteKcapCommands(json);
+        await Assert.That(abs.Count).IsEqualTo(1);
+        await Assert.That(abs[0].Name).IsEqualTo("kcap-review");
+        await Assert.That(abs[0].Command).IsEqualTo("/opt/kcap/bin/kcap");
+
+        // OpenCode's argv-array shape under its "mcp" block.
+        var opencode = """{ "mcp": { "kcap-review": { "command": ["/opt/kcap/bin/kcap", "mcp", "review"] } } }""";
+        var absArgv = McpRegistrationAudit.FindAbsoluteKcapCommands(opencode, blockKey: "mcp");
+        await Assert.That(absArgv.Count).IsEqualTo(1);
+        await Assert.That(absArgv[0].Command).IsEqualTo("/opt/kcap/bin/kcap");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpRegistrationAuditTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpRegistrationAuditTests.cs
@@ -57,6 +57,7 @@ public class McpRegistrationAuditTests {
     [Arguments("""{ "command": "kcap", "args": ["mcp","memory"] }""")]                                     // wrong args for name
     [Arguments("""{ "command": "kcap", "args": ["mcp","flows"], "custom": true }""")]                      // extra field
     [Arguments("""{ "command": "kcap", "args": ["mcp","flows","--extra"] }""")]                            // extra arg
+    [Arguments("""{ "command": "kcap", "args": ["mcp","flows"], "cwd": "/some/other/repo" }""")]           // arbitrary cwd redirects execution context
     public async Task Divergent_same_name_entry_is_a_conflict_and_never_removed(string entryJson) {
         var json = $$"""{ "mcpServers": { "kcap-flows": {{entryJson}} } }""";
 
@@ -69,6 +70,41 @@ public class McpRegistrationAuditTests {
         var servers = (JsonObject)JsonNode.Parse(removed)!["mcpServers"]!;
         await Assert.That(servers.ContainsKey("kcap-flows")).IsTrue();
         await Assert.That(JsonNode.DeepEquals(servers["kcap-flows"], JsonNode.Parse(entryJson))).IsTrue();
+    }
+
+    /// <summary>
+    /// cwd changes execution context (repo scoping), so it is never blanket-cosmetic: canonical
+    /// only as the shipped <c>${CLAUDE_PROJECT_DIR}</c> placeholder on a server that requires a
+    /// project cwd, or — project scope — the project's own path (what the placeholder expands to).
+    /// A wrong path, or ANY cwd on a server that takes none, is a customization to preserve.
+    /// </summary>
+    [Test]
+    public async Task Cwd_is_canonical_only_as_the_placeholder_or_the_projects_own_path() {
+        // User scope: placeholder OK (the shipped plugin shape); kcap-review takes no cwd at all.
+        var json = """
+        { "mcpServers": {
+            "kcap-flows":  { "command": "kcap", "args": ["mcp","flows"], "cwd": "${CLAUDE_PROJECT_DIR}" },
+            "kcap-review": { "command": "kcap", "args": ["mcp","review"], "cwd": "${CLAUDE_PROJECT_DIR}" } },
+          "projects": { "/w/repo": { "mcpServers": {
+            "kcap-sessions": { "command": "kcap", "args": ["mcp","sessions"], "cwd": "/w/repo" },
+            "kcap-memory":   { "command": "kcap", "args": ["mcp","memory"], "cwd": "/other/repo" } } } } }
+        """;
+
+        var findings = McpRegistrationAudit.FindClaudeDuplicates(json);
+
+        await Assert.That(findings.Single(f => f.Name == "kcap-flows").Issue).IsEqualTo(McpRegistrationIssue.CanonicalDuplicate);
+        await Assert.That(findings.Single(f => f.Name == "kcap-review").Issue).IsEqualTo(McpRegistrationIssue.Conflict);   // no-cwd server
+        await Assert.That(findings.Single(f => f.Name == "kcap-sessions").Issue).IsEqualTo(McpRegistrationIssue.CanonicalDuplicate); // == project key
+        await Assert.That(findings.Single(f => f.Name == "kcap-memory").Issue).IsEqualTo(McpRegistrationIssue.Conflict);   // != project key
+
+        // And removal honors the same split.
+        var removed = McpRegistrationAudit.RemoveClaudeDuplicates(json);
+        var root = (JsonObject)JsonNode.Parse(removed)!;
+        await Assert.That(((JsonObject)root["mcpServers"]!).ContainsKey("kcap-flows")).IsFalse();
+        await Assert.That(((JsonObject)root["mcpServers"]!).ContainsKey("kcap-review")).IsTrue();
+        var project = (JsonObject)root["projects"]!["/w/repo"]!["mcpServers"]!;
+        await Assert.That(project.ContainsKey("kcap-sessions")).IsFalse();
+        await Assert.That(project.ContainsKey("kcap-memory")).IsTrue();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandAntigravityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandAntigravityTests.cs
@@ -39,7 +39,8 @@ public class PluginCommandAntigravityTests {
         await Assert.That(exit).IsEqualTo(0);
 
         var servers = JsonNode.Parse(await File.ReadAllTextAsync(env.AntigravityMcpConfigJson))!.AsObject()["mcpServers"]!.AsObject();
-        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo("kcap");
+        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(Environment.ProcessPath!);
         await Assert.That(servers["kcap-review"]!["type"]).IsNull();   // Standard shape: no `type`
         await Assert.That(servers["kcap-review"]!["trust"]).IsNull();  // Antigravity has no config trust knob
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandAntigravityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandAntigravityTests.cs
@@ -39,8 +39,8 @@ public class PluginCommandAntigravityTests {
         await Assert.That(exit).IsEqualTo(0);
 
         var servers = JsonNode.Parse(await File.ReadAllTextAsync(env.AntigravityMcpConfigJson))!.AsObject()["mcpServers"]!.AsObject();
-        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
-        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(Environment.ProcessPath!);
+        // Registered command is the resolved native binary (injected seam), not the wrapper-resolved "kcap".
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(TestBinaryPath);
         await Assert.That(servers["kcap-review"]!["type"]).IsNull();   // Standard shape: no `type`
         await Assert.That(servers["kcap-review"]!["trust"]).IsNull();  // Antigravity has no config trust knob
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
@@ -151,12 +151,17 @@ public class PluginCommandAntigravityTests {
         await Assert.That(content).Contains(AgentInstructionsWriter.BeginMarker);   // kcap block LEFT for Gemini
     }
 
+    // Deterministic native-binary path: registration writes the resolved binary as the command
+    // (default: the running process), so tests inject their own value and assert that,
+    // never blessing whatever executable happens to run the suite.
+    internal const string TestBinaryPath = "/opt/kcap-test/bin/kcap";
+
     static PluginEnvironment TestEnv(string fakeHome) => new(
         HomeDirectory:     fakeHome,
         ResolvePluginPath: () => null,   // skills source unavailable → skills install no-ops (covered elsewhere)
         Stdout:            TextWriter.Null,
         Stderr:            TextWriter.Null
-    );
+    ) { ResolveMcpBinaryPath = () => TestBinaryPath };
 
     sealed class EnvScope : IDisposable {
         readonly string  _key;

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCopilotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCopilotTests.cs
@@ -36,7 +36,8 @@ public class PluginCommandCopilotTests {
 
         var root    = JsonNode.Parse(await File.ReadAllTextAsync(env.CopilotMcpConfigJson))!.AsObject();
         var servers = root["mcpServers"]!.AsObject();
-        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo("kcap");
+        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(Environment.ProcessPath!);
         await Assert.That(servers["kcap-review"]!["type"]!.GetValue<string>()).IsEqualTo("stdio");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCopilotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCopilotTests.cs
@@ -36,8 +36,8 @@ public class PluginCommandCopilotTests {
 
         var root    = JsonNode.Parse(await File.ReadAllTextAsync(env.CopilotMcpConfigJson))!.AsObject();
         var servers = root["mcpServers"]!.AsObject();
-        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
-        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(Environment.ProcessPath!);
+        // Registered command is the resolved native binary (injected seam), not the wrapper-resolved "kcap".
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(TestBinaryPath);
         await Assert.That(servers["kcap-review"]!["type"]!.GetValue<string>()).IsEqualTo("stdio");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");
@@ -227,12 +227,17 @@ public class PluginCommandCopilotTests {
         await Assert.That(content).DoesNotContain("Prefer kcap tools");
     }
 
+    // Deterministic native-binary path: registration writes the resolved binary as the command
+    // (default: the running process), so tests inject their own value and assert that,
+    // never blessing whatever executable happens to run the suite.
+    internal const string TestBinaryPath = "/opt/kcap-test/bin/kcap";
+
     static PluginEnvironment TestEnv(string fakeHome) => new(
         HomeDirectory:     fakeHome,
         ResolvePluginPath: () => null,
         Stdout:            TextWriter.Null,
         Stderr:            TextWriter.Null
-    );
+    ) { ResolveMcpBinaryPath = () => TestBinaryPath };
 
     // Sets an env var for the test's lifetime and restores the previous value on Dispose.
     // Used to clear COPILOT_HOME so CopilotPaths resolves under the fake home.

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -65,7 +65,8 @@ public class PluginCommandCursorTests {
 
         var root    = JsonNode.Parse(await File.ReadAllTextAsync(mcpPath))!.AsObject();
         var servers = root["mcpServers"]!.AsObject();
-        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo("kcap");
+        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(Environment.ProcessPath!);
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-memory");

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -65,8 +65,8 @@ public class PluginCommandCursorTests {
 
         var root    = JsonNode.Parse(await File.ReadAllTextAsync(mcpPath))!.AsObject();
         var servers = root["mcpServers"]!.AsObject();
-        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
-        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(Environment.ProcessPath!);
+        // Registered command is the resolved native binary (injected seam), not the wrapper-resolved "kcap".
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(TestBinaryPath);
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-memory");
@@ -177,11 +177,16 @@ public class PluginCommandCursorTests {
         await Assert.That(new McpMarker("cursor").Owned(mcpPath).ToArray()).IsEmpty();     // marker cleared after clean removal
     }
 
+    // Deterministic native-binary path: registration writes the resolved binary as the command
+    // (default: the running process), so tests inject their own value and assert that,
+    // never blessing whatever executable happens to run the suite.
+    internal const string TestBinaryPath = "/opt/kcap-test/bin/kcap";
+
     static PluginEnvironment TestEnv(string fakeHome) => new(
         HomeDirectory:     fakeHome,
         ResolvePluginPath: () => null,
         Stdout:            TextWriter.Null,
         Stderr:            TextWriter.Null
-    );
+    ) { ResolveMcpBinaryPath = () => TestBinaryPath };
 
 }

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandGeminiTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandGeminiTests.cs
@@ -36,8 +36,8 @@ public class PluginCommandGeminiTests {
 
         var root    = JsonNode.Parse(await File.ReadAllTextAsync(env.GeminiSettingsJson))!.AsObject();
         var servers = root["mcpServers"]!.AsObject();
-        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
-        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(Environment.ProcessPath!);
+        // Registered command is the resolved native binary (injected seam), not the wrapper-resolved "kcap".
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(TestBinaryPath);
         await Assert.That(servers["kcap-review"]!["type"]).IsNull();  // Gemini shape: no `type`
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");
@@ -282,12 +282,17 @@ public class PluginCommandGeminiTests {
         await Assert.That(File.Exists(env.GeminiSettingsJson)).IsFalse();
     }
 
+    // Deterministic native-binary path: registration writes the resolved binary as the command
+    // (default: the running process), so tests inject their own value and assert that,
+    // never blessing whatever executable happens to run the suite.
+    internal const string TestBinaryPath = "/opt/kcap-test/bin/kcap";
+
     static PluginEnvironment TestEnv(string fakeHome) => new(
         HomeDirectory:     fakeHome,
         ResolvePluginPath: () => null,
         Stdout:            TextWriter.Null,
         Stderr:            TextWriter.Null
-    );
+    ) { ResolveMcpBinaryPath = () => TestBinaryPath };
 
     // Sets an env var for the test's lifetime and restores the previous value on Dispose.
     // Used to clear GEMINI_CLI_HOME so GeminiPaths resolves under the fake home.

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandGeminiTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandGeminiTests.cs
@@ -36,7 +36,8 @@ public class PluginCommandGeminiTests {
 
         var root    = JsonNode.Parse(await File.ReadAllTextAsync(env.GeminiSettingsJson))!.AsObject();
         var servers = root["mcpServers"]!.AsObject();
-        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo("kcap");
+        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(Environment.ProcessPath!);
         await Assert.That(servers["kcap-review"]!["type"]).IsNull();  // Gemini shape: no `type`
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandKiroTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandKiroTests.cs
@@ -38,8 +38,8 @@ public class PluginCommandKiroTests {
 
         var servers = JsonNode.Parse(await File.ReadAllTextAsync(env.KiroMcpJson))!.AsObject()["mcpServers"]!.AsObject();
         // Standard shape: command="kcap" + args, no `type`, no `trust` (autoApprove left unset).
-        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
-        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(Environment.ProcessPath!);
+        // Registered command is the resolved native binary (injected seam), not the wrapper-resolved "kcap".
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(TestBinaryPath);
         await Assert.That(servers["kcap-review"]!["type"]).IsNull();
         await Assert.That(servers["kcap-review"]!["trust"]).IsNull();
         await Assert.That(servers["kcap-review"]!["autoApprove"]).IsNull();
@@ -143,12 +143,17 @@ public class PluginCommandKiroTests {
         await Assert.That(File.Exists(env.KiroKcapAgentJson)).IsFalse();
     }
 
+    // Deterministic native-binary path: registration writes the resolved binary as the command
+    // (default: the running process), so tests inject their own value and assert that,
+    // never blessing whatever executable happens to run the suite.
+    internal const string TestBinaryPath = "/opt/kcap-test/bin/kcap";
+
     static PluginEnvironment TestEnv(string fakeHome) => new(
         HomeDirectory:     fakeHome,
         ResolvePluginPath: () => null,
         Stdout:            TextWriter.Null,
         Stderr:            TextWriter.Null
-    );
+    ) { ResolveMcpBinaryPath = () => TestBinaryPath };
 
     // Sets an env var for the test's lifetime and restores it on Dispose. Clears KIRO_HOME so
     // KiroPaths resolves under the fake home.

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandKiroTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandKiroTests.cs
@@ -38,7 +38,8 @@ public class PluginCommandKiroTests {
 
         var servers = JsonNode.Parse(await File.ReadAllTextAsync(env.KiroMcpJson))!.AsObject()["mcpServers"]!.AsObject();
         // Standard shape: command="kcap" + args, no `type`, no `trust` (autoApprove left unset).
-        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo("kcap");
+        // Registered command is the running native binary (the test host here), not the wrapper-resolved "kcap".
+        await Assert.That(servers["kcap-review"]!["command"]!.GetValue<string>()).IsEqualTo(Environment.ProcessPath!);
         await Assert.That(servers["kcap-review"]!["type"]).IsNull();
         await Assert.That(servers["kcap-review"]!["trust"]).IsNull();
         await Assert.That(servers["kcap-review"]!["autoApprove"]).IsNull();

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandOpenCodeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandOpenCodeTests.cs
@@ -137,7 +137,7 @@ public class PluginCommandOpenCodeTests {
         await Assert.That(review["type"]!.GetValue<string>()).IsEqualTo("local");
         await Assert.That(review["enabled"]!.GetValue<bool>()).IsTrue();
         var cmd = string.Join(",", review["command"]!.AsArray().Select(n => n!.GetValue<string>()));
-        await Assert.That(cmd).IsEqualTo($"{Environment.ProcessPath},mcp,review"); // argv head = the running native binary
+        await Assert.That(cmd).IsEqualTo($"{TestBinaryPath},mcp,review"); // argv head = the resolved native binary (injected seam)
         await Assert.That(mcp.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(mcp.Select(kv => kv.Key)).Contains("kcap-flows");
         await Assert.That(mcp.Select(kv => kv.Key)).Contains("kcap-memory");
@@ -237,12 +237,17 @@ public class PluginCommandOpenCodeTests {
         public void Dispose() => Environment.SetEnvironmentVariable(_key, _prev);
     }
 
+    // Deterministic native-binary path: registration writes the resolved binary as the command
+    // (default: the running process), so tests inject their own value and assert that,
+    // never blessing whatever executable happens to run the suite.
+    internal const string TestBinaryPath = "/opt/kcap-test/bin/kcap";
+
     static PluginEnvironment TestEnv(string fakeHome) => new(
         HomeDirectory:     fakeHome,
         ResolvePluginPath: () => null,
         Stdout:            TextWriter.Null,
         Stderr:            TextWriter.Null
-    );
+    ) { ResolveMcpBinaryPath = () => TestBinaryPath };
 
     sealed class TempDir : IDisposable {
         public string Path { get; } = System.IO.Path.Combine(

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandOpenCodeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandOpenCodeTests.cs
@@ -137,7 +137,7 @@ public class PluginCommandOpenCodeTests {
         await Assert.That(review["type"]!.GetValue<string>()).IsEqualTo("local");
         await Assert.That(review["enabled"]!.GetValue<bool>()).IsTrue();
         var cmd = string.Join(",", review["command"]!.AsArray().Select(n => n!.GetValue<string>()));
-        await Assert.That(cmd).IsEqualTo("kcap,mcp,review");
+        await Assert.That(cmd).IsEqualTo($"{Environment.ProcessPath},mcp,review"); // argv head = the running native binary
         await Assert.That(mcp.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(mcp.Select(kv => kv.Key)).Contains("kcap-flows");
         await Assert.That(mcp.Select(kv => kv.Key)).Contains("kcap-memory");


### PR DESCRIPTION
## Problem

Every Claude Code session spawns one stdio pair (resident node wrapper + NativeAOT binary) per kcap MCP server — ~36 MB/pair unswapped, ~2 GB across a heavy multi-session day — a primary driver of the swap exhaustion that degraded the daemon and killed review flows on 2026-08-02. The node half exists only because `kcap.js`'s "exec" is actually spawn-and-wait; a user-scope duplicate registration multiplied it further.

## Fix (per the reviewed spec/plan on AI-1709 — Phases 1–2; merge-tier and idle-exit deliberately deferred)

- **Structural duplicate audit** (`McpRegistrationAudit`, both Claude scopes — top-level and `projects[…].mcpServers`): a user-scope entry is a removable duplicate only when semantically canonical; divergent same-name entries are reported as conflicts and preserved (repo policy: same name ≠ ownership). `ClaudeLauncher` stops propagating plugin-shadowed canonical entries into agent worktrees (plugin-installed-gated; mutation-checked both ways).
- **`kcap daemon doctor` gains an MCP-registrations section** (runs before the daemon-file early return; honors `CLAUDE_CONFIG_DIR`): reports duplicates/conflicts, `--clean` removes only canonical duplicates via atomic rewrite, and a stale-path scan covers the six JSON harness configs + Codex TOML + Claude's config, distinguishing missing-binary ("re-run kcap setup") from differs-from-current-resolution.
- **Generated configs register the native binary path** (`Environment.ProcessPath` with seam + `"kcap"` fallback) — threaded through the JSON writers AND `CodexConfigToml`. `McpMarker` evolved to **v2 per-entry fingerprints** (SHA-256 over canonical JSON; v1 read with legacy semantics, migrates on next record; marker recorded only after the config write commits) so refresh-healing across binary relayouts and uninstall both keep working with absolute paths, while genuine user edits are never clobbered (mutation-checked).
- **npm wrapper retired for MCP entries**: new side-effect-free `bin/resolve.js` (no require-cycle with `kcap.js` — pinned by a require-cache assertion); `refresh.js` patches the shipped plugin `.mcp.json` validate-first with sibling-temp + atomic rename, exactly one warning on failure, six canonical pairs only, stale-absolute re-patch. Exercised via a fake release layout (incl. a space in the path); node tests for all three JS files wired into CI on both matrix legs.

## Tests

Targeted classes green: McpRegistrationAuditTests 14, ClaudeLauncherWriteMcpConfigTests 5, JsonMcpConfigWriterTests 23, McpMarkerTests 13, SetupCommandTests 41, CodingAgentsStepTests 131, six PluginCommand harness classes, McpDoctorSectionTests 6, plus the three node test files (`ok`×3). Mutation-checked: launcher skip (both the skip and its structural gate), refresh patch guards (command + args), Codex fingerprint-mismatch heal guard. Pre-existing macOS failure clusters (CodexConfigTomlTests /var-symlink guard ×20, UninstallCommandTests ×11) proven **identical failing sets on a detached origin/main baseline** — not regressions. AOT publish clean for both csprojs (one IDE0059 in an untouched file, 0-line diff). Full suites delegated to CI.

Not done here (needs the live system): the before/after RSS measurement from the issue's recipe — run it post-merge on a fresh session.

Spec + plan + codex spec-review findings: https://linear.app/kurrent/issue/AI-1709

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Accepted limitation (review finding 5)

`ResolveCliSibling` intentionally has no fallback for daemon-without-sibling-`kcap` layouts: every official layout (npm platform packages, release archives) ships both binaries together, so those layouts are unsupported by design. The failure direction is safe — the registration is merely not recognized as canonical, so the agent worktree keeps the wrapper duplicate; nothing is lost or suppressed.
