### PR TITLE
Signal the PTY child's whole process group on terminate

### DIFF
--- a/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
@@ -264,6 +264,12 @@ public sealed class UnixPtyProcess : IPtyProcess {
     /// group id proves nothing and is never signalled; a descendant that outlived the group kill
     /// is the record/scan reap layers' job.</summary>
     void SignalGroup(int sig) {
+        // Same guard as ProcessReaper.SignalGroup: kill(2) gives non-positive pids special
+        // meanings — kill(0) signals the CALLER's own group and kill(-1) broadcasts — so a
+        // zero/negative Pid must never reach either call (this repo has a recorded incident of
+        // exactly that SIGKILLing the test host's group).
+        if (Pid <= 0) return;
+
         lock (_reapSignalGate) {
             if (HasExited) return; // reaped since the caller's check — the ids may be recycled
 

--- a/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
@@ -231,7 +231,7 @@ public sealed class UnixPtyProcess : IPtyProcess {
             return;
         }
 
-        UnixPtyInterop.kill(Pid, UnixPtyInterop.SIGTERM);
+        SignalGroup(UnixPtyInterop.SIGTERM);
 
         var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
 
@@ -243,9 +243,21 @@ public sealed class UnixPtyProcess : IPtyProcess {
         }
 
         if (!HasExited) {
-            UnixPtyInterop.kill(Pid, UnixPtyInterop.SIGKILL);
+            SignalGroup(UnixPtyInterop.SIGKILL);
             CheckExited();
         }
+    }
+
+    /// <summary>Signals the child's process GROUP, falling back to the pid alone (ProcessReaper's
+    /// pattern). The child is a forkpty session leader (pgid == pid), so helpers it spawned —
+    /// codex's code-mode host, MCP servers — are in the group; signalling only the leader orphans
+    /// them whenever the leader dies without forwarding (SIGKILL always, SIGTERM vendor-dependent).
+    /// Safe against pid reuse: callers only signal while <see cref="HasExited"/> is false, and the
+    /// leader is not reaped until <see cref="CheckExited"/>'s waitpid, so the pgid still names our
+    /// lineage. Once the leader is gone the group id proves nothing and is never signalled — a
+    /// descendant that outlived the group kill is the record/scan reap layers' job.</summary>
+    void SignalGroup(int sig) {
+        if (UnixPtyInterop.kill(-Pid, sig) != 0) UnixPtyInterop.kill(Pid, sig);
     }
 
     public async Task WaitForExitAsync(TimeSpan? timeout = null) {

--- a/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Pty/Unix/UnixPtyProcess.cs
@@ -248,16 +248,27 @@ public sealed class UnixPtyProcess : IPtyProcess {
         }
     }
 
+    /// <summary>Serializes the reap (<see cref="CheckExited"/>'s waitpid) against group signalling
+    /// (<see cref="SignalGroup"/>). The leader's unreaped zombie is what pins its pid AND pgid
+    /// against reuse; the read loop's own <see cref="ReadOutputAsync"/> can reap concurrently with
+    /// a terminate, and a signal sent after that reap could land on a recycled id. Under this gate
+    /// a signal is provably sent while the leader is unreaped, or not at all.</summary>
+    readonly object _reapSignalGate = new();
+
     /// <summary>Signals the child's process GROUP, falling back to the pid alone (ProcessReaper's
     /// pattern). The child is a forkpty session leader (pgid == pid), so helpers it spawned —
     /// codex's code-mode host, MCP servers — are in the group; signalling only the leader orphans
     /// them whenever the leader dies without forwarding (SIGKILL always, SIGTERM vendor-dependent).
-    /// Safe against pid reuse: callers only signal while <see cref="HasExited"/> is false, and the
-    /// leader is not reaped until <see cref="CheckExited"/>'s waitpid, so the pgid still names our
-    /// lineage. Once the leader is gone the group id proves nothing and is never signalled — a
-    /// descendant that outlived the group kill is the record/scan reap layers' job.</summary>
+    /// Safe against pid reuse: the signal is sent under <see cref="_reapSignalGate"/> only while
+    /// the leader is unreaped (its zombie pins the pid and pgid) — once it has been reaped the
+    /// group id proves nothing and is never signalled; a descendant that outlived the group kill
+    /// is the record/scan reap layers' job.</summary>
     void SignalGroup(int sig) {
-        if (UnixPtyInterop.kill(-Pid, sig) != 0) UnixPtyInterop.kill(Pid, sig);
+        lock (_reapSignalGate) {
+            if (HasExited) return; // reaped since the caller's check — the ids may be recycled
+
+            if (UnixPtyInterop.kill(-Pid, sig) != 0) UnixPtyInterop.kill(Pid, sig);
+        }
     }
 
     public async Task WaitForExitAsync(TimeSpan? timeout = null) {
@@ -278,11 +289,18 @@ public sealed class UnixPtyProcess : IPtyProcess {
     }
 
     void CheckExited() {
-        var result = UnixPtyInterop.waitpid(Pid, out var status, UnixPtyInterop.WNOHANG);
+        // Under the gate so the reap-and-publish is atomic with respect to SignalGroup: a signal
+        // can never interleave between the waitpid that frees the pid/pgid for reuse and the
+        // HasExited publication that tells SignalGroup to stand down.
+        lock (_reapSignalGate) {
+            if (HasExited) return;
 
-        if (result == Pid) {
-            HasExited = true;
-            ExitCode  = (status >> 8) & 0xFF;
+            var result = UnixPtyInterop.waitpid(Pid, out var status, UnixPtyInterop.WNOHANG);
+
+            if (result == Pid) {
+                HasExited = true;
+                ExitCode  = (status >> 8) & 0xFF;
+            }
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/UnixPtyProcessSpawnTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/UnixPtyProcessSpawnTests.cs
@@ -45,4 +45,60 @@ public class UnixPtyProcessSpawnTests {
             await proc.DisposeAsync();
         }
     }
+
+    /// <summary>Terminate must take down the leader's whole process group, not just the leader —
+    /// the shape a codex reviewer takes with its code-mode-host helper (kcap-cli#469). The shell
+    /// leader backgrounds a long sleep (same group, since the leader is a forkpty session leader),
+    /// reports its pid over the PTY, and waits. A leader-only kill leaves the sleep orphaned and
+    /// running, which is exactly the mutation this test exists to fail on.</summary>
+    [Test]
+    public async Task Terminate_kills_the_leaders_whole_process_group() {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+
+        using var spawner = new UnixSpawnerThread();
+        var       factory = new UnixPtyProcessFactory(spawner);
+        // The helper IGNORES SIGHUP (trap '' HUP survives the exec): a plain background sleep dies
+        // to the controlling terminal's leader-exit SIGHUP even under a leader-only kill, which let
+        // exactly that mutation pass this test — a helper that shrugs off HUP is also the shape
+        // that leaks in production. Only a signal to the GROUP reaches it.
+        var proc = factory.Spawn(
+            "/bin/sh", ["-c", "(trap '' HUP; exec sleep 300) & echo \"CHILD:$!:DONE\"; wait"],
+            Directory.GetCurrentDirectory());
+        try {
+            var childPid = await ReadReportedChildPidAsync(proc);
+            await Assert.That(childPid).IsGreaterThan(0);
+            // Positive control: the helper is alive before the terminate, so the "dead after"
+            // assertion below cannot pass vacuously on a pid that never existed.
+            await Assert.That(UnixPtyInterop.kill(childPid, 0)).IsEqualTo(0);
+
+            await proc.TerminateAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(proc.HasExited).IsTrue();
+
+            // The orphaned helper is reparented to init, which reaps it once it dies — poll
+            // briefly for ESRCH rather than racing the reap.
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+            while (UnixPtyInterop.kill(childPid, 0) == 0 && DateTime.UtcNow < deadline)
+                await Task.Delay(50);
+
+            await Assert.That(UnixPtyInterop.kill(childPid, 0)).IsNotEqualTo(0);
+        } finally {
+            await proc.DisposeAsync();
+        }
+    }
+
+    /// <summary>Reads PTY output until the leader reports its backgrounded child as
+    /// <c>CHILD:{pid}:DONE</c>. The trailing marker matters: without it a chunk boundary could
+    /// split the digits and a prefix of the pid would parse as a (wrong, possibly live) pid.</summary>
+    static async Task<int> ReadReportedChildPidAsync(Capacitor.Cli.Daemon.Pty.IPtyProcess proc) {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var buffer = new System.Text.StringBuilder();
+
+        await foreach (var chunk in proc.ReadOutputAsync(cts.Token)) {
+            buffer.Append(System.Text.Encoding.UTF8.GetString(chunk));
+            var match = System.Text.RegularExpressions.Regex.Match(buffer.ToString(), @"CHILD:(\d+):DONE");
+            if (match.Success) return int.Parse(match.Groups[1].Value);
+        }
+
+        return -1;
+    }
 }


### PR DESCRIPTION
Closes #469. Linear: AI-1742.

## Problem

`UnixPtyProcess.TerminateAsync` sends SIGTERM/SIGKILL to the leader pid alone. The child is a forkpty **session leader** (pgid == pid) and helpers it spawns — codex's `codex-code-mode-host`, MCP servers — live in its group, so a leader that dies without forwarding the signal (SIGKILL always; SIGTERM vendor-dependent) orphans them to init, still running. `ProcessReaper` already signals the group on the PID-record fallback path and documents the descendant-outliving-the-leader case as the deferred containment concern; the primary live-stop path never got the same treatment.

## Fix

`SignalGroup(sig)`: `kill(-pid, sig)` with a `kill(pid, sig)` fallback — the exact `ProcessReaper` pattern — used for both the SIGTERM and the SIGKILL escalation. Signalled only while `HasExited` is false: the leader is unreaped until `CheckExited`'s `waitpid`, so the pgid still names our lineage; once the leader is gone the group id proves nothing and is never signalled (the record/scan reap layers own that case).

## Test

`Terminate_kills_the_leaders_whole_process_group`: a shell leader backgrounds a helper, reports its pid over the PTY, and waits; after `TerminateAsync` the helper must be gone (`kill(pid, 0)` → ESRCH), with a positive control that it was alive before.

**Mutation-checked, with a trap worth recording:** the first version used a plain background `sleep`, and the leader-only-kill mutant *passed* — the kernel sends SIGHUP to the controlling terminal's foreground group when the session leader exits, so the helper died anyway. The shipped helper ignores SIGHUP (`trap '' HUP` surviving an `exec`), which both defeats that accidental cover and matches the shape that actually leaks in production. Leader-only mutant now fails the test; the fix passes it.

Local: targeted unit tests green, integration suite green, AOT publish clean of IL2026/IL3050, Linear-ID guard clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)