### PR TITLE
Stop kcap's stderr being read as hook output, and stop it carrying the raw server URL

### DIFF
--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -308,10 +308,32 @@ public static class HttpClientExtensions {
     }
 
     /// <summary>
-    /// Writes a structured JSON error to stderr for when the API is unreachable after all retries.
+    /// Renders the one stderr line written when the API is unreachable after every retry.
+    ///
+    /// <para>The URL goes through <see cref="UnusableUrlDiagnostic.Sanitize"/> — the same helper, in the
+    /// same assembly, that the unusable-URL guard has always used. A <c>server_url</c> may carry userinfo
+    /// credentials, and this line is reachable from the HOOK path (<c>AgentHookPoster</c> calls it on any
+    /// transport fault), so echoing it raw printed them on every lifecycle POST for every vendor. The host
+    /// survives sanitization, which is the part that makes the line actionable.</para>
+    ///
+    /// <para>Control characters are stripped from EVERY variable component, not just the URL: this line
+    /// goes to a stream harnesses parse — Gemini reads hook stderr as the hook's own result when stdout
+    /// is empty — so either half of the interpolation could otherwise fabricate a line. The fixed hint's
+    /// own <c>\r</c> is left alone; it is not attacker-reachable, and changing it would alter output
+    /// every existing call site produces.</para>
+    /// </summary>
+    public static string RenderUnreachableError(string? baseUrl, string? exceptionMessage) =>
+        $"{UnreachableHint} {UnusableUrlDiagnostic.Sanitize(baseUrl)} {StripControlCharacters(exceptionMessage)}";
+
+    static string StripControlCharacters(string? value) =>
+        string.IsNullOrEmpty(value) ? "" : new string(value.Where(c => !char.IsControl(c)).ToArray());
+
+    /// <summary>
+    /// Writes the unreachable-API diagnostic to stderr. See <see cref="RenderUnreachableError"/> for why
+    /// nothing here may be interpolated raw.
     /// </summary>
     public static void WriteUnreachableError(string baseUrl, HttpRequestException ex) {
-        Console.Error.WriteLine($"{UnreachableHint} {baseUrl} {ex.Message}");
+        Console.Error.WriteLine(RenderUnreachableError(baseUrl, ex.Message));
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -42,16 +42,9 @@ namespace Capacitor.Cli.Commands;
 /// and do not "harmonise" the empty-fragment write away to match the other memory
 /// adapters: those harnesses have no such fallback.
 ///
-/// State it as an ATTEMPT, not as "exactly one object reaches stdout", because the
-/// stronger claim is one this code deliberately does not make — and an invariant
-/// stated more absolutely than the code holds is an invitation to "restore" it. If
-/// the write itself throws, <see cref="HookResultWriter"/> still consumes the claim,
-/// so stdout is left empty (throw before any byte) or truncated (throw mid-payload),
-/// and the stderr fallback is back in play. That residue is accepted, not overlooked:
-/// retrying cannot tell those two cases apart, and appending a second object onto a
-/// partial one produces unparseable output — which is the very thing that degrades to
-/// reading stderr as plain text. A stdout we cannot write to has no recovery from
-/// inside this process. `GeminiHookOutputContractTests` pins both shapes.
+/// ATTEMPT, not "exactly one object reaches stdout": a throwing writer still consumes
+/// the claim. See <see cref="HookResultWriter"/> for the two residues that leaves and
+/// why neither is worth retrying.
 ///
 /// The second half of the contract is the EXIT CODE, which is easy to miss because
 /// nothing on this path mentions it. Gemini's plain-text fallback (what a stderr
@@ -129,12 +122,21 @@ static class GeminiHookCommand {
         /// claim is recorded BEFORE the attempt, so a throwing write cannot let the backstop append a
         /// second object onto a partial one.
         ///
-        /// <para>The consequence is deliberate and is the reason the invariant is phrased as an ATTEMPT:
-        /// a write that throws before any byte leaves stdout EMPTY, and one that throws mid-payload
-        /// leaves it TRUNCATED — in both cases the backstop no-ops and Gemini falls back to stderr.
-        /// Retrying is not the better trade: nothing here can distinguish the two cases, and appending a
-        /// second object onto a partial one is unparseable, which is the same fallback with extra
-        /// steps.</para></summary>
+        /// <para>THE CANONICAL NOTE ON WHY THE INVARIANT IS AN "ATTEMPT" — referenced from the class
+        /// remarks and the tests rather than repeated, since restating it is how the claim drifted twice.
+        /// A throwing writer leaves one of two residues, and they are NOT the same failure:</para>
+        ///
+        /// <para>• <b>Throw before any byte → stdout empty.</b> `"" || stderr` selects stderr, so this
+        /// is the original bug, unfixed for this one case.</para>
+        ///
+        /// <para>• <b>Throw mid-payload → stdout truncated.</b> A non-empty stdout is truthy, so it stays
+        /// selected and stderr is NOT reached. The truncated JSON fails to parse and degrades to plain
+        /// text — junk context from our own payload, and an allow at the exit codes this command
+        /// returns.</para>
+        ///
+        /// <para>Retrying fixes neither: nothing here can tell the two apart, and appending a second
+        /// object behind a partial one just guarantees the truncated case's invalid-but-selected stdout.
+        /// A stdout we cannot write to has no recovery from inside this process.</para></summary>
         internal void Write(string payload) {
             if (_written) return;
 
@@ -222,13 +224,11 @@ static class GeminiHookCommand {
         // result to attribute and nothing that would read it.
         if (string.IsNullOrEmpty(eventName)) return 0;
 
-        // Invariant: a RECOGNISED hook firing makes exactly one write ATTEMPT, on every returning path —
-        // one object reaches stdout whenever stdout is writable at all (see the remarks for the residue
-        // when it is not). Held structurally by the finally rather than by each path remembering: the
-        // per-path version held for SessionStart alone and left every other event emitting nothing,
-        // which handed Gemini kcap's stderr as the hook result. `eventName` is deliberately not filtered
-        // to the events we route — Gemini's close handler never consults it, so an unrouted event reads
-        // our stdout too.
+        // Invariant: a RECOGNISED hook firing makes exactly one write ATTEMPT, on every returning path.
+        // Held by the finally rather than by each path remembering — the per-path version held for
+        // SessionStart alone and left every other event handing Gemini kcap's stderr as the hook result.
+        // `eventName` is deliberately not filtered to the events we route: Gemini's close handler never
+        // consults it either.
         var result = new HookResultWriter(Console.Out);
 
         try {

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -36,11 +36,22 @@ namespace Capacitor.Cli.Commands;
 ///
 /// Hence the invariant, enforced structurally by <see cref="Handle"/>'s
 /// <c>finally</c> rather than by each path remembering: a RECOGNISED hook firing
-/// writes exactly one JSON object — the memory envelope on SessionStart when there
+/// makes exactly one write ATTEMPT — the memory envelope on SessionStart when there
 /// is one, else an explicit <c>{"continue":true}</c>. Only input with no parseable
 /// <c>hook_event_name</c> stays silent. Do not add a returning path that skips it,
 /// and do not "harmonise" the empty-fragment write away to match the other memory
 /// adapters: those harnesses have no such fallback.
+///
+/// State it as an ATTEMPT, not as "exactly one object reaches stdout", because the
+/// stronger claim is one this code deliberately does not make — and an invariant
+/// stated more absolutely than the code holds is an invitation to "restore" it. If
+/// the write itself throws, <see cref="HookResultWriter"/> still consumes the claim,
+/// so stdout is left empty (throw before any byte) or truncated (throw mid-payload),
+/// and the stderr fallback is back in play. That residue is accepted, not overlooked:
+/// retrying cannot tell those two cases apart, and appending a second object onto a
+/// partial one produces unparseable output — which is the very thing that degrades to
+/// reading stderr as plain text. A stdout we cannot write to has no recovery from
+/// inside this process. `GeminiHookOutputContractTests` pins both shapes.
 ///
 /// The second half of the contract is the EXIT CODE, which is easy to miss because
 /// nothing on this path mentions it. Gemini's plain-text fallback (what a stderr
@@ -69,7 +80,8 @@ static class GeminiHookCommand {
     /// <summary>Gemini's explicit allow-with-no-context result. A literal rather than a serializer call
     /// ON PURPOSE: this is the payload every failure path degrades to, so producing it must itself be
     /// incapable of failing. Serializing it would add a throw path to the one value that exists to
-    /// guarantee we never emit zero bytes.
+    /// remove one. That is a guarantee about RENDERING, not delivery: whether the bytes reach stdout is
+    /// <see cref="HookResultWriter"/>'s business, and it deliberately cannot promise that either.
     ///
     /// <para>Carries no <c>hookSpecificOutput</c> key, so Gemini's <c>getAdditionalContext()</c>
     /// short-circuits on its own <c>"additionalContext" in …</c> guard and contributes nothing; and no
@@ -115,7 +127,14 @@ static class GeminiHookCommand {
 
         /// <summary>Writes <paramref name="payload"/> unless something has already been written. The
         /// claim is recorded BEFORE the attempt, so a throwing write cannot let the backstop append a
-        /// second object onto a partial one.</summary>
+        /// second object onto a partial one.
+        ///
+        /// <para>The consequence is deliberate and is the reason the invariant is phrased as an ATTEMPT:
+        /// a write that throws before any byte leaves stdout EMPTY, and one that throws mid-payload
+        /// leaves it TRUNCATED — in both cases the backstop no-ops and Gemini falls back to stderr.
+        /// Retrying is not the better trade: nothing here can distinguish the two cases, and appending a
+        /// second object onto a partial one is unparseable, which is the same fallback with extra
+        /// steps.</para></summary>
         internal void Write(string payload) {
             if (_written) return;
 
@@ -203,11 +222,13 @@ static class GeminiHookCommand {
         // result to attribute and nothing that would read it.
         if (string.IsNullOrEmpty(eventName)) return 0;
 
-        // Invariant: a RECOGNISED hook firing writes exactly one JSON object on every returning path.
-        // Held structurally by the finally rather than by each path remembering — the per-path version
-        // held for SessionStart alone and left every other event emitting nothing, which handed Gemini
-        // kcap's stderr as the hook result. `eventName` is deliberately not filtered to the events we
-        // route: Gemini's close handler never consults it, so an unrouted event reads our stdout too.
+        // Invariant: a RECOGNISED hook firing makes exactly one write ATTEMPT, on every returning path —
+        // one object reaches stdout whenever stdout is writable at all (see the remarks for the residue
+        // when it is not). Held structurally by the finally rather than by each path remembering: the
+        // per-path version held for SessionStart alone and left every other event emitting nothing,
+        // which handed Gemini kcap's stderr as the hook result. `eventName` is deliberately not filtered
+        // to the events we route — Gemini's close handler never consults it, so an unrouted event reads
+        // our stdout too.
         var result = new HookResultWriter(Console.Out);
 
         try {

--- a/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/GeminiHookCommand.cs
@@ -27,15 +27,35 @@ namespace Capacitor.Cli.Commands;
 ///   SessionEnd   → kill watcher + capped inline drain (mirror of the Copilot /
 ///                  Claude pre-drain cap), then POST /hooks/session-end/gemini.
 ///   Notification → best-effort forward to the Claude-shaped /hooks/notification.
-/// Gemini treats hook stdout as a JSON decision channel, and selects the text to
-/// parse as <c>stdout.trim() || stderr.trim()</c> — so an EMPTY stdout makes it
-/// parse this process's STDERR (where kcap writes failed-POST and auth-lapse
-/// diagnostics) as the hook's result.
+/// KCAP'S STDERR IS PART OF GEMINI'S HOOK CONTRACT. Gemini treats hook stdout as a
+/// JSON decision channel and selects the text to parse as
+/// <c>stdout.trim() || stderr.trim()</c> — in a <c>child.on("close")</c> handler
+/// that never looks at the event name. So an EMPTY stdout on ANY event makes it
+/// parse this process's STDERR as the hook's result, and kcap writes failed-POST,
+/// unusable-URL and auth diagnostics there on every event.
 ///
-/// Because of that, a recognised SessionStart writes exactly one JSON object on
-/// every returning path: the memory envelope when there is one, else an explicit
-/// <c>{"continue":true}</c>. SessionEnd/Notification still emit nothing, which
-/// leaves them exposed to the same stderr fallback — tracked separately.
+/// Hence the invariant, enforced structurally by <see cref="Handle"/>'s
+/// <c>finally</c> rather than by each path remembering: a RECOGNISED hook firing
+/// writes exactly one JSON object — the memory envelope on SessionStart when there
+/// is one, else an explicit <c>{"continue":true}</c>. Only input with no parseable
+/// <c>hook_event_name</c> stays silent. Do not add a returning path that skips it,
+/// and do not "harmonise" the empty-fragment write away to match the other memory
+/// adapters: those harnesses have no such fallback.
+///
+/// The second half of the contract is the EXIT CODE, which is easy to miss because
+/// nothing on this path mentions it. Gemini's plain-text fallback (what a stderr
+/// string degrades to) is not unconditionally benign: it maps exit 0 and 1 to
+/// <c>decision: "allow"</c> but ANY other code to <c>decision: "deny"</c>, which
+/// <c>isBlockingDecision()</c> honours — that is a BLOCKED session, not junk
+/// context. kcap stays out of that band only because <c>hook</c> is one of
+/// <c>CrashReporter.FailOpenCommands</c>, which is what turns
+/// <c>HttpClientExtensions.EnsureAbsolute</c>'s <c>Environment.Exit(2)</c> into a
+/// throw and makes Program.cs's top-level catch return 0. That set is load-bearing
+/// here; <c>GeminiHookOutputContractTests</c> pins it.
+///
+/// Behaviour above is measured on <c>gemini 0.53.0</c> — a version-specific
+/// observation, not a guarantee. The mitigation does not depend on it: emitting a
+/// valid non-blocking object is correct under any of these selection rules.
 /// </remarks>
 static class GeminiHookCommand {
     // Mirror of CopilotHookCommand.PreHookDrainCap: the drain must
@@ -60,20 +80,13 @@ static class GeminiHookCommand {
     /// Renders the SessionStart hook result. With a fragment this is the memory envelope; without one it
     /// is <see cref="AllowPayload"/> — NOT zero bytes.
     ///
-    /// <para>Emitting on the empty path is deliberate and diverges from the other memory adapters. Gemini
-    /// parses <c>stdout.trim() || stderr.trim()</c>, so silent stdout makes it read kcap's STDERR
-    /// diagnostics as the hook's output; a payload wins the <c>||</c> and shadows them. Do not
-    /// "harmonise" this back to the other adapters' shape.</para>
-    ///
-    /// <para>Two separate try blocks on purpose: rendering completes before any byte is written, and a
-    /// write that throws mid-payload must not alter the command's exit code. A truncated payload is safe
-    /// on Gemini's side — a JSON parse failure degrades to plain text and never synthesises a blocking
-    /// decision, which requires an explicit <c>decision: "block"|"deny"</c>.</para>
+    /// <para>Pure, and separate from the write, so the rendering cannot fail a caller mid-payload:
+    /// rendering completes before any byte is written. A render throw OR an empty render degrades to the
+    /// allow object rather than to silence — silence is what re-exposes stderr.</para>
     /// </summary>
-    internal static void WriteSessionStartOutput(TextWriter writer, string? fragment) {
+    internal static string RenderSessionStartPayload(string? fragment) {
         // Start from the payload that cannot fail, and only upgrade to the memory envelope when
-        // rendering genuinely succeeds. Structured this way so that a render throw OR an empty render
-        // degrades to the allow object rather than to silence — silence is what re-exposes stderr.
+        // rendering genuinely succeeds.
         var payload = AllowPayload;
 
         if (fragment is not null) {
@@ -85,10 +98,35 @@ static class GeminiHookCommand {
             }
         }
 
-        // Separate try: a write throwing mid-payload must not alter the command's exit code. A truncated
-        // payload is safe on Gemini's side — a parse failure degrades to plain text, never a block.
-        try { writer.Write(payload); }
-        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) { }
+        return payload;
+    }
+
+    /// <summary>
+    /// Write-once stdout sink that makes the emit invariant STRUCTURAL rather than a discipline every
+    /// early return has to remember — which is exactly the discipline that failed for every event but
+    /// SessionStart. <see cref="Handle"/> guarantees the write from a <c>finally</c>; a path that has a
+    /// real payload claims the single write first, and the backstop then no-ops.
+    ///
+    /// <para>Deliberately not thread-safe: a hook invocation writes its result from one flow, and a lock
+    /// would add a failure mode to the one component whose whole job is that bytes get written.</para>
+    /// </summary>
+    internal sealed class HookResultWriter(TextWriter writer) {
+        bool _written;
+
+        /// <summary>Writes <paramref name="payload"/> unless something has already been written. The
+        /// claim is recorded BEFORE the attempt, so a throwing write cannot let the backstop append a
+        /// second object onto a partial one.</summary>
+        internal void Write(string payload) {
+            if (_written) return;
+
+            _written = true;
+
+            try { writer.Write(payload); }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) { }
+        }
+
+        /// <summary>The backstop: an explicit allow, carrying no context and no decision.</summary>
+        internal void EnsureWritten() => Write(AllowPayload);
     }
 
     /// <summary>The exact <see cref="SessionMemoryLifecycle"/> this adapter hands the orchestrator.
@@ -159,33 +197,47 @@ static class GeminiHookCommand {
         if (node is null) return 0;
 
         var eventName = TryGetString(node, "hook_event_name");
+
+        // The ONE path that stays silent, and the reason the invariant below says "recognised": with no
+        // parseable hook_event_name we cannot know Gemini invoked us as a hook at all, so there is no
+        // result to attribute and nothing that would read it.
         if (string.IsNullOrEmpty(eventName)) return 0;
 
+        // Invariant: a RECOGNISED hook firing writes exactly one JSON object on every returning path.
+        // Held structurally by the finally rather than by each path remembering — the per-path version
+        // held for SessionStart alone and left every other event emitting nothing, which handed Gemini
+        // kcap's stderr as the hook result. `eventName` is deliberately not filtered to the events we
+        // route: Gemini's close handler never consults it, so an unrouted event reads our stdout too.
+        var result = new HookResultWriter(Console.Out);
+
+        try {
+            return await DispatchAsync(baseUrl, node, eventName, result, ps,
+                                       memoryClientFactory, memoryStoreFactory);
+        } finally {
+            result.EnsureWritten();
+        }
+    }
+
+    static async Task<int> DispatchAsync(
+            string    baseUrl,
+            JsonNode  node,
+            string    eventName,
+            HookResultWriter result,
+            long      ps,
+            Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory,
+            Func<SessionStartMemoryLeaseStore>?                 memoryStoreFactory) {
         // Gemini session ids are dashed UUIDs; keep the dashless form for the
         // server (AgentSession-{dashless} convention shared by every vendor).
-        // Recognised from HERE, not after session-id validation. Gemini fired a SessionStart and WILL
-        // read our stdout whatever we make of the rest of the payload, so a bad session id must still
-        // emit — otherwise this path re-exposes the stdout||stderr fallback.
-        var isSessionStart = eventName == "SessionStart";
-
         var dashedSessionId = TryGetString(node, "session_id");
-        if (string.IsNullOrEmpty(dashedSessionId) || !Guid.TryParse(dashedSessionId, out _)) {
-            if (isSessionStart) WriteSessionStartOutput(Console.Out, fragment: null);
-            return 0;
-        }
+        if (string.IsNullOrEmpty(dashedSessionId) || !Guid.TryParse(dashedSessionId, out _)) return 0;
 
         var sessionId = dashedSessionId.Replace("-", "");
 
         // Mirror the Claude/Codex/Copilot disabled-session fast path: `kcap
-        // disable` must stop every POST and watcher restart for the session.
-        // Invariant: a RECOGNISED SessionStart writes exactly one JSON object on every returning path,
-        // including the suppression fast paths below — an exception-riddled invariant is not an
-        // invariant, and these paths are not stderr-free (Program.cs drains the spool before dispatch).
-        // Only genuinely unrecognisable input stays silent: unparseable stdin and a missing/blank
-        // hook_event_name, where we cannot know a SessionStart occurred at all.
+        // disable` must stop every POST and watcher restart for the session. Suppression is not
+        // silence — these paths are not stderr-free (Program.cs drains the spool before dispatch).
         if (DisabledSessions.IsDisabled(sessionId)) {
             if (eventName == "SessionEnd") DisabledSessions.RemoveMarker(sessionId);
-            if (isSessionStart) WriteSessionStartOutput(Console.Out, fragment: null);
             return 0;
         }
 
@@ -197,14 +249,11 @@ static class GeminiHookCommand {
         var activeProfile = await AppConfig.GetActiveProfileAsync();
 
         if (activeProfile?.ExcludedPaths is { Length: > 0 } excludedPaths
-         && PathExclusion.IsExcluded(cwd, excludedPaths)) {
-            if (isSessionStart) WriteSessionStartOutput(Console.Out, fragment: null);
-            return 0;
-        }
+         && PathExclusion.IsExcluded(cwd, excludedPaths)) return 0;
 
         return eventName switch {
             "SessionStart" => await HandleSessionStart(baseUrl, node, sessionId, cwd, activeProfile, spool,
-                                                       ps, memoryClientFactory, memoryStoreFactory),
+                                                       result, ps, memoryClientFactory, memoryStoreFactory),
             "SessionEnd"   => await HandleSessionEnd(baseUrl, node, sessionId, cwd),
             "Notification" => await HandleNotification(baseUrl, node, sessionId, cwd),
             _              => 0   // unknown / unsubscribed — fail-open like the other dispatchers
@@ -218,6 +267,7 @@ static class GeminiHookCommand {
             string?   cwd,
             Profile?  activeProfile,
             HookSpool spool,
+            HookResultWriter result,
             long      processStart,
             Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
             Func<SessionStartMemoryLeaseStore>?                 memoryStoreFactory  = null
@@ -260,7 +310,6 @@ static class GeminiHookCommand {
         if (activeProfile?.ExcludedRepos is { Length: > 0 } excludedRepos
          && await RepoExclusion.IsExcludedAsync(enriched, excludedRepos)) {
             DisabledSessions.Mark(sessionId);
-            WriteSessionStartOutput(Console.Out, fragment: null);
             return 0;
         }
 
@@ -284,13 +333,12 @@ static class GeminiHookCommand {
             baseUrl, "session-start/gemini", enriched, "gemini-hook",
             spool, sessionId, route: "session-start/gemini");
 
-        // Write the hook result BEFORE any return, including the failed-POST return below. The Codex
-        // adapter shipped a defect where an early `return 1` skipped the stdout handshake entirely; do
-        // not reintroduce it. The memory index is independent of lifecycle capture — a server rejecting
-        // the POST has not invalidated an index already fetched — and Gemini parses hook stdout
-        // unconditionally, with the exit code only setting its own `success` flag.
-        WriteSessionStartOutput(Console.Out,
-            await SessionStartMemoryHookSupport.AwaitBounded(memoryTask, processStart, "session-start"));
+        // Claim the single write HERE, before the failed-POST return below, so the memory envelope is
+        // what lands rather than the backstop's bare allow. The memory index is independent of lifecycle
+        // capture — a server rejecting the POST has not invalidated an index already fetched — and Gemini
+        // parses hook stdout unconditionally, with the exit code only setting its own `success` flag.
+        result.Write(RenderSessionStartPayload(
+            await SessionStartMemoryHookSupport.AwaitBounded(memoryTask, processStart, "session-start")));
 
         if (!AgentHookPoster.ShouldSpawnAfter(outcome, baseUrl)) return outcome == HookPostOutcome.Failed ? 1 : 0;
 

--- a/test/Capacitor.Cli.Tests.Integration/GeminiStderrShadowedOnPostFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/GeminiStderrShadowedOnPostFailureTests.cs
@@ -89,7 +89,7 @@ public class GeminiStderrShadowedOnPostFailureTests : IDisposable {
         await Assert.That(exit).IsEqualTo(0);
 
         using var doc = JsonDocument.Parse(stdout.Trim());
-        await Assert.That(doc.RootElement.TryGetProperty("decision", out _)).IsFalse();
+        await Assert.That(doc.RootElement.Str("decision")).IsNull();
     }
 
     async Task UseServerProfileAsync() =>

--- a/test/Capacitor.Cli.Tests.Integration/GeminiStderrShadowedOnPostFailureTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/GeminiStderrShadowedOnPostFailureTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// The failed-POST case for the events that are not SessionStart. A rejected lifecycle POST makes
+/// <c>AgentHookPoster</c> write a diagnostic to stderr, and Gemini reads
+/// <c>stdout.trim() || stderr.trim()</c> — so with nothing on stdout that diagnostic BECOMES the hook
+/// result and reaches the model as hook-sourced content.
+///
+/// <para>The stderr assertion here is a positive control, not decoration. Without it this test passes
+/// vacuously the day the diagnostic moves or is silenced: "stdout wins" is only evidence of shadowing
+/// when there is genuinely something to shadow.</para>
+///
+/// <para><see cref="GeminiSessionStartHandshakeOnPostFailureTests"/> is the SessionStart half, where the
+/// same write also has to carry the memory envelope.</para>
+/// </summary>
+public class GeminiStderrShadowedOnPostFailureTests : IDisposable {
+    // Declaration order is load-bearing — see GeminiSessionStartHandshakeOnPostFailureTests.
+    readonly string  _configPath     = PathHelpers.ConfigPath("config.json");
+    readonly string? _previousConfig = File.Exists(PathHelpers.ConfigPath("config.json"))
+        ? File.ReadAllText(PathHelpers.ConfigPath("config.json"))
+        : null;
+
+    readonly WireMockServer _server = WireMockServer.Start();
+
+    public void Dispose() {
+        try {
+            if (_previousConfig is null) {
+                if (File.Exists(_configPath)) File.Delete(_configPath);
+            } else {
+                File.WriteAllText(_configPath, _previousConfig);
+            }
+        } finally {
+            try { _server.Stop(); } catch { /* best-effort */ }
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task A_rejected_session_end_post_shadows_its_own_stderr_diagnostic() {
+        await UseServerProfileAsync();
+
+        // A genuine non-2xx: the one outcome that logs to stderr rather than spooling silently.
+        _server.Given(Request.Create().WithPath("/hooks/session-end/gemini").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(400));
+
+        var (exit, stdout, stderr) = await RunAsync($$"""
+            {"hook_event_name":"SessionEnd","session_id":"{{Guid.NewGuid()}}","cwd":"/tmp","reason":"exit"}
+            """);
+
+        // Positive control: the diagnostic this test exists to shadow really was written.
+        await Assert.That(stderr).Contains("session-end/gemini");
+
+        // And Gemini's own selection expression picks stdout over it.
+        await Assert.That(SelectedByGemini(stdout, stderr)).IsEqualTo(stdout.Trim());
+        await Assert.That(stdout.Trim()).IsEqualTo("""{"continue":true}""");
+
+        // The rejection is still reported — shadowing is not pretending the POST worked. Staying below
+        // 2 also keeps Gemini's plain-text fallback in its allow band if the payload ever fails to parse.
+        await Assert.That(exit).IsEqualTo(1);
+        await Assert.That(exit).IsLessThan(2);
+
+        var posts = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-end/gemini").UsingPost());
+        await Assert.That(posts.Count).IsEqualTo(1);
+    }
+
+    [Test, NotInParallel]
+    public async Task A_rejected_notification_post_still_emits_a_hook_result() {
+        await UseServerProfileAsync();
+
+        _server.Given(Request.Create().WithPath("/hooks/notification").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(500));
+
+        var (exit, stdout, _) = await RunAsync($$"""
+            {"hook_event_name":"Notification","session_id":"{{Guid.NewGuid()}}","cwd":"/tmp",
+             "message":"waiting for input","notification_type":"idle"}
+            """);
+
+        // Notification forwarding is telemetry and swallows its own failures, so it contributes no
+        // stderr of its own — but Program.cs's pre-dispatch spool drain and the auth layer do, on the
+        // very invocations where a server is unhealthy. The emit is what makes that irrelevant.
+        await Assert.That(stdout.Trim()).IsEqualTo("""{"continue":true}""");
+        await Assert.That(exit).IsEqualTo(0);
+
+        using var doc = JsonDocument.Parse(stdout.Trim());
+        await Assert.That(doc.RootElement.TryGetProperty("decision", out _)).IsFalse();
+    }
+
+    async Task UseServerProfileAsync() =>
+        await AppConfig.SaveProfileConfig(new ProfileConfig {
+            ActiveProfile = "work",
+            Profiles      = new() { ["work"] = new Profile { ServerUrl = _server.Url } }
+        });
+
+    /// <summary>Gemini 0.53.0's <c>const textToParse = stdout.trim() || stderr.trim()</c>.</summary>
+    static string SelectedByGemini(string stdout, string stderr) =>
+        stdout.Trim() is { Length: > 0 } o ? o : stderr.Trim();
+
+    async Task<(int ExitCode, string Stdout, string Stderr)> RunAsync(string payload) {
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+        var stdout      = new StringWriter();
+        var stderr      = new StringWriter();
+
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+
+        try {
+            var exit = await GeminiHookCommand.Handle(_server.Url!, new StringReader(payload));
+
+            return (exit, stdout.ToString(), stderr.ToString());
+        } finally {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/GeminiHookOutputContractTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiHookOutputContractTests.cs
@@ -15,13 +15,11 @@ namespace Capacitor.Cli.Tests.Unit;
 /// exists to prevent, which has now been shipped twice (Codex's early <c>return 1</c>, and every Gemini
 /// event but SessionStart).</para>
 ///
-/// <para>"Attempt", not "one object reaches stdout": a throwing writer still consumes the claim, leaving
-/// stdout empty or truncated and the stderr fallback live.
-/// <see cref="A_throwing_write_is_swallowed_and_still_consumes_the_single_claim"/> pins both shapes
-/// deliberately. That is an accepted residue — retrying cannot distinguish them, and a second object
-/// appended to a partial one is unparseable, which is itself what falls back to reading stderr — and a
-/// stdout we cannot write to is not recoverable from inside this process. Do not let the stated
-/// invariant drift back to the absolute form these very tests disprove.</para>
+/// <para>"Attempt", not "one object reaches stdout": a throwing writer still consumes the claim.
+/// <see cref="A_throwing_write_is_swallowed_and_still_consumes_the_single_claim"/> pins both resulting
+/// shapes deliberately — see <c>GeminiHookCommand.HookResultWriter</c> for which residue each one is and
+/// why neither is worth retrying. Do not let the stated invariant drift back to the absolute form these
+/// very tests disprove.</para>
 /// </summary>
 public class GeminiHookOutputContractTests {
     const string SessionId = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
@@ -133,13 +131,10 @@ public class GeminiHookOutputContractTests {
     }
 
     /// <summary>
-    /// A stdout write that throws — before any byte, or mid-payload — must be swallowed, so it cannot
-    /// alter the command's exit code and push it into Gemini's <c>deny</c> band. It must ALSO still
-    /// consume the single claim: retrying would append a second object onto a partial one, and two
-    /// concatenated objects are exactly the unparseable input that falls back to plain text.
-    ///
-    /// <para>A truncated payload on its own is safe — Gemini degrades truncated JSON to plain text and,
-    /// at the exit codes this command returns, that stays an allow.</para>
+    /// A stdout write that throws — before any byte (arg 0), or mid-payload (arg 5) — must be swallowed,
+    /// so it cannot alter the command's exit code and push it into Gemini's <c>deny</c> band, and must
+    /// still consume the single claim. The two arguments are the two residues; which is which, and why
+    /// neither is retried, is on <c>GeminiHookCommand.HookResultWriter</c>.
     /// </summary>
     [Test]
     [Arguments(0)]

--- a/test/Capacitor.Cli.Tests.Unit/GeminiHookOutputContractTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiHookOutputContractTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -114,8 +115,12 @@ public class GeminiHookOutputContractTests {
         sink.EnsureWritten();
 
         await Assert.That(writer.ToString()).IsEqualTo("""{"hookSpecificOutput":{"additionalContext":"memory"}}""");
-        using var doc = JsonDocument.Parse(writer.ToString());   // throwing IS the failure
-        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+
+        // Parse throwing IS the failure — a second object appended behind the first is what makes this
+        // unparseable. Reading the nested key back through the project's helper proves the root really is
+        // an object as well: Obj() yields null for any non-object root.
+        using var doc = JsonDocument.Parse(writer.ToString());
+        await Assert.That(doc.RootElement.Obj("hookSpecificOutput")).IsNotNull();
     }
 
     /// <summary>Writes <paramref name="charsBeforeThrowing"/> characters and THEN throws, so 0 exercises
@@ -152,19 +157,26 @@ public class GeminiHookOutputContractTests {
     }
 
     /// <summary>Asserts what Gemini would actually do with these bytes, not merely that some were
-    /// written: the runner must select stdout, parse it as an object, and find no blocking decision.</summary>
+    /// written: the runner must select stdout, parse it, and find no blocking decision.</summary>
     static async Task AssertNonBlockingJsonObject(string stdout) {
         await Assert.That(stdout.Trim()).IsNotEmpty();
 
+        // Parse throwing IS the failure: Gemini only treats the payload as a decision object when it
+        // parses, and anything else degrades to plain text.
         using var doc = JsonDocument.Parse(stdout.Trim());
 
-        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+        // `isBlockingDecision()` is `decision === "block" || decision === "deny"`. Str() returns null
+        // unless the root is an object AND the property is a string — the same two conditions Gemini
+        // itself applies before honouring a decision — so this one read covers both.
+        var decision = doc.RootElement.Str("decision");
 
-        // `isBlockingDecision()` is `decision === "block" || decision === "deny"`.
-        if (doc.RootElement.TryGetProperty("decision", out var decision)) {
-            await Assert.That(decision.GetString()).IsNotEqualTo("block");
-            await Assert.That(decision.GetString()).IsNotEqualTo("deny");
-        }
+        await Assert.That(decision).IsNotEqualTo("block");
+        await Assert.That(decision).IsNotEqualTo("deny");
+
+        // Every path reaching here is a suppression path, so the payload is the backstop verbatim. That
+        // equality is strictly stronger than a shape check, and pins the object-ness the read above
+        // cannot distinguish from a missing key.
+        await Assert.That(stdout.Trim()).IsEqualTo(GeminiHookCommand.AllowPayload);
     }
 
     static async Task<string> RunAsync(string payload) {

--- a/test/Capacitor.Cli.Tests.Unit/GeminiHookOutputContractTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiHookOutputContractTests.cs
@@ -9,10 +9,19 @@ namespace Capacitor.Cli.Tests.Unit;
 /// consumes kcap's STDERR as the hook result whenever kcap writes nothing to stdout, and kcap writes
 /// failed-POST and auth diagnostics to stderr on all of them.
 ///
-/// <para>These tests pin the shadowing invariant: a recognised hook firing emits exactly one JSON object,
-/// on every returning path, so stdout always wins the <c>||</c>. They fail if someone reintroduces an
-/// empty-stdout return alongside a stderr write — the regression this file exists to prevent, which has
-/// now been shipped twice (Codex's early <c>return 1</c>, and every Gemini event but SessionStart).</para>
+/// <para>These tests pin the shadowing invariant: a recognised hook firing makes exactly one write
+/// ATTEMPT, on every returning path, so stdout wins the <c>||</c> whenever stdout is writable. They fail
+/// if someone reintroduces an empty-stdout return alongside a stderr write — the regression this file
+/// exists to prevent, which has now been shipped twice (Codex's early <c>return 1</c>, and every Gemini
+/// event but SessionStart).</para>
+///
+/// <para>"Attempt", not "one object reaches stdout": a throwing writer still consumes the claim, leaving
+/// stdout empty or truncated and the stderr fallback live.
+/// <see cref="A_throwing_write_is_swallowed_and_still_consumes_the_single_claim"/> pins both shapes
+/// deliberately. That is an accepted residue — retrying cannot distinguish them, and a second object
+/// appended to a partial one is unparseable, which is itself what falls back to reading stderr — and a
+/// stdout we cannot write to is not recoverable from inside this process. Do not let the stated
+/// invariant drift back to the absolute form these very tests disprove.</para>
 /// </summary>
 public class GeminiHookOutputContractTests {
     const string SessionId = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";

--- a/test/Capacitor.Cli.Tests.Unit/GeminiHookOutputContractTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiHookOutputContractTests.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Gemini's hook runner picks the text it parses as <c>stdout.trim() || stderr.trim()</c> — in a
+/// <c>child.on("close")</c> handler that never consults the event name. So EVERY event kcap subscribes to
+/// consumes kcap's STDERR as the hook result whenever kcap writes nothing to stdout, and kcap writes
+/// failed-POST and auth diagnostics to stderr on all of them.
+///
+/// <para>These tests pin the shadowing invariant: a recognised hook firing emits exactly one JSON object,
+/// on every returning path, so stdout always wins the <c>||</c>. They fail if someone reintroduces an
+/// empty-stdout return alongside a stderr write — the regression this file exists to prevent, which has
+/// now been shipped twice (Codex's early <c>return 1</c>, and every Gemini event but SessionStart).</para>
+/// </summary>
+public class GeminiHookOutputContractTests {
+    const string SessionId = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
+
+    // Every event kcap registers, plus one it does not. The unrecognised entry is deliberate: Gemini's
+    // close handler is event-agnostic, so an event we do not route still has its stdout read, and a
+    // version bump that renames an event must not silently reopen the stderr channel.
+    public static IEnumerable<Func<string>> Events() {
+        yield return () => "SessionStart";
+        yield return () => "SessionEnd";
+        yield return () => "Notification";
+        yield return () => "PreToolUse";
+    }
+
+    [Test, MethodDataSource(nameof(Events)), NotInParallel]
+    public async Task An_unusable_session_id_still_emits_a_non_blocking_result(string eventName) {
+        // Gemini fired the hook and WILL read stdout whatever we make of the rest of the payload.
+        var stdout = await RunAsync($$"""
+            {"hook_event_name":"{{eventName}}","session_id":"not-a-guid","cwd":"/tmp"}
+            """);
+
+        await AssertNonBlockingJsonObject(stdout);
+    }
+
+    [Test, MethodDataSource(nameof(Events)), NotInParallel]
+    public async Task A_disabled_session_still_emits_a_non_blocking_result(string eventName) {
+        // `kcap disable` suppresses every POST and watcher restart — but suppression is not silence.
+        // Program.cs drains the spool before dispatch, so these paths are not stderr-free.
+        DisabledSessions.Mark(SessionId.Replace("-", ""));
+
+        try {
+            var stdout = await RunAsync($$"""
+                {"hook_event_name":"{{eventName}}","session_id":"{{SessionId}}","cwd":"/tmp"}
+                """);
+
+            await AssertNonBlockingJsonObject(stdout);
+        } finally {
+            DisabledSessions.RemoveMarker(SessionId.Replace("-", ""));
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task A_notification_missing_its_required_fields_still_emits_a_non_blocking_result() {
+        // The server's NotificationHook needs message + notification_type; without them the forward is
+        // abandoned. That abandonment used to return zero bytes.
+        var stdout = await RunAsync($$"""
+            {"hook_event_name":"Notification","session_id":"{{SessionId}}","cwd":"/tmp"}
+            """);
+
+        await AssertNonBlockingJsonObject(stdout);
+    }
+
+    [Test, NotInParallel]
+    public async Task Input_that_is_not_provably_a_hook_firing_stays_silent() {
+        // The deliberate exception to the invariant, and the reason it is stated as "a RECOGNISED
+        // firing": with no parseable `hook_event_name` we cannot know Gemini invoked us as a hook at
+        // all, and emitting a decision object into some other consumer's stdout is its own hazard.
+        await Assert.That(await RunAsync("not json at all")).IsEmpty();
+        await Assert.That(await RunAsync("""{"session_id":"x"}""")).IsEmpty();
+        await Assert.That(await RunAsync("""{"hook_event_name":""}""")).IsEmpty();
+    }
+
+    /// <summary>
+    /// The invariant that keeps a *parse failure* non-blocking, pinned because nothing else states it.
+    ///
+    /// <para>Gemini's plain-text fallback is not unconditionally benign: it maps exit 0 and 1 to
+    /// <c>decision: "allow"</c> but ANY other code to <c>decision: "deny"</c>. kcap stays out of that band
+    /// only because <c>hook</c> is a fail-open command — which is what turns
+    /// <c>EnsureAbsolute</c>'s <c>Environment.Exit(2)</c> into a throw and makes the top-level catch
+    /// return 0. Drop <c>"hook"</c> from that set and a malformed <c>server_url</c> becomes a stderr
+    /// string that BLOCKS the Gemini session.</para>
+    /// </summary>
+    [Test]
+    public async Task The_hook_command_stays_out_of_geminis_blocking_exit_code_band() {
+        await Assert.That(CrashReporter.IsFailOpenCommand("hook")).IsTrue();
+        await Assert.That(CrashReporter.ExitCode("hook")).IsLessThan(2);
+    }
+
+    // ── the sink's own contract ───────────────────────────────────────────────
+
+    /// <summary>
+    /// The backstop must not append a SECOND object behind a path that already wrote a real one — two
+    /// concatenated objects are not parseable JSON, so Gemini would fall back to reading the pair as
+    /// plain text, which is the very channel this design closes.
+    /// </summary>
+    [Test]
+    public async Task The_backstop_does_not_append_behind_a_payload_already_written() {
+        var writer = new StringWriter();
+        var sink   = new GeminiHookCommand.HookResultWriter(writer);
+
+        sink.Write("""{"hookSpecificOutput":{"additionalContext":"memory"}}""");
+        sink.EnsureWritten();
+
+        await Assert.That(writer.ToString()).IsEqualTo("""{"hookSpecificOutput":{"additionalContext":"memory"}}""");
+        using var doc = JsonDocument.Parse(writer.ToString());   // throwing IS the failure
+        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+    }
+
+    /// <summary>Writes <paramref name="charsBeforeThrowing"/> characters and THEN throws, so 0 exercises
+    /// "fails before any byte" and a positive value a genuine partial write. An earlier version of this
+    /// writer only ever threw before writing, leaving the advertised partial-write case untested.</summary>
+    sealed class ThrowingWriter(int charsBeforeThrowing) : StringWriter {
+        public override void Write(string? value) {
+            if (value is { Length: > 0 } && charsBeforeThrowing > 0)
+                base.Write(value[..Math.Min(charsBeforeThrowing, value.Length)]);
+
+            throw new IOException("stdout closed");
+        }
+    }
+
+    /// <summary>
+    /// A stdout write that throws — before any byte, or mid-payload — must be swallowed, so it cannot
+    /// alter the command's exit code and push it into Gemini's <c>deny</c> band. It must ALSO still
+    /// consume the single claim: retrying would append a second object onto a partial one, and two
+    /// concatenated objects are exactly the unparseable input that falls back to plain text.
+    ///
+    /// <para>A truncated payload on its own is safe — Gemini degrades truncated JSON to plain text and,
+    /// at the exit codes this command returns, that stays an allow.</para>
+    /// </summary>
+    [Test]
+    [Arguments(0)]
+    [Arguments(5)]
+    public async Task A_throwing_write_is_swallowed_and_still_consumes_the_single_claim(int charsBeforeThrowing) {
+        var writer = new ThrowingWriter(charsBeforeThrowing);
+        var sink   = new GeminiHookCommand.HookResultWriter(writer);
+
+        sink.Write("""{"hookSpecificOutput":{"additionalContext":"memory"}}""");
+        sink.EnsureWritten();   // must not propagate, and must not write a second object
+
+        // Reaching here without an exception is half the contract. The length proves the other half AND
+        // that the writer really threw where the case name claims — neither case can pass vacuously.
+        await Assert.That(writer.ToString().Length).IsEqualTo(charsBeforeThrowing);
+    }
+
+    /// <summary>Asserts what Gemini would actually do with these bytes, not merely that some were
+    /// written: the runner must select stdout, parse it as an object, and find no blocking decision.</summary>
+    static async Task AssertNonBlockingJsonObject(string stdout) {
+        await Assert.That(stdout.Trim()).IsNotEmpty();
+
+        using var doc = JsonDocument.Parse(stdout.Trim());
+
+        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+
+        // `isBlockingDecision()` is `decision === "block" || decision === "deny"`.
+        if (doc.RootElement.TryGetProperty("decision", out var decision)) {
+            await Assert.That(decision.GetString()).IsNotEqualTo("block");
+            await Assert.That(decision.GetString()).IsNotEqualTo("deny");
+        }
+    }
+
+    static async Task<string> RunAsync(string payload) {
+        var originalOut = Console.Out;
+        var writer      = new StringWriter();
+        Console.SetOut(writer);
+
+        try {
+            // A URL no POST can reach: these paths must all return before any network call, and a test
+            // that quietly started talking to a live server would be measuring something else.
+            await GeminiHookCommand.Handle("http://127.0.0.1:1", new StringReader(payload));
+
+            return writer.ToString();
+        } finally {
+            Console.SetOut(originalOut);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/GeminiSessionStartMemoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GeminiSessionStartMemoryTests.cs
@@ -18,12 +18,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// otherwise put kcap text into the model's context.</para>
 /// </summary>
 public class GeminiSessionStartMemoryTests {
-    static string Write(string? fragment) {
-        var sw = new StringWriter();
-        GeminiHookCommand.WriteSessionStartOutput(sw, fragment);
-
-        return sw.ToString();
-    }
+    static string Write(string? fragment) => GeminiHookCommand.RenderSessionStartPayload(fragment);
 
     // ── the divergence from every other adapter ───────────────────────────────
 
@@ -112,37 +107,8 @@ public class GeminiSessionStartMemoryTests {
         await Assert.That(isObject).IsTrue();
     }
 
-    // ── a failing writer must not change the command's exit code ──────────────
-
-    /// <summary>Writes <paramref name="charsBeforeThrowing"/> characters of the payload and THEN throws,
-    /// so 0 exercises "fails before any byte" and a positive value exercises a genuine partial write.
-    /// An earlier version only ever threw before writing, leaving the advertised partial-write case
-    /// untested — caught in review.</summary>
-    sealed class ThrowingWriter(int charsBeforeThrowing) : StringWriter {
-        public override void Write(string? value) {
-            if (value is { Length: > 0 } && charsBeforeThrowing > 0)
-                base.Write(value[..Math.Min(charsBeforeThrowing, value.Length)]);
-
-            throw new IOException("stdout closed");
-        }
-    }
-
-    /// <summary>A write that throws — before any byte, or mid-payload — must be swallowed. Rendering
-    /// completes before the single write, so a partial payload is the only exposure, and Gemini degrades
-    /// truncated JSON to plain text rather than synthesising a block.</summary>
-    [Test]
-    [Arguments(0)]
-    [Arguments(5)]
-    public async Task a_throwing_writer_does_not_propagate(int charsBeforeThrowing) {
-        var writer = new ThrowingWriter(charsBeforeThrowing);
-
-        GeminiHookCommand.WriteSessionStartOutput(writer, "## Team memory");
-        GeminiHookCommand.WriteSessionStartOutput(writer, null);
-
-        // Reaching here without an exception is the contract. Also prove the writer really did what the
-        // case name claims, so neither case can pass by never throwing at all.
-        await Assert.That(writer.ToString().Length).IsEqualTo(charsBeforeThrowing == 0 ? 0 : charsBeforeThrowing * 2);
-    }
+    // The writer half of this contract — a throwing stdout must be swallowed, and the single write
+    // claimed either way — now belongs to the write-once sink and lives in GeminiHookOutputContractTests.
 
     // ── the invariant at the Handle level, not just the writer ────────────────
 

--- a/test/Capacitor.Cli.Tests.Unit/Http/UnreachableErrorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/UnreachableErrorTests.cs
@@ -1,0 +1,75 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Http;
+
+/// <summary>
+/// The "server unreachable" stderr line. It echoed the base URL raw, while its sibling
+/// <see cref="UnusableUrlDiagnostic"/> — same assembly, same stream, same hazard — had sanitized for
+/// exactly this since it was written.
+///
+/// <para>Two things ride on the sanitization. A <c>server_url</c> may carry userinfo credentials, and
+/// this line is reachable from the hook path (<c>AgentHookPoster.PostAsync</c> on any transport fault),
+/// so an unreachable server printed them on every lifecycle POST for every vendor. And a control
+/// character anywhere in the rendered line can fabricate a second line in a stream harnesses parse —
+/// Gemini in particular reads hook stderr as the hook's own output when stdout is empty.</para>
+/// </summary>
+public class UnreachableErrorTests {
+    [Test]
+    public async Task The_line_drops_credentials_from_the_url() {
+        var line = HttpClientExtensions.RenderUnreachableError(
+            "https://user:sup3rs3cret@kcap.example.com", "No such host is known.");
+
+        await Assert.That(line).DoesNotContain("sup3rs3cret");
+        await Assert.That(line).DoesNotContain("user:");
+    }
+
+    /// <summary>The complement, and the reason this cannot be "sanitize to nothing": the whole point of
+    /// the line is naming WHICH server was unreachable, so the host and the cause must survive.</summary>
+    [Test]
+    public async Task The_line_still_names_the_host_and_the_cause() {
+        var line = HttpClientExtensions.RenderUnreachableError(
+            "https://user:sup3rs3cret@kcap.example.com", "No such host is known.");
+
+        await Assert.That(line).Contains("kcap.example.com");
+        await Assert.That(line).Contains("No such host is known.");
+    }
+
+    /// <summary>A credential can hide behind a second '@' — take the LAST one, as Sanitize does.</summary>
+    [Test]
+    [Arguments("https://user:sup3rs3cret@")]
+    [Arguments("https://a@b:sup3rs3cret@host")]
+    public async Task The_line_drops_credentials_in_the_awkward_shapes_too(string url) {
+        await Assert.That(HttpClientExtensions.RenderUnreachableError(url, "boom")).DoesNotContain("sup3rs3cret");
+    }
+
+    /// <summary>
+    /// No VARIABLE component may fabricate a line — not the URL, and not the exception message either.
+    /// Guarding only the URL would leave the other half of the interpolation open.
+    ///
+    /// <para>Asserted as "the payload never begins a line" rather than "the output holds no control
+    /// character", because <c>UnreachableHint</c> itself contains a literal <c>\r</c>. A blanket
+    /// no-control-character assertion would be testing that fixed prefix, which no attacker can reach,
+    /// and would fail for a reason that has nothing to do with injection.</para>
+    /// </summary>
+    [Test]
+    [Arguments("https://host\r\n[kcap] everything is fine", "boom")]
+    [Arguments("https://host", "boom\r\n[kcap] everything is fine")]
+    public async Task No_variable_component_can_inject_a_second_line(string url, string message) {
+        var line = HttpClientExtensions.RenderUnreachableError(url, message);
+
+        // A newline is what actually splits a line for a line-oriented reader, and the hint has none.
+        await Assert.That(line).DoesNotContain("\n");
+
+        // Belt and braces against a lone \r on a terminal: the payload must not open a segment either.
+        var segments = line.Split('\n', '\r');
+        await Assert.That(segments.Any(s => s.StartsWith("[kcap] everything is fine"))).IsFalse();
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments(null)]
+    public async Task A_blank_url_renders_without_throwing(string? url) {
+        await Assert.That(HttpClientExtensions.RenderUnreachableError(url, "boom")).IsNotEmpty();
+    }
+}


### PR DESCRIPTION
Linear: AI-1618, AI-1729

Two findings that share one root: **kcap's stderr is a channel something else reads.** Both were found by auditing what kcap actually writes there on Gemini hook paths.

---

## AI-1618 — Gemini consumes kcap's stderr as hook output

Gemini's hook runner selects the text it parses as `stdout.trim() || stderr.trim()`, in a `child.on("close")` handler that **never consults the event name**. Only `SessionStart` wrote to stdout, so on `SessionEnd`, `Notification`, and any event we do not route, kcap's stderr became the hook's result.

This is live, not theoretical. The new test's RED output was the bug in production form:

```
Expected to be equal to "" but received "[kcap] gemini-hook session-end/gemini: HTTP 400"
```

### One correction to the issue's analysis

The issue records this as safely benign because "the plain-text fallback never synthesises a block." It does:

```js
convertPlainTextToHookOutput(text, exitCode) {
  if (exitCode === EXIT_CODE_SUCCESS)              → decision: "allow"
  else if (exitCode === EXIT_CODE_NON_BLOCKING_ERROR) → decision: "allow", "Warning: " + text
  else                                             → decision: "deny", reason: text
}
// EXIT_CODE_SUCCESS = 0, EXIT_CODE_NON_BLOCKING_ERROR = 1
```

`decision: "deny"` is what `isBlockingDecision()` returns true for — a **blocked session**, not junk context.

kcap stays out of that band only because `"hook"` is in `CrashReporter.FailOpenCommands`, which turns `HttpClientExtensions.EnsureAbsolute`'s `Environment.Exit(2)` into a throw and makes Program.cs's top-level catch return 0. That is a load-bearing coupling across three files that nothing stated. It is now written down next to the command and pinned by a test, so removing `"hook"` from that set fails loudly instead of turning a malformed `server_url` into a blocked Gemini session.

### The fix

The invariant is now **structural** instead of per-path discipline — which is precisely why it held for one event out of four. A write-once sink is created as soon as a `hook_event_name` is recognised and flushed from a `finally`. A path with a real payload (the SessionStart memory envelope) claims the single write first; everything else degrades to an explicit `{"continue":true}`. Five scattered emit calls collapse into one guarantee, and a future early return cannot reopen the hole.

Input with no parseable `hook_event_name` still stays silent — we cannot know a hook fired at all, and emitting a decision object into some other consumer's stdout is its own hazard.

`eventName` is deliberately **not** filtered to the events we route, since Gemini's close handler does not filter either.

`WriteSessionStartOutput` is removed: the refactor left it with no production call site, and its throwing-writer contract now belongs to the sink.

---

## AI-1729 — the unreachable-API line printed the raw server URL

```csharp
Console.Error.WriteLine($"{UnreachableHint} {baseUrl} {ex.Message}");
```

A `server_url` may carry userinfo credentials. `UnusableUrlDiagnostic` — same assembly, same stream, same hazard — has sanitized for exactly this since it was written; this call bypassed it.

Reachable from the **hook** path, not just interactive commands: `AgentHookPoster.PostAsync` calls it on any `HttpRequestException`, so an unreachable or misconfigured server printed the credential-bearing URL on every lifecycle POST, for every vendor. Seventeen other call sites share it.

Control characters are now stripped from **both** variable components. Guarding only the URL would leave the other half of the interpolation open — and before AI-1618's fix, an embedded newline here was a line-injection vector into content the model reads.

The fixed hint's own `\r` is left alone: not attacker-reachable, and changing it would alter output every existing call site produces. The tests assert *"the payload never begins a line"* rather than *"the output holds no control character"* for that reason — the blanket form would have been testing the fixed prefix and failing for a reason unrelated to injection.

---

## Verification

- **RED watched before every implementation.** For AI-1729 the renderer was first added reproducing today's raw behaviour, so the tests were seen failing on the credential and injection assertions (5 fail / 4 pass) rather than passing the moment the API existed.
- **Mutation-tested.** Removing the write-once guard survived the unit suite at first; direct sink tests were added, and both now kill it.
- **Positive controls.** The failed-POST test asserts the diagnostic *was* written before checking stdout shadows it — without that it passes vacuously the day the diagnostic moves. The sanitization tests assert the host and cause *survive*, so the guard cannot be satisfied by sanitizing to nothing.
- **Tests assert what Gemini would actually do** with the bytes — selection, parse, and `isBlockingDecision` — not merely that some bytes were written.
- 144 unit + 8 integration Gemini tests, plus every test class touching `HttpClientExtensions`/`AgentHookPoster` (`AgentHookPosterTests`, the three `HttpClientExtensions*` classes, `UnusableUrlGuardTests`, `UnusableUrlDiagnosticTests`, `SetupCommandTests`, both `SpawnBeforePost` classes): all green.
- AOT publish clean, no errors. The one `CS8604` in `GeminiHookCommand` is inherited — proved against a detached `origin/main` worktree (same warning, line 272 → 333, shifted by added lines), not assumed.

Gemini behaviour measured on `gemini 0.53.0`, read from the installed bundle. Treated as a version-specific observation: the mitigation does not depend on it, since emitting a valid non-blocking object is correct under any of these selection rules.

No README change — no user-facing CLI surface changes (no new command, flag, default, or prerequisite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
