### PR TITLE
Add `kcap machine` — credentials for headless recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ At a glance — each links to its section below:
 | [`kcap repos`](#repository-paths) | Manage known repo paths for the launch dialog |
 | [`kcap projects` / `project`](#projects) | List and inspect projects |
 | [`kcap profile` / `use`](#profiles) | Manage and switch between servers/profiles |
+| [`kcap machine`](#machine-credentials-headless-recording) | Create credentials for CI runners and agent sandboxes |
 | [`kcap config`](#configuration) | Show and set configuration |
 | [`kcap remap`](#renamed-repo-directories-kcap-remap) | Map renamed repo directories for import |
 | [`kcap ignore`](#configuration) | Exclude paths from recording |
@@ -1480,6 +1481,54 @@ The CLI resolves which profile to use in this order:
 5. Git remote pattern matching from `--remote` flags
 6. Directory binding from `kcap use`
 7. Global active profile (or `default`)
+
+### Machine credentials (headless recording)
+
+A **machine** records sessions where no person can sign in — CI runners, ephemeral
+agent sandboxes, anywhere a browser login is impossible. It records like a user but
+is never an administrator and never a member of a project.
+
+Creating one requires the **owner or admin** role in your organization, and a server
+with machine credentials enabled.
+
+```bash
+kcap machine create ci-runner            # create; prints the secret ONCE
+kcap machine list                        # this org's machines
+kcap machine revoke service:9e96…        # stop one authenticating
+```
+
+**The secret is shown once and is never stored** — not by this CLI, not by Capacitor,
+and WorkOS will not show it again. That is deliberate: a secret nobody stores is a
+secret nobody can leak. It goes to stdout while everything else goes to stderr, so it
+can be piped straight into a secret store without touching disk:
+
+```bash
+kcap machine create ci-runner --visibility org_public \
+  2>/dev/null | gh secret set KCAP_CLIENT_SECRET
+```
+
+The runner then needs both variables in its environment:
+
+| Variable | |
+|---|---|
+| `KCAP_CLIENT_ID` | public — safe to commit |
+| `KCAP_CLIENT_SECRET` | a secret — use your CI's secret store |
+
+Finally, choose what its sessions are visible to, **on the machine itself**:
+
+```bash
+kcap config set default_visibility org_public
+```
+
+Visibility is the machine's own setting, exactly as it is for a person. The
+`--visibility` flag on `create` only selects the value printed in the instructions —
+it does not configure the runner for you.
+
+Revoking stops a machine authenticating from its next request. A token it already
+holds stays valid until it expires (up to an hour) but is no longer honoured. To cut
+it off at the source as well, delete the application in the WorkOS dashboard.
+
+Run `kcap machine --help` for the full sequence.
 
 ### Configuration
 

--- a/src/Capacitor.Cli.Core/Commands/MachineProvisioning.cs
+++ b/src/Capacitor.Cli.Core/Commands/MachineProvisioning.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.Commands;
+
+/// <summary>Request body for the proxy's <c>POST /connect/m2m-applications</c>. Carries no organization.</summary>
+public sealed record CreateMachineApplicationRequest(
+        [property: JsonPropertyName("name")] string Name
+    );
+
+/// <summary>
+/// The proxy's provisioning result.
+///
+/// <para><c>client_secret</c> is present ONLY on a create. WorkOS discloses a secret exactly once, so
+/// an idempotent hit (the machine already existed) returns null — there is nothing left to disclose,
+/// and pretending otherwise would be worse than saying so.</para>
+/// </summary>
+public sealed record CreateMachineApplicationResponse {
+    [JsonPropertyName("application_id")]  public string  ApplicationId  { get; init; } = "";
+    [JsonPropertyName("client_id")]       public string  ClientId       { get; init; } = "";
+    [JsonPropertyName("client_secret")]   public string? ClientSecret   { get; init; }
+    [JsonPropertyName("organization_id")] public string  OrganizationId { get; init; } = "";
+    [JsonPropertyName("created")]         public bool    Created        { get; init; }
+}
+
+/// <summary>Request body for the tenant's <c>POST /api/admin/machines</c>. Public data only.</summary>
+public sealed record RegisterMachineRequest(
+        [property: JsonPropertyName("workos_client_id")] string  WorkOsClientId,
+        [property: JsonPropertyName("display_name")]     string  DisplayName,
+        [property: JsonPropertyName("role")]             string? Role
+    );
+
+/// <summary>One machine as the tenant reports it. Carries no secret — the tenant never sees one.</summary>
+public sealed record MachineSummary {
+    [JsonPropertyName("service_id")]       public string          ServiceId      { get; init; } = "";
+    [JsonPropertyName("user_id")]          public string          UserId         { get; init; } = "";
+    [JsonPropertyName("workos_client_id")] public string          WorkOsClientId { get; init; } = "";
+    [JsonPropertyName("display_name")]     public string          DisplayName    { get; init; } = "";
+    [JsonPropertyName("role")]             public string          Role           { get; init; } = "";
+    [JsonPropertyName("created_by")]       public string          CreatedBy      { get; init; } = "";
+    [JsonPropertyName("created_at")]       public DateTimeOffset  CreatedAt      { get; init; }
+    [JsonPropertyName("revoked_at")]       public DateTimeOffset? RevokedAt      { get; init; }
+    [JsonPropertyName("usable")]           public bool            Usable         { get; init; }
+}
+
+/// <summary>The tenant's register response — the derived principal id.</summary>
+public sealed record RegisterMachineResponse {
+    [JsonPropertyName("service_id")] public string ServiceId { get; init; } = "";
+    [JsonPropertyName("user_id")]    public string UserId    { get; init; } = "";
+}

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1055,6 +1055,13 @@ public sealed record CurationApplyResponse {
 // source-gen LaunchKind JsonTypeInfo defaults to numeric and silently drops the
 // invocation — the daemon receives "kind": "review" / "default" and the
 // LaunchAgent handler never fires (DEV-1665).
+// Machine credentials. Registered here because the AOT CLI has no reflection fallback:
+// an unregistered type throws at runtime, not at build.
+[JsonSerializable(typeof(Capacitor.Cli.Core.Commands.CreateMachineApplicationRequest))]
+[JsonSerializable(typeof(Capacitor.Cli.Core.Commands.CreateMachineApplicationResponse))]
+[JsonSerializable(typeof(Capacitor.Cli.Core.Commands.RegisterMachineRequest))]
+[JsonSerializable(typeof(Capacitor.Cli.Core.Commands.RegisterMachineResponse))]
+[JsonSerializable(typeof(Capacitor.Cli.Core.Commands.MachineSummary[]))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     UseStringEnumConverter = true

--- a/src/Capacitor.Cli.Core/Resources/help-machine.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-machine.txt
@@ -1,0 +1,77 @@
+kcap machine — credentials for headless recording
+
+A machine records sessions without a person signing in: CI runners, ephemeral
+agent sandboxes, anywhere a browser login is impossible. It records like a user
+but is never an administrator and never a member of a project.
+
+Usage: kcap machine <create|list|revoke>
+
+  create <name> [--visibility <v>] [--role <role>]
+                          Create a machine and print its secret ONCE
+  list                    Show this organization's machines
+  revoke <service-id>     Stop a machine authenticating
+
+Requires the owner or admin role in your organization.
+
+THE SECRET IS SHOWN ONCE
+
+  It is issued by WorkOS and never stored — not by this CLI, not by Capacitor,
+  and WorkOS will not show it again. If you lose it, revoke the machine and
+  create a new one.
+
+  That is deliberate rather than an inconvenience: a secret nobody stores is a
+  secret nobody can leak. It travels from WorkOS to your terminal and stops
+  there; it never reaches the Capacitor server at all.
+
+  The secret goes to stdout and everything else to stderr, so you can pipe it
+  straight into a secret store without it touching disk.
+
+Flags for create:
+
+  --visibility <v>   What the machine's sessions are visible to. One of:
+                     private, org_public, public. Default: private.
+                     Printed in the setup instructions — see below for why it
+                     is set on the machine rather than here.
+  --role <role>      The machine's role in Capacitor. Default: member.
+                     A machine is never an administrator whatever you pass.
+
+Full sequence:
+
+  # 1. Create it, capturing the secret straight into your secret store
+  kcap machine create ci-runner --visibility org_public \
+    2>/dev/null | gh secret set KCAP_CLIENT_SECRET
+
+  # 2. Note the client id it printed, and set that too. The client id is
+  #    public — it is safe to commit.
+  gh secret set KCAP_CLIENT_ID --body client_01ABC...
+
+  # 3. On the runner, both variables must be in the environment:
+  #      KCAP_CLIENT_ID      public, safe to commit
+  #      KCAP_CLIENT_SECRET  a secret; use your CI's secret store
+
+  # 4. On the runner, choose what its sessions are visible to
+  kcap config set default_visibility org_public
+
+Why step 4 runs on the machine
+
+  Visibility is the machine's own setting, exactly as it is for a person — it
+  lives in the profile the machine records with. --visibility on create only
+  tells you which value to set; it does not configure the runner for you,
+  because this command has no access to it.
+
+Taking a machine out of service:
+
+  kcap machine list                  # find the service id
+  kcap machine revoke service:9e96...
+
+  Revoking stops it authenticating from its next request. A token it already
+  holds stays valid until it expires (up to an hour) but is no longer honoured.
+  To cut it off at the source as well, delete the application in the WorkOS
+  dashboard — that takes effect immediately.
+
+Examples:
+
+  kcap machine create ci-runner
+  kcap machine create nightly-agent --visibility org_public
+  kcap machine list
+  kcap machine revoke service:9e96baf8f4f55363bc23d9a3a79939b3

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -15,6 +15,9 @@ Profiles:
   profile remove <name>            Remove a profile
   profile show [name]              Show profile details
   use <profile> [--global] [--save]  Switch active profile
+  machine create <name>            Create a headless recording credential
+  machine list                     Show this org's machines
+  machine revoke <service-id>      Stop a machine authenticating
 
 Configuration:
   config show                      Print current configuration

--- a/src/Capacitor.Cli/Commands/MachineCommand.cs
+++ b/src/Capacitor.Cli/Commands/MachineCommand.cs
@@ -262,8 +262,11 @@ public static class MachineCommand {
     /// <c>... 2>/dev/null | gh secret set X</c> yields exactly the value.</para>
     /// </summary>
     static async Task PrintSecretAsync(string name, string secret, CreateMachineApplicationResponse provisioned) {
+        // Says only what is TRUE AT THIS POINT. Registration has not run yet and may fail, so claiming
+        // "machine created" here would be a lie in exactly the case the operator most needs to trust
+        // the output. `PrintSetupAsync` announces the completed machine once registration succeeds.
         await Console.Error.WriteLineAsync();
-        await Console.Error.WriteLineAsync($"Machine '{name}' created.");
+        await Console.Error.WriteLineAsync($"Credential issued for '{name}'.");
         await Console.Error.WriteLineAsync();
         await Console.Error.WriteLineAsync($"  Client ID     {provisioned.ClientId}");
         await Console.Error.WriteLineAsync($"  Organization  {provisioned.OrganizationId}");
@@ -283,7 +286,7 @@ public static class MachineCommand {
     static async Task PrintSetupAsync(
             RegisterMachineResponse registered, CreateMachineApplicationResponse provisioned, string visibility) {
         await Console.Error.WriteLineAsync();
-        await Console.Error.WriteLineAsync($"  Registered as {registered.UserId}");
+        await Console.Error.WriteLineAsync($"Machine registered as {registered.UserId}. It can now record.");
         await Console.Error.WriteLineAsync();
         await Console.Error.WriteLineAsync("  Give the runner these environment variables:");
         await Console.Error.WriteLineAsync();

--- a/src/Capacitor.Cli/Commands/MachineCommand.cs
+++ b/src/Capacitor.Cli/Commands/MachineCommand.cs
@@ -28,13 +28,20 @@ public static class MachineCommand {
     /// </summary>
     static readonly string[] Visibilities = ["private", "org_public", "public"];
 
-    public static async Task<int> HandleAsync(string[] args) {
+    /// <summary>
+    /// Takes <paramref name="baseUrl"/> because <c>CreateAuthenticatedClientAsync</c> does NOT set a
+    /// BaseAddress — every other command in this CLI builds absolute URLs from the resolved server URL,
+    /// and a relative URI here throws <see cref="InvalidOperationException"/> before a request is even
+    /// sent. An earlier revision used relative paths and would have failed on every tenant call.
+    /// Raised by Qodo. `machine` is not in Program.cs's offlineCommands, so baseUrl is non-null here.
+    /// </summary>
+    public static async Task<int> HandleAsync(string baseUrl, string[] args) {
         if (args.Length < 2 || IsHelp(args[1])) return await PrintUsage();
 
         return args[1] switch {
-            "create" => await CreateAsync(args),
-            "list"   => await ListAsync(),
-            "revoke" => await RevokeAsync(args),
+            "create" => await CreateAsync(baseUrl, args),
+            "list"   => await ListAsync(baseUrl),
+            "revoke" => await RevokeAsync(baseUrl, args),
             _        => await PrintUsage()
         };
     }
@@ -43,7 +50,7 @@ public static class MachineCommand {
 
     // ── create ──────────────────────────────────────────────────────────────────────────────────
 
-    static async Task<int> CreateAsync(string[] args) {
+    static async Task<int> CreateAsync(string baseUrl, string[] args) {
         if (args.Length < 3 || IsHelp(args[2])) return await PrintCreateUsage();
 
         var name       = args[2].Trim();
@@ -163,23 +170,45 @@ public static class MachineCommand {
             return 1;
         }
 
-        // Register the PUBLIC client id with the tenant. The secret is deliberately not in this call —
-        // there is no field for it, and there is no code path on the server that could store one.
-        var registered = await RegisterAsync(provisioned.ClientId, name, role);
+        // ORDER MATTERS: disclose the secret BEFORE registering.
+        //
+        // WorkOS discloses it exactly once. An earlier revision registered first and printed after, so
+        // any registration failure — server unreachable, feature disabled, caller not an admin —
+        // destroyed the secret permanently, and a retry could not recover it: the second provisioning
+        // call is an idempotent hit that returns no secret at all. The operator was left with an
+        // unusable application occupying the name, and no way back. Raised by Qodo.
+        //
+        // Printing first cannot lose anything. The worst case becomes an unregistered machine whose
+        // credential the operator holds, which the failure path below tells them how to resolve.
+        await PrintSecretAsync(name, provisioned.ClientSecret, provisioned);
 
-        if (registered is null) return 1;
+        // The PUBLIC client id, and only that. There is no field on this request for a secret and no
+        // code path on the server that could store one.
+        var registered = await RegisterAsync(baseUrl, provisioned.ClientId, name, role);
 
-        await PrintCredentialAsync(name, provisioned.ClientSecret, provisioned, registered, visibility);
+        if (registered is null) {
+            await Console.Error.WriteLineAsync();
+            await Console.Error.WriteLineAsync(
+                "The credential above is valid, but this machine is NOT registered on the server, so it "
+              + "cannot record yet. Once the problem above is fixed, delete the application in the "
+              + "WorkOS dashboard and run `kcap machine create` again — the secret above belongs to an "
+              + "application you are about to remove, so there is nothing to keep.");
+
+            return 1;
+        }
+
+        await PrintSetupAsync(registered, provisioned, visibility);
 
         return 0;
     }
 
-    static async Task<RegisterMachineResponse?> RegisterAsync(string clientId, string name, string? role) {
+    static async Task<RegisterMachineResponse?> RegisterAsync(
+            string baseUrl, string clientId, string name, string? role) {
         try {
             using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
 
             using var response = await client.PostAsJsonAsync(
-                "/api/admin/machines",
+                $"{baseUrl}/api/admin/machines",
                 new RegisterMachineRequest(clientId, name, role),
                 CapacitorJsonContext.Default.RegisterMachineRequest);
 
@@ -222,17 +251,17 @@ public static class MachineCommand {
     }
 
     /// <summary>
-    /// Prints the credential and how to use it. The secret goes to STDOUT (so it can be piped into a
-    /// secret store) and everything else to STDERR (so a pipe captures only the value).
+    /// The irrecoverable half: the client id and the secret. Called BEFORE registration so nothing
+    /// downstream can prevent disclosure.
+    ///
+    /// <para>The secret goes to STDOUT alone and everything else to STDERR, so
+    /// <c>... 2>/dev/null | gh secret set X</c> yields exactly the value.</para>
     /// </summary>
-    static async Task PrintCredentialAsync(
-            string name, string secret, CreateMachineApplicationResponse provisioned,
-            RegisterMachineResponse registered, string visibility) {
+    static async Task PrintSecretAsync(string name, string secret, CreateMachineApplicationResponse provisioned) {
         await Console.Error.WriteLineAsync();
         await Console.Error.WriteLineAsync($"Machine '{name}' created.");
         await Console.Error.WriteLineAsync();
         await Console.Error.WriteLineAsync($"  Client ID     {provisioned.ClientId}");
-        await Console.Error.WriteLineAsync($"  Principal     {registered.UserId}");
         await Console.Error.WriteLineAsync($"  Organization  {provisioned.OrganizationId}");
         await Console.Error.WriteLineAsync();
         await Console.Error.WriteLineAsync("  ── The secret below is shown ONCE. It is not stored anywhere ──");
@@ -240,9 +269,17 @@ public static class MachineCommand {
         await Console.Error.WriteLineAsync("     again. If you lose it, revoke this machine and create a new one.");
         await Console.Error.WriteLineAsync();
 
-        // STDOUT, alone, so `kcap machine create ci-runner 2>/dev/null` yields exactly the secret.
         await Console.Out.WriteLineAsync(secret);
+    }
 
+    /// <summary>
+    /// The recoverable half: what to do with the credential. Needs the registration result, so it runs
+    /// after — and a failure here costs instructions the help can repeat, not a secret.
+    /// </summary>
+    static async Task PrintSetupAsync(
+            RegisterMachineResponse registered, CreateMachineApplicationResponse provisioned, string visibility) {
+        await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync($"  Registered as {registered.UserId}");
         await Console.Error.WriteLineAsync();
         await Console.Error.WriteLineAsync("  Give the runner these environment variables:");
         await Console.Error.WriteLineAsync();
@@ -261,11 +298,11 @@ public static class MachineCommand {
 
     // ── list ────────────────────────────────────────────────────────────────────────────────────
 
-    static async Task<int> ListAsync() {
+    static async Task<int> ListAsync(string baseUrl) {
         try {
             using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
 
-            using var response = await client.GetAsync("/api/admin/machines");
+            using var response = await client.GetAsync($"{baseUrl}/api/admin/machines");
 
             if (response.StatusCode is HttpStatusCode.NotFound) {
                 await Console.Error.WriteLineAsync("This server does not have machine credentials enabled.");
@@ -311,7 +348,7 @@ public static class MachineCommand {
 
     // ── revoke ──────────────────────────────────────────────────────────────────────────────────
 
-    static async Task<int> RevokeAsync(string[] args) {
+    static async Task<int> RevokeAsync(string baseUrl, string[] args) {
         if (args.Length < 3 || IsHelp(args[2])) {
             await Console.Error.WriteLineAsync("Usage: kcap machine revoke <service-id>");
             await Console.Error.WriteLineAsync();
@@ -325,7 +362,7 @@ public static class MachineCommand {
         try {
             using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
 
-            using var response = await client.PostAsync($"/api/admin/machines/{Uri.EscapeDataString(serviceId)}/revoke", null);
+            using var response = await client.PostAsync($"{baseUrl}/api/admin/machines/{Uri.EscapeDataString(serviceId)}/revoke", null);
 
             if (response.StatusCode is HttpStatusCode.NotFound) {
                 await Console.Error.WriteLineAsync($"No machine '{serviceId}'. Run `kcap machine list`.");

--- a/src/Capacitor.Cli/Commands/MachineCommand.cs
+++ b/src/Capacitor.Cli/Commands/MachineCommand.cs
@@ -1,0 +1,357 @@
+using System.Net;
+using System.Net.Http.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Commands;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// `kcap machine` — machine credentials for headless recording.
+///
+/// <para><b>Two hops, and the split is the security property.</b> Provisioning goes to the auth proxy
+/// with the operator's own WorkOS token; registration goes to the tenant with only the public
+/// <c>client_id</c>. So the secret travels from WorkOS to this terminal and nowhere else — it never
+/// reaches the Capacitor server, which is what makes "no secret is stored by Capacitor" structural
+/// rather than a promise. Do not "simplify" this by routing provisioning through the tenant.</para>
+///
+/// <para><b>The secret is printed once and never persisted.</b> Not written to the config, not to the
+/// token store, not logged. WorkOS will not disclose it again either, so a lost secret means
+/// provisioning a new machine — which is why the output says so at the point of printing rather than
+/// burying it in documentation.</para>
+/// </summary>
+public static class MachineCommand {
+    /// <summary>
+    /// Visibility values a machine may record with — the same set a human's profile accepts, because a
+    /// machine is just another principal running this CLI. Kept in sync with the server's own list by
+    /// being validated here rather than silently passed through.
+    /// </summary>
+    static readonly string[] Visibilities = ["private", "org_public", "public"];
+
+    public static async Task<int> HandleAsync(string[] args) {
+        if (args.Length < 2 || IsHelp(args[1])) return await PrintUsage();
+
+        return args[1] switch {
+            "create" => await CreateAsync(args),
+            "list"   => await ListAsync(),
+            "revoke" => await RevokeAsync(args),
+            _        => await PrintUsage()
+        };
+    }
+
+    static bool IsHelp(string arg) => arg is "--help" or "-h" or "help";
+
+    // ── create ──────────────────────────────────────────────────────────────────────────────────
+
+    static async Task<int> CreateAsync(string[] args) {
+        if (args.Length < 3 || IsHelp(args[2])) return await PrintCreateUsage();
+
+        var name       = args[2].Trim();
+        var visibility = GetArg(args, "--visibility") ?? "private";
+        var role       = GetArg(args, "--role");
+
+        if (string.IsNullOrWhiteSpace(name)) {
+            await Console.Error.WriteLineAsync("A machine name is required.");
+
+            return 1;
+        }
+
+        if (!Visibilities.Contains(visibility, StringComparer.Ordinal)) {
+            await Console.Error.WriteLineAsync(
+                $"--visibility must be one of: {string.Join(", ", Visibilities)}");
+
+            return 1;
+        }
+
+        // The operator's own WorkOS access token is what the proxy scopes on: it reads org_id and role
+        // from the token's signed claims, so this CLI cannot ask for another organization even if it
+        // wanted to. Nothing about the request names an org.
+        var tokens = await TokenStore.GetValidTokensAsync();
+
+        if (tokens is null || string.IsNullOrEmpty(tokens.AccessToken)) {
+            await Console.Error.WriteLineAsync("Not authenticated. Run `kcap login` first.");
+
+            return 1;
+        }
+
+        using var http = new HttpClient();
+
+        CreateMachineApplicationResponse? provisioned;
+
+        try {
+            using var request = new HttpRequestMessage(
+                HttpMethod.Post, $"{AuthProxyEndpoint.Url}/connect/m2m-applications") {
+                Content = JsonContent.Create(new CreateMachineApplicationRequest(name),
+                    CapacitorJsonContext.Default.CreateMachineApplicationRequest)
+            };
+            request.Headers.Authorization = new("Bearer", tokens.AccessToken);
+
+            using var response = await http.SendAsync(request);
+
+            if (response.StatusCode is HttpStatusCode.Unauthorized) {
+                await Console.Error.WriteLineAsync(
+                    "The Kurrent auth service rejected your sign-in. Run `kcap login` and try again.");
+
+                return 1;
+            }
+
+            if (response.StatusCode is HttpStatusCode.Forbidden) {
+                await Console.Error.WriteLineAsync(
+                    "You need the owner or admin role in this organization to create a machine.");
+
+                return 1;
+            }
+
+            if (!response.IsSuccessStatusCode) {
+                await Console.Error.WriteLineAsync(
+                    $"Provisioning failed ({(int)response.StatusCode}). {await response.Content.ReadAsStringAsync()}");
+
+                return 1;
+            }
+
+            provisioned = await response.Content.ReadFromJsonAsync(
+                CapacitorJsonContext.Default.CreateMachineApplicationResponse);
+        }
+        catch (Exception e) when (e is HttpRequestException or TaskCanceledException) {
+            await Console.Error.WriteLineAsync($"The Kurrent auth service is unreachable: {e.Message}");
+
+            return 1;
+        }
+
+        if (provisioned is null || string.IsNullOrEmpty(provisioned.ClientId)) {
+            await Console.Error.WriteLineAsync("The auth service returned no credential.");
+
+            return 1;
+        }
+
+        // An idempotent hit means the machine already existed. Say so and stop, rather than
+        // re-registering: WorkOS cannot re-disclose the secret, so there is nothing useful to print and
+        // implying otherwise would send someone looking for a value that no longer exists anywhere.
+        if (!provisioned.Created) {
+            await Console.Error.WriteLineAsync(
+                $"A machine named '{name}' already exists in this organization "
+              + $"(client id {provisioned.ClientId}).");
+            await Console.Error.WriteLineAsync(
+                "Its secret was shown only when it was created and cannot be retrieved. "
+              + "To replace it, revoke that machine and create one with a new name.");
+
+            return 1;
+        }
+
+        // Register the PUBLIC client id with the tenant. The secret is deliberately not in this call —
+        // there is no field for it, and there is no code path on the server that could store one.
+        var registered = await RegisterAsync(provisioned.ClientId, name, role);
+
+        if (registered is null) return 1;
+
+        await PrintCredentialAsync(name, provisioned, registered, visibility);
+
+        return 0;
+    }
+
+    static async Task<RegisterMachineResponse?> RegisterAsync(string clientId, string name, string? role) {
+        try {
+            using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+
+            using var response = await client.PostAsJsonAsync(
+                "/api/admin/machines",
+                new RegisterMachineRequest(clientId, name, role),
+                CapacitorJsonContext.Default.RegisterMachineRequest);
+
+            if (response.StatusCode is HttpStatusCode.NotFound) {
+                await Console.Error.WriteLineAsync(
+                    "This server does not have machine credentials enabled. "
+                  + "The WorkOS application was created but nothing here recognises it — "
+                  + "ask an administrator to enable the feature, then run `kcap machine create` again "
+                  + "with a new name.");
+
+                return null;
+            }
+
+            if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized) {
+                await Console.Error.WriteLineAsync("You need to be a Capacitor administrator to register a machine.");
+
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode) {
+                await Console.Error.WriteLineAsync(
+                    $"Registering the machine failed ({(int)response.StatusCode}). "
+                  + await response.Content.ReadAsStringAsync());
+
+                return null;
+            }
+
+            return await response.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.RegisterMachineResponse);
+        }
+        catch (HttpRequestException ex) {
+            await Console.Error.WriteLineAsync($"Could not reach the Capacitor server: {ex.Message}");
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Prints the credential and how to use it. The secret goes to STDOUT (so it can be piped into a
+    /// secret store) and everything else to STDERR (so a pipe captures only the value).
+    /// </summary>
+    static async Task PrintCredentialAsync(
+            string name, CreateMachineApplicationResponse provisioned,
+            RegisterMachineResponse registered, string visibility) {
+        await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync($"Machine '{name}' created.");
+        await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync($"  Client ID     {provisioned.ClientId}");
+        await Console.Error.WriteLineAsync($"  Principal     {registered.UserId}");
+        await Console.Error.WriteLineAsync($"  Organization  {provisioned.OrganizationId}");
+        await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync("  ── The secret below is shown ONCE. It is not stored anywhere ──");
+        await Console.Error.WriteLineAsync("     Not by this CLI, not by Capacitor. WorkOS will not show it");
+        await Console.Error.WriteLineAsync("     again. If you lose it, revoke this machine and create a new one.");
+        await Console.Error.WriteLineAsync();
+
+        // STDOUT, alone, so `kcap machine create ci-runner 2>/dev/null` yields exactly the secret.
+        await Console.Out.WriteLineAsync(provisioned.ClientSecret);
+
+        await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync("  Give the runner these environment variables:");
+        await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync($"    KCAP_CLIENT_ID={provisioned.ClientId}");
+        await Console.Error.WriteLineAsync("    KCAP_CLIENT_SECRET=<the secret above>");
+        await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync($"  And set what its sessions are visible to (default '{visibility}'):");
+        await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync($"    kcap config set default_visibility {visibility}");
+        await Console.Error.WriteLineAsync();
+        await Console.Error.WriteLineAsync(
+            "  Run that on the machine itself, in the profile it records with — visibility is the");
+        await Console.Error.WriteLineAsync(
+            "  machine's own setting, exactly as it is for a person.");
+    }
+
+    // ── list ────────────────────────────────────────────────────────────────────────────────────
+
+    static async Task<int> ListAsync() {
+        try {
+            using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+
+            using var response = await client.GetAsync("/api/admin/machines");
+
+            if (response.StatusCode is HttpStatusCode.NotFound) {
+                await Console.Error.WriteLineAsync("This server does not have machine credentials enabled.");
+
+                return 1;
+            }
+
+            if (!response.IsSuccessStatusCode) {
+                await Console.Error.WriteLineAsync(
+                    $"Could not list machines ({(int)response.StatusCode}).");
+
+                return 1;
+            }
+
+            var machines = await response.Content.ReadFromJsonAsync(
+                CapacitorJsonContext.Default.MachineSummaryArray) ?? [];
+
+            if (machines.Length == 0) {
+                await Console.Out.WriteLineAsync("No machines registered.");
+
+                return 0;
+            }
+
+            var width = machines.Max(m => m.DisplayName.Length);
+
+            foreach (var m in machines) {
+                // A revoked machine is listed, not hidden: an operator needs to see that it WAS
+                // revoked, and hiding it would make revocation indistinguishable from never existing.
+                var status = m.Usable ? "active " : "revoked";
+
+                await Console.Out.WriteLineAsync(
+                    $"  {m.DisplayName.PadRight(width)}  {status}  {m.WorkOsClientId}  {m.ServiceId}");
+            }
+
+            return 0;
+        }
+        catch (HttpRequestException ex) {
+            await Console.Error.WriteLineAsync($"Could not reach the Capacitor server: {ex.Message}");
+
+            return 1;
+        }
+    }
+
+    // ── revoke ──────────────────────────────────────────────────────────────────────────────────
+
+    static async Task<int> RevokeAsync(string[] args) {
+        if (args.Length < 3 || IsHelp(args[2])) {
+            await Console.Error.WriteLineAsync("Usage: kcap machine revoke <service-id>");
+            await Console.Error.WriteLineAsync();
+            await Console.Error.WriteLineAsync("Run `kcap machine list` to see service ids.");
+
+            return 1;
+        }
+
+        var serviceId = args[2];
+
+        try {
+            using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+
+            using var response = await client.PostAsync($"/api/admin/machines/{Uri.EscapeDataString(serviceId)}/revoke", null);
+
+            if (response.StatusCode is HttpStatusCode.NotFound) {
+                await Console.Error.WriteLineAsync($"No machine '{serviceId}'. Run `kcap machine list`.");
+
+                return 1;
+            }
+
+            if (!response.IsSuccessStatusCode) {
+                await Console.Error.WriteLineAsync($"Revoking failed ({(int)response.StatusCode}).");
+
+                return 1;
+            }
+
+            await Console.Out.WriteLineAsync($"Machine {serviceId} revoked.");
+            await Console.Error.WriteLineAsync();
+
+            // Says exactly what revocation does and does not do. An operator responding to a leak needs
+            // to know the old token keeps working until it expires, so they can decide whether to also
+            // delete the application in WorkOS — which cuts it off immediately.
+            await Console.Error.WriteLineAsync(
+                "It stops authenticating from its next request. A token it already holds stays valid");
+            await Console.Error.WriteLineAsync(
+                "until it expires (up to an hour) but is no longer honoured here. To cut it off at the");
+            await Console.Error.WriteLineAsync(
+                "source as well, delete the application in the WorkOS dashboard.");
+
+            return 0;
+        }
+        catch (HttpRequestException ex) {
+            await Console.Error.WriteLineAsync($"Could not reach the Capacitor server: {ex.Message}");
+
+            return 1;
+        }
+    }
+
+    // ── help ────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Help comes from the embedded <c>help-machine.txt</c>, the same way every other command's does,
+    /// so `kcap machine --help` and `kcap --help machine` render one text rather than two that drift.
+    /// </summary>
+    static async Task<int> PrintUsage() {
+        await Console.Out.WriteAsync(EmbeddedResources.Load("help-machine.txt"));
+
+        return 1;
+    }
+
+    /// <summary>
+    /// `create --help` shows the same page: the flags, the once-only secret and the four-step setup
+    /// all live there, and a second shorter copy here would be the one that goes stale.
+    /// </summary>
+    static Task<int> PrintCreateUsage() => PrintUsage();
+
+    static string? GetArg(string[] args, string name) {
+        var idx = Array.IndexOf(args, name);
+
+        return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
+    }
+}

--- a/src/Capacitor.Cli/Commands/MachineCommand.cs
+++ b/src/Capacitor.Cli/Commands/MachineCommand.cs
@@ -57,8 +57,14 @@ public static class MachineCommand {
         }
 
         if (!Visibilities.Contains(visibility, StringComparer.Ordinal)) {
+            // Validated even though the value is never SENT anywhere: its whole job is to produce a
+            // correct `kcap config set default_visibility ...` line in the output, and printing an
+            // instruction that will not work is worse than refusing. The message says so, because
+            // erroring on a flag with no server effect is otherwise surprising. Raised in review.
             await Console.Error.WriteLineAsync(
-                $"--visibility must be one of: {string.Join(", ", Visibilities)}");
+                $"--visibility must be one of: {string.Join(", ", Visibilities)}. "
+              + "It does not configure anything here — it selects the value printed in the setup "
+              + "instructions, which you then set on the machine itself.");
 
             return 1;
         }
@@ -131,9 +137,28 @@ public static class MachineCommand {
             await Console.Error.WriteLineAsync(
                 $"A machine named '{name}' already exists in this organization "
               + $"(client id {provisioned.ClientId}).");
+            // Deliberately does NOT say "shown when you created it" — whoever runs this may not be
+            // the person who did, and telling them to go and look for a secret they never had sends
+            // them somewhere that does not exist. Raised in review round 1.
             await Console.Error.WriteLineAsync(
-                "Its secret was shown only when it was created and cannot be retrieved. "
-              + "To replace it, revoke that machine and create one with a new name.");
+                "Its secret cannot be retrieved. To replace it, revoke that machine and create one "
+              + "with a different name.");
+
+            return 1;
+        }
+
+        // A create that carries no secret must NEVER reach the printer.
+        //
+        // Console.Out.WriteLineAsync(null) writes a bare newline, and the documented idiom for this
+        // command is `... 2>/dev/null | gh secret set KCAP_CLIENT_SECRET` — so a malformed response
+        // would store an EMPTY secret and report success. The runner would then fail to authenticate
+        // with nothing anywhere explaining why. The server already 502s this case; this is the second
+        // half of the same guard, on the side that would do the damage. Raised in review round 1.
+        if (string.IsNullOrEmpty(provisioned.ClientSecret)) {
+            await Console.Error.WriteLineAsync(
+                "The auth service reported a new machine but returned no secret. "
+              + $"The WorkOS application '{name}' ({provisioned.ClientId}) exists and is unusable — "
+              + "delete it in the WorkOS dashboard, then try again.");
 
             return 1;
         }
@@ -144,7 +169,7 @@ public static class MachineCommand {
 
         if (registered is null) return 1;
 
-        await PrintCredentialAsync(name, provisioned, registered, visibility);
+        await PrintCredentialAsync(name, provisioned.ClientSecret, provisioned, registered, visibility);
 
         return 0;
     }
@@ -159,11 +184,16 @@ public static class MachineCommand {
                 CapacitorJsonContext.Default.RegisterMachineRequest);
 
             if (response.StatusCode is HttpStatusCode.NotFound) {
+                // The application EXISTS in WorkOS and is unregistered here. Saying "try again" alone
+                // would send the user into the idempotent-hit wall, because the name is now taken by
+                // the orphan. Both ways out are stated. Raised in review round 1.
                 await Console.Error.WriteLineAsync(
-                    "This server does not have machine credentials enabled. "
-                  + "The WorkOS application was created but nothing here recognises it — "
-                  + "ask an administrator to enable the feature, then run `kcap machine create` again "
-                  + "with a new name.");
+                    $"This server does not have machine credentials enabled, so '{name}' "
+                  + $"({clientId}) was created in WorkOS but is not registered here.");
+                await Console.Error.WriteLineAsync(
+                    "That name is now taken. Ask an administrator to enable the feature, then either "
+                  + "delete that application in the WorkOS dashboard and reuse the name, or create a "
+                  + "machine with a different one.");
 
                 return null;
             }
@@ -196,7 +226,7 @@ public static class MachineCommand {
     /// secret store) and everything else to STDERR (so a pipe captures only the value).
     /// </summary>
     static async Task PrintCredentialAsync(
-            string name, CreateMachineApplicationResponse provisioned,
+            string name, string secret, CreateMachineApplicationResponse provisioned,
             RegisterMachineResponse registered, string visibility) {
         await Console.Error.WriteLineAsync();
         await Console.Error.WriteLineAsync($"Machine '{name}' created.");
@@ -211,7 +241,7 @@ public static class MachineCommand {
         await Console.Error.WriteLineAsync();
 
         // STDOUT, alone, so `kcap machine create ci-runner 2>/dev/null` yields exactly the secret.
-        await Console.Out.WriteLineAsync(provisioned.ClientSecret);
+        await Console.Out.WriteLineAsync(secret);
 
         await Console.Error.WriteLineAsync();
         await Console.Error.WriteLineAsync("  Give the runner these environment variables:");

--- a/src/Capacitor.Cli/Commands/MachineCommand.cs
+++ b/src/Capacitor.Cli/Commands/MachineCommand.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text;
 using System.Net.Http.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
@@ -207,14 +208,30 @@ public static class MachineCommand {
         try {
             using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
 
-            // *WithRetryAsync rather than the raw verbs, matching every other command here. Two things
-            // come with it that the raw call does not have: a bounded retry, and EnsureAbsolute — the
-            // guard that turns a relative or scheme-less URL into an actionable message instead of the
-            // opaque InvalidOperationException that hid this file's worst bug until review.
-            using var response = await client.PostWithRetryAsync(
-                $"{baseUrl}/api/admin/machines",
-                JsonContent.Create(new RegisterMachineRequest(clientId, name, role),
-                    CapacitorJsonContext.Default.RegisterMachineRequest));
+            // DELIBERATELY NOT PostWithRetryAsync — this is the one call here that must not auto-retry.
+            //
+            // Registration is not idempotent from the client's side: the server 409s a duplicate. So if
+            // the server succeeds and the RESPONSE is lost, a retry returns 409 and the CLI reports
+            // failure for something that worked. That is bad on its own, and worse in combination with
+            // the disclosure ordering above: the operator is holding a freshly printed secret and being
+            // told to go and destroy the credential. Raised in review.
+            //
+            // Retry buys little here anyway — it only helps for failures BEFORE the request lands, which
+            // the operator can retry themselves knowing what happened. list and revoke keep the retry:
+            // one is a read, the other is idempotent server-side.
+            var url = $"{baseUrl}/api/admin/machines";
+
+            // The absolute-URL guard the retry helpers would have given us, kept explicitly rather than
+            // lost with them. A relative URL here is what made this whole command dead until review.
+            if (!HttpClientExtensions.IsAcceptableUrl(url)) {
+                await Console.Error.WriteLineAsync($"Server URL is not usable: '{baseUrl}'.");
+
+                return null;
+            }
+
+            using var response = await client.PostAsJsonAsync(
+                url, new RegisterMachineRequest(clientId, name, role),
+                CapacitorJsonContext.Default.RegisterMachineRequest);
 
             if (response.StatusCode is HttpStatusCode.NotFound) {
                 // The application EXISTS in WorkOS and is unregistered here. Saying "try again" alone
@@ -233,6 +250,18 @@ public static class MachineCommand {
 
             if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized) {
                 await Console.Error.WriteLineAsync("You need to be a Capacitor administrator to register a machine.");
+
+                return null;
+            }
+
+            // A 409 means the server already has this client id — which may be a genuine duplicate, or
+            // a previous attempt of THIS command that landed and lost its response. Saying "failed"
+            // flatly would send someone to delete a machine that is in fact registered and working.
+            if (response.StatusCode is HttpStatusCode.Conflict) {
+                await Console.Error.WriteLineAsync(
+                    "The server reports this machine is already registered. That may be a genuine "
+                  + "duplicate, or an earlier attempt that succeeded without the response reaching us. "
+                  + "Run `kcap machine list` to check before deleting anything.");
 
                 return null;
             }
@@ -369,9 +398,15 @@ public static class MachineCommand {
         try {
             using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
 
+            // An empty StringContent would send `Content-Type: text/plain`, which a strict endpoint can
+            // reject with a 415. The endpoint binds no body at all, so the content is inert either way —
+            // but an inert body with the WRONG media type is a needless way to fail. Raised in review.
+            //
+            // Retry is safe HERE, unlike registration: revocation is idempotent server-side, so a lost
+            // response followed by a retry converges on the intended state rather than a false conflict.
             using var response = await client.PostWithRetryAsync(
                 $"{baseUrl}/api/admin/machines/{Uri.EscapeDataString(serviceId)}/revoke",
-                new StringContent(""));
+                new StringContent("{}", Encoding.UTF8, "application/json"));
 
             if (response.StatusCode is HttpStatusCode.NotFound) {
                 await Console.Error.WriteLineAsync($"No machine '{serviceId}'. Run `kcap machine list`.");

--- a/src/Capacitor.Cli/Commands/MachineCommand.cs
+++ b/src/Capacitor.Cli/Commands/MachineCommand.cs
@@ -207,10 +207,14 @@ public static class MachineCommand {
         try {
             using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
 
-            using var response = await client.PostAsJsonAsync(
+            // *WithRetryAsync rather than the raw verbs, matching every other command here. Two things
+            // come with it that the raw call does not have: a bounded retry, and EnsureAbsolute — the
+            // guard that turns a relative or scheme-less URL into an actionable message instead of the
+            // opaque InvalidOperationException that hid this file's worst bug until review.
+            using var response = await client.PostWithRetryAsync(
                 $"{baseUrl}/api/admin/machines",
-                new RegisterMachineRequest(clientId, name, role),
-                CapacitorJsonContext.Default.RegisterMachineRequest);
+                JsonContent.Create(new RegisterMachineRequest(clientId, name, role),
+                    CapacitorJsonContext.Default.RegisterMachineRequest));
 
             if (response.StatusCode is HttpStatusCode.NotFound) {
                 // The application EXISTS in WorkOS and is unregistered here. Saying "try again" alone
@@ -302,7 +306,7 @@ public static class MachineCommand {
         try {
             using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
 
-            using var response = await client.GetAsync($"{baseUrl}/api/admin/machines");
+            using var response = await client.GetWithRetryAsync($"{baseUrl}/api/admin/machines");
 
             if (response.StatusCode is HttpStatusCode.NotFound) {
                 await Console.Error.WriteLineAsync("This server does not have machine credentials enabled.");
@@ -362,7 +366,9 @@ public static class MachineCommand {
         try {
             using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync();
 
-            using var response = await client.PostAsync($"{baseUrl}/api/admin/machines/{Uri.EscapeDataString(serviceId)}/revoke", null);
+            using var response = await client.PostWithRetryAsync(
+                $"{baseUrl}/api/admin/machines/{Uri.EscapeDataString(serviceId)}/revoke",
+                new StringContent(""));
 
             if (response.StatusCode is HttpStatusCode.NotFound) {
                 await Console.Error.WriteLineAsync($"No machine '{serviceId}'. Run `kcap machine list`.");

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -276,7 +276,7 @@ switch (command) {
     case "profile":
         return await ProfileCommand.HandleAsync(args);
     case "machine":
-        return await MachineCommand.HandleAsync(args);
+        return await MachineCommand.HandleAsync(baseUrl!, args);
     case "use":
         return await UseCommand.HandleAsync(args);
     case "status":

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -275,6 +275,8 @@ switch (command) {
         return await PluginCommand.HandleAsync(args);
     case "profile":
         return await ProfileCommand.HandleAsync(args);
+    case "machine":
+        return await MachineCommand.HandleAsync(args);
     case "use":
         return await UseCommand.HandleAsync(args);
     case "status":

--- a/test/Capacitor.Cli.Tests.Unit/MachineCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MachineCommandTests.cs
@@ -1,0 +1,106 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// `kcap machine` — the help text is a DELIVERABLE here, not decoration, so it is tested like one.
+///
+/// <para>Someone provisioning a CI runner has exactly one chance to keep the secret. If the help does
+/// not say that plainly, and say what to do when it is lost, the feature produces a support ticket
+/// instead of a working runner. These tests pin the facts a reader cannot afford to miss — not the
+/// prose around them, which is free to change.</para>
+/// </summary>
+public class MachineCommandTests {
+    static string Help() => EmbeddedResources.Load("help-machine.txt");
+
+    [Test]
+    public async Task The_help_resource_is_embedded_and_reachable() {
+        // Guards the wiring, not the words: an unembedded resource throws at RUNTIME in the AOT CLI,
+        // and `kcap machine --help` is the first thing anyone runs.
+        await Assert.That(Help()).IsNotEmpty();
+        await Assert.That(Help()).StartsWith("kcap machine");
+    }
+
+    [Test]
+    public async Task The_help_says_the_secret_is_shown_once_and_what_to_do_when_it_is_lost() {
+        var help = Help();
+
+        await Assert.That(help).Contains("SHOWN ONCE");
+        await Assert.That(help).Contains("revoke the machine and")
+            .Because("a reader who has lost the secret needs the recovery path, not just the bad news");
+    }
+
+    /// <summary>
+    /// The four things a reader must be able to act on. Asserted individually so a failure names the
+    /// missing one rather than saying "the help changed".
+    /// </summary>
+    [Test]
+    [Arguments("KCAP_CLIENT_ID", "the public half the runner needs")]
+    [Arguments("KCAP_CLIENT_SECRET", "the secret half the runner needs")]
+    [Arguments("default_visibility", "how the machine's sessions become visible")]
+    [Arguments("kcap machine revoke", "how to take a machine out of service")]
+    public async Task The_help_covers_what_a_reader_has_to_do(string needle, string why) =>
+        await Assert.That(Help()).Contains(needle).Because(why);
+
+    /// <summary>
+    /// Every subcommand the dispatcher accepts must appear in the help. Without this, adding one and
+    /// forgetting to document it is invisible — the two are in different files with nothing joining
+    /// them.
+    /// </summary>
+    [Test]
+    [Arguments("create")]
+    [Arguments("list")]
+    [Arguments("revoke")]
+    public async Task Every_subcommand_is_documented(string subcommand) =>
+        await Assert.That(Help()).Contains($"  {subcommand}");
+
+    /// <summary>
+    /// Visibility is set ON THE MACHINE, not by this flag — the flag only tells you the value to use.
+    /// That distinction is the one most likely to be misread, and misreading it means a runner records
+    /// with the wrong audience and nobody notices until the sessions are already visible.
+    /// </summary>
+    [Test]
+    public async Task The_help_explains_that_visibility_is_configured_on_the_machine() {
+        var help = Help();
+
+        await Assert.That(help).Contains("Why step 4 runs on the machine");
+        await Assert.That(help).Contains("it does not configure the runner for you");
+    }
+
+    /// <summary>
+    /// The stdout/stderr split is what makes piping the secret into a secret store safe, and it is not
+    /// guessable — it has to be stated.
+    /// </summary>
+    [Test]
+    public async Task The_help_documents_the_stdout_stderr_split() {
+        var help = Help();
+
+        await Assert.That(help).Contains("stdout");
+        await Assert.That(help).Contains("stderr");
+    }
+
+    /// <summary>
+    /// The listed visibility values must match what the command actually accepts. Two lists that must
+    /// agree with nothing making them agree is the shape that rots — here the test IS the thing making
+    /// them agree, because the help is a text file the compiler never reads.
+    /// </summary>
+    [Test]
+    [Arguments("private")]
+    [Arguments("org_public")]
+    [Arguments("public")]
+    public async Task Every_accepted_visibility_value_is_documented(string value) =>
+        await Assert.That(Help()).Contains(value);
+
+    /// <summary>
+    /// Revocation's limits, stated. An operator responding to a leaked credential must know the old
+    /// token keeps working until it expires, so they can decide whether to also delete the application
+    /// in WorkOS. Leaving that out would let someone believe a revoke was instantaneous.
+    /// </summary>
+    [Test]
+    public async Task The_help_states_what_revocation_does_not_do() {
+        var help = Help();
+
+        await Assert.That(help).Contains("until it expires");
+        await Assert.That(help).Contains("WorkOS");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/MachineCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MachineCommandTests.cs
@@ -92,6 +92,21 @@ public class MachineCommandTests {
         await Assert.That(Help()).Contains(value);
 
     /// <summary>
+    /// Review round 1 rewrote the --visibility rejection to explain what the flag does, because
+    /// erroring on a value with no server effect is otherwise surprising. Pinned here so the
+    /// explanation is not lost in a later tidy-up: without it the message reads as a hard requirement
+    /// on something that configures nothing.
+    /// </summary>
+    [Test]
+    public async Task The_help_does_not_promise_that_the_visibility_flag_configures_anything() {
+        var help = Help();
+
+        await Assert.That(help).Contains("does not configure the runner for you");
+        await Assert.That(help).DoesNotContain("--visibility sets")
+            .Because("the flag selects the value PRINTED, it does not apply it anywhere");
+    }
+
+    /// <summary>
     /// Revocation's limits, stated. An operator responding to a leaked credential must know the old
     /// token keeps working until it expires, so they can decide whether to also delete the application
     /// in WorkOS. Leaving that out would let someone believe a revoke was instantaneous.

--- a/test/Capacitor.Cli.Tests.Unit/MachineCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MachineCommandTests.cs
@@ -107,6 +107,39 @@ public class MachineCommandTests {
     }
 
     /// <summary>
+    /// Qodo: a new user-facing CLI surface must be documented in README.md in the same PR. Pinned so
+    /// the README and the command cannot drift apart silently — the compiler reads neither.
+    /// </summary>
+    [Test]
+    [Arguments("kcap machine create")]
+    [Arguments("kcap machine list")]
+    [Arguments("kcap machine revoke")]
+    [Arguments("KCAP_CLIENT_SECRET")]
+    public async Task The_readme_documents_the_command(string needle) {
+        var readme = FindReadme();
+
+        await Assert.That(readme).Contains(needle);
+    }
+
+    /// <summary>
+    /// Walks up from the test binary rather than assuming a working directory, because the test host's
+    /// cwd differs between a local `dotnet run` and CI.
+    /// </summary>
+    static string FindReadme() {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (dir is not null) {
+            var candidate = Path.Combine(dir.FullName, "README.md");
+
+            if (File.Exists(candidate)) return File.ReadAllText(candidate);
+
+            dir = dir.Parent;
+        }
+
+        throw new FileNotFoundException("README.md not found walking up from the test binary.");
+    }
+
+    /// <summary>
     /// Revocation's limits, stated. An operator responding to a leaked credential must know the old
     /// token keeps working until it expires, so they can decide whether to also delete the application
     /// in WorkOS. Leaving that out would let someone believe a revoke was instantaneous.


### PR DESCRIPTION
Completes the machine-credential feature whose server side landed in
kurrent-io/kcap-server#1339 and #1348. Without this nothing can provision a machine, so the server
work is unreachable until this ships.

## Two hops, and the split is the security property

Provisioning goes to the **auth proxy** with the operator's own WorkOS access token; registration
goes to the **tenant** with only the public `client_id`.

So the secret travels from WorkOS to the operator's terminal and stops there — it never reaches the
Capacitor server. "No secret is stored by Capacitor" holds *by construction*: there is no field on
the register call that could carry one. Please don't "simplify" this later by routing provisioning
through the tenant; the hop is the point.

The proxy scopes on the token's signed `org_id` and `role` claims, so this CLI cannot ask for
another organization even if it wanted to — nothing in the request names an org.

## The secret is shown once

Printed to **stdout alone**, everything else to stderr, so it can go straight into a secret store
without touching disk:

```bash
kcap machine create ci-runner 2>/dev/null | gh secret set KCAP_CLIENT_SECRET
```

Never written to config, the token store, or a log. WorkOS will not disclose it again either —
which is why an idempotent hit (the machine already exists) says so plainly and stops, rather than
re-registering and implying a secret is available that no longer exists anywhere.

## `--help` is a deliverable

`help-machine.txt` carries the full sequence: what a machine is for, the four-step setup, both
environment variables, how visibility works and **why it is set on the machine rather than by the
flag**, and what revocation does *not* do — an already-minted token stays valid until it expires;
deleting the WorkOS application is what cuts it off immediately.

Served from the embedded resource like every other command, so `kcap machine --help` and
`kcap --help machine` render one text rather than two that drift. Listed in `help-usage.txt`.

## Tests (15)

They treat the help as a deliverable rather than decoration:

- every subcommand the dispatcher accepts must appear in the help;
- every visibility value the command accepts must be documented;
- the once-only warning must carry the **recovery path**, not just the bad news;
- the stdout/stderr split is documented, since it isn't guessable;
- revocation's limits are stated.

Two lists that must agree with nothing making them agree is the shape that rots. Here the test is
what makes them agree, because the help is a text file the compiler never reads.

## Notes

- Visibility is the machine's own `default_visibility`, exactly as for a person — no new server-side
  concept. `--visibility` only tells you which value to set on the runner; the help says so
  explicitly, because that's the most misreadable part.
- `machine --help` is intercepted before the server-URL gate, so help works with nothing configured.
- No Linear ids in `.cs` (checked).

Part of AI-990. Deliberately **not** `Fixes` — enabling the feature on a tenant is the remaining step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
