### PR TITLE
Fix IL2026/IL3050 AOT warnings in McpWorkItemsServer.ReadStringArray

### DIFF
--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -354,7 +354,9 @@ static class McpWorkItemsServer {
 
             if (string.IsNullOrWhiteSpace(value)) throw new ArgumentException($"'{key}' must not contain blank entries.");
 
-            result.Add(value);
+            // Cast to JsonNode so the non-generic Add(JsonNode?) overload is chosen —
+            // the generic Add<T>(T) trips IL2026/IL3050 under AOT (see CLAUDE.md).
+            result.Add((JsonNode?)JsonValue.Create(value));
         }
 
         return result;


### PR DESCRIPTION
`ReadStringArray` built its validated copy with `result.Add(value)` on a `string`, which binds the generic `JsonArray.Add<T>(T)` overload — annotated `RequiresUnreferencedCode`/`RequiresDynamicCode`, so every AOT publish emitted IL2026 + IL3050 for this line.

Fix: `result.Add((JsonNode?)JsonValue.Create(value))` so the non-generic `Add(JsonNode?)` overload is chosen, matching the repo's established pattern (OpenCodeDb.cs, PluginCommand.cs, JsonMcpConfigWriter.cs). No behavior change.

Verification:
- `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release` — zero `IL[23]0xx` lines (was: 2 warnings at McpWorkItemsServer.cs:357)
- `McpWorkItemsServerTests` 36/36 pass

Found during AI-1325's publish verification (#454); no tracking issue — the fix is smaller than the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)