### PR TITLE
Snapshot submodule contents as plain files instead of refusing the repo

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -839,11 +839,9 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
                 generation = await CreateReviewContextGenerationAsync(
                     source, reviewContextRoot, sourceHead, initialIndex, caseSensitive, plan, ct);
 
-            // Submodules are snapshotted as PLAIN CONTENT. Borrowing means the reviewer sees the
-            // developer's working tree, and for a submodule that is the checked-out files — not the
-            // pinned commit, which a fresh clone would give instead. Their .git is never copied: it
-            // is a gitlink file into the superproject's .git/modules, which this snapshot does not
-            // have, so carrying it would leave a dangling reference.
+            // Submodules snapshot as plain content: borrowing shows the developer's checked-out
+            // files, not the pinned commit. Their .git is never copied — it is a gitlink into the
+            // superproject's .git/modules, which this snapshot does not have.
             var submodulePrefixes = ReadSubmodulePrefixes(initialIndex);
 
             var manifest = await ReadSourceManifestAsync(source, plan, caseSensitive, submodulePrefixes, ct);
@@ -945,7 +943,10 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             // checked BEFORE git is invoked here.
             EnsureNoLinkedComponents(source, subDir, subRel);
 
-            if (!Directory.Exists(subDir)) continue;   // uninitialized submodule: nothing checked out
+            // Gate on the submodule's OWN git, not on the directory: `git submodule` leaves an empty
+            // directory for an uninitialized one, so Directory.Exists is true there and `git -C`
+            // would fail and abort the entire snapshot — the opposite of skipping it.
+            if (!Path.Exists(Path.Combine(subDir, ".git"))) continue;
 
             // Nested submodules are NOT walked. Failing is deliberate: a silently incomplete snapshot
             // is invisible to the reviewer, who would report on source it never saw.
@@ -960,8 +961,6 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         // A stage-only addition has no working-tree bytes to mirror. Skip those exact raw paths
         // before decoding so an unrelated, absent non-UTF8 index entry cannot interfere with the
         // review-context extractor's classify-before-decode guarantee.
-        var deleted = await RunGitCaptureBytes(source, GitTimeout, true, ct,
-            "ls-files", "--deleted", "-z");
         var deletedPaths = deletedRecords
             .Select(static path => Convert.ToBase64String(path))
             .ToHashSet(StringComparer.Ordinal);

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -839,11 +839,14 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
                 generation = await CreateReviewContextGenerationAsync(
                     source, reviewContextRoot, sourceHead, initialIndex, caseSensitive, plan, ct);
 
-            if (SplitNulRecords(initialIndex)
-                .Any(entry => entry.Span.StartsWith("160000 "u8)))
-                throw new InvalidOperationException("borrowed_snapshot_submodules_unsupported");
+            // Submodules are snapshotted as PLAIN CONTENT. Borrowing means the reviewer sees the
+            // developer's working tree, and for a submodule that is the checked-out files — not the
+            // pinned commit, which a fresh clone would give instead. Their .git is never copied: it
+            // is a gitlink file into the superproject's .git/modules, which this snapshot does not
+            // have, so carrying it would leave a dangling reference.
+            var submodulePrefixes = ReadSubmodulePrefixes(initialIndex);
 
-            var manifest = await ReadSourceManifestAsync(source, plan, caseSensitive, ct);
+            var manifest = await ReadSourceManifestAsync(source, plan, caseSensitive, submodulePrefixes, ct);
             await ApplyReservedIndexPolicyAsync(destination, plan, caseSensitive, ct);
             await CopyManifestAsync(source, destination, manifest, ct);
             RemoveFilesOutsideManifest(destination, manifest.Keys, caseSensitive, ct);
@@ -854,7 +857,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             var finalIndex = await RunGitCaptureBytes(source, GitTimeout, true, ct,
                 "ls-files", "--stage", "-z");
             var finalManifest = await ReadSourceManifestAsync(
-                source, plan, caseSensitive, ct);
+                source, plan, caseSensitive, submodulePrefixes, ct);
             if (!string.Equals(sourceHead, finalHead, StringComparison.Ordinal) ||
                 !initialIndex.AsSpan().SequenceEqual(finalIndex) ||
                 !ManifestsEqual(manifest, finalManifest))
@@ -869,36 +872,94 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         }
     }
 
+    /// <summary>Gitlink paths from a `ls-files --stage -z` index dump, as raw bytes. Kept undecoded
+    /// so a non-UTF8 submodule path cannot break the classify-before-decode guarantee the manifest
+    /// loop relies on — it is decoded there, under the same guard as every other path.</summary>
+    static List<byte[]> ReadSubmodulePrefixes(byte[] index) {
+        var prefixes = new List<byte[]>();
+
+        foreach (var entry in SplitNulRecords(index)) {
+            if (!entry.Span.StartsWith("160000 "u8)) continue;
+
+            // `<mode> <sha> <stage>\t<path>` — the path is everything past the first tab.
+            var tab = entry.Span.IndexOf((byte)'\t');
+            if (tab < 0 || tab + 1 >= entry.Span.Length) continue;
+
+            prefixes.Add(entry.Span[(tab + 1)..].ToArray());
+        }
+
+        return prefixes;
+    }
+
+    /// <summary>Enumerates one repository's snapshot-eligible paths, each prefixed so it is relative
+    /// to the SUPERPROJECT. Every returned path therefore flows through the same containment,
+    /// symlink and capacity guards as a superproject path — a submodule is not a second, weaker
+    /// lane.</summary>
+    static async Task<List<byte[]>> RunLsFilesPrefixedAsync(
+            string repoDir, byte[] prefix, string[] args, CancellationToken ct) {
+        var stdout  = await RunGitCaptureBytes(repoDir, GitTimeout, true, ct, args);
+        var records = new List<byte[]>();
+
+        foreach (var record in SplitNulRecords(stdout)) {
+            if (prefix.Length == 0) {
+                records.Add(record.ToArray());
+                continue;
+            }
+
+            var combined = new byte[prefix.Length + 1 + record.Length];
+            prefix.CopyTo(combined, 0);
+            combined[prefix.Length] = (byte)'/';
+            record.Span.CopyTo(combined.AsSpan(prefix.Length + 1));
+            records.Add(combined);
+        }
+
+        return records;
+    }
+
     static async Task<Dictionary<string, SnapshotFile>> ReadSourceManifestAsync(
-            string source, SnapshotExclusionPlan plan, bool caseSensitive, CancellationToken ct) {
-        var stdout = await RunGitCaptureBytes(source, GitTimeout, true, ct,
-            "ls-files", "-co", "--exclude-standard", "-z");
+            string source, SnapshotExclusionPlan plan, bool caseSensitive,
+            IReadOnlyList<byte[]> submodulePrefixes, CancellationToken ct) {
+        string[] trackedArgs = ["ls-files", "-co", "--exclude-standard", "-z"];
+        string[] deletedArgs = ["ls-files", "--deleted", "-z"];
+
+        var stdoutRecords  = await RunLsFilesPrefixedAsync(source, [], trackedArgs, ct);
+        var deletedRecords = await RunLsFilesPrefixedAsync(source, [], deletedArgs, ct);
+
+        foreach (var prefix in submodulePrefixes) {
+            // Contained BEFORE the submodule's own git is invoked: the path comes from the index,
+            // and a hostile one must not steer `git -C` outside the source tree.
+            var subDir = ContainedPath(source, NormalizeRelativePath(StrictUtf8.GetString(prefix)));
+            if (!Directory.Exists(subDir)) continue;   // uninitialized submodule: nothing checked out
+
+            stdoutRecords.AddRange(await RunLsFilesPrefixedAsync(subDir, prefix, trackedArgs, ct));
+            deletedRecords.AddRange(await RunLsFilesPrefixedAsync(subDir, prefix, deletedArgs, ct));
+        }
         // A stage-only addition has no working-tree bytes to mirror. Skip those exact raw paths
         // before decoding so an unrelated, absent non-UTF8 index entry cannot interfere with the
         // review-context extractor's classify-before-decode guarantee.
         var deleted = await RunGitCaptureBytes(source, GitTimeout, true, ct,
             "ls-files", "--deleted", "-z");
-        var deletedPaths = SplitNulRecords(deleted)
-            .Select(static path => Convert.ToBase64String(path.Span))
+        var deletedPaths = deletedRecords
+            .Select(static path => Convert.ToBase64String(path))
             .ToHashSet(StringComparer.Ordinal);
         var comparison = caseSensitive
             ? StringComparer.Ordinal
             : StringComparer.OrdinalIgnoreCase;
         var result = new Dictionary<string, SnapshotFile>(comparison);
         long total = 0;
-        foreach (var rawBytes in SplitNulRecords(stdout)) {
+        foreach (var rawBytes in stdoutRecords) {
             ct.ThrowIfCancellationRequested();
-            if (deletedPaths.Contains(Convert.ToBase64String(rawBytes.Span))) continue;
+            if (deletedPaths.Contains(Convert.ToBase64String(rawBytes))) continue;
             // Vendor config is matched HERE, on the raw bytes, by the same classifier the review-context
             // extractor uses — and before decoding, preserving that extractor's classify-before-decode
             // guarantee. Routing it through IsUnderExcluded instead would be a second matcher with
             // different case-folding semantics (OrdinalIgnoreCase there, ASCII-only here), which is how a
             // path becomes excluded by one and invisible to the other.
-            if (ClassifyReservedPath(rawBytes.Span, plan.Reserved, caseSensitive).Kind
+            if (ClassifyReservedPath(rawBytes, plan.Reserved, caseSensitive).Kind
                     != ReservedPathMatchKind.Unrelated)
                 continue;
             string raw;
-            try { raw = StrictUtf8.GetString(rawBytes.Span); }
+            try { raw = StrictUtf8.GetString(rawBytes); }
             catch (DecoderFallbackException ex) {
                 throw new InvalidOperationException(
                     "borrowed_snapshot_invalid_path_encoding", ex);

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -926,10 +926,33 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         var deletedRecords = await RunLsFilesPrefixedAsync(source, [], deletedArgs, ct);
 
         foreach (var prefix in submodulePrefixes) {
-            // Contained BEFORE the submodule's own git is invoked: the path comes from the index,
-            // and a hostile one must not steer `git -C` outside the source tree.
-            var subDir = ContainedPath(source, NormalizeRelativePath(StrictUtf8.GetString(prefix)));
+            // Decoded HERE rather than in the loop below, so it needs the loop's coded error too —
+            // a raw DecoderFallbackException would surface as an unhandled fault instead of a
+            // diagnosable snapshot failure.
+            string subRaw;
+            try { subRaw = StrictUtf8.GetString(prefix); }
+            catch (DecoderFallbackException ex) {
+                throw new InvalidOperationException("borrowed_snapshot_invalid_path_encoding", ex);
+            }
+
+            var subRel = NormalizeRelativePath(subRaw);
+            var subDir = ContainedPath(source, subRel);
+
+            // ContainedPath is LEXICAL — Path.GetFullPath does not resolve links — so a gitlink whose
+            // working-tree directory is a symlink passes containment while `git -C` follows it and
+            // enumerates a tree the snapshot has no right to read. The per-file guards below cannot
+            // undo a directory-level traversal that has already happened, so the components are
+            // checked BEFORE git is invoked here.
+            EnsureNoLinkedComponents(source, subDir, subRel);
+
             if (!Directory.Exists(subDir)) continue;   // uninitialized submodule: nothing checked out
+
+            // Nested submodules are NOT walked. Failing is deliberate: a silently incomplete snapshot
+            // is invisible to the reviewer, who would report on source it never saw.
+            var subIndex = await RunGitCaptureBytes(subDir, GitTimeout, true, ct, "ls-files", "--stage", "-z");
+            if (ReadSubmodulePrefixes(subIndex).Count > 0)
+                throw new InvalidOperationException(
+                    $"borrowed_snapshot_nested_submodules_unsupported: {subRel}");
 
             stdoutRecords.AddRange(await RunLsFilesPrefixedAsync(subDir, prefix, trackedArgs, ct));
             deletedRecords.AddRange(await RunLsFilesPrefixedAsync(subDir, prefix, deletedArgs, ct));

--- a/test/Capacitor.Cli.Tests.Unit/WorktreeManagerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorktreeManagerTests.cs
@@ -291,6 +291,39 @@ public class WorktreeManagerTests {
         }
     }
 
+    /// <summary>
+    /// A gitlink whose working-tree directory is a SYMLINK must not cause git to be invoked outside
+    /// the source tree. ContainedPath is lexical — Path.GetFullPath does not resolve links — so the
+    /// escaped path passes containment while `git -C` follows the link and enumerates a directory the
+    /// snapshot has no right to read. The per-file guards downstream cannot retroactively undo a
+    /// directory-level traversal that already happened.
+    /// </summary>
+    [Test]
+    public async Task BorrowedSnapshot_RefusesSubmodulePathThatIsASymlink() {
+        var (_, super) = MakeUpstreamWithSideRef("refs/pull/93/head", out _);
+        var outside = Path.Combine(Path.GetTempPath(), "kcap-outside-" + Guid.NewGuid().ToString("N")[..8]);
+        var root    = Path.Combine(Path.GetTempPath(), "kcap-borrowed-lnk-" + Guid.NewGuid().ToString("N")[..8]);
+        try {
+            Directory.CreateDirectory(outside);
+            File.WriteAllText(Path.Combine(outside, "secret.txt"), "must-not-be-snapshotted");
+
+            // Forge a gitlink entry whose path is a symlink to a directory outside the source.
+            Directory.CreateSymbolicLink(Path.Combine(super, "vendored"), outside);
+            Git(super, "update-index", "--add", "--cacheinfo",
+                "160000," + new string('a', 40) + ",vendored");
+
+            var manager = new WorktreeManager(
+                new DaemonConfig { WorktreeRoot = root }, NullLogger<WorktreeManager>.Instance);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await manager.CreateBorrowedSnapshotAsync(super, "review", CancellationToken.None));
+            await Assert.That(ex!.Message).StartsWith("borrowed_snapshot_symlink_unsupported");
+        } finally {
+            try { Directory.Delete(root, true); } catch { /* best-effort */ }
+            try { Directory.Delete(outside, true); } catch { /* best-effort */ }
+        }
+    }
+
     [Test]
     public async Task BorrowedSnapshot_IsIndependent_CopiesDirtyContext_AndRefreshesPristinely() {
         var (upstream, clone) = MakeUpstreamWithSideRef("refs/pull/88/head", out _);

--- a/test/Capacitor.Cli.Tests.Unit/WorktreeManagerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorktreeManagerTests.cs
@@ -241,20 +241,12 @@ public class WorktreeManagerTests {
         }
     }
 
-    /// <summary>
-    /// A superproject with a submodule must snapshot. The snapshot lane refused any index carrying a
-    /// gitlink, which made borrowed review impossible on every repo that uses one — kcap-server pins
-    /// its CLI that way, so our own primary repo could not be reviewed by any snapshot vendor.
-    ///
-    /// <para>The submodule arrives as PLAIN CONTENT: the reviewer sees the files in the developer's
-    /// checkout, which is what "borrowed" means, and gains no git identity for them. Its .git must not
-    /// be copied — it is a gitlink file pointing into the superproject's .git/modules, so carrying it
-    /// would leave a dangling reference into a directory the snapshot deliberately does not have.</para>
-    /// </summary>
+    /// <summary>The submodule arrives as plain content — dirty and untracked files included, so this
+    /// cannot pass against a pinned-commit checkout — and with no .git of its own.</summary>
     [Test]
     public async Task BorrowedSnapshot_CarriesSubmoduleFilesAsPlainContentWithoutItsGit() {
-        var (_, sub)   = MakeUpstreamWithSideRef("refs/pull/91/head", out _);
-        var (_, super) = MakeUpstreamWithSideRef("refs/pull/92/head", out _);
+        var (subUpstream, sub)     = MakeUpstreamWithSideRef("refs/pull/91/head", out _);
+        var (superUpstream, super) = MakeUpstreamWithSideRef("refs/pull/92/head", out _);
         var root = Path.Combine(Path.GetTempPath(), "kcap-borrowed-sub-" + Guid.NewGuid().ToString("N")[..8]);
         try {
             File.WriteAllText(Path.Combine(sub, "lib.txt"), "sub-tracked");
@@ -287,7 +279,8 @@ public class WorktreeManagerTests {
                 await WorktreeManager.RemoveAsync(snapshot);
             }
         } finally {
-            try { Directory.Delete(root, true); } catch { /* best-effort */ }
+            foreach (var dir in new[] { root, sub, super, subUpstream, superUpstream })
+                try { Directory.Delete(dir, true); } catch { /* best-effort */ }
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/WorktreeManagerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorktreeManagerTests.cs
@@ -241,6 +241,56 @@ public class WorktreeManagerTests {
         }
     }
 
+    /// <summary>
+    /// A superproject with a submodule must snapshot. The snapshot lane refused any index carrying a
+    /// gitlink, which made borrowed review impossible on every repo that uses one — kcap-server pins
+    /// its CLI that way, so our own primary repo could not be reviewed by any snapshot vendor.
+    ///
+    /// <para>The submodule arrives as PLAIN CONTENT: the reviewer sees the files in the developer's
+    /// checkout, which is what "borrowed" means, and gains no git identity for them. Its .git must not
+    /// be copied — it is a gitlink file pointing into the superproject's .git/modules, so carrying it
+    /// would leave a dangling reference into a directory the snapshot deliberately does not have.</para>
+    /// </summary>
+    [Test]
+    public async Task BorrowedSnapshot_CarriesSubmoduleFilesAsPlainContentWithoutItsGit() {
+        var (_, sub)   = MakeUpstreamWithSideRef("refs/pull/91/head", out _);
+        var (_, super) = MakeUpstreamWithSideRef("refs/pull/92/head", out _);
+        var root = Path.Combine(Path.GetTempPath(), "kcap-borrowed-sub-" + Guid.NewGuid().ToString("N")[..8]);
+        try {
+            File.WriteAllText(Path.Combine(sub, "lib.txt"), "sub-tracked");
+            Git(sub, "add", "lib.txt");
+            Git(sub, "commit", "-m", "sub content");
+
+            Git(super, "-c", "protocol.file.allow=always", "submodule", "add", sub, "vendored");
+            Git(super, "commit", "-m", "add submodule");
+
+            // Dirty + untracked inside the submodule: the whole point of borrowing is that the
+            // reviewer sees the developer's actual working tree, not the pinned commit.
+            File.WriteAllText(Path.Combine(super, "vendored", "lib.txt"), "sub-dirty");
+            File.WriteAllText(Path.Combine(super, "vendored", "scratch.txt"), "sub-untracked");
+
+            var manager = new WorktreeManager(
+                new DaemonConfig { WorktreeRoot = root }, NullLogger<WorktreeManager>.Instance);
+            var snapshot = await manager.CreateBorrowedSnapshotAsync(super, "review", CancellationToken.None);
+
+            try {
+                await Assert.That(File.ReadAllText(Path.Combine(snapshot.Path, "vendored", "lib.txt")))
+                    .IsEqualTo("sub-dirty");
+                await Assert.That(File.ReadAllText(Path.Combine(snapshot.Path, "vendored", "scratch.txt")))
+                    .IsEqualTo("sub-untracked");
+                // No git identity for the submodule inside the snapshot, in either shape.
+                await Assert.That(File.Exists(Path.Combine(snapshot.Path, "vendored", ".git"))).IsFalse();
+                await Assert.That(Directory.Exists(Path.Combine(snapshot.Path, "vendored", ".git"))).IsFalse();
+                // The superproject's own snapshot .git is still the independent one.
+                await Assert.That(Directory.Exists(Path.Combine(snapshot.Path, ".git"))).IsTrue();
+            } finally {
+                await WorktreeManager.RemoveAsync(snapshot);
+            }
+        } finally {
+            try { Directory.Delete(root, true); } catch { /* best-effort */ }
+        }
+    }
+
     [Test]
     public async Task BorrowedSnapshot_IsIndependent_CopiesDirtyContext_AndRefreshesPristinely() {
         var (upstream, clone) = MakeUpstreamWithSideRef("refs/pull/88/head", out _);


### PR DESCRIPTION
Fixes AI-1794

## The problem

The `IndependentSnapshot` borrowed-review lane refused any repository whose index carried a gitlink:

```csharp
if (SplitNulRecords(initialIndex).Any(entry => entry.Span.StartsWith("160000 "u8)))
    throw new InvalidOperationException("borrowed_snapshot_submodules_unsupported");
```

`kcap-server` pins `src/cli` as a submodule, so **our own primary repo could not be borrowed-reviewed by any snapshot vendor**. Measured effect across vendors on a kcap-server changeset:

| vendor | containment | outcome |
|---|---|---|
| codex | borrows in place | ✅ sees the real tree |
| cursor | `IndependentSnapshot` | ❌ this guard |
| copilot | `IndependentSnapshot` | ❌ this guard |
| claude | none | ⚠️ falls back to an owned worktree — a fresh clone, so the submodule is at the **stale pin**. It does not error; it reviews code the branch never wrote and returns clean. |

## Approach

Submodules are snapshotted as **plain content**. Borrowing means the reviewer sees the developer's working tree, and for a submodule that is the checked-out files — not the pinned commit a fresh clone gives. Dirty and untracked files inside a submodule are carried for the same reason they are in the superproject.

Its `.git` is never copied: that is a gitlink *file* pointing into the superproject's `.git/modules`, which the snapshot deliberately does not have, so copying it would leave a dangling reference. The submodule gains no git identity inside the snapshot.

## Security-relevant details

This lane has history (AI-1675 was a credential-exfiltration-via-symlinks finding), so the new path source deliberately gets no shortcuts:

- **Every submodule path is prefixed to be relative to the SUPERPROJECT before it enters the manifest loop**, so it flows through the identical containment, symlink, reserved-path, encoding and capacity guards. A submodule is not a second, weaker lane. Notably `EnsureNoLinkedComponents` now walks the submodule directory component too, so a symlinked submodule dir is caught.
- **Prefixes stay raw bytes** until that loop's own decode, preserving its classify-before-decode guarantee — a non-UTF8 submodule path can't slip past `ClassifyReservedPath`.
- **The submodule directory is resolved through `ContainedPath` before its git is invoked**, so an index-supplied path cannot steer `git -C` outside the source tree.
- An **uninitialized** submodule (nothing checked out) is skipped rather than failing the snapshot.

## Testing

`BorrowedSnapshot_CarriesSubmoduleFilesAsPlainContentWithoutItsGit` — watched failing first with exactly `borrowed_snapshot_submodules_unsupported`. It asserts the submodule's **dirty** tracked file and its **untracked** file both arrive (so it can't pass on a pinned-commit checkout), and that no `.git` exists at the submodule path in either file or directory form, while the superproject's own independent `.git` still does.

Worth noting: the guard being removed had **no test at all** — `rg submodules_unsupported test/` returned nothing.

Local: `WorktreeManagerTests` 22 total / 0 failed, `BorrowedReviewContextTests` 19/0, `AgentOrchestratorVendorTests` 207/0.

## Out of scope

Option 4 from the issue — making the **claude** owned-worktree fallback refuse or warn on a submodule repo instead of silently reviewing at the stale pin — is deliberately not in this PR. It's a different mechanism (no snapshot involved) and separable, but it is the more dangerous half of the original report, since it fails silently rather than loudly. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)