### PR TITLE
Thread the requester display name through launch and status wires

### DIFF
--- a/src/Capacitor.App/ViewModels/AgentRowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/AgentRowViewModel.cs
@@ -57,7 +57,7 @@ public sealed class AgentRowViewModel : ReactiveObject, IDisposable {
         VendorDisplay = dto.Model is null ? dto.Vendor : $"{dto.Vendor} ({dto.Model})";
         RepoLeaf = RepoLabel.Leaf(dto.RepoPath);
         RepoFull = dto.RepoPath ?? "";
-        Requester = dto.Requester ?? "unknown";
+        Requester = !string.IsNullOrWhiteSpace(dto.RequesterDisplay) ? dto.RequesterDisplay : dto.Requester ?? "unknown";
         StatusText = dto.Status;
         CreatedAt = dto.CreatedAt;
 

--- a/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
@@ -23,11 +23,14 @@ public sealed record DaemonInfoDto(
 /// vocabulary — clients treat unknown values as opaque display text). <see cref="Kind"/>
 /// uses the KindText wire spellings (agent/review/review-flow, unknown enum names pass
 /// through) — one vocabulary across AgentList and this payload. <see cref="Requester"/> is
-/// null when unknown (old servers, local spawns); rendering "unknown" is presentation.
+/// the opaque server-stamped requester id, null when unknown (old servers, local spawns).
+/// <see cref="RequesterDisplay"/> is the server-stamped human-readable name for it, null on
+/// an old server or a local spawn; choosing which of the two to render is presentation.
 /// </summary>
 public sealed record AgentStatusDto(
     string Id, string Kind, string Vendor, string? RepoPath, string Status,
-    string? FlowRunId, string? FlowRole, string? Requester, DateTime CreatedAt, string? Model);
+    string? FlowRunId, string? FlowRole, string? Requester, DateTime CreatedAt, string? Model,
+    string? RequesterDisplay);
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(DaemonStatusDto))]

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1338,7 +1338,11 @@ public readonly record struct LaunchAgentCommand(
         //
         // Null for every non-review-flow launch and for a launch predating this field; an old daemon
         // ignores it.
-        int?              InactivityBoundSeconds = null
+        int?              InactivityBoundSeconds = null,
+        // The server-stamped human-readable name for RequesterUserId (issue #481). Display-only —
+        // NEVER used for consent matching, which stays on RequesterUserId. Appended last, same
+        // wire-compat rule as the fields above — old daemons ignore it, old servers never set it.
+        string?           RequesterDisplay = null
     );
 
 /// <summary>Caller-selected Codex launch posture. Valid ONLY for interactive, daemon-owned-worktree

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -53,7 +53,7 @@ internal partial class AgentOrchestrator {
                 // (ModelSelectionLaunchPolicy.Evaluate treats blank as Honor, i.e. pass-through
                 // unchanged) — but the wire contract pins absent = null. Normalize here, at the
                 // wire boundary, rather than changing what AgentInstance stores.
-                string.IsNullOrWhiteSpace(a.Model) ? null : a.Model))];
+                string.IsNullOrWhiteSpace(a.Model) ? null : a.Model, a.RequesterDisplay))];
 
     /// <summary>
     /// Serves the legacy <c>Stop</c> frame from older clients that predate --force. That frame

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -65,6 +65,11 @@ internal record AgentInstance(
     /// servers and local spawns — the supervision payload renders null as unknown.</summary>
     public string?              RequesterUserId   { get; init; }
 
+    /// <summary>The server-stamped human-readable name for <see cref="RequesterUserId"/>. Null for
+    /// old servers, local spawns, and a PID-record recovery (never persisted, best-effort only) —
+    /// the supervision payload falls back to <see cref="RequesterUserId"/>, then "unknown".</summary>
+    public string?              RequesterDisplay  { get; init; }
+
     /// <summary>The applied Codex sandbox/approval pair — the values actually passed to the vendor
     /// CLI, whether caller-selected or derived. Set only for an interactive Codex launch on a
     /// daemon-owned worktree; null everywhere else. Stored HERE (not recomputed at each send) so the
@@ -1150,7 +1155,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             string? flowRunId = null, string? flowRole = null,
             DateTime? createdAt = null, DateTime? lastOutputAt = null, bool isPrivate = false,
             IPtyProcess? pty = null, string? startIdentity = null, string? requester = null,
-            string? model = "default", int? inactivityBoundSeconds = null,
+            string? requesterDisplay = null, string? model = "default", int? inactivityBoundSeconds = null,
             // Task 12 (unified reviewer reaping): a test that needs to control the agent's monotonic
             // age/idle (rather than the wall-clock CreatedAt/LastOutputAt above, which the new
             // FindReviewersToReap no longer reads) constructs its own AgentActivityClock over a
@@ -1165,6 +1170,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             Kind = kind, FlowRunId = flowRunId, FlowRole = flowRole, IsPrivate = isPrivate,
             CreatedAt = createdAt ?? DateTime.UtcNow, StartIdentity = startIdentity,
             RequesterUserId = requester,
+            RequesterDisplay = requesterDisplay,
             InactivityBoundSeconds = inactivityBoundSeconds,
             ActivityClock = activityClock ?? CreateActivityClock()
         };
@@ -1733,6 +1739,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 FlowRunId           = cmd.FlowRunId,
                 FlowRole            = cmd.FlowRole,
                 RequesterUserId     = cmd.RequesterUserId,
+                RequesterDisplay    = cmd.RequesterDisplay,
                 InactivityBoundSeconds = cmd.InactivityBoundSeconds
             };
             PublishAgent(agent);

--- a/test/Capacitor.App.Tests.Unit/AgentGridTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AgentGridTests.cs
@@ -55,8 +55,9 @@ public class AgentGridTests {
 
     static AgentStatusDto Dto(
             string id = "a", string kind = "agent", string vendor = "claude", string? repoPath = "/repos/kcap-cli",
-            string status = "Running", string? requester = null, DateTime? createdAt = null, string? model = null) =>
-        new(id, kind, vendor, repoPath, status, null, null, requester, createdAt ?? DateTime.UtcNow, model);
+            string status = "Running", string? requester = null, DateTime? createdAt = null, string? model = null,
+            string? requesterDisplay = null) =>
+        new(id, kind, vendor, repoPath, status, null, null, requester, createdAt ?? DateTime.UtcNow, model, requesterDisplay);
 
     static AgentRowViewModel NewRow(
             AgentStatusDto dto, AgentActionService? actions = null, IObservable<long>? ticker = null,
@@ -117,6 +118,18 @@ public class AgentGridTests {
     public async Task Requester_present_renders_verbatim() {
         var row = NewRow(Dto(requester: "alice"));
         await Assert.That(row.Requester).IsEqualTo("alice");
+    }
+
+    [Test]
+    public async Task RequesterDisplay_present_takes_precedence_over_the_opaque_requester_id() {
+        var row = NewRow(Dto(requester: "github:12345", requesterDisplay: "Ada Lovelace"));
+        await Assert.That(row.Requester).IsEqualTo("Ada Lovelace");
+    }
+
+    [Test]
+    public async Task RequesterDisplay_blank_falls_back_to_the_opaque_requester_id() {
+        var row = NewRow(Dto(requester: "github:12345", requesterDisplay: "   "));
+        await Assert.That(row.Requester).IsEqualTo("github:12345");
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
@@ -62,7 +62,8 @@ public class DaemonClientServiceTests {
     static DaemonStatusDto Snap(string daemon, params string[] ids) {
         var agents = ids.Select(id => new AgentStatusDto(
             Id: id, Kind: "agent", Vendor: "claude", RepoPath: null, Status: "Running",
-            FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null
+            FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null,
+            RequesterDisplay: null
         )).ToList();
         return new DaemonStatusDto(
             new DaemonInfoDto(daemon, "1.0.0", "http://localhost:9999", "connected", MaxAgents: 10, ActiveAgents: agents.Count),

--- a/test/Capacitor.App.Tests.Unit/FakeDaemonClientService.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeDaemonClientService.cs
@@ -32,7 +32,8 @@ sealed class FakeDaemonClientService : IDaemonClientService {
             string connection = "connected", int active = 0, int max = 5) {
         var agents = Enumerable.Range(0, active).Select(i => new AgentStatusDto(
             Id: $"a{i}", Kind: "agent", Vendor: "claude", RepoPath: null, Status: "Running",
-            FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null
+            FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null,
+            RequesterDisplay: null
         )).ToList();
         return new DaemonStatusDto(new DaemonInfoDto(daemon, version, serverUrl, connection, max, active), agents);
     }

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -237,7 +237,7 @@ public class MainWindowSmokeTests {
             var emptyVisible = Header().IsVisible;
 
             service.Agents.AddOrUpdate(new AgentStatusDto(
-                "a", "agent", "claude", "/repos/kcap-cli", "Running", null, null, null, DateTime.UtcNow, null));
+                "a", "agent", "claude", "/repos/kcap-cli", "Running", null, null, null, DateTime.UtcNow, null, null));
             Dispatcher.UIThread.RunJobs();
             var withRowVisible = Header().IsVisible;
 

--- a/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
@@ -303,9 +303,9 @@ public class TrayViewModelTests {
 
             var t0 = new DateTime(2026, 8, 6, 10, 0, 0, DateTimeKind.Utc);
             var agents = new List<AgentStatusDto> {
-                new("b", "agent", "claude", "/repos/kcap-cli", "Running", null, null, null, t0.AddMinutes(2), null),
-                new("a", "agent", "claude", "/repos/kcap-cli", "Starting", null, null, null, t0, null),
-                new("c", "review", "codex", null, "Completed", null, null, null, t0.AddMinutes(1), null),
+                new("b", "agent", "claude", "/repos/kcap-cli", "Running", null, null, null, t0.AddMinutes(2), null, null),
+                new("a", "agent", "claude", "/repos/kcap-cli", "Starting", null, null, null, t0, null, null),
+                new("c", "review", "codex", null, "Completed", null, null, null, t0.AddMinutes(1), null, null),
             };
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
@@ -330,8 +330,8 @@ public class TrayViewModelTests {
 
             var t0 = new DateTime(2026, 8, 6, 10, 0, 0, DateTimeKind.Utc);
             var agents = new List<AgentStatusDto> {
-                new("z", "agent", "claude", null, "Running", null, null, null, t0, null),
-                new("a", "agent", "claude", null, "Running", null, null, null, t0, null),
+                new("z", "agent", "claude", null, "Running", null, null, null, t0, null, null),
+                new("a", "agent", "claude", null, "Running", null, null, null, t0, null, null),
             };
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
@@ -353,7 +353,7 @@ public class TrayViewModelTests {
             using var vm = new TrayViewModel(service, pause, actions);
 
             var agents = new List<AgentStatusDto> {
-                new("r", "review-flow", "codex", null, "Running", null, null, null, DateTime.UtcNow, null),
+                new("r", "review-flow", "codex", null, "Running", null, null, null, DateTime.UtcNow, null, null),
             };
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
@@ -373,7 +373,7 @@ public class TrayViewModelTests {
             using var vm = new TrayViewModel(service, pause, actions);
 
             var agents = new List<AgentStatusDto> {
-                new("a", "agent", "claude", "/Users/alexey/dev/kcap-server/.claude/worktrees/hazy-sleeping-plum", "Running", null, null, null, DateTime.UtcNow, null),
+                new("a", "agent", "claude", "/Users/alexey/dev/kcap-server/.claude/worktrees/hazy-sleeping-plum", "Running", null, null, null, DateTime.UtcNow, null, null),
             };
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
@@ -393,7 +393,7 @@ public class TrayViewModelTests {
             using var vm = new TrayViewModel(service, pause, actions);
 
             var agents = new List<AgentStatusDto> {
-                new("a", "agent", "claude", null, "Running", null, null, null, DateTime.UtcNow, null),
+                new("a", "agent", "claude", null, "Running", null, null, null, DateTime.UtcNow, null, null),
             };
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
@@ -629,7 +629,7 @@ public class TrayViewModelTests {
             using var vm = new TrayViewModel(service, pause, actions);
 
             var agents = new List<AgentStatusDto> {
-                new("a", "agent", "claude", null, "Running", null, null, null, DateTime.UtcNow, null),
+                new("a", "agent", "claude", null, "Running", null, null, null, DateTime.UtcNow, null, null),
             };
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap("connected", 1, agents));
@@ -659,7 +659,7 @@ public class TrayViewModelTests {
             using var vm = new TrayViewModel(service, pause, actions);
 
             var agents = new List<AgentStatusDto> {
-                new("a", "agent", "claude", "/repos/kcap-cli", "Running", null, null, null, DateTime.UtcNow, null),
+                new("a", "agent", "claude", "/repos/kcap-cli", "Running", null, null, null, DateTime.UtcNow, null, null),
             };
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap("connected", 1, agents));
@@ -688,7 +688,7 @@ public class TrayViewModelTests {
             using var vm = new TrayViewModel(service, pause, actions);
 
             var agents = new List<AgentStatusDto> {
-                new("a", "review-flow", "codex", "/repos/kcap-cli", "Running", null, null, null, DateTime.UtcNow, null),
+                new("a", "review-flow", "codex", "/repos/kcap-cli", "Running", null, null, null, DateTime.UtcNow, null, null),
             };
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap("connected", 1, agents));

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorRequesterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorRequesterTests.cs
@@ -7,6 +7,8 @@ namespace Capacitor.Cli.Tests.Unit;
 /// Requester stamping (spec §4.3): AgentInstance.RequesterUserId is captured from
 /// LaunchAgentCommand at construction — non-null when a new server sends it, null for
 /// old servers (field absent) — so the supervision payload can show who asked.
+/// RequesterDisplay (issue #481) is captured the same way, independently — a server may
+/// send the id without a display name (old server, or the server hasn't resolved one yet).
 /// </summary>
 public partial class AgentOrchestratorVendorTests {
     [Test]
@@ -31,12 +33,15 @@ public partial class AgentOrchestratorVendorTests {
                 Tools: null,
                 AttachmentIds: null,
                 Vendor: "claude",
-                RequesterUserId: "github:12345"
+                RequesterUserId: "github:12345",
+                RequesterDisplay: "Ada Lovelace"
             );
 
             await orch.HandleLaunchAgentForTest(cmd);
 
-            await Assert.That(orch.GetAgentForTest("req-1")!.RequesterUserId).IsEqualTo("github:12345");
+            var agent = orch.GetAgentForTest("req-1")!;
+            await Assert.That(agent.RequesterUserId).IsEqualTo("github:12345");
+            await Assert.That(agent.RequesterDisplay).IsEqualTo("Ada Lovelace");
         } finally {
             cleanup();
         }
@@ -68,7 +73,9 @@ public partial class AgentOrchestratorVendorTests {
 
             await orch.HandleLaunchAgentForTest(cmd);
 
-            await Assert.That(orch.GetAgentForTest("req-2")!.RequesterUserId).IsNull();
+            var agent = orch.GetAgentForTest("req-2")!;
+            await Assert.That(agent.RequesterUserId).IsNull();
+            await Assert.That(agent.RequesterDisplay).IsNull();
         } finally {
             cleanup();
         }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/AgentStatusSnapshotTests.cs
@@ -109,13 +109,14 @@ public class AgentStatusSnapshotTests {
         try {
             var createdAt = new DateTime(2026, 8, 1, 12, 30, 0, DateTimeKind.Utc);
             orch.SeedAgentForTest("r1", kind: LaunchKind.ReviewFlow, flowRunId: "flow_1",
-                flowRole: "reviewer", requester: "github:12345", createdAt: createdAt);
+                flowRole: "reviewer", requester: "github:12345", requesterDisplay: "Ada Lovelace", createdAt: createdAt);
             orch.SeedAgentForTest("d1"); // defaults: LaunchKind.Default, no flow identity, no requester
 
             var byId = orch.SnapshotAgentsForStatus().ToDictionary(a => a.Id);
 
             await Assert.That(byId["r1"].Kind).IsEqualTo("review-flow");
             await Assert.That(byId["r1"].Requester).IsEqualTo("github:12345");
+            await Assert.That(byId["r1"].RequesterDisplay).IsEqualTo("Ada Lovelace");
             await Assert.That(byId["r1"].FlowRunId).IsEqualTo("flow_1");
             // SeedAgentForTest's fixed constants — pins the Select against a same-typed-neighbor
             // transposition (e.g. Vendor/RepoPath swapped) that the other assertions can't catch.
@@ -126,6 +127,7 @@ public class AgentStatusSnapshotTests {
             await Assert.That(byId["r1"].CreatedAt).IsEqualTo(createdAt);
             await Assert.That(byId["d1"].Kind).IsEqualTo("agent");
             await Assert.That(byId["d1"].Requester).IsNull();
+            await Assert.That(byId["d1"].RequesterDisplay).IsNull();
             await Assert.That(byId["d1"].FlowRunId).IsNull();
         } finally {
             await fixture.CleanupAsync();

--- a/test/Capacitor.Cli.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LaunchAgentCommandWireFormatTests.cs
@@ -290,6 +290,34 @@ public class LaunchAgentCommandWireFormatTests {
         var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.LaunchAgentCommand);
         await Assert.That(back.InactivityBoundSeconds).IsEqualTo(180);
     }
+
+    [Test]
+    public async Task RequesterDisplay_roundtrips_and_defaults_null_when_absent() {
+        // An old server never sends this field (issue #481) — the daemon must default to null,
+        // never fail to bind the command.
+        var legacyJson = """{"agent_id":"a1","model":"m","repo_path":"/r","vendor":"claude"}""";
+        var legacy = JsonSerializer.Deserialize(legacyJson, CapacitorJsonContext.Default.LaunchAgentCommand);
+        await Assert.That(legacy.RequesterDisplay).IsNull();
+
+        var cmd = new LaunchAgentCommand(
+            AgentId: "a1",
+            Prompt: null,
+            Model: "m",
+            Effort: null,
+            RepoPath: "/r",
+            Tools: null,
+            AttachmentIds: null,
+            Vendor: "claude",
+            RequesterUserId: "github:2821205",
+            RequesterDisplay: "Ada Lovelace"
+        );
+        var json = JsonSerializer.Serialize(cmd, ServerWireOptions);
+        await Assert.That(json).Contains("\"requester_display\":\"Ada Lovelace\"");
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.LaunchAgentCommand);
+        await Assert.That(back.RequesterDisplay).IsEqualTo("Ada Lovelace");
+        // Display-only: never used for consent matching, which stays on RequesterUserId.
+        await Assert.That(back.RequesterUserId).IsEqualTo("github:2821205");
+    }
 }
 
 /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/StatusIpcJsonTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/StatusIpcJsonTests.cs
@@ -17,17 +17,19 @@ public class StatusIpcJsonTests {
                 new AgentStatusDto(
                     "agent-abc123", "review-flow", "codex", "/Users/x/dev/repo", "Live",
                     "flow_1", "reviewer", "github:12345",
-                    new DateTime(2026, 8, 1, 12, 34, 56, 789, DateTimeKind.Utc), "gpt-5-codex"),
+                    new DateTime(2026, 8, 1, 12, 34, 56, 789, DateTimeKind.Utc), "gpt-5-codex",
+                    "Ada Lovelace"),
                 new AgentStatusDto(
                     "agent-b", "agent", "claude", null, "Starting",
                     null, null, null,
-                    new DateTime(2026, 8, 1, 12, 35, 0, DateTimeKind.Utc), null),
+                    new DateTime(2026, 8, 1, 12, 35, 0, DateTimeKind.Utc), null,
+                    null),
             ]);
 
         var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.DaemonStatusDto);
 
         await Assert.That(json).IsEqualTo(
-            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex"},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null}]}""");
+            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex","requester_display":"Ada Lovelace"},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null,"requester_display":null}]}""");
     }
 
     [Test]


### PR DESCRIPTION
Closes #481. Linear: AI-1791 (pair: AI-1792 is the kcap-server half that stamps the value).

The desktop app's Agents grid shows the requester as the server-stamped opaque id (`github:2821205`). This threads an additive `RequesterDisplay` through the wire so the server can stamp a human name:

- `LaunchAgentCommand`: additive trailing `RequesterDisplay = null` (established wire-compat rule: old daemons ignore it, old servers never set it; display-only — consent matching stays on `RequesterUserId`).
- `AgentInstance` + the launch registration path store and forward it; recovery paths leave it null (best-effort, never persisted).
- `AgentStatusDto`: `requester_display` appended last, always emitted, null when unknown; exact-JSON wire tests updated for both cases. Deliberately no C# default — the record's positional-required convention forces every construction site to be updated consciously (wire compat is unaffected either way: STJ fills absent JSON as null).
- App: the requester cell prefers the display name, falls back to the id, then "unknown" (whitespace-only display falls back too).

Until the server half deploys, the app keeps showing the id — no behavior change. Reviewed internally (wire-compat, all stamping sites verified by independent grep, consent-path isolation confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)