### PR TITLE
Antigravity CLI (agy) as an unattended review-flow reviewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,7 +833,8 @@ kcap daemon reviewer affirm --vendor kiro
 Run that to move the minimum to whatever is installed now — which is how you exclude a build you have found
 to be broken, and, if you run it while an older build is installed, how you deliberately lower the bar
 again. The command records the version and nothing else — it does not enable the reviewer. No kcap release
-is ever needed; Gemini uses the same model and the same command (`--vendor gemini`).
+is ever needed; Gemini and Antigravity use the same model and the same command (`--vendor gemini`,
+`--vendor antigravity`).
 
 POSIX only: the isolated home holds the reviewer's own transcript, and therefore the review context, and
 cannot be created owner-only on Windows.
@@ -865,18 +866,21 @@ export GOOGLE_CLOUD_PROJECT=<your-project>
 export AGY_ADC_AUTH=1                           # selects ADC; without it agy still demands an OAuth login
 ```
 
-**Minimum version, not an affirmation.** There is **no affirm step** for Antigravity — there is nothing to
-affirm, and `kcap daemon reviewer affirm --vendor antigravity` refuses with a coded
-`antigravity_reviewer_not_affirmable` that says so. Unlike Gemini and Kiro, `agy` updates itself (observed
-going 1.1.8 → 1.1.10 mid-session), so a build-exact gate would take the reviewer offline on a cadence you
-do not control. Instead the daemon requires a **minimum** `agy` version
-(currently **1.1.10**, the build every measured behaviour behind this reviewer was established on) and
-accepts anything at or above it. A build below the floor, or one whose `agy --version` cannot be read, is
-withheld with a coded reason naming both versions. If a build is refused that you know to be good:
+**Minimum version.** Containment here depends on the installed build honouring `HOME` and reading no other
+global config source, so the daemon records a minimum `agy` version the first time you enable the reviewer.
+It is a **minimum, not an exact match**: any build at or above it runs, so **an `agy` upgrade needs no
+action from you** — which matters more here than for the other reviewers, since `agy` updates itself
+(observed going 1.1.8 → 1.1.10 mid-session). A build older than the recorded minimum, or one whose
+`agy --version` cannot be read, is withheld with a coded reason naming both versions.
 
 ```bash
-export KCAP_ANTIGRAVITY_MIN_CLI_VERSION=1.2.0   # daemon environment; restart the daemon after changing it
+kcap daemon reviewer affirm --vendor antigravity
 ```
+
+Same command and same model as Kiro and Gemini: run it to move the minimum to whatever is installed now —
+which is how you exclude a build you have found to be broken, and, if you run it while an older build is
+installed, how you deliberately lower the bar again. It records the version and nothing else; it does not
+enable the reviewer. No kcap release is ever needed.
 
 Like Gemini and Kiro, this never makes Antigravity a default reviewer — it is only ever reached by an
 explicit `vendor: "antigravity"`. Borrowed (in-place) review is not offered; a borrowed request falls back
@@ -896,9 +900,8 @@ kcap daemon service install --name "$(whoami)"    # captures the flag into the u
 
 The Antigravity ADC variables (`GOOGLE_CLOUD_PROJECT`, `AGY_ADC_AUTH`, `GOOGLE_APPLICATION_CREDENTIALS`)
 are captured by the same install, so a daemon installed *before* this shipped must be reinstalled from an
-interactive shell to pick them up. `KCAP_ANTIGRAVITY_PATH` and `KCAP_ANTIGRAVITY_MIN_CLI_VERSION` are
-**not** captured — like the other vendor path overrides, set them where the unit can see them if you need
-non-default values.
+interactive shell to pick them up. `KCAP_ANTIGRAVITY_PATH` is **not** captured — like the other vendor path
+overrides, set it where the unit can see it if you need a non-default value.
 
 Install prints a `Consent:` line naming each reviewer flag it captured. That freeze is the point to notice:
 the unit outlives the shell, so the reviewer stays enabled for that service until you reinstall without the

--- a/README.md
+++ b/README.md
@@ -865,9 +865,11 @@ export GOOGLE_CLOUD_PROJECT=<your-project>
 export AGY_ADC_AUTH=1                           # selects ADC; without it agy still demands an OAuth login
 ```
 
-**Minimum version, not an affirmation.** Unlike Gemini and Kiro, Antigravity has **no `affirm` verb** —
-`agy` updates itself (observed going 1.1.8 → 1.1.10 mid-session), so a build-exact gate would take the
-reviewer offline on a cadence you do not control. Instead the daemon requires a **minimum** `agy` version
+**Minimum version, not an affirmation.** There is **no affirm step** for Antigravity — there is nothing to
+affirm, and `kcap daemon reviewer affirm --vendor antigravity` refuses with a coded
+`antigravity_reviewer_not_affirmable` that says so. Unlike Gemini and Kiro, `agy` updates itself (observed
+going 1.1.8 → 1.1.10 mid-session), so a build-exact gate would take the reviewer offline on a cadence you
+do not control. Instead the daemon requires a **minimum** `agy` version
 (currently **1.1.10**, the build every measured behaviour behind this reviewer was established on) and
 accepts anything at or above it. A build below the floor, or one whose `agy --version` cannot be read, is
 withheld with a coded reason naming both versions. If a build is refused that you know to be good:

--- a/README.md
+++ b/README.md
@@ -838,9 +838,51 @@ is ever needed; Gemini uses the same model and the same command (`--vendor gemin
 POSIX only: the isolated home holds the reviewer's own transcript, and therefore the review context, and
 cannot be created owner-only on Windows.
 
+#### Unattended Antigravity reviews
+
+```bash
+export KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1   # this DAEMON's environment — not a server setting
+```
+
+The prerequisite is the Antigravity **CLI** — the `agy` binary on `PATH` (or `KCAP_ANTIGRAVITY_PATH`
+pointing at it). The Antigravity **IDE** alone is not enough: it ships no `agy`, and a daemon with only the
+IDE installed never offers the vendor at all.
+
+**Everything in the Gemini warning above applies.** Reviews run in a daemon-owned worktree under a
+per-launch, owner-only `HOME` (removed when the reviewer is disposed), so your own `~/.gemini` config and
+the kcap capture plugin inside it do not reach the reviewer, and your interactive Antigravity sessions are
+unaffected. POSIX only, for the same reason as Kiro: that home holds the reviewer's own transcript, and
+therefore the review context, and cannot be created owner-only on Windows.
+
+**Give the daemon durable credentials.** An unattended reviewer's stdin is closed, so it cannot complete an
+interactive login — an unauthenticated `agy` fails the launch with a coded
+`antigravity_reviewer_auth_unavailable` rather than hanging. Application Default Credentials are the
+supported setup:
+
+```bash
+gcloud auth application-default login
+export GOOGLE_CLOUD_PROJECT=<your-project>
+export AGY_ADC_AUTH=1                           # selects ADC; without it agy still demands an OAuth login
+```
+
+**Minimum version, not an affirmation.** Unlike Gemini and Kiro, Antigravity has **no `affirm` verb** —
+`agy` updates itself (observed going 1.1.8 → 1.1.10 mid-session), so a build-exact gate would take the
+reviewer offline on a cadence you do not control. Instead the daemon requires a **minimum** `agy` version
+(currently **1.1.10**, the build every measured behaviour behind this reviewer was established on) and
+accepts anything at or above it. A build below the floor, or one whose `agy --version` cannot be read, is
+withheld with a coded reason naming both versions. If a build is refused that you know to be good:
+
+```bash
+export KCAP_ANTIGRAVITY_MIN_CLI_VERSION=1.2.0   # daemon environment; restart the daemon after changing it
+```
+
+Like Gemini and Kiro, this never makes Antigravity a default reviewer — it is only ever reached by an
+explicit `vendor: "antigravity"`. Borrowed (in-place) review is not offered; a borrowed request falls back
+to a daemon-owned worktree.
+
 #### If your daemon runs as a service
 
-Both flags above are read from the **daemon's own environment**, and a supervised daemon (`kcap daemon
+All three consent flags above are read from the **daemon's own environment**, and a supervised daemon (`kcap daemon
 service install` — launchd, systemd, or a Windows scheduled task) inherits nothing from the shell you
 installed it from. Exporting a flag in your shell therefore does nothing for a service-installed daemon until
 the unit itself carries it, so export it *first* and then reinstall:
@@ -850,6 +892,12 @@ export KCAP_GEMINI_UNATTENDED_REVIEWER=1
 kcap daemon service install --name "$(whoami)"    # captures the flag into the unit
 ```
 
+The Antigravity ADC variables (`GOOGLE_CLOUD_PROJECT`, `AGY_ADC_AUTH`, `GOOGLE_APPLICATION_CREDENTIALS`)
+are captured by the same install, so a daemon installed *before* this shipped must be reinstalled from an
+interactive shell to pick them up. `KCAP_ANTIGRAVITY_PATH` and `KCAP_ANTIGRAVITY_MIN_CLI_VERSION` are
+**not** captured — like the other vendor path overrides, set them where the unit can see them if you need
+non-default values.
+
 Install prints a `Consent:` line naming each reviewer flag it captured. That freeze is the point to notice:
 the unit outlives the shell, so the reviewer stays enabled for that service until you reinstall without the
 variable set — unsetting it in your shell later changes nothing.
@@ -857,8 +905,8 @@ variable set — unsetting it in your shell later changes nothing.
 If a reviewer is still not offered, the daemon says why in its own log at startup — one line per vendor that
 is installed and unattended-capable but withheld, carrying the same text the launch path would have thrown
 (consent not set, version unresolved, no minimum recorded, version below the minimum). It logs at `Information`, not
-`Warning`: a daemon with Gemini or Kiro installed purely for interactive use and no opt-in is in a
-perfectly normal state, so this is a line to find when you go looking, not an alert.
+`Warning`: a daemon with Gemini, Kiro or the Antigravity CLI installed purely for interactive use and no
+opt-in is in a perfectly normal state, so this is a line to find when you go looking, not an alert.
 
 ```bash
 grep -i "is NOT offering it" ~/.config/kcap/daemon-*.log

--- a/docs/probes/2026-08-06-agy-reviewer/findings.md
+++ b/docs/probes/2026-08-06-agy-reviewer/findings.md
@@ -1,0 +1,235 @@
+# Antigravity CLI (`agy`) unattended-reviewer probe — containment, auth and the read boundary
+
+**Binary:** `agy --version` → `1.1.10`, resolved at `~/.local/bin/agy` (169,718,336 bytes).
+**Host:** macOS 26.5.2, arm64, .NET 10.0.9.
+**Dates:** 2026-08-06 (auth + capability surface), 2026-08-07 (containment enforcement, permission
+table, binary-namespace re-check).
+
+Everything below is a **measurement**. Where a claim could have been inferred from the agent's own
+words, it is instead an observation of the filesystem, the process table or the binary — a
+model-layer refusal is not containment evidence, and two of the issue's original premises were
+falsified by exactly this discipline (§4).
+
+The enforcement half of this probe is promoted to a gated test:
+`test/Capacitor.Cli.Tests.Unit/Acp/AntigravityContainmentTests.cs`.
+
+---
+
+## 1. The contained-launch recipe
+
+This is the launch shape every measurement below was taken under. `HOME` is a fresh, empty,
+per-launch directory; `TMPDIR` sits inside it.
+
+```sh
+env -i \
+  PATH=/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.local/bin \
+  HOME=<per-launch home> \
+  TMPDIR=<per-launch home>/tmp \
+  AGY_ADC_AUTH=1 \
+  GOOGLE_CLOUD_PROJECT=<project> \
+  GOOGLE_APPLICATION_CREDENTIALS=<real home>/.config/gcloud/application_default_credentials.json \
+  agy -p "<prompt>" --output-format stream-json
+```
+
+`GOOGLE_APPLICATION_CREDENTIALS` deliberately points **outside** the relocated home — an absolute
+path into the operator's real tree. That is the whole auth mechanism: it is an environment path, not
+HOME-anchored file state (§4.2).
+
+Production adds `--disable-slash-commands` and `--print-timeout <turn ceiling>s`, and passes
+`--conversation <id>` on every turn after the first. It does **not** pass
+`--dangerously-skip-permissions` or `--sandbox` (§5). `AntigravityHostedAgentRuntimeFactory.BuildTurnPsi`
+is the single builder for that vector, and the containment test drives the real one rather than a
+re-derivation.
+
+### 1.1 Wire shape
+
+NDJSON on stdout. The envelope key is **`event`**, with three values: `init` → `step_update`* →
+terminal `result`. `init.conversation_id` carries the id. A tool step's descriptor is `tool_info`,
+and its tool name is **`name`** — not `tool_name`.
+
+```json
+{"event":"init","conversation_id":"44508275-4e2f-4926-a5d9-f8c9af02bc27",
+ "init":{"cwd":"…","tools":[…54 names…],"permission_mode":"request-review"}}
+{"event":"step_update","step_update":{"step_index":1,"state":"DONE","step_type":"agent_response",
+ "text_delta":"\n","duration_seconds":1.409684,
+ "usage":{"input_tokens":11336,"output_tokens":35,"thinking_tokens":34,
+          "cache_read_tokens":0,"total_tokens":11371}}}
+{"event":"result","result":{"status":"SUCCESS","response":"OK\n","num_turns":1,"usage":{…}}}
+```
+
+Default `permission_mode` in print mode is `request-review`.
+
+---
+
+## 2. Containment — the four observations
+
+One real turn (`Reply with the single word OK. Do not use any tools.`) under the production
+per-launch home, built by `AntigravityReviewerHome.Create`, spawned by the production
+`BuildTurnPsi`. Result: `status=SUCCESS`, exit `0`, ~4s.
+
+| # | Observation | Measured |
+|---|---|---|
+| 1 | No kcap hook fired — no file under `~/.config/kcap/logs/` **or** `~/.config/kcap/watchers/` keyed on the conversation id | **none** (0 new keyed entries against an 8,512-entry pre-existing logs dir) |
+| 2 | No process on this host carries the conversation id, in either spelling | **none** |
+| 3 | `agy`'s Library writes landed **inside** the per-launch home | `<home>/Library/Caches/ms-playwright-go/1.57.0` — created under the RELOCATED home |
+| 4 | The operator's real agy conversation store gained no entry | `~/.gemini/antigravity-cli/{brain/<id>, conversations/<id>.db}` absent; same for the GUI root `~/.gemini/antigravity/` |
+
+Positive control for 3 and 4 together — the state exists, and this is about *where*:
+
+```
+<home>/.gemini/antigravity-cli/brain/<id>/.system_generated/logs/transcript_full.jsonl
+<home>/.gemini/antigravity-cli/conversations/<id>.db  (+ .db-wal)
+<home>/.gemini/antigravity-cli/presence/<id>.lock
+<home>/.gemini/antigravity-cli/cache/last_conversations.json
+```
+
+Full home shape after one turn: `.gemini/{config,antigravity-cli/{brain,conversations,log,cache,
+presence,knowledge,scratch,crashes,updater,bin,builtin}}`, `Library/Caches`, `tmp`.
+
+### 2.1 Why observation 3 is the load-bearing one
+
+The credential is *not* under `~/.gemini` (§4.2) — it is under `~/Library` and the keychain. So the
+sharpest available question is whether `agy` resolves `~/Library` from the **real** user or from
+`$HOME`. If it were the real user, a relocated HOME would contain nothing that matters and the
+containment claim would be a fiction.
+
+It resolves from `$HOME`. Two asymmetric consequences, both worth stating:
+
+- **Writes are contained.** Reviewer conversations, caches and brain state land in the per-launch
+  directory and are deleted with it.
+- **The keychain is NOT contained** — keychain access is not HOME-derived. Accepted: this design
+  never reads the keychain (auth is the ADC env path), and a `(deny default)` OS sandbox — the thing
+  that would actually bound it — is explicitly out of scope. A future borrowed lane must revisit it.
+
+### 2.2 The positive control that must not be run
+
+The same turn under the operator's **real** `HOME` *does* fire the kcap capture hooks and spawn a
+watcher: `agy -p` loads and fires `~/.gemini/config/plugins/kcap/hooks.json` in print mode. That is
+measured, and it is the reason the reviewer's home must never be the real one — it would
+double-capture the conversation the runtime is already parsing from NDJSON, and the watcher child
+would (on an unfixed build) hold agy's own stdout open, which for an exec-per-turn runtime means
+every turn blocks forever.
+
+It stays a recorded measurement rather than a test case: running it would record a real session
+against the operator's server and spawn a watcher over the reviewer's conversation — the exact damage
+the containment exists to prevent.
+
+### 2.3 One instrument defect, found by the control
+
+The containment test's **first live run failed** — and the containment was working perfectly. The
+positive control (`TreeMentions`) enumerated the home with a default `EnumerationOptions`, whose
+`AttributesToSkip` skips `Hidden`; .NET reports every Unix dot-entry as hidden, so the entire
+`.gemini` subtree — which is where `agy` writes *all* of its conversation state — was invisible to
+the search. Fixed by setting `AttributesToSkip = FileAttributes.None` explicitly.
+
+Worth recording because the failure mode is inverted: without the positive control the test would
+have passed, and its four absence-assertions would have been silently unfalsifiable in the same way.
+
+Each observation was then mutation-checked against a known-present value, and each detected it:
+
+| Observation | Mutant | Result |
+|---|---|---|
+| 1 (kcap logs) | search an existing log id against an empty before-set | **detected** `00134e9d….log` |
+| 2 (process table) | search a string certain to be in `ps` output | **detected** 6 command lines |
+| 4 (operator store) | search an existing `brain/<id>` | **detected** |
+
+---
+
+## 3. The permission table — `--dangerously-skip-permissions` IS the read boundary
+
+Same contained launch, same prompt: *"Use view_file to read the absolute path /etc/hosts and print
+its first line."* `/etc/hosts` is absolute and outside the workspace.
+
+| Flag | Tool step | `tool_info.error` | Content read? | `result` |
+|---|---|---|---|---|
+| absent (production) | `state: ERROR` | `{"type":"TOOL_ERROR","message":"User denied permission for read_file(/private/etc/hosts)."}` | **no** | `status: SUCCESS`, `response: ""` |
+| `--dangerously-skip-permissions` | `state: DONE` | — | **yes** (`output: "15 lines, 366 bytes"`) | `status: SUCCESS`, non-empty response quoting the file |
+
+stderr on the denied arm, verbatim:
+
+```
+jetski: no output produced — a tool required the "read_file" permission that headless mode cannot
+prompt for, so it was auto-denied. Add an allow-rule under permissions.allow in settings.json
+(e.g. read_file(<target>)). Alternatively, re-run with --dangerously-skip-permissions to
+auto-approve all tools.
+```
+
+Three consequences for anything built on this:
+
+1. **The flag is the entire read boundary.** The reviewer deliberately does not pass it: it works in
+   a daemon-**owned** worktree and needs only to read that, which the headless defaults already
+   permit. Adding the flag would grant a reviewer shell access and whole-filesystem reads it has no
+   reason to hold.
+2. **Assert the TYPED shape, never the message text.** The wire tool name is `view_file`; the name
+   inside the message is `read_file`. They disagree, and a message-text assertion pins the wrong one.
+3. **A denial ENDS the turn.** No closing `agent_response`, an empty `result.response`, and a second
+   instruction in the same prompt never runs. A test that waits for a post-denial summary will
+   **hang**, not fail — bound every wait.
+
+---
+
+## 4. Two falsified premises
+
+The issue's original design sketch rested on two claims. Both are wrong.
+
+### 4.1 `ANTIGRAVITY_API_KEY` / `ANTIGRAVITY_TOKEN` do not exist
+
+Re-verified 2026-08-07 against the shipped 1.1.10 binary:
+
+```sh
+strings -a $(which agy) | grep -cE 'ANTIGRAVITY_(API_KEY|TOKEN)'                # → 0
+strings -a $(which agy) | grep -oE 'ANTIGRAVITY_[A-Z0-9_]+' | sort -u | wc -l   # → 36
+```
+
+All 36 are IDE/sidecar plumbing or telemetry event names — `ANTIGRAVITY_SIDECAR_UI_TOKEN`,
+`ANTIGRAVITY_LS_ADDRESS`, `ANTIGRAVITY_CSRF_TOKEN`, `ANTIGRAVITY_EXTENSION_ACTIVATED`,
+`ANTIGRAVITY_CONVERSATION_ID`, … There is no API-key or bearer-token variable at any point in the
+namespace. `AGY_ADC_AUTH` is present (3 occurrences) and is the only auth switch that matters.
+
+### 4.2 Auth is NOT HOME-anchored file state
+
+A **byte-complete copy of `~/.gemini`** (69 MB, everything except the kcap plugin directory) into a
+relocated HOME **still demands fresh OAuth**. The credential is not in `~/.gemini` at all — the
+candidates are `~/Library/Application Support/Antigravity`,
+`~/Library/Preferences/com.google.antigravity.plist`, and a keychain item (service `gemini`, account
+`antigravity`).
+
+This is what makes the whole design work rather than what breaks it: because auth is *not* file
+state under HOME, a **completely empty** relocated HOME authenticates fine via
+`AGY_ADC_AUTH=1` + `GOOGLE_CLOUD_PROJECT` + `GOOGLE_APPLICATION_CREDENTIALS`. The containment does
+not have to smuggle a credential into the isolated home, and the isolated home does not have to be
+seeded with anything.
+
+It also retires a third premise by making it moot: "APFS-clone the binary into the launch state root
+so the sandbox profile grants nothing under home". There is no sandbox profile — containment here is
+the Kiro shape (an isolated `HOME`), not the Copilot shape (`sandbox-exec`).
+
+---
+
+## 5. What production deliberately does not do
+
+- **No `--dangerously-skip-permissions`** — §3. The soft-deny of shell and out-of-workspace
+  operations *is* the desired unattended posture.
+- **No `--sandbox`** — a vendor-side terminal restriction overlapping what containment already
+  provides, and unprobed.
+- **No borrowed-review lane.** `SupportsBorrowedReviewFlow` stays false; reviews fail closed to an
+  owned worktree. `BorrowedReviewRuntimeRoots.MeasuredPrefixes` is `["/opt/homebrew"]` and `agy`
+  installs to `~/.local/bin/agy` — **under `$HOME`**, which that roots shape refuses by design.
+- **No credential gate on advertisement.** Availability is binary presence
+  (`CliResolver.Exists(config.AntigravityPath)`) plus operator consent. An operator without durable
+  auth gets a bounded, coded spawn-time failure rather than a vendor that silently disappears.
+
+---
+
+## 6. Reproducing
+
+```sh
+KCAP_ANTIGRAVITY_REVIEWER_LIVE=1 GOOGLE_CLOUD_PROJECT=<project> \
+  dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj \
+    -- --treenode-filter "/*/*/AntigravityContainmentTests/*"
+```
+
+Without both variables it skips in ~15 ms and spends nothing — CI has neither an `agy` binary nor
+Google credentials. The test is read-only against `~/.config/kcap` and `~/.gemini`: it snapshots
+names before the run and keys every observation on that run's own conversation id, so a live daemon
+writing its own files alongside it can neither make it pass nor make it fail.

--- a/src/Capacitor.Cli.Core/JsonElementExtensions.cs
+++ b/src/Capacitor.Cli.Core/JsonElementExtensions.cs
@@ -4,17 +4,23 @@ namespace Capacitor.Cli.Core;
 
 static class JsonElementExtensions {
     extension(JsonElement el) {
-        public string? Str(string property) => el.ValueKind == JsonValueKind.Object && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+        // The one primitive the property accessors below cannot express: whether the element ITSELF
+        // is an object. They all answer about a named property, so a caller guarding a document root
+        // (or any element it is about to read properties off) had no helper to reach for and dropped
+        // to a raw ValueKind comparison instead.
+        public bool IsObject => el.ValueKind == JsonValueKind.Object;
+
+        public string? Str(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
 
         // Guard the ValueKind before TryGetInt64: it THROWS on a non-Number element (string,
         // bool, null, object, array), so an unguarded call lets a schema-drift frame bubble an
         // exception up and take out the whole notification instead of dropping one bad field.
         // Same defensive contract as Str/Obj/Arr above — a wrong-typed field reads as absent.
         // A fractional number still returns null via TryGetInt64 rather than truncating.
-        public long? Num(string property) => el.ValueKind == JsonValueKind.Object && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var n) ? n : null;
+        public long? Num(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var n) ? n : null;
 
-        public JsonElement? Obj(string property) => el.ValueKind == JsonValueKind.Object && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.Object ? v : null;
+        public JsonElement? Obj(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.IsObject ? v : null;
 
-        public JsonElement? Arr(string property) => el.ValueKind == JsonValueKind.Object && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.Array ? v : null;
+        public JsonElement? Arr(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.Array ? v : null;
     }
 }

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityNdjson.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityNdjson.cs
@@ -1,0 +1,279 @@
+// src/Capacitor.Cli.Daemon/Acp/AntigravityNdjson.cs
+using System.Text;
+using System.Text.Json;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Daemon.Acp;
+
+/// <summary>
+/// Discriminator for <see cref="AntigravityEvent.Kind"/> — agy's <c>--output-format stream-json</c>
+/// NDJSON has exactly three known top-level <c>event</c> values (<c>init</c>/<c>step_update</c>/
+/// <c>result</c>); anything else, including a missing <c>event</c> field, is <see cref="Unknown"/> so
+/// a future/unrecognized variant is dropped rather than thrown on.
+/// </summary>
+internal enum AntigravityEventKind {
+    Init,
+    StepUpdate,
+    Result,
+    Unknown,
+}
+
+/// <summary>
+/// Reduced, AOT-friendly DTO for one agy NDJSON line — mirrors <c>AcpSessionUpdate</c>'s role for
+/// ACP updates. Flat and non-polymorphic: every field below is nullable and only ever populated for
+/// the <see cref="Kind"/> it belongs to (see <see cref="AntigravityNdjson.TryParseLine"/>).
+///
+/// The usage counters (<see cref="InputTokens"/>/<see cref="OutputTokens"/>/
+/// <see cref="ThinkingTokens"/>/<see cref="CacheReadTokens"/>/<see cref="TotalTokens"/>) are agy's
+/// per-step token breakdown, observed live on a <c>step_update</c> whose <c>state</c> is
+/// <c>DONE</c> — captured fixtures satisfy <c>input_tokens + output_tokens == total_tokens</c>, so
+/// <c>thinking_tokens</c> reads as a subset of <c>output_tokens</c> rather than additional to it.
+/// A terminal <c>result</c> carries the same shape of usage block; it is captured here too even
+/// though this task's mapping does not yet surface it (the runtime reads <see cref="Status"/> off
+/// this same event to drive logical-terminal state).
+/// </summary>
+internal sealed record AntigravityEvent(
+    AntigravityEventKind Kind,
+    string? ConversationId  = null,
+    string? Cwd             = null, // init only
+    long?   StepIndex       = null, // step_update only
+    string? State           = null, // step_update only, e.g. "ACTIVE" / "DONE"
+    string? StepType        = null, // step_update only, e.g. "agent_response" / "checkpoint" / "unknown"
+    string? TextDelta       = null, // step_update only
+    string? Status          = null, // result only, e.g. "SUCCESS"
+    long?   InputTokens     = null,
+    long?   OutputTokens    = null,
+    long?   ThinkingTokens  = null,
+    long?   CacheReadTokens = null,
+    long?   TotalTokens     = null
+);
+
+/// <summary>
+/// Pure translation from agy's NDJSON lines to the daemon's canonical <see cref="AcpEventEnvelope"/>
+/// transcript events — no processes, no I/O, no state beyond what a caller explicitly threads
+/// through <see cref="AntigravityStepAccumulator"/>. See
+/// <c>docs/superpowers/specs/2026-08-06-ai1414-agy-unattended-reviewer-design.md</c> §5.4.
+///
+/// Neither <see cref="TryParseLine"/> nor <see cref="ToEnvelopes"/> stamps
+/// <see cref="AcpEventEnvelope.Seq"/>/<see cref="AcpEventEnvelope.TimestampIso"/> — both are
+/// caller/runtime-owned downstream, the same split <c>AcpEventTranslator</c> uses for the ACP path
+/// (<c>AcpTranscriptForwarder</c> reassigns the real monotonic seq on send). A <see langword="null"/>
+/// <c>TimestampIso</c> is harmless: the server falls back to "now".
+///
+/// <b>Deliberately out of scope here</b>: agy's <c>tool_info</c> shape (surfacing tool calls,
+/// results, and soft-denials) is added by a later, separately-scoped task once its wire shape is
+/// verified against real output (a sibling plan adds a "surface soft-denials as system_note" task
+/// that extends this same file). A <c>step_update</c> that happens to carry <c>tool_info</c> is
+/// handled today the same as any other <see cref="AntigravityEventKind.StepUpdate"/> — its
+/// <c>text_delta</c>/usage still aggregate normally; it just yields no tool-specific envelope yet.
+/// </summary>
+internal static class AntigravityNdjson {
+    /// <summary>
+    /// Parses one NDJSON line into an <see cref="AntigravityEvent"/>. Returns
+    /// <see langword="null"/> for a blank line or malformed JSON — never throws. A line that parses
+    /// as JSON but carries an unrecognized (or missing) <c>event</c> discriminator still returns a
+    /// non-null event with <see cref="AntigravityEventKind.Unknown"/>, so a caller can tell "nothing
+    /// to read" (blank/malformed) apart from "read something we don't understand yet" (schema
+    /// drift) — the same distinction <c>AcpSessionUpdate</c>'s reduction makes for ACP.
+    /// </summary>
+    public static AntigravityEvent? TryParseLine(string line) {
+        if (string.IsNullOrWhiteSpace(line)) return null;
+
+        JsonDocument doc;
+        try {
+            doc = JsonDocument.Parse(line);
+        } catch (JsonException) {
+            return null;
+        }
+
+        using (doc) {
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return null;
+
+            return root.Str("event") switch {
+                "init"        => ParseInit(root),
+                "step_update" => ParseStepUpdate(root),
+                "result"      => ParseResult(root),
+                _             => new AntigravityEvent(AntigravityEventKind.Unknown),
+            };
+        }
+    }
+
+    static AntigravityEvent ParseInit(JsonElement root) =>
+        new(
+            AntigravityEventKind.Init,
+            ConversationId: root.Str("conversation_id"),
+            Cwd: root.Obj("init")?.Str("cwd"));
+
+    static AntigravityEvent ParseStepUpdate(JsonElement root) {
+        // A malformed/schema-drifted line that named itself "step_update" but has no such object is
+        // treated as Unknown rather than a step_update with every field null — the caller (the step
+        // accumulator) requires a StepIndex to do anything, and a real one is never absent.
+        if (root.Obj("step_update") is not { } su) return new AntigravityEvent(AntigravityEventKind.Unknown);
+
+        var usage = su.Obj("usage");
+        return new AntigravityEvent(
+            AntigravityEventKind.StepUpdate,
+            ConversationId: su.Str("conversation_id"),
+            StepIndex: su.Num("step_index"),
+            State: su.Str("state"),
+            StepType: su.Str("step_type"),
+            TextDelta: su.Str("text_delta"),
+            InputTokens: usage?.Num("input_tokens"),
+            OutputTokens: usage?.Num("output_tokens"),
+            ThinkingTokens: usage?.Num("thinking_tokens"),
+            CacheReadTokens: usage?.Num("cache_read_tokens"),
+            TotalTokens: usage?.Num("total_tokens"));
+    }
+
+    static AntigravityEvent ParseResult(JsonElement root) {
+        if (root.Obj("result") is not { } result) return new AntigravityEvent(AntigravityEventKind.Unknown);
+
+        var usage = result.Obj("usage");
+        return new AntigravityEvent(
+            AntigravityEventKind.Result,
+            ConversationId: result.Str("conversation_id"),
+            Status: result.Str("status"),
+            InputTokens: usage?.Num("input_tokens"),
+            OutputTokens: usage?.Num("output_tokens"),
+            ThinkingTokens: usage?.Num("thinking_tokens"),
+            CacheReadTokens: usage?.Num("cache_read_tokens"),
+            TotalTokens: usage?.Num("total_tokens"));
+    }
+
+    /// <summary>
+    /// Translates ONE <paramref name="evt"/> directly into envelopes — only
+    /// <see cref="AntigravityEventKind.Init"/> yields anything here.
+    /// <see cref="AntigravityEventKind.Result"/> NEVER yields a <c>session_ended</c> envelope: the
+    /// server's <c>EndAgentSession</c> owns termination, and the runtime instead reads
+    /// <see cref="AntigravityEvent.Status"/> off this same event to drive its own logical-terminal
+    /// state (a translation concern, not this pure mapper's). <see cref="AntigravityEventKind.StepUpdate"/>
+    /// always yields <c>[]</c> here — a single step_update line is never enough on its own; text
+    /// aggregates per step and only becomes an envelope through
+    /// <see cref="AntigravityStepAccumulator.Flush"/> once that step reaches <c>DONE</c>.
+    /// <see cref="AntigravityEventKind.Unknown"/> yields <c>[]</c>.
+    /// </summary>
+    public static IReadOnlyList<AcpEventEnvelope> ToEnvelopes(AntigravityEvent evt, string? model) =>
+        evt.Kind switch {
+            AntigravityEventKind.Init =>
+                [new AcpEventEnvelope(
+                    Kind: AcpEventKind.SessionStarted,
+                    Cwd: evt.Cwd,
+                    Model: model,
+                    RawSessionId: evt.ConversationId)],
+
+            _ => [],
+        };
+
+    /// <summary>
+    /// Heuristic step-type name match for a "thinking" step. <b>Unverified against real agy
+    /// output</b> — every captured <c>step_type</c> to date is <c>agent_response</c>/
+    /// <c>checkpoint</c>/<c>user_input</c>/<c>unknown</c>; none carries a thinking-shaped delta.
+    /// Kept narrow and named so a wrong guess degrades to a benign misclassification
+    /// (<c>assistant_text</c> instead of <c>assistant_thinking</c>) rather than a thrown exception
+    /// or a silently dropped delta.
+    /// </summary>
+    internal static bool IsThinkingStepType(string? stepType) =>
+        stepType is not null &&
+        (stepType.Contains("thought", StringComparison.OrdinalIgnoreCase) ||
+         stepType.Contains("thinking", StringComparison.OrdinalIgnoreCase));
+}
+
+/// <summary>
+/// Per-step accumulator for agy's <c>text_delta</c> stream and per-step usage counters — the small
+/// piece of state <see cref="AntigravityNdjson"/> itself deliberately stays free of. One instance
+/// tracks however many step indices the caller feeds it concurrently; a step's buffer is dropped the
+/// moment it flushes, so a caller that never revisits a step index leaks nothing.
+///
+/// Deltas accumulate regardless of <c>state</c> — a real fixture shows the tail of a stream arriving
+/// on the SAME event that flips a step to <c>DONE</c>, so a delta must never be dropped just because
+/// its event happens to be the terminal one for that step. <see cref="Flush"/> only ever emits for a
+/// step whose LATEST <see cref="AntigravityEvent.State"/> is <c>DONE</c> — never a fabricated
+/// envelope, never a still-<c>ACTIVE</c> step's text.
+/// </summary>
+internal sealed class AntigravityStepAccumulator {
+    sealed class StepBuffer {
+        public readonly StringBuilder Text = new();
+        public string?  StepType;
+        public string?  State;
+        public bool     HasUsage;
+        public long?    InputTokens;
+        public long?    OutputTokens;
+        public long?    ThinkingTokens;
+        public long?    CacheReadTokens;
+        public long?    TotalTokens;
+    }
+
+    readonly Dictionary<long, StepBuffer> _steps = new();
+
+    /// <summary>
+    /// Folds one <see cref="AntigravityEventKind.StepUpdate"/> event into its step's buffer.
+    /// Anything else — including a null <see cref="AntigravityEvent.StepIndex"/>, which a
+    /// malformed/partial line can produce — is silently ignored: this accumulator only ever holds
+    /// step_update state.
+    /// </summary>
+    public void Add(AntigravityEvent evt) {
+        if (evt.Kind != AntigravityEventKind.StepUpdate || evt.StepIndex is not { } index) return;
+
+        if (!_steps.TryGetValue(index, out var buf)) _steps[index] = buf = new StepBuffer();
+
+        if (evt.StepType is { Length: > 0 }) buf.StepType = evt.StepType;
+        buf.State = evt.State;
+        if (evt.TextDelta is { Length: > 0 } delta) buf.Text.Append(delta);
+
+        if (evt.InputTokens is not null || evt.OutputTokens is not null || evt.ThinkingTokens is not null
+                || evt.CacheReadTokens is not null || evt.TotalTokens is not null) {
+            buf.HasUsage        = true;
+            buf.InputTokens     = evt.InputTokens;
+            buf.OutputTokens    = evt.OutputTokens;
+            buf.ThinkingTokens  = evt.ThinkingTokens;
+            buf.CacheReadTokens = evt.CacheReadTokens;
+            buf.TotalTokens     = evt.TotalTokens;
+        }
+    }
+
+    /// <summary>
+    /// Emits and DROPS the buffer for every step currently at <c>DONE</c>, in ascending step-index
+    /// order. A step contributes at most two envelopes: an <c>assistant_text</c> (or
+    /// <c>assistant_thinking</c> — see <see cref="AntigravityNdjson.IsThinkingStepType"/>) when it
+    /// accumulated any text, and a <c>usage</c> when its DONE event carried a usage block. A
+    /// content-free DONE step (e.g. a bare <c>user_input</c> marker) yields neither. A step still
+    /// <c>ACTIVE</c> is left untouched for a later <see cref="Flush"/> call.
+    ///
+    /// <see cref="AcpEventEnvelope.ContextUsedTokens"/> is stamped from <c>input_tokens</c> — the
+    /// closest agy counter to ACP's "context occupied so far" semantics (the context fed IN, as
+    /// opposed to <c>output_tokens</c>/<c>total_tokens</c>, which are cost/billing figures for the
+    /// step rather than window occupancy). agy reports no window/size figure, so
+    /// <see cref="AcpEventEnvelope.ContextWindowTokens"/> is always left null here.
+    /// </summary>
+    public IReadOnlyList<AcpEventEnvelope> Flush(string? model) {
+        List<AcpEventEnvelope>? envelopes = null;
+        List<long>?             done      = null;
+
+        foreach (var index in _steps.Keys.OrderBy(k => k)) {
+            var buf = _steps[index];
+            if (buf.State != "DONE") continue;
+
+            (done ??= []).Add(index);
+
+            if (buf.Text.Length > 0) {
+                (envelopes ??= []).Add(new AcpEventEnvelope(
+                    Kind: AntigravityNdjson.IsThinkingStepType(buf.StepType)
+                        ? AcpEventKind.AssistantThinking
+                        : AcpEventKind.AssistantText,
+                    Text: buf.Text.ToString()));
+            }
+
+            if (buf.HasUsage) {
+                (envelopes ??= []).Add(new AcpEventEnvelope(
+                    Kind: AcpEventKind.Usage,
+                    Model: model,
+                    ContextUsedTokens: buf.InputTokens));
+            }
+        }
+
+        if (done is not null) foreach (var index in done) _steps.Remove(index);
+
+        return envelopes ?? [];
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityNdjson.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityNdjson.cs
@@ -31,21 +31,33 @@ internal enum AntigravityEventKind {
 /// A terminal <c>result</c> carries the same shape of usage block; it is captured here too even
 /// though this task's mapping does not yet surface it (the runtime reads <see cref="Status"/> off
 /// this same event to drive logical-terminal state).
+///
+/// The tool fields (<see cref="ToolName"/>/<see cref="ToolInputJson"/>/<see cref="ToolOutput"/>/
+/// <see cref="ToolErrorType"/>/<see cref="ToolErrorMessage"/>) belong to a <c>step_update</c> whose
+/// <c>step_type</c> is <c>"tool"</c> — captured live across all three states a tool step reaches:
+/// <c>ACTIVE</c> (the call itself — name + parameters), <c>DONE</c> (a string <c>output</c>), and
+/// <c>ERROR</c> (an object <c>error</c>). <c>ERROR</c> is an ordinary terminal state for that step,
+/// not a parse failure — agy soft-denies rather than crashing.
 /// </summary>
 internal sealed record AntigravityEvent(
     AntigravityEventKind Kind,
     string? ConversationId  = null,
     string? Cwd             = null, // init only
     long?   StepIndex       = null, // step_update only
-    string? State           = null, // step_update only, e.g. "ACTIVE" / "DONE"
-    string? StepType        = null, // step_update only, e.g. "agent_response" / "checkpoint" / "unknown"
+    string? State           = null, // step_update only, e.g. "ACTIVE" / "DONE" / "ERROR"
+    string? StepType        = null, // step_update only, e.g. "agent_response" / "checkpoint" / "tool" / "unknown"
     string? TextDelta       = null, // step_update only
     string? Status          = null, // result only, e.g. "SUCCESS"
     long?   InputTokens     = null,
     long?   OutputTokens    = null,
     long?   ThinkingTokens  = null,
     long?   CacheReadTokens = null,
-    long?   TotalTokens     = null
+    long?   TotalTokens     = null,
+    string? ToolName        = null, // step_type "tool" only — tool_name, falling back to tool_info.name
+    string? ToolInputJson   = null, // step_type "tool" only — tool_info.parameters, verbatim JSON text
+    string? ToolOutput      = null, // step_type "tool" only, state DONE — tool_info.output
+    string? ToolErrorType   = null, // step_type "tool" only, state ERROR — tool_info.error.type
+    string? ToolErrorMessage = null // step_type "tool" only, state ERROR — tool_info.error.message
 );
 
 /// <summary>
@@ -60,12 +72,10 @@ internal sealed record AntigravityEvent(
 /// (<c>AcpTranscriptForwarder</c> reassigns the real monotonic seq on send). A <see langword="null"/>
 /// <c>TimestampIso</c> is harmless: the server falls back to "now".
 ///
-/// <b>Deliberately out of scope here</b>: agy's <c>tool_info</c> shape (surfacing tool calls,
-/// results, and soft-denials) is added by a later, separately-scoped task once its wire shape is
-/// verified against real output (a sibling plan adds a "surface soft-denials as system_note" task
-/// that extends this same file). A <c>step_update</c> that happens to carry <c>tool_info</c> is
-/// handled today the same as any other <see cref="AntigravityEventKind.StepUpdate"/> — its
-/// <c>text_delta</c>/usage still aggregate normally; it just yields no tool-specific envelope yet.
+/// <b>Still out of scope here</b>: surfacing a tool's soft-denial as a <c>system_note</c> is added
+/// by a later, separately-scoped task (a sibling plan's "surface soft-denials as system_note" task,
+/// which extends this same file) — an <c>ERROR</c> tool step maps only to a <c>tool_result</c> below,
+/// nothing more.
 /// </summary>
 internal static class AntigravityNdjson {
     /// <summary>
@@ -111,7 +121,10 @@ internal static class AntigravityNdjson {
         // accumulator) requires a StepIndex to do anything, and a real one is never absent.
         if (root.Obj("step_update") is not { } su) return new AntigravityEvent(AntigravityEventKind.Unknown);
 
-        var usage = su.Obj("usage");
+        var usage    = su.Obj("usage");
+        var toolInfo = su.Obj("tool_info");
+        var toolErr  = toolInfo?.Obj("error");
+
         return new AntigravityEvent(
             AntigravityEventKind.StepUpdate,
             ConversationId: su.Str("conversation_id"),
@@ -123,7 +136,14 @@ internal static class AntigravityNdjson {
             OutputTokens: usage?.Num("output_tokens"),
             ThinkingTokens: usage?.Num("thinking_tokens"),
             CacheReadTokens: usage?.Num("cache_read_tokens"),
-            TotalTokens: usage?.Num("total_tokens"));
+            TotalTokens: usage?.Num("total_tokens"),
+            // tool_name is the top-level field agy actually sends; tool_info.name is the fallback
+            // seen alongside it — never observed to differ, but the top-level field is preferred.
+            ToolName: su.Str("tool_name") ?? toolInfo?.Str("name"),
+            ToolInputJson: toolInfo?.Obj("parameters")?.GetRawText(),
+            ToolOutput: toolInfo?.Str("output"),
+            ToolErrorType: toolErr?.Str("type"),
+            ToolErrorMessage: toolErr?.Str("message"));
     }
 
     static AntigravityEvent ParseResult(JsonElement root) {
@@ -148,10 +168,10 @@ internal static class AntigravityNdjson {
     /// server's <c>EndAgentSession</c> owns termination, and the runtime instead reads
     /// <see cref="AntigravityEvent.Status"/> off this same event to drive its own logical-terminal
     /// state (a translation concern, not this pure mapper's). <see cref="AntigravityEventKind.StepUpdate"/>
-    /// always yields <c>[]</c> here — a single step_update line is never enough on its own; text
-    /// aggregates per step and only becomes an envelope through
-    /// <see cref="AntigravityStepAccumulator.Flush"/> once that step reaches <c>DONE</c>.
-    /// <see cref="AntigravityEventKind.Unknown"/> yields <c>[]</c>.
+    /// always yields <c>[]</c> here — a single step_update line is never enough on its own; text,
+    /// tool calls/results, and usage all aggregate per step and only become envelopes through
+    /// <see cref="AntigravityStepAccumulator.Flush"/>. <see cref="AntigravityEventKind.Unknown"/>
+    /// yields <c>[]</c>.
     /// </summary>
     public static IReadOnlyList<AcpEventEnvelope> ToEnvelopes(AntigravityEvent evt, string? model) =>
         evt.Kind switch {
@@ -164,32 +184,30 @@ internal static class AntigravityNdjson {
 
             _ => [],
         };
-
-    /// <summary>
-    /// Heuristic step-type name match for a "thinking" step. <b>Unverified against real agy
-    /// output</b> — every captured <c>step_type</c> to date is <c>agent_response</c>/
-    /// <c>checkpoint</c>/<c>user_input</c>/<c>unknown</c>; none carries a thinking-shaped delta.
-    /// Kept narrow and named so a wrong guess degrades to a benign misclassification
-    /// (<c>assistant_text</c> instead of <c>assistant_thinking</c>) rather than a thrown exception
-    /// or a silently dropped delta.
-    /// </summary>
-    internal static bool IsThinkingStepType(string? stepType) =>
-        stepType is not null &&
-        (stepType.Contains("thought", StringComparison.OrdinalIgnoreCase) ||
-         stepType.Contains("thinking", StringComparison.OrdinalIgnoreCase));
 }
 
 /// <summary>
-/// Per-step accumulator for agy's <c>text_delta</c> stream and per-step usage counters — the small
-/// piece of state <see cref="AntigravityNdjson"/> itself deliberately stays free of. One instance
-/// tracks however many step indices the caller feeds it concurrently; a step's buffer is dropped the
-/// moment it flushes, so a caller that never revisits a step index leaks nothing.
+/// Per-step accumulator for agy's <c>text_delta</c> stream, per-step usage counters, and a tool
+/// step's call/result lifecycle — the small piece of state <see cref="AntigravityNdjson"/> itself
+/// deliberately stays free of. One instance tracks however many step indices the caller feeds it
+/// concurrently; a step's buffer is dropped once it reaches a terminal state, so a caller that never
+/// revisits a step index leaks nothing.
 ///
-/// Deltas accumulate regardless of <c>state</c> — a real fixture shows the tail of a stream arriving
-/// on the SAME event that flips a step to <c>DONE</c>, so a delta must never be dropped just because
-/// its event happens to be the terminal one for that step. <see cref="Flush"/> only ever emits for a
-/// step whose LATEST <see cref="AntigravityEvent.State"/> is <c>DONE</c> — never a fabricated
-/// envelope, never a still-<c>ACTIVE</c> step's text.
+/// Deltas accumulate regardless of <c>state</c> — a real fixture shows the tail of a text stream
+/// arriving on the SAME event that flips a step to <c>DONE</c>, so a delta must never be dropped
+/// just because its event happens to be the terminal one for that step. Text/usage envelopes only
+/// ever flush for a step whose LATEST <see cref="AntigravityEvent.State"/> is terminal
+/// (<c>DONE</c> or <c>ERROR</c> — both are ordinary terminal states for a step, not protocol
+/// violations) — never a fabricated envelope, never a still-<c>ACTIVE</c> step's text.
+///
+/// A <c>step_type: "tool"</c> step is the one case with a THIRD envelope shape and an emission
+/// point earlier than terminal: its <c>ACTIVE</c> state carries the call itself (name + parameters),
+/// which flushes as a <c>tool_call</c> as soon as it's seen — not deferred to terminal, since a long
+/// running tool's call is meaningful transcript content on its own. Its terminal state
+/// (<c>DONE</c> with a string <c>output</c>, or <c>ERROR</c> with an object <c>error</c>) then
+/// flushes a <c>tool_result</c>. If a step is only ever observed at its terminal state (no prior
+/// <c>ACTIVE</c> reached this accumulator, e.g. a reconnect mid-turn), both envelopes flush together
+/// on that one <see cref="Flush"/> call, call before result.
 /// </summary>
 internal sealed class AntigravityStepAccumulator {
     sealed class StepBuffer {
@@ -202,6 +220,13 @@ internal sealed class AntigravityStepAccumulator {
         public long?    ThinkingTokens;
         public long?    CacheReadTokens;
         public long?    TotalTokens;
+        public bool     IsTool;
+        public bool     ToolCallEmitted;
+        public string?  ToolName;
+        public string?  ToolInputJson;
+        public string?  ToolOutput;
+        public string?  ToolErrorType;
+        public string?  ToolErrorMessage;
     }
 
     readonly Dictionary<long, StepBuffer> _steps = new();
@@ -230,20 +255,34 @@ internal sealed class AntigravityStepAccumulator {
             buf.CacheReadTokens = evt.CacheReadTokens;
             buf.TotalTokens     = evt.TotalTokens;
         }
+
+        if (buf.StepType == "tool") {
+            buf.IsTool = true;
+            if (evt.ToolName is not null) buf.ToolName = evt.ToolName;
+            if (evt.ToolInputJson is not null) buf.ToolInputJson = evt.ToolInputJson;
+            if (evt.ToolOutput is not null) buf.ToolOutput = evt.ToolOutput;
+            if (evt.ToolErrorType is not null) buf.ToolErrorType = evt.ToolErrorType;
+            if (evt.ToolErrorMessage is not null) buf.ToolErrorMessage = evt.ToolErrorMessage;
+        }
     }
 
     /// <summary>
-    /// Emits and DROPS the buffer for every step currently at <c>DONE</c>, in ascending step-index
-    /// order. A step contributes at most two envelopes: an <c>assistant_text</c> (or
-    /// <c>assistant_thinking</c> — see <see cref="AntigravityNdjson.IsThinkingStepType"/>) when it
-    /// accumulated any text, and a <c>usage</c> when its DONE event carried a usage block. A
-    /// content-free DONE step (e.g. a bare <c>user_input</c> marker) yields neither. A step still
-    /// <c>ACTIVE</c> is left untouched for a later <see cref="Flush"/> call.
+    /// Emits whatever is ready across every tracked step, in ascending step-index order, dropping a
+    /// step's buffer once it reaches terminal (<c>DONE</c> or <c>ERROR</c>).
     ///
-    /// <see cref="AcpEventEnvelope.ContextUsedTokens"/> is stamped from <c>input_tokens</c> — the
-    /// closest agy counter to ACP's "context occupied so far" semantics (the context fed IN, as
-    /// opposed to <c>output_tokens</c>/<c>total_tokens</c>, which are cost/billing figures for the
-    /// step rather than window occupancy). agy reports no window/size figure, so
+    /// A <c>tool</c> step contributes a <c>tool_call</c> the first time it has a name (regardless of
+    /// state — this is the one non-terminal emission) and, once terminal, a <c>tool_result</c>
+    /// carrying <c>output</c> (<c>ToolIsError: false</c>) or the error's <c>message</c> (prefixed
+    /// with its <c>type</c> when present, <c>ToolIsError: true</c>). Any other step contributes, only
+    /// once terminal, an <c>assistant_text</c> when it accumulated any text and a <c>usage</c> when
+    /// its terminal event carried a usage block — a content-free terminal step (e.g. a bare
+    /// <c>user_input</c> marker) yields neither. A step still <c>ACTIVE</c> (and not a tool call) is
+    /// left untouched for a later <see cref="Flush"/> call.
+    ///
+    /// <see cref="AcpEventEnvelope.ContextUsedTokens"/> is stamped from <c>input_tokens</c> — of
+    /// agy's counters it is the one that matches ACP's "context occupied so far" semantics (tokens
+    /// fed IN as context), unlike <c>output_tokens</c>/<c>total_tokens</c>, which are cost/billing
+    /// figures for the step rather than window occupancy. agy reports no window/size figure, so
     /// <see cref="AcpEventEnvelope.ContextWindowTokens"/> is always left null here.
     /// </summary>
     public IReadOnlyList<AcpEventEnvelope> Flush(string? model) {
@@ -251,16 +290,43 @@ internal sealed class AntigravityStepAccumulator {
         List<long>?             done      = null;
 
         foreach (var index in _steps.Keys.OrderBy(k => k)) {
-            var buf = _steps[index];
-            if (buf.State != "DONE") continue;
+            var buf      = _steps[index];
+            var terminal = buf.State is "DONE" or "ERROR";
+
+            if (buf.IsTool && !buf.ToolCallEmitted && buf.ToolName is not null) {
+                (envelopes ??= []).Add(new AcpEventEnvelope(
+                    Kind: AcpEventKind.ToolCall,
+                    ToolCallId: index.ToString(),
+                    ToolName: buf.ToolName,
+                    ToolInputJson: buf.ToolInputJson));
+                buf.ToolCallEmitted = true;
+            }
+
+            if (!terminal) continue; // still ACTIVE — the call (if any) is out, nothing else is ready yet
 
             (done ??= []).Add(index);
 
+            if (buf.IsTool) {
+                if (buf.ToolOutput is not null) {
+                    (envelopes ??= []).Add(new AcpEventEnvelope(
+                        Kind: AcpEventKind.ToolResult,
+                        ToolCallId: index.ToString(),
+                        ToolResult: buf.ToolOutput,
+                        ToolIsError: false));
+                } else if (buf.ToolErrorMessage is not null) {
+                    (envelopes ??= []).Add(new AcpEventEnvelope(
+                        Kind: AcpEventKind.ToolResult,
+                        ToolCallId: index.ToString(),
+                        ToolResult: buf.ToolErrorType is { Length: > 0 } type
+                            ? $"{type}: {buf.ToolErrorMessage}"
+                            : buf.ToolErrorMessage,
+                        ToolIsError: true));
+                }
+            }
+
             if (buf.Text.Length > 0) {
                 (envelopes ??= []).Add(new AcpEventEnvelope(
-                    Kind: AntigravityNdjson.IsThinkingStepType(buf.StepType)
-                        ? AcpEventKind.AssistantThinking
-                        : AcpEventKind.AssistantText,
+                    Kind: AcpEventKind.AssistantText,
                     Text: buf.Text.ToString()));
             }
 

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityNdjson.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityNdjson.cs
@@ -98,7 +98,7 @@ internal static class AntigravityNdjson {
 
         using (doc) {
             var root = doc.RootElement;
-            if (root.ValueKind != JsonValueKind.Object) return null;
+            if (!root.IsObject) return null;
 
             return root.Str("event") switch {
                 "init"        => ParseInit(root),

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
@@ -1,3 +1,5 @@
+using Capacitor.Cli.Core;
+
 namespace Capacitor.Cli.Daemon.Acp;
 
 internal enum AntigravityReviewerDecision {
@@ -5,51 +7,60 @@ internal enum AntigravityReviewerDecision {
     UnsupportedPlatform,
     Disabled,
     VersionUnresolved,
-    VersionBelowMinimum
+    VersionNoMinimum,
+    VersionBelowMinimum,
+    VersionIncomparable
 }
 
 /// <summary>
 /// Whether THIS daemon may run Antigravity's CLI (<c>agy</c>) as an unattended review-flow reviewer.
 /// Pure, so every arm is testable without a vendor or a process.
 ///
-/// <para><b>Why a minimum version FLOOR rather than an operator affirmation.</b> Kiro and Gemini
-/// require an operator to affirm each installed build, because their containment depends on the build
-/// honouring a HOME override. <c>agy</c> was observed auto-updating itself mid-session (1.1.8 →
-/// 1.1.10) while this reviewer was being explored, so an affirmation gate would park the reviewer on
-/// a release cadence the operator neither controls nor can predict — the reviewer would be offline
-/// more often than not, and clearing the gate would become a reflex rather than a decision. Meeting
-/// the floor is therefore enough; a defect in a later build is handled by a report and a raised
-/// floor, which is why <see cref="DaemonConfig.AntigravityMinimumCliVersion"/> is operator-settable.
-/// There is deliberately no <c>affirm</c> verb for this vendor, and no refusal below may point at
-/// one.</para>
+/// <para><b>What enabling it consents to.</b> An unattended reviewer runs in a daemon-owned worktree
+/// under a per-launch, owner-only <c>HOME</c>, and its findings text is returned to whoever requested
+/// the review. That risk lands on the daemon OPERATOR, who is not necessarily the requester, which is
+/// why the decision is daemon-local and enabling it is the consent event rather than a documented
+/// default. Deliberately NOT Kiro's whole-filesystem-read paragraph: that claim is about a trusted
+/// <c>fs_read</c> primitive this vendor does not expose, and a borrowed risk statement would be a
+/// false one in either direction.</para>
 ///
-/// <para>The comparison is <see cref="DaemonRunner.CliVersionAllowed"/> — the same range grammar
-/// reviewer certification already uses. A second version parser in this codebase is exactly the
-/// "two things that must agree, with nothing making them" shape.</para>
+/// <para><b>Why a version MINIMUM.</b> Containment here is source suppression — an empty per-launch
+/// <see cref="AntigravityReviewerHome"/> in place of the operator's own <c>~/.gemini</c>, whose kcap
+/// capture plugin would otherwise fire against the conversation this runtime is already recording.
+/// That the build honours <c>HOME</c> and reads no other global config source is a behaviour of the
+/// BUILD, not of this repository. The recorded value is the OLDEST build this daemon will run: an
+/// upgrade needs no action — which matters more here than for any sibling, since <c>agy</c> was
+/// observed auto-updating itself mid-session (1.1.8 → 1.1.10) — a downgrade below it is refused, and
+/// a build later found to be bad is excluded by raising the floor past it.</para>
+///
+/// <para><b>Why that record is state and not configuration.</b> An earlier revision of this gate read
+/// the floor from <c>KCAP_ANTIGRAVITY_MIN_CLI_VERSION</c>. A value the operator could set from a shell
+/// profile would be re-affirmed by their dotfiles rather than by them — the same "consent that isn't
+/// consent" failure the enable flag exists to avoid. Kiro and Gemini use the same model; the shared
+/// comparison lives in <see cref="Core.ReviewerVersionAffirmations"/> and the record in
+/// <see cref="Core.ReviewerVersionStore"/>.</para>
 ///
 /// <para><b>This is the whole ladder</b> (consent → platform → build), and
 /// <c>AntigravityHostedAgentRuntimeFactory.ReviewerRefusal</c> is its only production caller: it adds
 /// the one arm this decision cannot express — a binary that does not resolve at all — and takes every
 /// other verdict, and every text, from here. Both the advertisement seam and the launch boundary read
-/// that one method, so the floor cannot be enforced at only one of them.</para>
+/// that one method, so the minimum cannot be enforced at only one of them.</para>
 /// </summary>
 internal static class AntigravityReviewerCapability {
-    /// <summary>Production entry point: reads the host platform, then defers to the pure overload.</summary>
-    internal static AntigravityReviewerDecision Decide(
-            bool operatorEnabled, string? installedVersion, string minimumVersion) =>
-        Decide(!OperatingSystem.IsWindows(), operatorEnabled, installedVersion, minimumVersion);
-
     /// <summary>
-    /// The decision, with the platform passed IN rather than read from the ambient OS.
+    /// The decision, with the platform passed IN rather than read from the ambient OS. There is
+    /// deliberately no ambient-reading overload: the one production caller holds a platform seam of its
+    /// own, and an overload that read the OS here would be the obvious thing to reach for next.
     ///
-    /// <para>Kiro's gate records why: reading the OS inside the decision short-circuited every
-    /// consent and version arm to <see cref="AntigravityReviewerDecision.UnsupportedPlatform"/> on the
-    /// Windows CI leg, so a dozen tests failed for a reason unrelated to what they asserted. As a
-    /// parameter, every arm is reachable from any host — including the Windows one, which is
-    /// otherwise unassertable on POSIX.</para>
+    /// <para>Kiro's gate records why it must be a parameter: reading the OS inside the decision
+    /// short-circuited every consent and version arm to
+    /// <see cref="AntigravityReviewerDecision.UnsupportedPlatform"/> on the Windows CI leg, so a dozen
+    /// tests failed for a reason unrelated to what they asserted. As a parameter, every arm is
+    /// reachable from any host — including the Windows one, which is otherwise unassertable on
+    /// POSIX.</para>
     /// </summary>
     internal static AntigravityReviewerDecision Decide(
-            bool posixHost, bool operatorEnabled, string? installedVersion, string minimumVersion) {
+            bool posixHost, bool operatorEnabled, string? installedVersion, string? minimumVersion) {
         // Consent FIRST and short-circuiting: an installed-but-wedged agy must not be probed — let
         // alone stall a daemon start — for a feature the operator switched off.
         if (!operatorEnabled) return AntigravityReviewerDecision.Disabled;
@@ -58,20 +69,16 @@ internal static class AntigravityReviewerCapability {
         // therefore the review context — cannot be made owner-only.
         if (!posixHost) return AntigravityReviewerDecision.UnsupportedPlatform;
 
-        // Parseability asked THROUGH the same comparison rather than with a second parser: every
-        // version that parses at all satisfies this range, so a false here means precisely "we could
-        // not identify this build" and never "this build is old".
-        if (!DaemonRunner.CliVersionAllowed(installedVersion, AnyParseableVersion))
-            return AntigravityReviewerDecision.VersionUnresolved;
-
-        // An unparseable FLOOR yields false here, so an operator typo refuses rather than admitting
-        // every build.
-        return DaemonRunner.CliVersionAllowed(installedVersion, ">=" + minimumVersion)
-            ? AntigravityReviewerDecision.Allowed
-            : AntigravityReviewerDecision.VersionBelowMinimum;
+        // No discard: `_ => Allowed` would silently ADMIT any arm added later, which is the wrong
+        // direction for this gate. CS8509 makes the next one a build failure instead.
+        return ReviewerVersionAffirmations.Decide(installedVersion, minimumVersion) switch {
+            ReviewerVersionAffirmation.MeetsMinimum      => AntigravityReviewerDecision.Allowed,
+            ReviewerVersionAffirmation.Unresolved        => AntigravityReviewerDecision.VersionUnresolved,
+            ReviewerVersionAffirmation.NoMinimumRecorded => AntigravityReviewerDecision.VersionNoMinimum,
+            ReviewerVersionAffirmation.BelowMinimum      => AntigravityReviewerDecision.VersionBelowMinimum,
+            ReviewerVersionAffirmation.Incomparable      => AntigravityReviewerDecision.VersionIncomparable
+        };
     }
-
-    const string AnyParseableVersion = ">=0.0";
 
     /// <summary>
     /// The coded refusal an operator can act on. Separated from <see cref="Decide"/> so the two cannot
@@ -80,16 +87,15 @@ internal static class AntigravityReviewerCapability {
     /// <param name="binaryPath">The binary the daemon would launch, named in the unresolved arm so an
     /// operator checks the right one rather than whatever is first on PATH.</param>
     internal static string DenialReason(
-            AntigravityReviewerDecision decision, string? installedVersion, string minimumVersion,
+            AntigravityReviewerDecision decision, string? installedVersion, string? minimumVersion,
             string binaryPath) =>
         decision switch {
-            // Deliberately does NOT carry Kiro's whole-filesystem-read paragraph: that
-            // claim is about a trusted fs_read primitive this vendor does not expose, and a borrowed
-            // risk statement would be a false one in either direction.
             AntigravityReviewerDecision.Disabled =>
                 "antigravity_unattended_reviewer_disabled: unattended Antigravity reviews are off on "
-              + "this daemon. Set KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1 in the daemon's environment "
-              + "to opt in.",
+              + "this daemon. A review runs under this daemon user's authority and returns what it "
+              + "read to whoever requested it, so enable it only where the operator and the review "
+              + "requesters are in one trust domain: set KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1 in the "
+              + "daemon's environment (not on the server).",
 
             AntigravityReviewerDecision.UnsupportedPlatform =>
                 "antigravity_reviewer_unsupported_platform: the reviewer's per-launch home holds "
@@ -97,18 +103,39 @@ internal static class AntigravityReviewerCapability {
 
             AntigravityReviewerDecision.VersionUnresolved =>
                 $"antigravity_reviewer_version_unresolved: the version of '{binaryPath}' could not be "
-              + $"determined, so it cannot be shown to meet the {minimumVersion} minimum. Check that "
-              + "the Antigravity CLI is installed (the `agy` binary — the IDE alone is not enough), "
-              + "that `agy --version` succeeds, and set KCAP_ANTIGRAVITY_PATH if it lives elsewhere.",
+              + "determined, so it cannot be compared against this daemon's recorded minimum. Check "
+              + "that the Antigravity CLI is installed (the `agy` binary — the IDE alone is not "
+              + "enough), that `agy --version` succeeds, and set KCAP_ANTIGRAVITY_PATH if it lives "
+              + "elsewhere. A build we cannot identify is refused rather than assumed compatible.",
 
-            _ =>
+            AntigravityReviewerDecision.VersionNoMinimum =>
+                "antigravity_reviewer_version_no_minimum: this daemon has no recorded minimum agy "
+              + "version, so there is nothing to check the installed build against. The usual cause is "
+              + "enabling the reviewer against an already-running daemon — it records a minimum at "
+              + "startup, so restart it with KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER set. To set one now "
+              + "without restarting, run `kcap daemon reviewer affirm --vendor antigravity`.",
+
+            AntigravityReviewerDecision.VersionIncomparable =>
+                $"antigravity_reviewer_version_incomparable: agy {Describe(installedVersion)} and this "
+              + $"daemon's recorded minimum {Describe(minimumVersion)} cannot be ordered as version "
+              + "numbers, so neither can be said to be newer. Record the installed build as the "
+              + "minimum with `kcap daemon reviewer affirm --vendor antigravity`.",
+
+            // Exhaustive, like Decide's switch: a discard would print the below-minimum text for a
+            // future arm meaning something else, sending an operator to the wrong fix. Allowed throws
+            // because asking for the denial reason of a permitted decision is a caller bug.
+            AntigravityReviewerDecision.Allowed =>
+                throw new ArgumentOutOfRangeException(
+                    nameof(decision), decision, "Allowed is not a denial and has no reason."),
+
+            AntigravityReviewerDecision.VersionBelowMinimum =>
                 $"antigravity_reviewer_version_below_minimum: agy {Describe(installedVersion)} is "
-              + $"installed, below the {minimumVersion} minimum this daemon requires. Every behaviour "
-              + "this reviewer depends on was established on that build, so please upgrade the "
-              + "Antigravity CLI — or, if this build is known good, raise the floor with "
-              + "KCAP_ANTIGRAVITY_MIN_CLI_VERSION."
+              + $"installed but this daemon's recorded minimum is {Describe(minimumVersion)}. The "
+              + "reviewer's containment depends on the build honouring HOME and reading no other "
+              + "global config source, so an OLDER build than the one recorded is refused. Upgrade the "
+              + "Antigravity CLI, or deliberately lower the minimum to the installed build with "
+              + "`kcap daemon reviewer affirm --vendor antigravity`."
         };
 
-    static string Describe(string? version) =>
-        string.IsNullOrWhiteSpace(version) ? "(unknown)" : version.Trim();
+    static string Describe(string? version) => ReviewerVersionAffirmations.Describe(version);
 }

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
@@ -27,10 +27,11 @@ internal enum AntigravityReviewerDecision {
 /// reviewer certification already uses. A second version parser in this codebase is exactly the
 /// "two things that must agree, with nothing making them" shape.</para>
 ///
-/// <para><b>Ordering matches the shipped factory ladder</b> (consent → platform → build), so
-/// <c>AntigravityHostedAgentRuntimeFactory.ReviewerRefusal</c> can delegate to this without changing
-/// what any operator is told. <see cref="AntigravityReviewerDecision.Disabled"/>'s text is pinned
-/// byte-for-byte against that ladder by test.</para>
+/// <para><b>This is the whole ladder</b> (consent → platform → build), and
+/// <c>AntigravityHostedAgentRuntimeFactory.ReviewerRefusal</c> is its only production caller: it adds
+/// the one arm this decision cannot express — a binary that does not resolve at all — and takes every
+/// other verdict, and every text, from here. Both the advertisement seam and the launch boundary read
+/// that one method, so the floor cannot be enforced at only one of them.</para>
 /// </summary>
 internal static class AntigravityReviewerCapability {
     /// <summary>Production entry point: reads the host platform, then defers to the pure overload.</summary>
@@ -82,8 +83,7 @@ internal static class AntigravityReviewerCapability {
             AntigravityReviewerDecision decision, string? installedVersion, string minimumVersion,
             string binaryPath) =>
         decision switch {
-            // Byte-identical to AntigravityHostedAgentRuntimeFactory.ReviewerRefusal's consent arm,
-            // pinned by test. Deliberately does NOT carry Kiro's whole-filesystem-read paragraph: that
+            // Deliberately does NOT carry Kiro's whole-filesystem-read paragraph: that
             // claim is about a trusted fs_read primitive this vendor does not expose, and a borrowed
             // risk statement would be a false one in either direction.
             AntigravityReviewerDecision.Disabled =>

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
@@ -1,0 +1,114 @@
+namespace Capacitor.Cli.Daemon.Acp;
+
+internal enum AntigravityReviewerDecision {
+    Allowed,
+    UnsupportedPlatform,
+    Disabled,
+    VersionUnresolved,
+    VersionBelowMinimum
+}
+
+/// <summary>
+/// Whether THIS daemon may run Antigravity's CLI (<c>agy</c>) as an unattended review-flow reviewer.
+/// Pure, so every arm is testable without a vendor or a process.
+///
+/// <para><b>Why a minimum version FLOOR rather than an operator affirmation.</b> Kiro and Gemini
+/// require an operator to affirm each installed build, because their containment depends on the build
+/// honouring a HOME override. <c>agy</c> was observed auto-updating itself mid-session (1.1.8 →
+/// 1.1.10) while this reviewer was being explored, so an affirmation gate would park the reviewer on
+/// a release cadence the operator neither controls nor can predict — the reviewer would be offline
+/// more often than not, and clearing the gate would become a reflex rather than a decision. Meeting
+/// the floor is therefore enough; a defect in a later build is handled by a report and a raised
+/// floor, which is why <see cref="DaemonConfig.AntigravityMinimumCliVersion"/> is operator-settable.
+/// There is deliberately no <c>affirm</c> verb for this vendor, and no refusal below may point at
+/// one.</para>
+///
+/// <para>The comparison is <see cref="DaemonRunner.CliVersionAllowed"/> — the same range grammar
+/// reviewer certification already uses. A second version parser in this codebase is exactly the
+/// "two things that must agree, with nothing making them" shape.</para>
+///
+/// <para><b>Ordering matches the shipped factory ladder</b> (consent → platform → build), so
+/// <c>AntigravityHostedAgentRuntimeFactory.ReviewerRefusal</c> can delegate to this without changing
+/// what any operator is told. <see cref="AntigravityReviewerDecision.Disabled"/>'s text is pinned
+/// byte-for-byte against that ladder by test.</para>
+/// </summary>
+internal static class AntigravityReviewerCapability {
+    /// <summary>Production entry point: reads the host platform, then defers to the pure overload.</summary>
+    internal static AntigravityReviewerDecision Decide(
+            bool operatorEnabled, string? installedVersion, string minimumVersion) =>
+        Decide(!OperatingSystem.IsWindows(), operatorEnabled, installedVersion, minimumVersion);
+
+    /// <summary>
+    /// The decision, with the platform passed IN rather than read from the ambient OS.
+    ///
+    /// <para>Kiro's gate records why: reading the OS inside the decision short-circuited every
+    /// consent and version arm to <see cref="AntigravityReviewerDecision.UnsupportedPlatform"/> on the
+    /// Windows CI leg, so a dozen tests failed for a reason unrelated to what they asserted. As a
+    /// parameter, every arm is reachable from any host — including the Windows one, which is
+    /// otherwise unassertable on POSIX.</para>
+    /// </summary>
+    internal static AntigravityReviewerDecision Decide(
+            bool posixHost, bool operatorEnabled, string? installedVersion, string minimumVersion) {
+        // Consent FIRST and short-circuiting: an installed-but-wedged agy must not be probed — let
+        // alone stall a daemon start — for a feature the operator switched off.
+        if (!operatorEnabled) return AntigravityReviewerDecision.Disabled;
+
+        // Windows has no 0700, so the per-launch home that holds the reviewer's own transcript — and
+        // therefore the review context — cannot be made owner-only.
+        if (!posixHost) return AntigravityReviewerDecision.UnsupportedPlatform;
+
+        // Parseability asked THROUGH the same comparison rather than with a second parser: every
+        // version that parses at all satisfies this range, so a false here means precisely "we could
+        // not identify this build" and never "this build is old".
+        if (!DaemonRunner.CliVersionAllowed(installedVersion, AnyParseableVersion))
+            return AntigravityReviewerDecision.VersionUnresolved;
+
+        // An unparseable FLOOR yields false here, so an operator typo refuses rather than admitting
+        // every build.
+        return DaemonRunner.CliVersionAllowed(installedVersion, ">=" + minimumVersion)
+            ? AntigravityReviewerDecision.Allowed
+            : AntigravityReviewerDecision.VersionBelowMinimum;
+    }
+
+    const string AnyParseableVersion = ">=0.0";
+
+    /// <summary>
+    /// The coded refusal an operator can act on. Separated from <see cref="Decide"/> so the two cannot
+    /// disagree about WHY a launch was denied.
+    /// </summary>
+    /// <param name="binaryPath">The binary the daemon would launch, named in the unresolved arm so an
+    /// operator checks the right one rather than whatever is first on PATH.</param>
+    internal static string DenialReason(
+            AntigravityReviewerDecision decision, string? installedVersion, string minimumVersion,
+            string binaryPath) =>
+        decision switch {
+            // Byte-identical to AntigravityHostedAgentRuntimeFactory.ReviewerRefusal's consent arm,
+            // pinned by test. Deliberately does NOT carry Kiro's whole-filesystem-read paragraph: that
+            // claim is about a trusted fs_read primitive this vendor does not expose, and a borrowed
+            // risk statement would be a false one in either direction.
+            AntigravityReviewerDecision.Disabled =>
+                "antigravity_unattended_reviewer_disabled: unattended Antigravity reviews are off on "
+              + "this daemon. Set KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1 in the daemon's environment "
+              + "to opt in.",
+
+            AntigravityReviewerDecision.UnsupportedPlatform =>
+                "antigravity_reviewer_unsupported_platform: the reviewer's per-launch home holds "
+              + "review context and cannot be created owner-only on Windows.",
+
+            AntigravityReviewerDecision.VersionUnresolved =>
+                $"antigravity_reviewer_version_unresolved: the version of '{binaryPath}' could not be "
+              + $"determined, so it cannot be shown to meet the {minimumVersion} minimum. Check that "
+              + "the Antigravity CLI is installed (the `agy` binary — the IDE alone is not enough), "
+              + "that `agy --version` succeeds, and set KCAP_ANTIGRAVITY_PATH if it lives elsewhere.",
+
+            _ =>
+                $"antigravity_reviewer_version_below_minimum: agy {Describe(installedVersion)} is "
+              + $"installed, below the {minimumVersion} minimum this daemon requires. Every behaviour "
+              + "this reviewer depends on was established on that build, so please upgrade the "
+              + "Antigravity CLI — or, if this build is known good, raise the floor with "
+              + "KCAP_ANTIGRAVITY_MIN_CLI_VERSION."
+        };
+
+    static string Describe(string? version) =>
+        string.IsNullOrWhiteSpace(version) ? "(unknown)" : version.Trim();
+}

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerHome.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerHome.cs
@@ -1,0 +1,251 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Core.Antigravity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Acp;
+
+/// <summary>
+/// The per-launch isolated <c>HOME</c> for an unattended Antigravity (<c>agy</c>) reviewer.
+///
+/// <para><b>Four load-bearing jobs, not tidiness.</b></para>
+/// <para>1. <b>Capture stays single-lane.</b> A probe confirmed <c>agy -p</c> really does load and
+/// fire the kcap capture hooks it finds at <c>{HOME}/.gemini/config/plugins/kcap/hooks.json</c> — so
+/// pointing a reviewer at the operator's real <c>HOME</c> would spawn a second watcher against the
+/// SAME conversation the daemon is already recording, double-capturing it. This home never writes
+/// that plugin directory, so the hook has nothing to load.</para>
+/// <para>2. <b>No nested review flows.</b> Without a global <c>{HOME}/.gemini/config/mcp_config.json</c>,
+/// the operator's <c>kcap-flows</c> server is absent, so a reviewer cannot start its own review flow —
+/// the same reasoning <see cref="KiroReviewerHome"/> documents for Kiro's global <c>mcp.json</c>.</para>
+/// <para>3. <b>Isolation.</b> The reviewer's own conversation state — <c>brain/</c>, <c>conversations/*.db</c>,
+/// settings — lands under this HOME rather than the operator's real agy state.</para>
+/// <para>4. <b>No hook ⇒ no watcher ⇒ nothing to leak.</b> A fired capture hook spawns a <c>kcap watch</c>
+/// child; on an unfixed build that child inherits pipe descriptors and keeps the agent's OWN STDOUT
+/// open after the agent process exits — measured at 5s to files versus still hung at 10 minutes to a
+/// pipe. This runtime parses <c>agy</c>'s NDJSON from stdout once per turn, so that hang would block
+/// every turn forever. This is why "just reuse the operator's real HOME" is not an available
+/// simplification: an empty-of-hooks HOME is what keeps that failure mode structurally unreachable,
+/// not something a code fix in the descriptor-leak path alone would close for a reviewer launch.</para>
+///
+/// <para><b>Where this differs from Kiro's home.</b> <see cref="KiroReviewerHome"/> stays literally
+/// empty — Kiro reads its injected result-channel server off <c>session/new</c> directly. Antigravity
+/// does not: this home carries a WRITTEN <c>mcp_config.json</c> holding only the injected servers
+/// (in practice, the single <c>kcap-flow-result</c> submission channel) — job 2 above is what makes
+/// writing that file safe: it replaces the operator's global file rather than merging into it, so the
+/// reviewer's MCP surface is exactly the injected list, never the operator's own servers plus it. The
+/// plugin directory job 1 depends on must still never exist, and creation verifies that rather than
+/// assuming it.</para>
+///
+/// <para><b>Why disposal is a security requirement, not hygiene.</b> The reviewer's own conversation
+/// JSONL (<c>brain/&lt;id&gt;/.system_generated/logs/transcript_full.jsonl</c>, see
+/// <see cref="AntigravityPaths"/>) carries the caller's diff, source excerpts and findings. The home
+/// is read-EMPTY-of-operator-config but write-SENSITIVE, on a host that may serve several callers.</para>
+///
+/// <para><b>The root is per daemon, and that is load-bearing</b> — same reasoning as
+/// <see cref="KiroReviewerHome"/>: a shared root's "delete every home whose epoch is not mine" rule
+/// would delete a peer daemon's CURRENT, LIVE home, because a peer's epoch is never this daemon's.
+/// Per-daemon roots remove the question instead of adjudicating it.</para>
+/// </summary>
+internal static class AntigravityReviewerHome {
+    const string Prefix = "kcap-antigravity-reviewer-";
+
+    /// <summary>This daemon's own reviewer-home root. Never shared with a peer daemon.</summary>
+    internal static string RootFor(string stateDir) => Path.Combine(stateDir, "antigravity-reviewers");
+
+    /// <summary>One derivation of a home's directory name. Create and delete both go through it, so a
+    /// failed launch's cleanup cannot target a path the launch never made.</summary>
+    internal static string NameFor(string daemonEpoch, string launchId) =>
+        $"{Prefix}{Sanitize(daemonEpoch)}-{Sanitize(launchId)}";
+
+    /// <summary>
+    /// Creates an owner-only home carrying only a fresh <c>mcp_config.json</c> for
+    /// <paramref name="injected"/>. Never seeds the kcap plugin directory — that absence is what job
+    /// 1 above depends on, so it is verified after writing rather than assumed.
+    /// </summary>
+    internal static string Create(string stateDir, string daemonEpoch, string launchId,
+                                  IReadOnlyList<AcpMcpServerSpec> injected, ILogger? log = null) {
+        var root = RootFor(stateDir);
+        CreateOwnerOnly(root);
+
+        var home = Path.Combine(root, NameFor(daemonEpoch, launchId));
+
+        // A repeated launch under the same epoch+agent id must not inherit the previous one's
+        // conversation state (brain/, conversations/*.db) or a stale mcp_config.json:
+        // CreateDirectory silently succeeds on an existing directory, so "fresh" would be a hope
+        // rather than a property. Remove first, then create.
+        if (Path.Exists(home)) Delete(home, stateDir, log ?? NullLogger.Instance);
+
+        CreateOwnerOnly(home);
+        WriteMcpConfig(home, injected);
+
+        // The kcap plugin dir is what lets agy's OWN capture hooks fire (job 1) — its absence is
+        // the whole mechanism, so it is checked rather than trusted to follow from "we never wrote
+        // it". A future change that seeds a fuller home must trip this, not silently double-capture.
+        if (Directory.Exists(AntigravityPaths.PluginDir(home)))
+            throw new InvalidOperationException(
+                $"antigravity_reviewer_home_not_isolated: '{home}' carries a kcap plugin directory, "
+              + "which would let this reviewer's own capture hooks fire against its conversation.");
+
+        return home;
+    }
+
+    /// <summary>Writes <c>{home}/.gemini/config/mcp_config.json</c> — the plain, trust-less
+    /// <c>mcpServers</c> shape (<c>McpConfigShape.Standard</c>) — holding only <paramref name="injected"/>.
+    /// A fresh write into a fresh directory, so unlike <c>JsonMcpConfigWriter</c> (which merges into
+    /// and preserves an operator's live config) there is nothing to read-modify-write or mark as
+    /// kcap-owned: the whole file is this launch's content, one shot, atomic-by-single-write.
+    /// Built via <c>(JsonNode?)</c> string casts, not <c>JsonValue.Create</c> / collection expressions
+    /// — the latter lower to a generic <c>Add&lt;T&gt;</c> that trips NativeAOT (IL3050), the same
+    /// rule <c>ClaudeLauncher.BuildReviewFlowMcpConfig</c> and <c>ReviewLaunchBuilder</c> follow.</summary>
+    static void WriteMcpConfig(string home, IReadOnlyList<AcpMcpServerSpec> injected) {
+        var path = AntigravityPaths.McpConfigJson(home);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        var mcpServers = new JsonObject();
+
+        foreach (var server in injected) {
+            var args = new JsonArray();
+            foreach (var a in server.Args) args.Add((JsonNode?)a);
+
+            var env = new JsonObject();
+            foreach (var e in server.Env) env[e.Name] = (JsonNode?)e.Value;
+
+            mcpServers[server.Name] = new JsonObject {
+                ["command"] = (JsonNode?)server.Command,
+                ["args"]    = args,
+                ["env"]     = env
+            };
+        }
+
+        var root = new JsonObject { ["mcpServers"] = mcpServers };
+        File.WriteAllText(path, root.ToJsonString());
+    }
+
+    /// <summary>
+    /// Deletes every home in THIS daemon's root whose epoch is not the current one — the crash and
+    /// SIGKILL recovery. Safe by construction because the root is not shared.
+    /// </summary>
+    /// <para><b>Known ordering, accepted:</b> this runs at daemon start, before the orphan-agent
+    /// reaper — same accepted residual as <see cref="KiroReviewerHome.SweepStale"/>.</para>
+    internal static void SweepStale(string stateDir, string currentEpoch, ILogger? log = null) {
+        log ??= NullLogger.Instance;
+        var root = RootFor(stateDir);
+        if (!Directory.Exists(root)) return;
+
+        var live = $"{Prefix}{Sanitize(currentEpoch)}-";
+
+        IReadOnlyList<string> candidates;
+
+        try {
+            candidates = [.. Directory.EnumerateDirectories(root)];
+        } catch (Exception ex) {
+            log.LogWarning(ex, "Could not enumerate the Antigravity reviewer home root {Root}; skipping the sweep", root);
+            return;
+        }
+
+        foreach (var dir in candidates) {
+            var name = Path.GetFileName(dir);
+            if (!name.StartsWith(Prefix, StringComparison.Ordinal)) continue;
+            if (name.StartsWith(live,   StringComparison.Ordinal)) continue;
+
+            Delete(dir, stateDir, log);
+        }
+    }
+
+    /// <summary>
+    /// Removes a reviewer home. Never follows a link out of the tree, and refuses a path that does
+    /// not resolve inside this daemon's root — the same two recursive-delete hazards
+    /// <see cref="KiroReviewerHome.Delete"/> guards against, for the same reason: the content is
+    /// review context (transcript, diff, findings), not disposable scratch.
+    /// </summary>
+    internal static void Delete(string homePath, string stateDir, ILogger? log = null) {
+        log ??= NullLogger.Instance;
+        var root = Path.TrimEndingDirectorySeparator(Path.GetFullPath(RootFor(stateDir)));
+        var full = Path.TrimEndingDirectorySeparator(Path.GetFullPath(homePath));
+
+        if (!full.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.Ordinal)) {
+            log.LogWarning("Antigravity reviewer home {Path} resolves outside {Root}; refusing to delete", full, root);
+            return;
+        }
+
+        try {
+            // The containment check above is LEXICAL, so a link planted AT the home path resolves
+            // inside the root and would then be enumerated — following it into the target and
+            // deleting the target's contents. DeleteTreeNoFollow protects nested entries but takes
+            // the top-level path on trust, so the top level is checked here.
+            var attributes = new FileInfo(full).Attributes;
+
+            if (attributes.HasFlag(FileAttributes.ReparsePoint)) {
+                if (attributes.HasFlag(FileAttributes.Directory)) Directory.Delete(full);
+                else                                             File.Delete(full);
+
+                return;
+            }
+
+            DeleteTreeNoFollow(full);
+        } catch (Exception ex) {
+            // Log and continue: an undeletable home must not fail a round or block daemon startup.
+            // It IS undisposed review context accumulating on disk, so it is never silent.
+            log.LogWarning(ex, "Failed to delete Antigravity reviewer home {Path}", full);
+        }
+    }
+
+    /// <summary>
+    /// Recursive delete that unlinks a directory symlink rather than descending through it. Kind is
+    /// read from the attributes, which do NOT follow — <c>Directory.Exists</c> does, and would report
+    /// false for a dangling directory link, falling through to a <c>File.Delete</c> that a Windows
+    /// reparse point rejects.
+    /// </summary>
+    static void DeleteTreeNoFollow(string path) {
+        foreach (var entry in Directory.EnumerateFileSystemEntries(path)) {
+            var attributes  = new FileInfo(entry).Attributes;
+            var isDirectory = attributes.HasFlag(FileAttributes.Directory);
+            var isLink      = attributes.HasFlag(FileAttributes.ReparsePoint);
+
+            if (isDirectory && isLink) Directory.Delete(entry);   // the link; its target is untouched
+            else if (isDirectory)      DeleteTreeNoFollow(entry);
+            else                       File.Delete(entry);
+        }
+
+        Directory.Delete(path);
+    }
+
+    const UnixFileMode OwnerOnly =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
+    /// <summary>
+    /// Creates a directory that is owner-only FROM ITS FIRST INSTANT, and verifies it.
+    ///
+    /// <para>Not create-then-chmod: that leaves a window in which the directory exists at the default
+    /// umask, and the thing that gets written into it is a reviewer's own conversation state. .NET's
+    /// mode-carrying overload closes the window at the syscall.</para>
+    ///
+    /// <para>And not best-effort — same reasoning as <see cref="KiroReviewerHome"/>: the mode IS the
+    /// protection here, so a POSIX host that cannot achieve it must not run a reviewer at all.</para>
+    /// </summary>
+    static void CreateOwnerOnly(string path) {
+        if (OperatingSystem.IsWindows()) {
+            // Unreachable in production: the Antigravity reviewer capability refuses Windows before
+            // any launch. Kept total so a direct call in a test cannot silently create a
+            // world-readable directory.
+            throw new PlatformNotSupportedException(
+                "antigravity_reviewer_unsupported_platform: a reviewer home cannot be created owner-only here.");
+        }
+
+        Directory.CreateDirectory(path, OwnerOnly);
+
+        // An existing directory keeps its own mode — CreateDirectory's mode argument applies only when
+        // it creates. Verifying covers that, and any filesystem that ignores the request.
+        var mode = File.GetUnixFileMode(path);
+
+        if ((mode & (UnixFileMode.GroupRead  | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute |
+                     UnixFileMode.OtherRead  | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute)) != 0)
+            throw new InvalidOperationException(
+                $"antigravity_reviewer_home_not_owner_only: '{path}' is mode {mode}. The reviewer's "
+              + "conversation state, and so the review context, would be readable by other users on this host.");
+    }
+
+    static string Sanitize(string value) =>
+        string.Concat(value.Select(c => char.IsLetterOrDigit(c) ? c : '_'));
+}

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerHome.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerHome.cs
@@ -77,6 +77,19 @@ internal static class AntigravityReviewerHome {
         if (Path.Exists(home)) Delete(home, stateDir, log ?? NullLogger.Instance);
 
         CreateOwnerOnly(home);
+
+        // Delete is best-effort by design (an undeletable home must not fail a round), so a partial
+        // failure could leave the previous launch's brain/conversations content in place, and
+        // CreateOwnerOnly would happily accept the surviving directory — it does not check
+        // emptiness. A silently inherited conversation is the worst outcome this class can produce
+        // (the reviewer would resume someone else's review with no signal), so freshness is
+        // verified here, before anything is written, rather than assumed from "Delete ran".
+        if (Directory.EnumerateFileSystemEntries(home).Any())
+            throw new InvalidOperationException(
+                $"antigravity_reviewer_home_not_empty: '{home}' still holds content from a previous "
+              + "launch that could not be removed. Refusing rather than handing a reviewer another "
+              + "review's conversation state.");
+
         WriteMcpConfig(home, injected);
 
         // The kcap plugin dir is what lets agy's OWN capture hooks fire (job 1) — its absence is
@@ -100,7 +113,24 @@ internal static class AntigravityReviewerHome {
     /// rule <c>ClaudeLauncher.BuildReviewFlowMcpConfig</c> and <c>ReviewLaunchBuilder</c> follow.</summary>
     static void WriteMcpConfig(string home, IReadOnlyList<AcpMcpServerSpec> injected) {
         var path = AntigravityPaths.McpConfigJson(home);
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        // AntigravityPaths.McpConfigJson → GeminiPaths.Root honors THIS PROCESS's own
+        // GEMINI_CLI_HOME when set, falling back to `home` only when it is not — so on a daemon
+        // that happens to run with GEMINI_CLI_HOME set, the resolved path would escape `home`
+        // entirely, writing the reviewer's result channel outside the isolated home job 3 exists
+        // to guarantee (and potentially into the operator's own Gemini tree). Not something to fix
+        // in AntigravityPaths (that fallback is correct for its other, non-isolated callers) — this
+        // class's whole purpose is isolation, so it is verified here rather than assumed.
+        var homeFull = Path.TrimEndingDirectorySeparator(Path.GetFullPath(home));
+        var pathFull = Path.GetFullPath(path);
+
+        if (!pathFull.StartsWith(homeFull + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"antigravity_reviewer_home_escaped_root: mcp_config.json resolved to '{pathFull}', "
+              + $"outside the isolated home '{homeFull}' (likely GEMINI_CLI_HOME set in the daemon's "
+              + "own environment). Refusing to write a reviewer's result channel outside its isolated home.");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(pathFull)!);
 
         var mcpServers = new JsonObject();
 
@@ -119,7 +149,7 @@ internal static class AntigravityReviewerHome {
         }
 
         var root = new JsonObject { ["mcpServers"] = mcpServers };
-        File.WriteAllText(path, root.ToJsonString());
+        File.WriteAllText(pathFull, root.ToJsonString());
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Acp/IAgyTurnProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/IAgyTurnProcess.cs
@@ -1,0 +1,49 @@
+// src/Capacitor.Cli.Daemon/Acp/IAgyTurnProcess.cs
+namespace Capacitor.Cli.Daemon.Acp;
+
+/// <summary>
+/// Minimal process-lifecycle abstraction for ONE <c>agy -p</c> turn — the exec-per-turn analogue of
+/// <see cref="IAcpProcess"/>. Every other hosted runtime in this daemon (PTY or ACP) wraps a single
+/// long-lived child that outlives the whole session; <c>agy</c> has no such thing — each prompt turn
+/// spawns its own process that exits when the turn ends, and there is no process at all in between.
+/// So this seam is scoped to exactly one turn's lifetime: <c>AntigravityHostedAgentRuntime</c>'s
+/// injected spawner (<c>Func&lt;string prompt, string? conversationId, CancellationToken,
+/// Task&lt;IAgyTurnProcess&gt;&gt;</c>) returns a fresh instance per turn, never a reused one.
+///
+/// <para>Unlike <see cref="IAcpProcess"/>, this also carries the NDJSON line stream — agy has no
+/// persistent connection object (no <c>AcpConnection</c> equivalent) for the runtime to read from
+/// instead, so the process abstraction itself is the only place that stream can live.</para>
+///
+/// Exists so <c>AntigravityHostedAgentRuntime</c> is testable without spawning a real process; a
+/// later task's factory implements this over <see cref="System.Diagnostics.Process"/>.
+/// </summary>
+internal interface IAgyTurnProcess : IAsyncDisposable {
+    /// <summary>OS process id of this turn's <c>agy -p</c> child.</summary>
+    int Pid { get; }
+
+    /// <summary>True once this turn's process has exited.</summary>
+    bool HasExited { get; }
+
+    /// <summary>OS exit code once <see cref="HasExited"/>; null while running or if unknown. This is
+    /// the raw OS code for THIS ONE TURN — never confused with
+    /// <c>AntigravityHostedAgentRuntime.ExitCode</c>, which is derived from the agy <c>result</c>
+    /// event's <c>status</c> field across the runtime's whole logical lifetime, not any single
+    /// turn's OS exit code (upstream bug: a clean run can carry an empty <c>response</c>, so
+    /// <c>status</c> is the trustworthy signal, and a per-turn OS code describes one turn, not the
+    /// agent).</summary>
+    int? ExitCode { get; }
+
+    /// <summary>
+    /// Reads this turn's stdout NDJSON lines as they arrive, ending when stdout hits EOF (the
+    /// process exited, or is about to). Must not throw for a normal EOF — the sequence simply ends;
+    /// it throws <see cref="OperationCanceledException"/> if <paramref name="ct"/> is cancelled
+    /// first (the runtime's per-turn deadline or owner-cancel path).
+    /// </summary>
+    IAsyncEnumerable<string> ReadLinesAsync(CancellationToken ct);
+
+    /// <summary>Wait up to <paramref name="timeout"/> for this turn's process to exit (returns silently on timeout).</summary>
+    Task WaitForExitAsync(TimeSpan? timeout = null);
+
+    /// <summary>Terminate this turn's process (SIGTERM then SIGKILL) within <paramref name="timeout"/>.</summary>
+    Task TerminateAsync(TimeSpan? timeout = null);
+}

--- a/src/Capacitor.Cli.Daemon/Acp/IAgyTurnProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/IAgyTurnProcess.cs
@@ -19,6 +19,11 @@ namespace Capacitor.Cli.Daemon.Acp;
 ///
 /// <para><b>Two contracts a real implementation must honor — <c>AntigravityHostedAgentRuntime</c> is
 /// built against them, not just against the happy path:</b></para>
+/// <para>0. <see cref="IAsyncDisposable.DisposeAsync"/> MAY terminate a still-running child, and an
+/// implementation over a real process does. It is therefore NOT a source of exit evidence: a caller
+/// that needs to know whether a child exited must terminate it explicitly and read
+/// <see cref="HasExited"/> while the handle is still valid, BEFORE disposing — a disposed process
+/// object reports exited whether or not it is.</para>
 /// <para>1. <see cref="IAsyncDisposable.DisposeAsync"/> MUST be idempotent. Both
 /// <c>AntigravityHostedAgentRuntime.ProcessTurnAsync</c> (in its own <c>finally</c>) and the runtime's
 /// <c>DisposeAsync</c> can each independently reach a disposal call on the SAME instance across

--- a/src/Capacitor.Cli.Daemon/Acp/IAgyTurnProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/IAgyTurnProcess.cs
@@ -16,6 +16,22 @@ namespace Capacitor.Cli.Daemon.Acp;
 ///
 /// Exists so <c>AntigravityHostedAgentRuntime</c> is testable without spawning a real process; a
 /// later task's factory implements this over <see cref="System.Diagnostics.Process"/>.
+///
+/// <para><b>Two contracts a real implementation must honor — <c>AntigravityHostedAgentRuntime</c> is
+/// built against them, not just against the happy path:</b></para>
+/// <para>1. <see cref="IAsyncDisposable.DisposeAsync"/> MUST be idempotent. Both
+/// <c>AntigravityHostedAgentRuntime.ProcessTurnAsync</c> (in its own <c>finally</c>) and the runtime's
+/// <c>DisposeAsync</c> can each independently reach a disposal call on the SAME instance across
+/// different exit/race paths — a second call must be a safe no-op, never throw.</para>
+/// <para>2. <see cref="TerminateAsync"/> MUST be safe to call AFTER <see cref="IAsyncDisposable.DisposeAsync"/>
+/// has already run. <c>AntigravityHostedAgentRuntime.TerminateAsync</c> can call
+/// <c>current.TerminateAsync</c> on an instance the turn worker's own <c>finally</c> may have disposed
+/// microseconds earlier (a real interleaving, not a hypothetical one — see the class doc's rule (d) and
+/// the Terminate-races-spawn scenario its lock-ordering fix covers) — this must degrade gracefully
+/// (a no-op, or a caught/logged failure internally), never throw an exception the runtime doesn't
+/// already catch. Both callers DO catch and log any exception from either method today, so a violation
+/// degrades to log noise rather than an unhandled fault — but a real implementation should not rely on
+/// that safety net.</para>
 /// </summary>
 internal interface IAgyTurnProcess : IAsyncDisposable {
     /// <summary>OS process id of this turn's <c>agy -p</c> child.</summary>
@@ -44,6 +60,8 @@ internal interface IAgyTurnProcess : IAsyncDisposable {
     /// <summary>Wait up to <paramref name="timeout"/> for this turn's process to exit (returns silently on timeout).</summary>
     Task WaitForExitAsync(TimeSpan? timeout = null);
 
-    /// <summary>Terminate this turn's process (SIGTERM then SIGKILL) within <paramref name="timeout"/>.</summary>
+    /// <summary>Terminate this turn's process (SIGTERM then SIGKILL) within <paramref name="timeout"/>.
+    /// Must be safe to call even after <see cref="IAsyncDisposable.DisposeAsync"/> has already run —
+    /// see this interface's class doc.</summary>
     Task TerminateAsync(TimeSpan? timeout = null);
 }

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -218,6 +218,34 @@ public class DaemonConfig {
     /// </summary>
     public int KiroReviewerLaunchTimeoutSeconds { get; set; } = 120;
 
+    /// <summary>
+    /// Path or bare command for the Antigravity CLI, spawned per turn by
+    /// <c>AntigravityHostedAgentRuntimeFactory</c>. Overridable via <c>KCAP_ANTIGRAVITY_PATH</c>.
+    ///
+    /// <para><b>The default is <c>agy</c></b> — the name a standard install puts on PATH. Because
+    /// availability is <c>CliResolver.Exists(AntigravityPath)</c>, a wrong default would mean the
+    /// vendor is never advertised on a correct install: a silent no-op, not a visible failure.</para>
+    /// </summary>
+    public string AntigravityPath { get; set; } = "agy";
+
+    /// <summary>Daemon-wide default model for Antigravity reviewer launches, passed as
+    /// <c>--model</c>. Null leaves agy on its own default. An unknown slug makes agy hard-fail,
+    /// which is a clean audit signal rather than a silent downgrade.</summary>
+    public string? AntigravityModel { get; set; }
+
+    /// <summary>Operator consent for unattended Antigravity reviews. Fail-closed: only an
+    /// explicit affirmative enables it.</summary>
+    public bool AntigravityUnattendedReviewerEnabled { get; set; }
+
+    /// <summary>Absolute ceiling on the FIRST turn — spawn, NDJSON handshake and auth. An
+    /// unauthenticated agy can sit on an interactive OAuth wait, so this is what turns that into a
+    /// bounded, coded failure.</summary>
+    public int AntigravityReviewerLaunchTimeoutSeconds { get; set; } = 120;
+
+    /// <summary>Ceiling on every SUBSEQUENT turn. Bounding only the launch would leave turn 2+
+    /// unbounded, and with ReadOutputAsync parked by design nothing else would ever complete.</summary>
+    public int AntigravityReviewerTurnTimeoutSeconds { get; set; } = 600;
+
     /// <summary>Reserved — see CopilotPath. Overridable via KCAP_OPENCODE_PATH.</summary>
     public string OpenCodePath { get; set; } = "opencode";
 

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -234,20 +234,14 @@ public class DaemonConfig {
     public string? AntigravityModel { get; set; }
 
     /// <summary>Operator consent for unattended Antigravity reviews. Fail-closed: only an
-    /// explicit affirmative enables it.</summary>
-    public bool AntigravityUnattendedReviewerEnabled { get; set; }
-
-    /// <summary>
-    /// Lowest <c>agy</c> build this daemon will host as an unattended reviewer — a FLOOR, not an
-    /// affirmation: anything at or above it is accepted without a per-release acknowledgement, because
-    /// agy auto-updates itself and a build-exact gate would take the reviewer offline on a cadence the
-    /// operator does not control. Overridable via <c>KCAP_ANTIGRAVITY_MIN_CLI_VERSION</c> so an
-    /// operator hitting a false negative can move it without waiting for a release.
+    /// explicit affirmative enables it. Overridable via
+    /// <c>KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER</c>.
     ///
-    /// <para>The default is the build every measured behaviour behind this reviewer was established
-    /// on. A value that is not a version fails CLOSED (see <c>AntigravityReviewerCapability</c>).</para>
-    /// </summary>
-    public string AntigravityMinimumCliVersion { get; set; } = "1.1.10";
+    /// <para>The minimum <c>agy</c> build is deliberately NOT config: it is a daemon-owned record
+    /// (<c>ReviewerVersionStore</c>, moved by <c>kcap daemon reviewer affirm --vendor antigravity</c>),
+    /// exactly as for Kiro and Gemini. A floor an operator could set from a shell profile would be
+    /// re-affirmed by their dotfiles rather than by them.</para></summary>
+    public bool AntigravityUnattendedReviewerEnabled { get; set; }
 
     /// <summary>Absolute ceiling on the FIRST turn — spawn, NDJSON handshake and auth. An
     /// unauthenticated agy can sit on an interactive OAuth wait, so this is what turns that into a

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -237,6 +237,18 @@ public class DaemonConfig {
     /// explicit affirmative enables it.</summary>
     public bool AntigravityUnattendedReviewerEnabled { get; set; }
 
+    /// <summary>
+    /// Lowest <c>agy</c> build this daemon will host as an unattended reviewer — a FLOOR, not an
+    /// affirmation: anything at or above it is accepted without a per-release acknowledgement, because
+    /// agy auto-updates itself and a build-exact gate would take the reviewer offline on a cadence the
+    /// operator does not control. Overridable via <c>KCAP_ANTIGRAVITY_MIN_CLI_VERSION</c> so an
+    /// operator hitting a false negative can move it without waiting for a release.
+    ///
+    /// <para>The default is the build every measured behaviour behind this reviewer was established
+    /// on. A value that is not a version fails CLOSED (see <c>AntigravityReviewerCapability</c>).</para>
+    /// </summary>
+    public string AntigravityMinimumCliVersion { get; set; } = "1.1.10";
+
     /// <summary>Absolute ceiling on the FIRST turn — spawn, NDJSON handshake and auth. An
     /// unauthenticated agy can sit on an interactive OAuth wait, so this is what turns that into a
     /// bounded, coded failure.</summary>

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -476,8 +476,7 @@ public static partial class DaemonRunner {
         //
         // Classified ONCE and reused below: a gated reviewer's classification spawns the vendor binary
         // to read its version, so recomputing per consumer would probe it three times per startup.
-        var unattendedStatuses =
-            ApplyAntigravityVersionFloor(ClassifyUnattendedVendors(runtimeFactories), config);
+        var unattendedStatuses = ClassifyUnattendedVendors(runtimeFactories);
 
         config.UnattendedVendors = AdvertisedUnattendedVendors(unattendedStatuses);
         config.UnattendedVendorCapabilities =
@@ -918,12 +917,12 @@ public static partial class DaemonRunner {
     /// <see cref="ClassifyUnattendedVendors"/> so there is one rule rather than two that have to
     /// agree. Prefer classifying once where the reasons are also wanted — this overload re-probes.
     /// </summary>
-    /// <param name="config">Required, not optional: the Antigravity floor below reads it, and a
-    /// defaulted null here would be a silently fail-OPEN caller.</param>
+    /// <param name="config">Accepted, and required rather than defaulted, so a caller cannot silently
+    /// classify against a different daemon's configuration than the one whose factories it passed —
+    /// the gate ladders themselves read it through the factories.</param>
     internal static string[] ComputeUnattendedVendors(
             IEnumerable<IHostedAgentRuntimeFactory> factories, DaemonConfig config) =>
-        AdvertisedUnattendedVendors(
-            ApplyAntigravityVersionFloor(ClassifyUnattendedVendors(factories), config));
+        AdvertisedUnattendedVendors(ClassifyUnattendedVendors(factories));
 
     internal const string ClaudeLauncherPolicyVersion = "claude-unattended-v1";
     internal const string CursorLauncherPolicyVersion = "cursor-unattended-v4";
@@ -934,51 +933,6 @@ public static partial class DaemonRunner {
     /// <summary>The one vendor token this daemon knows agy by. Never <c>agy</c> — that is a binary
     /// name, and the server routes on the vendor.</summary>
     internal const string AntigravityVendor = "antigravity";
-
-    /// <summary>
-    /// Narrows a classification with the Antigravity minimum-version FLOOR — the arm that needs a
-    /// version probe, applied at the surface that decides advertisement, which is what stops a launch
-    /// being attempted at all.
-    ///
-    /// <para>Only ever turns an ADVERTISED antigravity into a withheld one: it never overrules a
-    /// refusal the factory's own ladder already made, so the two cannot disagree — an operator whose
-    /// real problem is a missing binary keeps that reason instead of being handed a version one. When
-    /// the factory's ladder consults <see cref="AntigravityReviewerCapability"/> directly this becomes
-    /// redundant and should be deleted rather than left to agree by coincidence.</para>
-    /// </summary>
-    /// <param name="resolveVersion">Test seam. Production resolves the configured binary's own
-    /// reported version, bounded, exactly as the affirmation-gated reviewers do.</param>
-    internal static IReadOnlyList<UnattendedVendorStatus> ApplyAntigravityVersionFloor(
-            IReadOnlyList<UnattendedVendorStatus> statuses, DaemonConfig config,
-            Func<string, string?>? resolveVersion = null) {
-        var index = -1;
-
-        for (var i = 0; i < statuses.Count; i++)
-            if (statuses[i] is { Advertised: true, Vendor: AntigravityVendor }) index = i;
-
-        if (index < 0) return statuses;
-
-        // ONCE: the decision and its explanation both need the version, and resolving it per consumer
-        // spawns the vendor binary twice to produce one refusal.
-        var installed = (resolveVersion ?? VendorVersionResolver.Resolve)(config.AntigravityPath);
-
-        var decision = AntigravityReviewerCapability.Decide(
-            !OperatingSystem.IsWindows(),
-            config.AntigravityUnattendedReviewerEnabled,
-            installed,
-            config.AntigravityMinimumCliVersion);
-
-        if (decision == AntigravityReviewerDecision.Allowed) return statuses;
-
-        var narrowed = statuses.ToArray();
-
-        narrowed[index] = new(
-            AntigravityVendor, false,
-            AntigravityReviewerCapability.DenialReason(
-                decision, installed, config.AntigravityMinimumCliVersion, config.AntigravityPath));
-
-        return narrowed;
-    }
 
     /// <param name="advertised">The already-classified advertised vendors, when the caller has them.
     /// Passing them avoids re-running a classification that spawns vendor binaries; omitting them

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -157,7 +157,14 @@ public static partial class DaemonRunner {
         if (Environment.GetEnvironmentVariable("KCAP_GEMINI_PATH") is { Length: > 0 } envGeminiPath)
             config.GeminiPath = envGeminiPath;
 
-        // The operator consent flags for the two unattended ACP reviewers. Both were previously
+        if (Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_PATH") is { Length: > 0 } agyPath)
+            config.AntigravityPath = agyPath;
+        if (Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_MODEL") is { Length: > 0 } agyModel)
+            config.AntigravityModel = agyModel;
+        if (Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER") is { } agyConsent)
+            config.AntigravityUnattendedReviewerEnabled = ParseConsentFlag(agyConsent);
+
+        // The operator consent flags for the unattended ACP/CLI reviewers. Both were previously
         // reachable only from a test constructor, which made the shipped Gemini reviewer impossible
         // to turn on in production; binding one and not the other would just move that hole.
         config.GeminiUnattendedReviewerEnabled =

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -163,6 +163,8 @@ public static partial class DaemonRunner {
             config.AntigravityModel = agyModel;
         if (Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER") is { } agyConsent)
             config.AntigravityUnattendedReviewerEnabled = ParseConsentFlag(agyConsent);
+        if (Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_MIN_CLI_VERSION") is { Length: > 0 } agyFloor)
+            config.AntigravityMinimumCliVersion = agyFloor;
 
         // The operator consent flags for the unattended ACP/CLI reviewers. Both were previously
         // reachable only from a test constructor, which made the shipped Gemini reviewer impossible
@@ -258,6 +260,14 @@ public static partial class DaemonRunner {
         // emit. The host's logging is not built yet at this point, so this writes to stderr like the
         // seeding block above.
         KiroReviewerHome.SweepStale(
+            coverageStateDir, config.DaemonEpoch ?? "unpinned", new ConsoleErrorLogger());
+
+        // The Antigravity reviewer disposes its own home on the normal path (the runtime's onDisposed
+        // hook), so this sweep covers exactly ONE case: a predecessor that was SIGKILLed and never ran
+        // it. Unconditional for the same reason as the line above — a daemon whose operator has since
+        // disabled the reviewer still owns the transcript-bearing directories its last incarnation
+        // left behind.
+        AntigravityReviewerHome.SweepStale(
             coverageStateDir, config.DaemonEpoch ?? "unpinned", new ConsoleErrorLogger());
 
         config.RecordlessSurvivorsImpossible = new CoverageJournal(coverageStateDir, NullLogger.Instance)
@@ -392,6 +402,17 @@ public static partial class DaemonRunner {
             )
         );
 
+        // Not an ACP factory: agy speaks NDJSON over one child process PER TURN, so it carries its own
+        // runtime rather than AcpHostedAgentRuntimeFactory's persistent-child shape. Takes the logger
+        // FACTORY, like the ACP registrations beside it — it builds a logger for the runtime and one
+        // per turn process, not a single typed logger.
+        builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
+            new AntigravityHostedAgentRuntimeFactory(
+                sp.GetRequiredService<DaemonConfig>(),
+                sp.GetRequiredService<ILoggerFactory>()
+            )
+        );
+
         builder.Services.AddSingleton<IReadOnlyDictionary<string, IHostedAgentRuntimeFactory>>(sp =>
             sp.GetServices<IHostedAgentRuntimeFactory>().ToDictionary(f => f.Vendor)
         );
@@ -455,7 +476,8 @@ public static partial class DaemonRunner {
         //
         // Classified ONCE and reused below: a gated reviewer's classification spawns the vendor binary
         // to read its version, so recomputing per consumer would probe it three times per startup.
-        var unattendedStatuses = ClassifyUnattendedVendors(runtimeFactories);
+        var unattendedStatuses =
+            ApplyAntigravityVersionFloor(ClassifyUnattendedVendors(runtimeFactories), config);
 
         config.UnattendedVendors = AdvertisedUnattendedVendors(unattendedStatuses);
         config.UnattendedVendorCapabilities =
@@ -896,13 +918,67 @@ public static partial class DaemonRunner {
     /// <see cref="ClassifyUnattendedVendors"/> so there is one rule rather than two that have to
     /// agree. Prefer classifying once where the reasons are also wanted — this overload re-probes.
     /// </summary>
-    internal static string[] ComputeUnattendedVendors(IEnumerable<IHostedAgentRuntimeFactory> factories) =>
-        AdvertisedUnattendedVendors(ClassifyUnattendedVendors(factories));
+    /// <param name="config">Required, not optional: the Antigravity floor below reads it, and a
+    /// defaulted null here would be a silently fail-OPEN caller.</param>
+    internal static string[] ComputeUnattendedVendors(
+            IEnumerable<IHostedAgentRuntimeFactory> factories, DaemonConfig config) =>
+        AdvertisedUnattendedVendors(
+            ApplyAntigravityVersionFloor(ClassifyUnattendedVendors(factories), config));
 
     internal const string ClaudeLauncherPolicyVersion = "claude-unattended-v1";
     internal const string CursorLauncherPolicyVersion = "cursor-unattended-v4";
     internal const string CodexLauncherPolicyVersion = "codex-unattended-v1";
     internal const string CopilotLauncherPolicyVersion = "copilot-unattended-v1";
+    internal const string AntigravityLauncherPolicyVersion = "antigravity-unattended-v1";
+
+    /// <summary>The one vendor token this daemon knows agy by. Never <c>agy</c> — that is a binary
+    /// name, and the server routes on the vendor.</summary>
+    internal const string AntigravityVendor = "antigravity";
+
+    /// <summary>
+    /// Narrows a classification with the Antigravity minimum-version FLOOR — the arm that needs a
+    /// version probe, applied at the surface that decides advertisement, which is what stops a launch
+    /// being attempted at all.
+    ///
+    /// <para>Only ever turns an ADVERTISED antigravity into a withheld one: it never overrules a
+    /// refusal the factory's own ladder already made, so the two cannot disagree — an operator whose
+    /// real problem is a missing binary keeps that reason instead of being handed a version one. When
+    /// the factory's ladder consults <see cref="AntigravityReviewerCapability"/> directly this becomes
+    /// redundant and should be deleted rather than left to agree by coincidence.</para>
+    /// </summary>
+    /// <param name="resolveVersion">Test seam. Production resolves the configured binary's own
+    /// reported version, bounded, exactly as the affirmation-gated reviewers do.</param>
+    internal static IReadOnlyList<UnattendedVendorStatus> ApplyAntigravityVersionFloor(
+            IReadOnlyList<UnattendedVendorStatus> statuses, DaemonConfig config,
+            Func<string, string?>? resolveVersion = null) {
+        var index = -1;
+
+        for (var i = 0; i < statuses.Count; i++)
+            if (statuses[i] is { Advertised: true, Vendor: AntigravityVendor }) index = i;
+
+        if (index < 0) return statuses;
+
+        // ONCE: the decision and its explanation both need the version, and resolving it per consumer
+        // spawns the vendor binary twice to produce one refusal.
+        var installed = (resolveVersion ?? VendorVersionResolver.Resolve)(config.AntigravityPath);
+
+        var decision = AntigravityReviewerCapability.Decide(
+            !OperatingSystem.IsWindows(),
+            config.AntigravityUnattendedReviewerEnabled,
+            installed,
+            config.AntigravityMinimumCliVersion);
+
+        if (decision == AntigravityReviewerDecision.Allowed) return statuses;
+
+        var narrowed = statuses.ToArray();
+
+        narrowed[index] = new(
+            AntigravityVendor, false,
+            AntigravityReviewerCapability.DenialReason(
+                decision, installed, config.AntigravityMinimumCliVersion, config.AntigravityPath));
+
+        return narrowed;
+    }
 
     /// <param name="advertised">The already-classified advertised vendors, when the caller has them.
     /// Passing them avoids re-running a classification that spawns vendor binaries; omitting them
@@ -910,7 +986,7 @@ public static partial class DaemonRunner {
     internal static IReadOnlyList<UnattendedVendorCapability> ComputeUnattendedVendorCapabilities(
             IEnumerable<IHostedAgentRuntimeFactory> factories, DaemonConfig config,
             IEnumerable<string>? advertised = null) {
-        var unattended = advertised?.ToArray() ?? ComputeUnattendedVendors(factories);
+        var unattended = advertised?.ToArray() ?? ComputeUnattendedVendors(factories, config);
         var capabilities = new List<UnattendedVendorCapability>();
         foreach (var vendor in unattended) {
             var factory = factories.First(f => string.Equals(f.Vendor, vendor, StringComparison.Ordinal));
@@ -919,6 +995,9 @@ public static partial class DaemonRunner {
                 "cursor"  => (config.CursorPath, CursorLauncherPolicyVersion),
                 "codex"   => (config.CodexPath, CodexLauncherPolicyVersion),
                 "copilot" => (config.CopilotPath, CopilotLauncherPolicyVersion),
+                // Named rather than left to the generic arm, which advertises CliVersion: null — there
+                // is a real configured path here to probe, and the floor is stated in that version.
+                AntigravityVendor => (config.AntigravityPath, AntigravityLauncherPolicyVersion),
                 _         => ("", $"{vendor}-unattended-v1")
             };
             // Trust-by-default: a vendor's borrowed-review capability is a property of its FACTORY,

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -163,8 +163,6 @@ public static partial class DaemonRunner {
             config.AntigravityModel = agyModel;
         if (Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER") is { } agyConsent)
             config.AntigravityUnattendedReviewerEnabled = ParseConsentFlag(agyConsent);
-        if (Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_MIN_CLI_VERSION") is { Length: > 0 } agyFloor)
-            config.AntigravityMinimumCliVersion = agyFloor;
 
         // The operator consent flags for the unattended ACP/CLI reviewers. Both were previously
         // reachable only from a test constructor, which made the shipped Gemini reviewer impossible
@@ -251,6 +249,10 @@ public static partial class DaemonRunner {
         SeedReviewerAffirmation(
             coverageStateDir, AcpVendorDescriptors.Gemini.Vendor,
             config.GeminiUnattendedReviewerEnabled, config.GeminiPath);
+
+        SeedReviewerAffirmation(
+            coverageStateDir, AntigravityVendor,
+            config.AntigravityUnattendedReviewerEnabled, config.AntigravityPath);
 
         // Recovers reviewer homes left by a SIGKILLed predecessor. Runs unconditionally: a daemon
         // whose operator has since disabled the reviewer still owns whatever its last incarnation

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1793,6 +1793,19 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     Clear:  () => DeletePidRecord(agent.Id));
             }
 
+            // The same seam at the exec-per-turn cadence: agy runs each round as its own short-lived
+            // child, so the one-shot record above names turn 1's pid and nothing after it. Recording
+            // per turn (and clearing on a confirmed turn exit) is what keeps the fail-closed contract
+            // true for round 2 onward — the env-marker fallback cannot cover them, since
+            // ComputeStartupReapComplete gates that scan on Linux and this reviewer is POSIX-only,
+            // meaning macOS in practice. Wired here, after registration, for the same reason the ACP
+            // branch is.
+            if (runtime is AntigravityHostedAgentRuntime antigravity) {
+                antigravity.PidCallbacks = new AgyPidRecordCallbacks(
+                    Record: pid => PersistPidRecordOrThrow(agent, pid, null),
+                    Clear:  () => DeletePidRecord(agent.Id));
+            }
+
             // Start reading output
             _ = ReadAgentOutputAsync(agent);
 

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -190,15 +190,29 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     readonly string? _model;
 
     /// <summary>
-    /// Best-effort teardown callback, invoked exactly once at the very END of <see cref="DisposeAsync"/>
-    /// — after the turn worker is joined and this runtime's last process handle is disposed, which is
-    /// the only point at which "no agy child of ours is still writing" is a fact rather than a hope.
-    /// The factory uses it to remove the per-launch <c>HOME</c>, whose content is the reviewer's own
-    /// conversation JSONL (the caller's diff, source excerpts and findings) — disposal, not disk
-    /// hygiene, and not something the daemon-epoch sweep should be left to do at the next boot.
+    /// Best-effort teardown callback, invoked at most once at the very END of <see cref="DisposeAsync"/>
+    /// — and only when every bound on that path actually SETTLED rather than merely expired (see
+    /// <see cref="DisposeAsync"/>'s gate and <see cref="_turnExitConfirmed"/>). The factory uses it to
+    /// remove the per-launch <c>HOME</c>, whose content is the reviewer's own conversation JSONL (the
+    /// caller's diff, source excerpts and findings) — disposal, not disk hygiene, and not something
+    /// the daemon-epoch sweep should be left to do at the next boot.
     /// Never throws: a home we cannot delete must not turn a completed review into a failed dispose.
     /// </summary>
     readonly Action? _onDisposed;
+
+    /// <summary>
+    /// Whether the LAST turn's child was OBSERVED exited while it was still observable — read inside
+    /// <see cref="ProcessTurnAsync"/>'s outer <c>finally</c>, immediately before this runtime lets go
+    /// of that process handle, because a disposed process object reports
+    /// <see cref="IAgyTurnProcess.HasExited"/> <see langword="true"/> and asking afterwards would
+    /// mistake "no longer observable" for "confirmed exited".
+    ///
+    /// <para>Starts <see langword="true"/> — a runtime that never spawned a turn has no child to
+    /// confirm — and is cleared the instant one exists. <see cref="DisposeAsync"/>'s cleanup gate is
+    /// its only consumer; declared <see langword="volatile"/> because the turn worker writes it and
+    /// the disposing caller reads it.</para>
+    /// </summary>
+    volatile bool _turnExitConfirmed = true;
 
     /// <summary>
     /// Liveness-supervision: the per-launch activity clock, assigned by the factory BEFORE the first
@@ -455,9 +469,18 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                     firstTurn = false;
                 }
             }
-        } catch (OperationCanceledException) {
+        } catch (OperationCanceledException) when (ownerCt.IsCancellationRequested) {
             // Normal shutdown (TerminateAsync/DisposeAsync cancelled _ownerCts) — Terminal was already
-            // entered by whoever cancelled it.
+            // entered by whoever cancelled it. FILTERED on the owner token deliberately: an unfiltered
+            // catch here makes "we asked for this" and "something cancelled that we did not expect"
+            // indistinguishable, and the second one must reach EnterTerminal below. ProcessTurnAsync
+            // individually catches every IAgyTurnProcess call EXCEPT its bounded exit-confirmation
+            // wait, whose contract ("returns silently on timeout") does not forbid an implementation
+            // propagating its own internal cancellation — and this runtime is built against the
+            // interface, not against AgyTurnProcess. Swallowing that would exit this loop without
+            // entering Terminal: _terminalTcs never completes, ReadOutputAsync parks forever and
+            // FinalizeAgentRunAsync never fires — rule (a)'s hang through a door rule (a) does not
+            // cover.
         } catch (Exception ex) {
             _logger.LogDebug(ex, "Antigravity: turn worker ended unexpectedly (agentId={AgentId}).", _agentId);
             EnterTerminal(exitCode: 1);
@@ -478,6 +501,11 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     async Task ProcessTurnAsync(PendingTurn turn, bool firstTurn, CancellationToken ownerCt) {
         var process = await SpawnTurnProcessAsync(turn, firstTurn, ownerCt).ConfigureAwait(false);
         if (process is null) return; // spawn failed/cancelled — SpawnTurnProcessAsync already handled it.
+
+        // A child exists from here on, so DisposeAsync may no longer assume there is nothing to
+        // confirm. Re-established (from what the process itself reports) in this method's outer
+        // finally, while it is still observable.
+        _turnExitConfirmed = false;
 
         // The first of two launch-handshake stamps (the second is `session_created`, when this turn's
         // `init` resolves the conversation id). Turn 1 only: LaunchStage is Starting-only and the
@@ -612,6 +640,12 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // result, the already-Terminal race, even ownerCt cancellation — lands here. A turn's
             // process is never reused, so it is always disposed exactly once, right here, regardless of
             // how the turn ended.
+
+            // Asked BEFORE that disposal, which is the only point this is a truthful question: a
+            // disposed process object reports HasExited true, so the same read afterwards would
+            // manufacture a confirmation. DisposeAsync's cleanup gate is the consumer.
+            _turnExitConfirmed = process.HasExited;
+
             try {
                 await process.DisposeAsync().ConfigureAwait(false);
             } catch (Exception ex) {
@@ -860,11 +894,27 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
         await TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
+        // Whether the worker actually JOINED, not merely that we waited for it. Every bound on this
+        // path is best-effort and swallowed, so a WaitAsync that timed out is otherwise
+        // indistinguishable from one that succeeded — and the cleanup gate below must not read the
+        // two the same way.
+        var workerJoined = true;
+
         try {
             await _turnWorkerTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-        } catch {
-            // Best-effort — a stuck turn worker must never hang dispose.
+        } catch (Exception ex) {
+            // Best-effort — a stuck turn worker must never hang dispose. It is NOT evidence of
+            // quiescence, which is what `workerJoined` records.
+            workerJoined = false;
+            _logger.LogDebug(
+                ex, "Antigravity: the turn worker did not join within the dispose budget (agentId={AgentId}).",
+                _agentId);
         }
+
+        // Asked BEFORE the handle is disposed, for the same reason ProcessTurnAsync's own capture is:
+        // a disposed process object reports HasExited true, so asking afterwards mistakes "no longer
+        // observable" for "confirmed exited" — the opposite of what the gate below is for.
+        var inFlightConfirmed = _current is not { } inFlight || inFlight.HasExited;
 
         if (_current is { } current) {
             try {
@@ -877,10 +927,31 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         _ownerCts.Dispose();
         _turnGate.Dispose();
 
-        // LAST, and only here: the turn worker is joined and this runtime holds no process handle, so
-        // nothing of ours can still be writing into whatever the callback is about to remove.
+        if (_onDisposed is null) return;
+
+        // LAST, and gated on MEASURED quiescence rather than an assumption of it. The callback removes
+        // the per-launch HOME, which holds the reviewer's own conversation JSONL — the caller's diff,
+        // source excerpts and findings. Kill(entireProcessTree: true) is not atomic against a
+        // grandchild forked between tree enumeration and signal, and agy's children include its MCP
+        // stdio servers, so a survivor past these budgets is a real shape rather than a hypothetical.
+        //
+        // Unconfirmed means SKIP the deletion, not force it: deleting under a live reviewer would
+        // leave it writing into an unlinked path and recreating the directory, which is worse than
+        // leaving it. The epoch-keyed startup sweep collects it on the next boot. Never silent — a
+        // retained transcript-bearing home is exactly what an operator has to be able to find.
+        if (!workerJoined || !inFlightConfirmed || !_turnExitConfirmed) {
+            _logger.LogWarning(
+                "Antigravity: could not confirm this reviewer's turn children exited (agentId={AgentId}, "
+              + "workerJoined={WorkerJoined}, inFlightChildExited={InFlightConfirmed}, "
+              + "lastTurnExitConfirmed={TurnExitConfirmed}); leaving its reviewer home for the startup "
+              + "sweep rather than deleting it under a live process.",
+                _agentId, workerJoined, inFlightConfirmed, _turnExitConfirmed);
+
+            return;
+        }
+
         try {
-            _onDisposed?.Invoke();
+            _onDisposed();
         } catch (Exception ex) {
             _logger.LogWarning(ex, "Antigravity: the runtime's disposal callback failed (agentId={AgentId}).", _agentId);
         }

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -1,0 +1,633 @@
+// src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// <see cref="IHostedAgentRuntime"/> for Antigravity's CLI (<c>agy</c>) as an unattended review-flow
+/// reviewer.
+///
+/// <para><b>Why this runtime looks nothing like <see cref="PtyHostedAgentRuntime"/> or
+/// <c>AcpHostedAgentRuntime</c>.</b> Every other runtime in this daemon wraps ONE long-lived child
+/// process (a PTY for Claude/Codex, or an ACP JSON-RPC connection for Cursor/Copilot/Kiro/Gemini)
+/// that lives for the whole hosted-agent session. <c>agy</c> has no such thing: every prompt turn is
+/// its own <c>agy -p …</c> invocation that exits when the turn ends, and there is NO PROCESS AT ALL
+/// between turns. That single fact is why this class needs an explicit phase machine where every
+/// other runtime gets logical liveness for free from "is the child still running".</para>
+///
+/// <para><b>Four rules, each a real defect if broken</b> (see the design spec's rationale for the
+/// full incident shapes these prevent):</para>
+///
+/// <para><b>(a) The phase machine.</b> <see cref="RuntimePhase.Starting"/> → <see cref="RuntimePhase.Executing"/>
+/// when turn 1 spawns; <see cref="RuntimePhase.Executing"/> → <see cref="RuntimePhase.Idle"/> ONLY when the
+/// turn's child exits AFTER emitting a terminal <c>result</c> event; <see cref="RuntimePhase.Idle"/> →
+/// <see cref="RuntimePhase.Executing"/> when the next turn is dequeued; any phase → <see cref="RuntimePhase.Terminal"/>
+/// on a launch/turn deadline, a spawn/auth failure, an explicit stop, or — critically — EOF WITHOUT a
+/// terminal <c>result</c>. That last transition is the one easiest to get backwards: reading "the
+/// child's stdout closed" as "the turn finished" and going to <see cref="RuntimePhase.Idle"/> would park
+/// <see cref="ReadOutputAsync"/> forever, because nothing would ever again drive it toward terminal — the
+/// orchestrator's <c>FinalizeAgentRunAsync</c> fires from that stream's <c>await foreach</c>'s <c>finally</c>,
+/// so the session would simply hang. A child that died without a terminal <c>result</c> has lost the
+/// reviewer outright, and flow semantics already fast-fail a round on participant death — going
+/// <see cref="RuntimePhase.Terminal"/> here is what lets that existing machinery see the death at all.</para>
+///
+/// <para><b>(b) <see cref="HasExited"/> reports LOGICAL liveness, not process liveness.</b> Between turns
+/// there is genuinely no child process — a naive "no live child ⇒ exited" would make every
+/// <c>StopAgentCoreAsync</c> (which uses <see cref="HasExited"/> as its success criterion) trivially
+/// succeed while the reviewer is merely idle between turns, and would mis-report the final status once
+/// the runtime later does something with the (already falsely "exited") state. <see cref="RuntimePhase.Idle"/>
+/// reports <see langword="false"/> for exactly this reason — logically alive, no process needed to prove it.</para>
+///
+/// <para><b>(c) <see cref="ReadOutputAsync"/> parks on ONE signal, created once.</b> It waits on
+/// <see cref="_terminalTcs"/> — a single <see cref="TaskCompletionSource"/> created in the constructor and
+/// completed EXACTLY ONCE, on entry to <see cref="RuntimePhase.Terminal"/> (see <see cref="EnterTerminal"/>).
+/// It must never be a per-turn signal: the orchestrator drives <c>FinalizeAgentRunAsync</c> from this
+/// stream's <c>await foreach</c> ending, so a signal that completed at the end of turn 1 would close the
+/// whole hosted-agent session after a single turn — exactly the bug this single, constructor-owned TCS
+/// exists to make structurally impossible.</para>
+///
+/// <para><b>(d) Lock order — <see cref="TerminateAsync"/> must NEVER take <see cref="_turnGate"/>.</b> The
+/// turn gate is held for a turn's WHOLE span — spawn, parse-drain, envelope-flush — by
+/// <see cref="RunTurnWorkerAsync"/>. <see cref="WaitForTurnIdleAsync"/> acquires it and releases
+/// IMMEDIATELY, so it only ever queues behind an in-flight turn; it never holds the gate itself.
+/// <see cref="TerminateAsync"/> instead takes the separate <see cref="_stateLock"/>, flips the phase to
+/// <see cref="RuntimePhase.Terminal"/>, and — OUTSIDE that lock — cancels <see cref="_ownerCts"/> and signals
+/// the current turn's child. Cancelling the owner token is what actually aborts the in-flight turn
+/// (<see cref="ProcessTurnAsync"/>'s line-read loop observes it) and so releases the gate. If
+/// <see cref="TerminateAsync"/> instead tried to acquire <see cref="_turnGate"/> before doing that, a
+/// long-running turn would already be holding it, <see cref="RuntimePhase.Terminal"/> could never be
+/// entered, <see cref="_terminalTcs"/> would never complete, and the runtime would be permanently
+/// unstoppable — a genuine deadlock, not a style preference. See the mutation check pinned in
+/// <c>AntigravityRuntimeLifecycleTests</c> for the reproduction.</para>
+///
+/// <para><b>Not this class's job (yet).</b> No ACP-style reconnect/resume — a dead turn child is either a
+/// clean end-of-turn (→ <see cref="RuntimePhase.Idle"/>) or a lost reviewer (→ <see cref="RuntimePhase.Terminal"/>),
+/// never something to resume mid-turn. No terminal capability (<see cref="EmitsTerminalOutput"/> is
+/// always <see langword="false"/> — agy's stdout is NDJSON protocol traffic, never terminal bytes).
+/// Never emits a <c>session_ended</c> envelope — the server's <c>EndAgentSession</c> owns that
+/// transition, exactly as it does for every other <see cref="IAcpTranscriptSource"/> runtime.</para>
+/// </summary>
+internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscriptSource {
+    /// <summary>
+    /// Runtime lifecycle phase — see the class doc's rule (a). Mutated only under
+    /// <see cref="_stateLock"/>, but read lock-free from <see cref="HasExited"/>/<see cref="ExitCode"/>
+    /// (a plain enum field gives those readers no visibility guarantee, so the backing store is the
+    /// <see langword="int"/> <see cref="_phase"/>, read/written via <see cref="Volatile"/> — the same
+    /// reasoning <c>AcpHostedAgentRuntime.Phase</c> documents).
+    /// </summary>
+    enum RuntimePhase { Starting, Executing, Idle, Terminal }
+
+    /// <summary>One queued prompt turn. <see cref="Written"/> is non-null only for
+    /// <see cref="SendUserInputAndWaitForWriteAsync"/> callers — resolved once this turn's process has
+    /// actually spawned (agy has no separate "write" step; the prompt IS the spawn argument), faulted
+    /// if the turn is dropped instead (terminal, full queue, or a spawn failure).</summary>
+    sealed record PendingTurn(string Text, TaskCompletionSource? Written);
+
+    readonly object _stateLock = new();
+    int _phase = (int)RuntimePhase.Starting;
+
+    /// <summary>See <see cref="RuntimePhase"/>'s remarks on why this is read via <see cref="Volatile"/>
+    /// rather than a plain field access.</summary>
+    RuntimePhase Phase => (RuntimePhase)Volatile.Read(ref _phase);
+
+    /// <summary>
+    /// The exit code this runtime WOULD report if it entered <see cref="RuntimePhase.Terminal"/> right
+    /// now — updated after every turn that ends cleanly (mapped from the agy <c>result</c> event's
+    /// <c>status</c>, NOT the OS exit code — see <see cref="ExitCode"/>'s remarks), so a
+    /// <see cref="TerminateAsync"/> call that lands while merely <see cref="RuntimePhase.Idle"/> (the
+    /// common case — a "terminate while merely idle between turns" test) reports the last
+    /// turn's real outcome instead of a fabricated default. Guarded by <see cref="_stateLock"/>; not
+    /// meaningful (and not read) until <see cref="Phase"/> is actually <see cref="RuntimePhase.Terminal"/>.
+    /// </summary>
+    int? _terminalExitCode;
+
+    /// <summary>Completed exactly once, on entry to <see cref="RuntimePhase.Terminal"/> — see the class
+    /// doc's rule (c). <see cref="ReadOutputAsync"/> parks on this and nothing else.</summary>
+    readonly TaskCompletionSource _terminalTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Cancelled by <see cref="TerminateAsync"/>/<see cref="DisposeAsync"/> — see the class
+    /// doc's rule (d). Linked into every in-flight turn's spawn/read tokens, so cancelling this ONE
+    /// token is what aborts whatever turn is currently running and frees <see cref="_turnGate"/>.</summary>
+    readonly CancellationTokenSource _ownerCts = new();
+
+    /// <summary>Held for a turn's WHOLE span (spawn → parse-drain → envelope-flush) by
+    /// <see cref="RunTurnWorkerAsync"/>. <see cref="TerminateAsync"/> must never acquire this — see the
+    /// class doc's rule (d).</summary>
+    readonly SemaphoreSlim _turnGate = new(1, 1);
+
+    /// <summary>This turn's live process, or <see langword="null"/> between turns — the field
+    /// <see cref="HasExited"/> reads for its <see cref="RuntimePhase.Executing"/> case. Declared
+    /// <see langword="volatile"/> so that lock-free read is well-defined; written only from the single
+    /// turn worker (<see cref="ProcessTurnAsync"/>), so no additional synchronization is needed for the
+    /// write side.</summary>
+    volatile IAgyTurnProcess? _current;
+
+    /// <summary>Injected turn spawner — the seam that keeps this runtime testable without ever
+    /// spawning a real process. Takes the prompt text and the currently-known conversation id
+    /// (<see langword="null"/> for turn 1), and returns the fresh <see cref="IAgyTurnProcess"/> for
+    /// THIS turn only; a real implementation runs <c>agy -p &lt;prompt&gt; [--conversation-id &lt;id&gt;]
+    /// --output-format stream-json</c>.</summary>
+    readonly Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> _spawnTurn;
+
+    /// <summary>
+    /// Bound on how long the very FIRST turn's spawn call may take before <see cref="RuntimePhase.Starting"/>
+    /// gives up and goes <see cref="RuntimePhase.Terminal"/> — <see langword="null"/> disables it. Applies
+    /// ONLY to the spawn call itself (there is no live process yet to bound anything else against);
+    /// every turn's actual execution, including turn 1's, is bounded by <see cref="_turnDeadline"/>
+    /// instead once the process exists.
+    /// </summary>
+    readonly TimeSpan? _launchDeadline;
+
+    /// <summary>Bound on how long ANY single turn (its process's whole run, from spawn to EOF) may take
+    /// before it is reaped and the runtime goes <see cref="RuntimePhase.Terminal"/> — <see langword="null"/>
+    /// disables it.</summary>
+    readonly TimeSpan? _turnDeadline;
+
+    /// <summary>How long a normal (non-deadline, non-cancelled) end-of-turn waits for the OS process to
+    /// actually confirm exit after its stdout hits EOF, before giving up and trusting EOF alone. Small
+    /// and fixed rather than configurable — this is a courtesy wait for the OS to catch up, not a
+    /// meaningful timeout a caller would ever want to tune.</summary>
+    static readonly TimeSpan ExitConfirmationGrace = TimeSpan.FromSeconds(5);
+
+    readonly ILogger _logger;
+    readonly string  _agentId;
+    readonly string? _model;
+
+    /// <summary>The ACP-equivalent conversation id — resolved from turn 1's <c>init</c> event and never
+    /// changed again. See <see cref="AcpSessionId"/> and
+    /// this runtime's own conversation-id-stability test: a LATER
+    /// turn reporting a different id would mean this runtime silently forked the reviewer's history,
+    /// which is treated as an unrecoverable protocol violation (→ <see cref="RuntimePhase.Terminal"/>),
+    /// never silently accepted.</summary>
+    string? _conversationId;
+
+    string? _cwd;
+    bool    _sessionStartedEmitted;
+    int     _disposed;
+
+    readonly Channel<AcpEventEnvelope> _transcript;
+    readonly Channel<PendingTurn>      _pendingTurns;
+
+    Task _turnWorkerTask = Task.CompletedTask;
+
+    const int DefaultTranscriptCapacity  = 2000;
+    const int DefaultPendingTurnsCapacity = 64;
+
+    public AntigravityHostedAgentRuntime(
+            Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawnTurn,
+            ILogger                                                        logger,
+            string                                                         agentId = "",
+            string?                                                        model = null,
+            string?                                                        cwd = null,
+            TimeSpan?                                                      launchDeadline = null,
+            TimeSpan?                                                      turnDeadline = null,
+            int?                                                           transcriptCapacity = null,
+            int?                                                           pendingTurnsCapacity = null
+        ) {
+        _spawnTurn      = spawnTurn;
+        _logger         = logger;
+        _agentId        = agentId;
+        _model          = model;
+        _cwd            = cwd;
+        _launchDeadline = launchDeadline;
+        _turnDeadline   = turnDeadline;
+
+        // DropOldest: this runtime is the sole writer (the turn worker), so unlike AcpHostedAgentRuntime
+        // there is no concurrent writer to reason about — a stalled forwarder just loses trailing
+        // transcript rather than ever blocking the worker.
+        _transcript = Channel.CreateBounded<AcpEventEnvelope>(
+            new BoundedChannelOptions(transcriptCapacity ?? DefaultTranscriptCapacity)
+                { SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.DropOldest });
+
+        // NOT SingleReader: EnterTerminal's drain (rule below) and the worker's own dequeue loop can
+        // both call TryRead around a Terminate race, so this channel must tolerate two readers even
+        // though exactly one of them ever "wins" any given item.
+        _pendingTurns = Channel.CreateBounded<PendingTurn>(
+            new BoundedChannelOptions(pendingTurnsCapacity ?? DefaultPendingTurnsCapacity)
+                { SingleReader = false, SingleWriter = false, FullMode = BoundedChannelFullMode.DropWrite });
+
+        _turnWorkerTask = RunTurnWorkerAsync();
+    }
+
+    public string Vendor              => "antigravity";
+    public int    Pid                 => _current?.Pid ?? 0;
+    public bool   EmitsTerminalOutput => false;
+
+    /// <summary>Rule (b): <see cref="RuntimePhase.Idle"/> is logically alive (no process needed to prove
+    /// it — see the class doc), <see cref="RuntimePhase.Terminal"/> is always exited, and
+    /// <see cref="RuntimePhase.Starting"/>/<see cref="RuntimePhase.Executing"/> defer to whatever process
+    /// (if any) is currently running.</summary>
+    public bool HasExited => Phase switch {
+        RuntimePhase.Idle     => false,
+        RuntimePhase.Terminal => true,
+        _                     => _current?.HasExited ?? false,
+    };
+
+    /// <summary>
+    /// Mapped from the agy <c>result</c> event's <c>status</c> field, NEVER the OS exit code —
+    /// <see langword="null"/> while non-terminal; <c>0</c> once <see cref="RuntimePhase.Terminal"/> if the
+    /// last completed turn's <c>result.status</c> was <c>SUCCESS</c>, non-zero otherwise (including "a
+    /// turn child died without ever emitting a terminal <c>result</c>", rule (a)'s EOF-without-result
+    /// case). A per-turn OS exit code describes one subprocess invocation, not the reviewer's overall
+    /// outcome, and an upstream agy bug means a clean run can carry an empty <c>response</c> — so
+    /// <c>status</c>, not the process's own exit code, is the only trustworthy signal here.
+    /// </summary>
+    public int? ExitCode => Phase == RuntimePhase.Terminal ? _terminalExitCode : null;
+
+    public string  AcpSessionId  => _conversationId ?? "";
+    public string  Cwd           => _cwd ?? "";
+    public string? ResolvedModel => _model;
+    public ChannelReader<AcpEventEnvelope> Envelopes => _transcript.Reader;
+
+    /// <summary>Rule (c): parks on the single constructor-owned <see cref="_terminalTcs"/> and nothing
+    /// else. Yields no bytes ever — agy's stdout is NDJSON protocol traffic, never terminal output
+    /// (mirrors <c>AcpHostedAgentRuntime.ReadOutputAsync</c>'s reasoning exactly).</summary>
+    public async IAsyncEnumerable<byte[]> ReadOutputAsync(
+            [EnumeratorCancellation] CancellationToken ct = default) {
+        await _terminalTcs.Task.WaitAsync(ct).ConfigureAwait(false);
+        yield break;
+    }
+
+    public Task SendUserInputAsync(string text) => EnqueueTurn(text, acknowledgeWrite: false);
+
+    public Task SendUserInputAndWaitForWriteAsync(string text) => EnqueueTurn(text, acknowledgeWrite: true);
+
+    /// <summary>Acquire-then-IMMEDIATELY-release: queues behind an in-flight turn and returns once it's
+    /// done, but never itself holds <see cref="_turnGate"/> — see the class doc's rule (d), which is the
+    /// exact property <see cref="TerminateAsync"/> also depends on.</summary>
+    public async Task WaitForTurnIdleAsync(CancellationToken ct) {
+        await _turnGate.WaitAsync(ct).ConfigureAwait(false);
+        _turnGate.Release();
+    }
+
+    /// <summary>
+    /// Enqueues the turn and returns immediately — never blocks on, or observes, the turn's
+    /// completion. A dropped enqueue (the runtime is already <see cref="RuntimePhase.Terminal"/>, or the
+    /// pending-turns queue is at capacity) never throws when no acknowledgement was requested: the
+    /// channel's own atomicity (<see cref="ChannelWriter{T}.TryWrite"/> against a completed or full
+    /// bounded channel) is what makes "terminal" and "full" collapse into the same silent-drop path
+    /// without a separate check-then-act race.
+    /// </summary>
+    Task EnqueueTurn(string text, bool acknowledgeWrite) {
+        var written = acknowledgeWrite
+            ? new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+            : null;
+
+        if (!_pendingTurns.Writer.TryWrite(new PendingTurn(text, written))) {
+            _logger.LogDebug(
+                "Antigravity: dropped a prompt turn — the runtime is terminal or its pending-turns queue is full.");
+            written?.TrySetException(new InvalidOperationException(
+                "Antigravity runtime dropped this input — it is terminal, or its pending-turns queue is full."));
+        }
+
+        return written?.Task ?? Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The single, long-running turn worker — the only reader that ever SPAWNS a turn (
+    /// <see cref="EnterTerminal"/>'s drain also reads from <see cref="_pendingTurns"/>, but only to fault
+    /// stranded turns, never to spawn one). Drains strictly FIFO, one turn fully at a time: the phase
+    /// flip to <see cref="RuntimePhase.Executing"/> happens at dequeue (rule (a)'s "next turn dequeued"
+    /// trigger, uniformly for turn 1 and every later turn), and the flip back to
+    /// <see cref="RuntimePhase.Idle"/> — or onward to <see cref="RuntimePhase.Terminal"/>, whichever
+    /// <see cref="ProcessTurnAsync"/> decided — happens BEFORE <see cref="_turnGate"/> is released, so a
+    /// <see cref="WaitForTurnIdleAsync"/> caller that returns always observes a fully-settled phase, never
+    /// a stale <see cref="RuntimePhase.Executing"/>.
+    /// </summary>
+    async Task RunTurnWorkerAsync() {
+        var ownerCt   = _ownerCts.Token;
+        var firstTurn = true;
+
+        try {
+            while (await _pendingTurns.Reader.WaitToReadAsync(ownerCt).ConfigureAwait(false)) {
+                while (_pendingTurns.Reader.TryRead(out var turn)) {
+                    if (Phase == RuntimePhase.Terminal) {
+                        // Lost the race with EnterTerminal's own drain for THIS item (or Terminal was
+                        // entered between WaitToReadAsync and TryRead) — never spawn a turn once
+                        // terminal, no matter which reader happened to pull it off the channel.
+                        turn.Written?.TrySetException(new InvalidOperationException(
+                            "Antigravity runtime is terminal; this input was never delivered."));
+                        continue;
+                    }
+
+                    lock (_stateLock) {
+                        if (Phase != RuntimePhase.Terminal)
+                            Volatile.Write(ref _phase, (int)RuntimePhase.Executing);
+                    }
+
+                    await _turnGate.WaitAsync(ownerCt).ConfigureAwait(false);
+                    try {
+                        await ProcessTurnAsync(turn, firstTurn, ownerCt).ConfigureAwait(false);
+
+                        // Settle the phase BEFORE releasing the gate (not after) — see this method's
+                        // remarks: WaitForTurnIdleAsync must never observe a stale Executing.
+                        lock (_stateLock) {
+                            if (Phase == RuntimePhase.Executing)
+                                Volatile.Write(ref _phase, (int)RuntimePhase.Idle);
+                        }
+                    } finally {
+                        _turnGate.Release();
+                    }
+
+                    firstTurn = false;
+                }
+            }
+        } catch (OperationCanceledException) {
+            // Normal shutdown (TerminateAsync/DisposeAsync cancelled _ownerCts) — Terminal was already
+            // entered by whoever cancelled it.
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "Antigravity: turn worker ended unexpectedly (agentId={AgentId}).", _agentId);
+            EnterTerminal(exitCode: 1);
+        }
+    }
+
+    /// <summary>
+    /// Processes exactly one turn: spawns its process (bounded by <see cref="_launchDeadline"/> for
+    /// turn 1 only), reads its NDJSON lines until EOF (bounded by <see cref="_turnDeadline"/>),
+    /// translates them into transcript envelopes, and decides the turn's outcome per rule (a) — Idle
+    /// only on "child exited after a terminal <c>result</c>", Terminal on every other ending. Never
+    /// throws: every failure path reports through <paramref name="turn"/>'s ack and/or
+    /// <see cref="EnterTerminal"/> instead, so <see cref="RunTurnWorkerAsync"/>'s loop never sees an
+    /// unexpected exception from a turn that merely failed (as opposed to the worker itself faulting).
+    /// </summary>
+    async Task ProcessTurnAsync(PendingTurn turn, bool firstTurn, CancellationToken ownerCt) {
+        IAgyTurnProcess process;
+
+        using (var spawnCts = CancellationTokenSource.CreateLinkedTokenSource(ownerCt)) {
+            if (firstTurn && _launchDeadline is { } launchDeadline)
+                spawnCts.CancelAfter(launchDeadline);
+
+            try {
+                process = await _spawnTurn(turn.Text, _conversationId, spawnCts.Token).ConfigureAwait(false);
+            } catch (OperationCanceledException) when (ownerCt.IsCancellationRequested) {
+                // Stop/dispose raced the spawn — EnterTerminal was already called by TerminateAsync.
+                turn.Written?.TrySetException(new InvalidOperationException(
+                    "Antigravity runtime stopped before this turn's process spawned."));
+                return;
+            } catch (OperationCanceledException) {
+                // Only the launch deadline could cancel spawnCts without ownerCt also being cancelled.
+                turn.Written?.TrySetException(new TimeoutException(
+                    "Antigravity: turn 1's process did not spawn within the launch deadline."));
+                _logger.LogWarning("Antigravity: turn 1 spawn exceeded the launch deadline; entering Terminal.");
+                EnterTerminal(exitCode: 1);
+                return;
+            } catch (Exception ex) {
+                // Spawn failure or auth failure, surfaced by the injected spawner as a thrown exception.
+                turn.Written?.TrySetException(ex);
+                _logger.LogWarning(ex, "Antigravity: turn process failed to spawn; entering Terminal.");
+                EnterTerminal(exitCode: 1);
+                return;
+            }
+        }
+
+        turn.Written?.TrySetResult();
+        _current = process;
+
+        var accumulator        = new AntigravityStepAccumulator();
+        var sawTerminalResult  = false;
+        var conversationChanged = false;
+        string? resultStatus   = null;
+
+        using var turnCts = CancellationTokenSource.CreateLinkedTokenSource(ownerCt);
+        if (_turnDeadline is { } turnDeadline) turnCts.CancelAfter(turnDeadline);
+
+        try {
+            await foreach (var line in process.ReadLinesAsync(turnCts.Token).ConfigureAwait(false)) {
+                var evt = AntigravityNdjson.TryParseLine(line);
+                if (evt is null) continue;
+
+                switch (evt.Kind) {
+                    case AntigravityEventKind.Init:
+                        if (!HandleInit(evt)) conversationChanged = true;
+                        break;
+
+                    case AntigravityEventKind.StepUpdate:
+                        accumulator.Add(evt);
+                        foreach (var env in accumulator.Flush(_model)) EmitEnvelope(env);
+                        break;
+
+                    case AntigravityEventKind.Result:
+                        // Never translated to an envelope (session_ended is the server's to own) —
+                        // only read here to drive this runtime's own logical-terminal state.
+                        sawTerminalResult = true;
+                        resultStatus      = evt.Status;
+                        break;
+                }
+
+                if (conversationChanged) break; // stop reading — this turn's outcome is already decided.
+            }
+        } catch (OperationCanceledException) {
+            // Distinguished below via ownerCt/turnCts — both are legitimate reasons this can throw.
+        } finally {
+            _current = null;
+        }
+
+        if (ownerCt.IsCancellationRequested) return; // stop/dispose — Terminal already entered by TerminateAsync.
+
+        if (conversationChanged) {
+            // A changed conversation id means this runtime silently forked the reviewer's history —
+            // an unrecoverable protocol violation, reaped the same way a blown deadline is: kill the
+            // child THEN go Terminal, never leave an orphaned process behind.
+            try {
+                await process.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            } catch (Exception ex) {
+                _logger.LogDebug(ex, "Antigravity: failed to terminate a turn after a conversation-id mismatch.");
+            }
+            EnterTerminal(exitCode: 1);
+            return;
+        }
+
+        if (turnCts.IsCancellationRequested) {
+            // The per-turn deadline fired, not an owner cancel — reap this turn's child and go Terminal.
+            try {
+                await process.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            } catch (Exception ex) {
+                _logger.LogDebug(ex, "Antigravity: failed to terminate a turn that exceeded its deadline.");
+            }
+            _logger.LogWarning("Antigravity: turn exceeded its per-turn deadline; entering Terminal.");
+            EnterTerminal(exitCode: 1);
+            return;
+        }
+
+        // Normal EOF — give the OS a short, bounded grace period to confirm the exit, then trust EOF
+        // regardless: a process whose stdout closed is done producing transcript either way.
+        await process.WaitForExitAsync(ExitConfirmationGrace).ConfigureAwait(false);
+
+        if (!sawTerminalResult) {
+            // Rule (a)'s load-bearing case: EOF without a terminal `result` means the reviewer died
+            // mid-turn. Terminal, never Idle — going Idle here would park ReadOutputAsync forever.
+            EnterTerminal(exitCode: process.ExitCode is { } code and not 0 ? code : 1);
+            return;
+        }
+
+        var success = string.Equals(resultStatus, "SUCCESS", StringComparison.OrdinalIgnoreCase);
+
+        // Not yet Terminal — this only records what Terminal WOULD report if entered right now (see
+        // _terminalExitCode's remarks). RunTurnWorkerAsync flips the phase itself, back in its caller.
+        lock (_stateLock) _terminalExitCode = success ? 0 : 1;
+    }
+
+    /// <summary>Emits <c>session_started</c> at most once (turn 1's <c>init</c> only — a later turn's own
+    /// fresh <c>init</c> must never re-fire it), and enforces conversation-id stability: a later turn
+    /// reporting a DIFFERENT id from the one turn 1 established would mean this runtime silently forked
+    /// the reviewer's history onto a new conversation. Returns <see langword="false"/> on that mismatch
+    /// (the caller reaps the turn and enters Terminal) rather than raising it directly — this method
+    /// runs inside the read loop, before the caller has decided how to shut the current process down,
+    /// so it must never trigger termination itself.</summary>
+    bool HandleInit(AntigravityEvent evt) {
+        if (evt.ConversationId is { Length: > 0 } cid) {
+            if (_conversationId is null) {
+                _conversationId = cid;
+            } else if (!string.Equals(_conversationId, cid, StringComparison.Ordinal)) {
+                _logger.LogError(
+                    "Antigravity: conversation id changed from {Old} to {New} mid-session (agentId={AgentId}); entering Terminal.",
+                    _conversationId, cid, _agentId);
+                return false;
+            }
+        }
+
+        if (evt.Cwd is { Length: > 0 } cwd) _cwd = cwd;
+
+        if (!_sessionStartedEmitted) {
+            _sessionStartedEmitted = true;
+            foreach (var env in AntigravityNdjson.ToEnvelopes(evt, _model)) EmitEnvelope(env);
+        }
+
+        return true;
+    }
+
+    void EmitEnvelope(AcpEventEnvelope env) {
+        if (!_transcript.Writer.TryWrite(env))
+            _logger.LogDebug("Antigravity: dropped a transcript envelope — the transcript channel is already completed.");
+    }
+
+    /// <summary>
+    /// Enters <see cref="RuntimePhase.Terminal"/>, idempotently: the phase check-and-flip happens under
+    /// <see cref="_stateLock"/> (reentrant-safe — <see cref="TerminateAsync"/> calls this from inside its
+    /// own already-held <see cref="_stateLock"/> section, which C#'s <see langword="lock"/> permits on the
+    /// same thread), and every other effect — completing <see cref="_terminalTcs"/>, draining
+    /// <see cref="_pendingTurns"/>, completing <see cref="_transcript"/> — runs exactly once, only for the
+    /// caller that actually performed the transition.
+    ///
+    /// <para>The pending-turns drain exists because a turn already sitting in the channel when Terminal
+    /// is entered would otherwise never be observed: once <see cref="TerminateAsync"/> cancels
+    /// <see cref="_ownerCts"/>, <see cref="RunTurnWorkerAsync"/>'s own <c>WaitToReadAsync</c> throws
+    /// immediately rather than draining what's left — so this method faults every stranded turn's
+    /// <c>Written</c> acknowledgement itself, rather than leaving a
+    /// <see cref="SendUserInputAndWaitForWriteAsync"/> caller awaiting a write that will never happen.</para>
+    /// </summary>
+    /// <returns><see langword="true"/> if this call actually performed the transition;
+    /// <see langword="false"/> if the runtime was already <see cref="RuntimePhase.Terminal"/>.</returns>
+    bool EnterTerminal(int exitCode) {
+        lock (_stateLock) {
+            if (Phase == RuntimePhase.Terminal) return false;
+
+            Volatile.Write(ref _phase, (int)RuntimePhase.Terminal);
+            _terminalExitCode = exitCode;
+        }
+
+        _terminalTcs.TrySetResult();
+
+        _pendingTurns.Writer.TryComplete();
+        while (_pendingTurns.Reader.TryRead(out var dropped))
+            dropped.Written?.TrySetException(new InvalidOperationException(
+                "Antigravity runtime is terminal; this input was never delivered."));
+
+        _transcript.Writer.TryComplete();
+
+        return true;
+    }
+
+    public Task SendSpecialKeyAsync(string key) {
+        // agy has no special-key channel (there is no live protocol connection between turns to send
+        // one over) — best-effort no-op, mirroring AcpHostedAgentRuntime's own no-op for the same
+        // reason.
+        _logger.LogDebug("Antigravity runtime ignoring SendSpecialKeyAsync({Key}) — no special-key surface.", key);
+        return Task.CompletedTask;
+    }
+
+    public Task SendRawInputAsync(byte[] data) =>
+        throw new NotSupportedException(
+            "Local-attach raw input is a PTY-only surface; the Antigravity runtime has no equivalent channel.");
+
+    public void Resize(ushort cols, ushort rows) {
+        // No terminal capability — agy's stdout is NDJSON protocol traffic, not a terminal. No-op.
+    }
+
+    /// <summary>
+    /// agy has no in-band cancel RPC (unlike ACP's <c>session/cancel</c>) — there is no live connection
+    /// to send one over between turns, and interrupting an IN-FLIGHT turn's process is exactly what
+    /// <see cref="TerminateAsync"/> already does. Best-effort no-op, matching
+    /// <see cref="IHostedAgentRuntime.RequestGracefulStopAsync"/>'s documented contract ("the
+    /// orchestrator falls through to terminate").
+    /// </summary>
+    public Task RequestGracefulStopAsync() {
+        _logger.LogDebug("Antigravity runtime: no graceful-stop channel between turns; falling through to terminate.");
+        return Task.CompletedTask;
+    }
+
+    /// <summary>"Exited" here means logically terminal (see rule (b)) — waits on the same
+    /// <see cref="_terminalTcs"/> signal <see cref="ReadOutputAsync"/> parks on. Returns silently on
+    /// timeout, per the interface contract, rather than propagating <see cref="TimeoutException"/>.</summary>
+    public async Task WaitForExitAsync(TimeSpan? timeout = null) {
+        if (timeout is { } t) {
+            try {
+                await _terminalTcs.Task.WaitAsync(t).ConfigureAwait(false);
+            } catch (TimeoutException) {
+                // Returns silently on timeout — per this method's interface contract.
+            }
+        } else {
+            await _terminalTcs.Task.ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Rule (d) — see the class doc. Takes <see cref="_stateLock"/> (NEVER <see cref="_turnGate"/>),
+    /// enters <see cref="RuntimePhase.Terminal"/>, then — OUTSIDE that lock — cancels
+    /// <see cref="_ownerCts"/> (which is what actually unblocks an in-flight turn and frees the gate) and
+    /// terminates the current turn's process, if any.</summary>
+    public async Task TerminateAsync(TimeSpan? timeout = null) {
+        IAgyTurnProcess? current;
+
+        lock (_stateLock) {                 // NOT _turnGate — see the class doc's rule (d).
+            if (!EnterTerminal(_terminalExitCode ?? 0)) return;
+            current = _current;
+        }
+
+        await _ownerCts.CancelAsync().ConfigureAwait(false);
+
+        if (current is not null) {
+            try {
+                await current.TerminateAsync(timeout).ConfigureAwait(false);
+            } catch (Exception ex) {
+                _logger.LogDebug(ex, "Antigravity: failed to terminate the in-flight turn's process.");
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync() {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+
+        await TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        try {
+            await _turnWorkerTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        } catch {
+            // Best-effort — a stuck turn worker must never hang dispose.
+        }
+
+        if (_current is { } current) {
+            try {
+                await current.DisposeAsync().ConfigureAwait(false);
+            } catch {
+                // Best-effort.
+            }
+        }
+
+        _ownerCts.Dispose();
+        _turnGate.Dispose();
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -75,7 +75,20 @@ namespace Capacitor.Cli.Daemon.Services;
 /// reads <see cref="AcpSessionId"/> unconditionally and synchronously the moment a launch returns — WILL
 /// bind the transcript to <c>""</c>: a silent, permanent correlation break, not a flaky race. <b>Any
 /// factory for this runtime MUST <see langword="await"/> <see cref="WaitForConversationIdAsync"/> after
-/// sending the initial prompt and BEFORE returning control to the orchestrator.</b></para>
+/// sending the initial prompt and BEFORE returning control to the orchestrator.</b> The barrier itself is
+/// what guarantees this never hangs — it resolves on EVERY path a turn can end on, not just the obvious
+/// ones: <see cref="EnterTerminal"/> faults it for every route to <see cref="RuntimePhase.Terminal"/>
+/// (spawn/auth failure, either deadline, EOF-without-a-result, an explicit stop), and the clean-success
+/// tail of <see cref="ProcessTurnAsync"/> ALSO faults it (via
+/// <see cref="FaultConversationIdBarrierIfUnresolved"/>) for the one path that does NOT call
+/// <see cref="EnterTerminal"/> at all — a turn that settles to <see cref="RuntimePhase.Idle"/> having
+/// never seen a non-empty <c>conversation_id</c> on an <c>init</c> event (a malformed or missing
+/// <c>init</c> whose transcript nonetheless reaches a terminal <c>result</c>). A first cut of this fix
+/// missed exactly that second path — the SAME failure mode the barrier exists to prevent, reopened
+/// through a different door, because a healthy-looking Idle transition is easy to assume can't need
+/// fault handling. As belt-and-braces ONLY (never the primary defense, which is the barrier's own total
+/// resolution above), a factory MAY additionally pass its own launch-deadline token into
+/// <see cref="WaitForConversationIdAsync"/>.</para>
 ///
 /// <para><b>Not this class's job (yet).</b> No ACP-style reconnect/resume — a dead turn child is either a
 /// clean end-of-turn (→ <see cref="RuntimePhase.Idle"/>) or a lost reviewer (→ <see cref="RuntimePhase.Terminal"/>),
@@ -539,6 +552,15 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // Not yet Terminal — this only records what Terminal WOULD report if entered right now (see
             // _terminalExitCode's remarks). RunTurnWorkerAsync flips the phase itself, back in its caller.
             lock (_stateLock) _terminalExitCode = success ? 0 : 1;
+
+            // Rule (e), second call site: this turn settled cleanly (→ Idle, no EnterTerminal call at
+            // all) WITHOUT ever resolving a conversation id — e.g. a transcript whose `init` line was
+            // missing or carried an empty conversation_id, yet still reached a terminal `result`. A
+            // no-op once an id already resolved (from this turn's own init, or an earlier turn's).
+            // Without this, a factory correctly following rule (e) would hang forever awaiting
+            // WaitForConversationIdAsync on a runtime that is otherwise perfectly healthy.
+            FaultConversationIdBarrierIfUnresolved(
+                "Antigravity: this turn ended without the runtime ever resolving a conversation id from an `init` event.");
         } finally {
             // Every exit path above — clean success, conversation-id mismatch, deadline, EOF-without-
             // result, the already-Terminal race, even ownerCt cancellation — lands here. A turn's
@@ -656,8 +678,8 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
         // Rule (e): unblock a factory parked in WaitForConversationIdAsync when a conversation id is
         // never going to arrive (e.g. turn 1's spawn itself failed) — never hang that caller forever.
-        _conversationIdResolved.TrySetException(new InvalidOperationException(
-            "Antigravity runtime went terminal before establishing a conversation id."));
+        FaultConversationIdBarrierIfUnresolved(
+            "Antigravity runtime went terminal before establishing a conversation id.");
 
         _pendingTurns.Writer.TryComplete();
         while (_pendingTurns.Reader.TryRead(out var dropped))
@@ -667,6 +689,38 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         _transcript.Writer.TryComplete();
 
         return true;
+    }
+
+    /// <summary>
+    /// Faults <see cref="_conversationIdResolved"/> if — and only if — nothing has resolved it yet
+    /// (<c>TrySetException</c> is a no-op against an already-successfully-completed task, so this can
+    /// never clobber a real id that was already established). Two call sites use this, not one:
+    /// <see cref="EnterTerminal"/> covers "the runtime went terminal before an id ever arrived", and
+    /// the clean-success tail of <see cref="ProcessTurnAsync"/> covers the MORE subtle case rule (e)'s
+    /// first cut missed — a turn can settle to <see cref="RuntimePhase.Idle"/> (no <see cref="EnterTerminal"/>
+    /// call at all) having never seen an <c>init</c> event with a non-empty <c>conversation_id</c> (a
+    /// malformed/missing <c>init</c> whose transcript nonetheless carries a terminal <c>result</c>) —
+    /// without this second call site, a caller correctly following rule (e) and awaiting
+    /// <see cref="WaitForConversationIdAsync"/> would hang forever on a HEALTHY (non-terminal) runtime.
+    ///
+    /// <para>Immediately "observes" a fault it actually caused via a synchronous, exception-swallowing
+    /// continuation — otherwise an unobserved faulted <see cref="Task"/> (e.g. a caller that never calls
+    /// <see cref="WaitForConversationIdAsync"/> at all, which every non-factory caller of this runtime
+    /// legitimately never does) risks <see cref="TaskScheduler.UnobservedTaskException"/> once the GC
+    /// finalizes it — benign under default .NET, but noisy or fatal under a host that escalates it. This
+    /// is purely about silencing that observability warning; a REAL caller of
+    /// <see cref="WaitForConversationIdAsync"/> still observes and can act on the actual exception via
+    /// its own <see langword="await"/>.</para>
+    /// </summary>
+    void FaultConversationIdBarrierIfUnresolved(string message) {
+        if (!_conversationIdResolved.TrySetException(new InvalidOperationException(message)))
+            return;
+
+        _conversationIdResolved.Task.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     public Task SendSpecialKeyAsync(string key) {

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -8,6 +8,32 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
+/// The per-turn durable PID-record callbacks — the exec-per-turn analogue of
+/// <c>AcpPidRecordCallbacks</c>, published as ONE immutable bundle for the same reason: two
+/// independently-settable callbacks have a partial-wiring window in which a real recorder is
+/// installed but the clearer is not, and a turn could then persist a record nothing would clear.
+///
+/// <para><b>Cadence: record on turn spawn, clear on CONFIRMED turn exit.</b> Every round of a review
+/// is a different child with a different pid, so a one-shot record taken at launch names turn 1's pid
+/// and nothing after it — a daemon SIGKILL during round 2 would leave a child reapable by neither the
+/// record pass nor the env-marker pass (which is Linux-only, and this reviewer is POSIX-meaning-macOS
+/// in practice).</para>
+///
+/// <para><b><see cref="Record"/> MUST throw on failure</b>, and the runtime treats a throw as the turn
+/// failing: a spawned child the daemon cannot durably record is reaped and the runtime goes terminal
+/// rather than running untracked. <see cref="Clear"/> runs only once the turn's child is OBSERVED
+/// exited — an unconfirmed survivor keeps its record, because the record is the only thing that can
+/// still reap it.</para>
+///
+/// <para>Left <see langword="null"/> on <see cref="AntigravityHostedAgentRuntime.PidCallbacks"/> the
+/// runtime records nothing. That is the deliberate pre-wiring state, not a fail-open hole: turn 1
+/// spawns INSIDE the factory's <c>StartAsync</c>, before the orchestrator can wire anything, and the
+/// orchestrator's own one-shot record covers exactly that turn immediately after the launch
+/// returns.</para>
+/// </summary>
+internal sealed record AgyPidRecordCallbacks(Action<int> Record, Action Clear);
+
+/// <summary>
 /// <see cref="IHostedAgentRuntime"/> for Antigravity's CLI (<c>agy</c>) as an unattended review-flow
 /// reviewer.
 ///
@@ -229,6 +255,12 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// turn AND on entry to <see cref="RuntimePhase.Terminal"/>.</para>
     /// </summary>
     internal AgentActivityClock? ActivityClock { get; set; }
+
+    /// <summary>The per-turn durable PID-record seam — see <see cref="AgyPidRecordCallbacks"/> for the
+    /// cadence and the fail-closed contract. Assigned by the orchestrator immediately after
+    /// registration, which is why turn 1 (spawned inside the factory's launch) is deliberately not
+    /// covered here.</summary>
+    internal AgyPidRecordCallbacks? PidCallbacks { get; set; }
 
     /// <summary>The ACP-equivalent conversation id — resolved from turn 1's <c>init</c> event and never
     /// changed again. See <see cref="AcpSessionId"/> and
@@ -514,6 +546,35 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         if (firstTurn) ActivityClock?.SetLaunchStage("spawned");
 
         try {
+            // The durable PID record precedes anything else this turn does with its child, and
+            // precedes the _current publish so a refusal leaves nothing published to reconcile. Same
+            // fail-closed contract the ACP reconnect seam applies per candidate, applied here per TURN
+            // because every round spawns a differently-pid'd child (see AgyPidRecordCallbacks). A
+            // throw is the record store refusing: the child is reaped and the runtime goes terminal
+            // rather than running untracked — never swallowed.
+            if (PidCallbacks is { } pids) {
+                try {
+                    pids.Record(process.Pid);
+                } catch (Exception ex) {
+                    _logger.LogWarning(
+                        ex, "Antigravity: could not durably record this turn's child (agentId={AgentId}, "
+                          + "pid={Pid}); failing the turn rather than running it untracked.",
+                        _agentId, process.Pid);
+
+                    turn.Written?.TrySetException(ex);
+
+                    try {
+                        await process.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                    } catch (Exception terminateEx) {
+                        _logger.LogDebug(
+                            terminateEx, "Antigravity: failed to terminate a turn whose PID record was refused.");
+                    }
+
+                    EnterTerminal(exitCode: 1);
+                    return;
+                }
+            }
+
             // Publish _current and check for an already-Terminal runtime as ONE atomic operation under
             // _stateLock — the SAME lock TerminateAsync captures _current under. This closes a real
             // orphan-child race: TerminateAsync's capture and this publish can interleave in either
@@ -645,6 +706,17 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // disposed process object reports HasExited true, so the same read afterwards would
             // manufacture a confirmation. DisposeAsync's cleanup gate is the consumer.
             _turnExitConfirmed = process.HasExited;
+
+            // Cleared on CONFIRMED exit only, off that same single read: an unconfirmed survivor keeps
+            // its record, because the record is the only thing that can still reap it. Never allowed
+            // to fault the turn — a record we failed to delete is stale bookkeeping, not a live child.
+            if (_turnExitConfirmed && PidCallbacks is { } recorded) {
+                try {
+                    recorded.Clear();
+                } catch (Exception ex) {
+                    _logger.LogDebug(ex, "Antigravity: failed to clear a completed turn's PID record.");
+                }
+            }
 
             try {
                 await process.DisposeAsync().ConfigureAwait(false);

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -64,6 +64,19 @@ namespace Capacitor.Cli.Daemon.Services;
 /// unstoppable — a genuine deadlock, not a style preference. See the mutation check pinned in
 /// <c>AntigravityRuntimeLifecycleTests</c> for the reproduction.</para>
 ///
+/// <para><b>(e) <see cref="WaitForConversationIdAsync"/> is not optional for a factory that binds a
+/// transcript.</b> <see cref="AcpSessionId"/> reads <c>""</c> until turn 1's <c>init</c> resolves it, and
+/// nothing else in this class's public surface forces that ordering: <see cref="SendUserInputAsync"/>
+/// returns as soon as the turn is enqueued — before the worker even dequeues it —
+/// <see cref="SendUserInputAndWaitForWriteAsync"/> resolves at SPAWN, still before any line is read, and
+/// <see cref="WaitForTurnIdleAsync"/> is NOT a substitute (its enqueue→gate hand-off is itself
+/// asynchronous, so it can observe a momentarily-free gate and return before the turn has even started).
+/// A factory that sends the initial prompt and immediately hands this runtime to the orchestrator — which
+/// reads <see cref="AcpSessionId"/> unconditionally and synchronously the moment a launch returns — WILL
+/// bind the transcript to <c>""</c>: a silent, permanent correlation break, not a flaky race. <b>Any
+/// factory for this runtime MUST <see langword="await"/> <see cref="WaitForConversationIdAsync"/> after
+/// sending the initial prompt and BEFORE returning control to the orchestrator.</b></para>
+///
 /// <para><b>Not this class's job (yet).</b> No ACP-style reconnect/resume — a dead turn child is either a
 /// clean end-of-turn (→ <see cref="RuntimePhase.Idle"/>) or a lost reviewer (→ <see cref="RuntimePhase.Terminal"/>),
 /// never something to resume mid-turn. No terminal capability (<see cref="EmitsTerminalOutput"/> is
@@ -108,6 +121,12 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// <summary>Completed exactly once, on entry to <see cref="RuntimePhase.Terminal"/> — see the class
     /// doc's rule (c). <see cref="ReadOutputAsync"/> parks on this and nothing else.</summary>
     readonly TaskCompletionSource _terminalTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Completed once <see cref="_conversationId"/> is first resolved (turn 1's <c>init</c>), or
+    /// faulted on entry to <see cref="RuntimePhase.Terminal"/> if that never happens (e.g. turn 1's spawn
+    /// itself failed) — see rule (e) and <see cref="WaitForConversationIdAsync"/>. <c>TrySet*</c> on both
+    /// sides means whichever happens first wins and the other is a harmless no-op.</summary>
+    readonly TaskCompletionSource _conversationIdResolved = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     /// <summary>Cancelled by <see cref="TerminateAsync"/>/<see cref="DisposeAsync"/> — see the class
     /// doc's rule (d). Linked into every in-flight turn's spawn/read tokens, so cancelling this ONE
@@ -162,15 +181,32 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// this runtime's own conversation-id-stability test: a LATER
     /// turn reporting a different id would mean this runtime silently forked the reviewer's history,
     /// which is treated as an unrecoverable protocol violation (→ <see cref="RuntimePhase.Terminal"/>),
-    /// never silently accepted.</summary>
-    string? _conversationId;
+    /// never silently accepted.
+    ///
+    /// <para>Written only from the single turn worker (inside <see cref="HandleInit"/>), but read
+    /// cross-thread from <see cref="AcpSessionId"/> — declared <see langword="volatile"/> for the same
+    /// reason <see cref="_current"/> is, so a reader on another thread is guaranteed to see the write
+    /// rather than a stale value (a plain field gives no such guarantee, e.g. on arm64). The primary
+    /// ordering guarantee for a factory is still <see cref="WaitForConversationIdAsync"/> (rule (e)) —
+    /// this is the belt-and-braces fix for every OTHER read of <see cref="AcpSessionId"/>/<see cref="Cwd"/>
+    /// that isn't preceded by that barrier.</para>
+    /// </summary>
+    volatile string? _conversationId;
 
-    string? _cwd;
-    bool    _sessionStartedEmitted;
-    int     _disposed;
+    /// <summary>See <see cref="_conversationId"/>'s remarks — same cross-thread visibility reasoning.</summary>
+    volatile string? _cwd;
+
+    /// <summary>Written and read only inside <see cref="HandleInit"/>, which always runs on the single
+    /// turn worker — not read cross-thread today, but declared <see langword="volatile"/> alongside its
+    /// siblings above so that stays true even if a future change adds a cross-thread reader.</summary>
+    volatile bool _sessionStartedEmitted;
+
+    int _disposed;
 
     readonly Channel<AcpEventEnvelope> _transcript;
     readonly Channel<PendingTurn>      _pendingTurns;
+    readonly int                       _pendingTurnsCapacity;
+    int                                _droppedPendingTurns;
 
     Task _turnWorkerTask = Task.CompletedTask;
 
@@ -188,26 +224,28 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             int?                                                           transcriptCapacity = null,
             int?                                                           pendingTurnsCapacity = null
         ) {
-        _spawnTurn      = spawnTurn;
-        _logger         = logger;
-        _agentId        = agentId;
-        _model          = model;
-        _cwd            = cwd;
-        _launchDeadline = launchDeadline;
-        _turnDeadline   = turnDeadline;
+        _spawnTurn            = spawnTurn;
+        _logger               = logger;
+        _agentId              = agentId;
+        _model                = model;
+        _cwd                  = cwd;
+        _launchDeadline       = launchDeadline;
+        _turnDeadline         = turnDeadline;
+        _pendingTurnsCapacity = pendingTurnsCapacity ?? DefaultPendingTurnsCapacity;
 
-        // DropOldest: this runtime is the sole writer (the turn worker), so unlike AcpHostedAgentRuntime
-        // there is no concurrent writer to reason about — a stalled forwarder just loses trailing
-        // transcript rather than ever blocking the worker.
+        // DropOldest: the turn worker is the only writer that matters for ordering, but
+        // SingleWriter=false — EnterTerminal's TryComplete() can run concurrently with an in-flight
+        // TryWrite from the worker thread (a Terminate racing the tail end of a turn), which is outside
+        // the SingleWriter contract even though only one thread ever calls TryWrite itself.
         _transcript = Channel.CreateBounded<AcpEventEnvelope>(
             new BoundedChannelOptions(transcriptCapacity ?? DefaultTranscriptCapacity)
-                { SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.DropOldest });
+                { SingleReader = true, SingleWriter = false, FullMode = BoundedChannelFullMode.DropOldest });
 
         // NOT SingleReader: EnterTerminal's drain (rule below) and the worker's own dequeue loop can
         // both call TryRead around a Terminate race, so this channel must tolerate two readers even
         // though exactly one of them ever "wins" any given item.
         _pendingTurns = Channel.CreateBounded<PendingTurn>(
-            new BoundedChannelOptions(pendingTurnsCapacity ?? DefaultPendingTurnsCapacity)
+            new BoundedChannelOptions(_pendingTurnsCapacity)
                 { SingleReader = false, SingleWriter = false, FullMode = BoundedChannelFullMode.DropWrite });
 
         _turnWorkerTask = RunTurnWorkerAsync();
@@ -258,19 +296,37 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
     /// <summary>Acquire-then-IMMEDIATELY-release: queues behind an in-flight turn and returns once it's
     /// done, but never itself holds <see cref="_turnGate"/> — see the class doc's rule (d), which is the
-    /// exact property <see cref="TerminateAsync"/> also depends on.</summary>
+    /// exact property <see cref="TerminateAsync"/> also depends on.
+    ///
+    /// <para><b>NOT a "has this turn started" barrier.</b> The enqueue→gate hand-off is itself
+    /// asynchronous (the worker has to wake up from its own await and actually acquire the gate), so a
+    /// caller that enqueues a turn and immediately awaits this can observe a momentarily-free gate and
+    /// return before that turn has even started — see rule (e) and
+    /// <see cref="WaitForConversationIdAsync"/> for the barrier that doesn't have this gap.</para>
+    /// </summary>
     public async Task WaitForTurnIdleAsync(CancellationToken ct) {
         await _turnGate.WaitAsync(ct).ConfigureAwait(false);
         _turnGate.Release();
     }
 
     /// <summary>
+    /// Rule (e) — see the class doc. Completes once <see cref="AcpSessionId"/> has been resolved from
+    /// turn 1's <c>init</c> event, or faults if the runtime reaches <see cref="RuntimePhase.Terminal"/>
+    /// first (e.g. turn 1's spawn itself failed) — so a caller can never hang on a conversation id that
+    /// will never arrive. <b>Any factory for this runtime must await this after sending the initial
+    /// prompt and before returning control to the orchestrator</b>, which reads
+    /// <see cref="AcpSessionId"/> unconditionally and synchronously the moment a launch returns.
+    /// </summary>
+    public Task WaitForConversationIdAsync(CancellationToken ct) => _conversationIdResolved.Task.WaitAsync(ct);
+
+    /// <summary>
     /// Enqueues the turn and returns immediately — never blocks on, or observes, the turn's
-    /// completion. A dropped enqueue (the runtime is already <see cref="RuntimePhase.Terminal"/>, or the
-    /// pending-turns queue is at capacity) never throws when no acknowledgement was requested: the
-    /// channel's own atomicity (<see cref="ChannelWriter{T}.TryWrite"/> against a completed or full
-    /// bounded channel) is what makes "terminal" and "full" collapse into the same silent-drop path
-    /// without a separate check-then-act race.
+    /// completion. A dropped enqueue never throws when no acknowledgement was requested: the channel's
+    /// own atomicity (<see cref="ChannelWriter{T}.TryWrite"/> against a completed or full bounded
+    /// channel) is what makes "terminal" and "full" collapse into one non-racy check, but the two are
+    /// still logged (and faulted, for an acknowledging caller) distinctly below — a full queue is an
+    /// operational signal worth a warning and a running count, matching
+    /// <c>AcpHostedAgentRuntime.EnqueueTurn</c>'s same distinction for its own pending-turns queue.
     /// </summary>
     Task EnqueueTurn(string text, bool acknowledgeWrite) {
         var written = acknowledgeWrite
@@ -278,10 +334,20 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             : null;
 
         if (!_pendingTurns.Writer.TryWrite(new PendingTurn(text, written))) {
-            _logger.LogDebug(
-                "Antigravity: dropped a prompt turn — the runtime is terminal or its pending-turns queue is full.");
-            written?.TrySetException(new InvalidOperationException(
-                "Antigravity runtime dropped this input — it is terminal, or its pending-turns queue is full."));
+            if (Phase == RuntimePhase.Terminal) {
+                _logger.LogDebug("Antigravity: dropped a prompt turn — the runtime is terminal.");
+                written?.TrySetException(new InvalidOperationException(
+                    "Antigravity runtime is terminal; this input was dropped."));
+            } else {
+                // The only other reason TryWrite can fail on this bounded, not-yet-completed channel.
+                var dropped = Interlocked.Increment(ref _droppedPendingTurns);
+                _logger.LogWarning(
+                    "Antigravity: pending-turns queue full (capacity={Capacity}) — dropping this input; "
+                  + "{DroppedCount} dropped this session so far (the turn worker is likely stuck on a "
+                  + "stalled turn).", _pendingTurnsCapacity, dropped);
+                written?.TrySetException(new InvalidOperationException(
+                    "Antigravity pending-turns queue is full; this input was dropped."));
+            }
         }
 
         return written?.Task ?? Task.CompletedTask;
@@ -353,122 +419,173 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// throws: every failure path reports through <paramref name="turn"/>'s ack and/or
     /// <see cref="EnterTerminal"/> instead, so <see cref="RunTurnWorkerAsync"/>'s loop never sees an
     /// unexpected exception from a turn that merely failed (as opposed to the worker itself faulting).
+    /// The spawned process is disposed on EVERY exit path (the outer <c>finally</c>) — every round of a
+    /// review would otherwise leak that turn's pipes/handles.
     /// </summary>
     async Task ProcessTurnAsync(PendingTurn turn, bool firstTurn, CancellationToken ownerCt) {
-        IAgyTurnProcess process;
-
-        using (var spawnCts = CancellationTokenSource.CreateLinkedTokenSource(ownerCt)) {
-            if (firstTurn && _launchDeadline is { } launchDeadline)
-                spawnCts.CancelAfter(launchDeadline);
-
-            try {
-                process = await _spawnTurn(turn.Text, _conversationId, spawnCts.Token).ConfigureAwait(false);
-            } catch (OperationCanceledException) when (ownerCt.IsCancellationRequested) {
-                // Stop/dispose raced the spawn — EnterTerminal was already called by TerminateAsync.
-                turn.Written?.TrySetException(new InvalidOperationException(
-                    "Antigravity runtime stopped before this turn's process spawned."));
-                return;
-            } catch (OperationCanceledException) {
-                // Only the launch deadline could cancel spawnCts without ownerCt also being cancelled.
-                turn.Written?.TrySetException(new TimeoutException(
-                    "Antigravity: turn 1's process did not spawn within the launch deadline."));
-                _logger.LogWarning("Antigravity: turn 1 spawn exceeded the launch deadline; entering Terminal.");
-                EnterTerminal(exitCode: 1);
-                return;
-            } catch (Exception ex) {
-                // Spawn failure or auth failure, surfaced by the injected spawner as a thrown exception.
-                turn.Written?.TrySetException(ex);
-                _logger.LogWarning(ex, "Antigravity: turn process failed to spawn; entering Terminal.");
-                EnterTerminal(exitCode: 1);
-                return;
-            }
-        }
-
-        turn.Written?.TrySetResult();
-        _current = process;
-
-        var accumulator        = new AntigravityStepAccumulator();
-        var sawTerminalResult  = false;
-        var conversationChanged = false;
-        string? resultStatus   = null;
-
-        using var turnCts = CancellationTokenSource.CreateLinkedTokenSource(ownerCt);
-        if (_turnDeadline is { } turnDeadline) turnCts.CancelAfter(turnDeadline);
+        var process = await SpawnTurnProcessAsync(turn, firstTurn, ownerCt).ConfigureAwait(false);
+        if (process is null) return; // spawn failed/cancelled — SpawnTurnProcessAsync already handled it.
 
         try {
-            await foreach (var line in process.ReadLinesAsync(turnCts.Token).ConfigureAwait(false)) {
-                var evt = AntigravityNdjson.TryParseLine(line);
-                if (evt is null) continue;
+            // Publish _current and check for an already-Terminal runtime as ONE atomic operation under
+            // _stateLock — the SAME lock TerminateAsync captures _current under. This closes a real
+            // orphan-child race: TerminateAsync's capture and this publish can interleave in either
+            // order around the spawn call above, and whichever one acquires _stateLock SECOND sees the
+            // other's effect and takes responsibility for the child — so exactly one of the two ever
+            // terminates it, never zero. (If TerminateAsync's capture logic instead ran outside a lock
+            // shared with this publish, the capture could read null — this turn's process not yet
+            // published — while this method's later cancellation-observation also finds ownerCt already
+            // cancelled and does nothing, and the child would never be reaped by either side.)
+            bool alreadyTerminal;
+            lock (_stateLock) {
+                alreadyTerminal = Phase == RuntimePhase.Terminal;
+                if (!alreadyTerminal) _current = process;
+            }
 
-                switch (evt.Kind) {
-                    case AntigravityEventKind.Init:
-                        if (!HandleInit(evt)) conversationChanged = true;
-                        break;
-
-                    case AntigravityEventKind.StepUpdate:
-                        accumulator.Add(evt);
-                        foreach (var env in accumulator.Flush(_model)) EmitEnvelope(env);
-                        break;
-
-                    case AntigravityEventKind.Result:
-                        // Never translated to an envelope (session_ended is the server's to own) —
-                        // only read here to drive this runtime's own logical-terminal state.
-                        sawTerminalResult = true;
-                        resultStatus      = evt.Status;
-                        break;
+            if (alreadyTerminal) {
+                // The spawn itself succeeded (the prompt WAS delivered — agy -p's argument list IS the
+                // write), so the ack reflects that; the runtime going terminal is what stops this turn
+                // from being tracked/continued, not a failure to deliver.
+                turn.Written?.TrySetResult();
+                try {
+                    await process.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                } catch (Exception ex) {
+                    _logger.LogDebug(ex, "Antigravity: failed to terminate a turn orphaned by a concurrent Terminate.");
                 }
-
-                if (conversationChanged) break; // stop reading — this turn's outcome is already decided.
+                return;
             }
-        } catch (OperationCanceledException) {
-            // Distinguished below via ownerCt/turnCts — both are legitimate reasons this can throw.
+
+            turn.Written?.TrySetResult();
+
+            var accumulator         = new AntigravityStepAccumulator();
+            var sawTerminalResult   = false;
+            var conversationChanged = false;
+            string? resultStatus    = null;
+
+            using var turnCts = CancellationTokenSource.CreateLinkedTokenSource(ownerCt);
+            if (_turnDeadline is { } turnDeadline) turnCts.CancelAfter(turnDeadline);
+
+            try {
+                await foreach (var line in process.ReadLinesAsync(turnCts.Token).ConfigureAwait(false)) {
+                    var evt = AntigravityNdjson.TryParseLine(line);
+                    if (evt is null) continue;
+
+                    switch (evt.Kind) {
+                        case AntigravityEventKind.Init:
+                            if (!HandleInit(evt)) conversationChanged = true;
+                            break;
+
+                        case AntigravityEventKind.StepUpdate:
+                            accumulator.Add(evt);
+                            foreach (var env in accumulator.Flush(_model)) EmitEnvelope(env);
+                            break;
+
+                        case AntigravityEventKind.Result:
+                            // Never translated to an envelope (session_ended is the server's to own) —
+                            // only read here to drive this runtime's own logical-terminal state.
+                            sawTerminalResult = true;
+                            resultStatus      = evt.Status;
+                            break;
+                    }
+
+                    if (conversationChanged) break; // stop reading — this turn's outcome is already decided.
+                }
+            } catch (OperationCanceledException) {
+                // Distinguished below via ownerCt/turnCts — both are legitimate reasons this can throw.
+            } finally {
+                _current = null;
+            }
+
+            if (ownerCt.IsCancellationRequested) return; // stop/dispose — Terminal already entered by TerminateAsync.
+
+            if (conversationChanged) {
+                // A changed conversation id means this runtime silently forked the reviewer's history —
+                // an unrecoverable protocol violation, reaped the same way a blown deadline is: kill the
+                // child THEN go Terminal, never leave an orphaned process behind.
+                try {
+                    await process.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                } catch (Exception ex) {
+                    _logger.LogDebug(ex, "Antigravity: failed to terminate a turn after a conversation-id mismatch.");
+                }
+                EnterTerminal(exitCode: 1);
+                return;
+            }
+
+            if (turnCts.IsCancellationRequested) {
+                // The per-turn deadline fired, not an owner cancel — reap this turn's child and go Terminal.
+                try {
+                    await process.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                } catch (Exception ex) {
+                    _logger.LogDebug(ex, "Antigravity: failed to terminate a turn that exceeded its deadline.");
+                }
+                _logger.LogWarning("Antigravity: turn exceeded its per-turn deadline; entering Terminal.");
+                EnterTerminal(exitCode: 1);
+                return;
+            }
+
+            // Normal EOF — give the OS a short, bounded grace period to confirm the exit, then trust EOF
+            // regardless: a process whose stdout closed is done producing transcript either way.
+            await process.WaitForExitAsync(ExitConfirmationGrace).ConfigureAwait(false);
+
+            if (!sawTerminalResult) {
+                // Rule (a)'s load-bearing case: EOF without a terminal `result` means the reviewer died
+                // mid-turn. Terminal, never Idle — going Idle here would park ReadOutputAsync forever.
+                EnterTerminal(exitCode: process.ExitCode is { } code and not 0 ? code : 1);
+                return;
+            }
+
+            var success = string.Equals(resultStatus, "SUCCESS", StringComparison.OrdinalIgnoreCase);
+
+            // Not yet Terminal — this only records what Terminal WOULD report if entered right now (see
+            // _terminalExitCode's remarks). RunTurnWorkerAsync flips the phase itself, back in its caller.
+            lock (_stateLock) _terminalExitCode = success ? 0 : 1;
         } finally {
-            _current = null;
-        }
-
-        if (ownerCt.IsCancellationRequested) return; // stop/dispose — Terminal already entered by TerminateAsync.
-
-        if (conversationChanged) {
-            // A changed conversation id means this runtime silently forked the reviewer's history —
-            // an unrecoverable protocol violation, reaped the same way a blown deadline is: kill the
-            // child THEN go Terminal, never leave an orphaned process behind.
+            // Every exit path above — clean success, conversation-id mismatch, deadline, EOF-without-
+            // result, the already-Terminal race, even ownerCt cancellation — lands here. A turn's
+            // process is never reused, so it is always disposed exactly once, right here, regardless of
+            // how the turn ended.
             try {
-                await process.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                await process.DisposeAsync().ConfigureAwait(false);
             } catch (Exception ex) {
-                _logger.LogDebug(ex, "Antigravity: failed to terminate a turn after a conversation-id mismatch.");
+                _logger.LogDebug(ex, "Antigravity: failed to dispose a turn's process.");
             }
+        }
+    }
+
+    /// <summary>
+    /// Spawns ONE turn's process (bounded by <see cref="_launchDeadline"/> for turn 1 only). Returns
+    /// <see langword="null"/> on any failure — spawn/auth failure, the launch deadline, or an owner
+    /// cancel racing the spawn — having already reported it through <paramref name="turn"/>'s ack and,
+    /// where it means the runtime cannot continue, <see cref="EnterTerminal"/>. Extracted from
+    /// <see cref="ProcessTurnAsync"/> so the caller's <c>try/finally</c> only ever has to dispose a
+    /// process that actually exists.
+    /// </summary>
+    async Task<IAgyTurnProcess?> SpawnTurnProcessAsync(PendingTurn turn, bool firstTurn, CancellationToken ownerCt) {
+        using var spawnCts = CancellationTokenSource.CreateLinkedTokenSource(ownerCt);
+        if (firstTurn && _launchDeadline is { } launchDeadline)
+            spawnCts.CancelAfter(launchDeadline);
+
+        try {
+            return await _spawnTurn(turn.Text, _conversationId, spawnCts.Token).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (ownerCt.IsCancellationRequested) {
+            // Stop/dispose raced the spawn — EnterTerminal was already called by TerminateAsync.
+            turn.Written?.TrySetException(new InvalidOperationException(
+                "Antigravity runtime stopped before this turn's process spawned."));
+            return null;
+        } catch (OperationCanceledException) {
+            // Only the launch deadline could cancel spawnCts without ownerCt also being cancelled.
+            turn.Written?.TrySetException(new TimeoutException(
+                "Antigravity: turn 1's process did not spawn within the launch deadline."));
+            _logger.LogWarning("Antigravity: turn 1 spawn exceeded the launch deadline; entering Terminal.");
             EnterTerminal(exitCode: 1);
-            return;
-        }
-
-        if (turnCts.IsCancellationRequested) {
-            // The per-turn deadline fired, not an owner cancel — reap this turn's child and go Terminal.
-            try {
-                await process.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-            } catch (Exception ex) {
-                _logger.LogDebug(ex, "Antigravity: failed to terminate a turn that exceeded its deadline.");
-            }
-            _logger.LogWarning("Antigravity: turn exceeded its per-turn deadline; entering Terminal.");
+            return null;
+        } catch (Exception ex) {
+            // Spawn failure or auth failure, surfaced by the injected spawner as a thrown exception.
+            turn.Written?.TrySetException(ex);
+            _logger.LogWarning(ex, "Antigravity: turn process failed to spawn; entering Terminal.");
             EnterTerminal(exitCode: 1);
-            return;
+            return null;
         }
-
-        // Normal EOF — give the OS a short, bounded grace period to confirm the exit, then trust EOF
-        // regardless: a process whose stdout closed is done producing transcript either way.
-        await process.WaitForExitAsync(ExitConfirmationGrace).ConfigureAwait(false);
-
-        if (!sawTerminalResult) {
-            // Rule (a)'s load-bearing case: EOF without a terminal `result` means the reviewer died
-            // mid-turn. Terminal, never Idle — going Idle here would park ReadOutputAsync forever.
-            EnterTerminal(exitCode: process.ExitCode is { } code and not 0 ? code : 1);
-            return;
-        }
-
-        var success = string.Equals(resultStatus, "SUCCESS", StringComparison.OrdinalIgnoreCase);
-
-        // Not yet Terminal — this only records what Terminal WOULD report if entered right now (see
-        // _terminalExitCode's remarks). RunTurnWorkerAsync flips the phase itself, back in its caller.
-        lock (_stateLock) _terminalExitCode = success ? 0 : 1;
     }
 
     /// <summary>Emits <c>session_started</c> at most once (turn 1's <c>init</c> only — a later turn's own
@@ -482,6 +599,10 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         if (evt.ConversationId is { Length: > 0 } cid) {
             if (_conversationId is null) {
                 _conversationId = cid;
+
+                // Rule (e): the ONE place this ever completes successfully — unblocks any factory
+                // awaiting WaitForConversationIdAsync before it reads AcpSessionId.
+                _conversationIdResolved.TrySetResult();
             } else if (!string.Equals(_conversationId, cid, StringComparison.Ordinal)) {
                 _logger.LogError(
                     "Antigravity: conversation id changed from {Old} to {New} mid-session (agentId={AgentId}); entering Terminal.",
@@ -509,9 +630,10 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// Enters <see cref="RuntimePhase.Terminal"/>, idempotently: the phase check-and-flip happens under
     /// <see cref="_stateLock"/> (reentrant-safe — <see cref="TerminateAsync"/> calls this from inside its
     /// own already-held <see cref="_stateLock"/> section, which C#'s <see langword="lock"/> permits on the
-    /// same thread), and every other effect — completing <see cref="_terminalTcs"/>, draining
-    /// <see cref="_pendingTurns"/>, completing <see cref="_transcript"/> — runs exactly once, only for the
-    /// caller that actually performed the transition.
+    /// same thread), and every other effect — completing <see cref="_terminalTcs"/>, faulting
+    /// <see cref="_conversationIdResolved"/> (rule (e); a no-op if it already resolved successfully),
+    /// draining <see cref="_pendingTurns"/>, completing <see cref="_transcript"/> — runs exactly once,
+    /// only for the caller that actually performed the transition.
     ///
     /// <para>The pending-turns drain exists because a turn already sitting in the channel when Terminal
     /// is entered would otherwise never be observed: once <see cref="TerminateAsync"/> cancels
@@ -531,6 +653,11 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         }
 
         _terminalTcs.TrySetResult();
+
+        // Rule (e): unblock a factory parked in WaitForConversationIdAsync when a conversation id is
+        // never going to arrive (e.g. turn 1's spawn itself failed) — never hang that caller forever.
+        _conversationIdResolved.TrySetException(new InvalidOperationException(
+            "Antigravity runtime went terminal before establishing a conversation id."));
 
         _pendingTurns.Writer.TryComplete();
         while (_pendingTurns.Reader.TryRead(out var dropped))

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -189,6 +189,33 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     readonly string  _agentId;
     readonly string? _model;
 
+    /// <summary>
+    /// Best-effort teardown callback, invoked exactly once at the very END of <see cref="DisposeAsync"/>
+    /// — after the turn worker is joined and this runtime's last process handle is disposed, which is
+    /// the only point at which "no agy child of ours is still writing" is a fact rather than a hope.
+    /// The factory uses it to remove the per-launch <c>HOME</c>, whose content is the reviewer's own
+    /// conversation JSONL (the caller's diff, source excerpts and findings) — disposal, not disk
+    /// hygiene, and not something the daemon-epoch sweep should be left to do at the next boot.
+    /// Never throws: a home we cannot delete must not turn a completed review into a failed dispose.
+    /// </summary>
+    readonly Action? _onDisposed;
+
+    /// <summary>
+    /// Liveness-supervision: the per-launch activity clock, assigned by the factory BEFORE the first
+    /// turn is enqueued. Every stamp below is a no-op guard rather than a throw, so a direct
+    /// construction (tests, a caller that does not care about liveness) keeps working — which is
+    /// exactly why a clock assigned LATE is dangerous: it fails silently, leaving the launch's whole
+    /// stamp sequence written against nothing.
+    ///
+    /// <para><b>The exec-per-turn shape makes <see cref="AgentActivityClock.TurnInFlight"/> the
+    /// load-bearing one.</b> <c>AgentOrchestrator.FindReviewersToReap</c> lets a held turn suppress
+    /// the plain idle rule OUTRIGHT, so a flag stuck <see langword="true"/> produces a reviewer that
+    /// is never idle-reaped — and between turns this runtime has no process at all, so nothing
+    /// external would ever contradict it. It is therefore cleared in a <c>finally</c> around the whole
+    /// turn AND on entry to <see cref="RuntimePhase.Terminal"/>.</para>
+    /// </summary>
+    internal AgentActivityClock? ActivityClock { get; set; }
+
     /// <summary>The ACP-equivalent conversation id — resolved from turn 1's <c>init</c> event and never
     /// changed again. See <see cref="AcpSessionId"/> and
     /// this runtime's own conversation-id-stability test: a LATER
@@ -235,7 +262,8 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             TimeSpan?                                                      launchDeadline = null,
             TimeSpan?                                                      turnDeadline = null,
             int?                                                           transcriptCapacity = null,
-            int?                                                           pendingTurnsCapacity = null
+            int?                                                           pendingTurnsCapacity = null,
+            Action?                                                        onDisposed = null
         ) {
         _spawnTurn            = spawnTurn;
         _logger               = logger;
@@ -245,6 +273,7 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         _launchDeadline       = launchDeadline;
         _turnDeadline         = turnDeadline;
         _pendingTurnsCapacity = pendingTurnsCapacity ?? DefaultPendingTurnsCapacity;
+        _onDisposed           = onDisposed;
 
         // DropOldest: the turn worker is the only writer that matters for ordering, but
         // SingleWriter=false — EnterTerminal's TryComplete() can run concurrently with an in-flight
@@ -399,6 +428,13 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                     }
 
                     await _turnGate.WaitAsync(ownerCt).ConfigureAwait(false);
+
+                    // The turn is in flight from here — set BEFORE the spawn, because a turn whose
+                    // process is still being created is legitimately not idle. The finally is what
+                    // makes the pair exact: a faulted, deadlined or cancelled turn must never leave
+                    // the flag held, since a held turn suppresses the reaper's idle rule outright.
+                    ActivityClock?.SetTurnInFlight(true);
+
                     try {
                         await ProcessTurnAsync(turn, firstTurn, ownerCt).ConfigureAwait(false);
 
@@ -409,6 +445,10 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                                 Volatile.Write(ref _phase, (int)RuntimePhase.Idle);
                         }
                     } finally {
+                        // Also before the release, for the same reason the phase settles first: a
+                        // WaitForTurnIdleAsync caller that returns must observe a fully-settled agent,
+                        // never one that still claims a turn.
+                        ActivityClock?.SetTurnInFlight(false);
                         _turnGate.Release();
                     }
 
@@ -438,6 +478,12 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     async Task ProcessTurnAsync(PendingTurn turn, bool firstTurn, CancellationToken ownerCt) {
         var process = await SpawnTurnProcessAsync(turn, firstTurn, ownerCt).ConfigureAwait(false);
         if (process is null) return; // spawn failed/cancelled — SpawnTurnProcessAsync already handled it.
+
+        // The first of two launch-handshake stamps (the second is `session_created`, when this turn's
+        // `init` resolves the conversation id). Turn 1 only: LaunchStage is Starting-only and the
+        // orchestrator clears it the instant the agent reaches Running, so a later turn re-stamping it
+        // would resurrect a stage on an already-running agent.
+        if (firstTurn) ActivityClock?.SetLaunchStage("spawned");
 
         try {
             // Publish _current and check for an already-Terminal runtime as ONE atomic operation under
@@ -625,6 +671,11 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 // Rule (e): the ONE place this ever completes successfully — unblocks any factory
                 // awaiting WaitForConversationIdAsync before it reads AcpSessionId.
                 _conversationIdResolved.TrySetResult();
+
+                // The handshake's second and last stamp — this is the moment the runtime has a
+                // conversation, the exec-per-turn analogue of an ACP `session/new` returning. Guarded
+                // by the same "id was null" branch, so it can fire at most once per runtime.
+                ActivityClock?.SetLaunchStage("session_created");
             } else if (!string.Equals(_conversationId, cid, StringComparison.Ordinal)) {
                 _logger.LogError(
                     "Antigravity: conversation id changed from {Old} to {New} mid-session (agentId={AgentId}); entering Terminal.",
@@ -644,6 +695,14 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     }
 
     void EmitEnvelope(AcpEventEnvelope env) {
+        // Advance BEFORE the channel write, never after: a reader blocked on Envelopes.ReadAsync can
+        // wake the instant TryWrite makes the item visible, on another thread, with no ordering
+        // relationship to what this one does next — so the reverse order is a race a fast reader wins,
+        // observing an envelope whose activity the clock has not yet recorded. Same reasoning
+        // AcpHostedAgentRuntime.EmitEnvelope documents. Advanced even on the dropped-because-completed
+        // path below: the content was genuinely produced.
+        ActivityClock?.Advance();
+
         if (!_transcript.Writer.TryWrite(env))
             _logger.LogDebug("Antigravity: dropped a transcript envelope — the transcript channel is already completed.");
     }
@@ -675,6 +734,13 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         }
 
         _terminalTcs.TrySetResult();
+
+        // Terminal is absorbing and no turn can run past it, so the reaper must never see a held turn
+        // from here on. The turn worker's own finally clears this too — but it does so only once the
+        // in-flight turn actually unwinds, which is AFTER TerminateAsync returns to its caller (and
+        // never at all, if a turn's process ignores cancellation). Clearing here is what makes "the
+        // runtime is stopped" and "the reviewer holds no turn" the same instant.
+        ActivityClock?.SetTurnInFlight(false);
 
         // Rule (e): unblock a factory parked in WaitForConversationIdAsync when a conversation id is
         // never going to arrive (e.g. turn 1's spawn itself failed) — never hang that caller forever.
@@ -810,5 +876,13 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
         _ownerCts.Dispose();
         _turnGate.Dispose();
+
+        // LAST, and only here: the turn worker is joined and this runtime holds no process handle, so
+        // nothing of ours can still be writing into whatever the callback is about to remove.
+        try {
+            _onDisposed?.Invoke();
+        } catch (Exception ex) {
+            _logger.LogWarning(ex, "Antigravity: the runtime's disposal callback failed (agentId={AgentId}).", _agentId);
+        }
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -211,6 +211,13 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// meaningful timeout a caller would ever want to tune.</summary>
     static readonly TimeSpan ExitConfirmationGrace = TimeSpan.FromSeconds(5);
 
+    /// <summary>How long a turn's teardown waits for a child it had to KILL — one that outlived both
+    /// its own stdout and <see cref="ExitConfirmationGrace"/> — before giving up and reporting the exit
+    /// unconfirmed. Deliberately shorter than <see cref="DisposeAsync"/>'s 5s turn-worker join budget:
+    /// this wait happens inside the worker, so a longer one could push a worker that was about to join
+    /// past that budget and produce the very "could not confirm" outcome it exists to avoid.</summary>
+    static readonly TimeSpan TurnExitForceGrace = TimeSpan.FromSeconds(2);
+
     readonly ILogger _logger;
     readonly string  _agentId;
     readonly string? _model;
@@ -232,6 +239,11 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// of that process handle, because a disposed process object reports
     /// <see cref="IAgyTurnProcess.HasExited"/> <see langword="true"/> and asking afterwards would
     /// mistake "no longer observable" for "confirmed exited".
+    ///
+    /// <para>Read AFTER that <c>finally</c> has terminated a child still running at teardown, not
+    /// before: the disposal it is about to perform kills the tree anyway, so asking first reported
+    /// "unconfirmed" for children this runtime itself went on to kill — firing the fail-safe, and
+    /// stranding a reviewer HOME, far more often than the surviving-grandchild case it is for.</para>
     ///
     /// <para>Starts <see langword="true"/> — a runtime that never spawned a turn has no child to
     /// confirm — and is cleared the instant one exists. <see cref="DisposeAsync"/>'s cleanup gate is
@@ -702,9 +714,27 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // process is never reused, so it is always disposed exactly once, right here, regardless of
             // how the turn ended.
 
+            // SETTLE the child before asking about it. A child still running here is one this method
+            // is about to kill anyway — process.DisposeAsync() below kills the tree — so reading
+            // HasExited first answered a question this turn had not finished deciding, and reported
+            // "unconfirmed" for a child that then genuinely exited. That mattered twice below: a PID
+            // record left naming a dead process, and a transcript-bearing HOME left on disk for the
+            // next daemon-epoch sweep. Bounded well under DisposeAsync's own worker-join budget, so
+            // forcing the exit can never itself turn a joinable worker into an unjoined one.
+            if (!process.HasExited) {
+                try {
+                    await process.TerminateAsync(TurnExitForceGrace).ConfigureAwait(false);
+                } catch (Exception ex) {
+                    _logger.LogDebug(ex, "Antigravity: failed to reap a turn child that outlived its output.");
+                }
+            }
+
             // Asked BEFORE that disposal, which is the only point this is a truthful question: a
             // disposed process object reports HasExited true, so the same read afterwards would
-            // manufacture a confirmation. DisposeAsync's cleanup gate is the consumer.
+            // manufacture a confirmation. The terminate above only makes the answer more often YES; it
+            // can never make a survivor read as exited, so the fail-safe direction is unchanged — a
+            // child that ignores the kill still reports unconfirmed. DisposeAsync's cleanup gate is
+            // the consumer.
             _turnExitConfirmed = process.HasExited;
 
             // Cleared on CONFIRMED exit only, off that same single read: an unconfirmed survivor keeps

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -986,11 +986,14 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // Asked BEFORE the handle is disposed, for the same reason ProcessTurnAsync's own capture is:
         // a disposed process object reports HasExited true, so asking afterwards mistakes "no longer
         // observable" for "confirmed exited" — the opposite of what the gate below is for.
-        var inFlightConfirmed = _current is not { } inFlight || inFlight.HasExited;
+        // ONE read of the volatile field, not two: the second could observe a different value and
+        // judge a process this method never disposed.
+        var inFlight          = _current;
+        var inFlightConfirmed = inFlight is null || inFlight.HasExited;
 
-        if (_current is { } current) {
+        if (inFlight is not null) {
             try {
-                await current.DisposeAsync().ConfigureAwait(false);
+                await inFlight.DisposeAsync().ConfigureAwait(false);
             } catch {
                 // Best-effort.
             }

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -213,9 +213,19 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
     /// <summary>How long a turn's teardown waits for a child it had to KILL — one that outlived both
     /// its own stdout and <see cref="ExitConfirmationGrace"/> — before giving up and reporting the exit
-    /// unconfirmed. Deliberately shorter than <see cref="DisposeAsync"/>'s 5s turn-worker join budget:
-    /// this wait happens inside the worker, so a longer one could push a worker that was about to join
-    /// past that budget and produce the very "could not confirm" outcome it exists to avoid.</summary>
+    /// unconfirmed.
+    ///
+    /// <para>Kept short because this wait happens INSIDE the turn worker, and
+    /// <see cref="DisposeAsync"/> gives that worker a 5s join budget. Note what this does and does not
+    /// buy: it does <b>not</b> guarantee the join is met, since the worker may already have spent
+    /// arbitrary time in the turn before reaching teardown, and the budget is measured from
+    /// <see cref="DisposeAsync"/>'s call rather than from here. It only keeps this particular wait
+    /// from being the thing that blows it. A review caught the earlier phrasing of this comment
+    /// claiming the stronger guarantee, which was not true.</para>
+    ///
+    /// <para>Overshooting the join is not a correctness failure in any case — it degrades to the
+    /// unconfirmed path, which skips the HOME deletion and leaves the epoch sweep to collect it. That
+    /// is the direction this whole gate is built to fail in.</para></summary>
     static readonly TimeSpan TurnExitForceGrace = TimeSpan.FromSeconds(2);
 
     readonly ILogger _logger;

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -51,9 +51,10 @@ internal interface IAgyTurnDiagnostics {
 /// passes null, which resolves the real binary through <c>PATH</c>. A test pins it so the CONSENT
 /// half is assertable on a host that happens to have (or not have) <c>agy</c> installed — otherwise
 /// the tests pass for the wrong reason on one machine and fail on another.</param>
-/// <param name="resolveVersion">Test seam ONLY, for the minimum-version half of the gate. Production
-/// passes null, which spawns the configured binary to read its own reported version — the same
-/// resolver the affirmation-gated reviewers use.</param>
+/// <param name="resolveVersion">Test seam ONLY, for the installed-version half of the gate.
+/// Production passes null, which spawns the configured binary to read its own reported version — the
+/// same resolver every other gated reviewer uses. The MINIMUM it is compared against is never seamed:
+/// it is a real record on disk, so a test moves it by writing one.</param>
 /// <param name="posixHost">Test seam ONLY, for the platform half of the gate. Production passes null,
 /// which reads the ambient OS.
 ///
@@ -65,7 +66,7 @@ internal interface IAgyTurnDiagnostics {
 /// a dozen consent and version tests short-circuited to <c>UnsupportedPlatform</c> — failing for a
 /// reason that had nothing to do with what they asserted. Collapsing this factory's ladder onto that
 /// decision reintroduced the ambient read one layer up, and CI caught exactly two tests
-/// (binary-missing, below-floor) refusing on platform before reaching the arm under test. Taking the
+/// (binary-missing, below-minimum) refusing on platform before reaching the arm under test. Taking the
 /// platform as an argument makes every arm reachable from any host — including the Windows arm
 /// itself, which is otherwise unassertable on POSIX.</para></param>
 internal sealed partial class AntigravityHostedAgentRuntimeFactory(
@@ -113,7 +114,7 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// <summary>Why this daemon refuses an unattended Antigravity reviewer, or null when it does not.
     /// The ONE place the ladder is written — advertisement and the launch boundary both read it, so a
     /// vendor cannot be dropped from advertisement and thereby never reach the path that holds the
-    /// explanation, and the FLOOR cannot be enforced at only one of the two (an explicit
+    /// explanation, and the recorded MINIMUM cannot be enforced at only one of the two (an explicit
     /// <c>vendor: "antigravity"</c> request reaches a launch without consulting advertisement).
     ///
     /// <para>Every verdict and every text comes from <see cref="AntigravityReviewerCapability"/>; the
@@ -122,23 +123,26 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// than that its version could not be read.</para>
     ///
     /// <para>Deliberately not cached: a long-running daemon must re-judge a binary installed (or
-    /// removed) under it rather than read a startup snapshot.</para></summary>
+    /// removed) under it rather than read a startup snapshot — and, since the minimum is a record on
+    /// disk rather than configuration, an affirmation taken while this daemon runs is picked up on the
+    /// next decision.</para></summary>
     internal string? ReviewerRefusal() {
         var posixHost = _posixHost;
 
-        // Consent and platform decided WITHOUT a probe. Decide short-circuits both before it looks at
-        // a version, but C# evaluates its arguments first — so an inline probe here would spawn agy
-        // for a daemon that switched the reviewer off, which is exactly what the consent arm's
-        // short-circuit exists to prevent. A null version can only yield those two arms or
-        // VersionUnresolved, so anything else is already a refusal that needs no probe, and the
-        // ORDER between consent and platform stays owned by Decide rather than restated here.
+        // Consent and platform decided with NO probe and NO filesystem read. Decide short-circuits
+        // both before it looks at a version, but C# evaluates arguments first — so reading the record
+        // or probing agy inline here would do both for a daemon that switched the reviewer off, which
+        // is exactly what the consent arm's short-circuit exists to prevent. A null installed version
+        // can only yield those two arms or VersionUnresolved (the shared comparison checks the
+        // installed side first), so that verdict is precisely "consent and platform passed", and the
+        // ORDER between them stays owned by Decide rather than restated here.
         var beforeProbe = AntigravityReviewerCapability.Decide(
             posixHost, config.AntigravityUnattendedReviewerEnabled,
-            installedVersion: null, config.AntigravityMinimumCliVersion);
+            installedVersion: null, minimumVersion: null);
 
         if (beforeProbe != AntigravityReviewerDecision.VersionUnresolved)
             return AntigravityReviewerCapability.DenialReason(
-                beforeProbe, null, config.AntigravityMinimumCliVersion, config.AntigravityPath);
+                beforeProbe, null, null, config.AntigravityPath);
 
         if (!IsAvailable())
             return $"antigravity_reviewer_binary_missing: '{config.AntigravityPath}' does not resolve to "
@@ -148,16 +152,23 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         // ONCE: the verdict and its explanation both need the version, and resolving it per consumer
         // spawns the vendor binary twice to produce one refusal.
         var installed = _resolveVersion(config.AntigravityPath);
+        var minimum   = VersionStoreFor(config).Affirmed;
 
         var decision = AntigravityReviewerCapability.Decide(
-            posixHost, config.AntigravityUnattendedReviewerEnabled, installed,
-            config.AntigravityMinimumCliVersion);
+            posixHost, config.AntigravityUnattendedReviewerEnabled, installed, minimum);
 
         return decision == AntigravityReviewerDecision.Allowed
             ? null
             : AntigravityReviewerCapability.DenialReason(
-                decision, installed, config.AntigravityMinimumCliVersion, config.AntigravityPath);
+                decision, installed, minimum, config.AntigravityPath);
     }
+
+    /// <summary>The daemon-owned record of the oldest <c>agy</c> build this daemon will run — the same
+    /// shared store Kiro and Gemini use, keyed by vendor, under this daemon's own state root. Read
+    /// through here rather than constructed at each site so the seeding path in <c>DaemonRunner</c>,
+    /// the <c>affirm</c> verb and this gate cannot end up pointing at different files.</summary>
+    internal static ReviewerVersionStore VersionStoreFor(DaemonConfig config) =>
+        new(ReviewerStateDir(config), DaemonRunner.AntigravityVendor);
 
     public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
         // An interactive launch is refused rather than silently accepted. This runtime parses agy's

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -51,11 +51,15 @@ internal interface IAgyTurnDiagnostics {
 /// passes null, which resolves the real binary through <c>PATH</c>. A test pins it so the CONSENT
 /// half is assertable on a host that happens to have (or not have) <c>agy</c> installed — otherwise
 /// the tests pass for the wrong reason on one machine and fail on another.</param>
+/// <param name="resolveVersion">Test seam ONLY, for the minimum-version half of the gate. Production
+/// passes null, which spawns the configured binary to read its own reported version — the same
+/// resolver the affirmation-gated reviewers use.</param>
 internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         DaemonConfig                                                     config,
         ILoggerFactory                                                   loggerFactory,
         Func<ProcessStartInfo, CancellationToken, Task<IAgyTurnProcess>>? turnSource = null,
-        Func<string, bool>?                                              binaryExists = null
+        Func<string, bool>?                                              binaryExists = null,
+        Func<string, string?>?                                           resolveVersion = null
     ) : IHostedAgentRuntimeFactory {
     readonly ILogger _logger = loggerFactory.CreateLogger<AntigravityHostedAgentRuntimeFactory>();
 
@@ -64,6 +68,8 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
             new AgyTurnProcess(psi, loggerFactory.CreateLogger<AgyTurnProcess>())));
 
     readonly Func<string, bool> _binaryExists = binaryExists ?? CliResolver.Exists;
+
+    readonly Func<string, string?> _resolveVersion = resolveVersion ?? VendorVersionResolver.Resolve;
 
     /// <summary>The vendor token, never <c>agy</c>: the server routes on this exact string and the
     /// capture side already knows <c>antigravity</c>. <c>agy</c> is only ever a binary name.</summary>
@@ -90,26 +96,50 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// <summary>Why this daemon refuses an unattended Antigravity reviewer, or null when it does not.
     /// The ONE place the ladder is written — advertisement and the launch boundary both read it, so a
     /// vendor cannot be dropped from advertisement and thereby never reach the path that holds the
-    /// explanation.
+    /// explanation, and the FLOOR cannot be enforced at only one of the two (an explicit
+    /// <c>vendor: "antigravity"</c> request reaches a launch without consulting advertisement).
+    ///
+    /// <para>Every verdict and every text comes from <see cref="AntigravityReviewerCapability"/>; the
+    /// only arm written here is the one that decision cannot express — a binary that does not resolve
+    /// at all — placed BEFORE the probe so a daemon with no <c>agy</c> is told it is missing rather
+    /// than that its version could not be read.</para>
     ///
     /// <para>Deliberately not cached: a long-running daemon must re-judge a binary installed (or
     /// removed) under it rather than read a startup snapshot.</para></summary>
     internal string? ReviewerRefusal() {
-        if (!config.AntigravityUnattendedReviewerEnabled)
-            return "antigravity_unattended_reviewer_disabled: unattended Antigravity reviews are off on "
-                 + "this daemon. Set KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1 in the daemon's environment "
-                 + "to opt in.";
+        var posixHost = !OperatingSystem.IsWindows();
 
-        if (OperatingSystem.IsWindows())
-            return "antigravity_reviewer_unsupported_platform: the reviewer's per-launch home holds "
-                 + "review context and cannot be created owner-only on Windows.";
+        // Consent and platform decided WITHOUT a probe. Decide short-circuits both before it looks at
+        // a version, but C# evaluates its arguments first — so an inline probe here would spawn agy
+        // for a daemon that switched the reviewer off, which is exactly what the consent arm's
+        // short-circuit exists to prevent. A null version can only yield those two arms or
+        // VersionUnresolved, so anything else is already a refusal that needs no probe, and the
+        // ORDER between consent and platform stays owned by Decide rather than restated here.
+        var beforeProbe = AntigravityReviewerCapability.Decide(
+            posixHost, config.AntigravityUnattendedReviewerEnabled,
+            installedVersion: null, config.AntigravityMinimumCliVersion);
+
+        if (beforeProbe != AntigravityReviewerDecision.VersionUnresolved)
+            return AntigravityReviewerCapability.DenialReason(
+                beforeProbe, null, config.AntigravityMinimumCliVersion, config.AntigravityPath);
 
         if (!IsAvailable())
             return $"antigravity_reviewer_binary_missing: '{config.AntigravityPath}' does not resolve to "
                  + "an executable. Install the Antigravity CLI (the `agy` binary — the IDE alone is not "
                  + "enough), or set KCAP_ANTIGRAVITY_PATH to its location.";
 
-        return null;
+        // ONCE: the verdict and its explanation both need the version, and resolving it per consumer
+        // spawns the vendor binary twice to produce one refusal.
+        var installed = _resolveVersion(config.AntigravityPath);
+
+        var decision = AntigravityReviewerCapability.Decide(
+            posixHost, config.AntigravityUnattendedReviewerEnabled, installed,
+            config.AntigravityMinimumCliVersion);
+
+        return decision == AntigravityReviewerDecision.Allowed
+            ? null
+            : AntigravityReviewerCapability.DenialReason(
+                decision, installed, config.AntigravityMinimumCliVersion, config.AntigravityPath);
     }
 
     public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -54,12 +54,27 @@ internal interface IAgyTurnDiagnostics {
 /// <param name="resolveVersion">Test seam ONLY, for the minimum-version half of the gate. Production
 /// passes null, which spawns the configured binary to read its own reported version — the same
 /// resolver the affirmation-gated reviewers use.</param>
+/// <param name="posixHost">Test seam ONLY, for the platform half of the gate. Production passes null,
+/// which reads the ambient OS.
+///
+/// <para><b>This exists because reading the ambient OS here made two arms unreachable on one
+/// platform, and it is the second time this repository has paid for that.</b>
+/// <see cref="Acp.AntigravityReviewerCapability.Decide"/> already takes the platform as a parameter,
+/// and its own comment records why: an earlier Kiro revision called
+/// <c>OperatingSystem.IsWindows()</c> inside a method claiming to be pure, and on the Windows CI leg
+/// a dozen consent and version tests short-circuited to <c>UnsupportedPlatform</c> — failing for a
+/// reason that had nothing to do with what they asserted. Collapsing this factory's ladder onto that
+/// decision reintroduced the ambient read one layer up, and CI caught exactly two tests
+/// (binary-missing, below-floor) refusing on platform before reaching the arm under test. Taking the
+/// platform as an argument makes every arm reachable from any host — including the Windows arm
+/// itself, which is otherwise unassertable on POSIX.</para></param>
 internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         DaemonConfig                                                     config,
         ILoggerFactory                                                   loggerFactory,
         Func<ProcessStartInfo, CancellationToken, Task<IAgyTurnProcess>>? turnSource = null,
         Func<string, bool>?                                              binaryExists = null,
-        Func<string, string?>?                                           resolveVersion = null
+        Func<string, string?>?                                           resolveVersion = null,
+        bool?                                                            posixHost = null
     ) : IHostedAgentRuntimeFactory {
     readonly ILogger _logger = loggerFactory.CreateLogger<AntigravityHostedAgentRuntimeFactory>();
 
@@ -70,6 +85,8 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     readonly Func<string, bool> _binaryExists = binaryExists ?? CliResolver.Exists;
 
     readonly Func<string, string?> _resolveVersion = resolveVersion ?? VendorVersionResolver.Resolve;
+
+    readonly bool _posixHost = posixHost ?? !OperatingSystem.IsWindows();
 
     /// <summary>The vendor token, never <c>agy</c>: the server routes on this exact string and the
     /// capture side already knows <c>antigravity</c>. <c>agy</c> is only ever a binary name.</summary>
@@ -107,7 +124,7 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// <para>Deliberately not cached: a long-running daemon must re-judge a binary installed (or
     /// removed) under it rather than read a startup snapshot.</para></summary>
     internal string? ReviewerRefusal() {
-        var posixHost = !OperatingSystem.IsWindows();
+        var posixHost = _posixHost;
 
         // Consent and platform decided WITHOUT a probe. Decide short-circuits both before it looks at
         // a version, but C# evaluates its arguments first — so an inline probe here would spawn agy

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -578,6 +578,12 @@ internal sealed partial class AgyTurnProcess : IAgyTurnProcess, IAgyTurnDiagnost
     public async ValueTask DisposeAsync() {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;   // idempotent, per the interface contract
 
+        // No bounded wait after the kill, deliberately. Kill(entireProcessTree: true) is SIGKILL on
+        // POSIX, which no child can catch or defer, so the death is already effectively synchronous
+        // with the call — a wait here was measured to change nothing observable against a real child.
+        // Callers that need a CONFIRMED exit terminate first and read HasExited while the handle is
+        // still valid (see AntigravityHostedAgentRuntime.ProcessTurnAsync's teardown), which is the
+        // only place that reading is truthful anyway.
         try {
             if (!_process.HasExited) _process.Kill(entireProcessTree: true);
         } catch {

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -1,0 +1,572 @@
+// src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// A turn process that can explain, after the fact, why it produced no protocol traffic. Kept off
+/// <see cref="IAgyTurnProcess"/> — the runtime never needs it, only the launch path does, and a
+/// runtime-visible diagnostics channel would invite exactly the kind of per-turn text accumulation
+/// this deliberately bounds.
+/// </summary>
+internal interface IAgyTurnDiagnostics {
+    /// <summary>A bounded capture of whatever the child wrote outside the NDJSON protocol (stderr,
+    /// plus stdout lines that were not JSON at all), or null if it wrote nothing. Read once, on a
+    /// failed launch, to turn "no <c>init</c> arrived" into a reason an operator can act on.</summary>
+    string? Diagnostics { get; }
+}
+
+/// <summary>
+/// <see cref="IHostedAgentRuntimeFactory"/> for Antigravity's CLI (<c>agy</c>) as an unattended
+/// review-flow reviewer, over the exec-per-turn <see cref="AntigravityHostedAgentRuntime"/>.
+///
+/// <para><b>What this factory owns that the runtime deliberately does not:</b> the argv and
+/// environment of every turn child, the per-launch isolated <c>HOME</c> (and its removal), the
+/// absolute bound on the launch handshake, and the ordering the orchestrator depends on — that
+/// <see cref="StartAsync"/> does not return until turn 1's <c>init</c> has resolved the conversation
+/// id, because the orchestrator reads <c>transcript.AcpSessionId</c> synchronously the moment a
+/// launch returns and would otherwise bind the transcript to <c>""</c> forever.</para>
+///
+/// <para><b>Auth is deliberately not an advertisement gate</b> (owner decision). The factory
+/// advertises whenever consent is given and the binary resolves; an operator whose only auth is an
+/// interactive <c>agy</c> login gets a bounded, coded launch failure naming the ADC remedy, rather
+/// than a vendor that silently disappears from the list.</para>
+///
+/// <para><b>No borrowed lane</b> — no <c>sandbox-exec</c> substrate here, so
+/// <see cref="SupportsBorrowedReviewFlow"/> stays false and a borrowed request fails closed to an
+/// owned worktree, exactly as Kiro and Claude do.</para>
+/// </summary>
+/// <param name="turnSource">Test seam ONLY. Production passes null, which spawns the real
+/// <see cref="AgyTurnProcess"/> from the <see cref="ProcessStartInfo"/> <see cref="BuildTurnPsi"/>
+/// built — so the seam changes nothing about production behaviour, and the argv assertions run
+/// against the same builder a real launch uses.</param>
+/// <param name="binaryExists">Test seam ONLY, for the availability half of the gate. Production
+/// passes null, which resolves the real binary through <c>PATH</c>. A test pins it so the CONSENT
+/// half is assertable on a host that happens to have (or not have) <c>agy</c> installed — otherwise
+/// the tests pass for the wrong reason on one machine and fail on another.</param>
+internal sealed partial class AntigravityHostedAgentRuntimeFactory(
+        DaemonConfig                                                     config,
+        ILoggerFactory                                                   loggerFactory,
+        Func<ProcessStartInfo, CancellationToken, Task<IAgyTurnProcess>>? turnSource = null,
+        Func<string, bool>?                                              binaryExists = null
+    ) : IHostedAgentRuntimeFactory {
+    readonly ILogger _logger = loggerFactory.CreateLogger<AntigravityHostedAgentRuntimeFactory>();
+
+    readonly Func<ProcessStartInfo, CancellationToken, Task<IAgyTurnProcess>> _turnSource =
+        turnSource ?? ((psi, _) => Task.FromResult<IAgyTurnProcess>(
+            new AgyTurnProcess(psi, loggerFactory.CreateLogger<AgyTurnProcess>())));
+
+    readonly Func<string, bool> _binaryExists = binaryExists ?? CliResolver.Exists;
+
+    /// <summary>The vendor token, never <c>agy</c>: the server routes on this exact string and the
+    /// capture side already knows <c>antigravity</c>. <c>agy</c> is only ever a binary name.</summary>
+    public string Vendor => "antigravity";
+
+    public bool IsAvailable() => _binaryExists(config.AntigravityPath);
+
+    public bool SupportsUnattended => DescribeUnattendedSupport().Supported;
+
+    /// <summary>
+    /// The gate ladder, in ONE pass — consent, then platform, then binary presence. Consent is read
+    /// first so a daemon that has not opted in never touches the filesystem to decide.
+    ///
+    /// <para>Every refusal here carries a reason, because this vendor DOES offer unattended hosting:
+    /// the <see langword="null"/> case in <see cref="UnattendedSupport"/> is for a vendor that never
+    /// claimed it, which is not this one. The reason names the switch an operator can act on.</para>
+    /// </summary>
+    public UnattendedSupport DescribeUnattendedSupport() {
+        var withheld = ReviewerRefusal();
+
+        return new(withheld is null, withheld);
+    }
+
+    /// <summary>Why this daemon refuses an unattended Antigravity reviewer, or null when it does not.
+    /// The ONE place the ladder is written — advertisement and the launch boundary both read it, so a
+    /// vendor cannot be dropped from advertisement and thereby never reach the path that holds the
+    /// explanation.
+    ///
+    /// <para>Deliberately not cached: a long-running daemon must re-judge a binary installed (or
+    /// removed) under it rather than read a startup snapshot.</para></summary>
+    internal string? ReviewerRefusal() {
+        if (!config.AntigravityUnattendedReviewerEnabled)
+            return "antigravity_unattended_reviewer_disabled: unattended Antigravity reviews are off on "
+                 + "this daemon. Set KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1 in the daemon's environment "
+                 + "to opt in.";
+
+        if (OperatingSystem.IsWindows())
+            return "antigravity_reviewer_unsupported_platform: the reviewer's per-launch home holds "
+                 + "review context and cannot be created owner-only on Windows.";
+
+        if (!IsAvailable())
+            return $"antigravity_reviewer_binary_missing: '{config.AntigravityPath}' does not resolve to "
+                 + "an executable. Install the Antigravity CLI (the `agy` binary — the IDE alone is not "
+                 + "enough), or set KCAP_ANTIGRAVITY_PATH to its location.";
+
+        return null;
+    }
+
+    public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+        // An interactive launch is refused rather than silently accepted. This runtime parses agy's
+        // NDJSON from stdout once per turn, and an inherited HOME lets agy's own kcap capture hooks
+        // fire — which spawns a watcher that can hold a write end of that stdout open after agy exits,
+        // so every turn would block forever with no visible cause. The isolated home below is what
+        // makes that unreachable, and it is a reviewer-only construct today.
+        if (!ctx.IsReviewFlow)
+            throw new InvalidOperationException(
+                "antigravity_interactive_launch_unsupported: the Antigravity runtime hosts unattended "
+              + "review-flow reviewers only. An interactive launch would run under the operator's own "
+              + "HOME, where agy's capture hooks fire and can hold this runtime's stdout open after the "
+              + "turn exits.");
+
+        // Defence in depth: the orchestrator's unattended gate runs first, but an explicit
+        // `vendor: "antigravity"` request can reach a factory without consulting advertisement.
+        if (ReviewerRefusal() is { } refusal) throw new InvalidOperationException(refusal);
+
+        if (ctx.Work != WorkLocation.OwnedWorktree)
+            throw new InvalidOperationException(
+                "antigravity_reviewer_requires_owned_worktree: this runtime has no borrowed-review "
+              + "containment strategy, so a review must run in a daemon-owned worktree.");
+
+        // A blank agent id would still yield a non-empty server list and slip past a count-only guard,
+        // so all three result-channel inputs are checked — a dead channel wedges the round.
+        if (string.IsNullOrWhiteSpace(ctx.ServerUrl) || string.IsNullOrWhiteSpace(ctx.CapacitorPath)
+         || string.IsNullOrWhiteSpace(ctx.AgentId))
+            throw new InvalidOperationException(
+                "antigravity_reviewer_result_channel_incomplete: cannot inject the kcap-flow-result "
+              + "channel (missing server url / kcap path / agent id).");
+
+        // Canonical wire names: agy's MCP surface is the file this launch writes, not a name-matched
+        // allowlist the reviewed repository could impersonate an entry in, so the per-launch aliasing
+        // Gemini and Kiro need buys nothing here.
+        ctx = ctx with { LaunchIdentity = LaunchIdentity.ForLaunch(aliasResultChannel: false) };
+
+        if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(ctx.McpAllowlist, out var allowlistServerIds, out var rejected))
+            throw new InvalidOperationException(
+                $"antigravity_reviewer_mcp_allowlist_rejected: '{rejected}' is not an auto-approvable "
+              + "read-only server.");
+
+        var injected = AcpReviewFlowMcp.Build(ctx, allowlistServerIds);
+
+        LogLaunching(ctx.AgentId, ctx.Worktree.Path);
+
+        // Created BEFORE any child exists, and owner-only from its first instant — the reviewer's own
+        // conversation state lands in it. Its ABSENCE of a kcap plugin directory is what keeps capture
+        // single-lane; the injected mcp_config.json is the reviewer's whole MCP surface.
+        var stateDir = ReviewerStateDir(config);
+        var home     = AntigravityReviewerHome.Create(
+            stateDir, config.DaemonEpoch ?? "unpinned", ctx.AgentId, injected, _logger);
+
+        // Created here rather than left to agy: TMPDIR must exist before the child writes into it, and
+        // it is inside the home precisely so it is removed with it.
+        Directory.CreateDirectory(TempDirIn(home));
+
+        var model = ResolveModel(config, ctx);
+
+        // Recorded so a failed launch can explain ITSELF — an unauthenticated agy produces no `init`,
+        // and "the conversation id never arrived" is not a reason anyone can act on.
+        IAgyTurnProcess? firstTurnProcess = null;
+
+        async Task<IAgyTurnProcess> SpawnTurnAsync(string prompt, string? conversationId, CancellationToken turnCt) {
+            var psi     = BuildTurnPsi(config, ctx, prompt, conversationId, home);
+            var process = await _turnSource(psi, turnCt).ConfigureAwait(false);
+
+            firstTurnProcess ??= process;
+
+            return process;
+        }
+
+        var runtime = new AntigravityHostedAgentRuntime(
+            spawnTurn: SpawnTurnAsync,
+            logger: loggerFactory.CreateLogger<AntigravityHostedAgentRuntime>(),
+            agentId: ctx.AgentId,
+            model: model,
+            cwd: ctx.Worktree.Path,
+            launchDeadline: TimeSpan.FromSeconds(Math.Max(1, config.AntigravityReviewerLaunchTimeoutSeconds)),
+            turnDeadline: TimeSpan.FromSeconds(Math.Max(1, config.AntigravityReviewerTurnTimeoutSeconds)),
+            // Disposal, not disk hygiene: the home holds the reviewer's own conversation JSONL — the
+            // caller's diff, source excerpts and findings. The daemon-epoch sweep is the crash
+            // backstop, not the disposal path.
+            onDisposed: () => AntigravityReviewerHome.Delete(home, stateDir, _logger));
+
+        // MUST precede the first turn: a clock assigned later makes every stamp inside the launch a
+        // silent no-op, and the reaper then judges this reviewer from an empty record.
+        runtime.ActivityClock = ctx.ActivityClock;
+
+        // ONE absolute budget across spawn → `init`, linked to the caller's token so a real shutdown
+        // still wins and is never misreported as a timeout. This is what turns the measured
+        // unauthenticated shapes — an immediate error, or an OAuth URL followed by a 60-second
+        // interactive wait — into a bounded failure.
+        using var launchDeadline = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        launchDeadline.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, config.AntigravityReviewerLaunchTimeoutSeconds)));
+
+        try {
+            await runtime.SendUserInputAsync(ctx.Prompt ?? "").ConfigureAwait(false);
+
+            // The ordering guarantee. SendUserInputAsync returns as soon as the turn is enqueued, and
+            // WaitForTurnIdleAsync is not a substitute (its enqueue→gate hand-off is itself async), so
+            // this barrier is the only thing standing between the orchestrator and a transcript bound
+            // to "".
+            await runtime.WaitForConversationIdAsync(launchDeadline.Token).ConfigureAwait(false);
+        } catch (Exception ex) {
+            // The launch is over either way; leaving the child alive would leave an unreapable reviewer
+            // holding a daemon slot, and leaving the home would leave review context on disk that
+            // nobody downstream will ever dispose for us. DisposeAsync does both (it terminates, joins
+            // the worker, then runs onDisposed).
+            await runtime.DisposeAsync().ConfigureAwait(false);
+
+            // A genuine shutdown propagates AS a cancellation. Dressing it up as a launch failure
+            // would put a coded reviewer error in the record for every agent in flight when the
+            // daemon stopped, and send an operator looking for a fault that never happened.
+            if (ex is OperationCanceledException && ct.IsCancellationRequested) throw;
+
+            throw DescribeLaunchFailure(ex, firstTurnProcess, ct, launchDeadline.Token);
+        }
+
+        // The runtime IS the transcript source, so the orchestrator binds and forwards without
+        // downcasting Runtime. McpConfigPath stays null deliberately: this launch's mcp config lives
+        // INSIDE the home, and the home's own disposal owns it — reporting it separately would have
+        // the orchestrator delete a file out of a directory it knows nothing about.
+        return new HostedRuntimeStart(runtime, McpConfigPath: null, Transcript: runtime);
+    }
+
+    /// <summary>
+    /// Turns a failed handshake into a reason an operator can act on. The auth arm is
+    /// <b>non-retryable and names the ADC remedy</b> — a generic launch failure would send an operator
+    /// looking at the daemon, the flow or the network, when the actual fix is three environment
+    /// variables.
+    /// </summary>
+    static InvalidOperationException DescribeLaunchFailure(
+            Exception cause, IAgyTurnProcess? firstTurn, CancellationToken callerToken, CancellationToken launchToken) {
+        if (firstTurn is IAgyTurnDiagnostics { Diagnostics: { } diagnostics } && LooksLikeAuthFailure(diagnostics))
+            return new InvalidOperationException(
+                "antigravity_reviewer_auth_unavailable: agy could not authenticate, and an unattended "
+              + "reviewer has no way to complete an interactive login (its stdin is closed). Give the "
+              + "daemon durable credentials: `gcloud auth application-default login`, then "
+              + "GOOGLE_CLOUD_PROJECT=<project> and AGY_ADC_AUTH=1 in the daemon's environment. A "
+              + "supervised daemon installed before this shipped must be reinstalled to capture them.",
+                cause);
+
+        if (launchToken.IsCancellationRequested && !callerToken.IsCancellationRequested)
+            return new InvalidOperationException(
+                "antigravity_reviewer_launch_timeout: agy did not report a conversation within the "
+              + "launch deadline. The child was terminated and its isolated home removed. An "
+              + "unauthenticated agy can sit on an interactive login prompt rather than failing, which "
+              + "is the shape this bound exists for.",
+                cause);
+
+        return new InvalidOperationException(
+            "antigravity_reviewer_launch_failed: agy's first turn ended without reporting a "
+          + "conversation id, so there is no session to bind a transcript to.",
+            cause);
+    }
+
+    /// <summary>
+    /// Whether a child's non-protocol output is the authentication signal. Substring, deliberately
+    /// loose, and never the sole basis for anything destructive: the two measured shapes are an
+    /// immediate <c>authentication required</c> error and an OAuth URL followed by an interactive
+    /// wait, and both only ever change which REASON a launch that already failed reports.
+    /// </summary>
+    internal static bool LooksLikeAuthFailure(string? diagnostics) =>
+        diagnostics is { Length: > 0 } text
+     && (text.Contains("authentication required", StringComparison.OrdinalIgnoreCase)
+      || text.Contains("log in", StringComparison.OrdinalIgnoreCase)
+      || text.Contains("oauth", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The effective reviewer model — the launch's own override, else the daemon-wide
+    /// default. ONE derivation, read by both the argv builder and the runtime's
+    /// <c>ResolvedModel</c>, so the model we report can never differ from the model we passed.
+    /// Mirrors the <c>"default"</c> sentinel convention the rest of the daemon already uses for
+    /// "no override requested".</summary>
+    internal static string? ResolveModel(DaemonConfig config, RuntimeStartContext ctx) =>
+        !string.IsNullOrEmpty(ctx.Model) && !string.Equals(ctx.Model, "default", StringComparison.OrdinalIgnoreCase)
+            ? ctx.Model
+            : config.AntigravityModel;
+
+    /// <summary>This daemon's own reviewer state directory — the same <c>{StateDir}/{name}</c> shape
+    /// the ACP reviewers use, so a reviewer home and a consent decision live under one owner-only root
+    /// per daemon. Per DAEMON, never shared: the home sweep's safety depends on every directory in its
+    /// root belonging to this daemon.</summary>
+    internal static string ReviewerStateDir(DaemonConfig config) =>
+        Path.Combine(config.StateDir ?? DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(config.Name));
+
+    internal static string TempDirIn(string home) => Path.Combine(home, "tmp");
+
+    /// <summary>
+    /// PURE builder for ONE turn's spawn shape — no process, no filesystem side effects. The real
+    /// spawn path and the launch tests both go through it, so an assertion here certifies the vector
+    /// the OS actually receives rather than a re-derivation of it.
+    ///
+    /// <para><b>What is deliberately absent.</b> No <c>--dangerously-skip-permissions</c>: the
+    /// reviewer runs in a daemon-OWNED worktree and needs only to read it, which agy's headless
+    /// defaults already permit — its soft-deny of shell and out-of-workspace operations IS the desired
+    /// unattended posture, and widening it would grant a reviewer shell access it has no reason to
+    /// hold. No <c>--sandbox</c>: a vendor-side terminal restriction overlapping what containment
+    /// already provides, and unprobed.</para>
+    ///
+    /// <para><c>--print-timeout</c> is passed on EVERY invocation rather than relying on agy's own
+    /// <c>5m0s</c> default — a vendor change would otherwise silently move a bound we did not
+    /// choose.</para>
+    /// </summary>
+    internal static ProcessStartInfo BuildTurnPsi(
+            DaemonConfig config, RuntimeStartContext ctx, string prompt, string? conversationId, string home) {
+        var argv = new List<string> {
+            "-p", prompt,
+            "--output-format", "stream-json",
+            "--disable-slash-commands",
+            "--print-timeout", $"{Math.Max(1, config.AntigravityReviewerTurnTimeoutSeconds)}s"
+        };
+
+        // Absent on turn 1 (there is nothing to resume yet) and present on every turn after it — this
+        // is what makes a multi-round review land as ONE conversation rather than one per round.
+        if (!string.IsNullOrEmpty(conversationId)) {
+            argv.Add("--conversation");
+            argv.Add(conversationId);
+        }
+
+        // An unknown slug makes agy hard-fail, which is a clean audit signal rather than a silent
+        // downgrade to whatever it would have picked.
+        if (ResolveModel(config, ctx) is { Length: > 0 } model) {
+            argv.Add("--model");
+            argv.Add(model);
+        }
+
+        var psi = new ProcessStartInfo(config.AntigravityPath, argv) {
+            WorkingDirectory = ctx.Worktree.Path,
+            // Redirected and then CLOSED at spawn (see AgyTurnProcess): nothing can consume a pasted
+            // OAuth code, so an unauthenticated agy fails against the launch deadline instead of
+            // waiting on a human who is not there.
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            // Also what makes the daemon's own Google auth variables reach the child by inheritance —
+            // they are deliberately not re-stamped below, so a rotated ADC path is read at spawn.
+            UseShellExecute = false,
+            CreateNoWindow  = true
+        };
+
+        // Containment: the whole HOME is the per-launch isolated one, and TMPDIR sits inside it so
+        // agy's temp writes are removed with the home rather than left in the operator's tree.
+        psi.Environment["HOME"]   = home;
+        psi.Environment["TMPDIR"] = TempDirIn(home);
+
+        if (!string.IsNullOrEmpty(ctx.ServerUrl)) psi.Environment["KCAP_URL"] = ctx.ServerUrl;
+
+        // Without these a surviving turn child is invisible to OrphanReaper's env-marker pass — and
+        // nothing fails visibly when they are omitted, which is exactly why they are stamped here
+        // rather than left to the runtime.
+        psi.Environment["KCAP_AGENT_ID"] = ctx.AgentId;
+        if (!string.IsNullOrEmpty(ctx.DaemonId))    psi.Environment["KCAP_DAEMON_ID"]    = ctx.DaemonId;
+        if (!string.IsNullOrEmpty(ctx.DaemonEpoch)) psi.Environment["KCAP_DAEMON_EPOCH"] = ctx.DaemonEpoch;
+
+        return psi;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Antigravity reviewer launch: agentId={AgentId} cwd={Cwd}")]
+    partial void LogLaunching(string agentId, string cwd);
+}
+
+/// <summary>
+/// <see cref="IAgyTurnProcess"/> over a real <see cref="Process"/> — ONE <c>agy -p</c> turn. Mirrors
+/// <see cref="AcpChildProcess"/>'s terminate/wait semantics (SIGTERM-then-kill via
+/// <see cref="Process.Kill(bool)"/>, bounded waits that return silently on timeout), and honours the
+/// two contracts <see cref="IAgyTurnProcess"/> states: <see cref="DisposeAsync"/> is idempotent, and
+/// <see cref="TerminateAsync"/> is safe after it — the runtime can reach both on the same instance
+/// microseconds apart when a stop races a turn's own unwinding.
+///
+/// <para><b>Identity is captured at construction</b>, not read on demand: <see cref="Process.Id"/>
+/// throws once the process object is disposed, and the PID is exactly what an orphan reaper needs
+/// most after the fact.</para>
+/// </summary>
+internal sealed partial class AgyTurnProcess : IAgyTurnProcess, IAgyTurnDiagnostics {
+    /// <summary>Enough to carry an auth error and the URL under it, and small enough that a chatty
+    /// child cannot grow the daemon's heap one turn at a time. Over-cap output is dropped, never
+    /// rotated — this exists to explain a FAILED launch, and that explanation is at the start.</summary>
+    const int DiagnosticsCap = 4096;
+
+    readonly Process                 _process;
+    readonly ILogger                 _logger;
+    readonly CancellationTokenSource _stderrDrainCts = new();
+    readonly Task                    _stderrDrainTask;
+    readonly Lock                    _diagnosticsGate = new();
+    readonly StringBuilder           _diagnostics     = new();
+
+    int _disposed;
+
+    internal AgyTurnProcess(ProcessStartInfo psi, ILogger logger)
+        : this(Process.Start(psi) ?? throw new InvalidOperationException(
+                   $"antigravity_turn_spawn_failed: '{psi.FileName}' did not start (Process.Start returned null)."),
+               logger) { }
+
+    internal AgyTurnProcess(Process process, ILogger logger) {
+        _process = process;
+        _logger  = logger;
+        Pid      = SafePid(process);
+
+        // Closed immediately, and this is a containment decision rather than tidiness: an
+        // unauthenticated agy prints an OAuth URL and waits for a pasted code, and a child with no
+        // readable stdin cannot be handed one. The launch deadline then bounds it.
+        try {
+            _process.StandardInput.Close();
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "Antigravity: could not close a turn child's stdin.");
+        }
+
+        _stderrDrainTask = DrainStderrAsync(_stderrDrainCts.Token);
+    }
+
+    public int  Pid       { get; }
+    public bool HasExited { get { try { return _process.HasExited; } catch { return true; } } }
+
+    public int? ExitCode {
+        get {
+            try {
+                return _process.HasExited ? _process.ExitCode : null;
+            } catch {
+                return null;
+            }
+        }
+    }
+
+    public string? Diagnostics {
+        get { lock (_diagnosticsGate) return _diagnostics.Length == 0 ? null : _diagnostics.ToString(); }
+    }
+
+    /// <summary>
+    /// This turn's stdout NDJSON, line by line, ending at EOF. Lines that are not JSON at all are
+    /// still yielded (the runtime's parser drops them) AND snooped into the diagnostics buffer:
+    /// measured, agy reports "authentication required" as plain text on this stream, so a
+    /// stderr-only capture would miss the one failure this whole bound exists for.
+    /// </summary>
+    public async IAsyncEnumerable<string> ReadLinesAsync([EnumeratorCancellation] CancellationToken ct) {
+        while (true) {
+            string? line;
+
+            try {
+                line = await _process.StandardOutput.ReadLineAsync(ct).ConfigureAwait(false);
+            } catch (IOException) {
+                break;   // pipe torn down (the child was killed mid-read) — EOF, per this method's contract
+            } catch (ObjectDisposedException) {
+                break;   // stream disposed under us by a racing DisposeAsync — likewise EOF
+            }
+
+            if (line is null) break;
+
+            if (!line.StartsWith('{')) Capture(line);
+
+            yield return line;
+        }
+    }
+
+    /// <summary>Keeps the stderr pipe drained — an undrained one fills at ~64KB and blocks the child
+    /// on its next write, which for this runtime would wedge a turn forever. Never logs the text
+    /// itself: agy's stderr can carry prompt fragments, paths and, on the auth path, a URL bearing a
+    /// login code.</summary>
+    async Task DrainStderrAsync(CancellationToken ct) {
+        try {
+            while (!ct.IsCancellationRequested) {
+                var line = await _process.StandardError.ReadLineAsync(ct).ConfigureAwait(false);
+
+                if (line is null) break;      // EOF — the child exited and closed the stream
+                if (line.Length == 0) continue;
+
+                Capture(line);
+                LogStderrShape(line.Length);
+            }
+        } catch (OperationCanceledException) {
+            // Disposal asked the drain to stop — expected.
+        } catch (IOException) {
+            // Pipe torn down on teardown — expected.
+        } catch (ObjectDisposedException) {
+            // Stream disposed out from under the read — expected.
+        }
+    }
+
+    void Capture(string line) {
+        lock (_diagnosticsGate) {
+            if (_diagnostics.Length >= DiagnosticsCap) return;
+
+            _diagnostics.Append(line).Append('\n');
+        }
+    }
+
+    public async Task WaitForExitAsync(TimeSpan? timeout = null) {
+        try {
+            if (timeout is { } t) {
+                using var cts = new CancellationTokenSource(t);
+
+                try {
+                    await _process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+                } catch (OperationCanceledException) {
+                    // Timed out — return silently, per this method's contract.
+                }
+            } else {
+                await _process.WaitForExitAsync().ConfigureAwait(false);
+            }
+        } catch {
+            // Already exited or disposed — nothing left to wait for.
+        }
+    }
+
+    public async Task TerminateAsync(TimeSpan? timeout = null) {
+        try {
+            if (_process.HasExited) return;
+
+            _process.Kill(entireProcessTree: true);
+        } catch {
+            // Already exited, already disposed (the contract explicitly permits this call after
+            // DisposeAsync), or the kill raced the exit — nothing left to terminate either way.
+            return;
+        }
+
+        await WaitForExitAsync(timeout ?? TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync() {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;   // idempotent, per the interface contract
+
+        try {
+            if (!_process.HasExited) _process.Kill(entireProcessTree: true);
+        } catch {
+            // Best-effort — already exited or inaccessible.
+        }
+
+        try {
+            await _stderrDrainCts.CancelAsync().ConfigureAwait(false);
+        } catch {
+            // Best-effort.
+        }
+
+        try {
+            await _stderrDrainTask.WaitAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+        } catch {
+            // DrainStderrAsync already swallows its expected exceptions; never let a stuck drain hang
+            // or fault a dispose.
+        }
+
+        _stderrDrainCts.Dispose();
+
+        try {
+            _process.Dispose();
+        } catch {
+            // Best-effort.
+        }
+    }
+
+    static int SafePid(Process process) {
+        try {
+            return process.Id;
+        } catch {
+            return 0;
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Antigravity turn stderr: {Length} chars")]
+    partial void LogStderrShape(int length);
+}

--- a/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
+++ b/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
@@ -28,6 +28,15 @@ public static class DaemonReviewerCommand {
 
         var requested = ValueOf(args, "--vendor");
 
+        // A vendor that HAS an unattended reviewer but no affirmation gate is refused with its own
+        // explanation, before the unknown-vendor branch below would call it a typo. Succeeding at a
+        // no-op would be worse still: the operator would believe a gate had been cleared.
+        if (NonAffirmableReviewer.Resolve(requested) is { } nonAffirmable) {
+            Console.Error.WriteLine(nonAffirmable.Explanation);
+
+            return Task.FromResult(1);
+        }
+
         if (AffirmableReviewer.Resolve(requested) is not { } reviewer) {
             Console.Error.WriteLine(
                 requested is null
@@ -118,6 +127,27 @@ public static class DaemonReviewerCommand {
         internal static string VendorList => string.Join(" | ", All.Select(r => r.Vendor));
 
         internal static AffirmableReviewer? Resolve(string? vendor) =>
+            All.FirstOrDefault(r => string.Equals(r.Vendor, vendor, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// A reviewer this build hosts unattended but whose build gate is NOT an affirmation, so there is
+    /// nothing here to record. A row rather than an arm, for the same reason
+    /// <see cref="AffirmableReviewer"/> is a table.
+    /// </summary>
+    internal sealed record NonAffirmableReviewer(string Vendor, string Explanation) {
+        internal static readonly NonAffirmableReviewer[] All = [
+            new("antigravity",
+                "antigravity_reviewer_not_affirmable: the Antigravity reviewer has no affirmation "
+              + "gate, so there is nothing to affirm. It takes a MINIMUM VERSION instead — anything at "
+              + "or above the floor is accepted — because agy updates itself, and a build-exact gate "
+              + "would take the reviewer offline on a cadence you do not control.\n"
+              + "  Enable it with KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1 in the daemon's environment, "
+              + "and move the floor with KCAP_ANTIGRAVITY_MIN_CLI_VERSION if a build is refused you "
+              + "know to be good. Restart the daemon after either.")
+        ];
+
+        internal static NonAffirmableReviewer? Resolve(string? vendor) =>
             All.FirstOrDefault(r => string.Equals(r.Vendor, vendor, StringComparison.OrdinalIgnoreCase));
     }
 

--- a/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
+++ b/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core.Config;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// <c>kcap daemon reviewer affirm --vendor &lt;kiro|gemini&gt;</c> — the operator's explicit
+/// <c>kcap daemon reviewer affirm --vendor &lt;kiro|gemini|antigravity&gt;</c> — the operator's explicit
 /// acknowledgement that the installed vendor build may host an unattended reviewer on this daemon.
 ///
 /// <para><b>Why a command and not a config key.</b> The record it writes is what makes a vendor
@@ -27,15 +27,6 @@ public static class DaemonReviewerCommand {
             return Task.FromResult(Usage());
 
         var requested = ValueOf(args, "--vendor");
-
-        // A vendor that HAS an unattended reviewer but no affirmation gate is refused with its own
-        // explanation, before the unknown-vendor branch below would call it a typo. Succeeding at a
-        // no-op would be worse still: the operator would believe a gate had been cleared.
-        if (NonAffirmableReviewer.Resolve(requested) is { } nonAffirmable) {
-            Console.Error.WriteLine(nonAffirmable.Explanation);
-
-            return Task.FromResult(1);
-        }
 
         if (AffirmableReviewer.Resolve(requested) is not { } reviewer) {
             Console.Error.WriteLine(
@@ -109,8 +100,8 @@ public static class DaemonReviewerCommand {
     }
 
     /// <summary>
-    /// A reviewer whose build an operator can affirm. Both gated reviewers use the same model, so the
-    /// verb is a table rather than a per-vendor branch — a third one is a row here, not a new arm.
+    /// A reviewer whose build an operator can affirm. Every gated reviewer uses the same model, so the
+    /// verb is a table rather than a per-vendor branch — the next one is a row here, not a new arm.
     /// </summary>
     /// <param name="Vendor">Canonical vendor token, and the key the daemon's store is written under.</param>
     /// <param name="DefaultBinary">Binary probed when the path env var is unset.</param>
@@ -120,34 +111,14 @@ public static class DaemonReviewerCommand {
     internal sealed record AffirmableReviewer(
             string Vendor, string DefaultBinary, string PathEnvVar, string EnableEnvVar) {
         internal static readonly AffirmableReviewer[] All = [
-            new("kiro",   "kiro-cli", "KCAP_KIRO_PATH",   "KCAP_KIRO_UNATTENDED_REVIEWER"),
-            new("gemini", "gemini",   "KCAP_GEMINI_PATH", "KCAP_GEMINI_UNATTENDED_REVIEWER")
+            new("kiro",        "kiro-cli", "KCAP_KIRO_PATH",        "KCAP_KIRO_UNATTENDED_REVIEWER"),
+            new("gemini",      "gemini",   "KCAP_GEMINI_PATH",      "KCAP_GEMINI_UNATTENDED_REVIEWER"),
+            new("antigravity", "agy",      "KCAP_ANTIGRAVITY_PATH", "KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER")
         ];
 
         internal static string VendorList => string.Join(" | ", All.Select(r => r.Vendor));
 
         internal static AffirmableReviewer? Resolve(string? vendor) =>
-            All.FirstOrDefault(r => string.Equals(r.Vendor, vendor, StringComparison.OrdinalIgnoreCase));
-    }
-
-    /// <summary>
-    /// A reviewer this build hosts unattended but whose build gate is NOT an affirmation, so there is
-    /// nothing here to record. A row rather than an arm, for the same reason
-    /// <see cref="AffirmableReviewer"/> is a table.
-    /// </summary>
-    internal sealed record NonAffirmableReviewer(string Vendor, string Explanation) {
-        internal static readonly NonAffirmableReviewer[] All = [
-            new("antigravity",
-                "antigravity_reviewer_not_affirmable: the Antigravity reviewer has no affirmation "
-              + "gate, so there is nothing to affirm. It takes a MINIMUM VERSION instead — anything at "
-              + "or above the floor is accepted — because agy updates itself, and a build-exact gate "
-              + "would take the reviewer offline on a cadence you do not control.\n"
-              + "  Enable it with KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1 in the daemon's environment, "
-              + "and move the floor with KCAP_ANTIGRAVITY_MIN_CLI_VERSION if a build is refused you "
-              + "know to be good. Restart the daemon after either.")
-        ];
-
-        internal static NonAffirmableReviewer? Resolve(string? vendor) =>
             All.FirstOrDefault(r => string.Equals(r.Vendor, vendor, StringComparison.OrdinalIgnoreCase));
     }
 

--- a/src/Capacitor.Cli/Commands/ReviewerVendors.cs
+++ b/src/Capacitor.Cli/Commands/ReviewerVendors.cs
@@ -13,7 +13,8 @@ namespace Capacitor.Cli.Commands;
 static class ReviewerVendors {
     /// <summary>Canonical tokens, rendered exactly as they are shown to a user. The single source —
     /// <see cref="Known"/> is derived from it, so a token can only be added in one place.</summary>
-    internal const string Tokens = "claude, codex, copilot, cursor, gemini, kiro, opencode, pi, agy";
+    internal const string Tokens =
+        "claude, codex, copilot, cursor, gemini, kiro, opencode, pi, antigravity";
 
     static readonly string[] Known = Tokens.Split(", ");
 

--- a/src/Capacitor.Cli/Services/ServiceEnvironment.cs
+++ b/src/Capacitor.Cli/Services/ServiceEnvironment.cs
@@ -45,7 +45,11 @@ static class ServiceEnvironment {
     /// </summary>
     static readonly string[] GoogleConfigKeys = [
         "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GOOGLE_CLOUD_LOCATION",
-        "GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_GENAI_USE_GCA"
+        "GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_GENAI_USE_GCA",
+        // Antigravity CLI's ADC switch. A boolean, not a credential — it selects the auth
+        // MODE, and without it agy demands an interactive OAuth login even with ADC and a
+        // project present. Belongs here rather than in the secret-capable list.
+        "AGY_ADC_AUTH"
     ];
 
     /// <summary>

--- a/src/Capacitor.Cli/Services/ServiceEnvironment.cs
+++ b/src/Capacitor.Cli/Services/ServiceEnvironment.cs
@@ -15,7 +15,7 @@ static class ServiceEnvironment {
         ["PATH", "KCAP_CONFIG_DIR", "KCAP_PROFILE", "KCAP_URL", "KCAP_CLAUDE_PATH", "KCAP_CODEX_PATH"];
 
     /// <summary>
-    /// Operator consent for the two gated unattended reviewers. Carried on every platform: these are
+    /// Operator consent for the gated unattended reviewers. Carried on every platform: these are
     /// booleans, not secret-capable, so <see cref="GoogleSecretCapableKeys"/>'s exclusion does not apply.
     ///
     /// <para>Required because the daemon reads them from its own environment and nowhere else — no
@@ -25,8 +25,11 @@ static class ServiceEnvironment {
     /// <para>Capture carries an EXISTING opt-in; it cannot create one. It does freeze it, which is what
     /// <see cref="CarriedConsentFlags"/> reports.</para>
     /// </summary>
-    internal static readonly string[] ReviewerConsentKeys =
-        ["KCAP_GEMINI_UNATTENDED_REVIEWER", "KCAP_KIRO_UNATTENDED_REVIEWER"];
+    internal static readonly string[] ReviewerConsentKeys = [
+        "KCAP_GEMINI_UNATTENDED_REVIEWER",
+        "KCAP_KIRO_UNATTENDED_REVIEWER",
+        "KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER"
+    ];
 
     /// <summary>
     /// Gemini's project/backend selection, carried on every platform because none of it is

--- a/test/Capacitor.Cli.Tests.Integration/ReviewerVendorPreferenceTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/ReviewerVendorPreferenceTests.cs
@@ -260,7 +260,8 @@ public class ReviewerVendorPreferenceTests : IDisposable {
         await Assert.That(stderr).Contains("Warning:");
         await Assert.That(stderr).Contains("'kodex' is not a vendor this kcap version knows");
         // The tokens the user can choose from, so the warning is actionable on its own.
-        await Assert.That(stderr).Contains("claude, codex, copilot, cursor, gemini, kiro, opencode, pi, agy");
+        await Assert.That(stderr).Contains(
+            "claude, codex, copilot, cursor, gemini, kiro, opencode, pi, antigravity");
         await Assert.That(stderr).Contains("the server has the authoritative list");
 
         // Warned, not refused: the value really is on disk.

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityContainmentTests.cs
@@ -1,0 +1,347 @@
+// test/Capacitor.Cli.Tests.Unit/Acp/AntigravityContainmentTests.cs
+using System.Diagnostics;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// GATED enforcement of the Antigravity reviewer's containment, run against a REAL <c>agy</c>
+/// process.
+///
+/// <para><b>Why a real process.</b> A model-layer refusal is not containment evidence: an agent that
+/// declines to touch the operator's home looks identical to one that is structurally unable to. Every
+/// assertion below is a filesystem or process-table observation made after a real turn, never a claim
+/// read out of the agent's own words. This is the same rule <c>BorrowedReviewSandbox</c>'s
+/// enforcement tests follow for Copilot, applied to the containment shape this vendor actually
+/// uses — an isolated per-launch <c>HOME</c>, not an OS sandbox.</para>
+///
+/// <para><b>What it certifies.</b> The three properties the design's containment section rests on,
+/// plus the probe finding that makes the whole shape sound:</para>
+/// <para>1. Capture stays single-lane — no kcap hook fired for this conversation, so no second
+/// watcher recorded it alongside the runtime's own NDJSON parse.</para>
+/// <para>2. No watcher process was spawned for it.</para>
+/// <para>3. <c>agy</c> derives <c>~/Library</c> from <c>$HOME</c>, so its Library writes land INSIDE
+/// the per-launch home. This is the observation that makes "the reviewer's state is contained" a
+/// measured fact rather than an assumption — if it were false, reviewer conversation state would
+/// pollute the operator's own agy history and containment would be a fiction.</para>
+/// <para>4. The operator's real agy conversation store gained no entry for this conversation.</para>
+///
+/// <para><b>Read-only against the operator's tree.</b> This test never creates, modifies or deletes
+/// anything under the real <c>~/.config/kcap</c> or <c>~/.gemini</c>. It only reads them, and it keys
+/// every observation on THIS run's conversation id so a concurrently-live daemon writing its own
+/// files cannot make it pass or fail.</para>
+///
+/// <para><b>The positive control is deliberately not run.</b> The same turn under the operator's real
+/// <c>HOME</c> DOES create a kcap log and a watcher — that was measured during the probe (agy's own
+/// hook contract fires in print mode) and is written down in
+/// <c>docs/probes/2026-08-06-agy-reviewer/findings.md</c>. Running it here would record a real session
+/// against the operator's server and spawn a watcher over the reviewer's conversation, which is the
+/// exact damage the containment exists to prevent — so the control stays a recorded measurement, not
+/// a test case.</para>
+///
+/// <para><b>Gated</b> behind <c>KCAP_ANTIGRAVITY_REVIEWER_LIVE=1</c> AND a non-empty
+/// <c>GOOGLE_CLOUD_PROJECT</c>: CI has neither an <c>agy</c> binary nor Google credentials, and the
+/// case spends a real model turn. Both gates are evaluated before anything else, so a CI run costs a
+/// skip.</para>
+/// </summary>
+public class AntigravityContainmentTests {
+    const string GateEnvVar = "KCAP_ANTIGRAVITY_REVIEWER_LIVE";
+
+    /// <summary>Bounded on purpose, and every wait in this test is bounded by it. A denial ENDS an agy
+    /// turn — no closing <c>agent_response</c>, an empty <c>result.response</c>, and any second
+    /// instruction in the prompt never runs — so a test that waits for post-denial output hangs rather
+    /// than fails.</summary>
+    static readonly TimeSpan TurnTimeout = TimeSpan.FromSeconds(180);
+
+    /// <summary>
+    /// One real <c>agy</c> turn under the production per-launch home, then four observations of the
+    /// operator's tree and this host's process table.
+    /// </summary>
+    [Test]
+    public async Task A_real_turn_under_the_per_launch_home_leaves_the_operators_tree_untouched() {
+        var project = Gate();
+
+        Skip.Unless(!OperatingSystem.IsWindows(),
+            "The Antigravity reviewer is POSIX-only — its per-launch home cannot be created owner-only on Windows.");
+
+        // Captured BEFORE anything overrides HOME: the operator's real tree is what the observations
+        // are made against, and GOOGLE_APPLICATION_CREDENTIALS points into it (auth is an env path,
+        // not HOME-anchored file state — see the probe findings).
+        var realHome = Environment.GetEnvironmentVariable("HOME") ?? "";
+        await Assert.That(realHome).IsNotEmpty().Because("the observations are made against the operator's real HOME");
+
+        var kcapLogs     = Path.Combine(realHome, ".config", "kcap", "logs");
+        var kcapWatchers = Path.Combine(realHome, ".config", "kcap", "watchers");
+
+        var logsBefore     = SnapshotNames(kcapLogs);
+        var watchersBefore = SnapshotNames(kcapWatchers);
+
+        var stateDir  = CreateTemp("kcap-agy-containment-state-");
+        var workspace = CreateTemp("kcap-agy-containment-ws-");
+        string? home  = null;
+
+        try {
+            await File.WriteAllTextAsync(Path.Combine(workspace, "README.md"), "containment probe workspace\n");
+
+            // Production home and production argv/env — an assertion over a re-derived spawn shape
+            // would certify the test's idea of the launch, not the launch.
+            home = AntigravityReviewerHome.Create(stateDir, "containment-epoch", "containment-agent", []);
+
+            var psi = AntigravityHostedAgentRuntimeFactory.BuildTurnPsi(
+                config: new DaemonConfig {
+                    AntigravityPath                      = "agy",
+                    AntigravityUnattendedReviewerEnabled = true,
+                    Name                                 = "containment-daemon",
+                    DaemonEpoch                          = "containment-epoch",
+                    StateDir                             = stateDir,
+                    AntigravityReviewerTurnTimeoutSeconds = (int)TurnTimeout.TotalSeconds
+                },
+                ctx: Ctx(workspace),
+                prompt: "Reply with the single word OK. Do not use any tools.",
+                conversationId: null,
+                home: home);
+
+            // The daemon's own Google auth block, which BuildTurnPsi deliberately does not re-stamp
+            // (it is inherited, so a rotated ADC path is read at spawn). Supplied here because a test
+            // process is not a supervised daemon; defaulted rather than required so the gate stays
+            // two variables.
+            psi.Environment["AGY_ADC_AUTH"]        = Environment.GetEnvironmentVariable("AGY_ADC_AUTH") ?? "1";
+            psi.Environment["GOOGLE_CLOUD_PROJECT"] = project;
+            psi.Environment["GOOGLE_APPLICATION_CREDENTIALS"] =
+                Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS")
+                ?? Path.Combine(realHome, ".config", "gcloud", "application_default_credentials.json");
+
+            var turn = await RunTurnAsync(psi);
+
+            Console.WriteLine($"[agy-containment] conversation={turn.ConversationId} status={turn.Status} "
+                            + $"exit={turn.ExitCode} detail={turn.Detail}");
+
+            // ── the run must have HAPPENED before any absence is evidence ──────────────────────────
+            // Without this, every observation below is satisfied by an agy that never started: no
+            // conversation means no hook, no watcher and no store entry, trivially.
+            await Assert.That(turn.ConversationId).IsNotNull()
+                .Because($"no conversation id, no evidence either way: {turn.Detail}");
+            await Assert.That(turn.SawResult).IsTrue()
+                .Because($"the turn must have reached its terminal result: {turn.Detail}");
+
+            var id       = turn.ConversationId!;
+            var dashless = Guid.TryParse(id, out var g) ? g.ToString("N") : id.Replace("-", "");
+
+            // Positive control for observations 3 and 4 together: the conversation state EXISTS, and
+            // the rest of the test is about where. Without it, "the operator's store gained nothing"
+            // could mean agy wrote its state nowhere at all.
+            await Assert.That(TreeMentions(home, id, dashless)).IsTrue()
+                .Because("agy must have written this conversation's state somewhere under the per-launch home");
+
+            // ── 1. no kcap hook fired ─────────────────────────────────────────────────────────────
+            // Keyed on the conversation id, not on a bare count: a live daemon on this host writes its
+            // own logs throughout, and a count comparison would be a coin flip.
+            await Assert.That(NewNamesMentioning(kcapLogs, logsBefore, id, dashless)).IsEmpty()
+                .Because("an empty HOME has no ~/.gemini/config/plugins/kcap/hooks.json, so agy's capture "
+                       + "hooks cannot fire — a log keyed on this conversation means the reviewer was "
+                       + "double-captured");
+            await Assert.That(NewNamesMentioning(kcapWatchers, watchersBefore, id, dashless)).IsEmpty()
+                .Because("a spawnlock or watcher marker keyed on this conversation is a watcher that ran");
+
+            // ── 2. no watcher process ─────────────────────────────────────────────────────────────
+            await Assert.That(turn.ProcessesMentioningConversation).IsEmpty()
+                .Because("no process may carry this conversation id — the NDJSON stream is the only capture lane");
+
+            // ── 3. agy's Library writes landed inside the per-launch home ─────────────────────────
+            // The sharpest containment question available: agy's own credential lives outside
+            // ~/.gemini, under ~/Library, so if agy resolved ~/Library from the real user rather than
+            // from $HOME the relocated home would contain nothing that matters. It does not — and
+            // this is the assertion that keeps that a measured fact.
+            await Assert.That(Directory.Exists(Path.Combine(home, "Library"))).IsTrue()
+                .Because("agy must derive ~/Library from $HOME; if it stopped, reviewer state would land "
+                       + "in the operator's own tree and the containment claim would be false");
+
+            // ── 4. the operator's real agy conversation store gained no entry ─────────────────────
+            // Both roots: the `agy` CLI writes ~/.gemini/antigravity-cli/, the GUI IDE writes
+            // ~/.gemini/antigravity/ — one vendor identity, two products, two stores.
+            foreach (var root in (string[])[Path.Combine(realHome, ".gemini", "antigravity-cli"),
+                                            Path.Combine(realHome, ".gemini", "antigravity")]) {
+                await Assert.That(Directory.Exists(Path.Combine(root, "brain", id))).IsFalse()
+                    .Because($"the reviewer's brain dir must not appear in the operator's store ({root})");
+                await Assert.That(File.Exists(Path.Combine(root, "conversations", $"{id}.db"))).IsFalse()
+                    .Because($"the reviewer's conversation db must not appear in the operator's store ({root})");
+            }
+        } finally {
+            if (home is not null) AntigravityReviewerHome.Delete(home, stateDir);
+            TryDelete(stateDir);
+            TryDelete(workspace);
+        }
+    }
+
+    // ── gate ──────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Both gates, evaluated before any work, so a CI run costs a skip and nothing else. The
+    /// two reasons are reported separately: "not opted in" and "opted in but misconfigured" are
+    /// different operator problems, and collapsing them hides the second.</summary>
+    static string Gate() {
+        Skip.Unless(Environment.GetEnvironmentVariable(GateEnvVar) == "1",
+            $"Gated live enforcement of the Antigravity reviewer's containment — set {GateEnvVar}=1 to run "
+          + "(spends one real agy turn; needs `agy` on PATH and application-default credentials). Observes "
+          + "the filesystem after a real process, because a model-layer refusal is not containment evidence.");
+
+        var project = Environment.GetEnvironmentVariable("GOOGLE_CLOUD_PROJECT") ?? "";
+
+        Skip.Unless(project.Length > 0,
+            $"{GateEnvVar}=1 but GOOGLE_CLOUD_PROJECT is unset — agy authenticates from an empty HOME via "
+          + "AGY_ADC_AUTH + GOOGLE_CLOUD_PROJECT + GOOGLE_APPLICATION_CREDENTIALS, and without the project "
+          + "it fails in a way that names a tier problem rather than the missing setting.");
+
+        return project;
+    }
+
+    // ── harness ───────────────────────────────────────────────────────────────────────────────────
+
+    readonly record struct TurnOutcome(
+        string? ConversationId, bool SawResult, string? Status, int? ExitCode,
+        IReadOnlyList<string> ProcessesMentioningConversation, string? Detail);
+
+    /// <summary>
+    /// Drives one real turn, parsing stdout with the PRODUCTION NDJSON parser. Takes the process-table
+    /// snapshot as soon as the conversation id is known — a watcher spawned by a hook would be alive
+    /// then, and might have exited by the time the turn ends.
+    /// </summary>
+    static async Task<TurnOutcome> RunTurnAsync(ProcessStartInfo psi) {
+        using var cts  = new CancellationTokenSource(TurnTimeout);
+        using var proc = Process.Start(psi) ?? throw new InvalidOperationException("agy did not start — is it on PATH?");
+
+        // Closed immediately, exactly as the production turn process does: nothing can consume a
+        // pasted OAuth code, so an unauthenticated agy fails against the deadline rather than waiting
+        // on a human who is not there.
+        proc.StandardInput.Close();
+
+        var stderrDrain = Task.Run(async () => {
+            try { return await proc.StandardError.ReadToEndAsync(cts.Token); } catch { return ""; }
+        }, cts.Token);
+
+        string?      conversationId = null;
+        string?      status         = null;
+        var          sawResult      = false;
+        List<string> processes      = [];
+
+        try {
+            while (await proc.StandardOutput.ReadLineAsync(cts.Token) is { } line) {
+                if (AntigravityNdjson.TryParseLine(line) is not { } evt) continue;
+
+                if (evt.Kind == AntigravityEventKind.Init && evt.ConversationId is { Length: > 0 } cid) {
+                    conversationId = cid;
+                    var dashless   = Guid.TryParse(cid, out var g) ? g.ToString("N") : cid.Replace("-", "");
+                    processes      = await ProcessesMentioningAsync(cid, dashless);
+                }
+
+                if (evt.Kind == AntigravityEventKind.Result) {
+                    sawResult = true;
+                    status    = evt.Status;
+                }
+            }
+
+            await proc.WaitForExitAsync(cts.Token);
+
+            // A watcher spawned late, or one that outlives the turn, is caught by this second pass.
+            if (conversationId is { Length: > 0 } done) {
+                var dashless = Guid.TryParse(done, out var g2) ? g2.ToString("N") : done.Replace("-", "");
+                processes    = [.. processes.Concat(await ProcessesMentioningAsync(done, dashless)).Distinct()];
+            }
+
+            return new(conversationId, sawResult, status, proc.HasExited ? proc.ExitCode : null, processes, null);
+        } catch (OperationCanceledException) {
+            // stderr is where agy reports an auth/project misconfiguration, which is by far the
+            // likeliest reason this times out on a fresh machine.
+            var err = stderrDrain.IsCompletedSuccessfully ? stderrDrain.Result : "(stderr not drained)";
+
+            return new(conversationId, sawResult, status, null, processes,
+                       $"timed out after {TurnTimeout.TotalSeconds:N0}s; stderr tail: "
+                     + err[Math.Max(0, err.Length - 400)..]);
+        } finally {
+            try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); } catch { /* already gone */ }
+        }
+    }
+
+    /// <summary>Every command line on this host mentioning the conversation, in either id spelling —
+    /// the watcher takes the dashless session id, agy uses the dashed one.</summary>
+    static async Task<List<string>> ProcessesMentioningAsync(string id, string dashless) {
+        try {
+            using var ps = Process.Start(new ProcessStartInfo("/bin/ps", ["-Ao", "args="]) {
+                RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false
+            });
+
+            if (ps is null) return [];
+
+            using var kill = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            var text = await ps.StandardOutput.ReadToEndAsync(kill.Token);
+            await ps.WaitForExitAsync(kill.Token);
+
+            return [.. text.Split('\n')
+                           .Where(l => l.Contains(id, StringComparison.Ordinal)
+                                    || l.Contains(dashless, StringComparison.Ordinal))
+                           // Our own agy child carries the id only once it is resumed; exclude nothing
+                           // else, so a `kcap watch` on this conversation cannot be filtered away.
+                           .Where(l => !l.Contains("/bin/ps", StringComparison.Ordinal))];
+        } catch {
+            return [];
+        }
+    }
+
+    static RuntimeStartContext Ctx(string workspace) => new(
+        AgentId: "containment-agent", Vendor: "antigravity", SourceRepoPath: workspace,
+        Worktree: new WorktreeInfo(Path: workspace, Branch: "containment", SourceRepo: workspace),
+        Prompt: null, Model: null, Effort: null, Tools: null,
+        IsReview: false, IsReviewFlow: true, Review: null,
+        Cols: 80, Rows: 24,
+        // No server URL: a hook that fired would still write its log, so leaving KCAP_URL unset keeps
+        // the measurement from touching a real server without weakening observation 1.
+        ServerUrl: null, DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap",
+        DaemonId: "containment-daemon", DaemonEpoch: "containment-epoch");
+
+    // ── observation helpers (read-only) ───────────────────────────────────────────────────────────
+
+    static HashSet<string> SnapshotNames(string dir) {
+        try {
+            return Directory.Exists(dir)
+                ? [.. Directory.EnumerateFileSystemEntries(dir).Select(Path.GetFileName)!]
+                : [];
+        } catch {
+            return [];
+        }
+    }
+
+    /// <summary>Entries that are BOTH new since the snapshot and keyed on this conversation. New-only
+    /// would be noise from a live daemon; keyed-only would count a pre-existing coincidence.</summary>
+    static IReadOnlyList<string> NewNamesMentioning(string dir, HashSet<string> before, string id, string dashless) =>
+        [.. SnapshotNames(dir)
+             .Where(n => !before.Contains(n))
+             .Where(n => n.Contains(id, StringComparison.OrdinalIgnoreCase)
+                      || n.Contains(dashless, StringComparison.OrdinalIgnoreCase))];
+
+    /// <summary><c>AttributesToSkip</c> is set explicitly to NONE, and that is load-bearing: its default
+    /// skips <c>Hidden</c>, and .NET reports every Unix dot-entry as hidden — so the default would make
+    /// the whole <c>.gemini</c> subtree, which is where agy writes ALL of its conversation state,
+    /// invisible to this search. The first live run of this test failed on exactly that, with the
+    /// containment itself working perfectly.</summary>
+    static bool TreeMentions(string root, string id, string dashless) {
+        try {
+            return Directory.EnumerateFileSystemEntries(root, "*", new EnumerationOptions {
+                RecurseSubdirectories = true, IgnoreInaccessible = true, AttributesToSkip = FileAttributes.None
+            }).Any(p => p.Contains(id, StringComparison.Ordinal) || p.Contains(dashless, StringComparison.Ordinal));
+        } catch {
+            return false;
+        }
+    }
+
+    static string CreateTemp(string prefix) {
+        var dir = Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    static void TryDelete(string dir) {
+        try { Directory.Delete(dir, recursive: true); } catch { /* temp dir */ }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityNdjsonTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityNdjsonTests.cs
@@ -61,6 +61,22 @@ public class AntigravityNdjsonTests {
             .IsEqualTo(AntigravityEventKind.Unknown);
     }
 
+    /// <summary>
+    /// A line that is valid JSON but not an OBJECT reads as "nothing to read" (null), not as schema
+    /// drift (<see cref="AntigravityEventKind.Unknown"/>). Every agy NDJSON line is an object, so a
+    /// bare array/scalar is a torn or foreign line rather than a variant we don't understand yet —
+    /// and the distinction is load-bearing: the runtime's read loop drops a null and keeps going,
+    /// while an Unknown is a real event a future handler could act on. Untested before this test, so
+    /// the top-level object guard could be deleted with the whole suite still green.
+    /// </summary>
+    [Test]
+    public async Task A_valid_json_line_that_is_not_an_object_returns_null() {
+        await Assert.That(AntigravityNdjson.TryParseLine("[1,2,3]")).IsNull();
+        await Assert.That(AntigravityNdjson.TryParseLine("\"just a string\"")).IsNull();
+        await Assert.That(AntigravityNdjson.TryParseLine("123")).IsNull();
+        await Assert.That(AntigravityNdjson.TryParseLine("null")).IsNull();
+    }
+
     [Test]
     public async Task Text_deltas_aggregate_per_step_and_flush_on_done() {
         var acc = new AntigravityStepAccumulator();

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityNdjsonTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityNdjsonTests.cs
@@ -1,0 +1,154 @@
+// test/Capacitor.Cli.Tests.Unit/Acp/AntigravityNdjsonTests.cs
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// Pure unit tests for <see cref="AntigravityNdjson"/> and
+/// <see cref="AntigravityStepAccumulator"/> — no process/runtime involved. Every non-obvious
+/// fixture below is a VERBATIM line captured from a live <c>agy 1.1.10 -p … --output-format
+/// stream-json</c> run (see the task brief), not invented, so a shape this test locks in is a shape
+/// actually observed on the wire.
+/// </summary>
+public class AntigravityNdjsonTests {
+    const string InitLine =
+        """{"event":"init","conversation_id":"e80c33bf-c10f-4d2f-b626-b0043f488fc0","init":{"cwd":"/w","tools":["call_mcp_tool"],"permission_mode":"request-review"}}""";
+
+    [Test]
+    public async Task Init_yields_a_session_started_carrying_the_conversation_id() {
+        var evt = AntigravityNdjson.TryParseLine(InitLine);
+        await Assert.That(evt!.Kind).IsEqualTo(AntigravityEventKind.Init);
+        await Assert.That(evt.ConversationId).IsEqualTo("e80c33bf-c10f-4d2f-b626-b0043f488fc0");
+
+        var envelopes = AntigravityNdjson.ToEnvelopes(evt, model: "gemini-3.5-flash");
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.SessionStarted);
+        await Assert.That(envelopes[0].RawSessionId).IsEqualTo("e80c33bf-c10f-4d2f-b626-b0043f488fc0");
+        await Assert.That(envelopes[0].Cwd).IsEqualTo("/w");
+        await Assert.That(envelopes[0].Model).IsEqualTo("gemini-3.5-flash");
+    }
+
+    [Test]
+    public async Task A_terminal_result_never_produces_a_session_ended_envelope() {
+        // The server's EndAgentSession owns session termination. A runtime that emits
+        // session_ended would double-end the session.
+        var evt = AntigravityNdjson.TryParseLine(
+            """{"event":"result","result":{"conversation_id":"c","status":"SUCCESS","response":"ok","num_turns":1}}""");
+
+        await Assert.That(evt!.Kind).IsEqualTo(AntigravityEventKind.Result);
+        await Assert.That(evt.Status).IsEqualTo("SUCCESS");
+        await Assert.That(AntigravityNdjson.ToEnvelopes(evt, null)
+            .Any(e => e.Kind == AcpEventKind.SessionEnded)).IsFalse();
+    }
+
+    [Test]
+    public async Task An_unknown_step_type_is_tolerated_not_rejected() {
+        // Real agy output contains step_type:"unknown". Treating it as a protocol
+        // violation would kill live reviewers.
+        var evt = AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"conversation_id":"c","step_index":1,"state":"DONE","step_type":"unknown"}}""");
+
+        await Assert.That(evt).IsNotNull();
+        await Assert.That(evt!.Kind).IsEqualTo(AntigravityEventKind.StepUpdate);
+    }
+
+    [Test]
+    public async Task A_malformed_or_blank_line_returns_null_rather_than_throwing() {
+        await Assert.That(AntigravityNdjson.TryParseLine("")).IsNull();
+        await Assert.That(AntigravityNdjson.TryParseLine("not json")).IsNull();
+        await Assert.That(AntigravityNdjson.TryParseLine("""{"event":"nope"}""")!.Kind)
+            .IsEqualTo(AntigravityEventKind.Unknown);
+    }
+
+    [Test]
+    public async Task Text_deltas_aggregate_per_step_and_flush_on_done() {
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"PROBE"}}""")!);
+        var mid = acc.Flush(model: null);
+        await Assert.That(mid.Count).IsEqualTo(0);   // nothing flushed while ACTIVE
+
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"step_index":2,"state":"DONE","step_type":"agent_response","text_delta":"_OK"}}""")!);
+        var done = acc.Flush(model: null);
+
+        await Assert.That(done.Any(e => e.Kind == AcpEventKind.AssistantText && e.Text == "PROBE_OK")).IsTrue();
+    }
+
+    [Test]
+    public async Task A_step_flushed_once_is_not_re_emitted_on_a_later_flush() {
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"step_index":2,"state":"DONE","step_type":"agent_response","text_delta":"ONCE"}}""")!);
+        var first = acc.Flush(model: null);
+        await Assert.That(first.Count(e => e.Kind == AcpEventKind.AssistantText)).IsEqualTo(1);
+
+        var second = acc.Flush(model: null);
+        await Assert.That(second.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Usage_on_a_done_agent_response_step_flushes_alongside_the_aggregated_text() {
+        // Verbatim captured line: the DONE step_update carries both the tail of the text_delta
+        // stream AND the step's usage block in the same event.
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"conversation_id":"e80c33bf-c10f-4d2f-b626-b0043f488fc0","step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"PROBE_OK"}}""")!);
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"conversation_id":"e80c33bf-c10f-4d2f-b626-b0043f488fc0","step_index":2,"state":"DONE","step_type":"agent_response","text_delta":"\n","duration_seconds":2.494169,"usage":{"input_tokens":16392,"output_tokens":46,"thinking_tokens":42,"cache_read_tokens":0,"total_tokens":16438}}}""")!);
+
+        var envelopes = acc.Flush(model: "gemini-3.5-flash");
+
+        var text = envelopes.Single(e => e.Kind == AcpEventKind.AssistantText);
+        await Assert.That(text.Text).IsEqualTo("PROBE_OK\n");
+
+        var usage = envelopes.Single(e => e.Kind == AcpEventKind.Usage);
+        await Assert.That(usage.Model).IsEqualTo("gemini-3.5-flash");
+        await Assert.That(usage.ContextUsedTokens).IsEqualTo(16392L);
+    }
+
+    [Test]
+    public async Task A_done_checkpoint_step_with_no_text_flushes_only_usage() {
+        // Verbatim captured line: a "checkpoint" step carries usage but no text_delta at all.
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"conversation_id":"e80c33bf-c10f-4d2f-b626-b0043f488fc0","step_index":3,"state":"DONE","step_type":"checkpoint","duration_seconds":0.787126,"usage":{"input_tokens":98,"output_tokens":3,"thinking_tokens":0,"cache_read_tokens":0,"total_tokens":101}}}""")!);
+
+        var envelopes = acc.Flush(model: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.Usage);
+        await Assert.That(envelopes[0].ContextUsedTokens).IsEqualTo(98L);
+    }
+
+    [Test]
+    public async Task A_done_step_with_neither_text_nor_usage_flushes_nothing() {
+        // Verbatim captured line: a bare "user_input" DONE marker carries neither.
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"conversation_id":"e80c33bf-c10f-4d2f-b626-b0043f488fc0","step_index":0,"state":"DONE","step_type":"user_input"}}""")!);
+
+        await Assert.That(acc.Flush(model: null).Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Independent_steps_flush_independently() {
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"step_index":1,"state":"DONE","step_type":"unknown","duration_seconds":0.001982}}""")!);
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"step_index":2,"state":"ACTIVE","step_type":"agent_response","text_delta":"still going"}}""")!);
+
+        var envelopes = acc.Flush(model: null);
+
+        // Step 1 (DONE, content-free) contributes nothing; step 2 (still ACTIVE) is untouched —
+        // neither should produce an envelope, and step 2 must survive for a later flush.
+        await Assert.That(envelopes.Count).IsEqualTo(0);
+
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"step_index":2,"state":"DONE","step_type":"agent_response","text_delta":"!"}}""")!);
+        var later = acc.Flush(model: null);
+        await Assert.That(later.Any(e => e.Kind == AcpEventKind.AssistantText && e.Text == "still going!")).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityNdjsonTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityNdjsonTests.cs
@@ -151,4 +151,103 @@ public class AntigravityNdjsonTests {
         var later = acc.Flush(model: null);
         await Assert.That(later.Any(e => e.Kind == AcpEventKind.AssistantText && e.Text == "still going!")).IsTrue();
     }
+
+    // Verbatim fixtures captured live from agy 1.1.10: a "tool" step moves through ACTIVE (the
+    // call), then either DONE (a string output) or ERROR (an object error) — never a parse failure.
+
+    const string ToolActiveLine =
+        """{"event":"step_update","step_update":{"step_index":3,"state":"ACTIVE","step_type":"tool","tool_name":"list_dir","tool_info":{"name":"list_dir","parameters":{"DirectoryPath":"/Users/tony/.gemini/antigravity-cli"}}}}""";
+
+    const string ToolDoneLine =
+        """{"event":"step_update","step_update":{"step_index":6,"state":"DONE","step_type":"tool","tool_name":"list_dir","duration_seconds":0.264916,"tool_info":{"name":"list_dir","parameters":{"DirectoryPath":"/Users/tony/.gemini/antigravity-cli"},"output":".system_generated/\n.user_uploaded/\nscratch/"}}}""";
+
+    const string ToolErrorLine =
+        """{"event":"step_update","step_update":{"step_index":3,"state":"ERROR","step_type":"tool","tool_name":"list_dir","duration_seconds":0.198566,"tool_info":{"name":"list_dir","parameters":{"DirectoryPath":"/Users/tony/.gemini/antigravity-cli"},"error":{"type":"TOOL_ERROR","message":"Permission denied for read_file(...). Matches hardcoded system protection boundary rule."}}}}""";
+
+    [Test]
+    public async Task An_active_tool_step_flushes_a_tool_call_immediately_not_deferred_to_terminal() {
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(ToolActiveLine)!);
+
+        var envelopes = acc.Flush(model: null);
+
+        var call = envelopes.Single(e => e.Kind == AcpEventKind.ToolCall);
+        await Assert.That(call.ToolCallId).IsEqualTo("3");
+        await Assert.That(call.ToolName).IsEqualTo("list_dir");
+        await Assert.That(call.ToolInputJson).Contains("DirectoryPath");
+        await Assert.That(call.ToolInputJson).Contains("/Users/tony/.gemini/antigravity-cli");
+
+        // No result yet — the step is still ACTIVE — and flushing again must not repeat the call.
+        await Assert.That(envelopes.Any(e => e.Kind == AcpEventKind.ToolResult)).IsFalse();
+        await Assert.That(acc.Flush(model: null).Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task A_done_tool_step_flushes_a_successful_tool_result() {
+        // Observed alone (no preceding ACTIVE reached this accumulator) — both the call and the
+        // result must still flush together, call first, since agy did send tool_info.name here too.
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(ToolDoneLine)!);
+
+        var envelopes = acc.Flush(model: null);
+
+        await Assert.That(envelopes.Any(e => e.Kind == AcpEventKind.ToolCall && e.ToolName == "list_dir")).IsTrue();
+
+        var result = envelopes.Single(e => e.Kind == AcpEventKind.ToolResult);
+        await Assert.That(result.ToolCallId).IsEqualTo("6");
+        await Assert.That(result.ToolIsError).IsFalse();
+        await Assert.That(result.ToolResult).IsEqualTo(".system_generated/\n.user_uploaded/\nscratch/");
+    }
+
+    [Test]
+    public async Task An_error_tool_step_flushes_a_failed_tool_result_not_a_thrown_exception() {
+        // ERROR is an ordinary terminal state for a tool step, not a protocol violation.
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(ToolErrorLine)!);
+
+        var envelopes = acc.Flush(model: null);
+
+        var result = envelopes.Single(e => e.Kind == AcpEventKind.ToolResult);
+        await Assert.That(result.ToolCallId).IsEqualTo("3");
+        await Assert.That(result.ToolIsError).IsTrue();
+        await Assert.That(result.ToolResult).Contains("TOOL_ERROR");
+        await Assert.That(result.ToolResult).Contains("Permission denied");
+    }
+
+    [Test]
+    public async Task A_tool_steps_call_and_result_flush_across_separate_flush_calls_for_the_same_step() {
+        // The realistic lifecycle: ACTIVE flushes the call on its own Flush call; the step survives
+        // in the accumulator; a later ERROR on the SAME step index then flushes the result.
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(ToolActiveLine)!);
+        var afterActive = acc.Flush(model: null);
+        await Assert.That(afterActive.Count(e => e.Kind == AcpEventKind.ToolCall)).IsEqualTo(1);
+
+        acc.Add(AntigravityNdjson.TryParseLine(ToolErrorLine)!);
+        var afterError = acc.Flush(model: null);
+
+        // The call must not repeat; only the result is new.
+        await Assert.That(afterError.Count).IsEqualTo(1);
+        await Assert.That(afterError[0].Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(afterError[0].ToolIsError).IsTrue();
+    }
+
+    [Test]
+    public async Task Checkpoint_and_unknown_step_types_remain_tolerated_alongside_tool_steps() {
+        // Confirms the full observed step_type set (agent_response/checkpoint/tool/unknown/
+        // user_input) coexists without cross-contamination — a tool step in the same batch must not
+        // change how a checkpoint or unknown step is handled.
+        var acc = new AntigravityStepAccumulator();
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"step_index":1,"state":"DONE","step_type":"unknown"}}""")!);
+        acc.Add(AntigravityNdjson.TryParseLine(
+            """{"event":"step_update","step_update":{"step_index":4,"state":"DONE","step_type":"checkpoint","usage":{"input_tokens":10,"output_tokens":1,"thinking_tokens":0,"cache_read_tokens":0,"total_tokens":11}}}""")!);
+        acc.Add(AntigravityNdjson.TryParseLine(ToolDoneLine)!);
+
+        var envelopes = acc.Flush(model: null);
+
+        await Assert.That(envelopes.Count(e => e.Kind == AcpEventKind.Usage)).IsEqualTo(1);
+        await Assert.That(envelopes.Count(e => e.Kind == AcpEventKind.ToolCall)).IsEqualTo(1);
+        await Assert.That(envelopes.Count(e => e.Kind == AcpEventKind.ToolResult)).IsEqualTo(1);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
@@ -1,7 +1,4 @@
-using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Acp;
-using Capacitor.Cli.Daemon.Services;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
@@ -123,27 +120,6 @@ public class AntigravityReviewerCapabilityTests {
         await Assert.That(reason).StartsWith("antigravity_unattended_reviewer_disabled");
         await Assert.That(reason).Contains("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
         await Assert.That(reason).Contains("daemon's environment");
-    }
-
-    /// <summary>
-    /// The strongest available pin on "one ladder, not two": the shipped factory judges consent with
-    /// its own inline check, and this asserts the capability's text is BYTE-IDENTICAL to what that
-    /// check produces. If either side is reworded on its own, this goes red — so the two cannot drift
-    /// into disagreeing about what an operator is told.
-    /// </summary>
-    [Test]
-    public async Task TheDisabledReason_IsExactlyWhatTheFactorysOwnLadderReports() {
-        var config = new DaemonConfig {
-            AntigravityPath                      = "agy",
-            AntigravityUnattendedReviewerEnabled = false,
-            Name                                 = "test-daemon"
-        };
-
-        var factoryReason = new AntigravityHostedAgentRuntimeFactory(
-            config, NullLoggerFactory.Instance, turnSource: null, binaryExists: _ => true)
-            .DescribeUnattendedSupport().WithheldReason;
-
-        await Assert.That(Reason(AntigravityReviewerDecision.Disabled, null)).IsEqualTo(factoryReason);
     }
 
     /// <summary>The platform refusal says WHY rather than merely refusing. Its text cannot be compared

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
@@ -1,15 +1,17 @@
+using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Acp;
 
 namespace Capacitor.Cli.Tests.Unit.Acp;
 
 /// <summary>
 /// The Antigravity reviewer gate is fail-closed on three axes: the operator's consent flag, the
-/// platform, and whether the installed <c>agy</c> meets a minimum version FLOOR.
+/// platform, and whether the installed <c>agy</c> meets the MINIMUM version this daemon recorded.
 ///
-/// <para>The floor is where this vendor deliberately diverges from Kiro and Gemini, which require an
-/// operator to affirm each installed build. <c>agy</c> was observed auto-updating itself mid-session
-/// (1.1.8 → 1.1.10), so an affirmation gate would park the reviewer on a release cadence the operator
-/// neither controls nor can predict. Meeting the floor is enough.</para>
+/// <para>The version half is the SHARED mechanism Kiro and Gemini use — a daemon-owned record, moved
+/// only by <c>kcap daemon reviewer affirm</c>. It is a minimum, not an exact match, so an <c>agy</c>
+/// that updates itself needs no operator action; a build found to be bad is excluded by raising the
+/// floor past it. What stays Antigravity's own is the consent flag, the POSIX-only refusal, and the
+/// binary-missing arm the factory adds around this decision.</para>
 /// </summary>
 public class AntigravityReviewerCapabilityTests {
     /// <summary>Pinned, never read from the running host: these arms are about consent and versions,
@@ -17,25 +19,25 @@ public class AntigravityReviewerCapabilityTests {
     /// unrelated to what it asserts.</summary>
     const bool Posix = true;
 
-    const string Floor = "1.1.10";
+    const string Minimum = "1.1.10";
 
     // ── the arms ──────────────────────────────────────────────────────────────────────────────────
 
     [Test]
-    public async Task ConsentPlusAFloorMeetingBuild_IsTheOnlyPermittedCombination() =>
-        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, "1.1.10", Floor))
+    public async Task ConsentPlusAMinimumMeetingBuild_IsTheOnlyPermittedCombination() =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, "1.1.10", Minimum))
             .IsEqualTo(AntigravityReviewerDecision.Allowed);
 
     /// <summary>Consent is read FIRST and short-circuits: an installed-but-wedged <c>agy</c> must not
     /// be probed — let alone hang a daemon start — for a feature the operator switched off. The
-    /// below-floor argument is what makes this a short-circuit assertion rather than a restatement of
-    /// the disabled arm.</summary>
+    /// below-minimum argument is what makes this a short-circuit assertion rather than a restatement
+    /// of the disabled arm.</summary>
     [Test]
     [Arguments("1.1.10")]
     [Arguments("0.0.1")]
     [Arguments(null)]
     public async Task DisabledByTheOperator_IsRefusedWhateverTheVersionSays(string? installed) =>
-        await Assert.That(AntigravityReviewerCapability.Decide(Posix, false, installed, Floor))
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, false, installed, Minimum))
             .IsEqualTo(AntigravityReviewerDecision.Disabled);
 
     /// <summary>The Windows arm, assertable from any host because the platform is a parameter. The
@@ -44,68 +46,83 @@ public class AntigravityReviewerCapabilityTests {
     [Test]
     public async Task AWindowsHost_IsRefusedEvenWhenConsentedAndCurrent() =>
         await Assert.That(AntigravityReviewerCapability.Decide(
-                posixHost: false, operatorEnabled: true, installedVersion: "1.1.10", minimumVersion: Floor))
+                posixHost: false, operatorEnabled: true, installedVersion: "1.1.10", minimumVersion: Minimum))
             .IsEqualTo(AntigravityReviewerDecision.UnsupportedPlatform);
 
-    // ── the floor ─────────────────────────────────────────────────────────────────────────────────
+    // ── the minimum ───────────────────────────────────────────────────────────────────────────────
 
     /// <summary>The regression guard for the owner's decision: a NEWER build is allowed, not refused.
-    /// An exact-match or affirmation compare reintroduced here would fail this.</summary>
+    /// An exact-match compare reintroduced here would fail this.</summary>
     [Test]
     [Arguments("1.1.11")]
     [Arguments("1.2.0")]
     [Arguments("2.0.0")]
     [Arguments("1.1.10.1")]
-    public async Task AboveTheFloor_IsAllowed(string installed) =>
-        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Floor))
+    public async Task ANewerVersion_IsAdmittedWithNoOperatorAction(string installed) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Minimum))
             .IsEqualTo(AntigravityReviewerDecision.Allowed);
 
     /// <summary>A floor, not a bar to clear: <c>&gt;=</c>, never <c>&gt;</c>.</summary>
     [Test]
-    public async Task ExactlyTheFloor_IsAllowed() =>
-        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, Floor, Floor))
+    public async Task ExactlyTheMinimum_IsAllowed() =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, Minimum, Minimum))
             .IsEqualTo(AntigravityReviewerDecision.Allowed);
 
     [Test]
     [Arguments("1.1.9")]
     [Arguments("1.0.0")]
     [Arguments("0.9.9")]
-    public async Task BelowTheFloor_IsRefused(string installed) =>
-        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Floor))
+    public async Task AnOlderVersion_IsRefused(string installed) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Minimum))
             .IsEqualTo(AntigravityReviewerDecision.VersionBelowMinimum);
 
-    /// <summary>A build we cannot identify has not been SHOWN to meet the floor, so it is refused —
+    /// <summary>A build we cannot identify has not been SHOWN to meet the minimum, so it is refused —
     /// and refused under its own arm, because the operator action differs from an old build's.</summary>
     [Test]
     [Arguments(null)]
     [Arguments("")]
     [Arguments("   ")]
-    [Arguments("banana")]
-    [Arguments("unknown")]
-    [Arguments("v")]
-    public async Task AnUnidentifiableBuild_IsUnresolvedRatherThanBelowTheFloor(string? installed) =>
-        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Floor))
+    public async Task AnUnresolvedVersion_IsRefused(string? installed) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Minimum))
             .IsEqualTo(AntigravityReviewerDecision.VersionUnresolved);
+
+    /// <summary>
+    /// The control for the seeding behaviour: an absent record must NOT read as permission. Without
+    /// this, a seeding bug and a working gate look identical.
+    /// </summary>
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task NoMinimumOnRecord_IsRefused(string? minimum) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, "1.1.10", minimum))
+            .IsEqualTo(AntigravityReviewerDecision.VersionNoMinimum);
+
+    /// <summary>An unorderable pair must reach its OWN arm, never the below-minimum one — refusing an
+    /// upgrade while calling it "too old" is the failure this arm exists to prevent.</summary>
+    [Test]
+    [Arguments("2.0.0", "1.2.3.4.5")]
+    [Arguments("1.2.3.4.5", "2.0.0")]
+    [Arguments("banana", "1.1.10")]
+    public async Task AnUnorderablePair_IsIncomparableNotBelowMinimum(string installed, string minimum) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, minimum))
+            .IsEqualTo(AntigravityReviewerDecision.VersionIncomparable);
 
     /// <summary>A vendor prerelease suffix is not an unidentifiable build — the shared comparison
     /// strips it, and refusing here would take the reviewer offline on a build that meets the
-    /// floor.</summary>
+    /// minimum.</summary>
     [Test]
     [Arguments("1.1.10-beta.1")]
     [Arguments("1.2.0+build7")]
-    public async Task APrereleaseOrBuildSuffixStillMeetsTheFloor(string installed) =>
-        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Floor))
+    public async Task APrereleaseOrBuildSuffixStillMeetsTheMinimum(string installed) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Minimum))
             .IsEqualTo(AntigravityReviewerDecision.Allowed);
 
-    /// <summary>A floor that is not itself a version fails CLOSED. The value is operator-settable, so
-    /// a typo must refuse rather than admit every build.</summary>
+    /// <summary>Surrounding whitespace is not a version change.</summary>
     [Test]
-    [Arguments("")]
-    [Arguments("latest")]
-    [Arguments("1.1.x")]
-    public async Task AnUnparseableFloor_RefusesRatherThanAdmittingEverything(string minimum) =>
-        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, "9.9.9", minimum))
-            .IsNotEqualTo(AntigravityReviewerDecision.Allowed);
+    public async Task VersionComparisonIgnoresSurroundingWhitespace() =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, " 1.1.10\n", Minimum))
+            .IsEqualTo(AntigravityReviewerDecision.Allowed);
 
     // ── the denial reasons ────────────────────────────────────────────────────────────────────────
 
@@ -115,61 +132,107 @@ public class AntigravityReviewerCapabilityTests {
     /// </summary>
     [Test]
     public async Task TheDisabledReason_NamesTheSwitchAndSaysWhereItGoes() {
-        var reason = Reason(AntigravityReviewerDecision.Disabled, null);
+        var reason = Reason(AntigravityReviewerDecision.Disabled, null, null);
 
         await Assert.That(reason).StartsWith("antigravity_unattended_reviewer_disabled");
         await Assert.That(reason).Contains("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
         await Assert.That(reason).Contains("daemon's environment");
     }
 
-    /// <summary>The platform refusal says WHY rather than merely refusing. Its text cannot be compared
-    /// against the factory's the way the consent one is — that ladder reads the ambient OS, so the arm
-    /// is unreachable from a POSIX test host — so the shared code is the pin.</summary>
+    /// <summary>The platform refusal says WHY rather than merely refusing.</summary>
     [Test]
     public async Task TheUnsupportedPlatformReason_SaysWhyRatherThanJustRefusing() {
-        var reason = Reason(AntigravityReviewerDecision.UnsupportedPlatform, null);
+        var reason = Reason(AntigravityReviewerDecision.UnsupportedPlatform, null, null);
 
         await Assert.That(reason).StartsWith("antigravity_reviewer_unsupported_platform");
         await Assert.That(reason).Contains("owner-only");
     }
 
     [Test]
-    public async Task TheBelowMinimumReason_NamesBothVersionsAndTheUpgrade() {
-        var reason = Reason(AntigravityReviewerDecision.VersionBelowMinimum, "1.1.8");
+    public async Task TheBelowMinimumReason_NamesBothVersionsAndTheFix() {
+        var reason = Reason(AntigravityReviewerDecision.VersionBelowMinimum, "1.1.8", Minimum);
 
         await Assert.That(reason).StartsWith("antigravity_reviewer_version_below_minimum");
         await Assert.That(reason).Contains("1.1.8");
-        await Assert.That(reason).Contains(Floor);
-        await Assert.That(reason).Contains("upgrade");
-        await Assert.That(reason).Contains("KCAP_ANTIGRAVITY_MIN_CLI_VERSION");
+        await Assert.That(reason).Contains(Minimum);
+        await Assert.That(reason).Contains("kcap daemon reviewer affirm --vendor antigravity");
     }
 
     /// <summary>An operator whose <c>agy --version</c> stopped parsing needs a different action from
-    /// one running an old build, which is the whole reason these are separate arms.</summary>
+    /// one running an old build, which is the whole reason these are separate arms. It names the
+    /// binary the DAEMON would launch, not whatever is first on PATH.</summary>
     [Test]
     public async Task TheUnresolvedReason_SendsTheOperatorToTheBinaryRatherThanToAnUpgrade() {
-        var reason = Reason(AntigravityReviewerDecision.VersionUnresolved, null);
+        var reason = Reason(AntigravityReviewerDecision.VersionUnresolved, null, Minimum);
 
         await Assert.That(reason).StartsWith("antigravity_reviewer_version_unresolved");
         await Assert.That(reason).Contains("--version");
         await Assert.That(reason).Contains("KCAP_ANTIGRAVITY_PATH");
+        await Assert.That(reason).Contains("agy");
     }
 
-    /// <summary>
-    /// Antigravity has NO affirmation model and no <c>affirm</c> verb will exist for it, so no refusal
-    /// may send an operator to one. Ranges over every arm because the trap is a text copied from a
-    /// sibling reviewer, which is exactly how it would arrive.
-    /// </summary>
+    /// <summary>The most common misconfiguration — enabling the reviewer against an already-running
+    /// daemon, which seeds its record at startup — so the remedy names BOTH the restart and the verb
+    /// that avoids one.</summary>
     [Test]
-    public async Task NoRefusalPointsAtAnAffirmCommand() {
+    public async Task TheNoMinimumReason_SendsTheOperatorToARestartOrTheAffirmVerb() {
+        var reason = Reason(AntigravityReviewerDecision.VersionNoMinimum, "1.1.10", null);
+
+        await Assert.That(reason).StartsWith("antigravity_reviewer_version_no_minimum");
+        await Assert.That(reason).Contains("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
+        await Assert.That(reason).Contains("kcap daemon reviewer affirm --vendor antigravity");
+    }
+
+    [Test]
+    public async Task TheIncomparableReason_SaysNeitherIsNewerRatherThanCallingTheBuildOld() {
+        var reason = Reason(AntigravityReviewerDecision.VersionIncomparable, "1.2.3.4.5", Minimum);
+
+        await Assert.That(reason).StartsWith("antigravity_reviewer_version_incomparable");
+        await Assert.That(reason).Contains("1.2.3.4.5");
+        await Assert.That(reason).Contains(Minimum);
+        await Assert.That(reason).Contains("kcap daemon reviewer affirm --vendor antigravity");
+    }
+
+    /// <summary>Asking for the denial reason of a PERMITTED decision is a caller bug, not a text to
+    /// invent — and a discard arm would have answered it with a neighbouring vendor's remedy.</summary>
+    [Test]
+    public async Task TheAllowedDecisionHasNoDenialReason() =>
+        await Assert.That(() => Reason(AntigravityReviewerDecision.Allowed, "1.1.10", Minimum))
+            .Throws<ArgumentOutOfRangeException>();
+
+    /// <summary>No refusal may point an operator at a variable this vendor no longer reads. The floor
+    /// used to be configuration; it is now a daemon-owned record moved by the affirm verb, and a text
+    /// left behind would send an operator to a switch that does nothing.</summary>
+    [Test]
+    public async Task NoRefusalPointsAtTheRetiredConfigurationVariable() {
         foreach (var decision in Enum.GetValues<AntigravityReviewerDecision>()) {
             if (decision == AntigravityReviewerDecision.Allowed) continue;
 
-            await Assert.That(Reason(decision, "1.1.8")).DoesNotContain("affirm")
-                .Because($"{decision} must not send an operator to a verb this vendor does not have");
+            await Assert.That(Reason(decision, "1.1.8", Minimum))
+                .DoesNotContain("KCAP_ANTIGRAVITY_MIN_CLI_VERSION")
+                .Because($"{decision} must not send an operator to a variable this daemon no longer reads");
         }
     }
 
-    static string Reason(AntigravityReviewerDecision decision, string? installed) =>
-        AntigravityReviewerCapability.DenialReason(decision, installed, Floor, binaryPath: "agy");
+    /// <summary>
+    /// Enabling a reviewer is a security consent event, so only an explicit affirmative counts —
+    /// a typo, a blank, or an unrecognised value must not be read as consent.
+    /// </summary>
+    [Test]
+    [Arguments("1", true)]
+    [Arguments("true", true)]
+    [Arguments("TRUE", true)]
+    [Arguments("yes", true)]
+    [Arguments("on", true)]
+    [Arguments("0", false)]
+    [Arguments("false", false)]
+    [Arguments("", false)]
+    [Arguments("   ", false)]
+    [Arguments("ture", false)]
+    [Arguments(null, false)]
+    public async Task TheConsentFlagOnlyAcceptsAnExplicitAffirmative(string? value, bool expected) =>
+        await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsEqualTo(expected);
+
+    static string Reason(AntigravityReviewerDecision decision, string? installed, string? minimum) =>
+        AntigravityReviewerCapability.DenialReason(decision, installed, minimum, binaryPath: "agy");
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
@@ -1,0 +1,199 @@
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// The Antigravity reviewer gate is fail-closed on three axes: the operator's consent flag, the
+/// platform, and whether the installed <c>agy</c> meets a minimum version FLOOR.
+///
+/// <para>The floor is where this vendor deliberately diverges from Kiro and Gemini, which require an
+/// operator to affirm each installed build. <c>agy</c> was observed auto-updating itself mid-session
+/// (1.1.8 → 1.1.10), so an affirmation gate would park the reviewer on a release cadence the operator
+/// neither controls nor can predict. Meeting the floor is enough.</para>
+/// </summary>
+public class AntigravityReviewerCapabilityTests {
+    /// <summary>Pinned, never read from the running host: these arms are about consent and versions,
+    /// and letting the CI leg decide the platform makes every one of them fail on Windows for a reason
+    /// unrelated to what it asserts.</summary>
+    const bool Posix = true;
+
+    const string Floor = "1.1.10";
+
+    // ── the arms ──────────────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ConsentPlusAFloorMeetingBuild_IsTheOnlyPermittedCombination() =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, "1.1.10", Floor))
+            .IsEqualTo(AntigravityReviewerDecision.Allowed);
+
+    /// <summary>Consent is read FIRST and short-circuits: an installed-but-wedged <c>agy</c> must not
+    /// be probed — let alone hang a daemon start — for a feature the operator switched off. The
+    /// below-floor argument is what makes this a short-circuit assertion rather than a restatement of
+    /// the disabled arm.</summary>
+    [Test]
+    [Arguments("1.1.10")]
+    [Arguments("0.0.1")]
+    [Arguments(null)]
+    public async Task DisabledByTheOperator_IsRefusedWhateverTheVersionSays(string? installed) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, false, installed, Floor))
+            .IsEqualTo(AntigravityReviewerDecision.Disabled);
+
+    /// <summary>The Windows arm, assertable from any host because the platform is a parameter. The
+    /// per-launch home holds the reviewer's own transcript — and so the review context — and cannot be
+    /// created owner-only there.</summary>
+    [Test]
+    public async Task AWindowsHost_IsRefusedEvenWhenConsentedAndCurrent() =>
+        await Assert.That(AntigravityReviewerCapability.Decide(
+                posixHost: false, operatorEnabled: true, installedVersion: "1.1.10", minimumVersion: Floor))
+            .IsEqualTo(AntigravityReviewerDecision.UnsupportedPlatform);
+
+    // ── the floor ─────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>The regression guard for the owner's decision: a NEWER build is allowed, not refused.
+    /// An exact-match or affirmation compare reintroduced here would fail this.</summary>
+    [Test]
+    [Arguments("1.1.11")]
+    [Arguments("1.2.0")]
+    [Arguments("2.0.0")]
+    [Arguments("1.1.10.1")]
+    public async Task AboveTheFloor_IsAllowed(string installed) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Floor))
+            .IsEqualTo(AntigravityReviewerDecision.Allowed);
+
+    /// <summary>A floor, not a bar to clear: <c>&gt;=</c>, never <c>&gt;</c>.</summary>
+    [Test]
+    public async Task ExactlyTheFloor_IsAllowed() =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, Floor, Floor))
+            .IsEqualTo(AntigravityReviewerDecision.Allowed);
+
+    [Test]
+    [Arguments("1.1.9")]
+    [Arguments("1.0.0")]
+    [Arguments("0.9.9")]
+    public async Task BelowTheFloor_IsRefused(string installed) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Floor))
+            .IsEqualTo(AntigravityReviewerDecision.VersionBelowMinimum);
+
+    /// <summary>A build we cannot identify has not been SHOWN to meet the floor, so it is refused —
+    /// and refused under its own arm, because the operator action differs from an old build's.</summary>
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments("banana")]
+    [Arguments("unknown")]
+    [Arguments("v")]
+    public async Task AnUnidentifiableBuild_IsUnresolvedRatherThanBelowTheFloor(string? installed) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Floor))
+            .IsEqualTo(AntigravityReviewerDecision.VersionUnresolved);
+
+    /// <summary>A vendor prerelease suffix is not an unidentifiable build — the shared comparison
+    /// strips it, and refusing here would take the reviewer offline on a build that meets the
+    /// floor.</summary>
+    [Test]
+    [Arguments("1.1.10-beta.1")]
+    [Arguments("1.2.0+build7")]
+    public async Task APrereleaseOrBuildSuffixStillMeetsTheFloor(string installed) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, installed, Floor))
+            .IsEqualTo(AntigravityReviewerDecision.Allowed);
+
+    /// <summary>A floor that is not itself a version fails CLOSED. The value is operator-settable, so
+    /// a typo must refuse rather than admit every build.</summary>
+    [Test]
+    [Arguments("")]
+    [Arguments("latest")]
+    [Arguments("1.1.x")]
+    public async Task AnUnparseableFloor_RefusesRatherThanAdmittingEverything(string minimum) =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, "9.9.9", minimum))
+            .IsNotEqualTo(AntigravityReviewerDecision.Allowed);
+
+    // ── the denial reasons ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The consent text is what an operator reads before turning this on, so its content is asserted
+    /// rather than its presence.
+    /// </summary>
+    [Test]
+    public async Task TheDisabledReason_NamesTheSwitchAndSaysWhereItGoes() {
+        var reason = Reason(AntigravityReviewerDecision.Disabled, null);
+
+        await Assert.That(reason).StartsWith("antigravity_unattended_reviewer_disabled");
+        await Assert.That(reason).Contains("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
+        await Assert.That(reason).Contains("daemon's environment");
+    }
+
+    /// <summary>
+    /// The strongest available pin on "one ladder, not two": the shipped factory judges consent with
+    /// its own inline check, and this asserts the capability's text is BYTE-IDENTICAL to what that
+    /// check produces. If either side is reworded on its own, this goes red — so the two cannot drift
+    /// into disagreeing about what an operator is told.
+    /// </summary>
+    [Test]
+    public async Task TheDisabledReason_IsExactlyWhatTheFactorysOwnLadderReports() {
+        var config = new DaemonConfig {
+            AntigravityPath                      = "agy",
+            AntigravityUnattendedReviewerEnabled = false,
+            Name                                 = "test-daemon"
+        };
+
+        var factoryReason = new AntigravityHostedAgentRuntimeFactory(
+            config, NullLoggerFactory.Instance, turnSource: null, binaryExists: _ => true)
+            .DescribeUnattendedSupport().WithheldReason;
+
+        await Assert.That(Reason(AntigravityReviewerDecision.Disabled, null)).IsEqualTo(factoryReason);
+    }
+
+    /// <summary>The platform refusal says WHY rather than merely refusing. Its text cannot be compared
+    /// against the factory's the way the consent one is — that ladder reads the ambient OS, so the arm
+    /// is unreachable from a POSIX test host — so the shared code is the pin.</summary>
+    [Test]
+    public async Task TheUnsupportedPlatformReason_SaysWhyRatherThanJustRefusing() {
+        var reason = Reason(AntigravityReviewerDecision.UnsupportedPlatform, null);
+
+        await Assert.That(reason).StartsWith("antigravity_reviewer_unsupported_platform");
+        await Assert.That(reason).Contains("owner-only");
+    }
+
+    [Test]
+    public async Task TheBelowMinimumReason_NamesBothVersionsAndTheUpgrade() {
+        var reason = Reason(AntigravityReviewerDecision.VersionBelowMinimum, "1.1.8");
+
+        await Assert.That(reason).StartsWith("antigravity_reviewer_version_below_minimum");
+        await Assert.That(reason).Contains("1.1.8");
+        await Assert.That(reason).Contains(Floor);
+        await Assert.That(reason).Contains("upgrade");
+        await Assert.That(reason).Contains("KCAP_ANTIGRAVITY_MIN_CLI_VERSION");
+    }
+
+    /// <summary>An operator whose <c>agy --version</c> stopped parsing needs a different action from
+    /// one running an old build, which is the whole reason these are separate arms.</summary>
+    [Test]
+    public async Task TheUnresolvedReason_SendsTheOperatorToTheBinaryRatherThanToAnUpgrade() {
+        var reason = Reason(AntigravityReviewerDecision.VersionUnresolved, null);
+
+        await Assert.That(reason).StartsWith("antigravity_reviewer_version_unresolved");
+        await Assert.That(reason).Contains("--version");
+        await Assert.That(reason).Contains("KCAP_ANTIGRAVITY_PATH");
+    }
+
+    /// <summary>
+    /// Antigravity has NO affirmation model and no <c>affirm</c> verb will exist for it, so no refusal
+    /// may send an operator to one. Ranges over every arm because the trap is a text copied from a
+    /// sibling reviewer, which is exactly how it would arrive.
+    /// </summary>
+    [Test]
+    public async Task NoRefusalPointsAtAnAffirmCommand() {
+        foreach (var decision in Enum.GetValues<AntigravityReviewerDecision>()) {
+            if (decision == AntigravityReviewerDecision.Allowed) continue;
+
+            await Assert.That(Reason(decision, "1.1.8")).DoesNotContain("affirm")
+                .Because($"{decision} must not send an operator to a verb this vendor does not have");
+        }
+    }
+
+    static string Reason(AntigravityReviewerDecision decision, string? installed) =>
+        AntigravityReviewerCapability.DenialReason(decision, installed, Floor, binaryPath: "agy");
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
@@ -23,6 +23,25 @@ public class AntigravityReviewerCapabilityTests {
 
     // ── the arms ──────────────────────────────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Pins a cross-file assumption the factory's ladder is BUILT on but does not own: with neither
+    /// version known, the verdict must be <see cref="AntigravityReviewerDecision.VersionUnresolved"/>.
+    ///
+    /// <para><c>ReviewerRefusal</c> calls <c>Decide(posix, enabled, null, null)</c> as a probe-free
+    /// pre-check and treats exactly that arm as "consent and platform are fine, keep going" — the
+    /// binary-missing check and the version probe both sit AFTER it. The arm depends on
+    /// <c>ReviewerVersionAffirmations.Decide</c> testing the installed version before the minimum,
+    /// which is a property of a shared type in another assembly. Reorder those two null checks — a
+    /// natural "no minimum recorded, skip the comparison" impulse — and this returns
+    /// <see cref="AntigravityReviewerDecision.VersionNoMinimum"/> instead, the pre-check refuses
+    /// before ever looking for the binary, and a daemon with no <c>agy</c> installed is told its
+    /// minimum is missing. Both halves would still look correct read on their own.</para>
+    /// </summary>
+    [Test]
+    public async Task NeitherVersionKnown_IsUnresolved_WhichTheFactorysPreProbeDependsOn() =>
+        await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, null, null))
+            .IsEqualTo(AntigravityReviewerDecision.VersionUnresolved);
+
     [Test]
     public async Task ConsentPlusAMinimumMeetingBuild_IsTheOnlyPermittedCombination() =>
         await Assert.That(AntigravityReviewerCapability.Decide(Posix, true, "1.1.10", Minimum))

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerHomeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerHomeTests.cs
@@ -12,6 +12,7 @@ namespace Capacitor.Cli.Tests.Unit.Acp;
 public class AntigravityReviewerHomeTests {
     [Test]
     public async Task The_home_carries_only_the_injected_mcp_server() {
+        if (OperatingSystem.IsWindows()) return;
         using var root = new TempDir();
         var home = AntigravityReviewerHome.Create(
             root.Path, "epoch1", "agent1",

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerHomeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerHomeTests.cs
@@ -1,0 +1,63 @@
+using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Daemon.Acp;
+
+namespace Capacitor.Cli.Tests.Unit.Acp;
+
+/// <summary>
+/// Unlike <see cref="KiroReviewerHomeTests"/>'s target, this home is not empty at spawn — it carries
+/// a written <c>mcp_config.json</c> for the injected servers. The absence of the kcap plugin
+/// directory is what keeps capture single-lane (a probe confirmed <c>agy -p</c> loads and fires it
+/// when present), so that absence is asserted directly rather than inferred from "we wrote nothing".
+/// </summary>
+public class AntigravityReviewerHomeTests {
+    [Test]
+    public async Task The_home_carries_only_the_injected_mcp_server() {
+        using var root = new TempDir();
+        var home = AntigravityReviewerHome.Create(
+            root.Path, "epoch1", "agent1",
+            [new AcpMcpServerSpec("kcap-flow-result", "kcap", ["mcp", "flow-result"], [])]);
+
+        var mcp = Path.Combine(home, ".gemini", "config", "mcp_config.json");
+        await Assert.That(File.Exists(mcp)).IsTrue();
+        await Assert.That(await File.ReadAllTextAsync(mcp)).Contains("kcap-flow-result");
+
+        // The kcap plugin dir must NOT exist — its absence is what keeps capture single-lane.
+        // If a future change seeds a fuller home, this is the assertion that catches it.
+        await Assert.That(Directory.Exists(Path.Combine(home, ".gemini", "config", "plugins"))).IsFalse();
+    }
+
+    [Test]
+    public async Task The_home_is_owner_only_from_creation() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root = new TempDir();
+        var home = AntigravityReviewerHome.Create(root.Path, "epoch1", "agent1", []);
+        var mode = File.GetUnixFileMode(home);
+
+        await Assert.That(mode.HasFlag(UnixFileMode.GroupRead)).IsFalse();
+        await Assert.That(mode.HasFlag(UnixFileMode.OtherRead)).IsFalse();
+    }
+
+    [Test]
+    public async Task Sweep_removes_foreign_epochs_and_keeps_the_current_one() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root = new TempDir();
+        var stale   = AntigravityReviewerHome.Create(root.Path, "old",     "a1", []);
+        var current = AntigravityReviewerHome.Create(root.Path, "current", "a2", []);
+
+        AntigravityReviewerHome.SweepStale(root.Path, "current");
+
+        await Assert.That(Directory.Exists(stale)).IsFalse();
+        await Assert.That(Directory.Exists(current)).IsTrue();
+    }
+
+    sealed class TempDir : IDisposable {
+        public string Path { get; } =
+            System.IO.Path.Combine(System.IO.Path.GetTempPath(), "kcap-agy-home-tests-" + Guid.NewGuid().ToString("N"));
+
+        public TempDir() => Directory.CreateDirectory(Path);
+
+        public void Dispose() {
+            try { Directory.Delete(Path, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityReviewerReapingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityReviewerReapingTests.cs
@@ -1,7 +1,9 @@
 // test/Capacitor.Cli.Tests.Unit/AntigravityReviewerReapingTests.cs
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Capacitor.Cli.Tests.Unit.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using static Capacitor.Cli.Tests.Unit.Services.AntigravityRuntimeFakes;
 
@@ -110,5 +112,84 @@ public partial class AgentOrchestratorVendorTests {
 
         await Assert.That(reap.Select(r => r.Id)).DoesNotContain("agy-mid-turn");
         await Assert.That(reap).Contains(("agy-settled", "reviewer_idle_expired"));
+    }
+
+    /// <summary>
+    /// The launch path must WIRE the exec-per-turn PID-record seam, and wire it to THIS agent's
+    /// durable record. Without it the runtime only ever gets the one-shot record of turn 1's pid taken
+    /// immediately after the launch, and every later round spawns a differently-pid'd child that never
+    /// enters the record at all.
+    ///
+    /// <para>Both directions are driven through the wired bundle rather than through a second round,
+    /// because a round's own record and the launch's one-shot record name the same live pid and would
+    /// be indistinguishable. Clearing first and then recording makes each assertion unambiguous. The
+    /// runtime's own per-turn CADENCE — a record per spawn, a clear per confirmed exit — is pinned
+    /// separately by <c>AntigravityRuntimeLifecycleTests</c>.</para>
+    /// </summary>
+    [Test]
+    public async Task An_antigravity_launch_wires_the_per_turn_pid_record_seam_to_this_agents_record() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var factory = new AntigravityRuntimeSpyFactory();
+
+            await using var orch = BuildOrchestrator(
+                new CaptureServerConnection(), new SpyPtyProcessFactory(),
+                new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+
+            await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "agy-pid-1", Prompt: "review this", Model: "auto", Effort: null,
+                RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "antigravity"));
+
+            var runtime = factory.LastRuntime;
+
+            await Assert.That(runtime).IsNotNull();
+            await Assert.That(runtime!.PidCallbacks).IsNotNull();
+
+            // The launch's own one-shot record exists — the baseline both assertions move away from.
+            await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "agy-pid-1")).IsTrue();
+
+            runtime.PidCallbacks!.Clear();
+            await Assert.That(orch.PidRecordsForTest().Any(r => r.AgentId == "agy-pid-1")).IsFalse();
+
+            // A live, capturable pid: PersistPidRecordOrThrow's legacy arm records only a process it
+            // can identify, so a fabricated pid would make this pass for the wrong reason.
+            runtime.PidCallbacks.Record(Environment.ProcessId);
+
+            await Assert.That(orch.PidRecordsForTest()
+                .Any(r => r.AgentId == "agy-pid-1" && r.Pid == Environment.ProcessId)).IsTrue();
+        } finally {
+            cleanup();
+        }
+    }
+
+    /// <summary>Returns the REAL exec-per-turn runtime (the type the orchestrator's wiring branch
+    /// matches on) over a fake turn child that stays alive, so the launch sees a live, capturable pid
+    /// exactly as a real first turn would. Mirrors the real factory's one load-bearing ordering: the
+    /// conversation id is resolved before control returns.</summary>
+    sealed class AntigravityRuntimeSpyFactory : IHostedAgentRuntimeFactory {
+        public string Vendor             => "antigravity";
+        public bool   SupportsUnattended => true;
+
+        public AntigravityHostedAgentRuntime? LastRuntime { get; private set; }
+
+        public bool IsAvailable() => true;
+
+        public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+            var runtime = new AntigravityHostedAgentRuntime(
+                spawnTurn: (_, _, _) => Task.FromResult<IAgyTurnProcess>(new FakeAgyTurnProcess(
+                    FakeTurn.NeverEnds, AntigravityRuntimeFakes.FixedConversationId,
+                    pid: Environment.ProcessId)),
+                logger: NullLogger.Instance,
+                agentId: ctx.AgentId);
+
+            LastRuntime = runtime;
+
+            await runtime.SendUserInputAsync(ctx.Prompt ?? "").ConfigureAwait(false);
+            await runtime.WaitForConversationIdAsync(ct).ConfigureAwait(false);
+
+            return new HostedRuntimeStart(runtime, McpConfigPath: null, Transcript: runtime);
+        }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityReviewerReapingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityReviewerReapingTests.cs
@@ -1,0 +1,114 @@
+// test/Capacitor.Cli.Tests.Unit/AntigravityReviewerReapingTests.cs
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Tests.Unit.Services;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.Cli.Tests.Unit.Services.AntigravityRuntimeFakes;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The exec-per-turn runtime's clock, judged by the REAL reaper
+/// (<see cref="AgentOrchestrator.FindReviewersToReap"/>) rather than by reading
+/// <see cref="AgentActivityClock.TurnInFlight"/> back. The unit tests in
+/// <see cref="AntigravityActivityClockTests"/> pin the flag; these pin what the flag DOES, which is
+/// the thing that actually leaks a daemon slot or kills a working reviewer.
+///
+/// <para>Between turns this runtime has no process at all. That needs no special case and no
+/// keepalive: <c>TurnInFlight</c> is false, so <c>ReviewerIdleTimeout</c> governs exactly as it does
+/// for any ACP reviewer waiting on the next round.</para>
+///
+/// Partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its <c>BuildOrchestrator</c> /
+/// <c>CaptureServerConnection</c> / <c>SpyPtyProcessFactory</c> doubles — the same pattern
+/// <c>ReviewerReapingTests.cs</c> follows.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    static readonly TimeSpan AntigravityHangGuard = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Between rounds the reviewer is a runtime with NO child process, and it must be idle-reapable
+    /// on the ordinary 2h rule. A build that left <c>TurnInFlight</c> held after a settled turn would
+    /// suppress that rule outright and the slot would never be reclaimed.
+    /// </summary>
+    [Test]
+    public async Task Antigravity_reviewer_between_turns_is_idle_reaped_like_any_other() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+
+        await using var rt = FakeRuntime();
+        rt.ActivityClock = clock;
+
+        await rt.SendUserInputAsync("round 1").WaitAsync(AntigravityHangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(AntigravityHangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(AntigravityHangGuard);
+
+        // The turn genuinely ran, so "no turn in flight" is a settled fact rather than a turn that
+        // never started.
+        await Assert.That(rt.AcpSessionId).IsEqualTo(FixedConversationId);
+
+        time.Advance(TimeSpan.FromHours(2) + TimeSpan.FromMinutes(1)); // past the 2h idle rule, under the 6h TTL
+
+        orch.SeedAgentForTest("agy-between-turns", LaunchKind.ReviewFlow, status: "Running", activityClock: clock);
+
+        // The REASON, not merely "it is in the list": at this elapsed time the TTL rule cannot fire,
+        // so naming the idle rule pins that the plain idle path was reached at all.
+        await Assert.That(orch.FindReviewersToReap()).Contains(("agy-between-turns", "reviewer_idle_expired"));
+    }
+
+    /// <summary>
+    /// The opposite direction, and the reason the flag cannot simply be pinned false: a turn that is
+    /// genuinely running SUPPRESSES the idle rule, so a long review round is not reaped out from under
+    /// itself. The settled twin is the control — identical elapsed time, opposite verdict, so neither
+    /// outcome can come from the elapsed time alone.
+    ///
+    /// <para>The wedge ceiling is disabled for this orchestrator deliberately. It is the one rule a
+    /// held turn leaves armed, so with it in force the mid-turn agent at 2h1m would be reaped as
+    /// <c>turn_wedged</c> — a different rule reaching the same verdict, which would prove nothing
+    /// about idle suppression. An earlier revision instead advanced the running clock only 30m, and a
+    /// mutation check showed that made the assertion vacuous: 30m is under the idle bound anyway, so
+    /// it passed with the flag never set at all. The wedge itself is covered by
+    /// <c>ReviewerReapingTests</c>.</para>
+    /// </summary>
+    [Test]
+    public async Task Antigravity_reviewer_mid_turn_is_not_idle_reaped_while_a_settled_one_is() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            configure: c => c.ReviewerTurnWedgeCeiling = TimeSpan.Zero);
+
+        var runningTime  = new FakeTimeProvider();
+        var runningClock = new AgentActivityClock(runningTime);
+
+        await using var running = FakeRuntime(FakeTurn.NeverEnds);
+        running.ActivityClock = runningClock;
+
+        _ = running.SendUserInputAsync("a long round");
+        await running.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(AntigravityHangGuard);
+
+        var settledTime  = new FakeTimeProvider();
+        var settledClock = new AgentActivityClock(settledTime);
+
+        await using var settled = FakeRuntime();
+        settled.ActivityClock = settledClock;
+
+        await settled.SendUserInputAsync("round 1").WaitAsync(AntigravityHangGuard);
+        await settled.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(AntigravityHangGuard);
+        await settled.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(AntigravityHangGuard);
+
+        // IDENTICAL elapsed time on both, past the 2h idle rule and under the 6h TTL. The only thing
+        // that differs between the two agents is whether a turn is in flight.
+        var elapsed = TimeSpan.FromHours(2) + TimeSpan.FromMinutes(1);
+        settledTime.Advance(elapsed);
+        runningTime.Advance(elapsed);
+
+        orch.SeedAgentForTest("agy-mid-turn", LaunchKind.ReviewFlow, status: "Running", activityClock: runningClock);
+        orch.SeedAgentForTest("agy-settled",  LaunchKind.ReviewFlow, status: "Running", activityClock: settledClock);
+
+        var reap = orch.FindReviewersToReap();
+
+        await Assert.That(reap.Select(r => r.Id)).DoesNotContain("agy-mid-turn");
+        await Assert.That(reap).Contains(("agy-settled", "reviewer_idle_expired"));
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/DaemonReviewerCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/DaemonReviewerCommandTests.cs
@@ -1,0 +1,73 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+/// <summary>
+/// <c>kcap daemon reviewer affirm --vendor …</c> for a vendor that HAS an unattended reviewer but no
+/// affirmation gate. Antigravity takes a minimum version FLOOR instead, so there is nothing to record
+/// — and the two failure modes worth avoiding are succeeding at a no-op (the operator believes a gate
+/// was cleared) and reporting it as an unknown vendor (the operator believes they typed it wrong).
+/// </summary>
+public class DaemonReviewerCommandTests {
+    [Test]
+    public async Task Antigravity_is_recognised_as_a_reviewer_with_no_affirmation_gate() =>
+        await Assert.That(DaemonReviewerCommand.NonAffirmableReviewer.Resolve("antigravity")).IsNotNull();
+
+    [Test]
+    [Arguments("ANTIGRAVITY")]
+    [Arguments("Antigravity")]
+    public async Task TheVendorMatchIsCaseInsensitive(string spelling) =>
+        await Assert.That(DaemonReviewerCommand.NonAffirmableReviewer.Resolve(spelling)).IsNotNull();
+
+    /// <summary>No vendor may sit in both tables: one would silently win by ordering, and which one it
+    /// is depends on the order of two checks nothing keeps in step.</summary>
+    [Test]
+    public async Task NoVendorIsBothAffirmableAndNonAffirmable() {
+        foreach (var nonAffirmable in DaemonReviewerCommand.NonAffirmableReviewer.All)
+            await Assert.That(DaemonReviewerCommand.AffirmableReviewer.Resolve(nonAffirmable.Vendor)).IsNull();
+    }
+
+    [Test]
+    [Arguments("kiro")]
+    [Arguments("gemini")]
+    public async Task TheAffirmableReviewersAreUnaffected(string vendor) =>
+        await Assert.That(DaemonReviewerCommand.NonAffirmableReviewer.Resolve(vendor)).IsNull();
+
+    /// <summary>The explanation has to redirect the operator, not just refuse: it names the mechanism
+    /// that replaced affirmation and both variables that drive it.</summary>
+    [Test]
+    public async Task TheExplanationNamesTheFloorAndTheVariablesThatDriveIt() {
+        var explanation = DaemonReviewerCommand.NonAffirmableReviewer.Resolve("antigravity")!.Explanation;
+
+        await Assert.That(explanation).StartsWith("antigravity_reviewer_not_affirmable");
+        await Assert.That(explanation).Contains("MINIMUM VERSION");
+        await Assert.That(explanation).Contains("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
+        await Assert.That(explanation).Contains("KCAP_ANTIGRAVITY_MIN_CLI_VERSION");
+    }
+
+    /// <summary>
+    /// Refused, never silently successful — and refused with ITS OWN explanation. The exit code alone
+    /// proves nothing here: the unknown-vendor branch below it also returns 1, so a wiring mistake that
+    /// dropped this arm entirely would look identical while telling the operator they typed the vendor
+    /// wrong. Captures stderr for that reason.
+    /// </summary>
+    [Test]
+    [NotInParallel]
+    public async Task Affirming_antigravity_refuses_with_its_own_explanation_not_as_an_unknown_vendor() {
+        var original = Console.Error;
+        var captured = new StringWriter();
+        int exitCode;
+
+        Console.SetError(captured);
+
+        try {
+            exitCode = await DaemonReviewerCommand.HandleAsync(["affirm", "--vendor", "antigravity"]);
+        } finally {
+            Console.SetError(original);
+        }
+
+        await Assert.That(exitCode).IsEqualTo(1);
+        await Assert.That(captured.ToString()).Contains("antigravity_reviewer_not_affirmable");
+        await Assert.That(captured.ToString()).DoesNotContain("Unknown reviewer vendor");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/DaemonReviewerCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/DaemonReviewerCommandTests.cs
@@ -3,57 +3,54 @@ using Capacitor.Cli.Commands;
 namespace Capacitor.Cli.Tests.Unit.Commands;
 
 /// <summary>
-/// <c>kcap daemon reviewer affirm --vendor …</c> for a vendor that HAS an unattended reviewer but no
-/// affirmation gate. Antigravity takes a minimum version FLOOR instead, so there is nothing to record
-/// — and the two failure modes worth avoiding are succeeding at a no-op (the operator believes a gate
-/// was cleared) and reporting it as an unknown vendor (the operator believes they typed it wrong).
+/// <c>kcap daemon reviewer affirm --vendor …</c> is a TABLE, not a per-vendor branch: every gated
+/// reviewer records its minimum through the same store, and adding one is a row. These pin that
+/// Antigravity is genuinely in that table — reachable, and reachable everywhere the table is read,
+/// since a row the usage text and the unknown-vendor message do not derive from would leave the verb
+/// working while telling operators it does not.
 /// </summary>
 public class DaemonReviewerCommandTests {
     [Test]
-    public async Task Antigravity_is_recognised_as_a_reviewer_with_no_affirmation_gate() =>
-        await Assert.That(DaemonReviewerCommand.NonAffirmableReviewer.Resolve("antigravity")).IsNotNull();
+    [Arguments("kiro")]
+    [Arguments("gemini")]
+    [Arguments("antigravity")]
+    public async Task EveryGatedReviewerIsAffirmable(string vendor) =>
+        await Assert.That(DaemonReviewerCommand.AffirmableReviewer.Resolve(vendor)).IsNotNull();
 
     [Test]
     [Arguments("ANTIGRAVITY")]
     [Arguments("Antigravity")]
     public async Task TheVendorMatchIsCaseInsensitive(string spelling) =>
-        await Assert.That(DaemonReviewerCommand.NonAffirmableReviewer.Resolve(spelling)).IsNotNull();
+        await Assert.That(DaemonReviewerCommand.AffirmableReviewer.Resolve(spelling)).IsNotNull();
 
-    /// <summary>No vendor may sit in both tables: one would silently win by ordering, and which one it
-    /// is depends on the order of two checks nothing keeps in step.</summary>
+    /// <summary>The row carries the binary and the two variables the DAEMON itself reads — the verb
+    /// affirms the build the daemon would launch, not whatever is first on PATH, so a wrong path
+    /// variable here records a version nothing will ever be compared against.</summary>
     [Test]
-    public async Task NoVendorIsBothAffirmableAndNonAffirmable() {
-        foreach (var nonAffirmable in DaemonReviewerCommand.NonAffirmableReviewer.All)
-            await Assert.That(DaemonReviewerCommand.AffirmableReviewer.Resolve(nonAffirmable.Vendor)).IsNull();
+    public async Task TheAntigravityRowNamesTheDaemonsOwnBinaryAndVariables() {
+        var reviewer = DaemonReviewerCommand.AffirmableReviewer.Resolve("antigravity")!;
+
+        await Assert.That(reviewer.DefaultBinary).IsEqualTo("agy");
+        await Assert.That(reviewer.PathEnvVar).IsEqualTo("KCAP_ANTIGRAVITY_PATH");
+        await Assert.That(reviewer.EnableEnvVar).IsEqualTo("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
     }
 
+    /// <summary>Both operator-facing lists derive from the table rather than restating it. Asserted on
+    /// the vendor the table gained last, because a hand-maintained copy is what would drop it.</summary>
     [Test]
-    [Arguments("kiro")]
-    [Arguments("gemini")]
-    public async Task TheAffirmableReviewersAreUnaffected(string vendor) =>
-        await Assert.That(DaemonReviewerCommand.NonAffirmableReviewer.Resolve(vendor)).IsNull();
-
-    /// <summary>The explanation has to redirect the operator, not just refuse: it names the mechanism
-    /// that replaced affirmation and both variables that drive it.</summary>
-    [Test]
-    public async Task TheExplanationNamesTheFloorAndTheVariablesThatDriveIt() {
-        var explanation = DaemonReviewerCommand.NonAffirmableReviewer.Resolve("antigravity")!.Explanation;
-
-        await Assert.That(explanation).StartsWith("antigravity_reviewer_not_affirmable");
-        await Assert.That(explanation).Contains("MINIMUM VERSION");
-        await Assert.That(explanation).Contains("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
-        await Assert.That(explanation).Contains("KCAP_ANTIGRAVITY_MIN_CLI_VERSION");
+    public async Task TheVendorListOfferedToOperatorsCoversTheWholeTable() {
+        foreach (var reviewer in DaemonReviewerCommand.AffirmableReviewer.All)
+            await Assert.That(DaemonReviewerCommand.AffirmableReviewer.VendorList).Contains(reviewer.Vendor);
     }
 
     /// <summary>
-    /// Refused, never silently successful — and refused with ITS OWN explanation. The exit code alone
-    /// proves nothing here: the unknown-vendor branch below it also returns 1, so a wiring mistake that
-    /// dropped this arm entirely would look identical while telling the operator they typed the vendor
-    /// wrong. Captures stderr for that reason.
+    /// An unrecognised vendor is refused as a typo and NAMES the alternatives, so an operator who
+    /// misspells one is not left guessing. Captures stderr because the exit code alone proves nothing
+    /// — every failure arm of this verb returns 1.
     /// </summary>
     [Test]
     [NotInParallel]
-    public async Task Affirming_antigravity_refuses_with_its_own_explanation_not_as_an_unknown_vendor() {
+    public async Task AnUnknownVendorIsRefusedAndOffersTheAffirmableOnes() {
         var original = Console.Error;
         var captured = new StringWriter();
         int exitCode;
@@ -61,13 +58,13 @@ public class DaemonReviewerCommandTests {
         Console.SetError(captured);
 
         try {
-            exitCode = await DaemonReviewerCommand.HandleAsync(["affirm", "--vendor", "antigravity"]);
+            exitCode = await DaemonReviewerCommand.HandleAsync(["affirm", "--vendor", "antigravitee"]);
         } finally {
             Console.SetError(original);
         }
 
         await Assert.That(exitCode).IsEqualTo(1);
-        await Assert.That(captured.ToString()).Contains("antigravity_reviewer_not_affirmable");
-        await Assert.That(captured.ToString()).DoesNotContain("Unknown reviewer vendor");
+        await Assert.That(captured.ToString()).Contains("Unknown reviewer vendor");
+        await Assert.That(captured.ToString()).Contains("antigravity");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerAntigravityFloorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerAntigravityFloorTests.cs
@@ -1,14 +1,14 @@
 using Capacitor.Cli.Daemon;
-using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// The Antigravity minimum-version floor at the surface that decides ADVERTISEMENT. A vendor the
-/// daemon does not advertise is refused server-side before a launch is attempted, so this is where
-/// the floor has to hold — and the reason has to travel with the refusal, because an unadvertised
-/// vendor otherwise vanishes in silence.
+/// The Antigravity minimum-version floor as seen from the DAEMON's vendor-list computation. The
+/// floor itself lives in the factory's one gate ladder (asserted arm-by-arm in
+/// <c>AntigravityReviewerLaunchTests</c>); what these pin is that the list this daemon advertises
+/// derives from that ladder rather than from a second, separately-maintained narrowing pass.
 /// </summary>
 public class DaemonRunnerAntigravityFloorTests {
     sealed class FakeFactory(string vendor, bool advertised) : IHostedAgentRuntimeFactory {
@@ -28,110 +28,17 @@ public class DaemonRunnerAntigravityFloorTests {
         Name                                 = "test-daemon"
     };
 
-    static IReadOnlyList<DaemonRunner.UnattendedVendorStatus> Floor(
-            DaemonConfig config, string? probed, params DaemonRunner.UnattendedVendorStatus[] statuses) =>
-        DaemonRunner.ApplyAntigravityVersionFloor(statuses, config, _ => probed);
-
-    static DaemonRunner.UnattendedVendorStatus Advertised(string vendor) => new(vendor, true, null);
-
-    [Test]
-    public async Task AFloorMeetingBuild_StaysAdvertised() {
-        var result = Floor(Config(), "1.1.10", Advertised("antigravity"), Advertised("claude"));
-
-        await Assert.That(result.Single(s => s.Vendor == "antigravity").Advertised).IsTrue();
-        await Assert.That(result.Single(s => s.Vendor == "antigravity").WithheldReason).IsNull();
-    }
-
-    [Test]
-    public async Task ABelowFloorBuild_IsWithheldWithAReasonThatNamesBothVersions() {
-        var result = Floor(Config(), "1.1.8", Advertised("antigravity"));
-        var status = result.Single();
-
-        await Assert.That(status.Advertised).IsFalse();
-        await Assert.That(status.WithheldReason!).StartsWith("antigravity_reviewer_version_below_minimum");
-        await Assert.That(status.WithheldReason!).Contains("1.1.8");
-        await Assert.That(status.WithheldReason!).Contains("1.1.10");
-    }
-
-    /// <summary>A probe that could not identify the build refuses under its OWN arm — the operator's
-    /// next action is to fix the binary, not to upgrade it.</summary>
-    [Test]
-    public async Task AnUnidentifiableBuild_IsWithheldAsUnresolved() {
-        var status = Floor(Config(), null, Advertised("antigravity")).Single();
-
-        await Assert.That(status.Advertised).IsFalse();
-        await Assert.That(status.WithheldReason!).StartsWith("antigravity_reviewer_version_unresolved");
-    }
-
-    /// <summary>The floor only ever NARROWS. A vendor the factory's own ladder already withheld keeps
-    /// that refusal — overwriting it would replace the operator's actual problem with a version one.</summary>
-    [Test]
-    public async Task AVendorTheFactoryAlreadyWithheld_KeepsItsOwnReason() {
-        DaemonRunner.UnattendedVendorStatus withheld = new("antigravity", false, "antigravity_reviewer_binary_missing: …");
-
-        var status = Floor(Config(), "0.0.1", withheld).Single();
-
-        await Assert.That(status.Advertised).IsFalse();
-        await Assert.That(status.WithheldReason!).StartsWith("antigravity_reviewer_binary_missing");
-    }
-
-    /// <summary>Never probes, and never touches, a classification this vendor is not part of.</summary>
-    [Test]
-    public async Task AClassificationWithoutAntigravity_IsReturnedUntouchedAndUnprobed() {
-        var probed = 0;
-
-        var result = DaemonRunner.ApplyAntigravityVersionFloor(
-            [Advertised("claude"), Advertised("kiro")],
-            Config(),
-            _ => { probed++; return "0.0.1"; });
-
-        await Assert.That(result.All(s => s.Advertised)).IsTrue();
-        await Assert.That(probed).IsEqualTo(0);
-    }
-
-    /// <summary>The binary is probed ONCE — the decision and its explanation both need the version,
-    /// and resolving it per consumer spawns the vendor binary twice to produce one refusal.</summary>
-    [Test]
-    public async Task TheVendorBinaryIsProbedExactlyOnce() {
-        var probed = 0;
-
-        DaemonRunner.ApplyAntigravityVersionFloor(
-            [Advertised("antigravity")], Config(), _ => { probed++; return "1.1.8"; });
-
-        await Assert.That(probed).IsEqualTo(1);
-    }
-
-    /// <summary>The floor is probed against the path the DAEMON would launch, not whatever `agy`
-    /// happens to resolve to first.</summary>
-    [Test]
-    public async Task TheProbeReadsTheConfiguredBinaryPath() {
-        string? seen  = null;
-        var config    = Config();
-        config.AntigravityPath = "/opt/agy/bin/agy";
-
-        DaemonRunner.ApplyAntigravityVersionFloor(
-            [Advertised("antigravity")], config, path => { seen = path; return "1.1.10"; });
-
-        await Assert.That(seen).IsEqualTo("/opt/agy/bin/agy");
-    }
-
-    /// <summary>The whole point of the owner's decision: a newer build is not refused. An
-    /// affirmation-style exact compare reintroduced at this seam would fail here.</summary>
-    [Test]
-    public async Task ANewerBuildThanTheFloor_StaysAdvertised() {
-        var status = Floor(Config(), "2.5.0", Advertised("antigravity")).Single();
-
-        await Assert.That(status.Advertised).IsTrue();
-    }
-
     /// <summary>
-    /// The floor is part of the vendor-list computation itself, not only of the startup path that
-    /// happens to call it. <c>ComputeUnattendedVendors</c> is what the orchestrator's post-rejection
-    /// capability refresh re-derives from, so a floor applied only at boot would silently re-advertise
-    /// a refused build the first time a launch was rejected.
+    /// The floor reaches the vendor-list computation THROUGH the factory's own gate ladder, which is
+    /// the only place it is now written. <c>ComputeUnattendedVendors</c> is what the orchestrator's
+    /// post-rejection capability refresh re-derives from, so a floor that did not travel with the
+    /// factory would silently re-advertise a refused build the first time a launch was rejected.
+    ///
+    /// <para>Uses the REAL factory over a stub <c>agy</c>, deliberately: a fake factory would answer
+    /// <c>SupportsUnattended</c> from a field and prove nothing about where the floor lives.</para>
     /// </summary>
     [Test]
-    public async Task TheComputedVendorListAppliesTheFloorToo() {
+    public async Task TheComputedVendorListAppliesTheFloorThroughTheFactory() {
         Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary below is a POSIX shell script.");
 
         var stub = await StubAgyAsync("0.9.0");
@@ -141,10 +48,32 @@ public class DaemonRunnerAntigravityFloorTests {
             config.AntigravityPath = stub;
 
             var vendors = DaemonRunner.ComputeUnattendedVendors(
-                [new FakeFactory("antigravity", advertised: true), new FakeFactory("claude", advertised: true)],
+                [new AntigravityHostedAgentRuntimeFactory(config, NullLoggerFactory.Instance),
+                 new FakeFactory("claude", advertised: true)],
                 config);
 
             await Assert.That(vendors).IsEquivalentTo(new[] { "claude" });
+        } finally {
+            File.Delete(stub);
+        }
+    }
+
+    /// <summary>The positive twin of the test above — without it, an antigravity that never advertised
+    /// for ANY reason (a broken stub, a path that does not resolve) would satisfy the exclusion.</summary>
+    [Test]
+    public async Task TheComputedVendorListKeepsAFloorMeetingBuild() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary below is a POSIX shell script.");
+
+        var stub = await StubAgyAsync("1.1.10");
+
+        try {
+            var config = Config();
+            config.AntigravityPath = stub;
+
+            var vendors = DaemonRunner.ComputeUnattendedVendors(
+                [new AntigravityHostedAgentRuntimeFactory(config, NullLoggerFactory.Instance)], config);
+
+            await Assert.That(vendors).IsEquivalentTo(new[] { "antigravity" });
         } finally {
             File.Delete(stub);
         }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerAntigravityFloorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerAntigravityFloorTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -5,8 +6,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// The Antigravity minimum-version floor as seen from the DAEMON's vendor-list computation. The
-/// floor itself lives in the factory's one gate ladder (asserted arm-by-arm in
+/// The Antigravity minimum-version gate as seen from the DAEMON's vendor-list computation. The
+/// minimum itself lives in the factory's one gate ladder (asserted arm-by-arm in
 /// <c>AntigravityReviewerLaunchTests</c>); what these pin is that the list this daemon advertises
 /// derives from that ladder rather than from a second, separately-maintained narrowing pass.
 /// </summary>
@@ -21,12 +22,25 @@ public class DaemonRunnerAntigravityFloorTests {
             throw new NotSupportedException("not exercised by this test");
     }
 
-    static DaemonConfig Config(string minimum = "1.1.10") => new() {
-        AntigravityPath                      = "agy",
-        AntigravityUnattendedReviewerEnabled = true,
-        AntigravityMinimumCliVersion         = minimum,
-        Name                                 = "test-daemon"
-    };
+    /// <param name="minimum">Recorded exactly as enabling the reviewer does in production. Null
+    /// records NOTHING — the gate is a daemon-owned record, not configuration, so "unset" is an absent
+    /// file rather than a value.</param>
+    static DaemonConfig Config(string? minimum = "1.1.10") {
+        var config = new DaemonConfig {
+            AntigravityPath                      = "agy",
+            AntigravityUnattendedReviewerEnabled = true,
+            StateDir                             = Path.Combine(
+                Path.GetTempPath(), "kcap-agy-floor-" + Guid.NewGuid().ToString("N")),
+            Name                                 = "test-daemon"
+        };
+
+        // Without a record every arm below refuses as version_no_minimum instead of on the comparison
+        // under test.
+        if (minimum is not null)
+            AntigravityHostedAgentRuntimeFactory.VersionStoreFor(config).Affirm(minimum);
+
+        return config;
+    }
 
     /// <summary>
     /// The floor reaches the vendor-list computation THROUGH the factory's own gate ladder, which is
@@ -69,6 +83,42 @@ public class DaemonRunnerAntigravityFloorTests {
         try {
             var config = Config();
             config.AntigravityPath = stub;
+
+            var vendors = DaemonRunner.ComputeUnattendedVendors(
+                [new AntigravityHostedAgentRuntimeFactory(config, NullLoggerFactory.Instance)], config);
+
+            await Assert.That(vendors).IsEquivalentTo(new[] { "antigravity" });
+        } finally {
+            File.Delete(stub);
+        }
+    }
+
+    /// <summary>
+    /// The daemon SEEDS the record and the factory READS it — two paths that must name the same file,
+    /// with nothing in the type system making them. Get the directory shape or the vendor key wrong
+    /// and every launch refuses as <c>version_no_minimum</c> forever, while both halves look correct
+    /// in isolation.
+    ///
+    /// <para>Seeds through <c>DaemonRunner.SeedReviewerAffirmation</c> at the directory
+    /// <c>RunAsync</c> computes — restated here on purpose, so a change to either side has to be made
+    /// twice — and then asserts through advertisement rather than by reading the file back, which
+    /// would only re-derive the writer's own answer.</para>
+    /// </summary>
+    [Test]
+    public async Task TheDaemonsSeededRecordIsTheOneTheFactoryReads() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary below is a POSIX shell script.");
+
+        var stub = await StubAgyAsync("1.1.10");
+
+        try {
+            var config = Config(minimum: null);
+            config.AntigravityPath = stub;
+
+            // Restated rather than taken from the factory: this is the shape RunAsync computes.
+            var stateDir = Path.Combine(config.StateDir!, DaemonLockPaths.Sanitize(config.Name));
+
+            DaemonRunner.SeedReviewerAffirmation(
+                stateDir, DaemonRunner.AntigravityVendor, enabled: true, stub);
 
             var vendors = DaemonRunner.ComputeUnattendedVendors(
                 [new AntigravityHostedAgentRuntimeFactory(config, NullLoggerFactory.Instance)], config);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerAntigravityFloorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerAntigravityFloorTests.cs
@@ -1,0 +1,191 @@
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// The Antigravity minimum-version floor at the surface that decides ADVERTISEMENT. A vendor the
+/// daemon does not advertise is refused server-side before a launch is attempted, so this is where
+/// the floor has to hold — and the reason has to travel with the refusal, because an unadvertised
+/// vendor otherwise vanishes in silence.
+/// </summary>
+public class DaemonRunnerAntigravityFloorTests {
+    sealed class FakeFactory(string vendor, bool advertised) : IHostedAgentRuntimeFactory {
+        public string Vendor             { get; } = vendor;
+        public bool   SupportsUnattended { get; } = advertised;
+
+        public bool IsAvailable() => true;
+
+        public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) =>
+            throw new NotSupportedException("not exercised by this test");
+    }
+
+    static DaemonConfig Config(string minimum = "1.1.10") => new() {
+        AntigravityPath                      = "agy",
+        AntigravityUnattendedReviewerEnabled = true,
+        AntigravityMinimumCliVersion         = minimum,
+        Name                                 = "test-daemon"
+    };
+
+    static IReadOnlyList<DaemonRunner.UnattendedVendorStatus> Floor(
+            DaemonConfig config, string? probed, params DaemonRunner.UnattendedVendorStatus[] statuses) =>
+        DaemonRunner.ApplyAntigravityVersionFloor(statuses, config, _ => probed);
+
+    static DaemonRunner.UnattendedVendorStatus Advertised(string vendor) => new(vendor, true, null);
+
+    [Test]
+    public async Task AFloorMeetingBuild_StaysAdvertised() {
+        var result = Floor(Config(), "1.1.10", Advertised("antigravity"), Advertised("claude"));
+
+        await Assert.That(result.Single(s => s.Vendor == "antigravity").Advertised).IsTrue();
+        await Assert.That(result.Single(s => s.Vendor == "antigravity").WithheldReason).IsNull();
+    }
+
+    [Test]
+    public async Task ABelowFloorBuild_IsWithheldWithAReasonThatNamesBothVersions() {
+        var result = Floor(Config(), "1.1.8", Advertised("antigravity"));
+        var status = result.Single();
+
+        await Assert.That(status.Advertised).IsFalse();
+        await Assert.That(status.WithheldReason!).StartsWith("antigravity_reviewer_version_below_minimum");
+        await Assert.That(status.WithheldReason!).Contains("1.1.8");
+        await Assert.That(status.WithheldReason!).Contains("1.1.10");
+    }
+
+    /// <summary>A probe that could not identify the build refuses under its OWN arm — the operator's
+    /// next action is to fix the binary, not to upgrade it.</summary>
+    [Test]
+    public async Task AnUnidentifiableBuild_IsWithheldAsUnresolved() {
+        var status = Floor(Config(), null, Advertised("antigravity")).Single();
+
+        await Assert.That(status.Advertised).IsFalse();
+        await Assert.That(status.WithheldReason!).StartsWith("antigravity_reviewer_version_unresolved");
+    }
+
+    /// <summary>The floor only ever NARROWS. A vendor the factory's own ladder already withheld keeps
+    /// that refusal — overwriting it would replace the operator's actual problem with a version one.</summary>
+    [Test]
+    public async Task AVendorTheFactoryAlreadyWithheld_KeepsItsOwnReason() {
+        DaemonRunner.UnattendedVendorStatus withheld = new("antigravity", false, "antigravity_reviewer_binary_missing: …");
+
+        var status = Floor(Config(), "0.0.1", withheld).Single();
+
+        await Assert.That(status.Advertised).IsFalse();
+        await Assert.That(status.WithheldReason!).StartsWith("antigravity_reviewer_binary_missing");
+    }
+
+    /// <summary>Never probes, and never touches, a classification this vendor is not part of.</summary>
+    [Test]
+    public async Task AClassificationWithoutAntigravity_IsReturnedUntouchedAndUnprobed() {
+        var probed = 0;
+
+        var result = DaemonRunner.ApplyAntigravityVersionFloor(
+            [Advertised("claude"), Advertised("kiro")],
+            Config(),
+            _ => { probed++; return "0.0.1"; });
+
+        await Assert.That(result.All(s => s.Advertised)).IsTrue();
+        await Assert.That(probed).IsEqualTo(0);
+    }
+
+    /// <summary>The binary is probed ONCE — the decision and its explanation both need the version,
+    /// and resolving it per consumer spawns the vendor binary twice to produce one refusal.</summary>
+    [Test]
+    public async Task TheVendorBinaryIsProbedExactlyOnce() {
+        var probed = 0;
+
+        DaemonRunner.ApplyAntigravityVersionFloor(
+            [Advertised("antigravity")], Config(), _ => { probed++; return "1.1.8"; });
+
+        await Assert.That(probed).IsEqualTo(1);
+    }
+
+    /// <summary>The floor is probed against the path the DAEMON would launch, not whatever `agy`
+    /// happens to resolve to first.</summary>
+    [Test]
+    public async Task TheProbeReadsTheConfiguredBinaryPath() {
+        string? seen  = null;
+        var config    = Config();
+        config.AntigravityPath = "/opt/agy/bin/agy";
+
+        DaemonRunner.ApplyAntigravityVersionFloor(
+            [Advertised("antigravity")], config, path => { seen = path; return "1.1.10"; });
+
+        await Assert.That(seen).IsEqualTo("/opt/agy/bin/agy");
+    }
+
+    /// <summary>The whole point of the owner's decision: a newer build is not refused. An
+    /// affirmation-style exact compare reintroduced at this seam would fail here.</summary>
+    [Test]
+    public async Task ANewerBuildThanTheFloor_StaysAdvertised() {
+        var status = Floor(Config(), "2.5.0", Advertised("antigravity")).Single();
+
+        await Assert.That(status.Advertised).IsTrue();
+    }
+
+    /// <summary>
+    /// The floor is part of the vendor-list computation itself, not only of the startup path that
+    /// happens to call it. <c>ComputeUnattendedVendors</c> is what the orchestrator's post-rejection
+    /// capability refresh re-derives from, so a floor applied only at boot would silently re-advertise
+    /// a refused build the first time a launch was rejected.
+    /// </summary>
+    [Test]
+    public async Task TheComputedVendorListAppliesTheFloorToo() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary below is a POSIX shell script.");
+
+        var stub = await StubAgyAsync("0.9.0");
+
+        try {
+            var config = Config();
+            config.AntigravityPath = stub;
+
+            var vendors = DaemonRunner.ComputeUnattendedVendors(
+                [new FakeFactory("antigravity", advertised: true), new FakeFactory("claude", advertised: true)],
+                config);
+
+            await Assert.That(vendors).IsEquivalentTo(new[] { "claude" });
+        } finally {
+            File.Delete(stub);
+        }
+    }
+
+    static async Task<string> StubAgyAsync(string version) {
+        var stub = Path.Combine(Path.GetTempPath(), "kcap-agy-stub-" + Guid.NewGuid().ToString("N"));
+
+        await File.WriteAllTextAsync(stub, $"#!/bin/sh\necho 'Antigravity CLI {version}'\n");
+        File.SetUnixFileMode(stub, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        return stub;
+    }
+
+    /// <summary>
+    /// The advertised capability carries the build this daemon would actually launch. Without an
+    /// explicit arm, antigravity falls through to the generic one — which advertises no CLI version at
+    /// all, even though there is a configured path right there to probe. The policy version is
+    /// identical either way, so a real probe of a real executable is the only assertion that can tell
+    /// the two apart.
+    /// </summary>
+    [Test]
+    public async Task TheAdvertisedCapabilityCarriesTheProbedCliVersion() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary below is a POSIX shell script.");
+
+        var stub = await StubAgyAsync("1.1.10");
+
+        try {
+            var config = Config();
+            config.AntigravityPath = stub;
+
+            var capabilities = DaemonRunner.ComputeUnattendedVendorCapabilities(
+                [new FakeFactory("antigravity", advertised: true)], config, advertised: ["antigravity"]);
+
+            var antigravity = capabilities.Single();
+
+            await Assert.That(antigravity.CliVersion).IsEqualTo("1.1.10");
+            await Assert.That(antigravity.LauncherPolicyVersion)
+                .IsEqualTo(DaemonRunner.AntigravityLauncherPolicyVersion);
+        } finally {
+            File.Delete(stub);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerCursorAvailabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerCursorAvailabilityTests.cs
@@ -86,7 +86,7 @@ public class DaemonRunnerCursorAvailabilityTests {
             new FakeRuntimeFactory("copilot", isAvailable: true, supportsUnattended: true),
         ];
 
-        await Assert.That(DaemonRunner.ComputeUnattendedVendors(factories))
+        await Assert.That(DaemonRunner.ComputeUnattendedVendors(factories, new DaemonConfig()))
             .IsEquivalentTo(["claude", "copilot"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
@@ -98,7 +98,7 @@ public class DaemonRunnerCursorAvailabilityTests {
             new FakeRuntimeFactory("cursor", isAvailable: true, supportsUnattended: false),
         ];
 
-        await Assert.That(DaemonRunner.ComputeUnattendedVendors(factories)).IsEquivalentTo(["claude", "codex"]);
+        await Assert.That(DaemonRunner.ComputeUnattendedVendors(factories, new DaemonConfig())).IsEquivalentTo(["claude", "codex"]);
     }
 
     [Test]
@@ -110,7 +110,7 @@ public class DaemonRunnerCursorAvailabilityTests {
             new FakeRuntimeFactory("codex", isAvailable: true, supportsUnattended: true),
         ];
 
-        await Assert.That(DaemonRunner.ComputeUnattendedVendors(factories)).IsEquivalentTo(["codex"]);
+        await Assert.That(DaemonRunner.ComputeUnattendedVendors(factories, new DaemonConfig())).IsEquivalentTo(["codex"]);
     }
 
     [Test]
@@ -120,12 +120,12 @@ public class DaemonRunnerCursorAvailabilityTests {
             new FakeRuntimeFactory("claude", isAvailable: true, supportsUnattended: true),
         ];
 
-        await Assert.That(DaemonRunner.ComputeUnattendedVendors(factories)).IsEquivalentTo(["claude", "codex"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await Assert.That(DaemonRunner.ComputeUnattendedVendors(factories, new DaemonConfig())).IsEquivalentTo(["claude", "codex"], TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
     public async Task ComputeUnattendedVendors_NoFactoriesReturnsEmptyArray() {
-        await Assert.That(DaemonRunner.ComputeUnattendedVendors([])).IsEmpty();
+        await Assert.That(DaemonRunner.ComputeUnattendedVendors([], new DaemonConfig())).IsEmpty();
     }
 
     // === Withheld-vendor startup diagnostic ===

--- a/test/Capacitor.Cli.Tests.Unit/Services/AgyTurnProcessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AgyTurnProcessTests.cs
@@ -1,0 +1,55 @@
+// test/Capacitor.Cli.Tests.Unit/Services/AgyTurnProcessTests.cs
+using System.Diagnostics;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// <see cref="AgyTurnProcess"/> against a REAL child — a trivial sleeper, not <c>agy</c>, so this is
+/// ungated and runs everywhere POSIX. What it pins is the process-lifecycle contract the runtime's
+/// confirmed-exit gate is built on, and that contract cannot be observed through a fake: the whole
+/// question is whether a KILL has actually landed by the time disposal returns, which only a real
+/// process table can answer.
+/// </summary>
+public class AgyTurnProcessTests {
+    /// <summary>
+    /// Disposal of a still-running child KILLS it. Exec-per-turn means one child per review round, so
+    /// a disposal that only released handles would leak a live <c>agy</c> (and its MCP stdio children)
+    /// per round for the life of the daemon.
+    ///
+    /// <para>Observed through a SECOND handle on the same pid, opened before disposal: the handle
+    /// <see cref="AgyTurnProcess"/> owns is disposed by the call under test, so asking it afterwards
+    /// would answer from a disposed object rather than from the OS.</para>
+    ///
+    /// <para><b>What this deliberately does NOT claim</b> is that disposal WAITS for the kill to
+    /// land. It cannot: <c>Kill(entireProcessTree: true)</c> is SIGKILL on POSIX, which a child can
+    /// neither catch nor defer, so an added bounded wait was measured to be unobservable — the mutant
+    /// that deletes it survived 6 of 6 runs of this very test. Exit CONFIRMATION is therefore not
+    /// disposal's job at all; it belongs to the caller, before it lets go of the handle.</para>
+    /// </summary>
+    [Test]
+    public async Task Disposing_a_running_turn_child_kills_it() {
+        Skip.Unless(!OperatingSystem.IsWindows(),
+            "Uses /bin/sh as a long-lived child; the Antigravity reviewer is POSIX-only anyway.");
+
+        var child = Process.Start(new ProcessStartInfo("/bin/sh", "-c \"sleep 300\"") {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+        })!;
+
+        using var observer = Process.GetProcessById(child.Id);
+        var turn = new AgyTurnProcess(child, NullLogger<AgyTurnProcess>.Instance);
+
+        // The precondition, asserted rather than assumed: without a child that is genuinely still
+        // running, disposal has nothing to settle and this test proves nothing.
+        await Assert.That(turn.HasExited).IsFalse();
+
+        await turn.DisposeAsync();
+
+        await Assert.That(observer.HasExited).IsTrue()
+            .Because("a disposal that only releases handles leaks one live agy child per review round");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/AgyTurnProcessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AgyTurnProcessTests.cs
@@ -49,6 +49,17 @@ public class AgyTurnProcessTests {
 
         await turn.DisposeAsync();
 
+        // Bounded WAIT, not an immediate read. SIGKILL is delivered asynchronously — the child
+        // transitions to zombie some scheduling moment after Kill() returns, and disposal does not
+        // block for that — so asserting HasExited on the very next line is a race that a loaded CI
+        // box can lose. It passed 14 consecutive local runs, which is exactly the sample size that
+        // makes a load-dependent flake look solved; this branch has already been bitten twice by
+        // that class. Waiting costs nothing on the happy path and removes the race outright.
+        //
+        // Waited on the OBSERVER, never on `child`: `child` is the handle AgyTurnProcess just
+        // disposed, and touching a disposed Process throws.
+        observer.WaitForExit(milliseconds: 5000);
+
         await Assert.That(observer.HasExited).IsTrue()
             .Because("a disposal that only releases handles leaks one live agy child per review round");
     }

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityActivityClockTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityActivityClockTests.cs
@@ -1,0 +1,189 @@
+// test/Capacitor.Cli.Tests.Unit/Services/AntigravityActivityClockTests.cs
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.Cli.Tests.Unit.Services.AntigravityRuntimeFakes;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// <see cref="AntigravityHostedAgentRuntime"/>'s wiring into <see cref="AgentActivityClock"/> — the
+/// evidence <c>AgentOrchestrator.FindReviewersToReap</c> makes every reaping decision from.
+///
+/// <para>Both directions of <c>TurnInFlight</c> are load-bearing and neither is a style preference.
+/// A flag stuck <see langword="true"/> suppresses the plain idle rule OUTRIGHT, so an idle reviewer
+/// is never idle-reaped — a slot leak. A flag stuck <see langword="false"/> during a long turn lets
+/// the idle rule reap a reviewer that is genuinely working. The exec-per-turn shape makes the first
+/// direction the easier one to get wrong: between turns there is no process at all, so nothing
+/// external ever contradicts a stale <see langword="true"/>.</para>
+/// </summary>
+public class AntigravityActivityClockTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    static (AntigravityHostedAgentRuntime Runtime, AgentActivityClock Clock, FakeTimeProvider Time) Wired(
+            FakeTurn turn = FakeTurn.Normal) {
+        var time    = new FakeTimeProvider();
+        var clock   = new AgentActivityClock(time);
+        var runtime = FakeRuntime(turn);
+        runtime.ActivityClock = clock;
+
+        return (runtime, clock, time);
+    }
+
+    /// <summary>Between turns there is genuinely no child, and that is exactly when the plain idle
+    /// rule must be allowed to apply — no keepalive, no special case.</summary>
+    [Test]
+    public async Task A_settled_turn_leaves_no_turn_in_flight() {
+        var (rt, clock, _) = Wired();
+        await using var _r = rt;
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // Positive check the turn genuinely ran, so "not in flight" cannot pass vacuously on a turn
+        // that never started.
+        await Assert.That(rt.AcpSessionId).IsEqualTo(FixedConversationId);
+        await Assert.That(clock.TurnInFlight).IsFalse();
+    }
+
+    /// <summary>The other direction: while a turn's child is genuinely running the gate is held, so
+    /// the idle rule stays suppressed and the wedge ceiling is what governs.</summary>
+    [Test]
+    public async Task A_running_turn_reports_the_turn_gate_as_held() {
+        var (rt, clock, _) = Wired(FakeTurn.NeverEnds);
+        await using var _r = rt;
+
+        _ = rt.SendUserInputAsync("hello");
+
+        // Resolves only once the worker has read a spawned turn's first line — i.e. the turn is
+        // genuinely in flight, not merely enqueued.
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(clock.TurnInFlight).IsTrue();
+    }
+
+    /// <summary>
+    /// A turn that dies mid-flight (EOF with no terminal <c>result</c>) drives the runtime terminal —
+    /// and must still clear the flag. Leaving it held would make the resulting agent permanently
+    /// exempt from the idle rule, which is the leak shape this direction exists to prevent.
+    /// </summary>
+    [Test]
+    public async Task A_turn_that_dies_mid_flight_still_releases_the_turn_gate_flag() {
+        var (rt, clock, _) = Wired(FakeTurn.EofWithoutResult);
+        await using var _r = rt;
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForExitAsync(HangGuard);
+
+        await Assert.That(rt.HasExited).IsTrue();
+        await Assert.That(clock.TurnInFlight).IsFalse();
+    }
+
+    /// <summary>A stop landing while a turn is genuinely in flight must clear it too — this is the
+    /// path where the turn worker may still be unwinding when the caller observes the clock.</summary>
+    [Test]
+    public async Task Terminating_a_running_turn_releases_the_turn_gate_flag() {
+        var (rt, clock, _) = Wired(FakeTurn.NeverEnds);
+        await using var _r = rt;
+
+        _ = rt.SendUserInputAsync("hello");
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await Assert.That(clock.TurnInFlight).IsTrue();
+
+        await rt.TerminateAsync(TimeSpan.FromSeconds(2)).WaitAsync(HangGuard);
+
+        await Assert.That(clock.TurnInFlight).IsFalse();
+    }
+
+    /// <summary>Every forwarded envelope is activity. Without this a reviewer streaming a long answer
+    /// looks silent, and only the turn-start/turn-end pair would ever re-arm the wedge ceiling.</summary>
+    [Test]
+    public async Task Each_forwarded_envelope_advances_the_clock() {
+        var (rt, clock, _t) = Wired();
+        await using var _r = rt;
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        var envelopes = 0;
+        while (rt.Envelopes.TryRead(out _)) envelopes++;
+
+        await Assert.That(envelopes).IsGreaterThan(0);
+
+        // Exact, not "greater than": a clean turn's contributions are enumerable, so an equality is
+        // the only form that goes red when the per-envelope Advance() is removed — the four stamps
+        // alone would still satisfy any inequality this turn could express.
+        //
+        //   1 — the clock's own construction value (a freshly-launched agent is never "already idle")
+        //   4 — turn start, `spawned`, `session_created`, turn end
+        //   + one per forwarded envelope
+        await Assert.That(clock.ActivitySeq).IsEqualTo(1UL + 4UL + (ulong) envelopes);
+    }
+
+    /// <summary>
+    /// The launch handshake stamps: <c>spawned</c> when turn 1's child exists, then
+    /// <c>session_created</c> when its <c>init</c> resolves the conversation id. These are the
+    /// evidence the out-of-cycle status report extends the server's registration wait on, and they
+    /// are silent no-ops against a clock attached after the launch — which is why the factory must
+    /// wire the clock before the first turn.
+    /// </summary>
+    [Test]
+    public async Task The_first_turn_stamps_spawned_then_session_created() {
+        var time    = new FakeTimeProvider();
+        var clock   = new AgentActivityClock(time);
+        var stages  = new List<string?>();
+        clock.OnLaunchStageChanged = () => stages.Add(clock.LaunchStage);
+
+        await using var rt = FakeRuntime();
+        rt.ActivityClock = clock;
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(string.Join(",", stages)).IsEqualTo("spawned,session_created");
+    }
+
+    /// <summary>A SECOND turn must not re-stamp a launch stage: <c>LaunchStage</c> is
+    /// <c>Starting</c>-only, and the orchestrator clears it the instant the agent reaches Running, so
+    /// a later stamp would resurrect a stage on a running agent.</summary>
+    [Test]
+    public async Task A_later_turn_does_not_re_stamp_a_launch_stage() {
+        var time   = new FakeTimeProvider();
+        var clock  = new AgentActivityClock(time);
+        var stages = new List<string?>();
+
+        await using var rt = FakeRuntime();
+        rt.ActivityClock = clock;
+
+        await rt.SendUserInputAsync("one").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // Subscribe only now: everything recorded below belongs to turn 2.
+        clock.OnLaunchStageChanged = () => stages.Add(clock.LaunchStage);
+
+        // SendUserInputAndWaitForWrite, NOT WaitForTurnIdleAsync: the ack resolves once turn 2's
+        // process has genuinely spawned, which is strictly after the point a `spawned` stamp would
+        // fire. WaitForTurnIdleAsync's acquire-then-release can complete against a momentarily-free
+        // gate before the worker has even dequeued the turn — a mutation check caught that letting
+        // this assertion pass with the guard removed entirely.
+        await rt.SendUserInputAndWaitForWriteAsync("two").WaitAsync(HangGuard);
+
+        await Assert.That(stages).IsEmpty();
+    }
+
+    /// <summary>A runtime with no clock at all (every direct construction, including the lifecycle
+    /// suite's) must keep working — every stamp site is a no-op guard, never a throw.</summary>
+    [Test]
+    public async Task A_runtime_without_a_clock_still_runs_a_turn() {
+        await using var rt = FakeRuntime();
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(rt.AcpSessionId).IsEqualTo(FixedConversationId);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityActivityClockTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityActivityClockTests.cs
@@ -1,4 +1,5 @@
 // test/Capacitor.Cli.Tests.Unit/Services/AntigravityActivityClockTests.cs
+using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
@@ -65,27 +66,58 @@ public class AntigravityActivityClockTests {
 
     /// <summary>
     /// A turn that dies mid-flight (EOF with no terminal <c>result</c>) drives the runtime terminal —
-    /// and must still clear the flag. Leaving it held would make the resulting agent permanently
-    /// exempt from the idle rule, which is the leak shape this direction exists to prevent.
+    /// and <c>EnterTerminal</c> must clear the flag ITSELF. Leaving it held would make the resulting
+    /// agent permanently exempt from the idle rule, which is the leak shape this direction exists to
+    /// prevent.
+    ///
+    /// <para><b>Why the child's disposal is held open.</b> The turn worker's own <c>finally</c> also
+    /// clears the flag, so a test that lets the worker unwind cannot tell the two clears apart: with
+    /// <c>EnterTerminal</c>'s clear deleted, the assertion passes or fails purely on whether the
+    /// worker's continuation happened to be scheduled yet. Measured across six runs of exactly that
+    /// mutant, this test failed 1, 1, 0, 2, 2, 1 times — a real regression with a one-in-six chance of
+    /// surviving CI. Parking the worker inside <c>IAgyTurnProcess.DisposeAsync</c> — which
+    /// <c>ProcessTurnAsync</c>'s outer <c>finally</c> awaits, strictly BEFORE the worker's own
+    /// <c>finally</c> can run — makes <c>EnterTerminal</c> the only thing that could possibly have
+    /// cleared the flag at the moment of the assertion.</para>
     /// </summary>
     [Test]
     public async Task A_turn_that_dies_mid_flight_still_releases_the_turn_gate_flag() {
-        var (rt, clock, _) = Wired(FakeTurn.EofWithoutResult);
-        await using var _r = rt;
+        var time    = new FakeTimeProvider();
+        var clock   = new AgentActivityClock(time);
+        var process = new HeldDisposalTurnProcess();
+
+        await using var rt = new AntigravityHostedAgentRuntime(
+            spawnTurn: (_, _, _) => Task.FromResult<IAgyTurnProcess>(process),
+            logger: NullLogger.Instance);
+        rt.ActivityClock = clock;
 
         await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
         await rt.WaitForExitAsync(HangGuard);
 
+        // Proves Terminal was genuinely entered — WaitForExitAsync returns silently on timeout, so
+        // without this the clock assertion below could be read off a turn that never finished.
         await Assert.That(rt.HasExited).IsTrue();
+
         await Assert.That(clock.TurnInFlight).IsFalse();
+
+        process.ReleaseDisposal();
     }
 
-    /// <summary>A stop landing while a turn is genuinely in flight must clear it too — this is the
-    /// path where the turn worker may still be unwinding when the caller observes the clock.</summary>
+    /// <summary>A stop landing while a turn is genuinely in flight must clear it too — and, again,
+    /// <c>EnterTerminal</c> must be the one that does it, because the worker's own <c>finally</c> runs
+    /// only once the turn actually unwinds (and never at all, for a child that ignores cancellation).
+    /// The wedged child below is exactly that case: it is provably still inside its read loop when the
+    /// assertion runs, so the worker's <c>finally</c> cannot have contributed.</summary>
     [Test]
     public async Task Terminating_a_running_turn_releases_the_turn_gate_flag() {
-        var (rt, clock, _) = Wired(FakeTurn.NeverEnds);
-        await using var _r = rt;
+        var time    = new FakeTimeProvider();
+        var clock   = new AgentActivityClock(time);
+        var process = new WedgedTurnProcess();
+
+        await using var rt = new AntigravityHostedAgentRuntime(
+            spawnTurn: (_, _, _) => Task.FromResult<IAgyTurnProcess>(process),
+            logger: NullLogger.Instance);
+        rt.ActivityClock = clock;
 
         _ = rt.SendUserInputAsync("hello");
         await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
@@ -94,6 +126,74 @@ public class AntigravityActivityClockTests {
         await rt.TerminateAsync(TimeSpan.FromSeconds(2)).WaitAsync(HangGuard);
 
         await Assert.That(clock.TurnInFlight).IsFalse();
+
+        // Only now — the turn worker unwinds, so disposal does not have to wait it out.
+        process.Release();
+    }
+
+    /// <summary>A turn child that emits <c>init</c> (so the turn is provably in flight) and then never
+    /// returns from its read loop, IGNORING cancellation. A real one is a child that does not die on
+    /// SIGTERM; here it is what keeps the turn worker's <c>finally</c> structurally out of the
+    /// picture.</summary>
+    sealed class WedgedTurnProcess : IAgyTurnProcess {
+        readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int  Pid       => 4247;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+
+        public void Release() => _release.TrySetResult();
+
+        public async IAsyncEnumerable<string> ReadLinesAsync(
+                [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct) {
+            yield return AntigravityFakeLines.Init;
+
+            // Deliberately NOT ct: a child that honours cancellation lets the worker's own finally run,
+            // which is the ambiguity this fake exists to remove.
+            await _release.Task.ConfigureAwait(false);
+
+            HasExited = true;
+            ExitCode  = 0;
+        }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan? timeout = null)   => Task.CompletedTask;
+        public ValueTask DisposeAsync()                        => ValueTask.CompletedTask;
+    }
+
+    /// <summary>A turn child that dies mid-turn (<c>init</c>, then EOF with no terminal
+    /// <c>result</c>) and then holds its own disposal open. <c>ProcessTurnAsync</c>'s outer
+    /// <c>finally</c> awaits that disposal, so the worker is parked between <c>EnterTerminal</c> and
+    /// its own <c>finally</c> for as long as the test wants.</summary>
+    sealed class HeldDisposalTurnProcess : IAgyTurnProcess {
+        readonly TaskCompletionSource _disposal = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int  Pid       => 4248;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+
+        public void ReleaseDisposal() => _disposal.TrySetResult();
+
+#pragma warning disable CS1998 // an async iterator whose lines are already in hand still needs the modifier
+        public async IAsyncEnumerable<string> ReadLinesAsync(
+                [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct) {
+            yield return AntigravityFakeLines.Init;
+
+            // No `result` line — the child exits having said nothing more.
+            HasExited = true;
+            ExitCode  = 1;
+        }
+#pragma warning restore CS1998
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan? timeout = null)   => Task.CompletedTask;
+
+        public async ValueTask DisposeAsync() => await _disposal.Task.ConfigureAwait(false);
+    }
+
+    static class AntigravityFakeLines {
+        public const string Init =
+            $$$"""{"event":"init","conversation_id":"{{{FixedConversationId}}}","init":{"cwd":"/w"}}""";
     }
 
     /// <summary>Every forwarded envelope is activity. Without this a reviewer streaming a long answer

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -1,0 +1,546 @@
+// test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+using System.Diagnostics;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.Cli.Tests.Unit.Services.AntigravityRuntimeFakes;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// The Antigravity reviewer's LAUNCH shape — the argv and environment a turn child would actually
+/// receive, and the ordering <c>StartAsync</c> owes the orchestrator — asserted directly rather than
+/// through a round's outcome. A round that completes proves nothing about which flags were passed:
+/// a reviewer that never attempts a shell call looks identical whether or not it was granted one.
+/// </summary>
+public class AntigravityReviewerLaunchTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(10);
+
+    /// <summary>A path, never a created directory — <see cref="BuildTurnPsi"/> is pure, so the argv
+    /// assertions below run identically on every platform (the real per-launch home is POSIX-only).</summary>
+    const string HomePath = "/tmp/kcap-antigravity-home";
+
+    static string TempStateDir() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-agy-launch-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    static DaemonConfig EnabledConfig(string? model = null, string? stateDir = null) => new() {
+        AntigravityPath                      = "agy",
+        AntigravityModel                     = model,
+        AntigravityUnattendedReviewerEnabled = true,
+        Name                                 = "test-daemon",
+        DaemonEpoch                          = "epoch-1",
+        StateDir                             = stateDir ?? TempStateDir()
+    };
+
+    static RuntimeStartContext Ctx(
+            bool isReviewFlow = true, AgentActivityClock? clock = null, string? model = null) => new(
+        AgentId: "agent-1", Vendor: "antigravity", SourceRepoPath: "/repo",
+        Worktree: new WorktreeInfo(Path: "/abs/wt", Branch: "b", SourceRepo: "/repo"),
+        Prompt: "review this",
+        Model: model, Effort: null, Tools: null,
+        IsReview: false, IsReviewFlow: isReviewFlow, Review: null,
+        Cols: 80, Rows: 24,
+        ServerUrl: "http://kcap.test", DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap",
+        DaemonId: "daemon-1", DaemonEpoch: "epoch-1",
+        ActivityClock: clock);
+
+    static ProcessStartInfo BuildPsi(DaemonConfig config, string? conversationId = null) =>
+        AntigravityHostedAgentRuntimeFactory.BuildTurnPsi(
+            config, Ctx(), prompt: "<PROMPT>", conversationId: conversationId, home: HomePath);
+
+    // ── argv ──────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Whole-vector, joined so a failure prints both sequences: a substring check would pass a
+    /// build that ADDED a flag, which is exactly the regression class this assertion exists for.</summary>
+    [Test]
+    public async Task The_whole_argv_vector_is_pinned() {
+        var psi = BuildPsi(EnabledConfig(model: "gemini-3.5-flash"));
+
+        await Assert.That(string.Join(" ", psi.ArgumentList)).IsEqualTo(string.Join(" ", [
+            "-p", "<PROMPT>",
+            "--output-format", "stream-json",
+            "--disable-slash-commands",
+            "--print-timeout", "600s",
+            "--model", "gemini-3.5-flash"
+        ]));
+    }
+
+    [Test]
+    public async Task The_reviewer_never_gets_skip_permissions_or_sandbox() {
+        var psi = BuildPsi(EnabledConfig());
+
+        // The reviewer reads an OWNED worktree; agy's headless soft-deny of shell and out-of-workspace
+        // operations IS the desired unattended posture. Widening it would grant shell access a
+        // reviewer never needs.
+        await Assert.That(psi.ArgumentList).DoesNotContain("--dangerously-skip-permissions");
+        await Assert.That(psi.ArgumentList).DoesNotContain("--sandbox");
+    }
+
+    [Test]
+    public async Task Turn_one_does_not_pass_a_conversation_flag() {
+        var psi = BuildPsi(EnabledConfig(), conversationId: null);
+
+        await Assert.That(psi.ArgumentList).DoesNotContain("--conversation");
+    }
+
+    [Test]
+    public async Task Turns_after_the_first_resume_the_same_conversation() {
+        var psi = BuildPsi(EnabledConfig(), conversationId: "e80c33bf-c10f-4d2f-b626-b0043f488fc0");
+
+        // Adjacent, not merely both present: a build that emitted the id under a different flag (or
+        // the flag with a different value) would satisfy two independent Contains checks while
+        // resuming nothing.
+        var i = psi.ArgumentList.IndexOf("--conversation");
+        await Assert.That(i).IsGreaterThanOrEqualTo(0);
+        await Assert.That(psi.ArgumentList[i + 1]).IsEqualTo("e80c33bf-c10f-4d2f-b626-b0043f488fc0");
+    }
+
+    /// <summary>The per-turn ceiling agy applies to ITSELF must be the one we configured, not its own
+    /// 5m default — a vendor default silently changes a bound we did not choose.</summary>
+    [Test]
+    public async Task The_print_timeout_is_derived_from_the_configured_turn_ceiling() {
+        var config = EnabledConfig();
+        config.AntigravityReviewerTurnTimeoutSeconds = 42;
+
+        var psi = BuildPsi(config);
+        var i   = psi.ArgumentList.IndexOf("--print-timeout");
+
+        await Assert.That(i).IsGreaterThanOrEqualTo(0);
+        await Assert.That(psi.ArgumentList[i + 1]).IsEqualTo("42s");
+    }
+
+    // ── env ───────────────────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Daemon_identity_markers_are_stamped_on_every_turn_child() {
+        var psi = BuildPsi(EnabledConfig());
+
+        // Without these, OrphanReaper's env-marker pass cannot see a survivor of a prior incarnation
+        // of this daemon — and nothing fails visibly when they are omitted.
+        await Assert.That(psi.Environment["KCAP_AGENT_ID"]).IsEqualTo("agent-1");
+        await Assert.That(psi.Environment["KCAP_DAEMON_ID"]).IsEqualTo("daemon-1");
+        await Assert.That(psi.Environment["KCAP_DAEMON_EPOCH"]).IsEqualTo("epoch-1");
+        await Assert.That(psi.Environment["KCAP_URL"]).IsEqualTo("http://kcap.test");
+    }
+
+    /// <summary>Containment: the turn child's whole HOME (and its temp tree, which agy writes into)
+    /// is the per-launch isolated one. An inherited HOME would let agy's own kcap capture hooks fire
+    /// against the conversation this runtime is already recording.</summary>
+    [Test]
+    public async Task The_turn_child_runs_under_the_isolated_home_and_a_home_local_tmpdir() {
+        var psi = BuildPsi(EnabledConfig());
+
+        await Assert.That(psi.Environment["HOME"]).IsEqualTo(HomePath);
+        await Assert.That(psi.Environment["TMPDIR"]).IsEqualTo(Path.Combine(HomePath, "tmp"));
+    }
+
+    /// <summary>Google auth is INHERITED from the daemon's own environment (<c>UseShellExecute</c> is
+    /// false, so the child gets the daemon's block plus our overrides). Re-stamping it here would mean
+    /// a rotated ADC path resolved at daemon start rather than at spawn.</summary>
+    [Test]
+    public async Task Google_auth_variables_are_inherited_rather_than_restamped() {
+        var psi = BuildPsi(EnabledConfig());
+
+        await Assert.That(psi.UseShellExecute).IsFalse();
+        await Assert.That(psi.Environment.ContainsKey("AGY_ADC_AUTH")).IsFalse();
+        await Assert.That(psi.Environment.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS")).IsFalse();
+    }
+
+    // ── advertisement ─────────────────────────────────────────────────────────────────────────────
+
+    static AntigravityHostedAgentRuntimeFactory Factory(
+            DaemonConfig config,
+            Func<ProcessStartInfo, CancellationToken, Task<IAgyTurnProcess>>? turnSource = null,
+            bool binaryExists = true) =>
+        new(config, NullLoggerFactory.Instance, turnSource, _ => binaryExists);
+
+    [Test]
+    public async Task A_consent_withheld_daemon_reports_an_operator_actionable_reason() {
+        var config = EnabledConfig();
+        config.AntigravityUnattendedReviewerEnabled = false;
+
+        var support = Factory(config).DescribeUnattendedSupport();
+
+        await Assert.That(support.Supported).IsFalse();
+        // The reason must name the switch the operator can actually flip, not merely say "disabled".
+        await Assert.That(support.WithheldReason).IsNotNull();
+        await Assert.That(support.WithheldReason!).Contains("antigravity_unattended_reviewer_disabled");
+        await Assert.That(support.WithheldReason!).Contains("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
+    }
+
+    /// <summary>A consenting daemon whose binary is not installed is withheld too, and says which path
+    /// it looked for — the failure mode the <c>agy</c> default exists to avoid is a vendor that is
+    /// silently never advertised.</summary>
+    [Test]
+    public async Task A_missing_binary_is_withheld_with_the_path_it_looked_for() {
+        var support = Factory(EnabledConfig(), binaryExists: false).DescribeUnattendedSupport();
+
+        await Assert.That(support.Supported).IsFalse();
+        await Assert.That(support.WithheldReason!).Contains("antigravity_reviewer_binary_missing");
+        await Assert.That(support.WithheldReason!).Contains("agy");
+    }
+
+    /// <summary>Consent plus a resolvable binary is enough — there is deliberately NO credential gate
+    /// (owner decision): an operator without durable auth gets a bounded, coded spawn-time failure,
+    /// not a vendor that silently disappears.</summary>
+    [Test]
+    public async Task Consent_plus_binary_is_supported_with_no_withheld_reason() {
+        Skip.Unless(!OperatingSystem.IsWindows(),
+            "The Antigravity reviewer is POSIX-only: its per-launch home holds review context and cannot be created owner-only on Windows.");
+
+        var support = Factory(EnabledConfig()).DescribeUnattendedSupport();
+
+        await Assert.That(support.Supported).IsTrue();
+        await Assert.That(support.WithheldReason).IsNull();
+    }
+
+    [Test]
+    public async Task Borrowed_review_is_not_offered() {
+        // No sandbox-exec substrate here: reviews fail closed to an owned worktree, as Kiro and
+        // Claude do. Read through the interface, since that is the only surface the orchestrator's
+        // routing ever consults.
+        IHostedAgentRuntimeFactory factory = Factory(EnabledConfig());
+
+        await Assert.That(factory.SupportsBorrowedReviewFlow).IsFalse();
+        await Assert.That(factory.BorrowedReviewContainment).IsNull();
+        await Assert.That(factory.Vendor).IsEqualTo("antigravity");
+    }
+
+    // ── StartAsync ────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Records every spawned turn's <see cref="ProcessStartInfo"/> so a test can assert on
+    /// what the SECOND turn's argv carried without a real process.</summary>
+    sealed class SpyTurnSource {
+        readonly FakeTurn _turn;
+        public List<ProcessStartInfo> Spawns { get; } = [];
+
+        public SpyTurnSource(FakeTurn turn = FakeTurn.Normal) => _turn = turn;
+
+        public Task<IAgyTurnProcess> SpawnAsync(ProcessStartInfo psi, CancellationToken ct) {
+            Spawns.Add(psi);
+            return Task.FromResult<IAgyTurnProcess>(new FakeAgyTurnProcess(_turn, FixedConversationId));
+        }
+    }
+
+    /// <summary>Waits (in small real increments — this is process synchronization, not the thing under
+    /// test) until the spy has recorded <paramref name="count"/> spawns, and fails loudly rather than
+    /// silently proceeding on a count that never arrived.</summary>
+    static async Task SpawnedAtLeast(SpyTurnSource spy, int count) {
+        var deadline = DateTime.UtcNow + HangGuard;
+
+        while (spy.Spawns.Count < count && DateTime.UtcNow < deadline) await Task.Delay(5);
+
+        if (spy.Spawns.Count < count)
+            throw new TimeoutException($"Only {spy.Spawns.Count} turn(s) were spawned; expected {count}.");
+    }
+
+    /// <summary>
+    /// The ordering the orchestrator depends on: it reads <c>transcript.AcpSessionId</c> synchronously
+    /// the moment a launch returns, so a <c>StartAsync</c> that returned before turn 1's <c>init</c>
+    /// was parsed would bind the transcript to <c>""</c> — a silent, permanent correlation break.
+    ///
+    /// <para>Also pins the clock wiring: the clock must be attached BEFORE the first turn runs, since
+    /// a clock assigned later makes every stamp inside the launch a silent no-op. <c>ActivitySeq</c>
+    /// starts at 1 and only a real stamp against THIS instance can move it.</para>
+    /// </summary>
+    [Test]
+    public async Task StartAsync_returns_with_the_conversation_id_bound_and_the_clock_already_wired() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy   = new SpyTurnSource();
+        var clock = new AgentActivityClock(new FakeTimeProvider());
+
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(clock: clock), CancellationToken.None).WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        await Assert.That(start.Transcript).IsNotNull();
+        await Assert.That(start.Transcript!.AcpSessionId).IsEqualTo(FixedConversationId);
+
+        // >1 is only reachable if a stamp ran against THIS clock instance during the launch.
+        await Assert.That(clock.ActivitySeq).IsGreaterThan(1UL);
+    }
+
+    /// <summary>Turn 2 must resume turn 1's conversation, or every round lands as its own kcap
+    /// session. Asserted on the SECOND spawn's argv — the id is read back from the launch rather than
+    /// reconstructed, so this cannot pass against a launch that resumed something else.</summary>
+    [Test]
+    public async Task A_second_turn_resumes_the_conversation_the_first_turn_established() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy   = new SpyTurnSource();
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(), CancellationToken.None).WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        await runtime.SendUserInputAsync("round 2").WaitAsync(HangGuard);
+
+        // Polled, not WaitForTurnIdleAsync: that call's acquire-then-release can complete against a
+        // momentarily-free gate before the worker has even dequeued the turn, so it is not a "the
+        // turn ran" barrier (see the runtime's own class doc). This waits for the observable fact.
+        await SpawnedAtLeast(spy, 2);
+        await Assert.That(spy.Spawns[0].ArgumentList).DoesNotContain("--conversation");
+
+        var second = spy.Spawns[1].ArgumentList;
+        var i      = second.IndexOf("--conversation");
+        await Assert.That(i).IsGreaterThanOrEqualTo(0);
+        await Assert.That(second[i + 1]).IsEqualTo(start.Transcript!.AcpSessionId);
+    }
+
+    /// <summary>
+    /// An interactive launch is refused, not silently accepted. This runtime parses agy's NDJSON from
+    /// stdout once per turn, and an inherited HOME lets agy's own kcap capture hooks fire — which
+    /// spawns a watcher that can hold a write end of that stdout open after agy exits, so every turn
+    /// would block forever. A coded refusal is the honest shape until the interactive lane is built.
+    /// </summary>
+    [Test]
+    public async Task An_interactive_launch_is_refused_rather_than_hanging_on_an_inherited_home() {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(EnabledConfig(), new SpyTurnSource().SpawnAsync)
+                .StartAsync(Ctx(isReviewFlow: false), CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_interactive_launch_unsupported");
+    }
+
+    /// <summary>Defence in depth: the orchestrator's unattended gate runs first, but an explicit
+    /// vendor request can reach a factory directly, so the consent gate is re-applied at the launch
+    /// boundary rather than trusted to advertisement.</summary>
+    [Test]
+    public async Task A_consent_withheld_daemon_refuses_a_review_launch() {
+        var config = EnabledConfig();
+        config.AntigravityUnattendedReviewerEnabled = false;
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(config, new SpyTurnSource().SpawnAsync)
+                .StartAsync(Ctx(), CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_unattended_reviewer_disabled");
+    }
+
+    /// <summary>
+    /// The measured unauthenticated shapes: an immediate `authentication required` error, or an OAuth
+    /// URL followed by an interactive wait. Either way the child says so and produces no <c>init</c>,
+    /// so the launch must fail with the coded, non-retryable reason NAMING the ADC remedy — a generic
+    /// launch failure would send an operator looking at the wrong thing.
+    /// </summary>
+    [Test]
+    public async Task An_unauthenticated_first_turn_fails_with_the_coded_adc_remedy() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var factory = Factory(EnabledConfig(), (_, _) => Task.FromResult<IAgyTurnProcess>(
+            new UnauthenticatedTurnProcess()));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.StartAsync(Ctx(), CancellationToken.None).WaitAsync(HangGuard));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_auth_unavailable");
+        await Assert.That(ex.Message).Contains("AGY_ADC_AUTH");
+    }
+
+    /// <summary>
+    /// The control for the test above, and it must carry NON-EMPTY output that simply is not an auth
+    /// signal. An earlier revision used a child that said nothing at all — a mutation check showed
+    /// that made the assertion vacuous, because a null-diagnostics child is rejected by the pattern
+    /// match before the classifier is ever consulted, so a classifier hard-wired to <c>true</c>
+    /// survived. With real, unrelated output the classifier is the guard that decides.
+    /// </summary>
+    [Test]
+    public async Task A_first_turn_that_dies_with_unrelated_output_is_not_reported_as_an_auth_failure() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var factory = Factory(EnabledConfig(), (_, _) => Task.FromResult<IAgyTurnProcess>(
+            new DyingTurnProcess("panic: runtime error: index out of range [3]")));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.StartAsync(Ctx(), CancellationToken.None).WaitAsync(HangGuard));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_launch_failed");
+    }
+
+    /// <summary>And a child that says nothing at all is likewise not an auth failure — the arm the
+    /// pattern match, rather than the classifier, is responsible for.</summary>
+    [Test]
+    public async Task A_first_turn_that_dies_silently_is_not_reported_as_an_auth_failure() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var factory = Factory(EnabledConfig(), (_, _) => Task.FromResult<IAgyTurnProcess>(
+            new DyingTurnProcess(null)));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.StartAsync(Ctx(), CancellationToken.None).WaitAsync(HangGuard));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_launch_failed");
+    }
+
+    /// <summary>
+    /// A child that is ALIVE and never says anything — the production shape, and the one the two
+    /// terminating fixtures above structurally cannot produce. Measured, an unauthenticated agy can
+    /// print an OAuth URL and wait ~60s for a paste that will never come; without an absolute bound
+    /// the launch would sit there, and <c>ReadOutputAsync</c> is parked by design so nothing else
+    /// would ever complete. Asserts the child was REAPED, not merely that an error was thrown:
+    /// abandoning it would leave a reviewer holding a daemon slot the server has already given up on.
+    /// </summary>
+    [Test]
+    public async Task An_alive_but_silent_first_turn_hits_the_launch_deadline_and_is_reaped() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var config = EnabledConfig();
+        config.AntigravityReviewerLaunchTimeoutSeconds = 1;
+
+        var child   = new AliveSilentTurnProcess();
+        var factory = Factory(config, (_, _) => Task.FromResult<IAgyTurnProcess>(child));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.StartAsync(Ctx(), CancellationToken.None).WaitAsync(HangGuard));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_launch_timeout");
+        await Assert.That(child.Terminated).IsTrue();
+    }
+
+    /// <summary>A daemon shutdown mid-launch propagates AS a cancellation, not as a coded reviewer
+    /// fault — otherwise every agent in flight when the daemon stopped leaves a launch-failure record
+    /// describing a problem that never happened.</summary>
+    [Test]
+    public async Task A_shutdown_mid_launch_surfaces_as_cancellation_not_a_reviewer_fault() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var child   = new AliveSilentTurnProcess();
+        var spawned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var factory = Factory(EnabledConfig(), (_, _) => {
+            spawned.TrySetResult();
+            return Task.FromResult<IAgyTurnProcess>(child);
+        });
+
+        using var cts = new CancellationTokenSource();
+        var launch    = factory.StartAsync(Ctx(), cts.Token);
+
+        // Cancel only once the child genuinely exists. Cancelling earlier is a DIFFERENT (also
+        // correct) path — the turn is dropped without ever spawning — and asserting the reap below
+        // would then be judging a child that was never created.
+        await spawned.Task.WaitAsync(HangGuard);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => launch.WaitAsync(HangGuard));
+
+        // Still reaped: a shutdown must not be the one path that leaks a child.
+        await Assert.That(child.Terminated).IsTrue();
+    }
+
+    /// <summary>
+    /// The per-launch home carries the reviewer's own conversation JSONL — the caller's diff, source
+    /// excerpts and findings — so its removal is disposal, not disk hygiene. The daemon-epoch sweep is
+    /// a crash backstop, not the disposal path: without this the home survives every completed review
+    /// until the next daemon boot.
+    /// </summary>
+    [Test]
+    public async Task The_reviewer_home_is_removed_when_the_runtime_is_disposed() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy   = new SpyTurnSource();
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(), CancellationToken.None).WaitAsync(HangGuard);
+
+        var home = spy.Spawns[0].Environment["HOME"]!;
+        await Assert.That(Directory.Exists(home)).IsTrue();
+
+        await start.Runtime.DisposeAsync();
+
+        await Assert.That(Directory.Exists(home)).IsFalse();
+    }
+
+    /// <summary>A launch that fails must not leave review context behind either — the failed-launch
+    /// path is the one where nobody downstream will ever call <c>DisposeAsync</c> for us.</summary>
+    [Test]
+    public async Task A_failed_launch_removes_the_reviewer_home_it_created() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        string? home    = null;
+        var     factory = Factory(EnabledConfig(), (psi, _) => {
+            home = psi.Environment["HOME"];
+            return Task.FromResult<IAgyTurnProcess>(new DyingTurnProcess(null));
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.StartAsync(Ctx(), CancellationToken.None).WaitAsync(HangGuard));
+
+        await Assert.That(home).IsNotNull();
+        await Assert.That(Directory.Exists(home!)).IsFalse();
+    }
+
+    /// <summary>A turn child that prints an auth error and exits — no <c>init</c>, so the conversation
+    /// barrier faults and the factory classifies the failure from the captured diagnostics.</summary>
+    sealed class UnauthenticatedTurnProcess : IAgyTurnProcess, IAgyTurnDiagnostics {
+        public int  Pid       => 4243;
+        public bool HasExited => true;
+        public int? ExitCode  => 1;
+
+        public string? Diagnostics => "Error: authentication required. Run 'agy' to log in, then retry.";
+
+#pragma warning disable CS1998 // an async iterator that yields nothing still needs the async modifier
+        public async IAsyncEnumerable<string> ReadLinesAsync(
+                [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct) {
+            yield break;
+        }
+#pragma warning restore CS1998
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan? timeout = null)   => Task.CompletedTask;
+        public ValueTask DisposeAsync()                        => ValueTask.CompletedTask;
+    }
+
+    /// <summary>A turn child that is up, with an open pipe, and never emits a line — it ends only when
+    /// something cancels or kills it.</summary>
+    sealed class AliveSilentTurnProcess : IAgyTurnProcess {
+        public int  Pid        => 4245;
+        public bool HasExited  { get; private set; }
+        public int? ExitCode   { get; private set; }
+        public bool Terminated { get; private set; }
+
+        public async IAsyncEnumerable<string> ReadLinesAsync(
+                [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct) {
+            await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+            yield break;
+        }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+
+        public Task TerminateAsync(TimeSpan? timeout = null) {
+            Terminated = true;
+            HasExited  = true;
+            ExitCode ??= -1;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    /// <summary>The same shape with caller-chosen diagnostics — the control that keeps the auth
+    /// classifier from being a constant.</summary>
+    sealed class DyingTurnProcess(string? diagnostics) : IAgyTurnProcess, IAgyTurnDiagnostics {
+        public int  Pid       => 4244;
+        public bool HasExited => true;
+        public int? ExitCode  => 1;
+
+        public string? Diagnostics => diagnostics;
+
+#pragma warning disable CS1998
+        public async IAsyncEnumerable<string> ReadLinesAsync(
+                [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct) {
+            yield break;
+        }
+#pragma warning restore CS1998
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan? timeout = null)   => Task.CompletedTask;
+        public ValueTask DisposeAsync()                        => ValueTask.CompletedTask;
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -154,11 +154,16 @@ public class AntigravityReviewerLaunchTests {
 
     // ── advertisement ─────────────────────────────────────────────────────────────────────────────
 
+    /// <param name="version">Seamed on EVERY construction, never left to a real probe: the gate reads
+    /// the installed <c>agy</c>'s version, so an unseamed test would resolve <see langword="null"/> on
+    /// any host without the binary (CI) and refuse as <c>version_unresolved</c> — passing or failing
+    /// for a reason unrelated to what it asserts. Defaults to the shipped floor.</param>
     static AntigravityHostedAgentRuntimeFactory Factory(
             DaemonConfig config,
             Func<ProcessStartInfo, CancellationToken, Task<IAgyTurnProcess>>? turnSource = null,
-            bool binaryExists = true) =>
-        new(config, NullLoggerFactory.Instance, turnSource, _ => binaryExists);
+            bool binaryExists = true,
+            string? version = "1.1.10") =>
+        new(config, NullLoggerFactory.Instance, turnSource, _ => binaryExists, _ => version);
 
     [Test]
     public async Task A_consent_withheld_daemon_reports_an_operator_actionable_reason() {
@@ -198,6 +203,98 @@ public class AntigravityReviewerLaunchTests {
 
         await Assert.That(support.Supported).IsTrue();
         await Assert.That(support.WithheldReason).IsNull();
+    }
+
+    // ── the minimum-version floor, at the ONE ladder that owns it ─────────────────────────────────
+
+    /// <summary>The floor lives in the factory's own gate ladder, so advertisement and the launch
+    /// boundary cannot disagree about it. A build that meets it is advertised with nothing
+    /// withheld.</summary>
+    [Test]
+    [Arguments("1.1.10")]
+    [Arguments("2.5.0")]
+    public async Task A_floor_meeting_build_is_advertised(string installed) {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var support = Factory(EnabledConfig(), version: installed).DescribeUnattendedSupport();
+
+        await Assert.That(support.Supported).IsTrue();
+        await Assert.That(support.WithheldReason).IsNull();
+    }
+
+    [Test]
+    public async Task A_below_floor_build_is_withheld_with_a_reason_naming_both_versions() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var support = Factory(EnabledConfig(), version: "1.1.8").DescribeUnattendedSupport();
+
+        await Assert.That(support.Supported).IsFalse();
+        await Assert.That(support.WithheldReason!).StartsWith("antigravity_reviewer_version_below_minimum");
+        await Assert.That(support.WithheldReason!).Contains("1.1.8");
+        await Assert.That(support.WithheldReason!).Contains("1.1.10");
+    }
+
+    /// <summary>A probe that could not identify the build refuses under its OWN arm — the operator's
+    /// next action is to fix the binary, not to upgrade it.</summary>
+    [Test]
+    public async Task An_unidentifiable_build_is_withheld_as_unresolved() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var support = Factory(EnabledConfig(), version: null).DescribeUnattendedSupport();
+
+        await Assert.That(support.Supported).IsFalse();
+        await Assert.That(support.WithheldReason!).StartsWith("antigravity_reviewer_version_unresolved");
+    }
+
+    /// <summary>A missing binary reports as MISSING, not as an unidentifiable version — the presence
+    /// check has to precede the probe, or an operator with no <c>agy</c> at all is sent to check a
+    /// version that was never going to resolve.</summary>
+    [Test]
+    public async Task A_missing_binary_outranks_the_version_arm() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var support = Factory(EnabledConfig(), binaryExists: false, version: null).DescribeUnattendedSupport();
+
+        await Assert.That(support.WithheldReason!).StartsWith("antigravity_reviewer_binary_missing");
+    }
+
+    /// <summary>Consent is read FIRST and short-circuits before the probe: an installed-but-wedged
+    /// <c>agy</c> must not be spawned — let alone stall a daemon start — for a feature the operator
+    /// switched off. The below-floor version is what makes this a short-circuit assertion rather than
+    /// a restatement of the disabled arm.</summary>
+    [Test]
+    public async Task A_consent_withheld_daemon_never_probes_the_binary() {
+        var config = EnabledConfig();
+        config.AntigravityUnattendedReviewerEnabled = false;
+
+        var probes = 0;
+        var factory = new AntigravityHostedAgentRuntimeFactory(
+            config, NullLoggerFactory.Instance, turnSource: null, binaryExists: _ => true,
+            resolveVersion: _ => { probes++; return "0.0.1"; });
+
+        await Assert.That(factory.DescribeUnattendedSupport().Supported).IsFalse();
+        await Assert.That(probes).IsEqualTo(0);
+    }
+
+    /// <summary>The binary is probed ONCE per decision — the verdict and its explanation both need the
+    /// version, and resolving it per consumer spawns the vendor binary twice to produce one
+    /// refusal — and it is probed at the path this DAEMON would launch, not whatever <c>agy</c>
+    /// happens to resolve to first.</summary>
+    [Test]
+    public async Task The_probe_reads_the_configured_path_exactly_once() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var config = EnabledConfig();
+        config.AntigravityPath = "/opt/agy/bin/agy";
+
+        var seen   = new List<string>();
+        var factory = new AntigravityHostedAgentRuntimeFactory(
+            config, NullLoggerFactory.Instance, turnSource: null, binaryExists: _ => true,
+            resolveVersion: path => { seen.Add(path); return "1.1.8"; });
+
+        factory.DescribeUnattendedSupport();
+
+        await Assert.That(seen).IsEquivalentTo(new[] { "/opt/agy/bin/agy" });
     }
 
     [Test]
@@ -323,6 +420,21 @@ public class AntigravityReviewerLaunchTests {
                 .StartAsync(Ctx(), CancellationToken.None));
 
         await Assert.That(ex!.Message).StartsWith("antigravity_unattended_reviewer_disabled");
+    }
+
+    /// <summary>
+    /// The same defence in depth for the FLOOR, which is the gap a floor applied only at
+    /// advertisement leaves: advertisement is what stops a launch being attempted, but an explicit
+    /// <c>vendor: "antigravity"</c> request reaches this factory without consulting it, so a
+    /// below-floor build could be launched. One ladder, read at both seams, closes it.
+    /// </summary>
+    [Test]
+    public async Task A_below_floor_build_is_refused_at_the_launch_boundary_too() {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(EnabledConfig(), new SpyTurnSource().SpawnAsync, version: "1.1.8")
+                .StartAsync(Ctx(), CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_version_below_minimum");
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -158,12 +158,31 @@ public class AntigravityReviewerLaunchTests {
     /// the installed <c>agy</c>'s version, so an unseamed test would resolve <see langword="null"/> on
     /// any host without the binary (CI) and refuse as <c>version_unresolved</c> — passing or failing
     /// for a reason unrelated to what it asserts. Defaults to the shipped floor.</param>
+    /// <param name="posixHost">Pinned rather than inherited from the runner, so every arm of the
+    /// ladder is reachable from any host. Defaulting this to the ambient OS is what reddened the
+    /// Windows CI leg: the platform arm short-circuits ahead of the binary and floor arms, so
+    /// <c>A_missing_binary_…</c> and <c>A_below_floor_…</c> both refused on platform and failed for a
+    /// reason unrelated to what they assert. Tests that genuinely touch the POSIX-only reviewer HOME
+    /// still need their own <c>Skip.Unless</c> — this seam decides the gate, not the filesystem.</param>
     static AntigravityHostedAgentRuntimeFactory Factory(
             DaemonConfig config,
             Func<ProcessStartInfo, CancellationToken, Task<IAgyTurnProcess>>? turnSource = null,
             bool binaryExists = true,
-            string? version = "1.1.10") =>
-        new(config, NullLoggerFactory.Instance, turnSource, _ => binaryExists, _ => version);
+            string? version = "1.1.10",
+            bool posixHost = true) =>
+        new(config, NullLoggerFactory.Instance, turnSource, _ => binaryExists, _ => version, posixHost);
+
+    /// <summary>The platform arm itself — assertable from POSIX only because the seam above exists,
+    /// which is the point of having it. The reviewer's per-launch home holds review context and
+    /// cannot be created owner-only on Windows, so the vendor is withheld rather than advertised with
+    /// a world-readable home.</summary>
+    [Test]
+    public async Task A_windows_host_is_withheld_as_an_unsupported_platform() {
+        var support = Factory(EnabledConfig(), posixHost: false).DescribeUnattendedSupport();
+
+        await Assert.That(support.Supported).IsFalse();
+        await Assert.That(support.WithheldReason!).Contains("antigravity_reviewer_unsupported_platform");
+    }
 
     [Test]
     public async Task A_consent_withheld_daemon_reports_an_operator_actionable_reason() {

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -429,7 +429,16 @@ public class AntigravityReviewerLaunchTests {
         await spawned.Task.WaitAsync(HangGuard);
         await cts.CancelAsync();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(() => launch.WaitAsync(HangGuard));
+        // Assignable, not exact. Which cancellation type surfaces depends on WHERE the cancel is
+        // observed — `OperationCanceledException` from a token check, `TaskCanceledException` from an
+        // awaited task — and both are correct here. `Assert.ThrowsAsync<T>` matches the type exactly,
+        // so it made this assertion load-dependent: it passed under the whole-suite filter and failed
+        // deterministically when this class ran alone.
+        Exception? caught = null;
+        try { await launch.WaitAsync(HangGuard); } catch (Exception ex) { caught = ex; }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught!).IsAssignableTo<OperationCanceledException>();
 
         // Still reaped: a shutdown must not be the one path that leaks a child.
         await Assert.That(child.Terminated).IsTrue();

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -29,14 +29,31 @@ public class AntigravityReviewerLaunchTests {
         return dir;
     }
 
-    static DaemonConfig EnabledConfig(string? model = null, string? stateDir = null) => new() {
-        AntigravityPath                      = "agy",
-        AntigravityModel                     = model,
-        AntigravityUnattendedReviewerEnabled = true,
-        Name                                 = "test-daemon",
-        DaemonEpoch                          = "epoch-1",
-        StateDir                             = stateDir ?? TempStateDir()
-    };
+    /// <summary>The minimum this daemon has on record — the same value the seeded record and the
+    /// version seam default to, so the "meets it exactly" case is the baseline every other arm moves
+    /// away from.</summary>
+    const string RecordedMinimum = "1.1.10";
+
+    /// <param name="minimum">The recorded minimum, seeded exactly as enabling the reviewer does in
+    /// production (<c>DaemonRunner</c> seeds from the consent event). Null records NOTHING, which is
+    /// how the no-minimum arm is reached — the gate is not configuration, so there is no value to pass
+    /// for "unset".</param>
+    static DaemonConfig EnabledConfig(
+            string? model = null, string? stateDir = null, string? minimum = RecordedMinimum) {
+        var config = new DaemonConfig {
+            AntigravityPath                      = "agy",
+            AntigravityModel                     = model,
+            AntigravityUnattendedReviewerEnabled = true,
+            Name                                 = "test-daemon",
+            DaemonEpoch                          = "epoch-1",
+            StateDir                             = stateDir ?? TempStateDir()
+        };
+
+        if (minimum is not null)
+            AntigravityHostedAgentRuntimeFactory.VersionStoreFor(config).Affirm(minimum);
+
+        return config;
+    }
 
     static RuntimeStartContext Ctx(
             bool isReviewFlow = true, AgentActivityClock? clock = null, string? model = null) => new(
@@ -224,15 +241,16 @@ public class AntigravityReviewerLaunchTests {
         await Assert.That(support.WithheldReason).IsNull();
     }
 
-    // ── the minimum-version floor, at the ONE ladder that owns it ─────────────────────────────────
+    // ── the recorded minimum, at the ONE ladder that owns it ──────────────────────────────────────
 
-    /// <summary>The floor lives in the factory's own gate ladder, so advertisement and the launch
-    /// boundary cannot disagree about it. A build that meets it is advertised with nothing
+    /// <summary>The minimum reaches advertisement THROUGH the factory's own gate ladder, so
+    /// advertisement and the launch boundary cannot disagree about it. A build that meets it — or any
+    /// later one, since the record is a minimum and not an exact match — is advertised with nothing
     /// withheld.</summary>
     [Test]
     [Arguments("1.1.10")]
     [Arguments("2.5.0")]
-    public async Task A_floor_meeting_build_is_advertised(string installed) {
+    public async Task A_minimum_meeting_build_is_advertised(string installed) {
         Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
 
         var support = Factory(EnabledConfig(), version: installed).DescribeUnattendedSupport();
@@ -242,7 +260,7 @@ public class AntigravityReviewerLaunchTests {
     }
 
     [Test]
-    public async Task A_below_floor_build_is_withheld_with_a_reason_naming_both_versions() {
+    public async Task A_below_minimum_build_is_withheld_with_a_reason_naming_both_versions() {
         Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
 
         var support = Factory(EnabledConfig(), version: "1.1.8").DescribeUnattendedSupport();
@@ -250,7 +268,38 @@ public class AntigravityReviewerLaunchTests {
         await Assert.That(support.Supported).IsFalse();
         await Assert.That(support.WithheldReason!).StartsWith("antigravity_reviewer_version_below_minimum");
         await Assert.That(support.WithheldReason!).Contains("1.1.8");
-        await Assert.That(support.WithheldReason!).Contains("1.1.10");
+        await Assert.That(support.WithheldReason!).Contains(RecordedMinimum);
+    }
+
+    /// <summary>An absent record must not read as permission. This is the control for the seeding
+    /// path: without it, a daemon that never seeded and a working gate look identical from here.
+    /// </summary>
+    [Test]
+    public async Task A_daemon_with_no_recorded_minimum_is_withheld() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var support = Factory(EnabledConfig(minimum: null)).DescribeUnattendedSupport();
+
+        await Assert.That(support.Supported).IsFalse();
+        await Assert.That(support.WithheldReason!).StartsWith("antigravity_reviewer_version_no_minimum");
+    }
+
+    /// <summary>The record is read per decision, never snapshotted at construction: `kcap daemon
+    /// reviewer affirm` runs in a DIFFERENT process while this daemon is live, and a cached read would
+    /// leave the operator's affirmation inert until a restart the verb does not require of them.
+    /// </summary>
+    [Test]
+    public async Task An_affirmation_taken_under_a_running_daemon_is_picked_up() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var config  = EnabledConfig(minimum: "9.9.9");
+        var factory = Factory(config, version: "1.1.10");
+
+        await Assert.That(factory.DescribeUnattendedSupport().Supported).IsFalse();
+
+        AntigravityHostedAgentRuntimeFactory.VersionStoreFor(config).Affirm("1.1.10");
+
+        await Assert.That(factory.DescribeUnattendedSupport().Supported).IsTrue();
     }
 
     /// <summary>A probe that could not identify the build refuses under its OWN arm — the operator's
@@ -442,13 +491,13 @@ public class AntigravityReviewerLaunchTests {
     }
 
     /// <summary>
-    /// The same defence in depth for the FLOOR, which is the gap a floor applied only at
+    /// The same defence in depth for the recorded MINIMUM, which is the gap a check applied only at
     /// advertisement leaves: advertisement is what stops a launch being attempted, but an explicit
     /// <c>vendor: "antigravity"</c> request reaches this factory without consulting it, so a
-    /// below-floor build could be launched. One ladder, read at both seams, closes it.
+    /// below-minimum build could be launched. One ladder, read at both seams, closes it.
     /// </summary>
     [Test]
-    public async Task A_below_floor_build_is_refused_at_the_launch_boundary_too() {
+    public async Task A_below_minimum_build_is_refused_at_the_launch_boundary_too() {
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             Factory(EnabledConfig(), new SpyTurnSource().SpawnAsync, version: "1.1.8")
                 .StartAsync(Ctx(), CancellationToken.None));

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLiveCertTests.cs
@@ -31,7 +31,8 @@ namespace Capacitor.Cli.Tests.Unit.Services;
 ///
 /// <para><b>Gated</b> behind <c>KCAP_ANTIGRAVITY_REVIEWER_LIVE=1</c>: CI has no <c>agy</c> binary and
 /// no Google account, and each case spends real model turns. Requires <c>agy</c> on <c>PATH</c> (or
-/// <c>KCAP_ANTIGRAVITY_PATH</c>) at or above the shipped floor, plus the same durable ADC
+/// <c>KCAP_ANTIGRAVITY_PATH</c>) — the harness records that build as this daemon's minimum, exactly
+/// as enabling the reviewer does — plus the same durable ADC
 /// credentials a supervised daemon needs — <c>gcloud auth application-default login</c>,
 /// <c>GOOGLE_CLOUD_PROJECT</c> and <c>AGY_ADC_AUTH=1</c> — which the launch path deliberately
 /// INHERITS from this process's environment rather than re-stamping, exactly as it inherits them
@@ -60,7 +61,7 @@ public class AntigravityReviewerLiveCertTests {
     static void Gate() {
         Skip.Unless(Environment.GetEnvironmentVariable(GateEnvVar) == "1",
             $"Gated live certification of the unattended Antigravity reviewer — set {GateEnvVar}=1 to run "
-          + "(spends real agy turns; needs `agy` on PATH at or above the shipped floor, and the daemon's "
+          + "(spends real agy turns; needs `agy` on PATH, and the daemon's "
           + "own ADC credentials: gcloud auth application-default login, GOOGLE_CLOUD_PROJECT=<project>, "
           + "AGY_ADC_AUTH=1). Re-run it against a new agy before recommending that build to operators.");
 
@@ -238,12 +239,20 @@ public class AntigravityReviewerLiveCertTests {
                 StateDir                              = stateDir
             };
 
+            // Seeded through the DAEMON's own path, not a hand-written record: production records the
+            // minimum from the consent event at startup, and this harness is standing in for a daemon
+            // whose operator has just enabled the reviewer. It resolves the version by really running
+            // the installed agy, so the cert still judges the INSTALLED build rather than a seamed one.
+            DaemonRunner.SeedReviewerAffirmation(
+                AntigravityHostedAgentRuntimeFactory.ReviewerStateDir(config),
+                DaemonRunner.AntigravityVendor, enabled: true, config.AntigravityPath);
+
             return new LiveHarness(root, worktree, config);
         }
 
         internal Task<HostedRuntimeStart> LaunchAsync(string prompt) {
             // binaryExists/resolveVersion left to production: this cert exists to judge the INSTALLED
-            // agy, so seaming the floor would certify a build the gate would have refused.
+            // agy, so seaming the version would certify a build the gate would have refused.
             var factory = new AntigravityHostedAgentRuntimeFactory(
                 Config, NullLoggerFactory.Instance, turnSource: SpawnAsync);
 
@@ -293,7 +302,7 @@ public class AntigravityReviewerLiveCertTests {
             if (SpawnCount < rounds)
                 throw new TimeoutException(
                     $"Only {SpawnCount} agy turn(s) spawned; expected {rounds}. The reviewer never started "
-                  + "this round — check the daemon's ADC environment and the agy version floor.");
+                  + "this round — check the daemon's ADC environment and its recorded agy minimum.");
 
             using var cts = new CancellationTokenSource(RoundBudget);
             await runtime.WaitForTurnIdleAsync(cts.Token);

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLiveCertTests.cs
@@ -1,0 +1,332 @@
+// test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLiveCertTests.cs
+using System.Diagnostics;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// GATED live certification of the unattended Antigravity reviewer against a REAL <c>agy</c>.
+///
+/// <para><b>What this certifies.</b> The daemon half of a
+/// <c>start_review_flow(kind: "code-review", vendor: "antigravity")</c> — the reviewer launch the
+/// server drives — end to end: a real turn child spawns under the per-launch isolated
+/// <c>HOME</c>, authenticates from the daemon's own ADC environment, reports a conversation id, and
+/// completes its round with no human answering anything. The server-side half (the MCP call itself,
+/// and the result arriving over <c>kcap mcp flow-result</c>) needs a running tenant and a daemon
+/// that ADVERTISES antigravity, so it is deliberately not simulated here: a fake would certify
+/// nothing and would read as a green light nobody earned.</para>
+///
+/// <para><b>The second cert is the load-bearing one.</b> <c>agy</c> has no long-lived process —
+/// every round is its own <c>agy -p …</c> invocation, resumed with <c>--conversation &lt;id&gt;</c>.
+/// That exec-per-turn shape is invisible from a single round, and a regression in it is silent: the
+/// review still "works", it just lands as one kcap session PER ROUND instead of one session for the
+/// whole review, splitting the reviewer's history at exactly the point a re-review depends on it.
+/// <see cref="Cert2_EveryRoundOfAMultiRoundReviewLandsAsOneSession"/> pins all three observable
+/// halves of the claim — one stable conversation id, a distinct process per round, and the resume
+/// flag actually carrying that id.</para>
+///
+/// <para><b>Gated</b> behind <c>KCAP_ANTIGRAVITY_REVIEWER_LIVE=1</c>: CI has no <c>agy</c> binary and
+/// no Google account, and each case spends real model turns. Requires <c>agy</c> on <c>PATH</c> (or
+/// <c>KCAP_ANTIGRAVITY_PATH</c>) at or above the shipped floor, plus the same durable ADC
+/// credentials a supervised daemon needs — <c>gcloud auth application-default login</c>,
+/// <c>GOOGLE_CLOUD_PROJECT</c> and <c>AGY_ADC_AUTH=1</c> — which the launch path deliberately
+/// INHERITS from this process's environment rather than re-stamping, exactly as it inherits them
+/// from the daemon's.</para>
+/// </summary>
+public class AntigravityReviewerLiveCertTests {
+    const string GateEnvVar = "KCAP_ANTIGRAVITY_REVIEWER_LIVE";
+
+    /// <summary>Bounded on purpose, and generously: a real model turn under a cold ADC handshake is
+    /// slow, but "never completed" and "skipped or inconclusive" must stay distinguishable, or a
+    /// broken reviewer looks exactly like a test that did not run.</summary>
+    static readonly TimeSpan RoundBudget = TimeSpan.FromMinutes(6);
+
+    const int LaunchTimeoutSeconds = 180;
+    const int TurnTimeoutSeconds   = 300;
+
+    /// <summary>
+    /// The gate. <see cref="Skip"/> is the FIRST statement executed on every path, so an
+    /// ungated run costs a process-environment read and nothing else — no filesystem, no spawn.
+    ///
+    /// <para>Everything after it fails LOUDLY rather than skipping: once an operator has asked for a
+    /// live run, a missing <c>GOOGLE_CLOUD_PROJECT</c> presents downstream as
+    /// <c>antigravity_reviewer_launch_timeout</c> — a bounded failure that names the wrong culprit
+    /// unless the harness says so first.</para>
+    /// </summary>
+    static void Gate() {
+        Skip.Unless(Environment.GetEnvironmentVariable(GateEnvVar) == "1",
+            $"Gated live certification of the unattended Antigravity reviewer — set {GateEnvVar}=1 to run "
+          + "(spends real agy turns; needs `agy` on PATH at or above the shipped floor, and the daemon's "
+          + "own ADC credentials: gcloud auth application-default login, GOOGLE_CLOUD_PROJECT=<project>, "
+          + "AGY_ADC_AUTH=1). Re-run it against a new agy before recommending that build to operators.");
+
+        Skip.Unless(!OperatingSystem.IsWindows(),
+            "The Antigravity reviewer is POSIX-only: its per-launch home holds review context and cannot "
+          + "be created owner-only on Windows.");
+
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GOOGLE_CLOUD_PROJECT")))
+            throw new InvalidOperationException(
+                $"{GateEnvVar}=1 but GOOGLE_CLOUD_PROJECT is unset. The launch path inherits the ADC "
+              + "variables from this process rather than re-stamping them, so agy would sit on an "
+              + "interactive login and the run would fail as antigravity_reviewer_launch_timeout — "
+              + "naming the deadline rather than the missing project. Export GOOGLE_CLOUD_PROJECT (and "
+              + "AGY_ADC_AUTH=1) and re-run.");
+    }
+
+    /// <summary>
+    /// One real review round, launched exactly as a review flow launches it, completing with nothing
+    /// to answer — the positive control, and the thing without which there is no feature.
+    ///
+    /// <para>Asserts the round REACHED A TERMINAL RESULT, not merely that the launch returned:
+    /// <c>StartAsync</c> resolves at turn 1's <c>init</c>, so a reviewer that reported a conversation
+    /// and then died mid-turn would satisfy a launch-only assertion. The runtime distinguishes the
+    /// two for us — EOF without a terminal <c>result</c> is Terminal, a clean round is Idle — and
+    /// Idle is what <c>HasExited == false</c> after the turn settles means.</para>
+    /// </summary>
+    [Test]
+    public async Task Cert1_OneReviewRoundCompletesUnattended() {
+        Gate();
+
+        using var harness = LiveHarness.Create();
+
+        var start = await harness.LaunchAsync("Reply with the single word OK. Do not use any tools.")
+                                 .WaitAsync(RoundBudget);
+
+        await using var runtime = start.Runtime;
+
+        // The correlation identity the orchestrator binds a transcript to. Empty here is the silent,
+        // permanent break the launch barrier exists to prevent.
+        var conversationId = start.Transcript!.AcpSessionId;
+        await Assert.That(conversationId).IsNotEmpty()
+            .Because("no conversation id means the orchestrator binds this reviewer's transcript to \"\"");
+
+        await harness.AwaitRoundAsync(runtime, rounds: 1);
+
+        harness.Report("cert1", conversationId);
+
+        await Assert.That(runtime.HasExited).IsFalse()
+            .Because("the reviewer must be logically ALIVE between rounds — Terminal here means the turn "
+                   + "hit EOF without a terminal `result`, i.e. the reviewer died mid-round");
+
+        // A round that produced no transcript at all would still satisfy every assertion above.
+        await Assert.That(LiveHarness.EnvelopeCount(start.Transcript!)).IsGreaterThan(0)
+            .Because("a reviewer that reports a conversation and then emits nothing has recorded no review");
+    }
+
+    /// <summary>
+    /// The exec-per-turn claim, in the only shape that can fail silently: three rounds must land as
+    /// ONE kcap session.
+    ///
+    /// <para>Three independent observations, because each alone is satisfiable by a broken build.
+    /// A stable id alone could come from a runtime that never actually resumed (it would simply
+    /// report the id it already held while <c>agy</c> started a fresh conversation each time);
+    /// distinct pids alone prove separate processes but say nothing about continuity; and the resume
+    /// flag alone proves what we PASSED, not what the vendor did with it. Together they pin
+    /// "separate process per round, resuming the one conversation the first round established" —
+    /// and the runtime's own conversation-id-stability rule is the fourth: a vendor that forked the
+    /// history mid-review drives Terminal, which the final liveness assertion would catch.</para>
+    /// </summary>
+    [Test]
+    public async Task Cert2_EveryRoundOfAMultiRoundReviewLandsAsOneSession() {
+        Gate();
+
+        using var harness = LiveHarness.Create();
+
+        var start = await harness.LaunchAsync("Reply with the single word ONE. Do not use any tools.")
+                                 .WaitAsync(RoundBudget);
+
+        await using var runtime = start.Runtime;
+
+        var conversationId = start.Transcript!.AcpSessionId;
+        await Assert.That(conversationId).IsNotEmpty();
+
+        await harness.AwaitRoundAsync(runtime, rounds: 1);
+
+        await runtime.SendUserInputAsync("Reply with the single word TWO. Do not use any tools.");
+        await harness.AwaitRoundAsync(runtime, rounds: 2);
+
+        await runtime.SendUserInputAsync("Reply with the single word THREE. Do not use any tools.");
+        await harness.AwaitRoundAsync(runtime, rounds: 3);
+
+        harness.Report("cert2", conversationId);
+
+        // (1) ONE session across every round — read from the live runtime AFTER the last round, so a
+        // mid-review fork could not have been overwritten back to the original value.
+        await Assert.That(start.Transcript!.AcpSessionId).IsEqualTo(conversationId)
+            .Because("a changed conversation id means the review forked into a second kcap session");
+
+        // (2) A DISTINCT process per round — the literal exec-per-turn shape. A runtime that quietly
+        // acquired a long-lived child would report the same pid three times.
+        var pids = harness.Spawns.Select(s => s.Process.Pid).ToList();
+        await Assert.That(pids.Distinct().Count()).IsEqualTo(3)
+            .Because($"every round is its own `agy -p` invocation; observed pids [{string.Join(",", pids)}]");
+
+        // (3) The resume flag, adjacent to the id — not merely present. A build that emitted the id
+        // under a different flag, or the flag with a different value, would satisfy two independent
+        // Contains checks while resuming nothing.
+        await Assert.That(harness.Spawns[0].Psi.ArgumentList).DoesNotContain("--conversation")
+            .Because("turn 1 has nothing to resume");
+
+        foreach (var round in harness.Spawns.Skip(1)) {
+            var argv = round.Psi.ArgumentList;
+            var i    = argv.IndexOf("--conversation");
+
+            await Assert.That(i).IsGreaterThanOrEqualTo(0)
+                .Because("a round that omits --conversation starts a brand-new agy conversation");
+            await Assert.That(argv[i + 1]).IsEqualTo(conversationId);
+        }
+
+        // (4) Still logically alive: the runtime reaps itself to Terminal on a conversation-id
+        // mismatch, so this is what makes the stability rule's own enforcement part of the evidence.
+        await Assert.That(runtime.HasExited).IsFalse();
+    }
+
+    // ── harness ───────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>One spawned round: the vector the OS received, and the child it produced.</summary>
+    readonly record struct SpawnedRound(ProcessStartInfo Psi, IAgyTurnProcess Process);
+
+    /// <summary>
+    /// Drives the PRODUCTION launch path — the same <see cref="AntigravityHostedAgentRuntimeFactory"/>
+    /// a review flow reaches, with the real version probe and the real binary resolution — and spawns
+    /// the real <see cref="AgyTurnProcess"/> from the <see cref="ProcessStartInfo"/> the factory built.
+    ///
+    /// <para>The turn-source seam is used only to OBSERVE (it records the psi and the child, then
+    /// constructs exactly what production's default constructs), so nothing about the spawn shape is
+    /// re-derived here: the argv assertions above run against the vector the OS actually got.</para>
+    /// </summary>
+    sealed class LiveHarness : IDisposable {
+        readonly string _root;
+
+        LiveHarness(string root, string worktree, DaemonConfig config) {
+            _root    = root;
+            Worktree = worktree;
+            Config   = config;
+        }
+
+        internal string       Worktree { get; }
+        internal DaemonConfig Config   { get; }
+
+        internal List<SpawnedRound> Spawns { get; } = [];
+
+        internal static LiveHarness Create() {
+            var root     = Directory.CreateTempSubdirectory("kcap-agy-cert-").FullName;
+            var worktree = Path.Combine(root, "wt");
+            var stateDir = Path.Combine(root, "state");
+
+            Directory.CreateDirectory(worktree);
+            Directory.CreateDirectory(stateDir);
+
+            // Something to be reviewing. The prompts deliberately never ask for it — a cert that
+            // depended on the model reading a file would be measuring the model, not the reviewer —
+            // but an empty cwd is not a review-shaped launch.
+            File.WriteAllText(Path.Combine(worktree, "subject.txt"),
+                              "int Add(int a, int b) => a - b;\n");
+
+            var config = new DaemonConfig {
+                AntigravityPath                       = Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_PATH") is
+                                                        { Length: > 0 } path ? path : "agy",
+                AntigravityUnattendedReviewerEnabled  = true,
+                AntigravityReviewerLaunchTimeoutSeconds = LaunchTimeoutSeconds,
+                AntigravityReviewerTurnTimeoutSeconds   = TurnTimeoutSeconds,
+                Name                                  = "agy-live-cert",
+                DaemonEpoch                           = "cert-" + Guid.NewGuid().ToString("N")[..8],
+                StateDir                              = stateDir
+            };
+
+            return new LiveHarness(root, worktree, config);
+        }
+
+        internal Task<HostedRuntimeStart> LaunchAsync(string prompt) {
+            // binaryExists/resolveVersion left to production: this cert exists to judge the INSTALLED
+            // agy, so seaming the floor would certify a build the gate would have refused.
+            var factory = new AntigravityHostedAgentRuntimeFactory(
+                Config, NullLoggerFactory.Instance, turnSource: SpawnAsync);
+
+            var ctx = new RuntimeStartContext(
+                AgentId: "agy-cert-" + Guid.NewGuid().ToString("N")[..8],
+                Vendor: "antigravity",
+                SourceRepoPath: Worktree,
+                Worktree: new WorktreeInfo(Path: Worktree, Branch: "cert", SourceRepo: Worktree),
+                Prompt: prompt,
+                Model: null, Effort: null, Tools: null,
+                IsReview: false, IsReviewFlow: true, Review: null,
+                Cols: 80, Rows: 24,
+                // A reachable tenant is not needed (and not assumed): the injected result channel is
+                // part of the launch shape being certified, but this cert judges the reviewer's own
+                // round, never a submitted result.
+                ServerUrl: Environment.GetEnvironmentVariable("KCAP_URL") is { Length: > 0 } url
+                           ? url : "http://kcap.invalid",
+                DaemonBridgeUrl: null,
+                CapacitorPath: Environment.GetEnvironmentVariable("KCAP_PATH") is { Length: > 0 } kcap
+                               ? kcap : "kcap",
+                DaemonId: "agy-live-cert",
+                DaemonEpoch: Config.DaemonEpoch!);
+
+            return factory.StartAsync(ctx, CancellationToken.None);
+        }
+
+        Task<IAgyTurnProcess> SpawnAsync(ProcessStartInfo psi, CancellationToken ct) {
+            var process = new AgyTurnProcess(psi, NullLogger<AgyTurnProcess>.Instance);
+
+            lock (Spawns) Spawns.Add(new SpawnedRound(psi, process));
+
+            return Task.FromResult<IAgyTurnProcess>(process);
+        }
+
+        /// <summary>
+        /// Waits for round <paramref name="rounds"/> to finish. Two barriers, in order, because
+        /// neither alone is one: first the round must be OBSERVED spawned (the enqueue→gate hand-off
+        /// is asynchronous, so <c>WaitForTurnIdleAsync</c> on its own can return against a
+        /// momentarily-free gate before the worker has even dequeued), and only then does the
+        /// gate-acquire genuinely queue behind the in-flight turn.
+        /// </summary>
+        internal async Task AwaitRoundAsync(IHostedAgentRuntime runtime, int rounds) {
+            var deadline = DateTime.UtcNow + RoundBudget;
+
+            while (SpawnCount < rounds && DateTime.UtcNow < deadline) await Task.Delay(25);
+
+            if (SpawnCount < rounds)
+                throw new TimeoutException(
+                    $"Only {SpawnCount} agy turn(s) spawned; expected {rounds}. The reviewer never started "
+                  + "this round — check the daemon's ADC environment and the agy version floor.");
+
+            using var cts = new CancellationTokenSource(RoundBudget);
+            await runtime.WaitForTurnIdleAsync(cts.Token);
+        }
+
+        int SpawnCount { get { lock (Spawns) return Spawns.Count; } }
+
+        /// <summary>How much transcript this reviewer actually produced. Drains what is READY only —
+        /// the channel stays open for the whole session, so a blocking read would never return.</summary>
+        internal static int EnvelopeCount(IAcpTranscriptSource transcript) {
+            var count = 0;
+
+            while (transcript.Envelopes.TryRead(out _)) count++;
+
+            return count;
+        }
+
+        internal void Report(string label, string conversationId) {
+            lock (Spawns)
+                Console.WriteLine(
+                    $"[agy-cert:{label}] conversation={conversationId} rounds={Spawns.Count} "
+                  + $"pids=[{string.Join(",", Spawns.Select(s => s.Process.Pid))}] "
+                  + $"binary={Config.AntigravityPath} worktree={Worktree}");
+        }
+
+        public void Dispose() {
+            lock (Spawns)
+                foreach (var spawn in Spawns) {
+                    try { spawn.Process.TerminateAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult(); }
+                    catch { /* best-effort — the runtime owns these; this is the leak backstop */ }
+                }
+
+            try { Directory.Delete(_root, recursive: true); } catch { /* temp dir */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeFakes.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeFakes.cs
@@ -45,8 +45,11 @@ internal enum FakeTurn {
 /// <summary><see cref="IAgyTurnProcess"/> fake for ONE turn. A fresh instance is handed out by
 /// the injected spawner for every turn, mirroring agy's real exec-per-turn shape — this is never
 /// reused across turns.</summary>
-internal sealed class FakeAgyTurnProcess(FakeTurn turn, string conversationId) : IAgyTurnProcess {
-    public int  Pid            { get; } = 4242;
+/// <param name="pid">Defaulted so every existing caller is unchanged; a test that needs to tell one
+/// turn's child from the next (the per-turn PID record) passes a distinct value.</param>
+internal sealed class FakeAgyTurnProcess(FakeTurn turn, string conversationId, int pid = 4242)
+        : IAgyTurnProcess {
+    public int  Pid            { get; } = pid;
     public bool HasExited      { get; private set; }
     public int? ExitCode       { get; private set; }
     public int  TerminateCalls { get; private set; }

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeFakes.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeFakes.cs
@@ -32,6 +32,14 @@ internal enum FakeTurn {
     /// bespoke spawn closure rather than <see cref="AntigravityRuntimeFakes.FakeRuntime"/> (which uses
     /// one fixed <see cref="FakeTurn"/> for every spawn).</summary>
     ChangedConversationId,
+
+    /// <summary>Emits <c>init</c> with an EMPTY <c>conversation_id</c> (never the fixed one), then a
+    /// <c>result</c> with <c>status: SUCCESS</c> — a turn that settles cleanly to Idle, healthy, WITHOUT
+    /// the runtime ever resolving a conversation id. Exercises the second
+    /// <c>WaitForConversationIdAsync</c> fault call site (the clean-success tail of
+    /// <c>ProcessTurnAsync</c>, not <c>EnterTerminal</c>) — a review caught a first cut of rule (e)
+    /// missing exactly this path.</summary>
+    NormalWithoutConversationId,
 }
 
 /// <summary><see cref="IAgyTurnProcess"/> fake for ONE turn. A fresh instance is handed out by
@@ -45,14 +53,17 @@ internal sealed class FakeAgyTurnProcess(FakeTurn turn, string conversationId) :
     public int  DisposeCalls   { get; private set; }
 
     public async IAsyncEnumerable<string> ReadLinesAsync([EnumeratorCancellation] CancellationToken ct) {
-        var effectiveId = turn == FakeTurn.ChangedConversationId
-            ? AntigravityRuntimeFakes.ChangedConversationId
-            : conversationId;
+        var effectiveId = turn switch {
+            FakeTurn.ChangedConversationId       => AntigravityRuntimeFakes.ChangedConversationId,
+            FakeTurn.NormalWithoutConversationId => "",
+            _                                    => conversationId,
+        };
 
         yield return $$$"""{"event":"init","conversation_id":"{{{effectiveId}}}","init":{"cwd":"/w"}}""";
 
         switch (turn) {
             case FakeTurn.Normal:
+            case FakeTurn.NormalWithoutConversationId:
                 yield return $$$"""{"event":"result","result":{"conversation_id":"{{{effectiveId}}}","status":"SUCCESS"}}""";
                 HasExited = true;
                 ExitCode  = 0;

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeFakes.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeFakes.cs
@@ -1,0 +1,130 @@
+// test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeFakes.cs
+using System.Runtime.CompilerServices;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>How one fake turn behaves, driving <see cref="FakeAgyTurnProcess.ReadLinesAsync"/>. Pinned
+/// exactly per the design brief — a sibling plan reuses this shape, which is also why this and the
+/// other fakes below live as TOP-LEVEL types here rather than nested inside a test class: a nested
+/// type (even <see langword="public"/>) is only reachable through its enclosing class, and a sibling
+/// test class in a different file has no reason to depend on this file's test class.</summary>
+internal enum FakeTurn {
+    /// <summary>Emits <c>init</c> then a <c>result</c> with <c>status: SUCCESS</c>, then EOFs —
+    /// the ordinary clean-turn shape.</summary>
+    Normal,
+
+    /// <summary>Emits <c>init</c> only, then EOFs with NO <c>result</c> line at all — the "the
+    /// reviewer died mid-turn" shape rule (a) exists for.</summary>
+    EofWithoutResult,
+
+    /// <summary>Emits <c>init</c>, then blocks forever until its cancellation token fires — the
+    /// "a turn is genuinely still running" shape the deadlock mutation check exercises.</summary>
+    NeverEnds,
+
+    /// <summary>Emits <c>init</c> carrying <see cref="AntigravityRuntimeFakes.ChangedConversationId"/>
+    /// instead of whatever id the spawner closure was constructed with — the "this turn's process
+    /// reports a DIFFERENT conversation than the one already established" shape rule (a)'s
+    /// conversation-id-stability check exists for. Only meaningful for a turn AFTER the first (a first
+    /// turn has nothing to mismatch against yet), so tests combine this with <see cref="Normal"/> via a
+    /// bespoke spawn closure rather than <see cref="AntigravityRuntimeFakes.FakeRuntime"/> (which uses
+    /// one fixed <see cref="FakeTurn"/> for every spawn).</summary>
+    ChangedConversationId,
+}
+
+/// <summary><see cref="IAgyTurnProcess"/> fake for ONE turn. A fresh instance is handed out by
+/// the injected spawner for every turn, mirroring agy's real exec-per-turn shape — this is never
+/// reused across turns.</summary>
+internal sealed class FakeAgyTurnProcess(FakeTurn turn, string conversationId) : IAgyTurnProcess {
+    public int  Pid            { get; } = 4242;
+    public bool HasExited      { get; private set; }
+    public int? ExitCode       { get; private set; }
+    public int  TerminateCalls { get; private set; }
+    public int  DisposeCalls   { get; private set; }
+
+    public async IAsyncEnumerable<string> ReadLinesAsync([EnumeratorCancellation] CancellationToken ct) {
+        var effectiveId = turn == FakeTurn.ChangedConversationId
+            ? AntigravityRuntimeFakes.ChangedConversationId
+            : conversationId;
+
+        yield return $$$"""{"event":"init","conversation_id":"{{{effectiveId}}}","init":{"cwd":"/w"}}""";
+
+        switch (turn) {
+            case FakeTurn.Normal:
+                yield return $$$"""{"event":"result","result":{"conversation_id":"{{{effectiveId}}}","status":"SUCCESS"}}""";
+                HasExited = true;
+                ExitCode  = 0;
+                break;
+
+            case FakeTurn.EofWithoutResult:
+                // No result line — the child exits having said nothing more. The runtime must
+                // not read this EOF as "turn complete".
+                HasExited = true;
+                ExitCode  = 1;
+                break;
+
+            case FakeTurn.NeverEnds:
+                // Blocks until the runtime's own cancellation (owner-cancel or a deadline) fires —
+                // simulates a turn that is genuinely still running.
+                await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+                break;
+
+            case FakeTurn.ChangedConversationId:
+                // The runtime detects the mismatch on the init line just yielded above and stops
+                // consuming immediately (AntigravityHostedAgentRuntime.ProcessTurnAsync breaks out of
+                // its read loop the instant HandleInit reports a mismatch) — nothing after this point
+                // is ever read, so EOF here (no result line) is enough.
+                HasExited = true;
+                ExitCode  = 0;
+                break;
+        }
+    }
+
+    public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+
+    public Task TerminateAsync(TimeSpan? timeout = null) {
+        TerminateCalls++;
+        HasExited = true;
+        ExitCode ??= -1;
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() {
+        DisposeCalls++;
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>Shared construction helpers for <see cref="AntigravityHostedAgentRuntime"/> tests — a
+/// sibling plan reuses <see cref="FakeRuntime"/> directly, so its signature is pinned exactly per the
+/// design brief.</summary>
+internal static class AntigravityRuntimeFakes {
+    public const string FixedConversationId    = "fixed-conversation-id";
+    public const string ChangedConversationId  = "changed-conversation-id";
+
+    /// <summary>
+    /// Builds a runtime whose turn spawner never touches a real process. Signature pinned exactly
+    /// per the design brief — a sibling plan reuses this helper directly, so <paramref name="onSpawn"/>
+    /// receiving the PROMPT (not a bare notification) and <paramref name="queueCap"/> both matter to
+    /// get right here. Every spawn uses the SAME <paramref name="turn"/> behavior — a test that needs
+    /// different behavior across turns (e.g. a conversation-id mismatch, which only makes sense after a
+    /// first turn has already established an id) constructs <see cref="AntigravityHostedAgentRuntime"/>
+    /// directly with its own spawn closure instead.
+    /// </summary>
+    public static AntigravityHostedAgentRuntime FakeRuntime(
+            FakeTurn        turn     = FakeTurn.Normal,
+            Action<string>? onSpawn  = null,
+            int             queueCap = 64) {
+        Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawn = (prompt, _, _) => {
+            onSpawn?.Invoke(prompt);
+            return Task.FromResult<IAgyTurnProcess>(new FakeAgyTurnProcess(turn, FixedConversationId));
+        };
+
+        return new AntigravityHostedAgentRuntime(
+            spawnTurn: spawn,
+            logger: NullLogger.Instance,
+            pendingTurnsCapacity: queueCap);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
@@ -430,6 +430,86 @@ public class AntigravityRuntimeLifecycleTests {
         await Assert.That(invoked).IsEqualTo(1);
     }
 
+    /// <summary>
+    /// The other half of the gate, and the one that was wrong: a child that LINGERS past its stdout
+    /// EOF and the exit-confirmation grace, but dies the moment it is actually killed. The runtime's
+    /// own turn teardown kills it — so it genuinely exited before the runtime let go of the handle —
+    /// and the confirmed-exit consequences must therefore BOTH follow: the durable PID record is
+    /// cleared, and the per-launch HOME (this callback) is removed.
+    ///
+    /// <para>Before the fix, <c>_turnExitConfirmed</c> was latched from <c>HasExited</c> BEFORE the
+    /// kill that made it true, so this shape reported "unconfirmed": the fail-safe fired on a child
+    /// that had in fact exited, stranding the reviewer's conversation JSONL on disk until the next
+    /// daemon-epoch sweep and leaving a PID record naming a dead process. The fail-safe direction is
+    /// unchanged — see the sibling test above, where the kill does NOT work and the skip still
+    /// stands — only the moment the question is asked.</para>
+    /// </summary>
+    [Test]
+    public async Task Dispose_runs_the_teardown_callback_when_a_lingering_turn_child_is_killed_at_teardown() {
+        var invoked = 0;
+        var cleared = 0;
+        var process = new LingeringTurnProcess();
+
+        await using (var rt = new AntigravityHostedAgentRuntime(
+                spawnTurn: (_, _, _) => Task.FromResult<IAgyTurnProcess>(process),
+                logger: NullLogger.Instance,
+                agentId: "agy-lingerer",
+                onDisposed: () => Interlocked.Increment(ref invoked))) {
+            rt.PidCallbacks = new AgyPidRecordCallbacks(
+                Record: _ => { },
+                Clear:  () => Interlocked.Increment(ref cleared));
+
+            await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+            await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+            await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+            // The child was genuinely still alive when its stdout hit EOF — otherwise this asserts
+            // nothing about a lingering child at all, and the fake could have exited on its own.
+            await Assert.That(process.WasKilledWhileRunning).IsTrue();
+        }
+
+        await Assert.That(cleared).IsEqualTo(1);
+        await Assert.That(invoked).IsEqualTo(1);
+    }
+
+    /// <summary>A turn child whose stdout EOFs while the process itself is still running (it never
+    /// exits on its own, and its bounded exit-confirmation wait times out), but which dies as soon as
+    /// it is signalled — the ordinary shape of a child that outlives its own output by a moment.
+    /// Terminate and dispose both kill, mirroring <c>AgyTurnProcess</c>, where both are the same
+    /// <c>Kill(entireProcessTree: true)</c>.</summary>
+    sealed class LingeringTurnProcess : IAgyTurnProcess {
+        int _killed;
+
+        public int  Pid       => 4250;
+        public bool HasExited => Volatile.Read(ref _killed) != 0;
+        public int? ExitCode  => HasExited ? 0 : null;
+
+        /// <summary>True once a kill landed on a process that was still running — the precondition
+        /// this fake exists to create, asserted rather than assumed.</summary>
+        public bool WasKilledWhileRunning { get; private set; }
+
+#pragma warning disable CS1998 // an async iterator whose lines are already in hand still needs the modifier
+        public async IAsyncEnumerable<string> ReadLinesAsync(
+                [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct) {
+            yield return $$$"""{"event":"init","conversation_id":"{{{FixedConversationId}}}","init":{"cwd":"/w"}}""";
+            yield return $$$"""{"event":"result","result":{"conversation_id":"{{{FixedConversationId}}}","status":"SUCCESS"}}""";
+
+            // EOF here, with the process still running — HasExited stays false.
+        }
+#pragma warning restore CS1998
+
+        /// <summary>Returns silently on timeout, per the interface contract — this child never exits
+        /// of its own accord, so the runtime's grace wait always expires.</summary>
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+
+        public Task TerminateAsync(TimeSpan? timeout = null) { Kill(); return Task.CompletedTask; }
+        public ValueTask DisposeAsync()                      { Kill(); return ValueTask.CompletedTask; }
+
+        void Kill() {
+            if (Interlocked.Exchange(ref _killed, 1) == 0) WasKilledWhileRunning = true;
+        }
+    }
+
     /// <summary>A turn child that honours cancellation — so the turn worker unwinds normally — but
     /// never reports itself exited, and whose terminate does not make it so. The measured shape is a
     /// grandchild that outlived a non-atomic process-tree kill; the runtime cannot tell that apart

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
@@ -102,14 +102,66 @@ public class AntigravityRuntimeLifecycleTests {
 
     [Test]
     public async Task Terminate_during_a_long_turn_completes_rather_than_deadlocking() {
-        await using var rt = FakeRuntime(turn: FakeTurn.NeverEnds);
+        var spawned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var rt = FakeRuntime(turn: FakeTurn.NeverEnds, onSpawn: _ => spawned.TrySetResult());
         _ = rt.SendUserInputAsync("hello");
+
+        // Structural, not timing-based: proves the NeverEnds turn has genuinely spawned (and so is
+        // genuinely holding _turnGate inside its read loop) before TerminateAsync races it — the
+        // mutation check pins that TerminateAsync would deadlock here if it took the gate itself.
+        await spawned.Task.WaitAsync(HangGuard);
 
         // If TerminateAsync took the turn gate, this would hang forever: the turn holds the
         // gate, Terminal could never be entered, and the park would never resolve.
         await rt.TerminateAsync(TimeSpan.FromSeconds(5)).WaitAsync(TimeSpan.FromSeconds(10));
 
         await Assert.That(rt.HasExited).IsTrue();
+    }
+
+    [Test]
+    public async Task Terminate_racing_a_still_running_spawn_reaps_the_process_it_never_got_to_track() {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        FakeAgyTurnProcess? spawnedProcess = null;
+
+        Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawn = async (_, _, _) => {
+            entered.TrySetResult();
+
+            // Deliberately ignores the passed-in token: TerminateAsync (below) cancels _ownerCts
+            // before this returns, and the spawn must still SUCCEED afterward — otherwise
+            // SpawnTurnProcessAsync's own "stop/dispose raced the spawn" branch would fire instead,
+            // and this test would exercise a different path than the one under test.
+            await release.Task.ConfigureAwait(false);
+
+            var process = new FakeAgyTurnProcess(FakeTurn.Normal, FixedConversationId);
+            spawnedProcess = process;
+            return process;
+        };
+
+        await using var rt = new AntigravityHostedAgentRuntime(spawnTurn: spawn, logger: NullLogger.Instance);
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+
+        // The worker is now parked INSIDE _spawnTurn — before ProcessTurnAsync has any process to
+        // publish to _current at all.
+        await entered.Task.WaitAsync(HangGuard);
+
+        // Guaranteed to win the "publish vs. capture" race under _stateLock: ProcessTurnAsync's
+        // publish literally cannot run until the spawn call above returns, which it hasn't yet.
+        await rt.TerminateAsync(TimeSpan.FromSeconds(5)).WaitAsync(HangGuard);
+
+        // NOW let the spawn actually complete — the process is only handed back to ProcessTurnAsync
+        // once the runtime is ALREADY Terminal, exercising its atomic already-Terminal check.
+        release.TrySetResult();
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (spawnedProcess is not { DisposeCalls: >= 1 } && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        await Assert.That(spawnedProcess).IsNotNull();
+        // Reaped (never orphaned) AND disposed (never leaked) despite never being tracked in _current.
+        await Assert.That(spawnedProcess!.TerminateCalls).IsEqualTo(1);
+        await Assert.That(spawnedProcess.DisposeCalls).IsEqualTo(1);
     }
 
     [Test]
@@ -238,5 +290,26 @@ public class AntigravityRuntimeLifecycleTests {
 
         await Assert.That(spawned).IsNotNull();
         await Assert.That(spawned!.DisposeCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task A_turn_that_settles_without_a_conversation_id_faults_the_barrier_instead_of_hanging() {
+        // A turn can settle cleanly (→ Idle, healthy — no EnterTerminal call at all) having never seen
+        // a non-empty conversation_id on its init line. A first cut of rule (e) only faulted the
+        // barrier from EnterTerminal, so a factory correctly awaiting WaitForConversationIdAsync would
+        // hang forever here even though the runtime itself is perfectly healthy.
+        await using var rt = FakeRuntime(turn: FakeTurn.NormalWithoutConversationId);
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard));
+
+        // Confirms this genuinely is the "healthy but never resolved an id" case, not a disguised
+        // Terminal transition — HasExited must still read the between-turns-alive value. The barrier
+        // fault (awaited above) runs slightly BEFORE the phase settles to Idle, so give the worker a
+        // moment to finish that transition (matches this file's existing "let it settle" convention).
+        await Task.Delay(100);
+        await Assert.That(rt.HasExited).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
@@ -1,0 +1,236 @@
+// test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+using System.Runtime.CompilerServices;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// Exercises <see cref="AntigravityHostedAgentRuntime"/>'s phase machine end-to-end against
+/// <see cref="FakeAgyTurnProcess"/> — no real <c>agy</c> process is spawned. This is the
+/// highest-risk runtime in the daemon: unlike every other <c>IHostedAgentRuntime</c>, it has no
+/// long-lived child at all — each turn is its own <c>agy -p …</c> invocation, so "the process
+/// exited" and "the runtime is done" are NOT the same event, and getting that distinction wrong
+/// produces a silent hang rather than a failing test. See the class doc on
+/// <see cref="AntigravityHostedAgentRuntime"/> for the four rules these tests pin.
+/// </summary>
+public class AntigravityRuntimeLifecycleTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    const string FixedConversationId = "fixed-conversation-id";
+
+    /// <summary>How one fake turn behaves, driving <see cref="FakeAgyTurnProcess.ReadLinesAsync"/>.
+    /// Pinned exactly per the design brief — a sibling plan reuses this shape.</summary>
+    public enum FakeTurn {
+        /// <summary>Emits <c>init</c> then a <c>result</c> with <c>status: SUCCESS</c>, then EOFs —
+        /// the ordinary clean-turn shape.</summary>
+        Normal,
+
+        /// <summary>Emits <c>init</c> only, then EOFs with NO <c>result</c> line at all — the "the
+        /// reviewer died mid-turn" shape rule (a) exists for.</summary>
+        EofWithoutResult,
+
+        /// <summary>Emits <c>init</c>, then blocks forever until its cancellation token fires — the
+        /// "a turn is genuinely still running" shape the deadlock mutation check exercises.</summary>
+        NeverEnds,
+    }
+
+    /// <summary><see cref="IAgyTurnProcess"/> fake for ONE turn. A fresh instance is handed out by
+    /// the injected spawner for every turn, mirroring agy's real exec-per-turn shape — this is never
+    /// reused across turns.</summary>
+    sealed class FakeAgyTurnProcess(FakeTurn turn, string conversationId) : IAgyTurnProcess {
+        public int  Pid            { get; } = 4242;
+        public bool HasExited      { get; private set; }
+        public int? ExitCode       { get; private set; }
+        public int  TerminateCalls { get; private set; }
+
+        public async IAsyncEnumerable<string> ReadLinesAsync([EnumeratorCancellation] CancellationToken ct) {
+            yield return $$$"""{"event":"init","conversation_id":"{{{conversationId}}}","init":{"cwd":"/w"}}""";
+
+            switch (turn) {
+                case FakeTurn.Normal:
+                    yield return $$$"""{"event":"result","result":{"conversation_id":"{{{conversationId}}}","status":"SUCCESS"}}""";
+                    HasExited = true;
+                    ExitCode  = 0;
+                    break;
+
+                case FakeTurn.EofWithoutResult:
+                    // No result line — the child exits having said nothing more. The runtime must
+                    // not read this EOF as "turn complete".
+                    HasExited = true;
+                    ExitCode  = 1;
+                    break;
+
+                case FakeTurn.NeverEnds:
+                    // Blocks until the runtime's own cancellation (owner-cancel or a deadline) fires —
+                    // simulates a turn that is genuinely still running.
+                    await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+                    break;
+            }
+        }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+
+        public Task TerminateAsync(TimeSpan? timeout = null) {
+            TerminateCalls++;
+            HasExited = true;
+            ExitCode ??= -1;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Builds a runtime whose turn spawner never touches a real process. Signature pinned exactly
+    /// per the design brief — a sibling plan reuses this helper directly, so <paramref name="onSpawn"/>
+    /// receiving the PROMPT (not a bare notification) and <paramref name="queueCap"/> both matter to
+    /// get right here.
+    /// </summary>
+    static AntigravityHostedAgentRuntime FakeRuntime(
+            FakeTurn        turn     = FakeTurn.Normal,
+            Action<string>? onSpawn  = null,
+            int             queueCap = 64) {
+        Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawn = (prompt, _, _) => {
+            onSpawn?.Invoke(prompt);
+            return Task.FromResult<IAgyTurnProcess>(new FakeAgyTurnProcess(turn, FixedConversationId));
+        };
+
+        return new AntigravityHostedAgentRuntime(
+            spawnTurn: spawn,
+            logger: NullLogger.Instance,
+            pendingTurnsCapacity: queueCap);
+    }
+
+    [Test]
+    public async Task Between_turns_the_runtime_is_logically_alive() {
+        await using var rt = FakeRuntime();
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // No child process exists right now. Reporting exited here would make every stop
+        // trivially succeed and would mis-report the final status.
+        await Assert.That(rt.HasExited).IsFalse();
+        await Assert.That(rt.ExitCode).IsNull();
+    }
+
+    [Test]
+    public async Task ReadOutputAsync_does_not_complete_while_idle() {
+        await using var rt = FakeRuntime();
+        var read = Task.Run(async () => { await foreach (var _ in rt.ReadOutputAsync()) { } });
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // Completing here would drive FinalizeAgentRunAsync and close the session after turn 1.
+        await Assert.That(read.IsCompleted).IsFalse();
+    }
+
+    [Test]
+    public async Task ReadOutputAsync_completes_once_terminal_is_entered() {
+        await using var rt = FakeRuntime();
+        var read = Task.Run(async () => { await foreach (var _ in rt.ReadOutputAsync()) { } });
+
+        await rt.TerminateAsync(TimeSpan.FromSeconds(5)).WaitAsync(HangGuard);
+        await read.WaitAsync(HangGuard);
+
+        await Assert.That(read.IsCompletedSuccessfully).IsTrue();
+        await Assert.That(rt.HasExited).IsTrue();
+    }
+
+    [Test]
+    public async Task Eof_without_a_terminal_result_drives_terminal_not_idle() {
+        await using var rt = FakeRuntime(turn: FakeTurn.EofWithoutResult);
+        var read = Task.Run(async () => { await foreach (var _ in rt.ReadOutputAsync()) { } });
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+
+        // A turn child that died without a terminal `result` has lost the reviewer.
+        // Going Idle here would park ReadOutputAsync forever.
+        await read.WaitAsync(HangGuard);
+        await Assert.That(rt.HasExited).IsTrue();
+        await Assert.That(rt.ExitCode).IsNotEqualTo(0);
+    }
+
+    [Test]
+    public async Task Terminate_while_idle_is_not_a_no_op() {
+        await using var rt = FakeRuntime();
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await rt.TerminateAsync(TimeSpan.FromSeconds(5)).WaitAsync(HangGuard);
+
+        await Assert.That(rt.HasExited).IsTrue();
+    }
+
+    [Test]
+    public async Task Terminate_during_a_long_turn_completes_rather_than_deadlocking() {
+        await using var rt = FakeRuntime(turn: FakeTurn.NeverEnds);
+        _ = rt.SendUserInputAsync("hello");
+
+        // If TerminateAsync took the turn gate, this would hang forever: the turn holds the
+        // gate, Terminal could never be entered, and the park would never resolve.
+        await rt.TerminateAsync(TimeSpan.FromSeconds(5)).WaitAsync(TimeSpan.FromSeconds(10));
+
+        await Assert.That(rt.HasExited).IsTrue();
+    }
+
+    [Test]
+    public async Task A_turn_enqueued_after_terminal_is_dropped_without_spawning() {
+        var spawns = 0;
+        await using var rt = FakeRuntime(onSpawn: _ => spawns++);
+        await rt.TerminateAsync(TimeSpan.FromSeconds(5)).WaitAsync(HangGuard);
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await Task.Delay(100);
+
+        await Assert.That(spawns).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task The_conversation_id_is_stable_and_a_change_drives_terminal() {
+        await using var rt = FakeRuntime();
+        await rt.SendUserInputAsync("one").WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+        var first = rt.AcpSessionId;
+
+        await rt.SendUserInputAsync("two").WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // A changed conversation id means we silently forked the reviewer's history.
+        await Assert.That(rt.AcpSessionId).IsEqualTo(first);
+    }
+
+    [Test]
+    public async Task Spawner_receives_the_prompt_text() {
+        var prompts = new List<string>();
+        await using var rt = FakeRuntime(onSpawn: p => prompts.Add(p));
+
+        await rt.SendUserInputAsync("do the review").WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(prompts).Contains("do the review");
+    }
+
+    [Test]
+    public async Task A_full_queue_rejects_further_input_without_spawning() {
+        var spawns = 0;
+        await using var rt = FakeRuntime(turn: FakeTurn.NeverEnds, onSpawn: _ => spawns++, queueCap: 1);
+
+        // Turn 1 is picked up immediately and never ends, holding the gate — turn 2 fills the
+        // 1-deep queue, and a 3rd send has nowhere to go.
+        await rt.SendUserInputAsync("one").WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (spawns < 1 && DateTime.UtcNow < deadline) await Task.Delay(10);
+        await Assert.That(spawns).IsEqualTo(1);
+
+        await rt.SendUserInputAsync("two").WaitAsync(HangGuard);
+        await rt.SendUserInputAsync("three").WaitAsync(HangGuard);
+        await Task.Delay(100);
+
+        // Only turn 1 ever spawned — turn 2 sits in the (capacity-1) queue and turn 3 was dropped.
+        await Assert.That(spawns).IsEqualTo(1);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
@@ -293,6 +293,81 @@ public class AntigravityRuntimeLifecycleTests {
         await Assert.That(spawned!.DisposeCalls).IsEqualTo(1);
     }
 
+    // ── the per-turn durable PID record ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Exec-per-turn means every ROUND of a review is a different child with a different pid, so the
+    /// one-shot record the orchestrator takes at launch names turn 1's and nothing after it. A daemon
+    /// SIGKILL during round 2 would then leave a child reapable by neither the record pass nor the
+    /// env-marker pass (which is gated on Linux, while this reviewer is POSIX-meaning-macOS in
+    /// practice). Both directions are asserted: a record per spawn, DISTINCT per turn, and a clear on
+    /// each confirmed exit — a record that is written but never cleared names a dead pid for the rest
+    /// of the session.
+    /// </summary>
+    [Test]
+    public async Task Each_turn_records_its_own_child_pid_and_clears_it_on_confirmed_exit() {
+        var recorded = new List<int>();
+        var cleared  = 0;
+        var spawns   = 0;
+
+        Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawn = (_, _, _) =>
+            Task.FromResult<IAgyTurnProcess>(new FakeAgyTurnProcess(
+                FakeTurn.Normal, FixedConversationId, pid: 5000 + Interlocked.Increment(ref spawns)));
+
+        await using var rt = new AntigravityHostedAgentRuntime(spawnTurn: spawn, logger: NullLogger.Instance);
+        rt.PidCallbacks = new AgyPidRecordCallbacks(
+            Record: pid => { lock (recorded) recorded.Add(pid); },
+            Clear:  () => Interlocked.Increment(ref cleared));
+
+        // The write ack resolves once the turn's process has genuinely spawned, which is strictly
+        // after the record — so two acks mean two records were attempted, with no polling for the
+        // record half at all.
+        await rt.SendUserInputAndWaitForWriteAsync("round 1").WaitAsync(HangGuard);
+        await rt.SendUserInputAndWaitForWriteAsync("round 2").WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (Volatile.Read(ref cleared) < 2 && DateTime.UtcNow < deadline) await Task.Delay(10);
+
+        int[] snapshot;
+        lock (recorded) snapshot = [.. recorded];
+
+        // Distinct, not merely two: a runtime that re-recorded turn 1's pid would satisfy a count.
+        await Assert.That(snapshot).IsEquivalentTo(new[] { 5001, 5002 });
+        await Assert.That(cleared).IsEqualTo(2);
+    }
+
+    /// <summary>
+    /// The fail-closed half of the contract: the record write throws by design, and a spawned child
+    /// the daemon cannot durably record must not proceed. The turn fails, the child is reaped rather
+    /// than left running untracked, and the runtime goes terminal — never swallowed into a turn that
+    /// looks healthy.
+    /// </summary>
+    [Test]
+    public async Task A_turn_whose_pid_record_is_refused_reaps_its_child_and_goes_terminal() {
+        var process = new FakeAgyTurnProcess(FakeTurn.Normal, FixedConversationId);
+
+        await using var rt = new AntigravityHostedAgentRuntime(
+            spawnTurn: (_, _, _) => Task.FromResult<IAgyTurnProcess>(process),
+            logger: NullLogger.Instance);
+
+        rt.PidCallbacks = new AgyPidRecordCallbacks(
+            Record: _ => throw new InvalidOperationException("pid record store is unavailable"),
+            Clear:  () => { });
+
+        var read = Task.Run(async () => { await foreach (var _ in rt.ReadOutputAsync()) { } });
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+
+        // Completes only if Terminal was entered — the turn was not quietly skipped.
+        await read.WaitAsync(HangGuard);
+
+        await Assert.That(rt.HasExited).IsTrue();
+        await Assert.That(rt.ExitCode).IsNotEqualTo(0);
+
+        // The untracked child was reaped, not abandoned.
+        await Assert.That(process.TerminateCalls).IsEqualTo(1);
+    }
+
     // ── the disposal callback's confirmed-exit gate ───────────────────────────────────────────────
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
@@ -1,6 +1,7 @@
 // test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using static Capacitor.Cli.Tests.Unit.Services.AntigravityRuntimeFakes;
 
@@ -290,6 +291,160 @@ public class AntigravityRuntimeLifecycleTests {
 
         await Assert.That(spawned).IsNotNull();
         await Assert.That(spawned!.DisposeCalls).IsEqualTo(1);
+    }
+
+    // ── the disposal callback's confirmed-exit gate ───────────────────────────────────────────────
+
+    /// <summary>
+    /// The callback removes the per-launch <c>HOME</c>, which holds the reviewer's own conversation
+    /// JSONL — the caller's diff, source excerpts and findings. Every bound on the disposal path
+    /// (<c>TerminateAsync</c>'s timeout, the turn worker's join, the process handle's own disposal) is
+    /// best-effort and swallowed, so "nothing of ours can still be writing" has to be MEASURED rather
+    /// than asserted: a <c>WaitAsync</c> that timed out is otherwise indistinguishable from one that
+    /// succeeded. <c>Kill(entireProcessTree: true)</c> is not atomic against a grandchild forked
+    /// between tree enumeration and signal — and agy's children include its MCP stdio servers — so a
+    /// survivor is a real shape.
+    ///
+    /// <para>Unconfirmed means SKIP the deletion, not force it: deleting under a live reviewer would
+    /// leave it writing into an unlinked path and recreating the directory, which is worse than
+    /// leaving it. The epoch-keyed startup sweep collects it on the next boot. The skip must be
+    /// LOGGED — a retained transcript-bearing home must never be silent.</para>
+    /// </summary>
+    [Test]
+    public async Task Dispose_skips_the_teardown_callback_when_a_turn_child_never_confirmed_exit() {
+        var invoked = 0;
+        var logger  = new CaptureLogger();
+        var process = new UnconfirmedExitTurnProcess();
+
+        await using (var rt = new AntigravityHostedAgentRuntime(
+                spawnTurn: (_, _, _) => Task.FromResult<IAgyTurnProcess>(process),
+                logger: logger,
+                agentId: "agy-survivor",
+                onDisposed: () => Interlocked.Increment(ref invoked))) {
+            await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+
+            // The turn genuinely spawned a child, so "unconfirmed" is a fact about a real process
+            // rather than a runtime that never started one.
+            await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+        }
+
+        await Assert.That(invoked).IsEqualTo(0);
+        await Assert.That(logger.Entries).Contains(e =>
+            e.Level == LogLevel.Warning && e.Message.Contains("agy-survivor"));
+    }
+
+    /// <summary>The positive control for the gate above — without it a callback that never ran at all
+    /// would satisfy the skip test.</summary>
+    [Test]
+    public async Task Dispose_runs_the_teardown_callback_once_the_turn_child_confirmed_exit() {
+        var invoked = 0;
+
+        await using (var rt = new AntigravityHostedAgentRuntime(
+                spawnTurn: (_, _, _) => Task.FromResult<IAgyTurnProcess>(
+                    new FakeAgyTurnProcess(FakeTurn.Normal, FixedConversationId)),
+                logger: NullLogger.Instance,
+                agentId: "agy-clean",
+                onDisposed: () => Interlocked.Increment(ref invoked))) {
+            await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+            await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+            await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+            await Assert.That(rt.AcpSessionId).IsEqualTo(FixedConversationId);
+        }
+
+        await Assert.That(invoked).IsEqualTo(1);
+    }
+
+    /// <summary>A turn child that honours cancellation — so the turn worker unwinds normally — but
+    /// never reports itself exited, and whose terminate does not make it so. The measured shape is a
+    /// grandchild that outlived a non-atomic process-tree kill; the runtime cannot tell that apart
+    /// from a child that simply has not died yet, and must not.</summary>
+    sealed class UnconfirmedExitTurnProcess : IAgyTurnProcess {
+        public int  Pid       => 4249;
+        public bool HasExited => false;
+        public int? ExitCode  => null;
+
+        public async IAsyncEnumerable<string> ReadLinesAsync(
+                [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct) {
+            yield return $$$"""{"event":"init","conversation_id":"{{{FixedConversationId}}}","init":{"cwd":"/w"}}""";
+
+            await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+        }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan? timeout = null)   => Task.CompletedTask;
+        public ValueTask DisposeAsync()                        => ValueTask.CompletedTask;
+    }
+
+    /// <summary>Records every log call — mirrors the pattern the ACP suites already use.</summary>
+    sealed class CaptureLogger : ILogger {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool         IsEnabled(LogLevel logLevel)                            => true;
+
+        public void Log<TState>(
+                LogLevel level, EventId id, TState state, Exception? ex,
+                Func<TState, Exception?, string> formatter) {
+            lock (Entries) Entries.Add((level, formatter(state, ex)));
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="OperationCanceledException"/> that is NOT the owner's shutdown must still reach
+    /// <c>EnterTerminal</c>. <c>ProcessTurnAsync</c> individually catches every
+    /// <see cref="IAgyTurnProcess"/> call except its bounded exit-confirmation wait, and that method's
+    /// contract ("returns silently on timeout") does not FORBID an implementation propagating its own
+    /// internal cancellation — this runtime is built against the interface, not against
+    /// <c>AgyTurnProcess</c>. A turn worker that read such an exception as "normal shutdown" would exit
+    /// its loop without entering Terminal: <c>_terminalTcs</c> never completes,
+    /// <see cref="AntigravityHostedAgentRuntime.ReadOutputAsync"/> parks forever, and the
+    /// orchestrator's <c>FinalizeAgentRunAsync</c> never fires — rule (a)'s hang, reached through the
+    /// one door rule (a) does not cover.
+    /// </summary>
+    [Test]
+    public async Task An_unexpected_cancellation_from_a_turn_drives_terminal_rather_than_parking_the_reader() {
+        Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawn = (_, _, _) =>
+            Task.FromResult<IAgyTurnProcess>(new ThrowingWaitForExitTurnProcess());
+
+        await using var rt = new AntigravityHostedAgentRuntime(spawnTurn: spawn, logger: NullLogger.Instance);
+        var read = Task.Run(async () => { await foreach (var _ in rt.ReadOutputAsync()) { } });
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+
+        // The whole assertion: this completes only if Terminal was entered. A swallowed cancellation
+        // leaves it parked forever.
+        await read.WaitAsync(HangGuard);
+
+        await Assert.That(rt.HasExited).IsTrue();
+        await Assert.That(rt.ExitCode).IsNotEqualTo(0);
+    }
+
+    /// <summary>A turn child whose bounded exit-confirmation wait PROPAGATES a cancellation instead of
+    /// returning silently — the shape the test above exists for. Everything else about it is an
+    /// ordinary clean turn, so the only thing under test is what the worker does with that
+    /// exception.</summary>
+    sealed class ThrowingWaitForExitTurnProcess : IAgyTurnProcess {
+        public int  Pid       => 4246;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+
+#pragma warning disable CS1998 // no await on the happy path — the lines are already in hand
+        public async IAsyncEnumerable<string> ReadLinesAsync(
+                [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct) {
+            yield return $$$"""{"event":"init","conversation_id":"{{{FixedConversationId}}}","init":{"cwd":"/w"}}""";
+            yield return $$$"""{"event":"result","result":{"conversation_id":"{{{FixedConversationId}}}","status":"SUCCESS"}}""";
+
+            HasExited = true;
+            ExitCode  = 0;
+        }
+#pragma warning restore CS1998
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) =>
+            throw new OperationCanceledException("this implementation propagates its own internal timeout");
+
+        public Task TerminateAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public ValueTask DisposeAsync()                      => ValueTask.CompletedTask;
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
@@ -1,113 +1,43 @@
 // test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
-using System.Runtime.CompilerServices;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using static Capacitor.Cli.Tests.Unit.Services.AntigravityRuntimeFakes;
 
 namespace Capacitor.Cli.Tests.Unit.Services;
 
 /// <summary>
 /// Exercises <see cref="AntigravityHostedAgentRuntime"/>'s phase machine end-to-end against
-/// <see cref="FakeAgyTurnProcess"/> — no real <c>agy</c> process is spawned. This is the
-/// highest-risk runtime in the daemon: unlike every other <c>IHostedAgentRuntime</c>, it has no
-/// long-lived child at all — each turn is its own <c>agy -p …</c> invocation, so "the process
-/// exited" and "the runtime is done" are NOT the same event, and getting that distinction wrong
-/// produces a silent hang rather than a failing test. See the class doc on
-/// <see cref="AntigravityHostedAgentRuntime"/> for the four rules these tests pin.
+/// <see cref="FakeAgyTurnProcess"/> (in <c>AntigravityRuntimeFakes.cs</c>, shared with a sibling plan)
+/// — no real <c>agy</c> process is spawned. This is the highest-risk runtime in the daemon: unlike
+/// every other <c>IHostedAgentRuntime</c>, it has no long-lived child at all — each turn is its own
+/// <c>agy -p …</c> invocation, so "the process exited" and "the runtime is done" are NOT the same
+/// event, and getting that distinction wrong produces a silent hang rather than a failing test. See
+/// the class doc on <see cref="AntigravityHostedAgentRuntime"/> for the rules these tests pin.
+///
+/// <para><b>Why most tests await <see cref="AntigravityHostedAgentRuntime.WaitForConversationIdAsync"/>
+/// before <see cref="AntigravityHostedAgentRuntime.WaitForTurnIdleAsync"/>.</b>
+/// <see cref="AntigravityHostedAgentRuntime.SendUserInputAsync"/> returns as soon as a turn is
+/// enqueued — before the worker even dequeues it — and <c>WaitForTurnIdleAsync</c>'s
+/// acquire-then-release on a currently-FREE gate can complete synchronously, before the worker's own
+/// continuation is even scheduled to acquire it. Calling <c>WaitForTurnIdleAsync</c> right after
+/// <c>SendUserInputAsync</c> is therefore not a reliable "the turn ran" barrier — a review caught this
+/// after it let a comparison test pass on two empty strings without a single turn actually completing.
+/// <c>WaitForConversationIdAsync</c> only resolves once the worker has genuinely read a spawned turn's
+/// first line, so awaiting it first closes the gap.</para>
 /// </summary>
 public class AntigravityRuntimeLifecycleTests {
     static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
-
-    const string FixedConversationId = "fixed-conversation-id";
-
-    /// <summary>How one fake turn behaves, driving <see cref="FakeAgyTurnProcess.ReadLinesAsync"/>.
-    /// Pinned exactly per the design brief — a sibling plan reuses this shape.</summary>
-    public enum FakeTurn {
-        /// <summary>Emits <c>init</c> then a <c>result</c> with <c>status: SUCCESS</c>, then EOFs —
-        /// the ordinary clean-turn shape.</summary>
-        Normal,
-
-        /// <summary>Emits <c>init</c> only, then EOFs with NO <c>result</c> line at all — the "the
-        /// reviewer died mid-turn" shape rule (a) exists for.</summary>
-        EofWithoutResult,
-
-        /// <summary>Emits <c>init</c>, then blocks forever until its cancellation token fires — the
-        /// "a turn is genuinely still running" shape the deadlock mutation check exercises.</summary>
-        NeverEnds,
-    }
-
-    /// <summary><see cref="IAgyTurnProcess"/> fake for ONE turn. A fresh instance is handed out by
-    /// the injected spawner for every turn, mirroring agy's real exec-per-turn shape — this is never
-    /// reused across turns.</summary>
-    sealed class FakeAgyTurnProcess(FakeTurn turn, string conversationId) : IAgyTurnProcess {
-        public int  Pid            { get; } = 4242;
-        public bool HasExited      { get; private set; }
-        public int? ExitCode       { get; private set; }
-        public int  TerminateCalls { get; private set; }
-
-        public async IAsyncEnumerable<string> ReadLinesAsync([EnumeratorCancellation] CancellationToken ct) {
-            yield return $$$"""{"event":"init","conversation_id":"{{{conversationId}}}","init":{"cwd":"/w"}}""";
-
-            switch (turn) {
-                case FakeTurn.Normal:
-                    yield return $$$"""{"event":"result","result":{"conversation_id":"{{{conversationId}}}","status":"SUCCESS"}}""";
-                    HasExited = true;
-                    ExitCode  = 0;
-                    break;
-
-                case FakeTurn.EofWithoutResult:
-                    // No result line — the child exits having said nothing more. The runtime must
-                    // not read this EOF as "turn complete".
-                    HasExited = true;
-                    ExitCode  = 1;
-                    break;
-
-                case FakeTurn.NeverEnds:
-                    // Blocks until the runtime's own cancellation (owner-cancel or a deadline) fires —
-                    // simulates a turn that is genuinely still running.
-                    await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
-                    break;
-            }
-        }
-
-        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
-
-        public Task TerminateAsync(TimeSpan? timeout = null) {
-            TerminateCalls++;
-            HasExited = true;
-            ExitCode ??= -1;
-            return Task.CompletedTask;
-        }
-
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-    }
-
-    /// <summary>
-    /// Builds a runtime whose turn spawner never touches a real process. Signature pinned exactly
-    /// per the design brief — a sibling plan reuses this helper directly, so <paramref name="onSpawn"/>
-    /// receiving the PROMPT (not a bare notification) and <paramref name="queueCap"/> both matter to
-    /// get right here.
-    /// </summary>
-    static AntigravityHostedAgentRuntime FakeRuntime(
-            FakeTurn        turn     = FakeTurn.Normal,
-            Action<string>? onSpawn  = null,
-            int             queueCap = 64) {
-        Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawn = (prompt, _, _) => {
-            onSpawn?.Invoke(prompt);
-            return Task.FromResult<IAgyTurnProcess>(new FakeAgyTurnProcess(turn, FixedConversationId));
-        };
-
-        return new AntigravityHostedAgentRuntime(
-            spawnTurn: spawn,
-            logger: NullLogger.Instance,
-            pendingTurnsCapacity: queueCap);
-    }
 
     [Test]
     public async Task Between_turns_the_runtime_is_logically_alive() {
         await using var rt = FakeRuntime();
         await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
         await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // Positive check that the turn genuinely ran (not "" == "" from a turn that never started).
+        await Assert.That(rt.AcpSessionId).IsEqualTo(FixedConversationId);
 
         // No child process exists right now. Reporting exited here would make every stop
         // trivially succeed and would mis-report the final status.
@@ -121,7 +51,10 @@ public class AntigravityRuntimeLifecycleTests {
         var read = Task.Run(async () => { await foreach (var _ in rt.ReadOutputAsync()) { } });
 
         await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
         await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(rt.AcpSessionId).IsEqualTo(FixedConversationId);
 
         // Completing here would drive FinalizeAgentRunAsync and close the session after turn 1.
         await Assert.That(read.IsCompleted).IsFalse();
@@ -157,7 +90,10 @@ public class AntigravityRuntimeLifecycleTests {
     public async Task Terminate_while_idle_is_not_a_no_op() {
         await using var rt = FakeRuntime();
         await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
         await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(rt.AcpSessionId).IsEqualTo(FixedConversationId);
 
         await rt.TerminateAsync(TimeSpan.FromSeconds(5)).WaitAsync(HangGuard);
 
@@ -190,16 +126,67 @@ public class AntigravityRuntimeLifecycleTests {
 
     [Test]
     public async Task The_conversation_id_is_stable_and_a_change_drives_terminal() {
-        await using var rt = FakeRuntime();
+        // WaitForConversationIdAsync only ever resolves ONCE (turn 1's id) — it can't also prove turn
+        // 2 genuinely ran. Track each spawn explicitly instead of relying on WaitForTurnIdleAsync's
+        // racy gate hand-off (see the class doc).
+        var spawnSignals = new TaskCompletionSource[2];
+        for (var i = 0; i < spawnSignals.Length; i++)
+            spawnSignals[i] = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var spawnCount = 0;
+
+        await using var rt = FakeRuntime(onSpawn: _ => {
+            var i = Interlocked.Increment(ref spawnCount) - 1;
+            if (i < spawnSignals.Length) spawnSignals[i].TrySetResult();
+        });
+
         await rt.SendUserInputAsync("one").WaitAsync(HangGuard);
+        await spawnSignals[0].Task.WaitAsync(HangGuard); // turn 1 genuinely started
         await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
         var first = rt.AcpSessionId;
 
+        // Positive check — a vacuous run (turn 1 never actually processed) would leave this "".
+        await Assert.That(first).IsEqualTo(FixedConversationId);
+
         await rt.SendUserInputAsync("two").WaitAsync(HangGuard);
+        await spawnSignals[1].Task.WaitAsync(HangGuard); // turn 2 genuinely started
         await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
 
         // A changed conversation id means we silently forked the reviewer's history.
         await Assert.That(rt.AcpSessionId).IsEqualTo(first);
+        await Assert.That(rt.HasExited).IsFalse(); // still idle — two clean turns, no mismatch.
+    }
+
+    [Test]
+    public async Task A_changed_conversation_id_mid_session_drives_terminal() {
+        // FakeRuntime always uses ONE FakeTurn for every spawn, so a mismatch (which only makes sense
+        // after a first turn has already established an id) needs a bespoke spawn closure: turn 1
+        // Normal (establishes the baseline id), turn 2 ChangedConversationId (reports a different one).
+        var callIndex = 0;
+        Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawn = (_, _, _) => {
+            var kind = Interlocked.Increment(ref callIndex) == 1 ? FakeTurn.Normal : FakeTurn.ChangedConversationId;
+            return Task.FromResult<IAgyTurnProcess>(new FakeAgyTurnProcess(kind, FixedConversationId));
+        };
+
+        await using var rt = new AntigravityHostedAgentRuntime(spawnTurn: spawn, logger: NullLogger.Instance);
+
+        await rt.SendUserInputAsync("one").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await Assert.That(rt.AcpSessionId).IsEqualTo(FixedConversationId);
+        await Assert.That(rt.HasExited).IsFalse(); // idle after a clean first turn, not terminal yet.
+
+        var read = Task.Run(async () => { await foreach (var _ in rt.ReadOutputAsync()) { } });
+        await rt.SendUserInputAsync("two").WaitAsync(HangGuard);
+
+        // The mismatch drives Terminal, never Idle — wait on the terminal signal itself, since this
+        // turn will never reach WaitForTurnIdleAsync's "idle" outcome.
+        await read.WaitAsync(HangGuard);
+
+        await Assert.That(rt.HasExited).IsTrue();
+        await Assert.That(rt.ExitCode).IsNotEqualTo(0);
+
+        // The stable id from turn 1 is preserved — never silently overwritten by the mismatched one.
+        await Assert.That(rt.AcpSessionId).IsEqualTo(FixedConversationId);
     }
 
     [Test]
@@ -208,6 +195,7 @@ public class AntigravityRuntimeLifecycleTests {
         await using var rt = FakeRuntime(onSpawn: p => prompts.Add(p));
 
         await rt.SendUserInputAsync("do the review").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
         await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
 
         await Assert.That(prompts).Contains("do the review");
@@ -232,5 +220,23 @@ public class AntigravityRuntimeLifecycleTests {
 
         // Only turn 1 ever spawned — turn 2 sits in the (capacity-1) queue and turn 3 was dropped.
         await Assert.That(spawns).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task A_turns_process_is_disposed_after_the_turn_ends() {
+        FakeAgyTurnProcess? spawned = null;
+        Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawn = (_, _, _) => {
+            spawned = new FakeAgyTurnProcess(FakeTurn.Normal, FixedConversationId);
+            return Task.FromResult<IAgyTurnProcess>(spawned);
+        };
+
+        await using var rt = new AntigravityHostedAgentRuntime(spawnTurn: spawn, logger: NullLogger.Instance);
+
+        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(spawned).IsNotNull();
+        await Assert.That(spawned!.DisposeCalls).IsEqualTo(1);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
@@ -160,21 +160,25 @@ public class ServiceEnvironmentTests {
     // supervised daemon, silently — which is the failure this whole group exists to pin.
 
     static Dictionary<string, string> ConsentSource() => new() {
-        ["PATH"]                            = "/usr/bin",
-        ["KCAP_GEMINI_UNATTENDED_REVIEWER"] = "1",
-        ["KCAP_KIRO_UNATTENDED_REVIEWER"]   = "true",
+        ["PATH"]                                 = "/usr/bin",
+        ["KCAP_GEMINI_UNATTENDED_REVIEWER"]      = "1",
+        ["KCAP_KIRO_UNATTENDED_REVIEWER"]        = "true",
+        ["KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER"] = "yes",
     };
 
     [Test]
     [Arguments(false)]
     [Arguments(true)]
-    public async Task Build_carries_both_reviewer_consent_flags_on_every_platform(bool isWindows) {
+    public async Task Build_carries_every_reviewer_consent_flag_on_every_platform(bool isWindows) {
         var env = ServiceEnvironment.Build(profileName: null, source: ConsentSource(), isWindows: isWindows);
 
         await Assert.That(env["KCAP_GEMINI_UNATTENDED_REVIEWER"]).IsEqualTo("1")
             .Because("a supervised daemon inherits nothing from the installing shell");
         await Assert.That(env["KCAP_KIRO_UNATTENDED_REVIEWER"]).IsEqualTo("true")
-            .Because("binding one reviewer's consent and not the other just moves the hole");
+            .Because("binding one reviewer's consent and not another just moves the hole");
+        await Assert.That(env["KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER"]).IsEqualTo("yes")
+            .Because("Antigravity's consent has no config or profile binding either — dropping it here "
+                   + "makes the reviewer unreachable for a service-installed daemon, silently");
     }
 
     /// <summary>A flag the installing environment never set must not appear — capture carries an
@@ -195,7 +199,11 @@ public class ServiceEnvironmentTests {
         var env = ServiceEnvironment.Build(profileName: null, source: ConsentSource(), isWindows: false);
 
         await Assert.That(ServiceEnvironment.CarriedConsentFlags(env))
-            .IsEquivalentTo(new[] { "KCAP_GEMINI_UNATTENDED_REVIEWER", "KCAP_KIRO_UNATTENDED_REVIEWER" });
+            .IsEquivalentTo(new[] {
+                "KCAP_GEMINI_UNATTENDED_REVIEWER",
+                "KCAP_KIRO_UNATTENDED_REVIEWER",
+                "KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER"
+            });
     }
 
     /// <summary>Reads the BUILT environment, not the ambient one — so the install notice cannot claim a

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
@@ -211,4 +211,27 @@ public class ServiceEnvironmentTests {
 
         await Assert.That(ServiceEnvironment.CarriedConsentFlags(env)).IsEmpty();
     }
+
+    [Test]
+    public async Task Agy_adc_auth_is_carried_as_a_non_secret_config_key() {
+        var env = ServiceEnvironment.Build("prof", new Dictionary<string, string> {
+            ["PATH"]                  = "/usr/bin",
+            ["AGY_ADC_AUTH"]          = "1",
+            ["GOOGLE_CLOUD_PROJECT"]  = "proj"
+        });
+
+        // AGY_ADC_AUTH is a boolean switch, not a credential, so it belongs in the
+        // always-carried config list beside GOOGLE_GENAI_USE_VERTEXAI — not in the
+        // secret-capable list that is withheld on Windows.
+        await Assert.That(env["AGY_ADC_AUTH"]).IsEqualTo("1");
+    }
+
+    [Test]
+    public async Task Agy_adc_auth_is_carried_on_windows_too() {
+        var env = ServiceEnvironment.Build("prof",
+            new Dictionary<string, string> { ["PATH"] = "/usr/bin", ["AGY_ADC_AUTH"] = "1" },
+            isWindows: true);
+
+        await Assert.That(env["AGY_ADC_AUTH"]).IsEqualTo("1");
+    }
 }


### PR DESCRIPTION
Adds `agy` — the Antigravity **CLI** — as an unattended review-flow reviewer, via the codebase's first **exec-per-turn** hosted-agent runtime.

Fixes AI-1414

## Why this one is shaped differently

Every other hosted runtime here wraps a single long-lived child (PTY or ACP). `agy` speaks neither protocol: each turn is a separate `agy -p … --output-format stream-json --conversation <id>` process that exits when the turn ends, and **between turns there is no process at all**. So the runtime is a phase machine over a turn queue, translating agy's NDJSON into `AcpEventEnvelope`s and feeding the *existing* `AcpTranscriptForwarder` unchanged.

Server-side: no changes. Routing was already vendor-neutral.

## Containment

A daemon-owned worktree plus an **empty per-launch `HOME`**. That single choice does two jobs: no kcap plugin means no capture hooks, so recording stays single-lane; and no global `mcp_config.json` means nested review flows can't be launched. ADC env auth (`AGY_ADC_AUTH=1` + `GOOGLE_CLOUD_PROJECT` + inherited credentials) is what lets that HOME stay empty.

Enforced by a **real-process** test, not a model-layer refusal — live run observed: zero kcap log/watcher entries keyed on the conversation id, zero processes carrying it, agy's `Library` writes landing under the *relocated* home, and the operator's own agy store untouched, with a positive control proving that state does exist in the contained tree.

The reviewer deliberately does **not** pass `--dangerously-skip-permissions`. Measured on 1.1.10: without it, an absolute out-of-workspace `view_file` is refused (`state: "ERROR"`, `tool_info.error = {TOOL_ERROR, "User denied permission for read_file(…)"}`, content never read); with it, the same read succeeds. That flag is the entire read boundary, and a reviewer only reads.

## Gating

Consent (`KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1`) → POSIX-only → binary present → **minimum version floor** (`KCAP_ANTIGRAVITY_MIN_CLI_VERSION`, default `1.1.10`), through the existing `CliVersionAllowed` range grammar rather than a third version mechanism.

A floor rather than a per-build affirmation, unlike Kiro and Gemini, because `agy` auto-updates on a cadence the operator neither controls nor predicts — it moved 1.1.8 → 1.1.10 mid-development. `kcap daemon reviewer affirm --vendor antigravity` therefore refuses with a coded `antigravity_reviewer_not_affirmable` rather than silently succeeding at a no-op. An unidentifiable version still refuses: a build we can't name can't be shown to meet a floor.

The floor is applied at **both** advertisement and the launch boundary, off one shared decision — an explicit vendor request that bypasses advertisement can't slip a below-floor build through.

## Notable details

- **`ServiceEnvironment.ReviewerConsentKeys`** gains the Antigravity flag. Without it a *service-installed* daemon silently drops the operator's consent from its unit and the reviewer could never be enabled.
- **Per-turn PID records.** The durable record is rewritten on every turn spawn and cleared on confirmed exit, so rounds 2+ stay reapable — a one-shot record would only ever name turn 1's pid.
- **Teardown is measured, not assumed.** The per-launch HOME holds the reviewer's conversation JSONL (the caller's diff and findings), so it's deleted only on confirmed quiescence; unconfirmed **skips and logs**, leaving the epoch sweep to collect it, because deleting under a live child leaves it writing into an unlinked path.
- **A denial ends the turn** — no closing `agent_response`, empty `result.response`. Anything waiting on a post-denial summary hangs rather than fails, so waits are bounded.

## Testing

209 Antigravity tests (204 pass, 5 skipped — the env-gated live certs). Full suite sits at the current `origin/main` baseline of 49 failures, verified by set-diffing against a detached baseline worktree; the two branch-only entries are the known load-dependent PTY class and pass in isolation. Daemon and CLI AOT publishes are both clean.

The end-to-end live cert (`AntigravityReviewerLiveCertTests`) is written and proven to skip at ~13 ms with zero spend, but **has not been run live** — it needs a daemon advertising `antigravity`, which means the consent flag captured into a supervised daemon's unit and a restart. That's an operator action, noted rather than simulated.

Probe record: `docs/probes/2026-08-06-agy-reviewer/findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)