### PR TITLE
[AI-1240] Advertise the form-mode elicitation client capability

### DIFF
--- a/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
+++ b/src/Capacitor.Cli.Core/Acp/AcpMessages.cs
@@ -18,7 +18,9 @@ namespace Capacitor.Cli.Core.Acp;
 /// <summary>
 /// <c>initialize</c> params. Deliberately advertises MINIMAL client capabilities (no <c>fs</c>, no
 /// <c>terminal</c>) — those get decided later based on ACP probe findings; this type implements
-/// neither capability.
+/// neither capability. Since the multi-select end-to-end shipped (form-mode elicitation lane in
+/// this daemon + the server/UI half in kcap-server), <see cref="ClientCapabilities.Elicitation"/>
+/// advertises FORM-mode elicitation support.
 /// </summary>
 public sealed record InitializeParams(
     [property: JsonPropertyName("protocolVersion")]  int                     ProtocolVersion,
@@ -27,8 +29,27 @@ public sealed record InitializeParams(
 
 public sealed record ClientCapabilities(
     [property: JsonPropertyName("fs")]       FsCapabilities Fs,
-    [property: JsonPropertyName("terminal")] bool           Terminal
+    [property: JsonPropertyName("terminal")] bool           Terminal,
+    // Trailing + WhenWritingNull so every pre-existing 2-arg construction (and its wire shape)
+    // stays byte-for-byte unchanged; the runtime's initialize call sites opt in explicitly.
+    [property: JsonPropertyName("elicitation"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+                                             ElicitationCapabilities? Elicitation = null
 );
+
+/// <summary>
+/// Client elicitation capability advertisement (marked UNSTABLE in the SDK schema — pinned by
+/// the fixture generator's drift contract, see <c>test-fixtures/acp-elicitation/generate.mjs</c>).
+/// FORM mode only: supplying <c>{}</c> for <see cref="Form"/> means "form-based elicitation
+/// supported" per the schema. <c>url</c> is DELIBERATELY not modeled — omission is the spec's
+/// "unsupported" signal, and this daemon cancels url-mode frames
+/// (<c>AcpInteractionBridge</c>'s mode gate) rather than opening arbitrary URLs on the host.
+/// </summary>
+public sealed record ElicitationCapabilities(
+    [property: JsonPropertyName("form")] ElicitationFormCapabilities Form
+);
+
+/// <summary>Serializes as the bare <c>{}</c> the schema requires for "supported".</summary>
+public sealed record ElicitationFormCapabilities;
 
 /// <summary>
 /// <c>initialize</c> result — <c>AcpHostedAgentRuntime.StartAsync</c> deserializes the agent's
@@ -218,11 +239,11 @@ public sealed record PermissionOutcomeDto(
 /// Scope variants: session-scoped (<see cref="SessionId"/>) or request-scoped
 /// (<see cref="RequestId"/>, unsupported — cancelled). Every member is nullable at the DTO
 /// layer: <c>Capacitor.Cli.Daemon.Acp.AcpInteractionBridge</c> owns ALL semantic validation
-/// (a non-nullable C# string would not guarantee the wire supplied one). The daemon still never
-/// advertises the <c>elicitation</c> client capability (see
-/// <c>AcpHostedAgentRuntime.StartAsync</c>'s minimal <see cref="ClientCapabilities"/>) — that
-/// flip ships with the end-to-end multi-select work; until then this lane answers unsolicited
-/// frames spec-correctly instead of with the old malformed <c>{outcome}</c> result.
+/// (a non-nullable C# string would not guarantee the wire supplied one). The daemon now
+/// advertises the <c>elicitation</c> client capability (form mode only — see
+/// <see cref="ElicitationCapabilities"/> and <c>AcpHostedAgentRuntime</c>'s initialize call
+/// sites), the end-to-end multi-select work having shipped; this lane also still answers
+/// UNSOLICITED frames spec-correctly instead of with the old malformed <c>{outcome}</c> result.
 /// <see cref="RequestedSchema"/> is forwarded to the server verbatim for audit (capped
 /// server-side); the daemon's own <c>ElicitationSchemaClassifier</c> parses it separately.
 /// </summary>

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -563,12 +563,16 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // Advertise NO client fs/terminal: cursor-agent does file/shell ops itself and never asks
             // the client to serve them (rationale: docs/ai-687-fs-terminal-capability-decision-design.md).
             // Any unadvertised request is declined -32601 by AcpConnection, never falsely acknowledged.
+            // Elicitation IS advertised (form mode only, never url) — the end-to-end multi-select
+            // lane shipped on both sides, so agents may now send elicitation/create; the bridge's
+            // gate pipeline still owns every per-frame accept/cancel decision.
             var initializeParams = JsonSerializer.SerializeToElement(
                 new InitializeParams(
                     ProtocolVersion: 1,
                     ClientCapabilities: new ClientCapabilities(
                         Fs: new FsCapabilities(ReadTextFile: false, WriteTextFile: false),
-                        Terminal: false)),
+                        Terminal: false,
+                        Elicitation: new ElicitationCapabilities(Form: new ElicitationFormCapabilities()))),
                 CapacitorJsonContext.Default.InitializeParams);
 
             var initializeResultElement = await connection.RequestAsync("initialize", initializeParams, ct).ConfigureAwait(false);
@@ -1667,12 +1671,16 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     }
 
     async Task InitializeCandidateAsync(Incarnation candidate, CancellationToken ct) {
+        // Must advertise the SAME capability set as StartAsync's initialize — a reconnect
+        // candidate that silently dropped the elicitation advertisement would flip the agent
+        // back to never asking, mid-session.
         var initializeParams = JsonSerializer.SerializeToElement(
             new InitializeParams(
                 ProtocolVersion: 1,
                 ClientCapabilities: new ClientCapabilities(
                     Fs: new FsCapabilities(ReadTextFile: false, WriteTextFile: false),
-                    Terminal: false)),
+                    Terminal: false,
+                    Elicitation: new ElicitationCapabilities(Form: new ElicitationFormCapabilities()))),
             CapacitorJsonContext.Default.InitializeParams);
 
         var resultElement = await candidate.Connection.RequestAsync("initialize", initializeParams, ct).ConfigureAwait(false);

--- a/test/Capacitor.Cli.Tests.Unit/Acp/InitializeCapabilityAdvertisementTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/InitializeCapabilityAdvertisementTests.cs
@@ -1,0 +1,59 @@
+// test/Capacitor.Cli.Tests.Unit/Acp/InitializeCapabilityAdvertisementTests.cs
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// The daemon's <c>initialize</c> advertisement is a wire contract: agents decide whether they may
+/// send <c>elicitation/create</c> from exactly this JSON. These tests serialize through
+/// <c>CapacitorJsonContext.Default.InitializeParams</c> — the same source-generated type info both
+/// runtime call sites use — and pin the FULL payload, so an accidental member rename, a dropped
+/// capability, or a stray <c>url</c> advertisement fails here before it ships.
+/// </summary>
+public class InitializeCapabilityAdvertisementTests {
+    /// <summary>Byte-for-byte the construction both <c>AcpHostedAgentRuntime</c> initialize call
+    /// sites use (StartAsync and the reconnect candidate path — which must advertise the SAME set,
+    /// or a reconnect would silently flip the agent back to never asking).</summary>
+    static JsonElement RuntimeInitializeParams() => JsonSerializer.SerializeToElement(
+        new InitializeParams(
+            ProtocolVersion: 1,
+            ClientCapabilities: new ClientCapabilities(
+                Fs: new FsCapabilities(ReadTextFile: false, WriteTextFile: false),
+                Terminal: false,
+                Elicitation: new ElicitationCapabilities(Form: new ElicitationFormCapabilities()))),
+        CapacitorJsonContext.Default.InitializeParams);
+
+    [Test]
+    public async Task Initialize_AdvertisesFormElicitation_ExactWireShape() {
+        var json = RuntimeInitializeParams().GetRawText();
+
+        // Full-payload pin, not substring probes: the schema's "supported" signal is the bare {}.
+        await Assert.That(json).IsEqualTo(
+            """{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":false,"writeTextFile":false},"terminal":false,"elicitation":{"form":{}}}}""");
+    }
+
+    [Test]
+    public async Task Initialize_NeverAdvertisesUrlElicitation() {
+        // url-mode would commit the daemon to opening arbitrary agent-supplied URLs on the host —
+        // omission is the spec's "unsupported" signal, and the bridge cancels url-mode frames.
+        await Assert.That(RuntimeInitializeParams().GetRawText()).DoesNotContain("url");
+    }
+
+    [Test]
+    public async Task ClientCapabilities_TwoArgumentShape_OmitsElicitationEntirely() {
+        // The trailing-default construction (every pre-existing call site's shape) must keep
+        // its old wire form: absent member, not "elicitation":null — WhenWritingNull is what
+        // keeps an old-shaped payload byte-identical.
+        var json = JsonSerializer.SerializeToElement(
+            new InitializeParams(
+                ProtocolVersion: 1,
+                ClientCapabilities: new ClientCapabilities(
+                    Fs: new FsCapabilities(ReadTextFile: false, WriteTextFile: false),
+                    Terminal: false)),
+            CapacitorJsonContext.Default.InitializeParams).GetRawText();
+
+        await Assert.That(json).DoesNotContain("elicitation");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -582,6 +582,12 @@ public class AcpHostedAgentRuntimeFactoryTests {
         await Assert.That(initializeCall.Params!.Value.GetProperty("protocolVersion").GetInt32()).IsEqualTo(1);
         await Assert.That(initializeCall.Params!.Value.GetProperty("clientCapabilities").GetProperty("terminal").GetBoolean()).IsFalse();
         await Assert.That(initializeCall.Params!.Value.GetProperty("clientCapabilities").GetProperty("fs").GetProperty("readTextFile").GetBoolean()).IsFalse();
+        // Elicitation capability flip: the LIVE StartAsync path must advertise form-mode (the bare
+        // {} is the schema's "supported" signal) and must never advertise url-mode — asserted here
+        // through the real runtime rather than only on the hand-built InitializeParams (see
+        // InitializeCapabilityAdvertisementTests for the full-payload pin).
+        await Assert.That(initializeCall.Params!.Value.GetProperty("clientCapabilities").GetProperty("elicitation").GetProperty("form").GetRawText()).IsEqualTo("{}");
+        await Assert.That(initializeCall.Params!.Value.GetProperty("clientCapabilities").GetProperty("elicitation").TryGetProperty("url", out _)).IsFalse();
 
         var sessionNewCall = fake.ReceivedCalls.Single(c => c.Method == "session/new");
         await Assert.That(sessionNewCall.Params!.Value.GetProperty("cwd").GetString()).IsEqualTo(ctx.Worktree.Path);


### PR DESCRIPTION
Closes the final piece of AI-1240 (multi-select ACP elicitation end-to-end). The daemon's elicitation lane shipped in #453 with the capability deliberately NOT advertised; the server/UI half is merged (kurrent-io/kcap-server#1315). This PR flips the advertisement: both `AcpHostedAgentRuntime` initialize call sites — `StartAsync` and the reconnect candidate path (which must advertise the SAME set, or a reconnect would silently flip the agent back to never asking mid-session) — now send `clientCapabilities.elicitation.form = {}`.

**Form mode only, never url.** The `url` member is deliberately not modeled on the new `ElicitationCapabilities` record — omission is the spec's "unsupported" signal, and the bridge cancels url-mode frames rather than opening agent-supplied URLs on the host.

**Old wire shapes untouched.** The capability rides as a trailing `WhenWritingNull` member, so every pre-existing two-argument `ClientCapabilities` construction serializes byte-identically (absent member, not `"elicitation": null`) — pinned by test.

**Tests:** `InitializeCapabilityAdvertisementTests` (full-payload pin through the same source-generated `CapacitorJsonContext` type info the runtime uses, a no-`url` guard, the old-shape omission pin) plus live-path assertions through the real `StartAsync` initialize frame in `AcpHostedAgentRuntimeFactoryTests` — the construction pin alone can't prove the call sites use it. Unit ACP classes + full integration suite (199) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)