### PR TITLE
Record the Copilot session/new stdio MCP call-level measurement

### DIFF
--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -196,9 +196,24 @@ internal static class AcpVendorDescriptors {
     );
 
     /// <summary>GitHub Copilot CLI as an ACP hosted agent (<c>copilot --acp --stdio</c>).
-    /// ACP itself advertises MCP over http/sse only, so interactive <c>session/new</c> stdio servers
-    /// stay disabled. Review flows preload their validated stdio servers through Copilot's
-    /// <c>--additional-mcp-config</c> process argument and clamp the visible tool surface.</summary>
+    ///
+    /// <para><b><see cref="AcpVendorDescriptor.SupportsMcpServers"/> is <c>false</c> on call-level
+    /// measurement, not on the <c>mcpCapabilities</c> advertisement</b> — the advertised
+    /// <c>{http, sse}</c> shape cannot decide this flag either way (Kiro and Gemini advertise exactly
+    /// the same shape and both honour stdio servers). Measured against Copilot CLI 1.0.78
+    /// (2026-08-04): a purpose-built stdio server passed in <c>session/new.mcpServers</c> is silently
+    /// ignored. <c>session/new</c> succeeds, but the server process is never spawned (its own log
+    /// stays empty), no tool-call frame ever references it, and the model reports the tool
+    /// unavailable — identical on the interactive argv and on the full unattended review argv, where
+    /// <c>--available-tools</c> additionally rejects the injected tool's flattened id as an unknown
+    /// tool name. The same server, same build, same driver preloaded through
+    /// <c>--additional-mcp-config</c> completes <c>initialize</c> → <c>tools/list</c> →
+    /// <c>tools/call</c> with the tool's nonce reaching the model and the turn ending
+    /// <c>end_turn</c> — so the negative is Copilot's <c>session/new</c> handling, not the probe.
+    /// Re-flip only on an equivalent call-level probe succeeding against a newer build.</para>
+    ///
+    /// <para>Review flows therefore preload their validated stdio servers through Copilot's
+    /// <c>--additional-mcp-config</c> process argument and clamp the visible tool surface.</para></summary>
     public static readonly AcpVendorDescriptor Copilot = new(
         Vendor:              "copilot",
         ResolveBinaryPath:   cfg => cfg.CopilotPath,

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -315,14 +315,17 @@ internal static class AcpVendorDescriptors {
     /// unguessable name — reduces the allowlist to nothing the repository can match, which blocks it. Repo-authored <i>hooks</i> were separately measured NOT to run on the ACP path (they do
     /// on the <c>--prompt</c> path — the two paths differ, and neither predicts the other).</para>
     ///
-    /// <para><b>Deny-all is the launch default, and any launch that injects servers must open the
-    /// gate to exactly those names.</b> A review launch replaces the substituted value with the
-    /// injected result channel's wire name (replace, never append — the option is comma-coerced, so
-    /// a second entry would widen the gate rather than move it); an interactive launch injects
-    /// nothing and keeps the unguessable deny-all, which permits nothing and costs nothing. A future
-    /// interactive caller that starts populating <c>RuntimeStartContext.McpServers</c> must widen
-    /// the allowlist in the SAME change, or its servers ship silently blocked.
-    /// <c>AcpVendorDescriptorTests</c> and <c>GeminiReviewerLaunchTests</c> assert both halves.</para>
+    /// <para><b>Deny-all is the launch default; a review launch opens the gate to exactly ONE name —
+    /// the injected result channel's wire name</b> (replace, never append — the option is
+    /// comma-coerced, so appending would widen the gate rather than move it); an interactive launch
+    /// injects nothing and keeps the unguessable deny-all, which permits nothing and costs nothing.
+    /// <c>AcpVendorDescriptorTests</c> and <c>GeminiReviewerLaunchTests</c> assert both halves.
+    /// KNOWN LIMIT (#449): <c>AcpReviewFlowMcp.Build</c> puts any additional validated allowlist
+    /// servers in <c>session/new.mcpServers</c> under their canonical ids, which this single-name
+    /// gate does NOT admit — inert today because the built-in review definitions carry no MCP
+    /// allowlist, but a launch that needs those servers (or a future interactive caller populating
+    /// <c>RuntimeStartContext.McpServers</c>) must widen the gate in the same change, or its servers
+    /// ship silently blocked.</para>
     ///
     /// <para><see cref="NoOpModelSelector"/> for the same reason as Kiro: <c>session/new</c> does return a
     /// <c>models</c> object, so <see cref="ConfigOptionModelSelector"/>'s read half would fit, but its

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -200,7 +200,7 @@ internal static class AcpVendorDescriptors {
     /// <para><b><see cref="AcpVendorDescriptor.SupportsMcpServers"/> is <c>false</c> on call-level
     /// measurement, not on the <c>mcpCapabilities</c> advertisement</b> — the advertised
     /// <c>{http, sse}</c> shape cannot decide this flag either way (Kiro and Gemini advertise exactly
-    /// the same shape and both honour stdio servers). Measured against Copilot CLI 1.0.78
+    /// the same shape and both honour stdio servers). Measured on macOS against Copilot CLI 1.0.78
     /// (2026-08-04): a purpose-built stdio server passed in <c>session/new.mcpServers</c> is silently
     /// ignored. <c>session/new</c> succeeds, but the server process is never spawned (its own log
     /// stays empty), no tool-call frame ever references it, and the model reports the tool
@@ -297,7 +297,7 @@ internal static class AcpVendorDescriptors {
     internal const string UnmatchableMcpNamePlaceholder = "__kcap_unmatchable_mcp_name__";
 
     /// <summary>Google Gemini CLI as an ACP hosted agent (<c>gemini --experimental-acp</c>).
-    /// Interactive hosting only; the unattended reviewer is its own issue, as with Kiro.
+    /// Hosted interactively and as an unattended review-flow reviewer.
     ///
     /// <para><b><c>--skip-trust</c> is required, and is NOT a containment measure.</b> Gemini refuses a
     /// headless turn in an untrusted directory outright — <c>exit 55</c> before any model call — and a
@@ -315,11 +315,14 @@ internal static class AcpVendorDescriptors {
     /// unguessable name — reduces the allowlist to nothing the repository can match, which blocks it. Repo-authored <i>hooks</i> were separately measured NOT to run on the ACP path (they do
     /// on the <c>--prompt</c> path — the two paths differ, and neither predicts the other).</para>
     ///
-    /// <para><b>Denying everything is only correct while <see cref="AcpVendorDescriptor.SupportsMcpServers"/>
-    /// is false.</b> It permits nothing, so with nothing injected it costs nothing. The day the stdio
-    /// call-level probe flips that flag, this list must become the injected server names in the SAME
-    /// change, or hosted Gemini ships with MCP silently broken. <c>AcpVendorDescriptorTests</c> asserts
-    /// the coupling so the two cannot drift apart.</para>
+    /// <para><b>Deny-all is the launch default, and any launch that injects servers must open the
+    /// gate to exactly those names.</b> A review launch replaces the substituted value with the
+    /// injected result channel's wire name (replace, never append — the option is comma-coerced, so
+    /// a second entry would widen the gate rather than move it); an interactive launch injects
+    /// nothing and keeps the unguessable deny-all, which permits nothing and costs nothing. A future
+    /// interactive caller that starts populating <c>RuntimeStartContext.McpServers</c> must widen
+    /// the allowlist in the SAME change, or its servers ship silently blocked.
+    /// <c>AcpVendorDescriptorTests</c> and <c>GeminiReviewerLaunchTests</c> assert both halves.</para>
     ///
     /// <para><see cref="NoOpModelSelector"/> for the same reason as Kiro: <c>session/new</c> does return a
     /// <c>models</c> object, so <see cref="ConfigOptionModelSelector"/>'s read half would fit, but its

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -322,10 +322,11 @@ internal static class AcpVendorDescriptors {
     /// <c>AcpVendorDescriptorTests</c> and <c>GeminiReviewerLaunchTests</c> assert both halves.
     /// KNOWN LIMIT (#449): <c>AcpReviewFlowMcp.Build</c> puts any additional validated allowlist
     /// servers in <c>session/new.mcpServers</c> under their canonical ids, which this single-name
-    /// gate does NOT admit — inert today because the built-in review definitions carry no MCP
-    /// allowlist, but a launch that needs those servers (or a future interactive caller populating
-    /// <c>RuntimeStartContext.McpServers</c>) must widen the gate in the same change, or its servers
-    /// ship silently blocked.</para>
+    /// gate does NOT admit. The built-in review definitions carry no MCP allowlist and do not
+    /// exercise the gap, but any catalog or dynamic definition with a non-empty <c>mcp:</c> list
+    /// targeting a Gemini reviewer reaches it today: its servers are injected and silently blocked.
+    /// A launch that needs those servers (or a future interactive caller populating
+    /// <c>RuntimeStartContext.McpServers</c>) must widen the gate in the same change.</para>
     ///
     /// <para><see cref="NoOpModelSelector"/> for the same reason as Kiro: <c>session/new</c> does return a
     /// <c>models</c> object, so <see cref="ConfigOptionModelSelector"/>'s read half would fit, but its

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -543,9 +543,10 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             throw new InvalidOperationException("borrowed_snapshot_containment_mismatch");
     }
 
-    /// <summary>Builds Copilot CLI's process-level stdio MCP config. Copilot's ACP capability
-    /// advertises only HTTP/SSE for <c>session/new</c>, but the CLI accepts stdio servers in this
-    /// alternate config shape before the ACP session starts.</summary>
+    /// <summary>Builds Copilot CLI's process-level stdio MCP config. Copilot silently ignores stdio
+    /// servers passed in <c>session/new.mcpServers</c> (measured at call level against CLI 1.0.78 —
+    /// see the <see cref="AcpVendorDescriptors.Copilot"/> descriptor comment), but accepts them in
+    /// this alternate config shape before the ACP session starts.</summary>
     static string BuildCopilotAdditionalMcpConfig(IReadOnlyList<AcpMcpServerSpec> servers) {
         var mcpServers = new JsonObject();
 


### PR DESCRIPTION
AI-1614.

## What this is

The call-level re-probe of Copilot's stdio MCP handling that AI-1614 asked for, and the recording of its result. **Comment-only change** — the probe came back negative, so `SupportsMcpServers: false` stands and the `CopilotAdditionalConfig` transport stays.

## Why

`AcpVendorDescriptors.Copilot`'s `SupportsMcpServers: false` was justified by the `mcpCapabilities: {http, sse}` advertisement. Kiro (AI-1404) and Gemini (AI-899) advertise exactly the same shape and both honour `session/new.mcpServers` stdio servers anyway, so the advertisement is useless as a discriminator — the flag was an unverified empirical claim keeping a whole second MCP transport (`--additional-mcp-config`) alive. The AI-1404 descriptor comment set the bar: only an equivalent call-level probe against Copilot may flip it.

## The measurement (Copilot CLI 1.0.78, 2026-08-04, macOS/arm64)

Method, per the AI-1404 bar: a purpose-built stdio MCP server exposing one uniquely-named tool (virgin server/tool name + nonce per run — Cursor was measured persisting approvals by name, so identifiers are never reused), logging every frame it receives to its own file; an ACP driver replicating the daemon's exact wire shapes (`initialize` with `protocolVersion: 1` + minimal client caps, `session/new` with the spec's `{name, command, args, env:[{name,value}]}` shape, `session/prompt` asking the model to call the tool and echo the nonce, least-privilege permission auto-approve transliterated from `AcpInteractionBridge`).

| Run | Transport | Argv shape | Server log evidence | Outcome |
|---|---|---|---|---|
| Positive control | `--additional-mcp-config` | interactive | `initialize` → `tools/list` → `tools/call`, env canary intact | Nonce reached the model and came back verbatim; `end_turn` |
| Probe | `session/new.mcpServers` | interactive (`--acp --stdio`), 2 runs | **empty — server never spawned** | `session/new` succeeds (sessionId returned), zero tool-call frames, model answers `TOOL-UNAVAILABLE`; `end_turn` |
| Probe | `session/new.mcpServers` | full unattended review argv (`--allow-all-tools --no-ask-user --no-custom-instructions --disable-builtin-mcps --available-tools=<flattened id>`) | **empty — server never spawned** | Same, plus Copilot reports `Unknown tool name in the tool allowlist: "<server>-<tool>"` — session/new-delivered servers contribute nothing to the surface `--available-tools` filters |

Control and probes all ran on the same build (1.0.78 — Copilot self-updated from 1.0.77 after the first control run, so the control was re-run on 1.0.78 to keep the pair version-matched). Same server, same driver, same workspace shape in every run: the negative is Copilot's `session/new` handling, not the harness.

## What changed

- The Copilot descriptor comment now records the measurement, the version, and the re-flip bar, replacing the advertisement-derived justification.
- `BuildCopilotAdditionalMcpConfig`'s comment repeated the advertisement reasoning; it now states the measured behavior and points at the descriptor comment.

No behavior change, no README impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
