### PR TITLE
Carry git config overrides via GIT_CONFIG_KEY_n/VALUE_n instead of -c

### DIFF
--- a/README.md
+++ b/README.md
@@ -1186,6 +1186,12 @@ kcap agent start claude -d                    # start without attaching; prints 
 
     Disabled drivers are logged per worktree so the effect is visible rather than mysterious.
 
+    Both the hook and the filter overrides are carried in git's environment (`GIT_CONFIG_COUNT` /
+    `GIT_CONFIG_KEY_n`) rather than on the command line, so a config key that legally contains `=` — a filter
+    driver named `evil=x` — stays intact instead of being cut at the `=` and left live. kcap measures at
+    launch that the git it found honours those variables and refuses to build the worktree if not, rather
+    than reporting containment it does not have: **creating an agent worktree needs git 2.31 or newer.**
+
 - **Detach** without stopping the agent with the prefix key **`Ctrl-Q` then `d`**. The agent keeps running in the daemon.
 - **Permissions:** for a registered agent, permission prompts appear in the web UI (the same dialog as hosted agents); with `--private`, prompts are answered natively in your terminal.
 

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
@@ -47,7 +47,13 @@ public partial class WorktreeManager {
     /// </summary>
     /// <exception cref="BranchFilterInventoryException">Enumeration failed, or a driver name cannot be
     /// safely expressed as an override.</exception>
-    internal static async Task<string[]> BranchFilterOverridesAsync(string gitContextPath) {
+    /// <exception cref="GitConfigTransportException">The transport that would carry the overrides does not
+    /// reach git, so they would be silently dropped.</exception>
+    internal static async Task<GitConfigOverride[]> BranchFilterOverridesAsync(string gitContextPath) {
+        // Before the inventory, not after: an override set that cannot be delivered is not containment, and
+        // the caller's next step is the command that materialises branch content.
+        await ProveConfigTransportAsync(gitContextPath);
+
         // Enumerate EVERY key and match the shape here, rather than asking git to match a regex.
         //
         // Measured: git's `--get-regexp` runs through the platform regex in the ambient locale, where `.`
@@ -58,7 +64,7 @@ public partial class WorktreeManager {
         // bypass this file exists to prevent, reintroduced by trusting git to enumerate.
         //
         // `--list` takes no pattern, so there is no regex, no locale, and nothing to slip past.
-        var listed = await RunGitCaptureResult(gitContextPath, GitTimeout, sourceReadOnly: false,
+        var listed = await RunGitCaptureResult(gitContextPath, GitTimeout, sourceReadOnly: false, [],
             "config", "--list", "--name-only", "-z");
 
         // No "no keys" exit code to tolerate here: `--list` succeeds on an empty config. A non-zero exit
@@ -91,26 +97,21 @@ public partial class WorktreeManager {
                     "A filter driver name is not valid UTF-8, so an override cannot be expressed for it "
                   + "and the driver cannot be contained.");
 
-            // `-c key=value` splits at the FIRST '='. A driver legally named `evil=x` would be written as
-            // key `filter.evil`, leaving `filter.evil=x.smudge` live while the override LOOKED applied.
-            // Git permits arbitrary subsection characters, so refuse rather than mis-encode: a guard that
-            // silently does nothing is worse than a launch that fails. The env transport that would carry
-            // such a name safely is tracked separately.
-            if (driver.Contains('=') || driver.Contains('\n') || driver.Contains('\0'))
-                throw new BranchFilterInventoryException(gitContextPath,
-                    $"Filter driver '{driver}' has a name that cannot be safely expressed as a command-line "
-                  + "override, so it cannot be contained.");
-
+            // A name containing `=` needs no special handling: overrides travel as key/value PAIRS in the
+            // environment, so `filter.evil=x.smudge` arrives whole. It could not be spelled as
+            // `-c key=value`, which splits at the first `=` — key `filter.evil`, the real driver still live,
+            // the override apparently applied — and was refused for that reason alone. Measured: plain git
+            // runs such a driver, `-c` does not stop it, this does.
             drivers.Add(driver);
         }
 
-        return [.. drivers.SelectMany(static driver => new[] {
-            "-c", $"filter.{driver}.clean=",
-            "-c", $"filter.{driver}.smudge=",
-            "-c", $"filter.{driver}.process=",
+        return [.. drivers.SelectMany(static driver => new GitConfigOverride[] {
+            new($"filter.{driver}.clean", ""),
+            new($"filter.{driver}.smudge", ""),
+            new($"filter.{driver}.process", ""),
             // Measured: with `required=true`, an empty command is FATAL and the checkout fails outright.
             // Clearing the command alone would turn this guard into a denial of service.
-            "-c", $"filter.{driver}.required=false"
+            new($"filter.{driver}.required", "false")
         })];
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.BranchFilters.cs
@@ -47,13 +47,9 @@ public partial class WorktreeManager {
     /// </summary>
     /// <exception cref="BranchFilterInventoryException">Enumeration failed, or a driver name cannot be
     /// safely expressed as an override.</exception>
-    /// <exception cref="GitConfigTransportException">The transport that would carry the overrides does not
-    /// reach git, so they would be silently dropped.</exception>
+    /// <exception cref="GitConfigTransportException">Thrown by the runner these overrides are passed to,
+    /// when the transport carrying them does not reach git and they would be silently dropped.</exception>
     internal static async Task<GitConfigOverride[]> BranchFilterOverridesAsync(string gitContextPath) {
-        // Before the inventory, not after: an override set that cannot be delivered is not containment, and
-        // the caller's next step is the command that materialises branch content.
-        await ProveConfigTransportAsync(gitContextPath);
-
         // Enumerate EVERY key and match the shape here, rather than asking git to match a regex.
         //
         // Measured: git's `--get-regexp` runs through the platform regex in the ambient locale, where `.`

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ExclusionPlan.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ExclusionPlan.cs
@@ -229,6 +229,7 @@ public partial class WorktreeManager {
     static async Task<byte[]> RunGitCaptureBoundedAsync(
             string cwd, TimeSpan timeout, int maxBytes, CancellationToken ct, GitConfigOverride[] config,
             params string[] args) {
+        await ProveConfigTransportIfCarryingAsync(cwd, config);
         var psi = NewGitPsi(cwd, args, sourceReadOnly: true, config);
         using var process = Process.Start(psi)!;
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ExclusionPlan.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ExclusionPlan.cs
@@ -229,7 +229,7 @@ public partial class WorktreeManager {
     static async Task<byte[]> RunGitCaptureBoundedAsync(
             string cwd, TimeSpan timeout, int maxBytes, CancellationToken ct, GitConfigOverride[] config,
             params string[] args) {
-        await ProveConfigTransportIfCarryingAsync(cwd, config);
+        await ProveConfigTransportIfCarryingAsync(cwd, sourceReadOnly: true, config);
         var psi = NewGitPsi(cwd, args, sourceReadOnly: true, config);
         using var process = Process.Start(psi)!;
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ExclusionPlan.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ExclusionPlan.cs
@@ -77,8 +77,8 @@ public partial class WorktreeManager {
         // "one namespace" invariant this derivation exists to hold. So the work-tree top is captured and
         // required to be the source root before the prefix is trusted.
         var topRaw = await RunGitCaptureBoundedAsync(
-            sourceCwd, GitTimeout, MaxCwdPrefixCaptureBytes, ct,
-            "-c", "core.quotePath=false", "rev-parse", "--show-toplevel");
+            sourceCwd, GitTimeout, MaxCwdPrefixCaptureBytes, ct, NoQuotedPaths,
+            "rev-parse", "--show-toplevel");
         var top = ParseSingleLine(topRaw);
         if (top.Length == 0 ||
             !ResolveDeepestExisting(top).Equals(
@@ -86,8 +86,8 @@ public partial class WorktreeManager {
             throw new InvalidOperationException("borrowed_snapshot_cwd_foreign_repository");
 
         var raw = await RunGitCaptureBoundedAsync(
-            sourceCwd, GitTimeout, MaxCwdPrefixCaptureBytes, ct,
-            "-c", "core.quotePath=false", "rev-parse", "--show-prefix");
+            sourceCwd, GitTimeout, MaxCwdPrefixCaptureBytes, ct, NoQuotedPaths,
+            "rev-parse", "--show-prefix");
 
         return ParseGitRelativeCwd(raw);
     }
@@ -212,12 +212,17 @@ public partial class WorktreeManager {
         return true;
     }
 
+    /// <summary>Reports paths verbatim. Without it a non-ASCII component comes back C-quoted, and the
+    /// prefix would not match the manifest it filters.</summary>
+    static readonly GitConfigOverride[] NoQuotedPaths = [new("core.quotePath", "false")];
+
     /// <summary>Captures a git command's stdout, refusing rather than truncating past
     /// <paramref name="maxBytes"/>. Reads <c>BaseStream</c>, not the <c>StreamReader</c>, because
     /// <c>StandardOutputEncoding</c> alone does not disable the reader's BOM detection.</summary>
     static async Task<byte[]> RunGitCaptureBoundedAsync(
-            string cwd, TimeSpan timeout, int maxBytes, CancellationToken ct, params string[] args) {
-        var psi = NewGitPsi(cwd, args, sourceReadOnly: true);
+            string cwd, TimeSpan timeout, int maxBytes, CancellationToken ct, GitConfigOverride[] config,
+            params string[] args) {
+        var psi = NewGitPsi(cwd, args, sourceReadOnly: true, config);
         using var process = Process.Start(psi)!;
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeoutCts.CancelAfter(timeout);

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ExclusionPlan.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ExclusionPlan.cs
@@ -212,8 +212,15 @@ public partial class WorktreeManager {
         return true;
     }
 
-    /// <summary>Reports paths verbatim. Without it a non-ASCII component comes back C-quoted, and the
-    /// prefix would not match the manifest it filters.</summary>
+    /// <summary>Stops git escaping bytes at or above 0x80 in path output, so a non-ASCII component cannot
+    /// come back C-quoted and fail to match the manifest it filters.
+    ///
+    /// <para>That is ALL this governs — measured: with it set, <c>ls-files</c> still returns
+    /// <c>"a\"b/f"</c> for a path containing a double quote, and the same holds for a backslash or a control
+    /// character. It is not a request for verbatim output. The two consumers here are
+    /// <c>rev-parse --show-prefix</c> and <c>--show-toplevel</c>, which print the path raw with or without
+    /// it (measured on git 2.49, both spellings), so for them this is belt-and-braces rather than
+    /// load-bearing; the manifest side reads <c>ls-files -z</c>, which never quotes.</para></summary>
     static readonly GitConfigOverride[] NoQuotedPaths = [new("core.quotePath", "false")];
 
     /// <summary>Captures a git command's stdout, refusing rather than truncating past

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.GitConfig.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.GitConfig.cs
@@ -45,6 +45,14 @@ public partial class WorktreeManager {
 
         var first = InheritedConfigCount(environment);
 
+        // An inherited count large enough to wrap the additions below would name entries at negative
+        // indices and write a negative total. Git rejects that count, so it is loud rather than silent —
+        // but the refusal belongs here, where the reason can be stated.
+        if (first > int.MaxValue - overrides.Count)
+            throw new GitConfigTransportException(
+                $"{ConfigCountVariable} is {first}, leaving no room to append {overrides.Count} more "
+              + "config overrides.");
+
         for (var i = 0; i < overrides.Count; i++) {
             var (key, value) = overrides[i];
 
@@ -95,26 +103,16 @@ public partial class WorktreeManager {
 
     /// <summary>
     /// Proves, by running git, that config overrides carried in the environment actually reach it — once per
-    /// process, before any containment override is handed out.
+    /// process, and awaited by every git run that carries any.
     ///
-    /// <para><b>Why a runtime proof and not a version check.</b> A git older than 2.31 does not know
-    /// <c>GIT_CONFIG_COUNT</c> and IGNORES it: every filter and hook override would be dropped and every
-    /// command would still succeed, so the guard would report containment it never had. That is strictly
-    /// worse than the mis-encoding this transport replaced, which at least only affected names containing
-    /// <c>=</c>. Parsing <c>git --version</c> would answer a narrower question — distributions ship suffixed
-    /// versions, and the property we need is not "which git" but "do these entries apply here", which also
-    /// covers an environment that cannot carry them at all.</para>
+    /// <para><b>Why a runtime proof and not a version check.</b> A git older than 2.31 IGNORES
+    /// <c>GIT_CONFIG_COUNT</c>: every override would be dropped and every command would still succeed, so
+    /// containment would be reported and never had. <c>git --version</c> answers a narrower question —
+    /// distributions ship suffixed versions, and the property needed is "do these entries apply here", which
+    /// also covers an environment that cannot carry them.</para>
     ///
-    /// <para>The probe asserts both value shapes the overrides use: an EMPTY value, which is how a filter
-    /// command is disabled and the one an environment block is least likely to carry, and a non-empty one at
-    /// a non-zero index, which fails if the count is miscomputed. Its key contains <c>=</c>, so the boundary
-    /// this transport exists for is measured rather than assumed. The key is unguessable per probe, so no
-    /// config a repository or branch can write could supply the record that would satisfy it in the
-    /// transport's place.</para>
-    ///
-    /// <para>Only success is remembered: a spawn that failed for an unrelated reason must not wedge the
-    /// daemon until restart. Whether the entries apply is a property of the git binary and the platform, not
-    /// of the repository, so one measurement holds for the process.</para>
+    /// <para>Only success is remembered, so an unrelated spawn failure cannot wedge the daemon until
+    /// restart; the property is one of the git binary and the platform, not of the repository.</para>
     /// </summary>
     /// <exception cref="GitConfigTransportException">The entries did not reach git.</exception>
     internal static async Task ProveConfigTransportAsync(string gitContextPath) {
@@ -135,10 +133,18 @@ public partial class WorktreeManager {
     /// The measurement itself, separate from the memoization above so it can be run on demand — a test of a
     /// cached proof would otherwise pass by returning early, testing nothing.
     ///
-    /// <para>Run in the caller's own git context rather than a directory of our own: this is a context the
-    /// caller is about to run git in regardless, so the probe cannot invent a failure the real command would
-    /// not have had — a repository git refuses to touch (dubious ownership, say) fails either way, and no
-    /// directory has to be created, permissioned or cleaned up to hold it.</para>
+    /// <para>The probe asserts both value shapes the overrides use: an EMPTY value, which is how a filter
+    /// command is disabled and the one an environment block is least likely to carry, and a non-empty one at
+    /// a NON-ZERO index, which fails if the count is miscomputed. Its key contains <c>=</c>, so the boundary
+    /// this transport exists for is measured rather than assumed, and it is unguessable per probe, so no
+    /// config a repository can write could satisfy the check in the transport's place.</para>
+    ///
+    /// <para>Run in the caller's own git context rather than a directory of our own: a context the caller is
+    /// about to run git in regardless, so the probe cannot invent a failure the real command would not have
+    /// had, and no directory has to be created, permissioned or cleaned up.</para>
+    ///
+    /// <para>Runs through the UNPROVEN runner, which is what stops the gate recursing into itself — the gate
+    /// is not reentrant and would deadlock on its own semaphore.</para>
     /// </summary>
     internal static async Task ProbeConfigTransportAsync(string gitContextPath) {
         var driver = $"kcap-transport-probe={Guid.NewGuid():N}";
@@ -147,7 +153,7 @@ public partial class WorktreeManager {
             new($"filter.{driver}.required", "false")
         ];
 
-        var listing = await RunGitCaptureResult(
+        var listing = await RunGitCaptureResultUnproven(
             gitContextPath, GitTimeout, sourceReadOnly: false, probe, "config", "--list", "-z");
 
         if (listing.ExitCode != 0)

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.GitConfig.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.GitConfig.cs
@@ -1,0 +1,177 @@
+using System.Globalization;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>Thrown when git config overrides cannot be carried to a git process, so it is not known that the
+/// overrides a command was given are the overrides it will honour. Fail-closed: the alternative is running a
+/// containment command that silently has no containment.</summary>
+public sealed class GitConfigTransportException(string detail)
+    : Exception("Refusing to run git with config overrides that may not apply. " + detail) { }
+
+/// <summary>
+/// One git config override, as a key and a value that stay SEPARATE all the way to git.
+///
+/// <para>A driver, section or variable name may legally contain <c>=</c>, and <c>-c key=value</c> is parsed
+/// at the FIRST one: <c>-c filter.evil=x.smudge=</c> reaches git as key <c>filter.evil</c> with value
+/// <c>x.smudge=</c>, so <c>filter.evil=x.smudge</c> stays live while the override looks applied. That is why
+/// this is a pair and not a string — there is no boundary left to guess at.</para>
+/// </summary>
+internal readonly record struct GitConfigOverride(string Key, string Value);
+
+public partial class WorktreeManager {
+    /// <summary>Config git applies with the same precedence as <c>-c</c>, taken from the environment rather
+    /// than argv. Available since git 2.31; <see cref="ProveConfigTransportAsync"/> is what makes an older
+    /// git — which would ignore these entirely — a refusal instead of silent non-containment.</summary>
+    const string ConfigCountVariable = "GIT_CONFIG_COUNT";
+
+    /// <summary>
+    /// Writes <paramref name="overrides"/> into a git process environment as
+    /// <c>GIT_CONFIG_KEY_n</c>/<c>GIT_CONFIG_VALUE_n</c> pairs, APPENDING to whatever entries the
+    /// environment already carries.
+    ///
+    /// <para><b>Appending is the whole contract.</b> The environment a git child inherits may already hold
+    /// entries — this daemon's own <c>sourceReadOnly</c> suppressions compose through here, and an operator
+    /// may have launched the daemon with entries of their own. Writing from index 0 would overwrite theirs,
+    /// and a count that does not cover every index makes git ignore the tail: both lose overrides while the
+    /// call site believes they were applied, which is the same silent failure as the <c>=</c> mis-encoding
+    /// this transport exists to remove.</para>
+    /// </summary>
+    /// <exception cref="GitConfigTransportException">An inherited count cannot be parsed, so the entries
+    /// cannot be appended without displacing it; or a key or value contains NUL, which cannot survive an
+    /// environment block and would be silently truncated.</exception>
+    internal static void ApplyConfigOverrides(
+            IDictionary<string, string?> environment, IReadOnlyList<GitConfigOverride> overrides) {
+        if (overrides.Count == 0) return;
+
+        var first = InheritedConfigCount(environment);
+
+        for (var i = 0; i < overrides.Count; i++) {
+            var (key, value) = overrides[i];
+
+            // An environment entry is NUL-terminated by construction, so a NUL inside one truncates it
+            // there: the key that reached git would be a PREFIX of the key we checked and meant to
+            // neutralize. Unreachable from the filter inventory, whose records are NUL-separated to begin
+            // with, and refused here rather than assumed, because this is the layer whose invariant it is.
+            if (key.Contains('\0') || value.Contains('\0'))
+                throw new GitConfigTransportException(
+                    "A config override contains NUL, which an environment entry cannot carry.");
+
+            environment[$"GIT_CONFIG_KEY_{first + i}"] = key;
+            environment[$"GIT_CONFIG_VALUE_{first + i}"] = value;
+        }
+
+        environment[ConfigCountVariable] =
+            (first + overrides.Count).ToString(CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>How many config entries the environment already claims. Absent or empty is none — git reads
+    /// an empty count as zero (measured), so agreeing with it keeps our indices where git looks for
+    /// them.</summary>
+    static int InheritedConfigCount(IDictionary<string, string?> environment) {
+        if (!environment.TryGetValue(ConfigCountVariable, out var raw) || string.IsNullOrEmpty(raw))
+            return 0;
+
+        // NumberStyles.None: no sign, no whitespace, no separators — the spelling git itself accepts.
+        // Anything else and we do not know which indices are already taken. Git dies on such a value
+        // anyway; refusing here says why, and never silently renumbers an operator's entries.
+        if (!int.TryParse(raw, NumberStyles.None, CultureInfo.InvariantCulture, out var count))
+            throw new GitConfigTransportException(
+                $"{ConfigCountVariable} is set to '{raw}', which is not a count, so config overrides "
+              + "cannot be appended to it.");
+
+        return count;
+    }
+
+    /// <summary>The <c>sourceReadOnly</c> suppressions, composed through the same transport as everything
+    /// else so their indices are allocated in one place. <c>maintenance.auto</c> stops a read from launching
+    /// background maintenance that would touch <c>.git/worktrees</c> outside the metadata gate.</summary>
+    static readonly GitConfigOverride[] SourceReadOnlyConfig = [
+        new("maintenance.auto", "false"),
+        new("core.fsmonitor", "false")
+    ];
+
+    static volatile bool _configTransportProven;
+    static readonly SemaphoreSlim ConfigTransportGate = new(1, 1);
+
+    /// <summary>
+    /// Proves, by running git, that config overrides carried in the environment actually reach it — once per
+    /// process, before any containment override is handed out.
+    ///
+    /// <para><b>Why a runtime proof and not a version check.</b> A git older than 2.31 does not know
+    /// <c>GIT_CONFIG_COUNT</c> and IGNORES it: every filter and hook override would be dropped and every
+    /// command would still succeed, so the guard would report containment it never had. That is strictly
+    /// worse than the mis-encoding this transport replaced, which at least only affected names containing
+    /// <c>=</c>. Parsing <c>git --version</c> would answer a narrower question — distributions ship suffixed
+    /// versions, and the property we need is not "which git" but "do these entries apply here", which also
+    /// covers an environment that cannot carry them at all.</para>
+    ///
+    /// <para>The probe asserts both value shapes the overrides use: an EMPTY value, which is how a filter
+    /// command is disabled and the one an environment block is least likely to carry, and a non-empty one at
+    /// a non-zero index, which fails if the count is miscomputed. Its key contains <c>=</c>, so the boundary
+    /// this transport exists for is measured rather than assumed. The key is unguessable per probe and the
+    /// probe runs outside any repository, so nothing a repository or branch can write could satisfy it in
+    /// the transport's place.</para>
+    ///
+    /// <para>Only success is remembered: a spawn that failed for an unrelated reason must not wedge the
+    /// daemon until restart. Whether the entries apply is a property of the git binary and the platform, not
+    /// of the repository, so one measurement holds for the process.</para>
+    /// </summary>
+    /// <exception cref="GitConfigTransportException">The entries did not reach git.</exception>
+    internal static async Task ProveConfigTransportAsync(string gitContextPath) {
+        if (_configTransportProven) return;
+
+        await ConfigTransportGate.WaitAsync();
+        try {
+            if (_configTransportProven) return;
+
+            await ProbeConfigTransportAsync(gitContextPath);
+            _configTransportProven = true;
+        } finally {
+            ConfigTransportGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// The measurement itself, separate from the memoization above so it can be run on demand — a test of a
+    /// cached proof would otherwise pass by returning early, testing nothing.
+    ///
+    /// <para>Run in the caller's own git context rather than a directory of our own: this is a context the
+    /// caller is about to run git in regardless, so the probe cannot invent a failure the real command would
+    /// not have had — a repository git refuses to touch (dubious ownership, say) fails either way, and no
+    /// directory has to be created, permissioned or cleaned up to hold it.</para>
+    /// </summary>
+    internal static async Task ProbeConfigTransportAsync(string gitContextPath) {
+        var driver = $"kcap-transport-probe={Guid.NewGuid():N}";
+        GitConfigOverride[] probe = [
+            new($"filter.{driver}.smudge", ""),
+            new($"filter.{driver}.required", "false")
+        ];
+
+        var listing = await RunGitCaptureResult(
+            gitContextPath, GitTimeout, sourceReadOnly: false, probe, "config", "--list", "-z");
+
+        if (listing.ExitCode != 0)
+            throw new GitConfigTransportException(
+                $"`git config --list` exited {listing.ExitCode} while reading probe overrides from the "
+              + $"environment: {listing.Stderr.Trim()}");
+
+        RequireProbeApplied(listing.Stdout, probe);
+    }
+
+    /// <summary>Checks a <c>config --list -z</c> listing reports every probe entry with the value it was
+    /// given. Records are <c>key\nvalue\0</c>; an entry with an empty value is <c>key\n</c>, which is why
+    /// the comparison is against the whole record and not a prefix of it. Presence, not exclusivity: the
+    /// probe directory may sit inside a repository, and the probe key is unguessable, so a real config
+    /// cannot supply the record that would pass this.</summary>
+    internal static void RequireProbeApplied(string listing, IReadOnlyList<GitConfigOverride> probe) {
+        var records = listing.Split('\0', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var (key, value) in probe) {
+            if (!records.Contains($"{key}\n{value}", StringComparer.Ordinal))
+                throw new GitConfigTransportException(
+                    $"git did not report the config override '{key}' this process passed in "
+                  + $"{ConfigCountVariable}/GIT_CONFIG_KEY_n. Overrides carried that way would be silently "
+                  + "dropped — git 2.31 or newer is required to create an agent worktree.");
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.GitConfig.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.GitConfig.cs
@@ -92,7 +92,10 @@ public partial class WorktreeManager {
 
     /// <summary>The <c>sourceReadOnly</c> suppressions, composed through the same transport as everything
     /// else so their indices are allocated in one place. <c>maintenance.auto</c> stops a read from launching
-    /// background maintenance that would touch <c>.git/worktrees</c> outside the metadata gate.</summary>
+    /// background maintenance that would touch <c>.git/worktrees</c> outside the metadata gate.
+    /// <c>core.fsmonitor</c> set to anything but a boolean names a hook PROGRAM that git runs whenever it
+    /// refreshes the index, so this pair is an execution surface and not merely a performance one — which is
+    /// why a run carrying it proves the transport like any other.</summary>
     static readonly GitConfigOverride[] SourceReadOnlyConfig = [
         new("maintenance.auto", "false"),
         new("core.fsmonitor", "false")

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.GitConfig.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.GitConfig.cs
@@ -108,9 +108,9 @@ public partial class WorktreeManager {
     /// <para>The probe asserts both value shapes the overrides use: an EMPTY value, which is how a filter
     /// command is disabled and the one an environment block is least likely to carry, and a non-empty one at
     /// a non-zero index, which fails if the count is miscomputed. Its key contains <c>=</c>, so the boundary
-    /// this transport exists for is measured rather than assumed. The key is unguessable per probe and the
-    /// probe runs outside any repository, so nothing a repository or branch can write could satisfy it in
-    /// the transport's place.</para>
+    /// this transport exists for is measured rather than assumed. The key is unguessable per probe, so no
+    /// config a repository or branch can write could supply the record that would satisfy it in the
+    /// transport's place.</para>
     ///
     /// <para>Only success is remembered: a spawn that failed for an unrelated reason must not wedge the
     /// daemon until restart. Whether the entries apply is a property of the git binary and the platform, not

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -230,7 +230,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // containment and could reject a safe launch, since a source-only conditional include can define a
         // driver the target never sees.
         if (await IsGitRepoWithCommits(repoPath)) {
-            var noHooks = await NoBranchHooksAsync(repoPath);
+            var noHooks = NoBranchHooks();
             if (!string.IsNullOrEmpty(baseRef)) {
                 // Fetch into a per-worktree ref instead of the shared FETCH_HEAD
                 // so concurrent review launches in the same source repo can't
@@ -283,7 +283,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // BEFORE the initial commit, so the snapshot's own history never carries the hostile config
         // either — a later `git checkout` inside the tree would otherwise restore it.
         StripWorkspaceMcpConfig(worktreePath);
-        var noHooks = await NoBranchHooksAsync(worktreePath);
+        var noHooks = NoBranchHooks();
         await RunGit(worktreePath, GitTimeout, noHooks, "init");
         // Inventoried and logged here, not at the source: `add -A` in this worktree is where the standalone
         // path's filters resolve. Round 6 removed the source-level logging as dead, and this call was
@@ -338,15 +338,9 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// </summary>
     internal const string NoHooksPath = "/dev/null";
 
-    /// <summary>The hook override, available only once the transport carrying it has been proved to reach
-    /// git. Handing out containment config and proving it applies are the same step on purpose: a caller
-    /// cannot obtain the override and forget the proof, the way each materialising path once had to remember
-    /// to log its own disabled drivers.</summary>
-    static async Task<GitConfigOverride[]> NoBranchHooksAsync(string gitContextPath) {
-        await ProveConfigTransportAsync(gitContextPath);
-
-        return [new("core.hooksPath", NoHooksPath)];
-    }
+    /// <summary>The hook override. The transport carrying it is proved by the runner that hands it to git
+    /// (see <c>ProveConfigTransportIfCarryingAsync</c>), so nothing here has to remember to.</summary>
+    static GitConfigOverride[] NoBranchHooks() => [new("core.hooksPath", NoHooksPath)];
 
     /// <summary>
     /// Neutralizes the tree, and UNDOES the creation if that fails.
@@ -384,7 +378,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// </summary>
     async Task CheckoutInTargetContextAsync(string worktreePath) {
         var overrides = await FilterOverridesForAsync(worktreePath);
-        var noHooks = await NoBranchHooksAsync(worktreePath);
+        var noHooks = NoBranchHooks();
 
         // `reset --hard HEAD`, not `checkout -- .`: --no-checkout leaves the INDEX unpopulated too, so a
         // pathspec matches nothing. This is the step that materialises the tree, and therefore the step
@@ -686,7 +680,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             // core.hooksPath would run the branch's post-checkout here too. Missed when the guard was
             // added — it went on the worktree paths only.
             await RunGit(destination, GitTimeout,
-                [.. await NoBranchHooksAsync(destination), .. await FilterOverridesForAsync(destination)],
+                [.. NoBranchHooks(), .. await FilterOverridesForAsync(destination)],
                 "checkout", "--detach", "HEAD");
             var clonedHead = (await RunGitCapture(destination, GitTimeout, false, "rev-parse", "HEAD")).Trim();
             if (!string.Equals(sourceHead, clonedHead, StringComparison.Ordinal)) throw new SourceChangedException();
@@ -1320,6 +1314,33 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     }
 
     internal static async Task<(int ExitCode, string Stdout, string Stderr)> RunGitCaptureResult(
+            string cwd, TimeSpan timeout, bool sourceReadOnly, GitConfigOverride[] config,
+            params string[] args) {
+        await ProveConfigTransportIfCarryingAsync(cwd, config);
+
+        return await RunGitCaptureResultUnproven(cwd, timeout, sourceReadOnly, config, args);
+    }
+
+    /// <summary>
+    /// The proof gate, applied where the overrides are HANDED TO GIT rather than where they are composed.
+    ///
+    /// <para>An earlier revision proved the transport inside each producer of containment config instead.
+    /// Review found the hole that shape leaves: <c>ReadGitRelativeCwdAsync</c> passes
+    /// <c>core.quotePath=false</c> and is not a containment producer, so it carried an override past no
+    /// proof at all — a fourth call site would have had the same problem, and a fifth. Gating on "this run
+    /// carries config" cannot be forgotten by a new caller.</para>
+    ///
+    /// <para>Deliberately keyed on caller-supplied config, NOT on <c>sourceReadOnly</c>: that flag's own two
+    /// suppressions ride the same transport, but losing them costs a maintenance run, not containment, and
+    /// gating every plain read would turn an old git into a daemon that cannot read a repository at all.</para>
+    /// </summary>
+    static Task ProveConfigTransportIfCarryingAsync(string cwd, GitConfigOverride[] config) =>
+        config.Length > 0 ? ProveConfigTransportAsync(cwd) : Task.CompletedTask;
+
+    /// <summary>Runs git WITHOUT proving the transport first. Only the probe itself may use this — it is
+    /// what the gate above is measuring, so routing it through the gate would deadlock on the
+    /// non-reentrant semaphore.</summary>
+    static async Task<(int ExitCode, string Stdout, string Stderr)> RunGitCaptureResultUnproven(
             string cwd, TimeSpan timeout, bool sourceReadOnly, GitConfigOverride[] config,
             params string[] args) {
         var psi = NewGitPsi(cwd, args, sourceReadOnly, config);

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -1316,7 +1316,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     internal static async Task<(int ExitCode, string Stdout, string Stderr)> RunGitCaptureResult(
             string cwd, TimeSpan timeout, bool sourceReadOnly, GitConfigOverride[] config,
             params string[] args) {
-        await ProveConfigTransportIfCarryingAsync(cwd, config);
+        await ProveConfigTransportIfCarryingAsync(cwd, sourceReadOnly, config);
 
         return await RunGitCaptureResultUnproven(cwd, timeout, sourceReadOnly, config, args);
     }
@@ -1328,14 +1328,21 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// Review found the hole that shape leaves: <c>ReadGitRelativeCwdAsync</c> passes
     /// <c>core.quotePath=false</c> and is not a containment producer, so it carried an override past no
     /// proof at all — a fourth call site would have had the same problem, and a fifth. Gating on "this run
-    /// carries config" cannot be forgotten by a new caller.</para>
+    /// carries overrides" cannot be forgotten by a new caller.</para>
     ///
-    /// <para>Deliberately keyed on caller-supplied config, NOT on <c>sourceReadOnly</c>: that flag's own two
-    /// suppressions ride the same transport, but losing them costs a maintenance run, not containment, and
-    /// gating every plain read would turn an old git into a daemon that cannot read a repository at all.</para>
+    /// <para><b>Including <c>sourceReadOnly</c>'s own pair.</b> A revision of this gated only on
+    /// caller-supplied config, reasoning that losing that flag's suppressions costs a maintenance run.
+    /// Review corrected it: <c>core.fsmonitor</c> set to anything other than a boolean names a HOOK
+    /// PROGRAM, which git runs whenever a command refreshes the index, so silently dropping
+    /// <c>core.fsmonitor=false</c> re-exposes an execution surface — not a performance one. There is no
+    /// per-key classification here for the same reason there is no filter-driver exemption: the argument
+    /// for "this one is harmless to lose" is exactly what keeps turning out to be wrong. Every git run
+    /// carrying ANY override proves the transport first. The cost is that a git too old to honour the
+    /// transport cannot be used for these reads either — that git already cannot create a worktree.</para>
     /// </summary>
-    static Task ProveConfigTransportIfCarryingAsync(string cwd, GitConfigOverride[] config) =>
-        config.Length > 0 ? ProveConfigTransportAsync(cwd) : Task.CompletedTask;
+    static Task ProveConfigTransportIfCarryingAsync(
+            string cwd, bool sourceReadOnly, GitConfigOverride[] config) =>
+        sourceReadOnly || config.Length > 0 ? ProveConfigTransportAsync(cwd) : Task.CompletedTask;
 
     /// <summary>Runs git WITHOUT proving the transport first. Only the probe itself may use this — it is
     /// what the gate above is measuring, so routing it through the gate would deadlock on the

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -133,13 +133,14 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             // --path-format=absolute needs git 2.31+; on older git this exits non-zero and we resolve
             // the (possibly relative) plain form against the checkout instead.
             var absolute = await RunGitCaptureResult(
-                repoPath, GitTimeout, sourceReadOnly: false, "rev-parse", "--path-format=absolute", "--git-common-dir");
+                repoPath, GitTimeout, sourceReadOnly: false, [],
+                "rev-parse", "--path-format=absolute", "--git-common-dir");
 
             if (absolute.ExitCode == 0 && absolute.Stdout.Trim() is { Length: > 0 } fromAbsolute)
                 return NormalizePathKey(fromAbsolute);
 
             var plain = await RunGitCaptureResult(
-                repoPath, GitTimeout, sourceReadOnly: false, "rev-parse", "--git-common-dir");
+                repoPath, GitTimeout, sourceReadOnly: false, [], "rev-parse", "--git-common-dir");
 
             if (plain.ExitCode == 0 && plain.Stdout.Trim() is { Length: > 0 } fromPlain)
                 return NormalizePathKey(Path.IsPathRooted(fromPlain) ? fromPlain : Path.Combine(repoPath, fromPlain));
@@ -229,6 +230,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // containment and could reject a safe launch, since a source-only conditional include can define a
         // driver the target never sees.
         if (await IsGitRepoWithCommits(repoPath)) {
+            var noHooks = await NoBranchHooksAsync(repoPath);
             if (!string.IsNullOrEmpty(baseRef)) {
                 // Fetch into a per-worktree ref instead of the shared FETCH_HEAD
                 // so concurrent review launches in the same source repo can't
@@ -239,14 +241,14 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
                 // it's the slow, network-bound half. But a plain fetch ends by running automatic
                 // maintenance, whose task list includes worktree-prune — which WOULD touch
                 // .git/worktrees, unguarded, while another launch is mid-add. Disable it for this call
-                // (both spellings, so the old gc.auto era is covered too). `-c` rather than
-                // --no-auto-maintenance: that flag needs a newer git, `-c` works everywhere.
+                // (both spellings, so the old gc.auto era is covered too). A config override rather than
+                // --no-auto-maintenance: that flag needs a newer git than the override transport does.
                 await RunGit(repoPath, FetchTimeout,
-                    "-c", "maintenance.auto=false", "-c", "gc.auto=0",
+                    [new("maintenance.auto", "false"), new("gc.auto", "0")],
                     "fetch", "origin", $"{baseRef}:{fetchedRef}");
                 await WithWorktreeMetadataGate(repoPath, () =>
-                    RunGit(repoPath, GitTimeout, [..NoBranchHooks(),
-                        "worktree", "add", "--no-checkout", "-B", branch, worktreePath, fetchedRef]));
+                    RunGit(repoPath, GitTimeout, noHooks,
+                        "worktree", "add", "--no-checkout", "-B", branch, worktreePath, fetchedRef));
                 var fetched = new WorktreeInfo(worktreePath, branch, repoPath, FetchedRef: fetchedRef);
                 await StripOrRollBackAsync(fetched);
 
@@ -254,8 +256,8 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             }
 
             await WithWorktreeMetadataGate(repoPath, () =>
-                RunGit(repoPath, GitTimeout, [..NoBranchHooks(),
-                    "worktree", "add", "--no-checkout", worktreePath, "-b", branch]));
+                RunGit(repoPath, GitTimeout, noHooks,
+                    "worktree", "add", "--no-checkout", worktreePath, "-b", branch));
             var linked = new WorktreeInfo(worktreePath, branch, repoPath);
             await StripOrRollBackAsync(linked);
 
@@ -281,23 +283,22 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // BEFORE the initial commit, so the snapshot's own history never carries the hostile config
         // either — a later `git checkout` inside the tree would otherwise restore it.
         StripWorkspaceMcpConfig(worktreePath);
-        await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), "init"]);
+        var noHooks = await NoBranchHooksAsync(worktreePath);
+        await RunGit(worktreePath, GitTimeout, noHooks, "init");
         // Inventoried and logged here, not at the source: `add -A` in this worktree is where the standalone
         // path's filters resolve. Round 6 removed the source-level logging as dead, and this call was
         // applying overrides inline — silently disabling LFS against a README that promises the opposite.
         var standaloneOverrides = await FilterOverridesForAsync(worktreePath);
-        await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..standaloneOverrides, "add", "-A"]);
+        await RunGit(worktreePath, GitTimeout, [.. noHooks, .. standaloneOverrides], "add", "-A");
         // Identity supplied explicitly. This is the daemon's OWN bookkeeping commit, not the user's work,
         // so it must not depend on the host having git identity configured — a machine without a global
         // user.email fails with "Author identity unknown". Found while CopyDirectory was temporarily
         // repaired and this line became reachable for the first time; that repair was then reverted (see
         // CopyDirectory), so the path still cannot get here — the fix is kept because it is correct and
         // because the repair will land eventually.
-        await RunGit(worktreePath, GitTimeout, [
-            ..NoBranchHooks(),
-            "-c", "user.email=daemon@kcap.local", "-c", "user.name=kcap",
-            "commit", "-m", "Initial snapshot"
-        ]);
+        await RunGit(worktreePath, GitTimeout,
+            [.. noHooks, new("user.email", "daemon@kcap.local"), new("user.name", "kcap")],
+            "commit", "-m", "Initial snapshot");
 
         return new WorktreeInfo(worktreePath, "", repoPath, IsStandalone: true);
     }
@@ -337,7 +338,15 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// </summary>
     internal const string NoHooksPath = "/dev/null";
 
-    static string[] NoBranchHooks() => ["-c", $"core.hooksPath={NoHooksPath}"];
+    /// <summary>The hook override, available only once the transport carrying it has been proved to reach
+    /// git. Handing out containment config and proving it applies are the same step on purpose: a caller
+    /// cannot obtain the override and forget the proof, the way each materialising path once had to remember
+    /// to log its own disabled drivers.</summary>
+    static async Task<GitConfigOverride[]> NoBranchHooksAsync(string gitContextPath) {
+        await ProveConfigTransportAsync(gitContextPath);
+
+        return [new("core.hooksPath", NoHooksPath)];
+    }
 
     /// <summary>
     /// Neutralizes the tree, and UNDOES the creation if that fails.
@@ -375,11 +384,12 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// </summary>
     async Task CheckoutInTargetContextAsync(string worktreePath) {
         var overrides = await FilterOverridesForAsync(worktreePath);
+        var noHooks = await NoBranchHooksAsync(worktreePath);
 
         // `reset --hard HEAD`, not `checkout -- .`: --no-checkout leaves the INDEX unpopulated too, so a
         // pathspec matches nothing. This is the step that materialises the tree, and therefore the step
         // the overrides have to guard.
-        await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..overrides, "reset", "--hard", "HEAD"]);
+        await RunGit(worktreePath, GitTimeout, [.. noHooks, .. overrides], "reset", "--hard", "HEAD");
     }
 
     /// <summary>
@@ -391,7 +401,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// an LFS host silently got pointer files. Two rounds, one class. Computing and logging together means
     /// a fourth path cannot repeat it.</para>
     /// </summary>
-    async Task<string[]> FilterOverridesForAsync(string gitContextPath) {
+    async Task<GitConfigOverride[]> FilterOverridesForAsync(string gitContextPath) {
         var overrides = await BranchFilterOverridesAsync(gitContextPath);
         LogDisabledFilters(overrides, gitContextPath);
 
@@ -401,10 +411,11 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// <summary>Logs which filter drivers were disabled, so an operator whose LFS-tracked file checks out
     /// as pointer text can see why rather than guessing. Silent containment is how a deliberate trade turns
     /// into a bug report.</summary>
-    void LogDisabledFilters(string[] overrides, string repoPath) {
+    void LogDisabledFilters(GitConfigOverride[] overrides, string repoPath) {
         var drivers = overrides
-            .Where(static o => o.StartsWith("filter.", StringComparison.Ordinal) && o.EndsWith(".clean=", StringComparison.Ordinal))
-            .Select(static o => o["filter.".Length..^".clean=".Length])
+            .Where(static o => o.Key.StartsWith("filter.", StringComparison.Ordinal)
+                            && o.Key.EndsWith(".clean", StringComparison.Ordinal))
+            .Select(static o => o.Key["filter.".Length..^".clean".Length])
             .ToArray();
 
         if (drivers.Length > 0)
@@ -674,7 +685,9 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             // Same guard as `worktree add`: this checkout materialises branch content, so a relative
             // core.hooksPath would run the branch's post-checkout here too. Missed when the guard was
             // added — it went on the worktree paths only.
-            await RunGit(destination, GitTimeout, [..NoBranchHooks(), ..await FilterOverridesForAsync(destination), "checkout", "--detach", "HEAD"]);
+            await RunGit(destination, GitTimeout,
+                [.. await NoBranchHooksAsync(destination), .. await FilterOverridesForAsync(destination)],
+                "checkout", "--detach", "HEAD");
             var clonedHead = (await RunGitCapture(destination, GitTimeout, false, "rev-parse", "HEAD")).Trim();
             if (!string.Equals(sourceHead, clonedHead, StringComparison.Ordinal)) throw new SourceChangedException();
             await RunGitBestEffort(destination, "remote", "remove", "origin");
@@ -1275,32 +1288,41 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     }
 
     static Task RunGit(string cwd, TimeSpan timeout, params string[] args) =>
-        RunGit(cwd, timeout, sourceReadOnly: false, args);
+        RunGit(cwd, timeout, sourceReadOnly: false, [], args);
 
-    static async Task RunGit(string cwd, TimeSpan timeout, bool sourceReadOnly, params string[] args) {
-        var result = await RunGitCaptureResult(cwd, timeout, sourceReadOnly, args);
+    static Task RunGit(string cwd, TimeSpan timeout, bool sourceReadOnly, params string[] args) =>
+        RunGit(cwd, timeout, sourceReadOnly, [], args);
+
+    static Task RunGit(string cwd, TimeSpan timeout, GitConfigOverride[] config, params string[] args) =>
+        RunGit(cwd, timeout, sourceReadOnly: false, config, args);
+
+    static async Task RunGit(
+            string cwd, TimeSpan timeout, bool sourceReadOnly, GitConfigOverride[] config,
+            params string[] args) {
+        var result = await RunGitCaptureResult(cwd, timeout, sourceReadOnly, config, args);
         if (result.ExitCode != 0)
             throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {result.Stderr}");
     }
 
     static async Task<string> RunGitCapture(string cwd, TimeSpan timeout, bool sourceReadOnly, params string[] args) {
-        var result = await RunGitCaptureResult(cwd, timeout, sourceReadOnly, args);
+        var result = await RunGitCaptureResult(cwd, timeout, sourceReadOnly, [], args);
         if (result.ExitCode != 0)
             throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {result.Stderr}");
         return result.Stdout;
     }
 
     static async Task<bool> GitConfigBoolAsync(string cwd, string key) {
-        var result = await RunGitCaptureResult(cwd, GitTimeout, true, "config", "--bool", "--get", key);
+        var result = await RunGitCaptureResult(cwd, GitTimeout, true, [], "config", "--bool", "--get", key);
         if (result.ExitCode == 1) return false; // key is absent
         if (result.ExitCode != 0)
             throw new InvalidOperationException($"git config --bool --get {key} failed: {result.Stderr}");
         return string.Equals(result.Stdout.Trim(), "true", StringComparison.OrdinalIgnoreCase);
     }
 
-    static async Task<(int ExitCode, string Stdout, string Stderr)> RunGitCaptureResult(
-            string cwd, TimeSpan timeout, bool sourceReadOnly, params string[] args) {
-        var psi = NewGitPsi(cwd, args, sourceReadOnly);
+    internal static async Task<(int ExitCode, string Stdout, string Stderr)> RunGitCaptureResult(
+            string cwd, TimeSpan timeout, bool sourceReadOnly, GitConfigOverride[] config,
+            params string[] args) {
+        var psi = NewGitPsi(cwd, args, sourceReadOnly, config);
         using var proc = Process.Start(psi)!;
         using var cts = new CancellationTokenSource(timeout);
 
@@ -1362,7 +1384,8 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// (<c>GIT_TERMINAL_PROMPT=0</c>, <c>GCM_INTERACTIVE=Never</c>) so an
     /// unattended daemon can never block on a credential prompt.
     /// </summary>
-    static ProcessStartInfo NewGitPsi(string cwd, string[] args, bool sourceReadOnly = false) {
+    static ProcessStartInfo NewGitPsi(
+            string cwd, string[] args, bool sourceReadOnly = false, GitConfigOverride[]? config = null) {
         var psi = new ProcessStartInfo("git", args) {
             WorkingDirectory       = cwd,
             RedirectStandardOutput = true,
@@ -1381,12 +1404,16 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         if (sourceReadOnly) {
             psi.Environment["GIT_OPTIONAL_LOCKS"] = "0";
             psi.Environment["GIT_CONFIG_NOSYSTEM"] = "1";
-            psi.Environment["GIT_CONFIG_COUNT"] = "2";
-            psi.Environment["GIT_CONFIG_KEY_0"] = "maintenance.auto";
-            psi.Environment["GIT_CONFIG_VALUE_0"] = "false";
-            psi.Environment["GIT_CONFIG_KEY_1"] = "core.fsmonitor";
-            psi.Environment["GIT_CONFIG_VALUE_1"] = "false";
         }
+
+        // Every override this process passes goes through ONE composition, so the indices and the count are
+        // allocated in a single place. An earlier revision wrote the sourceReadOnly pair at fixed indices
+        // 0 and 1 with a fixed count of 2, which both displaced any inherited entry and left no room for a
+        // caller's own overrides.
+        GitConfigOverride[] composed = sourceReadOnly
+            ? [.. SourceReadOnlyConfig, .. config ?? []]
+            : config ?? [];
+        ApplyConfigOverrides(psi.Environment, composed);
 
         return psi;
     }

--- a/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/BranchFilterContainmentTests.cs
@@ -38,10 +38,10 @@ public class BranchFilterContainmentTests {
         var repo = NewRepo();
         Git(repo, "config", "filter.custom.smudge", command);
 
-        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
+        var overrides = await WorktreeManager.BranchFilterOverridesAsync(repo);
 
-        await Assert.That(joined).Contains("filter.custom.smudge=");
-        await Assert.That(joined).Contains("filter.custom.required=false");
+        await Assert.That(overrides).Contains(new GitConfigOverride("filter.custom.smudge", ""));
+        await Assert.That(overrides).Contains(new GitConfigOverride("filter.custom.required", "false"));
     }
 
     /// <summary>
@@ -57,10 +57,10 @@ public class BranchFilterContainmentTests {
         Git(repo, "config", "filter.lfs.process", "git-lfs filter-process");
         Git(repo, "config", "filter.lfs.required", "true");
 
-        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
+        var overrides = await WorktreeManager.BranchFilterOverridesAsync(repo);
 
-        await Assert.That(joined).Contains("filter.lfs.smudge=");
-        await Assert.That(joined).Contains("filter.lfs.required=false");
+        await Assert.That(overrides).Contains(new GitConfigOverride("filter.lfs.smudge", ""));
+        await Assert.That(overrides).Contains(new GitConfigOverride("filter.lfs.required", "false"));
     }
 
     /// <summary>
@@ -77,17 +77,14 @@ public class BranchFilterContainmentTests {
         Git(repo, "config", "filter.custom.smudge", "./tools/f");
 
         var expected = EffectiveDriverNames(repo);
-        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
+        var overrides = await WorktreeManager.BranchFilterOverridesAsync(repo);
 
         await Assert.That(expected).Contains("custom");          // the fixture's own driver is in scope
         foreach (var driver in expected)
-            await Assert.That(joined).Contains($"filter.{driver}.smudge=");
+            await Assert.That(overrides).Contains(new GitConfigOverride($"filter.{driver}.smudge", ""));
 
         // ...and nothing outside that set is emitted.
-        var emitted = joined.Split(' ')
-            .Where(static t => t.StartsWith("filter.", StringComparison.Ordinal) && t.EndsWith(".clean=", StringComparison.Ordinal))
-            .Select(static t => t["filter.".Length..^".clean=".Length])
-            .ToHashSet(StringComparer.Ordinal);
+        var emitted = DisabledDriverNames(overrides);
 
         await Assert.That(emitted.Except(expected).Any()).IsFalse();
     }
@@ -119,13 +116,22 @@ public class BranchFilterContainmentTests {
         // Precondition: git really does resolve the value under the canonical spelling.
         await Assert.That(EffectiveDriverNames(repo)).Contains(subsection);
 
-        var joined = string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo));
+        var overrides = await WorktreeManager.BranchFilterOverridesAsync(repo);
+        var prefix = canonical[..canonical.LastIndexOf('.')];
 
-        await Assert.That(joined).Contains($"{canonical[..canonical.LastIndexOf('.')]}.clean=");
-        await Assert.That(joined).Contains($"{canonical[..canonical.LastIndexOf('.')]}.smudge=");
-        await Assert.That(joined).Contains($"{canonical[..canonical.LastIndexOf('.')]}.process=");
-        await Assert.That(joined).Contains($"{canonical[..canonical.LastIndexOf('.')]}.required=false");
+        await Assert.That(overrides).Contains(new GitConfigOverride($"{prefix}.clean", ""));
+        await Assert.That(overrides).Contains(new GitConfigOverride($"{prefix}.smudge", ""));
+        await Assert.That(overrides).Contains(new GitConfigOverride($"{prefix}.process", ""));
+        await Assert.That(overrides).Contains(new GitConfigOverride($"{prefix}.required", "false"));
     }
+
+    /// <summary>The drivers an override set disables, read back from the keys it emits.</summary>
+    static HashSet<string> DisabledDriverNames(GitConfigOverride[] overrides) =>
+        overrides
+            .Where(static o => o.Key.StartsWith("filter.", StringComparison.Ordinal)
+                            && o.Key.EndsWith(".clean", StringComparison.Ordinal))
+            .Select(static o => o.Key["filter.".Length..^".clean".Length])
+            .ToHashSet(StringComparer.Ordinal);
 
     /// <summary>Driver names git reports for the repo's EFFECTIVE config, global scope included.</summary>
     static HashSet<string> EffectiveDriverNames(string repo) {
@@ -153,8 +159,8 @@ public class BranchFilterContainmentTests {
         var repo = NewRepo();
         Git(repo, "config", "filter.my.tool.smudge", "./tools/f");
 
-        await Assert.That(string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo)))
-            .Contains("filter.my.tool.smudge=");
+        await Assert.That(await WorktreeManager.BranchFilterOverridesAsync(repo))
+            .Contains(new GitConfigOverride("filter.my.tool.smudge", ""));
     }
 
     /// <summary>A newline inside a config VALUE must not hide a driver. A line-splitting inventory reads
@@ -165,27 +171,54 @@ public class BranchFilterContainmentTests {
         var repo = NewRepo();
         Git(repo, "config", "filter.sneaky.smudge", "cat\n./tools/f");
 
-        await Assert.That(string.Join(' ', await WorktreeManager.BranchFilterOverridesAsync(repo)))
-            .Contains("filter.sneaky.smudge=");
-    }
-
-    /// <summary>
-    /// `-c key=value` splits at the FIRST '='. A driver legally named `evil=x` would be written as key
-    /// `filter.evil`, leaving `filter.evil=x.smudge` live while the override looked applied. Refused rather
-    /// than mis-encoded; the env transport that would carry it safely is tracked separately.
-    /// </summary>
-    [Test]
-    public async Task A_driver_name_that_cannot_be_safely_overridden_is_refused() {
-        var repo = NewRepo();
-        Git(repo, "config", "filter.evil=x.smudge", "./tools/f");
-
-        var ex = await Assert.ThrowsAsync<BranchFilterInventoryException>(
-            async () => await WorktreeManager.BranchFilterOverridesAsync(repo));
-
-        await Assert.That(ex!.Message).Contains("evil=x");
+        await Assert.That(await WorktreeManager.BranchFilterOverridesAsync(repo))
+            .Contains(new GitConfigOverride("filter.sneaky.smudge", ""));
     }
 
     // ── end to end ──
+
+    /// <summary>
+    /// A driver named `evil=x` is CONTAINED, not refused. `-c key=value` splits at the first '=', so that
+    /// name arrived as key `filter.evil` with value `x.smudge=` — the real driver stayed live while the
+    /// override looked applied — and the guard refused such a name rather than mis-encode it. The env
+    /// transport keeps the key/value boundary explicit, so the name is expressible and the launch proceeds.
+    ///
+    /// <para>Measured before this was written: plain git runs a driver whose name contains '=' (the control
+    /// below), and `-c` really does fail to disable it. Git parses a `.gitattributes` attribute at its first
+    /// '=' too, so `filter=evil=x` selects this driver — a branch can reach it.</para>
+    /// </summary>
+    [Test]
+    public async Task An_equals_in_a_driver_name_is_contained_rather_than_refused() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX filter script with a shebang");
+
+        var marker = Path.Combine(NewDir("eqmarker"), "fired");
+        var repo = NewRepo();
+        Directory.CreateDirectory(Path.Combine(repo, "tools"));
+        var script = Path.Combine(repo, "tools", "f");
+        File.WriteAllText(script, $"#!/bin/sh\nprintf fired > '{marker}'\ncat\n");
+        File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        File.WriteAllText(Path.Combine(repo, "zz.txt"), "payload\n");   // sorts after tools/f — see above
+        File.WriteAllText(Path.Combine(repo, ".gitattributes"), "zz.txt filter=evil=x\n");
+        Git(repo, "add", "-A");
+        Git(repo, "commit", "-q", "-m", "branch selects a driver whose name contains '='");
+        Git(repo, "config", "filter.evil=x.smudge", "./tools/f");
+
+        // CONTROL — plain git honours the '='-named driver and runs branch code.
+        Git(repo, "worktree", "add", "-q", Path.Combine(NewDir("ctl"), "wt"),
+            "-b", "ctl-" + Guid.NewGuid().ToString("N")[..8]);
+        await Assert.That(File.Exists(marker))
+            .IsTrue()
+            .Because("the control must reproduce filter execution, or the assertion below is vacuous");
+
+        File.Delete(marker);
+
+        var info = await new WorktreeManager(new DaemonConfig(), NullLogger<WorktreeManager>.Instance)
+            .CreateAsync(repo);
+
+        await Assert.That(File.Exists(marker)).IsFalse();
+        // Contained, not refused: the worktree exists and the filtered path is materialised.
+        await Assert.That(File.Exists(Path.Combine(info.Path, "zz.txt"))).IsTrue();
+    }
 
     /// <summary>
     /// The real thing: a branch that ships its own filter executable, with the operator's config pointing at

--- a/test/Capacitor.Cli.Tests.Unit/GitConfigTransportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitConfigTransportTests.cs
@@ -1,0 +1,185 @@
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Config overrides reach git as <c>GIT_CONFIG_COUNT</c> / <c>GIT_CONFIG_KEY_n</c> / <c>GIT_CONFIG_VALUE_n</c>
+/// rather than <c>-c key=value</c>, so a key containing <c>=</c> keeps its boundary.
+///
+/// <para>The count is the load-bearing part: entries are APPENDED, because the environment may already carry
+/// some — this daemon's own read-only suppressions, or an operator's. Write from index 0 and theirs are
+/// displaced; leave the count short and git ignores the tail. Either way overrides go missing while the call
+/// site believes they applied, which is the failure mode the <c>=</c> mis-encoding had. So git is the oracle
+/// here, not the environment dictionary: these run a real <c>git config --list</c> through the production
+/// runner and read back what git resolved.</para>
+/// </summary>
+public class GitConfigTransportTests {
+    static readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>`--list -z` records are `key\nvalue\0`; an empty value is `key\n`.</summary>
+    static async Task<string[]> EffectiveConfigAsync(bool sourceReadOnly, params GitConfigOverride[] config) {
+        var result = await WorktreeManager.RunGitCaptureResult(
+            Path.GetTempPath(), Timeout, sourceReadOnly, config, "config", "--list", "-z");
+
+        await Assert.That(result.ExitCode).IsEqualTo(0).Because(result.Stderr);
+
+        return result.Stdout.Split('\0', StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    /// <summary>
+    /// The `=` this whole transport exists for: `-c filter.evil=x.smudge=` reaches git as key `filter.evil`
+    /// with value `x.smudge=`, so the driver stays live. Here the key arrives whole, with the empty value
+    /// that disables a filter command.
+    ///
+    /// <para>Platform-agnostic on purpose. The end-to-end containment test needs a POSIX shebang and cannot
+    /// run on Windows, which is exactly where an empty value is least certain to survive an environment
+    /// block — an override that arrived without its value would be a fatal `missing config value`, but one
+    /// whose value arrived as absent-vs-empty is the silent case, and this is its coverage.</para>
+    /// </summary>
+    [Test]
+    public async Task An_equals_in_a_key_reaches_git_as_part_of_the_key() {
+        var records = await EffectiveConfigAsync(
+            sourceReadOnly: false, new GitConfigOverride("filter.evil=x.smudge", ""));
+
+        await Assert.That(records).Contains("filter.evil=x.smudge\n");
+        // The `-c` spelling's damage, stated as an assertion: the key must not have been cut at the '='.
+        await Assert.That(records.Any(static r => r.StartsWith("filter.evil\n", StringComparison.Ordinal)))
+            .IsFalse();
+    }
+
+    /// <summary>
+    /// A read-only invocation carries two suppressions of its own. Overrides passed alongside them must be
+    /// appended and the count must cover all of them — a count that stops short leaves git ignoring the tail,
+    /// which is a containment override silently dropped.
+    /// </summary>
+    [Test]
+    public async Task Overrides_compose_with_the_source_read_only_entries() {
+        var records = await EffectiveConfigAsync(
+            sourceReadOnly: true,
+            new GitConfigOverride("filter.evil=x.smudge", ""),
+            new GitConfigOverride("filter.evil=x.required", "false"));
+
+        // Every entry resolves, whichever end of the composed set it sits at.
+        await Assert.That(records).Contains("maintenance.auto\nfalse");
+        await Assert.That(records).Contains("core.fsmonitor\nfalse");
+        await Assert.That(records).Contains("filter.evil=x.smudge\n");
+        await Assert.That(records).Contains("filter.evil=x.required\nfalse");
+    }
+
+    /// <summary>
+    /// An inherited <c>GIT_CONFIG_COUNT</c> is appended to, not overwritten. Writing from index 0 would
+    /// replace the operator's own entries with ours while reporting a count that covers both — their config
+    /// silently gone, ours apparently fine.
+    /// </summary>
+    [Test]
+    [NotInParallel]
+    public async Task An_inherited_count_is_appended_to_rather_than_overwritten() {
+        var restore = (
+            Count: Environment.GetEnvironmentVariable("GIT_CONFIG_COUNT"),
+            Key: Environment.GetEnvironmentVariable("GIT_CONFIG_KEY_0"),
+            Value: Environment.GetEnvironmentVariable("GIT_CONFIG_VALUE_0"));
+        try {
+            Environment.SetEnvironmentVariable("GIT_CONFIG_COUNT", "1");
+            Environment.SetEnvironmentVariable("GIT_CONFIG_KEY_0", "kcap.inherited");
+            Environment.SetEnvironmentVariable("GIT_CONFIG_VALUE_0", "yes");
+
+            var records = await EffectiveConfigAsync(
+                sourceReadOnly: false, new GitConfigOverride("filter.evil=x.smudge", ""));
+
+            await Assert.That(records).Contains("kcap.inherited\nyes");
+            await Assert.That(records).Contains("filter.evil=x.smudge\n");
+        } finally {
+            Environment.SetEnvironmentVariable("GIT_CONFIG_COUNT", restore.Count);
+            Environment.SetEnvironmentVariable("GIT_CONFIG_KEY_0", restore.Key);
+            Environment.SetEnvironmentVariable("GIT_CONFIG_VALUE_0", restore.Value);
+        }
+    }
+
+    /// <summary>A count we cannot parse means we do not know which indices are taken. Refused rather than
+    /// renumbered: git dies on such a value anyway, and overwriting it would silently consume whatever the
+    /// operator meant to pass.</summary>
+    [Test]
+    [Arguments("not-a-number")]
+    [Arguments("-1")]
+    [Arguments(" 1")]
+    [Arguments("1.0")]
+    public void An_unparseable_inherited_count_is_refused(string count) {
+        var environment = new Dictionary<string, string?> { ["GIT_CONFIG_COUNT"] = count };
+
+        Assert.Throws<GitConfigTransportException>(() => WorktreeManager.ApplyConfigOverrides(
+            environment, [new GitConfigOverride("filter.x.smudge", "")]));
+    }
+
+    /// <summary>An environment entry ends at its first NUL, so a NUL inside a key would hand git a PREFIX of
+    /// the key we checked — the authorised name not being the used name. Unreachable from the filter
+    /// inventory, whose records are NUL-separated, and refused here regardless.</summary>
+    [Test]
+    public void A_NUL_in_an_override_is_refused() {
+        var environment = new Dictionary<string, string?>();
+
+        Assert.Throws<GitConfigTransportException>(() => WorktreeManager.ApplyConfigOverrides(
+            environment, [new GitConfigOverride("filter.ev\0il.smudge", "")]));
+        Assert.Throws<GitConfigTransportException>(() => WorktreeManager.ApplyConfigOverrides(
+            environment, [new GitConfigOverride("filter.evil.smudge", "ca\0t")]));
+    }
+
+    /// <summary>An empty override set leaves the environment alone — including an inherited count it has no
+    /// entries to append to, which must not be renumbered or validated into a failure.</summary>
+    [Test]
+    public async Task An_empty_override_set_touches_nothing() {
+        var environment = new Dictionary<string, string?> { ["GIT_CONFIG_COUNT"] = "bogus" };
+
+        WorktreeManager.ApplyConfigOverrides(environment, []);
+
+        await Assert.That(environment).HasCount(1);
+        await Assert.That(environment["GIT_CONFIG_COUNT"]).IsEqualTo("bogus");
+    }
+
+    // ── the runtime proof ──
+
+    /// <summary>
+    /// The transport is proved by running git before any containment override is handed out. A git older than
+    /// 2.31 IGNORES these variables: every filter and hook override would be dropped and every command would
+    /// still succeed. This asserts the measurement passes here — it is the gate every worktree creation now
+    /// goes through.
+    ///
+    /// <para>The UNCACHED probe on purpose: the cached gate short-circuits once any other test has created a
+    /// worktree, so calling it here would assert nothing about git.</para>
+    /// </summary>
+    [Test]
+    public async Task The_transport_is_proved_against_the_git_on_this_machine() {
+        await WorktreeManager.ProbeConfigTransportAsync(Path.GetTempPath());
+    }
+
+    /// <summary>The proof's own predicate, against listings git could return. Without this the proof would be
+    /// a positive control with nothing establishing it can fail: a verifier that accepts a listing missing
+    /// the entry would pass on the very git it exists to reject.</summary>
+    [Test]
+    public void The_proof_rejects_a_listing_that_does_not_report_the_probe() {
+        GitConfigOverride[] probe = [
+            new("filter.probe=1.smudge", ""),
+            new("filter.probe=1.required", "false")
+        ];
+
+        // Honoured: both records exactly as passed, alongside unrelated config.
+        WorktreeManager.RequireProbeApplied(
+            "user.name\nT\0filter.probe=1.smudge\n\0filter.probe=1.required\nfalse\0", probe);
+
+        // Ignored entirely — the old-git case.
+        Assert.Throws<GitConfigTransportException>(() =>
+            WorktreeManager.RequireProbeApplied("user.name\nT\0", probe));
+
+        // The tail dropped — the miscounted case.
+        Assert.Throws<GitConfigTransportException>(() =>
+            WorktreeManager.RequireProbeApplied("filter.probe=1.smudge\n\0", probe));
+
+        // Present but not the value passed: an empty value that arrived as something else.
+        Assert.Throws<GitConfigTransportException>(() =>
+            WorktreeManager.RequireProbeApplied(
+                "filter.probe=1.smudge\ncat\0filter.probe=1.required\nfalse\0", probe));
+
+        // The key cut at its '=' — what the transport this replaces did.
+        Assert.Throws<GitConfigTransportException>(() =>
+            WorktreeManager.RequireProbeApplied("filter.probe\n1.smudge=\0", probe));
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/GitConfigTransportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitConfigTransportTests.cs
@@ -144,7 +144,7 @@ public class GitConfigTransportTests {
 
         WorktreeManager.ApplyConfigOverrides(environment, []);
 
-        await Assert.That(environment).HasCount(1);
+        await Assert.That(environment).Count().IsEqualTo(1);
         await Assert.That(environment["GIT_CONFIG_COUNT"]).IsEqualTo("bogus");
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/GitConfigTransportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/GitConfigTransportTests.cs
@@ -110,6 +110,19 @@ public class GitConfigTransportTests {
             environment, [new GitConfigOverride("filter.x.smudge", "")]));
     }
 
+    /// <summary>An inherited count with no room left to append to would wrap the index arithmetic and name
+    /// entries at negative indices. Refused with a reason rather than left to git's own rejection of the
+    /// resulting count.</summary>
+    [Test]
+    public void An_inherited_count_with_no_room_to_append_is_refused() {
+        var environment = new Dictionary<string, string?> {
+            ["GIT_CONFIG_COUNT"] = int.MaxValue.ToString(System.Globalization.CultureInfo.InvariantCulture)
+        };
+
+        Assert.Throws<GitConfigTransportException>(() => WorktreeManager.ApplyConfigOverrides(
+            environment, [new GitConfigOverride("filter.x.smudge", "")]));
+    }
+
     /// <summary>An environment entry ends at its first NUL, so a NUL inside a key would hand git a PREFIX of
     /// the key we checked — the authorised name not being the used name. Unreachable from the filter
     /// inventory, whose records are NUL-separated, and refused here regardless.</summary>


### PR DESCRIPTION
Follow-up to #432, raised by the code review there. Linear: AI-1701.

## The limitation

`WorktreeManager` passed config overrides as `-c key=value`, which git parses at the **first** `=`. A filter driver may legally be named with an `=` in it, so `-c filter.evil=x.smudge=` reached git as key `filter.evil` with value `x.smudge=`: `filter.evil=x.smudge` stayed LIVE while the override *looked* applied. #432 handled that by **refusing** the name (fail-closed, no launch) — safe, but a repository with a legal if pathological driver name could never host an agent.

Measured on git 2.49 before writing any code, with `.gitattributes` containing `zz.txt filter=evil=x` (git parses an attribute at its first `=` too, so a branch really can select driver `evil=x`) and local config `filter.evil=x.smudge=./tools/f` pointing at a branch-committed `tools/f`:

| | driver `evil=x` selected by the branch |
|---|---|
| plain `git worktree add` | filter **runs** |
| `-c filter.evil=x.smudge=` | filter **runs** — the override was silently misdirected |
| `GIT_CONFIG_KEY_n` / `VALUE_n` | filter does **not** run, and the filtered path is still checked out |

## What changed

- **`GitConfigOverride(Key, Value)`** — overrides are pairs, so no boundary is left to infer. `ApplyConfigOverrides` writes them as `GIT_CONFIG_KEY_n`/`VALUE_n` **appended** to any entries the environment already carries, with `GIT_CONFIG_COUNT` covering all of them.
- **Every** config override in `WorktreeManager` moves to the transport, not just the filter ones: `core.hooksPath`, the fetch `maintenance.auto`/`gc.auto` suppression, the snapshot commit identity, `core.quotePath`, and the `sourceReadOnly` pair — which previously wrote fixed indices 0/1 with a fixed count of 2, displacing any inherited entry and leaving no room for a caller's own overrides. `-c` no longer appears in these files, so a future override cannot reintroduce the split.
- The `=`-name **refusal is gone**; such a driver is neutralized. The refusals that remain are the ones the transport genuinely cannot carry: a name that is not valid UTF-8 (an override built from `U+FFFD` would name a *different* driver), NUL in a key or value (an environment entry ends at its first NUL, so the key reaching git would be a prefix of the one checked), and an inherited count with no room left to append to (which would wrap into negative indices).
- **A runtime proof, before any git run that carries an override.** This is the fail-open risk the change itself introduces: a git older than 2.31 does not know `GIT_CONFIG_COUNT` and **ignores** it, so every override would be dropped *and every command would still succeed* — worse than the mis-encoding being replaced, which at least only affected names containing `=`. The probe runs git with two throwaway overrides and requires git to report both back; its key contains `=`, one value is empty (the shape that disables a filter command, and the one an environment block is least likely to carry), and the second sits at a non-zero index so a miscount fails it. Not a `git --version` parse: the property needed is "do these entries apply here", not "which git". The key is unguessable per probe, and it runs in the caller's own git context — a context git is about to be used in anyway, so the probe cannot invent a failure the real command would not have had.
- The gate sits in the **runners that hand config to git**, not in the callers that compose it, and fires for *any* run carrying an override — including `sourceReadOnly`'s own pair. Both of those placements are review corrections; see below.
- README documents the resulting prerequisite (git 2.31+) and why a launch refuses rather than reporting containment it does not have.

## Review corrections worth reading

Two reviewers moved this design, and both changes are load-bearing:

1. **The proof belonged at the handover, not at the producer.** It was originally awaited by the two producers of containment config. `ReadGitRelativeCwdAsync` passes `core.quotePath=false` and is *not* a containment producer, so it carried an override past no proof at all — and the next such caller would repeat it. Gating on "this run carries an override" cannot be forgotten by a new caller. (The specific failure that finding described is not reachable today: `rev-parse --show-prefix`/`--show-toplevel` print paths raw with or without `core.quotePath=false` — measured, a `ünïcode/` cwd returns raw bytes even with the override absent — and a transport-ignoring git fails the borrowed snapshot at its own `checkout --detach HEAD`. The fix is to the shape, not to a live hole.)
2. **`core.fsmonitor` is an execution surface, not a performance one.** The gate initially excluded `sourceReadOnly`'s own suppressions, reasoning that losing them costs a maintenance run. Git's docs describe `core.fsmonitor` alongside *hook-based* file system monitors (hence `core.fsmonitorHookVersion`, versioning the protocol for "invoking the fsmonitor hook"), so a non-boolean value names a **program git runs when refreshing the index**. There is now **no per-key classification at all** — for the same reason the filter set has no git-lfs exemption: the argument for "this one is harmless to lose" is what keeps turning out to be wrong. A git too old to honour the transport can no longer be used for these reads either; that git already cannot create a worktree.

Also corrected: `core.quotePath=false` only stops git escaping bytes ≥0x80 — with it set, `ls-files` still returns `"a\"b/f"` — so the comment claiming "verbatim" output was narrowed to what the setting actually governs.

## Tests

- `An_equals_in_a_driver_name_is_contained_rather_than_refused` — end-to-end, with a control that must first prove plain git executes the `evil=x` driver, then asserts `CreateAsync` does not run it **and** still materialises the filtered path. This is the inverted test: it failed on the refusal before the change.
- `Overrides_compose_with_the_source_read_only_entries` — a real `git config --list` through the production runner, asserting all four entries resolve; a short count drops the tail.
- `An_inherited_count_is_appended_to_rather_than_overwritten` — seeds `GIT_CONFIG_COUNT`/`KEY_0` in the process environment and asserts git reports the inherited entry *and* ours.
- `An_equals_in_a_key_reaches_git_as_part_of_the_key` — platform-agnostic, and the Windows coverage: the end-to-end test needs a POSIX shebang, and Windows is where an empty environment value is least certain to survive. **windows-latest CI passes it**, so the empty `GIT_CONFIG_VALUE_n` surviving .NET's environment block is measured, not assumed.
- Unparseable inherited count, no-room-to-append, NUL, empty override set, and the proof's own predicate against listings git could return (missing entry / dropped tail / wrong value / key cut at its `=`).

**Every guard was mutation-verified** — 12 mutants, each killed by the test that should catch it: index-from-zero, count ignoring the inherited entries, count one short, lax count parse, no overflow guard, dropped caller config, no NUL check, key split at `=`, no early return, probe-never-fails, restored `=` refusal, filter command not emptied. Count-one-short and split-key were also caught by the runtime proof, which is evidence it is load-bearing rather than decorative.

Local: `GitConfigTransportTests` 12/12, `BranchFilterContainmentTests` 18/18, plus `WorktreeManagerTests`, `WorktreeMetadataGateTests`, `WorkspaceMcpNeutralizationTests`, `BorrowedReviewContextTests`, `BorrowedSnapshotExclusionScopeTests`, `BorrowedReviewSandboxTests`, `AcpHostedAgentRuntimeFactory*`, `AgentOrchestratorVendorTests` green. `dotnet publish -c Release` clean, zero IL2026/IL3050.

## Residual

That every config-carrying run awaits the proof is now structural — the gate is in the runners, and only the probe uses the deliberately unproven runner (routing it through the gate would deadlock on the non-reentrant semaphore) — but it is not itself asserted by a test; forcing the transport to fail would need a fake git on PATH. What *is* tested is the proof's predicate and that the measurement passes on this machine via the uncached probe.

`RunGitWithNulStdinAsync` (the `update-index --skip-worktree` batch) passes no override and no flag, so it stays ungated.
