### PR TITLE
Treat the recorded reviewer version as a minimum, not an exact match

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
              maps to the permissive outcome makes the safe direction of a fail-closed gate whatever
              nobody thought about. The reviewer version gate shipped exactly that bug. Measured before
              enabling: zero CS8509 warnings across the daemon, Core, the CLI and the unit tests. -->
-        <WarningsAsErrors>CS8509</WarningsAsErrors>
+        <WarningsAsErrors>$(WarningsAsErrors);CS8509</WarningsAsErrors>
         <MinVerTagPrefix>v</MinVerTagPrefix>
     </PropertyGroup>
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,12 @@
     <PropertyGroup>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <NoWarn>IDE0055;IDE1006</NoWarn>
+        <!-- CS8509: a switch expression that does not cover every named enum value. An error, not a
+             warning, because the alternative to exhaustiveness is a discard arm, and a discard that
+             maps to the permissive outcome makes the safe direction of a fail-closed gate whatever
+             nobody thought about. The reviewer version gate shipped exactly that bug. Measured before
+             enabling: zero CS8509 warnings across the daemon, Core, the CLI and the unit tests. -->
+        <WarningsAsErrors>CS8509</WarningsAsErrors>
         <MinVerTagPrefix>v</MinVerTagPrefix>
     </PropertyGroup>
     <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -780,13 +780,19 @@ review is not necessarily you) and defaults off.
 
 Two further things it does *not* do:
 
-- it does not bypass the **build affirmation**. The reviewer's only containment is Gemini's exact-name MCP
-  allowlist, which is a behaviour of the installed build — so a `gemini` version other than the one this
-  daemon affirmed is refused even with the flag on, with a coded error naming both builds. Enabling the
-  reviewer affirms whatever is installed at that moment, so you only meet this after an upgrade; clear it
-  with `kcap daemon reviewer affirm --vendor gemini`. (This replaced a maintainer-curated *certified version
-  set*, which took the reviewer offline on every Gemini release until a new kcap shipped — a build one patch
-  ahead of the certified one made the feature unreachable.)
+- it does not bypass the **minimum version**. The reviewer's only containment is Gemini's exact-name MCP
+  allowlist, which is a behaviour of the installed build, so the daemon records a minimum `gemini` version
+  the first time you enable the reviewer. That recorded version is a **minimum, not an exact match**: any
+  build at or above it runs, so **a Gemini upgrade needs no action from you**; an older one is refused, with
+  a coded error naming both versions. Run `kcap daemon reviewer affirm --vendor gemini` to move the minimum
+  to whatever is installed now — which is how you exclude a build you have found to be broken, and, if you
+  run it while an older build is installed, how you deliberately lower the bar again.
+
+  (Two earlier models are worth knowing about if you hit old docs. A maintainer-curated *certified version
+  set* took the reviewer offline on every Gemini release until a new kcap shipped — a build one patch ahead
+  of the certified one made the feature unreachable. Requiring an exact match to a version you affirmed
+  removed the kcap-release coupling but kept the treadmill, just moved onto you. The minimum keeps the
+  fail-closed direction for downgrades while letting routine upgrades through untouched.)
 - it does not make Gemini a default reviewer. It is only ever reached by an explicit `vendor: "gemini"`.
 
 #### Unattended Kiro reviews
@@ -815,16 +821,19 @@ A review launch also runs with a daemon-owned, empty `KIRO_HOME`, so your global
 `~/.kiro/settings/mcp.json` servers — `kcap-flows` among them — do not reach the reviewer. Your own
 interactive Kiro sessions are unaffected, and the file is never modified.
 
-**Version affirmation.** That suppression depends on the installed build honouring `KIRO_HOME`, so a
-`kiro-cli` version change takes the reviewer offline until you acknowledge it:
+**Minimum version.** That suppression depends on the installed build honouring `KIRO_HOME`, so the daemon
+records a minimum `kiro-cli` version the first time you enable the reviewer. It is a **minimum, not an exact
+match**: any build at or above it runs, so **a `kiro-cli` upgrade needs no action from you**; a build older
+than the recorded minimum is refused.
 
 ```bash
 kcap daemon reviewer affirm --vendor kiro
 ```
 
-Enabling the reviewer affirms whatever is installed at that moment, so you only meet this after an upgrade.
-The command records the version and nothing else — it does not enable the reviewer. No kcap release is
-needed to clear it; Gemini uses the same model and the same command (`--vendor gemini`).
+Run that to move the minimum to whatever is installed now — which is how you exclude a build you have found
+to be broken, and, if you run it while an older build is installed, how you deliberately lower the bar
+again. The command records the version and nothing else — it does not enable the reviewer. No kcap release
+is ever needed; Gemini uses the same model and the same command (`--vendor gemini`).
 
 POSIX only: the isolated home holds the reviewer's own transcript, and therefore the review context, and
 cannot be created owner-only on Windows.
@@ -847,7 +856,7 @@ variable set — unsetting it in your shell later changes nothing.
 
 If a reviewer is still not offered, the daemon says why in its own log at startup — one line per vendor that
 is installed and unattended-capable but withheld, carrying the same text the launch path would have thrown
-(consent not set, version unresolved, version uncertified/unaffirmed). It logs at `Information`, not
+(consent not set, version unresolved, no minimum recorded, version below the minimum). It logs at `Information`, not
 `Warning`: a daemon with Gemini or Kiro installed purely for interactive use and no opt-in is in a
 perfectly normal state, so this is a line to find when you go looking, not an alert.
 

--- a/docs/superpowers/specs/2026-08-06-ai1776-reviewer-version-floor-design.md
+++ b/docs/superpowers/specs/2026-08-06-ai1776-reviewer-version-floor-design.md
@@ -1,0 +1,385 @@
+# AI-1776 — Reviewer version gate: minimum floor, not exact match — Design
+
+## 0. What this is
+
+`KiroReviewerCapability` and `GeminiReviewerCapability` are the only two version-gated reviewers in
+the product. Both currently fail closed the instant the installed vendor build **changes** in any
+direction, because `ReviewerVersionAffirmations.Decide` compares with
+`string.Equals(installed, affirmed, StringComparison.Ordinal)`.
+
+This changes that one comparison to a **minimum version floor**: the recorded value stops meaning
+"the exact build the operator accepted" and starts meaning "the oldest build this daemon will run".
+
+Nothing else about either gate changes. The operator consent flags
+(`KCAP_KIRO_UNATTENDED_REVIEWER` / `KCAP_GEMINI_UNATTENDED_REVIEWER`) are untouched, Kiro's POSIX
+precondition is untouched, and the per-vendor consent text is untouched.
+
+## 1. This reverses a decision that was written down — deliberately
+
+`GeminiReviewerCapability`'s own class doc rejects exactly this design:
+
+> *"A **minimum-version floor** was considered and rejected: it would assume the allowlist's
+> semantics can only improve, which is an assumption about someone else's code, and would silently
+> admit a future build that changed matching to prefix, flipped empty-list semantics, or let
+> repository settings win."*
+
+That objection is not wrong, and this spec does not pretend it is. It is **overruled on stated
+grounds** (owner decision, 2026-08-06):
+
+> *"Treat the version already certified as the minimum version and that's it. We'll assume new
+> versions work fine until we learn of bugs and fix them."*
+
+The reasoning that makes it defensible rather than merely decided:
+
+1. **The same doc records that the stricter model already failed in production, twice over.** The
+   maintainer-curated certified set took the Gemini reviewer offline at `0.54.0`, *one patch* ahead
+   of certified `0.53.0`, recoverable only by a kcap release — "every Gemini release repeated it".
+   Affirmation fixed the release-coupling but kept the treadmill, just relocated onto the operator.
+2. **The rest of the product already made this trade.** Copilot and Cursor borrowed review are
+   trust-by-default, on the reasoning that *"a vendor auto-update would then silently withdraw the
+   capability and reviewers would fall back to a stale committed base."* Claude's certification is a
+   `>=`-capable **range** defaulting to unrestricted. No hosted agent is version-gated at all. Kiro
+   and Gemini are the outliers.
+3. **The response mechanism survives.** "Fix them when we learn of bugs" is executable here: `kcap
+   daemon reviewer affirm` becomes *raise the floor past the bad build*, and it takes effect without
+   a kcap release. The old model had no way to express "anything newer is fine"; the new one has no
+   way to express "not this one specific build" — but it can express "not this one or anything
+   older", which is the actionable half.
+
+**The residual, stated once, plainly:** a future vendor build that *weakens* its own containment
+behaviour is admitted silently. Per vendor:
+
+| Vendor | What containment rests on | What a bad newer build costs |
+|---|---|---|
+| **Gemini** | the build's MCP allowlist being an exclusive exact-match gate the reviewed repo cannot widen | repository-controlled process execution under the daemon uid — the doc's own phrase is *"a broken MCP gate degrades to repository-controlled process execution"* |
+| **Kiro** | the build honouring `KIRO_HOME` and reading no other global config source | the reviewer's transcript-bearing home stops being isolated |
+
+A second vector, raised in review and **not** obvious from the above: because the floor can be
+*lowered*, an operator who runs `affirm` while an older build is installed re-admits that build **and
+everything above it**, including builds a higher floor had previously excluded. The asymmetry with the
+old model is real and worth naming — exact-match required a positive act to admit *each* new build,
+whereas a floor requires a positive act to *exclude* an old one, and re-admitting a known-bad old
+build costs one command. This is accepted rather than mitigated: the operator lowering their own
+floor is the same party who consented to the reviewer at all, and the alternative (a monotonic,
+never-lowerable floor) would leave an operator who upgraded into a broken build with no way back
+short of deleting state files.
+
+Both of the table's risks were already accepted at the moment of the operator's *first* affirmation — what changes
+is that the acceptance now carries forward across upgrades instead of being re-taken each time. That
+is the whole of the change, and it should be described that way in the code comments rather than
+deleting the rejected-alternative paragraph, which stays as the record of why the boundary sits
+where it does.
+
+## 2. The rule
+
+`Decide(installed, floor)`, evaluated **in this order**:
+
+| # | Condition | Result |
+|---|---|---|
+| 1 | `installed` missing / empty / whitespace | **Unresolved** — refuse |
+| 2 | no floor recorded (absent, empty, or unreadable file) | **NoMinimumRecorded** — refuse (new arm; §4) |
+| 3 | **both** sides fail to parse as a version | ordinal equality: equal → **MeetsMinimum**, else **BelowMinimum** (§3) |
+| 4 | **exactly one** side fails to parse | **Incomparable** — refuse (new arm; §2.3) |
+| 5 | `installed >= floor` | **MeetsMinimum** — allow |
+| 6 | `installed < floor` | **BelowMinimum** — refuse |
+
+Two corrections to an earlier draft of this table, both from review, both load-bearing:
+
+- **Row 1 does NOT include "unparseable".** `Unresolved` today means *only* that the installed string
+  is null/empty/whitespace — there is no version parsing in this type at all. Widening it to cover
+  unparseable input would refuse a pair that is allowed today (see §3), which is the one thing this
+  change must not do. `Unresolved` keeps its exact current meaning.
+- **Row 3 requires BOTH sides to fail**, and a one-sided failure is its own arm (row 4). Two earlier
+  drafts got this wrong in opposite directions — the first refused whenever the *installed* side was
+  odd (breaking monotonicity, §3), the second ordinal-compared whenever *either* side was odd, which
+  silently refused a genuine upgrade whenever the recorded floor happened to be unparseable. Ordinal
+  equality is only sound when both values are in the same domain; when they are not, we do not have
+  an ordering and must not fabricate one from string equality.
+
+Row 2 covers the empty-file case without a separate arm, because `ReviewerVersionStore.Affirmed`
+already returns `null` for empty, whitespace-only, unreadable, or absent content — one null, one arm.
+
+### 2.1 The floor never auto-advances
+
+Seeing a newer build does **not** rewrite the record. The floor moves only when an operator runs
+`affirm`. An auto-advancing floor would silently convert every upgrade into a new downgrade barrier,
+re-creating a treadmill in the opposite direction — and would make the record no longer mean what an
+operator set.
+
+### 2.2 A downgrade below the floor is still refused
+
+"Minimum" is load-bearing, not decorative. The owner's instruction covers *new* versions; an older
+build than the one we certified is not that case, and refusing it costs nothing an operator cannot
+undo with one command.
+
+### 2.3 `Incomparable`, and why the remedy actually works
+
+Row 4 fires when one value orders and the other does not — e.g. floor `1.2.3.4.5` (five components;
+`System.Version` tops out at four) against installed `2.0.0`. Refusing here is unsatisfying, since the
+installed build is obviously newer, but the alternatives are worse: ordinal-comparing them refuses
+the same upgrade while *claiming* it is "below minimum", and admitting them means asserting an order
+we did not compute.
+
+What makes the refusal acceptable is that **`affirm` provably clears it, in both directions**:
+
+- floor odd, installed orders → `affirm` writes the installed value, so the floor now orders. Fixed.
+- installed odd, floor orders → `affirm` writes the installed value, so *both* are now that same odd
+  value → row 3, ordinal-equal → allowed. Fixed.
+
+So the denial text must name `affirm` as the remedy, and it is not the dead-end loop it would be if
+`affirm` re-wrote the same unusable value.
+
+### 2.4 Rejected: widening the parse to make row 4 unreachable
+
+The obvious alternative is a tolerant dotted-numeric comparison (split on `.`, compare components
+numerically, no four-component ceiling), which would order `1.2.3.4.5` fine and empty row 4 of
+everything except genuinely malformed input.
+
+**Rejected on scope, not on merit.** §6 requires one shared comparison, and the other caller is
+`DaemonRunner.CliVersionAllowed` — the *Claude certification* gate. Widening what parses there widens
+what that gate admits, since it denies anything `Version.TryParse` rejects. Loosening a second
+vendor's security gate as a side effect of this issue is not a trade this spec gets to make silently.
+If row 4 is ever observed in the wild, that is the fix to reach for, as its own change with its own
+review.
+
+**This argument is load-bearing only once §6's extraction is done, and §6 is in this PR.** Until the
+two paths share a parser they are independent, and a maintainer could widen one without touching the
+other — the scope constraint would then be a convention rather than a structural fact. That is
+another reason §6 is not optional tidying.
+
+Also rejected: tightening `VendorVersionResolver.ExtractVersionToken` to reject what `TryParse`
+rejects. It is shared beyond this path, and it would convert a vendor that emits a five-component
+version from "works" (today, via ordinal equality) into `Unresolved` — a regression, and a silent one.
+
+## 3. Monotonicity — the property that makes this safe to ship
+
+**The new rule must never refuse a pair the current rule allows.** Today's only allowed pair is
+`installed == floor` (ordinal, both non-blank). Two cases, both covered:
+
+- both parse → equal versions satisfy `>=` → row 5, allowed;
+- both fail to parse → row 3, ordinal-equal, allowed.
+
+A pair cannot be ordinal-equal with exactly one side parsing (identical strings parse identically),
+so **row 4 — `Incomparable` — is unreachable for an allowed-today pair** and cannot break the
+property. That is the specific check the second draft failed, and it is worth re-running by hand
+against any future change to the row order.
+
+An earlier draft got this wrong and review caught it. The counterexample: a record hand-written as
+`daily-20240806` with the same string installed is **allowed today** (ordinal equality does not care
+about format), but the draft mapped unparseable-installed to `Unresolved → refuse`. That would have
+been a regression introduced by a change whose entire purpose is to loosen the gate — the worst
+possible shape for this PR. The symmetric row 3 removes the whole class rather than patching the one
+case.
+
+### 3.1 How reachable the fallback actually is — state the contract, keep the guard
+
+Both writers of the record (`DaemonRunner.SeedReviewerAffirmation` and the `affirm` verb) store
+`VendorVersionResolver.Resolve` output, and `ExtractVersionToken` constrains that hard:
+
+```csharp
+var tok = raw.Trim().TrimStart('v', 'V');
+if (tok.Length > 0 && tok.All(c => char.IsAsciiDigit(c) || c == '.') && tok.Contains('.'))
+    return tok;
+```
+
+So a resolver-written value is **digits and dots only, with the `v` prefix already stripped and at
+least one dot present**. It can never be `v0.53.0`, `0.54.0-rc1`, `1.2.3+build.456`, a date stamp or a
+git describe string. That answers the review's sharpest practical worry — that real version strings
+would fail `TryParse`, silently fall back to ordinal, and leave the change a no-op for the exact
+upgrade case it exists to fix. They will not: `0.53.0` → `0.54.0` parses and compares on row 4.
+
+The fallback is therefore **near-unreachable, not dead**, and stays for two reasons:
+
+1. `ExtractVersionToken`'s character filter still admits strings `Version.TryParse` rejects —
+   `1.2.3.4.5` (five components), `.5`, `1.`, `1..2`. Pathological, but the resolver would return them.
+2. The record is a plain file an operator can edit, and the store reads whatever is there.
+
+## 3.2 Test it as a property, not as arms
+
+Pin monotonicity directly: a table of `(installed, floor)` pairs, asserting that every pair the *old*
+comparison admits the *new* one also admits. Include at minimum
+`(daily-20240806, daily-20240806)`, `(1.2.3.4.5, 1.2.3.4.5)`, `(0.53.0, 0.53.0)`. Arm-by-arm tests
+cannot express this property and will not catch its violation.
+
+## 4. `NoMinimumRecorded` as its own arm
+
+Today "nothing recorded" and "a different build is installed" both collapse into `Unaffirmed`. Under
+floor semantics they have genuinely different remedies:
+
+- **no record** → `SeedReviewerAffirmation` writes one only when the reviewer is enabled **and only at
+  daemon startup**. Review made the point that "seeding failed" is an incomplete characterisation, and
+  it is: the ordinary way to reach this state is not failure at all but the **normal first-enable
+  path** — an operator sets `KCAP_*_UNATTENDED_REVIEWER=1` against a daemon that is already running,
+  so no startup has yet observed the flag. The other routes are a record the operator removed, or a
+  seeding attempt that threw (it is caught and warned, never fatal). The denial text must lead with
+  the restart, since that is the common case: *restart the daemon with the reviewer enabled so it can
+  record a minimum, or set one now with `kcap daemon reviewer affirm --vendor <v>`.*
+- **below minimum** → the installed build is older than the floor. Remedy: upgrade the vendor CLI,
+  or deliberately lower the floor with `affirm`.
+
+Both vendor decision enums gain the corresponding arm, **and so does `Incomparable` from §2.3.**
+
+### 4.1 Delete the `_ => Allowed` default — it makes every new arm fail OPEN
+
+Both vendor `Decide` methods currently end:
+
+```csharp
+return ReviewerVersionAffirmations.Decide(installedVersion, affirmedVersion) switch {
+    ReviewerVersionAffirmation.Unresolved => KiroReviewerDecision.VersionUnresolved,
+    ReviewerVersionAffirmation.Unaffirmed => KiroReviewerDecision.VersionUnaffirmed,
+    _                                     => KiroReviewerDecision.Allowed   // ← everything else ALLOWS
+};
+```
+
+Review caught that adding `Incomparable` (or `NoMinimumRecorded`) without touching these switches
+routes it to `_` and **allows the launch** — inverting a refusal into an admission, silently, in a
+gate whose entire purpose is to fail closed. That would have made §2.3's whole analysis moot.
+
+Adding the two arms fixes the instance. **Also remove the discard**, which fixes the class:
+
+```csharp
+=> ReviewerVersionAffirmations.Decide(installed, floor) switch {
+    ReviewerVersionAffirmation.MeetsMinimum      => KiroReviewerDecision.Allowed,
+    ReviewerVersionAffirmation.Unresolved        => KiroReviewerDecision.VersionUnresolved,
+    ReviewerVersionAffirmation.NoMinimumRecorded => KiroReviewerDecision.VersionNoMinimum,
+    ReviewerVersionAffirmation.BelowMinimum      => KiroReviewerDecision.VersionBelowMinimum,
+    ReviewerVersionAffirmation.Incomparable      => KiroReviewerDecision.VersionIncomparable
+};
+```
+
+With every named arm listed and no `_`, the compiler's exhaustiveness check (CS8509) flags the next
+arm someone adds. A default that maps the permissive outcome is the wrong shape for a fail-closed
+gate regardless of how many arms exist today: it means the safe direction is whatever nobody thought
+about.
+
+**CS8509 is a warning by default, so this PR must also make it an error — otherwise the guarantee is
+a hope.** Review flagged that an earlier draft of this section asserted "build failure" without
+checking, and the check says it was wrong: `Directory.Build.props` sets only `EnforceCodeStyleInBuild`
+and a `NoWarn` for two IDE rules — there is no `TreatWarningsAsErrors` and no `WarningsAsErrors`
+anywhere in the repo.
+
+Add to `Directory.Build.props`:
+
+```xml
+<WarningsAsErrors>CS8509</WarningsAsErrors>
+```
+
+**Measured before proposing it:** a build of `Capacitor.Cli.Daemon` (and transitively Core and the
+CLI) plus `Capacitor.Cli.Tests.Unit` currently emits **zero** CS8509 warnings, so this breaks nothing
+today. It is repo-wide rather than scoped to these two assemblies deliberately — a non-exhaustive
+switch that silently picks a default is a hazard everywhere, this one just happens to be a security
+gate — and repo-wide costs nothing given the measurement. Narrow it to the two `.csproj` files if a
+future build disagrees, but do not drop it and leave §4.1 asserting a guarantee that is not there.
+
+The same applies to the mutation check — deleting one explicit arm must now fail the *build*, which
+is a stronger guarantee than a reddening test. Where a test is still wanted, assert that
+`Incomparable` and `NoMinimumRecorded` each produce a refusing vendor decision, per vendor.
+
+### 4.2 Implementation note: a cascade, not a two-parse match
+
+Row 2 must be evaluated **before** rows 3 and 4. `Version.TryParse(null)` returns `false` silently, so
+an implementation that parses both sides up front and then matches on the two boolean results routes
+a missing record into `Incomparable` or `BelowMinimum` instead of `NoMinimumRecorded` — a wrong,
+confusing denial for the most common misconfiguration. `ReviewerVersionStore.Affirmed` returns `null`
+for the missing-file case, which is exactly the input that makes this silent. Write the rows as an
+ordered cascade with the null checks first, and say so in a comment at the site.
+
+## 5. Do not rename the record file
+
+`ReviewerVersionStore.FileNameFor(vendor)` is `{vendor}-reviewer-affirmed-version`. It reads
+"affirmed" and this change makes that word inaccurate — **leave it alone anyway.** The store's own
+doc already records why: *"Kiro's filename is unchanged from when this type was Kiro-only — renaming
+it would have silently discarded every existing affirmation and taken shipped reviewers offline on
+upgrade."* The identical hazard applies here, and it is precisely the sort of tidying this rename-heavy
+change invites. A comment at the constant should say so.
+
+Likewise the `affirm` verb keeps its name. Its *meaning* becomes "record the installed build as the
+minimum", its help text and output change, but renaming the verb would break documented operator
+muscle memory and every README reference for no functional gain.
+
+## 6. Share the version parsing — do not write a second one
+
+`DaemonRunner.CliVersionAllowed` already normalizes a vendor version string for comparison:
+`TrimStart('v','V')`, `Split('-','+')[0]`, `Version.TryParse`. This change needs a
+string→`Version?` step in `Capacitor.Cli.Core`.
+
+**Extract it into Core and have `CliVersionAllowed` call it.** Do not copy the three lines and add a
+test asserting the two agree — two implementations that must agree with nothing structurally making
+them agree is a known recurring defect shape in this codebase, and the fix is to delete one, not to
+watch them.
+
+**The justification is cross-path consistency, not merely drift prevention.** Review's point, and it
+is the stronger form of the argument: per §3.1 the extra trimming is a no-op on these values, so
+"they might drift apart later" is a style preference an implementer can argue with. The invariant
+that is *not* arguable is that **both paths must agree on what counts as an orderable version.** The
+same resolver output feeds this gate and `CliVersionAllowed`; if the two disagreed on parseability,
+a reviewer could be admitted as running a version the rest of the daemon's version logic would treat
+as unrecognisable — and §2.4 turns that agreement into a load-bearing property, since it is exactly
+why widening one parse cannot be done without considering the other. Share the parse because the two
+gates must classify identically, not because they happen to today.
+
+## 7. Operator-facing text
+
+Every message that today says a build "was affirmed" and a "changed build is refused" must stop
+saying that — the refusal is now specifically *older than*. Update:
+
+- `KiroReviewerCapability.DenialReason` / `GeminiReviewerCapability.DenialReason` — coded prefixes
+  become `*_reviewer_version_below_minimum`, `*_reviewer_version_no_minimum`, and
+  `*_reviewer_version_incomparable` (§2.3), each naming the installed version, the floor, and the
+  remedy. `*_incomparable` must name `affirm` specifically — §2.3's proof that the remedy terminates
+  is the reason that arm is acceptable, and an operator cannot act on it if the text is vague.
+- `DaemonReviewerCommand` usage + success output. The verb can now **lower** a floor (affirming an
+  older build than the record); say so explicitly in that case rather than reusing the neutral
+  `(was {previous})` phrasing.
+- `README.md`, which currently states the exact-match rule in two places (~L783-787 Gemini, ~L818-825
+  Kiro) plus the startup-diagnostic line (~L850). The Gemini passage explicitly documents the old
+  behaviour — *"a build other than the one this daemon affirmed is refused even with the flag on"* —
+  and must not be left contradicting the code. Per the repo's own README-sync rule, this lands in the
+  **same PR**.
+
+  Review asked for the replacement wording rather than "say it's a minimum", on the grounds that a
+  vague phrasing like *"at least the affirmed version"* can still be read as exact-or-newer by a
+  confused operator. Use this shape, adapted per vendor:
+
+  > The recorded version is a **minimum**, not an exact match. Any build at or above it runs; an older
+  > one is refused. A vendor upgrade needs no action from you. Use
+  > `kcap daemon reviewer affirm --vendor <v>` to move the minimum to whatever is installed now —
+  > which is also how you exclude a build you have found to be broken.
+
+## 8. Testing
+
+- The five rows of §2's table, per vendor, each reachable from any host (Kiro's platform argument
+  stays a parameter — the existing comment records that reading the ambient OS broke a dozen tests on
+  the Windows CI leg).
+- **The monotonicity property of §3**, as its own table-driven test over `(installed, floor)` pairs,
+  including `(daily-20240806, daily-20240806)` and `(1.2.3.4.5, 1.2.3.4.5)` — the pairs an
+  arm-by-arm suite cannot express and the earlier draft would have regressed.
+- **Row 4 (`Incomparable`) in both directions**: unparseable floor + parseable installed, and the
+  reverse. Assert it is NOT reported as `BelowMinimum` — mislabelling it is how the second draft hid
+  a refused upgrade behind a plausible-sounding message.
+- **`affirm` clears `Incomparable` in both directions** (§2.3) — the property that makes refusing
+  acceptable. Two tests, one per direction, each asserting the *next* `Decide` allows.
+- `Unresolved` still fires **only** for null/empty/whitespace installed — a test that an unparseable
+  but non-blank installed string does NOT reach it.
+- Floor does not auto-advance (§2.1): a `Decide` returning `MeetsMinimum` for a newer build leaves the
+  store untouched.
+- Downgrade refused (§2.2).
+- Empty record file → `NoMinimumRecorded`, same as an absent one (§2 row 2).
+- `affirm` lowering the floor reports that it lowered it.
+- Mutation-check each guard: break the comparison, confirm the specific test reddens, restore with the
+  inverse edit.
+
+## 9. Acceptance
+
+1. A daemon whose vendor upgraded past its recorded version runs the reviewer with **no operator
+   action** — the failure this issue exists to remove. Scoped honestly: this holds for any pair
+   `System.Version` can order, which per §3.1 is every value the resolver can produce except the
+   pathological `1.2.3.4.5` / `1.` / `.5` class. That class lands on §2.3's `Incomparable`, which
+   costs one `affirm` and is documented rather than hidden.
+2. A daemon whose vendor is older than its record refuses, with text naming both versions.
+3. No existing record is rewritten, moved, or invalidated by deploying this.
+4. `rg 'AI-[0-9]+' src/ test/ --type cs` stays empty (repo rule; this file is documentation and is
+   exempt).
+5. No IL2026/IL3050 from `dotnet publish -c Release` on either the CLI or the daemon.
+6. `WarningsAsErrors` includes CS8509 (§4.1), and the solution still builds clean — the exhaustiveness
+   guard is only real if it is enforced, and a green build proves it costs nothing.

--- a/src/Capacitor.Cli.Core/ReviewerVersionStore.cs
+++ b/src/Capacitor.Cli.Core/ReviewerVersionStore.cs
@@ -9,12 +9,14 @@ namespace Capacitor.Cli.Core;
 /// <c>--allowed-mcp-server-names</c> is an exclusive exact-match gate a repository's own settings
 /// cannot widen. A vendor release can change either.</para>
 ///
-/// <para><b>Why an operator affirmation and not a curated certified set.</b> A maintainer-curated set
+/// <para><b>Why an operator-set MINIMUM and not a curated certified set.</b> A maintainer-curated set
 /// takes the reviewer offline on every vendor release until a re-certification PR ships — untenable
 /// against CLIs that move several versions a week, and it did exactly that: the Gemini reviewer was
-/// unreachable at a version one patch ahead of the certified one. Failing closed on a version CHANGE,
-/// cleared by the operator who is already the consenting party, keeps the fail-closed direction
-/// without the treadmill.</para>
+/// unreachable at a version one patch ahead of the certified one. Failing closed on a version CHANGE
+/// removed the kcap-release coupling but kept the treadmill, merely relocating it onto the operator,
+/// who then re-took the same acceptance on every patch. The recorded value is therefore the OLDEST
+/// build this daemon will run: an upgrade needs no action, a downgrade below it is refused, and a
+/// build later found to be bad is excluded by raising the floor past it.</para>
 ///
 /// <para><b>Why this is state and not configuration.</b> A value the operator could set from a shell
 /// profile would be re-affirmed by their dotfiles rather than by them — the same "consent that isn't
@@ -79,35 +81,100 @@ public sealed class ReviewerVersionStore(string stateDir, string vendor) {
     }
 }
 
-/// <summary>Whether the installed build matches what the operator affirmed.</summary>
+/// <summary>Whether the installed build clears the recorded minimum.</summary>
 public enum ReviewerVersionAffirmation {
-    Affirmed,
-    /// <summary>The installed build could not be identified — denied, since it cannot be matched.</summary>
+    /// <summary>Installed is at or above the recorded minimum — allowed.</summary>
+    MeetsMinimum,
+    /// <summary>The installed build could not be identified — denied, since it cannot be compared.</summary>
     Unresolved,
-    /// <summary>Nothing affirmed, or a build other than the affirmed one is installed.</summary>
-    Unaffirmed
+    /// <summary>No minimum recorded at all. Distinct from <see cref="BelowMinimum"/> because the
+    /// operator's remedy differs: record one, rather than change the installed build.</summary>
+    NoMinimumRecorded,
+    /// <summary>Installed is older than the recorded minimum.</summary>
+    BelowMinimum,
+    /// <summary>Exactly one of the two values orders as a version and the other does not, so there is
+    /// no ordering to apply. Denied — but see <see cref="ReviewerVersionAffirmations"/> for why the
+    /// affirm remedy provably terminates rather than looping.</summary>
+    Incomparable
 }
 
 /// <summary>
 /// The version half of every gated reviewer's decision, written once so the vendors cannot drift
-/// apart on what "the operator accepted this build" means. Each vendor keeps its own decision enum,
-/// its own preconditions (Kiro's POSIX requirement) and its own consent text, because what enabling
-/// a reviewer grants differs per vendor — only this comparison is common.
+/// apart on what "this build clears the bar" means. Each vendor keeps its own decision enum, its own
+/// preconditions (Kiro's POSIX requirement) and its own consent text, because what enabling a
+/// reviewer grants differs per vendor — only this comparison is common.
+///
+/// <para><b>The recorded value is a MINIMUM, not an exact match.</b> It previously required the
+/// installed build to equal the recorded one, which took a reviewer offline on every vendor patch
+/// release until an operator re-ran the affirm verb. That is the treadmill the maintainer-curated
+/// certified set was abandoned for; affirmation only relocated it from a kcap release onto the
+/// operator. The recorded value now means "the oldest build this daemon will run", and a vendor
+/// upgrade needs no action at all.</para>
+///
+/// <para><b>What that gives up.</b> A future vendor build that weakens its own containment behaviour
+/// is admitted silently — for Gemini the MCP-allowlist semantics, for Kiro the <c>KIRO_HOME</c>
+/// suppression. Both were already accepted at the operator's first affirmation; what changed is that
+/// the acceptance carries forward across upgrades instead of being re-taken each time. When a bad
+/// build is found, the affirm verb raises the floor past it without a kcap release. See
+/// <c>GeminiReviewerCapability</c>'s class doc, which records the earlier decision this reverses and
+/// why the boundary sat where it did.</para>
 /// </summary>
 public static class ReviewerVersionAffirmations {
     /// <summary>
-    /// Pure. Both sides are trimmed before comparison because a vendor's <c>--version</c> output and
-    /// a hand-written record both carry stray whitespace, and an Ordinal comparison of untrimmed text
-    /// would refuse a build the operator did affirm.
+    /// Pure. An ORDERED cascade, not a match over two parse results — see the inline note on why the
+    /// null checks must come first.
+    ///
+    /// <para>Both sides are trimmed because a vendor's <c>--version</c> output and a hand-written
+    /// record both carry stray whitespace.</para>
     /// </summary>
-    public static ReviewerVersionAffirmation Decide(string? installedVersion, string? affirmedVersion) {
+    public static ReviewerVersionAffirmation Decide(string? installedVersion, string? minimumVersion) {
+        // Rows 1-2 FIRST, and this ordering is load-bearing: Version.TryParse(null) returns false
+        // silently, so parsing both sides up front and matching on the two results would route a
+        // MISSING record into Incomparable/BelowMinimum instead of NoMinimumRecorded — the wrong
+        // denial for the most common misconfiguration (a reviewer enabled against an already-running
+        // daemon, which has not yet had a startup to seed one).
         if (Normalize(installedVersion) is not { } installed) return ReviewerVersionAffirmation.Unresolved;
-        if (Normalize(affirmedVersion) is not { } affirmed)   return ReviewerVersionAffirmation.Unaffirmed;
+        if (Normalize(minimumVersion) is not { } minimum)     return ReviewerVersionAffirmation.NoMinimumRecorded;
 
-        return string.Equals(installed, affirmed, StringComparison.Ordinal)
-            ? ReviewerVersionAffirmation.Affirmed
-            : ReviewerVersionAffirmation.Unaffirmed;
+        var installedVersionParsed = TryParseVersion(installed);
+        var minimumVersionParsed   = TryParseVersion(minimum);
+
+        // Both unorderable: fall back to the ordinal equality this type used to apply unconditionally.
+        // That is what keeps the change monotone — every pair the old rule ALLOWED (which is exactly
+        // the ordinal-equal ones) is still allowed, including values no version parser accepts.
+        if (installedVersionParsed is null && minimumVersionParsed is null)
+            return string.Equals(installed, minimum, StringComparison.Ordinal)
+                ? ReviewerVersionAffirmation.MeetsMinimum
+                : ReviewerVersionAffirmation.BelowMinimum;
+
+        // Exactly one orders. Ordinal equality is only sound when both values are in the same domain;
+        // comparing across domains would refuse a genuine upgrade while LABELLING it "below minimum".
+        // Say we cannot order them instead. The affirm remedy terminates either way: if the minimum
+        // is the odd one, affirming writes the (orderable) installed value; if the installed one is
+        // odd, affirming makes both that same odd string, which the ordinal branch above then allows.
+        if (installedVersionParsed is null || minimumVersionParsed is null)
+            return ReviewerVersionAffirmation.Incomparable;
+
+        return installedVersionParsed >= minimumVersionParsed
+            ? ReviewerVersionAffirmation.MeetsMinimum
+            : ReviewerVersionAffirmation.BelowMinimum;
     }
+
+    /// <summary>
+    /// A vendor version string as an orderable <see cref="Version"/>, or null when it does not order.
+    ///
+    /// <para>Shared with <c>DaemonRunner.CliVersionAllowed</c> rather than duplicated, because the two
+    /// gates must agree on WHAT COUNTS AS AN ORDERABLE VERSION. The same
+    /// <see cref="VendorVersionResolver"/> output feeds both; if they classified parseability
+    /// differently, a reviewer could be admitted running a version the rest of the daemon's version
+    /// logic treats as unrecognisable. That shared classification is also what bounds the reviewer
+    /// gate's scope — widening what parses here would widen what the certification gate admits, so it
+    /// cannot be done as a side effect of a reviewer change.</para>
+    /// </summary>
+    public static Version? TryParseVersion(string? version) =>
+        Version.TryParse((version ?? "").Trim().TrimStart('v', 'V').Split('-', '+')[0], out var parsed)
+            ? parsed
+            : null;
 
     /// <summary>Trimmed, or null when there is nothing there — whitespace-only is not a version.</summary>
     public static string? Normalize(string? version) =>

--- a/src/Capacitor.Cli.Core/ReviewerVersionStore.cs
+++ b/src/Capacitor.Cli.Core/ReviewerVersionStore.cs
@@ -171,8 +171,17 @@ public static class ReviewerVersionAffirmations {
     /// gate's scope — widening what parses here would widen what the certification gate admits, so it
     /// cannot be done as a side effect of a reviewer change.</para>
     /// </summary>
+    /// <para><b>Byte-identical to the normalization <c>CliVersionAllowed</c> applied before it moved
+    /// here — deliberately, and do not "tidy" a <c>.Trim()</c> back in.</b> An earlier revision added
+    /// one, on the reasoning that trimming is harmless. It is not: <see cref="Version.TryParse"/>
+    /// already tolerates surrounding whitespace, so the trim changes nothing on its own — but it lets
+    /// <c>TrimStart('v','V')</c> reach a <c>v</c> it could not otherwise see, so <c>" v1.2.3"</c> flips
+    /// from REFUSED to allowed (measured). For the certification gate that is a silent widening of what
+    /// it admits, made as a side effect of a reviewer change. Every caller here already passes trimmed
+    /// input anyway (<see cref="Normalize"/>'s output, <see cref="ReviewerVersionStore.Affirmed"/>, and
+    /// <see cref="VendorVersionResolver"/>'s token), so the trim bought nothing and cost that.</para>
     public static Version? TryParseVersion(string? version) =>
-        Version.TryParse((version ?? "").Trim().TrimStart('v', 'V').Split('-', '+')[0], out var parsed)
+        Version.TryParse((version ?? "").TrimStart('v', 'V').Split('-', '+')[0], out var parsed)
             ? parsed
             : null;
 

--- a/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
@@ -67,10 +67,8 @@ internal static class GeminiReviewerCapability {
         // is switched off.
         if (!operatorEnabled) return GeminiReviewerDecision.Disabled;
 
-        // Every arm listed, NO discard: a `_ => Allowed` default meant any arm added to
-        // ReviewerVersionAffirmation later was silently ADMITTED rather than refused, inverting a
-        // fail-closed gate. Without it, CS8509 (an error via Directory.Build.props) makes the next
-        // arm a build failure.
+        // No discard: `_ => Allowed` silently ADMITTED any arm added later, which is the wrong
+        // direction for this gate. CS8509 makes the next one a build failure instead.
         return ReviewerVersionAffirmations.Decide(installedVersion, minimumVersion) switch {
             ReviewerVersionAffirmation.MeetsMinimum      => GeminiReviewerDecision.Allowed,
             ReviewerVersionAffirmation.Unresolved        => GeminiReviewerDecision.VersionUnresolved,

--- a/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
@@ -6,7 +6,9 @@ internal enum GeminiReviewerDecision {
     Allowed,
     Disabled,
     VersionUnresolved,
-    VersionUnaffirmed
+    VersionNoMinimum,
+    VersionBelowMinimum,
+    VersionIncomparable
 }
 
 /// <summary>
@@ -36,10 +38,18 @@ internal enum GeminiReviewerDecision {
 /// <para><b>What that trade is, stated plainly.</b> The certified set asserted that a maintainer had read
 /// that build's matcher. An affirmation asserts only that the operator accepted this build. It is the weaker
 /// claim — but it is made by the party who carries the risk, on the machine that carries it, and the
-/// alternative was a reviewer nobody could run. A <i>minimum-version floor</i> was considered and rejected:
-/// it would assume the allowlist's semantics can only improve, which is an assumption about someone else's
-/// code, and would silently admit a future build that changed matching to prefix, flipped empty-list
-/// semantics, or let repository settings win.</para>
+/// alternative was a reviewer nobody could run.</para>
+///
+/// <para><b>And the recorded value is now a MINIMUM, not an exact match — which this doc used to argue
+/// against.</b> The paragraph is kept rather than deleted, because it states the real cost: a floor
+/// assumes the allowlist's semantics can only improve, which is an assumption about someone else's code,
+/// and it silently admits a future build that changed matching to prefix, flipped empty-list semantics, or
+/// let repository settings win. That objection stands on its merits and was overruled deliberately —
+/// exact-match kept the treadmill the certified set was abandoned for, merely relocating it from a kcap
+/// release onto the operator, who then re-took the same acceptance on every patch. The acceptance now
+/// carries forward across upgrades instead, and the affirm verb raises the floor past a build once found
+/// to be bad. If a Gemini release is ever found to have weakened the allowlist, this is the paragraph that
+/// says what to reach for.</para>
 ///
 /// <para>Deliberately stricter than the interactive hosting path, which runs any installed Gemini.
 /// Broken hosting degrades to a broken agent; a broken MCP gate degrades to repository-controlled process
@@ -51,16 +61,22 @@ internal static class GeminiReviewerCapability {
     /// actually use — null when it could not be resolved, which is treated as unknown and therefore denied.
     /// </summary>
     internal static GeminiReviewerDecision Decide(
-            bool operatorEnabled, string? installedVersion, string? affirmedVersion) {
+            bool operatorEnabled, string? installedVersion, string? minimumVersion) {
         // Operator flag FIRST and short-circuiting, so a daemon that opted out never interrogates the
         // vendor binary at all — an installed-but-wedged binary must not hang startup on a feature that
         // is switched off.
         if (!operatorEnabled) return GeminiReviewerDecision.Disabled;
 
-        return ReviewerVersionAffirmations.Decide(installedVersion, affirmedVersion) switch {
-            ReviewerVersionAffirmation.Unresolved => GeminiReviewerDecision.VersionUnresolved,
-            ReviewerVersionAffirmation.Unaffirmed => GeminiReviewerDecision.VersionUnaffirmed,
-            _                                     => GeminiReviewerDecision.Allowed
+        // Every arm listed, NO discard: a `_ => Allowed` default meant any arm added to
+        // ReviewerVersionAffirmation later was silently ADMITTED rather than refused, inverting a
+        // fail-closed gate. Without it, CS8509 (an error via Directory.Build.props) makes the next
+        // arm a build failure.
+        return ReviewerVersionAffirmations.Decide(installedVersion, minimumVersion) switch {
+            ReviewerVersionAffirmation.MeetsMinimum      => GeminiReviewerDecision.Allowed,
+            ReviewerVersionAffirmation.Unresolved        => GeminiReviewerDecision.VersionUnresolved,
+            ReviewerVersionAffirmation.NoMinimumRecorded => GeminiReviewerDecision.VersionNoMinimum,
+            ReviewerVersionAffirmation.BelowMinimum      => GeminiReviewerDecision.VersionBelowMinimum,
+            ReviewerVersionAffirmation.Incomparable      => GeminiReviewerDecision.VersionIncomparable
         };
     }
 
@@ -69,7 +85,7 @@ internal static class GeminiReviewerCapability {
     /// <see cref="Decide"/> so the two cannot disagree about WHY a launch was denied.
     /// </summary>
     internal static string DenialReason(
-            GeminiReviewerDecision decision, string? installedVersion, string? affirmedVersion) =>
+            GeminiReviewerDecision decision, string? installedVersion, string? minimumVersion) =>
         decision switch {
             GeminiReviewerDecision.Disabled =>
                 "gemini_unattended_reviewer_disabled: this daemon has not enabled Gemini as an unattended "
@@ -80,16 +96,30 @@ internal static class GeminiReviewerCapability {
 
             GeminiReviewerDecision.VersionUnresolved =>
                 "gemini_reviewer_version_unresolved: the installed gemini version could not be "
-              + "determined, so it cannot be matched against the version this daemon affirmed. The "
+              + "determined, so it cannot be compared against this daemon's recorded minimum. The "
               + "reviewer's only containment is that build's MCP allowlist, so an unverifiable build is "
               + "refused.",
 
+            GeminiReviewerDecision.VersionNoMinimum =>
+                "gemini_reviewer_version_no_minimum: this daemon has no recorded minimum gemini "
+              + "version, so there is nothing to check the installed build against. The usual cause is "
+              + "enabling the reviewer against an already-running daemon — it records a minimum at "
+              + "startup, so restart it with KCAP_GEMINI_UNATTENDED_REVIEWER set. To set one now "
+              + "without restarting, run `kcap daemon reviewer affirm --vendor gemini`.",
+
+            GeminiReviewerDecision.VersionIncomparable =>
+                $"gemini_reviewer_version_incomparable: gemini {Describe(installedVersion)} and this "
+              + $"daemon's recorded minimum {Describe(minimumVersion)} cannot be ordered as version "
+              + "numbers, so neither can be said to be newer. Record the installed build as the "
+              + "minimum with `kcap daemon reviewer affirm --vendor gemini`.",
+
             _ =>
-                $"gemini_reviewer_version_unaffirmed: gemini {Describe(installedVersion)} is installed but "
-              + $"this daemon affirmed {Describe(affirmedVersion)}. The reviewer's containment rests on "
-              + "this build's MCP-allowlist semantics — an exclusive exact-match gate the reviewed "
-              + "repository cannot widen — so a changed build is refused until an operator confirms it: "
-              + "run `kcap daemon reviewer affirm --vendor gemini`."
+                $"gemini_reviewer_version_below_minimum: gemini {Describe(installedVersion)} is "
+              + $"installed but this daemon's recorded minimum is {Describe(minimumVersion)}. The "
+              + "reviewer's containment rests on the build's MCP-allowlist semantics — an exclusive "
+              + "exact-match gate the reviewed repository cannot widen — so an OLDER build than the "
+              + "one recorded is refused. Upgrade gemini, or deliberately lower the minimum to the "
+              + "installed build with `kcap daemon reviewer affirm --vendor gemini`."
         };
 
     static string Describe(string? version) => ReviewerVersionAffirmations.Describe(version);

--- a/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
@@ -113,7 +113,15 @@ internal static class GeminiReviewerCapability {
               + "numbers, so neither can be said to be newer. Record the installed build as the "
               + "minimum with `kcap daemon reviewer affirm --vendor gemini`.",
 
-            _ =>
+            // Exhaustive, like Decide's switch and for a weaker but real version of the same reason: a
+            // discard here would print the below-minimum text for a future arm that means something
+            // else, telling an operator to fix the wrong thing. Allowed throws rather than returning a
+            // string, because asking for the denial reason of a permitted decision is a caller bug.
+            GeminiReviewerDecision.Allowed =>
+                throw new ArgumentOutOfRangeException(
+                    nameof(decision), decision, "Allowed is not a denial and has no reason."),
+
+            GeminiReviewerDecision.VersionBelowMinimum =>
                 $"gemini_reviewer_version_below_minimum: gemini {Describe(installedVersion)} is "
               + $"installed but this daemon's recorded minimum is {Describe(minimumVersion)}. The "
               + "reviewer's containment rests on the build's MCP-allowlist semantics — an exclusive "

--- a/src/Capacitor.Cli.Daemon/Acp/KiroReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/KiroReviewerCapability.cs
@@ -121,7 +121,14 @@ internal static class KiroReviewerCapability {
               + "numbers, so neither can be said to be newer. Record the installed build as the "
               + "minimum with `kcap daemon reviewer affirm --vendor kiro`.",
 
-            _ =>
+            // Exhaustive, like Decide's switch: a discard would print the below-minimum text for a
+            // future arm meaning something else, sending an operator to the wrong fix. Allowed throws
+            // because asking for the denial reason of a permitted decision is a caller bug.
+            KiroReviewerDecision.Allowed =>
+                throw new ArgumentOutOfRangeException(
+                    nameof(decision), decision, "Allowed is not a denial and has no reason."),
+
+            KiroReviewerDecision.VersionBelowMinimum =>
                 $"kiro_reviewer_version_below_minimum: kiro-cli {Describe(installedVersion)} is "
               + $"installed but this daemon's recorded minimum is {Describe(minimumVersion)}. The "
               + "reviewer's containment depends on the build honouring KIRO_HOME and reading no other "

--- a/src/Capacitor.Cli.Daemon/Acp/KiroReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/KiroReviewerCapability.cs
@@ -7,7 +7,9 @@ internal enum KiroReviewerDecision {
     UnsupportedPlatform,
     Disabled,
     VersionUnresolved,
-    VersionUnaffirmed
+    VersionNoMinimum,
+    VersionBelowMinimum,
+    VersionIncomparable
 }
 
 /// <summary>
@@ -24,20 +26,24 @@ internal enum KiroReviewerDecision {
 /// The reviewer is supported only where the operator and the review requesters are in one trust
 /// domain.</para>
 ///
-/// <para><b>Why a version affirmation rather than a certified set.</b> Containment is source
-/// suppression — an empty per-launch <see cref="KiroReviewerHome"/> plus the worktree layer's removal
-/// of branch-authored config. The second is ours; the first is not, because Kiro honouring
-/// <c>KIRO_HOME</c> and reading no other global config source are behaviours of the build. A
-/// maintainer-curated certified set would take the reviewer offline on every vendor release, so this
-/// fails closed when the installed version CHANGES and the operator clears it. Gemini now uses the
-/// same model; the shared comparison lives in <see cref="Core.ReviewerVersionAffirmations"/> and the
-/// record in <see cref="Core.ReviewerVersionStore"/>.</para>
+/// <para><b>Why a version MINIMUM rather than a certified set or an exact affirmation.</b> Containment
+/// is source suppression — an empty per-launch <see cref="KiroReviewerHome"/> plus the worktree
+/// layer's removal of branch-authored config. The second is ours; the first is not, because Kiro
+/// honouring <c>KIRO_HOME</c> and reading no other global config source are behaviours of the build.
+/// A maintainer-curated certified set took the reviewer offline on every vendor release, recoverable
+/// only by a kcap release; an exact affirmation fixed the release-coupling but kept the treadmill,
+/// merely relocating it onto the operator. The recorded value is now the OLDEST build this daemon
+/// will run, so a vendor upgrade needs no action and a downgrade below it is refused. The trade — a
+/// future build that weakens its own containment is admitted silently — is accepted, and the affirm
+/// verb raises the floor past a build once found to be bad. Gemini uses the same model; the shared
+/// comparison lives in <see cref="Core.ReviewerVersionAffirmations"/> and the record in
+/// <see cref="Core.ReviewerVersionStore"/>.</para>
 /// </summary>
 internal static class KiroReviewerCapability {
     /// <summary>Production entry point: reads the host platform, then defers to the pure overload.</summary>
     internal static KiroReviewerDecision Decide(
-            bool operatorEnabled, string? installedVersion, string? affirmedVersion) =>
-        Decide(!OperatingSystem.IsWindows(), operatorEnabled, installedVersion, affirmedVersion);
+            bool operatorEnabled, string? installedVersion, string? minimumVersion) =>
+        Decide(!OperatingSystem.IsWindows(), operatorEnabled, installedVersion, minimumVersion);
 
     /// <summary>
     /// The decision, with the platform passed IN rather than read from the ambient OS.
@@ -50,7 +56,7 @@ internal static class KiroReviewerCapability {
     /// from any host — including the Windows arm itself, which was previously unassertable on POSIX.</para>
     /// </summary>
     internal static KiroReviewerDecision Decide(
-            bool posixHost, bool operatorEnabled, string? installedVersion, string? affirmedVersion) {
+            bool posixHost, bool operatorEnabled, string? installedVersion, string? minimumVersion) {
         // Windows has no 0700, so the transcript-bearing reviewer home cannot be made owner-only and
         // the disposal requirement cannot be met. Refuse rather than advertise a reviewer whose review
         // context is world-readable.
@@ -62,10 +68,17 @@ internal static class KiroReviewerCapability {
         if (!operatorEnabled) return KiroReviewerDecision.Disabled;
 
         // The version half is shared with the other gated reviewers — see ReviewerVersionAffirmations.
-        return ReviewerVersionAffirmations.Decide(installedVersion, affirmedVersion) switch {
-            ReviewerVersionAffirmation.Unresolved => KiroReviewerDecision.VersionUnresolved,
-            ReviewerVersionAffirmation.Unaffirmed => KiroReviewerDecision.VersionUnaffirmed,
-            _                                     => KiroReviewerDecision.Allowed
+        //
+        // Every arm is listed and there is NO discard. A `_ => Allowed` default meant any arm added to
+        // ReviewerVersionAffirmation later was silently ADMITTED rather than refused — a fail-closed
+        // gate whose safe direction was whatever nobody thought about. Without the discard, CS8509
+        // (an error via Directory.Build.props) makes the next arm a build failure instead.
+        return ReviewerVersionAffirmations.Decide(installedVersion, minimumVersion) switch {
+            ReviewerVersionAffirmation.MeetsMinimum      => KiroReviewerDecision.Allowed,
+            ReviewerVersionAffirmation.Unresolved        => KiroReviewerDecision.VersionUnresolved,
+            ReviewerVersionAffirmation.NoMinimumRecorded => KiroReviewerDecision.VersionNoMinimum,
+            ReviewerVersionAffirmation.BelowMinimum      => KiroReviewerDecision.VersionBelowMinimum,
+            ReviewerVersionAffirmation.Incomparable      => KiroReviewerDecision.VersionIncomparable
         };
     }
 
@@ -75,7 +88,7 @@ internal static class KiroReviewerCapability {
     /// for the risk in this type's summary, so its content is asserted, not just its presence.
     /// </summary>
     internal static string DenialReason(
-            KiroReviewerDecision decision, string? installedVersion, string? affirmedVersion) =>
+            KiroReviewerDecision decision, string? installedVersion, string? minimumVersion) =>
         decision switch {
             KiroReviewerDecision.UnsupportedPlatform =>
                 "kiro_reviewer_unsupported_platform: the Kiro unattended reviewer is POSIX-only. Its "
@@ -92,14 +105,28 @@ internal static class KiroReviewerCapability {
 
             KiroReviewerDecision.VersionUnresolved =>
                 "kiro_reviewer_version_unresolved: the installed kiro-cli version could not be "
-              + "determined, so it cannot be matched against the version this daemon affirmed. A build "
+              + "determined, so it cannot be compared against this daemon's recorded minimum. A build "
               + "we cannot identify is refused rather than assumed compatible.",
 
+            KiroReviewerDecision.VersionNoMinimum =>
+                "kiro_reviewer_version_no_minimum: this daemon has no recorded minimum kiro-cli "
+              + "version, so there is nothing to check the installed build against. The usual cause is "
+              + "enabling the reviewer against an already-running daemon — it records a minimum at "
+              + "startup, so restart it with KCAP_KIRO_UNATTENDED_REVIEWER set. To set one now without "
+              + "restarting, run `kcap daemon reviewer affirm --vendor kiro`.",
+
+            KiroReviewerDecision.VersionIncomparable =>
+                $"kiro_reviewer_version_incomparable: kiro-cli {Describe(installedVersion)} and this "
+              + $"daemon's recorded minimum {Describe(minimumVersion)} cannot be ordered as version "
+              + "numbers, so neither can be said to be newer. Record the installed build as the "
+              + "minimum with `kcap daemon reviewer affirm --vendor kiro`.",
+
             _ =>
-                $"kiro_reviewer_version_unaffirmed: kiro-cli {Describe(installedVersion)} is installed "
-              + $"but this daemon affirmed {Describe(affirmedVersion)}. The reviewer's MCP containment "
-              + "depends on this build honouring KIRO_HOME and reading no other global config source, "
-              + "so a changed build is refused until an operator confirms it: run "
+                $"kiro_reviewer_version_below_minimum: kiro-cli {Describe(installedVersion)} is "
+              + $"installed but this daemon's recorded minimum is {Describe(minimumVersion)}. The "
+              + "reviewer's containment depends on the build honouring KIRO_HOME and reading no other "
+              + "global config source, so an OLDER build than the one recorded is refused. Upgrade "
+              + "kiro-cli, or deliberately lower the minimum to the installed build with "
               + "`kcap daemon reviewer affirm --vendor kiro`."
         };
 

--- a/src/Capacitor.Cli.Daemon/Acp/KiroReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/KiroReviewerCapability.cs
@@ -67,12 +67,8 @@ internal static class KiroReviewerCapability {
         // off — the same trap the Gemini gate documents.
         if (!operatorEnabled) return KiroReviewerDecision.Disabled;
 
-        // The version half is shared with the other gated reviewers — see ReviewerVersionAffirmations.
-        //
-        // Every arm is listed and there is NO discard. A `_ => Allowed` default meant any arm added to
-        // ReviewerVersionAffirmation later was silently ADMITTED rather than refused — a fail-closed
-        // gate whose safe direction was whatever nobody thought about. Without the discard, CS8509
-        // (an error via Directory.Build.props) makes the next arm a build failure instead.
+        // No discard: `_ => Allowed` silently ADMITTED any arm added later, which is the wrong
+        // direction for this gate. CS8509 makes the next one a build failure instead.
         return ReviewerVersionAffirmations.Decide(installedVersion, minimumVersion) switch {
             ReviewerVersionAffirmation.MeetsMinimum      => KiroReviewerDecision.Allowed,
             ReviewerVersionAffirmation.Unresolved        => KiroReviewerDecision.VersionUnresolved,

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1038,8 +1038,9 @@ public static partial class DaemonRunner {
     static readonly char[] WhitespaceSeparators = [' ', '\t', '\r', '\n'];
 
     internal static bool CliVersionAllowed(string? rawVersion, string ranges) {
-        var normalized = (rawVersion ?? "").TrimStart('v', 'V').Split('-', '+')[0];
-        if (!Version.TryParse(normalized, out var version)) return false;
+        // Shared with the reviewer minimum-version gate rather than parsed here — see
+        // ReviewerVersionAffirmations.TryParseVersion for why the two must classify identically.
+        if (ReviewerVersionAffirmations.TryParseVersion(rawVersion) is not { } version) return false;
         if (string.IsNullOrWhiteSpace(ranges)) return false;
         return ranges.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Any(range => range.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)

--- a/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
+++ b/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
@@ -63,12 +63,24 @@ public static class DaemonReviewerCommand {
         var previous = store.Affirmed;
         store.Affirm(installed);
 
+        // The recorded value is a MINIMUM, so this verb can move it DOWN as well as up — affirming
+        // while an older build is installed deliberately re-admits that build and everything above
+        // it. Say which direction it moved rather than a neutral "(was X)": lowering a floor is a
+        // security-relevant act and should not read identically to raising one.
+        var lowered = previous is not null
+                   && ReviewerVersionAffirmations.TryParseVersion(installed) is { } now
+                   && ReviewerVersionAffirmations.TryParseVersion(previous) is { } before
+                   && now < before;
+
         Console.WriteLine(
             previous is null
-                ? $"Affirmed {reviewer.DefaultBinary} {installed} for daemon '{name}' (no previous affirmation)."
+                ? $"Recorded {reviewer.DefaultBinary} {installed} as the minimum for daemon '{name}' (none was set)."
                 : previous == installed
-                    ? $"{reviewer.DefaultBinary} {installed} was already affirmed for daemon '{name}'."
-                    : $"Affirmed {reviewer.DefaultBinary} {installed} for daemon '{name}' (was {previous}).");
+                    ? $"{reviewer.DefaultBinary} {installed} is already the minimum for daemon '{name}'."
+                    : lowered
+                        ? $"LOWERED the minimum for daemon '{name}' to {reviewer.DefaultBinary} {installed} "
+                        + $"(was {previous}) — builds from {installed} up are now admitted again."
+                        : $"Raised the minimum for daemon '{name}' to {reviewer.DefaultBinary} {installed} (was {previous}).");
 
         Console.WriteLine("Restart the daemon for a running instance to pick this up.");
 
@@ -107,8 +119,13 @@ public static class DaemonReviewerCommand {
         Console.Error.WriteLine($"""
             Usage: kcap daemon reviewer affirm --vendor <{AffirmableReviewer.VendorList}> [--name <daemon>]
 
-              Records the installed vendor version as reviewed by you, clearing the fail-closed gate
-              that a version change raises. Does NOT enable the unattended reviewer — set
+              Records the installed vendor version as the MINIMUM this daemon will run. Any build at
+              or above it is admitted, so a vendor upgrade needs no action from you; an older one is
+              refused. Run this to move the minimum to whatever is installed now — which is how you
+              exclude a build you have found to be broken, and, if you run it while an OLDER build is
+              installed, how you deliberately lower the bar again.
+
+              Does NOT enable the unattended reviewer — set
               {string.Join(" / ", AffirmableReviewer.All.Select(r => r.EnableEnvVar))}
               for that, and read what it grants first.
             """);

--- a/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
+++ b/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
@@ -67,20 +67,32 @@ public static class DaemonReviewerCommand {
         // while an older build is installed deliberately re-admits that build and everything above
         // it. Say which direction it moved rather than a neutral "(was X)": lowering a floor is a
         // security-relevant act and should not read identically to raising one.
-        var lowered = previous is not null
-                   && ReviewerVersionAffirmations.TryParseVersion(installed) is { } now
-                   && ReviewerVersionAffirmations.TryParseVersion(previous) is { } before
-                   && now < before;
+        // Three-way, not two: when either side does not order as a version there is no direction to
+        // report, and claiming "Raised" would be a statement we did not compute — the same
+        // across-domains mistake the Incomparable arm exists to avoid in the gate itself.
+        var direction =
+            ReviewerVersionAffirmations.TryParseVersion(installed) is { } now
+         && ReviewerVersionAffirmations.TryParseVersion(previous) is { } before
+                ? now < before ? "lowered" : "raised"
+                : "unknown";
 
         Console.WriteLine(
             previous is null
                 ? $"Recorded {reviewer.DefaultBinary} {installed} as the minimum for daemon '{name}' (none was set)."
                 : previous == installed
                     ? $"{reviewer.DefaultBinary} {installed} is already the minimum for daemon '{name}'."
-                    : lowered
-                        ? $"LOWERED the minimum for daemon '{name}' to {reviewer.DefaultBinary} {installed} "
-                        + $"(was {previous}) — builds from {installed} up are now admitted again."
-                        : $"Raised the minimum for daemon '{name}' to {reviewer.DefaultBinary} {installed} (was {previous}).");
+                    : direction switch {
+                        "lowered" =>
+                            $"LOWERED the minimum for daemon '{name}' to {reviewer.DefaultBinary} {installed} "
+                          + $"(was {previous}) — builds from {installed} up are now admitted again.",
+                        "raised" =>
+                            $"Raised the minimum for daemon '{name}' to {reviewer.DefaultBinary} {installed} "
+                          + $"(was {previous}).",
+                        _ =>
+                            $"Set the minimum for daemon '{name}' to {reviewer.DefaultBinary} {installed} "
+                          + $"(was {previous}); the two do not order as version numbers, so this may have "
+                          + "raised or lowered it."
+                    });
 
         Console.WriteLine("Restart the daemon for a running instance to pick this up.");
 

--- a/test/Capacitor.Cli.Tests.Unit/Acp/GeminiReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/GeminiReviewerCapabilityTests.cs
@@ -36,36 +36,44 @@ public class GeminiReviewerCapabilityTests {
             .IsEqualTo(GeminiReviewerDecision.VersionUnresolved);
     }
 
-    /// <summary>Nothing affirmed is not the same as affirmed-and-matching: a daemon that has never
-    /// recorded a build must refuse rather than accept whatever is installed.</summary>
+    /// <summary>No minimum recorded is not the same as meeting one: a daemon that has never recorded a
+    /// build must refuse rather than accept whatever is installed.</summary>
     [Test]
     [Arguments(null)]
     [Arguments("")]
     [Arguments("   ")]
-    public async Task NothingAffirmed_IsRefused(string? affirmed) {
-        await Assert.That(GeminiReviewerCapability.Decide(true, Installed, affirmed))
-            .IsEqualTo(GeminiReviewerDecision.VersionUnaffirmed);
+    public async Task NoMinimumRecorded_IsRefused(string? minimum) {
+        await Assert.That(GeminiReviewerCapability.Decide(true, Installed, minimum))
+            .IsEqualTo(GeminiReviewerDecision.VersionNoMinimum);
     }
 
     /// <summary>
-    /// The direction that matters, and the one that changed: a build DIFFERENT from the affirmed one is
-    /// refused whichever way it moved. A newer build may have changed the matcher — which is the whole
-    /// hazard — and an older one was never affirmed either.
+    /// The direction that matters, and it is the inverse of what this gate used to do: a NEWER build is
+    /// admitted with no operator action. Refusing every vendor release was the treadmill the
+    /// certified-set model was abandoned for, and exact-match only relocated it onto the operator.
     /// </summary>
     [Test]
     [Arguments("0.55.0")]
     [Arguments("0.54.1")]
     [Arguments("1.0.0")]
+    public async Task ANewerBuildThanTheMinimum_IsAdmitted(string installed) {
+        await Assert.That(GeminiReviewerCapability.Decide(true, installed, Installed))
+            .IsEqualTo(GeminiReviewerDecision.Allowed);
+    }
+
+    /// <summary>…while an older build than the recorded minimum is still refused, and the denial names
+    /// both versions or an operator cannot tell what to do about it.</summary>
+    [Test]
     [Arguments("0.53.0")]
-    public async Task ABuildOtherThanTheAffirmedOne_IsRefusedInBothDirections(string installed) {
+    [Arguments("0.1.0")]
+    public async Task AnOlderBuildThanTheMinimum_IsRefused(string installed) {
         var decision = GeminiReviewerCapability.Decide(true, installed, Installed);
 
-        await Assert.That(decision).IsEqualTo(GeminiReviewerDecision.VersionUnaffirmed);
+        await Assert.That(decision).IsEqualTo(GeminiReviewerDecision.VersionBelowMinimum);
 
         var reason = GeminiReviewerCapability.DenialReason(decision, installed, Installed);
 
-        await Assert.That(reason).Contains("version_unaffirmed");
-        // Both builds must appear, or the operator cannot tell what changed.
+        await Assert.That(reason).Contains("version_below_minimum");
         await Assert.That(reason).Contains(installed);
         await Assert.That(reason).Contains(Installed);
         await Assert.That(reason).Contains("kcap daemon reviewer affirm --vendor gemini");
@@ -75,9 +83,10 @@ public class GeminiReviewerCapabilityTests {
     public async Task SurroundingWhitespaceIsToleratedOnBothSides() {
         await Assert.That(GeminiReviewerCapability.Decide(true, $"  {Installed}\n", $"{Installed} "))
             .IsEqualTo(GeminiReviewerDecision.Allowed);
-        // …but the comparison is otherwise exact — a decorated build is a different build.
+        // A `v` prefix is decoration the shared parse strips, not a different build — under the old
+        // ordinal-equality rule this exact pair was refused.
         await Assert.That(GeminiReviewerCapability.Decide(true, $"v{Installed}", Installed))
-            .IsEqualTo(GeminiReviewerDecision.VersionUnaffirmed);
+            .IsEqualTo(GeminiReviewerDecision.Allowed);
     }
 
     /// <summary>The denial reason must name the actual cause, or an operator cannot act on it.</summary>
@@ -89,8 +98,15 @@ public class GeminiReviewerCapabilityTests {
                 GeminiReviewerCapability.DenialReason(GeminiReviewerDecision.VersionUnresolved, null, Installed))
             .Contains("version_unresolved");
         await Assert.That(
-                GeminiReviewerCapability.DenialReason(GeminiReviewerDecision.VersionUnaffirmed, Installed, null))
-            .Contains("version_unaffirmed");
+                GeminiReviewerCapability.DenialReason(GeminiReviewerDecision.VersionBelowMinimum, Installed, null))
+            .Contains("version_below_minimum");
+        await Assert.That(
+                GeminiReviewerCapability.DenialReason(GeminiReviewerDecision.VersionNoMinimum, Installed, null))
+            .Contains("version_no_minimum");
+        await Assert.That(
+                GeminiReviewerCapability.DenialReason(
+                    GeminiReviewerDecision.VersionIncomparable, "1.2.3.4.5", Installed))
+            .Contains("version_incomparable");
     }
 
     /// <summary>
@@ -148,18 +164,17 @@ public class GeminiReviewerCapabilityTests {
     }
 
     /// <summary>
-    /// The regression this model exists to prevent: a build ONE PATCH ahead of the last one is not
-    /// permanently refused — an operator affirmation clears it, with no kcap release involved. Under the
-    /// certified-set model this exact case (0.53.0 certified, 0.54.0 installed) made the reviewer
-    /// unreachable until a maintainer shipped a new version of kcap.
+    /// The regression this model exists to prevent, now closed outright rather than made recoverable.
+    ///
+    /// <para>Historic case: the certified-set model made 0.54.0 unreachable against a certified 0.53.0
+    /// until a maintainer shipped a new kcap. Exact-match affirmation removed the release coupling but
+    /// still refused the upgrade until an operator re-affirmed. Under a minimum, the same pair needs
+    /// <b>no action from anyone</b> — which is the whole point of the change.</para>
     /// </summary>
     [Test]
-    public async Task AVendorUpgrade_IsClearedByAffirmingIt_NotByAKcapRelease() {
+    public async Task TheOnePatchAheadUpgrade_NeedsNoActionAtAll() {
         await Assert.That(GeminiReviewerCapability.Decide(true, "0.54.0", "0.53.0"))
-            .IsEqualTo(GeminiReviewerDecision.VersionUnaffirmed);
-
-        // The operator runs `kcap daemon reviewer affirm --vendor gemini`, which records 0.54.0.
-        await Assert.That(GeminiReviewerCapability.Decide(true, "0.54.0", "0.54.0"))
-            .IsEqualTo(GeminiReviewerDecision.Allowed);
+            .IsEqualTo(GeminiReviewerDecision.Allowed)
+            .Because("a vendor patch release must not take the reviewer offline");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/KiroReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/KiroReviewerCapabilityTests.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
 /// The Kiro reviewer gate is fail-closed on three axes: platform, the operator's consent flag, and
-/// whether the installed kiro-cli is the build this daemon affirmed.
+/// whether the installed kiro-cli meets the MINIMUM version this daemon recorded.
 /// </summary>
 public class KiroReviewerCapabilityTests {
     /// <summary>Pinned, never read from the running host: these arms are about consent and versions,
@@ -24,18 +24,35 @@ public class KiroReviewerCapabilityTests {
             .IsEqualTo(KiroReviewerDecision.Disabled);
 
     /// <summary>
-    /// The direction that matters: a NEWER build is refused, not accepted. The record is an
-    /// affirmation of a specific build, not a floor — a later build may have changed how it treats
-    /// KIRO_HOME, which is the whole hazard.
+    /// The direction that matters, and it is now the opposite of what this gate used to do: a NEWER
+    /// build is ADMITTED. The record is a floor, not an affirmation of one specific build, because
+    /// refusing every vendor patch release was a treadmill with no safety payoff. If this ever
+    /// reverts to an equality compare, these arguments are what catch it.
     /// </summary>
     [Test]
     [Arguments("2.17.0")]
     [Arguments("2.16.1")]
     [Arguments("3.0.0")]
-    [Arguments("2.15.2")]
-    public async Task AChangedVersion_IsRefusedInBothDirections(string installed) =>
+    public async Task ANewerVersion_IsAdmittedWithNoOperatorAction(string installed) =>
         await Assert.That(KiroReviewerCapability.Decide(Posix, true, installed, "2.16.0"))
-            .IsEqualTo(KiroReviewerDecision.VersionUnaffirmed);
+            .IsEqualTo(KiroReviewerDecision.Allowed);
+
+    /// <summary>The other half of "minimum": older than the record is still refused.</summary>
+    [Test]
+    [Arguments("2.15.2")]
+    [Arguments("1.0.0")]
+    public async Task AnOlderVersion_IsRefused(string installed) =>
+        await Assert.That(KiroReviewerCapability.Decide(Posix, true, installed, "2.16.0"))
+            .IsEqualTo(KiroReviewerDecision.VersionBelowMinimum);
+
+    /// <summary>An unorderable pair must reach its OWN arm, never the below-minimum one — refusing an
+    /// upgrade while calling it "too old" is the failure this arm exists to prevent.</summary>
+    [Test]
+    [Arguments("2.0.0", "1.2.3.4.5")]
+    [Arguments("1.2.3.4.5", "2.0.0")]
+    public async Task AnUnorderablePair_IsIncomparableNotBelowMinimum(string installed, string minimum) =>
+        await Assert.That(KiroReviewerCapability.Decide(Posix, true, installed, minimum))
+            .IsEqualTo(KiroReviewerDecision.VersionIncomparable);
 
     /// <summary>
     /// The control for the seeding behaviour: an absent record must NOT read as permission. Without
@@ -45,9 +62,9 @@ public class KiroReviewerCapabilityTests {
     [Arguments(null)]
     [Arguments("")]
     [Arguments("   ")]
-    public async Task NoAffirmationOnRecord_IsRefused(string? affirmed) =>
-        await Assert.That(KiroReviewerCapability.Decide(Posix, true, "2.16.0", affirmed))
-            .IsEqualTo(KiroReviewerDecision.VersionUnaffirmed);
+    public async Task NoMinimumOnRecord_IsRefused(string? minimum) =>
+        await Assert.That(KiroReviewerCapability.Decide(Posix, true, "2.16.0", minimum))
+            .IsEqualTo(KiroReviewerDecision.VersionNoMinimum);
 
     [Test]
     [Arguments(null)]
@@ -64,12 +81,12 @@ public class KiroReviewerCapabilityTests {
             .IsEqualTo(KiroReviewerDecision.Allowed);
 
     [Test]
-    public async Task TheUnaffirmedReason_NamesBothVersionsAndTheFix() {
+    public async Task TheBelowMinimumReason_NamesBothVersionsAndTheFix() {
         var reason = KiroReviewerCapability.DenialReason(
-            KiroReviewerDecision.VersionUnaffirmed, "2.17.0", "2.16.0");
+            KiroReviewerDecision.VersionBelowMinimum, "2.15.0", "2.16.0");
 
-        await Assert.That(reason).StartsWith("kiro_reviewer_version_unaffirmed");
-        await Assert.That(reason).Contains("2.17.0");
+        await Assert.That(reason).StartsWith("kiro_reviewer_version_below_minimum");
+        await Assert.That(reason).Contains("2.15.0");
         await Assert.That(reason).Contains("2.16.0");
         await Assert.That(reason).Contains("kcap daemon reviewer affirm");
     }
@@ -119,7 +136,7 @@ public class KiroReviewerCapabilityTests {
     public async Task AWindowsHost_IsRefusedEvenWhenEnabledAndAffirmed() =>
         await Assert.That(KiroReviewerCapability.Decide(
                 posixHost: false, operatorEnabled: true,
-                installedVersion: "2.16.0", affirmedVersion: "2.16.0"))
+                installedVersion: "2.16.0", minimumVersion: "2.16.0"))
             .IsEqualTo(KiroReviewerDecision.UnsupportedPlatform);
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/ReviewerVersionAffirmationsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/ReviewerVersionAffirmationsTests.cs
@@ -179,6 +179,34 @@ public class ReviewerVersionAffirmationsTests {
         await Assert.That(ReviewerVersionAffirmations.TryParseVersion(raw) is not null).IsEqualTo(orders);
     }
 
+    /// <summary>
+    /// Pins that extracting this helper did not WIDEN what the Claude certification gate admits.
+    ///
+    /// <para>Review flagged the risk and it was real, though by a subtler route than "trimming changes
+    /// parsing": <c>Version.TryParse</c> already tolerates surrounding whitespace, so a trim looks
+    /// harmless — but it lets <c>TrimStart('v','V')</c> reach a <c>v</c> that leading whitespace was
+    /// hiding, flipping <c>" v1.2.3"</c> from refused to allowed. That is a security gate for a
+    /// different vendor being loosened as a side effect of a reviewer change, which this PR's own spec
+    /// forbids. The normalization is therefore byte-identical to what <c>CliVersionAllowed</c> did
+    /// before, and this test is what keeps it that way.</para>
+    /// </summary>
+    [Test]
+    [Arguments(" v1.2.3")]
+    [Arguments("\tv1.2.3\n")]
+    public async Task LeadingWhitespaceBeforeAVPrefix_StillDoesNotOrder(string raw) {
+        await Assert.That(ReviewerVersionAffirmations.TryParseVersion(raw)).IsNull()
+            .Because("trimming here would silently widen what the certification gate admits");
+    }
+
+    /// <summary>The cases that DO order are unchanged, so the guard above is not over-tightening.</summary>
+    [Test]
+    [Arguments("v1.2.3")]
+    [Arguments("1.2.3 ")]
+    [Arguments(" 1.2.3")]
+    public async Task TheOrderableCasesAreUnaffectedByThatGuard(string raw) {
+        await Assert.That(ReviewerVersionAffirmations.TryParseVersion(raw)).IsNotNull();
+    }
+
     [Test]
     [Arguments(null, "<none>")]
     [Arguments("", "<none>")]

--- a/test/Capacitor.Cli.Tests.Unit/Acp/ReviewerVersionAffirmationsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/ReviewerVersionAffirmationsTests.cs
@@ -4,66 +4,179 @@ namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
 /// The version half of every gated reviewer's decision. Written once so Kiro and Gemini cannot drift
-/// apart on what "the operator accepted this build" means — these cases are the contract both inherit.
+/// apart on what "this build clears the bar" means — these cases are the contract both inherit.
+///
+/// <para>The recorded value is a MINIMUM: a vendor upgrade needs no operator action, a downgrade below
+/// the record is refused.</para>
 /// </summary>
 public class ReviewerVersionAffirmationsTests {
     [Test]
-    public async Task AMatchingBuild_IsAffirmed() {
+    public async Task AnExactlyEqualBuild_MeetsTheMinimum() {
         await Assert.That(ReviewerVersionAffirmations.Decide("2.16.0", "2.16.0"))
-            .IsEqualTo(ReviewerVersionAffirmation.Affirmed);
+            .IsEqualTo(ReviewerVersionAffirmation.MeetsMinimum);
     }
 
-    /// <summary>Unresolved is checked BEFORE unaffirmed, and the distinction is load-bearing: "we could
-    /// not identify the build" and "you have not accepted this build" send an operator to different
-    /// fixes.</summary>
+    /// <summary>The whole point of the change: a vendor patch release must not take the reviewer
+    /// offline. If this ever reverts to an equality compare, this is the test that catches it.</summary>
+    [Test]
+    [Arguments("2.16.1")]
+    [Arguments("2.17.0")]
+    [Arguments("3.0.0")]
+    [Arguments("10.0.0")]
+    public async Task ANewerBuild_MeetsTheMinimum_WithNoOperatorAction(string installed) {
+        await Assert.That(ReviewerVersionAffirmations.Decide(installed, "2.16.0"))
+            .IsEqualTo(ReviewerVersionAffirmation.MeetsMinimum);
+    }
+
+    /// <summary>"Minimum" is load-bearing, not decorative — an older build than the one recorded is
+    /// still refused.</summary>
+    [Test]
+    [Arguments("2.15.0")]
+    [Arguments("2.16")]
+    [Arguments("1.99.99")]
+    public async Task AnOlderBuild_IsBelowTheMinimum(string installed) {
+        await Assert.That(ReviewerVersionAffirmations.Decide(installed, "2.16.0"))
+            .IsEqualTo(ReviewerVersionAffirmation.BelowMinimum);
+    }
+
+    /// <summary>Unresolved is checked FIRST, and it means only "the installed string is blank" — it
+    /// deliberately does NOT mean "unparseable", which would refuse pairs allowed today (see the
+    /// monotonicity tests below).</summary>
     [Test]
     [Arguments(null)]
     [Arguments("")]
     [Arguments("   ")]
-    public async Task AnUnidentifiableBuild_IsUnresolved_EvenWithNothingAffirmed(string? installed) {
+    public async Task AnUnidentifiableBuild_IsUnresolved_EvenWithNoMinimumRecorded(string? installed) {
         await Assert.That(ReviewerVersionAffirmations.Decide(installed, null))
             .IsEqualTo(ReviewerVersionAffirmation.Unresolved);
     }
 
+    /// <summary>An unparseable but NON-BLANK installed string must not reach Unresolved: blank and
+    /// unorderable are different problems with different remedies.</summary>
+    [Test]
+    [Arguments("daily-20240806")]
+    [Arguments("1.2.3.4.5")]
+    public async Task AnUnparseableButNonBlankBuild_IsNotUnresolved(string installed) {
+        await Assert.That(ReviewerVersionAffirmations.Decide(installed, "2.16.0"))
+            .IsNotEqualTo(ReviewerVersionAffirmation.Unresolved);
+    }
+
+    /// <summary>Its own arm, not folded into BelowMinimum: the remedy differs — record a minimum,
+    /// rather than change the installed build.</summary>
     [Test]
     [Arguments(null)]
     [Arguments("")]
     [Arguments("   ")]
-    public async Task NothingAffirmed_IsUnaffirmed(string? affirmed) {
-        await Assert.That(ReviewerVersionAffirmations.Decide("2.16.0", affirmed))
-            .IsEqualTo(ReviewerVersionAffirmation.Unaffirmed);
-    }
-
-    /// <summary>A CHANGED build is refused whichever way it moved — a downgrade was never affirmed
-    /// either, and the gate is "this exact build", not "at least this build".</summary>
-    [Test]
-    [Arguments("2.17.0")]
-    [Arguments("2.15.0")]
-    [Arguments("2.16.1")]
-    [Arguments("10.0.0")]
-    public async Task AChangedBuild_IsUnaffirmedInBothDirections(string installed) {
-        await Assert.That(ReviewerVersionAffirmations.Decide(installed, "2.16.0"))
-            .IsEqualTo(ReviewerVersionAffirmation.Unaffirmed);
+    public async Task NoMinimumRecorded_IsItsOwnOutcome(string? minimum) {
+        await Assert.That(ReviewerVersionAffirmations.Decide("2.16.0", minimum))
+            .IsEqualTo(ReviewerVersionAffirmation.NoMinimumRecorded);
     }
 
     /// <summary>Whitespace is tolerated on both sides — a vendor's own output and a written record both
-    /// carry it, and refusing over a trailing newline would refuse a build the operator did affirm.</summary>
+    /// carry it.</summary>
     [Test]
     public async Task SurroundingWhitespaceIsTolerated() {
         await Assert.That(ReviewerVersionAffirmations.Decide("  2.16.0\n", "\t2.16.0 "))
-            .IsEqualTo(ReviewerVersionAffirmation.Affirmed);
+            .IsEqualTo(ReviewerVersionAffirmation.MeetsMinimum);
     }
 
-    /// <summary>…but nothing else is. A decorated build string is a different build: the comparison is
-    /// Ordinal, so it cannot quietly accept a `v`-prefixed or suffixed variant.</summary>
+    /// <summary>A `v` prefix and a pre-release/build suffix are decoration, not a different build: the
+    /// shared parse strips them, so a decorated newer build still clears the floor. Under the old
+    /// ordinal-equality rule every one of these was refused.</summary>
     [Test]
-    [Arguments("v2.16.0")]
-    [Arguments("2.16.0-nightly")]
-    [Arguments("2.16.0 (build abc)")]
-    [Arguments("2.16.O")]
-    public async Task ADecoratedBuildStringIsADifferentBuild(string installed) {
+    [Arguments("v2.17.0")]
+    [Arguments("2.17.0-nightly")]
+    [Arguments("2.17.0+build.9")]
+    public async Task ADecoratedNewerBuildStillClearsTheFloor(string installed) {
         await Assert.That(ReviewerVersionAffirmations.Decide(installed, "2.16.0"))
-            .IsEqualTo(ReviewerVersionAffirmation.Unaffirmed);
+            .IsEqualTo(ReviewerVersionAffirmation.MeetsMinimum);
+    }
+
+    // ── Incomparable ─────────────────────────────────────────────────────────
+    //
+    // Exactly one side orders. Ordinal-comparing across domains would refuse a genuine upgrade while
+    // LABELLING it "below minimum" — the bug an earlier revision of this design shipped in review.
+
+    [Test]
+    public async Task AnUnorderableMinimum_WithAnOrderableBuild_IsIncomparable() {
+        await Assert.That(ReviewerVersionAffirmations.Decide("2.0.0", "1.2.3.4.5"))
+            .IsEqualTo(ReviewerVersionAffirmation.Incomparable);
+    }
+
+    [Test]
+    public async Task AnUnorderableBuild_WithAnOrderableMinimum_IsIncomparable() {
+        await Assert.That(ReviewerVersionAffirmations.Decide("1.2.3.4.5", "2.0.0"))
+            .IsEqualTo(ReviewerVersionAffirmation.Incomparable);
+    }
+
+    /// <summary>Never mislabelled as BelowMinimum — the denial text sends an operator somewhere
+    /// different, and "below minimum" would be a claim we did not compute.</summary>
+    [Test]
+    [Arguments("2.0.0", "1.2.3.4.5")]
+    [Arguments("1.2.3.4.5", "2.0.0")]
+    public async Task Incomparable_IsNeverReportedAsBelowMinimum(string installed, string minimum) {
+        await Assert.That(ReviewerVersionAffirmations.Decide(installed, minimum))
+            .IsNotEqualTo(ReviewerVersionAffirmation.BelowMinimum);
+    }
+
+    /// <summary>
+    /// What makes refusing an Incomparable pair acceptable: recording the installed build as the
+    /// minimum — what `kcap daemon reviewer affirm` does — clears it in BOTH directions, so the arm is
+    /// not a dead end.
+    /// </summary>
+    [Test]
+    [Arguments("2.0.0")]      // orderable installed, previously-unorderable floor
+    [Arguments("1.2.3.4.5")]  // unorderable installed: both sides become that same string
+    public async Task AffirmingTheInstalledBuild_ClearsIncomparable(string installed) {
+        await Assert.That(ReviewerVersionAffirmations.Decide(installed, installed))
+            .IsEqualTo(ReviewerVersionAffirmation.MeetsMinimum);
+    }
+
+    // ── Monotonicity ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// THE property that makes this change safe: the new rule must never refuse a pair the old
+    /// ordinal-equality rule allowed. The old rule allowed exactly the ordinal-equal non-blank pairs,
+    /// so every such pair must still be admitted — including values no version parser accepts, which
+    /// an earlier revision of this design regressed.
+    /// </summary>
+    [Test]
+    [Arguments("2.16.0")]          // orders
+    [Arguments("daily-20240806")]  // does not order at all
+    [Arguments("1.2.3.4.5")]       // five components — passes the vendor token filter, fails TryParse
+    [Arguments("1.")]
+    [Arguments(".5")]
+    public async Task EveryPairTheOldRuleAllowed_IsStillAllowed(string value) {
+        await Assert.That(ReviewerVersionAffirmations.Decide(value, value))
+            .IsEqualTo(ReviewerVersionAffirmation.MeetsMinimum)
+            .Because("ordinal-equal pairs were allowed before this change and must stay allowed");
+    }
+
+    /// <summary>Two unorderable but DIFFERENT strings were refused before and still are — the fallback
+    /// preserves the old behaviour in both directions, not just the permissive one.</summary>
+    [Test]
+    public async Task TwoDifferentUnorderableStrings_AreStillRefused() {
+        await Assert.That(ReviewerVersionAffirmations.Decide("daily-20240806", "daily-20240101"))
+            .IsEqualTo(ReviewerVersionAffirmation.BelowMinimum);
+    }
+
+    // ── The shared parse ─────────────────────────────────────────────────────
+
+    /// <summary>Shared with <c>DaemonRunner.CliVersionAllowed</c> so the two gates cannot disagree
+    /// about what counts as an orderable version.</summary>
+    [Test]
+    [Arguments("2.16.0", true)]
+    [Arguments("v2.16.0", true)]
+    [Arguments("2.16.0-rc1", true)]
+    [Arguments("2.16.0+build", true)]
+    [Arguments("  2.16.0 ", true)]
+    [Arguments("1.2.3.4", true)]
+    [Arguments("1.2.3.4.5", false)]
+    [Arguments("daily-20240806", false)]
+    [Arguments("", false)]
+    [Arguments(null, false)]
+    public async Task TryParseVersion_ClassifiesOrderability(string? raw, bool orders) {
+        await Assert.That(ReviewerVersionAffirmations.TryParseVersion(raw) is not null).IsEqualTo(orders);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -2151,12 +2151,17 @@ public class AcpHostedAgentRuntimeFactoryTests {
             .Because("the positive control: without it, an advertisement that always said false would pass");
     }
 
-    /// <summary>An enabled daemon whose installed build is NOT the affirmed one still does not advertise —
-    /// the two halves of the gate are independent, and this is the half a vendor upgrade trips.</summary>
+    /// <summary>An enabled daemon whose installed build is BELOW the recorded minimum still does not
+    /// advertise — the two halves of the gate are independent.
+    ///
+    /// <para>The version this test uses is now HIGHER than the installed build, not lower. It previously
+    /// recorded <c>0.53.0</c> against an installed <c>0.54.0</c> and asserted no advertisement, i.e. that
+    /// a vendor UPGRADE trips the gate. That is the behaviour the minimum deliberately removes, so the
+    /// arm being pinned here is a downgrade instead.</para></summary>
     [Test]
-    public async Task Gemini_AnEnabledDaemonOnAnUnaffirmedBuild_DoesNotAdvertise() {
+    public async Task Gemini_AnEnabledDaemonBelowTheMinimum_DoesNotAdvertise() {
         IHostedAgentRuntimeFactory factory = new AcpHostedAgentRuntimeFactory(
-            AcpVendorDescriptors.Gemini, GeminiEnabledConfig(affirmed: "0.53.0"),
+            AcpVendorDescriptors.Gemini, GeminiEnabledConfig(affirmed: "0.55.0"),
             NullLoggerFactory.Instance, new CaptureServerConnection(),
             resolveVendorVersion: _ => GeminiBuild);
 
@@ -2199,11 +2204,11 @@ public class AcpHostedAgentRuntimeFactoryTests {
         await Assert.That(support.WithheldReason!).StartsWith("gemini_unattended_reviewer_disabled");
     }
 
-    /// <summary>The unaffirmed-build arm names BOTH builds and the command that clears it, not a generic
-    /// refusal — otherwise an operator cannot tell a consent problem from an upgrade problem, nor what to
-    /// do about the upgrade.</summary>
+    /// <summary>A build NEWER than the recorded minimum is advertised, withholding nothing. This
+    /// previously asserted the opposite — an upgrade past the recorded version used to withhold the
+    /// vendor until an operator re-affirmed, which is the treadmill the minimum removes.</summary>
     [Test]
-    public async Task Gemini_AnUnaffirmedBuild_IsNamedInTheWithheldReason() {
+    public async Task Gemini_ABuildNewerThanTheMinimum_IsAdvertised() {
         IHostedAgentRuntimeFactory factory = new AcpHostedAgentRuntimeFactory(
             AcpVendorDescriptors.Gemini, GeminiEnabledConfig(affirmed: "0.53.0"),
             NullLoggerFactory.Instance, new CaptureServerConnection(),
@@ -2211,11 +2216,28 @@ public class AcpHostedAgentRuntimeFactoryTests {
 
         var support = factory.DescribeUnattendedSupport();
 
+        await Assert.That(support.Supported).IsTrue();
+        await Assert.That(support.WithheldReason).IsNull();
+    }
+
+    /// <summary>The below-minimum arm names BOTH versions and the command that moves the minimum, not a
+    /// generic refusal — otherwise an operator cannot tell a consent problem from a version problem, nor
+    /// what to do about it. This is also the control for the test above: without a refusing direction,
+    /// deleting the version check entirely would still pass.</summary>
+    [Test]
+    public async Task Gemini_ABuildOlderThanTheMinimum_IsNamedInTheWithheldReason() {
+        IHostedAgentRuntimeFactory factory = new AcpHostedAgentRuntimeFactory(
+            AcpVendorDescriptors.Gemini, GeminiEnabledConfig(affirmed: "0.55.0"),
+            NullLoggerFactory.Instance, new CaptureServerConnection(),
+            resolveVendorVersion: _ => GeminiBuild);
+
+        var support = factory.DescribeUnattendedSupport();
+
         await Assert.That(support.Supported).IsFalse();
         await Assert.That(support.WithheldReason!).Contains(GeminiBuild);
-        await Assert.That(support.WithheldReason!).Contains("0.53.0");
+        await Assert.That(support.WithheldReason!).Contains("0.55.0");
         await Assert.That(support.WithheldReason!).Contains("kcap daemon reviewer affirm --vendor gemini");
-        await Assert.That(support.WithheldReason!).StartsWith("gemini_reviewer_version_unaffirmed");
+        await Assert.That(support.WithheldReason!).StartsWith("gemini_reviewer_version_below_minimum");
     }
 
     /// <summary>An ADVERTISED vendor withholds nothing — the negative control for the two above, without

--- a/test/Capacitor.Cli.Tests.Unit/Services/GeminiReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/GeminiReviewerLaunchTests.cs
@@ -261,14 +261,17 @@ public class GeminiReviewerLaunchTests {
         await Assert.That(ex!.Message).Contains("gemini_unattended_reviewer_disabled");
     }
 
-    /// <summary>A build other than the affirmed one — or one that cannot be identified at all — is refused
-    /// even when the operator has opted in: the reviewer's only containment is that build's MCP-allowlist
-    /// semantics, so an unaffirmed build is refused rather than assumed compatible.</summary>
+    /// <summary>A build OLDER than the recorded minimum — or one that cannot be identified at all — is
+    /// refused even when the operator has opted in: the reviewer's only containment is that build's
+    /// MCP-allowlist semantics, so a build we cannot vouch for is refused rather than assumed compatible.
+    ///
+    /// <para>`0.55.0` was in this list until the recorded version became a MINIMUM; a build newer than
+    /// the minimum is now admitted, and <see cref="ANewerBuildThanTheMinimum_LaunchesUnchanged"/> pins
+    /// that direction instead.</para></summary>
     [Test]
-    [Arguments("0.55.0")]
     [Arguments("0.53.1")]
     [Arguments("")]
-    public async Task AnUnaffirmedOrUnresolvableBuild_RefusesAReviewLaunch(string version) {
+    public async Task ABuildBelowTheMinimumOrUnresolvable_RefusesAReviewLaunch(string version) {
         var ex = Assert.Throws<InvalidOperationException>(
             () => Build(isReviewFlow: true, version: version));
 
@@ -280,6 +283,20 @@ public class GeminiReviewerLaunchTests {
     [Test]
     public async Task TheAffirmedBuild_PermitsAReviewLaunch() {
         var argv = Build(isReviewFlow: true, version: CertifiedVersion);
+
+        await Assert.That(argv).Contains("--experimental-acp");
+    }
+
+    /// <summary>
+    /// The direction the minimum exists to allow: a build NEWER than the recorded one launches with no
+    /// operator action. `0.55.0` used to be an argument to the refusal case above — a vendor patch
+    /// release took the reviewer offline until someone re-affirmed, which is the treadmill removed here.
+    /// </summary>
+    [Test]
+    [Arguments("0.55.0")]
+    [Arguments("1.0.0")]
+    public async Task ANewerBuildThanTheMinimum_LaunchesUnchanged(string version) {
+        var argv = Build(isReviewFlow: true, version: version);
 
         await Assert.That(argv).Contains("--experimental-acp");
     }

--- a/test/Capacitor.Cli.Tests.Unit/Services/KiroReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/KiroReviewerLaunchTests.cs
@@ -152,8 +152,32 @@ public class KiroReviewerLaunchTests {
     /// The gate must fire on an upgrade. Asserted with the operator flag ON, so this cannot pass for
     /// the wrong reason (a disabled daemon refuses everything).
     /// </summary>
+    /// <summary>
+    /// An UPGRADED kiro-cli launches, with no operator action. This test used to assert the opposite,
+    /// and inverting it is the point of the change: the recorded version is a minimum, so a routine
+    /// vendor release no longer takes the reviewer offline.
+    /// </summary>
     [Test]
-    public async Task AnUpgradedKiro_RefusesAReviewLaunchUntilAffirmed() {
+    public async Task AnUpgradedKiro_LaunchesWithoutAnyOperatorAction() {
+        Skip.Unless(!OperatingSystem.IsWindows(),
+            "The Kiro unattended reviewer is POSIX-only: its isolated home holds review context and cannot be created owner-only on Windows.");
+
+        var config = EnabledConfig(StateDir());
+
+        var psi = AcpHostedAgentRuntimeFactory.BuildProcessStartInfo(
+            AcpVendorDescriptors.Kiro, config, Ctx(isReviewFlow: true),
+            resolveGeminiVersion: _ => "2.17.0");
+
+        await Assert.That(psi).IsNotNull();
+    }
+
+    /// <summary>
+    /// …and the other direction still refuses, which is what keeps "minimum" meaningful rather than
+    /// "no gate at all". Without this control the test above would also pass if the version check had
+    /// simply been deleted.
+    /// </summary>
+    [Test]
+    public async Task AKiroOlderThanTheRecordedMinimum_StillRefusesAReviewLaunch() {
         Skip.Unless(!OperatingSystem.IsWindows(),
             "The Kiro unattended reviewer is POSIX-only: its isolated home holds review context and cannot be created owner-only on Windows.");
 
@@ -161,9 +185,9 @@ public class KiroReviewerLaunchTests {
 
         await Assert.That(() => AcpHostedAgentRuntimeFactory.BuildProcessStartInfo(
                 AcpVendorDescriptors.Kiro, config, Ctx(isReviewFlow: true),
-                resolveGeminiVersion: _ => "2.17.0"))
+                resolveGeminiVersion: _ => "2.15.0"))
             .Throws<InvalidOperationException>()
-            .WithMessageContaining("kiro_reviewer_version_unaffirmed");
+            .WithMessageContaining("kiro_reviewer_version_below_minimum");
     }
 
     /// <summary>


### PR DESCRIPTION
Kiro and Gemini are the only version-gated reviewers in the product, and both failed closed the moment the installed build **changed** — in either direction. A routine vendor patch release took the reviewer offline until an operator re-ran `kcap daemon reviewer affirm`.

This reinterprets the recorded value as **the oldest build the daemon will run**. An upgrade needs no action from anyone; a downgrade below the record is still refused; a build later found to be bad is excluded by raising the floor with the same verb.

**No migration.** `DaemonRunner.SeedReviewerAffirmation` already recorded the installed build the first time a reviewer was enabled, so every existing record already holds "the version we certified" — only its interpretation changes. A daemon currently blocked by a vendor upgrade unblocks itself.

### What this gives up, stated rather than hidden

A future vendor build that weakens its own containment is now admitted silently — for Gemini the MCP-allowlist semantics, for Kiro `KIRO_HOME` suppression. `GeminiReviewerCapability`'s class doc argued against exactly this design; that paragraph is **kept rather than deleted**, because it records what the boundary cost and what to reach for if a Gemini release is ever found to have weakened the allowlist. Both risks were already accepted at the operator's first affirmation — what changed is that the acceptance carries forward across upgrades instead of being re-taken every patch.

It is also the second time the strict shape has bitten: a maintainer-curated certified set took the Gemini reviewer offline at `0.54.0`, one patch ahead of certified `0.53.0`, recoverable only by a kcap release. Exact-match affirmation removed the release coupling but kept the treadmill, just moved it onto the operator.

### Three things review turned up

- **Ordinal equality is only sound when both values are in the same domain.** An earlier revision ordinal-compared whenever *either* side failed to parse, which refused a genuine upgrade while **labelling it "below minimum"**. A one-sided parse failure is now its own `Incomparable` outcome, and the `affirm` remedy provably terminates it in both directions (tested).
- **The vendor switches ended in `_ => Allowed`.** A new refusing arm would have been silently **admitted** — a fail-closed gate whose safe direction was whatever nobody thought about. Every arm is now explicit with no discard, and `CS8509` is an error repo-wide so the next arm is a build failure instead. Measured before enabling: **zero** CS8509 warnings across the daemon, Core, the CLI and the tests.
- **The version parse is shared** with `DaemonRunner.CliVersionAllowed` rather than duplicated, because both gates must classify orderability identically — and that shared classification is what bounds this change's scope, since widening what parses here would widen what the Claude certification gate admits.

### Verification

- `ReviewerVersionAffirmationsTests` 46/46 · `KiroReviewerCapabilityTests` 32/32 · `GeminiReviewerCapabilityTests` 31/31 · `ReviewerVersionStoreVendorKeyingTests` 3/3 · `KiroReviewerVersionStoreTests` 8/8 · `DaemonRunnerVersionProbeTests` 11/11
- **Mutation-checked**: reverting the floor to an equality compare reddens 7 tests; restored with the inverse edit, green again.
- AOT publish clean (no IL2026/IL3050) on both the CLI and the daemon.
- Monotonicity is pinned as a property, not just per-arm: every pair the old ordinal rule allowed is still allowed, including values no version parser accepts.

Spec: `docs/superpowers/specs/2026-08-06-ai1776-reviewer-version-floor-design.md` (Copilot spec review, clean after 5 rounds).

Fixes AI-1776

🤖 Generated with [Claude Code](https://claude.com/claude-code)