### PR TITLE
Host Antigravity CLI agents: posture, queued input, and the reviewer split

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,7 +869,9 @@ export AGY_ADC_AUTH=1                           # selects ADC; without it agy st
 ```
 
 **Minimum version.** Containment here depends on the installed build honouring `HOME` and reading no other
-global config source, so the daemon records a minimum `agy` version the first time you enable the reviewer.
+global config source, so the daemon records a minimum `agy` version at the first startup that finds `agy`
+installed — for this vendor that is not conditional on the flag above, because the same minimum also gates
+[hosted Antigravity agents](#hosted-antigravity-agents-run-without-permission-prompts).
 It is a **minimum, not an exact match**: any build at or above it runs, so **an `agy` upgrade needs no
 action from you** — which matters more here than for the other reviewers, since `agy` updates itself
 (observed going 1.1.8 → 1.1.10 mid-session). A build older than the recorded minimum, or one whose
@@ -905,9 +907,18 @@ soft-deny is the posture they want.
 
 Hosted launches otherwise take the same route as the reviewer above — the per-launch isolated `HOME`
 included, so your own `~/.gemini` config and the kcap capture plugin inside it never reach a hosted agent,
-and its transcript is recorded once rather than twice. They are gated by the same daemon switches for the
-same reason: `KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1` and a recorded minimum `agy` version are required for
-a hosted launch too, because the containment those protect is the isolated home both shapes rely on.
+and its transcript is recorded once rather than twice.
+
+**`KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER` is not required for a hosted launch, and setting it does not
+enable one.** Hosted Antigravity is on as soon as `agy` resolves, like every other hosted vendor. That flag
+consents specifically to an *unattended review*, whose risk is that it runs under your daemon's authority
+and returns what it read to whoever asked for the review — someone who need not be you. A hosted agent has
+no such gap: the server only ever launches on a daemon you own, so the person launching it is you.
+
+What a hosted launch *does* share with the reviewer is the **minimum `agy` version** (and POSIX), because
+the containment that protects is the isolated `HOME` both shapes rely on. Your daemon records that minimum
+at startup whenever `agy` resolves, so there is normally nothing to do; if you installed `agy` after the
+daemon started, restart it or run `kcap daemon reviewer affirm --vendor antigravity`.
 
 #### If your daemon runs as a service
 
@@ -1393,6 +1404,8 @@ Agent ids are long, so `attach` and `stop` accept **any unique prefix** — an a
 
 - `kcap agent attach` on one is **read-only** — you see its output, your keystrokes are not delivered, and your terminal size is not applied to it.
 - `kcap agent stop` on one is **refused** unless you pass `--force`, and `stop --all` skips them and says how many it skipped.
+
+**Agents with no terminal.** Some hosted vendors (Antigravity's `agy`, and the ACP-backed ones — Cursor, Copilot, Kiro, Gemini) never produce terminal output at all: their stdout is protocol traffic, not a screen. `kcap agent attach` on one of those is **refused by name**, telling you which vendor it is and to drive the agent from the dashboard, rather than attaching you to a blank window that never repaints. They still appear in `kcap agent ls`, and `kcap agent stop` works on them normally.
 
 Enforcement lives in the daemon, so a current CLI can't bypass it by skipping the check or lying about `--force`. That guarantee has two version-skew exceptions: an old `kcap` sends the legacy `Stop` request, which has no `--force` concept — the daemon treats that as `--force`, so an old client can silently force-stop a review or review-flow agent. And against an old daemon, `ls`/`attach` degrade silently (no kind reported, every agent reads as `agent`), but `stop` doesn't degrade — it sends a newer request format the old daemon can't decode, so the connection closes and the CLI tells you to restart the daemon instead of stopping anything.
 

--- a/README.md
+++ b/README.md
@@ -877,6 +877,12 @@ action from you** — which matters more here than for the other reviewers, sinc
 (observed going 1.1.8 → 1.1.10 mid-session). A build older than the recorded minimum, or one whose
 `agy --version` cannot be read, is withheld with a coded reason naming both versions.
 
+Because this vendor's minimum is recorded when `agy` first resolves rather than when you enable the
+reviewer, there is one window worth knowing about: install `agy`, run a daemon with the reviewer *off*,
+then upgrade `agy` and only afterwards turn the reviewer on — and the recorded minimum is still the older
+build you started with, so a later *downgrade* back to it would be admitted. Run the command below once
+after enabling the reviewer if you want the minimum to be the build you actually reviewed with.
+
 ```bash
 kcap daemon reviewer affirm --vendor antigravity
 ```
@@ -888,7 +894,11 @@ enable the reviewer. No kcap release is ever needed.
 
 Like Gemini and Kiro, this never makes Antigravity a default reviewer — it is only ever reached by an
 explicit `vendor: "antigravity"`. Borrowed (in-place) review is not offered; a borrowed request falls back
-to a daemon-owned worktree.
+to a daemon-owned worktree. **PR review (`kcap review <pr>` / the dashboard's Review PR action) is not
+supported on this vendor either** — that agent needs the `kcap mcp review` tool surface, which only the
+PTY-backed vendors are given, so an Antigravity PR-review launch is refused with
+`antigravity_pr_review_unsupported` rather than started without its review tools. Use Claude for a PR
+review.
 
 #### Hosted Antigravity agents run without permission prompts
 

--- a/README.md
+++ b/README.md
@@ -888,6 +888,27 @@ Like Gemini and Kiro, this never makes Antigravity a default reviewer — it is 
 explicit `vendor: "antigravity"`. Borrowed (in-place) review is not offered; a borrowed request falls back
 to a daemon-owned worktree.
 
+#### Hosted Antigravity agents run without permission prompts
+
+The same `agy` binary also backs **hosted** Antigravity agents launched from the dashboard, and there the
+posture is the opposite of the reviewer's: the daemon passes `--dangerously-skip-permissions` on every
+hosted launch, unconditionally. `agy` soft-denies shell and out-of-workspace operations in headless mode
+while still exiting 0, so without it a hosted agent quietly fails to do the work you asked for. This is the
+same posture hosted Claude agents already carry (`--permission-mode bypassPermissions`).
+
+**Measured on `agy` 1.1.10, that flag is the read boundary — the worktree is not.** With it, the agent can
+read absolute paths outside its worktree, so a daemon-owned worktree does not confine what a hosted agent
+sees. A hosted agent runs on your own machine, under your own daemon, at your own request; if you would
+rather it asked first, restrict the vendor with [`kcap daemon consent`](#launch-consent-kcap-daemon-consent).
+**Review-flow reviewers never get the flag** — they read an owned worktree and nothing else, so the
+soft-deny is the posture they want.
+
+Hosted launches otherwise take the same route as the reviewer above — the per-launch isolated `HOME`
+included, so your own `~/.gemini` config and the kcap capture plugin inside it never reach a hosted agent,
+and its transcript is recorded once rather than twice. They are gated by the same daemon switches for the
+same reason: `KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1` and a recorded minimum `agy` version are required for
+a hosted launch too, because the containment those protect is the isolated home both shapes rely on.
+
 #### If your daemon runs as a service
 
 All three consent flags above are read from the **daemon's own environment**, and a supervised daemon (`kcap daemon

--- a/src/Capacitor.Cli.Core/ReviewerVersionStore.cs
+++ b/src/Capacitor.Cli.Core/ReviewerVersionStore.cs
@@ -23,24 +23,13 @@ namespace Capacitor.Cli.Core;
 /// consent" failure the enable flag exists to avoid. The daemon writes it; only an explicit operator
 /// command changes it.</para>
 ///
-/// <para><b>ONE per-vendor exception: antigravity's record is not anchored to a consent event.</b>
-/// Every other vendor's floor is seeded when its reviewer is turned ON, so the recorded build is the
-/// one installed at the moment the operator consented. Antigravity's floor gates more than its
-/// reviewer — it also gates HOSTED <c>agy</c> launches, which ship on by default and take no consent
-/// — so a consent-less daemon must still record one, or every hosted launch refuses as
-/// <c>version_no_minimum</c> forever. <c>DaemonRunner.SeedReviewerFloors</c> therefore seeds this one
-/// vendor from the binary RESOLVING, and seeding is once-only (keyed on the record's presence), so
-/// the two facts compose into a window: install <c>agy</c> 1.0.0 and boot with the reviewer off →
-/// floor 1.0.0; later upgrade to 1.1.10 and turn the reviewer on → seeding no-ops and the floor stays
-/// 1.0.0, so a subsequent DOWNGRADE to 1.0.0 runs an unattended reviewer that a consent-anchored
-/// floor would have refused as <c>version_below_minimum</c>. Accepted deliberately: the exposure is
-/// bounded to builds at or above the one installed before consent (never an arbitrarily old one), the
-/// hosted requirement is real, and the operator's remedy is one command —
-/// <c>kcap daemon reviewer affirm --vendor antigravity</c> raises the floor to what is installed now.
-/// The gate is NOT weakened to compensate, and consent deliberately does NOT re-seed: a re-seed on
-/// consent is the "acknowledge the upgrade you never read" failure this type's minimum-not-exact rule
-/// exists to remove, and it would silently carry a floor forward past a build the operator had
-/// already been refused on.</para>
+/// <para><b>ONE per-vendor exception: antigravity's floor is seeded from the binary resolving, not
+/// from a consent event</b> — it also gates HOSTED <c>agy</c> launches, which take no consent, and a
+/// consent-less daemon with no floor refuses every one as <c>version_no_minimum</c>. Seeding is
+/// once-only, so a floor recorded before consent is not raised when the reviewer is later enabled:
+/// a downgrade to that pre-consent build is admitted where a consent-anchored floor would refuse it.
+/// Accepted — bounded to builds at or above that one, remedy is
+/// <c>kcap daemon reviewer affirm --vendor antigravity</c>. Consent must not re-seed.</para>
 ///
 /// <para>Keyed by vendor, one file each, so affirming one vendor's build says nothing about another's.
 /// Kiro's filename is unchanged from when this type was Kiro-only — renaming it would have silently

--- a/src/Capacitor.Cli.Core/ReviewerVersionStore.cs
+++ b/src/Capacitor.Cli.Core/ReviewerVersionStore.cs
@@ -23,6 +23,25 @@ namespace Capacitor.Cli.Core;
 /// consent" failure the enable flag exists to avoid. The daemon writes it; only an explicit operator
 /// command changes it.</para>
 ///
+/// <para><b>ONE per-vendor exception: antigravity's record is not anchored to a consent event.</b>
+/// Every other vendor's floor is seeded when its reviewer is turned ON, so the recorded build is the
+/// one installed at the moment the operator consented. Antigravity's floor gates more than its
+/// reviewer — it also gates HOSTED <c>agy</c> launches, which ship on by default and take no consent
+/// — so a consent-less daemon must still record one, or every hosted launch refuses as
+/// <c>version_no_minimum</c> forever. <c>DaemonRunner.SeedReviewerFloors</c> therefore seeds this one
+/// vendor from the binary RESOLVING, and seeding is once-only (keyed on the record's presence), so
+/// the two facts compose into a window: install <c>agy</c> 1.0.0 and boot with the reviewer off →
+/// floor 1.0.0; later upgrade to 1.1.10 and turn the reviewer on → seeding no-ops and the floor stays
+/// 1.0.0, so a subsequent DOWNGRADE to 1.0.0 runs an unattended reviewer that a consent-anchored
+/// floor would have refused as <c>version_below_minimum</c>. Accepted deliberately: the exposure is
+/// bounded to builds at or above the one installed before consent (never an arbitrarily old one), the
+/// hosted requirement is real, and the operator's remedy is one command —
+/// <c>kcap daemon reviewer affirm --vendor antigravity</c> raises the floor to what is installed now.
+/// The gate is NOT weakened to compensate, and consent deliberately does NOT re-seed: a re-seed on
+/// consent is the "acknowledge the upgrade you never read" failure this type's minimum-not-exact rule
+/// exists to remove, and it would silently carry a floor forward past a build the operator had
+/// already been refused on.</para>
+///
 /// <para>Keyed by vendor, one file each, so affirming one vendor's build says nothing about another's.
 /// Kiro's filename is unchanged from when this type was Kiro-only — renaming it would have silently
 /// discarded every existing affirmation and taken shipped reviewers offline on upgrade.</para>

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
@@ -24,9 +24,16 @@ internal enum AntigravityReviewerDecision {
 /// <c>fs_read</c> primitive this vendor does not expose, and a borrowed risk statement would be a
 /// false one in either direction.</para>
 ///
+/// <para><b>Consent is the ONE arm that is reviewer-only</b> (see
+/// <c>AntigravityHostedAgentRuntimeFactory.LaunchRefusal</c>'s parameter doc). The paragraph above is
+/// exactly why: the risk it describes is cross-principal, and a HOSTED launch has no counterpart —
+/// the server resolves a launch's daemon with the caller's own user id, so the launcher is the
+/// daemon's owner. Hosted Antigravity ships on by default; every other arm below still gates it.</para>
+///
 /// <para><b>Why a version MINIMUM.</b> Containment here is source suppression — an empty per-launch
 /// <see cref="AntigravityReviewerHome"/> in place of the operator's own <c>~/.gemini</c>, whose kcap
 /// capture plugin would otherwise fire against the conversation this runtime is already recording.
+/// That is a HOSTED concern as much as a reviewer one, which is why this arm is not parameterised.
 /// That the build honours <c>HOME</c> and reads no other global config source is a behaviour of the
 /// BUILD, not of this repository. The recorded value is the OLDEST build this daemon will run: an
 /// upgrade needs no action — which matters more here than for any sibling, since <c>agy</c> was
@@ -41,10 +48,15 @@ internal enum AntigravityReviewerDecision {
 /// <see cref="Core.ReviewerVersionStore"/>.</para>
 ///
 /// <para><b>This is the whole ladder</b> (consent → platform → build), and
-/// <c>AntigravityHostedAgentRuntimeFactory.ReviewerRefusal</c> is its only production caller: it adds
+/// <c>AntigravityHostedAgentRuntimeFactory.LaunchRefusal</c> is its only production caller: it adds
 /// the one arm this decision cannot express — a binary that does not resolve at all — and takes every
 /// other verdict, and every text, from here. Both the advertisement seam and the launch boundary read
-/// that one method, so the minimum cannot be enforced at only one of them.</para>
+/// that one method, so the minimum cannot be enforced at only one of them, and the hosted/review
+/// difference is a PARAMETER of that method rather than a second ladder that must agree with it.</para>
+///
+/// <para><b>The denial texts below are read by both launch shapes</b> (consent excepted, which only a
+/// review can reach), so they describe the containment rather than the reviewer — a hosted operator
+/// must never be sent to the reviewer consent flag by a version arm.</para>
 /// </summary>
 internal static class AntigravityReviewerCapability {
     /// <summary>
@@ -98,8 +110,8 @@ internal static class AntigravityReviewerCapability {
               + "daemon's environment (not on the server).",
 
             AntigravityReviewerDecision.UnsupportedPlatform =>
-                "antigravity_reviewer_unsupported_platform: the reviewer's per-launch home holds "
-              + "review context and cannot be created owner-only on Windows.",
+                "antigravity_reviewer_unsupported_platform: the per-launch home holds the agent's own "
+              + "conversation transcript and cannot be created owner-only on Windows.",
 
             AntigravityReviewerDecision.VersionUnresolved =>
                 $"antigravity_reviewer_version_unresolved: the version of '{binaryPath}' could not be "
@@ -110,10 +122,10 @@ internal static class AntigravityReviewerCapability {
 
             AntigravityReviewerDecision.VersionNoMinimum =>
                 "antigravity_reviewer_version_no_minimum: this daemon has no recorded minimum agy "
-              + "version, so there is nothing to check the installed build against. The usual cause is "
-              + "enabling the reviewer against an already-running daemon — it records a minimum at "
-              + "startup, so restart it with KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER set. To set one now "
-              + "without restarting, run `kcap daemon reviewer affirm --vendor antigravity`.",
+              + "version, so there is nothing to check the installed build against. A daemon records "
+              + "one at startup whenever the Antigravity CLI resolves, so the usual cause is a daemon "
+              + "that started before `agy` was installed — restart it, or record the installed build "
+              + "now with `kcap daemon reviewer affirm --vendor antigravity`.",
 
             AntigravityReviewerDecision.VersionIncomparable =>
                 $"antigravity_reviewer_version_incomparable: agy {Describe(installedVersion)} and this "
@@ -130,11 +142,11 @@ internal static class AntigravityReviewerCapability {
 
             AntigravityReviewerDecision.VersionBelowMinimum =>
                 $"antigravity_reviewer_version_below_minimum: agy {Describe(installedVersion)} is "
-              + $"installed but this daemon's recorded minimum is {Describe(minimumVersion)}. The "
-              + "reviewer's containment depends on the build honouring HOME and reading no other "
-              + "global config source, so an OLDER build than the one recorded is refused. Upgrade the "
-              + "Antigravity CLI, or deliberately lower the minimum to the installed build with "
-              + "`kcap daemon reviewer affirm --vendor antigravity`."
+              + $"installed but this daemon's recorded minimum is {Describe(minimumVersion)}. "
+              + "Containment here depends on the build honouring HOME and reading no other global "
+              + "config source — for a hosted agent as much as for a reviewer — so an OLDER build than "
+              + "the one recorded is refused. Upgrade the Antigravity CLI, or deliberately lower the "
+              + "minimum to the installed build with `kcap daemon reviewer affirm --vendor antigravity`."
         };
 
     static string Describe(string? version) => ReviewerVersionAffirmations.Describe(version);

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -238,27 +238,7 @@ public static partial class DaemonRunner {
         // this early — the host's logging pipeline isn't built yet.
         var coverageStateDir = Path.Combine(
             config.StateDir ?? DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(config.Name));
-        // Seed each gated reviewer's affirmation from the CONSENT event, not from a first refusal: an
-        // operator who has just turned a reviewer on should not be refused over an upgrade that never
-        // happened, which teaches people to clear the gate without reading it. Cheap, and a no-op for
-        // a vendor the operator has not opted into.
-        SeedReviewerAffirmation(
-            coverageStateDir, AcpVendorDescriptors.Kiro.Vendor,
-            config.KiroUnattendedReviewerEnabled, config.KiroPath);
-
-        SeedReviewerAffirmation(
-            coverageStateDir, AcpVendorDescriptors.Gemini.Vendor,
-            config.GeminiUnattendedReviewerEnabled, config.GeminiPath);
-
-        // Antigravity is the one vendor whose floor is NOT reviewer-only: it gates hosted agy launches
-        // too (the isolated HOME they rely on is the containment it protects), and those ship on by
-        // default with no consent flag. Seeding from the consent event would therefore leave every
-        // consent-less daemon refusing hosted launches as version_no_minimum forever — the reviewer
-        // gate removed from the front of the ladder and reinstated behind it. Installing agy IS the
-        // event here; the resolver's null-for-a-missing-binary answer is what keeps this a no-op
-        // otherwise, at the cost of one bounded `agy --version` on the first boot that finds no
-        // record, never again.
-        SeedVersionFloor(coverageStateDir, AntigravityVendor, config.AntigravityPath);
+        SeedReviewerFloors(coverageStateDir, config);
 
         // Recovers reviewer homes left by a SIGKILLed predecessor. Runs unconditionally: a daemon
         // whose operator has since disabled the reviewer still owns whatever its last incarnation
@@ -861,6 +841,43 @@ public static partial class DaemonRunner {
     /// </summary>
     internal static bool ShouldWarnCursorUnavailable(IEnumerable<IHostedAgentRuntimeFactory> factories) =>
         factories.FirstOrDefault(f => f.Vendor == "cursor") is { } cursorFactory && !cursorFactory.IsAvailable();
+
+    /// <summary>
+    /// Every gated vendor's version floor, seeded in one place — the whole block <see cref="RunAsync"/>
+    /// runs before anything else touches a reviewer record.
+    ///
+    /// <para><b>The asymmetry between the three is the point, and it is why this is a method rather
+    /// than three lines inline.</b> Nothing invokes <see cref="RunAsync"/> from a test — it builds and
+    /// runs the entire DI host — so seeding stated only there is asserted by nothing, and a test that
+    /// calls <see cref="SeedVersionFloor"/> by hand pins the directory shape while leaving the
+    /// CONDITION each vendor is seeded under unpinned. Driving this method instead makes the
+    /// difference between the vendors the thing under test.</para>
+    ///
+    /// <para>Kiro and Gemini seed from the CONSENT event, not from a first refusal: an operator who
+    /// has just turned a reviewer on should not be refused over an upgrade that never happened, which
+    /// teaches people to clear the gate without reading it. Cheap, and a no-op for a vendor the
+    /// operator has not opted into.</para>
+    ///
+    /// <para>Antigravity is the one vendor whose floor is NOT reviewer-only: it gates hosted
+    /// <c>agy</c> launches too (the isolated <c>HOME</c> they rely on is the containment it protects),
+    /// and those ship on by default with no consent flag. Seeding from the consent event would
+    /// therefore leave every consent-less daemon refusing hosted launches as
+    /// <c>version_no_minimum</c> forever — the reviewer gate removed from the front of the ladder and
+    /// reinstated behind it. Installing <c>agy</c> IS the event here; the resolver's
+    /// null-for-a-missing-binary answer is what keeps this a no-op otherwise, at the cost of one
+    /// bounded <c>agy --version</c> on the first boot that finds no record, never again.</para>
+    /// </summary>
+    internal static void SeedReviewerFloors(string stateDir, DaemonConfig config) {
+        SeedReviewerAffirmation(
+            stateDir, AcpVendorDescriptors.Kiro.Vendor,
+            config.KiroUnattendedReviewerEnabled, config.KiroPath);
+
+        SeedReviewerAffirmation(
+            stateDir, AcpVendorDescriptors.Gemini.Vendor,
+            config.GeminiUnattendedReviewerEnabled, config.GeminiPath);
+
+        SeedVersionFloor(stateDir, AntigravityVendor, config.AntigravityPath);
+    }
 
     /// <summary>
     /// Records the installed build as affirmed the first time a vendor's reviewer is enabled.

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -250,9 +250,15 @@ public static partial class DaemonRunner {
             coverageStateDir, AcpVendorDescriptors.Gemini.Vendor,
             config.GeminiUnattendedReviewerEnabled, config.GeminiPath);
 
-        SeedReviewerAffirmation(
-            coverageStateDir, AntigravityVendor,
-            config.AntigravityUnattendedReviewerEnabled, config.AntigravityPath);
+        // Antigravity is the one vendor whose floor is NOT reviewer-only: it gates hosted agy launches
+        // too (the isolated HOME they rely on is the containment it protects), and those ship on by
+        // default with no consent flag. Seeding from the consent event would therefore leave every
+        // consent-less daemon refusing hosted launches as version_no_minimum forever — the reviewer
+        // gate removed from the front of the ladder and reinstated behind it. Installing agy IS the
+        // event here; the resolver's null-for-a-missing-binary answer is what keeps this a no-op
+        // otherwise, at the cost of one bounded `agy --version` on the first boot that finds no
+        // record, never again.
+        SeedVersionFloor(coverageStateDir, AntigravityVendor, config.AntigravityPath);
 
         // Recovers reviewer homes left by a SIGKILLed predecessor. Runs unconditionally: a daemon
         // whose operator has since disabled the reviewer still owns whatever its last incarnation
@@ -869,6 +875,19 @@ public static partial class DaemonRunner {
             string stateDir, string vendor, bool enabled, string binaryPath) {
         if (!enabled) return;
 
+        SeedVersionFloor(stateDir, vendor, binaryPath);
+    }
+
+    /// <summary>
+    /// The same seeding with NO consent condition — for a vendor whose recorded floor gates more than
+    /// its reviewer.
+    ///
+    /// <para>Deliberately a separate name rather than <c>SeedReviewerAffirmation(…, enabled: true)</c>:
+    /// a literal <c>true</c> sitting between two <c>config.XUnattendedReviewerEnabled</c> siblings
+    /// reads as an oversight, and "tidying" it back to the flag would silently reinstate the very gate
+    /// the caller exists to avoid. With no boolean to flip, the asymmetry has to be read.</para>
+    /// </summary>
+    internal static void SeedVersionFloor(string stateDir, string vendor, string binaryPath) {
         try {
             if (!ReviewerVersionStore.RecordExists(stateDir, vendor)
              && VendorVersionResolver.Resolve(binaryPath) is { Length: > 0 } installed)

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -233,6 +233,18 @@ internal partial class AgentOrchestrator {
         if (!_agents.TryGetValue(agentId, out var agent))
             return FrameCodec.WriteAsync(stream, LocalFrame.Error($"no such agent {agentId}"), ct);
 
+        // A runtime that emits no terminal output has nothing for a terminal to attach TO: its
+        // stdout is protocol traffic (agy's NDJSON, ACP's JSON-RPC), and its output buffer is
+        // therefore always empty. Attaching anyway painted a blank screen that never repaints and
+        // only admitted the problem if the user typed (AttachClientLoopAsync's raw-input refusal) —
+        // indistinguishable from a wedged daemon. Refuse by name instead, and say where the agent
+        // actually lives. Decided here rather than in the CLI: `kcap agent attach` sends a full id
+        // verbatim without fetching the agent table, so the client cannot know the vendor.
+        if (!agent.Runtime.EmitsTerminalOutput)
+            return FrameCodec.WriteAsync(stream, LocalFrame.Error(
+                $"{agentId} is a hosted {agent.Runtime.Vendor} agent — it has no terminal to attach to. "
+              + "Drive it from the dashboard."), ct);
+
         // A review or flow agent is addressed through the flow protocol, never by typing at it,
         // so the daemon — not the client — decides this attach carries no input.
         return AttachClientLoopAsync(agent, stream, ct, readOnly: agent.Kind != LaunchKind.Default);

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -314,7 +314,7 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     readonly Channel<AcpEventEnvelope> _transcript;
     readonly Channel<PendingTurn>      _pendingTurns;
     readonly int                       _pendingTurnsCapacity;
-    int                                _droppedPendingTurns;
+    int                                _rejectedPendingTurns;
 
     Task _turnWorkerTask = Task.CompletedTask;
 
@@ -354,9 +354,16 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // NOT SingleReader: EnterTerminal's drain (rule below) and the worker's own dequeue loop can
         // both call TryRead around a Terminate race, so this channel must tolerate two readers even
         // though exactly one of them ever "wins" any given item.
+        //
+        // FullMode.Wait, paired with TryWrite (never WriteAsync), is what makes an over-cap send
+        // REJECTABLE: under DropWrite — which this used to use — TryWrite returns TRUE and discards
+        // the item, so EnqueueTurn's full-queue branch was unreachable and a user's message vanished
+        // with not even a log line. Wait mode is only "waiting" for a caller that awaits WriteAsync;
+        // TryWrite under it returns false immediately, which is the non-blocking rejection this
+        // runtime wants (see EnqueueTurn on why blocking here would stall the whole command lane).
         _pendingTurns = Channel.CreateBounded<PendingTurn>(
             new BoundedChannelOptions(_pendingTurnsCapacity)
-                { SingleReader = false, SingleWriter = false, FullMode = BoundedChannelFullMode.DropWrite });
+                { SingleReader = false, SingleWriter = false, FullMode = BoundedChannelFullMode.Wait });
 
         _turnWorkerTask = RunTurnWorkerAsync();
     }
@@ -431,36 +438,66 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
     /// <summary>
     /// Enqueues the turn and returns immediately — never blocks on, or observes, the turn's
-    /// completion. A dropped enqueue never throws when no acknowledgement was requested: the channel's
-    /// own atomicity (<see cref="ChannelWriter{T}.TryWrite"/> against a completed or full bounded
-    /// channel) is what makes "terminal" and "full" collapse into one non-racy check, but the two are
-    /// still logged (and faulted, for an acknowledging caller) distinctly below — a full queue is an
-    /// operational signal worth a warning and a running count, matching
-    /// <c>AcpHostedAgentRuntime.EnqueueTurn</c>'s same distinction for its own pending-turns queue.
+    /// completion. The channel's own atomicity (<see cref="ChannelWriter{T}.TryWrite"/> against a
+    /// completed or full bounded channel) is what makes "terminal" and "full" collapse into one
+    /// non-racy check, but the two are answered very differently below.
+    ///
+    /// <para><b>A full queue is REJECTED, for every caller, not just an acknowledging one.</b> The
+    /// two alternatives are each wrong in their own way. Blocking until space frees would stall the
+    /// daemon's serial command lane behind a reviewer whose turn is stuck — and a stuck turn is the
+    /// only way this queue ever fills — so one wedged agent would stop launches and stops for every
+    /// other one. Dropping silently (what this used to do for a caller that asked for no write ack,
+    /// i.e. every server-driven <c>SendInput</c>) loses a message the user has already sent, with
+    /// nothing anywhere to say so. So the send task faults, AND a <c>system_note</c> goes onto the
+    /// transcript: the fault reaches the daemon log through the orchestrator's handler, and the note
+    /// is the only surface the person who typed the message actually sees. One note per rejected
+    /// message — each is a separately lost message, and summarising them is the silent drop again in
+    /// miniature.</para>
+    ///
+    /// <para>A TERMINAL runtime is deliberately NOT symmetric: it still only logs (and faults an
+    /// acknowledging caller, as before). The transcript channel is completed on entry to
+    /// <see cref="RuntimePhase.Terminal"/>, so no note could be delivered anyway, and the agent's
+    /// session ending is itself the user-visible signal — a thrown error for input that raced a
+    /// normal end-of-session would be noise, not news.</para>
     /// </summary>
     Task EnqueueTurn(string text, bool acknowledgeWrite) {
         var written = acknowledgeWrite
             ? new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
             : null;
 
-        if (!_pendingTurns.Writer.TryWrite(new PendingTurn(text, written))) {
-            if (Phase == RuntimePhase.Terminal) {
-                _logger.LogDebug("Antigravity: dropped a prompt turn — the runtime is terminal.");
-                written?.TrySetException(new InvalidOperationException(
-                    "Antigravity runtime is terminal; this input was dropped."));
-            } else {
-                // The only other reason TryWrite can fail on this bounded, not-yet-completed channel.
-                var dropped = Interlocked.Increment(ref _droppedPendingTurns);
-                _logger.LogWarning(
-                    "Antigravity: pending-turns queue full (capacity={Capacity}) — dropping this input; "
-                  + "{DroppedCount} dropped this session so far (the turn worker is likely stuck on a "
-                  + "stalled turn).", _pendingTurnsCapacity, dropped);
-                written?.TrySetException(new InvalidOperationException(
-                    "Antigravity pending-turns queue is full; this input was dropped."));
-            }
+        if (_pendingTurns.Writer.TryWrite(new PendingTurn(text, written)))
+            return written?.Task ?? Task.CompletedTask;
+
+        if (Phase == RuntimePhase.Terminal) {
+            _logger.LogDebug("Antigravity: dropped a prompt turn — the runtime is terminal.");
+            written?.TrySetException(new InvalidOperationException(
+                "Antigravity runtime is terminal; this input was dropped."));
+
+            return written?.Task ?? Task.CompletedTask;
         }
 
-        return written?.Task ?? Task.CompletedTask;
+        // The only other reason TryWrite can fail on this bounded, not-yet-completed channel.
+        var rejected = Interlocked.Increment(ref _rejectedPendingTurns);
+        _logger.LogWarning(
+            "Antigravity: pending-turns queue full (capacity={Capacity}) — rejecting this input; "
+          + "{RejectedCount} rejected this session so far (the turn worker is likely stuck on a "
+          + "stalled turn).", _pendingTurnsCapacity, rejected);
+
+        EmitEnvelope(new AcpEventEnvelope(
+            Kind: AcpEventKind.SystemNote,
+            Text: $"Your message was not delivered — this agent's input queue is full "
+                + $"({_pendingTurnsCapacity} waiting) while it works through an earlier message. "
+                + "Send it again once it catches up."));
+
+        var failure = new InvalidOperationException(
+            $"Antigravity pending-turns queue is full (capacity {_pendingTurnsCapacity}); this input "
+          + "was not queued.");
+
+        written?.TrySetException(failure);
+
+        // The acknowledging caller awaits `written`; everyone else awaits this. Never both — an
+        // unawaited faulted Task is what TaskScheduler.UnobservedTaskException is for.
+        return written?.Task ?? Task.FromException(failure);
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -452,7 +452,9 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// transcript: the fault reaches the daemon log through the orchestrator's handler, and the note
     /// is the only surface the person who typed the message actually sees. One note per rejected
     /// message — each is a separately lost message, and summarising them is the silent drop again in
-    /// miniature.</para>
+    /// miniature. That note goes out through <see cref="EmitDaemonNotice"/>, NOT
+    /// <see cref="EmitEnvelope"/>: a refusal must not refresh the liveness attestation of the very
+    /// agent whose wedged turn caused it.</para>
     ///
     /// <para>A TERMINAL runtime is deliberately NOT symmetric: it still only logs (and faults an
     /// acknowledging caller, as before). The transcript channel is completed on entry to
@@ -483,7 +485,7 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
           + "{RejectedCount} rejected this session so far (the turn worker is likely stuck on a "
           + "stalled turn).", _pendingTurnsCapacity, rejected);
 
-        EmitEnvelope(new AcpEventEnvelope(
+        EmitDaemonNotice(new AcpEventEnvelope(
             Kind: AcpEventKind.SystemNote,
             Text: $"Your message was not delivered — this agent's input queue is full "
                 + $"({_pendingTurnsCapacity} waiting) while it works through an earlier message. "
@@ -877,14 +879,30 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         return true;
     }
 
-    void EmitEnvelope(AcpEventEnvelope env) {
+    /// <summary>An envelope the AGENT produced. Advances the activity clock — that is what makes this
+    /// runtime's output the liveness signal a supervisor reads.</summary>
+    void EmitEnvelope(AcpEventEnvelope env) => Write(env, agentActivity: true);
+
+    /// <summary>
+    /// An envelope the DAEMON authored ABOUT the agent — today, the full-queue rejection note. Reaches
+    /// the transcript identically, but does NOT advance the activity clock.
+    ///
+    /// <para>The clock's contract is "the content was genuinely produced" by the agent, and a refusal
+    /// is the opposite: the queue is full only because a turn is wedged, so counting the notice as
+    /// activity would let every user retry against a stuck agent reset <c>IdleForMs</c> and bump
+    /// <c>ActivitySeq</c> — the attempts to unstick it are what keep it from ever being reported idle.
+    /// A reviewer is bounded by its TTL arm regardless; a hosted agent is not bounded at all.</para>
+    /// </summary>
+    void EmitDaemonNotice(AcpEventEnvelope env) => Write(env, agentActivity: false);
+
+    void Write(AcpEventEnvelope env, bool agentActivity) {
         // Advance BEFORE the channel write, never after: a reader blocked on Envelopes.ReadAsync can
         // wake the instant TryWrite makes the item visible, on another thread, with no ordering
         // relationship to what this one does next — so the reverse order is a race a fast reader wins,
         // observing an envelope whose activity the clock has not yet recorded. Same reasoning
         // AcpHostedAgentRuntime.EmitEnvelope documents. Advanced even on the dropped-because-completed
         // path below: the content was genuinely produced.
-        ActivityClock?.Advance();
+        if (agentActivity) ActivityClock?.Advance();
 
         if (!_transcript.Writer.TryWrite(env))
             _logger.LogDebug("Antigravity: dropped a transcript envelope — the transcript channel is already completed.");

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntime.cs
@@ -479,17 +479,36 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         }
 
         // The only other reason TryWrite can fail on this bounded, not-yet-completed channel.
+        //
+        // The LOG line below is the reliable record of a rejection; the transcript note under it is
+        // best-effort. The Terminal check above ran under the lock and released it, so a
+        // TerminateAsync landing in the gap completes the transcript writer and the note is dropped
+        // (Write logs that at Debug). Deliberately not closed by holding the lock across the emit —
+        // that would put a channel write under _stateLock, and "no await/no foreign call under the
+        // state lock" is one of this class's four standing invariants. A rejection racing teardown
+        // is also the case where the note matters least: the agent is going away, and the user is
+        // about to be told that instead.
         var rejected = Interlocked.Increment(ref _rejectedPendingTurns);
         _logger.LogWarning(
             "Antigravity: pending-turns queue full (capacity={Capacity}) — rejecting this input; "
           + "{RejectedCount} rejected this session so far (the turn worker is likely stuck on a "
           + "stalled turn).", _pendingTurnsCapacity, rejected);
 
-        EmitDaemonNotice(new AcpEventEnvelope(
+        var noticed = EmitDaemonNotice(new AcpEventEnvelope(
             Kind: AcpEventKind.SystemNote,
             Text: $"Your message was not delivered — this agent's input queue is full "
                 + $"({_pendingTurnsCapacity} waiting) while it works through an earlier message. "
                 + "Send it again once it catches up."));
+
+        // Escalated HERE rather than inside Write, because the drop only matters at this one call
+        // site: this note is the sole feedback the person who typed the message receives (the faulted
+        // send reaches the daemon's log, never their screen). Everywhere else a teardown-time drop is
+        // routine. Without this, the authoritative record would say "rejected" while staying silent
+        // about the user having been told nothing.
+        if (!noticed)
+            _logger.LogWarning(
+                "Antigravity: the queue-full notice for this input never reached the transcript (the "
+              + "channel had already completed), so the sender received no feedback at all.");
 
         var failure = new InvalidOperationException(
             $"Antigravity pending-turns queue is full (capacity {_pendingTurnsCapacity}); this input "
@@ -893,9 +912,12 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// <c>ActivitySeq</c> — the attempts to unstick it are what keep it from ever being reported idle.
     /// A reviewer is bounded by its TTL arm regardless; a hosted agent is not bounded at all.</para>
     /// </summary>
-    void EmitDaemonNotice(AcpEventEnvelope env) => Write(env, agentActivity: false);
+    /// <summary>Returns whether the notice actually reached the transcript, so a caller whose notice
+    /// is a user's ONLY feedback can say so when it did not. Ordinary agent output does not need
+    /// this — it is one of many envelopes, and losing one at teardown is unremarkable.</summary>
+    bool EmitDaemonNotice(AcpEventEnvelope env) => Write(env, agentActivity: false);
 
-    void Write(AcpEventEnvelope env, bool agentActivity) {
+    bool Write(AcpEventEnvelope env, bool agentActivity) {
         // Advance BEFORE the channel write, never after: a reader blocked on Envelopes.ReadAsync can
         // wake the instant TryWrite makes the item visible, on another thread, with no ordering
         // relationship to what this one does next — so the reverse order is a race a fast reader wins,
@@ -904,8 +926,14 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // path below: the content was genuinely produced.
         if (agentActivity) ActivityClock?.Advance();
 
-        if (!_transcript.Writer.TryWrite(env))
-            _logger.LogDebug("Antigravity: dropped a transcript envelope — the transcript channel is already completed.");
+        // Debug, not Warning, and deliberately: an envelope arriving after the channel closed is the
+        // ORDINARY shape of teardown — the turn worker is still draining agy's last lines while
+        // TerminateAsync completes the writer — so warning here would fire on every clean stop. A
+        // caller for whom the drop is actually meaningful escalates it itself, off this return value.
+        if (_transcript.Writer.TryWrite(env)) return true;
+
+        _logger.LogDebug("Antigravity: dropped a transcript envelope — the transcript channel is already completed.");
+        return false;
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -41,6 +41,13 @@ internal interface IAgyTurnDiagnostics {
 /// id, because the orchestrator reads <c>transcript.AcpSessionId</c> synchronously the moment a
 /// launch returns and would otherwise bind the transcript to <c>""</c> forever.</para>
 ///
+/// <para><b>One gate ladder, parameterised by launch shape</b> (<see cref="LaunchRefusal"/>). Platform,
+/// binary presence and the recorded build minimum gate BOTH shapes — they protect the isolated
+/// <c>HOME</c> above, which is not reviewer-specific. Operator CONSENT
+/// (<c>KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER</c>) gates only a review, because only a review is
+/// cross-principal; hosted Antigravity ships on by default like the other hosted vendors. Advertisement
+/// keeps the full ladder, consent included — advertising IS the offer to review unattended.</para>
+///
 /// <para><b>Auth is deliberately not an advertisement gate</b> (owner decision). The factory
 /// advertises whenever consent is given and the binary resolves; an operator whose only auth is an
 /// interactive <c>agy</c> login gets a bounded, coded launch failure naming the ADC remedy, rather
@@ -105,24 +112,30 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     public bool SupportsUnattended => DescribeUnattendedSupport().Supported;
 
     /// <summary>
-    /// The gate ladder, in ONE pass — consent, then platform, then binary presence. Consent is read
-    /// first so a daemon that has not opted in never touches the filesystem to decide.
+    /// Advertisement keeps the FULL ladder, consent included, because advertising is specifically an
+    /// offer to REVIEW unattended — the one thing the consent flag governs. A daemon that advertised
+    /// without consent would be offering exactly what its operator never opted into, and the server
+    /// refuses an unadvertised reviewer, so this is also the only seam that can withhold one.
     ///
     /// <para>Every refusal here carries a reason, because this vendor DOES offer unattended hosting:
     /// the <see langword="null"/> case in <see cref="UnattendedSupport"/> is for a vendor that never
     /// claimed it, which is not this one. The reason names the switch an operator can act on.</para>
     /// </summary>
     public UnattendedSupport DescribeUnattendedSupport() {
-        var withheld = ReviewerRefusal();
+        var withheld = LaunchRefusal(reviewFlow: true);
 
         return new(withheld is null, withheld);
     }
 
-    /// <summary>Why this daemon refuses an unattended Antigravity reviewer, or null when it does not.
-    /// The ONE place the ladder is written — advertisement and the launch boundary both read it, so a
-    /// vendor cannot be dropped from advertisement and thereby never reach the path that holds the
-    /// explanation, and the recorded MINIMUM cannot be enforced at only one of the two (an explicit
-    /// <c>vendor: "antigravity"</c> request reaches a launch without consulting advertisement).
+    /// <summary>Why this daemon refuses to launch <c>agy</c> for a launch of the given shape, or null
+    /// when it does not. The ONE place the ladder is written — advertisement and the launch boundary
+    /// both read it, so a vendor cannot be dropped from advertisement and thereby never reach the path
+    /// that holds the explanation, and the recorded MINIMUM cannot be enforced at only one of the two
+    /// (an explicit <c>vendor: "antigravity"</c> request reaches a launch without consulting
+    /// advertisement).
+    ///
+    /// <para><b>The two launch shapes differ in ONE arm, and it is a parameter rather than a second
+    /// ladder</b> — two ladders that must agree is a shape this file has already paid for once.</para>
     ///
     /// <para>Every verdict and every text comes from <see cref="AntigravityReviewerCapability"/>; the
     /// only arm written here is the one that decision cannot express — a binary that does not resolve
@@ -133,8 +146,27 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// removed) under it rather than read a startup snapshot — and, since the minimum is a record on
     /// disk rather than configuration, an affirmation taken while this daemon runs is picked up on the
     /// next decision.</para></summary>
-    internal string? ReviewerRefusal() {
+    /// <param name="reviewFlow">Whether this launch is an unattended review, which is the ONLY shape
+    /// the operator consent flag governs.
+    ///
+    /// <para><b>Consent is reviewer-only because its whole justification is cross-principal.</b> An
+    /// unattended reviewer runs under the daemon user's authority and returns what it read to whoever
+    /// requested the review — who need not be the operator. A hosted launch has no such exposure: the
+    /// server's daemon registry is keyed <c>(TeamId, OwnerUserId, Name)</c> and both daemon discovery
+    /// and the launch hub resolve a daemon with the CALLER's own normalized user id, so the launcher
+    /// IS the daemon's owner. Hosted Antigravity therefore ships on by default, like the other hosted
+    /// vendors, and a hosted launch on a consent-less daemon must not fail with a review complaint.
+    /// </para>
+    ///
+    /// <para><b>Every OTHER arm applies to both shapes</b> — platform, binary presence and the
+    /// recorded build minimum all exist to protect the per-launch isolated <c>HOME</c>, which a hosted
+    /// launch depends on exactly as a review does.</para></param>
+    internal string? LaunchRefusal(bool reviewFlow) {
         var posixHost = _posixHost;
+
+        // The one parameterised arm. `true` for a hosted launch means "consent is not a question
+        // here", so Decide's consent arm cannot fire and the ladder continues at platform.
+        var consented = !reviewFlow || config.AntigravityUnattendedReviewerEnabled;
 
         // Consent and platform decided with NO probe and NO filesystem read. Decide short-circuits
         // both before it looks at a version, but C# evaluates arguments first — so reading the record
@@ -144,8 +176,7 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         // installed side first), so that verdict is precisely "consent and platform passed", and the
         // ORDER between them stays owned by Decide rather than restated here.
         var beforeProbe = AntigravityReviewerCapability.Decide(
-            posixHost, config.AntigravityUnattendedReviewerEnabled,
-            installedVersion: null, minimumVersion: null);
+            posixHost, consented, installedVersion: null, minimumVersion: null);
 
         if (beforeProbe != AntigravityReviewerDecision.VersionUnresolved)
             return AntigravityReviewerCapability.DenialReason(
@@ -161,8 +192,7 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         var installed = _resolveVersion(config.AntigravityPath);
         var minimum   = VersionStoreFor(config).Affirmed;
 
-        var decision = AntigravityReviewerCapability.Decide(
-            posixHost, config.AntigravityUnattendedReviewerEnabled, installed, minimum);
+        var decision = AntigravityReviewerCapability.Decide(posixHost, consented, installed, minimum);
 
         return decision == AntigravityReviewerDecision.Allowed
             ? null
@@ -178,19 +208,21 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         new(ReviewerStateDir(config), DaemonRunner.AntigravityVendor);
 
     public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
-        // Applied to EVERY launch, interactive included — not just to review flows. Defence in depth
-        // for a review (the orchestrator's unattended gate runs first, but an explicit
-        // `vendor: "antigravity"` request can reach a factory without consulting advertisement), and
-        // the only gate at all for an interactive launch, whose vendor is advertised on binary
-        // presence alone. The build minimum in particular is not reviewer-specific: it exists because
-        // containment here is the per-launch isolated home below, which a hosted launch relies on
-        // exactly as a review does.
-        if (ReviewerRefusal() is { } refusal) throw new InvalidOperationException(refusal);
+        // ONE ladder, told which shape of launch it is judging. Every arm but consent applies to both
+        // — they protect the per-launch isolated home below, which a hosted launch relies on exactly
+        // as a review does. Defence in depth for a review (the orchestrator's unattended gate runs
+        // first, but an explicit `vendor: "antigravity"` request can reach a factory without
+        // consulting advertisement), and the whole gate for a hosted launch, whose vendor is
+        // advertised on binary presence alone.
+        if (LaunchRefusal(ctx.IsReviewFlow) is { } refusal) throw new InvalidOperationException(refusal);
 
+        // A property of THIS RUNTIME, not of reviews: there is no sandbox-exec substrate here, so
+        // nothing bounds what a launch could read out of a checkout it does not own. Worded for either
+        // shape — a borrowed request is review-only today, but the guard reads ctx.Work, not IsReviewFlow.
         if (ctx.Work != WorkLocation.OwnedWorktree)
             throw new InvalidOperationException(
-                "antigravity_reviewer_requires_owned_worktree: this runtime has no borrowed-review "
-              + "containment strategy, so a review must run in a daemon-owned worktree.");
+                "antigravity_reviewer_requires_owned_worktree: this runtime has no containment "
+              + "strategy for a borrowed workspace, so it runs only in a daemon-owned worktree.");
 
         // A blank agent id would still yield a non-empty server list and slip past a count-only guard,
         // so all three result-channel inputs are checked — a dead channel wedges the round.
@@ -212,7 +244,7 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
 
         var injected = AcpReviewFlowMcp.Build(ctx, allowlistServerIds);
 
-        LogLaunching(ctx.AgentId, ctx.Worktree.Path);
+        LogLaunching(ctx.AgentId, ctx.Worktree.Path, ctx.IsReviewFlow);
 
         // Created BEFORE any child exists, and owner-only from its first instant — the agent's own
         // conversation state lands in it. Its ABSENCE of a kcap plugin directory is what keeps capture
@@ -309,8 +341,8 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
             Exception cause, IAgyTurnProcess? firstTurn, CancellationToken callerToken, CancellationToken launchToken) {
         if (firstTurn is IAgyTurnDiagnostics { Diagnostics: { } diagnostics } && LooksLikeAuthFailure(diagnostics))
             return new InvalidOperationException(
-                "antigravity_reviewer_auth_unavailable: agy could not authenticate, and an unattended "
-              + "reviewer has no way to complete an interactive login (its stdin is closed). Give the "
+                "antigravity_reviewer_auth_unavailable: agy could not authenticate, and a daemon-hosted "
+              + "agy has no way to complete an interactive login (its stdin is closed). Give the "
               + "daemon durable credentials: `gcloud auth application-default login`, then "
               + "GOOGLE_CLOUD_PROJECT=<project> and AGY_ADC_AUTH=1 in the daemon's environment. A "
               + "supervised daemon installed before this shipped must be reinstalled to capture them.",
@@ -450,8 +482,9 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         return psi;
     }
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Antigravity reviewer launch: agentId={AgentId} cwd={Cwd}")]
-    partial void LogLaunching(string agentId, string cwd);
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Antigravity launch: agentId={AgentId} cwd={Cwd} reviewFlow={ReviewFlow}")]
+    partial void LogLaunching(string agentId, string cwd, bool reviewFlow);
 }
 
 /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -452,25 +452,14 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// <c>tool_info.error</c>. Nothing here should be read as the daemon-owned worktree confining what
     /// a hosted agent can see.</para>
     ///
-    /// <para><b>What Claude is, and is NOT, a precedent for.</b> It is the precedent for a SINGLE-AXIS
-    /// no-prompt posture existing at all: <c>--permission-mode bypassPermissions</c> is one flag with
-    /// nothing underneath it, already shipped, and grouped with this concept by
-    /// <see cref="IHostedAgentLauncher"/>'s own doc. Codex is not that analogue — its posture is two
-    /// independent axes (<c>Sandbox</c> × <c>Approval</c>), so a no-prompt Codex still sits on a
-    /// sandbox value, whereas this vendor and Claude each have one axis and no floor beneath it.
-    ///
-    /// <b>It is explicitly NOT a precedent for WHICH launch kind gets that posture — Claude's split
-    /// runs the other way.</b> <c>ClaudeLauncher.BuildArgs</c> adds the flag only inside its
-    /// <c>ctx.IsReviewFlow</c> branch (and not for a borrowed workspace), and
-    /// <c>ClaudeLauncher.DisablesApprovalPrompts</c> is
-    /// <c>ctx.IsReviewFlow &amp;&amp; ctx.Work == WorkLocation.OwnedWorktree</c> — its own comment
-    /// states that interactive launches always prompt. So Claude widens its REVIEWER and prompts on
-    /// its interactive agent, the mirror image of the split here, and for its own reason: a Claude
-    /// reviewer's writes are confined to a daemon-owned throwaway worktree, whereas an interactive
-    /// Claude has a human present to answer a dialog. This runtime has neither property — a hosted
-    /// <c>agy</c> turn is exec-per-turn with no dialog anyone could answer, and a soft-denied tool
-    /// still exits 0, so the agent merely looks broken. Do NOT "align with the precedent" by moving
-    /// this flag onto the reviewer arm; that is the exact direction the split exists to prevent.</para>
+    /// <para><b>Claude is a precedent for a single-axis no-prompt posture existing, NOT for which
+    /// launch kind gets it.</b> Codex is not the analogue — its posture is two axes
+    /// (<c>Sandbox</c> × <c>Approval</c>), so a no-prompt Codex still sits on a sandbox. But Claude's
+    /// own split runs the OTHER way: <c>ClaudeLauncher.BuildArgs</c> adds
+    /// <c>bypassPermissions</c> only under <c>ctx.IsReviewFlow</c>, because its reviewer writes into a
+    /// throwaway worktree while its interactive agent has a human to answer the dialog. This runtime
+    /// has neither property. Do not "align with the precedent" by moving this flag to the reviewer
+    /// arm — that is the direction the split exists to prevent.</para>
     ///
     /// <para><b>What is deliberately absent.</b> No <c>--dangerously-skip-permissions</c> for a
     /// reviewer: it runs in a daemon-OWNED worktree and needs only to read it, which agy's headless

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -28,11 +28,13 @@ internal interface IAgyTurnDiagnostics {
 /// review-flow reviewer and an interactive hosted agent — over the exec-per-turn
 /// <see cref="AntigravityHostedAgentRuntime"/>.
 ///
-/// <para><b>The two launch shapes differ in exactly one argument</b>
-/// (<c>--dangerously-skip-permissions</c>, hosted only; see <see cref="BuildTurnPsi"/>) and in nothing
-/// else. In particular the per-launch isolated <c>HOME</c> is NOT reviewer-only: this runtime is
-/// itself the transcript source, so a launch under the operator's own home is captured a second time
-/// by the hook lane — isolation removes a duplicate rather than removing capture.</para>
+/// <para><b>The two launch shapes differ in exactly two things:</b> one argument
+/// (<c>--dangerously-skip-permissions</c>, hosted only; see <see cref="BuildTurnPsi"/>) and the
+/// injected MCP surface (the <c>kcap-flow-result</c> channel plus the flow definition's allowlist,
+/// review only; see <see cref="BuildReviewFlowMcp"/>). In particular the per-launch isolated
+/// <c>HOME</c> is NOT reviewer-only: this runtime is itself the transcript source, so a launch under
+/// the operator's own home is captured a second time by the hook lane — isolation removes a duplicate
+/// rather than removing capture.</para>
 ///
 /// <para><b>What this factory owns that the runtime deliberately does not:</b> the argv and
 /// environment of every turn child, the per-launch isolated <c>HOME</c> (and its removal), the
@@ -224,25 +226,23 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
                 "antigravity_reviewer_requires_owned_worktree: this runtime has no containment "
               + "strategy for a borrowed workspace, so it runs only in a daemon-owned worktree.");
 
-        // A blank agent id would still yield a non-empty server list and slip past a count-only guard,
-        // so all three result-channel inputs are checked — a dead channel wedges the round.
-        if (string.IsNullOrWhiteSpace(ctx.ServerUrl) || string.IsNullOrWhiteSpace(ctx.CapacitorPath)
-         || string.IsNullOrWhiteSpace(ctx.AgentId))
-            throw new InvalidOperationException(
-                "antigravity_reviewer_result_channel_incomplete: cannot inject the kcap-flow-result "
-              + "channel (missing server url / kcap path / agent id).");
-
         // Canonical wire names: agy's MCP surface is the file this launch writes, not a name-matched
         // allowlist the reviewed repository could impersonate an entry in, so the per-launch aliasing
-        // Gemini and Kiro need buys nothing here.
+        // Gemini and Kiro need buys nothing here. Overwritten for BOTH shapes, so a caller-supplied
+        // identity can never reach a launch of either kind.
         ctx = ctx with { LaunchIdentity = LaunchIdentity.ForLaunch(aliasResultChannel: false) };
 
-        if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(ctx.McpAllowlist, out var allowlistServerIds, out var rejected))
-            throw new InvalidOperationException(
-                $"antigravity_reviewer_mcp_allowlist_rejected: '{rejected}' is not an auto-approvable "
-              + "read-only server.");
-
-        var injected = AcpReviewFlowMcp.Build(ctx, allowlistServerIds);
+        // Both the result channel AND its fail-closed validation are review-only — the same split
+        // AcpHostedAgentRuntimeFactory.ValidateAndBuildReviewFlowMcp draws. A hosted agent has no flow
+        // to report to, so injecting kcap-flow-result would hand it a tool it can only call
+        // meaninglessly, and validating that channel's inputs would refuse a hosted launch for a
+        // channel it never needed. The allowlist is the review-flow DEFINITION's, so its rejection is
+        // review-only for the same reason.
+        //
+        // The hosted arm forwards ctx.McpServers, mirroring the ACP factory's hosted arm. No caller
+        // populates that field today (see its comment on RuntimeStartContext), so a hosted launch's
+        // surface is empty — deliberately, because nothing is offered, rather than by a drop here.
+        var injected = ctx.IsReviewFlow ? BuildReviewFlowMcp(ctx) : ctx.McpServers ?? [];
 
         LogLaunching(ctx.AgentId, ctx.Worktree.Path, ctx.IsReviewFlow);
 
@@ -329,6 +329,31 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         // INSIDE the home, and the home's own disposal owns it — reporting it separately would have
         // the orchestrator delete a file out of a directory it knows nothing about.
         return new HostedRuntimeStart(runtime, McpConfigPath: null, Transcript: runtime);
+    }
+
+    /// <summary>The reviewer's injected MCP surface — the <c>kcap-flow-result</c> submit channel plus
+    /// the flow definition's allowlist — or a throw naming what makes it undeliverable. Called for a
+    /// review flow ONLY: every refusal in here describes a review, and a hosted launch that hit one
+    /// would be refused for machinery it has no use for.
+    ///
+    /// <para>Fails closed rather than launching a reviewer with a missing or partial channel: such a
+    /// reviewer starts, runs and can never report, so the flow waits for a verdict that cannot
+    /// arrive.</para></summary>
+    static IReadOnlyList<AcpMcpServerSpec> BuildReviewFlowMcp(RuntimeStartContext ctx) {
+        // A blank agent id would still yield a non-empty server list and slip past a count-only guard,
+        // so all three result-channel inputs are checked — a dead channel wedges the round.
+        if (string.IsNullOrWhiteSpace(ctx.ServerUrl) || string.IsNullOrWhiteSpace(ctx.CapacitorPath)
+         || string.IsNullOrWhiteSpace(ctx.AgentId))
+            throw new InvalidOperationException(
+                "antigravity_reviewer_result_channel_incomplete: cannot inject the kcap-flow-result "
+              + "channel (missing server url / kcap path / agent id).");
+
+        if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(ctx.McpAllowlist, out var allowlistServerIds, out var rejected))
+            throw new InvalidOperationException(
+                $"antigravity_reviewer_mcp_allowlist_rejected: '{rejected}' is not an auto-approvable "
+              + "read-only server.");
+
+        return AcpReviewFlowMcp.Build(ctx, allowlistServerIds);
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -28,13 +28,18 @@ internal interface IAgyTurnDiagnostics {
 /// review-flow reviewer and an interactive hosted agent — over the exec-per-turn
 /// <see cref="AntigravityHostedAgentRuntime"/>.
 ///
-/// <para><b>The two launch shapes differ in exactly two things:</b> one argument
+/// <para><b>The two launch shapes it SERVES differ in exactly two things:</b> one argument
 /// (<c>--dangerously-skip-permissions</c>, hosted only; see <see cref="BuildTurnPsi"/>) and the
 /// injected MCP surface (the <c>kcap-flow-result</c> channel plus the flow definition's allowlist,
 /// review only; see <see cref="BuildReviewFlowMcp"/>). In particular the per-launch isolated
 /// <c>HOME</c> is NOT reviewer-only: this runtime is itself the transcript source, so a launch under
 /// the operator's own home is captured a second time by the hook lane — isolation removes a duplicate
 /// rather than removing capture.</para>
+///
+/// <para><b>The context carries a THIRD, which this factory refuses.</b> <c>LaunchKind.Review</c> (a
+/// PR review, <c>ctx.IsReview</c>) is neither of the above and shares the hosted arm's
+/// <c>!IsReviewFlow</c> predicate, so it is rejected at the top of <see cref="StartAsync"/> with
+/// <c>antigravity_pr_review_unsupported</c> rather than served degraded — see the guard for why.</para>
 ///
 /// <para><b>What this factory owns that the runtime deliberately does not:</b> the argv and
 /// environment of every turn child, the per-launch isolated <c>HOME</c> (and its removal), the
@@ -210,6 +215,21 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         new(ReviewerStateDir(config), DaemonRunner.AntigravityVendor);
 
     public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+        // A THIRD launch shape. Everything hosted below keys off !ctx.IsReviewFlow, which is true for
+        // LaunchKind.Default AND LaunchKind.Review — so without this a PR-review launch takes the
+        // hosted arm and runs with --dangerously-skip-permissions, an EMPTY MCP surface and no review
+        // system prompt, because only PtyHostedAgentRuntimeFactory builds LauncherContext.ReviewLaunch
+        // (the `kcap mcp review` config and that prompt). A PR-review agent silently missing every
+        // review tool is worse than none; refuse it.
+        //
+        // FIRST, ahead of the containment ladder: no install, affirmation or consent can make this
+        // shape work, so an operator should read that rather than a remedy that would not help.
+        if (ctx.IsReview)
+            throw new InvalidOperationException(
+                "antigravity_pr_review_unsupported: this runtime hosts interactive agents and "
+              + "review-flow reviewers only. A PR review needs the `kcap mcp review` tool surface and "
+              + "review prompt, which only the PTY launchers build — launch the PR review with Claude.");
+
         // ONE ladder, told which shape of launch it is judging. Every arm but consent applies to both
         // — they protect the per-launch isolated home below, which a hosted launch relies on exactly
         // as a review does. Defence in depth for a review (the orchestrator's unattended gate runs
@@ -430,11 +450,27 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// worktree is not:</b> measured on agy 1.1.10, with it an absolute <c>view_file</c> of a path
     /// OUTSIDE the workspace succeeds, and without it the same read is refused with a typed
     /// <c>tool_info.error</c>. Nothing here should be read as the daemon-owned worktree confining what
-    /// a hosted agent can see. The precedent is Claude, which passes <c>--permission-mode
-    /// bypassPermissions</c> — one axis, already shipped, and grouped with this concept by
-    /// <see cref="IHostedAgentLauncher"/>'s own doc. Codex is NOT the analogue: its posture is two
-    /// independent axes, so a no-prompt Codex still sits on a sandbox value, whereas this vendor has
-    /// one axis with nothing underneath it.</para>
+    /// a hosted agent can see.</para>
+    ///
+    /// <para><b>What Claude is, and is NOT, a precedent for.</b> It is the precedent for a SINGLE-AXIS
+    /// no-prompt posture existing at all: <c>--permission-mode bypassPermissions</c> is one flag with
+    /// nothing underneath it, already shipped, and grouped with this concept by
+    /// <see cref="IHostedAgentLauncher"/>'s own doc. Codex is not that analogue — its posture is two
+    /// independent axes (<c>Sandbox</c> × <c>Approval</c>), so a no-prompt Codex still sits on a
+    /// sandbox value, whereas this vendor and Claude each have one axis and no floor beneath it.
+    ///
+    /// <b>It is explicitly NOT a precedent for WHICH launch kind gets that posture — Claude's split
+    /// runs the other way.</b> <c>ClaudeLauncher.BuildArgs</c> adds the flag only inside its
+    /// <c>ctx.IsReviewFlow</c> branch (and not for a borrowed workspace), and
+    /// <c>ClaudeLauncher.DisablesApprovalPrompts</c> is
+    /// <c>ctx.IsReviewFlow &amp;&amp; ctx.Work == WorkLocation.OwnedWorktree</c> — its own comment
+    /// states that interactive launches always prompt. So Claude widens its REVIEWER and prompts on
+    /// its interactive agent, the mirror image of the split here, and for its own reason: a Claude
+    /// reviewer's writes are confined to a daemon-owned throwaway worktree, whereas an interactive
+    /// Claude has a human present to answer a dialog. This runtime has neither property — a hosted
+    /// <c>agy</c> turn is exec-per-turn with no dialog anyone could answer, and a soft-denied tool
+    /// still exits 0, so the agent merely looks broken. Do NOT "align with the precedent" by moving
+    /// this flag onto the reviewer arm; that is the exact direction the split exists to prevent.</para>
     ///
     /// <para><b>What is deliberately absent.</b> No <c>--dangerously-skip-permissions</c> for a
     /// reviewer: it runs in a daemon-OWNED worktree and needs only to read it, which agy's headless

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -24,8 +24,15 @@ internal interface IAgyTurnDiagnostics {
 }
 
 /// <summary>
-/// <see cref="IHostedAgentRuntimeFactory"/> for Antigravity's CLI (<c>agy</c>) as an unattended
-/// review-flow reviewer, over the exec-per-turn <see cref="AntigravityHostedAgentRuntime"/>.
+/// <see cref="IHostedAgentRuntimeFactory"/> for Antigravity's CLI (<c>agy</c>) — both an unattended
+/// review-flow reviewer and an interactive hosted agent — over the exec-per-turn
+/// <see cref="AntigravityHostedAgentRuntime"/>.
+///
+/// <para><b>The two launch shapes differ in exactly one argument</b>
+/// (<c>--dangerously-skip-permissions</c>, hosted only; see <see cref="BuildTurnPsi"/>) and in nothing
+/// else. In particular the per-launch isolated <c>HOME</c> is NOT reviewer-only: this runtime is
+/// itself the transcript source, so a launch under the operator's own home is captured a second time
+/// by the hook lane — isolation removes a duplicate rather than removing capture.</para>
 ///
 /// <para><b>What this factory owns that the runtime deliberately does not:</b> the argv and
 /// environment of every turn child, the per-launch isolated <c>HOME</c> (and its removal), the
@@ -171,20 +178,13 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         new(ReviewerStateDir(config), DaemonRunner.AntigravityVendor);
 
     public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
-        // An interactive launch is refused rather than silently accepted. This runtime parses agy's
-        // NDJSON from stdout once per turn, and an inherited HOME lets agy's own kcap capture hooks
-        // fire — which spawns a watcher that can hold a write end of that stdout open after agy exits,
-        // so every turn would block forever with no visible cause. The isolated home below is what
-        // makes that unreachable, and it is a reviewer-only construct today.
-        if (!ctx.IsReviewFlow)
-            throw new InvalidOperationException(
-                "antigravity_interactive_launch_unsupported: the Antigravity runtime hosts unattended "
-              + "review-flow reviewers only. An interactive launch would run under the operator's own "
-              + "HOME, where agy's capture hooks fire and can hold this runtime's stdout open after the "
-              + "turn exits.");
-
-        // Defence in depth: the orchestrator's unattended gate runs first, but an explicit
-        // `vendor: "antigravity"` request can reach a factory without consulting advertisement.
+        // Applied to EVERY launch, interactive included — not just to review flows. Defence in depth
+        // for a review (the orchestrator's unattended gate runs first, but an explicit
+        // `vendor: "antigravity"` request can reach a factory without consulting advertisement), and
+        // the only gate at all for an interactive launch, whose vendor is advertised on binary
+        // presence alone. The build minimum in particular is not reviewer-specific: it exists because
+        // containment here is the per-launch isolated home below, which a hosted launch relies on
+        // exactly as a review does.
         if (ReviewerRefusal() is { } refusal) throw new InvalidOperationException(refusal);
 
         if (ctx.Work != WorkLocation.OwnedWorktree)
@@ -214,9 +214,14 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
 
         LogLaunching(ctx.AgentId, ctx.Worktree.Path);
 
-        // Created BEFORE any child exists, and owner-only from its first instant — the reviewer's own
+        // Created BEFORE any child exists, and owner-only from its first instant — the agent's own
         // conversation state lands in it. Its ABSENCE of a kcap plugin directory is what keeps capture
-        // single-lane; the injected mcp_config.json is the reviewer's whole MCP surface.
+        // single-lane; the injected mcp_config.json is the agent's whole MCP surface.
+        //
+        // Kept for interactive launches too, and for the capture reason rather than a stdout one:
+        // measured, a run under the operator's real HOME is recorded a SECOND time by the hook lane as
+        // its own watcher session, while this runtime is already the transcript source. An inherited
+        // HOME would duplicate capture, not add it.
         var stateDir = ReviewerStateDir(config);
         var home     = AntigravityReviewerHome.Create(
             stateDir, config.DaemonEpoch ?? "unpinned", ctx.AgentId, injected, _logger);
@@ -361,12 +366,25 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// spawn path and the launch tests both go through it, so an assertion here certifies the vector
     /// the OS actually receives rather than a re-derivation of it.
     ///
-    /// <para><b>What is deliberately absent.</b> No <c>--dangerously-skip-permissions</c>: the
-    /// reviewer runs in a daemon-OWNED worktree and needs only to read it, which agy's headless
+    /// <para><b>The one asymmetry between a hosted agent and a reviewer</b> is
+    /// <c>--dangerously-skip-permissions</c>, added on the hosted arm only. A hosted agent exists to DO
+    /// work, and without it agy's shell and out-of-workspace operations soft-deny while the run still
+    /// exits 0 — so the agent merely looks broken. <b>That flag is also the read boundary, and the
+    /// worktree is not:</b> measured on agy 1.1.10, with it an absolute <c>view_file</c> of a path
+    /// OUTSIDE the workspace succeeds, and without it the same read is refused with a typed
+    /// <c>tool_info.error</c>. Nothing here should be read as the daemon-owned worktree confining what
+    /// a hosted agent can see. The precedent is Claude, which passes <c>--permission-mode
+    /// bypassPermissions</c> — one axis, already shipped, and grouped with this concept by
+    /// <see cref="IHostedAgentLauncher"/>'s own doc. Codex is NOT the analogue: its posture is two
+    /// independent axes, so a no-prompt Codex still sits on a sandbox value, whereas this vendor has
+    /// one axis with nothing underneath it.</para>
+    ///
+    /// <para><b>What is deliberately absent.</b> No <c>--dangerously-skip-permissions</c> for a
+    /// reviewer: it runs in a daemon-OWNED worktree and needs only to read it, which agy's headless
     /// defaults already permit — its soft-deny of shell and out-of-workspace operations IS the desired
     /// unattended posture, and widening it would grant a reviewer shell access it has no reason to
-    /// hold. No <c>--sandbox</c>: a vendor-side terminal restriction overlapping what containment
-    /// already provides, and unprobed.</para>
+    /// hold. No <c>--sandbox</c> on either arm: a vendor-side terminal restriction overlapping what
+    /// containment already provides, and unprobed.</para>
     ///
     /// <para><c>--print-timeout</c> is passed on EVERY invocation rather than relying on agy's own
     /// <c>5m0s</c> default — a vendor change would otherwise silently move a bound we did not
@@ -377,9 +395,15 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         var argv = new List<string> {
             "-p", prompt,
             "--output-format", "stream-json",
-            "--disable-slash-commands",
-            "--print-timeout", $"{Math.Max(1, config.AntigravityReviewerTurnTimeoutSeconds)}s"
+            "--disable-slash-commands"
         };
+
+        // Hosted only, never a reviewer — see this method's doc for what the flag does and does not
+        // bound. Passed unconditionally on that arm: no caller input selects it.
+        if (!ctx.IsReviewFlow) argv.Add("--dangerously-skip-permissions");
+
+        argv.Add("--print-timeout");
+        argv.Add($"{Math.Max(1, config.AntigravityReviewerTurnTimeoutSeconds)}s");
 
         // Absent on turn 1 (there is nothing to resume yet) and present on every turn after it — this
         // is what makes a multi-round review land as ONE conversation rather than one per round.

--- a/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
+++ b/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
@@ -20,6 +20,10 @@ namespace Capacitor.Cli.Commands;
 /// <para>Deliberately does NOT enable the reviewer. Affirming a build and consenting to unattended
 /// review are separate decisions, and collapsing them would let an upgrade acknowledgement silently
 /// turn the feature on.</para>
+///
+/// <para>The converse does not hold uniformly either: <c>antigravity</c>'s floor is seeded WITHOUT a
+/// consent event, because it also gates hosted <c>agy</c> launches. That leaves one window this verb
+/// is the remedy for — see the per-vendor exception on <see cref="ReviewerVersionStore"/>.</para>
 /// </summary>
 public static class DaemonReviewerCommand {
     public static Task<int> HandleAsync(string[] args) {

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
@@ -27,7 +27,7 @@ public class AntigravityReviewerCapabilityTests {
     /// Pins a cross-file assumption the factory's ladder is BUILT on but does not own: with neither
     /// version known, the verdict must be <see cref="AntigravityReviewerDecision.VersionUnresolved"/>.
     ///
-    /// <para><c>ReviewerRefusal</c> calls <c>Decide(posix, enabled, null, null)</c> as a probe-free
+    /// <para><c>LaunchRefusal</c> calls <c>Decide(posix, consented, null, null)</c> as a probe-free
     /// pre-check and treats exactly that arm as "consent and platform are fine, keep going" — the
     /// binary-missing check and the version probe both sit AFTER it. The arm depends on
     /// <c>ReviewerVersionAffirmations.Decide</c> testing the installed version before the minimum,
@@ -190,16 +190,25 @@ public class AntigravityReviewerCapabilityTests {
         await Assert.That(reason).Contains("agy");
     }
 
-    /// <summary>The most common misconfiguration — enabling the reviewer against an already-running
-    /// daemon, which seeds its record at startup — so the remedy names BOTH the restart and the verb
-    /// that avoids one.</summary>
+    /// <summary>
+    /// The remedy names BOTH the restart (a daemon seeds its record at startup) and the verb that
+    /// avoids one.
+    ///
+    /// <para><b>And it must NOT name the reviewer consent flag.</b> This arm gates hosted launches as
+    /// well as reviews — the floor protects the per-launch isolated home, which is not a reviewer
+    /// concern — so pointing a hosted operator at <c>KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER</c> would
+    /// send them to a switch that has no bearing on their launch. It is also no longer true even for a
+    /// reviewer: the daemon now seeds this vendor's floor whenever <c>agy</c> resolves, consent or
+    /// not.</para>
+    /// </summary>
     [Test]
     public async Task TheNoMinimumReason_SendsTheOperatorToARestartOrTheAffirmVerb() {
         var reason = Reason(AntigravityReviewerDecision.VersionNoMinimum, "1.1.10", null);
 
         await Assert.That(reason).StartsWith("antigravity_reviewer_version_no_minimum");
-        await Assert.That(reason).Contains("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
+        await Assert.That(reason).Contains("restart");
         await Assert.That(reason).Contains("kcap daemon reviewer affirm --vendor antigravity");
+        await Assert.That(reason).DoesNotContain("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorLocalAttachTests.cs
@@ -456,16 +456,69 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(ids).DoesNotContain("priv-1");
     }
 
+    /// <summary>
+    /// A runtime that emits no terminal output has nothing for a terminal to attach TO — its stdout
+    /// is protocol traffic (agy's NDJSON, ACP's JSON-RPC), never bytes to paint. Attaching anyway
+    /// gave the user a blank screen that never repaints and only admits the problem if they type
+    /// (the raw-input refusal below), which reads exactly like the daemon hanging. The refusal has to
+    /// be named, immediate, and identify the vendor, so it points at the dashboard rather than at
+    /// `kcap daemon logs`.
+    ///
+    /// <para>Enforced on the DAEMON side, not in the CLI: `kcap agent attach` sends a full agent id
+    /// verbatim without ever fetching the agent table, and that table's row format is column-count
+    /// validated, so the client genuinely cannot know the vendor without a wire change. The daemon
+    /// holds the runtime and can simply ask it.</para>
+    /// </summary>
     [Test]
-    public async Task Attach_to_an_ACP_runtime_gets_an_error_frame_and_detaches_instead_of_crashing() {
+    [Arguments("antigravity")]
+    [Arguments("cursor")]
+    public async Task Attach_to_a_runtime_with_no_terminal_is_refused_by_name(string vendor) {
         var server = new CaptureServerConnection();
         await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
 
-        // A cursor/ACP-backed agent: SendRawInputAsync throws NotSupportedException, exactly like
-        // the real AcpHostedAgentRuntime (local attach is a PTY-only surface).
-        var runtime = new NoRawInputRuntime("cursor");
+        var runtime = new NoRawInputRuntime(vendor);
         var agent = new AgentInstance(
-            "acp-1", null, "", null, "/r", "cursor",
+            "hosted-1", null, "", null, "/r", vendor,
+            runtime, new WorktreeInfo("/r", "", "/r", IsStandalone: true), new CancellationTokenSource()
+        );
+        orch.RegisterAgentForTest(agent);
+
+        // A client that sends nothing and never closes: if the handler attached instead of refusing,
+        // it would sit in its read loop until the token fires rather than returning promptly — which
+        // is the hang this refusal exists to prevent, and is what the bounded wait below detects.
+        using var client = new DuplexTestStream(new NeverEndingStream(), new MemoryStream());
+        using var cts    = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await orch.HandleLocalAttachAsync("hosted-1", client, cts.Token).WaitAsync(TimeSpan.FromSeconds(5));
+
+        client.WrittenStream.Position = 0;
+        var frames = new List<LocalFrame>();
+        while (await FrameCodec.ReadAsync(client.WrittenStream, default) is { } f) frames.Add(f);
+
+        // Refused BEFORE attaching — never a blank Attached screen the user has to guess about.
+        await Assert.That(frames.Any(f => f.Type is FrameType.Attached or FrameType.AttachedReadOnly)).IsFalse();
+
+        var error = frames.SingleOrDefault(f => f.Type == FrameType.Error);
+        await Assert.That(error).IsNotNull();
+        await Assert.That(error!.Text).Contains(vendor);
+        await Assert.That(error.Text).Contains("no terminal to attach to");
+        await Assert.That(error.Text).Contains("dashboard");
+
+        // The agent itself is untouched — a refused attach must not stop or dispose the runtime.
+        await Assert.That(runtime.Disposed).IsFalse();
+    }
+
+    [Test]
+    public async Task Attach_to_a_terminal_runtime_that_rejects_raw_input_gets_an_error_frame_instead_of_crashing() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        // Claims a terminal (so the refusal above does not apply) but throws NotSupportedException on
+        // raw input — the defence-in-depth path, still reachable for any runtime whose two answers
+        // disagree.
+        var runtime = new NoRawInputRuntime("claude", emitsTerminalOutput: true);
+        var agent = new AgentInstance(
+            "pty-1", null, "", null, "/r", "claude",
             runtime, new WorktreeInfo("/r", "", "/r", IsStandalone: true), new CancellationTokenSource()
         );
         orch.RegisterAgentForTest(agent);
@@ -480,7 +533,7 @@ public partial class AgentOrchestratorVendorTests {
         // Must complete (not throw) within a bounded time — the bug this guards against was an
         // unhandled NotSupportedException escaping the read loop and crashing the attach handler.
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await orch.HandleLocalAttachAsync("acp-1", client, cts.Token);
+        await orch.HandleLocalAttachAsync("pty-1", client, cts.Token);
 
         // Replay the frames the client received off the write side of the duplex stream.
         client.WrittenStream.Position = 0;
@@ -497,16 +550,40 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(runtime.Disposed).IsFalse();
     }
 
+    /// <summary>A read side that never yields a byte and never EOFs — an attached client that is
+    /// simply sitting there. Any handler that attaches instead of refusing stays parked in its read
+    /// loop on this, which is what turns "refused promptly" into an assertable difference rather than
+    /// a frame-content-only one.</summary>
+    sealed class NeverEndingStream : Stream {
+        public override bool CanRead  => true;
+        public override bool CanWrite => false;
+        public override bool CanSeek  => false;
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default) {
+            await Task.Delay(Timeout.Infinite, ct);
+            return 0;
+        }
+
+        public override int  Read(byte[] b, int o, int c) { Task.Delay(Timeout.Infinite).Wait(); return 0; }
+        public override void Write(byte[] b, int o, int c) => throw new NotSupportedException();
+        public override void Flush()                       { }
+        public override long Length                        => throw new NotSupportedException();
+        public override long Position { get => 0; set { } }
+        public override long Seek(long o, SeekOrigin s)    => throw new NotSupportedException();
+        public override void SetLength(long v)             => throw new NotSupportedException();
+    }
+
     /// <summary>Minimal <see cref="IHostedAgentRuntime"/> double mirroring AcpHostedAgentRuntime's
-    /// contract: no raw-input surface (throws NotSupportedException), never emits terminal output.</summary>
-    sealed class NoRawInputRuntime(string vendor) : IHostedAgentRuntime {
+    /// contract: no raw-input surface (throws NotSupportedException), and — unless a test says
+    /// otherwise — no terminal output either.</summary>
+    sealed class NoRawInputRuntime(string vendor, bool emitsTerminalOutput = false) : IHostedAgentRuntime {
         public bool Disposed { get; private set; }
 
         public string Vendor              => vendor;
         public int    Pid                 => 4242;
         public bool   HasExited           => false;
         public int?   ExitCode            => null;
-        public bool   EmitsTerminalOutput => false;
+        public bool   EmitsTerminalOutput => emitsTerminalOutput;
 
 #pragma warning disable CS1998
         public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken ct = default) {
@@ -523,6 +600,66 @@ public partial class AgentOrchestratorVendorTests {
         public Task TerminateAsync(TimeSpan?    timeout = null) => Task.CompletedTask;
 
         public ValueTask DisposeAsync() { Disposed = true; return default; }
+    }
+
+    /// <summary>
+    /// Reachability, not just handler behaviour: the refusal above is only worth anything if an
+    /// actual <c>kcap agent attach</c> reaches it. This drives the real Unix socket and the real
+    /// <see cref="LocalControlServer"/> frame routing with the same <see cref="FrameType.Attach"/>
+    /// frame the CLI sends, and asserts the client gets ONE Error frame and the connection closes —
+    /// which is exactly the shape <c>LocalAgentClient</c>'s Error branch prints and exits 1 on
+    /// (shared with every other daemon refusal, e.g. the review-agent stop protection).
+    /// </summary>
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Attach_over_the_real_socket_refuses_a_hosted_agent_with_no_terminal() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        var sockDir = Directory.CreateTempSubdirectory("kcap-sock-");
+        DaemonLockPaths.OverrideDirectoryForTesting(sockDir.FullName);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        LocalControlServer? listener = null;
+        AgentOrchestrator?  orch     = null;
+
+        try {
+            var server = new CaptureServerConnection();
+            orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+            orch.RegisterAgentForTest(new AgentInstance(
+                "agy-xyz", null, "", null, "/tmp/repo", "antigravity",
+                new NoRawInputRuntime("antigravity"), new WorktreeInfo("/tmp/repo", "", "/tmp/repo"), new CancellationTokenSource()
+            ) {
+                Work = WorkLocation.OwnedWorktree, Status = "Running"
+            });
+
+            var config = new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" };
+            listener = new LocalControlServer(config, orch, TestCoordinator(), TestConsentIpc(), TestStatusIpc(config, orch, server), NullLogger<LocalControlServer>.Instance);
+            await listener.StartAsync(cts.Token);
+
+            var sockPath = LocalSocketPaths.Socket("test");
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (!File.Exists(sockPath) && DateTime.UtcNow < deadline) await Task.Delay(20, cts.Token);
+            await Assert.That(File.Exists(sockPath)).IsTrue();
+
+            using var sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            await sock.ConnectAsync(new UnixDomainSocketEndPoint(sockPath), cts.Token);
+            await using var stream = new NetworkStream(sock, ownsSocket: false);
+
+            await FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.Attach) { Text = "agy-xyz" }, cts.Token);
+
+            // Bounded: an unrefused attach would hold this connection open with no reply at all,
+            // which is the hang the refusal replaces.
+            var resp = await FrameCodec.ReadAsync(stream, cts.Token).WaitAsync(TimeSpan.FromSeconds(5), cts.Token);
+
+            await Assert.That(resp!.Type).IsEqualTo(FrameType.Error);
+            await Assert.That(resp.Text).Contains("antigravity");
+            await Assert.That(resp.Text).Contains("no terminal to attach to");
+        } finally {
+            if (orch is not null) await orch.DisposeAsync();
+            if (listener is not null) { await listener.StopAsync(CancellationToken.None); listener.Dispose(); }
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(sockDir.FullName, true); } catch { /* best-effort */ }
+        }
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerAntigravityFloorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerAntigravityFloorTests.cs
@@ -129,6 +129,71 @@ public class DaemonRunnerAntigravityFloorTests {
         }
     }
 
+    /// <summary>
+    /// <b>The half of the hosted-launch fix that lives in the daemon rather than the factory.</b>
+    /// Antigravity's floor gates hosted launches too, and those need no reviewer consent — so a
+    /// consent-less daemon must still SEED a floor. Seeded from the consent event (as Kiro and Gemini
+    /// are) it never would, and every hosted launch on such a daemon would refuse as
+    /// <c>version_no_minimum</c>: the consent gate removed from the front of the ladder and quietly
+    /// reinstated behind it.
+    ///
+    /// <para>Asserted through a real hosted <c>StartAsync</c> reaching PAST the ladder rather than by
+    /// reading the record back, which would only re-derive the writer's own answer. The observable is
+    /// that a turn child was REQUESTED — the first thing beyond the gate — and not the launch's
+    /// outcome: <c>StartAsync</c> wraps everything after the gate in its own coded
+    /// <c>InvalidOperationException</c>, so a thrown sentinel is indistinguishable from a refusal,
+    /// while a turn source that was never called is exactly what a refusal looks like.</para>
+    /// </summary>
+    [Test]
+    public async Task AConsentLessDaemonSeedsTheFloorThatAdmitsAHostedLaunch() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary below is a POSIX shell script.");
+
+        var stub = await StubAgyAsync("1.1.10");
+
+        try {
+            var config = Config(minimum: null);
+            config.AntigravityPath                      = stub;
+            config.AntigravityUnattendedReviewerEnabled = false;
+
+            // Restated rather than taken from the factory: this is the shape RunAsync computes.
+            var stateDir = Path.Combine(config.StateDir!, DaemonLockPaths.Sanitize(config.Name));
+
+            DaemonRunner.SeedVersionFloor(stateDir, DaemonRunner.AntigravityVendor, stub);
+
+            var spawned = false;
+            var factory = new AntigravityHostedAgentRuntimeFactory(
+                config, NullLoggerFactory.Instance,
+                turnSource: (_, _) => {
+                    spawned = true;
+                    throw new NotSupportedException("the launch itself is not what this test is about");
+                });
+
+            try {
+                await factory.StartAsync(HostedCtx(), CancellationToken.None);
+            } catch (InvalidOperationException) {
+                // Expected: the turn source above cannot produce a conversation.
+            }
+
+            await Assert.That(spawned).IsTrue();
+
+            // The control: consent is still withheld, so the REVIEWER is still not advertised. Without
+            // it, seeding having somehow re-enabled the reviewer would read as a pass.
+            await Assert.That(factory.SupportsUnattended).IsFalse();
+        } finally {
+            File.Delete(stub);
+        }
+    }
+
+    static RuntimeStartContext HostedCtx() => new(
+        AgentId: "agent-1", Vendor: "antigravity", SourceRepoPath: "/repo",
+        Worktree: new WorktreeInfo(Path: Path.GetTempPath(), Branch: "b", SourceRepo: "/repo"),
+        Prompt: "do the thing",
+        Model: null, Effort: null, Tools: null,
+        IsReview: false, IsReviewFlow: false, Review: null,
+        Cols: 80, Rows: 24,
+        ServerUrl: "http://kcap.test", DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap",
+        DaemonId: "daemon-1", DaemonEpoch: "epoch-1");
+
     static async Task<string> StubAgyAsync(string version) {
         var stub = Path.Combine(Path.GetTempPath(), "kcap-agy-stub-" + Guid.NewGuid().ToString("N"));
 

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerAntigravityFloorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonRunnerAntigravityFloorTests.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -137,6 +138,13 @@ public class DaemonRunnerAntigravityFloorTests {
     /// <c>version_no_minimum</c>: the consent gate removed from the front of the ladder and quietly
     /// reinstated behind it.
     ///
+    /// <para>Driven through <c>SeedReviewerFloors</c> — the whole seeding block, exactly as
+    /// <c>RunAsync</c> invokes it — and NOT through <c>SeedVersionFloor</c> directly. Calling the
+    /// unconditional helper by hand would pin only the directory shape and leave the CONDITIONALITY,
+    /// which is the half this fix changed, asserted by nothing: reinstating
+    /// <c>SeedReviewerAffirmation(…, config.AntigravityUnattendedReviewerEnabled, …)</c> at the call
+    /// site would still pass.</para>
+    ///
     /// <para>Asserted through a real hosted <c>StartAsync</c> reaching PAST the ladder rather than by
     /// reading the record back, which would only re-derive the writer's own answer. The observable is
     /// that a turn child was REQUESTED — the first thing beyond the gate — and not the launch's
@@ -158,7 +166,7 @@ public class DaemonRunnerAntigravityFloorTests {
             // Restated rather than taken from the factory: this is the shape RunAsync computes.
             var stateDir = Path.Combine(config.StateDir!, DaemonLockPaths.Sanitize(config.Name));
 
-            DaemonRunner.SeedVersionFloor(stateDir, DaemonRunner.AntigravityVendor, stub);
+            DaemonRunner.SeedReviewerFloors(stateDir, config);
 
             var spawned = false;
             var factory = new AntigravityHostedAgentRuntimeFactory(
@@ -181,6 +189,91 @@ public class DaemonRunnerAntigravityFloorTests {
             await Assert.That(factory.SupportsUnattended).IsFalse();
         } finally {
             File.Delete(stub);
+        }
+    }
+
+    /// <summary>
+    /// The ASYMMETRY inside the one seeding block, asserted as a difference rather than described in a
+    /// comment. With consent withheld for all three vendors and all three binaries resolvable, only
+    /// antigravity records a floor — because only antigravity's floor gates something (a hosted
+    /// launch) that consent does not govern.
+    ///
+    /// <para>Both directions are load-bearing. Without the antigravity arm, seeding it from consent
+    /// like its siblings passes. Without the kiro/gemini arms, dropping the consent condition
+    /// altogether — "tidying" three call sites into one unconditional loop — passes too, and silently
+    /// seeds an affirmation for a reviewer nobody opted into, which is the "consent that isn't
+    /// consent" failure <c>ReviewerVersionStore</c> exists to avoid.</para>
+    ///
+    /// <para>All three paths point at REAL stubs on purpose: with a bare <c>kiro-cli</c>/<c>gemini</c>
+    /// default the siblings would record nothing because their binary does not resolve, and the test
+    /// would pass with the consent condition deleted.</para>
+    /// </summary>
+    [Test]
+    public async Task OnlyAntigravitySeedsAFloorWithoutConsent() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binaries below are POSIX shell scripts.");
+
+        var agy    = await StubAgyAsync("1.1.10");
+        var kiro   = await StubAgyAsync("2.0.0");
+        var gemini = await StubAgyAsync("3.0.0");
+
+        try {
+            var config = Config(minimum: null);
+            config.AntigravityPath                      = agy;
+            config.KiroPath                             = kiro;
+            config.GeminiPath                           = gemini;
+            config.AntigravityUnattendedReviewerEnabled = false;
+            config.KiroUnattendedReviewerEnabled        = false;
+            config.GeminiUnattendedReviewerEnabled      = false;
+
+            // Restated rather than taken from the factory: this is the shape RunAsync computes.
+            var stateDir = Path.Combine(config.StateDir!, DaemonLockPaths.Sanitize(config.Name));
+
+            DaemonRunner.SeedReviewerFloors(stateDir, config);
+
+            await Assert.That(ReviewerVersionStore.RecordExists(stateDir, DaemonRunner.AntigravityVendor))
+                .IsTrue();
+            await Assert.That(ReviewerVersionStore.RecordExists(stateDir, AcpVendorDescriptors.Kiro.Vendor))
+                .IsFalse();
+            await Assert.That(ReviewerVersionStore.RecordExists(stateDir, AcpVendorDescriptors.Gemini.Vendor))
+                .IsFalse();
+        } finally {
+            File.Delete(agy);
+            File.Delete(kiro);
+            File.Delete(gemini);
+        }
+    }
+
+    /// <summary>The positive twin of the siblings' half above: with consent GIVEN they do seed, so
+    /// their absence in that test is the consent condition and not a broken stub or a mis-keyed
+    /// vendor token.</summary>
+    [Test]
+    public async Task ConsentingSiblingsSeedTheirOwnFloors() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binaries below are POSIX shell scripts.");
+
+        var agy    = await StubAgyAsync("1.1.10");
+        var kiro   = await StubAgyAsync("2.0.0");
+        var gemini = await StubAgyAsync("3.0.0");
+
+        try {
+            var config = Config(minimum: null);
+            config.AntigravityPath                 = agy;
+            config.KiroPath                        = kiro;
+            config.GeminiPath                      = gemini;
+            config.KiroUnattendedReviewerEnabled   = true;
+            config.GeminiUnattendedReviewerEnabled = true;
+
+            var stateDir = Path.Combine(config.StateDir!, DaemonLockPaths.Sanitize(config.Name));
+
+            DaemonRunner.SeedReviewerFloors(stateDir, config);
+
+            await Assert.That(new ReviewerVersionStore(stateDir, AcpVendorDescriptors.Kiro.Vendor).Affirmed)
+                .IsEqualTo("2.0.0");
+            await Assert.That(new ReviewerVersionStore(stateDir, AcpVendorDescriptors.Gemini.Vendor).Affirmed)
+                .IsEqualTo("3.0.0");
+        } finally {
+            File.Delete(agy);
+            File.Delete(kiro);
+            File.Delete(gemini);
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -1,6 +1,7 @@
 // test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
 using System.Diagnostics;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Acp;
@@ -56,16 +57,28 @@ public class AntigravityReviewerLaunchTests {
         return config;
     }
 
+    /// <param name="serverUrl">Defaulted to a real value; blanked by the result-channel tests, which
+    /// is the ONE input a hosted launch legitimately lacks and a review legitimately cannot.</param>
+    /// <param name="mcpAllowlist">The review-flow DEFINITION's allowlist. Never populated for a hosted
+    /// launch in production — a test passes one only to assert that the hosted arm ignores it rather
+    /// than validating it.</param>
+    /// <param name="mcpServers">The literal per-launch MCP server list. No production caller populates
+    /// it today (see the field's own comment on <see cref="RuntimeStartContext"/>); a test passes one
+    /// to pin which arm forwards it.</param>
     static RuntimeStartContext Ctx(
-            bool isReviewFlow = true, AgentActivityClock? clock = null, string? model = null) => new(
+            bool isReviewFlow = true, AgentActivityClock? clock = null, string? model = null,
+            string? serverUrl = "http://kcap.test", string capacitorPath = "/usr/local/bin/kcap",
+            string[]? mcpAllowlist = null, IReadOnlyList<AcpMcpServerSpec>? mcpServers = null) => new(
         AgentId: "agent-1", Vendor: "antigravity", SourceRepoPath: "/repo",
         Worktree: new WorktreeInfo(Path: "/abs/wt", Branch: "b", SourceRepo: "/repo"),
         Prompt: "review this",
         Model: model, Effort: null, Tools: null,
         IsReview: false, IsReviewFlow: isReviewFlow, Review: null,
         Cols: 80, Rows: 24,
-        ServerUrl: "http://kcap.test", DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap",
+        ServerUrl: serverUrl, DaemonBridgeUrl: null, CapacitorPath: capacitorPath,
+        McpAllowlist: mcpAllowlist,
         DaemonId: "daemon-1", DaemonEpoch: "epoch-1",
+        McpServers: mcpServers,
         ActivityClock: clock);
 
     static ProcessStartInfo BuildPsi(
@@ -701,6 +714,175 @@ public class AntigravityReviewerLaunchTests {
         await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_requires_owned_worktree");
         await Assert.That(ex.Message).Contains("daemon-owned worktree");
         await Assert.That(ex.Message).DoesNotContain("a review must run");
+    }
+
+    // ── the injected MCP surface ───────────────────────────────────────────────────────────────────
+    //
+    // The per-launch home's mcp_config.json IS the launch's whole MCP surface (the home carries no
+    // operator config to merge with), so these assertions read that file rather than a builder's
+    // return value — the same file agy would load.
+
+    /// <summary>Reads the mcp_config.json the launch actually wrote, from the home the child was
+    /// handed. Literal path rather than <c>AntigravityPaths.McpConfigJson</c>: that resolver honours
+    /// the TEST PROCESS's own <c>GEMINI_CLI_HOME</c>, so it could read somewhere the launch never
+    /// wrote.</summary>
+    static async Task<string> McpConfigOf(SpyTurnSource spy) {
+        var home = spy.Spawns[0].Environment["HOME"]!;
+        var path = Path.Combine(home, ".gemini", "config", "mcp_config.json");
+
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"The launch wrote no mcp_config.json under '{home}'.", path);
+
+        return await File.ReadAllTextAsync(path);
+    }
+
+    /// <summary>
+    /// <b>A hosted agent has no flow to report a result to</b>, so it gets neither the
+    /// <c>kcap-flow-result</c> channel nor the fail-closed validation of that channel's inputs. Both
+    /// halves matter, and the second is what this test is shaped around: the launch runs with a BLANK
+    /// server url — the exact input the review-side guard rejects — because a hosted launch refused
+    /// with <c>antigravity_reviewer_result_channel_incomplete</c> would be refused for a channel it
+    /// never needed.
+    ///
+    /// <para>The config file must still EXIST and be valid: its presence is what replaces the
+    /// operator's global config with an empty surface, which is the same mechanism that keeps a
+    /// reviewer from starting a nested flow. Absent, agy would be free to fall back.</para>
+    /// </summary>
+    [Test]
+    public async Task A_hosted_launch_gets_no_result_channel_and_is_not_refused_for_missing_one() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy = new SpyTurnSource();
+
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(isReviewFlow: false, serverUrl: null, capacitorPath: ""), CancellationToken.None)
+            .WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        // It launched — bound conversation, not merely "did not throw".
+        await Assert.That(start.Transcript!.AcpSessionId).IsEqualTo(FixedConversationId);
+
+        // Present, valid, and EMPTY — no result channel smuggled in under any name.
+        await Assert.That(await McpConfigOf(spy)).IsEqualTo("""{"mcpServers":{}}""");
+    }
+
+    /// <summary>
+    /// The review direction of the same split, and the harder one to lose safely: a reviewer with no
+    /// result channel starts, runs, and can never report — the flow then waits for a verdict that
+    /// cannot arrive. Asserts the channel's COMMAND and both env vars, not just its name: the server
+    /// exits when <c>KCAP_FLOW_AGENT_ID</c> is absent, so a name-only assertion would pass a channel
+    /// that dies on first use.
+    ///
+    /// <para>Also pins that the review arm builds its OWN list rather than forwarding
+    /// <c>ctx.McpServers</c> — a caller-supplied server must not join a reviewer's surface.</para>
+    /// </summary>
+    [Test]
+    public async Task A_review_launch_injects_the_flow_result_channel_and_ignores_caller_supplied_servers() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy = new SpyTurnSource();
+
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(isReviewFlow: true,
+                            mcpServers: [new AcpMcpServerSpec("caller-supplied", "/bin/false", null, null)]),
+                        CancellationToken.None)
+            .WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        var config = await McpConfigOf(spy);
+
+        await Assert.That(config).Contains("\"kcap-flow-result\"");
+        await Assert.That(config).Contains("\"/usr/local/bin/kcap\"");
+        await Assert.That(config).Contains("\"KCAP_FLOW_AGENT_ID\"");
+        await Assert.That(config).Contains("\"agent-1\"");
+        await Assert.That(config).Contains("\"KCAP_URL\"");
+        await Assert.That(config).DoesNotContain("caller-supplied");
+    }
+
+    /// <summary>A review whose result-channel inputs are incomplete must STILL fail closed with the
+    /// coded reason — scoping the injection to review flows must not weaken it. Blank server url only:
+    /// the guard is an OR over three inputs, and blanking one is what proves it still runs.</summary>
+    [Test]
+    public async Task A_review_launch_missing_result_channel_inputs_still_fails_closed() {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(EnabledConfig(), new SpyTurnSource().SpawnAsync)
+                .StartAsync(Ctx(isReviewFlow: true, serverUrl: null), CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_result_channel_incomplete");
+    }
+
+    /// <summary>The allowlist is the review-flow DEFINITION's, so its rejection is review-only too —
+    /// asserted as a split on one factory, because a hosted launch refused for a definition it has no
+    /// definition for is the same category error as the result-channel refusal above.</summary>
+    [Test]
+    public async Task A_non_auto_approvable_allowlist_refuses_a_review_but_not_a_hosted_launch() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy     = new SpyTurnSource();
+        var factory = Factory(EnabledConfig(), spy.SpawnAsync);
+
+        // kcap-flows starts flows — the recursion the reviewer allowlist exists to refuse.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            factory.StartAsync(Ctx(isReviewFlow: true, mcpAllowlist: ["kcap-flows"]), CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_mcp_allowlist_rejected");
+
+        // The same allowlist on a hosted launch is simply not its concern — and is never materialized.
+        var start = await factory
+            .StartAsync(Ctx(isReviewFlow: false, mcpAllowlist: ["kcap-flows"]), CancellationToken.None)
+            .WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        await Assert.That(await McpConfigOf(spy)).DoesNotContain("kcap-flows");
+    }
+
+    /// <summary>An auto-approvable allowlist entry reaches the reviewer's surface alongside the result
+    /// channel. Without this the allowlist could be resolved and then dropped, and every assertion
+    /// above would still pass.</summary>
+    [Test]
+    public async Task An_auto_approvable_allowlist_entry_reaches_the_reviewers_surface() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy = new SpyTurnSource();
+
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(isReviewFlow: true, mcpAllowlist: ["kcap-review"]), CancellationToken.None)
+            .WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        var config = await McpConfigOf(spy);
+
+        await Assert.That(config).Contains("\"kcap-review\"");
+        await Assert.That(config).Contains("\"kcap-flow-result\"");
+    }
+
+    /// <summary>The hosted arm forwards <c>ctx.McpServers</c> verbatim, mirroring
+    /// <c>AcpHostedAgentRuntimeFactory</c>'s hosted arm. <b>No production caller populates that field
+    /// today</b>, so this pins a contract rather than a live path — the point being that a hosted agy
+    /// launch ends up with nothing DELIBERATELY (nothing is offered) rather than by a drop this
+    /// change introduced.</summary>
+    [Test]
+    public async Task A_hosted_launch_forwards_the_mcp_servers_it_was_given() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy = new SpyTurnSource();
+
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(isReviewFlow: false,
+                            mcpServers: [new AcpMcpServerSpec("caller-supplied", "/bin/echo", ["hi"], null)]),
+                        CancellationToken.None)
+            .WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        var config = await McpConfigOf(spy);
+
+        await Assert.That(config).Contains("\"caller-supplied\"");
+        await Assert.That(config).DoesNotContain("kcap-flow-result");
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -65,15 +65,19 @@ public class AntigravityReviewerLaunchTests {
     /// <param name="mcpServers">The literal per-launch MCP server list. No production caller populates
     /// it today (see the field's own comment on <see cref="RuntimeStartContext"/>); a test passes one
     /// to pin which arm forwards it.</param>
+    /// <param name="isReview">The PR-review launch kind (<c>LaunchKind.Review</c>) — a THIRD shape,
+    /// distinct from both arms above and refused outright; see the test that pins it.</param>
     static RuntimeStartContext Ctx(
             bool isReviewFlow = true, AgentActivityClock? clock = null, string? model = null,
             string? serverUrl = "http://kcap.test", string capacitorPath = "/usr/local/bin/kcap",
-            string[]? mcpAllowlist = null, IReadOnlyList<AcpMcpServerSpec>? mcpServers = null) => new(
+            string[]? mcpAllowlist = null, IReadOnlyList<AcpMcpServerSpec>? mcpServers = null,
+            bool isReview = false) => new(
         AgentId: "agent-1", Vendor: "antigravity", SourceRepoPath: "/repo",
         Worktree: new WorktreeInfo(Path: "/abs/wt", Branch: "b", SourceRepo: "/repo"),
         Prompt: "review this",
         Model: model, Effort: null, Tools: null,
-        IsReview: false, IsReviewFlow: isReviewFlow, Review: null,
+        IsReview: isReview, IsReviewFlow: isReviewFlow,
+        Review: isReview ? new ReviewLaunchInfo("owner", "repo", 42) : null,
         Cols: 80, Rows: 24,
         ServerUrl: serverUrl, DaemonBridgeUrl: null, CapacitorPath: capacitorPath,
         McpAllowlist: mcpAllowlist,
@@ -799,6 +803,54 @@ public class AntigravityReviewerLaunchTests {
         await Assert.That(config).Contains("\"agent-1\"");
         await Assert.That(config).Contains("\"KCAP_URL\"");
         await Assert.That(config).DoesNotContain("caller-supplied");
+    }
+
+    /// <summary>
+    /// <b>The THIRD launch shape is refused, not silently degraded.</b> Everything hosted here keys off
+    /// <c>!ctx.IsReviewFlow</c>, which is true for <c>LaunchKind.Default</c> AND
+    /// <c>LaunchKind.Review</c> — so a PR-review launch would otherwise take the hosted arm and run
+    /// with <c>--dangerously-skip-permissions</c>, an EMPTY MCP surface (no <c>kcap mcp review</c>
+    /// tools) and no review system prompt: only <c>PtyHostedAgentRuntimeFactory</c> builds
+    /// <c>LauncherContext.ReviewLaunch</c>, so nothing on this path can supply them. A PR-review agent
+    /// with none of its review tools and no error is worse than no PR-review agent.
+    ///
+    /// <para>Refused BEFORE the containment ladder deliberately: no amount of installing, affirming or
+    /// consenting can make this shape work, so the operator should read that rather than "install
+    /// agy". The shipped UI cannot request it today (the server's
+    /// <c>AgentStoreDataService.RequestLaunchReviewAgentAsync</c> hard-codes Claude, and
+    /// <c>ReviewPrDialog</c> has no vendor picker) — but the hub's <c>RequestLaunchAgent</c> takes
+    /// <c>vendor</c> and <c>kind</c> as independent client-supplied arguments and rejects only
+    /// Codex+Review, so this is a wire-reachable shape, not merely a latent one.</para>
+    /// </summary>
+    [Test]
+    public async Task A_pr_review_launch_is_refused_rather_than_taking_the_hosted_arm() {
+        var spy = new SpyTurnSource();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(EnabledConfig(), spy.SpawnAsync)
+                .StartAsync(Ctx(isReviewFlow: false, isReview: true), CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_pr_review_unsupported");
+
+        // Refused, not merely reported: nothing was spawned.
+        await Assert.That(spy.Spawns.Count).IsEqualTo(0);
+    }
+
+    /// <summary>The negative control for the refusal above: an ordinary hosted launch shares its
+    /// <c>!IsReviewFlow</c> arm, so a guard written against the wrong predicate would refuse every
+    /// interactive agent — and this vendor's whole hosted lane with it.</summary>
+    [Test]
+    public async Task An_ordinary_hosted_launch_is_not_refused_as_a_pr_review() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy = new SpyTurnSource();
+
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(isReviewFlow: false), CancellationToken.None).WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        await Assert.That(spy.Spawns.Count).IsGreaterThan(0);
     }
 
     /// <summary>A review whose result-channel inputs are incomplete must STILL fail closed with the

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -1,6 +1,7 @@
 // test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
 using System.Diagnostics;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
@@ -536,25 +537,49 @@ public class AntigravityReviewerLaunchTests {
         await Assert.That(spy.Spawns[0].ArgumentList).Contains("--dangerously-skip-permissions");
     }
 
-    /// <summary>Lifting the interactive refusal did NOT lift the vendor ladder: consent, platform and
-    /// the recorded build minimum still gate every launch from this factory. Deliberate — the isolated
-    /// home a hosted launch depends on is the same containment the version floor exists to protect —
-    /// and pinned here so the coupling cannot be dropped silently.</summary>
+    /// <summary>
+    /// <b>The split this ladder exists for, asserted on ONE daemon so it is a split and not two
+    /// independent facts.</b> The consent flag is REVIEWER-ONLY, and its own justification is what
+    /// makes that so: an unattended review runs under the daemon user's authority and returns what it
+    /// read to whoever requested the review, who need not be the operator. A hosted launch has no such
+    /// exposure — the server's <c>DaemonRegistry</c> is keyed
+    /// <c>(TeamId, OwnerUserId, Name)</c> and the launch hub resolves a daemon with the CALLER's own
+    /// normalized user id, so the launcher IS the daemon's owner — and hosted Antigravity therefore
+    /// ships on by default, like every other hosted vendor.
+    ///
+    /// <para>Before this, a hosted launch on a daemon that had simply never set the reviewer flag
+    /// failed with <c>antigravity_unattended_reviewer_disabled</c> — a review complaint about a launch
+    /// that is not a review.</para>
+    /// </summary>
     [Test]
-    public async Task A_consent_withheld_daemon_refuses_an_interactive_launch_too() {
+    public async Task Consent_gates_a_review_launch_but_not_a_hosted_launch_on_the_same_daemon() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
         var config = EnabledConfig();
         config.AntigravityUnattendedReviewerEnabled = false;
 
+        var factory = Factory(config, new SpyTurnSource().SpawnAsync);
+
+        // Hosted: runs. Reading the bound conversation id (not merely "did not throw") is what makes
+        // this a launch assertion rather than a gate assertion.
+        var start = await factory.StartAsync(Ctx(isReviewFlow: false), CancellationToken.None)
+            .WaitAsync(HangGuard);
+
+        await using (var runtime = start.Runtime)
+            await Assert.That(start.Transcript!.AcpSessionId).IsEqualTo(FixedConversationId);
+
+        // Review: still refused, on the SAME factory instance, with the text that names the switch.
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            Factory(config, new SpyTurnSource().SpawnAsync)
-                .StartAsync(Ctx(isReviewFlow: false), CancellationToken.None));
+            factory.StartAsync(Ctx(isReviewFlow: true), CancellationToken.None));
 
         await Assert.That(ex!.Message).StartsWith("antigravity_unattended_reviewer_disabled");
+        await Assert.That(ex.Message).Contains("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
     }
 
     /// <summary>Defence in depth: the orchestrator's unattended gate runs first, but an explicit
     /// vendor request can reach a factory directly, so the consent gate is re-applied at the launch
-    /// boundary rather than trusted to advertisement.</summary>
+    /// boundary rather than trusted to advertisement. Separate from the split test above because this
+    /// arm throws before touching the filesystem, so it is assertable on Windows too.</summary>
     [Test]
     public async Task A_consent_withheld_daemon_refuses_a_review_launch() {
         var config = EnabledConfig();
@@ -565,6 +590,117 @@ public class AntigravityReviewerLaunchTests {
                 .StartAsync(Ctx(), CancellationToken.None));
 
         await Assert.That(ex!.Message).StartsWith("antigravity_unattended_reviewer_disabled");
+    }
+
+    /// <summary>
+    /// <b>The arm most likely to be lost by an over-broad "hosted skips the ladder" fix.</b> The build
+    /// minimum is not reviewer-specific: it protects the per-launch isolated <c>HOME</c>, which is
+    /// containment a hosted launch depends on exactly as a review does — losing it silently removes
+    /// that protection.
+    ///
+    /// <para>Asserted on a CONSENT-LESS daemon deliberately. On a consenting one the refusal could not
+    /// distinguish "the floor applies to hosted" from "the ladder still runs at all", and a fix that
+    /// skipped the whole ladder for hosted launches would pass.</para>
+    /// </summary>
+    [Test]
+    public async Task A_below_minimum_build_is_refused_for_a_hosted_launch_too() {
+        var config = EnabledConfig();
+        config.AntigravityUnattendedReviewerEnabled = false;
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(config, new SpyTurnSource().SpawnAsync, version: "1.1.8")
+                .StartAsync(Ctx(isReviewFlow: false), CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_version_below_minimum");
+    }
+
+    /// <summary>The platform arm is shared for the same reason as the floor: Windows cannot create the
+    /// per-launch home owner-only, and that home holds a hosted agent's own conversation transcript as
+    /// surely as it holds a reviewer's.</summary>
+    [Test]
+    public async Task A_windows_host_refuses_a_hosted_launch_too() {
+        var config = EnabledConfig();
+        config.AntigravityUnattendedReviewerEnabled = false;
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(config, new SpyTurnSource().SpawnAsync, posixHost: false)
+                .StartAsync(Ctx(isReviewFlow: false), CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_unsupported_platform");
+    }
+
+    /// <summary>Binary presence is shared too — there is nothing to launch either way.</summary>
+    [Test]
+    public async Task A_missing_binary_refuses_a_hosted_launch_too() {
+        var config = EnabledConfig();
+        config.AntigravityUnattendedReviewerEnabled = false;
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(config, new SpyTurnSource().SpawnAsync, binaryExists: false)
+                .StartAsync(Ctx(isReviewFlow: false), CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_binary_missing");
+    }
+
+    /// <summary>
+    /// The floor's "nothing recorded" arm reaches a hosted launch, and its remedy must not send a
+    /// hosted operator to the REVIEWER consent flag. That switch has no bearing on a hosted launch, and
+    /// telling someone to set it is the same confusion — one layer down — that this whole split
+    /// removes. The affirm verb is the remedy that works for both.
+    /// </summary>
+    [Test]
+    public async Task A_hosted_launch_with_no_recorded_minimum_is_refused_without_naming_the_reviewer_flag() {
+        var config = EnabledConfig(minimum: null);
+        config.AntigravityUnattendedReviewerEnabled = false;
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(config, new SpyTurnSource().SpawnAsync)
+                .StartAsync(Ctx(isReviewFlow: false), CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_version_no_minimum");
+        await Assert.That(ex.Message).DoesNotContain("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER");
+        await Assert.That(ex.Message).Contains("kcap daemon reviewer affirm");
+    }
+
+    /// <summary>Advertisement is specifically an offer to REVIEW unattended, so it keeps the full
+    /// ladder — consent included. Lifting consent from the launch boundary must not lift it here: the
+    /// server refuses an unadvertised reviewer, and a daemon that advertised without consent would be
+    /// offering the very thing its operator never opted into.</summary>
+    [Test]
+    public async Task Advertisement_still_requires_consent_even_though_a_hosted_launch_does_not() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var config = EnabledConfig();
+        config.AntigravityUnattendedReviewerEnabled = false;
+
+        var factory = Factory(config, new SpyTurnSource().SpawnAsync);
+
+        // Withheld from advertisement...
+        await Assert.That(factory.SupportsUnattended).IsFalse();
+        await Assert.That(factory.DescribeUnattendedSupport().WithheldReason!)
+            .StartsWith("antigravity_unattended_reviewer_disabled");
+
+        // ...on the very daemon whose hosted launches this same factory admits.
+        var start = await factory.StartAsync(Ctx(isReviewFlow: false), CancellationToken.None)
+            .WaitAsync(HangGuard);
+
+        await start.Runtime.DisposeAsync();
+    }
+
+    /// <summary>A borrowed workspace is refused because this runtime has no containment strategy for
+    /// one — a fact about the runtime, not about reviews — so the refusal must not describe the launch
+    /// as a review. Reachable from the hosted arm, which is exactly where the old wording read wrong.
+    /// </summary>
+    [Test]
+    public async Task A_borrowed_workspace_is_refused_without_calling_the_launch_a_review() {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(EnabledConfig(), new SpyTurnSource().SpawnAsync)
+                .StartAsync(Ctx(isReviewFlow: false) with { Work = WorkLocation.BorrowedCwd },
+                            CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_requires_owned_worktree");
+        await Assert.That(ex.Message).Contains("daemon-owned worktree");
+        await Assert.That(ex.Message).DoesNotContain("a review must run");
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -67,9 +67,11 @@ public class AntigravityReviewerLaunchTests {
         DaemonId: "daemon-1", DaemonEpoch: "epoch-1",
         ActivityClock: clock);
 
-    static ProcessStartInfo BuildPsi(DaemonConfig config, string? conversationId = null) =>
+    static ProcessStartInfo BuildPsi(
+            DaemonConfig config, string? conversationId = null, bool isReviewFlow = true) =>
         AntigravityHostedAgentRuntimeFactory.BuildTurnPsi(
-            config, Ctx(), prompt: "<PROMPT>", conversationId: conversationId, home: HomePath);
+            config, Ctx(isReviewFlow: isReviewFlow), prompt: "<PROMPT>",
+            conversationId: conversationId, home: HomePath);
 
     // ── argv ──────────────────────────────────────────────────────────────────────────────────────
 
@@ -97,6 +99,43 @@ public class AntigravityReviewerLaunchTests {
         // reviewer never needs.
         await Assert.That(psi.ArgumentList).DoesNotContain("--dangerously-skip-permissions");
         await Assert.That(psi.ArgumentList).DoesNotContain("--sandbox");
+    }
+
+    /// <summary>
+    /// The hosted/reviewer asymmetry, pinned in ONE test so the two directions cannot drift apart —
+    /// and as WHOLE vectors, because the interesting regression is a flag appearing on the arm that
+    /// must not have it, which every substring check would pass.
+    ///
+    /// <para><b>What the flag actually buys, measured on agy 1.1.10:</b> with it, an absolute
+    /// out-of-workspace <c>view_file</c> succeeds; without it the same read is refused with a typed
+    /// <c>tool_info.error</c>. So the flag IS the read boundary — the daemon-owned worktree is not one
+    /// — and a hosted agent launched without it soft-denies shell and out-of-workspace work and merely
+    /// looks broken. A reviewer only reads its own worktree, so the soft-deny is the posture it
+    /// wants.</para>
+    ///
+    /// <para>Pure builder, so both arms run on every host — no process, no filesystem.</para>
+    /// </summary>
+    [Test]
+    public async Task A_hosted_launch_widens_permissions_but_a_reviewer_launch_does_not() {
+        var config = EnabledConfig();
+
+        var hosted   = BuildPsi(config, isReviewFlow: false);
+        var reviewer = BuildPsi(config, isReviewFlow: true);
+
+        await Assert.That(string.Join(" ", hosted.ArgumentList)).IsEqualTo(string.Join(" ", [
+            "-p", "<PROMPT>",
+            "--output-format", "stream-json",
+            "--disable-slash-commands",
+            "--dangerously-skip-permissions",
+            "--print-timeout", "600s"
+        ]));
+
+        await Assert.That(string.Join(" ", reviewer.ArgumentList)).IsEqualTo(string.Join(" ", [
+            "-p", "<PROMPT>",
+            "--output-format", "stream-json",
+            "--disable-slash-commands",
+            "--print-timeout", "600s"
+        ]));
     }
 
     [Test]
@@ -461,18 +500,56 @@ public class AntigravityReviewerLaunchTests {
     }
 
     /// <summary>
-    /// An interactive launch is refused, not silently accepted. This runtime parses agy's NDJSON from
-    /// stdout once per turn, and an inherited HOME lets agy's own kcap capture hooks fire — which
-    /// spawns a watcher that can hold a write end of that stdout open after agy exits, so every turn
-    /// would block forever. A coded refusal is the honest shape until the interactive lane is built.
+    /// An interactive (hosted) launch runs — it is not refused — and it runs under the SAME per-launch
+    /// isolated home the reviewer gets, with the widened permission flag the reviewer never gets.
+    ///
+    /// <para>Both halves are measured facts rather than preferences. The refusal this replaces claimed
+    /// an inherited HOME would let agy's capture hooks spawn a watcher that holds the turn's stdout
+    /// open; four piped runs under a real HOME, on a kcap predating the descriptor fix, all reached
+    /// EOF in 6–16s, so the wedge does not reproduce. What those runs DID show is that each was also
+    /// recorded by the hook lane as its own watcher session — and this runtime is already the
+    /// transcript source, so an inherited HOME would not add capture, it would DUPLICATE it. Isolation
+    /// is the fix here, not a cost, which is why the hosted arm keeps it.</para>
     /// </summary>
     [Test]
-    public async Task An_interactive_launch_is_refused_rather_than_hanging_on_an_inherited_home() {
+    public async Task An_interactive_launch_is_hosted_under_the_isolated_home_with_permissions_widened() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var config = EnabledConfig();
+        var spy    = new SpyTurnSource();
+
+        var start = await Factory(config, spy.SpawnAsync)
+            .StartAsync(Ctx(isReviewFlow: false), CancellationToken.None).WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        // The launch completed and bound a conversation — the same contract a review launch owes.
+        await Assert.That(start.Transcript).IsNotNull();
+        await Assert.That(start.Transcript!.AcpSessionId).IsEqualTo(FixedConversationId);
+
+        // Positive containment assertion, not an inequality against the ambient HOME: the child's home
+        // is one this daemon created under its OWN state root, and is therefore removed with it.
+        await Assert.That(spy.Spawns[0].Environment["HOME"]!)
+            .StartsWith(AntigravityHostedAgentRuntimeFactory.ReviewerStateDir(config));
+
+        // The widened argv reaches the real spawn path, not merely the pure builder.
+        await Assert.That(spy.Spawns[0].ArgumentList).Contains("--dangerously-skip-permissions");
+    }
+
+    /// <summary>Lifting the interactive refusal did NOT lift the vendor ladder: consent, platform and
+    /// the recorded build minimum still gate every launch from this factory. Deliberate — the isolated
+    /// home a hosted launch depends on is the same containment the version floor exists to protect —
+    /// and pinned here so the coupling cannot be dropped silently.</summary>
+    [Test]
+    public async Task A_consent_withheld_daemon_refuses_an_interactive_launch_too() {
+        var config = EnabledConfig();
+        config.AntigravityUnattendedReviewerEnabled = false;
+
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            Factory(EnabledConfig(), new SpyTurnSource().SpawnAsync)
+            Factory(config, new SpyTurnSource().SpawnAsync)
                 .StartAsync(Ctx(isReviewFlow: false), CancellationToken.None));
 
-        await Assert.That(ex!.Message).StartsWith("antigravity_interactive_launch_unsupported");
+        await Assert.That(ex!.Message).StartsWith("antigravity_unattended_reviewer_disabled");
     }
 
     /// <summary>Defence in depth: the orchestrator's unattended gate runs first, but an explicit

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -1,5 +1,6 @@
 // test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
 using System.Diagnostics;
+using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
 using Capacitor.Cli.Core.LocalIpc;
@@ -737,7 +738,9 @@ public class AntigravityReviewerLaunchTests {
         if (!File.Exists(path))
             throw new FileNotFoundException($"The launch wrote no mcp_config.json under '{home}'.", path);
 
-        return await File.ReadAllTextAsync(path);
+        // Shared read: this file lives in the child's own config dir, so agy may rewrite it. A
+        // write-denying open is mandatory sharing on Windows and invisible on macOS/Linux.
+        return await WatchCommand.ReadAllTextSharedAsync(path);
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
@@ -1,4 +1,5 @@
 // test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging;
@@ -254,8 +255,70 @@ public class AntigravityRuntimeLifecycleTests {
         await Assert.That(prompts).Contains("do the review");
     }
 
+    // ── the bounded input queue ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A turn is one process, so input that arrives mid-turn cannot steer the running turn. It must
+    /// become the NEXT turn — in order, and as a separate turn per message: concatenating two of a
+    /// user's messages into one prompt changes their meaning, and a turn's prompt is its process's
+    /// argument, so a coalesced pair is unrecoverable rather than merely untidy.
+    ///
+    /// <para>Deterministic by construction rather than by delay: turn 1 is a
+    /// <see cref="GatedTurnProcess"/> that has emitted its <c>init</c> (so
+    /// <c>WaitForConversationIdAsync</c> proves it is genuinely mid-turn, holding the gate) and does
+    /// not finish until this test releases it — so the two later sends are guaranteed to be enqueued
+    /// while a turn is in flight, which is the whole point.</para>
+    /// </summary>
     [Test]
-    public async Task A_full_queue_rejects_further_input_without_spawning() {
+    public async Task Input_sent_during_a_turn_becomes_the_next_turn_in_order() {
+        var prompts = new List<string>();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var spawns  = 0;
+
+        Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawn = (prompt, _, _) => {
+            lock (prompts) prompts.Add(prompt);
+
+            // Only turn 1 is held open; later turns run to completion normally.
+            return Task.FromResult<IAgyTurnProcess>(Interlocked.Increment(ref spawns) == 1
+                ? new GatedTurnProcess(release.Task, FixedConversationId)
+                : new FakeAgyTurnProcess(FakeTurn.Normal, FixedConversationId));
+        };
+
+        await using var rt = new AntigravityHostedAgentRuntime(spawnTurn: spawn, logger: NullLogger.Instance);
+
+        await rt.SendUserInputAsync("first").WaitAsync(HangGuard);
+
+        // Turn 1 has read its own init line — it is genuinely executing and holding the turn gate.
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await rt.SendUserInputAsync("second").WaitAsync(HangGuard);
+        await rt.SendUserInputAsync("third").WaitAsync(HangGuard);
+
+        release.TrySetResult();
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (Volatile.Read(ref spawns) < 3 && DateTime.UtcNow < deadline) await Task.Delay(10);
+
+        string[] snapshot;
+        lock (prompts) snapshot = [.. prompts];
+
+        // Joined rather than compared element-wise so ONE assertion pins both halves: a reordered
+        // queue and a coalesced pair (which would arrive as a single prompt containing all three
+        // texts) each produce a different string.
+        await Assert.That(string.Join("|", snapshot)).IsEqualTo("first|second|third");
+    }
+
+    /// <summary>
+    /// Over-cap input is <b>rejected visibly</b>, never silently discarded. The two alternatives are
+    /// both wrong in their own way: blocking the caller would stall the daemon's command lane behind
+    /// a stalled reviewer's turn (the queue is only ever full BECAUSE a turn is stuck), and dropping
+    /// silently loses a message the user has already sent with nothing to tell them so. Both send
+    /// entry points reject — the acknowledging one (used for borrowed launches) and the plain one
+    /// (every server-driven <c>SendInput</c>), since a caller that never asked for a write ack is
+    /// exactly the caller that would otherwise never learn.
+    /// </summary>
+    [Test]
+    public async Task An_over_cap_enqueue_is_rejected_visibly_rather_than_dropped() {
         var spawns = 0;
         await using var rt = FakeRuntime(turn: FakeTurn.NeverEnds, onSpawn: _ => spawns++, queueCap: 1);
 
@@ -264,15 +327,97 @@ public class AntigravityRuntimeLifecycleTests {
         await rt.SendUserInputAsync("one").WaitAsync(HangGuard);
 
         var deadline = DateTime.UtcNow + HangGuard;
-        while (spawns < 1 && DateTime.UtcNow < deadline) await Task.Delay(10);
+        while (Volatile.Read(ref spawns) < 1 && DateTime.UtcNow < deadline) await Task.Delay(10);
         await Assert.That(spawns).IsEqualTo(1);
 
         await rt.SendUserInputAsync("two").WaitAsync(HangGuard);
-        await rt.SendUserInputAsync("three").WaitAsync(HangGuard);
+
+        var rejected = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => rt.SendUserInputAsync("three").WaitAsync(HangGuard));
+        await Assert.That(rejected!.Message).Contains("queue is full");
+
+        // The acknowledging entry point rejects identically — same queue, same answer.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => rt.SendUserInputAndWaitForWriteAsync("four").WaitAsync(HangGuard));
+
         await Task.Delay(100);
 
-        // Only turn 1 ever spawned — turn 2 sits in the (capacity-1) queue and turn 3 was dropped.
+        // Only turn 1 ever spawned — turn 2 sits in the (capacity-1) queue, and neither rejected
+        // message became a turn.
         await Assert.That(spawns).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// The rejection reaches the HUMAN, not just the daemon log: a faulted send task is observed by
+    /// the orchestrator's own handler, which logs it and returns — the user's dashboard would show
+    /// nothing at all. A <c>system_note</c> envelope on the runtime's own transcript is the one
+    /// surface the person who typed the message actually sees.
+    ///
+    /// <para>One note PER rejected message, deliberately not one per full-queue episode: each
+    /// rejected message is a separately lost message, and telling the user about the first while
+    /// swallowing the rest is the silent drop this whole rule exists to prevent. The transcript
+    /// channel is DropOldest-bounded, so a pathological sender cannot grow memory here.</para>
+    /// </summary>
+    [Test]
+    public async Task A_rejected_over_cap_enqueue_tells_the_user_on_the_transcript() {
+        await using var rt = FakeRuntime(turn: FakeTurn.NeverEnds, queueCap: 1);
+
+        await rt.SendUserInputAsync("one").WaitAsync(HangGuard);
+
+        // Turn 1 is genuinely executing (its init has been read), so the queue state below is real.
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await rt.SendUserInputAsync("two").WaitAsync(HangGuard);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => rt.SendUserInputAsync("three").WaitAsync(HangGuard));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => rt.SendUserInputAsync("four").WaitAsync(HangGuard));
+
+        var envelopes = new List<AcpEventEnvelope>();
+        while (rt.Envelopes.TryRead(out var env)) envelopes.Add(env);
+
+        var notes = envelopes.Where(e => e.Kind == AcpEventKind.SystemNote).ToList();
+
+        // Two rejected messages, two notes — never one summary note for both.
+        await Assert.That(notes.Count).IsEqualTo(2);
+        await Assert.That(notes[0].Text).IsNotNull();
+        await Assert.That(notes[0].Text!).Contains("not delivered");
+
+        // The turn that DID get queued is not announced as lost — a note per rejection, not per send.
+        await Assert.That(envelopes.Any(e => e.Kind == AcpEventKind.SessionStarted)).IsTrue();
+    }
+
+    /// <summary>A turn child that emits its <c>init</c> and then holds the turn open until the test
+    /// releases it, ending cleanly with a terminal <c>result</c>. The structural stand-in for "a turn
+    /// is genuinely in flight" — unlike <see cref="FakeTurn.NeverEnds"/>, it can also be let go, so a
+    /// test can observe what the queue does with the turns that piled up behind it.</summary>
+    sealed class GatedTurnProcess(Task gate, string conversationId) : IAgyTurnProcess {
+        public int  Pid       => 4251;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+
+        public async IAsyncEnumerable<string> ReadLinesAsync(
+                [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct) {
+            yield return $$$"""{"event":"init","conversation_id":"{{{conversationId}}}","init":{"cwd":"/w"}}""";
+
+            await gate.WaitAsync(ct).ConfigureAwait(false);
+
+            yield return $$$"""{"event":"result","result":{"conversation_id":"{{{conversationId}}}","status":"SUCCESS"}}""";
+
+            HasExited = true;
+            ExitCode  = 0;
+        }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+
+        public Task TerminateAsync(TimeSpan? timeout = null) {
+            HasExited = true;
+            ExitCode ??= -1;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
@@ -4,6 +4,7 @@ using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using static Capacitor.Cli.Tests.Unit.Services.AntigravityRuntimeFakes;
 
 namespace Capacitor.Cli.Tests.Unit.Services;
@@ -379,13 +380,65 @@ public class AntigravityRuntimeLifecycleTests {
 
         var notes = envelopes.Where(e => e.Kind == AcpEventKind.SystemNote).ToList();
 
-        // Two rejected messages, two notes — never one summary note for both.
+        // Two rejected messages, two notes — never one summary note for both, and never a note for the
+        // turn that WAS queued (three sends, two of them rejected, would otherwise read as three).
         await Assert.That(notes.Count).IsEqualTo(2);
         await Assert.That(notes[0].Text).IsNotNull();
         await Assert.That(notes[0].Text!).Contains("not delivered");
+    }
 
-        // The turn that DID get queued is not announced as lost — a note per rejection, not per send.
-        await Assert.That(envelopes.Any(e => e.Kind == AcpEventKind.SessionStarted)).IsTrue();
+    /// <summary>
+    /// <b>A REJECTED input must not refresh the liveness attestation.</b> The rejection note goes onto
+    /// the transcript through the same emit path as agent output, whose contract is to advance the
+    /// activity clock ("the content was genuinely produced"). That justification does not hold for a
+    /// note the DAEMON authored about input it refused: the queue is full only because a turn is
+    /// wedged, so every retry against a stuck agent would reset <c>IdleForMs</c> and bump
+    /// <c>ActivitySeq</c> — the user's attempts to unstick it keeping the supervisor from ever seeing
+    /// it as idle. Bounded for a reviewer (its TTL arm fires regardless), unbounded for a hosted agent.
+    ///
+    /// <para>Both attestation fields are asserted, because they fail independently: <c>ActivitySeq</c>
+    /// is what a server compares between reports, <c>IdleForMs</c> is what a reaper thresholds on.</para>
+    /// </summary>
+    [Test]
+    public async Task A_rejected_enqueue_does_not_advance_the_activity_clock() {
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+
+        await using var rt = FakeRuntime(turn: FakeTurn.NeverEnds, queueCap: 1);
+
+        rt.ActivityClock = clock;
+
+        await rt.SendUserInputAsync("one").WaitAsync(HangGuard);
+
+        // Turn 1 is genuinely executing (its init has been read), so the queue state below is real —
+        // and the launch's own stamps have already landed before the readings are taken.
+        await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await rt.SendUserInputAsync("two").WaitAsync(HangGuard);
+
+        // Non-zero idleness to lose: without this the "unchanged" assertion below would hold trivially
+        // at 0 whether or not the clock advanced.
+        time.Advance(TimeSpan.FromSeconds(7));
+
+        var seqBefore  = clock.ActivitySeq;
+        var idleBefore = clock.IdleForMs;
+
+        await Assert.That(idleBefore).IsEqualTo(7000UL);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => rt.SendUserInputAsync("three").WaitAsync(HangGuard));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => rt.SendUserInputAsync("four").WaitAsync(HangGuard));
+
+        // The notes DID reach the transcript — this is about the clock, not about suppressing them.
+        var notes = 0;
+        while (rt.Envelopes.TryRead(out var env))
+            if (env.Kind == AcpEventKind.SystemNote) notes++;
+
+        await Assert.That(notes).IsEqualTo(2);
+
+        await Assert.That(clock.ActivitySeq).IsEqualTo(seqBefore);
+        await Assert.That(clock.IdleForMs).IsEqualTo(idleBefore);
     }
 
     /// <summary>A turn child that emits its <c>init</c> and then holds the turn open until the test


### PR DESCRIPTION
Makes `agy` usable as a **hosted** dashboard agent, alongside the unattended reviewer that landed in #479. One factory now serves both, so most of this is getting that split right.

Fixes AI-1412

Server-side half: kurrent-io/kcap-server#1347 (merged).

## The split

| | hosted | reviewer |
|---|---|---|
| `--dangerously-skip-permissions` | ✅ | ❌ |
| `KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER` consent | — | ✅ |
| `kcap-flow-result` MCP + result-channel validation | — | ✅ |
| platform / binary / version floor | ✅ | ✅ |
| isolated per-launch `HOME` | ✅ | ✅ |

**The flag is the entire read boundary; the owned worktree is not one.** Measured on 1.1.10: with it, an absolute out-of-workspace `view_file` succeeds; without it, refused with a typed `tool_info.error`. Claude is the precedent for a *single-axis* no-prompt posture existing at all (Codex's is two axes, so its no-prompt mode still sits on a sandbox) — but explicitly **not** for which launch kind gets it, since Claude widens its reviewer and prompts on interactive, the mirror image of this.

**Consent is reviewer-only.** Its justification is cross-principal exposure — a reviewer returns what it read to whoever requested the review. A hosted launch has no such exposure: `DaemonRegistry` is keyed `(TeamId, OwnerUserId, Name)` and `CapacitorHub` resolves the daemon from the caller's own id, so the launcher *is* the owner. Hosted agy ships on by default, per the owner's decision.

**The isolated HOME stays for hosted too**, and not for the reason originally supposed. Four piped runs under a real HOME reached EOF in 6–16s, so the "capture hooks wedge the turn's stdout" premise doesn't hold. What the probe *did* find: every run was also captured by the hook lane as a second watcher session, while the runtime already forwards its own transcript. An inherited HOME **duplicates** capture rather than adding it.

## Also here

- **Bounded input queue.** Input sent mid-turn is delivered in order as the next turn. Fixing this uncovered a real defect: the channel used `BoundedChannelFullMode.DropWrite`, where `TryWrite` returns *true* and silently discards — so the existing "queue full" branch was unreachable dead code and an over-cap message vanished without a log line. Over-cap now faults the send **and** writes a `system_note`, one per rejected message.
- **`kcap agent attach` refused by name**, daemon-side on `!EmitsTerminalOutput` — the client sends an id verbatim and cannot know the vendor. Replaces a blank-screen hang; the remove-the-refusal mutant fails *by timeout*, reproducing it.
- **A PR-review launch is refused.** `LaunchKind.Review` is wire-reachable independently of vendor (`CapacitorHub` takes `vendor` and `kind` as separate client arguments and rejects only the Codex pair), and would otherwise have got the hosted arm with no review tools and no error.
- **A rejected input no longer advances the liveness clock** — the queue is full only because a turn is wedged, so retries were refreshing the very attestation that would report it idle.

## Testing

253 Antigravity, 377 across all reviewer suites, 53 `DaemonRunner` — all green; daemon AOT clean. Every guard mutation-verified.

Two worth calling out. The consent fix's one production line was **untested** — reverting it passed 248/0, because nothing invokes `DaemonRunner.RunAsync` and the test called the seeding helper directly, pinning the directory but not the conditionality. Hoisted into `SeedReviewerFloors` so the asymmetry is the thing under test. And one mutant "survived" six runs having never compiled: a scripted edit left the source mtime not newer than the last build output, so MSBuild skipped it.

One accepted trade is documented in `ReviewerVersionStore`: antigravity's floor is seeded from the binary resolving rather than from a consent event, because hosted launches need one without consent. That leaves a narrow window where a downgrade below the pre-consent build is admitted; the remedy is `kcap daemon reviewer affirm --vendor antigravity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)