### PR TITLE
Kiro hosted-agent model override via probe-verified session/set_model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1021,17 +1021,27 @@ failing at launch.
 KCAP_KIRO_PATH=/opt/kiro/bin/kiro-cli kcap daemon
 ```
 
-Two limits are worth knowing before you pick Kiro:
+`KCAP_KIRO_MODEL` overrides the model a `kiro` hosted agent runs, mirroring `KCAP_CURSOR_MODEL` —
+with one deliberate difference: there is **no built-in default**, so with nothing set (and no
+per-launch model from the dashboard, which takes precedence) a Kiro hosted agent runs whatever
+Kiro's own default model is and kcap reports none. The value is matched against the models the Kiro
+account actually offers (Kiro's ids are bare names like `claude-haiku-4.5`); an unrecognized value
+falls back to Kiro's own default with none reported. Applied over ACP `session/set_model` —
+verified to take effect at the turn level, not just accepted — because Kiro does not implement the
+`session/set_config_option` call Cursor uses.
+
+```bash
+KCAP_KIRO_MODEL=claude-haiku-4.5 kcap daemon
+```
+
+One limit is worth knowing before you pick Kiro:
 
 - **Interactive hosting only.** Kiro cannot yet be selected as an unattended review-flow reviewer.
   Kiro inherits the MCP servers from your global `~/.kiro/settings/mcp.json` into every ACP session,
   which is exactly what you want for a session you are driving yourself, but means an unattended
   reviewer would be handed the flow-starting `kcap-flows` server. Containment for that is tracked
-  separately.
-- **No model override.** A Kiro hosted agent always runs Kiro's own default model. Kiro's ACP
-  model-selection call is unverified and fails silently, so rather than report a model it might not be
-  running, kcap ignores a requested model for `kiro` and reports none — there is deliberately no
-  `KCAP_KIRO_MODEL`. A *pinned reviewer* model is refused outright rather than silently substituted.
+  separately. (This also means a *pinned reviewer* model never reaches Kiro today — reviewer model
+  overrides remain gated on the vendors that advertise resolver support.)
 
 **Hosted Cursor agents run over ACP.** The `cursor` vendor is launched by the daemon as
 `cursor-agent acp` (Cursor's Agent Client Protocol server) in an isolated worktree, driven from the

--- a/docs/probes/2026-08-05-kiro-model-override/.gitignore
+++ b/docs/probes/2026-08-05-kiro-model-override/.gitignore
@@ -1,0 +1,2 @@
+out/
+out-free-phase/

--- a/docs/probes/2026-08-05-kiro-model-override/findings.md
+++ b/docs/probes/2026-08-05-kiro-model-override/findings.md
@@ -57,8 +57,11 @@ account default `minimax-m2.5`, so no identity confusion is possible, and the ch
    model its platform id, i.e. the runtime itself believes the turn's model is the requested one.)
 3. **Kiro's persisted session state:** `rts_model_state.model_info` flipped from `null` to
    `{"model_name": "deepseek-3.2", "model_id": "deepseek-3.2", "context_window_tokens": 164000,
-   "rate_multiplier": 0.25, "rate_unit": "Credit"}` — model-specific runtime parameters (DeepSeek's
-   164k context window, vs 200k observed for `auto`), not an echo of the requested string.
+   "rate_multiplier": 0.25, "rate_unit": "Credit"}` — model-specific runtime parameters that appear
+   nowhere in the request (164k is DeepSeek V3.2's actual context window), not an echo of the
+   requested string. (For contrast: a separate pre-existing local session's sidecar on model `auto`
+   shows `context_window_tokens: 200000` — observed outside this harness's committed runs, so
+   treat that comparator as anecdotal; the in-run evidence above stands without it.)
 
 ## Verdict
 
@@ -83,7 +86,12 @@ account default `minimax-m2.5`, so no identity confusion is possible, and the ch
 
 ## Files
 
-- `probe.py` — the harness (free phase by default; `--turn` spends exactly one prompt request).
-- `kiro-free-phase-summary.json` / `kiro-turn-summary.json` — captured summaries of the two runs,
-  with raw client-log excerpt fields stripped (they can embed injected session context; the
-  decisive lines are quoted above).
+- `probe.py` — the harness (free phase by default; `--turn` spends exactly one prompt request;
+  `--redact SRC DST` derives a committable summary from a raw `out*/summary.json`).
+- `kiro-free-phase-summary.json` / `kiro-turn-summary.json` — the two runs' summaries, derived by
+  `probe.py --redact` (drops the raw client-log excerpt fields — trace lines can embed injected
+  session context — and rewrites the home-directory prefix to `~`; each file's `_redaction` object
+  records exactly what was done; the decisive log lines are quoted above). The free-phase summary
+  is from a re-run with the final harness (the measurement reproduced identically — same
+  `-32601` for `set_config_option`, same `{}` success for `set_model`); the turn summary is the
+  original single-billable-request run.

--- a/docs/probes/2026-08-05-kiro-model-override/findings.md
+++ b/docs/probes/2026-08-05-kiro-model-override/findings.md
@@ -1,0 +1,89 @@
+# Kiro model-override probe — `session/set_config_option` vs `session/set_model` (2026-08-05)
+
+**Question** (the follow-up the Kiro hosting work deferred): does Kiro's ACP surface let a client
+select the session model in a way that **takes effect**, at the standard the hosting work set —
+not "the RPC returned success" but "the turn demonstrably ran on the requested model"?
+
+**Environment:** `kiro-cli 2.16.0`, macOS/arm64, spawned as `kiro-cli acp` (the daemon's exact
+argv), `initialize protocolVersion: 1`, `session/new {cwd, mcpServers: []}` — the same handshake
+`AcpHostedAgentRuntime.StartAsync` performs, with the selector RPC sent after `session/new` and
+before the first `session/prompt`, mirroring `IAcpModelSelector`'s call point. Harness:
+`probe.py` (reuses the ACP child driver from `../2026-08-04-acp-reconnect-c0/acp_c0_probe.py`).
+
+## Measurements
+
+### Free phase (control-plane only, no billable request)
+
+1. `session/new` returns a `models` object: `currentModelId` (the account's configured default —
+   `minimax-m2.5` on the probe account) plus nine `availableModels`, each `{modelId, name,
+   description}` with **bare** ids (`auto`, `claude-sonnet-4.5`, `claude-sonnet-4`,
+   `claude-haiku-4.5`, `deepseek-3.2`, `minimax-m2.5`, `minimax-m2.1`, `glm-5`,
+   `qwen3-coder-next`) — no parameterized variants, unlike Cursor. There is no `configOptions`
+   object in the result.
+2. `session/set_config_option {sessionId, configId: "model", value: "<exact id>"}` — the exact
+   frame `ConfigOptionModelSelector` sends — answers:
+
+   ```json
+   {"error": {"code": -32601, "message": "Method not found", "data": "session/set_config_option"}}
+   ```
+
+   **The method does not exist on Kiro.** `ConfigOptionModelSelector` can never work there, and
+   the hosting work's fear was structurally justified: that selector swallows this error and
+   continues on the vendor default, which would have been a silent no-op on every launch.
+3. `session/set_model {sessionId, modelId: "<exact id>"}` (the stabilized ACP model-selection
+   method) answers `{"result": {}}` — accepted at the RPC level. By the standard above this alone
+   proves nothing; hence the paid phase.
+4. The session sidecar (`~/.kiro/sessions/cli/{sessionId}.json`) shows
+   `session_state.rts_model_state.model_info: null` before any turn — the setting is not yet
+   observable there, so persistence evidence requires the turn.
+
+### Effect phase (exactly one billable request)
+
+`session/set_model {modelId: "deepseek-3.2"}` (chosen: a different vendor **family** from the
+account default `minimax-m2.5`, so no identity confusion is possible, and the cheapest tier —
+`rate_multiplier: 0.25`), then one no-tools prompt asking the model to identify itself. Turn ended
+`stopReason: end_turn`. Three independent channels agree:
+
+1. **The wire request** (client trace log, `KIRO_LOG_LEVEL=trace`): the turn's actual backend
+   inference request — `CodeWhispererStreaming.GenerateAssistantResponse`, "transmitting request"
+   — carries the requested id verbatim in its body:
+
+   ```
+   ...,"origin":"KIRO_CLI","modelId":"deepseek-3.2"}},"chatTriggerType":"MANUAL",...
+   ```
+
+2. **Self-identification:** the reply text was exactly `deepseek-3.2` — an id that appears nowhere
+   in the prompt, from a session whose default was a MiniMax model. (Kiro evidently tells the
+   model its platform id, i.e. the runtime itself believes the turn's model is the requested one.)
+3. **Kiro's persisted session state:** `rts_model_state.model_info` flipped from `null` to
+   `{"model_name": "deepseek-3.2", "model_id": "deepseek-3.2", "context_window_tokens": 164000,
+   "rate_multiplier": 0.25, "rate_unit": "Credit"}` — model-specific runtime parameters (DeepSeek's
+   164k context window, vs 200k observed for `auto`), not an echo of the requested string.
+
+## Verdict
+
+- `session/set_config_option`: **conclusively absent** on Kiro (`-32601`). Closed as "won't work",
+  with the measurement recorded here and in the hosting design doc.
+- `session/set_model`: **works and takes effect at the turn level.** This clears the bar for
+  carrying a live selector: Kiro now ships `SetModelSelector` (same resolution half as
+  `ConfigOptionModelSelector` via `AcpModelResolver`, `session/set_model` write half) plus
+  `DaemonConfig.KiroModel` / `KCAP_KIRO_MODEL` (default **null** — zero-configuration launches keep
+  Kiro's own default model with nothing reported, unchanged).
+
+## Boundaries this probe does NOT move
+
+- **Gemini** stays `NoOpModelSelector`: nothing here measures Gemini. This probe is the template —
+  determine which write method Gemini implements, then verify it at effect level.
+- **Reviewer (review-flow) model override** stays refused for Kiro:
+  `AcpHostedAgentRuntimeFactory.ReviewerModelResolver` remains `null`, and Kiro is not
+  unattended-certified anyway. The unattended reviewer issue owns that decision.
+- An unresolvable requested model still resolves to null before any RPC (no `session/set_model`
+  sent), so with the handshake-confirmed-model registration fix in place a launch with a bad model
+  runs and reports Kiro's default rather than claiming the requested one.
+
+## Files
+
+- `probe.py` — the harness (free phase by default; `--turn` spends exactly one prompt request).
+- `kiro-free-phase-summary.json` / `kiro-turn-summary.json` — captured summaries of the two runs,
+  with raw client-log excerpt fields stripped (they can embed injected session context; the
+  decisive lines are quoted above).

--- a/docs/probes/2026-08-05-kiro-model-override/kiro-free-phase-summary.json
+++ b/docs/probes/2026-08-05-kiro-model-override/kiro-free-phase-summary.json
@@ -1,0 +1,107 @@
+{
+  "started": "2026-08-05T02:02:37.580770+00:00",
+  "argv": [
+    "kiro-cli",
+    "acp"
+  ],
+  "turn_requested": false,
+  "notes": [
+    "initialize ok",
+    "session/new ok; sessionId=5b4fb355-c146-457f-8e9b-23ea89d445c2 currentModelId=minimax-m2.5 availableModels=['auto', 'claude-sonnet-4.5', 'claude-sonnet-4', 'claude-haiku-4.5', 'deepseek-3.2', 'minimax-m2.5', 'minimax-m2.1', 'glm-5', 'qwen3-coder-next']",
+    "target model: claude-haiku-4.5",
+    "session/set_config_option -> {\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32601, \"message\": \"Method not found\", \"data\": \"session/set_config_option\"}, \"id\": 3}",
+    "session/set_model (for the record) -> {\"jsonrpc\": \"2.0\", \"result\": {}, \"id\": 4}",
+    "sidecar after set: {\"conversation_id\": \"5b4fb355-c146-457f-8e9b-23ea89d445c2\", \"model_info\": null, \"context_usage_percentage\": null}"
+  ],
+  "agent_capabilities": {
+    "loadSession": true,
+    "promptCapabilities": {
+      "image": true,
+      "audio": false,
+      "embeddedContext": false
+    },
+    "mcpCapabilities": {
+      "http": true,
+      "sse": false
+    },
+    "sessionCapabilities": {},
+    "auth": {}
+  },
+  "session_id": "5b4fb355-c146-457f-8e9b-23ea89d445c2",
+  "session_new_models": {
+    "currentModelId": "minimax-m2.5",
+    "availableModels": [
+      {
+        "modelId": "auto",
+        "name": "auto",
+        "description": "Models chosen by task for optimal usage and consistent quality"
+      },
+      {
+        "modelId": "claude-sonnet-4.5",
+        "name": "claude-sonnet-4.5",
+        "description": "Claude Sonnet 4.5 model"
+      },
+      {
+        "modelId": "claude-sonnet-4",
+        "name": "claude-sonnet-4",
+        "description": "Hybrid reasoning and coding for regular use"
+      },
+      {
+        "modelId": "claude-haiku-4.5",
+        "name": "claude-haiku-4.5",
+        "description": "The latest Claude Haiku model"
+      },
+      {
+        "modelId": "deepseek-3.2",
+        "name": "deepseek-3.2",
+        "description": "Experimental preview of DeepSeek V3.2"
+      },
+      {
+        "modelId": "minimax-m2.5",
+        "name": "minimax-m2.5",
+        "description": "MiniMax M2.5 model"
+      },
+      {
+        "modelId": "minimax-m2.1",
+        "name": "minimax-m2.1",
+        "description": "Experimental preview of MiniMax M2.1"
+      },
+      {
+        "modelId": "glm-5",
+        "name": "glm-5",
+        "description": "GLM-5 model"
+      },
+      {
+        "modelId": "qwen3-coder-next",
+        "name": "qwen3-coder-next",
+        "description": "Experimental preview of Qwen3 Coder Next"
+      }
+    ]
+  },
+  "session_new_config_options": null,
+  "target_model": "claude-haiku-4.5",
+  "set_config_option_response": {
+    "jsonrpc": "2.0",
+    "error": {
+      "code": -32601,
+      "message": "Method not found",
+      "data": "session/set_config_option"
+    },
+    "id": 3
+  },
+  "set_model_response": {
+    "jsonrpc": "2.0",
+    "result": {},
+    "id": 4
+  },
+  "sidecar_after_set": {
+    "path": "~/.kiro/sessions/cli/5b4fb355-c146-457f-8e9b-23ea89d445c2.json",
+    "rts_model_state": {
+      "conversation_id": "5b4fb355-c146-457f-8e9b-23ea89d445c2",
+      "model_info": null,
+      "context_usage_percentage": null
+    }
+  },
+  "ended": "2026-08-05T02:03:03.893005+00:00",
+  "_note": "raw client-log excerpt fields stripped before commit: kiro_home_log_model_lines, session_log_model_lines"
+}

--- a/docs/probes/2026-08-05-kiro-model-override/kiro-free-phase-summary.json
+++ b/docs/probes/2026-08-05-kiro-model-override/kiro-free-phase-summary.json
@@ -1,5 +1,5 @@
 {
-  "started": "2026-08-05T02:02:37.580770+00:00",
+  "started": "2026-08-05T02:52:57.812071+00:00",
   "argv": [
     "kiro-cli",
     "acp"
@@ -7,11 +7,11 @@
   "turn_requested": false,
   "notes": [
     "initialize ok",
-    "session/new ok; sessionId=5b4fb355-c146-457f-8e9b-23ea89d445c2 currentModelId=minimax-m2.5 availableModels=['auto', 'claude-sonnet-4.5', 'claude-sonnet-4', 'claude-haiku-4.5', 'deepseek-3.2', 'minimax-m2.5', 'minimax-m2.1', 'glm-5', 'qwen3-coder-next']",
+    "session/new ok; sessionId=a0e2eb6c-7386-4d70-97f2-ffebcb02b1c6 currentModelId=minimax-m2.5 availableModels=['auto', 'claude-sonnet-4.5', 'claude-sonnet-4', 'claude-haiku-4.5', 'deepseek-3.2', 'minimax-m2.5', 'minimax-m2.1', 'glm-5', 'qwen3-coder-next']",
     "target model: claude-haiku-4.5",
     "session/set_config_option -> {\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32601, \"message\": \"Method not found\", \"data\": \"session/set_config_option\"}, \"id\": 3}",
-    "session/set_model (for the record) -> {\"jsonrpc\": \"2.0\", \"result\": {}, \"id\": 4}",
-    "sidecar after set: {\"conversation_id\": \"5b4fb355-c146-457f-8e9b-23ea89d445c2\", \"model_info\": null, \"context_usage_percentage\": null}"
+    "session/set_model -> {\"jsonrpc\": \"2.0\", \"result\": {}, \"id\": 4}",
+    "sidecar after set: {\"conversation_id\": \"a0e2eb6c-7386-4d70-97f2-ffebcb02b1c6\", \"model_info\": null, \"context_usage_percentage\": null}"
   ],
   "agent_capabilities": {
     "loadSession": true,
@@ -27,7 +27,7 @@
     "sessionCapabilities": {},
     "auth": {}
   },
-  "session_id": "5b4fb355-c146-457f-8e9b-23ea89d445c2",
+  "session_id": "a0e2eb6c-7386-4d70-97f2-ffebcb02b1c6",
   "session_new_models": {
     "currentModelId": "minimax-m2.5",
     "availableModels": [
@@ -94,14 +94,22 @@
     "result": {},
     "id": 4
   },
+  "applied_via": "set_model",
   "sidecar_after_set": {
-    "path": "~/.kiro/sessions/cli/5b4fb355-c146-457f-8e9b-23ea89d445c2.json",
+    "path": "~/.kiro/sessions/cli/a0e2eb6c-7386-4d70-97f2-ffebcb02b1c6.json",
     "rts_model_state": {
-      "conversation_id": "5b4fb355-c146-457f-8e9b-23ea89d445c2",
+      "conversation_id": "a0e2eb6c-7386-4d70-97f2-ffebcb02b1c6",
       "model_info": null,
       "context_usage_percentage": null
     }
   },
-  "ended": "2026-08-05T02:03:03.893005+00:00",
-  "_note": "raw client-log excerpt fields stripped before commit: kiro_home_log_model_lines, session_log_model_lines"
+  "ended": "2026-08-05T02:53:31.562249+00:00",
+  "_redaction": {
+    "by": "probe.py --redact",
+    "dropped_fields": [
+      "session_log_model_lines",
+      "kiro_home_log_model_lines"
+    ],
+    "home_dir_rewritten_to": "~"
+  }
 }

--- a/docs/probes/2026-08-05-kiro-model-override/kiro-turn-summary.json
+++ b/docs/probes/2026-08-05-kiro-model-override/kiro-turn-summary.json
@@ -1,0 +1,135 @@
+{
+  "started": "2026-08-05T02:17:33.213489+00:00",
+  "argv": [
+    "kiro-cli",
+    "acp"
+  ],
+  "turn_requested": true,
+  "notes": [
+    "initialize ok",
+    "session/new ok; sessionId=c2336f9b-d2ca-4bca-8edd-ffb2f8956950 currentModelId=minimax-m2.5 availableModels=['auto', 'claude-sonnet-4.5', 'claude-sonnet-4', 'claude-haiku-4.5', 'deepseek-3.2', 'minimax-m2.5', 'minimax-m2.1', 'glm-5', 'qwen3-coder-next']",
+    "target model: deepseek-3.2",
+    "session/set_config_option -> {\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32601, \"message\": \"Method not found\", \"data\": \"session/set_config_option\"}, \"id\": 3}",
+    "session/set_model -> {\"jsonrpc\": \"2.0\", \"result\": {}, \"id\": 4}",
+    "sidecar after set: {\"conversation_id\": \"c2336f9b-d2ca-4bca-8edd-ffb2f8956950\", \"model_info\": null, \"context_usage_percentage\": null}",
+    "turn stopReason=end_turn",
+    "agent reply: 'deepseek-3.2'",
+    "sidecar after turn: {\"conversation_id\": \"c2336f9b-d2ca-4bca-8edd-ffb2f8956950\", \"model_info\": {\"model_name\": \"deepseek-3.2\", \"description\": \"Experimental preview of DeepSeek V3.2\", \"model_id\": \"deepseek-3.2\", \"context_window_tokens\": 164000, \"rate_multiplier\": 0.25, \"rate_unit\": \"Credit\"}, \"context_usage_percentage\": 1"
+  ],
+  "agent_capabilities": {
+    "loadSession": true,
+    "promptCapabilities": {
+      "image": true,
+      "audio": false,
+      "embeddedContext": false
+    },
+    "mcpCapabilities": {
+      "http": true,
+      "sse": false
+    },
+    "sessionCapabilities": {},
+    "auth": {}
+  },
+  "session_id": "c2336f9b-d2ca-4bca-8edd-ffb2f8956950",
+  "session_new_models": {
+    "currentModelId": "minimax-m2.5",
+    "availableModels": [
+      {
+        "modelId": "auto",
+        "name": "auto",
+        "description": "Models chosen by task for optimal usage and consistent quality"
+      },
+      {
+        "modelId": "claude-sonnet-4.5",
+        "name": "claude-sonnet-4.5",
+        "description": "Claude Sonnet 4.5 model"
+      },
+      {
+        "modelId": "claude-sonnet-4",
+        "name": "claude-sonnet-4",
+        "description": "Hybrid reasoning and coding for regular use"
+      },
+      {
+        "modelId": "claude-haiku-4.5",
+        "name": "claude-haiku-4.5",
+        "description": "The latest Claude Haiku model"
+      },
+      {
+        "modelId": "deepseek-3.2",
+        "name": "deepseek-3.2",
+        "description": "Experimental preview of DeepSeek V3.2"
+      },
+      {
+        "modelId": "minimax-m2.5",
+        "name": "minimax-m2.5",
+        "description": "MiniMax M2.5 model"
+      },
+      {
+        "modelId": "minimax-m2.1",
+        "name": "minimax-m2.1",
+        "description": "Experimental preview of MiniMax M2.1"
+      },
+      {
+        "modelId": "glm-5",
+        "name": "glm-5",
+        "description": "GLM-5 model"
+      },
+      {
+        "modelId": "qwen3-coder-next",
+        "name": "qwen3-coder-next",
+        "description": "Experimental preview of Qwen3 Coder Next"
+      }
+    ]
+  },
+  "session_new_config_options": null,
+  "target_model": "deepseek-3.2",
+  "set_config_option_response": {
+    "jsonrpc": "2.0",
+    "error": {
+      "code": -32601,
+      "message": "Method not found",
+      "data": "session/set_config_option"
+    },
+    "id": 3
+  },
+  "set_model_response": {
+    "jsonrpc": "2.0",
+    "result": {},
+    "id": 4
+  },
+  "applied_via": "set_model",
+  "sidecar_after_set": {
+    "path": "~/.kiro/sessions/cli/c2336f9b-d2ca-4bca-8edd-ffb2f8956950.json",
+    "rts_model_state": {
+      "conversation_id": "c2336f9b-d2ca-4bca-8edd-ffb2f8956950",
+      "model_info": null,
+      "context_usage_percentage": null
+    }
+  },
+  "turn_response": {
+    "jsonrpc": "2.0",
+    "result": {
+      "stopReason": "end_turn"
+    },
+    "id": 5
+  },
+  "turn_stop": "end_turn",
+  "agent_reply_text": "deepseek-3.2",
+  "sidecar_after_turn": {
+    "path": "~/.kiro/sessions/cli/c2336f9b-d2ca-4bca-8edd-ffb2f8956950.json",
+    "rts_model_state": {
+      "conversation_id": "c2336f9b-d2ca-4bca-8edd-ffb2f8956950",
+      "model_info": {
+        "model_name": "deepseek-3.2",
+        "description": "Experimental preview of DeepSeek V3.2",
+        "model_id": "deepseek-3.2",
+        "context_window_tokens": 164000,
+        "rate_multiplier": 0.25,
+        "rate_unit": "Credit"
+      },
+      "context_usage_percentage": 11.4896345
+    }
+  },
+  "ended": "2026-08-05T02:18:09.127474+00:00",
+  "_note": "raw client-log excerpt fields stripped before commit: kiro_home_log_model_lines, session_log_model_lines, turn_log_model_lines"
+}

--- a/docs/probes/2026-08-05-kiro-model-override/kiro-turn-summary.json
+++ b/docs/probes/2026-08-05-kiro-model-override/kiro-turn-summary.json
@@ -131,5 +131,13 @@
     }
   },
   "ended": "2026-08-05T02:18:09.127474+00:00",
-  "_note": "raw client-log excerpt fields stripped before commit: kiro_home_log_model_lines, session_log_model_lines, turn_log_model_lines"
+  "_redaction": {
+    "by": "probe.py --redact",
+    "dropped_fields": [
+      "session_log_model_lines",
+      "kiro_home_log_model_lines",
+      "turn_log_model_lines"
+    ],
+    "home_dir_rewritten_to": "~"
+  }
 }

--- a/docs/probes/2026-08-05-kiro-model-override/probe.py
+++ b/docs/probes/2026-08-05-kiro-model-override/probe.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Kiro model-override probe: does session/set_config_option {configId:"model"} TAKE EFFECT?
+
+The hosting work deliberately shipped Kiro with NoOpModelSelector because
+ConfigOptionModelSelector's write half (session/set_config_option) was unverified on Kiro and
+that selector fails silently. This probe measures the write half at the EFFECT level, mirroring
+the daemon's exact wire behavior (initialize protocolVersion 1 -> session/new {cwd, mcpServers:[]}
+-> session/set_config_option {sessionId, configId:"model", value:<exact modelId from
+availableModels>} -> first session/prompt).
+
+Phases:
+  free (default; ZERO billable requests -- Kiro bills per prompt request, not per control RPC):
+    1. initialize, session/new -> record result.models (currentModelId + availableModels).
+    2. pick target: first availableModels id containing --prefer (default "haiku", the cheapest
+       distinguishable tier), else first id != currentModelId.
+    3. session/set_config_option -> record the raw response.
+       On "method not found" ALSO probe session/set_model {sessionId, modelId} for the record.
+    4. read the session sidecar ~/.kiro/sessions/cli/{sessionId}.json ->
+       session_state.rts_model_state.model_info (the persisted model setting).
+  --turn (EXACTLY ONE billable request):
+    5. one session/prompt asking the model to self-identify (no tools), record stopReason +
+       every session/update frame.
+    6. re-read the sidecar; capture new kiro-cli log lines (KIRO_LOG_LEVEL=trace) that name a
+       model id around the request, from $TMPDIR/kiro-log/ and ~/.kiro/logs/.
+
+Usage: python3 probe.py [--turn] [--prefer haiku] [--model EXACT_ID] [--outdir DIR]
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "2026-08-04-acp-reconnect-c0"))
+from acp_c0_probe import AcpClient  # noqa: E402  (reuse the proven ACP child driver)
+
+KIRO_SESSIONS = Path.home() / ".kiro" / "sessions" / "cli"
+KIRO_LOG_ROOT = Path.home() / ".kiro" / "logs"
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def tmp_log_dir():
+    return Path(os.environ.get("TMPDIR", "/tmp")) / "kiro-log"
+
+
+def snapshot_log_offsets():
+    offs = {}
+    d = tmp_log_dir()
+    if d.is_dir():
+        for f in d.glob("*.log"):
+            offs[str(f)] = f.stat().st_size
+    return offs
+
+
+def new_log_lines(offsets):
+    """Lines appended to $TMPDIR/kiro-log/*.log since snapshot, plus any ~/.kiro/logs dir
+    created after the snapshot was taken (kiro-cli picks one of the two at startup)."""
+    out = {}
+    d = tmp_log_dir()
+    if d.is_dir():
+        for f in d.glob("*.log"):
+            prev = offsets.get(str(f), 0)
+            size = f.stat().st_size
+            if size > prev:
+                with open(f, "rb") as fh:
+                    fh.seek(prev)
+                    out[str(f)] = fh.read().decode("utf-8", "replace").splitlines()
+    return out
+
+
+def newest_kiro_log_dirs(since_epoch):
+    out = {}
+    if KIRO_LOG_ROOT.is_dir():
+        for d in sorted(KIRO_LOG_ROOT.iterdir()):
+            if d.is_dir() and d.stat().st_mtime >= since_epoch - 2:
+                for f in d.glob("*.log"):
+                    try:
+                        out[str(f)] = f.read_text("utf-8", errors="replace").splitlines()
+                    except OSError:
+                        pass
+    return out
+
+
+def read_sidecar(session_id):
+    p = KIRO_SESSIONS / f"{session_id}.json"
+    for _ in range(10):
+        if p.exists():
+            try:
+                d = json.loads(p.read_text())
+                state = (d.get("session_state") or {}).get("rts_model_state") or {}
+                return {"path": str(p), "rts_model_state": state}
+            except (json.JSONDecodeError, OSError):
+                pass
+        time.sleep(0.3)
+    return {"path": str(p), "rts_model_state": None, "note": "sidecar absent/unreadable after 3s"}
+
+
+def model_lines(lines_by_file, needles):
+    hits = {}
+    for f, lines in lines_by_file.items():
+        keep = [ln for ln in lines if any(n.lower() in ln.lower() for n in needles)]
+        if keep:
+            hits[f] = keep[:400]
+    return hits
+
+
+async def run(args):
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    cwd = outdir / "cwd"
+    cwd.mkdir(exist_ok=True)
+    frames = []
+    phase_ref = ["init"]
+    summary = {"started": now_iso(), "argv": ["kiro-cli", "acp"], "turn_requested": args.turn,
+               "notes": []}
+
+    def note(msg):
+        summary["notes"].append(msg)
+        print(f"  [kiro-model] {msg}", flush=True)
+
+    t0 = time.time()
+    offsets = snapshot_log_offsets()
+    client = AcpClient(["kiro-cli", "acp"], str(cwd), frames, phase_ref, "child1",
+                       outdir / "stderr.log", {"KIRO_LOG_LEVEL": "trace"})
+    try:
+        await client.start()
+        init = await client.request("initialize", {
+            "protocolVersion": 1,
+            "clientCapabilities": {"fs": {"readTextFile": False, "writeTextFile": False},
+                                     "terminal": False}}, timeout=60)
+        summary["agent_capabilities"] = (init.get("result") or {}).get("agentCapabilities")
+        note("initialize ok")
+
+        phase_ref[0] = "session_new"
+        sn = await client.request("session/new", {"cwd": str(cwd), "mcpServers": []}, timeout=90)
+        snr = sn.get("result") or {}
+        client.session_id = snr.get("sessionId")
+        summary["session_id"] = client.session_id
+        summary["session_new_models"] = snr.get("models")
+        summary["session_new_config_options"] = snr.get("configOptions")
+        if not client.session_id:
+            note(f"session/new gave no sessionId: {json.dumps(sn)[:500]}")
+            return summary
+        models = (snr.get("models") or {}).get("availableModels") or []
+        current = (snr.get("models") or {}).get("currentModelId")
+        note(f"session/new ok; sessionId={client.session_id} currentModelId={current} "
+             f"availableModels={[m.get('modelId') for m in models]}")
+
+        target = args.model
+        if not target:
+            for m in models:
+                if args.prefer.lower() in (m.get("modelId") or "").lower():
+                    target = m["modelId"]
+                    break
+        if not target:
+            target = next((m["modelId"] for m in models
+                           if m.get("modelId") and m["modelId"] != current), None)
+        summary["target_model"] = target
+        if not target:
+            note("no selectable non-default model in availableModels -- nothing to probe")
+            return summary
+        note(f"target model: {target}")
+
+        phase_ref[0] = "set_config_option"
+        try:
+            resp = await client.request(
+                "session/set_config_option",
+                {"sessionId": client.session_id, "configId": "model", "value": target},
+                timeout=60)
+        except (asyncio.TimeoutError, ConnectionError) as ex:
+            resp = {"transport_error": repr(ex)}
+        summary["set_config_option_response"] = resp
+        err = resp.get("error") if isinstance(resp, dict) else None
+        note(f"session/set_config_option -> {json.dumps(resp)[:300]}")
+
+        applied_via = None if err else "set_config_option"
+        if err and err.get("code") == -32601:
+            phase_ref[0] = "set_model_fallback"
+            try:
+                sm = await client.request(
+                    "session/set_model",
+                    {"sessionId": client.session_id, "modelId": target}, timeout=60)
+            except (asyncio.TimeoutError, ConnectionError) as ex:
+                sm = {"transport_error": repr(ex)}
+            summary["set_model_response"] = sm
+            if isinstance(sm, dict) and "result" in sm and "error" not in sm:
+                applied_via = "set_model"
+            note(f"session/set_model -> {json.dumps(sm)[:300]}")
+        summary["applied_via"] = applied_via
+
+        summary["sidecar_after_set"] = read_sidecar(client.session_id)
+        note(f"sidecar after set: {json.dumps(summary['sidecar_after_set'].get('rts_model_state'))[:300]}")
+
+        if args.turn and applied_via:
+            phase_ref[0] = "turn"
+            turn_offsets = snapshot_log_offsets()
+            try:
+                tr = await client.request(
+                    "session/prompt",
+                    {"sessionId": client.session_id,
+                     "prompt": [{"type": "text",
+                                  "text": "Without using any tools, reply in one short line: "
+                                          "exactly which AI model are you (family and version)?"}]},
+                    timeout=240)
+            except (asyncio.TimeoutError, ConnectionError) as ex:
+                tr = {"transport_error": repr(ex)}
+            summary["turn_response"] = tr
+            summary["turn_stop"] = ((tr or {}).get("result") or {}).get("stopReason")
+            note(f"turn stopReason={summary['turn_stop']}")
+            agent_text = []
+            for fr in frames:
+                if fr["dir"] == "in" and fr["frame"].get("method") == "session/update":
+                    upd = (fr["frame"].get("params") or {}).get("update") or {}
+                    if upd.get("sessionUpdate") == "agent_message_chunk":
+                        agent_text.append(((upd.get("content") or {}).get("text")) or "")
+            summary["agent_reply_text"] = "".join(agent_text)
+            note(f"agent reply: {summary['agent_reply_text'][:200]!r}")
+            summary["sidecar_after_turn"] = read_sidecar(client.session_id)
+            note(f"sidecar after turn: {json.dumps(summary['sidecar_after_turn'].get('rts_model_state'))[:300]}")
+            needles = ["model", target]
+            summary["turn_log_model_lines"] = model_lines(new_log_lines(turn_offsets), needles)
+    finally:
+        phase_ref[0] = "teardown"
+        await client.shutdown()
+        summary["ended"] = now_iso()
+        needles = ["model_id", "modelid", "set_config", "set_model"]
+        if summary.get("target_model"):
+            needles.append(summary["target_model"])
+        summary["session_log_model_lines"] = model_lines(new_log_lines(offsets), needles)
+        summary["kiro_home_log_model_lines"] = model_lines(newest_kiro_log_dirs(t0), needles)
+        with open(outdir / "frames.jsonl", "w") as f:
+            for fr in frames:
+                f.write(json.dumps(fr) + "\n")
+        with open(outdir / "summary.json", "w") as f:
+            json.dump(summary, f, indent=2)
+        print(f"== done in {time.time()-t0:.0f}s; outputs in {outdir} ==", flush=True)
+    return summary
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--turn", action="store_true",
+                    help="spend EXACTLY ONE billable prompt request to verify at effect level")
+    ap.add_argument("--prefer", default="haiku",
+                    help="substring picking the target from availableModels (default: haiku)")
+    ap.add_argument("--model", default=None, help="exact target modelId (overrides --prefer)")
+    ap.add_argument("--outdir", default=str(Path(__file__).parent / "out"))
+    args = ap.parse_args()
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/probes/2026-08-05-kiro-model-override/probe.py
+++ b/docs/probes/2026-08-05-kiro-model-override/probe.py
@@ -244,6 +244,37 @@ async def run(args):
     return summary
 
 
+REDACT_FIELDS = ("session_log_model_lines", "kiro_home_log_model_lines", "turn_log_model_lines")
+
+
+def redact(src, dst):
+    """Deterministically derive a committable summary from a raw run summary: drop the raw
+    client-log excerpt fields (trace lines can embed injected session context), rewrite this
+    user's home directory prefix to ~ in every string value, and record exactly what was done.
+    The checked-in kiro-*-summary.json files are produced by THIS step from out*/summary.json."""
+    home = str(Path.home())
+
+    def scrub(o):
+        if isinstance(o, dict):
+            return {k: scrub(v) for k, v in o.items()}
+        if isinstance(o, list):
+            return [scrub(v) for v in o]
+        if isinstance(o, str) and home in o:
+            return o.replace(home, "~")
+        return o
+
+    d = json.loads(Path(src).read_text())
+    dropped = [k for k in REDACT_FIELDS if d.pop(k, None) is not None]
+    d = scrub(d)
+    d["_redaction"] = {
+        "by": "probe.py --redact",
+        "dropped_fields": dropped,
+        "home_dir_rewritten_to": "~",
+    }
+    Path(dst).write_text(json.dumps(d, indent=2) + "\n")
+    print(f"redacted {src} -> {dst} (dropped: {dropped})")
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--turn", action="store_true",
@@ -252,7 +283,12 @@ def main():
                     help="substring picking the target from availableModels (default: haiku)")
     ap.add_argument("--model", default=None, help="exact target modelId (overrides --prefer)")
     ap.add_argument("--outdir", default=str(Path(__file__).parent / "out"))
+    ap.add_argument("--redact", nargs=2, metavar=("SRC", "DST"),
+                    help="no probe run: derive a committable summary from a raw one, then exit")
     args = ap.parse_args()
+    if args.redact:
+        redact(*args.redact)
+        return
     asyncio.run(run(args))
 
 

--- a/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
+++ b/docs/superpowers/specs/2026-07-30-ai1404-kiro-acp-hosted-agent-design.md
@@ -88,6 +88,20 @@ The selector parses `session/new`'s `models.availableModels` and then sends
 shape it needs. Its write half (`session/set_config_option` actually taking effect) is **still
 unverified** and must be measured before relying on it.
 
+> **Resolved 2026-08-05** (the follow-up this premise deferred to;
+> `docs/probes/2026-08-05-kiro-model-override/`, kiro-cli 2.16.0): `session/set_config_option`
+> **does not exist on Kiro** — it answers `-32601 Method not found`, so `ConfigOptionModelSelector`
+> can never work there and the silent-failure risk this premise guarded against was real. The
+> stabilized `session/set_model {sessionId, modelId}` succeeds instead **and takes effect at the
+> turn level**: the next turn's backend inference request carried the requested `modelId` verbatim,
+> the reply self-identified as it (a different vendor family from the account's default), and
+> Kiro's persisted session state recorded it with model-specific parameters. Kiro now carries
+> `SetModelSelector` + `DaemonConfig.KiroModel` (`KCAP_KIRO_MODEL`, default null so
+> zero-configuration behaviour is unchanged). The rest of this premise — `NoOpModelSelector`
+> mechanics, `ResolveDefaultModel: null` being insufficient alone — is kept as written for the
+> historical record, and the reviewer-model paragraph below still stands: `ReviewerModelResolver`
+> stays `null`, so review-flow model override remains a separate follow-up.
+
 **Decision: Kiro ships with `NoOpModelSelector` and no model override in either issue.** An earlier draft
 kept `ConfigOptionModelSelector` while AI-1410 deferred override — two implementers could then ship
 opposite behaviour, each following part of the spec. Note that `ResolveDefaultModel: null` is NOT

--- a/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
+++ b/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
@@ -141,6 +141,22 @@ public sealed record SetConfigOptionParams(
 );
 
 /// <summary>
+/// <c>session/set_model</c> params — the stabilized ACP model-selection method, used by vendors
+/// that do not implement <c>session/set_config_option</c>. Sent at the same point in the handshake
+/// as <see cref="SetConfigOptionParams"/> (after <c>session/new</c>, before the first
+/// <c>session/prompt</c>, response awaited). Wire shape probe-confirmed against real
+/// <c>kiro-cli</c> 2.16.0 (<c>docs/probes/2026-08-05-kiro-model-override/</c>):
+/// <see cref="ModelId"/> is an exact id from <see cref="SessionModelsInfo.AvailableModels"/>
+/// (Kiro's are bare, e.g. <c>deepseek-3.2</c> — resolved by
+/// <c>Capacitor.Cli.Core.Acp.AcpModelResolver</c> like Cursor's), and the success response is an
+/// empty object.
+/// </summary>
+public sealed record SetModelParams(
+    [property: JsonPropertyName("sessionId")] string SessionId,
+    [property: JsonPropertyName("modelId")]   string ModelId
+);
+
+/// <summary>
 /// Typed shape for <c>session/new</c>'s <c>result.models</c> object — the daemon
 /// otherwise treats the <c>session/new</c> result as an opaque <see cref="JsonElement"/> (only
 /// <c>sessionId</c> is read out of it today); this record exists purely so

--- a/src/Capacitor.Cli.Core/Acp/AcpModelResolver.cs
+++ b/src/Capacitor.Cli.Core/Acp/AcpModelResolver.cs
@@ -2,20 +2,23 @@
 namespace Capacitor.Cli.Core.Acp;
 
 /// <summary>
-/// Pure model-resolution helper for <c>session/set_config_option</c>. The wire
-/// requires the EXACT, parameterized <c>modelId</c> from <c>session/new</c>'s
-/// <c>result.models.availableModels</c> (e.g. <c>claude-sonnet-4-5[thinking=true,context=200k]</c>)
-/// — a bare family name like <c>claude-sonnet-4-5</c> (the shape both <c>RuntimeStartContext.Model</c>
-/// and <c>DaemonConfig.CursorModel</c>'s default are typically given in) is not itself a valid wire
-/// value. This resolves the caller's requested string against that list; the caller (
-/// <c>AcpHostedAgentRuntime.StartAsync</c>) treats a <see langword="null"/> result as "skip
-/// <c>session/set_config_option</c> — use Cursor's own default model" rather than a failure.
+/// Pure model-resolution helper shared by both wire model selectors
+/// (<c>session/set_config_option</c> for Cursor/Copilot, <c>session/set_model</c> for Kiro). The
+/// wire requires an EXACT <c>modelId</c> from <c>session/new</c>'s
+/// <c>result.models.availableModels</c>. Cursor's ids are parameterized (e.g.
+/// <c>claude-sonnet-4-5[thinking=true,context=200k]</c>), so a bare family name like
+/// <c>claude-sonnet-4-5</c> (the shape both <c>RuntimeStartContext.Model</c> and
+/// <c>DaemonConfig.CursorModel</c>'s default are typically given in) is not itself a valid wire
+/// value there; Kiro's ids are already bare (e.g. <c>claude-haiku-4.5</c>) and pass through the
+/// exact-match arm. This resolves the caller's requested string against that list; the caller
+/// (<c>AcpHostedAgentRuntime.StartAsync</c>) treats a <see langword="null"/> result as "skip the
+/// selector's RPC — use the vendor's own default model" rather than a failure.
 /// </summary>
 public static class AcpModelResolver {
     /// <summary>
     /// Resolves <paramref name="requested"/> to an exact <see cref="AvailableModelDto.ModelId"/>
-    /// using first-hit-wins precedence, all comparisons case-insensitive (the exact casing
-    /// convention <c>cursor-agent</c> uses for family names is not pinned by the probe):
+    /// using first-hit-wins precedence, all comparisons case-insensitive (no vendor's family-name
+    /// casing convention is pinned by probe):
     /// <list type="number">
     /// <item><description>an exact <see cref="AvailableModelDto.ModelId"/> match;</description></item>
     /// <item><description>the first <see cref="AvailableModelDto.ModelId"/> that starts with
@@ -25,7 +28,7 @@ public static class AcpModelResolver {
     /// contains <paramref name="requested"/>.</description></item>
     /// </list>
     /// Returns <see langword="null"/> (no match — or nothing was requested, or no models were
-    /// offered) so the caller can fall back to Cursor's own default model rather than fail the
+    /// offered) so the caller can fall back to the vendor's own default model rather than fail the
     /// launch.
     /// </summary>
     public static string? Resolve(string? requested, IReadOnlyList<AvailableModelDto>? availableModels) {

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1029,6 +1029,7 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(Acp.PromptContentBlock))]
 [JsonSerializable(typeof(Acp.SessionCancelParams))]
 [JsonSerializable(typeof(Acp.SetConfigOptionParams))]
+[JsonSerializable(typeof(Acp.SetModelParams))]
 [JsonSerializable(typeof(Acp.SessionModelsInfo))]
 [JsonSerializable(typeof(Acp.AvailableModelDto))]
 [JsonSerializable(typeof(Acp.SessionRequestPermissionParams))]

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -285,21 +285,15 @@ internal static class AcpVendorDescriptors {
     /// <c>tools/list</c>, refused by trust policy, mis-namespaced, or fail at invocation. Flipping
     /// Copilot's flag needs an equivalent call-level probe against Copilot, not this result.</para>
     ///
-    /// <para><see cref="SetModelSelector"/>, not <see cref="ConfigOptionModelSelector"/> and no
-    /// longer <see cref="NoOpModelSelector"/> — measured, both halves
-    /// (<c>docs/probes/2026-08-05-kiro-model-override/</c>, kiro-cli 2.16.0). The hosting work had
-    /// deferred model override because <c>session/set_config_option</c>'s write half was unverified
-    /// and the selector fails SILENTLY; the probe settled it in a direction the deferral did not
-    /// anticipate: <c>session/set_config_option</c> does not exist on Kiro at all (<c>-32601 Method
-    /// not found</c>), while the stabilized <c>session/set_model</c> both succeeds and TAKES EFFECT
-    /// at the turn level — the next turn's backend inference request carried the requested
-    /// <c>modelId</c> verbatim, the model self-identified as it (a different vendor family from the
-    /// account's default, so not confusable), and Kiro's persisted session state recorded it with
-    /// model-specific parameters (context window, rate multiplier). <c>ResolveDefaultModel</c> reads
-    /// <c>DaemonConfig.KiroModel</c> (<c>KCAP_KIRO_MODEL</c>), which defaults to NULL — so a
-    /// zero-configuration launch still runs Kiro's own default model and reports none, exactly the
-    /// pre-override behaviour; a per-launch <c>RuntimeStartContext.Model</c> takes precedence as for
-    /// Cursor.</para>
+    /// <para><see cref="SetModelSelector"/>, not <see cref="ConfigOptionModelSelector"/>: measured
+    /// (<c>docs/probes/2026-08-05-kiro-model-override/</c>, kiro-cli 2.16.0), Kiro answers
+    /// <c>session/set_config_option</c> with <c>-32601 Method not found</c> but honours
+    /// <c>session/set_model</c> at effect level — the evidence the earlier
+    /// <see cref="NoOpModelSelector"/> deferral was waiting for (detail on
+    /// <see cref="SetModelSelector"/> and in the probe record). <c>ResolveDefaultModel</c> reads
+    /// <c>DaemonConfig.KiroModel</c> (<c>KCAP_KIRO_MODEL</c>), default NULL: a zero-configuration
+    /// launch keeps Kiro's own default model with none reported; a per-launch
+    /// <c>RuntimeStartContext.Model</c> takes precedence as for Cursor.</para>
     ///
     /// <para><c>--agent-engine v1|v2|v3</c> (default <c>v2</c>) is deliberately NOT passed: pinning it
     /// diverges the hosted session from what the user gets interactively and buys an upgrade

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -284,16 +284,21 @@ internal static class AcpVendorDescriptors {
     /// <c>tools/list</c>, refused by trust policy, mis-namespaced, or fail at invocation. Flipping
     /// Copilot's flag needs an equivalent call-level probe against Copilot, not this result.</para>
     ///
-    /// <para><see cref="NoOpModelSelector"/> is deliberate rather than inherited: Kiro's
-    /// <c>session/new</c> does return a <c>models</c> object, so the read half of
-    /// <see cref="ConfigOptionModelSelector"/> would find the shape it needs — but the write half
-    /// (<c>session/set_config_option</c> actually taking effect) is unverified on Kiro, and that
-    /// selector fails SILENTLY when it does not take. Carrying a live selector would risk a session
-    /// that reports the requested model while running another. <c>ResolveDefaultModel: null</c> alone
-    /// would not be enough, because <c>ResolveRequestedModel</c> prioritises a per-launch
-    /// <c>RuntimeStartContext.Model</c> and would reach a live selector anyway; the selector itself
-    /// has to be the no-op. Model override arrives with the follow-up that verifies the write
-    /// half.</para>
+    /// <para><see cref="SetModelSelector"/>, not <see cref="ConfigOptionModelSelector"/> and no
+    /// longer <see cref="NoOpModelSelector"/> — measured, both halves
+    /// (<c>docs/probes/2026-08-05-kiro-model-override/</c>, kiro-cli 2.16.0). The hosting work had
+    /// deferred model override because <c>session/set_config_option</c>'s write half was unverified
+    /// and the selector fails SILENTLY; the probe settled it in a direction the deferral did not
+    /// anticipate: <c>session/set_config_option</c> does not exist on Kiro at all (<c>-32601 Method
+    /// not found</c>), while the stabilized <c>session/set_model</c> both succeeds and TAKES EFFECT
+    /// at the turn level — the next turn's backend inference request carried the requested
+    /// <c>modelId</c> verbatim, the model self-identified as it (a different vendor family from the
+    /// account's default, so not confusable), and Kiro's persisted session state recorded it with
+    /// model-specific parameters (context window, rate multiplier). <c>ResolveDefaultModel</c> reads
+    /// <c>DaemonConfig.KiroModel</c> (<c>KCAP_KIRO_MODEL</c>), which defaults to NULL — so a
+    /// zero-configuration launch still runs Kiro's own default model and reports none, exactly the
+    /// pre-override behaviour; a per-launch <c>RuntimeStartContext.Model</c> takes precedence as for
+    /// Cursor.</para>
     ///
     /// <para><c>--agent-engine v1|v2|v3</c> (default <c>v2</c>) is deliberately NOT passed: pinning it
     /// diverges the hosted session from what the user gets interactively and buys an upgrade
@@ -301,11 +306,11 @@ internal static class AcpVendorDescriptors {
     public static readonly AcpVendorDescriptor Kiro = new(
         Vendor:              "kiro",
         ResolveBinaryPath:   cfg => cfg.KiroPath,
-        ResolveDefaultModel: _ => null,
+        ResolveDefaultModel: cfg => cfg.KiroModel,
         Argv:                ["acp"],
         UnattendedTrustArgv: [],
         SupportsUnattended:  false,
-        ModelSelector:       NoOpModelSelector.Instance,
+        ModelSelector:       SetModelSelector.Instance,
         SupportsMcpServers:  true,
         // Measured INELIGIBLE 2026-08-04 (docs/probes/2026-08-04-acp-reconnect-c0/): Kiro advertises
         // loadSession but refuses session/load after a SIGKILLed owner with a DURABLE stale-owner
@@ -364,12 +369,17 @@ internal static class AcpVendorDescriptors {
     /// <c>AcpVendorDescriptorTests</c> and <c>GeminiReviewerLaunchTests</c> assert both halves, the
     /// latter pinning gate == injected set.</para>
     ///
-    /// <para><see cref="NoOpModelSelector"/> for the same reason as Kiro: <c>session/new</c> does return a
-    /// <c>models</c> object, so <see cref="ConfigOptionModelSelector"/>'s read half would fit, but its
-    /// write half is unverified on Gemini and that selector fails SILENTLY — a session that reports the
-    /// requested model while running another. <c>ResolveDefaultModel: null</c> alone is not enough,
-    /// because <c>ResolveRequestedModel</c> prioritises a per-launch model and would reach a live
-    /// selector anyway.</para>
+    /// <para><see cref="NoOpModelSelector"/> because Gemini's model-selection WRITE half is
+    /// unverified: <c>session/new</c> does return a <c>models</c> object, so a live selector's read
+    /// half would fit, but both wire selectors fail SILENTLY when the write does not take — a
+    /// session that reports the requested model while running another. <c>ResolveDefaultModel:
+    /// null</c> alone is not enough, because <c>ResolveRequestedModel</c> prioritises a per-launch
+    /// model and would reach a live selector anyway. Kiro's probe
+    /// (<c>docs/probes/2026-08-05-kiro-model-override/</c>) is the template for flipping this: it
+    /// found Kiro rejects <c>session/set_config_option</c> outright but honours
+    /// <c>session/set_model</c> at effect level — Gemini needs its own equivalent effect-level
+    /// measurement (which method, and does the turn actually run on it) before carrying
+    /// <see cref="SetModelSelector"/> or <see cref="ConfigOptionModelSelector"/>.</para>
     ///
     /// <para><c>--approval-mode</c> is deliberately not passed: interactive hosting should behave as the
     /// user's own session does, and pinning <c>plan</c> would silently make hosted Gemini read-only.

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -75,7 +75,8 @@ internal enum AcpBorrowedReviewContainment {
 /// the field removes the dead state and the asymmetric guard together: there is exactly one thing
 /// to get right — which selector object the descriptor carries — not a boolean that also has to
 /// agree with it. This also drops any expectation that <c>ModelSelector</c> be
-/// <c>ReferenceEquals</c> to one of the two singletons below: the runtime only needs SOME
+/// <c>ReferenceEquals</c> to one of the selector singletons (<c>ConfigOptionModelSelector</c>,
+/// <c>SetModelSelector</c>, <c>NoOpModelSelector</c>): the runtime only needs SOME
 /// <see cref="IAcpModelSelector"/>, so a future vendor's own implementation, or a test double, is
 /// exactly as valid.
 ///

--- a/src/Capacitor.Cli.Daemon/Acp/IAcpModelSelector.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/IAcpModelSelector.cs
@@ -57,25 +57,18 @@ internal interface IAcpModelSelector {
 }
 
 /// <summary>
-/// Today's original Cursor behavior, unchanged, generalized to take sessionId/connection as
-/// parameters instead of reading AcpHostedAgentRuntime's private fields: parses session/new's
-/// `models.availableModels` via AcpModelResolver.Resolve, and — on a match — sends
-/// session/set_config_option {sessionId, configId: "model", value} and awaits it. Every failure
-/// mode (missing/unparsable `models`, no match, a JSON-RPC error response) is caught and logged,
-/// never fatal — matches the "model selection is a nice-to-have, never a launch precondition"
-/// contract from docs/ai-688-cursor-prototype-findings.md.
+/// The resolution half both wire selectors share: parse <c>session/new</c>'s
+/// <c>models.availableModels</c> and resolve the requested string to an exact <c>modelId</c> via
+/// <see cref="AcpModelResolver"/>. Pure and synchronous — the cancellation contract above concerns
+/// only the wire write, which each selector keeps for itself; the <see cref="JsonException"/>
+/// catch here is the narrow concrete-type shape the interface remarks require (structurally unable
+/// to swallow an <see cref="OperationCanceledException"/>).
 /// </summary>
-internal sealed class ConfigOptionModelSelector : IAcpModelSelector {
-    public static readonly ConfigOptionModelSelector Instance = new();
-
-    /// <summary>This selector really does send <c>session/set_config_option</c>, so a requested model
-    /// may be applied. Note it can still fail to MATCH a model and return null — "can select" is a
-    /// capability, not a promise about a specific request.</summary>
-    public bool CanSelectModel => true;
-
-    public async Task<string?> TrySelectAsync(
-            AcpConnection connection, string sessionId, JsonElement sessionNewResult,
-            string? requestedModel, ILogger logger, CancellationToken ct) {
+file static class SessionModelResolution {
+    /// <summary>Null when nothing was requested, the <c>models</c> object is missing/unparsable, or
+    /// nothing matched (the no-match case logs the Warning both selectors share).</summary>
+    public static string? ResolveOrNull(
+            JsonElement sessionNewResult, string? requestedModel, ILogger logger) {
         if (string.IsNullOrWhiteSpace(requestedModel))
             return null;
 
@@ -97,8 +90,35 @@ internal sealed class ConfigOptionModelSelector : IAcpModelSelector {
             logger.LogWarning(
                 "ACP: requested model '{RequestedModel}' was not found in session/new's availableModels; continuing with the vendor's default model.",
                 requestedModel);
-            return null;
         }
+
+        return resolvedModelId;
+    }
+}
+
+/// <summary>
+/// Today's original Cursor behavior, unchanged, generalized to take sessionId/connection as
+/// parameters instead of reading AcpHostedAgentRuntime's private fields: parses session/new's
+/// `models.availableModels` via AcpModelResolver.Resolve, and — on a match — sends
+/// session/set_config_option {sessionId, configId: "model", value} and awaits it. Every failure
+/// mode (missing/unparsable `models`, no match, a JSON-RPC error response) is caught and logged,
+/// never fatal — matches the "model selection is a nice-to-have, never a launch precondition"
+/// contract from docs/ai-688-cursor-prototype-findings.md.
+/// </summary>
+internal sealed class ConfigOptionModelSelector : IAcpModelSelector {
+    public static readonly ConfigOptionModelSelector Instance = new();
+
+    /// <summary>This selector really does send <c>session/set_config_option</c>, so a requested model
+    /// may be applied. Note it can still fail to MATCH a model and return null — "can select" is a
+    /// capability, not a promise about a specific request.</summary>
+    public bool CanSelectModel => true;
+
+    public async Task<string?> TrySelectAsync(
+            AcpConnection connection, string sessionId, JsonElement sessionNewResult,
+            string? requestedModel, ILogger logger, CancellationToken ct) {
+        var resolvedModelId = SessionModelResolution.ResolveOrNull(sessionNewResult, requestedModel, logger);
+        if (resolvedModelId is null)
+            return null;
 
         var setConfigOptionParams = JsonSerializer.SerializeToElement(
             new SetConfigOptionParams(SessionId: sessionId, ConfigId: "model", Value: resolvedModelId),
@@ -110,6 +130,53 @@ internal sealed class ConfigOptionModelSelector : IAcpModelSelector {
         } catch (Exception ex) when (ex is not OperationCanceledException) {
             logger.LogWarning(ex,
                 "ACP: session/set_config_option failed for model '{ResolvedModelId}'; continuing with the vendor's default model.",
+                resolvedModelId);
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// The <c>session/set_model</c> twin of <see cref="ConfigOptionModelSelector"/>, for vendors that
+/// implement the stabilized ACP model-selection method instead of the config-option one. Same
+/// resolution half (<see cref="SessionModelResolution"/>), same never-fatal contract, same
+/// cancellation shape (the catch below cannot swallow <see cref="OperationCanceledException"/>) —
+/// only the wire write differs: <c>session/set_model {sessionId, modelId}</c>.
+///
+/// <para>Carried by Kiro on direct measurement (<c>docs/probes/2026-08-05-kiro-model-override/</c>,
+/// kiro-cli 2.16.0): Kiro answers <c>session/set_config_option</c> with <c>-32601 Method not
+/// found</c>, while <c>session/set_model</c> succeeds AND takes effect — the next turn's backend
+/// request carried the requested <c>modelId</c>, the reply self-identified as it, and Kiro's own
+/// persisted session state recorded it with model-specific parameters. A vendor adopting this
+/// selector needs that same effect-level evidence, not just a success response: an RPC that
+/// returns <c>{}</c> and changes nothing would make the session report a model it is not
+/// running.</para>
+/// </summary>
+internal sealed class SetModelSelector : IAcpModelSelector {
+    public static readonly SetModelSelector Instance = new();
+
+    /// <summary>This selector really does send <c>session/set_model</c>, so a requested model may
+    /// be applied. It can still fail to MATCH and return null — "can select" is a capability, not a
+    /// promise about a specific request.</summary>
+    public bool CanSelectModel => true;
+
+    public async Task<string?> TrySelectAsync(
+            AcpConnection connection, string sessionId, JsonElement sessionNewResult,
+            string? requestedModel, ILogger logger, CancellationToken ct) {
+        var resolvedModelId = SessionModelResolution.ResolveOrNull(sessionNewResult, requestedModel, logger);
+        if (resolvedModelId is null)
+            return null;
+
+        var setModelParams = JsonSerializer.SerializeToElement(
+            new SetModelParams(SessionId: sessionId, ModelId: resolvedModelId),
+            CapacitorJsonContext.Default.SetModelParams);
+
+        try {
+            await connection.RequestAsync("session/set_model", setModelParams, ct).ConfigureAwait(false);
+            return resolvedModelId;
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            logger.LogWarning(ex,
+                "ACP: session/set_model failed for model '{ResolvedModelId}'; continuing with the vendor's default model.",
                 resolvedModelId);
             return null;
         }

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -146,6 +146,22 @@ public class DaemonConfig {
     public string KiroPath { get; set; } = "kiro-cli";
 
     /// <summary>
+    /// Daemon-wide default model for Kiro ACP sessions, e.g. <c>"claude-haiku-4.5"</c>, resolved
+    /// against <c>session/new</c>'s <c>availableModels</c> at launch time by
+    /// <c>AcpModelResolver.Resolve</c> (Kiro's ids are bare, unlike Cursor's parameterized ones,
+    /// but the resolution path is shared) and applied via <c>session/set_model</c> —
+    /// probe-verified at effect level (<c>docs/probes/2026-08-05-kiro-model-override/</c>).
+    /// Overridable via <c>KCAP_KIRO_MODEL</c>, mirroring <see cref="CursorModel"/>.
+    ///
+    /// <para>Unlike <see cref="CursorModel"/> the default is NULL, deliberately: zero-configuration
+    /// Kiro hosting keeps the vendor's own default model, with nothing requested and nothing
+    /// reported — the behaviour Kiro hosting shipped with. A per-launch model override
+    /// (<c>RuntimeStartContext.Model</c>) takes precedence over this daemon-wide default — see
+    /// <c>AcpHostedAgentRuntimeFactory</c>.</para>
+    /// </summary>
+    public string? KiroModel { get; set; }
+
+    /// <summary>
     /// Whether THIS daemon may run Gemini as an unattended review-flow reviewer. **Default false, and
     /// enabling it is the operator's consent event.**
     ///

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -145,6 +145,9 @@ public static partial class DaemonRunner {
         if (Environment.GetEnvironmentVariable("KCAP_KIRO_PATH") is { Length: > 0 } envKiroPath)
             config.KiroPath = envKiroPath;
 
+        if (Environment.GetEnvironmentVariable("KCAP_KIRO_MODEL") is { Length: > 0 } envKiroModel)
+            config.KiroModel = envKiroModel;
+
         if (Environment.GetEnvironmentVariable("KCAP_OPENCODE_PATH") is { Length: > 0 } envOpenCodePath)
             config.OpenCodePath = envOpenCodePath;
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -529,8 +529,10 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// Performs the ACP handshake: starts the connection's read loop, then
     /// <c>initialize</c> → <c>session/new</c> (with the absolute <paramref name="cwd"/>) → an optional
     /// model-selection step — resolves <paramref name="requestedModel"/> against
-    /// <c>session/new</c>'s <c>availableModels</c> and, if it matches, sends
-    /// <c>session/set_config_option</c> and awaits the response BEFORE the first turn fires (see
+    /// <c>session/new</c>'s <c>availableModels</c> and, if it matches, sends the vendor's
+    /// model-selection RPC (<c>session/set_config_option</c> for Cursor/Copilot,
+    /// <c>session/set_model</c> for Kiro — the descriptor's selector decides) and awaits the
+    /// response BEFORE the first turn fires (see
     /// <see cref="IAcpModelSelector.TrySelectAsync"/>). If <paramref name="initialPrompt"/> is non-empty,
     /// <see cref="EnqueueTurn"/>s it onto the serialized prompt-turn worker (see
     /// <see cref="RunTurnWorkerAsync"/>) and returns as soon as the session is established — it

--- a/src/Capacitor.Cli.Daemon/Services/IAcpTranscriptSource.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IAcpTranscriptSource.cs
@@ -21,8 +21,9 @@ internal interface IAcpTranscriptSource {
     string Cwd { get; }
 
     /// <summary>
-    /// The model id actually resolved AND applied by model selection (i.e.
-    /// <c>session/set_config_option</c> was sent and answered without error) — or
+    /// The model id actually resolved AND applied by model selection (i.e. the vendor's
+    /// model-selection RPC — <c>session/set_config_option</c> or <c>session/set_model</c>,
+    /// whichever the descriptor's selector sends — was sent and answered without error) — or
     /// <see langword="null"/> when no model was requested, resolution found no match in
     /// <c>session/new</c>'s <c>availableModels</c>, or the agent rejected the option. In every "null"
     /// case Cursor's own default model applies, which is why this is nullable rather than falling

--- a/src/Capacitor.Cli.Daemon/Services/IAcpTranscriptSource.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IAcpTranscriptSource.cs
@@ -26,8 +26,9 @@ internal interface IAcpTranscriptSource {
     /// whichever the descriptor's selector sends — was sent and answered without error) — or
     /// <see langword="null"/> when no model was requested, resolution found no match in
     /// <c>session/new</c>'s <c>availableModels</c>, or the agent rejected the option. In every "null"
-    /// case Cursor's own default model applies, which is why this is nullable rather than falling
-    /// back to the requested-but-unconfirmed id.
+    /// case the vendor's own default model applies (Cursor's for a Cursor session, Kiro's for a
+    /// Kiro session, …), which is why this is nullable rather than falling back to the
+    /// requested-but-unconfirmed id.
     /// </summary>
     string? ResolvedModel { get; }
 

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeModelSelectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeModelSelectionTests.cs
@@ -41,11 +41,13 @@ public class AcpHostedAgentRuntimeModelSelectionTests {
 
         Task _fakeRunTask = Task.CompletedTask;
 
-        public Harness() {
+        public Harness(IAcpModelSelector? modelSelector = null) {
             Fake    = new FakeAcpAgent();
             Conn    = new AcpConnection(Fake.ClientWriteStream, Fake.ClientReadStream, NullLogger.Instance);
             Process = new FakeAcpProcess();
-            Runtime = new AcpHostedAgentRuntime(Conn, Process, NullLogger.Instance);
+            // null keeps the runtime's legacy ConfigOptionModelSelector default, preserving every
+            // existing test unchanged; the set_model composition test passes SetModelSelector.
+            Runtime = new AcpHostedAgentRuntime(Conn, Process, NullLogger.Instance, modelSelector: modelSelector);
         }
 
         public void StartFakeAgentLoop() => _fakeRunTask = Fake.RunAsync(Cts.Token);
@@ -79,6 +81,48 @@ public class AcpHostedAgentRuntimeModelSelectionTests {
             await Task.Delay(10);
 
         return fake.ReceivedCalls;
+    }
+
+    // The probe-measured Kiro shape (docs/probes/2026-08-05-kiro-model-override/): bare ids,
+    // modelId == name.
+    static readonly (string ModelId, string Name)[] KiroAvailableModels = [
+        ("auto", "auto"),
+        ("claude-haiku-4.5", "claude-haiku-4.5"),
+        ("deepseek-3.2", "deepseek-3.2"),
+    ];
+
+    /// <summary>The set_model composition case: the SAME runtime handshake, carrying
+    /// <see cref="SetModelSelector"/> the way the factory passes Kiro's descriptor selector,
+    /// sends <c>session/set_model</c> (never <c>session/set_config_option</c>) before the first
+    /// prompt and exposes the applied id as <see cref="AcpHostedAgentRuntime.ResolvedModel"/> —
+    /// the value registration reports as the live model.</summary>
+    [Test]
+    public async Task StartAsync_SetModelSelector_SendsSetModelBeforeThePrompt_AndExposesResolvedModel() {
+        await using var h = new Harness(modelSelector: SetModelSelector.Instance);
+        h.Fake.SetSessionNewResult(FakeAcpAgent.BuildSessionNewResult(
+            FakeAcpAgent.FixedSessionId, currentModelId: "minimax-m2.5", KiroAvailableModels));
+        h.StartFakeAgentLoop();
+
+        await h.Runtime.StartAsync(
+            "/abs/worktree", "do the thing", h.Cts.Token,
+            requestedModel: "claude-haiku-4.5"
+        ).WaitAsync(HangGuard);
+
+        var calls = await WaitForCallCountAsync(h.Fake, minCount: 4);
+        await Assert.That(calls.Count).IsGreaterThanOrEqualTo(4);
+
+        await Assert.That(calls[0].Method).IsEqualTo("initialize");
+        await Assert.That(calls[1].Method).IsEqualTo("session/new");
+
+        await Assert.That(calls[2].Method).IsEqualTo("session/set_model");
+        await Assert.That(calls[2].Params!.Value.GetProperty("sessionId").GetString()).IsEqualTo(FakeAcpAgent.FixedSessionId);
+        await Assert.That(calls[2].Params!.Value.GetProperty("modelId").GetString()).IsEqualTo("claude-haiku-4.5");
+        await Assert.That(h.Fake.ReceivedCalls.Any(c => c.Method == "session/set_config_option")).IsFalse();
+
+        // The model must be set BEFORE the turn starts, and the applied id is what registration
+        // will report as live.
+        await Assert.That(calls[3].Method).IsEqualTo("session/prompt");
+        await Assert.That(h.Runtime.ResolvedModel).IsEqualTo("claude-haiku-4.5");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
@@ -96,11 +96,14 @@ public class AcpVendorDescriptorTests {
         await Assert.That(descriptor.ReviewFlowMcpTransport)
             .IsEqualTo(AcpReviewFlowMcpTransport.SessionNew);
 
-        // NoOp, not ConfigOptionModelSelector. Kiro's session/new DOES return a models object, so the
-        // selector's read half would find its shape — but the write half
-        // (session/set_config_option taking effect) is unverified, and that selector fails SILENTLY.
-        // A live selector would risk a session reporting one model while running another.
-        await Assert.That(descriptor.ModelSelector).IsEqualTo(NoOpModelSelector.Instance);
+        // SetModelSelector, not ConfigOptionModelSelector: probe-measured (docs/probes/
+        // 2026-08-05-kiro-model-override/, kiro-cli 2.16.0) — session/set_config_option does not
+        // exist on Kiro (-32601 Method not found), while session/set_model succeeds AND takes
+        // effect: the very next turn's backend request carried the requested modelId, the reply
+        // self-identified as it, and Kiro's own session state persisted it with model-specific
+        // parameters. Not NoOp either — that deferral existed only while the write half was
+        // unverified.
+        await Assert.That(descriptor.ModelSelector).IsEqualTo(SetModelSelector.Instance);
     }
 
     [Test]
@@ -128,14 +131,18 @@ public class AcpVendorDescriptorTests {
             .IsEqualTo("kiro-cli");
     }
 
-    /// <summary>Model override is out of scope until <c>session/set_config_option</c> is verified on
-    /// Kiro, so no daemon-wide default model is offered either — for ANY config, including one whose
-    /// other vendor model fields are populated.</summary>
+    /// <summary>Zero-configuration behaviour is unchanged from the no-override era: with no
+    /// <c>KiroModel</c> configured the descriptor offers no daemon-wide default — Kiro runs its own
+    /// default model and none is reported — and ANOTHER vendor's model field must never leak in.
+    /// When <c>KiroModel</c> IS configured it is the daemon-wide default, resolved against
+    /// <c>session/new</c>'s <c>availableModels</c> at launch like Cursor's.</summary>
     [Test]
-    public async Task Kiro_ResolveDefaultModel_IsAlwaysNull() {
+    public async Task Kiro_ResolveDefaultModel_ReadsConfigKiroModel_NullByDefault() {
         await Assert.That(AcpVendorDescriptors.Kiro.ResolveDefaultModel(new DaemonConfig())).IsNull();
         await Assert.That(AcpVendorDescriptors.Kiro.ResolveDefaultModel(
             new DaemonConfig { CursorModel = "claude-opus-4-8" })).IsNull();
+        await Assert.That(AcpVendorDescriptors.Kiro.ResolveDefaultModel(
+            new DaemonConfig { KiroModel = "claude-haiku-4.5" })).IsEqualTo("claude-haiku-4.5");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -53,6 +53,7 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
 
     JsonElement _sessionNewResult = ProbeConfirmedSessionNewResult;
     bool        _failNextSetConfigOption;
+    bool        _failNextSetModel;
 
     JsonElement                  _initializeResult = ProbeConfirmedInitializeResult;
     (int Code, string Message)? _failNextInitialize;
@@ -175,6 +176,14 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// continue with Cursor's default model" handling.
     /// </summary>
     public void FailNextSetConfigOption() => _failNextSetConfigOption = true;
+
+    /// <summary>
+    /// Arranges the NEXT <c>session/set_model</c> request to be answered with a JSON-RPC error
+    /// instead of a success result — models a real agent rejecting the resolved model id,
+    /// exercising <see cref="Capacitor.Cli.Daemon.Acp.SetModelSelector"/>'s non-fatal "log a
+    /// warning and continue with the vendor's default model" handling.
+    /// </summary>
+    public void FailNextSetModel() => _failNextSetModel = true;
 
     /// <summary>
     /// Overrides the <c>initialize</c> response this fake returns for every subsequent
@@ -312,6 +321,12 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// </summary>
     public TaskCompletionSource? HoldSetConfigOptionResponse { get; set; }
 
+    /// <summary>When set, a <c>session/set_model</c> request's RESPONSE is held back until the gate
+    /// completes — mirrors <see cref="HoldSetConfigOptionResponse"/> exactly (the call is still
+    /// recorded immediately), proving a <c>ct</c> canceled while THIS RPC is in flight propagates
+    /// <see cref="OperationCanceledException"/> out of the selector.</summary>
+    public TaskCompletionSource? HoldSetModelResponse { get; set; }
+
     /// <summary>
     /// The fake's read loop: parses newline-delimited JSON-RPC frames arriving from the connection
     /// under test (its simulated stdin) and dispatches <c>initialize</c> / <c>session/new</c> /
@@ -444,6 +459,10 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
                 await HandleSetConfigOptionAsync(id, paramsElement, ct).ConfigureAwait(false);
                 break;
 
+            case "session/set_model":
+                await HandleSetModelAsync(id, ct).ConfigureAwait(false);
+                break;
+
             case "session/prompt":
                 await RunPromptScriptAsync(id, ct).ConfigureAwait(false);
                 break;
@@ -512,6 +531,28 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
         }
 
         var result = JsonDocument.Parse(stream.ToArray()).RootElement.Clone();
+        await WriteResponseAsync(id, result, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Answers a <c>session/set_model</c> request — either the scripted JSON-RPC error (see
+    /// <see cref="FailNextSetModel"/>) or the probe-confirmed success shape: an EMPTY object
+    /// (<c>docs/probes/2026-08-05-kiro-model-override/</c> measured Kiro answering
+    /// <c>{"result":{}}</c>), unlike <c>session/set_config_option</c>'s configOptions echo. The
+    /// request itself is already captured in <see cref="ReceivedCalls"/> by
+    /// <c>DispatchLineAsync</c> before this runs.
+    /// </summary>
+    async Task HandleSetModelAsync(JsonElement id, CancellationToken ct) {
+        if (_failNextSetModel) {
+            _failNextSetModel = false;
+            await WriteErrorResponseAsync(id, -32602, "Invalid params: unknown model", ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (HoldSetModelResponse is { } gate)
+            await gate.Task.ConfigureAwait(false);
+
+        var result = JsonDocument.Parse("{}").RootElement.Clone();
         await WriteResponseAsync(id, result, ct).ConfigureAwait(false);
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Acp/SetModelSelectorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/SetModelSelectorTests.cs
@@ -1,0 +1,210 @@
+// test/Capacitor.Cli.Tests.Unit/Acp/SetModelSelectorTests.cs
+using System.Text.Json;
+using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// Unit-tests <see cref="SetModelSelector.TrySelectAsync"/> directly against a
+/// <see cref="FakeAcpAgent"/>-backed <see cref="AcpConnection"/>, mirroring
+/// <see cref="ConfigOptionModelSelectorTests"/> case-for-case: the two selectors share the
+/// resolution half (guard → parse <c>session/new.models</c> → <see
+/// cref="Capacitor.Cli.Core.Acp.AcpModelResolver"/>) and differ only in the wire write —
+/// <c>session/set_model {sessionId, modelId}</c> here versus
+/// <c>session/set_config_option {sessionId, configId, value}</c> there — plus one case the
+/// sibling covers elsewhere: a JSON-RPC ERROR response to the write must be swallowed into
+/// <see langword="null"/> (model selection is never a launch precondition), while a canceled
+/// <c>ct</c> must propagate <see cref="OperationCanceledException"/> uncaught.
+/// </summary>
+public class SetModelSelectorTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    /// <summary>Records every log call — used to assert a Warning was (or wasn't) logged.</summary>
+    sealed class CaptureLogger : ILogger {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool         IsEnabled(LogLevel logLevel)                            => true;
+
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex, Func<TState, Exception?, string> formatter)
+            => Entries.Add((level, formatter(state, ex)));
+    }
+
+    sealed class Harness : IAsyncDisposable {
+        public FakeAcpAgent            Fake { get; } = new();
+        public AcpConnection           Conn { get; }
+        public CaptureLogger           Logger { get; } = new();
+        public CancellationTokenSource Cts  { get; } = new();
+
+        Task _fakeRunTask = Task.CompletedTask;
+
+        public Harness() => Conn = new AcpConnection(Fake.ClientWriteStream, Fake.ClientReadStream, NullLogger.Instance);
+
+        public void StartFakeAgentLoop() {
+            _fakeRunTask = Fake.RunAsync(Cts.Token);
+            _ = Conn.RunAsync(Cts.Token);
+        }
+
+        public async ValueTask DisposeAsync() {
+            Cts.Cancel();
+            try {
+                await _fakeRunTask.WaitAsync(HangGuard);
+            } catch (OperationCanceledException) {
+                // expected shutdown path
+            }
+            await Conn.DisposeAsync();
+            await Fake.DisposeAsync();
+            Cts.Dispose();
+        }
+    }
+
+    // The probe-measured Kiro shape: bare ids, modelId == name, no parameterized variants.
+    static readonly (string ModelId, string Name)[] AvailableModels = [
+        ("auto", "auto"),
+        ("claude-haiku-4.5", "claude-haiku-4.5"),
+        ("deepseek-3.2", "deepseek-3.2"),
+    ];
+
+    // (a) no requested model → returns null, no session/set_model sent.
+    [Test]
+    public async Task TrySelectAsync_NoRequestedModel_ReturnsNull_NoRpcSent() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        var sessionNewResult = FakeAcpAgent.BuildSessionNewResult(FakeAcpAgent.FixedSessionId, "auto", AvailableModels);
+
+        var result = await SetModelSelector.Instance
+            .TrySelectAsync(h.Conn, FakeAcpAgent.FixedSessionId, sessionNewResult, requestedModel: null, h.Logger, h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(h.Fake.ReceivedCalls.Any(c => c.Method == "session/set_model")).IsFalse();
+    }
+
+    // (b) a resolvable model → sends session/set_model with the resolved id, returns it.
+    [Test]
+    public async Task TrySelectAsync_ResolvableModel_SendsSetModel_ReturnsResolvedId() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        var sessionNewResult = FakeAcpAgent.BuildSessionNewResult(FakeAcpAgent.FixedSessionId, "auto", AvailableModels);
+
+        var result = await SetModelSelector.Instance
+            .TrySelectAsync(h.Conn, FakeAcpAgent.FixedSessionId, sessionNewResult, requestedModel: "deepseek-3.2", h.Logger, h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        await Assert.That(result).IsEqualTo("deepseek-3.2");
+
+        var call = h.Fake.ReceivedCalls.Single(c => c.Method == "session/set_model");
+        await Assert.That(call.Params!.Value.GetProperty("sessionId").GetString()).IsEqualTo(FakeAcpAgent.FixedSessionId);
+        await Assert.That(call.Params!.Value.GetProperty("modelId").GetString()).IsEqualTo("deepseek-3.2");
+        // session/set_model carries the id under "modelId" — never set_config_option's
+        // {configId, value} pair.
+        await Assert.That(call.Params!.Value.TryGetProperty("configId", out _)).IsFalse();
+        await Assert.That(call.Params!.Value.TryGetProperty("value", out _)).IsFalse();
+    }
+
+    // (c) an unresolvable model (not in availableModels) → returns null, no RPC sent, a Warning logged.
+    [Test]
+    public async Task TrySelectAsync_UnresolvableModel_ReturnsNull_NoRpcSent_LogsWarning() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        var sessionNewResult = FakeAcpAgent.BuildSessionNewResult(FakeAcpAgent.FixedSessionId, "auto", AvailableModels);
+
+        var result = await SetModelSelector.Instance
+            .TrySelectAsync(h.Conn, FakeAcpAgent.FixedSessionId, sessionNewResult, requestedModel: "totally-unknown-model", h.Logger, h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(h.Fake.ReceivedCalls.Any(c => c.Method == "session/set_model")).IsFalse();
+        await Assert.That(h.Logger.Entries.Any(e => e.Level == LogLevel.Warning && e.Message.Contains("totally-unknown-model"))).IsTrue();
+    }
+
+    // (d) session/new's 'models' property absent/malformed → returns null, no throw.
+    [Test]
+    public async Task TrySelectAsync_ModelsPropertyAbsent_ReturnsNull_NoThrow() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        var sessionNewResult = JsonDocument.Parse($$"""{"sessionId":"{{FakeAcpAgent.FixedSessionId}}"}""").RootElement;
+
+        var result = await SetModelSelector.Instance
+            .TrySelectAsync(h.Conn, FakeAcpAgent.FixedSessionId, sessionNewResult, requestedModel: "deepseek-3.2", h.Logger, h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(h.Fake.ReceivedCalls.Any(c => c.Method == "session/set_model")).IsFalse();
+    }
+
+    [Test]
+    public async Task TrySelectAsync_ModelsPropertyMalformed_ReturnsNull_NoThrow() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        var sessionNewResult = JsonDocument.Parse($$"""{"sessionId":"{{FakeAcpAgent.FixedSessionId}}","models":"not-an-object"}""").RootElement;
+
+        var result = await SetModelSelector.Instance
+            .TrySelectAsync(h.Conn, FakeAcpAgent.FixedSessionId, sessionNewResult, requestedModel: "deepseek-3.2", h.Logger, h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(h.Fake.ReceivedCalls.Any(c => c.Method == "session/set_model")).IsFalse();
+    }
+
+    // (e) a JSON-RPC ERROR response to session/set_model → swallowed to null + Warning, never fatal
+    // (the "model selection is a nice-to-have, never a launch precondition" contract).
+    [Test]
+    public async Task TrySelectAsync_SetModelErrorResponse_ReturnsNull_LogsWarning() {
+        await using var h = new Harness();
+        h.Fake.FailNextSetModel();
+        h.StartFakeAgentLoop();
+
+        var sessionNewResult = FakeAcpAgent.BuildSessionNewResult(FakeAcpAgent.FixedSessionId, "auto", AvailableModels);
+
+        var result = await SetModelSelector.Instance
+            .TrySelectAsync(h.Conn, FakeAcpAgent.FixedSessionId, sessionNewResult, requestedModel: "deepseek-3.2", h.Logger, h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        await Assert.That(result).IsNull();
+        await Assert.That(h.Fake.ReceivedCalls.Any(c => c.Method == "session/set_model")).IsTrue();
+        await Assert.That(h.Logger.Entries.Any(e => e.Level == LogLevel.Warning && e.Message.Contains("deepseek-3.2"))).IsTrue();
+    }
+
+    // (f) a ct canceled WHILE session/set_model is in flight — TrySelectAsync must let
+    // OperationCanceledException propagate out, never returning null for a cancellation the way it
+    // does for a resolution failure (the IAcpModelSelector cancellation contract).
+    [Test]
+    public async Task TrySelectAsync_CanceledWhileSetModelInFlight_PropagatesOperationCanceled() {
+        await using var h = new Harness();
+        h.Fake.HoldSetModelResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        h.StartFakeAgentLoop();
+
+        var sessionNewResult = FakeAcpAgent.BuildSessionNewResult(FakeAcpAgent.FixedSessionId, "auto", AvailableModels);
+
+        using var innerCts = new CancellationTokenSource();
+
+        var selectTask = SetModelSelector.Instance
+            .TrySelectAsync(h.Conn, FakeAcpAgent.FixedSessionId, sessionNewResult, requestedModel: "deepseek-3.2", h.Logger, innerCts.Token);
+
+        // Wait for the RPC to actually be in flight (recorded by the fake) before cancelling.
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!h.Fake.ReceivedCalls.Any(c => c.Method == "session/set_model") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(h.Fake.ReceivedCalls.Any(c => c.Method == "session/set_model")).IsTrue();
+
+        await innerCts.CancelAsync();
+
+        await Assert.That(async () => await selectTask.WaitAsync(HangGuard)).Throws<OperationCanceledException>();
+
+        // Release the fake's held response so the harness can tear down cleanly.
+        h.Fake.HoldSetModelResponse.TrySetResult();
+    }
+
+    [Test]
+    public async Task CanSelectModel_IsTrue() {
+        await Assert.That(SetModelSelector.Instance.CanSelectModel).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonConfigEnvOverrideTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonConfigEnvOverrideTests.cs
@@ -91,6 +91,40 @@ public class DaemonConfigEnvOverrideTests {
         await Assert.That(config.KiroPath).IsEqualTo("kiro-cli");
     }
 
+    // ── KCAP_KIRO_MODEL ───────────────────────────────────────────────────────
+
+    // Mirrors DaemonRunner.RunAsync's KCAP_KIRO_MODEL conditional verbatim, same pattern as
+    // ApplyEnvOverrides above (kept separate so the four-path helper's signature stays a verbatim
+    // copy of the block it mirrors).
+    static DaemonConfig ApplyKiroModelOverride(DaemonConfig config, string? kiroModel) {
+        if (kiroModel is { Length: > 0 })
+            config.KiroModel = kiroModel;
+
+        return config;
+    }
+
+    /// <summary>Unlike <c>CursorModel</c>'s <c>"claude-sonnet-4-5"</c>, the default is NULL:
+    /// zero-configuration Kiro hosting keeps the vendor's own default model with nothing requested
+    /// and nothing reported, exactly the pre-override behaviour.</summary>
+    [Test]
+    public async Task KiroModel_DefaultsToNull_NoDaemonWideDefaultModel() {
+        await Assert.That(new DaemonConfig().KiroModel).IsNull();
+    }
+
+    [Test]
+    public async Task KiroModel_EnvVarSet_OverridesDefault() {
+        var config = ApplyKiroModelOverride(new DaemonConfig(), kiroModel: "claude-haiku-4.5");
+
+        await Assert.That(config.KiroModel).IsEqualTo("claude-haiku-4.5");
+    }
+
+    [Test]
+    public async Task KiroModel_EnvVarEmpty_KeepsNull() {
+        var config = ApplyKiroModelOverride(new DaemonConfig(), kiroModel: "");
+
+        await Assert.That(config.KiroModel).IsNull();
+    }
+
     // ── KCAP_OPENCODE_PATH ────────────────────────────────────────────────────
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -106,7 +106,11 @@ public class AcpHostedAgentRuntimeFactoryTests {
                 connectionSource: _ => throw new InvalidOperationException(
                     "SupportsModelSelection must not spawn a process."));
 
-        await Assert.That(Build(AcpVendorDescriptors.Kiro).SupportsModelSelection).IsFalse();
+        // Kiro reports true since the probe that verified session/set_model at effect level
+        // (docs/probes/2026-08-05-kiro-model-override/); Gemini keeps the false arm of this
+        // mutation guard — its write half stays unverified, so it still carries NoOpModelSelector.
+        await Assert.That(Build(AcpVendorDescriptors.Kiro).SupportsModelSelection).IsTrue();
+        await Assert.That(Build(AcpVendorDescriptors.Gemini).SupportsModelSelection).IsFalse();
         await Assert.That(Build(AcpVendorDescriptors.Cursor).SupportsModelSelection).IsTrue();
         await Assert.That(Build(AcpVendorDescriptors.Copilot).SupportsModelSelection).IsTrue();
     }

--- a/test/Capacitor.Cli.Tests.Unit/Services/ModelSelectionLaunchPolicyTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ModelSelectionLaunchPolicyTests.cs
@@ -82,16 +82,20 @@ public class ModelSelectionLaunchPolicyTests {
     // ── the selectors are the source of truth for the flag above ──────────────
 
     [Test]
-    public async Task ConfigOptionSelector_CanSelect_NoOpSelector_Cannot() {
+    public async Task ConfigOptionSelector_And_SetModelSelector_CanSelect_NoOpSelector_Cannot() {
         await Assert.That(ConfigOptionModelSelector.Instance.CanSelectModel).IsTrue();
+        await Assert.That(SetModelSelector.Instance.CanSelectModel).IsTrue();
         await Assert.That(NoOpModelSelector.Instance.CanSelectModel).IsFalse();
     }
 
-    /// <summary>The whole reason this policy exists: Kiro's descriptor is the first to report false.
-    /// Pinned per-vendor so flipping Kiro's selector cannot quietly re-open the mismatch.</summary>
+    /// <summary>Pinned per-vendor so flipping a selector cannot quietly re-open the
+    /// reported-vs-running mismatch. Kiro flipped to true on the probe that verified
+    /// <c>session/set_model</c> at effect level (docs/probes/2026-08-05-kiro-model-override/);
+    /// Gemini is now the vendor this policy exists for — its write half stays unverified.</summary>
     [Test]
     public async Task DescriptorSelectors_ReportSelectionCapabilityPerVendor() {
-        await Assert.That(AcpVendorDescriptors.Kiro.ModelSelector.CanSelectModel).IsFalse();
+        await Assert.That(AcpVendorDescriptors.Kiro.ModelSelector.CanSelectModel).IsTrue();
+        await Assert.That(AcpVendorDescriptors.Gemini.ModelSelector.CanSelectModel).IsFalse();
         await Assert.That(AcpVendorDescriptors.Cursor.ModelSelector.CanSelectModel).IsTrue();
         await Assert.That(AcpVendorDescriptors.Copilot.ModelSelector.CanSelectModel).IsTrue();
     }


### PR DESCRIPTION
Linear: AI-1613

The Kiro hosting work deliberately shipped with `NoOpModelSelector` and no `KCAP_KIRO_MODEL`, because `ConfigOptionModelSelector`'s write half (`session/set_config_option` actually taking effect) was unverified on Kiro and that selector fails silently — wiring it blind risked a session that reports one model while running another. This PR runs the deferred probe at the required effect level and lands the enable branch it justifies.

## The probe (`docs/probes/2026-08-05-kiro-model-override/`, kiro-cli 2.16.0)

Mirrors the daemon's exact handshake (`initialize` pv1 → `session/new {cwd, mcpServers: []}` → selector RPC → first `session/prompt`). Findings:

- **`session/set_config_option` does not exist on Kiro** — `-32601 Method not found`. The Cursor selector could never work there, and its silent-failure mode would have made every launch a silent no-op. Conclusive at zero billable requests.
- **`session/set_model` succeeds and takes effect at the turn level.** With the account default `minimax-m2.5`, `session/set_model {modelId: "deepseek-3.2"}` was applied and one no-tools turn measured three agreeing channels:
  1. the turn's actual backend inference request (`CodeWhispererStreaming.GenerateAssistantResponse`, client trace log) carried `"modelId":"deepseek-3.2"` verbatim;
  2. the reply self-identified as `deepseek-3.2` — an id nowhere in the prompt, from a different vendor family than the default, so not confusable;
  3. Kiro's persisted session state flipped `rts_model_state.model_info` from `null` to deepseek-3.2 **with model-specific parameters** (164k context window vs auto's 200k, `rate_multiplier: 0.25`) — real model params, not an echo.

`findings.md` records the method and evidence; the committed run summaries have raw client-log excerpt fields stripped (they can embed injected session context).

## The change

- **`SetModelSelector`** — the `session/set_model` twin of `ConfigOptionModelSelector`: shared resolution half (new file-scoped `SessionModelResolution` + the existing `AcpModelResolver`), same never-fatal contract (any RPC error → warn + null → vendor default), same cancellation shape (`OperationCanceledException` propagates uncaught).
- **Kiro descriptor**: `ModelSelector: SetModelSelector.Instance`, `ResolveDefaultModel: cfg => cfg.KiroModel`.
- **`DaemonConfig.KiroModel` + `KCAP_KIRO_MODEL`**, mirroring `CursorModel`/`KCAP_CURSOR_MODEL` with one deliberate difference: **default null** — zero-configuration launches keep Kiro's own default model with nothing reported, exactly the pre-override behaviour.
- **README**: the "deliberately no `KCAP_KIRO_MODEL`" bullet replaced with the new contract; new env-var section.
- **AI-1404 design doc**: Premise 3 annotated with the resolved measurement (kept as written otherwise, for the historical record).
- Wire DTO `SetModelParams` + AOT serializer registration.

## Deliberately unchanged

- **Gemini keeps `NoOpModelSelector`** — nothing here measures Gemini; the probe is the template for its own effect-level measurement. Gemini now carries the false arm of the per-vendor capability pins.
- **Reviewer-flow model override stays refused for Kiro** — `ReviewerModelResolver` stays null and Kiro is not unattended-certified; that remains the unattended-reviewer issue's call.
- An unresolvable requested model resolves to null before any RPC, so with #450's handshake-confirmed-model registration a launch with a bad model runs and reports Kiro's default rather than claiming the requested one.

## Tests

- New `SetModelSelectorTests` (7): resolution paths, exact wire shape (`modelId`, never `configId`/`value`), error-response swallow, cancellation propagation, `CanSelectModel`.
- New runtime composition test: real `AcpHostedAgentRuntime` + `SetModelSelector` sends `session/set_model` before the first prompt and exposes `ResolvedModel` (what registration reports live).
- `FakeAcpAgent` handles `session/set_model` (probe-confirmed empty-object success shape) with fail/hold injection.
- Descriptor/factory/policy pins flipped with rationale; Gemini added as the false case so the mutation guards keep both directions.
- `DaemonConfig` env-override tests extended for `KCAP_KIRO_MODEL` (incl. null default).
- Targeted classes green: `*ModelSelect*` 33, `AcpVendorDescriptorTests` 20, `DaemonConfigEnvOverrideTests` 14, `AcpHostedAgentRuntimeFactoryTests` 75. AOT publish surfaces only the four known inherited `McpWorkItemsServer.cs:357` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
