### PR TITLE
Observe the pending RequestAsync in the DebugFrames outbound-frame test

### DIFF
--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpConnectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpConnectionTests.cs
@@ -587,11 +587,8 @@ public class AcpConnectionTests {
         await Assert.That(logger.Entries).Contains(e =>
             e.Level == LogLevel.Debug && e.Message.Contains("ACP >>>") && e.Message.Contains("session/prompt"));
 
-        // Clean shutdown: still owe the pending request a response before disposing — and the
-        // task must be OBSERVED, not discarded. A discarded task races the Cancel below: if the
-        // read loop is cancelled before it parses the response frame, FaultAllPending faults the
-        // pending request and the abandoned task raises an unobserved-task exception at an
-        // arbitrary later GC, surfacing as a flake in whatever test happens to be running.
+        // Clean shutdown: answer the pending request and OBSERVE the task — discarded, it races
+        // the Cancel below and can fault as an unobserved-task exception at a later GC.
         await harness.WriteFrameToConnectionAsync($$$"""{"jsonrpc":"2.0","id":{{{id}}},"result":{}}""");
         await requestTask.WaitAsync(HangGuard);
 

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpConnectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpConnectionTests.cs
@@ -580,15 +580,20 @@ public class AcpConnectionTests {
         using var        cts     = new CancellationTokenSource();
         var               runTask = harness.Connection.RunAsync(cts.Token);
 
-        _ = harness.Connection.RequestAsync("session/prompt", null, CancellationToken.None);
-        var frame = await harness.ReadFrameFromConnectionAsync();
-        var id    = JsonDocument.Parse(frame).RootElement.GetProperty("id").GetInt64();
+        var requestTask = harness.Connection.RequestAsync("session/prompt", null, CancellationToken.None);
+        var frame        = await harness.ReadFrameFromConnectionAsync();
+        var id           = JsonDocument.Parse(frame).RootElement.GetProperty("id").GetInt64();
 
         await Assert.That(logger.Entries).Contains(e =>
             e.Level == LogLevel.Debug && e.Message.Contains("ACP >>>") && e.Message.Contains("session/prompt"));
 
-        // Clean shutdown: still owe the pending request a response before disposing.
+        // Clean shutdown: still owe the pending request a response before disposing — and the
+        // task must be OBSERVED, not discarded. A discarded task races the Cancel below: if the
+        // read loop is cancelled before it parses the response frame, FaultAllPending faults the
+        // pending request and the abandoned task raises an unobserved-task exception at an
+        // arbitrary later GC, surfacing as a flake in whatever test happens to be running.
         await harness.WriteFrameToConnectionAsync($$$"""{"jsonrpc":"2.0","id":{{{id}}},"result":{}}""");
+        await requestTask.WaitAsync(HangGuard);
 
         cts.Cancel();
         await SwallowCancellation(runTask);


### PR DESCRIPTION
`DebugFrames_on_logs_the_full_outbound_request_frame` discarded its `RequestAsync` task (`_ = harness.Connection.RequestAsync(...)`). The test then writes the owed response frame — the author's comment says "still owe the pending request a response before disposing" — but never awaits the task, so the response write **races the `cts.Cancel()`** that follows:

- read loop parses the response first → task completes, fine;
- cancel wins → `FaultAllPending` faults the pending request → the discarded task's exception is observed by nobody → **unobserved-task exception at an arbitrary later GC**, blamed on whatever test happens to be running at finalization time.

That is the pre-existing cross-test flake shape seen while running the ACP unit tests during #454 (baseline-verified on main at the time — not introduced by that PR). Finalizer timing makes it unattributable by bisection; causally, this is the **only** discarded `RequestAsync` in the test suite (`rg '_ = .*RequestAsync'`), so it is the only candidate producer.

Fix: hold the task and `await requestTask.WaitAsync(HangGuard)` after writing the response — the exact shape the sibling `DebugFrames_off…` test already uses. Observes any fault *and* removes the race. Test-only change.

Verification: `AcpConnectionTests` 22/22 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)