### PR TITLE
Widen the Gemini review MCP gate to exactly the injected server set

### DIFF
--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -282,7 +282,7 @@ internal static class AcpVendorDescriptors {
     internal const string UnmatchableMcpNamePlaceholder = "__kcap_unmatchable_mcp_name__";
 
     /// <summary>Google Gemini CLI as an ACP hosted agent (<c>gemini --experimental-acp</c>).
-    /// Interactive hosting only; the unattended reviewer is its own issue, as with Kiro.
+    /// Hosted interactively and as an unattended review-flow reviewer.
     ///
     /// <para><b><c>--skip-trust</c> is required, and is NOT a containment measure.</b> Gemini refuses a
     /// headless turn in an untrusted directory outright — <c>exit 55</c> before any model call — and a
@@ -300,11 +300,16 @@ internal static class AcpVendorDescriptors {
     /// unguessable name — reduces the allowlist to nothing the repository can match, which blocks it. Repo-authored <i>hooks</i> were separately measured NOT to run on the ACP path (they do
     /// on the <c>--prompt</c> path — the two paths differ, and neither predicts the other).</para>
     ///
-    /// <para><b>Denying everything is only correct while <see cref="AcpVendorDescriptor.SupportsMcpServers"/>
-    /// is false.</b> It permits nothing, so with nothing injected it costs nothing. The day the stdio
-    /// call-level probe flips that flag, this list must become the injected server names in the SAME
-    /// change, or hosted Gemini ships with MCP silently broken. <c>AcpVendorDescriptorTests</c> asserts
-    /// the coupling so the two cannot drift apart.</para>
+    /// <para><b>Deny-all is the launch default; a review launch opens the gate to exactly the servers it
+    /// injects.</b> The factory replaces the substituted value with the comma-joined names of the built
+    /// <c>session/new</c> list — the result channel plus any resolved allowlist servers, every one under
+    /// a per-launch aliased name, because a canonical id is a fixed public literal the reviewed
+    /// repository could declare its own server under and have it spawned as the daemon user (the
+    /// impersonation shape measured in spec §2.3/§2.6; multi-name admission measured on 0.53.0 — both
+    /// admitted servers reach <c>tools/call</c>, an injected name outside the gate never spawns). An
+    /// interactive launch injects nothing and keeps the unguessable deny-all, which permits nothing and
+    /// costs nothing; a future interactive caller populating <c>RuntimeStartContext.McpServers</c> must
+    /// widen the gate in the same change. <c>GeminiReviewerLaunchTests</c> pins gate == injected set.</para>
     ///
     /// <para><see cref="NoOpModelSelector"/> for the same reason as Kiro: <c>session/new</c> does return a
     /// <c>models</c> object, so <see cref="ConfigOptionModelSelector"/>'s read half would fit, but its

--- a/src/Capacitor.Cli.Daemon/Acp/LaunchIdentity.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/LaunchIdentity.cs
@@ -38,17 +38,34 @@ internal sealed record LaunchIdentity {
     /// interactive launch admits no repository-authored server.</summary>
     public string UnmatchableMcpName { get; }
 
+    readonly bool _aliases;
+    readonly Guid _allowlistSuffix;
+
     // Private: a caller can ask for a fresh identity but cannot construct an arbitrary one. This is the
     // seam where a fixed or reused name would otherwise slip in, and every argv-equality test in the suite
     // would still pass while the containment was gone.
-    private LaunchIdentity(string canonicalId, string wireName, string unmatchableName) {
+    private LaunchIdentity(string canonicalId, string wireName, string unmatchableName, bool aliases, Guid allowlistSuffix) {
         ResultChannelCanonicalId = canonicalId;
         ResultChannelWireName    = wireName;
         UnmatchableMcpName       = unmatchableName;
+        _aliases                 = aliases;
+        _allowlistSuffix         = allowlistSuffix;
     }
 
     /// <summary>
-    /// The ONLY production entry point. Two INDEPENDENT v4 GUIDs, and no launch context in scope — so the
+    /// The name an injected NON-result-channel review server (an allowlist server, or the borrowed-snapshot
+    /// review-context server) carries on the wire. For an aliasing vendor this is the canonical id plus the
+    /// launch's allowlist suffix — the vendor's MCP gate is an exact-name allowlist that must admit these
+    /// servers, and admitting the CANONICAL id would let the repository being worked in declare a server of
+    /// that fixed, public name and have it spawned as the daemon user (the same impersonation shape measured
+    /// for the result channel; see the Gemini reviewer design spec §2.3/§2.6). For every other vendor this
+    /// returns the input unchanged, keeping their wire behaviour byte-identical.
+    /// </summary>
+    public string AllowlistWireName(string canonicalId) =>
+        _aliases ? $"{canonicalId}-{_allowlistSuffix:N}" : canonicalId;
+
+    /// <summary>
+    /// The ONLY production entry point. Three INDEPENDENT v4 GUIDs, and no launch context in scope — so the
     /// names cannot be derived from a session id, an agent id, a worktree path or the clock even by
     /// accident, because none of those values is reachable from here.
     /// </summary>
@@ -56,29 +73,32 @@ internal sealed record LaunchIdentity {
     /// also admit our own channel, so the channel's name has to be unguessable too (Gemini today). False
     /// keeps the canonical id on the wire, which is what every other vendor has always sent.</param>
     public static LaunchIdentity ForLaunch(bool aliasResultChannel) =>
-        FromGuids(Guid.NewGuid(), Guid.NewGuid(), aliasResultChannel);
+        FromGuids(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), aliasResultChannel);
 
     /// <summary>
     /// Test seam. Takes concrete <see cref="Guid"/> VALUES rather than a factory delegate: a delegate would
     /// close over its caller's scope, which is how an earlier revision of this design left
     /// derivation-from-launch-context legal while its tests still passed. A value cannot close over anything.
     /// </summary>
-    internal static LaunchIdentity FromGuids(Guid resultChannel, Guid unmatchable, bool aliasResultChannel) {
+    internal static LaunchIdentity FromGuids(Guid resultChannel, Guid unmatchable, Guid allowlistSuffix, bool aliasResultChannel) {
         // No fallback, predictable or otherwise. The security property is that these strings are unguessable
         // at the instant the repository's own MCP declarations are read, so a degraded name is worse than no
         // agent at all. Independence is asserted rather than assumed: the wire name is visible to the agent
         // (it is in its own process argv), so a shared GUID would make the unmatchable name derivable from it.
-        if (resultChannel == Guid.Empty || unmatchable == Guid.Empty || resultChannel == unmatchable)
+        if (resultChannel == Guid.Empty || unmatchable == Guid.Empty || allowlistSuffix == Guid.Empty
+         || resultChannel == unmatchable || resultChannel == allowlistSuffix || unmatchable == allowlistSuffix)
             throw new InvalidOperationException(
                 "Refusing to build a launch identity: a generated name would be predictable or reused. A "
-              + "vendor's MCP allowlist is an exact-name gate, so either name being guessable lets the "
-              + "repository being worked in impersonate the agent's result channel.");
+              + "vendor's MCP allowlist is an exact-name gate, so any of these names being guessable lets "
+              + "the repository being worked in impersonate an injected review server.");
 
         return new(
             KcapMcpRegistry.ReservedResultChannelId,
             aliasResultChannel
                 ? $"{KcapMcpRegistry.ReservedResultChannelId}-{resultChannel:N}"
                 : KcapMcpRegistry.ReservedResultChannelId,
-            $"kcap-deny-{unmatchable:N}");
+            $"kcap-deny-{unmatchable:N}",
+            aliasResultChannel,
+            allowlistSuffix);
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -413,17 +413,34 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
 
         var argv = SubstituteUnmatchableNames([.. descriptor.Argv], identity);
 
+        // The comma-joined allowlist value a review launch opens its MCP gate to — null on every other
+        // launch. Held here so the whole-vector assertion below asserts the same value the argv got.
+        string? reviewGate = null;
+
         if (ctx.IsReviewFlow) {
             argv.AddRange(descriptor.UnattendedTrustArgv);
 
-            // A review launch REPLACES the deny-all allowlist value with the channel's wire name. Replace,
-            // never append: the option is array-typed and comma-coerced by the vendor, so a second entry
-            // would widen the gate rather than move it. Deny-all is what a launch gets by default and only
-            // this arm opens it, which is the fail-closed direction.
-            if (AliasesResultChannel(descriptor))
+            // A review launch REPLACES the deny-all allowlist value with the names of exactly the servers
+            // this launch injects — the result channel plus any resolved allowlist servers — as ONE
+            // comma-joined value. Replace, never append: the option is array-typed and comma-coerced by
+            // the vendor, so a second option occurrence would widen the gate rather than move it. Deriving
+            // the value from the BUILT list (not re-deriving from ids) is what keeps the gate and the
+            // session/new payload the same set by construction: Build is deterministic given ctx (every
+            // name comes from the identity or the registry), so StartAsync's own call for session/new
+            // yields the same names — the same-instance identity threading is what guarantees it.
+            // Measured on gemini 0.53.0: both admitted servers spawn and reach tools/call, a third
+            // injected name outside the gate never spawns. Deny-all is what a launch gets by default and
+            // only this arm opens it, the fail-closed direction. Built inside the arm (like Copilot's
+            // below) because only these two argv consumers need the list here — for every other vendor
+            // session/new is the sole consumer and StartAsync builds it, so validating in the builder too
+            // would change direct-builder behavior for vendors whose argv never carries MCP names.
+            if (AliasesResultChannel(descriptor)) {
+                var reviewMcp = ValidateAndBuildReviewFlowMcp(ctx, descriptor, resolved)!;
+                reviewGate = string.Join(",", reviewMcp.Select(s => s.Name));
                 for (var i = 0; i < argv.Count; i++)
                     if (argv[i] == identity.UnmatchableMcpName)
-                        argv[i] = identity.ResultChannelWireName;
+                        argv[i] = reviewGate;
+            }
 
             if (descriptor.ReviewFlowMcpTransport == AcpReviewFlowMcpTransport.CopilotAdditionalConfig) {
                 var reviewMcp = ValidateAndBuildReviewFlowMcp(ctx, descriptor, resolved)!;
@@ -526,7 +543,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         // touches it. Asserting the local list instead would certify something the OS never sees, which is
         // worse than no assertion because it looks like coverage.
         if (AliasesResultChannel(descriptor) && psi.FileName != BorrowedReviewSandbox.SandboxExecPath)
-            AssertGeminiArgvIsCanonical(psi.ArgumentList, ctx.IsReviewFlow, identity);
+            AssertGeminiArgvIsCanonical(psi.ArgumentList, ctx.IsReviewFlow, identity, reviewGate);
 
         return psi;
     }
@@ -704,10 +721,14 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// an oracle derived from the thing under test. Written out so a fourth contributor to the argv, or an
     /// edited constant, goes red.</para>
     /// </summary>
-    internal static string[] ExpectedGeminiArgv(bool isReviewFlow, LaunchIdentity identity) =>
+    internal static string[] ExpectedGeminiArgv(bool isReviewFlow, LaunchIdentity identity, string? reviewGate) =>
         isReviewFlow
             ? ["--experimental-acp", "--skip-trust",
-               "--allowed-mcp-server-names", identity.ResultChannelWireName,
+               "--allowed-mcp-server-names",
+               reviewGate ?? throw new InvalidOperationException(
+                   "gemini_review_gate_missing: a review launch's expected argv needs the comma-joined "
+                 + "allowlist value the launch computed; asserting against a re-derived one would let the "
+                 + "gate and the assertion drift apart."),
                "--approval-mode", "yolo"]
             : ["--experimental-acp", "--skip-trust",
                "--allowed-mcp-server-names", identity.UnmatchableMcpName];
@@ -722,12 +743,17 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// approval or widens the MCP gate. It should be unfalsifiable today; if it ever throws, a contributor
     /// was added without reading this.</para>
     ///
+    /// <para>The review gate value is an INPUT, not re-derived here: the template's job is catching a new
+    /// argv contributor, while gate↔session/new parity is pinned separately by the launch tests, against
+    /// the built server list.</para>
+    ///
     /// <para>Whole-vector rather than a scan for dangerous options, because a template fails on any new
     /// token whatever its spelling — so it needs no model of the vendor's option grammar, where camel-case
     /// expansion and boolean negation both make an enumerated key list unprovable.</para>
     /// </summary>
-    internal static void AssertGeminiArgvIsCanonical(IReadOnlyList<string> argv, bool isReviewFlow, LaunchIdentity identity) {
-        var expected = ExpectedGeminiArgv(isReviewFlow, identity);
+    internal static void AssertGeminiArgvIsCanonical(
+            IReadOnlyList<string> argv, bool isReviewFlow, LaunchIdentity identity, string? reviewGate) {
+        var expected = ExpectedGeminiArgv(isReviewFlow, identity, reviewGate);
 
         if (argv.SequenceEqual(expected)) return;
 
@@ -735,8 +761,8 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             $"gemini_launch_argv_not_canonical: built [{string.Join(" ", argv)}] but this launch shape is "
           + $"[{string.Join(" ", expected)}]. A contributor to the Gemini argv was added or changed; a "
           + "review launch must carry exactly one --approval-mode yolo and exactly one allowlist entry "
-          + "naming its own result channel, and an interactive launch must carry the deny-all name and no "
-          + "approval mode (the Gemini reviewer design spec §3.3a).");
+          + "naming exactly the servers it injects, and an interactive launch must carry the deny-all name "
+          + "and no approval mode (the Gemini reviewer design spec §3.3a).");
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -407,6 +407,12 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         // different identities and the allowlist would not admit its own result channel.
         var identity = ctx.LaunchIdentity ?? LaunchIdentity.ForLaunch(AliasesResultChannel(descriptor));
 
+        // The fallback identity must also be what every ctx-reading consumer below sees —
+        // AcpReviewFlowMcp.Build derives server wire names from ctx.LaunchIdentity, and with ctx still
+        // carrying null it falls back to canonical, repository-matchable ids while the argv substitution
+        // uses the fresh identity (review finding). The checked value must BE the used value.
+        ctx = ctx with { LaunchIdentity = identity };
+
         // Defence in depth: StartAsync gates before any connection source runs, but a direct builder call
         // (a test, a future caller, a refactor that inlines the spawn) is its own path to an argv.
         RequireGeminiReviewerCapability(descriptor, config, ctx.IsReviewFlow, resolveGeminiVersion);

--- a/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
@@ -31,8 +31,12 @@ internal static class AcpReviewFlowMcp {
 
         foreach (var id in allowlistServerIds) {
             // id is a validated canonical id, so Resolve is non-null. Allowlist servers get KCAP_URL only.
+            // Injected under the launch's wire name: for an aliasing vendor the canonical id is a fixed,
+            // public literal the reviewed repository could declare a server under, so admitting it in the
+            // vendor's name gate would be the same impersonation hole the result channel's alias closes.
             var descriptor = KcapMcpRegistry.Resolve(id)!;
-            servers.Add(new(descriptor.Id, ctx.CapacitorPath, descriptor.Args, [new("KCAP_URL", ctx.ServerUrl!)]));
+            servers.Add(new(WireName(ctx, descriptor.Id), ctx.CapacitorPath, descriptor.Args,
+                [new("KCAP_URL", ctx.ServerUrl!)]));
         }
 
         if (ctx.IsBorrowedSnapshot) {
@@ -40,11 +44,16 @@ internal static class AcpReviewFlowMcp {
                 throw new InvalidOperationException(
                     "Borrowed-snapshot review cannot inject kcap-review-context (missing capability URL).");
             servers.Add(new(
-                "kcap-review-context", ctx.CapacitorPath, ["mcp", "review"],
+                WireName(ctx, "kcap-review-context"), ctx.CapacitorPath, ["mcp", "review"],
                 [new("KCAP_REVIEW_CONTEXT_MODE", "1"),
                  new("KCAP_REVIEW_CONTEXT_URL", ctx.ReviewContextCapabilityUrl)]));
         }
 
         return servers;
     }
+
+    // Same fallback shape as channelName above: a context that never went through the factory (a direct
+    // test call) keeps canonical names, and every non-aliasing vendor's identity returns the input as-is.
+    static string WireName(RuntimeStartContext ctx, string canonicalId) =>
+        ctx.LaunchIdentity?.AllowlistWireName(canonicalId) ?? canonicalId;
 }

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -123,9 +123,9 @@ internal sealed record RuntimeStartContext(
         string?           DaemonBridgeUrl,
         string            CapacitorPath,
         // D-c: the review-flow definition's MCP allowlist, carried verbatim from
-        // LaunchAgentCommand.McpAllowlist through to LauncherContext.McpAllowlist for the PTY
-        // launchers to materialize. Unused by the ACP factory (Cursor has no MCP-allowlist
-        // materialization yet).
+        // LaunchAgentCommand.McpAllowlist. PTY launchers materialize it into a temp mcp-config;
+        // the ACP factory resolves it (TryResolveReviewFlowAllowlist) into extra session/new
+        // servers, admitted by an aliasing vendor's name gate under per-launch wire names.
         string[]?         McpAllowlist = null,
         // Phase A: owned worktree (daemon-created) vs borrowed cwd (the user's own
         // checkout), carried from LaunchAgentCommand.Borrowed through to LauncherContext.Work.

--- a/test/Capacitor.Cli.Tests.Unit/Acp/LaunchIdentityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/LaunchIdentityTests.cs
@@ -15,15 +15,17 @@ namespace Capacitor.Cli.Tests.Unit.Acp;
 public class LaunchIdentityTests {
     static Guid A => Guid.Parse("11111111-1111-1111-1111-111111111111");
     static Guid B => Guid.Parse("22222222-2222-2222-2222-222222222222");
+    static Guid C => Guid.Parse("33333333-3333-3333-3333-333333333333");
 
     const string AHex = "11111111111111111111111111111111";
     const string BHex = "22222222222222222222222222222222";
+    const string CHex = "33333333333333333333333333333333";
 
     // ── the aliasing vendor (Gemini today) ──
 
     [Test]
     public async Task Aliasing_WireNameIsTheCanonicalIdSuffixedWithExactlyTheChannelGuid() {
-        var id = LaunchIdentity.FromGuids(A, B, aliasResultChannel: true);
+        var id = LaunchIdentity.FromGuids(A, B, C, aliasResultChannel: true);
 
         // Exact equality against a value the test chose. A derived generator — a hash of a session id, a
         // counter, a clock — would produce a GUID-shaped string that passes uniqueness and format checks
@@ -34,16 +36,26 @@ public class LaunchIdentityTests {
 
     [Test]
     public async Task UnmatchableName_IsExactlyTheDenyPrefixAndTheOtherGuid() {
-        var id = LaunchIdentity.FromGuids(A, B, aliasResultChannel: true);
+        var id = LaunchIdentity.FromGuids(A, B, C, aliasResultChannel: true);
 
         await Assert.That(id.UnmatchableMcpName).IsEqualTo($"kcap-deny-{BHex}");
+    }
+
+    /// <summary>An allowlist server rides the wire under the canonical id plus the launch's allowlist
+    /// suffix — a canonical id alone is a fixed public literal the reviewed repository could declare its
+    /// own server under, and the vendor's gate matches names exactly.</summary>
+    [Test]
+    public async Task Aliasing_AllowlistWireNameIsTheCanonicalIdSuffixedWithExactlyTheAllowlistGuid() {
+        var id = LaunchIdentity.FromGuids(A, B, C, aliasResultChannel: true);
+
+        await Assert.That(id.AllowlistWireName("kcap-review")).IsEqualTo($"kcap-review-{CHex}");
     }
 
     /// <summary>Reserved-name comparisons must keep resolving on the canonical id, or the registry's
     /// reservation check and Copilot's tool-id builder start disagreeing with what the vendor was sent.</summary>
     [Test]
     public async Task Aliasing_CanonicalIdIsTheReservedChannelId_NotTheWireName() {
-        var id = LaunchIdentity.FromGuids(A, B, aliasResultChannel: true);
+        var id = LaunchIdentity.FromGuids(A, B, C, aliasResultChannel: true);
 
         await Assert.That(id.ResultChannelCanonicalId).IsEqualTo(KcapMcpRegistry.ReservedResultChannelId);
         await Assert.That(id.ResultChannelCanonicalId).IsNotEqualTo(id.ResultChannelWireName);
@@ -57,10 +69,20 @@ public class LaunchIdentityTests {
     /// </summary>
     [Test]
     public async Task NonAliasing_WireNameEqualsTheCanonicalId() {
-        var id = LaunchIdentity.FromGuids(A, B, aliasResultChannel: false);
+        var id = LaunchIdentity.FromGuids(A, B, C, aliasResultChannel: false);
 
         await Assert.That(id.ResultChannelWireName).IsEqualTo(KcapMcpRegistry.ReservedResultChannelId);
         await Assert.That(id.ResultChannelWireName).IsEqualTo(id.ResultChannelCanonicalId);
+    }
+
+    /// <summary>Same guard for the allowlist names: a non-aliasing vendor's injected servers keep their
+    /// canonical ids on the wire, which is what Copilot's tool-id builder and additional-mcp-config key on.</summary>
+    [Test]
+    public async Task NonAliasing_AllowlistWireNameReturnsTheCanonicalIdUnchanged() {
+        var id = LaunchIdentity.FromGuids(A, B, C, aliasResultChannel: false);
+
+        await Assert.That(id.AllowlistWireName("kcap-review")).IsEqualTo("kcap-review");
+        await Assert.That(id.AllowlistWireName("kcap-review-context")).IsEqualTo("kcap-review-context");
     }
 
     /// <summary>The unmatchable name is per-launch for EVERY vendor — that behaviour predates aliasing and
@@ -77,17 +99,18 @@ public class LaunchIdentityTests {
     // ── properties both arms must hold ──
 
     /// <summary>
-    /// Both names carry into an argv option whose value the vendor comma-splits, so a comma in either would
+    /// Every name carries into an argv option whose value the vendor comma-splits, so a comma in any would
     /// silently become two allowlist entries. A GUID hex cannot contain one — asserted rather than assumed,
     /// because it is the reason the vendor's coercion semantics never have to be reproduced.
     /// </summary>
     [Test]
     [Arguments(true)]
     [Arguments(false)]
-    public async Task NeitherNameCanCarryACommaOrWhitespace(bool alias) {
+    public async Task NoNameCanCarryACommaOrWhitespace(bool alias) {
         var id = LaunchIdentity.ForLaunch(alias);
 
-        foreach (var name in new[] { id.ResultChannelWireName, id.UnmatchableMcpName }) {
+        foreach (var name in new[] {
+                     id.ResultChannelWireName, id.UnmatchableMcpName, id.AllowlistWireName("kcap-review") }) {
             await Assert.That(name).DoesNotContain(",");
             await Assert.That(name.Any(char.IsWhiteSpace)).IsFalse();
         }
@@ -100,39 +123,47 @@ public class LaunchIdentityTests {
 
         await Assert.That(a.ResultChannelWireName).IsNotEqualTo(b.ResultChannelWireName);
         await Assert.That(a.UnmatchableMcpName).IsNotEqualTo(b.UnmatchableMcpName);
+        await Assert.That(a.AllowlistWireName("kcap-review")).IsNotEqualTo(b.AllowlistWireName("kcap-review"));
     }
 
     /// <summary>
-    /// The two names must not be derivable from each other: the agent can read its own argv, so learning the
-    /// wire name must not yield the unmatchable name.
+    /// The three names must not be derivable from one another: the agent can read its own argv, so learning
+    /// one generated suffix must not yield another.
     /// </summary>
     [Test]
-    public async Task ForLaunch_UsesIndependentGuidsForTheTwoNames() {
+    public async Task ForLaunch_UsesIndependentGuidsForTheThreeNames() {
         var id = LaunchIdentity.ForLaunch(aliasResultChannel: true);
 
-        var channelGuid = id.ResultChannelWireName[(KcapMcpRegistry.ReservedResultChannelId.Length + 1)..];
-        var denyGuid    = id.UnmatchableMcpName["kcap-deny-".Length..];
+        var channelGuid   = id.ResultChannelWireName[(KcapMcpRegistry.ReservedResultChannelId.Length + 1)..];
+        var denyGuid      = id.UnmatchableMcpName["kcap-deny-".Length..];
+        var allowlistGuid = id.AllowlistWireName("kcap-review")["kcap-review-".Length..];
 
         await Assert.That(channelGuid).IsNotEqualTo(denyGuid);
+        await Assert.That(channelGuid).IsNotEqualTo(allowlistGuid);
+        await Assert.That(denyGuid).IsNotEqualTo(allowlistGuid);
     }
 
     [Test]
-    [Arguments("00000000-0000-0000-0000-000000000000", "22222222-2222-2222-2222-222222222222")]
-    [Arguments("11111111-1111-1111-1111-111111111111", "00000000-0000-0000-0000-000000000000")]
-    public async Task AnEmptyGuid_IsRefused(string channel, string unmatchable) {
+    [Arguments("00000000-0000-0000-0000-000000000000", "22222222-2222-2222-2222-222222222222", "33333333-3333-3333-3333-333333333333")]
+    [Arguments("11111111-1111-1111-1111-111111111111", "00000000-0000-0000-0000-000000000000", "33333333-3333-3333-3333-333333333333")]
+    [Arguments("11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222", "00000000-0000-0000-0000-000000000000")]
+    public async Task AnEmptyGuid_IsRefused(string channel, string unmatchable, string allowlist) {
         var ex = Assert.Throws<InvalidOperationException>(
-            () => LaunchIdentity.FromGuids(Guid.Parse(channel), Guid.Parse(unmatchable), true));
+            () => LaunchIdentity.FromGuids(Guid.Parse(channel), Guid.Parse(unmatchable), Guid.Parse(allowlist), true));
 
         await Assert.That(ex!.Message).Contains("predictable");
     }
 
-    /// <summary>A refactor sharing one GUID between the two names would pass every format assertion.</summary>
+    /// <summary>A refactor sharing one GUID between any two names would pass every format assertion.</summary>
     [Test]
     [Arguments(true)]
     [Arguments(false)]
-    public async Task ReusingOneGuidForBothNames_IsRefused(bool alias) {
-        var ex = Assert.Throws<InvalidOperationException>(() => LaunchIdentity.FromGuids(A, A, alias));
+    public async Task ReusingOneGuidAcrossNames_IsRefused(bool alias) {
+        foreach (var (channel, unmatchable, allowlist) in new[] { (A, A, C), (A, B, A), (A, B, B) }) {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => LaunchIdentity.FromGuids(channel, unmatchable, allowlist, alias));
 
-        await Assert.That(ex!.Message).Contains("reused");
+            await Assert.That(ex!.Message).Contains("reused");
+        }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -2058,6 +2058,7 @@ public class AcpHostedAgentRuntimeFactoryTests {
         var attacker = LaunchIdentity.FromGuids(
             Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
             Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+            Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"),
             aliasResultChannel: true);
 
         var seen = (LaunchIdentity?)null;

--- a/test/Capacitor.Cli.Tests.Unit/Services/GeminiReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/GeminiReviewerLaunchTests.cs
@@ -16,28 +16,32 @@ namespace Capacitor.Cli.Tests.Unit.Services;
 /// restored (it stalls on a permission frame no human answers).</para>
 /// </summary>
 public class GeminiReviewerLaunchTests {
-    static readonly Guid ChannelGuid = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-    static readonly Guid DenyGuid    = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    static readonly Guid ChannelGuid   = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    static readonly Guid DenyGuid      = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    static readonly Guid AllowlistGuid = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
 
-    static LaunchIdentity Identity => LaunchIdentity.FromGuids(ChannelGuid, DenyGuid, aliasResultChannel: true);
+    static LaunchIdentity Identity =>
+        LaunchIdentity.FromGuids(ChannelGuid, DenyGuid, AllowlistGuid, aliasResultChannel: true);
 
     /// <summary>A daemon that has opted in, on a certified vendor build — the only combination that launches.</summary>
     static DaemonConfig EnabledConfig => new() { GeminiUnattendedReviewerEnabled = true };
 
     static string CertifiedVersion => GeminiReviewerCapability.CertifiedVersions.First();
 
-    static RuntimeStartContext Ctx(bool isReviewFlow) => new RuntimeStartContext(
+    static RuntimeStartContext Ctx(bool isReviewFlow, string[]? mcpAllowlist = null) => new RuntimeStartContext(
         AgentId: "agent-1", Vendor: "gemini", SourceRepoPath: "/repo",
         Worktree: new WorktreeInfo(Path: "/abs/wt", Branch: "b", SourceRepo: "/repo"), Prompt: "",
         Model: null, Effort: null, Tools: null,
         IsReview: false, IsReviewFlow: isReviewFlow, Review: null,
         Cols: 80, Rows: 24,
         ServerUrl: isReviewFlow ? "http://kcap.test" : null,
-        DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap") with { LaunchIdentity = Identity };
+        DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap")
+        with { LaunchIdentity = Identity, McpAllowlist = mcpAllowlist };
 
-    static string[] Build(bool isReviewFlow, DaemonConfig? config = null, string? version = null) =>
+    static string[] Build(bool isReviewFlow, DaemonConfig? config = null, string? version = null,
+                          string[]? mcpAllowlist = null) =>
         [.. AcpHostedAgentRuntimeFactory.BuildProcessStartInfo(
-                AcpVendorDescriptors.Gemini, config ?? EnabledConfig, Ctx(isReviewFlow),
+                AcpVendorDescriptors.Gemini, config ?? EnabledConfig, Ctx(isReviewFlow, mcpAllowlist),
                 resolveGeminiVersion: _ => version ?? CertifiedVersion)
             .ArgumentList];
 
@@ -98,8 +102,9 @@ public class GeminiReviewerLaunchTests {
         await Assert.That(allowed).IsEqualTo(ctx.LaunchIdentity!.ResultChannelWireName);
     }
 
-    /// <summary>The allowlist must hold exactly one name: the option is array-typed and comma-coerced by the
-    /// vendor, so a second entry widens the gate, and an EMPTY one disables it rather than denying all.</summary>
+    /// <summary>The allowlist is exactly one OPTION occurrence (a second occurrence widens the gate — the
+    /// option is array-typed) with one non-empty value (an EMPTY one disables the gate rather than denying
+    /// all). With nothing extra injected the value is a single name, no comma.</summary>
     [Test]
     [Arguments(true)]
     [Arguments(false)]
@@ -111,6 +116,58 @@ public class GeminiReviewerLaunchTests {
         var value = argv[Array.IndexOf(argv, "--allowed-mcp-server-names") + 1];
         await Assert.That(value).IsNotEmpty();
         await Assert.That(value).DoesNotContain(",");
+    }
+
+    // ── allowlist servers: the gate widens to exactly the injected set, under aliased names ──
+
+    /// <summary>
+    /// A review launch with a definition MCP allowlist still carries ONE option occurrence; the extra
+    /// servers ride the same value comma-joined (the option is comma-coerced — measured on 0.53.0: both
+    /// admitted servers spawn and reach tools/call, an injected name outside the gate never spawns).
+    /// </summary>
+    [Test]
+    public async Task ReviewLaunchWithAllowlist_StillCarriesExactlyOneAllowlistOption() {
+        var argv = Build(isReviewFlow: true, mcpAllowlist: ["kcap-review"]);
+
+        await Assert.That(argv.Count(a => a == "--allowed-mcp-server-names")).IsEqualTo(1);
+        await Assert.That(argv[Array.IndexOf(argv, "--allowed-mcp-server-names") + 1])
+            .IsEqualTo($"{Identity.ResultChannelWireName},{Identity.AllowlistWireName("kcap-review")}");
+    }
+
+    /// <summary>
+    /// THE parity assertion for the widened gate: the comma-split gate value must equal — same names, same
+    /// order — the server list the SAME launch context builds for <c>session/new</c>. A gate admitting fewer
+    /// names than the injection ships blocked servers (the original defect: injected but silently excluded);
+    /// a gate admitting more opens the exact-name allowlist beyond what this launch runs.
+    /// </summary>
+    [Test]
+    public async Task ReviewLaunchWithAllowlist_GateNamesExactlyTheInjectedServerSet() {
+        var ctx = Ctx(isReviewFlow: true, mcpAllowlist: ["kcap-review", "kcap-sessions"]);
+
+        var argv = AcpHostedAgentRuntimeFactory.BuildProcessStartInfo(
+                AcpVendorDescriptors.Gemini, EnabledConfig, ctx,
+                resolveGeminiVersion: _ => CertifiedVersion)
+            .ArgumentList;
+        var injected = AcpReviewFlowMcp.Build(ctx, ["kcap-review", "kcap-sessions"]);
+
+        var gate = argv[argv.IndexOf("--allowed-mcp-server-names") + 1];
+
+        await Assert.That(gate.Split(',').SequenceEqual(injected.Select(s => s.Name))).IsTrue();
+    }
+
+    /// <summary>
+    /// The gate must never admit a CANONICAL allowlist id: it is a fixed public literal the reviewed
+    /// repository can declare its own <c>.gemini/settings.json</c> server under, and the vendor's gate is an
+    /// exact-name match — admitting it would spawn that repo-authored process as the daemon user, the same
+    /// impersonation shape the result channel's per-launch alias closes (spec §2.3/§2.6).
+    /// </summary>
+    [Test]
+    public async Task ReviewLaunchWithAllowlist_AdmitsAliasedNames_NeverTheCanonicalId() {
+        var argv = Build(isReviewFlow: true, mcpAllowlist: ["kcap-review"]);
+        var gate = argv[Array.IndexOf(argv, "--allowed-mcp-server-names") + 1].Split(',');
+
+        await Assert.That(gate).DoesNotContain("kcap-review");
+        await Assert.That(gate).Contains(Identity.AllowlistWireName("kcap-review"));
     }
 
     /// <summary>Neither the placeholder nor a deny-all name may survive into a review launch — the review arm
@@ -203,7 +260,7 @@ public class GeminiReviewerLaunchTests {
     public async Task CursorReviewLaunch_IsUnaffectedByTheGeminiAlias() {
         var ctx = Ctx(isReviewFlow: true) with {
             Vendor         = "cursor",
-            LaunchIdentity = LaunchIdentity.FromGuids(ChannelGuid, DenyGuid, aliasResultChannel: false)
+            LaunchIdentity = LaunchIdentity.FromGuids(ChannelGuid, DenyGuid, AllowlistGuid, aliasResultChannel: false)
         };
 
         var argv = AcpHostedAgentRuntimeFactory
@@ -213,8 +270,11 @@ public class GeminiReviewerLaunchTests {
         await Assert.That(argv).DoesNotContain("--allowed-mcp-server-names");
         await Assert.That(argv).DoesNotContain("--approval-mode");
 
-        var injected = AcpReviewFlowMcp.Build(ctx, []);
+        var injected = AcpReviewFlowMcp.Build(ctx, ["kcap-review"]);
         await Assert.That(injected.Select(s => s.Name)).Contains(KcapMcpRegistry.ReservedResultChannelId);
+        // Allowlist servers keep their CANONICAL ids for a non-aliasing vendor — Cursor has no name gate,
+        // and renaming its servers as a side effect of a Gemini change is exactly what this guard exists for.
+        await Assert.That(injected.Select(s => s.Name)).Contains("kcap-review");
     }
 
     // ── the whole-vector assertion itself ──
@@ -281,7 +341,8 @@ public class GeminiReviewerLaunchTests {
             "--approval-mode", "yolo"
         ];
 
-        AcpHostedAgentRuntimeFactory.AssertGeminiArgvIsCanonical(argv, isReviewFlow: true, Identity);
+        AcpHostedAgentRuntimeFactory.AssertGeminiArgvIsCanonical(
+            argv, isReviewFlow: true, Identity, reviewGate: Identity.ResultChannelWireName);
 
         await Assert.That(argv).HasCount().EqualTo(6);
     }
@@ -293,7 +354,7 @@ public class GeminiReviewerLaunchTests {
             "--allowed-mcp-server-names", Identity.UnmatchableMcpName
         ];
 
-        AcpHostedAgentRuntimeFactory.AssertGeminiArgvIsCanonical(argv, isReviewFlow: false, Identity);
+        AcpHostedAgentRuntimeFactory.AssertGeminiArgvIsCanonical(argv, isReviewFlow: false, Identity, reviewGate: null);
 
         await Assert.That(argv).HasCount().EqualTo(4);
     }
@@ -309,7 +370,8 @@ public class GeminiReviewerLaunchTests {
         ];
 
         var ex = Assert.Throws<InvalidOperationException>(
-            () => AcpHostedAgentRuntimeFactory.AssertGeminiArgvIsCanonical(argv, true, Identity));
+            () => AcpHostedAgentRuntimeFactory.AssertGeminiArgvIsCanonical(
+                argv, true, Identity, Identity.ResultChannelWireName));
 
         await Assert.That(ex!.Message).Contains("not_canonical");
     }
@@ -324,8 +386,20 @@ public class GeminiReviewerLaunchTests {
         ];
 
         var ex = Assert.Throws<InvalidOperationException>(
-            () => AcpHostedAgentRuntimeFactory.AssertGeminiArgvIsCanonical(argv, true, Identity));
+            () => AcpHostedAgentRuntimeFactory.AssertGeminiArgvIsCanonical(
+                argv, true, Identity, Identity.ResultChannelWireName));
 
         await Assert.That(ex!.Message).Contains("not_canonical");
+    }
+
+    /// <summary>A review launch whose gate the caller failed to compute cannot be asserted canonical —
+    /// asserting against a re-derived gate would let the gate and the assertion drift apart.</summary>
+    [Test]
+    public async Task AReviewVectorWithoutAGateValue_FailsTheAssertion() {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => AcpHostedAgentRuntimeFactory.AssertGeminiArgvIsCanonical(
+                ["--experimental-acp"], isReviewFlow: true, Identity, reviewGate: null));
+
+        await Assert.That(ex!.Message).Contains("gemini_review_gate_missing");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/GeminiReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/GeminiReviewerLaunchTests.cs
@@ -170,6 +170,27 @@ public class GeminiReviewerLaunchTests {
         await Assert.That(gate).Contains(Identity.AllowlistWireName("kcap-review"));
     }
 
+    /// <summary>
+    /// Same guarantee on the direct-builder path with NO caller-supplied identity (review finding): the
+    /// builder's fallback identity must also be what the MCP-list builder reads, or the gate is computed
+    /// from a null identity's canonical fallbacks — repository-matchable names — while the argv
+    /// substitution uses the fresh identity. The checked value must BE the used value.
+    /// </summary>
+    [Test]
+    public async Task ReviewLaunchWithoutACallerIdentity_StillGatesOnAliasedNames_NeverCanonical() {
+        var ctx = Ctx(isReviewFlow: true, mcpAllowlist: ["kcap-review"]) with { LaunchIdentity = null };
+
+        var argv = AcpHostedAgentRuntimeFactory.BuildProcessStartInfo(
+                AcpVendorDescriptors.Gemini, EnabledConfig, ctx,
+                resolveGeminiVersion: _ => CertifiedVersion)
+            .ArgumentList;
+
+        var gate = argv[argv.IndexOf("--allowed-mcp-server-names") + 1].Split(',');
+
+        await Assert.That(gate).DoesNotContain(KcapMcpRegistry.ReservedResultChannelId);
+        await Assert.That(gate).DoesNotContain("kcap-review");
+    }
+
     /// <summary>Neither the placeholder nor a deny-all name may survive into a review launch — the review arm
     /// REPLACES the value, and appending instead would leave the gate open on the deny entry.</summary>
     [Test]


### PR DESCRIPTION
AI-1732 (Linear; the auto-imported GitHub twin #449 is closed — tracking moved to Linear at the maintainer's direction).

## The defect

A Gemini review launch replaced the deny-all `--allowed-mcp-server-names` value with **only** `identity.ResultChannelWireName`, while `AcpReviewFlowMcp.Build` could put more into `session/new.mcpServers`: every server resolved from the definition's `mcp:` allowlist. Gemini's gate is measured exclusive exact-match (AI-1413 spec §2.2/§2.6 — it gates *injected* servers too), so those extra servers were injected and silently blocked: the reviewer starts and can report, but never sees the context servers the definition granted it. Unexercised by the built-in `code-review`/`spec-review` definitions (no `mcp:` list); reachable today by any catalog or dynamic definition with one targeting a Gemini reviewer.

## The fix

- **Gate == injected set, by construction.** The review arm now builds the same `AcpReviewFlowMcp.Build` list the launch sends in `session/new` and joins its names into the ONE allowlist value (replace-never-append preserved — the option is comma-coerced, a second occurrence would widen the gate). The whole-vector argv assertion takes the computed gate as an input.
- **Aliased, never canonical.** Every non-result-channel injected server rides under a per-launch wire name — canonical id + a third independent `LaunchIdentity` GUID (`AllowlistWireName`). A canonical id is a fixed public literal the reviewed repository could declare its own `.gemini/settings.json` server under, and the gate matches names exactly: admitting it would spawn that repo-authored process as the daemon user — the impersonation shape the result channel's alias already closes (§2.3). The borrowed-snapshot `kcap-review-context` name goes through the same helper (identity for non-aliasing vendors, future-proof for aliasing ones).
- **Non-aliasing vendors byte-identical.** `AllowlistWireName` returns the input unchanged for Cursor/Copilot/Kiro identities — pinned by `LaunchIdentityTests` and the extended Cursor regression test, and `CopilotAvailableToolIds`/`BuildCopilotAdditionalMcpConfig` keep seeing canonical names.

## Measured before coding (gemini 0.53.0, review argv)

Purpose-built logging stdio servers (the AI-1614 probe harness): with `--allowed-mcp-server-names "A,B"` as one comma-joined value, **both** admitted servers spawn and complete `initialize` → `tools/list` → `tools/call` with their nonces reaching the model (`A=<nonceA> B=<nonceB>`, `end_turn`), while a **third injected server outside the gate never spawns** — exclusivity survives multi-name mode — and `--approval-mode yolo` emits zero interaction frames.

## Tests

- `GeminiReviewerLaunchTests`: one option occurrence with the joined value; **gate.Split(',') == injected list names, same order** (the parity pin); **never-the-canonical-id** (verified by mutation: an `AllowlistWireName` returning the canonical id goes red in 4 tests — this one is the oracle-independent kill); gate-missing assertion arm; Cursor keeps canonical ids.
- `LaunchIdentityTests`: third-GUID construction rules (exact suffix, independence, pairwise-reuse refusal, comma/whitespace freedom, non-aliasing passthrough).
- Empty-allowlist launches are byte-identical to before (all pre-existing vectors unchanged).
- Local: unit Acp namespace 408 ✓, GeminiReviewerLaunchTests 28 ✓, AcpHostedAgentRuntimeFactoryTests 75 ✓, integration 199 ✓, AOT publish clean.

## Note for the merge queue

This touches the same Gemini descriptor comment region as #447 (which records a KNOWN LIMIT for exactly this gap). Whichever merges second will see a trivial comment conflict there — **this PR's paragraph is the post-fix truth and supersedes #447's KNOWN LIMIT sentence.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
