### PR TITLE
Supervision IPC: daemon state + live agent list over the control socket

### DIFF
--- a/docs/superpowers/plans/2026-08-03-ai1649-supervision-ipc.md
+++ b/docs/superpowers/plans/2026-08-03-ai1649-supervision-ipc.md
@@ -1,0 +1,1086 @@
+# Supervision IPC (AI-1649) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the daemon's local control socket a v1 supervision surface — `StatusSubscribe` → pushed full `DaemonStatus` snapshots (daemon block + live agent list) driven by a monotonic change generation — plus a `RequesterUserId` field on the agent record, per the approved spec `docs/superpowers/specs/2026-08-01-slice2-prework-control-ipc-design.md` §4 (PR 2, AI-1649).
+
+**Architecture:** A new frame pair (`StatusSubscribe = 16` client→daemon, `DaemonStatus = 76` daemon→client) rides the existing length-prefixed codec. A `DaemonStatusNotifier` holds a monotonic generation counter + one shared rearm `TaskCompletionSource` under a single lock; the orchestrator and `ServerConnection` pulse it strictly *after* each state mutation via centralized helpers. A `DaemonStatusIpc` handler (long-lived connection, same EOF-watcher discipline as `ConsentSubscribe`) pushes a full snapshot immediately on subscribe, then a debounced re-push whenever the generation advances past the subscriber's per-connection cursor. Stop needs nothing new — the app reuses the shipped `StopV2` frame (spec §4.4; zero work in this plan).
+
+**Tech Stack:** .NET 10 NativeAOT, System.Text.Json source generation (snake_case, no reflection), TUnit on Microsoft Testing Platform, real Unix-domain-socket integration tests.
+
+## Global Constraints
+
+- **Append-only wire values:** `StatusSubscribe = 16`, `DaemonStatus = 76`. No other `FrameType` value may move (spec §1.1, §7).
+- **JSON:** snake_case via a new source-gen `JsonSerializerContext` in Core; **every field always emitted, absent values are JSON `null`** — do NOT set `DefaultIgnoreCondition` (spec §4.1); deserialization must ignore unmapped members (STJ default — never opt into `Disallow`) (spec §5).
+- **Wire semantics pinned (spec §4.1):** `connection` ∈ `connected|connecting|reconnecting|disconnected` (lowercase); `agent.status` verbatim PascalCase internal string; `kind` uses the existing `KindText` spellings; agents ordered `created_at` asc, tie-broken by `id` (ordinal); `active_agents` computed from the materialized array with the `Status is "Starting" or "Running"` predicate.
+- **Mutation first, `Pulse()` second — always** (spec §4.2). Pulse call sites live in centralized helpers only.
+- **Capability list:** `LocalControlCapabilities.Current` becomes `["consent/1", "status/1"]` in the same PR that wires the `StatusSubscribe` handler — never before (invariant documented in that file).
+- **AOT:** `dotnet build` does NOT surface IL3050/IL2026 — run `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` after changes and expect no output.
+- **Tests:** TUnit on MTP — run one class with `--treenode-filter "/*/*/ClassName/*"` (the bare `"*ClassName*"` glob silently matches nothing). Real-socket tests need: `if (OperatingSystem.IsWindows()) return;` guard, short daemon names (macOS `sockaddr_un` ~104-byte path limit), and `[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]`.
+- **No README change:** this PR adds no CLI command/flag/behavior — the surface is app-facing IPC only. State this in the PR description so the README-sync check is visibly considered.
+- **Comments:** no Linear issue numbers in code comments; keep comments to constraints code can't show.
+
+**Branch:** `alexeyzimarev/ai-1649-supervision-ipc-daemon-state-live-agent-list-stop-agent` off current `main`.
+
+```bash
+git checkout -b alexeyzimarev/ai-1649-supervision-ipc-daemon-state-live-agent-list-stop-agent
+```
+
+---
+
+### Task 1: Wire contract — frame values, codec arms, LocalFrame helper
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/FrameType.cs`
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs` (Encode/Decode switches)
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs` (StatusJson helper)
+- Test: `test/Capacitor.Cli.Tests.Unit/FrameCodecStatusTests.cs` (create)
+
+**Interfaces:**
+- Consumes: existing `FrameCodec.WriteAsync/ReadAsync`, `LocalFrame`.
+- Produces: `FrameType.StatusSubscribe = 16` (no payload), `FrameType.DaemonStatus = 76` (Text = JSON), `LocalFrame.StatusJson(FrameType type, string json)`.
+
+- [ ] **Step 1: Write the failing round-trip tests**
+
+```csharp
+// test/Capacitor.Cli.Tests.Unit/FrameCodecStatusTests.cs
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Round-trips for the supervision frame pair. StatusSubscribe carries no payload
+/// (Detach/List shape); DaemonStatus carries UTF-8 JSON in Text (consent-frame shape).
+/// </summary>
+public class FrameCodecStatusTests {
+    [Test]
+    public async Task StatusSubscribe_round_trips_with_an_empty_payload() {
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(ms, new LocalFrame(FrameType.StatusSubscribe), CancellationToken.None);
+        ms.Position = 0;
+        var f = await FrameCodec.ReadAsync(ms, CancellationToken.None);
+        await Assert.That(f!.Type).IsEqualTo(FrameType.StatusSubscribe);
+        await Assert.That(f.Text).IsEmpty();
+        await Assert.That(f.Bytes).IsEmpty();
+    }
+
+    [Test]
+    public async Task DaemonStatus_round_trips_its_json_text_payload() {
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(
+            ms, LocalFrame.StatusJson(FrameType.DaemonStatus, """{"daemon":{"name":"x"}}"""), CancellationToken.None);
+        ms.Position = 0;
+        var f = await FrameCodec.ReadAsync(ms, CancellationToken.None);
+        await Assert.That(f!.Type).IsEqualTo(FrameType.DaemonStatus);
+        await Assert.That(f.Text).IsEqualTo("""{"daemon":{"name":"x"}}""");
+    }
+
+    [Test]
+    public async Task Frame_values_are_pinned_16_and_76() {
+        // Append-only wire contract: these bytes are claimed by the spec and must never move.
+        await Assert.That((byte)FrameType.StatusSubscribe).IsEqualTo((byte)16);
+        await Assert.That((byte)FrameType.DaemonStatus).IsEqualTo((byte)76);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/FrameCodecStatusTests/*"
+```
+
+Expected: compile error — `StatusSubscribe` is not a member of `FrameType`.
+
+- [ ] **Step 3: Implement the wire contract**
+
+In `FrameType.cs`, append to the client→daemon block (after `Hello = 15`):
+
+```csharp
+    StatusSubscribe = 16, // long-lived: push DaemonStatus snapshots (immediate + on change)
+```
+
+and to the daemon→client block (after `HelloReply = 75`):
+
+```csharp
+    DaemonStatus = 76, // Text = DaemonStatusDto JSON: daemon block + full agent list snapshot
+```
+
+In `FrameCodec.cs` `Encode`, change the empty-payload arm and the Text arm:
+
+```csharp
+        FrameType.Detach or FrameType.List or FrameType.StatusSubscribe => [],
+```
+
+and add `or FrameType.DaemonStatus` to the long Text arm (after `or FrameType.ConsentAck`):
+
+```csharp
+            or FrameType.ConsentAck or FrameType.DaemonStatus => Encoding.UTF8.GetBytes(f.Text),
+```
+
+Mirror both changes in `Decode` (`new(t)` for the empty arm, `new(t) { Text = ... }` for the Text arm).
+
+In `LocalFrame.cs`, after the `HelloJson` helper:
+
+```csharp
+    /// Constructs a DaemonStatus frame, whose payload is UTF-8 JSON
+    /// (snake_case via StatusIpcJsonContext) carried in Text — see StatusIpc.cs.
+    public static LocalFrame StatusJson(FrameType type, string json) => new(type) { Text = json };
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/FrameCodecStatusTests/*"
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/LocalIpc/FrameType.cs src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs test/Capacitor.Cli.Tests.Unit/FrameCodecStatusTests.cs
+git commit -m "Add StatusSubscribe/DaemonStatus frames to the local IPC wire contract"
+```
+
+---
+
+### Task 2: Status DTOs + snake_case JSON context (Core) with exact-JSON contract tests
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/StatusIpcJsonTests.cs` (create)
+
+**Interfaces:**
+- Produces (all public, in `Capacitor.Cli.Core.LocalIpc`):
+  - `sealed record DaemonStatusDto(DaemonInfoDto Daemon, List<AgentStatusDto> Agents)`
+  - `sealed record DaemonInfoDto(string Name, string Version, string ServerUrl, string Connection, int MaxAgents, int ActiveAgents)`
+  - `sealed record AgentStatusDto(string Id, string Kind, string Vendor, string? RepoPath, string Status, string? FlowRunId, string? FlowRole, string? Requester, DateTime CreatedAt, string? Model)`
+  - `partial class StatusIpcJsonContext : JsonSerializerContext` (snake_case; nulls always written)
+- Property declaration order matches the spec §4.1 example — source-gen serializes in declaration order and the exact-JSON tests pin it.
+
+- [ ] **Step 1: Write the failing contract tests**
+
+```csharp
+// test/Capacitor.Cli.Tests.Unit/StatusIpcJsonTests.cs
+using System.Text.Json;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Exact-JSON pins for the DaemonStatus payload (spec §4.1): snake_case, every field always
+/// emitted (absent = null, never omitted), field order as declared, ISO-8601 UTC created_at.
+/// Plus the §5 forward-compat pin: unknown members deserialize without error.
+/// </summary>
+public class StatusIpcJsonTests {
+    [Test]
+    public async Task DaemonStatus_serializes_exactly_with_nulls_present_and_pinned_field_order() {
+        var dto = new DaemonStatusDto(
+            new DaemonInfoDto("main", "0.12.3", "https://tenant.example.com", "connected", 5, 1),
+            [
+                new AgentStatusDto(
+                    "agent-abc123", "review-flow", "codex", "/Users/x/dev/repo", "Live",
+                    "flow_1", "reviewer", "github:12345",
+                    new DateTime(2026, 8, 1, 12, 34, 56, 789, DateTimeKind.Utc), "gpt-5-codex"),
+                new AgentStatusDto(
+                    "agent-b", "agent", "claude", null, "Starting",
+                    null, null, null,
+                    new DateTime(2026, 8, 1, 12, 35, 0, DateTimeKind.Utc), null),
+            ]);
+
+        var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.DaemonStatusDto);
+
+        await Assert.That(json).IsEqualTo(
+            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex"},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null}]}""");
+    }
+
+    [Test]
+    public async Task Unknown_members_in_a_payload_deserialize_without_error() {
+        // §5 forward compat: an older client must survive a future additive field.
+        var json =
+            """{"daemon":{"name":"m","version":"1","server_url":"u","connection":"connected","max_agents":5,"active_agents":0,"future_field":42},"agents":[{"id":"a","kind":"agent","vendor":"codex","repo_path":null,"status":"Live","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T00:00:00Z","model":null,"future_field":{"x":1}}],"future_top":true}""";
+
+        var dto = JsonSerializer.Deserialize(json, StatusIpcJsonContext.Default.DaemonStatusDto);
+
+        await Assert.That(dto!.Daemon.Name).IsEqualTo("m");
+        await Assert.That(dto.Agents[0].Id).IsEqualTo("a");
+        await Assert.That(dto.Agents[0].Status).IsEqualTo("Live");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/StatusIpcJsonTests/*"
+```
+
+Expected: compile error — `DaemonStatusDto` does not exist.
+
+- [ ] **Step 3: Implement the DTOs + context**
+
+```csharp
+// src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// JSON payload for the DaemonStatus frame. snake_case on the wire; shared verbatim by the
+/// daemon, the CLI, and the desktop app. Every field is ALWAYS emitted — absent values are
+/// JSON null, never omitted (one wire shape, exact-JSON testable), so this context must never
+/// gain a DefaultIgnoreCondition. Deserialization ignores unmapped members (STJ default) —
+/// additive fields must never break an older client.
+public sealed record DaemonStatusDto(DaemonInfoDto Daemon, List<AgentStatusDto> Agents);
+
+/// <summary>
+/// <see cref="Connection"/> ∈ connected|connecting|reconnecting|disconnected (lowercase).
+/// <see cref="ActiveAgents"/> is derived from the SAME materialized agents array it ships
+/// with (Status is "Starting" or "Running"), so count and array can never disagree within
+/// one payload.
+/// </summary>
+public sealed record DaemonInfoDto(
+    string Name, string Version, string ServerUrl, string Connection, int MaxAgents, int ActiveAgents);
+
+/// <summary>
+/// <see cref="Status"/> is the daemon's internal status string VERBATIM (PascalCase, open
+/// vocabulary — clients treat unknown values as opaque display text). <see cref="Kind"/>
+/// uses the KindText wire spellings (agent/review/review-flow, unknown enum names pass
+/// through) — one vocabulary across AgentList and this payload. <see cref="Requester"/> is
+/// null when unknown (old servers, local spawns); rendering "unknown" is presentation.
+/// </summary>
+public sealed record AgentStatusDto(
+    string Id, string Kind, string Vendor, string? RepoPath, string Status,
+    string? FlowRunId, string? FlowRole, string? Requester, DateTime CreatedAt, string? Model);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(DaemonStatusDto))]
+public partial class StatusIpcJsonContext : JsonSerializerContext;
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/StatusIpcJsonTests/*"
+```
+
+Expected: 2 PASS. If the exact-JSON assertion fails on `created_at` formatting, fix the *test's* expected string to STJ's actual ISO-8601 output — the DTO shape and null emission are the contract, and STJ's UTC DateTime format is stable.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs test/Capacitor.Cli.Tests.Unit/StatusIpcJsonTests.cs
+git commit -m "Add DaemonStatus DTOs with pinned snake_case wire shape"
+```
+
+---
+
+### Task 3: DaemonStatusNotifier — monotonic generation, broadcast-safe
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/DaemonStatusNotifier.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusNotifierTests.cs` (create)
+
+**Interfaces:**
+- Produces (`internal sealed class DaemonStatusNotifier`, namespace `Capacitor.Cli.Daemon.Services`):
+  - `long Version { get; }` — monotonic change generation.
+  - `void Pulse()` — increments Version and wakes every current waiter; never blocks on consumers.
+  - `Task WaitBeyondAsync(long seen, CancellationToken ct)` — completed synchronously when `Version > seen`; otherwise completes on the next `Pulse()`. Broadcast: N waiters each hold their own cursor and can never consume each other's signal.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusNotifierTests.cs
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// The generation counter behind DaemonStatus pushes (spec §4.2): version check and source
+/// capture are atomic, Pulse is a broadcast, and a stale cursor returns synchronously —
+/// a missed pulse can never strand a subscriber.
+/// </summary>
+public class DaemonStatusNotifierTests {
+    [Test]
+    public async Task Wait_returns_synchronously_when_version_is_already_beyond_seen() {
+        var n = new DaemonStatusNotifier();
+        n.Pulse();
+        var t = n.WaitBeyondAsync(0, CancellationToken.None);
+        await Assert.That(t.IsCompletedSuccessfully).IsTrue();
+    }
+
+    [Test]
+    public async Task Pulse_wakes_a_waiter_captured_at_the_current_version() {
+        var n = new DaemonStatusNotifier();
+        var t = n.WaitBeyondAsync(n.Version, CancellationToken.None);
+        await Assert.That(t.IsCompleted).IsFalse();
+        n.Pulse();
+        await t.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Pulse_is_a_broadcast_every_waiter_in_the_generation_wakes() {
+        var n = new DaemonStatusNotifier();
+        var seen = n.Version;
+        var a = n.WaitBeyondAsync(seen, CancellationToken.None);
+        var b = n.WaitBeyondAsync(seen, CancellationToken.None);
+        n.Pulse();
+        await Task.WhenAll(a, b).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task A_fresh_wait_after_a_pulse_blocks_until_the_next_pulse() {
+        var n = new DaemonStatusNotifier();
+        n.Pulse();
+        var t = n.WaitBeyondAsync(n.Version, CancellationToken.None);
+        await Assert.That(t.IsCompleted).IsFalse();
+        n.Pulse();
+        await t.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Cancellation_aborts_one_wait_without_disturbing_other_waiters() {
+        var n = new DaemonStatusNotifier();
+        var seen = n.Version;
+        using var cts = new CancellationTokenSource();
+        var cancelled = n.WaitBeyondAsync(seen, cts.Token);
+        var live      = n.WaitBeyondAsync(seen, CancellationToken.None);
+
+        cts.Cancel();
+        var threw = false;
+        try { await cancelled; } catch (OperationCanceledException) { threw = true; }
+        await Assert.That(threw).IsTrue();
+
+        n.Pulse();
+        await live.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/DaemonStatusNotifierTests/*"
+```
+
+Expected: compile error — `DaemonStatusNotifier` does not exist.
+
+- [ ] **Step 3: Implement the notifier**
+
+```csharp
+// src/Capacitor.Cli.Daemon/Services/DaemonStatusNotifier.cs
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Monotonic change generation behind DaemonStatus pushes. Version and the shared rearm
+/// source live under ONE lock: Pulse() increments and completes-and-rearms in the same
+/// critical section; WaitBeyondAsync reads Version and captures the current source in that
+/// same critical section — no torn interleaving between the check and the capture. This is
+/// a broadcast: N subscribers each hold their own cursor (the `seen` they pass in) and can
+/// never consume each other's signal. Call sites must mutate state FIRST and Pulse() second,
+/// or a subscriber could snapshot old state at the new version and then wait forever.
+/// </summary>
+internal sealed class DaemonStatusNotifier {
+    readonly Lock _lock = new();
+    long _version;
+    // RunContinuationsAsynchronously: completed under _lock — a waiter's continuation must
+    // not run inline while the lock is held.
+    TaskCompletionSource _next = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public long Version {
+        get { lock (_lock) return _version; }
+    }
+
+    public void Pulse() {
+        lock (_lock) {
+            _version++;
+            var done = _next;
+            _next = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            done.TrySetResult();
+        }
+    }
+
+    public Task WaitBeyondAsync(long seen, CancellationToken ct) {
+        TaskCompletionSource wait;
+        lock (_lock) {
+            if (_version > seen) return Task.CompletedTask;
+            wait = _next;
+        }
+        // A timeout/cancellation here only stops THIS waiter's wait — the shared source is
+        // never completed or replaced by a consumer.
+        return wait.Task.WaitAsync(ct);
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/DaemonStatusNotifierTests/*"
+```
+
+Expected: 5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/DaemonStatusNotifier.cs test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusNotifierTests.cs
+git commit -m "Add DaemonStatusNotifier generation counter for supervision pushes"
+```
+
+---
+
+### Task 4: RequesterUserId on AgentInstance, stamped from the launch command
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (AgentInstance record ~line 44; launch-core `new AgentInstance(...)` initializer ~line 1467; new test accessor; `SeedAgentForTest` gains a `requester` parameter ~line 956)
+- Test: `test/Capacitor.Cli.Tests.Unit/AgentOrchestratorRequesterTests.cs` (create)
+
+**Interfaces:**
+- Consumes: `LaunchAgentCommand.RequesterUserId` (already on the wire, `src/Capacitor.Cli.Core/Models.cs` — null for old servers), the vendor-test harness `AgentOrchestratorVendorTests.BuildOrchestrator(...)` and its fakes (`SpyPtyProcessFactory`, fake `IHostedAgentLauncher`, fake `ServerConnection`, `CreateGitRepo`) — reuse them exactly as the existing vendor routing tests do.
+- Produces:
+  - `AgentInstance.RequesterUserId` — `public string? RequesterUserId { get; init; }`
+  - `internal AgentInstance? GetAgentForTest(string id)` on `AgentOrchestrator`
+  - `SeedAgentForTest(..., string? requester = null)` stamps `RequesterUserId = requester`
+
+- [ ] **Step 1: Write the failing test**
+
+Model the harness usage on an existing launch test in `AgentOrchestratorVendorTests.cs` (it is a `partial class` — if `BuildOrchestrator`/fakes are `static` members there, declare this new class `public partial class AgentOrchestratorVendorTests` in the new file so they're in scope; otherwise mirror the harness construction inline).
+
+```csharp
+// test/Capacitor.Cli.Tests.Unit/AgentOrchestratorRequesterTests.cs
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Requester stamping (spec §4.3): AgentInstance.RequesterUserId is captured from
+/// LaunchAgentCommand at construction — non-null when a new server sends it, null for
+/// old servers (field absent) — so the supervision payload can show who asked.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Launch_stamps_RequesterUserId_from_the_command() {
+        var (repoPath, cleanup) = CreateGitRepo();
+        try {
+            var server       = new FakeServerConnection();          // same fake the routing tests use
+            var ptyFactory   = new SpyPtyProcessFactory();
+            var orchestrator = BuildOrchestrator(
+                server, ptyFactory, ClaudeOnlyLaunchers(), allowedRepoPath: repoPath);
+
+            await orchestrator.HandleLaunchAgent(new LaunchAgentCommand(
+                AgentId: "req-1", Prompt: "p", Model: "default", Effort: null,
+                RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude",
+                RequesterUserId: "github:12345"));
+
+            await Assert.That(orchestrator.GetAgentForTest("req-1")!.RequesterUserId)
+                .IsEqualTo("github:12345");
+        } finally { cleanup(); }
+    }
+
+    [Test]
+    public async Task Launch_without_a_requester_leaves_RequesterUserId_null() {
+        var (repoPath, cleanup) = CreateGitRepo();
+        try {
+            var server       = new FakeServerConnection();
+            var ptyFactory   = new SpyPtyProcessFactory();
+            var orchestrator = BuildOrchestrator(
+                server, ptyFactory, ClaudeOnlyLaunchers(), allowedRepoPath: repoPath);
+
+            await orchestrator.HandleLaunchAgent(new LaunchAgentCommand(
+                AgentId: "req-2", Prompt: "p", Model: "default", Effort: null,
+                RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "claude"));
+
+            await Assert.That(orchestrator.GetAgentForTest("req-2")!.RequesterUserId).IsNull();
+        } finally { cleanup(); }
+    }
+}
+```
+
+Adjust the fake names (`FakeServerConnection`, `SpyPtyProcessFactory`, the launcher-dictionary helper) to whatever the existing vendor tests actually define — copy the exact construction lines from a passing launch test in that file rather than inventing new fakes. If `HandleLaunchAgent` requires awaiting agent registration (it registers before the read loop), assert with a short poll: `GetAgentForTest` non-null within 5 s.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/AgentOrchestratorVendorTests/*"
+```
+
+Expected: compile error — `RequesterUserId` / `GetAgentForTest` not defined.
+
+- [ ] **Step 3: Implement**
+
+In the `AgentInstance` record body (next to `FlowRunId`/`FlowRole`, ~line 46):
+
+```csharp
+    /// <summary>Who asked for this launch (server-stamped requester user id). Null for old
+    /// servers and local spawns — the supervision payload renders null as unknown.</summary>
+    public string?              RequesterUserId   { get; init; }
+```
+
+In the launch core's `new AgentInstance(...)` initializer (~line 1467, next to `Kind = cmd.Kind`):
+
+```csharp
+                RequesterUserId     = cmd.RequesterUserId,
+```
+
+Add the test accessor next to `RegisterAgentForTest` (~line 3341):
+
+```csharp
+    internal AgentInstance? GetAgentForTest(string id) => _agents.GetValueOrDefault(id);
+```
+
+In `SeedAgentForTest` (~line 956): add parameter `string? requester = null` and `RequesterUserId = requester` in the object initializer.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/AgentOrchestratorVendorTests/*"
+```
+
+Expected: new tests PASS, existing vendor tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs test/Capacitor.Cli.Tests.Unit/AgentOrchestratorRequesterTests.cs
+git commit -m "Stamp RequesterUserId onto AgentInstance from the launch command"
+```
+
+---
+
+### Task 5: Orchestrator snapshot + centralized mutate-then-pulse helpers
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (ctor param, helpers, replace mutation sites)
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs` (snapshot builder; local-spawn registry write)
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs` (create)
+
+**Interfaces:**
+- Consumes: `DaemonStatusNotifier` (Task 3), `AgentStatusDto` (Task 2), `AgentInstance.RequesterUserId` (Task 4), private static `KindText(LaunchKind)` (same partial class).
+- Produces on `AgentOrchestrator`:
+  - ctor gains trailing optional param `DaemonStatusNotifier? statusNotifier = null`; field `readonly DaemonStatusNotifier _statusNotifier;` = `statusNotifier ?? new()`. (Optional so the existing 3 direct construction sites and DI keep compiling; MS DI injects the registered singleton into an optional parameter when one is registered.)
+  - `internal void SetAgentStatus(AgentInstance agent, string status)` — writes `agent.Status`, then pulses.
+  - `internal void PublishAgent(AgentInstance agent)` — `_agents[agent.Id] = agent`, then pulses.
+  - `internal void UnpublishAgent(string agentId)` — `_agents.TryRemove(agentId, out _)`, then pulses.
+  - `internal List<AgentStatusDto> SnapshotAgentsForStatus()` — one enumeration pass, pinned order.
+
+- [ ] **Step 1: Write the failing tests**
+
+Use the existing `SeedAgentForTest` seam (plus Task 4's `requester` param). Build a bare orchestrator exactly the way `LocalControlHelloTests.StartAsync` does (Noop factories, empty launcher dicts), passing a shared notifier: `new AgentOrchestrator(config, connection, worktreeManager, repoMatcher, new NoopPtyProcessFactory(), new NoopHttpClientFactory(), permissionBridge, new Dictionary<string, IHostedAgentLauncher>(), new Dictionary<string, IHostedAgentRuntimeFactory>(), new NoopHostLifetime(), NullLogger<AgentOrchestrator>.Instance, gate, statusNotifier: notifier)` — copy the support types from that file into a small shared local helper in this test class.
+
+```csharp
+// test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs  (test bodies)
+    [Test]
+    public async Task Snapshot_orders_by_created_at_then_id_ordinal_and_includes_all_statuses() {
+        var (orch, _) = Build();
+        var t0 = new DateTime(2026, 8, 1, 10, 0, 0, DateTimeKind.Utc);
+        orch.SeedAgentForTest("b-second", status: "Quarantined", createdAt: t0.AddMinutes(1));
+        orch.SeedAgentForTest("z-first",  status: "Starting",    createdAt: t0);
+        orch.SeedAgentForTest("a-tie",    status: "Completed",   createdAt: t0.AddMinutes(1));
+
+        var agents = orch.SnapshotAgentsForStatus();
+
+        await Assert.That(agents.Select(a => a.Id)).IsEquivalentTo(
+            new[] { "z-first", "a-tie", "b-second" }, CollectionOrdering.Matching);
+        // All statuses ride along verbatim — the vocabulary is open, PascalCase as stored.
+        await Assert.That(agents.Select(a => a.Status)).IsEquivalentTo(
+            new[] { "Starting", "Completed", "Quarantined" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Snapshot_maps_kind_spellings_requester_and_nullables() {
+        var (orch, _) = Build();
+        orch.SeedAgentForTest("r1", kind: LaunchKind.ReviewFlow, flowRunId: "flow_1",
+            flowRole: "reviewer", requester: "github:12345");
+        orch.SeedAgentForTest("d1"); // defaults: LaunchKind.Default, no flow identity, no requester
+
+        var byId = orch.SnapshotAgentsForStatus().ToDictionary(a => a.Id);
+
+        await Assert.That(byId["r1"].Kind).IsEqualTo("review-flow");
+        await Assert.That(byId["r1"].Requester).IsEqualTo("github:12345");
+        await Assert.That(byId["r1"].FlowRunId).IsEqualTo("flow_1");
+        await Assert.That(byId["d1"].Kind).IsEqualTo("agent");
+        await Assert.That(byId["d1"].Requester).IsNull();
+        await Assert.That(byId["d1"].FlowRunId).IsNull();
+    }
+
+    [Test]
+    public async Task Publish_status_change_and_unpublish_each_advance_the_generation() {
+        var (orch, notifier) = Build();
+
+        var v0 = notifier.Version;
+        var agent = orch.SeedAgentForTest("gen-1"); // registers via PublishAgent
+        await Assert.That(notifier.Version).IsGreaterThan(v0);
+
+        var v1 = notifier.Version;
+        orch.SetAgentStatus(agent, "Completed");
+        await Assert.That(notifier.Version).IsGreaterThan(v1);
+
+        var v2 = notifier.Version;
+        orch.UnpublishAgent("gen-1");
+        await Assert.That(notifier.Version).IsGreaterThan(v2);
+        await Assert.That(orch.SnapshotAgentsForStatus()).IsEmpty();
+    }
+```
+
+(`Build()` is the local helper returning `(AgentOrchestrator, DaemonStatusNotifier)`. If TUnit's ordered-collection assertion spelling differs, assert element-by-element on the indexed list instead — the *order* is the contract.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/AgentStatusSnapshotTests/*"
+```
+
+Expected: compile error — `SnapshotAgentsForStatus` / `statusNotifier:` not defined.
+
+- [ ] **Step 3: Implement**
+
+Ctor (~line 366): append `DaemonStatusNotifier? statusNotifier = null` after `deferProcessorPublication` and in the body set `_statusNotifier = statusNotifier ?? new();` (field declared near `_agents`).
+
+Helpers (place near `ActiveCount`, ~line 568):
+
+```csharp
+    /// Mutation FIRST, Pulse() second — always (a pulse published before its mutation lets a
+    /// subscriber read the new version, snapshot the OLD state, and wait forever). These
+    /// helpers are the only writers of agent status and registry membership, so the ordering
+    /// cannot be forgotten at a call site.
+    internal void SetAgentStatus(AgentInstance agent, string status) {
+        agent.Status = status;
+        _statusNotifier.Pulse();
+    }
+
+    internal void PublishAgent(AgentInstance agent) {
+        _agents[agent.Id] = agent;
+        _statusNotifier.Pulse();
+    }
+
+    internal void UnpublishAgent(string agentId) {
+        _agents.TryRemove(agentId, out _);
+        _statusNotifier.Pulse();
+    }
+```
+
+Replace the mutation sites (verify each with `grep -n '\.Status = \|_agents\[' src/Capacitor.Cli.Daemon/Services/AgentOrchestrator*.cs` — line numbers may have drifted):
+
+| Site (approx.) | Old | New |
+|---|---|---|
+| `AgentOrchestrator.cs` ~1750 (read loop Starting→Running) | `agent.Status = "Running";` | `SetAgentStatus(agent, "Running");` |
+| `AgentOrchestrator.cs` ~1911 (launch failure status) | `agent.Status = status;` | `SetAgentStatus(agent, status);` |
+| `AgentOrchestrator.cs` ~2102 (stop path) | `agent.Status = "Completed";` | `SetAgentStatus(agent, "Completed");` |
+| `AgentOrchestrator.cs` ~1479 (launch core) | `_agents[agentId] = agent;` | `PublishAgent(agent);` |
+| `AgentOrchestrator.cs` ~972 (`SeedAgentForTest`) | `_agents[id] = agent;` | `PublishAgent(agent);` |
+| `AgentOrchestrator.cs` ~3341 (`RegisterAgentForTest`) | `_agents[agent.Id] = agent;` | `PublishAgent(agent);` |
+| `AgentOrchestrator.cs` ~3058 (cleanup removal) | `_agents.TryRemove(agentId, out _);` | `UnpublishAgent(agentId);` (keep the surrounding comment) |
+| `AgentOrchestrator.LocalIpc.cs` ~185 (local spawn) | `_agents[agentId] = agent;` | `PublishAgent(agent);` |
+
+Do NOT pulse on `LastOutputAt`/`HasReceivedOutput` writes — they are not in the payload. `SeedAgentForTest`'s pre-publication `agent.Status = status;` (~line 970) stays a plain write: the instance is not yet visible, and `PublishAgent` pulses right after.
+
+Snapshot builder in `AgentOrchestrator.LocalIpc.cs` (next to `HandleLocalListAsync`, where `KindText` lives):
+
+```csharp
+    /// <summary>
+    /// The supervision payload's agent rows: every entry in _agents (all statuses — same
+    /// visibility as `kcap agent ls`; quarantined-but-removed children are gone from _agents
+    /// already). Order is a wire contract: created_at ascending, id-ordinal tie-break —
+    /// ConcurrentDictionary enumeration order must never leak into the payload.
+    /// </summary>
+    internal List<AgentStatusDto> SnapshotAgentsForStatus() =>
+        [.. _agents.Values
+            .OrderBy(a => a.CreatedAt)
+            .ThenBy(a => a.Id, StringComparer.Ordinal)
+            .Select(a => new AgentStatusDto(
+                a.Id, KindText(a.Kind), a.Vendor, a.RepoPath, a.Status,
+                a.FlowRunId, a.FlowRole, a.RequesterUserId, a.CreatedAt, a.Model))];
+```
+
+- [ ] **Step 4: Run the new tests, then the full unit suite (the mutation-site swap touches launch/stop/cleanup paths)**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/AgentStatusSnapshotTests/*"
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+```
+
+Expected: new tests PASS; zero regressions in the full suite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
+git commit -m "Centralize agent mutations behind pulse helpers and add the status snapshot"
+```
+
+---
+
+### Task 6: DaemonStatusIpc handler, routing, capability, ServerConnection pulses, DI
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/DaemonStatusIpc.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs` (ctor + route + default-arm message)
+- Modify: `src/Capacitor.Cli.Daemon/Services/LocalControlCapabilities.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` (optional ctor param + 4 pulse sites)
+- Modify: `src/Capacitor.Cli.Daemon/DaemonRunner.cs` (DI registrations)
+- Modify: `test/Capacitor.Cli.Tests.Unit/Daemon/LocalControlHelloTests.cs` (capability expectations ×3; harness gains the status pieces)
+- Test: `test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs` (create — first test only; the full matrix is Task 7)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–5; `LaunchConsentIpc.HandleSubscribeAsync` EOF-watcher shape; `DaemonRunner.ResolveDaemonVersion()`; `ServerConnection.HubState` (`Microsoft.AspNetCore.SignalR.Client.HubConnectionState`).
+- Produces:
+  - `internal sealed class DaemonStatusIpc(DaemonConfig config, AgentOrchestrator orchestrator, ServerConnection connection, DaemonStatusNotifier notifier)` with `Task HandleSubscribeAsync(Stream stream, CancellationToken ct)`, `internal TimeSpan Debounce { get; set; }` (default 250 ms), `internal int ActiveSubscribersForTest { get; }`, `internal Action? AfterSnapshotForTest { get; set; }`.
+  - `LocalControlServer` ctor gains `DaemonStatusIpc statusIpc`; routes `FrameType.StatusSubscribe`.
+  - `LocalControlCapabilities.Current == ["consent/1", "status/1"]`.
+  - `ServerConnection` ctor gains trailing optional `DaemonStatusNotifier? statusNotifier = null` (subclass test doubles keep compiling).
+
+- [ ] **Step 1: Write the failing first integration test**
+
+Create `DaemonStatusIpcTests.cs` with a harness copied from `LocalControlHelloTests` (`StartAsync`/`StopAsync`/`RunAsync`/`ConnectAsync`, Noop support types), extended with the status pieces — this harness is reused verbatim by Task 7:
+
+```csharp
+// Harness deltas vs LocalControlHelloTests.StartAsync (everything else copied as-is):
+        var notifier   = new DaemonStatusNotifier();
+        var connection = new ServerConnection(
+            config, NullLoggerFactory.Instance, NullLogger<ServerConnection>.Instance, notifier);
+        // orchestrator: same arguments as the hello harness, plus `statusNotifier: notifier`
+        var statusIpc  = new DaemonStatusIpc(config, orchestrator, connection, notifier) {
+            Debounce = TimeSpan.FromMilliseconds(25), // fast tests; 250ms is the production default
+        };
+        var server = new LocalControlServer(
+            config, orchestrator, restart, consentIpc, statusIpc, NullLogger<LocalControlServer>.Instance);
+// Harness record carries: Server, Orchestrator, Connection, Config, SockPath, Notifier, StatusIpc.
+
+    static async Task<DaemonStatusDto> ReadStatusAsync(Stream s, CancellationToken ct) {
+        var f = await FrameCodec.ReadAsync(s, ct);
+        await Assert.That(f!.Type).IsEqualTo(FrameType.DaemonStatus);
+        return JsonSerializer.Deserialize(f.Text, StatusIpcJsonContext.Default.DaemonStatusDto)!;
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Subscribe_pushes_an_immediate_snapshot_with_daemon_block_and_agents() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("st-a", async (h, ct) => {
+            h.Orchestrator.SeedAgentForTest("s1", kind: LaunchKind.ReviewFlow,
+                flowRunId: "flow_1", flowRole: "reviewer", requester: "github:12345");
+            h.Orchestrator.SeedAgentForTest("s2", status: "Starting");
+
+            await using var s = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(s, new LocalFrame(FrameType.StatusSubscribe), ct);
+
+            var dto = await ReadStatusAsync(s, ct);
+            await Assert.That(dto.Daemon.Name).IsEqualTo(h.Config.Name);
+            await Assert.That(dto.Daemon.Version).IsNotEmpty();
+            await Assert.That(dto.Daemon.ServerUrl).IsEqualTo(h.Config.ServerUrl);
+            await Assert.That(dto.Daemon.Connection).IsEqualTo("disconnected"); // no live hub in tests
+            await Assert.That(dto.Daemon.MaxAgents).IsEqualTo(h.Config.MaxConcurrentAgents);
+            await Assert.That(dto.Daemon.ActiveAgents).IsEqualTo(2); // Running + Starting
+            await Assert.That(dto.Agents.Count).IsEqualTo(2);
+            var r1 = dto.Agents.Single(a => a.Id == "s1");
+            await Assert.That(r1.Kind).IsEqualTo("review-flow");
+            await Assert.That(r1.Requester).IsEqualTo("github:12345");
+        });
+    }
+```
+
+Also update the three `LocalControlHelloTests` capability assertions from `new[] { "consent/1" }` to `new[] { "consent/1", "status/1" }`, and add `statusIpc` to that harness's `LocalControlServer` construction (a minimal `new DaemonStatusIpc(config, orchestrator, connection, new DaemonStatusNotifier())` is fine there).
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/DaemonStatusIpcTests/*"
+```
+
+Expected: compile error — `DaemonStatusIpc` does not exist.
+
+- [ ] **Step 3: Implement the handler**
+
+```csharp
+// src/Capacitor.Cli.Daemon/Services/DaemonStatusIpc.cs
+using System.Text.Json;
+using Capacitor.Cli.Core.LocalIpc;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// Local-socket handler for StatusSubscribe: one full DaemonStatusDto snapshot immediately,
+/// then a debounced re-push whenever the change generation advances past this connection's
+/// cursor. Full snapshots + per-connection cursors mean a missed pulse can never desync a
+/// client, and a slow subscriber delays only itself. Trust model: same 0600-socket owner
+/// trust as every other local frame.
+internal sealed class DaemonStatusIpc(
+    DaemonConfig config, AgentOrchestrator orchestrator, ServerConnection connection,
+    DaemonStatusNotifier notifier) {
+
+    /// Coalesces a pulse burst into one trailing snapshot. A tuning constant, not a wire
+    /// contract; tests shrink it.
+    internal TimeSpan Debounce { get; set; } = TimeSpan.FromMilliseconds(250);
+
+    int _subscribers;
+    internal int ActiveSubscribersForTest => Volatile.Read(ref _subscribers);
+
+    /// Test seam: runs between materializing a snapshot and pushing it, so a test can land a
+    /// mutation exactly at the cursor/snapshot boundary deterministically.
+    internal Action? AfterSnapshotForTest { get; set; }
+
+    public async Task HandleSubscribeAsync(Stream stream, CancellationToken ct) {
+        Interlocked.Increment(ref _subscribers);
+        try {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            // EOF watcher: a vanished subscriber must be reaped promptly (same discipline as
+            // ConsentSubscribe), or the daemon would keep serializing snapshots for nobody.
+            _ = Task.Run(async () => {
+                try { while (await FrameCodec.ReadAsync(stream, cts.Token) is not null) { } }
+                catch { }
+                try { cts.Cancel(); } catch (ObjectDisposedException) { }
+            }, cts.Token);
+
+            while (true) {
+                var seen = notifier.Version; // cursor BEFORE snapshotting: a mutation during
+                var json = Snapshot();       // the snapshot/push advances Version past `seen`
+                AfterSnapshotForTest?.Invoke();
+                await FrameCodec.WriteAsync(stream, LocalFrame.StatusJson(FrameType.DaemonStatus, json), cts.Token);
+                await notifier.WaitBeyondAsync(seen, cts.Token);
+                await Task.Delay(Debounce, cts.Token);
+            }
+        } catch (OperationCanceledException) {
+            // subscriber EOF or daemon shutdown — either way the connection just closes
+        } finally {
+            Interlocked.Decrement(ref _subscribers);
+        }
+    }
+
+    string Snapshot() {
+        var agents = orchestrator.SnapshotAgentsForStatus();
+        // Same predicate as the orchestrator's ActiveCount, applied to the SAME materialized
+        // array — the count and the array can never disagree within one payload.
+        var active = agents.Count(a => a.Status is "Starting" or "Running");
+        var dto = new DaemonStatusDto(
+            new DaemonInfoDto(
+                config.Name, DaemonRunner.ResolveDaemonVersion(), config.ServerUrl,
+                ConnectionText(connection.HubState), config.MaxConcurrentAgents, active),
+            agents);
+        return JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.DaemonStatusDto);
+    }
+
+    static string ConnectionText(HubConnectionState s) => s switch {
+        HubConnectionState.Connected    => "connected",
+        HubConnectionState.Connecting   => "connecting",
+        HubConnectionState.Reconnecting => "reconnecting",
+        _                               => "disconnected",
+    };
+}
+```
+
+`LocalControlServer.cs`: add `DaemonStatusIpc statusIpc` to the primary constructor (after `consentIpc`); add the route after the `Hello` case:
+
+```csharp
+                case FrameType.StatusSubscribe: await statusIpc.HandleSubscribeAsync(stream, ct); break;
+```
+
+and extend the default-arm message's frame list with `/StatusSubscribe` (before `, got {first.Type}`).
+
+`LocalControlCapabilities.cs`: set `Current = ["consent/1", "status/1"];` and rewrite the last doc sentence to state both entries' handlers (`ConsentSubscribe`… and `StatusSubscribe`) are live in this build — keep the invariant sentence, drop the "a later change appends" sentence.
+
+`ServerConnection.cs`: append optional ctor param `DaemonStatusNotifier? statusNotifier = null` (~line 170), store `_statusNotifier = statusNotifier ?? new();`. Pulse at the four HubState transition points — the hub mutates `State` before invoking these, so pulse-inside-handler is mutation-first:
+- `OnReconnecting` (~line 649): after `_gate.MarkUnregistered();` add `_statusNotifier.Pulse();`
+- `OnReconnected` (~line 669): first statement `_statusNotifier.Pulse();` (before `RegisterDaemonAsync`, which can throw)
+- `OnClosed` (locate with `grep -n "OnClosed" src/Capacitor.Cli.Daemon/Services/ServerConnection.cs`): first statement `_statusNotifier.Pulse();`
+- `ConnectWithRetryAsync` success path (~line 456): after `LogConnected(_config.Name);` add `_statusNotifier.Pulse();`
+
+`DaemonRunner.cs`: next to the consent registrations (~line 241):
+
+```csharp
+        builder.Services.AddSingleton<DaemonStatusNotifier>();
+        builder.Services.AddSingleton<DaemonStatusIpc>();
+```
+
+(The registered notifier satisfies the optional ctor params of `AgentOrchestrator` and `ServerConnection` — MS DI resolves a registered service for an optional parameter and only falls back to the default when unregistered.)
+
+- [ ] **Step 4: Run the new test, the hello tests, and the full unit suite**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/DaemonStatusIpcTests/*"
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/LocalControlHelloTests/*"
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+```
+
+Expected: all PASS (hello tests now assert both capabilities).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src test
+git commit -m "Serve StatusSubscribe with pushed DaemonStatus snapshots and advertise status/1"
+```
+
+---
+
+### Task 7: Real-socket behavior matrix (spec §6 PR 2)
+
+**Files:**
+- Modify: `test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs` (extend with the matrix; harness from Task 6)
+
+**Interfaces:**
+- Consumes: Task 6 harness (`RunAsync`, `ConnectAsync`, `ReadStatusAsync`), `SeedAgentForTest`, `SetAgentStatus`, `UnpublishAgent`, `Debounce`, `AfterSnapshotForTest`, `ActiveSubscribersForTest`.
+- Produces: the pinned behavior tests below. Add one helper:
+
+```csharp
+    /// Reads one frame or returns null when none arrives within the window — for asserting
+    /// "no further push" without hanging the suite.
+    static async Task<LocalFrame?> ReadOrNullAsync(Stream s, TimeSpan window, CancellationToken ct) {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(window);
+        try { return await FrameCodec.ReadAsync(s, cts.Token); }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested) { return null; }
+    }
+```
+
+- [ ] **Step 1: Write the matrix tests** (each `[Test]` carries the Windows guard + `[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]`; distinct short daemon names `st-b`…`st-h`)
+
+```csharp
+    [Test] // add / status-change / removal each trigger a re-push
+    public async Task Each_mutation_triggers_a_re_push() {
+        // subscribe → drain immediate snapshot
+        // SeedAgentForTest("m1") → next frame contains m1
+        // SetAgentStatus(m1, "Completed") → next frame shows m1 Completed and active_agents dropped
+        // UnpublishAgent("m1") → next frame has empty agents
+        // Assert each step via ReadStatusAsync; internal consistency: dto.Daemon.ActiveAgents ==
+        // dto.Agents.Count(a => a.Status is "Starting" or "Running") on every payload.
+    }
+
+    [Test] // burst coalescing: at most one trailing snapshot after the in-flight push
+    public async Task A_pulse_burst_coalesces_into_one_trailing_snapshot() {
+        // h.StatusIpc.Debounce = TimeSpan.FromMilliseconds(150) (set in harness before subscribe
+        // via a RunAsync overload or by seeding Debounce per-test through the harness record).
+        // subscribe → drain immediate snapshot
+        // seed 5 agents back-to-back (5 pulses, no reads in between)
+        // next frame: converged (all 5 present)
+        // ReadOrNullAsync(s, 400ms): null — no second trailing push for the same burst
+    }
+
+    [Test] // two-subscriber convergence + slow subscriber doesn't stall the fast one
+    public async Task Both_subscribers_converge_after_a_change_and_a_slow_one_stalls_only_itself() {
+        // open two subscriptions, drain both immediate snapshots
+        // seed one agent
+        // subscriber A: read until a frame contains the agent (converged)
+        // subscriber B: never read until now — then read: its buffered/next frame also converges
+        // (per-connection cursors: B's snapshot is at least as new as the final generation)
+    }
+
+    [Test] // cursor-before-snapshot + pulse-after-mutation regressions, deterministic via the hook
+    public async Task A_mutation_at_the_snapshot_boundary_still_converges() {
+        // BEFORE subscribing:
+        //   h.StatusIpc.AfterSnapshotForTest = () => {
+        //       h.StatusIpc.AfterSnapshotForTest = null;              // fire once
+        //       h.Orchestrator.SeedAgentForTest("boundary");          // mutation + pulse land
+        //   };                                                        // between snapshot and wait
+        // subscribe → first frame does NOT contain "boundary" (snapshot was taken first)
+        // next frame (no further external pulses!) DOES contain "boundary":
+        //   the loop's WaitBeyondAsync(seen) completes synchronously because the seed advanced
+        //   the generation past the pre-snapshot cursor — pinning cursor-before-snapshot AND
+        //   that a final mutation with no later pulse converges.
+    }
+
+    [Test] // subscriber EOF reaps the handler promptly
+    public async Task Subscriber_eof_reaps_the_handler_promptly() {
+        // subscribe, drain immediate snapshot, assert ActiveSubscribersForTest == 1
+        // dispose the client stream
+        // poll (20ms steps, 5s deadline) until h.StatusIpc.ActiveSubscribersForTest == 0
+    }
+
+    [Test] // snapshot stress: no exceptions, every payload internally consistent, converges
+    public async Task Concurrent_mutations_never_produce_an_inconsistent_payload() {
+        // subscribe with Debounce = 25ms; reader task: collect DaemonStatusDto frames,
+        //   asserting per-payload ActiveAgents == Count(Starting|Running) as they arrive
+        // mutator task: 50 iterations of seed("x{i}") / SetAgentStatus / UnpublishAgent mix
+        // after mutations settle on a known final registry, read until a frame matches the
+        //   final agent-id set (5s deadline) — convergence, not per-generation delivery
+    }
+
+    [Test] // §5: StatusSubscribe on a shutting-down daemon — the connection just closes
+    public async Task Daemon_shutdown_closes_the_subscription() {
+        // subscribe, drain immediate snapshot
+        // await h.Server.StopAsync(CancellationToken.None)  (harness re-entrancy: skip StopAsync
+        //   in the finally for this test, or make StopAsync idempotent-safe)
+        // FrameCodec.ReadAsync returns null (clean EOF) or throws EndOfStream/IOException —
+        //   assert the read does NOT return another DaemonStatus frame
+    }
+```
+
+Write these as real test bodies (the comments above are the specification of each body — expand them into code following Task 6's first test's style; every read uses the harness `ct`).
+
+- [ ] **Step 2: Run to verify the new tests fail** (before any needed seams exist — e.g. the harness `Debounce` plumbing)
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/DaemonStatusIpcTests/*"
+```
+
+- [ ] **Step 3: Make them pass** — this is test-plumbing work only (harness knobs, timing); production changes should not be needed. If a test exposes a real defect (e.g. a missed pulse site), fix production and note it in the commit message.
+
+- [ ] **Step 4: Run the status tests 3× to shake out flake, then the full unit suite**
+
+```bash
+for i in 1 2 3; do dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/DaemonStatusIpcTests/*" || break; done
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+```
+
+Expected: PASS ×3, no regressions. Timing assertions must be one-sided (deadlines for things that must happen; generous quiet-windows for things that must not) — never assert an exact push count under load.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs
+git commit -m "Pin supervision IPC behavior: re-push, coalescing, convergence, EOF, stress"
+```
+
+---
+
+### Task 8: Verification, AOT check, PR
+
+**Files:**
+- No new code. Verification + PR only.
+
+- [ ] **Step 1: Full unit + integration suites**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj
+```
+
+Expected: all PASS. (Windows CI note: the new socket tests self-skip on Windows via the `OperatingSystem.IsWindows()` guard; no `Path.Combine` assertions were introduced.)
+
+- [ ] **Step 2: AOT publish — zero IL warnings**
+
+```bash
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+Expected: no output. (The new `StatusIpcJsonContext` is source-gen; nothing reflects.)
+
+- [ ] **Step 3: README check** — confirmed no user-facing CLI surface changed (no new command/flag/default/prereq), so no README edit; say so in the PR description.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin alexeyzimarev/ai-1649-supervision-ipc-daemon-state-live-agent-list-stop-agent
+gh pr create --title "Supervision IPC: daemon state + live agent list over the control socket" --body "$(cat <<'EOF'
+Implements the supervision surface from the slice-2 pre-work spec (§4, docs/superpowers/specs/2026-08-01-slice2-prework-control-ipc-design.md): `StatusSubscribe = 16` opens a long-lived connection that receives full `DaemonStatus = 76` snapshots — immediately on subscribe, then debounced re-pushes driven by a monotonic change generation (`DaemonStatusNotifier`, mutation-first/pulse-second via centralized orchestrator helpers). `AgentInstance` gains `RequesterUserId` stamped from the launch command. The hello capability list now advertises `status/1` alongside `consent/1`. Stop reuses the existing `StopV2` frame — no new stop machinery.
+
+No CLI surface changes — this is app-facing IPC only, so no README update is needed.
+
+AI-1649
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Watch CI to green** — poll `gh pr checks` (do NOT rely on `gh pr merge --auto`: only `license/cla` is a required check, so auto-merge fires before build/test/AOT legs finish). Mind the Windows leg.
+
+---
+
+## Self-Review (performed while writing)
+
+- **Spec coverage:** §4.1 frames/wire semantics → Tasks 1, 2, 5, 6; §4.2 notifier + pulse sites + subscriber loop → Tasks 3, 5, 6; §4.3 requester → Task 4; §4.4 stop → no work by design; §5 error handling (nulls-written context, forward compat, shutdown close, extended default-arm message) → Tasks 2, 6, 7; §6 PR-2 test list → Tasks 1, 2, 4, 5, 7 (round-trips; exact JSON incl. order/nulls/active-count consistency; unmapped-member compat; immediate snapshot; convergence ×2 subscribers incl. boundary-mutation regressions; per-mutation re-push; burst coalescing; stress; EOF reap; requester stamping).
+- **Deliberate deviations:** none from the spec. Test-only seams added beyond it: `AfterSnapshotForTest`, `ActiveSubscribersForTest`, settable `Debounce`, `GetAgentForTest` — all internal, all needed to make §6's pinned behaviors deterministic.
+- **Type consistency:** `SnapshotAgentsForStatus() → List<AgentStatusDto>` consumed by `DaemonStatusIpc.Snapshot()`; `WaitBeyondAsync(long, CancellationToken) → Task` consumed by the subscriber loop; helper names (`SetAgentStatus`/`PublishAgent`/`UnpublishAgent`) used identically in Tasks 5 and 7.
+- **Known drift risks for the implementer:** line numbers are approximate — re-grep before editing; TUnit assertion spellings for ordered collections may differ — the pinned *order* is the contract, not the assertion API; the Task 4 fakes must be copied from the existing vendor tests, not invented.

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
@@ -45,7 +45,7 @@ public static class FrameCodec {
     static byte[] Encode(LocalFrame f) => f.Type switch {
         FrameType.Stdin or FrameType.Stdout => f.Bytes,
         FrameType.Resize                    => Dims(f.Cols, f.Rows),
-        FrameType.Detach or FrameType.List  => [],
+        FrameType.Detach or FrameType.List or FrameType.StatusSubscribe => [],
         FrameType.Exited                    => BeInt(f.ExitCode),
         FrameType.Error or FrameType.Attach or FrameType.AgentList
             or FrameType.Restart or FrameType.RestartAck
@@ -54,7 +54,7 @@ public static class FrameCodec {
             or FrameType.ConsentSubscribe or FrameType.ConsentResolve
             or FrameType.ConsentRulesGet or FrameType.ConsentRulesPut
             or FrameType.ConsentPending or FrameType.ConsentRules
-            or FrameType.ConsentAck => Encoding.UTF8.GetBytes(f.Text),
+            or FrameType.ConsentAck or FrameType.DaemonStatus => Encoding.UTF8.GetBytes(f.Text),
         FrameType.Attached or FrameType.Spawn
             or FrameType.StopV2 or FrameType.AttachedReadOnly => f.Bytes, // pre-encoded by the helpers below
         _ => throw new InvalidDataException($"unencodable frame {f.Type}"),
@@ -63,7 +63,7 @@ public static class FrameCodec {
     static LocalFrame Decode(FrameType t, byte[] p) => t switch {
         FrameType.Stdin or FrameType.Stdout => new(t) { Bytes = p },
         FrameType.Resize  => new(t) { Cols = Be16(p, 0), Rows = Be16(p, 2) },
-        FrameType.Detach or FrameType.List => new(t),
+        FrameType.Detach or FrameType.List or FrameType.StatusSubscribe => new(t),
         FrameType.Exited  => new(t) { ExitCode = BinaryPrimitives.ReadInt32BigEndian(p) },
         FrameType.Error or FrameType.Attach or FrameType.AgentList
             or FrameType.Restart or FrameType.RestartAck
@@ -72,7 +72,7 @@ public static class FrameCodec {
             or FrameType.ConsentSubscribe or FrameType.ConsentResolve
             or FrameType.ConsentRulesGet or FrameType.ConsentRulesPut
             or FrameType.ConsentPending or FrameType.ConsentRules
-            or FrameType.ConsentAck => new(t) { Text = Encoding.UTF8.GetString(p) },
+            or FrameType.ConsentAck or FrameType.DaemonStatus => new(t) { Text = Encoding.UTF8.GetString(p) },
         FrameType.Attached or FrameType.Spawn
             or FrameType.StopV2 or FrameType.AttachedReadOnly => new(t) { Bytes = p },
         _ => throw new InvalidDataException($"undecodable frame {t}"),

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
@@ -14,6 +14,7 @@ public enum FrameType : byte {
     Stop    = 8,   // stop an agent (Text = agent id; empty = every agent this daemon hosts)
     StopV2  = 10,  // stop with a force flag (see FrameCodec.StopV2); supersedes Stop
     Hello   = 15,  // optional one-shot: client info (Text = ClientHelloDto JSON; empty valid)
+    StatusSubscribe = 16, // long-lived: push DaemonStatus snapshots (immediate + on change)
     // Consent control frames — values append-only
     ConsentSubscribe = 11, // long-lived: replay pending + push new ConsentPending frames
     ConsentResolve   = 12, // one-shot: resolve a pending request (Text = ConsentResolveDto JSON)
@@ -29,6 +30,7 @@ public enum FrameType : byte {
     StopAck    = 70, // acknowledgement for Stop (Text = one `id\tstatus` line per agent; status is "stopped", "skipped", or "failed")
     AttachedReadOnly = 71, // Attached for a protected agent: id + reason + snapshot, no input accepted
     HelloReply = 75, // Text = HelloReplyDto JSON: protocol/daemon version, name, capabilities
+    DaemonStatus = 76, // Text = DaemonStatusDto JSON: daemon block + full agent list snapshot
     // Consent control frames — values append-only
     ConsentPending = 72, // Text = ConsentPendingDto JSON, pushed on ConsentSubscribe
     ConsentRules   = 73, // Text = ConsentPolicyDto JSON, reply to ConsentRulesGet

--- a/src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs
@@ -31,4 +31,8 @@ public sealed record LocalFrame(FrameType Type) {
     /// Constructs a Hello or HelloReply frame, whose payload is UTF-8 JSON
     /// (snake_case via HelloIpcJsonContext) carried in Text — see HelloIpc.cs.
     public static LocalFrame HelloJson(FrameType type, string json) => new(type) { Text = json };
+
+    /// Constructs a DaemonStatus frame, whose payload is UTF-8 JSON
+    /// (snake_case via StatusIpcJsonContext) carried in Text — see StatusIpc.cs.
+    public static LocalFrame StatusJson(FrameType type, string json) => new(type) { Text = json };
 }

--- a/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// JSON payload for the DaemonStatus frame. snake_case on the wire; shared verbatim by the
+/// daemon, the CLI, and the desktop app. Every field is ALWAYS emitted — absent values are
+/// JSON null, never omitted (one wire shape, exact-JSON testable), so this context must never
+/// gain a DefaultIgnoreCondition. Deserialization ignores unmapped members (STJ default) —
+/// additive fields must never break an older client.
+public sealed record DaemonStatusDto(DaemonInfoDto Daemon, List<AgentStatusDto> Agents);
+
+/// <summary>
+/// <see cref="Connection"/> ∈ connected|connecting|reconnecting|disconnected (lowercase).
+/// <see cref="ActiveAgents"/> is derived from the SAME materialized agents array it ships
+/// with (Status is "Starting" or "Running"), so count and array can never disagree within
+/// one payload.
+/// </summary>
+public sealed record DaemonInfoDto(
+    string Name, string Version, string ServerUrl, string Connection, int MaxAgents, int ActiveAgents);
+
+/// <summary>
+/// <see cref="Status"/> is the daemon's internal status string VERBATIM (PascalCase, open
+/// vocabulary — clients treat unknown values as opaque display text). <see cref="Kind"/>
+/// uses the KindText wire spellings (agent/review/review-flow, unknown enum names pass
+/// through) — one vocabulary across AgentList and this payload. <see cref="Requester"/> is
+/// null when unknown (old servers, local spawns); rendering "unknown" is presentation.
+/// </summary>
+public sealed record AgentStatusDto(
+    string Id, string Kind, string Vendor, string? RepoPath, string Status,
+    string? FlowRunId, string? FlowRole, string? Requester, DateTime CreatedAt, string? Model);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(DaemonStatusDto))]
+public partial class StatusIpcJsonContext : JsonSerializerContext;

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -16,6 +16,10 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Daemon;
 
 public static partial class DaemonRunner {
+    // Reflection-resolved once: the assembly attribute is fixed for the process lifetime, and
+    // DaemonStatusIpc's Snapshot() now calls ResolveDaemonVersion() on every status push.
+    static string? _cachedDaemonVersion;
+
     /// <summary>
     /// Daemon binary version from <c>[AssemblyInformationalVersion]</c>,
     /// baked at build time by MSBuild's git-info integration. Surfaces on
@@ -23,7 +27,7 @@ public static partial class DaemonRunner {
     /// line and <c>DaemonInfo</c> can show "v0.4.11+sha.abc1234".
     /// </summary>
     public static string ResolveDaemonVersion() =>
-        typeof(DaemonRunner).Assembly
+        _cachedDaemonVersion ??= typeof(DaemonRunner).Assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion ?? "unknown";
 

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -242,7 +242,12 @@ public static partial class DaemonRunner {
 
         // The DaemonStatus push: ONE notifier singleton shared by ServerConnection (pulses on hub
         // state transitions) and AgentOrchestrator (pulses on agent mutation) via their optional
-        // ctor params, so a StatusSubscribe waiter sees both kinds of change.
+        // ctor params, so a StatusSubscribe waiter sees both kinds of change. This depends on the
+        // ServerConnection/AgentOrchestrator registrations below/above staying bare AddSingleton<T>()
+        // (no factory delegate) — DI only injects a registered service into an optional trailing
+        // parameter when it resolves the constructor itself. A factory delegate that constructs
+        // either type without passing this notifier would silently sever status pushes with no
+        // failing test; DaemonStatusWiringTests pins this mechanism.
         builder.Services.AddSingleton<DaemonStatusNotifier>();
         builder.Services.AddSingleton<DaemonStatusIpc>();
 

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -240,6 +240,12 @@ public static partial class DaemonRunner {
         // through, so a subscriber connected via ConsentSubscribe sees the gate's own pending requests.
         builder.Services.AddSingleton<LaunchConsentIpc>();
 
+        // The DaemonStatus push: ONE notifier singleton shared by ServerConnection (pulses on hub
+        // state transitions) and AgentOrchestrator (pulses on agent mutation) via their optional
+        // ctor params, so a StatusSubscribe waiter sees both kinds of change.
+        builder.Services.AddSingleton<DaemonStatusNotifier>();
+        builder.Services.AddSingleton<DaemonStatusIpc>();
+
         // Local HTTP bridge that fronts the server's permission flow. Registered as a
         // singleton so AgentOrchestrator can read its bound URL at agent-spawn time, AND
         // as a hosted service so its IHostedService lifecycle starts the listener before

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -47,7 +47,13 @@ internal partial class AgentOrchestrator {
             .ThenBy(a => a.Id, StringComparer.Ordinal)
             .Select(a => new AgentStatusDto(
                 a.Id, KindText(a.Kind), a.Vendor, a.RepoPath, a.Status,
-                a.FlowRunId, a.FlowRole, a.RequesterUserId, a.CreatedAt, a.Model))];
+                a.FlowRunId, a.FlowRole, a.RequesterUserId, a.CreatedAt,
+                // Local spawns store "" for "no model" (HandleLocalSpawnAsync's LauncherContext),
+                // and a server-driven launch with a blank requested model can retain "" too
+                // (ModelSelectionLaunchPolicy.Evaluate treats blank as Honor, i.e. pass-through
+                // unchanged) — but the wire contract pins absent = null. Normalize here, at the
+                // wire boundary, rather than changing what AgentInstance stores.
+                string.IsNullOrWhiteSpace(a.Model) ? null : a.Model))];
 
     /// <summary>
     /// Serves the legacy <c>Stop</c> frame from older clients that predate --force. That frame

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -36,6 +36,20 @@ internal partial class AgentOrchestrator {
     };
 
     /// <summary>
+    /// The supervision payload's agent rows: every entry in _agents (all statuses — same
+    /// visibility as `kcap agent ls`; quarantined-but-removed children are gone from _agents
+    /// already). Order is a wire contract: created_at ascending, id-ordinal tie-break —
+    /// ConcurrentDictionary enumeration order must never leak into the payload.
+    /// </summary>
+    internal List<AgentStatusDto> SnapshotAgentsForStatus() =>
+        [.. _agents.Values
+            .OrderBy(a => a.CreatedAt)
+            .ThenBy(a => a.Id, StringComparer.Ordinal)
+            .Select(a => new AgentStatusDto(
+                a.Id, KindText(a.Kind), a.Vendor, a.RepoPath, a.Status,
+                a.FlowRunId, a.FlowRole, a.RequesterUserId, a.CreatedAt, a.Model))];
+
+    /// <summary>
     /// Serves the legacy <c>Stop</c> frame from older clients that predate --force. That frame
     /// has no force concept, so it always behaves as if --force were passed: an older client
     /// gets exactly its previous (unprotected) behaviour, and gains no new refusals it has no
@@ -182,7 +196,7 @@ internal partial class AgentOrchestrator {
                 CurrentCols    = cols,
                 CurrentRows    = rows
             };
-            _agents[agentId] = agent;
+            PublishAgent(agent);
         } catch (Exception ex) {
             // Don't leak a daemon-created worktree if Prepare / passthrough-arg building /
             // spawn fails after the worktree was created (mirrors the server launch path).

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -213,6 +213,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // registered singleton when one exists) keep compiling unchanged.
     readonly DaemonStatusNotifier _statusNotifier;
 
+    /// <summary>Test seam: exposes which notifier this orchestrator actually pulses into, so a DI
+    /// wiring test can pin that the registered singleton — not a private fallback nobody
+    /// subscribes to — is the one every agent mutation reaches (see DaemonStatusWiringTests).</summary>
+    internal DaemonStatusNotifier StatusNotifierForTest => _statusNotifier;
+
     // Phase B (D4): durable PID records + this daemon's logical identity/epoch for
     // crash-survivor reaping. Initialized in the ctor from config.
     AgentPidRecordStore? _pidRecords;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -45,6 +45,10 @@ internal record AgentInstance(
     public string?              FlowRunId         { get; init; }
     public string?              FlowRole          { get; init; }
 
+    /// <summary>Who asked for this launch (server-stamped requester user id). Null for old
+    /// servers and local spawns — the supervision payload renders null as unknown.</summary>
+    public string?              RequesterUserId   { get; init; }
+
     /// <summary>The applied Codex sandbox/approval pair — the values actually passed to the vendor
     /// CLI, whether caller-selected or derived. Set only for an interactive Codex launch on a
     /// daemon-owned worktree; null everywhere else. Stored HERE (not recomputed at each send) so the
@@ -958,14 +962,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             string id, LaunchKind kind = LaunchKind.Default, string status = "Running",
             string? flowRunId = null, string? flowRole = null,
             DateTime? createdAt = null, DateTime? lastOutputAt = null, bool isPrivate = false,
-            IPtyProcess? pty = null, string? startIdentity = null) {
+            IPtyProcess? pty = null, string? startIdentity = null, string? requester = null) {
         var agent = new AgentInstance(
             id, null, "default", null, "/repo", "codex",
             new PtyHostedAgentRuntime("codex", pty ?? NoopPtyProcess.Instance),
             new WorktreeInfo("/repo", "b", "/repo"),
             new CancellationTokenSource()) {
             Kind = kind, FlowRunId = flowRunId, FlowRole = flowRole, IsPrivate = isPrivate,
-            CreatedAt = createdAt ?? DateTime.UtcNow, StartIdentity = startIdentity
+            CreatedAt = createdAt ?? DateTime.UtcNow, StartIdentity = startIdentity,
+            RequesterUserId = requester
         };
         agent.Status = status;
         if (lastOutputAt is { } lo) agent.LastOutputAt = lo;
@@ -1474,7 +1479,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 BorrowedSnapshotSource = borrowedSnapshotSource,
                 Kind                = cmd.Kind,       // Phase B (D2): flow identity + kind for LiveAgents/status report
                 FlowRunId           = cmd.FlowRunId,
-                FlowRole            = cmd.FlowRole
+                FlowRole            = cmd.FlowRole,
+                RequesterUserId     = cmd.RequesterUserId
             };
             _agents[agentId] = agent;
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -996,9 +996,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             string id, LaunchKind kind = LaunchKind.Default, string status = "Running",
             string? flowRunId = null, string? flowRole = null,
             DateTime? createdAt = null, DateTime? lastOutputAt = null, bool isPrivate = false,
-            IPtyProcess? pty = null, string? startIdentity = null, string? requester = null) {
+            IPtyProcess? pty = null, string? startIdentity = null, string? requester = null,
+            string? model = "default") {
         var agent = new AgentInstance(
-            id, null, "default", null, "/repo", "codex",
+            id, null, model, null, "/repo", "codex",
             new PtyHostedAgentRuntime("codex", pty ?? NoopPtyProcess.Instance),
             new WorktreeInfo("/repo", "b", "/repo"),
             new CancellationTokenSource()) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -208,6 +208,11 @@ public class TerminalOutputBuffer {
 internal partial class AgentOrchestrator : IAsyncDisposable {
     readonly ConcurrentDictionary<string, AgentInstance>       _agents = new();
 
+    // The change-generation counter behind the DaemonStatus push. Optional ctor param so the
+    // existing direct-construction sites (and DI, which resolves an optional parameter to a
+    // registered singleton when one exists) keep compiling unchanged.
+    readonly DaemonStatusNotifier _statusNotifier;
+
     // Phase B (D4): durable PID records + this daemon's logical identity/epoch for
     // crash-survivor reaping. Initialized in the ctor from config.
     AgentPidRecordStore? _pidRecords;
@@ -384,7 +389,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // pre-settlement inline arm and the publication barrier explicitly (see
             // PublishSequencedProcessorForTest). Production ALWAYS publishes here, before any handler is
             // wired, so the null window this exposes never exists in a running daemon.
-            bool                                              deferProcessorPublication = false
+            bool                                              deferProcessorPublication = false,
+            // Null in every pre-existing construction site — those daemons just get a private
+            // notifier nobody subscribes to. DaemonRunner passes the DI-registered singleton so a
+            // StatusSubscribe waiter sees every mutation this orchestrator makes.
+            DaemonStatusNotifier?                             statusNotifier = null
         ) {
         _shutdownCts       = CancellationTokenSource.CreateLinkedTokenSource(lifetime.ApplicationStopping);
         _config            = config;
@@ -398,6 +407,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _runtimeFactories  = runtimeFactories;
         _logger            = logger;
         _consentGate       = consentGate;
+        _statusNotifier    = statusNotifier ?? new();
 
         // Phase B (D4): per-daemon PID-record store + this daemon's logical id + boot epoch.
         // Records live under "{stateDir}/{name}/agents" so they are unambiguously THIS daemon's own
@@ -570,6 +580,25 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     }
 
     internal int ActiveCount => _agents.Count(a => a.Value.Status is "Starting" or "Running");
+
+    /// Mutation FIRST, Pulse() second — always (a pulse published before its mutation lets a
+    /// subscriber read the new version, snapshot the OLD state, and wait forever). These
+    /// helpers are the only writers of agent status and registry membership, so the ordering
+    /// cannot be forgotten at a call site.
+    internal void SetAgentStatus(AgentInstance agent, string status) {
+        agent.Status = status;
+        _statusNotifier.Pulse();
+    }
+
+    internal void PublishAgent(AgentInstance agent) {
+        _agents[agent.Id] = agent;
+        _statusNotifier.Pulse();
+    }
+
+    internal void UnpublishAgent(string agentId) {
+        _agents.TryRemove(agentId, out _);
+        _statusNotifier.Pulse();
+    }
 
     /// <summary>Phase B (D3): clock seam so the reviewer-TTL heartbeat check is testable with a
     /// fixed time. Production uses the real UTC clock.</summary>
@@ -974,7 +1003,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         };
         agent.Status = status;
         if (lastOutputAt is { } lo) agent.LastOutputAt = lo;
-        _agents[id] = agent;
+        PublishAgent(agent);
         return agent;
     }
 
@@ -1482,7 +1511,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 FlowRole            = cmd.FlowRole,
                 RequesterUserId     = cmd.RequesterUserId
             };
-            _agents[agentId] = agent;
+            PublishAgent(agent);
 
             // Phase B (D4 §6.4(2)): capture the start-identity + write the durable PID record
             // immediately after the process exists (before registration) so a daemon crash right after
@@ -1501,7 +1530,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // runtimes are unaffected — they keep the existing on-first-chunk flip in
             // ReadAgentOutputAsync unchanged.
             if (!runtime.EmitsTerminalOutput) {
-                agent.Status            = "Running";
+                SetAgentStatus(agent, "Running");
                 agent.HasReceivedOutput = true;
                 if (!agent.IsPrivate) _ = _server.AgentStatusChangedAsync(agent.Id, "Running", agent.SessionId);
             }
@@ -1753,7 +1782,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 agent.HasReceivedOutput = true;
 
                 if (agent.Status == "Starting") {
-                    agent.Status = "Running";
+                    SetAgentStatus(agent, "Running");
                     if (!agent.IsPrivate) _ = _server.AgentStatusChangedAsync(agent.Id, "Running", agent.SessionId);
                 }
 
@@ -1835,7 +1864,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // Capture the banner before termination/cleanup discards the buffer.
         PersistFailedLaunchLog(agent, reason);
 
-        agent.Status           = "Failed";
+        SetAgentStatus(agent, "Failed");
         agent.PendingEndReason = "consent_dialog_wedge";
 
         if (!agent.IsPrivate) {
@@ -1914,7 +1943,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     if (!agent.IsPrivate) _ = _server.LaunchFailedAsync(agent.Id, reason);
                 }
 
-                agent.Status = status;
+                SetAgentStatus(agent, status);
 
                 // PrivateLocal agents make no per-agent server calls (deny-all).
                 if (!agent.IsPrivate) {
@@ -2105,7 +2134,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             // Set status BEFORE cancelling ReadCts so the read loop's finally
             // block sees "Completed" and skips its own status change / event append.
-            agent.Status = "Completed";
+            SetAgentStatus(agent, "Completed");
             // Mark this as a user-initiated stop so the read-loop's finally-block
             // EndAgentSessionAsync call uses "agent_stopped" if it ends up being
             // the only successful call (e.g., transient SignalR failure here).
@@ -3061,7 +3090,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         // Now drop the agent from the live registry — after a surviving child is already in quarantine,
         // so a concurrent launch never sees EffectiveCount transiently under-count this agent.
-        _agents.TryRemove(agentId, out _);
+        UnpublishAgent(agentId);
 
         // Skip server unregister during shutdown — _ct is cancelled and the call
         // would throw TaskCanceledException. The server detects the daemon
@@ -3344,7 +3373,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal FailedLaunchLog? FailedLaunchLogForTest => _failedLaunchLog;
 
     /// <summary>Test-only: register a pre-built agent so cleanup/lifecycle can be driven directly.</summary>
-    internal void RegisterAgentForTest(AgentInstance agent) => _agents[agent.Id] = agent;
+    internal void RegisterAgentForTest(AgentInstance agent) => PublishAgent(agent);
 
     /// <summary>Test-only: look up a tracked agent by id (null if absent), so a launch test can
     /// assert the resolved <see cref="AgentInstance.Work"/> / <see cref="AgentInstance.Worktree"/>.</summary>

--- a/src/Capacitor.Cli.Daemon/Services/DaemonStatusIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/DaemonStatusIpc.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using Capacitor.Cli.Core.LocalIpc;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// Local-socket handler for StatusSubscribe: one full DaemonStatusDto snapshot immediately,
+/// then a debounced re-push whenever the change generation advances past this connection's
+/// cursor. Full snapshots + per-connection cursors mean a missed pulse can never desync a
+/// client, and a slow subscriber delays only itself. Trust model: same 0600-socket owner
+/// trust as every other local frame.
+internal sealed class DaemonStatusIpc(
+    DaemonConfig config, AgentOrchestrator orchestrator, ServerConnection connection,
+    DaemonStatusNotifier notifier) {
+
+    /// Coalesces a pulse burst into one trailing snapshot. A tuning constant, not a wire
+    /// contract; tests shrink it.
+    internal TimeSpan Debounce { get; set; } = TimeSpan.FromMilliseconds(250);
+
+    int _subscribers;
+    internal int ActiveSubscribersForTest => Volatile.Read(ref _subscribers);
+
+    /// Test seam: runs between materializing a snapshot and pushing it, so a test can land a
+    /// mutation exactly at the cursor/snapshot boundary deterministically.
+    internal Action? AfterSnapshotForTest { get; set; }
+
+    public async Task HandleSubscribeAsync(Stream stream, CancellationToken ct) {
+        Interlocked.Increment(ref _subscribers);
+        try {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            // EOF watcher: a vanished subscriber must be reaped promptly (same discipline as
+            // ConsentSubscribe), or the daemon would keep serializing snapshots for nobody.
+            _ = Task.Run(async () => {
+                try { while (await FrameCodec.ReadAsync(stream, cts.Token) is not null) { } }
+                catch { }
+                try { cts.Cancel(); } catch (ObjectDisposedException) { }
+            }, cts.Token);
+
+            while (true) {
+                var seen = notifier.Version; // cursor BEFORE snapshotting: a mutation during
+                var json = Snapshot();       // the snapshot/push advances Version past `seen`
+                AfterSnapshotForTest?.Invoke();
+                await FrameCodec.WriteAsync(stream, LocalFrame.StatusJson(FrameType.DaemonStatus, json), cts.Token);
+                await notifier.WaitBeyondAsync(seen, cts.Token);
+                await Task.Delay(Debounce, cts.Token);
+            }
+        } catch (OperationCanceledException) {
+            // subscriber EOF or daemon shutdown — either way the connection just closes
+        } finally {
+            Interlocked.Decrement(ref _subscribers);
+        }
+    }
+
+    string Snapshot() {
+        var agents = orchestrator.SnapshotAgentsForStatus();
+        // Same predicate as the orchestrator's ActiveCount, applied to the SAME materialized
+        // array — the count and the array can never disagree within one payload.
+        var active = agents.Count(a => a.Status is "Starting" or "Running");
+        var dto = new DaemonStatusDto(
+            new DaemonInfoDto(
+                config.Name, DaemonRunner.ResolveDaemonVersion(), config.ServerUrl,
+                ConnectionText(connection.HubState), config.MaxConcurrentAgents, active),
+            agents);
+        return JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.DaemonStatusDto);
+    }
+
+    static string ConnectionText(HubConnectionState s) => s switch {
+        HubConnectionState.Connected    => "connected",
+        HubConnectionState.Connecting   => "connecting",
+        HubConnectionState.Reconnecting => "reconnecting",
+        _                               => "disconnected",
+    };
+}

--- a/src/Capacitor.Cli.Daemon/Services/DaemonStatusIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/DaemonStatusIpc.cs
@@ -64,7 +64,10 @@ internal sealed class DaemonStatusIpc(
         return JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.DaemonStatusDto);
     }
 
-    static string ConnectionText(HubConnectionState s) => s switch {
+    /// Wire spelling of <see cref="HubConnectionState"/>. Internal (not private) so
+    /// <c>DaemonStatusIpcTests</c> can pin all four spellings directly — a pure static switch is
+    /// smaller to test this way than standing up a HubState test double through the full snapshot.
+    internal static string ConnectionText(HubConnectionState s) => s switch {
         HubConnectionState.Connected    => "connected",
         HubConnectionState.Connecting   => "connecting",
         HubConnectionState.Reconnecting => "reconnecting",

--- a/src/Capacitor.Cli.Daemon/Services/DaemonStatusIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/DaemonStatusIpc.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using System.Text.Json;
 using Capacitor.Cli.Core.LocalIpc;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -46,6 +47,14 @@ internal sealed class DaemonStatusIpc(
             }
         } catch (OperationCanceledException) {
             // subscriber EOF or daemon shutdown — either way the connection just closes
+        } catch (IOException) {
+            // A vanished subscriber is normal lifecycle for a long-lived subscription, not a
+            // fault: FrameCodec.WriteAsync throws IOException (EndOfStreamException included —
+            // it derives from IOException) when the client disconnects mid-push. Absorb it here
+            // so LocalControlServer's generic catch doesn't log a routine disconnect at Warning.
+        } catch (SocketException) {
+            // Same as above, for the underlying transport signaling the disconnect instead of
+            // the stream wrapper.
         } finally {
             Interlocked.Decrement(ref _subscribers);
         }

--- a/src/Capacitor.Cli.Daemon/Services/DaemonStatusNotifier.cs
+++ b/src/Capacitor.Cli.Daemon/Services/DaemonStatusNotifier.cs
@@ -1,0 +1,42 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Monotonic change generation behind DaemonStatus pushes. Version and the shared rearm
+/// source live under ONE lock: Pulse() increments and completes-and-rearms in the same
+/// critical section; WaitBeyondAsync reads Version and captures the current source in that
+/// same critical section — no torn interleaving between the check and the capture. This is
+/// a broadcast: N subscribers each hold their own cursor (the `seen` they pass in) and can
+/// never consume each other's signal. Call sites must mutate state FIRST and Pulse() second,
+/// or a subscriber could snapshot old state at the new version and then wait forever.
+/// </summary>
+internal sealed class DaemonStatusNotifier {
+    readonly Lock _lock = new();
+    long _version;
+    // RunContinuationsAsynchronously: completed under _lock — a waiter's continuation must
+    // not run inline while the lock is held.
+    TaskCompletionSource _next = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public long Version {
+        get { lock (_lock) return _version; }
+    }
+
+    public void Pulse() {
+        lock (_lock) {
+            _version++;
+            var done = _next;
+            _next = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            done.TrySetResult();
+        }
+    }
+
+    public Task WaitBeyondAsync(long seen, CancellationToken ct) {
+        TaskCompletionSource wait;
+        lock (_lock) {
+            if (_version > seen) return Task.CompletedTask;
+            wait = _next;
+        }
+        // A timeout/cancellation here only stops THIS waiter's wait — the shared source is
+        // never completed or replaced by a consumer.
+        return wait.Task.WaitAsync(ct);
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/LocalControlCapabilities.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalControlCapabilities.cs
@@ -5,9 +5,10 @@ namespace Capacitor.Cli.Daemon.Services;
 /// INVARIANT: an entry may exist here ONLY if <see cref="LocalControlServer"/> actually
 /// routes the corresponding frame(s) to a real handler — this list is assembled right next
 /// to that routing switch so a capability can never be advertised without behavior behind
-/// it. A later change appends <c>"status/1"</c> once <see cref="LocalControlServer"/> gains
-/// a <c>StatusSubscribe</c> handler; until then it must not appear here.
+/// it. Both entries' handlers are live in this build: <c>"consent/1"</c> routes
+/// ConsentSubscribe/ConsentResolve/ConsentRulesGet/ConsentRulesPut to <see cref="LaunchConsentIpc"/>,
+/// and <c>"status/1"</c> routes StatusSubscribe to <see cref="DaemonStatusIpc"/>.
 /// </summary>
 internal static class LocalControlCapabilities {
-    public static readonly IReadOnlyList<string> Current = ["consent/1"];
+    public static readonly IReadOnlyList<string> Current = ["consent/1", "status/1"];
 }

--- a/src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs
@@ -12,7 +12,7 @@ namespace Capacitor.Cli.Daemon.Services;
 /// the same trust boundary as the daemon PID/lock files.
 internal sealed partial class LocalControlServer(
         DaemonConfig config, AgentOrchestrator orchestrator, RestartCoordinator restart,
-        LaunchConsentIpc consentIpc, ILogger<LocalControlServer> logger
+        LaunchConsentIpc consentIpc, DaemonStatusIpc statusIpc, ILogger<LocalControlServer> logger
     ) : BackgroundService {
     protected override async Task ExecuteAsync(CancellationToken ct) {
         var path = LocalSocketPaths.Socket(config.Name);
@@ -57,7 +57,8 @@ internal sealed partial class LocalControlServer(
                 case FrameType.ConsentRulesGet:  await consentIpc.HandleRulesGetAsync(stream, ct); break;
                 case FrameType.ConsentRulesPut:  await consentIpc.HandleRulesPutAsync(first.Text, stream, ct); break;
                 case FrameType.Hello: await HandleHelloAsync(first.Text, stream, ct); break;
-                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List/Stop/StopV2/Restart/ConsentSubscribe/ConsentResolve/ConsentRulesGet/ConsentRulesPut/Hello, got {first.Type}"), ct); break;
+                case FrameType.StatusSubscribe: await statusIpc.HandleSubscribeAsync(stream, ct); break;
+                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List/Stop/StopV2/Restart/ConsentSubscribe/ConsentResolve/ConsentRulesGet/ConsentRulesPut/Hello/StatusSubscribe, got {first.Type}"), ct); break;
             }
         } catch (Exception ex) when (ex is not OperationCanceledException) {
             LogConnectionError(ex);

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -462,6 +462,10 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                     if (HubState == HubConnectionState.Disconnected) {
                         LogConnecting(_config.ServerUrl);
                         await StartHubAsync(ct);
+                        // Hub is now Connected (pre-registration) — pulse so a subscriber that
+                        // snapshotted while still "connecting" converges without waiting for
+                        // RegisterDaemonAsync too.
+                        _statusNotifier.Pulse();
                     }
 
                     await RegisterDaemonAsync();
@@ -483,6 +487,10 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 } catch (Exception ex) {
                     var delay = ConnectRetryDelays[Math.Min(attempt, ConnectRetryDelays.Length - 1)];
                     LogConnectionAttemptFailed(ex, attempt + 1, delay.TotalSeconds);
+                    // The failed attempt has returned the hub to Disconnected — pulse so a
+                    // subscriber converges to "disconnected" during the backoff instead of a
+                    // stale "connecting" (Codex P2: initial-start failures never fired a pulse).
+                    _statusNotifier.Pulse();
                     await Task.Delay(delay, ct);
                     attempt++;
                 }

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -22,6 +22,12 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     readonly PendingPermissionRegistry _pendingPermissions  = new();
     readonly PendingAcpInteractionRegistry _pendingAcpInteractions = new();
 
+    // The change-generation counter behind the DaemonStatus push. Optional ctor param so the
+    // existing direct-construction sites (and DI, which resolves an optional parameter to a
+    // registered singleton when one exists) keep compiling unchanged; several test files
+    // subclass ServerConnection calling the 3-arg base, which the trailing default preserves.
+    readonly DaemonStatusNotifier _statusNotifier;
+
     /// <summary>
     /// Every currently-active ACP session↔agent binding this daemon owns, keyed by agentId.
     /// Populated by <see cref="RegisterAcpBinding"/> (right after the initial
@@ -167,9 +173,12 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         catch (Exception ex) { _logger.LogDebug(ex, "CommandRejected send failed (old server or transient)"); }
     }
 
-    public ServerConnection(DaemonConfig config, ILoggerFactory loggerFactory, ILogger<ServerConnection> logger) {
-        _config = config;
-        _logger = logger;
+    public ServerConnection(
+            DaemonConfig config, ILoggerFactory loggerFactory, ILogger<ServerConnection> logger,
+            DaemonStatusNotifier? statusNotifier = null) {
+        _config          = config;
+        _logger          = logger;
+        _statusNotifier  = statusNotifier ?? new();
 
         _hub = new HubConnectionBuilder()
             .WithUrl(
@@ -453,6 +462,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                     await RegisterDaemonAsync();
                     _connectedTimestamp = Stopwatch.GetTimestamp();
                     LogConnected(_config.Name);
+                    _statusNotifier.Pulse();
 
                     return;
                 } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
@@ -480,6 +490,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     }
 
     async Task OnClosed(Exception? ex) {
+        _statusNotifier.Pulse();
         _gate.MarkUnregistered();
 
         if (_disposed || _ct.IsCancellationRequested) {
@@ -648,6 +659,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// </summary>
     Task OnReconnecting(Exception? error) {
         _gate.MarkUnregistered();
+        _statusNotifier.Pulse();
 
         return Task.CompletedTask;
     }
@@ -667,6 +679,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     internal virtual string? CurrentConnectionId => _hub.ConnectionId;
 
     async Task OnReconnected(string? connectionId) {
+        _statusNotifier.Pulse();
         LogReconnected();
         await RegisterDaemonAsync();
         _connectedTimestamp = Stopwatch.GetTimestamp();

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -28,6 +28,11 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     // subclass ServerConnection calling the 3-arg base, which the trailing default preserves.
     readonly DaemonStatusNotifier _statusNotifier;
 
+    /// <summary>Test seam: exposes which notifier this connection actually pulses into, so a DI
+    /// wiring test can pin that the registered singleton — not a private fallback nobody
+    /// subscribes to — is the one every hub-state pulse reaches (see DaemonStatusWiringTests).</summary>
+    internal DaemonStatusNotifier StatusNotifierForTest => _statusNotifier;
+
     /// <summary>
     /// Every currently-active ACP session↔agent binding this daemon owns, keyed by agentId.
     /// Populated by <see cref="RegisterAcpBinding"/> (right after the initial

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -30,11 +30,12 @@ public partial class AgentOrchestratorVendorTests {
             NullLogger<LaunchConsentIpc>.Instance);
     }
 
-    // Status: a throwaway connection + notifier — these pre-existing LocalControlServer tests
-    // don't exercise StatusSubscribe at all, so the wiring only needs to satisfy the ctor.
-    static DaemonStatusIpc TestStatusIpc(DaemonConfig config, AgentOrchestrator orch) =>
-        new(config, orch, new ServerConnection(config, NullLoggerFactory.Instance, NullLogger<ServerConnection>.Instance),
-            new DaemonStatusNotifier());
+    // Status: reuses the caller's own ServerConnection (already passed to BuildOrchestrator, and
+    // already the caller's to dispose) rather than minting a second one this helper couldn't hand
+    // back for disposal — these pre-existing LocalControlServer tests don't exercise StatusSubscribe
+    // at all, so the wiring only needs to satisfy the ctor.
+    static DaemonStatusIpc TestStatusIpc(DaemonConfig config, AgentOrchestrator orch, ServerConnection connection) =>
+        new(config, orch, connection, new DaemonStatusNotifier());
 
     static DaemonConfig LauncherCfg() => new() { Name = "t", ServerUrl = "http://127.0.0.1:1" };
 
@@ -537,7 +538,8 @@ public partial class AgentOrchestratorVendorTests {
         AgentOrchestrator?  orch     = null;
 
         try {
-            orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+            var server = new CaptureServerConnection();
+            orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
             orch.RegisterAgentForTest(new AgentInstance(
                 "agent-xyz", null, "", null, "/tmp/repo", "claude",
                 new PtyHostedAgentRuntime("claude", new StubPtyProcess()), new WorktreeInfo("/tmp/repo", "", "/tmp/repo"), new CancellationTokenSource()
@@ -546,7 +548,7 @@ public partial class AgentOrchestratorVendorTests {
             });
 
             var config = new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" };
-            listener = new LocalControlServer(config, orch, TestCoordinator(), TestConsentIpc(), TestStatusIpc(config, orch), NullLogger<LocalControlServer>.Instance);
+            listener = new LocalControlServer(config, orch, TestCoordinator(), TestConsentIpc(), TestStatusIpc(config, orch, server), NullLogger<LocalControlServer>.Instance);
             await listener.StartAsync(cts.Token);
 
             var sockPath = LocalSocketPaths.Socket("test");
@@ -587,11 +589,12 @@ public partial class AgentOrchestratorVendorTests {
         AgentOrchestrator?  orch     = null;
 
         try {
-            orch = BuildOrchestrator(new TripwireServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+            var server = new TripwireServerConnection();
+            orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
             orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
 
             var config = new DaemonConfig { Name = daemonName, ServerUrl = "http://127.0.0.1:1" };
-            listener = new LocalControlServer(config, orch, TestCoordinator(), TestConsentIpc(), TestStatusIpc(config, orch), NullLogger<LocalControlServer>.Instance);
+            listener = new LocalControlServer(config, orch, TestCoordinator(), TestConsentIpc(), TestStatusIpc(config, orch, server), NullLogger<LocalControlServer>.Instance);
             await listener.StartAsync(cts.Token);
 
             var sockPath = LocalSocketPaths.Socket(daemonName);

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -30,6 +30,12 @@ public partial class AgentOrchestratorVendorTests {
             NullLogger<LaunchConsentIpc>.Instance);
     }
 
+    // Status: a throwaway connection + notifier — these pre-existing LocalControlServer tests
+    // don't exercise StatusSubscribe at all, so the wiring only needs to satisfy the ctor.
+    static DaemonStatusIpc TestStatusIpc(DaemonConfig config, AgentOrchestrator orch) =>
+        new(config, orch, new ServerConnection(config, NullLoggerFactory.Instance, NullLogger<ServerConnection>.Instance),
+            new DaemonStatusNotifier());
+
     static DaemonConfig LauncherCfg() => new() { Name = "t", ServerUrl = "http://127.0.0.1:1" };
 
     static LauncherContext CtxFor(string path)
@@ -540,7 +546,7 @@ public partial class AgentOrchestratorVendorTests {
             });
 
             var config = new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" };
-            listener = new LocalControlServer(config, orch, TestCoordinator(), TestConsentIpc(), NullLogger<LocalControlServer>.Instance);
+            listener = new LocalControlServer(config, orch, TestCoordinator(), TestConsentIpc(), TestStatusIpc(config, orch), NullLogger<LocalControlServer>.Instance);
             await listener.StartAsync(cts.Token);
 
             var sockPath = LocalSocketPaths.Socket("test");
@@ -585,7 +591,7 @@ public partial class AgentOrchestratorVendorTests {
             orch.SeedAgentForTest("flow-1", kind: LaunchKind.ReviewFlow, flowRunId: "flow-7f3a", flowRole: "reviewer");
 
             var config = new DaemonConfig { Name = daemonName, ServerUrl = "http://127.0.0.1:1" };
-            listener = new LocalControlServer(config, orch, TestCoordinator(), TestConsentIpc(), NullLogger<LocalControlServer>.Instance);
+            listener = new LocalControlServer(config, orch, TestCoordinator(), TestConsentIpc(), TestStatusIpc(config, orch), NullLogger<LocalControlServer>.Instance);
             await listener.StartAsync(cts.Token);
 
             var sockPath = LocalSocketPaths.Socket(daemonName);

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorRequesterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorRequesterTests.cs
@@ -1,0 +1,96 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Requester stamping (spec §4.3): AgentInstance.RequesterUserId is captured from
+/// LaunchAgentCommand at construction — non-null when a new server sends it, null for
+/// old servers (field absent) — so the supervision payload can show who asked.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Launch_stamps_RequesterUserId_from_the_command() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new SpyPtyProcessFactory();
+            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude");
+
+            var launchers = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+
+            var cmd = new LaunchAgentCommand(
+                AgentId: "req-1",
+                Prompt: "p",
+                Model: "default",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "claude",
+                RequesterUserId: "github:12345"
+            );
+
+            await orch.HandleLaunchAgentForTest(cmd);
+
+            await Assert.That(orch.GetAgentForTest("req-1")!.RequesterUserId).IsEqualTo("github:12345");
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test]
+    public async Task Launch_without_a_requester_leaves_RequesterUserId_null() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server     = new CaptureServerConnection();
+            var ptyFactory = new SpyPtyProcessFactory();
+            var claudeSpy  = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude");
+
+            var launchers = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = claudeSpy };
+
+            await using var orch = BuildOrchestrator(server, ptyFactory, launchers, allowedRepoPath: repoPath);
+
+            var cmd = new LaunchAgentCommand(
+                AgentId: "req-2",
+                Prompt: "p",
+                Model: "default",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "claude"
+            );
+
+            await orch.HandleLaunchAgentForTest(cmd);
+
+            await Assert.That(orch.GetAgentForTest("req-2")!.RequesterUserId).IsNull();
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test]
+    public async Task SeedAgentForTest_with_no_requester_stamps_null() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = orch.SeedAgentForTest("seed-1");
+
+        await Assert.That(agent.RequesterUserId).IsNull();
+    }
+
+    [Test]
+    public async Task SeedAgentForTest_stamps_the_given_requester() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = orch.SeedAgentForTest("seed-2", requester: "github:99");
+
+        await Assert.That(agent.RequesterUserId).IsEqualTo("github:99");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
@@ -35,18 +35,34 @@ public class AgentStatusSnapshotTests {
         public HttpClient CreateClient(string name) => new();
     }
 
-    static (AgentOrchestrator Orchestrator, DaemonStatusNotifier Notifier) Build() {
+    /// <summary>Bundles the orchestrator with the two temp directories <see cref="Build"/> creates,
+    /// so callers can delete them once done — <see cref="Directory.CreateTempSubdirectory"/> leaves
+    /// its directory on disk until something explicitly removes it.</summary>
+    sealed record Fixture(AgentOrchestrator Orchestrator, DaemonStatusNotifier Notifier, string StateDir, string WorktreeRoot) {
+        public async Task CleanupAsync() {
+            await Orchestrator.DisposeAsync();
+            try { Directory.Delete(StateDir, true); } catch { /* best-effort */ }
+            // Never actually created by these tests (no PTY spawn touches it), but delete
+            // defensively in case a future test starts using it.
+            if (Directory.Exists(WorktreeRoot)) {
+                try { Directory.Delete(WorktreeRoot, true); } catch { /* best-effort */ }
+            }
+        }
+    }
+
+    static Fixture Build() {
         var stateDir = Directory.CreateTempSubdirectory("kcap-status-snapshot-state-").FullName;
         var store       = new LaunchConsentStore(stateDir, NullLogger.Instance);
         var broker      = new LaunchConsentBroker();
         var decisionLog = new LaunchConsentDecisionLog(stateDir, NullLogger.Instance);
         var gate        = new LaunchConsentGate(store, decisionLog, broker, TimeProvider.System, NullLogger<LaunchConsentGate>.Instance);
+        var worktreeRoot = Path.Combine(Path.GetTempPath(), "kcap-status-snapshot-wt-" + Guid.NewGuid().ToString("N")[..8]);
 
         var config = new DaemonConfig {
             Name         = "status-snapshot-test",
             ServerUrl    = "http://127.0.0.1:1",
             StateDir     = stateDir,
-            WorktreeRoot = Path.Combine(Path.GetTempPath(), "kcap-status-snapshot-wt-" + Guid.NewGuid().ToString("N")[..8]),
+            WorktreeRoot = worktreeRoot,
         };
 
         var connection       = new ServerConnection(config, NullLoggerFactory.Instance, NullLogger<ServerConnection>.Instance);
@@ -61,12 +77,13 @@ public class AgentStatusSnapshotTests {
             new Dictionary<string, IHostedAgentRuntimeFactory>(), new NoopHostLifetime(),
             NullLogger<AgentOrchestrator>.Instance, gate, statusNotifier: notifier);
 
-        return (orchestrator, notifier);
+        return new Fixture(orchestrator, notifier, stateDir, worktreeRoot);
     }
 
     [Test]
     public async Task Snapshot_orders_by_created_at_then_id_ordinal_and_includes_all_statuses() {
-        var (orch, _) = Build();
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
         try {
             var t0 = new DateTime(2026, 8, 1, 10, 0, 0, DateTimeKind.Utc);
             orch.SeedAgentForTest("b-second", status: "Quarantined", createdAt: t0.AddMinutes(1));
@@ -81,13 +98,14 @@ public class AgentStatusSnapshotTests {
             await Assert.That(agents.Select(a => a.Status)).IsEquivalentTo(
                 new[] { "Starting", "Completed", "Quarantined" }, CollectionOrdering.Matching);
         } finally {
-            await orch.DisposeAsync();
+            await fixture.CleanupAsync();
         }
     }
 
     [Test]
     public async Task Snapshot_maps_kind_spellings_requester_and_nullables() {
-        var (orch, _) = Build();
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
         try {
             var createdAt = new DateTime(2026, 8, 1, 12, 30, 0, DateTimeKind.Utc);
             orch.SeedAgentForTest("r1", kind: LaunchKind.ReviewFlow, flowRunId: "flow_1",
@@ -110,13 +128,15 @@ public class AgentStatusSnapshotTests {
             await Assert.That(byId["d1"].Requester).IsNull();
             await Assert.That(byId["d1"].FlowRunId).IsNull();
         } finally {
-            await orch.DisposeAsync();
+            await fixture.CleanupAsync();
         }
     }
 
     [Test]
     public async Task Publish_status_change_and_unpublish_each_advance_the_generation() {
-        var (orch, notifier) = Build();
+        var fixture = Build();
+        var orch     = fixture.Orchestrator;
+        var notifier = fixture.Notifier;
         try {
             var v0 = notifier.Version;
             var agent = orch.SeedAgentForTest("gen-1"); // registers via PublishAgent
@@ -131,7 +151,7 @@ public class AgentStatusSnapshotTests {
             await Assert.That(notifier.Version).IsGreaterThan(v2);
             await Assert.That(orch.SnapshotAgentsForStatus()).IsEmpty();
         } finally {
-            await orch.DisposeAsync();
+            await fixture.CleanupAsync();
         }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
@@ -132,6 +132,28 @@ public class AgentStatusSnapshotTests {
         }
     }
 
+    /// <summary>AI-1649 review finding: a blank/whitespace <c>Model</c> is the orchestrator's
+    /// "no model" sentinel (local spawns store "" verbatim; see
+    /// <c>AgentOrchestrator.HandleLocalSpawnAsync</c>), but the wire contract represents an
+    /// absent model as JSON <c>null</c>. The snapshot mapping must normalize at the wire
+    /// boundary rather than leak the sentinel.</summary>
+    [Test]
+    public async Task Snapshot_normalizes_blank_model_to_null_and_passes_real_model_verbatim() {
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
+        try {
+            orch.SeedAgentForTest("blank-model", model: "");
+            orch.SeedAgentForTest("real-model",  model: "gpt-5-codex");
+
+            var byId = orch.SnapshotAgentsForStatus().ToDictionary(a => a.Id);
+
+            await Assert.That(byId["blank-model"].Model).IsNull();
+            await Assert.That(byId["real-model"].Model).IsEqualTo("gpt-5-codex");
+        } finally {
+            await fixture.CleanupAsync();
+        }
+    }
+
     [Test]
     public async Task Publish_status_change_and_unpublish_each_advance_the_generation() {
         var fixture = Build();

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
@@ -89,8 +89,9 @@ public class AgentStatusSnapshotTests {
     public async Task Snapshot_maps_kind_spellings_requester_and_nullables() {
         var (orch, _) = Build();
         try {
+            var createdAt = new DateTime(2026, 8, 1, 12, 30, 0, DateTimeKind.Utc);
             orch.SeedAgentForTest("r1", kind: LaunchKind.ReviewFlow, flowRunId: "flow_1",
-                flowRole: "reviewer", requester: "github:12345");
+                flowRole: "reviewer", requester: "github:12345", createdAt: createdAt);
             orch.SeedAgentForTest("d1"); // defaults: LaunchKind.Default, no flow identity, no requester
 
             var byId = orch.SnapshotAgentsForStatus().ToDictionary(a => a.Id);
@@ -98,6 +99,13 @@ public class AgentStatusSnapshotTests {
             await Assert.That(byId["r1"].Kind).IsEqualTo("review-flow");
             await Assert.That(byId["r1"].Requester).IsEqualTo("github:12345");
             await Assert.That(byId["r1"].FlowRunId).IsEqualTo("flow_1");
+            // SeedAgentForTest's fixed constants — pins the Select against a same-typed-neighbor
+            // transposition (e.g. Vendor/RepoPath swapped) that the other assertions can't catch.
+            await Assert.That(byId["r1"].Vendor).IsEqualTo("codex");
+            await Assert.That(byId["r1"].RepoPath).IsEqualTo("/repo");
+            await Assert.That(byId["r1"].Model).IsEqualTo("default");
+            await Assert.That(byId["r1"].FlowRole).IsEqualTo("reviewer");
+            await Assert.That(byId["r1"].CreatedAt).IsEqualTo(createdAt);
             await Assert.That(byId["d1"].Kind).IsEqualTo("agent");
             await Assert.That(byId["d1"].Requester).IsNull();
             await Assert.That(byId["d1"].FlowRunId).IsNull();

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
@@ -132,7 +132,7 @@ public class AgentStatusSnapshotTests {
         }
     }
 
-    /// <summary>AI-1649 review finding: a blank/whitespace <c>Model</c> is the orchestrator's
+    /// <summary>A blank/whitespace <c>Model</c> is the orchestrator's
     /// "no model" sentinel (local spawns store "" verbatim; see
     /// <c>AgentOrchestrator.HandleLocalSpawnAsync</c>), but the wire contract represents an
     /// absent model as JSON <c>null</c>. The snapshot mapping must normalize at the wire

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
@@ -1,0 +1,129 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Pty;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// Covers <see cref="AgentOrchestrator.SnapshotAgentsForStatus"/> (the supervision payload's
+/// agent rows) and the three mutate-then-pulse helpers (<c>SetAgentStatus</c>/<c>PublishAgent</c>/
+/// <c>UnpublishAgent</c>) that are now the only writers of agent status and registry membership.
+/// No socket/<see cref="LocalControlServer"/> involved — these tests drive the orchestrator +
+/// <see cref="DaemonStatusNotifier"/> directly, mirroring <c>LocalControlHelloTests.StartAsync</c>'s
+/// bare-orchestrator construction without the socket plumbing.
+/// </summary>
+public class AgentStatusSnapshotTests {
+    sealed class NoopHostLifetime : IHostApplicationLifetime {
+        public CancellationToken ApplicationStarted  => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped  => CancellationToken.None;
+        public void StopApplication() { }
+    }
+
+    sealed class NoopPtyProcessFactory : IPtyProcessFactory {
+        public IPtyProcess Spawn(
+                string command, string[] args, string cwd,
+                Dictionary<string, string>? extraEnv = null, ushort cols = 120, ushort rows = 40
+            ) => throw new NotSupportedException("AgentStatusSnapshotTests never spawns a PTY");
+    }
+
+    sealed class NoopHttpClientFactory : IHttpClientFactory {
+        public HttpClient CreateClient(string name) => new();
+    }
+
+    static (AgentOrchestrator Orchestrator, DaemonStatusNotifier Notifier) Build() {
+        var stateDir = Directory.CreateTempSubdirectory("kcap-status-snapshot-state-").FullName;
+        var store       = new LaunchConsentStore(stateDir, NullLogger.Instance);
+        var broker      = new LaunchConsentBroker();
+        var decisionLog = new LaunchConsentDecisionLog(stateDir, NullLogger.Instance);
+        var gate        = new LaunchConsentGate(store, decisionLog, broker, TimeProvider.System, NullLogger<LaunchConsentGate>.Instance);
+
+        var config = new DaemonConfig {
+            Name         = "status-snapshot-test",
+            ServerUrl    = "http://127.0.0.1:1",
+            StateDir     = stateDir,
+            WorktreeRoot = Path.Combine(Path.GetTempPath(), "kcap-status-snapshot-wt-" + Guid.NewGuid().ToString("N")[..8]),
+        };
+
+        var connection       = new ServerConnection(config, NullLoggerFactory.Instance, NullLogger<ServerConnection>.Instance);
+        var worktreeManager  = new WorktreeManager(config, NullLogger<WorktreeManager>.Instance);
+        var repoMatcher      = new RepoMatcher(config, NullLogger<RepoMatcher>.Instance);
+        var permissionBridge = new LocalPermissionBridge(connection, NullLogger<LocalPermissionBridge>.Instance);
+        var notifier         = new DaemonStatusNotifier();
+
+        var orchestrator = new AgentOrchestrator(
+            config, connection, worktreeManager, repoMatcher, new NoopPtyProcessFactory(), new NoopHttpClientFactory(),
+            permissionBridge, new Dictionary<string, IHostedAgentLauncher>(),
+            new Dictionary<string, IHostedAgentRuntimeFactory>(), new NoopHostLifetime(),
+            NullLogger<AgentOrchestrator>.Instance, gate, statusNotifier: notifier);
+
+        return (orchestrator, notifier);
+    }
+
+    [Test]
+    public async Task Snapshot_orders_by_created_at_then_id_ordinal_and_includes_all_statuses() {
+        var (orch, _) = Build();
+        try {
+            var t0 = new DateTime(2026, 8, 1, 10, 0, 0, DateTimeKind.Utc);
+            orch.SeedAgentForTest("b-second", status: "Quarantined", createdAt: t0.AddMinutes(1));
+            orch.SeedAgentForTest("z-first",  status: "Starting",    createdAt: t0);
+            orch.SeedAgentForTest("a-tie",    status: "Completed",   createdAt: t0.AddMinutes(1));
+
+            var agents = orch.SnapshotAgentsForStatus();
+
+            await Assert.That(agents.Select(a => a.Id)).IsEquivalentTo(
+                new[] { "z-first", "a-tie", "b-second" }, CollectionOrdering.Matching);
+            // All statuses ride along verbatim — the vocabulary is open, PascalCase as stored.
+            await Assert.That(agents.Select(a => a.Status)).IsEquivalentTo(
+                new[] { "Starting", "Completed", "Quarantined" }, CollectionOrdering.Matching);
+        } finally {
+            await orch.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Snapshot_maps_kind_spellings_requester_and_nullables() {
+        var (orch, _) = Build();
+        try {
+            orch.SeedAgentForTest("r1", kind: LaunchKind.ReviewFlow, flowRunId: "flow_1",
+                flowRole: "reviewer", requester: "github:12345");
+            orch.SeedAgentForTest("d1"); // defaults: LaunchKind.Default, no flow identity, no requester
+
+            var byId = orch.SnapshotAgentsForStatus().ToDictionary(a => a.Id);
+
+            await Assert.That(byId["r1"].Kind).IsEqualTo("review-flow");
+            await Assert.That(byId["r1"].Requester).IsEqualTo("github:12345");
+            await Assert.That(byId["r1"].FlowRunId).IsEqualTo("flow_1");
+            await Assert.That(byId["d1"].Kind).IsEqualTo("agent");
+            await Assert.That(byId["d1"].Requester).IsNull();
+            await Assert.That(byId["d1"].FlowRunId).IsNull();
+        } finally {
+            await orch.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Publish_status_change_and_unpublish_each_advance_the_generation() {
+        var (orch, notifier) = Build();
+        try {
+            var v0 = notifier.Version;
+            var agent = orch.SeedAgentForTest("gen-1"); // registers via PublishAgent
+            await Assert.That(notifier.Version).IsGreaterThan(v0);
+
+            var v1 = notifier.Version;
+            orch.SetAgentStatus(agent, "Completed");
+            await Assert.That(notifier.Version).IsGreaterThan(v1);
+
+            var v2 = notifier.Version;
+            orch.UnpublishAgent("gen-1");
+            await Assert.That(notifier.Version).IsGreaterThan(v2);
+            await Assert.That(orch.SnapshotAgentsForStatus()).IsEmpty();
+        } finally {
+            await orch.DisposeAsync();
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ConnectWithRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ConnectWithRetryTests.cs
@@ -18,10 +18,11 @@ namespace Capacitor.Cli.Tests.Unit.Daemon;
 public class ConnectWithRetryTests {
     static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
 
-    sealed class RetryTestConnection() : ServerConnection(
+    sealed class RetryTestConnection(DaemonStatusNotifier? notifier = null) : ServerConnection(
         new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" },
         NullLoggerFactory.Instance,
-        NullLogger<ServerConnection>.Instance
+        NullLogger<ServerConnection>.Instance,
+        notifier
     ) {
         public HubConnectionState State { get; set; } = HubConnectionState.Disconnected;
         public bool Ready { get; set; }
@@ -32,6 +33,11 @@ public class ConnectWithRetryTests {
         /// <summary>How many RegisterDaemonAsync calls should throw before they start
         /// succeeding — drives the "register failed after a successful start" path.</summary>
         public int FailRegisterRemaining { get; set; }
+
+        /// <summary>When set, every StartHubAsync call throws this instead of attempting the
+        /// normal Disconnected-state contract — drives the initial-start-failure pulse test,
+        /// which needs StartAsync to fail regardless of State.</summary>
+        public Exception? StartThrows { get; set; }
 
         /// <summary>When set, StartHubAsync awaits this before returning — lets a test hold the
         /// first loop mid-connect while a concurrent ConnectWithRetryAsync call is issued.</summary>
@@ -50,6 +56,8 @@ public class ConnectWithRetryTests {
 
         internal override async Task StartHubAsync(CancellationToken ct) {
             StartCalls++;
+
+            if (StartThrows is { } ex) throw ex;
 
             if (State != HubConnectionState.Disconnected)
                 throw new InvalidOperationException("The HubConnection cannot be started if it is not in the Disconnected state.");
@@ -209,5 +217,40 @@ public class ConnectWithRetryTests {
 
         await Assert.That(async () => await conn.ConnectWithRetryAsync(cts.Token).WaitAsync(HangGuard))
             .Throws<OperationCanceledException>();
+    }
+
+    /// <summary>
+    /// Codex P2 (production): ConnectWithRetryAsync only pulsed <c>_statusNotifier</c> on the
+    /// success path (after LogConnected). An initial-start failure fired neither
+    /// OnReconnecting nor OnClosed, so a status subscriber that snapshotted while the hub was
+    /// Connecting kept displaying "connecting" for the whole outage — no pulse ever refreshed
+    /// it, and <c>DaemonRunner</c> starts <c>LocalControlServer</c> before <c>ConnectAsync</c>,
+    /// so the race is reachable. Drives a StartHubAsync that always throws (simulating repeated
+    /// initial-connect failures) with a fast retry schedule, and polls the notifier's Version
+    /// until it advances past its pre-call snapshot — proving every failed attempt now pulses,
+    /// not just the eventual success.
+    /// </summary>
+    [Test]
+    public async Task Failed_connect_attempts_pulse_the_status_notifier() {
+        var notifier = new DaemonStatusNotifier();
+        var conn = new RetryTestConnection(notifier) {
+            State              = HubConnectionState.Disconnected,
+            StartThrows        = new InvalidOperationException("simulated transport failure"),
+            ConnectRetryDelays = [TimeSpan.FromMilliseconds(1)]
+        };
+
+        var versionBefore = notifier.Version;
+
+        using var cts = new CancellationTokenSource();
+        var loop = conn.ConnectWithRetryAsync(cts.Token);
+
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (notifier.Version <= versionBefore && DateTime.UtcNow < deadline)
+            await Task.Delay(5);
+
+        cts.Cancel();
+        try { await loop.WaitAsync(HangGuard); } catch (OperationCanceledException) { /* expected teardown */ }
+
+        await Assert.That(notifier.Version).IsGreaterThan(versionBefore);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs
@@ -47,6 +47,82 @@ public class DaemonStatusIpcTests {
         public RestartOutcome Restart() => RestartOutcome.NoOp;
     }
 
+    /// <summary>
+    /// Fake <see cref="Stream"/> for <see cref="HandleSubscribeAsync_absorbs_a_write_side_disconnect_without_faulting"/>:
+    /// <see cref="ReadAsync"/> never completes (until cancelled) — mirroring a subscriber that
+    /// vanished without an explicit EOF — so the WRITE path has to be what surfaces the
+    /// disconnect. Once <see cref="ThrowOnNextWrite"/> is armed, the next write throws exactly
+    /// what a broken pipe against a real socket throws: an <see cref="IOException"/> wrapping a
+    /// <see cref="SocketException"/>.
+    /// </summary>
+    sealed class VanishedSubscriberStream : Stream {
+        public volatile bool ThrowOnNextWrite;
+
+        public override bool CanRead  => true;
+        public override bool CanSeek  => false;
+        public override bool CanWrite => true;
+        public override long Length   => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+
+            return 0;
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) {
+            if (ThrowOnNextWrite)
+                throw new IOException("Broken pipe", new SocketException((int)SocketError.ConnectionReset));
+
+            return ValueTask.CompletedTask;
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public override void Flush()                                            { }
+        public override int  Read(byte[] buffer, int offset, int count)         => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin)               => throw new NotSupportedException();
+        public override void SetLength(long value)                              => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count)        => throw new NotSupportedException();
+    }
+
+    /// <summary>Bare orchestrator + notifier + DaemonStatusIpc, no LocalControlServer/socket —
+    /// mirrors <c>AgentStatusSnapshotTests.Build</c> — for the pure write-path exception test
+    /// below, which drives <see cref="DaemonStatusIpc.HandleSubscribeAsync"/> directly against a
+    /// fake stream instead of a real connection.</summary>
+    static (AgentOrchestrator Orchestrator, DaemonStatusIpc StatusIpc, string StateDir) BuildBareStatusIpc(string name) {
+        var stateDir = Directory.CreateTempSubdirectory("kcap-status-ipc-throw-state-").FullName;
+        var store       = new LaunchConsentStore(stateDir, NullLogger.Instance);
+        var broker      = new LaunchConsentBroker();
+        var decisionLog = new LaunchConsentDecisionLog(stateDir, NullLogger.Instance);
+        var gate        = new LaunchConsentGate(store, decisionLog, broker, TimeProvider.System, NullLogger<LaunchConsentGate>.Instance);
+
+        var config = new DaemonConfig {
+            Name         = name,
+            ServerUrl    = "http://127.0.0.1:1",
+            StateDir     = stateDir,
+            WorktreeRoot = Path.Combine(Path.GetTempPath(), "kcap-status-ipc-throw-wt-" + Guid.NewGuid().ToString("N")[..8]),
+        };
+
+        var notifier         = new DaemonStatusNotifier();
+        var connection       = new ServerConnection(config, NullLoggerFactory.Instance, NullLogger<ServerConnection>.Instance, notifier);
+        var worktreeManager  = new WorktreeManager(config, NullLogger<WorktreeManager>.Instance);
+        var repoMatcher      = new RepoMatcher(config, NullLogger<RepoMatcher>.Instance);
+        var permissionBridge = new LocalPermissionBridge(connection, NullLogger<LocalPermissionBridge>.Instance);
+
+        var orchestrator = new AgentOrchestrator(
+            config, connection, worktreeManager, repoMatcher, new NoopPtyProcessFactory(), new NoopHttpClientFactory(),
+            permissionBridge, new Dictionary<string, IHostedAgentLauncher>(),
+            new Dictionary<string, IHostedAgentRuntimeFactory>(), new NoopHostLifetime(),
+            NullLogger<AgentOrchestrator>.Instance, gate, statusNotifier: notifier);
+
+        var statusIpc = new DaemonStatusIpc(config, orchestrator, connection, notifier) {
+            Debounce = TimeSpan.FromMilliseconds(1),
+        };
+
+        return (orchestrator, statusIpc, stateDir);
+    }
+
     sealed record Harness(
         LocalControlServer Server, AgentOrchestrator Orchestrator, ServerConnection Connection,
         DaemonConfig Config, string SockPath, DaemonStatusNotifier Notifier, DaemonStatusIpc StatusIpc,
@@ -345,6 +421,54 @@ public class DaemonStatusIpcTests {
                 await Task.Delay(20, ct);
             await Assert.That(h.StatusIpc.ActiveSubscribersForTest).IsEqualTo(0);
         });
+    }
+
+    /// <summary>
+    /// Qodo (production): a client vanishing mid-push makes <c>FrameCodec.WriteAsync</c> throw
+    /// <see cref="IOException"/>/<see cref="SocketException"/>, which only
+    /// <see cref="OperationCanceledException"/> was treated as normal termination for — the
+    /// exception bubbled out of <c>HandleSubscribeAsync</c> to <c>LocalControlServer</c>'s
+    /// generic catch and logged "Local control connection faulted" at Warning for a routine
+    /// disconnect. Drives <see cref="DaemonStatusIpc.HandleSubscribeAsync"/> directly against a
+    /// fake stream (no socket/LocalControlServer involved) whose first write (the immediate
+    /// snapshot) succeeds and whose second write throws — deterministic, no OS-level raciness
+    /// between the read-side EOF watcher and the write path. Before the fix, this IOException
+    /// escaped uncaught; after it, <c>HandleSubscribeAsync</c> returns cleanly.
+    /// </summary>
+    [Test]
+    public async Task HandleSubscribeAsync_absorbs_a_write_side_disconnect_without_faulting() {
+        var (orchestrator, statusIpc, stateDir) = BuildBareStatusIpc("status-ipc-throw-test");
+        try {
+            var stream           = new VanishedSubscriberStream();
+            var firstSnapshotSeen = false;
+            statusIpc.AfterSnapshotForTest = () => {
+                if (firstSnapshotSeen) stream.ThrowOnNextWrite = true; // arm for the SECOND push only
+                firstSnapshotSeen = true;
+            };
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            try {
+                var handleTask = statusIpc.HandleSubscribeAsync(stream, cts.Token);
+
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (!firstSnapshotSeen && DateTime.UtcNow < deadline) await Task.Delay(5);
+                await Assert.That(firstSnapshotSeen).IsTrue();
+
+                // Triggers the second push, whose write hits the now-armed stream and throws —
+                // exactly what a real vanished subscriber does mid-push.
+                orchestrator.SeedAgentForTest("throw-trigger");
+
+                // Must return cleanly within the deadline: before the fix this IOException would
+                // propagate out of HandleSubscribeAsync uncaught (only OCE was absorbed).
+                await handleTask.WaitAsync(TimeSpan.FromSeconds(5));
+                await Assert.That(statusIpc.ActiveSubscribersForTest).IsEqualTo(0);
+            } finally {
+                cts.Cancel(); // unblock the fake stream's indefinitely-blocked ReadAsync promptly
+            }
+        } finally {
+            await orchestrator.DisposeAsync();
+            try { Directory.Delete(stateDir, true); } catch { /* best-effort */ }
+        }
     }
 
     [Test] // snapshot stress: no exceptions, every payload internally consistent, converges

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs
@@ -1,0 +1,157 @@
+using System.Net.Sockets;
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Pty;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// End-to-end coverage of the StatusSubscribe/DaemonStatus frame pair over a REAL Unix-domain
+/// socket — the same <see cref="LocalControlServer.HandleConnectionAsync"/> routing switch a real
+/// `kcap` client talks to. The harness mirrors <see cref="LocalControlHelloTests"/> (temp
+/// DaemonLockPaths override, socket-file poll, Windows guard) and is reused verbatim by the
+/// follow-up task that exercises the debounce/pulse matrix — hence the harness exposing
+/// <c>Notifier</c>/<c>StatusIpc</c> on <see cref="Harness"/>.
+/// </summary>
+public class DaemonStatusIpcTests {
+    sealed class NoopHostLifetime : IHostApplicationLifetime {
+        public CancellationToken ApplicationStarted  => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped  => CancellationToken.None;
+        public void StopApplication() { }
+    }
+
+    sealed class NoopPtyProcessFactory : IPtyProcessFactory {
+        public IPtyProcess Spawn(
+                string command, string[] args, string cwd,
+                Dictionary<string, string>? extraEnv = null, ushort cols = 120, ushort rows = 40
+            ) => throw new NotSupportedException("DaemonStatusIpcTests never spawns a PTY");
+    }
+
+    sealed class NoopHttpClientFactory : IHttpClientFactory {
+        public HttpClient CreateClient(string name) => new();
+    }
+
+    sealed class NoopRestartStrategy : IRestartStrategy {
+        public RestartOutcome Restart() => RestartOutcome.NoOp;
+    }
+
+    sealed record Harness(
+        LocalControlServer Server, AgentOrchestrator Orchestrator, ServerConnection Connection,
+        DaemonConfig Config, string SockPath, DaemonStatusNotifier Notifier, DaemonStatusIpc StatusIpc);
+
+    static async Task<Harness> StartAsync(string daemonName, CancellationToken ct) {
+        var stateDir = Directory.CreateTempSubdirectory("kcap-status-ipc-state-").FullName;
+        var store       = new LaunchConsentStore(stateDir, NullLogger.Instance);
+        var broker      = new LaunchConsentBroker();
+        var decisionLog = new LaunchConsentDecisionLog(stateDir, NullLogger.Instance);
+        var gate        = new LaunchConsentGate(store, decisionLog, broker, TimeProvider.System, NullLogger<LaunchConsentGate>.Instance);
+        var consentIpc  = new LaunchConsentIpc(broker, store, NullLogger<LaunchConsentIpc>.Instance);
+
+        var config = new DaemonConfig {
+            Name         = daemonName,
+            ServerUrl    = "http://127.0.0.1:1",
+            StateDir     = stateDir,
+            WorktreeRoot = Path.Combine(Path.GetTempPath(), "kcap-status-ipc-wt-" + Guid.NewGuid().ToString("N")[..8]),
+        };
+
+        var notifier   = new DaemonStatusNotifier();
+        var connection = new ServerConnection(
+            config, NullLoggerFactory.Instance, NullLogger<ServerConnection>.Instance, notifier);
+        var worktreeManager  = new WorktreeManager(config, NullLogger<WorktreeManager>.Instance);
+        var repoMatcher      = new RepoMatcher(config, NullLogger<RepoMatcher>.Instance);
+        var permissionBridge = new LocalPermissionBridge(connection, NullLogger<LocalPermissionBridge>.Instance);
+
+        var orchestrator = new AgentOrchestrator(
+            config, connection, worktreeManager, repoMatcher, new NoopPtyProcessFactory(), new NoopHttpClientFactory(),
+            permissionBridge, new Dictionary<string, IHostedAgentLauncher>(),
+            new Dictionary<string, IHostedAgentRuntimeFactory>(), new NoopHostLifetime(),
+            NullLogger<AgentOrchestrator>.Instance, gate, statusNotifier: notifier);
+
+        var statusIpc = new DaemonStatusIpc(config, orchestrator, connection, notifier) {
+            Debounce = TimeSpan.FromMilliseconds(25), // fast tests; 250ms is the production default
+        };
+
+        var restart = RestartCoordinator.ForTest(daemonName, daemonName, new NoopRestartStrategy());
+        var server = new LocalControlServer(config, orchestrator, restart, consentIpc, statusIpc, NullLogger<LocalControlServer>.Instance);
+        await server.StartAsync(ct);
+
+        var sockPath = LocalSocketPaths.Socket(daemonName);
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (!File.Exists(sockPath) && DateTime.UtcNow < deadline) await Task.Delay(20, ct);
+
+        return new Harness(server, orchestrator, connection, config, sockPath, notifier, statusIpc);
+    }
+
+    static async Task StopAsync(Harness h) {
+        await h.Orchestrator.DisposeAsync();
+        await h.Server.StopAsync(CancellationToken.None);
+        h.Server.Dispose();
+        await h.Connection.DisposeAsync();
+    }
+
+    /// Wraps a test body with the temp-dir DaemonLockPaths override + harness lifecycle, mirroring
+    /// LocalControlHelloTests's RunAsync. Each [Test] still carries its own
+    /// [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")] + Windows guard,
+    /// since those must be visible on the test method itself.
+    static async Task RunAsync(string daemonName, Func<Harness, CancellationToken, Task> body) {
+        var sockDir = Directory.CreateTempSubdirectory("kcap-status-sock-");
+        DaemonLockPaths.OverrideDirectoryForTesting(sockDir.FullName);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        Harness? h = null;
+        try {
+            h = await StartAsync(daemonName, cts.Token);
+            await Assert.That(File.Exists(h.SockPath)).IsTrue();
+            await body(h, cts.Token);
+        } finally {
+            if (h is not null) await StopAsync(h);
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(sockDir.FullName, true); } catch { /* best-effort */ }
+        }
+    }
+
+    static async Task<NetworkStream> ConnectAsync(string sockPath, CancellationToken ct) {
+        var sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        await sock.ConnectAsync(new UnixDomainSocketEndPoint(sockPath), ct);
+        return new NetworkStream(sock, ownsSocket: true);
+    }
+
+    static async Task<DaemonStatusDto> ReadStatusAsync(Stream s, CancellationToken ct) {
+        var f = await FrameCodec.ReadAsync(s, ct);
+        await Assert.That(f!.Type).IsEqualTo(FrameType.DaemonStatus);
+        return JsonSerializer.Deserialize(f.Text, StatusIpcJsonContext.Default.DaemonStatusDto)!;
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Subscribe_pushes_an_immediate_snapshot_with_daemon_block_and_agents() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("st-a", async (h, ct) => {
+            h.Orchestrator.SeedAgentForTest("s1", kind: LaunchKind.ReviewFlow,
+                flowRunId: "flow_1", flowRole: "reviewer", requester: "github:12345");
+            h.Orchestrator.SeedAgentForTest("s2", status: "Starting");
+
+            await using var s = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(s, new LocalFrame(FrameType.StatusSubscribe), ct);
+
+            var dto = await ReadStatusAsync(s, ct);
+            await Assert.That(dto.Daemon.Name).IsEqualTo(h.Config.Name);
+            await Assert.That(dto.Daemon.Version).IsNotEmpty();
+            await Assert.That(dto.Daemon.ServerUrl).IsEqualTo(h.Config.ServerUrl);
+            await Assert.That(dto.Daemon.Connection).IsEqualTo("disconnected"); // no live hub in tests
+            await Assert.That(dto.Daemon.MaxAgents).IsEqualTo(h.Config.MaxConcurrentAgents);
+            await Assert.That(dto.Daemon.ActiveAgents).IsEqualTo(2); // Running + Starting
+            await Assert.That(dto.Agents.Count).IsEqualTo(2);
+            var r1 = dto.Agents.Single(a => a.Id == "s1");
+            await Assert.That(r1.Kind).IsEqualTo("review-flow");
+            await Assert.That(r1.Requester).IsEqualTo("github:12345");
+        });
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs
@@ -5,6 +5,7 @@ using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Pty;
 using Capacitor.Cli.Daemon.Services;
+using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -160,6 +161,21 @@ public class DaemonStatusIpcTests {
     static async Task AssertConsistent(DaemonStatusDto dto) {
         var expectedActive = dto.Agents.Count(a => a.Status is "Starting" or "Running");
         await Assert.That(dto.Daemon.ActiveAgents).IsEqualTo(expectedActive);
+    }
+
+    /// <summary>
+    /// Pins all four <see cref="HubConnectionState"/> spellings through
+    /// <see cref="DaemonStatusIpc.ConnectionText"/> — the end-to-end tests below only ever
+    /// observe "disconnected" (no live hub in tests), so the other three arms
+    /// (connected/connecting/reconnecting) were untested through this mapping.
+    /// </summary>
+    [Test]
+    [Arguments(HubConnectionState.Connected,    "connected")]
+    [Arguments(HubConnectionState.Connecting,   "connecting")]
+    [Arguments(HubConnectionState.Reconnecting, "reconnecting")]
+    [Arguments(HubConnectionState.Disconnected, "disconnected")]
+    public async Task ConnectionText_maps_every_HubConnectionState_spelling(HubConnectionState state, string expected) {
+        await Assert.That(DaemonStatusIpc.ConnectionText(state)).IsEqualTo(expected);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusIpcTests.cs
@@ -14,9 +14,14 @@ namespace Capacitor.Cli.Tests.Unit.Daemon;
 /// End-to-end coverage of the StatusSubscribe/DaemonStatus frame pair over a REAL Unix-domain
 /// socket — the same <see cref="LocalControlServer.HandleConnectionAsync"/> routing switch a real
 /// `kcap` client talks to. The harness mirrors <see cref="LocalControlHelloTests"/> (temp
-/// DaemonLockPaths override, socket-file poll, Windows guard) and is reused verbatim by the
-/// follow-up task that exercises the debounce/pulse matrix — hence the harness exposing
-/// <c>Notifier</c>/<c>StatusIpc</c> on <see cref="Harness"/>.
+/// DaemonLockPaths override, socket-file poll, Windows guard). Beyond the single wiring test,
+/// this file pins the debounce/pulse/convergence behavior matrix: every mutation triggers a
+/// re-push, a pulse burst coalesces into one trailing snapshot, two subscribers converge
+/// independently via their own cursors, a mutation landing exactly at the snapshot/cursor
+/// boundary still converges, subscriber EOF reaps the handler promptly, concurrent mutations
+/// never produce an internally-inconsistent payload, and a shutting-down daemon just closes the
+/// connection. The observable guarantee throughout is CONVERGENCE, not per-generation delivery —
+/// debounce is free to collapse a burst into fewer pushes than pulses.
 /// </summary>
 public class DaemonStatusIpcTests {
     sealed class NoopHostLifetime : IHostApplicationLifetime {
@@ -43,7 +48,18 @@ public class DaemonStatusIpcTests {
 
     sealed record Harness(
         LocalControlServer Server, AgentOrchestrator Orchestrator, ServerConnection Connection,
-        DaemonConfig Config, string SockPath, DaemonStatusNotifier Notifier, DaemonStatusIpc StatusIpc);
+        DaemonConfig Config, string SockPath, DaemonStatusNotifier Notifier, DaemonStatusIpc StatusIpc,
+        string StateDir) {
+        int _serverStopped;
+
+        /// Re-entrant-safe: the shutdown test stops the server itself (to observe the
+        /// subscription close), and RunAsync's finally stops it again unconditionally
+        /// afterward. The guard makes the second call a no-op instead of a crash.
+        internal async Task StopServerOnceAsync(CancellationToken ct) {
+            if (Interlocked.Exchange(ref _serverStopped, 1) != 0) return;
+            await Server.StopAsync(ct);
+        }
+    }
 
     static async Task<Harness> StartAsync(string daemonName, CancellationToken ct) {
         var stateDir = Directory.CreateTempSubdirectory("kcap-status-ipc-state-").FullName;
@@ -85,14 +101,15 @@ public class DaemonStatusIpcTests {
         var deadline = DateTime.UtcNow.AddSeconds(5);
         while (!File.Exists(sockPath) && DateTime.UtcNow < deadline) await Task.Delay(20, ct);
 
-        return new Harness(server, orchestrator, connection, config, sockPath, notifier, statusIpc);
+        return new Harness(server, orchestrator, connection, config, sockPath, notifier, statusIpc, stateDir);
     }
 
     static async Task StopAsync(Harness h) {
         await h.Orchestrator.DisposeAsync();
-        await h.Server.StopAsync(CancellationToken.None);
+        await h.StopServerOnceAsync(CancellationToken.None);
         h.Server.Dispose();
         await h.Connection.DisposeAsync();
+        try { Directory.Delete(h.StateDir, true); } catch { /* best-effort */ }
     }
 
     /// Wraps a test body with the temp-dir DaemonLockPaths override + harness lifecycle, mirroring
@@ -128,6 +145,23 @@ public class DaemonStatusIpcTests {
         return JsonSerializer.Deserialize(f.Text, StatusIpcJsonContext.Default.DaemonStatusDto)!;
     }
 
+    /// Reads one frame or returns null when none arrives within the window — for asserting
+    /// "no further push" without hanging the suite.
+    static async Task<LocalFrame?> ReadOrNullAsync(Stream s, TimeSpan window, CancellationToken ct) {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(window);
+        try { return await FrameCodec.ReadAsync(s, cts.Token); }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested) { return null; }
+    }
+
+    /// Internal-consistency invariant every DaemonStatus payload must satisfy, regardless of
+    /// how many mutations landed between pushes: ActiveAgents is derived from the SAME
+    /// materialized Agents array it ships with, so the two can never disagree.
+    static async Task AssertConsistent(DaemonStatusDto dto) {
+        var expectedActive = dto.Agents.Count(a => a.Status is "Starting" or "Running");
+        await Assert.That(dto.Daemon.ActiveAgents).IsEqualTo(expectedActive);
+    }
+
     [Test]
     [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
     public async Task Subscribe_pushes_an_immediate_snapshot_with_daemon_block_and_agents() {
@@ -152,6 +186,220 @@ public class DaemonStatusIpcTests {
             var r1 = dto.Agents.Single(a => a.Id == "s1");
             await Assert.That(r1.Kind).IsEqualTo("review-flow");
             await Assert.That(r1.Requester).IsEqualTo("github:12345");
+        });
+    }
+
+    [Test] // add / status-change / removal each trigger a re-push
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Each_mutation_triggers_a_re_push() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("st-b", async (h, ct) => {
+            await using var s = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(s, new LocalFrame(FrameType.StatusSubscribe), ct);
+
+            var initial = await ReadStatusAsync(s, ct);
+            await AssertConsistent(initial);
+            await Assert.That(initial.Agents).IsEmpty();
+
+            var m1 = h.Orchestrator.SeedAgentForTest("m1");
+            var afterAdd = await ReadStatusAsync(s, ct);
+            await AssertConsistent(afterAdd);
+            await Assert.That(afterAdd.Agents.Select(a => a.Id)).Contains("m1");
+
+            h.Orchestrator.SetAgentStatus(m1, "Completed");
+            var afterStatus = await ReadStatusAsync(s, ct);
+            await AssertConsistent(afterStatus);
+            await Assert.That(afterStatus.Agents.Single(a => a.Id == "m1").Status).IsEqualTo("Completed");
+            await Assert.That(afterStatus.Daemon.ActiveAgents).IsEqualTo(0); // Completed isn't active
+
+            h.Orchestrator.UnpublishAgent("m1");
+            var afterRemove = await ReadStatusAsync(s, ct);
+            await AssertConsistent(afterRemove);
+            await Assert.That(afterRemove.Agents).IsEmpty();
+        });
+    }
+
+    [Test] // burst coalescing: at most one trailing snapshot after the in-flight push
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task A_pulse_burst_coalesces_into_one_trailing_snapshot() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("st-c", async (h, ct) => {
+            // Wide enough that 5 back-to-back synchronous pulses land inside one debounce window.
+            h.StatusIpc.Debounce = TimeSpan.FromMilliseconds(150);
+
+            await using var s = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(s, new LocalFrame(FrameType.StatusSubscribe), ct);
+            await ReadStatusAsync(s, ct); // drain immediate snapshot
+
+            for (var i = 0; i < 5; i++) h.Orchestrator.SeedAgentForTest($"b{i}");
+
+            var converged = await ReadStatusAsync(s, ct);
+            await AssertConsistent(converged);
+            var ids = converged.Agents.Select(a => a.Id).ToHashSet();
+            for (var i = 0; i < 5; i++) await Assert.That(ids).Contains($"b{i}");
+
+            // No second trailing push for the same burst.
+            await Assert.That(await ReadOrNullAsync(s, TimeSpan.FromMilliseconds(400), ct)).IsNull();
+        });
+    }
+
+    [Test] // two-subscriber convergence + slow subscriber doesn't stall the fast one
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Both_subscribers_converge_after_a_change_and_a_slow_one_stalls_only_itself() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("st-d", async (h, ct) => {
+            await using var a = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(a, new LocalFrame(FrameType.StatusSubscribe), ct);
+            await ReadStatusAsync(a, ct); // drain A's immediate snapshot
+
+            await using var b = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(b, new LocalFrame(FrameType.StatusSubscribe), ct);
+            await ReadStatusAsync(b, ct); // drain B's immediate snapshot
+
+            h.Orchestrator.SeedAgentForTest("both");
+
+            // A reads promptly, converging on the mutation.
+            DaemonStatusDto dtoA;
+            while (true) {
+                dtoA = await ReadStatusAsync(a, ct);
+                await AssertConsistent(dtoA);
+                if (dtoA.Agents.Any(x => x.Id == "both")) break;
+            }
+
+            // B never read until now — its cursor still converges to at least this generation
+            // (buffered or next frame), and reading it does not disturb A above.
+            DaemonStatusDto dtoB;
+            while (true) {
+                dtoB = await ReadStatusAsync(b, ct);
+                await AssertConsistent(dtoB);
+                if (dtoB.Agents.Any(x => x.Id == "both")) break;
+            }
+        });
+    }
+
+    [Test] // cursor-before-snapshot + pulse-after-mutation regressions, deterministic via the hook
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task A_mutation_at_the_snapshot_boundary_still_converges() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("st-e", async (h, ct) => {
+            // BEFORE subscribing: land a mutation+pulse exactly between snapshot and wait,
+            // deterministically, via the self-clearing test hook.
+            h.StatusIpc.AfterSnapshotForTest = () => {
+                h.StatusIpc.AfterSnapshotForTest = null; // fire once
+                h.Orchestrator.SeedAgentForTest("boundary"); // mutation + pulse land here
+            };
+
+            await using var s = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(s, new LocalFrame(FrameType.StatusSubscribe), ct);
+
+            // The snapshot was taken (and the hook fired) BEFORE the mutation, so the first
+            // frame must not contain it — pinning cursor-before-snapshot.
+            var first = await ReadStatusAsync(s, ct);
+            await AssertConsistent(first);
+            await Assert.That(first.Agents.Any(a => a.Id == "boundary")).IsFalse();
+
+            // No further external pulses: this converges purely because the hook's seed already
+            // advanced the generation past the pre-snapshot cursor — WaitBeyondAsync(seen)
+            // completes synchronously and the loop immediately re-snapshots and pushes.
+            var second = await ReadStatusAsync(s, ct);
+            await AssertConsistent(second);
+            await Assert.That(second.Agents.Any(a => a.Id == "boundary")).IsTrue();
+        });
+    }
+
+    [Test] // subscriber EOF reaps the handler promptly
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Subscriber_eof_reaps_the_handler_promptly() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("st-f", async (h, ct) => {
+            var s = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(s, new LocalFrame(FrameType.StatusSubscribe), ct);
+            await ReadStatusAsync(s, ct); // drain immediate snapshot
+            await Assert.That(h.StatusIpc.ActiveSubscribersForTest).IsEqualTo(1);
+
+            await s.DisposeAsync(); // subscriber vanishes
+
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (h.StatusIpc.ActiveSubscribersForTest != 0 && DateTime.UtcNow < deadline)
+                await Task.Delay(20, ct);
+            await Assert.That(h.StatusIpc.ActiveSubscribersForTest).IsEqualTo(0);
+        });
+    }
+
+    [Test] // snapshot stress: no exceptions, every payload internally consistent, converges
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Concurrent_mutations_never_produce_an_inconsistent_payload() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("st-g", async (h, ct) => {
+            h.StatusIpc.Debounce = TimeSpan.FromMilliseconds(25);
+
+            await using var s = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(s, new LocalFrame(FrameType.StatusSubscribe), ct);
+            await ReadStatusAsync(s, ct); // drain immediate snapshot
+
+            // Known ahead of time from the fixed mutation pattern below — no mutable state
+            // shared between the mutator loop and the reader task besides the notifier/registry.
+            var finalIds = Enumerable.Range(0, 50).Where(i => i % 3 != 0).Select(i => $"x{i}").ToHashSet();
+            var converged = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var reader = Task.Run(async () => {
+                while (!converged.Task.IsCompleted) {
+                    var frame = await ReadOrNullAsync(s, TimeSpan.FromSeconds(5), ct);
+                    if (frame is null) return; // nothing else pins this iteration; outer wait decides pass/fail
+                    await Assert.That(frame.Type).IsEqualTo(FrameType.DaemonStatus);
+                    var dto = JsonSerializer.Deserialize(frame.Text, StatusIpcJsonContext.Default.DaemonStatusDto)!;
+                    await AssertConsistent(dto);
+                    if (dto.Agents.Select(a => a.Id).ToHashSet().SetEquals(finalIds)) converged.TrySetResult();
+                }
+            }, ct);
+
+            // 50 iterations of seed(Starting) -> Running, then either settle (2/3) or
+            // complete+unpublish (1/3) — a mix of add/status-change/removal under load.
+            for (var i = 0; i < 50; i++) {
+                var id = $"x{i}";
+                var agent = h.Orchestrator.SeedAgentForTest(id, status: "Starting");
+                h.Orchestrator.SetAgentStatus(agent, "Running");
+                if (i % 3 == 0) {
+                    h.Orchestrator.SetAgentStatus(agent, "Completed");
+                    h.Orchestrator.UnpublishAgent(id);
+                }
+            }
+
+            // Convergence, not per-generation delivery: the final registry state must show up
+            // in SOME payload within a generous deadline, however many pulses got coalesced.
+            await converged.Task.WaitAsync(TimeSpan.FromSeconds(5), ct);
+            await reader; // propagate any per-payload assertion failure from inside the loop
+        });
+    }
+
+    [Test] // §5: StatusSubscribe on a shutting-down daemon — the connection just closes
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Daemon_shutdown_closes_the_subscription() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("st-h", async (h, ct) => {
+            await using var s = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(s, new LocalFrame(FrameType.StatusSubscribe), ct);
+            await ReadStatusAsync(s, ct); // drain immediate snapshot
+
+            // Stop the daemon's local control server directly (RunAsync's finally will try to
+            // stop it again — StopServerOnceAsync's guard makes that a no-op, not a crash).
+            await h.StopServerOnceAsync(ct);
+
+            // The peer closes the connection: a clean EOF (null) or an abrupt-close read error —
+            // either is "the connection just closes"; never another DaemonStatus frame.
+            try {
+                var frame = await FrameCodec.ReadAsync(s, ct);
+                await Assert.That(frame).IsNull();
+            } catch (Exception ex) when (ex is IOException or SocketException) {
+                // an abrupt close surfacing as a read error is an equally valid outcome
+            }
         });
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusNotifierTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusNotifierTests.cs
@@ -1,0 +1,64 @@
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// The generation counter behind DaemonStatus pushes (spec §4.2): version check and source
+/// capture are atomic, Pulse is a broadcast, and a stale cursor returns synchronously —
+/// a missed pulse can never strand a subscriber.
+/// </summary>
+public class DaemonStatusNotifierTests {
+    [Test]
+    public async Task Wait_returns_synchronously_when_version_is_already_beyond_seen() {
+        var n = new DaemonStatusNotifier();
+        n.Pulse();
+        var t = n.WaitBeyondAsync(0, CancellationToken.None);
+        await Assert.That(t.IsCompletedSuccessfully).IsTrue();
+    }
+
+    [Test]
+    public async Task Pulse_wakes_a_waiter_captured_at_the_current_version() {
+        var n = new DaemonStatusNotifier();
+        var t = n.WaitBeyondAsync(n.Version, CancellationToken.None);
+        await Assert.That(t.IsCompleted).IsFalse();
+        n.Pulse();
+        await t.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Pulse_is_a_broadcast_every_waiter_in_the_generation_wakes() {
+        var n = new DaemonStatusNotifier();
+        var seen = n.Version;
+        var a = n.WaitBeyondAsync(seen, CancellationToken.None);
+        var b = n.WaitBeyondAsync(seen, CancellationToken.None);
+        n.Pulse();
+        await Task.WhenAll(a, b).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task A_fresh_wait_after_a_pulse_blocks_until_the_next_pulse() {
+        var n = new DaemonStatusNotifier();
+        n.Pulse();
+        var t = n.WaitBeyondAsync(n.Version, CancellationToken.None);
+        await Assert.That(t.IsCompleted).IsFalse();
+        n.Pulse();
+        await t.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Cancellation_aborts_one_wait_without_disturbing_other_waiters() {
+        var n = new DaemonStatusNotifier();
+        var seen = n.Version;
+        using var cts = new CancellationTokenSource();
+        var cancelled = n.WaitBeyondAsync(seen, cts.Token);
+        var live      = n.WaitBeyondAsync(seen, CancellationToken.None);
+
+        cts.Cancel();
+        var threw = false;
+        try { await cancelled; } catch (OperationCanceledException) { threw = true; }
+        await Assert.That(threw).IsTrue();
+
+        n.Pulse();
+        await live.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusWiringTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusWiringTests.cs
@@ -1,6 +1,8 @@
 using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Pty;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -39,6 +41,87 @@ public class DaemonStatusWiringTests {
             await Assert.That(ReferenceEquals(connection.StatusNotifierForTest, notifier)).IsTrue();
         } finally {
             await connection.DisposeAsync();
+        }
+    }
+
+    sealed class NoopHostLifetime : IHostApplicationLifetime {
+        public CancellationToken ApplicationStarted  => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped  => CancellationToken.None;
+        public void StopApplication() { }
+    }
+
+    sealed class NoopPtyProcessFactory : IPtyProcessFactory {
+        public IPtyProcess Spawn(
+                string command, string[] args, string cwd,
+                Dictionary<string, string>? extraEnv = null, ushort cols = 120, ushort rows = 40
+            ) => throw new NotSupportedException("DaemonStatusWiringTests never spawns a PTY");
+    }
+
+    sealed class NoopHttpClientFactory : IHttpClientFactory {
+        public HttpClient CreateClient(string name) => new();
+    }
+
+    /// <summary>
+    /// The AgentOrchestrator-side half of the same DI wiring hazard pinned above for
+    /// ServerConnection: AgentOrchestrator's ctor also ends in an optional
+    /// <c>DaemonStatusNotifier?</c> parameter, resolved to the ONE registered singleton only
+    /// because its production registration (<c>DaemonRunner</c>) is a bare
+    /// <c>AddSingleton&lt;AgentOrchestrator&gt;()</c> — no factory delegate. If a future change
+    /// rewrites that registration with a factory that omits the notifier, every agent mutation
+    /// (SetAgentStatus/PublishAgent/UnpublishAgent) would silently stop reaching StatusSubscribe
+    /// clients — with no other test noticing, since every other observable behavior (including
+    /// SnapshotAgentsForStatus's own contents) stays correct. Builds the full DI graph
+    /// AgentOrchestrator's ctor needs, mirroring AgentStatusSnapshotTests's Build(), so the SAME
+    /// bare-registration mechanism DaemonRunner relies on is exercised — a direct
+    /// <c>new AgentOrchestrator(...)</c> call wouldn't exercise DI resolution at all.
+    /// </summary>
+    [Test]
+    public async Task AgentOrchestrator_resolved_via_DI_shares_the_one_registered_notifier() {
+        var stateDir = Directory.CreateTempSubdirectory("kcap-wiring-orch-state-").FullName;
+        try {
+            var services = new ServiceCollection();
+            services.AddSingleton(new DaemonConfig {
+                Name         = "wiring-orch-test",
+                ServerUrl    = "http://127.0.0.1:1",
+                StateDir     = stateDir,
+                WorktreeRoot = Path.Combine(Path.GetTempPath(), "kcap-wiring-orch-wt-" + Guid.NewGuid().ToString("N")[..8]),
+            });
+            services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+            services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+            services.AddSingleton<DaemonStatusNotifier>();
+            services.AddSingleton<ServerConnection>();
+            services.AddSingleton<WorktreeManager>();
+            services.AddSingleton<RepoMatcher>();
+            services.AddSingleton<IPtyProcessFactory>(new NoopPtyProcessFactory());
+            services.AddSingleton<IHttpClientFactory>(new NoopHttpClientFactory());
+            services.AddSingleton<LocalPermissionBridge>();
+            services.AddSingleton<IReadOnlyDictionary<string, IHostedAgentLauncher>>(
+                new Dictionary<string, IHostedAgentLauncher>());
+            services.AddSingleton<IReadOnlyDictionary<string, IHostedAgentRuntimeFactory>>(
+                new Dictionary<string, IHostedAgentRuntimeFactory>());
+            services.AddSingleton<IHostApplicationLifetime>(new NoopHostLifetime());
+            services.AddSingleton(sp => new LaunchConsentGate(
+                new LaunchConsentStore(stateDir, NullLogger.Instance),
+                new LaunchConsentDecisionLog(stateDir, NullLogger.Instance),
+                prompter: null,
+                TimeProvider.System,
+                sp.GetRequiredService<ILogger<LaunchConsentGate>>()));
+            services.AddSingleton<AgentOrchestrator>();
+
+            await using var provider = services.BuildServiceProvider();
+
+            var notifier     = provider.GetRequiredService<DaemonStatusNotifier>();
+            var orchestrator = provider.GetRequiredService<AgentOrchestrator>();
+
+            try {
+                await Assert.That(ReferenceEquals(orchestrator.StatusNotifierForTest, notifier)).IsTrue();
+            } finally {
+                await orchestrator.DisposeAsync();
+                await provider.GetRequiredService<ServerConnection>().DisposeAsync();
+            }
+        } finally {
+            try { Directory.Delete(stateDir, true); } catch { /* best-effort */ }
         }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusWiringTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonStatusWiringTests.cs
@@ -1,0 +1,44 @@
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// Pins the non-obvious DI mechanism <see cref="DaemonRunner"/> depends on for the DaemonStatus
+/// push to ever reach a real hub connection: <see cref="ServerConnection"/>'s trailing optional
+/// <c>DaemonStatusNotifier?</c> parameter is resolved to the ONE registered singleton only because
+/// its DI registration is a bare <c>AddSingleton&lt;ServerConnection&gt;()</c> — no factory
+/// delegate. If a future change rewrites that registration with a factory that omits the
+/// notifier (e.g. <c>AddSingleton(sp => new ServerConnection(...))</c> without the 4th arg),
+/// <c>ServerConnection</c> falls back to a private notifier nobody subscribes to and every
+/// hub-state pulse silently stops reaching StatusSubscribe clients — with no other test noticing,
+/// since <see cref="ServerConnection.HubState"/> and every other observable behavior stay correct.
+/// Uses the SAME bare registration shape <see cref="DaemonRunner"/> uses in production, not a
+/// direct <c>new ServerConnection(...)</c> call — a direct construction wouldn't exercise the DI
+/// resolution behavior this test exists to pin.
+/// </summary>
+public class DaemonStatusWiringTests {
+    [Test]
+    public async Task ServerConnection_resolved_via_DI_shares_the_one_registered_notifier() {
+        var services = new ServiceCollection();
+        services.AddSingleton(new DaemonConfig { Name = "wiring-test", ServerUrl = "http://127.0.0.1:1" });
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<DaemonStatusNotifier>();
+        services.AddSingleton<ServerConnection>();
+
+        await using var provider = services.BuildServiceProvider();
+
+        var notifier   = provider.GetRequiredService<DaemonStatusNotifier>();
+        var connection = provider.GetRequiredService<ServerConnection>();
+
+        try {
+            await Assert.That(ReferenceEquals(connection.StatusNotifierForTest, notifier)).IsTrue();
+        } finally {
+            await connection.DisposeAsync();
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentIpcTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentIpcTests.cs
@@ -76,8 +76,9 @@ public class LaunchConsentIpcTests {
             new Dictionary<string, IHostedAgentRuntimeFactory>(), new NoopHostLifetime(),
             NullLogger<AgentOrchestrator>.Instance, gate);
 
+        var statusIpc = new DaemonStatusIpc(config, orchestrator, connection, new DaemonStatusNotifier());
         var restart = RestartCoordinator.ForTest(daemonName, daemonName, new NoopRestartStrategy());
-        var server = new LocalControlServer(config, orchestrator, restart, consentIpc, NullLogger<LocalControlServer>.Instance);
+        var server = new LocalControlServer(config, orchestrator, restart, consentIpc, statusIpc, NullLogger<LocalControlServer>.Instance);
         await server.StartAsync(ct);
 
         var sockPath = LocalSocketPaths.Socket(daemonName);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LocalControlHelloTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LocalControlHelloTests.cs
@@ -70,8 +70,9 @@ public class LocalControlHelloTests {
             new Dictionary<string, IHostedAgentRuntimeFactory>(), new NoopHostLifetime(),
             NullLogger<AgentOrchestrator>.Instance, gate);
 
+        var statusIpc = new DaemonStatusIpc(config, orchestrator, connection, new DaemonStatusNotifier());
         var restart = RestartCoordinator.ForTest(daemonName, daemonName, new NoopRestartStrategy());
-        var server = new LocalControlServer(config, orchestrator, restart, consentIpc, NullLogger<LocalControlServer>.Instance);
+        var server = new LocalControlServer(config, orchestrator, restart, consentIpc, statusIpc, NullLogger<LocalControlServer>.Instance);
         await server.StartAsync(ct);
 
         var sockPath = LocalSocketPaths.Socket(daemonName);
@@ -132,7 +133,7 @@ public class LocalControlHelloTests {
             await Assert.That(dto!.ProtocolVersion).IsEqualTo(1);
             await Assert.That(dto.DaemonVersion).IsNotEmpty();
             await Assert.That(dto.DaemonName).IsEqualTo(h.Config.Name);
-            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1" });
+            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "status/1" });
         });
     }
 
@@ -151,7 +152,7 @@ public class LocalControlHelloTests {
             await Assert.That(dto!.ProtocolVersion).IsEqualTo(1);
             await Assert.That(dto.DaemonVersion).IsNotEmpty();
             await Assert.That(dto.DaemonName).IsEqualTo(h.Config.Name);
-            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1" });
+            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "status/1" });
         });
     }
 
@@ -173,7 +174,7 @@ public class LocalControlHelloTests {
             await Assert.That(dto!.ProtocolVersion).IsEqualTo(1);
             await Assert.That(dto.DaemonVersion).IsNotEmpty();
             await Assert.That(dto.DaemonName).IsEqualTo(h.Config.Name);
-            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1" });
+            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "status/1" });
         });
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/FrameCodecStatusTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FrameCodecStatusTests.cs
@@ -1,0 +1,38 @@
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Round-trips for the supervision frame pair. StatusSubscribe carries no payload
+/// (Detach/List shape); DaemonStatus carries UTF-8 JSON in Text (consent-frame shape).
+/// </summary>
+public class FrameCodecStatusTests {
+    [Test]
+    public async Task StatusSubscribe_round_trips_with_an_empty_payload() {
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(ms, new LocalFrame(FrameType.StatusSubscribe), CancellationToken.None);
+        ms.Position = 0;
+        var f = await FrameCodec.ReadAsync(ms, CancellationToken.None);
+        await Assert.That(f!.Type).IsEqualTo(FrameType.StatusSubscribe);
+        await Assert.That(f.Text).IsEmpty();
+        await Assert.That(f.Bytes).IsEmpty();
+    }
+
+    [Test]
+    public async Task DaemonStatus_round_trips_its_json_text_payload() {
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(
+            ms, LocalFrame.StatusJson(FrameType.DaemonStatus, """{"daemon":{"name":"x"}}"""), CancellationToken.None);
+        ms.Position = 0;
+        var f = await FrameCodec.ReadAsync(ms, CancellationToken.None);
+        await Assert.That(f!.Type).IsEqualTo(FrameType.DaemonStatus);
+        await Assert.That(f.Text).IsEqualTo("""{"daemon":{"name":"x"}}""");
+    }
+
+    [Test]
+    public async Task Frame_values_are_pinned_16_and_76() {
+        // Append-only wire contract: these bytes are claimed by the spec and must never move.
+        await Assert.That((byte)FrameType.StatusSubscribe).IsEqualTo((byte)16);
+        await Assert.That((byte)FrameType.DaemonStatus).IsEqualTo((byte)76);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/StatusIpcJsonTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/StatusIpcJsonTests.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Exact-JSON pins for the DaemonStatus payload (spec §4.1): snake_case, every field always
+/// emitted (absent = null, never omitted), field order as declared, ISO-8601 UTC created_at.
+/// Plus the §5 forward-compat pin: unknown members deserialize without error.
+/// </summary>
+public class StatusIpcJsonTests {
+    [Test]
+    public async Task DaemonStatus_serializes_exactly_with_nulls_present_and_pinned_field_order() {
+        var dto = new DaemonStatusDto(
+            new DaemonInfoDto("main", "0.12.3", "https://tenant.example.com", "connected", 5, 1),
+            [
+                new AgentStatusDto(
+                    "agent-abc123", "review-flow", "codex", "/Users/x/dev/repo", "Live",
+                    "flow_1", "reviewer", "github:12345",
+                    new DateTime(2026, 8, 1, 12, 34, 56, 789, DateTimeKind.Utc), "gpt-5-codex"),
+                new AgentStatusDto(
+                    "agent-b", "agent", "claude", null, "Starting",
+                    null, null, null,
+                    new DateTime(2026, 8, 1, 12, 35, 0, DateTimeKind.Utc), null),
+            ]);
+
+        var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.DaemonStatusDto);
+
+        await Assert.That(json).IsEqualTo(
+            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex"},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null}]}""");
+    }
+
+    [Test]
+    public async Task Unknown_members_in_a_payload_deserialize_without_error() {
+        // §5 forward compat: an older client must survive a future additive field.
+        var json =
+            """{"daemon":{"name":"m","version":"1","server_url":"u","connection":"connected","max_agents":5,"active_agents":0,"future_field":42},"agents":[{"id":"a","kind":"agent","vendor":"codex","repo_path":null,"status":"Live","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T00:00:00Z","model":null,"future_field":{"x":1}}],"future_top":true}""";
+
+        var dto = JsonSerializer.Deserialize(json, StatusIpcJsonContext.Default.DaemonStatusDto);
+
+        await Assert.That(dto!.Daemon.Name).IsEqualTo("m");
+        await Assert.That(dto.Agents[0].Id).IsEqualTo("a");
+        await Assert.That(dto.Agents[0].Status).IsEqualTo("Live");
+    }
+}


### PR DESCRIPTION
Implements the supervision surface from the slice-2 pre-work spec (§4, docs/superpowers/specs/2026-08-01-slice2-prework-control-ipc-design.md): `StatusSubscribe = 16` opens a long-lived connection that receives full `DaemonStatus = 76` snapshots — immediately on subscribe, then debounced re-pushes driven by a monotonic change generation (`DaemonStatusNotifier`, mutation-first/pulse-second via centralized orchestrator helpers). `AgentInstance` gains `RequesterUserId` stamped from the launch command. The hello capability list now advertises `status/1` alongside `consent/1`. Stop reuses the existing `StopV2` frame — no new stop machinery.

No CLI surface changes — this is app-facing IPC only, so no README update is needed.

Notes for the desktop-app consumer (AI-1650): `active_agents` counts Starting/Running agents (display semantics), not the daemon's admission gate (`EffectiveCount`, which includes kill-quarantine); and a client that routinely disconnects mid-push currently logs a Warning per vanish on the daemon side.

AI-1649

🤖 Generated with [Claude Code](https://claude.com/claude-code)