### PR TITLE
Register the ACP handshake-confirmed model, not the requested one

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1550,10 +1550,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // take (no availableModels match / the agent rejected the option — the vendor's default
             // runs in every null case). Register the CONFIRMED value, never the request: agent.Model
             // feeds AgentRegisteredAsync (live model chip + hosted_agent_started analytics),
-            // AgentRunStarted (agent_runs), and every reconnect re-registration. Same
-            // requested-vs-running rule as ModelSelectionLaunchPolicy, applied per-request instead of
-            // per-capability. PTY runtimes have no confirmation seam (Transcript is null) and keep
-            // reporting effectiveModel.
+            // AgentRunStarted (agent_runs), every reconnect re-registration, and the local
+            // supervision status payload (SnapshotAgentsForStatus). Same requested-vs-running rule
+            // as ModelSelectionLaunchPolicy, applied per-request instead of per-capability. PTY
+            // runtimes have no confirmation seam (Transcript is null) and keep reporting
+            // effectiveModel.
             var registeredModel = start.Transcript is { } confirmed ? confirmed.ResolvedModel : effectiveModel;
 
             var agent = new AgentInstance(agentId, prompt, registeredModel, effort, repoPath, cmd.Vendor, runtime, worktree, cts) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1134,10 +1134,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         var prompt        = cmd.Prompt;
         var model         = cmd.Model;
         // A protocol-v3 explicit-reviewer-model launch pins the server-resolved LaunchModel VERBATIM.
-        // Compute the effective model ONCE here so every site that records/reports the model the
-        // process actually runs — the launch log, the runtime start context, and the registered
-        // AgentInstance the server sees via RegisterAgentAsync / AgentRunStarted / every reconnect
-        // re-registration — reads the same value. Null block ⇒ legacy path, cmd.Model unchanged.
+        // Compute the effective model ONCE here so every site that records/reports the model this
+        // launch REQUESTS — the launch log and the runtime start context — reads the same value.
+        // (What the server sees registered is registeredModel below: for an ACP runtime the
+        // handshake-confirmed model narrows this request; PTY runtimes register it as-is.)
+        // Null block ⇒ legacy path, cmd.Model unchanged.
         // Explicitly string?, not var: ModelSelectionLaunchPolicy below clears this when the selected
         // runtime cannot apply a model, and "no model reported" must be representable in the type.
         string? effectiveModel = cmd.ExplicitReviewerModel?.LaunchModel ?? model;
@@ -1454,8 +1455,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 Prompt: prompt,
                 // Task 8: for an explicit-model reviewer launch, launch with the server-pinned
                 // LaunchModel VERBATIM (the launcher passes ctx.Model straight to the argument list —
-                // never recanonicalized). effectiveModel (computed once above) resolves this — the
-                // registered AgentInstance below reads the SAME local so they can never diverge.
+                // never recanonicalized). effectiveModel (computed once above) resolves this. The
+                // registered AgentInstance below reads the same local for PTY runtimes; an ACP
+                // runtime instead registers the handshake-confirmed model (see registeredModel),
+                // which can only narrow this request, never substitute a different one.
                 Model: effectiveModel,
                 Effort: effort,
                 Tools: tools,
@@ -1542,7 +1545,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 LogBridgeDefeatingPosture(agentId, applied.Sandbox, applied.Approval);
             }
 
-            var agent = new AgentInstance(agentId, prompt, effectiveModel, effort, repoPath, cmd.Vendor, runtime, worktree, cts) {
+            // An ACP runtime confirms model application during its StartAsync handshake:
+            // Transcript.ResolvedModel is the id actually applied, or null when the request did not
+            // take (no availableModels match / the agent rejected the option — the vendor's default
+            // runs in every null case). Register the CONFIRMED value, never the request: agent.Model
+            // feeds AgentRegisteredAsync (live model chip + hosted_agent_started analytics),
+            // AgentRunStarted (agent_runs), and every reconnect re-registration. Same
+            // requested-vs-running rule as ModelSelectionLaunchPolicy, applied per-request instead of
+            // per-capability. PTY runtimes have no confirmation seam (Transcript is null) and keep
+            // reporting effectiveModel.
+            var registeredModel = start.Transcript is { } confirmed ? confirmed.ResolvedModel : effectiveModel;
+
+            var agent = new AgentInstance(agentId, prompt, registeredModel, effort, repoPath, cmd.Vendor, runtime, worktree, cts) {
                 McpConfigPath       = mcpConfigPath,
                 CurrentCols         = HostedPtyCols,
                 CurrentRows         = HostedPtyRows,

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorAcpForwardingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorAcpForwardingTests.cs
@@ -540,17 +540,23 @@ public partial class AgentOrchestratorVendorTests {
         public string Vendor             { get; } = vendor;
         public bool   SupportsUnattended => false;
 
-        public int             StartCalls  { get; private set; }
-        public string?         LastAgentId { get; private set; }
-        public FakeAcpRuntime? LastRuntime { get; private set; }
+        /// <summary>Threaded onto the <see cref="FakeAcpRuntime"/> as its handshake-confirmed model —
+        /// null stands in for a request that did not take (no match / agent rejected the option).</summary>
+        public string? ResolvedModel { get; init; } = "gpt-x";
+
+        public int                  StartCalls  { get; private set; }
+        public string?              LastAgentId { get; private set; }
+        public RuntimeStartContext? LastContext { get; private set; }
+        public FakeAcpRuntime?      LastRuntime { get; private set; }
 
         public bool IsAvailable() => true;
 
         public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
             StartCalls++;
             LastAgentId = ctx.AgentId;
+            LastContext = ctx;
 
-            var runtime = new FakeAcpRuntime();
+            var runtime = new FakeAcpRuntime { ResolvedModel = ResolvedModel };
             LastRuntime = runtime;
 
             return Task.FromResult(new HostedRuntimeStart(runtime, McpConfigPath: null, Transcript: runtime));

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -1480,6 +1480,91 @@ public partial class AgentOrchestratorVendorTests {
         }
     }
 
+    /// <summary>
+    /// The request-level sibling of the capability-level test above: this vendor CAN select models,
+    /// but THIS request did not take (no availableModels match, or the agent rejected the config
+    /// option — the selector is best-effort and the vendor's default runs). The runtime's transcript
+    /// carries the confirmed outcome (<c>ResolvedModel == null</c>), and the registration must report
+    /// that — never the unresolved request the dashboard and analytics would otherwise claim is live.
+    /// </summary>
+    [Test]
+    public async Task Acp_launch_whose_requested_model_did_not_resolve_registers_no_model() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server        = new CaptureServerConnection();
+            var ptyFactory    = new SpyPtyProcessFactory();
+            var cursorFactory = new SpyAcpHostedAgentRuntimeFactory { ResolvedModel = null };
+
+            await using var orch = BuildOrchestrator(
+                server, ptyFactory, new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [cursorFactory]);
+            orch.AcpFinalDrainBudget = TimeSpan.FromMilliseconds(200);
+
+            await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "agent-acp-unresolved",
+                Prompt: "do the thing",
+                Model: "claude-opus-4-8",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "cursor"));
+
+            // Not refused, and the REQUEST still reached the runtime (selection stays best-effort
+            // there) — this test is about what gets reported, not what gets attempted.
+            await Assert.That(server.LaunchFailedCalls).IsEmpty();
+            await Assert.That(cursorFactory.StartCalls).IsEqualTo(1);
+            await Assert.That(cursorFactory.LastContext!.Model).IsEqualTo("claude-opus-4-8");
+
+            await Assert.That(server.AgentRegisteredCalls).Contains(("agent-acp-unresolved", (string?)null));
+
+            await orch.HandleStopAgentForTest("agent-acp-unresolved");
+        } finally {
+            cleanup();
+        }
+    }
+
+    /// <summary>Paired positive: when the handshake CONFIRMS the applied model, the registration
+    /// reports the confirmed id — for ACP that is the vendor's own (possibly parameterized) form,
+    /// not necessarily the requested string. Proves the fix forwards the confirmation rather than
+    /// blanking every ACP launch's model.</summary>
+    [Test]
+    public async Task Acp_launch_whose_requested_model_resolved_registers_the_confirmed_id() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server        = new CaptureServerConnection();
+            var ptyFactory    = new SpyPtyProcessFactory();
+            var cursorFactory = new SpyAcpHostedAgentRuntimeFactory {
+                ResolvedModel = "claude-opus-4-8[thinking=true,context=200k]"
+            };
+
+            await using var orch = BuildOrchestrator(
+                server, ptyFactory, new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [cursorFactory]);
+            orch.AcpFinalDrainBudget = TimeSpan.FromMilliseconds(200);
+
+            await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "agent-acp-resolved",
+                Prompt: "do the thing",
+                Model: "claude-opus-4-8",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "cursor"));
+
+            await Assert.That(server.LaunchFailedCalls).IsEmpty();
+            await Assert.That(server.AgentRegisteredCalls)
+                .Contains(("agent-acp-resolved", (string?)"claude-opus-4-8[thinking=true,context=200k]"));
+
+            await orch.HandleStopAgentForTest("agent-acp-resolved");
+        } finally {
+            cleanup();
+        }
+    }
+
     /// <summary>The other half of <see cref="ModelSelectionLaunchPolicy"/>: a PINNED reviewer model is
     /// different in kind from an interactive request. A review round's authority depends on which model
     /// produced it, so silently reviewing with the vendor default — even with truthful metadata — is


### PR DESCRIPTION
Linear: AI-1612

## The bug

An ACP launch applies its requested model **best-effort** during `StartAsync` (`ConfigOptionModelSelector` → `session/set_config_option`): no `availableModels` match, an unparsable `models` object, or a JSON-RPC error all leave the **vendor's default model** running. But the orchestrator registered the *requested* value (`effectiveModel`) on the `AgentInstance`, and `agent.Model` is what every reporting channel reads:

- `AgentRegisteredAsync` → the live model chip **and** the `hosted_agent_started` analytics capture,
- `AgentRunStarted` → the `agent_runs` read model (ended-agent history view),
- every reconnect re-registration.

So requesting `model="claude-opus-4-8"` on Cursor and having it not resolve showed Opus as live on the dashboard and in analytics while the session ran Cursor's default.

Neither existing correction channel covers this: `ReportAgentResolvedModel` is called Codex-only (and rejects null, so it cannot express "no model"), and the server deliberately does not persist `AcpSessionStarted`'s `model` argument.

## Why the fix is CLI-side, at registration

AI-1612 suggested applying `AcpSessionStarted`'s already-on-the-wire model server-side (option 1). Investigating the ordering shows a strictly better seam: **the truth is available before registration**. `runtimeFactory.StartAsync` completes the whole ACP handshake — including model selection — before the orchestrator constructs the `AgentInstance`, and `IAcpTranscriptSource.ResolvedModel` was explicitly designed to carry the confirmed outcome ("nullable rather than falling back to the requested-but-unconfirmed id"). The canonical `SessionStarted@Seq0` envelope already uses it; only the registration lane ignored it.

Registering the confirmed value fixes every consumer with one assignment — `AgentRegisteredAsync` (chip + analytics), `AgentRunStarted` (`agent_runs`), reconnect re-registration, and the local supervision status payload (`SnapshotAgentsForStatus`, named by review round 2 — the corrected value propagates there correctly). That includes the `hosted_agent_started` analytics capture, which is point-in-time at registration and therefore **unreachable by any after-the-fact server-side correction**.

## The change

At `AgentInstance` construction, a transcript-bearing (ACP) runtime registers `start.Transcript.ResolvedModel` instead of `effectiveModel`:

- request did not take → registers **null** ("no model" beats a wrong model — the same asymmetry `ModelSelectionLaunchPolicy` settled at the capability level, now applied per-request),
- request resolved → registers the vendor's **confirmed** (possibly parameterized) id, e.g. `claude-opus-4-8[thinking=true,context=200k]` — the same string the canonical transcript events already carry,
- no model requested → null, unchanged.

PTY runtimes (`Transcript == null`) keep registering `effectiveModel` unchanged; Codex's `ReportAgentResolvedModel` path and the protocol-v3 `ExplicitReviewerModel` channel are untouched (ACP factories have no reviewer-model resolver, so explicit-model reviewer launches already fail closed at the report waiter). No wire change — `AgentRegisteredAsync`'s arity is frozen and unchanged; only the value the daemon passes is corrected.

## Tests

Two regression tests at the **reported-value seam** (what `AgentRegisteredAsync` receives), per the issue's acceptance — not the selector's return:

- `Acp_launch_whose_requested_model_did_not_resolve_registers_no_model` — request reaches the runtime (selection stays best-effort) but registration reports null, never the unresolved request. Red before the fix (registered `claude-opus-4-8`), green after.
- `Acp_launch_whose_requested_model_resolved_registers_the_confirmed_id` — the confirmed parameterized id is registered, proving the fix forwards the confirmation rather than blanking every ACP launch. Also red before the fix.

`SpyAcpHostedAgentRuntimeFactory` gains a configurable `ResolvedModel` (default preserves all existing forwarding tests) and `LastContext` capture.

## Verification

- Both new tests: red pre-fix → green post-fix.
- `AgentOrchestratorVendorTests` (all partials, 177 tests): green except one consent-dialog timeout that passes solo — load flake, and causally excluded (PTY path, where the registered value is identical by construction).
- Full unit suite vs a detached `origin/main` baseline worktree: identical pre-existing failure set (46 env-dependent config/install failures on this machine, both suites); the only branch-only diffs pass solo in isolation.
- Integration suite: 199/199.
- AOT publish: the 4 IL2026/IL3050 warnings in `McpWorkItemsServer.cs` reproduce identically on `origin/main` (pre-existing, filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
