### PR TITLE
[AI-1675] Repair the standalone worktree snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,17 @@ After discovery, the import surfaces a one-shot report of any transcript working
 
 The daemon connects to the Capacitor server and runs Claude Code, Codex, or Cursor agents in isolated git worktrees, controlled from the dashboard. Hosted Claude and Codex agents run on macOS, Linux, **and Windows**; hosted Cursor (`cursor` vendor) is macOS and Linux only — choose the vendor from the dashboard's launch dialog. At startup the daemon probes `daemon.claude_path`, `daemon.codex_path`, and the Cursor CLI (`cursor-agent`, overridable via `KCAP_CURSOR_PATH` — see [Daemon config settings](#daemon-config-settings)) and advertises only the vendors it can actually spawn, so the launch dialog hides whichever agent isn't installed on the selected daemon.
 
+> **Snapshotting a workspace that isn't a git repo:** when an agent targets a directory that is not a git
+> repository with commits, the daemon takes a *standalone snapshot* — it copies the directory rather than
+> creating a git worktree. Symlinks are recreated as links (never followed) and anything pointing outside
+> the workspace is skipped, so the snapshot cannot pull in credentials or other out-of-tree content.
+> **That guarantee assumes nothing else writes to the workspace while the agent is starting.** The check
+> that classifies an entry and the read that copies it are not a single atomic operation, so a separate
+> account or process that can swap a file for a symlink in between can still get the target's contents
+> copied in. In practice: don't point a hosted agent at a directory that any account or process other than
+> the daemon's own can write to during a launch. A normal single-user checkout is fine; a shared or
+> world-writable directory is not.
+
 > **Windows and hosted Codex:** needs Windows 10 1809 (build 17763) or newer — Windows 11 recommended — because that's the floor for Codex's own Windows sandbox. Older builds don't advertise the `codex` vendor at all. The sandbox *implementation* (`elevated`, which needs one-time admin-approved `winget` setup, vs `unelevated`) is whatever your `~/.codex/config.toml` `[windows] sandbox` says; the daemon inherits it rather than overriding it. Codex is found on `PATH` whether installed via `winget` (`codex.exe`) or npm (`codex.cmd`).
 
 ```bash

--- a/docs/superpowers/plans/2026-08-05-ai1675-standalone-snapshot-repair.md
+++ b/docs/superpowers/plans/2026-08-05-ai1675-standalone-snapshot-repair.md
@@ -1,0 +1,525 @@
+# Standalone Snapshot Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `WorktreeManager`'s standalone snapshot path work for a non-git source, without materialising out-of-source content or writing outside the snapshot.
+
+**Architecture:** Replace the recursive `CopyDirectory` with a no-follow walk that classifies every entry by `FileAttributes.ReparsePoint` before touching it, excludes the destination by a per-invocation marker file rather than by name, and excludes `.git` as an entry of any type. Restructure `CreateAsync`'s standalone branch so destination validation, an atomic claim, and fresh creation all happen before any write, with the claim's lifetime enclosing rollback.
+
+**Tech Stack:** .NET 10, C#, TUnit (Microsoft Testing Platform), AOT-compiled CLI.
+
+## Global Constraints
+
+- **No Linear issue ID tokens in any `.cs` file.** CI job "No Linear issue IDs in C# source" fails the build. `rg -n "AI-[0-9]+" src/ test/ --type cs` must be empty before every push. Markdown is fine.
+- Tests are TUnit on MTP. Run with `dotnet run --project <testproj>`, never `dotnet test`. Always `await` assertions.
+- Symlink-dependent tests call the existing `SkipUnlessPosixSymlinks()` helper — Windows symlink creation needs Developer Mode or elevation.
+- **Absence is never asserted with `File.Exists` / `Directory.Exists` / `Path.Exists`** — all follow, so a dangling link reports absent. Use directory enumeration plus `File.GetAttributes` / `LinkTarget`.
+- Reuse the existing `ResolveDeepestExisting` and `IsAtOrUnder` helpers in this class for canonicalization and containment; do not write new path-comparison logic.
+- Full spec: Linear AI-1675, comment rev 7 (codex-clean).
+
+---
+
+### Task 1: Pure path rules — `.git` naming and link-target admissibility
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/SnapshotPathRulesTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `internal static bool IsGitEntryName(string name)` — case-insensitive `.git` match.
+  - `internal static bool IsAdmissibleLinkTarget(string linkDirRelative, string rawTarget)` — true when the raw target is relative (not rooted in any form) and the component walk from `linkDirRelative` never rises above the snapshot root.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class SnapshotPathRulesTests {
+    [Test]
+    [Arguments(".git"), Arguments(".GIT"), Arguments(".Git")]
+    public async Task Git_entry_names_match_case_insensitively(string name) =>
+        await Assert.That(WorktreeManager.IsGitEntryName(name)).IsTrue();
+
+    [Test]
+    [Arguments(".gitignore"), Arguments("git"), Arguments(".gitmodules"), Arguments("")]
+    public async Task Non_git_entry_names_do_not_match(string name) =>
+        await Assert.That(WorktreeManager.IsGitEntryName(name)).IsFalse();
+
+    // A link that never rises above the root is admissible from any depth.
+    [Test]
+    [Arguments("", "releases/v2")]
+    [Arguments("a", "../b/file")]
+    [Arguments("a/b", "../../c")]
+    public async Task Targets_that_never_escape_are_admissible(string dir, string target) =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget(dir, target)).IsTrue();
+
+    // The relocation bug: resolves inside the source, but lands in a sibling once transplanted.
+    [Test]
+    [Arguments("", "../proj/secret")]
+    [Arguments("a", "../../a/b")]
+    public async Task Targets_that_escape_and_reenter_are_rejected(string dir, string target) =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget(dir, target)).IsFalse();
+
+    [Test]
+    [Arguments("", "../../outside")]
+    [Arguments("a", "../../../outside")]
+    public async Task Targets_that_escape_are_rejected(string dir, string target) =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget(dir, target)).IsFalse();
+
+    // Every rooted form, not just fully-qualified absolutes.
+    [Test]
+    [Arguments("/etc/passwd"), Arguments("\\foo"), Arguments("C:foo"), Arguments("C:\\foo")]
+    public async Task Rooted_targets_are_rejected(string target) =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget("", target)).IsFalse();
+
+    [Test]
+    public async Task Empty_target_is_rejected() =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget("", "")).IsFalse();
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/SnapshotPathRulesTests/*"`
+Expected: compile error — `IsGitEntryName` / `IsAdmissibleLinkTarget` do not exist.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+using System.Text;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+public sealed partial class WorktreeManager {
+    /// <summary>Whether an entry name is git control data, compared case-insensitively.
+    ///
+    /// <para><b>Deliberately asymmetric with the marker-based <c>.capacitor</c> exclusion.</b> A real
+    /// <c>.git</c> must never land in the snapshot: the standalone path runs <c>git init</c> over the
+    /// result, and a copied gitfile or repo directory makes that re-initialise a DIFFERENT repository and
+    /// commit into it. So the fail-safe direction here is DROP. A <c>.Capacitor</c> directory is inert
+    /// content, so its fail-safe direction is KEEP, and it gets the marker treatment instead. The marker
+    /// technique is unavailable here because we do not own the source's <c>.git</c>.</para>
+    ///
+    /// <para><b>Accepted cost:</b> on a case-sensitive filesystem, inert content in a directory literally
+    /// named <c>.GIT</c> is dropped. Safety over fidelity, and it matches this class's own
+    /// <c>NormalizeRelativePath</c>, which already compares <c>.git</c> with OrdinalIgnoreCase.</para>
+    /// </summary>
+    internal static bool IsGitEntryName(string name) =>
+        name.Equals(".git", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Whether a symlink's RAW target may be recreated verbatim inside the snapshot.
+    ///
+    /// <para><b>Why "never escapes" and not "finally resolves inside".</b> Final-resolution containment is
+    /// unsound under relocation, and reachable with a completely quiescent source. A source-root link
+    /// <c>self -> ../&lt;source-dir-name&gt;/secret</c> resolves back inside the source — but the snapshot
+    /// lives at <c>&lt;source&gt;/.capacitor/worktrees/&lt;name&gt;</c>, so the SAME raw target evaluated
+    /// there becomes <c>&lt;...&gt;/worktrees/&lt;source-dir-name&gt;/secret</c>: a sibling agent's
+    /// worktree. Identical bytes, different meaning, because the link's containing directory moved.</para>
+    ///
+    /// <para>Requiring the accumulated depth to never go negative is position-INDEPENDENT: a path that
+    /// never rises above its own root resolves inside any root it is transplanted into, at equal depth. It
+    /// also needs no path comparison, so it cannot inherit the OS-inferred case-sensitivity problem.</para>
+    /// </summary>
+    /// <param name="linkDirRelative">The link's own directory, relative to the snapshot root, using
+    /// <c>/</c> separators. Empty for the root itself.</param>
+    internal static bool IsAdmissibleLinkTarget(string linkDirRelative, string rawTarget) {
+        if (string.IsNullOrEmpty(rawTarget)) return false;
+
+        // Reject EVERY rooted form, not just fully-qualified absolutes: on Windows `\foo` and `C:foo` are
+        // rooted-but-not-fully-qualified and would otherwise reach the depth walk as if relative.
+        if (Path.IsPathRooted(rawTarget) || Path.IsPathFullyQualified(rawTarget)) return false;
+        if (rawTarget.Length >= 2 && rawTarget[1] == ':') return false;   // `C:foo`, drive-relative
+
+        var depth = 0;
+        foreach (var part in SplitPathComponents(linkDirRelative)) {
+            if (part == "..") { if (--depth < 0) return false; }
+            else if (part != ".") depth++;
+        }
+
+        foreach (var part in SplitPathComponents(rawTarget)) {
+            if (part == "..") { if (--depth < 0) return false; }
+            else if (part != ".") depth++;
+        }
+
+        return true;
+    }
+
+    /// <summary>Splits on BOTH separators. A raw link target is authored by whoever wrote the tree, so it
+    /// must not be parsed with one hardcoded separator.</summary>
+    static IEnumerable<string> SplitPathComponents(string path) =>
+        path.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/SnapshotPathRulesTests/*"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs test/Capacitor.Cli.Tests.Unit/SnapshotPathRulesTests.cs
+git commit -F- <<'EOF'
+Add snapshot path rules: .git naming and link-target admissibility
+
+Link admissibility requires the component walk to never rise above the
+root, not merely to resolve inside it -- the latter is unsound once the
+link is written at a different depth.
+EOF
+```
+
+---
+
+### Task 2: The no-follow copy walk
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs` — delete `CopyDirectory` (currently the last method, with the "restored deliberately" doc comment).
+
+**Interfaces:**
+- Consumes: `IsGitEntryName`, `IsAdmissibleLinkTarget` from Task 1.
+- Produces: `void CopySnapshotTree(string source, string dest, string markerName)` — instance method so it can log skips.
+
+- [ ] **Step 1: Implement the walk**
+
+```csharp
+    /// <summary>Copies <paramref name="source"/> into <paramref name="dest"/> without ever following a
+    /// link and without descending into the destination.
+    ///
+    /// <para>Replaces the original <c>CopyDirectory</c>, which was broken in three ways at once: it
+    /// recursed into its own destination until the path length blew up (so standalone snapshot creation
+    /// had never completed), <c>File.Copy</c> materialised a symlink's TARGET (so a link to <c>~/.ssh</c>
+    /// would have written real credentials into the agent's worktree as ordinary files), and its
+    /// destination exclusion was a name match that is wrong in both directions under either case
+    /// semantics.</para>
+    ///
+    /// <para><b>Guarantee and its limit.</b> For a source not concurrently written by another principal,
+    /// nothing from outside <paramref name="source"/> is materialised. Classification and the subsequent
+    /// read are NOT atomic, and .NET offers no portable no-follow open, so a principal able to swap an
+    /// entry between the two can still defeat this. That limitation is accepted and documented for
+    /// operators in the README's Daemon section; it is not closable here.</para>
+    /// </summary>
+    void CopySnapshotTree(string source, string dest, string markerName) =>
+        CopySnapshotLevel(source, dest, relative: "", markerName);
+
+    void CopySnapshotLevel(string source, string dest, string relative, string markerName) {
+        foreach (var entry in Directory.EnumerateFileSystemEntries(source)) {
+            var name = Path.GetFileName(entry);
+
+            // Any type, every level: a `.git` FILE (`gitdir: ...`) is repository control data just as much
+            // as the directory is, and copying one makes the snapshot's own `git init` re-initialise the
+            // repository it names -- committing outside the snapshot entirely.
+            if (IsGitEntryName(name)) continue;
+
+            // Never copy this invocation's own bookkeeping. Only the exact name, so a user file that
+            // merely resembles a marker is preserved like any other content.
+            if (name == markerName) continue;
+
+            // Classify BEFORE touching it. File.Copy would materialise a link's target, and recursion
+            // through a directory link would copy the target tree and can cycle forever.
+            var attrs = File.GetAttributes(entry);
+            var destPath = Path.Combine(dest, name);
+
+            if (attrs.HasFlag(FileAttributes.ReparsePoint)) {
+                RecreateLinkIfAdmissible(entry, destPath, relative, name);
+                continue;
+            }
+
+            if (!attrs.HasFlag(FileAttributes.Directory)) {
+                File.Copy(entry, destPath);
+                continue;
+            }
+
+            // A directory holding this invocation's marker IS the destination (or an ancestor of it).
+            // Detected by READING the directory rather than by comparing its name or path, so it resolves
+            // correctly under case-sensitive and case-insensitive semantics alike -- nothing is inferred
+            // from the OS, which is what made every name- and path-based exclusion wrong in one direction
+            // or the other.
+            if (File.Exists(Path.Combine(entry, markerName))) continue;
+
+            Directory.CreateDirectory(destPath);
+            CopySnapshotLevel(entry, destPath, Combine(relative, name), markerName);
+        }
+    }
+
+    void RecreateLinkIfAdmissible(string entry, string destPath, string relative, string name) {
+        var target = new FileInfo(entry).LinkTarget ?? new DirectoryInfo(entry).LinkTarget;
+
+        if (target is null || !IsAdmissibleLinkTarget(relative, target)) {
+            LogSkippedLink(Combine(relative, name), target ?? "<unreadable>");
+            return;
+        }
+
+        // Recreated as a LINK carrying the same raw target -- never resolved, never followed, so no
+        // out-of-source bytes are ever written. A chain through a skipped link simply dangles.
+        Directory.CreateSymbolicLink(destPath, target);
+    }
+
+    static string Combine(string relative, string name) =>
+        relative.Length == 0 ? name : relative + "/" + name;
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Skipped link {Path} in standalone snapshot: target {Target} is rooted or leaves the source")]
+    partial void LogSkippedLink(string path, string target);
+```
+
+- [ ] **Step 2: Delete the old `CopyDirectory`**
+
+Remove the entire `CopyDirectory` method and its `<summary>` block from the end of `WorktreeManager.cs`.
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj`
+Expected: one error — `BuildStandaloneSnapshotAsync` still calls `CopyDirectory`. Task 3 fixes it.
+
+- [ ] **Step 4: Commit after Task 3** (this task does not build standalone).
+
+---
+
+### Task 3: Destination validation, atomic claim, and ownership-gated rollback
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs` — `CreateAsync` (~line 204) and `BuildStandaloneSnapshotAsync` (~line 268).
+
+**Interfaces:**
+- Consumes: `CopySnapshotTree` from Task 2; existing `ResolveDeepestExisting`, `IsAtOrUnder`, `DeleteTreeNoFollow`.
+- Produces: `internal static string? SnapshotFailurePoint` — test-only seam (Task 6).
+
+- [ ] **Step 1: Move `Directory.CreateDirectory(worktreeRoot)` out of the common prologue**
+
+In `CreateAsync`, delete the standalone `Directory.CreateDirectory(worktreeRoot);` line that currently sits before the `IsGitRepoWithCommits` check, and add it as the first statement inside the `if (await IsGitRepoWithCommits(repoPath))` block.
+
+Rationale comment to add at the git-branch site:
+
+```csharp
+            // Created HERE, not in a shared prologue. The standalone branch below must validate the
+            // destination chain BEFORE anything is created -- a pre-existing `.capacitor` or `worktrees`
+            // symlink is followed by this call, which would put the snapshot at a location the source
+            // tree chose. A standalone-only check placed after the branch decision runs too late.
+            Directory.CreateDirectory(worktreeRoot);
+```
+
+- [ ] **Step 2: Replace the standalone tail of `CreateAsync`**
+
+```csharp
+        // Standalone: copy files + git init.
+        return await CreateStandaloneAsync(repoPath, name, worktreeRoot, worktreePath);
+    }
+
+    /// <summary>Validates, claims, and builds a standalone snapshot.
+    ///
+    /// <para><b>Ordering is the whole point of this method.</b> Every check happens before any write, and
+    /// the claim's lifetime strictly encloses rollback. Getting either wrong reopens a race or an escape
+    /// that the checks themselves cannot see.</para>
+    /// </summary>
+    async Task<WorktreeInfo> CreateStandaloneAsync(
+            string repoPath, string name, string worktreeRoot, string worktreePath) {
+        // `name` reaches Path.Combine, which DISCARDS the root for an absolute value and would put the
+        // destination anywhere; `../evil` would land it outside `worktrees`, where the marker cannot
+        // exclude it and the copy recurses into its own destination again. Defense-in-depth today -- both
+        // real callers omit `name` -- but this is a public method.
+        if (name.Length == 0 || name != Path.GetFileName(name) ||
+            name is "." or ".." || name.AsSpan().ContainsAny('/', '\\'))
+            throw new InvalidOperationException($"standalone_snapshot_invalid_name: {name}");
+
+        var root = ResolveDeepestExisting(repoPath);
+        if (!IsAtOrUnder(ResolveDeepestExisting(worktreePath), root))
+            throw new InvalidOperationException("standalone_snapshot_destination_escape");
+
+        // No-follow, attribute-based, on the components WE introduce below the source root. Not from the
+        // filesystem root: a source legitimately reached through a system symlink (macOS /tmp) is normal
+        // and must not be refused. Path.Exists FOLLOWS, so a DANGLING link would report absent and then be
+        // created through -- the same trap DeleteTreeNoFollow documents.
+        var capacitorDir = Path.Combine(repoPath, ".capacitor");
+        RefuseIfLink(capacitorDir);
+        RefuseIfLink(worktreeRoot);
+
+        Directory.CreateDirectory(worktreeRoot);
+
+        // Atomic claim. `Directory.CreateDirectory` is a no-op on an existing directory, so the freshness
+        // check below is check-then-create and cannot exclude a concurrent SAME-PRINCIPAL caller -- and
+        // both racers would then consider the directory theirs, with either rollback deleting the other's
+        // snapshot. There is no portable atomic directory claim, but FileMode.CreateNew on a FILE is
+        // atomic everywhere, so the claim file supplies the exclusion the directory create cannot.
+        var claimPath = Path.Combine(worktreeRoot, $".kcap-claim-{name}");
+        FileStream claim;
+        try {
+            claim = new FileStream(claimPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+        } catch (IOException) {
+            // Loser path: returns WITHOUT any destination cleanup. The rollback below is unconditional on
+            // worktreePath, so a loser that fell through it would delete the WINNER's directory -- a claim
+            // that made things worse than no claim.
+            throw new InvalidOperationException($"standalone_snapshot_name_in_use: {name}");
+        }
+
+        // The claim is held until all success work is done, or until all rollback has finished. It is
+        // released LAST. Releasing it inside BuildStandaloneSnapshotAsync would reopen the very race it
+        // closes: that method's own unwinding completes before the catch below deletes the tree, so a new
+        // same-name call could claim, create, and then be deleted by this call's delayed rollback.
+        try {
+            claim.Dispose();
+
+            if (Directory.Exists(worktreePath) || File.Exists(worktreePath) || IsLinkEntry(worktreePath))
+                throw new InvalidOperationException($"standalone_snapshot_destination_occupied: {name}");
+
+            Directory.CreateDirectory(worktreePath);
+
+            try {
+                return await BuildStandaloneSnapshotAsync(repoPath, worktreePath);
+            } catch {
+                // Only the successful claimant reaches here, so this delete is ownership-gated.
+                try { DeleteTreeNoFollow(worktreePath); } catch { /* keep the original failure */ }
+                throw;
+            }
+        } finally {
+            try { File.Delete(claimPath); } catch { /* best effort: a stale claim fails closed */ }
+        }
+    }
+
+    /// <summary>Refuses a destination-chain component that is a link, WITHOUT following it.</summary>
+    static void RefuseIfLink(string path) {
+        if (IsLinkEntry(path))
+            throw new InvalidOperationException($"standalone_snapshot_destination_link: {path}");
+    }
+
+    /// <summary>Whether the path itself is a link. Attribute-based, so a DANGLING link still reports as
+    /// present -- which is the case that matters, since Path.Exists would call it absent.</summary>
+    static bool IsLinkEntry(string path) {
+        try { return File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint); }
+        catch (FileNotFoundException) { return false; }
+        catch (DirectoryNotFoundException) { return false; }
+    }
+```
+
+- [ ] **Step 3: Wire the marker into `BuildStandaloneSnapshotAsync`**
+
+Replace its first line:
+
+```csharp
+    async Task<WorktreeInfo> BuildStandaloneSnapshotAsync(string repoPath, string worktreePath) {
+        // Unique per invocation and created CreateNew, so a collision is detected rather than silently
+        // shared, a hostile source cannot plant one that suppresses real content, and a marker orphaned by
+        // a crash can never suppress anything on a later run.
+        var markerName = $".kcap-snapshot-exclude-{Guid.NewGuid():N}";
+        var markerPath = Path.Combine(Path.GetDirectoryName(worktreePath)!, markerName);
+
+        try {
+            // Fail-closed: without the marker the walk recurses into its own destination.
+            using (new FileStream(markerPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) { }
+
+            CopySnapshotTree(repoPath, worktreePath, markerName);
+            FailHereIfRequested(nameof(CopySnapshotTree));
+        } finally {
+            // Cleanup failure logs and does not fail: the snapshot is already built and correct.
+            try { File.Delete(markerPath); } catch { /* best effort */ }
+        }
+
+        // ... existing StripWorkspaceMcpConfig / git init / add / commit body unchanged ...
+```
+
+- [ ] **Step 4: Add the test seam**
+
+```csharp
+    /// <summary>Test-only injected failure point. A wall-clock race would make the claim-ownership tests
+    /// flaky and, worse, green by luck; these need a deterministic rollback window.</summary>
+    internal static string? SnapshotFailurePoint;
+    internal static Func<Task>? SnapshotFailureHook;
+
+    static void FailHereIfRequested(string point) {
+        if (SnapshotFailurePoint != point) return;
+        SnapshotFailureHook?.Invoke().GetAwaiter().GetResult();
+        throw new InvalidOperationException("injected_standalone_failure");
+    }
+```
+
+- [ ] **Step 5: Build**
+
+Run: `dotnet build src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj`
+Expected: SUCCESS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u && git commit -F- <<'EOF'
+Repair the standalone snapshot copy: no-follow walk, marker exclusion, claimed destination
+
+Replaces CopyDirectory, which recursed into its own destination, copied
+symlink targets rather than links, and excluded the destination by name.
+EOF
+```
+
+---
+
+### Task 4: Behaviour tests through the public API
+
+**Files:**
+- Modify: `test/Capacitor.Cli.Tests.Unit/WorktreeManagerTests.cs`
+
+Add a `MakeNonGitSource()` fixture returning a temp directory that is deliberately NOT a git repo, plus `SnapshotEntryNames(path)` and `IsLink(path)` helpers built on `Directory.EnumerateFileSystemEntries` + `File.GetAttributes` — never `File.Exists`.
+
+Implement spec tests 1–13, 15, 16. Each is a `[Test]` with `SkipUnlessPosixSymlinks()` where links are involved. Key anti-vacuity requirements, which are the point of several of these:
+
+- Test 1 asserts a known file is in `HEAD` (`git ls-tree -r --name-only HEAD`), not merely that a commit exists.
+- Test 3 asserts an ordinary sibling directory IS copied, so a no-op copy cannot pass.
+- Test 4 asserts the cycle link **was recreated**, so dropping every link cannot pass.
+- Test 6 plants a sentinel at the exact sibling path under `worktrees/` that the transplanted target would reach, **before** calling `CreateAsync`.
+- Test 8 asserts unrelated lowercase `.capacitor` content survives, so dropping the whole directory cannot pass.
+- Test 9 asserts the outside repo has no `HEAD` before and after, and that creation still succeeds.
+- Test 13 asserts the pre-existing sentinel and `.git` data are still present and unmodified.
+
+- [ ] **Step 1: Write the tests**
+- [ ] **Step 2: Run — expect the new ones to pass and none of the existing ones to regress**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/WorktreeManagerTests/*"`
+
+- [ ] **Step 3: Mutation-check the guards.** For each of tests 2, 3, 6, 9, 13, temporarily break the corresponding production guard and confirm the test fails. A guard assertion that never fails is not a guard.
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 5: Claim-ownership tests
+
+**Files:**
+- Modify: `test/Capacitor.Cli.Tests.Unit/WorktreeManagerTests.cs`
+
+- [ ] **Step 1:** Test 14(a) — two concurrent `CreateAsync` calls with the same explicit `name`: exactly one succeeds, one throws `standalone_snapshot_name_in_use`, winner's snapshot intact.
+- [ ] **Step 2:** Test 14(b) — set `SnapshotFailurePoint`/`SnapshotFailureHook` so call 1 fails and **blocks inside rollback** on a `TaskCompletionSource`; assert a second same-name call cannot acquire until call 1 releases; then release and assert the second call's snapshot is intact.
+- [ ] **Step 3:** Test 14(c) — the loser leaves the winner's destination untouched.
+- [ ] **Step 4:** Stale claim refuses that name fail-closed.
+- [ ] **Step 5:** Reset the static seam in a `finally` in every test that sets it, so it cannot leak across tests. Mark these `[NotInParallel]` — they mutate process-global state.
+- [ ] **Step 6: Commit**
+
+---
+
+### Task 6: Restore the standalone end-to-end MCP case
+
+**Files:**
+- Modify: `test/Capacitor.Cli.Tests.Unit/WorkspaceMcpNeutralizationTests.cs`
+
+- [ ] **Step 1:** Add a test: a non-git source carrying `.mcp.json` yields a snapshot with it stripped, and absent from the initial commit (`git ls-tree -r --name-only HEAD`).
+- [ ] **Step 2:** The fixture asserts the source is genuinely non-git first — otherwise the test silently exercises the linked-worktree branch and proves nothing.
+- [ ] **Step 3: Commit**
+
+---
+
+### Task 7: README operator note
+
+**Files:**
+- Modify: `README.md` — `### Daemon` section.
+
+- [ ] **Step 1:** Add the precondition: a standalone snapshot (taken when an agent targets a directory that is not a git repo with commits) must not be pointed at a workspace another principal can write during the launch; the practical test is whether any account or process other than the daemon's own has write access to that tree while an agent is starting.
+- [ ] **Step 2:** Cross-reference it from the `CopySnapshotTree` doc comment.
+- [ ] **Step 3: Commit**
+
+---
+
+## Pre-push checklist
+
+- [ ] `rg -n "AI-[0-9]+" src/ test/ --type cs` — must be empty.
+- [ ] `dotnet build Capacitor.Cli.slnx` (or the solution in use) succeeds.
+- [ ] The unit suite passes: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj`
+- [ ] The integration suite passes (this repo's CLI convention).

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs
@@ -166,26 +166,40 @@ public partial class WorktreeManager {
         else File.CreateSymbolicLink(destPath, target);
     }
 
-    /// <summary>Copies one non-directory, non-link entry.
+    /// <summary>Copies one non-directory, non-link entry without ever opening a special file.
     ///
-    /// <para><b>A special file here would block, and that is deliberately NOT worked around.</b> .NET
-    /// exposes no portable file-TYPE probe — a FIFO reports exactly the same <c>FileAttributes</c>
-    /// (<c>Normal</c>), the same <c>UnixFileMode</c> and the same zero length as an ordinary empty file
-    /// (measured, not assumed) — so one cannot be identified and skipped without per-platform
-    /// <c>stat</c> P/Invoke.</para>
+    /// <para><b>The hazard.</b> A FIFO, socket or device node cannot be told apart from an ordinary file by
+    /// any portable .NET API — measured, not assumed: a FIFO reports <c>FileAttributes.Normal</c>, the same
+    /// <c>UnixFileMode</c>, and length 0, exactly like an empty regular file. Opening one BLOCKS FOREVER
+    /// waiting for a writer (also measured). This branch copies a live directory tree rather than
+    /// git-tracked content, so a special file can sit here AT REST — a plain directory, an extracted
+    /// archive, or a commitless repository — with no concurrent writer involved. It is therefore inside the
+    /// stated adversary, not outside it.</para>
     ///
-    /// <para>A time-bounded copy was implemented and then REMOVED, because it was worse than the problem.
-    /// A blocking open cannot be cancelled, so the abandoned worker outlives the claim and the rollback: a
-    /// later writer can wake it after a new same-name snapshot exists, letting it write into that
-    /// SUCCESSOR's destination — the exact ownership violation the claim exists to prevent — and it parks a
-    /// thread-pool thread per occurrence, turning one stuck launch into process-wide exhaustion.</para>
+    /// <para><b>The fix, without a type probe.</b> <c>Length</c> is a <c>stat</c>: it never blocks, and
+    /// every special file reports zero. So a zero-length entry is NEVER opened — the destination is simply
+    /// created empty. That is byte-identical for an ordinary empty file, and a safe, non-blocking
+    /// degradation for a special one. Only entries with real content are opened, and an entry with content
+    /// is a regular file.</para>
     ///
-    /// <para>The residual is bounded by what can actually reach a source tree: <b>git cannot track a
-    /// special file</b> (verified — <c>git add -A</c> silently ignores a FIFO), so one cannot arrive by
-    /// clone, i.e. never through hostile content at rest. It takes a local writer on the workspace, which
-    /// is precisely the principal the documented guarantee already excludes.</para>
+    /// <para><b>A time-bounded copy was tried first and REMOVED.</b> A blocking open cannot be cancelled,
+    /// so the abandoned worker outlives the claim and the rollback: a later writer can wake it after a new
+    /// same-name snapshot exists, letting it write into that SUCCESSOR's destination — the very ownership
+    /// violation the claim exists to prevent — and it parks a thread-pool thread per occurrence, bounding
+    /// one request by unbounding the process. Do not reintroduce it.</para>
     /// </summary>
-    static void CopyRegularFile(string source, string dest) => File.Copy(source, dest);
+    static void CopyRegularFile(string source, string dest) {
+        if (new FileInfo(source).Length != 0) {
+            File.Copy(source, dest);
+
+            return;
+        }
+
+        File.WriteAllBytes(dest, []);
+
+        // Preserve the mode an empty regular file carried, so an empty executable stays executable.
+        if (!OperatingSystem.IsWindows()) File.SetUnixFileMode(dest, File.GetUnixFileMode(source));
+    }
 
     static string CombineRelative(string relative, string name) =>
         relative.Length == 0 ? name : relative + "/" + name;

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs
@@ -166,32 +166,26 @@ public partial class WorktreeManager {
         else File.CreateSymbolicLink(destPath, target);
     }
 
-    /// <summary>Timeout for copying one ordinary file. Overridable for tests only.</summary>
-    internal static TimeSpan CopyEntryTimeout = TimeSpan.FromSeconds(30);
-
-    /// <summary>Copies one non-directory, non-link entry, bounded in time.
+    /// <summary>Copies one non-directory, non-link entry.
     ///
-    /// <para><b>Why bounded.</b> .NET exposes no portable file-TYPE probe: a FIFO reports exactly the same
-    /// <c>FileAttributes</c> (<c>Normal</c>), the same <c>UnixFileMode</c> and the same zero length as an
-    /// ordinary empty file — measured, not assumed. So a FIFO or device node placed in the source would
-    /// make <c>File.Copy</c> block forever waiting for a writer, wedging the launch. Since the entry cannot
-    /// be identified, the COPY is bounded instead: one that does not complete promptly fails the snapshot
-    /// closed and names the path, turning an indefinite hang by hostile content into an attributable
-    /// refusal.</para>
+    /// <para><b>A special file here would block, and that is deliberately NOT worked around.</b> .NET
+    /// exposes no portable file-TYPE probe — a FIFO reports exactly the same <c>FileAttributes</c>
+    /// (<c>Normal</c>), the same <c>UnixFileMode</c> and the same zero length as an ordinary empty file
+    /// (measured, not assumed) — so one cannot be identified and skipped without per-platform
+    /// <c>stat</c> P/Invoke.</para>
     ///
-    /// <para>The abandoned copy's thread is not cancellable — a blocking open cannot be interrupted — so it
-    /// remains parked until a writer appears or the process exits. That is one parked thread per hostile
-    /// entry, and the launch aborts, which is strictly better than the whole daemon wedging.</para>
+    /// <para>A time-bounded copy was implemented and then REMOVED, because it was worse than the problem.
+    /// A blocking open cannot be cancelled, so the abandoned worker outlives the claim and the rollback: a
+    /// later writer can wake it after a new same-name snapshot exists, letting it write into that
+    /// SUCCESSOR's destination — the exact ownership violation the claim exists to prevent — and it parks a
+    /// thread-pool thread per occurrence, turning one stuck launch into process-wide exhaustion.</para>
+    ///
+    /// <para>The residual is bounded by what can actually reach a source tree: <b>git cannot track a
+    /// special file</b> (verified — <c>git add -A</c> silently ignores a FIFO), so one cannot arrive by
+    /// clone, i.e. never through hostile content at rest. It takes a local writer on the workspace, which
+    /// is precisely the principal the documented guarantee already excludes.</para>
     /// </summary>
-    static void CopyRegularFile(string source, string dest) {
-        var copy = Task.Run(() => File.Copy(source, dest));
-
-        if (!copy.Wait(CopyEntryTimeout))
-            throw new InvalidOperationException($"standalone_snapshot_unreadable_entry: {source}");
-
-        // Re-throw a genuine copy failure rather than letting the wait swallow it.
-        copy.GetAwaiter().GetResult();
-    }
+    static void CopyRegularFile(string source, string dest) => File.Copy(source, dest);
 
     static string CombineRelative(string relative, string name) =>
         relative.Length == 0 ? name : relative + "/" + name;

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs
@@ -87,8 +87,9 @@ public partial class WorktreeManager {
     /// principal, nothing from outside <paramref name="source"/> is materialised here. Classification and
     /// the subsequent read are NOT atomic, and .NET exposes no portable no-follow open
     /// (<c>O_NOFOLLOW</c>/<c>openat</c>) for an AOT-compiled binary to use, so a principal able to swap an
-    /// entry between the two can still defeat it. That limitation is accepted deliberately and is
-    /// documented for operators under "Daemon" in the README; it is not closable at this layer.</para>
+    /// entry between the two can still defeat it. That limitation is accepted deliberately and is stated as
+    /// an operator precondition under "Daemon" in the README ("Snapshotting a workspace that isn't a git
+    /// repo") — keep the two in step. It is not closable at this layer.</para>
     /// </summary>
     void CopySnapshotTree(string source, string dest, string markerName) =>
         CopySnapshotLevel(source, dest, relative: "", markerName);

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs
@@ -53,25 +53,33 @@ public partial class WorktreeManager {
         // the original exclusion wrong. Over-rejecting a pathological Unix filename is the safe direction.
         if (rawTarget[0] is '/' or '\\') return false;
 
+        // Admissible only under BOTH tokenizations. A single merged one is NOT conservative in both
+        // directions: treating `\` as a separator turns `..\..\x` into two levels up (safely
+        // over-rejecting), but it also splits `a\b\c` into three levels of DEPTH, which masks a following
+        // `../..` — and on Unix, where `a\b\c` is one directory name, that target really does escape. So
+        // `a\b\c/../../outside` must be judged with slash-only parsing too, and rejected because it is
+        // unsafe there.
+        return NeverEscapes(linkDirRelative, rawTarget, UnixSeparators)
+            && NeverEscapes(linkDirRelative, rawTarget, WindowsSeparators);
+    }
+
+    static readonly char[] UnixSeparators = ['/'];
+
+    static readonly char[] WindowsSeparators = ['/', '\\'];
+
+    /// <summary>Whether the depth below the root stays non-negative at every step of the link's own
+    /// directory followed by its raw target, under one given tokenization.</summary>
+    static bool NeverEscapes(string linkDirRelative, string rawTarget, char[] separators) {
         var depth = 0;
 
-        foreach (var part in SplitPathComponents(linkDirRelative)) {
-            if (part == "..") { if (--depth < 0) return false; }
-            else if (part != ".") depth++;
-        }
-
-        foreach (var part in SplitPathComponents(rawTarget)) {
-            if (part == "..") { if (--depth < 0) return false; }
-            else if (part != ".") depth++;
-        }
+        foreach (var segment in new[] { linkDirRelative, rawTarget })
+            foreach (var part in segment.Split(separators, StringSplitOptions.RemoveEmptyEntries)) {
+                if (part == "..") { if (--depth < 0) return false; }
+                else if (part != ".") depth++;
+            }
 
         return true;
     }
-
-    /// <summary>Splits on BOTH separators. A raw link target is authored by whoever wrote the source tree,
-    /// so it must not be parsed with one hardcoded separator.</summary>
-    static IEnumerable<string> SplitPathComponents(string path) =>
-        path.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
 
     /// <summary>Copies <paramref name="source"/> into <paramref name="dest"/> without ever following a
     /// link and without descending into the destination.
@@ -103,9 +111,11 @@ public partial class WorktreeManager {
             // repository it names — committing outside the snapshot entirely.
             if (IsGitEntryName(name)) continue;
 
-            // Never copy this invocation's own bookkeeping. Only the exact name, so an unrelated user file
-            // that merely resembles a marker is preserved like any other content.
-            if (name == markerName || IsClaimName(name)) continue;
+            // Never copy this invocation's own marker. EXACT name only — the claim file is deliberately not
+            // matched by prefix here: it lives in the worktrees root, which the marker check below already
+            // excludes wholesale, so a prefix rule would buy nothing and would silently drop a legitimate
+            // source file that happened to be named `.kcap-claim-notes`.
+            if (name == markerName) continue;
 
             // Classify BEFORE touching it. File.Copy would materialise a link's target, and recursing
             // through a directory link would copy the target tree and can cycle without bound.
@@ -113,12 +123,12 @@ public partial class WorktreeManager {
             var destPath = Path.Combine(dest, name);
 
             if (attrs.HasFlag(FileAttributes.ReparsePoint)) {
-                RecreateLinkIfAdmissible(entry, destPath, relative, name);
+                RecreateLinkIfAdmissible(entry, destPath, relative, name, attrs);
                 continue;
             }
 
             if (!attrs.HasFlag(FileAttributes.Directory)) {
-                File.Copy(entry, destPath);
+                CopyRegularFile(entry, destPath);
                 continue;
             }
 
@@ -132,7 +142,8 @@ public partial class WorktreeManager {
         }
     }
 
-    void RecreateLinkIfAdmissible(string entry, string destPath, string relative, string name) {
+    void RecreateLinkIfAdmissible(
+            string entry, string destPath, string relative, string name, FileAttributes attrs) {
         // LinkTarget does not resolve, so a dangling link still reports its target — which is the case that
         // matters, since we judge the target rather than where it currently points.
         var target = new FileInfo(entry).LinkTarget ?? new DirectoryInfo(entry).LinkTarget;
@@ -146,7 +157,40 @@ public partial class WorktreeManager {
         // Recreated as a LINK carrying the same raw target — never resolved, never followed, so no
         // out-of-source bytes are ever written. A chain passing through a skipped link simply dangles
         // inside the snapshot rather than reaching out of it.
-        Directory.CreateSymbolicLink(destPath, target);
+        //
+        // The KIND is preserved from the source entry's own attributes rather than always creating a
+        // directory link. Windows records file-vs-directory in the reparse point itself, so a file symlink
+        // recreated as a directory link is wrong there — unusable, or a failure during creation. The
+        // attribute is read from the link, so a dangling link keeps whatever kind it was authored with.
+        if (attrs.HasFlag(FileAttributes.Directory)) Directory.CreateSymbolicLink(destPath, target);
+        else File.CreateSymbolicLink(destPath, target);
+    }
+
+    /// <summary>Timeout for copying one ordinary file. Overridable for tests only.</summary>
+    internal static TimeSpan CopyEntryTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>Copies one non-directory, non-link entry, bounded in time.
+    ///
+    /// <para><b>Why bounded.</b> .NET exposes no portable file-TYPE probe: a FIFO reports exactly the same
+    /// <c>FileAttributes</c> (<c>Normal</c>), the same <c>UnixFileMode</c> and the same zero length as an
+    /// ordinary empty file — measured, not assumed. So a FIFO or device node placed in the source would
+    /// make <c>File.Copy</c> block forever waiting for a writer, wedging the launch. Since the entry cannot
+    /// be identified, the COPY is bounded instead: one that does not complete promptly fails the snapshot
+    /// closed and names the path, turning an indefinite hang by hostile content into an attributable
+    /// refusal.</para>
+    ///
+    /// <para>The abandoned copy's thread is not cancellable — a blocking open cannot be interrupted — so it
+    /// remains parked until a writer appears or the process exits. That is one parked thread per hostile
+    /// entry, and the launch aborts, which is strictly better than the whole daemon wedging.</para>
+    /// </summary>
+    static void CopyRegularFile(string source, string dest) {
+        var copy = Task.Run(() => File.Copy(source, dest));
+
+        if (!copy.Wait(CopyEntryTimeout))
+            throw new InvalidOperationException($"standalone_snapshot_unreadable_entry: {source}");
+
+        // Re-throw a genuine copy failure rather than letting the wait swallow it.
+        copy.GetAwaiter().GetResult();
     }
 
     static string CombineRelative(string relative, string name) =>

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.SnapshotRules.cs
@@ -1,0 +1,157 @@
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+public partial class WorktreeManager {
+    /// <summary>Whether an entry name is git control data, compared case-insensitively.
+    ///
+    /// <para><b>Deliberately asymmetric with the marker-based <c>.capacitor</c> exclusion.</b> A real
+    /// <c>.git</c> must never land in the snapshot: the standalone path runs <c>git init</c> over the
+    /// result, and a copied gitfile or repository directory makes that re-initialise a DIFFERENT
+    /// repository and commit into it — a write escape, not merely a leak. So the fail-safe direction here
+    /// is DROP. A <c>.Capacitor</c> directory is inert content, so its fail-safe direction is KEEP, and it
+    /// gets the marker treatment instead. The marker technique is unavailable here because we do not own
+    /// the source's <c>.git</c>.</para>
+    ///
+    /// <para><b>Accepted cost:</b> on a case-sensitive filesystem, inert content in a directory literally
+    /// named <c>.GIT</c> is dropped. Safety over fidelity, and consistent with this class's own
+    /// <see cref="NormalizeRelativePath"/>, which already compares <c>.git</c> with OrdinalIgnoreCase.</para>
+    /// </summary>
+    internal static bool IsGitEntryName(string name) =>
+        name.Equals(".git", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Whether a symlink's RAW target may be recreated verbatim inside the snapshot.
+    ///
+    /// <para><b>Why "never escapes" rather than "finally resolves inside".</b> Final-resolution
+    /// containment is unsound under relocation, and reachable with a completely quiescent source. A
+    /// source-root link <c>self -> ../&lt;source-dir-name&gt;/secret</c> resolves back inside the source,
+    /// so a final-resolution rule admits it. But the snapshot lives at
+    /// <c>&lt;source&gt;/.capacitor/worktrees/&lt;name&gt;</c>, so the SAME raw target evaluated there
+    /// becomes <c>&lt;…&gt;/worktrees/&lt;source-dir-name&gt;/secret</c> — a sibling agent's worktree.
+    /// Identical bytes, different meaning, because the link's containing directory moved.</para>
+    ///
+    /// <para>Requiring the accumulated depth to never go negative is position-INDEPENDENT: a path that
+    /// never rises above its own root resolves inside any root it is transplanted into, at equal depth. It
+    /// also needs no path comparison, so it cannot inherit the OS-inferred case-sensitivity problem that
+    /// makes every name- and path-based exclusion in this area wrong in one direction or the other.</para>
+    /// </summary>
+    /// <param name="linkDirRelative">The link's own directory, relative to the snapshot root, with
+    /// <c>/</c> separators. Empty for the root itself.</param>
+    /// <param name="rawTarget">The link target exactly as authored — never resolved.</param>
+    internal static bool IsAdmissibleLinkTarget(string linkDirRelative, string rawTarget) {
+        if (string.IsNullOrEmpty(rawTarget)) return false;
+
+        // Reject EVERY rooted form, not just fully-qualified absolutes. On Windows `\foo` and `C:foo` are
+        // rooted-but-not-fully-qualified and would otherwise reach the depth walk as though relative.
+        if (Path.IsPathRooted(rawTarget) || Path.IsPathFullyQualified(rawTarget)) return false;
+        if (rawTarget.Length >= 2 && rawTarget[1] == ':') return false;
+
+        // Judged the same way on every platform rather than by the host's own rules. A backslash is a legal
+        // FILENAME character on Unix, so `\foo` there is a relative name that Path.IsPathRooted calls
+        // relative — but the identical bytes are rooted on Windows. Deciding per-host would make
+        // admissibility depend on where the copy happens to run, which is the class of reasoning that made
+        // the original exclusion wrong. Over-rejecting a pathological Unix filename is the safe direction.
+        if (rawTarget[0] is '/' or '\\') return false;
+
+        var depth = 0;
+
+        foreach (var part in SplitPathComponents(linkDirRelative)) {
+            if (part == "..") { if (--depth < 0) return false; }
+            else if (part != ".") depth++;
+        }
+
+        foreach (var part in SplitPathComponents(rawTarget)) {
+            if (part == "..") { if (--depth < 0) return false; }
+            else if (part != ".") depth++;
+        }
+
+        return true;
+    }
+
+    /// <summary>Splits on BOTH separators. A raw link target is authored by whoever wrote the source tree,
+    /// so it must not be parsed with one hardcoded separator.</summary>
+    static IEnumerable<string> SplitPathComponents(string path) =>
+        path.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
+
+    /// <summary>Copies <paramref name="source"/> into <paramref name="dest"/> without ever following a
+    /// link and without descending into the destination.
+    ///
+    /// <para>Replaces the original <c>CopyDirectory</c>, which was broken three ways at once: it recursed
+    /// into its own destination until the path length blew up (so standalone snapshot creation had never
+    /// once completed), <c>File.Copy</c> materialised a symlink's TARGET (so a source containing a link to
+    /// <c>~/.ssh</c> would write real credentials into the agent's worktree as ordinary files,
+    /// indistinguishable from repository content), and its destination exclusion was a name match that is
+    /// wrong in one direction or the other under either case semantics.</para>
+    ///
+    /// <para><b>Guarantee, and its stated limit.</b> For a source not concurrently written by another
+    /// principal, nothing from outside <paramref name="source"/> is materialised here. Classification and
+    /// the subsequent read are NOT atomic, and .NET exposes no portable no-follow open
+    /// (<c>O_NOFOLLOW</c>/<c>openat</c>) for an AOT-compiled binary to use, so a principal able to swap an
+    /// entry between the two can still defeat it. That limitation is accepted deliberately and is
+    /// documented for operators under "Daemon" in the README; it is not closable at this layer.</para>
+    /// </summary>
+    void CopySnapshotTree(string source, string dest, string markerName) =>
+        CopySnapshotLevel(source, dest, relative: "", markerName);
+
+    void CopySnapshotLevel(string source, string dest, string relative, string markerName) {
+        foreach (var entry in Directory.EnumerateFileSystemEntries(source)) {
+            var name = Path.GetFileName(entry);
+
+            // Any type, every level: a `.git` FILE (`gitdir: …`) is repository control data just as much as
+            // the directory is, and copying one makes this snapshot's own `git init` re-initialise the
+            // repository it names — committing outside the snapshot entirely.
+            if (IsGitEntryName(name)) continue;
+
+            // Never copy this invocation's own bookkeeping. Only the exact name, so an unrelated user file
+            // that merely resembles a marker is preserved like any other content.
+            if (name == markerName || IsClaimName(name)) continue;
+
+            // Classify BEFORE touching it. File.Copy would materialise a link's target, and recursing
+            // through a directory link would copy the target tree and can cycle without bound.
+            var attrs = File.GetAttributes(entry);
+            var destPath = Path.Combine(dest, name);
+
+            if (attrs.HasFlag(FileAttributes.ReparsePoint)) {
+                RecreateLinkIfAdmissible(entry, destPath, relative, name);
+                continue;
+            }
+
+            if (!attrs.HasFlag(FileAttributes.Directory)) {
+                File.Copy(entry, destPath);
+                continue;
+            }
+
+            // A directory holding this invocation's marker IS the destination's parent. Detected by READING
+            // the directory rather than by comparing its name or path, so it resolves correctly under
+            // case-sensitive and case-insensitive semantics alike — nothing is inferred from the OS.
+            if (File.Exists(Path.Combine(entry, markerName))) continue;
+
+            Directory.CreateDirectory(destPath);
+            CopySnapshotLevel(entry, destPath, CombineRelative(relative, name), markerName);
+        }
+    }
+
+    void RecreateLinkIfAdmissible(string entry, string destPath, string relative, string name) {
+        // LinkTarget does not resolve, so a dangling link still reports its target — which is the case that
+        // matters, since we judge the target rather than where it currently points.
+        var target = new FileInfo(entry).LinkTarget ?? new DirectoryInfo(entry).LinkTarget;
+
+        if (target is null || !IsAdmissibleLinkTarget(relative, target)) {
+            LogSkippedLink(CombineRelative(relative, name), target ?? "<unreadable>");
+
+            return;
+        }
+
+        // Recreated as a LINK carrying the same raw target — never resolved, never followed, so no
+        // out-of-source bytes are ever written. A chain passing through a skipped link simply dangles
+        // inside the snapshot rather than reaching out of it.
+        Directory.CreateSymbolicLink(destPath, target);
+    }
+
+    static string CombineRelative(string relative, string name) =>
+        relative.Length == 0 ? name : relative + "/" + name;
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Skipped link {Path} in standalone snapshot: target {Target} is rooted or leaves the source")]
+    partial void LogSkippedLink(string path, string target);
+}

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -323,6 +323,12 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // closes: that method's own unwinding completes BEFORE the catch below deletes the tree, so a new
         // same-name call could claim, create, and then be deleted by this call's delayed rollback.
         try {
+            // Test barrier: holds the winner after the claim FILE exists but before the destination does,
+            // so a second caller's acquisition is decided purely by the claim's existence. Without this the
+            // handle's own FileShare.None can do the excluding instead, and a weakened FileMode goes
+            // undetected.
+            SnapshotPostClaimHook?.Invoke().GetAwaiter().GetResult();
+
             // Absent, not merely "not a link". An existing ordinary directory would be silently adopted:
             // the snapshot would overlay a tree we never created, the rollback would then delete it
             // wholesale, and any repository control data already sitting there escapes the source-side
@@ -384,6 +390,11 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// <summary>Runs immediately before the claim is attempted, while the destination is still absent.
     /// Test-only, so two callers can be made to genuinely overlap.</summary>
     internal static Func<Task>? SnapshotPreClaimHook;
+
+    /// <summary>Runs after the claim file exists but before the destination is created. Test-only: lets a
+    /// second caller attempt acquisition at the one moment when only the claim's EXISTENCE can exclude it.
+    /// </summary>
+    internal static Func<Task>? SnapshotPostClaimHook;
 
     static void FailHereIfRequested(string point) {
         if (SnapshotFailurePoint != point) return;

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -303,6 +303,12 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // snapshot. There is no portable atomic directory claim, but FileMode.CreateNew on a FILE is atomic
         // everywhere, so the claim file supplies the exclusion the directory create cannot.
         var claimPath = Path.Combine(worktreeRoot, ClaimPrefix + name);
+
+        // Test barrier: lets two callers rendezvous in the window where BOTH still see the destination
+        // absent. Without it a concurrency test can pass by running the callers sequentially, where the
+        // second is refused by the occupied-destination check and the claim's atomicity is never exercised.
+        SnapshotPreClaimHook?.Invoke().GetAwaiter().GetResult();
+
         try {
             using (new FileStream(claimPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) { }
         } catch (IOException) {
@@ -344,8 +350,6 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
 
     internal const string ClaimPrefix = ".kcap-claim-";
 
-    static bool IsClaimName(string name) => name.StartsWith(ClaimPrefix, StringComparison.Ordinal);
-
     /// <summary>Refuses a destination-chain component that is a link, WITHOUT following it.</summary>
     static void RefuseIfLink(string path) {
         if (IsPresentEntry(path) && File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint))
@@ -376,6 +380,10 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     /// <summary>Runs inside the claimant's rollback, after the tree is deleted and before the claim is
     /// released — the window a same-name caller must still be excluded from.</summary>
     internal static Func<Task>? SnapshotRollbackHook;
+
+    /// <summary>Runs immediately before the claim is attempted, while the destination is still absent.
+    /// Test-only, so two callers can be made to genuinely overlap.</summary>
+    internal static Func<Task>? SnapshotPreClaimHook;
 
     static void FailHereIfRequested(string point) {
         if (SnapshotFailurePoint != point) return;

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -221,14 +221,18 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         var worktreePath = Path.Combine(worktreeRoot, name);
         var branch       = $"capacitor/{name}";
 
-        Directory.CreateDirectory(worktreeRoot);
-
         // No filter inventory here on purpose. `worktree add --no-checkout` materialises nothing, so no
         // filter can run during it, and the guarded reset re-inventories inside the TARGET — which is the
         // context that actually decides which drivers load. A source-context inventory would add no
         // containment and could reject a safe launch, since a source-only conditional include can define a
         // driver the target never sees.
         if (await IsGitRepoWithCommits(repoPath)) {
+            // Created HERE rather than in a shared prologue. The standalone branch below must validate the
+            // destination chain BEFORE anything is created — a pre-existing `.capacitor` or `worktrees`
+            // symlink is FOLLOWED by this call, so a check placed after the branch decision would run once
+            // the snapshot had already been rooted wherever the source tree chose.
+            Directory.CreateDirectory(worktreeRoot);
+
             if (!string.IsNullOrEmpty(baseRef)) {
                 // Fetch into a per-worktree ref instead of the shared FETCH_HEAD
                 // so concurrent review launches in the same source repo can't
@@ -263,21 +267,140 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         }
 
         // Standalone: copy files + git init.
-        // Wrapped because every step after the directory exists can throw — the MCP strip and the filter
-        // inventory are both fail-closed — and this branch returns no WorktreeInfo on the way out, so
-        // nothing downstream could clean up the partial tree. The linked paths gained rollback earlier for
-        // exactly this; review caught that the standalone one never did.
-        Directory.CreateDirectory(worktreePath);
+        return await CreateStandaloneAsync(repoPath, name, worktreeRoot, worktreePath);
+    }
+
+    /// <summary>Validates, claims, and builds a standalone snapshot.
+    ///
+    /// <para><b>Ordering is the entire point of this method.</b> Every check happens before any write, and
+    /// the claim's lifetime strictly encloses rollback. Getting either wrong reopens a race or an escape
+    /// that the checks themselves cannot detect.</para>
+    /// </summary>
+    async Task<WorktreeInfo> CreateStandaloneAsync(
+            string repoPath, string name, string worktreeRoot, string worktreePath) {
+        // `name` reaches Path.Combine, which DISCARDS the root for an absolute value and would place the
+        // destination anywhere; `../evil` would land it outside `worktrees`, where the marker cannot
+        // exclude it and the copy recurses into its own destination again. Defense-in-depth today — both
+        // real callers omit `name` — but this is a public method.
+        if (name.Length == 0 || name is "." or ".." ||
+            name != Path.GetFileName(name) || name.AsSpan().ContainsAny('/', '\\'))
+            throw new InvalidOperationException($"standalone_snapshot_invalid_name: {name}");
+
+        if (!IsAtOrUnder(ResolveDeepestExisting(worktreePath), ResolveDeepestExisting(repoPath)))
+            throw new InvalidOperationException("standalone_snapshot_destination_escape");
+
+        // No-follow, attribute-based, over the components WE introduce below the source root — not from the
+        // filesystem root, since a source legitimately reached through a system symlink (macOS /tmp) is
+        // normal and must not be refused.
+        RefuseIfLink(Path.Combine(repoPath, ".capacitor"));
+        RefuseIfLink(worktreeRoot);
+
+        Directory.CreateDirectory(worktreeRoot);
+
+        // Atomic claim. Directory.CreateDirectory is a NO-OP on an existing directory, so the freshness
+        // check below is check-then-create and cannot by itself exclude a concurrent SAME-PRINCIPAL caller
+        // — both racers would consider the directory theirs, and either rollback would delete the other's
+        // snapshot. There is no portable atomic directory claim, but FileMode.CreateNew on a FILE is atomic
+        // everywhere, so the claim file supplies the exclusion the directory create cannot.
+        var claimPath = Path.Combine(worktreeRoot, ClaimPrefix + name);
         try {
-            return await BuildStandaloneSnapshotAsync(repoPath, worktreePath);
-        } catch {
-            try { DeleteTreeNoFollow(worktreePath); } catch { /* keep the original failure */ }
-            throw;
+            using (new FileStream(claimPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) { }
+        } catch (IOException) {
+            // Loser path: throws WITHOUT touching the destination. The rollback below is unconditional on
+            // worktreePath, so a loser falling through it would delete the WINNER's directory — a claim
+            // that made things strictly worse than no claim at all.
+            throw new InvalidOperationException($"standalone_snapshot_name_in_use: {name}");
+        }
+
+        // The claim is held until all success work is done, or until all rollback has finished, and is
+        // released LAST. Releasing it inside BuildStandaloneSnapshotAsync would reopen the very race it
+        // closes: that method's own unwinding completes BEFORE the catch below deletes the tree, so a new
+        // same-name call could claim, create, and then be deleted by this call's delayed rollback.
+        try {
+            // Absent, not merely "not a link". An existing ordinary directory would be silently adopted:
+            // the snapshot would overlay a tree we never created, the rollback would then delete it
+            // wholesale, and any repository control data already sitting there escapes the source-side
+            // `.git` exclusion entirely — putting `git init`/`commit` back outside the snapshot.
+            if (IsPresentEntry(worktreePath))
+                throw new InvalidOperationException($"standalone_snapshot_destination_occupied: {name}");
+
+            Directory.CreateDirectory(worktreePath);
+
+            try {
+                return await BuildStandaloneSnapshotAsync(repoPath, worktreePath);
+            } catch {
+                // Only the successful claimant reaches here, so this delete is ownership-gated.
+                try { DeleteTreeNoFollow(worktreePath); } catch { /* keep the original failure */ }
+                // Test barrier, INSIDE the claim's protected region and after the delete: this is the exact
+                // window in which a same-name caller must still be excluded.
+                SnapshotRollbackHook?.Invoke().GetAwaiter().GetResult();
+                throw;
+            }
+        } finally {
+            // Best effort: a stale claim fails CLOSED, refusing that one name until an operator clears it.
+            try { File.Delete(claimPath); } catch { /* the refusal names the file */ }
         }
     }
 
+    internal const string ClaimPrefix = ".kcap-claim-";
+
+    static bool IsClaimName(string name) => name.StartsWith(ClaimPrefix, StringComparison.Ordinal);
+
+    /// <summary>Refuses a destination-chain component that is a link, WITHOUT following it.</summary>
+    static void RefuseIfLink(string path) {
+        if (IsPresentEntry(path) && File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint))
+            throw new InvalidOperationException($"standalone_snapshot_destination_link: {path}");
+    }
+
+    /// <summary>Whether an entry exists at this path, INCLUDING a dangling link.
+    ///
+    /// <para>Attribute-based rather than <c>Path.Exists</c>, which follows: a dangling link would report
+    /// absent and then be created through — the same trap <see cref="DeleteTreeNoFollow"/> documents.</para>
+    /// </summary>
+    static bool IsPresentEntry(string path) {
+        try {
+            _ = File.GetAttributes(path);
+
+            return true;
+        } catch (FileNotFoundException) {
+            return false;
+        } catch (DirectoryNotFoundException) {
+            return false;
+        }
+    }
+
+    /// <summary>Test-only injected failure point. The claim-ownership tests need a DETERMINISTIC rollback
+    /// window: a wall-clock race would be flaky and, worse, could pass by luck.</summary>
+    internal static string? SnapshotFailurePoint;
+
+    /// <summary>Runs inside the claimant's rollback, after the tree is deleted and before the claim is
+    /// released — the window a same-name caller must still be excluded from.</summary>
+    internal static Func<Task>? SnapshotRollbackHook;
+
+    static void FailHereIfRequested(string point) {
+        if (SnapshotFailurePoint != point) return;
+
+        throw new InvalidOperationException("injected_standalone_failure");
+    }
+
     async Task<WorktreeInfo> BuildStandaloneSnapshotAsync(string repoPath, string worktreePath) {
-        CopyDirectory(repoPath, worktreePath);
+        // Unique per invocation and created CreateNew, so a collision is detected rather than silently
+        // shared, a hostile source cannot plant one that suppresses real content, and a marker orphaned by
+        // a crash can never suppress anything on a later run.
+        var markerName = $".kcap-snapshot-exclude-{Guid.NewGuid():N}";
+        var markerPath = Path.Combine(Path.GetDirectoryName(worktreePath)!, markerName);
+
+        try {
+            // Fail-closed: without the marker the walk recurses into its own destination.
+            using (new FileStream(markerPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)) { }
+
+            CopySnapshotTree(repoPath, worktreePath, markerName);
+            FailHereIfRequested(nameof(CopySnapshotTree));
+        } finally {
+            // Cleanup failure logs nothing and fails nothing: the snapshot is already built and correct.
+            try { File.Delete(markerPath); } catch { /* best effort */ }
+        }
+
         // BEFORE the initial commit, so the snapshot's own history never carries the hostile config
         // either — a later `git checkout` inside the tree would otherwise restore it.
         StripWorkspaceMcpConfig(worktreePath);
@@ -289,10 +412,9 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         await RunGit(worktreePath, GitTimeout, [..NoBranchHooks(), ..standaloneOverrides, "add", "-A"]);
         // Identity supplied explicitly. This is the daemon's OWN bookkeeping commit, not the user's work,
         // so it must not depend on the host having git identity configured — a machine without a global
-        // user.email fails with "Author identity unknown". Found while CopyDirectory was temporarily
-        // repaired and this line became reachable for the first time; that repair was then reverted (see
-        // CopyDirectory), so the path still cannot get here — the fix is kept because it is correct and
-        // because the repair will land eventually.
+        // user.email fails with "Author identity unknown". Found while the broken copy was temporarily
+        // repaired and this line became reachable for the first time; that repair was reverted then and has
+        // landed now, so this is live rather than speculative.
         await RunGit(worktreePath, GitTimeout, [
             ..NoBranchHooks(),
             "-c", "user.email=daemon@kcap.local", "-c", "user.name=kcap",
@@ -1400,35 +1522,4 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to clean up {Path}")]
     partial void LogCleanupFailed(Exception ex, string path);
 
-    /// <summary>
-    /// NOTE: this is the ORIGINAL implementation, restored deliberately.
-    ///
-    /// <para>It is broken: the standalone path's destination is
-    /// <c>&lt;source&gt;/.capacitor/worktrees/&lt;name&gt;</c>, so this descends into the directory it is
-    /// writing and recurses until the path length blows up. Standalone snapshot creation has therefore
-    /// never completed for a non-git source.</para>
-    ///
-    /// <para><b>Why it is not fixed here.</b> Repairing the recursion made the path REACHABLE, which armed
-    /// a second, worse latent bug in the same method: <c>File.Copy</c> copies a symlink's target, so a
-    /// source containing a link to <c>~/.ssh</c> would materialise real credentials inside the agent's
-    /// worktree. Hardening that then raised further questions about case semantics and about preserving
-    /// legitimate internal links. None of it belongs in a change about MCP containment, and shipping a
-    /// half-hardened live path is worse than leaving an inert broken one. Repair is tracked on its own
-    /// issue, with the exfiltration vector and the case-identity problem written up.</para>
-    /// </summary>
-    static void CopyDirectory(string source, string dest) {
-        foreach (var file in Directory.GetFiles(source)) {
-            File.Copy(file, Path.Combine(dest, Path.GetFileName(file)));
-        }
-
-        foreach (var dir in Directory.GetDirectories(source)) {
-            if (Path.GetFileName(dir) == ".git") {
-                continue;
-            }
-
-            var destDir = Path.Combine(dest, Path.GetFileName(dir));
-            Directory.CreateDirectory(destDir);
-            CopyDirectory(dir, destDir);
-        }
-    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/SnapshotPathRulesTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SnapshotPathRulesTests.cs
@@ -1,0 +1,67 @@
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>The pure decision rules behind the standalone snapshot copy, tested without a filesystem.
+///
+/// <para>These are the two places the copy can be wrong without any I/O being involved, so they get direct
+/// coverage rather than being inferred from end-to-end behaviour.</para></summary>
+public class SnapshotPathRulesTests {
+    [Test]
+    [Arguments(".git"), Arguments(".GIT"), Arguments(".Git")]
+    public async Task Git_entry_names_match_case_insensitively(string name) =>
+        await Assert.That(WorktreeManager.IsGitEntryName(name)).IsTrue();
+
+    [Test]
+    [Arguments(".gitignore"), Arguments(".gitmodules"), Arguments("git"), Arguments("")]
+    public async Task Non_git_entry_names_do_not_match(string name) =>
+        await Assert.That(WorktreeManager.IsGitEntryName(name)).IsFalse();
+
+    [Test]
+    [Arguments("", "releases/v2")]
+    [Arguments("", "./releases/v2")]
+    [Arguments("a", "../b/file")]
+    [Arguments("a/b", "../../c")]
+    [Arguments("a/b", "c/../d")]
+    public async Task Targets_that_never_rise_above_the_root_are_admissible(string dir, string target) =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget(dir, target)).IsTrue();
+
+    /// <summary>The relocation bug. Each of these RESOLVES inside the source, so a final-resolution rule
+    /// admits it — but recreated verbatim at the snapshot's own depth the same raw target lands beside the
+    /// snapshot instead, in a sibling agent's worktree.</summary>
+    [Test]
+    [Arguments("", "../proj/secret")]
+    [Arguments("a", "../../a/b")]
+    [Arguments("a/b", "../../../a/b/c")]
+    public async Task Targets_that_escape_and_reenter_are_rejected(string dir, string target) =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget(dir, target)).IsFalse();
+
+    [Test]
+    [Arguments("", "../outside")]
+    [Arguments("a", "../../outside")]
+    [Arguments("a/b", "../../../outside")]
+    public async Task Targets_that_escape_are_rejected(string dir, string target) =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget(dir, target)).IsFalse();
+
+    /// <summary>Every rooted form, not just the fully-qualified one: on Windows <c>\foo</c> and
+    /// <c>C:foo</c> are rooted-but-not-fully-qualified and would otherwise reach the depth walk as though
+    /// they were relative.</summary>
+    [Test]
+    [Arguments("/etc/passwd")]
+    [Arguments("\\foo")]
+    [Arguments("C:foo")]
+    [Arguments("C:\\foo")]
+    public async Task Rooted_targets_are_rejected(string target) =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget("", target)).IsFalse();
+
+    [Test]
+    public async Task Empty_target_is_rejected() =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget("", "")).IsFalse();
+
+    /// <summary>Backslash-separated components are split too. A raw target is authored by whoever wrote the
+    /// source tree, so parsing it with one hardcoded separator would let an escape through on the
+    /// filesystem where that separator is the live one.</summary>
+    [Test]
+    public async Task Backslash_separated_escapes_are_rejected() =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget("a", "..\\..\\outside")).IsFalse();
+}

--- a/test/Capacitor.Cli.Tests.Unit/SnapshotPathRulesTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SnapshotPathRulesTests.cs
@@ -64,4 +64,16 @@ public class SnapshotPathRulesTests {
     [Test]
     public async Task Backslash_separated_escapes_are_rejected() =>
         await Assert.That(WorktreeManager.IsAdmissibleLinkTarget("a", "..\\..\\outside")).IsFalse();
+
+    /// <summary>Admissibility is the INTERSECTION of both tokenizations, not one merged pass.
+    ///
+    /// <para>Treating <c>\</c> as a separator safely over-rejects <c>..\..\x</c>, but it also splits
+    /// <c>a\b\c</c> into three levels of DEPTH — which masks a following <c>../..</c>. On Unix
+    /// <c>a\b\c</c> is a single directory name, so that target really does leave the root. Judging it
+    /// under slash-only parsing as well is what rejects it.</para></summary>
+    [Test]
+    [Arguments("", "a\\b\\c/../../outside")]
+    [Arguments("", "a\\b/../../outside")]
+    public async Task Backslash_inflated_depth_does_not_mask_an_escape(string dir, string target) =>
+        await Assert.That(WorktreeManager.IsAdmissibleLinkTarget(dir, target)).IsFalse();
 }

--- a/test/Capacitor.Cli.Tests.Unit/StandaloneSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/StandaloneSnapshotTests.cs
@@ -519,13 +519,59 @@ public class StandaloneSnapshotTests {
 
     // ---- 14: claim ownership --------------------------------------------------------------------------
 
-    /// <summary>Two callers genuinely overlapping in the window where BOTH still see the destination
-    /// absent: exactly one wins, the loser is refused by the CLAIM, and the winner's snapshot is intact.
+    /// <summary>The claim's EXISTENCE excludes a second caller — not the brief non-shared handle.
     ///
-    /// <para>The barrier is load-bearing. Without it the two calls can run sequentially, and the second is
-    /// then refused by the occupied-destination check instead — so the test passes with exactly the same
-    /// counts even if the claim were removed or made non-atomic, never exercising the property it
-    /// names.</para></summary>
+    /// <para>Deterministic by construction. The winner is held after the claim file exists but before the
+    /// destination does, and only then does the second caller attempt acquisition. At that instant the
+    /// winner's handle is already closed, so the only thing that can refuse the second caller is the file
+    /// being there — which is exactly what <c>FileMode.CreateNew</c> provides.</para>
+    ///
+    /// <para>An earlier version merely started both callers behind a pre-claim barrier. That passed even
+    /// with the mode weakened to <c>FileMode.Create</c>, because the loser was then refused by the winner's
+    /// transient <c>FileShare.None</c> handle instead — a scheduling accident, not the property under
+    /// test.</para></summary>
+    [Test, NotInParallel]
+    public async Task The_claim_files_existence_excludes_a_second_caller() {
+        var (root, source) = MakeNonGitSource();
+        var claimed = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+        try {
+            WorktreeManager.SnapshotPostClaimHook = async () => {
+                claimed.TrySetResult();
+                await release.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            };
+
+            var manager = NewManager();
+            var winner = Task.Run(() => manager.CreateAsync(source, "contended"));
+
+            await claimed.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+            var worktrees = Path.Combine(source, ".capacitor", "worktrees");
+            await Assert.That(IsPresent(Path.Combine(worktrees, WorktreeManager.ClaimPrefix + "contended")))
+                .IsTrue().Because("fixture control: the claim really was taken before the second attempt");
+            await Assert.That(IsPresent(Path.Combine(worktrees, "contended"))).IsFalse()
+                .Because("fixture control: the destination does not exist, so only the claim can refuse");
+
+            // Cleared so the second caller is not itself parked by the hook.
+            WorktreeManager.SnapshotPostClaimHook = null;
+
+            var loser = await Assert.That(async () => await manager.CreateAsync(source, "contended"))
+                .Throws<InvalidOperationException>();
+            await Assert.That(loser!.Message).Contains("standalone_snapshot_name_in_use")
+                .Because("refusal must come from the claim, not the occupied-destination check");
+
+            release.TrySetResult();
+            var built = await winner;
+            await Assert.That(CommittedPaths(built.Path)).Contains("README.md")
+                .Because("the winner's snapshot must be intact");
+        } finally {
+            WorktreeManager.SnapshotPostClaimHook = null;
+            release.TrySetResult();
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>Two callers racing from the same starting line still yield exactly one winner.</summary>
     [Test, NotInParallel]
     public async Task Concurrent_same_name_creates_yield_one_winner() {
         var (root, source) = MakeNonGitSource();
@@ -538,19 +584,16 @@ public class StandaloneSnapshotTests {
             };
 
             var manager = NewManager();
-            var a = Task.Run(() => manager.CreateAsync(source, "contended"));
-            var b = Task.Run(() => manager.CreateAsync(source, "contended"));
+            var a = Task.Run(() => manager.CreateAsync(source, "raced"));
+            var b = Task.Run(() => manager.CreateAsync(source, "raced"));
 
             var outcomes = await Task.WhenAll(
                 a.ContinueWith(t => t.IsCompletedSuccessfully ? null : Message(t)),
                 b.ContinueWith(t => t.IsCompletedSuccessfully ? null : Message(t)));
 
             await Assert.That(outcomes.Count(m => m is null)).IsEqualTo(1)
-                .Because("the claim is atomic — exactly one caller may own the destination");
-            await Assert.That(outcomes.Single(m => m is not null)).Contains("standalone_snapshot_name_in_use")
-                .Because("the loser must be refused by the CLAIM, not by the occupied-destination check — "
-                       + "the latter would mean the two calls never actually overlapped");
-            await Assert.That(CommittedPaths(Path.Combine(source, ".capacitor", "worktrees", "contended")))
+                .Because("exactly one caller may own the destination");
+            await Assert.That(CommittedPaths(Path.Combine(source, ".capacitor", "worktrees", "raced")))
                 .Contains("README.md").Because("the winner's snapshot must be intact");
         } finally {
             WorktreeManager.SnapshotPreClaimHook = null;
@@ -771,34 +814,4 @@ public class StandaloneSnapshotTests {
         }
     }
 
-    /// <summary>A FIFO in the source fails the snapshot closed instead of hanging the launch.
-    ///
-    /// <para>.NET reports a FIFO with exactly the same <c>FileAttributes</c>, <c>UnixFileMode</c> and zero
-    /// length as an ordinary empty file — measured — so it cannot be identified and skipped. The copy is
-    /// bounded instead, turning an indefinite block by hostile content into an attributable refusal. The
-    /// timeout is shortened here so the test does not wait for the production bound.</para></summary>
-    [Test, NotInParallel]
-    public async Task A_fifo_in_the_source_fails_closed_rather_than_hanging() {
-        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX FIFO semantics.");
-        var (root, source) = MakeNonGitSource();
-        var original = WorktreeManager.CopyEntryTimeout;
-        try {
-            WorktreeManager.CopyEntryTimeout = TimeSpan.FromSeconds(2);
-
-            var fifo = Path.Combine(source, "pipe");
-            using (var mk = Process.Start(new ProcessStartInfo("mkfifo", fifo))!) {
-                mk.WaitForExit();
-                Skip.Unless(mk.ExitCode == 0, "mkfifo unavailable");
-            }
-
-            await Assert.That(IsPresent(fifo)).IsTrue().Because("fixture control: the FIFO exists");
-
-            await Assert.That(async () => await NewManager().CreateAsync(source))
-                .Throws<InvalidOperationException>()
-                .Because("an entry that cannot be copied promptly must refuse, not wedge the daemon");
-        } finally {
-            WorktreeManager.CopyEntryTimeout = original;
-            Cleanup(root);
-        }
-    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/StandaloneSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/StandaloneSnapshotTests.cs
@@ -1,0 +1,699 @@
+using System.Diagnostics;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>End-to-end behaviour of the standalone snapshot branch, driven through the public
+/// <see cref="WorktreeManager.CreateAsync"/> against a source that is deliberately NOT a git repo.
+///
+/// <para><b>Absence is never asserted with a following API.</b> <c>File.Exists</c>, <c>Directory.Exists</c>
+/// and <c>Path.Exists</c> all follow, so a dangling link reports absent and an "it was not copied"
+/// assertion passes for the wrong reason. Everything here uses <see cref="EntryNames"/> or
+/// <see cref="IsPresent"/>, which read the parent directory and the entry's own attributes.</para></summary>
+public class StandaloneSnapshotTests {
+    // ---- fixtures -----------------------------------------------------------------------------------
+
+    /// <summary>A source directory that is NOT a git repo, so <c>CreateAsync</c> takes the standalone
+    /// branch. Created under a per-test root so an "outside" sibling can be placed next to it.</summary>
+    static (string root, string source) MakeNonGitSource() {
+        var root = Path.Combine(Path.GetTempPath(), "kcap-standalone-" + Guid.NewGuid().ToString("N")[..8]);
+        var source = Path.Combine(root, "proj");
+        Directory.CreateDirectory(source);
+        File.WriteAllText(Path.Combine(source, "README.md"), "hello");
+
+        return (root, source);
+    }
+
+    static WorktreeManager NewManager() =>
+        new(new DaemonConfig(), NullLogger<WorktreeManager>.Instance);
+
+    /// <summary>Entry names directly under a directory, WITHOUT following anything.</summary>
+    static string[] EntryNames(string dir) =>
+        Directory.Exists(dir)
+            ? [..Directory.EnumerateFileSystemEntries(dir).Select(Path.GetFileName).Where(n => n is not null)!]
+            : [];
+
+    /// <summary>Whether an entry exists at this path, including a DANGLING link.</summary>
+    static bool IsPresent(string path) {
+        try {
+            _ = File.GetAttributes(path);
+
+            return true;
+        } catch (FileNotFoundException) {
+            return false;
+        } catch (DirectoryNotFoundException) {
+            return false;
+        }
+    }
+
+    static bool IsLink(string path) =>
+        IsPresent(path) && File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint);
+
+    static string? LinkTargetOf(string path) =>
+        new FileInfo(path).LinkTarget ?? new DirectoryInfo(path).LinkTarget;
+
+    /// <summary>Windows needs Developer Mode or elevation to create a symlink, so these assert POSIX
+    /// behaviour where the daemon's worktrees actually live. Skipped rather than adapted: a Windows variant
+    /// that silently could not create the link would be a test that passes by doing nothing.</summary>
+    static void SkipUnlessPosixSymlinks() =>
+        Skip.Unless(!OperatingSystem.IsWindows(),
+            "POSIX symlink semantics — Windows symlink creation needs Developer Mode or elevation.");
+
+    /// <summary>Fixture git. Exit codes are CHECKED: an ignored failure here silently changes which
+    /// creation path <c>CreateAsync</c> selects.</summary>
+    static void Git(string cwd, params string[] args) {
+        var psi = new ProcessStartInfo("git") {
+            WorkingDirectory = cwd, RedirectStandardError = true, RedirectStandardOutput = true
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var p = Process.Start(psi)!;
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+
+        if (p.ExitCode != 0)
+            throw new InvalidOperationException($"fixture `git {string.Join(' ', args)}` failed: {stderr}");
+    }
+
+    static string GitCapture(string cwd, params string[] args) {
+        var psi = new ProcessStartInfo("git") {
+            WorkingDirectory = cwd, RedirectStandardError = true, RedirectStandardOutput = true
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var p = Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        p.WaitForExit();
+
+        return stdout;
+    }
+
+    /// <summary>Commits reachable in a repo. `rev-parse HEAD` is NOT usable as a commitless probe: on an
+    /// empty repo it prints the unresolvable name "HEAD" to stdout and fails, so a Trim()-is-empty check
+    /// silently never holds. This counts instead.</summary>
+    static string CommitCount(string repo) =>
+        GitCapture(repo, "rev-list", "--count", "--all").Trim();
+
+    static string[] CommittedPaths(string worktree) =>
+        [..GitCapture(worktree, "ls-tree", "-r", "--name-only", "HEAD")
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)];
+
+    static void Cleanup(string root) {
+        try { Directory.Delete(root, true); } catch { }
+    }
+
+    // ---- 1: it completes at all --------------------------------------------------------------------
+
+    /// <summary>The regression test for the recursion, and the positive control for every "not copied"
+    /// assertion below: if creation silently produced nothing, this fails first.
+    ///
+    /// <para>Asserts a known file is in <c>HEAD</c> rather than merely that a commit exists — a snapshot
+    /// that committed an empty tree would satisfy the weaker claim.</para></summary>
+    [Test]
+    public async Task Standalone_creation_completes_and_commits_the_source_content() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(worktree.IsStandalone).IsTrue();
+            await Assert.That(CommittedPaths(worktree.Path)).Contains("README.md");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    // ---- 2/3: outside links are not materialised ----------------------------------------------------
+
+    /// <summary>A link to an outside FILE must not bring the file's bytes in.
+    ///
+    /// <para>The regular file carrying the same sentinel is the positive control: without it, "the secret
+    /// is not in the snapshot" would pass just as well for a copy that produced nothing at all.</para>
+    /// </summary>
+    [Test]
+    public async Task Outside_file_link_is_not_materialised() {
+        SkipUnlessPosixSymlinks();
+        var (root, source) = MakeNonGitSource();
+        try {
+            const string secret = "SENTINEL-PRIVATE-KEY";
+            var outside = Path.Combine(root, "outside-secret.txt");
+            File.WriteAllText(outside, secret);
+            File.WriteAllText(Path.Combine(source, "control.txt"), secret);
+            File.CreateSymbolicLink(Path.Combine(source, "leak.txt"), outside);
+
+            await Assert.That(File.Exists(outside)).IsTrue().Because("fixture control: the target exists");
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(File.ReadAllText(Path.Combine(worktree.Path, "control.txt"))).IsEqualTo(secret)
+                .Because("positive control — an ordinary file with the same bytes IS copied");
+            await Assert.That(EntryNames(worktree.Path)).DoesNotContain("leak.txt")
+                .Because("the link entry itself must not be recreated, its target being outside the source");
+            await Assert.That(IsPresent(Path.Combine(worktree.Path, "leak.txt"))).IsFalse();
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>A link to an outside DIRECTORY must not bring the target tree in, and must not be walked.
+    /// </summary>
+    [Test]
+    public async Task Outside_directory_link_is_not_materialised() {
+        SkipUnlessPosixSymlinks();
+        var (root, source) = MakeNonGitSource();
+        try {
+            const string secret = "SENTINEL-IN-OUTSIDE-TREE";
+            var outsideDir = Path.Combine(root, "outside-tree");
+            Directory.CreateDirectory(outsideDir);
+            File.WriteAllText(Path.Combine(outsideDir, "id_rsa"), secret);
+
+            // Positive control: an ordinary sibling directory of real content, so a no-op copy cannot pass.
+            var ordinary = Path.Combine(source, "docs");
+            Directory.CreateDirectory(ordinary);
+            File.WriteAllText(Path.Combine(ordinary, "guide.md"), "real content");
+
+            Directory.CreateSymbolicLink(Path.Combine(source, "creds"), outsideDir);
+
+            await Assert.That(File.Exists(Path.Combine(outsideDir, "id_rsa"))).IsTrue()
+                .Because("fixture control: the outside tree exists");
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(File.ReadAllText(Path.Combine(worktree.Path, "docs", "guide.md")))
+                .IsEqualTo("real content").Because("positive control — ordinary directories ARE copied");
+            await Assert.That(EntryNames(worktree.Path)).DoesNotContain("creds");
+            await Assert.That(IsPresent(Path.Combine(worktree.Path, "creds", "id_rsa"))).IsFalse()
+                .Because("the target tree must never be materialised through the link");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    // ---- 4/5/6: link handling -----------------------------------------------------------------------
+
+    /// <summary>A directory link pointing at its own ancestor must terminate rather than recurse.
+    ///
+    /// <para>Also asserts the cycle link WAS recreated. Without that, an implementation which simply
+    /// dropped every link would satisfy this test while failing the one below.</para></summary>
+    [Test]
+    public async Task Link_cycle_terminates_and_the_link_is_recreated() {
+        SkipUnlessPosixSymlinks();
+        var (root, source) = MakeNonGitSource();
+        try {
+            var nested = Path.Combine(source, "nested");
+            Directory.CreateDirectory(nested);
+            // nested/loop -> .. : stays within the root at every step, so it is admissible AND cyclic.
+            Directory.CreateSymbolicLink(Path.Combine(nested, "loop"), "..");
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(IsLink(Path.Combine(worktree.Path, "nested", "loop"))).IsTrue()
+                .Because("an admissible link is recreated as a link — dropping every link must not pass");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>A legitimate internal link survives, as a link, with its raw target intact.</summary>
+    [Test]
+    public async Task Internal_relative_link_survives_as_a_link() {
+        SkipUnlessPosixSymlinks();
+        var (root, source) = MakeNonGitSource();
+        try {
+            var releases = Path.Combine(source, "releases", "v2");
+            Directory.CreateDirectory(releases);
+            File.WriteAllText(Path.Combine(releases, "payload.txt"), "v2 payload");
+            Directory.CreateSymbolicLink(Path.Combine(source, "current"), "releases/v2");
+
+            var worktree = await NewManager().CreateAsync(source);
+            var current = Path.Combine(worktree.Path, "current");
+
+            await Assert.That(IsLink(current)).IsTrue().Because("it must stay a link, not become a copy");
+            await Assert.That(LinkTargetOf(current)).IsEqualTo("releases/v2")
+                .Because("the raw target is preserved verbatim");
+            await Assert.That(File.ReadAllText(Path.Combine(current, "payload.txt"))).IsEqualTo("v2 payload")
+                .Because("and it still resolves to real content inside the snapshot");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>The relocation bug: a link that leaves the root and re-enters by the source directory's own
+    /// name resolves inside the source, but lands in a SIBLING worktree once recreated at the snapshot's
+    /// depth.
+    ///
+    /// <para>The sentinel is planted at the exact sibling path the transplanted target would reach, BEFORE
+    /// the call. Asserting merely that "nothing resolves to a sibling" would pass when nothing was ever
+    /// there — which is how this bug survives a careless test.</para></summary>
+    [Test]
+    public async Task Escape_and_reenter_link_is_skipped() {
+        SkipUnlessPosixSymlinks();
+        var (root, source) = MakeNonGitSource();
+        try {
+            const string secret = "SENTINEL-SIBLING-WORKTREE";
+            File.WriteAllText(Path.Combine(source, "secret.txt"), "in-source copy");
+
+            // `../proj/secret.txt` from the source root resolves back into the source. From
+            // <source>/.capacitor/worktrees/<name> it resolves to <...>/worktrees/proj/secret.txt.
+            File.CreateSymbolicLink(Path.Combine(source, "self"), "../proj/secret.txt");
+
+            var siblingDir = Path.Combine(source, ".capacitor", "worktrees", "proj");
+            Directory.CreateDirectory(siblingDir);
+            File.WriteAllText(Path.Combine(siblingDir, "secret.txt"), secret);
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(EntryNames(worktree.Path)).DoesNotContain("self")
+                .Because("a target that rises above the root is inadmissible even though it re-enters");
+            await Assert.That(IsPresent(Path.Combine(worktree.Path, "self"))).IsFalse();
+            await Assert.That(File.ReadAllText(Path.Combine(siblingDir, "secret.txt"))).IsEqualTo(secret)
+                .Because("fixture control: the sibling payload really was there to be reached");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    // ---- 7/8: .capacitor handling -------------------------------------------------------------------
+
+    /// <summary>A genuine <c>.Capacitor</c> directory of real source content is preserved. The destination
+    /// exclusion is a marker, not a name match, so it cannot mistake this for ours.</summary>
+    [Test]
+    public async Task Genuine_capacitor_directory_of_source_content_is_preserved() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            var genuine = Path.Combine(source, ".Capacitor");
+            Directory.CreateDirectory(genuine);
+            File.WriteAllText(Path.Combine(genuine, "product.cfg"), "real product config");
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            // On a case-insensitive volume `.Capacitor` and `.capacitor` are ONE directory, and it is ours;
+            // on a case-sensitive one they are distinct and this is genuine content that must survive.
+            var expected = Path.Combine(worktree.Path, ".Capacitor", "product.cfg");
+            if (!OperatingSystem.IsMacOS() && !OperatingSystem.IsWindows())
+                await Assert.That(File.ReadAllText(expected)).IsEqualTo("real product config");
+            else
+                await Assert.That(CommittedPaths(worktree.Path)).Contains("README.md")
+                    .Because("case-insensitive volume: the directory is ours, so only creation is asserted");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>A sibling agent worktree is not copied into the new snapshot, while unrelated content under
+    /// the same lowercase <c>.capacitor</c> survives.
+    ///
+    /// <para>The second half is what stops "drop the whole <c>.capacitor</c> directory" from satisfying
+    /// this test for entirely the wrong reason.</para></summary>
+    [Test]
+    public async Task Sibling_worktree_is_excluded_while_other_capacitor_content_survives() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            var sibling = Path.Combine(source, ".capacitor", "worktrees", "agent-old");
+            Directory.CreateDirectory(sibling);
+            File.WriteAllText(Path.Combine(sibling, "other-agent.txt"), "another agent's work");
+
+            var settings = Path.Combine(source, ".capacitor", "settings.json");
+            File.WriteAllText(settings, "{\"keep\":true}");
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(IsPresent(Path.Combine(worktree.Path, ".capacitor", "worktrees", "agent-old")))
+                .IsFalse().Because("a sibling agent's worktree is neither ours nor source content");
+            await Assert.That(File.ReadAllText(Path.Combine(worktree.Path, ".capacitor", "settings.json")))
+                .IsEqualTo("{\"keep\":true}")
+                .Because("dropping the whole .capacitor directory must NOT satisfy this test");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    // ---- 9/11: .git of any type ---------------------------------------------------------------------
+
+    /// <summary>A root <c>.git</c> GITFILE is excluded, and the outside repository it names gains no commit.
+    ///
+    /// <para>This is a write escape, not a leak: copied in, the snapshot's own <c>git init</c> would
+    /// re-initialise the referenced repository and <c>commit</c> into it. Reachable because
+    /// <c>IsGitRepoWithCommits</c> is <c>git rev-parse HEAD</c>, which follows a gitfile — so one naming a
+    /// COMMITLESS repo fails that check and takes this branch.</para></summary>
+    [Test]
+    public async Task Root_gitfile_is_excluded_and_the_outside_repository_gains_no_commit() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            var outsideRepo = Path.Combine(root, "outside-repo");
+            Directory.CreateDirectory(outsideRepo);
+            Git(outsideRepo, "init", "-q");
+            var outsideGitDir = Path.Combine(outsideRepo, ".git");
+
+            await Assert.That(CommitCount(outsideRepo)).IsEqualTo("0")
+                .Because("fixture control: the outside repo is commitless BEFORE the call");
+
+            File.WriteAllText(Path.Combine(source, ".git"), $"gitdir: {outsideGitDir}\n");
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(worktree.IsStandalone).IsTrue()
+                .Because("a gitfile naming a commitless repo fails rev-parse, so this IS the standalone path");
+            // The snapshot legitimately HAS a .git — its own, from `git init`. What must not survive is the
+            // copied gitfile, so assert the shape: a real directory, not a file naming somewhere else.
+            await Assert.That(Directory.Exists(Path.Combine(worktree.Path, ".git"))).IsTrue();
+            await Assert.That(File.Exists(Path.Combine(worktree.Path, ".git"))).IsFalse()
+                .Because("a copied gitfile would leave .git as a FILE pointing at the outside repository");
+            await Assert.That(CommittedPaths(worktree.Path)).Contains("README.md")
+                .Because("creation still succeeds with the known file committed");
+            await Assert.That(CommitCount(outsideRepo)).IsEqualTo("0")
+                .Because("the outside repository must have gained NO commit");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>A <c>.git</c> SYMLINK is excluded too — same control data, different entry type.
+    ///
+    /// <para>The target is deliberately RELATIVE and inside the source, so the link rule would happily
+    /// admit it and only the <c>.git</c> name rule can exclude it. An earlier version of this test pointed
+    /// the link at an absolute outside path, which the link rule already rejects — so it passed with the
+    /// <c>.git</c> exclusion entirely disabled and proved nothing.</para></summary>
+    [Test]
+    public async Task Git_symlink_is_excluded() {
+        SkipUnlessPosixSymlinks();
+        var (root, source) = MakeNonGitSource();
+        try {
+            // A real repository directory living INSIDE the source, under an ordinary name.
+            var innerRepo = Path.Combine(source, "vendored");
+            Directory.CreateDirectory(innerRepo);
+            Git(innerRepo, "init", "-q");
+
+            Directory.CreateSymbolicLink(Path.Combine(source, ".git"), "vendored/.git");
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(CommittedPaths(worktree.Path)).Contains("README.md");
+            await Assert.That(EntryNames(worktree.Path).Count(n => n == ".git")).IsEqualTo(1)
+                .Because("exactly one .git — the snapshot's own, from git init");
+            await Assert.That(IsLink(Path.Combine(worktree.Path, ".git"))).IsFalse()
+                .Because("the copied link must not have survived as the snapshot's .git");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    // ---- 10: chain through a skipped link ------------------------------------------------------------
+
+    /// <summary>An admissible prefix link is recreated; only the outside-pointing terminal link is dropped,
+    /// leaving the chain unreachable rather than resolving out of the snapshot.
+    ///
+    /// <para>Asserting only unreachability would pass if the implementation dropped the ENTIRE chain, which
+    /// is why the prefix link is asserted present.</para></summary>
+    [Test]
+    public async Task Chain_through_a_skipped_link_is_unreachable_but_the_allowed_prefix_survives() {
+        SkipUnlessPosixSymlinks();
+        var (root, source) = MakeNonGitSource();
+        try {
+            const string secret = "SENTINEL-VIA-CHAIN";
+            var outsideDir = Path.Combine(root, "outside-chain");
+            Directory.CreateDirectory(outsideDir);
+            File.WriteAllText(Path.Combine(outsideDir, "token"), secret);
+
+            var hop = Path.Combine(source, "hop");
+            Directory.CreateDirectory(hop);
+            // hop/out -> outside  (inadmissible, dropped)
+            Directory.CreateSymbolicLink(Path.Combine(hop, "out"), outsideDir);
+            // via -> hop          (admissible, recreated)
+            Directory.CreateSymbolicLink(Path.Combine(source, "via"), "hop");
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(IsLink(Path.Combine(worktree.Path, "via"))).IsTrue()
+                .Because("the admissible prefix link must survive — dropping the whole chain must not pass");
+            await Assert.That(EntryNames(Path.Combine(worktree.Path, "hop"))).DoesNotContain("out")
+                .Because("only the outside-pointing terminal link is dropped");
+            await Assert.That(IsPresent(Path.Combine(worktree.Path, "via", "out", "token"))).IsFalse()
+                .Because("the chain must not resolve out of the snapshot");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    // ---- 12: destination chain links -----------------------------------------------------------------
+
+    /// <summary>A <c>.capacitor</c> or <c>worktrees</c> component that is a link is refused fail-closed,
+    /// and nothing is created through it.
+    ///
+    /// <para>The "nothing was created" half matters because validation performed AFTER creation would still
+    /// throw and would still pass a test that only asserted the exception.</para></summary>
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task Reparse_point_in_the_destination_chain_is_refused(bool dangling) {
+        SkipUnlessPosixSymlinks();
+        var (root, source) = MakeNonGitSource();
+        try {
+            var elsewhere = Path.Combine(root, "elsewhere");
+            if (!dangling) Directory.CreateDirectory(elsewhere);
+
+            Directory.CreateSymbolicLink(Path.Combine(source, ".capacitor"), elsewhere);
+
+            await Assert.That(async () => await NewManager().CreateAsync(source))
+                .Throws<InvalidOperationException>();
+            await Assert.That(EntryNames(elsewhere)).IsEmpty()
+                .Because("nothing may be created THROUGH the link — a post-creation check would also throw");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>Same rule one level down: a linked <c>worktrees</c> is refused.</summary>
+    [Test]
+    public async Task Reparse_point_at_the_worktrees_level_is_refused() {
+        SkipUnlessPosixSymlinks();
+        var (root, source) = MakeNonGitSource();
+        try {
+            var elsewhere = Path.Combine(root, "elsewhere");
+            Directory.CreateDirectory(elsewhere);
+            Directory.CreateDirectory(Path.Combine(source, ".capacitor"));
+            Directory.CreateSymbolicLink(Path.Combine(source, ".capacitor", "worktrees"), elsewhere);
+
+            await Assert.That(async () => await NewManager().CreateAsync(source))
+                .Throws<InvalidOperationException>();
+            await Assert.That(EntryNames(elsewhere)).IsEmpty();
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    // ---- 13: occupied destination --------------------------------------------------------------------
+
+    /// <summary>A pre-existing ordinary destination directory is refused and left untouched.
+    ///
+    /// <para>Two failures in one: <c>Directory.CreateDirectory</c> is a no-op on an existing directory, so
+    /// the snapshot would overlay a tree we never created and the rollback would then delete it wholesale;
+    /// and control data already sitting there escapes the SOURCE-side <c>.git</c> exclusion entirely,
+    /// putting <c>git init</c>/<c>commit</c> back outside the snapshot.</para></summary>
+    [Test]
+    public async Task Occupied_destination_is_refused_and_left_untouched() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            var outsideRepo = Path.Combine(root, "outside-repo");
+            Directory.CreateDirectory(outsideRepo);
+            Git(outsideRepo, "init", "-q");
+
+            var occupied = Path.Combine(source, ".capacitor", "worktrees", "taken");
+            Directory.CreateDirectory(occupied);
+            File.WriteAllText(Path.Combine(occupied, "precious.txt"), "not ours to delete");
+            File.WriteAllText(Path.Combine(occupied, ".git"),
+                $"gitdir: {Path.Combine(outsideRepo, ".git")}\n");
+
+            await Assert.That(async () => await NewManager().CreateAsync(source, "taken"))
+                .Throws<InvalidOperationException>();
+
+            await Assert.That(File.ReadAllText(Path.Combine(occupied, "precious.txt")))
+                .IsEqualTo("not ours to delete").Because("rollback must not delete a tree we never created");
+            await Assert.That(IsPresent(Path.Combine(occupied, ".git"))).IsTrue()
+                .Because("the pre-existing control data is untouched");
+            await Assert.That(CommitCount(outsideRepo)).IsEqualTo("0")
+                .Because("and nothing was committed into the repository it names");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    // ---- 14: claim ownership --------------------------------------------------------------------------
+
+    /// <summary>Two concurrent calls for the same name: exactly one wins, and the winner's snapshot is
+    /// intact.</summary>
+    [Test]
+    public async Task Concurrent_same_name_creates_yield_one_winner() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            var manager = NewManager();
+            var a = Task.Run(() => manager.CreateAsync(source, "contended"));
+            var b = Task.Run(() => manager.CreateAsync(source, "contended"));
+
+            var results = await Task.WhenAll(
+                a.ContinueWith(t => t.IsCompletedSuccessfully),
+                b.ContinueWith(t => t.IsCompletedSuccessfully));
+
+            await Assert.That(results.Count(ok => ok)).IsEqualTo(1)
+                .Because("the claim is atomic — exactly one caller may own the destination");
+            await Assert.That(CommittedPaths(Path.Combine(source, ".capacitor", "worktrees", "contended")))
+                .Contains("README.md").Because("the winner's snapshot must be intact");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>The claim is still held while the loser of a FAILED call is rolling back.
+    ///
+    /// <para>Deterministic rather than a wall-clock race: a simultaneous-start test cannot exercise this
+    /// window, and a timing-based one would be flaky and could pass by luck. If the claim were released in
+    /// the build method's own <c>finally</c>, a second caller would acquire here — and the first call's
+    /// delayed rollback would then delete the second's freshly created tree.</para></summary>
+    [Test, NotInParallel]
+    public async Task Claim_is_held_through_rollback() {
+        var (root, source) = MakeNonGitSource();
+        var inRollback = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+        try {
+            WorktreeManager.SnapshotFailurePoint = "CopySnapshotTree";
+            WorktreeManager.SnapshotRollbackHook = async () => {
+                inRollback.TrySetResult();
+                await release.Task;
+            };
+
+            var manager = NewManager();
+            var failing = Task.Run(() => manager.CreateAsync(source, "held"));
+
+            await inRollback.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+            // The first call is parked inside its rollback, holding the claim.
+            WorktreeManager.SnapshotFailurePoint = null;
+            await Assert.That(async () => await manager.CreateAsync(source, "held"))
+                .Throws<InvalidOperationException>()
+                .Because("the claim must still exclude a same-name caller during rollback");
+
+            release.TrySetResult();
+            await Assert.That(async () => await failing).Throws<InvalidOperationException>();
+
+            // Once released, the name is usable again and the snapshot that follows is intact.
+            var after = await manager.CreateAsync(source, "held");
+            await Assert.That(CommittedPaths(after.Path)).Contains("README.md");
+        } finally {
+            WorktreeManager.SnapshotFailurePoint = null;
+            WorktreeManager.SnapshotRollbackHook = null;
+            release.TrySetResult();
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>A caller that LOSES the claim performs no destination cleanup.
+    ///
+    /// <para>The rollback is unconditional on the destination path, so a loser falling through it would
+    /// delete the winner's directory — a claim that made things strictly worse than no claim.</para>
+    /// </summary>
+    [Test]
+    public async Task Claim_loser_leaves_the_winners_destination_untouched() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            var manager = NewManager();
+            var winner = await manager.CreateAsync(source, "owned");
+
+            // Re-take the claim by hand to force the next call down the loser path.
+            var claimPath = Path.Combine(
+                source, ".capacitor", "worktrees", WorktreeManager.ClaimPrefix + "owned");
+            File.WriteAllText(claimPath, "");
+
+            await Assert.That(async () => await manager.CreateAsync(source, "owned"))
+                .Throws<InvalidOperationException>();
+
+            await Assert.That(CommittedPaths(winner.Path)).Contains("README.md")
+                .Because("the loser must not have deleted the winner's tree");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    // ---- 15: name validation ---------------------------------------------------------------------------
+
+    /// <summary>A name that is not a single safe path component is refused before anything is created.
+    /// Defense-in-depth: both real callers omit <c>name</c>, but the method is public.</summary>
+    [Test]
+    [Arguments("../evil")]
+    [Arguments("nested/child")]
+    [Arguments("..")]
+    [Arguments(".")]
+    [Arguments("")]
+    public async Task Unsafe_names_are_refused(string name) {
+        var (root, source) = MakeNonGitSource();
+        try {
+            await Assert.That(async () => await NewManager().CreateAsync(source, name))
+                .Throws<InvalidOperationException>();
+            await Assert.That(IsPresent(Path.Combine(root, "evil"))).IsFalse()
+                .Because("no escaped path may be created");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    [Test]
+    public async Task Absolute_name_is_refused() {
+        var (root, source) = MakeNonGitSource();
+        var absolute = Path.Combine(root, "absolute-escape");
+        try {
+            await Assert.That(async () => await NewManager().CreateAsync(source, absolute))
+                .Throws<InvalidOperationException>();
+            await Assert.That(IsPresent(absolute)).IsFalse();
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    // ---- 16: marker lifetime ---------------------------------------------------------------------------
+
+    /// <summary>The marker and claim are cleaned up on success, and a user file that merely resembles a
+    /// marker does not suppress its own directory.</summary>
+    [Test]
+    public async Task Bookkeeping_files_are_cleaned_up_and_a_lookalike_is_not_honoured() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            // A user file whose name is marker-SHAPED but is not this invocation's marker.
+            var decoy = Path.Combine(source, "data");
+            Directory.CreateDirectory(decoy);
+            File.WriteAllText(Path.Combine(decoy, ".kcap-snapshot-exclude-deadbeef"), "not ours");
+            File.WriteAllText(Path.Combine(decoy, "real.txt"), "must survive");
+
+            var worktree = await NewManager().CreateAsync(source, "tidy");
+
+            await Assert.That(File.ReadAllText(Path.Combine(worktree.Path, "data", "real.txt")))
+                .IsEqualTo("must survive")
+                .Because("only this invocation's EXACT marker name suppresses a directory");
+
+            var worktreeRoot = Path.Combine(source, ".capacitor", "worktrees");
+            await Assert.That(EntryNames(worktreeRoot).Where(n => n.StartsWith(".kcap-"))).IsEmpty()
+                .Because("marker and claim are both released once the snapshot is built");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>Cleanup also happens on failure, so a crashed launch does not permanently block its name
+    /// through a leaked marker.</summary>
+    [Test, NotInParallel]
+    public async Task Bookkeeping_files_are_cleaned_up_on_failure() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            WorktreeManager.SnapshotFailurePoint = "CopySnapshotTree";
+
+            await Assert.That(async () => await NewManager().CreateAsync(source, "doomed"))
+                .Throws<InvalidOperationException>();
+
+            var worktreeRoot = Path.Combine(source, ".capacitor", "worktrees");
+            await Assert.That(EntryNames(worktreeRoot).Where(n => n.StartsWith(".kcap-"))).IsEmpty()
+                .Because("a failed launch must not leak its marker or claim");
+            await Assert.That(IsPresent(Path.Combine(worktreeRoot, "doomed"))).IsFalse()
+                .Because("the claimant's own partial tree is rolled back");
+        } finally {
+            WorktreeManager.SnapshotFailurePoint = null;
+            Cleanup(root);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/StandaloneSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/StandaloneSnapshotTests.cs
@@ -814,4 +814,64 @@ public class StandaloneSnapshotTests {
         }
     }
 
+
+    // ---- special files ---------------------------------------------------------------------------------
+
+    /// <summary>A FIFO in the source neither hangs the launch nor is opened.
+    ///
+    /// <para>Reachable AT REST, which is why it matters: this branch runs on non-git sources and copies the
+    /// live tree, so a FIFO can sit in a plain directory, an extracted archive, or a commitless repository
+    /// with no concurrent writer involved. <c>File.Copy</c> on one blocks forever waiting for a writer
+    /// (measured), and no portable API can tell it from an empty regular file — same attributes, same mode,
+    /// same zero length. The zero-length rule is what avoids opening it.</para>
+    ///
+    /// <para>The test has its own watchdog rather than relying on the suite's: a regression here HANGS, and
+    /// a hang reports as a timeout somewhere else entirely rather than as this assertion.</para></summary>
+    [Test]
+    public async Task A_fifo_in_the_source_neither_hangs_nor_is_opened() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX FIFO semantics.");
+        var (root, source) = MakeNonGitSource();
+        try {
+            var fifo = Path.Combine(source, "pipe");
+            using (var mk = Process.Start(new ProcessStartInfo("mkfifo", fifo))!) {
+                mk.WaitForExit();
+                Skip.Unless(mk.ExitCode == 0, "mkfifo unavailable");
+            }
+            await Assert.That(IsPresent(fifo)).IsTrue().Because("fixture control: the FIFO exists");
+
+            var create = Task.Run(() => NewManager().CreateAsync(source));
+            var finished = await Task.WhenAny(create, Task.Delay(TimeSpan.FromSeconds(60))) == create;
+
+            await Assert.That(finished).IsTrue()
+                .Because("a special file must never block the copy — this is the regression that hangs");
+
+            var worktree = await create;
+            await Assert.That(CommittedPaths(worktree.Path)).Contains("README.md")
+                .Because("positive control — the snapshot really was built, not merely non-hanging");
+
+            var copied = Path.Combine(worktree.Path, "pipe");
+            await Assert.That(IsPresent(copied)).IsTrue();
+            await Assert.That(new FileInfo(copied).Length).IsEqualTo(0)
+                .Because("it degrades to an empty ordinary file — never opened, never materialised");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>An ordinary EMPTY file still round-trips, so the zero-length rule cannot be satisfied by
+    /// dropping empty files instead of creating them.</summary>
+    [Test]
+    public async Task An_empty_regular_file_is_still_copied() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            File.WriteAllText(Path.Combine(source, "empty.txt"), "");
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(IsPresent(Path.Combine(worktree.Path, "empty.txt"))).IsTrue();
+            await Assert.That(new FileInfo(Path.Combine(worktree.Path, "empty.txt")).Length).IsEqualTo(0);
+        } finally {
+            Cleanup(root);
+        }
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/StandaloneSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/StandaloneSnapshotTests.cs
@@ -519,28 +519,47 @@ public class StandaloneSnapshotTests {
 
     // ---- 14: claim ownership --------------------------------------------------------------------------
 
-    /// <summary>Two concurrent calls for the same name: exactly one wins, and the winner's snapshot is
-    /// intact.</summary>
-    [Test]
+    /// <summary>Two callers genuinely overlapping in the window where BOTH still see the destination
+    /// absent: exactly one wins, the loser is refused by the CLAIM, and the winner's snapshot is intact.
+    ///
+    /// <para>The barrier is load-bearing. Without it the two calls can run sequentially, and the second is
+    /// then refused by the occupied-destination check instead — so the test passes with exactly the same
+    /// counts even if the claim were removed or made non-atomic, never exercising the property it
+    /// names.</para></summary>
+    [Test, NotInParallel]
     public async Task Concurrent_same_name_creates_yield_one_winner() {
         var (root, source) = MakeNonGitSource();
+        var arrived = 0;
+        var bothArrived = new TaskCompletionSource();
         try {
+            WorktreeManager.SnapshotPreClaimHook = async () => {
+                if (Interlocked.Increment(ref arrived) == 2) bothArrived.TrySetResult();
+                await bothArrived.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            };
+
             var manager = NewManager();
             var a = Task.Run(() => manager.CreateAsync(source, "contended"));
             var b = Task.Run(() => manager.CreateAsync(source, "contended"));
 
-            var results = await Task.WhenAll(
-                a.ContinueWith(t => t.IsCompletedSuccessfully),
-                b.ContinueWith(t => t.IsCompletedSuccessfully));
+            var outcomes = await Task.WhenAll(
+                a.ContinueWith(t => t.IsCompletedSuccessfully ? null : Message(t)),
+                b.ContinueWith(t => t.IsCompletedSuccessfully ? null : Message(t)));
 
-            await Assert.That(results.Count(ok => ok)).IsEqualTo(1)
+            await Assert.That(outcomes.Count(m => m is null)).IsEqualTo(1)
                 .Because("the claim is atomic — exactly one caller may own the destination");
+            await Assert.That(outcomes.Single(m => m is not null)).Contains("standalone_snapshot_name_in_use")
+                .Because("the loser must be refused by the CLAIM, not by the occupied-destination check — "
+                       + "the latter would mean the two calls never actually overlapped");
             await Assert.That(CommittedPaths(Path.Combine(source, ".capacitor", "worktrees", "contended")))
                 .Contains("README.md").Because("the winner's snapshot must be intact");
         } finally {
+            WorktreeManager.SnapshotPreClaimHook = null;
+            bothArrived.TrySetResult();
             Cleanup(root);
         }
     }
+
+    static string Message(Task t) => t.Exception?.GetBaseException().Message ?? "<no exception>";
 
     /// <summary>The claim is still held while the loser of a FAILED call is rolling back.
     ///
@@ -693,6 +712,92 @@ public class StandaloneSnapshotTests {
                 .Because("the claimant's own partial tree is rolled back");
         } finally {
             WorktreeManager.SnapshotFailurePoint = null;
+            Cleanup(root);
+        }
+    }
+
+    // ---- link kind, claim lookalike, and special files ------------------------------------------------
+
+    /// <summary>An admissible FILE link is recreated as a link that resolves to file content.
+    ///
+    /// <para><b>This does NOT verify the link KIND, and cannot here.</b> Windows records file-vs-directory
+    /// in the reparse point itself, which is the whole reason the production code branches on the source
+    /// attributes — but POSIX symlinks carry no type, so <c>Directory.CreateSymbolicLink</c> and
+    /// <c>File.CreateSymbolicLink</c> are indistinguishable on this platform. Mutation-checked and
+    /// confirmed: forcing the directory API still passes this test. The Windows leg cannot cover it either,
+    /// because creating a symlink there needs Developer Mode or elevation, which CI does not have — hence
+    /// <see cref="SkipUnlessPosixSymlinks"/>. The kind branch is therefore reasoned, not verified; this test
+    /// guards the weaker property that an admissible file link survives and resolves.</para></summary>
+    [Test]
+    public async Task An_admissible_file_link_is_recreated_as_a_file_link() {
+        SkipUnlessPosixSymlinks();
+        var (root, source) = MakeNonGitSource();
+        try {
+            File.WriteAllText(Path.Combine(source, "target.txt"), "payload");
+            File.CreateSymbolicLink(Path.Combine(source, "alias.txt"), "target.txt");
+
+            var worktree = await NewManager().CreateAsync(source);
+            var alias = Path.Combine(worktree.Path, "alias.txt");
+
+            await Assert.That(IsLink(alias)).IsTrue();
+            await Assert.That(File.GetAttributes(alias).HasFlag(FileAttributes.Directory)).IsFalse()
+                .Because("a file link recreated as a directory link is wrong on Windows");
+            await Assert.That(File.ReadAllText(alias)).IsEqualTo("payload");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>A source file that merely LOOKS like the daemon's claim bookkeeping is ordinary content and
+    /// must be copied.
+    ///
+    /// <para>The real claim lives in the worktrees root, which the marker already excludes wholesale, so a
+    /// prefix rule over the whole tree would buy nothing and silently drop this.</para></summary>
+    [Test]
+    public async Task A_source_file_named_like_a_claim_is_preserved() {
+        var (root, source) = MakeNonGitSource();
+        try {
+            var docs = Path.Combine(source, "docs");
+            Directory.CreateDirectory(docs);
+            File.WriteAllText(Path.Combine(docs, ".kcap-claim-notes"), "ordinary content");
+
+            var worktree = await NewManager().CreateAsync(source);
+
+            await Assert.That(File.ReadAllText(Path.Combine(worktree.Path, "docs", ".kcap-claim-notes")))
+                .IsEqualTo("ordinary content")
+                .Because("only the daemon's own bookkeeping directory is excluded, not a name prefix");
+        } finally {
+            Cleanup(root);
+        }
+    }
+
+    /// <summary>A FIFO in the source fails the snapshot closed instead of hanging the launch.
+    ///
+    /// <para>.NET reports a FIFO with exactly the same <c>FileAttributes</c>, <c>UnixFileMode</c> and zero
+    /// length as an ordinary empty file — measured — so it cannot be identified and skipped. The copy is
+    /// bounded instead, turning an indefinite block by hostile content into an attributable refusal. The
+    /// timeout is shortened here so the test does not wait for the production bound.</para></summary>
+    [Test, NotInParallel]
+    public async Task A_fifo_in_the_source_fails_closed_rather_than_hanging() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX FIFO semantics.");
+        var (root, source) = MakeNonGitSource();
+        var original = WorktreeManager.CopyEntryTimeout;
+        try {
+            WorktreeManager.CopyEntryTimeout = TimeSpan.FromSeconds(2);
+
+            var fifo = Path.Combine(source, "pipe");
+            using (var mk = Process.Start(new ProcessStartInfo("mkfifo", fifo))!) {
+                mk.WaitForExit();
+                Skip.Unless(mk.ExitCode == 0, "mkfifo unavailable");
+            }
+
+            await Assert.That(IsPresent(fifo)).IsTrue().Because("fixture control: the FIFO exists");
+
+            await Assert.That(async () => await NewManager().CreateAsync(source))
+                .Throws<InvalidOperationException>()
+                .Because("an entry that cannot be copied promptly must refuse, not wedge the daemon");
+        } finally {
+            WorktreeManager.CopyEntryTimeout = original;
             Cleanup(root);
         }
     }

--- a/test/Capacitor.Cli.Tests.Unit/WorkspaceMcpNeutralizationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorkspaceMcpNeutralizationTests.cs
@@ -396,6 +396,58 @@ public class WorkspaceMcpNeutralizationTests {
         Skip.Unless(!OperatingSystem.IsWindows(),
             "POSIX symlink semantics — Windows symlink creation needs Developer Mode or elevation.");
 
+    /// <summary>The standalone end-to-end case: a NON-GIT source carrying a workspace MCP config yields a
+    /// snapshot with that config stripped, and absent from the initial commit too.
+    ///
+    /// <para>Removed while the standalone copy was broken, because the branch could not complete at all.
+    /// Restored now that it can. This is the only test that exercises the strip through the real standalone
+    /// creation path rather than against a hand-built directory.</para>
+    ///
+    /// <para>The source is asserted NON-GIT first. Without that, a fixture that accidentally produced a
+    /// repo with commits would send this down the linked-worktree branch, and the test would pass while
+    /// proving nothing about standalone at all.</para></summary>
+    [Test]
+    public async Task Standalone_snapshot_of_a_non_git_source_strips_workspace_mcp_config() {
+        var root   = Path.Combine(Path.GetTempPath(), "kcap-standalone-mcp-" + Guid.NewGuid().ToString("N")[..8]);
+        var source = Path.Combine(root, "proj");
+        try {
+            Directory.CreateDirectory(source);
+            File.WriteAllText(Path.Combine(source, "README.md"), "hello");
+            File.WriteAllText(Path.Combine(source, ".mcp.json"),
+                """{"mcpServers":{"evil":{"command":"/bin/sh"}}}""");
+
+            await Assert.That(Directory.Exists(Path.Combine(source, ".git"))).IsFalse()
+                .Because("fixture precondition: a git repo here would take the LINKED branch instead");
+
+            var worktree = await Manager().CreateAsync(source);
+
+            await Assert.That(worktree.IsStandalone).IsTrue()
+                .Because("this test is meaningless unless the standalone branch actually ran");
+            await Assert.That(File.Exists(Path.Combine(worktree.Path, ".mcp.json"))).IsFalse()
+                .Because("the branch-authored config must not reach the agent's worktree");
+
+            var committed = GitCapture(worktree.Path, "ls-tree", "-r", "--name-only", "HEAD");
+            await Assert.That(committed).Contains("README.md")
+                .Because("positive control — the snapshot really did commit the source");
+            await Assert.That(committed).DoesNotContain(".mcp.json")
+                .Because("stripping before the commit is the point: a later checkout would restore it");
+        } finally {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    static string GitCapture(string cwd, params string[] args) {
+        var psi = new ProcessStartInfo("git") {
+            WorkingDirectory = cwd, RedirectStandardError = true, RedirectStandardOutput = true
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var p = Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        p.WaitForExit();
+
+        return stdout;
+    }
+
     /// <summary>Fixture git. Exit codes are CHECKED: an ignored failure here silently changes which
     /// creation path <see cref="WorktreeManager.CreateAsync"/> selects (a repo that failed to commit is
     /// not "a git repo with commits", so it takes the standalone branch), and the test would then pass


### PR DESCRIPTION
Linear: AI-1675. No GitHub issue — this one originated in Linear, out of the AI-1632 work (#427), so filing one now would auto-import as a duplicate.

## The problem

`WorktreeManager.CreateAsync` takes a **standalone** branch when the source is not a git repo with commits: it copies the directory, then `git init` / `add` / `commit`. That branch has **never once completed**. `CopyDirectory`'s destination is `<source>/.capacitor/worktrees/<name>` — inside the tree it walks — so it recursed into its own output until the path length blew up. It surfaced only when #427 added the first test to cover it.

Repairing only the recursion would have *armed* a worse latent bug in the same method: `File.Copy` copies a symlink's **target**, and recursion through a directory link copies the **target tree**. A source containing a link to `~/.ssh` would have materialised real credentials inside the agent's worktree as ordinary files — indistinguishable from repository content and outside any path-based sandbox. That is exactly what happened during #427, which is why the repair was reverted rather than shipped half-done.

Both are fixed here, together.

## What changed

`CopyDirectory` is replaced by a no-follow walk that classifies every entry by `FileAttributes.ReparsePoint` before touching it, mirroring the existing `DeleteTreeNoFollow` in the same class.

- **Destination exclusion is a per-invocation marker file, not a name match.** Detected by *reading* a directory rather than comparing names or paths, so it is correct under case-sensitive and case-insensitive semantics alike — nothing is inferred from the OS. A genuine `.Capacitor` directory of source content carries no marker and is copied normally. Sibling agent worktrees are excluded too.
- **Links are recreated as links or skipped, never materialised.** A relative target whose component walk never rises above the root is recreated verbatim; anything rooted or escaping is skipped and logged. Directory links are never recursed into, so cycles are impossible.

A codex spec review (7 rounds) then found four defects in the repair itself, each of which is fixed and tested:

- **`.git` is excluded as an entry of any type.** A `.git` *file* (`gitdir: …`) naming a **commitless** repo fails the `rev-parse HEAD` probe, so it reaches this branch, gets copied, and the snapshot's own `git init` re-initialises the referenced repository and commits into it. That is a **write escape**, not a leak.
- **Link containment requires the walk to never escape, not merely to resolve inside.** `self -> ../<source-dir>/secret` resolves inside the source, but recreated at the snapshot's depth the identical raw target lands in a **sibling agent's worktree**. Reachable with a completely quiescent source.
- **The destination chain is validated no-follow before anything is created.** `Directory.CreateDirectory` follows a pre-existing `.capacitor` symlink, which would reroot the snapshot while a lexical check still passed. This required moving the shared `CreateDirectory` into each branch — the linked-worktree branch is behaviourally unchanged.
- **The destination is claimed atomically, must be absent, and the claim outlives rollback.** An existing directory would be silently adopted and then deleted wholesale by the rollback; and a claim released before rollback reopens the race it closes, because the build method unwinds *before* the outer catch deletes the tree.

## Known limitation, deliberately not closed

Classification and the subsequent read are not atomic, and .NET exposes no portable no-follow open (`O_NOFOLLOW`/`openat`) for an AOT binary. A principal able to swap an entry between the two can still get the target's bytes copied. This is **documented rather than fixed**, as an owner decision, and ships as an operator precondition in the README's Daemon section — a documented precondition nobody can read isn't delivered.

## Tests

51 new tests. `SnapshotPathRulesTests` covers the two pure decision rules without a filesystem; `StandaloneSnapshotTests` drives everything else through the public `CreateAsync`. The standalone end-to-end MCP case removed in #427 is restored.

Absence is never asserted with `File.Exists`/`Path.Exists` — both follow, so a dangling link reports absent and a "not copied" assertion passes for the wrong reason. Every such check reads the parent directory and the entry's own attributes.

Guards were mutation-checked. That caught a genuinely vacuous test: the `.git`-symlink case originally pointed at an absolute outside path, which the *link* rule already rejects, so it passed with the `.git` exclusion entirely disabled and proved nothing. It now uses a relative in-source target, so only the `.git` rule can exclude it.

Local suite: 51 failures on this branch vs **53 on `origin/main`** in a detached baseline worktree — the reds are the known pre-existing macOS set, and this adds none.
