### PR TITLE
Make the CreateGitRepo git-spawn failure diagnose itself

### DIFF
--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -24,17 +24,10 @@ namespace Capacitor.Cli.Tests.Unit;
 /// </summary>
 public partial class AgentOrchestratorVendorTests {
     static (string repoPath, Action cleanup) CreateGitRepo() {
-        // The path used to be Path.Combine(GetTempPath(), "kcap-orch-" + 8 hex chars of a GUID)
-        // followed by CreateDirectory. Two problems, both removed by using the platform's own
-        // unique-temp-dir call (which the rest of this file already uses):
-        //
-        //  * 32 bits of name is a real birthday risk across the dozens of tests using this helper,
-        //    and CreateDirectory is idempotent — so a collision silently SHARES a directory and
-        //    either test's cleanup() then Directory.Delete(..., recursive: true)'s the other's
-        //    repo out from under it. Probability alone never explained the observed failures, but
-        //    the truncation bought nothing, so the whole class goes rather than being argued about.
-        //  * CreateTempSubdirectory creates the directory atomically, so there is no window
-        //    between choosing a name and owning it.
+        // Atomic and unique by OS guarantee. A hand-rolled "prefix + 8 hex chars of a GUID" path is
+        // 32 bits across 59 call sites, and since CreateDirectory is idempotent a collision silently
+        // SHARES a directory — after which either test's cleanup() recursively deletes the other's
+        // repo. Also closes the window between choosing a name and owning it.
         var repoPath = Directory.CreateTempSubdirectory("kcap-orch-").FullName;
 
         Git(repoPath, "init", "-q");
@@ -63,24 +56,20 @@ public partial class AgentOrchestratorVendorTests {
         try {
             proc = Process.Start(psi)!;
         } catch (Win32Exception ex) {
-            // Self-diagnosing on purpose. On Unix this spawn fails with ENOENT / "No such file or
-            // directory" for TWO unrelated causes, and .NET interpolates the working directory into
-            // the message either way:
-            //
-            //   1. the working directory does not exist  (chdir fails in the forked child)
-            //   2. the executable was not found          (PATH resolution / execve fails)
-            //
-            // A CI log therefore cannot say which happened, which is exactly why the intermittent
-            // failures in this helper went two rounds without a root cause. Capture both facts at
-            // the moment of failure so the NEXT occurrence diagnoses itself instead of costing
-            // another investigation.
+            // On Unix this spawn fails with the SAME ENOENT for two unrelated causes — (1) the
+            // working directory does not exist, (2) the executable was not found — and .NET
+            // interpolates the working directory into the message either way. A CI log therefore
+            // cannot say which happened. Capture both facts here so the next occurrence diagnoses
+            // itself.
             var cwdExists = Directory.Exists(cwd);
             var gitProbe  = ProbeGitStartable();
+            var resolved  = CliExecutable.Resolve("git");   // shared helper: PATHEXT + Unix exec bit
 
             throw new InvalidOperationException(
                 $"Failed to start 'git {string.Join(' ', args)}'. " +
                 $"WorkingDirectory '{cwd}' exists: {cwdExists}. " +
                 $"'git' startable from a known-good directory: {gitProbe}. " +
+                $"'git' resolves to: {resolved ?? "NOT FOUND"}. " +
                 $"PATH={Environment.GetEnvironmentVariable("PATH")}",
                 ex);
         }
@@ -135,25 +124,24 @@ public partial class AgentOrchestratorVendorTests {
         // the probe is broken, not the environment.
         await Assert.That(ex.Message).Contains("startable from a known-good directory: YES");
 
+        // The shared resolver's answer is part of the diagnostic too — assert it found something,
+        // not merely that the field is present, for the same reason as above.
+        await Assert.That(ex.Message).DoesNotContain("resolves to: NOT FOUND");
+
         // The original Win32Exception must be preserved, not swallowed for a prettier message.
         await Assert.That(ex.InnerException).IsTypeOf<Win32Exception>();
     }
 
     /// <summary>
     /// Answers "could this process start git at all?" by ASKING THE OS — spawning `git --version`
-    /// in a directory known to exist — rather than trying to re-implement executable resolution.
+    /// from a directory known to exist — rather than modelling executable resolution, which cannot
+    /// be done correctly here: `Process.Start` with UseShellExecute=false (forced by redirecting
+    /// streams) will not run a .cmd/.bat shim even though PATHEXT lists it, and a Unix execute bit
+    /// says nothing about EFFECTIVE permission or whether each PATH directory is traversable.
     ///
-    /// Review round 2 killed the previous approach, and the reason generalises: a hand-rolled PATH
-    /// walk cannot be right. Existence is not resolvability; `Process.Start` with
-    /// UseShellExecute=false (which redirecting streams forces) will not run a .cmd/.bat shim via
-    /// PATHEXT even though PATHEXT lists it; and a Unix execute bit says nothing about EFFECTIVE
-    /// permission for this user, nor whether every PATH directory is traversable. Each of those is
-    /// another rule to replicate, and a diagnostic that reports a false positive is worse than
-    /// none — misdirecting the next investigator is the exact failure this change exists to stop.
-    ///
-    /// The probe is authoritative because it uses the same mechanism that just failed. It also
-    /// splits the ENOENT ambiguity cleanly: startable means the fault was the working directory,
-    /// not startable means it was the executable.
+    /// Authoritative because it uses the same mechanism that just failed, and it splits the ENOENT
+    /// ambiguity: startable means the fault was the working directory, not startable means it was
+    /// the executable. `CliExecutable.Resolve` reports WHICH git alongside it.
     /// </summary>
     static string ProbeGitStartable() {
         // Bounded so the diagnostic can never become the problem. This runs on a FAILURE path in a
@@ -161,13 +149,10 @@ public partial class AgentOrchestratorVendorTests {
         // report at all — strictly worse than the error it is trying to explain.
         const int probeTimeoutMs = 10_000;
 
-        // Structured so that "NO" means exactly one thing: git could not be STARTED. A broad
-        // catch around the whole body reported NO for post-start failures too (stream reads, the
-        // wait, ExitCode, disposal) — conflating the two facts this probe exists to separate, which
-        // is the same defect as the earlier "NO — exited N" in a place easy to overlook.
-        //
-        // It must also NEVER throw: it is called from inside `catch (Win32Exception)` above, so an
-        // escaping exception would REPLACE the informative message with the probe's own.
+        // "NO" must mean exactly one thing: git could not be STARTED. Post-start failures (stream
+        // reads, the wait, ExitCode, disposal) keep the YES, or they conflate the two facts this
+        // probe exists to separate. It must also NEVER throw — it runs inside the
+        // `catch (Win32Exception)` above, so an escaping exception would REPLACE the message.
         Process? probe = null;
 
         try {

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -128,29 +128,63 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(ex!.Message).Contains(neverCreated);
         await Assert.That(ex.Message).Contains("exists: False");
 
-        // ...and its second horn: whether the executable resolved at all.
+        // ...and its second horn: whether the executable resolved at all. Asserting only that the
+        // FIELD is present would pass while the resolver reported "NOT FOUND" for everything, which
+        // is precisely the half of the ambiguity this is supposed to settle. Every sibling test in
+        // this class spawns git successfully, so on any machine that runs this suite git IS
+        // resolvable — a NOT FOUND here means the resolver is broken, not the environment.
         await Assert.That(ex.Message).Contains("resolved on PATH:");
+        await Assert.That(ex.Message).DoesNotContain("resolved on PATH: NOT FOUND");
 
         // The original Win32Exception must be preserved, not swallowed for a prettier message.
         await Assert.That(ex.InnerException).IsTypeOf<Win32Exception>();
     }
 
-    /// <summary>Returns the resolved absolute path of <paramref name="exe"/> on PATH, or null.
-    /// Used only to make a failed spawn explain itself.</summary>
+    /// <summary>
+    /// Returns the resolved absolute path of <paramref name="exe"/> on PATH, or null. Used only to
+    /// make a failed spawn explain itself, so it is best-effort — but deliberately not naive:
+    /// existence is NOT resolvability, and reporting a path the OS would have refused to execute
+    /// would send the next investigator the wrong way, which is the exact failure this whole change
+    /// exists to prevent.
+    ///
+    ///   • Unix requires the execute bit; a readable-but-not-executable file is not on PATH as far
+    ///     as execve is concerned.
+    ///   • Windows resolves by PATHEXT, not by a hardcoded guess at .exe/.cmd (git ships a .exe,
+    ///     but shims are commonly .cmd or .bat and PATHEXT is the authority).
+    /// </summary>
     static string? ResolveOnPath(string exe) {
         var path = Environment.GetEnvironmentVariable("PATH");
 
         if (string.IsNullOrEmpty(path)) return null;
 
+        var candidates = OperatingSystem.IsWindows()
+            ? (Environment.GetEnvironmentVariable("PATHEXT") ?? ".EXE;.CMD;.BAT")
+                .Split(';', StringSplitOptions.RemoveEmptyEntries)
+                .Select(ext => exe + ext)
+                .Prepend(exe)
+                .ToArray()
+            : [exe];
+
         foreach (var dir in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)) {
-            foreach (var candidate in OperatingSystem.IsWindows()
-                         ? new[] { exe + ".exe", exe + ".cmd", exe }
-                         : new[] { exe }) {
+            foreach (var candidate in candidates) {
                 string full;
 
                 try { full = Path.Combine(dir, candidate); } catch { continue; }
 
-                if (File.Exists(full)) return full;
+                if (!File.Exists(full)) continue;
+
+                if (OperatingSystem.IsWindows()) return full;
+
+                // Unix: the execute bit is what makes it resolvable.
+                try {
+                    var mode = File.GetUnixFileMode(full);
+
+                    if ((mode & (UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute)) != 0)
+                        return full;
+                } catch {
+                    // Unreadable mode — report it as found rather than losing the fact entirely.
+                    return full;
+                }
             }
         }
 

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -156,6 +156,11 @@ public partial class AgentOrchestratorVendorTests {
     /// not startable means it was the executable.
     /// </summary>
     static string ProbeGitStartable() {
+        // Bounded so the diagnostic can never become the problem. This runs on a FAILURE path in a
+        // suite CI executes serially, so an unbounded wait would wedge the entire run and produce no
+        // report at all — strictly worse than the error it is trying to explain.
+        const int probeTimeoutMs = 10_000;
+
         try {
             var psi = new ProcessStartInfo("git", "--version") {
                 WorkingDirectory       = Path.GetTempPath(), // known to exist; not the suspect dir
@@ -165,23 +170,28 @@ public partial class AgentOrchestratorVendorTests {
 
             using var probe = Process.Start(psi);
 
+            // "NO" is reserved for genuinely NOT STARTABLE — Start threw, or handed back nothing.
             if (probe is null) return "NO — Process.Start returned null";
 
-            // Drained the same way as the main path above, not with a blocking ReadToEnd pair.
-            // `git --version` is far too small to fill a pipe, but the shape is the defect — and a
-            // helper that only runs on a FAILURE path is the worst place to leave a potential hang,
-            // since it would replace a diagnosable error with a run that produces no report at all.
+            // Past this point startability is PROVEN: Start returned a process. Whatever the child
+            // then does is a separate fact and must not be folded back into the startable verdict.
+            // Reporting NO for a nonzero `--version` exit would misclassify precisely the question
+            // this probe exists to answer.
             var versionTask = probe.StandardOutput.ReadToEndAsync();
             var errTask     = probe.StandardError.ReadToEndAsync();
 
-            probe.WaitForExit();
+            if (!probe.WaitForExit(probeTimeoutMs)) {
+                try { probe.Kill(entireProcessTree: true); } catch { /* best effort */ }
+
+                return $"YES (startable; probe did not exit within {probeTimeoutMs}ms, killed)";
+            }
 
             var version = versionTask.GetAwaiter().GetResult().Trim();
-            _           = errTask.GetAwaiter().GetResult();
+            var err     = errTask.GetAwaiter().GetResult().Trim();
 
             return probe.ExitCode == 0
                 ? $"YES ({version})"
-                : $"NO — exited {probe.ExitCode}";
+                : $"YES (startable; --version exited {probe.ExitCode}: {err})";
         } catch (Exception probeEx) {
             return $"NO — {probeEx.GetType().Name}: {probeEx.Message}";
         }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -161,39 +161,53 @@ public partial class AgentOrchestratorVendorTests {
         // report at all — strictly worse than the error it is trying to explain.
         const int probeTimeoutMs = 10_000;
 
+        // Structured so that "NO" means exactly one thing: git could not be STARTED. A broad
+        // catch around the whole body reported NO for post-start failures too (stream reads, the
+        // wait, ExitCode, disposal) — conflating the two facts this probe exists to separate, which
+        // is the same defect as the earlier "NO — exited N" in a place easy to overlook.
+        //
+        // It must also NEVER throw: it is called from inside `catch (Win32Exception)` above, so an
+        // escaping exception would REPLACE the informative message with the probe's own.
+        Process? probe = null;
+
         try {
-            var psi = new ProcessStartInfo("git", "--version") {
-                WorkingDirectory       = Path.GetTempPath(), // known to exist; not the suspect dir
-                RedirectStandardOutput = true,
-                RedirectStandardError  = true
-            };
-
-            using var probe = Process.Start(psi);
-
-            // "NO" is reserved for genuinely NOT STARTABLE — Start threw, or handed back nothing.
-            if (probe is null) return "NO — Process.Start returned null";
-
-            // Past this point startability is PROVEN: Start returned a process. Whatever the child
-            // then does is a separate fact and must not be folded back into the startable verdict.
-            // Reporting NO for a nonzero `--version` exit would misclassify precisely the question
-            // this probe exists to answer.
-            var versionTask = probe.StandardOutput.ReadToEndAsync();
-            var errTask     = probe.StandardError.ReadToEndAsync();
-
-            if (!probe.WaitForExit(probeTimeoutMs)) {
-                try { probe.Kill(entireProcessTree: true); } catch { /* best effort */ }
-
-                return $"YES (startable; probe did not exit within {probeTimeoutMs}ms, killed)";
+            try {
+                probe = Process.Start(new ProcessStartInfo("git", "--version") {
+                    WorkingDirectory       = Path.GetTempPath(), // known to exist; not the suspect dir
+                    RedirectStandardOutput = true,
+                    RedirectStandardError  = true
+                });
+            } catch (Exception startEx) {
+                return $"NO — {startEx.GetType().Name}: {startEx.Message}";
             }
 
-            var version = versionTask.GetAwaiter().GetResult().Trim();
-            var err     = errTask.GetAwaiter().GetResult().Trim();
+            if (probe is null) return "NO — Process.Start returned null";
 
-            return probe.ExitCode == 0
-                ? $"YES ({version})"
-                : $"YES (startable; --version exited {probe.ExitCode}: {err})";
-        } catch (Exception probeEx) {
-            return $"NO — {probeEx.GetType().Name}: {probeEx.Message}";
+            // Past here startability is PROVEN. Everything below is a separate fact and must keep
+            // the YES, however it goes wrong.
+            try {
+                var versionTask = probe.StandardOutput.ReadToEndAsync();
+                var errTask     = probe.StandardError.ReadToEndAsync();
+
+                if (!probe.WaitForExit(probeTimeoutMs)) {
+                    try { probe.Kill(entireProcessTree: true); } catch { /* best effort */ }
+
+                    return $"YES (startable; probe did not exit within {probeTimeoutMs}ms, killed)";
+                }
+
+                var version = versionTask.GetAwaiter().GetResult().Trim();
+                var err     = errTask.GetAwaiter().GetResult().Trim();
+
+                return probe.ExitCode == 0
+                    ? $"YES ({version})"
+                    : $"YES (startable; --version exited {probe.ExitCode}: {err})";
+            } catch (Exception afterStartEx) {
+                return $"YES (startable; probe failed after starting — " +
+                       $"{afterStartEx.GetType().Name}: {afterStartEx.Message})";
+            }
+        } finally {
+            // Disposal must not be able to change the verdict or escape.
+            try { probe?.Dispose(); } catch { /* best effort */ }
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -167,10 +167,17 @@ public partial class AgentOrchestratorVendorTests {
 
             if (probe is null) return "NO — Process.Start returned null";
 
-            var version = probe.StandardOutput.ReadToEnd().Trim();
-            _           = probe.StandardError.ReadToEnd();
+            // Drained the same way as the main path above, not with a blocking ReadToEnd pair.
+            // `git --version` is far too small to fill a pipe, but the shape is the defect — and a
+            // helper that only runs on a FAILURE path is the worst place to leave a potential hang,
+            // since it would replace a diagnosable error with a run that produces no report at all.
+            var versionTask = probe.StandardOutput.ReadToEndAsync();
+            var errTask     = probe.StandardError.ReadToEndAsync();
 
             probe.WaitForExit();
+
+            var version = versionTask.GetAwaiter().GetResult().Trim();
+            _           = errTask.GetAwaiter().GetResult();
 
             return probe.ExitCode == 0
                 ? $"YES ({version})"

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -23,8 +24,18 @@ namespace Capacitor.Cli.Tests.Unit;
 /// </summary>
 public partial class AgentOrchestratorVendorTests {
     static (string repoPath, Action cleanup) CreateGitRepo() {
-        var repoPath = Path.Combine(Path.GetTempPath(), "kcap-orch-" + Guid.NewGuid().ToString("N")[..8]);
-        Directory.CreateDirectory(repoPath);
+        // The path used to be Path.Combine(GetTempPath(), "kcap-orch-" + 8 hex chars of a GUID)
+        // followed by CreateDirectory. Two problems, both removed by using the platform's own
+        // unique-temp-dir call (which the rest of this file already uses):
+        //
+        //  * 32 bits of name is a real birthday risk across the dozens of tests using this helper,
+        //    and CreateDirectory is idempotent — so a collision silently SHARES a directory and
+        //    either test's cleanup() then Directory.Delete(..., recursive: true)'s the other's
+        //    repo out from under it. Probability alone never explained the observed failures, but
+        //    the truncation bought nothing, so the whole class goes rather than being argued about.
+        //  * CreateTempSubdirectory creates the directory atomically, so there is no window
+        //    between choosing a name and owning it.
+        var repoPath = Directory.CreateTempSubdirectory("kcap-orch-").FullName;
 
         Git(repoPath, "init", "-q");
         Git(repoPath, "config", "user.email", "test@example.com");
@@ -46,12 +57,104 @@ public partial class AgentOrchestratorVendorTests {
             RedirectStandardOutput = true,
             RedirectStandardError  = true
         };
-        using var proc = Process.Start(psi)!;
-        proc.WaitForExit();
 
-        if (proc.ExitCode != 0) {
-            throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {proc.StandardError.ReadToEnd()}");
+        Process proc;
+
+        try {
+            proc = Process.Start(psi)!;
+        } catch (Win32Exception ex) {
+            // Self-diagnosing on purpose. On Unix this spawn fails with ENOENT / "No such file or
+            // directory" for TWO unrelated causes, and .NET interpolates the working directory into
+            // the message either way:
+            //
+            //   1. the working directory does not exist  (chdir fails in the forked child)
+            //   2. the executable was not found          (PATH resolution / execve fails)
+            //
+            // A CI log therefore cannot say which happened, which is exactly why the intermittent
+            // failures in this helper went two rounds without a root cause. Capture both facts at
+            // the moment of failure so the NEXT occurrence diagnoses itself instead of costing
+            // another investigation.
+            var cwdExists = Directory.Exists(cwd);
+            var onPath    = ResolveOnPath("git");
+
+            throw new InvalidOperationException(
+                $"Failed to start 'git {string.Join(' ', args)}'. " +
+                $"WorkingDirectory '{cwd}' exists: {cwdExists}. " +
+                $"'git' resolved on PATH: {onPath ?? "NOT FOUND"}. " +
+                $"PATH={Environment.GetEnvironmentVariable("PATH")}",
+                ex);
         }
+
+        using (proc) {
+            // Drain BOTH redirected streams before waiting. Redirecting a stream and never reading
+            // it risks the child blocking forever once the pipe buffer fills, which would turn a
+            // test failure into a hung run — the worst outcome, since a hang produces no report.
+            // These commands are quiet enough that it has not bitten, but the shape is the bug.
+            var stdout = proc.StandardOutput.ReadToEndAsync();
+            var stderr = proc.StandardError.ReadToEndAsync();
+
+            proc.WaitForExit();
+
+            var err = stderr.GetAwaiter().GetResult();
+            _       = stdout.GetAwaiter().GetResult();
+
+            if (proc.ExitCode != 0) {
+                throw new InvalidOperationException($"git {string.Join(' ', args)} failed: {err}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Guards the diagnostic itself. The intermittent failures this replaced were unresolvable
+    /// precisely because the message could not distinguish a missing working directory from a
+    /// missing executable, so the replacement message is now load-bearing and gets a test —
+    /// otherwise it is a diagnostic nobody has ever seen produce output.
+    ///
+    /// Uses a directory that was never created, so the spawn fails for a KNOWN reason and the
+    /// message can be checked against it. Cross-platform: Unix fails with ENOENT, Windows with
+    /// "the directory name is invalid", and both surface as Win32Exception.
+    /// </summary>
+    [Test]
+    public async Task Git_spawn_failure_reports_the_working_directory_and_PATH_resolution() {
+        var neverCreated = Path.Combine(
+            Path.GetTempPath(), "kcap-orch-never-created-" + Guid.NewGuid().ToString("N"));
+
+        await Assert.That(Directory.Exists(neverCreated)).IsFalse(); // precondition
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Task.Run(() => Git(neverCreated, "init", "-q")));
+
+        // Names the ambiguity's first horn: the working directory.
+        await Assert.That(ex!.Message).Contains(neverCreated);
+        await Assert.That(ex.Message).Contains("exists: False");
+
+        // ...and its second horn: whether the executable resolved at all.
+        await Assert.That(ex.Message).Contains("resolved on PATH:");
+
+        // The original Win32Exception must be preserved, not swallowed for a prettier message.
+        await Assert.That(ex.InnerException).IsTypeOf<Win32Exception>();
+    }
+
+    /// <summary>Returns the resolved absolute path of <paramref name="exe"/> on PATH, or null.
+    /// Used only to make a failed spawn explain itself.</summary>
+    static string? ResolveOnPath(string exe) {
+        var path = Environment.GetEnvironmentVariable("PATH");
+
+        if (string.IsNullOrEmpty(path)) return null;
+
+        foreach (var dir in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)) {
+            foreach (var candidate in OperatingSystem.IsWindows()
+                         ? new[] { exe + ".exe", exe + ".cmd", exe }
+                         : new[] { exe }) {
+                string full;
+
+                try { full = Path.Combine(dir, candidate); } catch { continue; }
+
+                if (File.Exists(full)) return full;
+            }
+        }
+
+        return null;
     }
 
     static AgentOrchestrator BuildOrchestrator(

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -75,12 +75,12 @@ public partial class AgentOrchestratorVendorTests {
             // the moment of failure so the NEXT occurrence diagnoses itself instead of costing
             // another investigation.
             var cwdExists = Directory.Exists(cwd);
-            var onPath    = ResolveOnPath("git");
+            var gitProbe  = ProbeGitStartable();
 
             throw new InvalidOperationException(
                 $"Failed to start 'git {string.Join(' ', args)}'. " +
                 $"WorkingDirectory '{cwd}' exists: {cwdExists}. " +
-                $"'git' resolved on PATH: {onPath ?? "NOT FOUND"}. " +
+                $"'git' startable from a known-good directory: {gitProbe}. " +
                 $"PATH={Environment.GetEnvironmentVariable("PATH")}",
                 ex);
         }
@@ -128,67 +128,56 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(ex!.Message).Contains(neverCreated);
         await Assert.That(ex.Message).Contains("exists: False");
 
-        // ...and its second horn: whether the executable resolved at all. Asserting only that the
-        // FIELD is present would pass while the resolver reported "NOT FOUND" for everything, which
-        // is precisely the half of the ambiguity this is supposed to settle. Every sibling test in
-        // this class spawns git successfully, so on any machine that runs this suite git IS
-        // resolvable — a NOT FOUND here means the resolver is broken, not the environment.
-        await Assert.That(ex.Message).Contains("resolved on PATH:");
-        await Assert.That(ex.Message).DoesNotContain("resolved on PATH: NOT FOUND");
+        // ...and its second horn, answered by actually starting git. Asserting only that the FIELD
+        // is present would pass while the probe reported NO for everything, leaving exactly the half
+        // of the ambiguity this exists to settle unverified. Every sibling test in this class spawns
+        // git successfully, so on any machine running this suite git IS startable — a NO here means
+        // the probe is broken, not the environment.
+        await Assert.That(ex.Message).Contains("startable from a known-good directory: YES");
 
         // The original Win32Exception must be preserved, not swallowed for a prettier message.
         await Assert.That(ex.InnerException).IsTypeOf<Win32Exception>();
     }
 
     /// <summary>
-    /// Returns the resolved absolute path of <paramref name="exe"/> on PATH, or null. Used only to
-    /// make a failed spawn explain itself, so it is best-effort — but deliberately not naive:
-    /// existence is NOT resolvability, and reporting a path the OS would have refused to execute
-    /// would send the next investigator the wrong way, which is the exact failure this whole change
-    /// exists to prevent.
+    /// Answers "could this process start git at all?" by ASKING THE OS — spawning `git --version`
+    /// in a directory known to exist — rather than trying to re-implement executable resolution.
     ///
-    ///   • Unix requires the execute bit; a readable-but-not-executable file is not on PATH as far
-    ///     as execve is concerned.
-    ///   • Windows resolves by PATHEXT, not by a hardcoded guess at .exe/.cmd (git ships a .exe,
-    ///     but shims are commonly .cmd or .bat and PATHEXT is the authority).
+    /// Review round 2 killed the previous approach, and the reason generalises: a hand-rolled PATH
+    /// walk cannot be right. Existence is not resolvability; `Process.Start` with
+    /// UseShellExecute=false (which redirecting streams forces) will not run a .cmd/.bat shim via
+    /// PATHEXT even though PATHEXT lists it; and a Unix execute bit says nothing about EFFECTIVE
+    /// permission for this user, nor whether every PATH directory is traversable. Each of those is
+    /// another rule to replicate, and a diagnostic that reports a false positive is worse than
+    /// none — misdirecting the next investigator is the exact failure this change exists to stop.
+    ///
+    /// The probe is authoritative because it uses the same mechanism that just failed. It also
+    /// splits the ENOENT ambiguity cleanly: startable means the fault was the working directory,
+    /// not startable means it was the executable.
     /// </summary>
-    static string? ResolveOnPath(string exe) {
-        var path = Environment.GetEnvironmentVariable("PATH");
+    static string ProbeGitStartable() {
+        try {
+            var psi = new ProcessStartInfo("git", "--version") {
+                WorkingDirectory       = Path.GetTempPath(), // known to exist; not the suspect dir
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true
+            };
 
-        if (string.IsNullOrEmpty(path)) return null;
+            using var probe = Process.Start(psi);
 
-        var candidates = OperatingSystem.IsWindows()
-            ? (Environment.GetEnvironmentVariable("PATHEXT") ?? ".EXE;.CMD;.BAT")
-                .Split(';', StringSplitOptions.RemoveEmptyEntries)
-                .Select(ext => exe + ext)
-                .Prepend(exe)
-                .ToArray()
-            : [exe];
+            if (probe is null) return "NO — Process.Start returned null";
 
-        foreach (var dir in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)) {
-            foreach (var candidate in candidates) {
-                string full;
+            var version = probe.StandardOutput.ReadToEnd().Trim();
+            _           = probe.StandardError.ReadToEnd();
 
-                try { full = Path.Combine(dir, candidate); } catch { continue; }
+            probe.WaitForExit();
 
-                if (!File.Exists(full)) continue;
-
-                if (OperatingSystem.IsWindows()) return full;
-
-                // Unix: the execute bit is what makes it resolvable.
-                try {
-                    var mode = File.GetUnixFileMode(full);
-
-                    if ((mode & (UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute)) != 0)
-                        return full;
-                } catch {
-                    // Unreadable mode — report it as found rather than losing the fact entirely.
-                    return full;
-                }
-            }
+            return probe.ExitCode == 0
+                ? $"YES ({version})"
+                : $"NO — exited {probe.ExitCode}";
+        } catch (Exception probeEx) {
+            return $"NO — {probeEx.GetType().Name}: {probeEx.Message}";
         }
-
-        return null;
     }
 
     static AgentOrchestrator BuildOrchestrator(


### PR DESCRIPTION
Fixes the diagnostic gap behind two filed flake reports (Linear AI-1719 and AI-1735, GitHub #452) — the same failure seen twice:

```
failed <various AgentOrchestrator tests> (1ms)
  Win32Exception: An error occurred trying to start process 'git' with working
  directory '/tmp/kcap-orch-4412504b'. No such file or directory
    at AgentOrchestratorVendorTests.Git(...)
    at AgentOrchestratorVendorTests.CreateGitRepo()
```

Both times it failed on the **first line of the test**, inside `CreateGitRepo()`, spawning `git init` in a directory `Directory.CreateDirectory` had just returned successfully for. Both times it **passed on a rerun of the same commit**. Nothing under test had run yet.

## Why two investigations produced no root cause

The message cannot produce one. On Unix this spawn fails with `ENOENT` / "No such file or directory" for **two unrelated causes**, and .NET interpolates the working directory into the text either way:

1. the working directory does not exist — `chdir` fails in the forked child
2. the executable was not found — PATH resolution / `execve` fails

So the log is genuinely ambiguous, and no amount of re-reading it settles which happened.

`Git()` now catches the `Win32Exception` and rethrows naming **both** facts — whether the working directory exists, whether `git` resolves on PATH and where, and the PATH itself — preserving the original as `InnerException`. The next occurrence diagnoses itself.

**This does not claim to fix the flake.** Root cause remains unknown. Both reports asked for diagnosis before a blind fix, and explicitly *not* for a retry, which would mask a genuine lifetime bug.

## Two things fixed while in here

**Temp path.** It was `Path.Combine(GetTempPath(), "kcap-orch-" + 8 hex chars of a GUID)` then `CreateDirectory`. 32 bits across this helper's **59 call sites** is a real birthday risk, and since `CreateDirectory` is idempotent a collision silently **shares** a directory — after which either test's `cleanup()` recursively deletes the other's repo. Probability never explained the observed failures, but the truncation bought nothing, so the class is gone rather than argued about:

```csharp
var repoPath = Directory.CreateTempSubdirectory("kcap-orch-").FullName;
```

Atomic and unique by OS guarantee — and already what the rest of this file uses. `CreateGitRepo` was the outlier.

**A latent hang.** `Git()` redirected both stdout and stderr and read neither before `WaitForExit`. Redirecting a stream and never draining it risks the child blocking forever once the pipe buffer fills, turning a test failure into a **hung run** — the worst outcome, since a hang produces no report at all. These commands are quiet enough that it hasn't bitten; the shape is the bug. Both streams are now drained before the wait.

## The diagnostic is tested, not hoped for

A diagnostic nobody has seen produce output is not a fix. `Git_spawn_failure_reports_the_working_directory_and_PATH_resolution` spawns into a directory that was never created — so the failure has a **known** cause — and asserts the message names the working directory, its existence, PATH resolution, and preserves the `Win32Exception`. Cross-platform: Unix gives ENOENT, Windows "the directory name is invalid", both `Win32Exception`.

**Mutation-verified:** reverting the catch to a bare `throw;` fails that test.

## Candidates ruled out (carried forward from the reports, plus one new)

- `UninstallCommand.SweepCapacitorPrefixedDirs` — only ever runs against the skills dirs, never the temp root
- PATH mutation by a parallel test — the only global PATH writes are `[NotInParallel]` *and* early-return on non-Windows
- Tests redirecting `HOME`/cwd — all scoped below their own `CreateTempSubdirectory`
- **New: `TMPDIR` mutation.** Worth checking since `Path.GetTempPath()` honours it and a moved-then-deleted temp root would match the evidence exactly. Ruled out — the only write is `psi.Environment["TMPDIR"]`, which is per-child-process and cannot move the test host's temp root.

## Verification

178/178 in `AgentOrchestratorVendorTests`.

_🤖 Generated with [Claude Code](https://claude.com/claude-code)_