### PR TITLE
Deliver a borrowed reviewer's result through a daemon-brokered capability

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
@@ -36,7 +36,7 @@ internal static class AcpReviewFlowMcp {
                 "Borrowed-snapshot review cannot inject kcap-flow-result (missing result capability URL).");
 
         var resultEnv = ctx.IsBorrowedSnapshot
-            ? new AcpMcpServerEnvVar[] { new("KCAP_FLOW_RESULT_URL", ctx.FlowResultCapabilityUrl!),
+            ? new AcpMcpServerEnvVar[] { new("KCAP_FLOW_CAPABILITY_URL", ctx.FlowResultCapabilityUrl!),
                                          new("KCAP_FLOW_AGENT_ID", ctx.AgentId) }
             : [new("KCAP_URL", ctx.ServerUrl!), new("KCAP_FLOW_AGENT_ID", ctx.AgentId)];
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
@@ -24,9 +24,24 @@ internal static class AcpReviewFlowMcp {
         var channelName = ctx.LaunchIdentity?.ResultChannelWireName
                        ?? KcapMcpRegistry.ReservedResultChannelId;
 
+        // A borrowed launch reports through a daemon-minted loopback capability, NOT through
+        // KCAP_URL. The two are mutually exclusive on purpose. KCAP_URL is what sends the channel to
+        // HttpClientExtensions.CreateAuthenticatedClientAsync, which loads the token store out of
+        // HOME — and a borrowed launch's HOME is the per-launch state dir, so that load cannot
+        // succeed. Passing both would leave the broken path reachable as a silent fallback; the
+        // observable was a generic "internal error handling the request" with the real reason on
+        // stderr, after the reviewer had already done all its work.
+        if (ctx.IsBorrowedSnapshot && string.IsNullOrWhiteSpace(ctx.FlowResultCapabilityUrl))
+            throw new InvalidOperationException(
+                "Borrowed-snapshot review cannot inject kcap-flow-result (missing result capability URL).");
+
+        var resultEnv = ctx.IsBorrowedSnapshot
+            ? new AcpMcpServerEnvVar[] { new("KCAP_FLOW_RESULT_URL", ctx.FlowResultCapabilityUrl!),
+                                         new("KCAP_FLOW_AGENT_ID", ctx.AgentId) }
+            : [new("KCAP_URL", ctx.ServerUrl!), new("KCAP_FLOW_AGENT_ID", ctx.AgentId)];
+
         var servers = new List<AcpMcpServerSpec> {
-            new(channelName, ctx.CapacitorPath, ["mcp", "flow-result"],
-                [new("KCAP_URL", ctx.ServerUrl!), new("KCAP_FLOW_AGENT_ID", ctx.AgentId)])
+            new(channelName, ctx.CapacitorPath, ["mcp", "flow-result"], resultEnv)
         };
 
         foreach (var id in allowlistServerIds) {

--- a/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
@@ -24,13 +24,9 @@ internal static class AcpReviewFlowMcp {
         var channelName = ctx.LaunchIdentity?.ResultChannelWireName
                        ?? KcapMcpRegistry.ReservedResultChannelId;
 
-        // A borrowed launch reports through a daemon-minted loopback capability, NOT through
-        // KCAP_URL. The two are mutually exclusive on purpose. KCAP_URL is what sends the channel to
-        // HttpClientExtensions.CreateAuthenticatedClientAsync, which loads the token store out of
-        // HOME — and a borrowed launch's HOME is the per-launch state dir, so that load cannot
-        // succeed. Passing both would leave the broken path reachable as a silent fallback; the
-        // observable was a generic "internal error handling the request" with the real reason on
-        // stderr, after the reviewer had already done all its work.
+        // A borrowed launch delivers through a daemon capability, never KCAP_URL — that variable
+        // routes the channel at the token store, which its redirected HOME cannot reach. Mutually
+        // exclusive on purpose: passing both leaves the broken path reachable as a silent fallback.
         if (ctx.IsBorrowedSnapshot && string.IsNullOrWhiteSpace(ctx.FlowResultCapabilityUrl))
             throw new InvalidOperationException(
                 "Borrowed-snapshot review cannot inject kcap-flow-result (missing result capability URL).");

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1553,6 +1553,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             var daemonBridgeUrl    = _permissionBridge.BaseUrl;
             var effectiveAllowlist = cmd.McpAllowlist;
             string? reviewContextCapabilityUrl = null;
+            string? flowResultCapabilityUrl    = null;
 
             // A token record is minted for the union of two independent authorities: Codex's
             // unattended permission allowlist and a borrowed snapshot's immutable review context.
@@ -1591,9 +1592,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     daemonBridgeUrl = reviewerUrl;
                     effectiveAllowlist = reviewerServers;
                 }
-                if (snapshotBorrow)
+                if (snapshotBorrow) {
                     reviewContextCapabilityUrl = reviewerUrl +
                         "/review-context/workspace-mcp-configs";
+                    // Both capabilities hang off the SAME reviewer grant, so revoking that one token
+                    // closes the read path and the submit path together. A separately-minted token
+                    // could outlive the first and leave a live submit path after the reviewer is gone.
+                    flowResultCapabilityUrl = reviewerUrl + "/flow-result";
+                }
             }
 
             var runtimeCtx = new RuntimeStartContext(
@@ -1625,6 +1631,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 DaemonEpoch: _daemonEpoch,
                 IsBorrowedSnapshot: snapshotBorrow,
                 ReviewContextCapabilityUrl: reviewContextCapabilityUrl,
+                FlowResultCapabilityUrl: flowResultCapabilityUrl,
                 CodexPosture: cmd.CodexPosture,
                 // Handed to the factory so it can wire the clock onto the runtime BEFORE StartAsync —
                 // assigning it after that call returns silently defeats every handshake stage stamp.

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -229,6 +229,26 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // registered singleton when one exists) keep compiling unchanged.
     readonly DaemonStatusNotifier _statusNotifier;
 
+    /// <summary>
+    /// Relays a borrowed reviewer's flow submission to the server under the DAEMON's credential.
+    ///
+    /// <para>The daemon runs unsandboxed with the real HOME, so its token store resolves; the
+    /// reviewer's does not. <paramref name="apiPath"/> comes from the bridge's own fixed route table,
+    /// never from the request, so a sandboxed child cannot steer this at an arbitrary API path.</para>
+    ///
+    /// <para>The client is per-call, matching <see cref="EvalRunner"/>: a submission happens once per
+    /// round, and a cached client would pin a token across a rotation.</para>
+    /// </summary>
+    async Task<(int Status, string Body)> ForwardFlowSubmissionAsync(
+            string apiPath, string body, CancellationToken ct) {
+        using var http = await HttpClientExtensions.CreateAuthenticatedClientAsync(_config.ServerUrl, ct);
+        using var content  = new StringContent(body, Encoding.UTF8, "application/json");
+        using var response = await http.PostAsync(
+            $"{_config.ServerUrl.TrimEnd('/')}{apiPath}", content, ct);
+
+        return ((int)response.StatusCode, await response.Content.ReadAsStringAsync(ct));
+    }
+
     /// <summary>Test seam: exposes which notifier this orchestrator actually pulses into, so a DI
     /// wiring test can pin that the registered singleton — not a private fallback nobody
     /// subscribes to — is the one every agent mutation reaches (see DaemonStatusWiringTests).</summary>
@@ -1586,7 +1606,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                           "borrowed_snapshot_review_context_missing")
                     : null;
                 var reviewerUrl = _permissionBridge.RegisterReviewerToken(
-                    reviewerServers, reviewGeneration, activityClock);
+                    reviewerServers, reviewGeneration, activityClock,
+                    // Only a borrowed snapshot gets a submit forwarder. Its sandbox redirects HOME,
+                    // so its result channel has no token store; every other reviewer authenticates
+                    // for itself and must NOT be handed a daemon-credentialed relay it has no need
+                    // for. Withholding it also keeps the endpoint 404 rather than merely unused.
+                    snapshotBorrow ? ForwardFlowSubmissionAsync : null);
                 reviewerToken = reviewerUrl; // the URL doubles as the revoke handle
                 if (codexReviewer) {
                     daemonBridgeUrl = reviewerUrl;
@@ -1598,7 +1623,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     // Both capabilities hang off the SAME reviewer grant, so revoking that one token
                     // closes the read path and the submit path together. A separately-minted token
                     // could outlive the first and leave a live submit path after the reviewer is gone.
-                    flowResultCapabilityUrl = reviewerUrl + "/flow-result";
+                    flowResultCapabilityUrl = reviewerUrl;
                 }
             }
 

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -170,6 +170,12 @@ internal sealed record RuntimeStartContext(
         // Exact loopback GET capability for the immutable Git-index review-context generation.
         // Present only for borrowed-snapshot review flows; never a backend or filesystem URL.
         string?            ReviewContextCapabilityUrl = null,
+        // Exact loopback POST capability the result channel submits through, so a borrowed
+        // reviewer can report without a credential inside the sandbox. Required — not merely
+        // permitted — for a borrowed snapshot: that launch's HOME is a per-launch state dir, so the
+        // channel's own token store is unreachable and the ambient-credential path cannot work.
+        // The daemon holds the authenticated connection and forwards; nothing here is a backend URL.
+        string?            FlowResultCapabilityUrl = null,
         // Caller-selected Codex sandbox/approval posture, carried verbatim from
         // LaunchAgentCommand.CodexPosture through to LauncherContext.CodexPosture. Non-null only for
         // an interactive daemon-owned-worktree Codex launch that passed the orchestrator's guard.

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -214,7 +214,17 @@ internal sealed partial class LocalPermissionBridge(
             BorrowedReviewContextGeneration? reviewContext = null,
             // The launch's activity clock, so a tool-call hit on this token advances it. Optional and
             // trailing so pre-existing call sites keep compiling; production always supplies one.
-            AgentActivityClock? activityClock = null) {
+            AgentActivityClock? activityClock = null,
+            // Forwards a borrowed reviewer's result submission to the server using the DAEMON's
+            // credential. Supplied only for a borrowed snapshot, whose sandbox redirects HOME and so
+            // leaves the result channel with no token store of its own; every other reviewer keeps
+            // authenticating for itself and passes null, which withholds the capability entirely
+            // rather than exposing an endpoint that would 500.
+            //
+            // It hangs off the GRANT rather than the bridge so it is revoked in the same operation
+            // that revokes the token — a submit path outliving its reviewer would let a lingering
+            // child report into a flow whose participant the server has already reaped.
+            Func<string, string, CancellationToken, Task<(int Status, string Body)>>? submitForwarder = null) {
         if (_listener is null || _sharedToken is null)
             throw new InvalidOperationException("LocalPermissionBridge not started");
 
@@ -224,7 +234,8 @@ internal sealed partial class LocalPermissionBridge(
                 token = NewToken();   // CSPRNG collisions are negligible; never silently reuse one
 
             _listener.Prefixes.Add($"http://127.0.0.1:{_port}/{token}/");
-            _reviewerTokens[token] = new ReviewerGrant([.. allowlistServers], reviewContext, activityClock);
+            _reviewerTokens[token] = new ReviewerGrant(
+                [.. allowlistServers], reviewContext, activityClock, submitForwarder);
 
             return $"http://127.0.0.1:{_port}/{token}";
         }
@@ -333,6 +344,59 @@ internal sealed partial class LocalPermissionBridge(
                 context.Response.StatusCode = 404;
                 context.Response.Close();
                 return;
+            }
+
+            // The borrowed reviewer's result-delivery capability, routed before the permission-request
+            // parser for the same reasons as review-context above: one exact method/path, no query or
+            // caller-selected path segment, and reachable only on a live grant that was minted WITH a
+            // forwarder. A grant without one (every non-borrowed reviewer, which authenticates for
+            // itself) falls through to 404 rather than exposing an endpoint that could only fail.
+            if (context.Request.HttpMethod == "POST" && rawUrl is not null) {
+                var trimmedRaw = rawUrl.TrimStart('/');
+                var slash      = trimmedRaw.IndexOf('/');
+                if (slash > 0) {
+                    var submitToken = trimmedRaw[..slash];
+                    // The API path is chosen HERE, from a fixed table, never echoed from the request.
+                    // The caller is a sandboxed vendor child; letting it name the upstream path would
+                    // turn an authenticated daemon proxy into an open relay onto the kcap API.
+                    var apiPath = rawUrl switch {
+                        _ when rawUrl.Equals($"/{submitToken}/flow-result", StringComparison.Ordinal)
+                            => "/api/flows/reviewer/result",
+                        _ when rawUrl.Equals($"/{submitToken}/flow-message", StringComparison.Ordinal)
+                            => "/api/flows/participant/message",
+                        _   => null
+                    };
+                    if (apiPath is not null) {
+                        if (!_reviewerTokens.TryGetValue(submitToken, out var submitGrant) ||
+                            submitGrant.SubmitForwarder is not { } forward) {
+                            context.Response.StatusCode = 404;
+                            context.Response.Close();
+
+                            return;
+                        }
+
+                        // The clock advances on a submit for the same reason it advances on a tool
+                        // call: a reviewer mid-delivery is demonstrably alive, and letting the wedge
+                        // detector reap it here would discard the very result it spent the round
+                        // producing.
+                        submitGrant.ActivityClock?.Advance();
+
+                        string submitBody;
+                        using (var submitReader = new StreamReader(
+                                context.Request.InputStream, Encoding.UTF8, leaveOpen: false))
+                            submitBody = await submitReader.ReadToEndAsync(ct);
+
+                        var (status, responseBody) = await forward(apiPath, submitBody, ct);
+                        var payload = Encoding.UTF8.GetBytes(responseBody);
+                        context.Response.ContentType     = "application/json";
+                        context.Response.StatusCode      = status;
+                        context.Response.ContentLength64 = payload.LongLength;
+                        await context.Response.OutputStream.WriteAsync(payload, ct);
+                        context.Response.Close();
+
+                        return;
+                    }
+                }
             }
 
             // Require token + vendor + endpoint match. The HttpListener prefix already routed us
@@ -580,7 +644,8 @@ internal sealed partial class LocalPermissionBridge(
     sealed record ReviewerGrant(
         string[] AllowlistServers,
         BorrowedReviewContextGeneration? ReviewContext,
-        AgentActivityClock? ActivityClock = null);
+        AgentActivityClock? ActivityClock = null,
+        Func<string, string, CancellationToken, Task<(int Status, string Body)>>? SubmitForwarder = null);
 
     static string BuildHookResponseJson(PermissionDecision decision, string vendor) =>
         vendor switch {

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -30,6 +30,10 @@ internal sealed partial class LocalPermissionBridge(
     const int    MaxBindAttempts = 15;
     const string PathSuffix      = "/permission-request";
 
+    /// <summary>Cap on a reviewer submission body. The poster is a sandboxed vendor child, so an
+    /// unbounded read is a memory-exhaustion lever.</summary>
+    internal const int MaxSubmitBodyBytes = 1024 * 1024;
+
     static readonly object       PortClaimsLock = new();
     static readonly HashSet<int>  ClaimedPorts   = [];
 
@@ -215,15 +219,9 @@ internal sealed partial class LocalPermissionBridge(
             // The launch's activity clock, so a tool-call hit on this token advances it. Optional and
             // trailing so pre-existing call sites keep compiling; production always supplies one.
             AgentActivityClock? activityClock = null,
-            // Forwards a borrowed reviewer's result submission to the server using the DAEMON's
-            // credential. Supplied only for a borrowed snapshot, whose sandbox redirects HOME and so
-            // leaves the result channel with no token store of its own; every other reviewer keeps
-            // authenticating for itself and passes null, which withholds the capability entirely
-            // rather than exposing an endpoint that would 500.
-            //
-            // It hangs off the GRANT rather than the bridge so it is revoked in the same operation
-            // that revokes the token — a submit path outliving its reviewer would let a lingering
-            // child report into a flow whose participant the server has already reaped.
+            // Relays a borrowed reviewer's submission under the DAEMON's credential; null for every
+            // other reviewer, which authenticates for itself. On the GRANT so it is revoked with the
+            // token — a submit path outliving its reviewer could report into an already-reaped flow.
             Func<string, string, CancellationToken, Task<(int Status, string Body)>>? submitForwarder = null) {
         if (_listener is null || _sharedToken is null)
             throw new InvalidOperationException("LocalPermissionBridge not started");
@@ -346,19 +344,16 @@ internal sealed partial class LocalPermissionBridge(
                 return;
             }
 
-            // The borrowed reviewer's result-delivery capability, routed before the permission-request
-            // parser for the same reasons as review-context above: one exact method/path, no query or
-            // caller-selected path segment, and reachable only on a live grant that was minted WITH a
-            // forwarder. A grant without one (every non-borrowed reviewer, which authenticates for
-            // itself) falls through to 404 rather than exposing an endpoint that could only fail.
+            // Borrowed-reviewer result delivery. Routed like review-context above: exact method/path,
+            // live grant only. A grant minted without a forwarder 404s rather than exposing an
+            // endpoint that could only fail.
             if (context.Request.HttpMethod == "POST" && rawUrl is not null) {
                 var trimmedRaw = rawUrl.TrimStart('/');
                 var slash      = trimmedRaw.IndexOf('/');
                 if (slash > 0) {
                     var submitToken = trimmedRaw[..slash];
-                    // The API path is chosen HERE, from a fixed table, never echoed from the request.
-                    // The caller is a sandboxed vendor child; letting it name the upstream path would
-                    // turn an authenticated daemon proxy into an open relay onto the kcap API.
+                    // Upstream path chosen from a fixed table, never echoed from the request: the
+                    // caller is sandboxed, and echoing would make this an open authenticated relay.
                     var apiPath = rawUrl switch {
                         _ when rawUrl.Equals($"/{submitToken}/flow-result", StringComparison.Ordinal)
                             => "/api/flows/reviewer/result",
@@ -375,16 +370,16 @@ internal sealed partial class LocalPermissionBridge(
                             return;
                         }
 
-                        // The clock advances on a submit for the same reason it advances on a tool
-                        // call: a reviewer mid-delivery is demonstrably alive, and letting the wedge
-                        // detector reap it here would discard the very result it spent the round
-                        // producing.
+                        // A reviewer mid-delivery is alive; reaping it here would discard the result.
                         submitGrant.ActivityClock?.Advance();
 
-                        string submitBody;
-                        using (var submitReader = new StreamReader(
-                                context.Request.InputStream, Encoding.UTF8, leaveOpen: false))
-                            submitBody = await submitReader.ReadToEndAsync(ct);
+                        var submitBody = await ReadCappedBodyAsync(context.Request.InputStream, ct);
+                        if (submitBody is null) {
+                            context.Response.StatusCode = 413;
+                            context.Response.Close();
+
+                            return;
+                        }
 
                         var (status, responseBody) = await forward(apiPath, submitBody, ct);
                         var payload = Encoding.UTF8.GetBytes(responseBody);
@@ -639,6 +634,27 @@ internal sealed partial class LocalPermissionBridge(
                 return true;
 
         return false;
+    }
+
+    /// <summary>Reads at most <see cref="MaxSubmitBodyBytes"/>, returning null when the body exceeds
+    /// it. Bounded on BYTES ACTUALLY READ rather than Content-Length, which a chunked or hostile
+    /// client need not send truthfully — checking the header alone would be a guard the attacker
+    /// controls. One byte past the cap is enough to reject, so an oversized body is never fully
+    /// buffered.</summary>
+    static async Task<string?> ReadCappedBodyAsync(Stream input, CancellationToken ct) {
+        var buffer = new byte[8192];
+        using var accumulated = new MemoryStream();
+
+        while (true) {
+            var read = await input.ReadAsync(buffer, ct);
+            if (read == 0) break;
+
+            if (accumulated.Length + read > MaxSubmitBodyBytes) return null;
+
+            accumulated.Write(buffer, 0, read);
+        }
+
+        return Encoding.UTF8.GetString(accumulated.GetBuffer(), 0, (int)accumulated.Length);
     }
 
     sealed record ReviewerGrant(

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -217,7 +217,8 @@ static class McpFlowResultServer {
             using var response = await SendWithRefreshRetryAsync(
                 client,
                 apiRoot,
-                c => c.PostAsync(url, JsonContent.Create(body, McpJsonContext.Default.SubmitReviewerResultDto))
+                c => c.PostAsync(url, JsonContent.Create(body, McpJsonContext.Default.SubmitReviewerResultDto)),
+                allowRefresh: submitUrlOverride is null
             );
             var responseBody = await response.Content.ReadAsStringAsync();
 
@@ -293,7 +294,8 @@ static class McpFlowResultServer {
             using var response = await SendWithRefreshRetryAsync(
                 client,
                 apiRoot,
-                c => c.PostAsync(url, JsonContent.Create(body, McpJsonContext.Default.SendFlowMessageDto))
+                c => c.PostAsync(url, JsonContent.Create(body, McpJsonContext.Default.SendFlowMessageDto)),
+                allowRefresh: messageUrlOverride is null
             );
 
             if (response.IsSuccessStatusCode)
@@ -344,10 +346,17 @@ static class McpFlowResultServer {
     /// <see cref="TokenStore.GetValidTokensAsync"/> for a fresh token, update the client's
     /// <c>Authorization</c> header, and retry the same request once.
     /// </summary>
-    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(HttpClient client, string baseUrl, Func<HttpClient, Task<HttpResponseMessage>> send) {
+    /// <param name="allowRefresh">False on the borrowed-reviewer capability path. That process has
+    /// no token store — its HOME is a per-launch state dir — so a 401 must be surfaced as-is rather
+    /// than sent into TokenStore, which is the very read this delivery path exists to avoid. A 401
+    /// there means the DAEMON's credential was rejected upstream, and this process could not heal
+    /// that even if it could read a token: it is not the authenticating party.</param>
+    static async Task<HttpResponseMessage> SendWithRefreshRetryAsync(
+            HttpClient client, string baseUrl, Func<HttpClient, Task<HttpResponseMessage>> send,
+            bool allowRefresh = true) {
         var response = await send(client);
 
-        if (response.StatusCode != HttpStatusCode.Unauthorized) return response;
+        if (!allowRefresh || response.StatusCode != HttpStatusCode.Unauthorized) return response;
 
         // Force a refresh against the token this client actually sent: the 401 proves the server
         // rejected it even though it may still look unexpired locally, which a plain load would

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -21,17 +21,13 @@ namespace Capacitor.Cli.Commands;
 static class McpFlowResultServer {
     internal const string AgentIdEnvVar = "KCAP_FLOW_AGENT_ID";
 
-    /// <summary>The daemon-minted loopback capability a BORROWED reviewer delivers through. That
-    /// launch's sandbox redirects HOME to a per-launch state dir, so this process has no token store
-    /// and cannot authenticate for itself; the daemon runs unsandboxed, holds the real credential,
-    /// and forwards. Present only for a borrowed snapshot — every other launch keeps KCAP_URL and the
-    /// authenticated-client path, and the two are mutually exclusive by construction.</summary>
+    /// <summary>Daemon-minted loopback capability a BORROWED reviewer delivers through: its sandbox
+    /// redirects HOME, so this process has no token store to authenticate with. Mutually exclusive
+    /// with KCAP_URL.</summary>
     internal const string CapabilityUrlEnvVar = "KCAP_FLOW_CAPABILITY_URL";
 
-    /// <summary>Leaf paths appended to the capability BASE. The base carries the whole grant, and
-    /// both tools ride it, so the daemon publishes one value and this server appends — deriving a
-    /// sibling endpoint by rewriting the tail of a leaf URL would be fragile string surgery on a
-    /// security boundary.</summary>
+    /// <summary>Leaves appended to the capability BASE. Both tools ride one grant, so the daemon
+    /// publishes the base rather than a leaf whose sibling would need string surgery to derive.</summary>
     const string CapabilitySubmitLeaf  = "/flow-result";
     const string CapabilityMessageLeaf = "/flow-message";
 
@@ -193,10 +189,8 @@ static class McpFlowResultServer {
             string               agentId,
             JsonObject?          arguments,
             Func<TimeSpan, Task> delay,
-            // Absolute delivery URL for a borrowed reviewer (see CapabilityUrlEnvVar). When set it
-            // REPLACES the apiRoot-composed path entirely: the capability is a daemon loopback
-            // endpoint, not a kcap API root, so composing under it would produce a 404 no caller
-            // could diagnose.
+            // Absolute delivery URL for a borrowed reviewer; REPLACES the apiRoot-composed path,
+            // since the capability is a daemon loopback endpoint and not a kcap API root.
             string?              submitUrlOverride = null
         ) {
         var roundToken = arguments?["round_token"]?.GetValue<string>();

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -21,6 +21,20 @@ namespace Capacitor.Cli.Commands;
 static class McpFlowResultServer {
     internal const string AgentIdEnvVar = "KCAP_FLOW_AGENT_ID";
 
+    /// <summary>The daemon-minted loopback capability a BORROWED reviewer delivers through. That
+    /// launch's sandbox redirects HOME to a per-launch state dir, so this process has no token store
+    /// and cannot authenticate for itself; the daemon runs unsandboxed, holds the real credential,
+    /// and forwards. Present only for a borrowed snapshot — every other launch keeps KCAP_URL and the
+    /// authenticated-client path, and the two are mutually exclusive by construction.</summary>
+    internal const string CapabilityUrlEnvVar = "KCAP_FLOW_CAPABILITY_URL";
+
+    /// <summary>Leaf paths appended to the capability BASE. The base carries the whole grant, and
+    /// both tools ride it, so the daemon publishes one value and this server appends — deriving a
+    /// sibling endpoint by rewriting the tail of a leaf URL would be fragile string surgery on a
+    /// security boundary.</summary>
+    const string CapabilitySubmitLeaf  = "/flow-result";
+    const string CapabilityMessageLeaf = "/flow-message";
+
     const int MaxAttempts = 5;
     static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(3);
 
@@ -42,7 +56,11 @@ static class McpFlowResultServer {
 
         // Validate the server_url shape once, locally (pure string check — no network, token,
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
-        var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
+        // A borrowed reviewer delivers through the daemon capability and never authenticates; every
+        // other launch keeps the token-store path. Mutually exclusive, decided once here.
+        var capabilityBase = Environment.GetEnvironmentVariable(CapabilityUrlEnvVar)?.TrimEnd('/');
+        var borrowed       = !string.IsNullOrWhiteSpace(capabilityBase);
+        var urlOk = HttpClientExtensions.IsAcceptableUrl(borrowed ? capabilityBase! : baseUrl);
 
         // The authenticated client is created on the first tools/call, not at startup — mirrors
         // McpFlowsServer/McpReviewServer: keeps startup local-only (no GET /auth/config, token
@@ -94,11 +112,20 @@ static class McpFlowResultServer {
                 if (toolName is not ("submit_review_result" or "send_flow_message"))
                     return BuildToolResult(callId, $"Error: Unknown tool: {toolName}", isError: true);
 
-                client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, autoRetryUnauthorized: false);
+                // The borrowed path deliberately does NOT create an authenticated client: the token
+                // store lives under a HOME this process cannot reach, so attempting it is what
+                // produced the original silent failure.
+                client ??= borrowed
+                    ? new HttpClient()
+                    : await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl, autoRetryUnauthorized: false);
 
                 var (text, isError) = toolName switch {
-                    "submit_review_result" => await SubmitCoreAsync(client, apiRoot, agentId, arguments, delay: Task.Delay),
-                    "send_flow_message"    => await SendMessageCoreAsync(client, apiRoot, agentId, arguments, delay: Task.Delay),
+                    "submit_review_result" => await SubmitCoreAsync(
+                        client, apiRoot, agentId, arguments, delay: Task.Delay,
+                        submitUrlOverride: borrowed ? capabilityBase + CapabilitySubmitLeaf : null),
+                    "send_flow_message"    => await SendMessageCoreAsync(
+                        client, apiRoot, agentId, arguments, delay: Task.Delay,
+                        messageUrlOverride: borrowed ? capabilityBase + CapabilityMessageLeaf : null),
                     _                      => ($"Error: Unknown tool: {toolName}", true)
                 };
 
@@ -165,7 +192,12 @@ static class McpFlowResultServer {
             string               apiRoot,
             string               agentId,
             JsonObject?          arguments,
-            Func<TimeSpan, Task> delay
+            Func<TimeSpan, Task> delay,
+            // Absolute delivery URL for a borrowed reviewer (see CapabilityUrlEnvVar). When set it
+            // REPLACES the apiRoot-composed path entirely: the capability is a daemon loopback
+            // endpoint, not a kcap API root, so composing under it would produce a 404 no caller
+            // could diagnose.
+            string?              submitUrlOverride = null
         ) {
         var roundToken = arguments?["round_token"]?.GetValue<string>();
         var kind       = arguments?["kind"]?.GetValue<string>();
@@ -179,7 +211,7 @@ static class McpFlowResultServer {
             return ("Error: findings text is required when kind is \"findings\".", true);
 
         var body = new SubmitReviewerResultDto(agentId, roundToken, kind, kind == "findings" ? findings : null);
-        var url  = $"{apiRoot.TrimEnd('/')}/api/flows/reviewer/result";
+        var url  = submitUrlOverride ?? $"{apiRoot.TrimEnd('/')}/api/flows/reviewer/result";
 
         for (var attempt = 1; attempt <= MaxAttempts; attempt++) {
             using var response = await SendWithRefreshRetryAsync(
@@ -242,7 +274,9 @@ static class McpFlowResultServer {
             string               agentId,
             JsonObject?          arguments,
             Func<TimeSpan, Task> delay,
-            string?              messageId = null
+            string?              messageId = null,
+            // Same contract as SubmitCoreAsync's submitUrlOverride.
+            string?              messageUrlOverride = null
         ) {
         // Type-safe extraction: a non-string `text` (number/object/array) must yield this clean
         // validation error, not throw into the dispatch guard's generic "internal error"
@@ -253,7 +287,7 @@ static class McpFlowResultServer {
             return ("Error: text must be a non-empty string.", true);
 
         var body = new SendFlowMessageDto(agentId, messageId ?? Guid.NewGuid().ToString("N"), text);
-        var url  = $"{apiRoot.TrimEnd('/')}/api/flows/participant/message";
+        var url  = messageUrlOverride ?? $"{apiRoot.TrimEnd('/')}/api/flows/participant/message";
 
         for (var attempt = 1; attempt <= MaxAttempts; attempt++) {
             using var response = await SendWithRefreshRetryAsync(

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBorrowLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBorrowLaunchTests.cs
@@ -92,7 +92,7 @@ public partial class AgentOrchestratorVendorTests {
             // token count below stays at 1.
             await Assert.That(ctx.FlowResultCapabilityUrl).IsNotNull();
             await Assert.That(ctx.FlowResultCapabilityUrl!)
-                .StartsWith(ctx.ReviewContextCapabilityUrl!.Split("/review-context")[0]);
+                .IsEqualTo(ctx.ReviewContextCapabilityUrl!.Split("/review-context")[0]);
             await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(1);
             await Assert.That(orch.GetAgentForTest(cmd.AgentId)!.BorrowedSnapshotSource)
                 .IsEqualTo(BorrowAuthorizer.Canonicalize(cwd));

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBorrowLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorBorrowLaunchTests.cs
@@ -86,6 +86,13 @@ public partial class AgentOrchestratorVendorTests {
                 .IsEqualTo("untracked-one");
             await Assert.That(File.Exists(Path.Combine(ctx.Worktree.Path, ".mcp.json"))).IsFalse();
             await Assert.That(ctx.ReviewContextCapabilityUrl).IsNotNull();
+            // The result channel's delivery capability rides the SAME reviewer grant as the context
+            // capability, so one revocation closes both. A separately-minted token could outlive the
+            // first and leave a live submit path after the reviewer is gone — which is also why the
+            // token count below stays at 1.
+            await Assert.That(ctx.FlowResultCapabilityUrl).IsNotNull();
+            await Assert.That(ctx.FlowResultCapabilityUrl!)
+                .StartsWith(ctx.ReviewContextCapabilityUrl!.Split("/review-context")[0]);
             await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(1);
             await Assert.That(orch.GetAgentForTest(cmd.AgentId)!.BorrowedSnapshotSource)
                 .IsEqualTo(BorrowAuthorizer.Canonicalize(cwd));

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -1200,6 +1200,70 @@ public class LocalPermissionBridgeTests {
         await Assert.That(LocalPermissionBridge.IsAddressInUse(new HttpListenerException(errorCode)))
             .IsEqualTo(expected);
     }
+
+    /// <summary>
+    /// The borrowed reviewer's delivery path. Its sandbox redirects HOME to a per-launch state dir,
+    /// so the result channel cannot load a token store — it POSTs here instead and the daemon, which
+    /// runs unsandboxed and holds the real credential, forwards. The forwarder lives on the GRANT so
+    /// revoking the reviewer closes the submit path in the same operation that closes the read path.
+    /// </summary>
+    [Test]
+    public async Task Reviewer_flow_result_capability_forwards_the_body_then_dies_with_the_token() {
+        var (bridge, _) = CreateBridge();
+        await bridge.StartAsync(CancellationToken.None);
+
+        try {
+            string? forwardedPath = null;
+            string? forwarded     = null;
+            var reviewerUrl = bridge.RegisterReviewerToken([],
+                submitForwarder: (apiPath, body, _) => {
+                    forwardedPath = apiPath;
+                    forwarded     = body;
+                    return Task.FromResult((200, "{\"status\":\"accepted\"}"));
+                });
+
+            using var client = CreateClient();
+            var response = await client.PostAsync($"{reviewerUrl}/flow-result",
+                new StringContent("{\"kind\":\"clean\"}", Encoding.UTF8, "application/json"));
+
+            await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(forwarded).IsEqualTo("{\"kind\":\"clean\"}");
+            // The upstream path is the bridge's own constant, not anything the caller supplied.
+            await Assert.That(forwardedPath).IsEqualTo("/api/flows/reviewer/result");
+            await Assert.That(await response.Content.ReadAsStringAsync())
+                .IsEqualTo("{\"status\":\"accepted\"}");
+
+            // Fail-safe on revoke: a live submit path outliving the reviewer would let a lingering
+            // child process report into a flow whose participant the server already reaped.
+            bridge.RevokeReviewerToken(reviewerUrl);
+            var afterRevoke = await client.PostAsync($"{reviewerUrl}/flow-result",
+                new StringContent("{\"kind\":\"clean\"}", Encoding.UTF8, "application/json"));
+            await Assert.That(afterRevoke.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+        } finally {
+            await bridge.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>A grant minted without a forwarder (every non-borrowed reviewer) must not expose a
+    /// submit path at all — not a 500, not an empty 200. Pins that the capability is scoped to the
+    /// launches that actually need it rather than opening on every reviewer token.</summary>
+    [Test]
+    public async Task Reviewer_without_a_submit_forwarder_has_no_flow_result_capability() {
+        var (bridge, _) = CreateBridge();
+        await bridge.StartAsync(CancellationToken.None);
+
+        try {
+            var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+
+            using var client = CreateClient();
+            var response = await client.PostAsync($"{reviewerUrl}/flow-result",
+                new StringContent("{\"kind\":\"clean\"}", Encoding.UTF8, "application/json"));
+
+            await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+        } finally {
+            await bridge.StopAsync(CancellationToken.None);
+        }
+    }
 }
 
 sealed class CapturingLogger : ILogger<LocalPermissionBridge> {

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -1244,6 +1244,64 @@ public class LocalPermissionBridgeTests {
         }
     }
 
+    /// <summary>
+    /// The submit body is attacker-controlled: the POSTing process is a sandboxed vendor child. An
+    /// unbounded ReadToEndAsync would let it exhaust the daemon's memory, so the bridge caps the read
+    /// itself rather than trusting Content-Length — which a chunked or lying client need not honour.
+    /// The forwarder must never run for a rejected body.
+    /// </summary>
+    [Test]
+    public async Task Oversized_submit_body_is_rejected_without_reaching_the_forwarder() {
+        var (bridge, _) = CreateBridge();
+        await bridge.StartAsync(CancellationToken.None);
+
+        try {
+            var forwarded = 0;
+            var reviewerUrl = bridge.RegisterReviewerToken([],
+                submitForwarder: (_, _, _) => {
+                    forwarded++;
+                    return Task.FromResult((200, "{}"));
+                });
+
+            using var client = CreateClient();
+            var oversized = new string('x', LocalPermissionBridge.MaxSubmitBodyBytes + 1024);
+            var response = await client.PostAsync($"{reviewerUrl}/flow-result",
+                new StringContent(oversized, Encoding.UTF8, "application/json"));
+
+            await Assert.That((int)response.StatusCode).IsEqualTo(413);
+            await Assert.That(forwarded).IsEqualTo(0);
+        } finally {
+            await bridge.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>A body just under the cap still goes through, so the guard cannot pass by rejecting
+    /// everything — the failure mode a bare size check invites.</summary>
+    [Test]
+    public async Task Submit_body_just_under_the_cap_still_reaches_the_forwarder() {
+        var (bridge, _) = CreateBridge();
+        await bridge.StartAsync(CancellationToken.None);
+
+        try {
+            string? forwarded = null;
+            var reviewerUrl = bridge.RegisterReviewerToken([],
+                submitForwarder: (_, body, _) => {
+                    forwarded = body;
+                    return Task.FromResult((200, "{}"));
+                });
+
+            using var client = CreateClient();
+            var payload = new string('y', LocalPermissionBridge.MaxSubmitBodyBytes - 1024);
+            var response = await client.PostAsync($"{reviewerUrl}/flow-result",
+                new StringContent(payload, Encoding.UTF8, "application/json"));
+
+            await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(forwarded).IsEqualTo(payload);
+        } finally {
+            await bridge.StopAsync(CancellationToken.None);
+        }
+    }
+
     /// <summary>A grant minted without a forwarder (every non-borrowed reviewer) must not expose a
     /// submit path at all — not a 500, not an empty 200. Pins that the capability is scoped to the
     /// launches that actually need it rather than opening on every reviewer token.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowResultServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowResultServerTests.cs
@@ -44,6 +44,29 @@ public class McpFlowResultServerTests {
         await Assert.That(body).Contains("agent-1");
     }
 
+    /// <summary>
+    /// The borrowed-reviewer delivery path. That launch's HOME is a per-launch state dir, so the
+    /// channel has no token store and must POST to the daemon-minted loopback capability verbatim
+    /// rather than composing an API path under a server root. The deliberately unusable apiRoot is
+    /// the load-bearing half: if the override were ignored, the request would go there and the
+    /// capability endpoint would see nothing.
+    /// </summary>
+    [Test]
+    public async Task Capability_url_overrides_the_api_root_for_a_borrowed_reviewer() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/abc123/flow-result").UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"flow_run_id":"f1","round_id":"r1","round_number":1}"""));
+        using var client = new HttpClient();
+
+        var (text, isError) = await McpFlowResultServer.SubmitCoreAsync(
+            client, "http://unreachable.invalid", "agent-1", Args(), NoDelay([]),
+            submitUrlOverride: $"{server.Url}/abc123/flow-result");
+
+        await Assert.That(isError).IsFalse();
+        await Assert.That(text).IsEqualTo("Result recorded. You may end your reply now.");
+        await Assert.That(server.LogEntries.Single().RequestMessage.Path).IsEqualTo("/abc123/flow-result");
+    }
+
     [Test]
     public async Task Clean_kind_omits_null_text_from_the_wire() {
         using var server = WireMockServer.Start();

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -991,7 +991,7 @@ public class AcpHostedAgentRuntimeFactoryTests {
             // A borrowed launch must carry a delivery capability or AcpReviewFlowMcp.Build
             // refuses it. Set on the shared helper so every borrowed fixture below stays constructable.
             FlowResultCapabilityUrl =
-                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/flow-result"
+                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef"
         };
 
     /// <summary>A factory whose connectionSource INCREMENTS a counter (never throws — a throw would

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -987,7 +987,11 @@ public class AcpHostedAgentRuntimeFactoryTests {
             ServerUrl    = "http://kcap.test",
             McpAllowlist = allowlist,
             ReviewContextCapabilityUrl =
-                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/review-context/workspace-mcp-configs"
+                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/review-context/workspace-mcp-configs",
+            // A borrowed launch must carry a delivery capability or AcpReviewFlowMcp.Build
+            // refuses it. Set on the shared helper so every borrowed fixture below stays constructable.
+            FlowResultCapabilityUrl =
+                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/flow-result"
         };
 
     /// <summary>A factory whose connectionSource INCREMENTS a counter (never throws — a throw would

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpReviewFlowMcpContextTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpReviewFlowMcpContextTests.cs
@@ -8,7 +8,11 @@ public class AcpReviewFlowMcpContextTests {
         var servers = AcpReviewFlowMcp.Build(Context() with {
             IsBorrowedSnapshot = true,
             ReviewContextCapabilityUrl =
-                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/review-context/workspace-mcp-configs"
+                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/review-context/workspace-mcp-configs",
+            // A borrowed launch now requires BOTH capabilities, so this must be present to
+            // reach the context assertions at all.
+            FlowResultCapabilityUrl =
+                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/flow-result"
         }, ["kcap-review"]);
 
         var context = servers.Single(server => server.Name == "kcap-review-context");
@@ -17,6 +21,53 @@ public class AcpReviewFlowMcpContextTests {
         await Assert.That(context.Env.Select(pair => pair.Name)).IsEquivalentTo([
             "KCAP_REVIEW_CONTEXT_MODE", "KCAP_REVIEW_CONTEXT_URL"]);
         await Assert.That(context.Env.Any(pair => pair.Name == "KCAP_URL")).IsFalse();
+    }
+
+    /// <summary>A borrowed reviewer's HOME is redirected to a per-launch state dir, so the
+    /// result channel cannot load the token store — it must be handed a daemon-minted capability
+    /// instead. KCAP_URL is the thing that drives the ambient-credential path, so its ABSENCE is the
+    /// load-bearing half of this assertion, not decoration.</summary>
+    [Test]
+    public async Task Borrowed_snapshot_result_channel_uses_capability_not_ambient_credential() {
+        var servers = AcpReviewFlowMcp.Build(Context() with {
+            IsBorrowedSnapshot = true,
+            ReviewContextCapabilityUrl =
+                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/review-context/workspace-mcp-configs",
+            FlowResultCapabilityUrl =
+                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/flow-result"
+        }, []);
+
+        var channel = servers.Single(server => server.Name == "kcap-flow-result");
+        await Assert.That(channel.Env.Select(pair => pair.Name))
+            .IsEquivalentTo(["KCAP_FLOW_RESULT_URL", "KCAP_FLOW_AGENT_ID"]);
+        await Assert.That(channel.Env.Single(pair => pair.Name == "KCAP_FLOW_RESULT_URL").Value)
+            .IsEqualTo("http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/flow-result");
+    }
+
+    /// <summary>The non-borrowed launch keeps the ambient-credential path: its HOME is the real one,
+    /// the token store resolves, and nothing about the sandboxed case applies. Pins that the fix is scoped to
+    /// the sandboxed case rather than silently rerouting every reviewer.</summary>
+    [Test]
+    public async Task Direct_review_result_channel_keeps_server_url() {
+        var servers = AcpReviewFlowMcp.Build(Context(), []);
+
+        var channel = servers.Single(server => server.Name == "kcap-flow-result");
+        await Assert.That(channel.Env.Select(pair => pair.Name))
+            .IsEquivalentTo(["KCAP_URL", "KCAP_FLOW_AGENT_ID"]);
+    }
+
+    /// <summary>Same fail-before-launch shape as the context capability: a borrowed launch whose
+    /// result channel has no capability can never report, and that failure is otherwise silent —
+    /// the reviewer runs to completion and its answer is discarded at the delivery step.</summary>
+    [Test]
+    public async Task Snapshot_without_result_capability_fails_before_launch() {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            AcpReviewFlowMcp.Build(Context() with {
+                IsBorrowedSnapshot = true,
+                ReviewContextCapabilityUrl =
+                    "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/review-context/workspace-mcp-configs"
+            }, []));
+        await Assert.That(ex.Message).Contains("missing result capability URL");
     }
 
     [Test]
@@ -31,7 +82,13 @@ public class AcpReviewFlowMcpContextTests {
     [Test]
     public async Task Snapshot_without_context_capability_fails_before_launch() {
         var ex = Assert.Throws<InvalidOperationException>(() =>
-            AcpReviewFlowMcp.Build(Context() with { IsBorrowedSnapshot = true }, []));
+            AcpReviewFlowMcp.Build(Context() with {
+                IsBorrowedSnapshot = true,
+                // Supplied so the result-capability guard passes and this test still
+                // exercises the CONTEXT guard it was written for, rather than the new one.
+                FlowResultCapabilityUrl =
+                    "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/flow-result"
+            }, []));
         await Assert.That(ex.Message).Contains("missing capability URL");
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpReviewFlowMcpContextTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpReviewFlowMcpContextTests.cs
@@ -12,7 +12,7 @@ public class AcpReviewFlowMcpContextTests {
             // A borrowed launch now requires BOTH capabilities, so this must be present to
             // reach the context assertions at all.
             FlowResultCapabilityUrl =
-                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/flow-result"
+                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef"
         }, ["kcap-review"]);
 
         var context = servers.Single(server => server.Name == "kcap-review-context");
@@ -34,14 +34,14 @@ public class AcpReviewFlowMcpContextTests {
             ReviewContextCapabilityUrl =
                 "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/review-context/workspace-mcp-configs",
             FlowResultCapabilityUrl =
-                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/flow-result"
+                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef"
         }, []);
 
         var channel = servers.Single(server => server.Name == "kcap-flow-result");
         await Assert.That(channel.Env.Select(pair => pair.Name))
-            .IsEquivalentTo(["KCAP_FLOW_RESULT_URL", "KCAP_FLOW_AGENT_ID"]);
-        await Assert.That(channel.Env.Single(pair => pair.Name == "KCAP_FLOW_RESULT_URL").Value)
-            .IsEqualTo("http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/flow-result");
+            .IsEquivalentTo(["KCAP_FLOW_CAPABILITY_URL", "KCAP_FLOW_AGENT_ID"]);
+        await Assert.That(channel.Env.Single(pair => pair.Name == "KCAP_FLOW_CAPABILITY_URL").Value)
+            .IsEqualTo("http://127.0.0.1:1234/0123456789abcdef0123456789abcdef");
     }
 
     /// <summary>The non-borrowed launch keeps the ambient-credential path: its HOME is the real one,
@@ -87,7 +87,7 @@ public class AcpReviewFlowMcpContextTests {
                 // Supplied so the result-capability guard passes and this test still
                 // exercises the CONTEXT guard it was written for, rather than the new one.
                 FlowResultCapabilityUrl =
-                    "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/flow-result"
+                    "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef"
             }, []));
         await Assert.That(ex.Message).Contains("missing capability URL");
     }


### PR DESCRIPTION
Fixes AI-1797

## The bug

A borrowed Copilot review does all its work correctly and then throws the answer away.

Reviewer session `01144c0060e04a7b8fa6ecbab1ac2752`, verbatim:

```
+00:02  Viewing …/borrowed-d40cc491/src/Capacitor.Cli.Core/ProcessUrlPolicy.cs
+00:02  {"content":"namespace Capacitor.Cli.Core;\n\n/// <summary>What a process should do…
+00:06  submit_review_result → {"message":"MCP server 'kcap-flow-result': Error:
                                internal error handling the request.","code":"failure"}
+00:11  submit_review_result → same
+00:15  submit_review_result → same
+00:19  "The tool is returning an internal error on every attempt. Here are my results directly: …"
```

The sandbox admitted the read, containment held (`Disabled tools: bash, create, edit, …`), and the brokered vendor token authenticated. The reviewer produced a correct answer at +00:19 — then the driver waited out the round's full 12.5-minute timeout, because the result had nowhere to go and the result contract ignores reply text by design.

## Mechanism

`AcpHostedAgentRuntimeFactory` redirects the sandboxed vendor's `HOME` to a per-launch state dir so it cannot reach `~/.copilot` or the keychain. MCP servers are spawned as the vendor's **children**, so they inherit that `HOME` — but `AcpReviewFlowMcp` handed the result channel only `KCAP_URL`, which routes it to `CreateAuthenticatedClientAsync` and a token store that is no longer reachable. The exception was caught and reported as a generic error, with the real reason written to stderr and discarded.

The vendor's own credential was explicitly brokered in one line later. kcap's own MCP children never got the same treatment.

## Approach

A daemon-brokered loopback capability, mirroring `kcap-review-context` — which sits six lines below the bug and already solves exactly this by taking a capability URL instead of ambient credentials.

- `LocalPermissionBridge` serves `POST /{token}/flow-result` and `/{token}/flow-message` on a reviewer grant minted **with** a forwarder, and relays under the daemon's credential (the daemon runs unsandboxed, so its token store resolves).
- The upstream API path is chosen from a **fixed table in the bridge**, never echoed from the request — the caller is a sandboxed vendor child, and letting it name the path would turn an authenticated relay into an open one.
- The forwarder lives on the **grant**, so revoking the reviewer closes the submit path in the same operation that closes the read path. A submit path outliving its reviewer would let a lingering child report into a flow whose participant the server already reaped.
- A grant minted **without** a forwarder 404s rather than exposing an endpoint that could only fail, so the capability is scoped to launches that need it.
- On a borrowed launch the channel gets `KCAP_FLOW_CAPABILITY_URL` **instead of** `KCAP_URL`, mutually exclusive by construction — passing both would leave the broken path reachable as a silent fallback. In capability mode it never constructs an authenticated client at all.
- A borrowed launch with no capability now fails **before launch**, mirroring the existing `kcap-review-context` guard, rather than at delivery after the reviewer has done all its work.

`send_flow_message` is covered too — it shares the channel and would have broken identically.

## Why it wasn't caught

The sandbox's enforcement tests are genuinely thorough: real `cat`/`ls` processes under the production profile, per closed tree, no model-layer refusal accepted as evidence. Every one passed. But they assert only what the reviewer **cannot read** — nothing asserted it could still **report**. Denial coverage and function coverage are independent axes.

It was also unreachable until now: every previous Copilot review ran non-borrowed, where `HOME` is real and the token resolves. This is the first borrowed Copilot run, which only became possible once a daemon token source was configured.

## Testing

TDD throughout — each behavioural test watched failing first, for the stated reason.

- `Borrowed_snapshot_result_channel_uses_capability_not_ambient_credential` — the **absence** of `KCAP_URL` is the load-bearing half
- `Direct_review_result_channel_keeps_server_url` — regression guard pinning the fix to the sandboxed case (passes without the change, labelled as a guard)
- `Snapshot_without_result_capability_fails_before_launch`
- `Reviewer_flow_result_capability_forwards_the_body_then_dies_with_the_token` — includes the post-revoke 404 and asserts the upstream path is the bridge's constant
- `Reviewer_without_a_submit_forwarder_has_no_flow_result_capability`
- `Capability_url_overrides_the_api_root_for_a_borrowed_reviewer` — the deliberately unusable `apiRoot` is what makes it non-vacuous

The new guard initially broke 9 existing borrowed-snapshot containment tests, which is the design working — a delivery-less borrowed launch is now unconstructable. Fixed at the shared fixture helper.

Local: `AcpReviewFlowMcpContextTests` 6/6, `LocalPermissionBridgeTests` 58/58, `McpFlowResultServerTests` 16/16, `AcpHostedAgentRuntimeFactory*` 85 total / 0 failed. `AgentOrchestratorVendorTests` 207 total / 5 failed — **the same 5-failure count on a clean `origin/main` detached baseline**, all from the slow PTY/timeout family with membership varying per run.

## Not in this PR

Two sub-issues noted on AI-1797, both separable: the uninformative error text, and fast-failing a round after terminal channel failures instead of burning the full timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)