### PR TITLE
Let the unattended agy reviewer deliver its result

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,7 +874,15 @@ supported setup:
 gcloud auth application-default login
 export GOOGLE_CLOUD_PROJECT=<your-project>
 export AGY_ADC_AUTH=1                           # selects ADC; without it agy still demands an OAuth login
+export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
 ```
+
+All three are required. The credential path looks redundant — ADC has a well-known default location, and
+that is exactly where `gcloud auth application-default login` just wrote it — but a reviewer launch
+redirects `HOME` to a per-launch state directory, so the default location is not visible to the child.
+Without the explicit path `agy` reports `authentication required. Run 'agy' to log in.` even with the
+other two set correctly. The daemon does not fill this in for you: it never reads a credential location
+of its own accord, only forwards what you exported.
 
 **Minimum version.** Containment here depends on the installed build honouring `HOME` and reading no other
 global config source, so the daemon records a minimum `agy` version at the first startup that finds `agy`

--- a/README.md
+++ b/README.md
@@ -858,6 +858,13 @@ the kcap capture plugin inside it do not reach the reviewer, and your interactiv
 unaffected. POSIX only, for the same reason as Kiro: that home holds the reviewer's own transcript, and
 therefore the review context, and cannot be created owner-only on Windows.
 
+That home also carries a small `settings.json` holding `permissions.allow` rules for exactly the MCP tools
+the launch injected — the `kcap-flow-result` submit channel, plus any read-only servers the flow definition
+allowlisted — named one `server/tool` pair at a time, never a wildcard. `agy -p` has no human to approve a
+tool confirmation and auto-denies every one it raises, so without those rules a reviewer reads its context,
+reasons, and can never deliver its result. The grant admits those named tools and nothing else;
+`--dangerously-skip-permissions`, which *is* the read boundary, stays off this arm.
+
 **Give the daemon durable credentials.** An unattended reviewer's stdin is closed, so it cannot complete an
 interactive login — an unauthenticated `agy` fails the launch with a coded
 `antigravity_reviewer_auth_unavailable` rather than hanging. Application Default Credentials are the
@@ -914,7 +921,8 @@ read absolute paths outside its worktree, so a daemon-owned worktree does not co
 sees. A hosted agent runs on your own machine, under your own daemon, at your own request; if you would
 rather it asked first, restrict the vendor with [`kcap daemon consent`](#launch-consent-kcap-daemon-consent).
 **Review-flow reviewers never get the flag** — they read an owned worktree and nothing else, so the
-soft-deny is the posture they want.
+soft-deny is the posture they want; the one thing they must still be able to call, their own result
+channel, is admitted by name instead (above).
 
 Hosted launches otherwise take the same route as the reviewer above — the per-launch isolated `HOME`
 included, so your own `~/.gemini` config and the kcap capture plugin inside it never reach a hosted agent,

--- a/docs/probes/2026-08-06-agy-reviewer/findings.md
+++ b/docs/probes/2026-08-06-agy-reviewer/findings.md
@@ -166,6 +166,51 @@ Three consequences for anything built on this:
    instruction in the same prompt never runs. A test that waits for a post-denial summary will
    **hang**, not fail — bound every wait.
 
+### 3.1 The same auto-deny applies to MCP, and it silently broke every round
+
+**Binary:** `agy --version` → `1.1.13`. **Date:** 2026-08-07.
+
+The table above was read as being about *reads*. It is about **every** tool kind, and the reviewer's
+own **result channel is an MCP tool** — so the one call a round depends on was the one call print
+mode refused. Observed on a live review: the conversation stopped at `PLANNER_RESPONSE` with no
+`TOOL_CALL`, and agy's log inside the per-launch home read
+
+```
+Print mode: soft-denying tool confirmation "McpTool" at step 2
+Tool confirmation for conversation … step 2 (type=*Step_McpTool approved=false)
+permission check failed for mcp "kcap-flow-result/submit_review_result": user denied permission for mcp
+```
+
+The round then hung until the flow timed out. Every containment assertion in the suite passed in
+that state — a pure containment suite is perfectly consistent with a reviewer that never works.
+
+**Measured fix.** A fresh, isolated `HOME` with one stub stdio MCP server named `kcap-flow-result`
+serving `submit_review_result`, launched exactly as §1, differing only in
+`{HOME}/.gemini/antigravity-cli/settings.json` — a **different** file from the
+`{HOME}/.gemini/config/mcp_config.json` that carries the server list:
+
+| `settings.json` | `tools/call` reached the server? | stderr |
+|---|---|---|
+| absent | **no** — the server logged `tools/list` and nothing after | the §3 auto-deny notice, with `"mcp"` as the permission name |
+| `{"permissions":{"allow":["mcp(kcap-flow-result/send_flow_message)","mcp(kcap-flow-result/submit_review_result)"]}}` | **yes** | empty |
+
+The second row is byte-for-byte what `AntigravityReviewerHome.WriteSettings` produces — no `gcp`,
+`model` or `trustedWorkspaces` key is needed for the grant to take effect.
+
+Three notes for anyone changing this:
+
+1. **The exact `server/tool` pair works.** No wildcard is required, so `mcp(kcap-flow-result/*)`
+   would be a widening nothing buys. The rule form is agy's own: its binary ships
+   `mcp(chrome_devtools/evaluate_script)`, `mcp(chrome-devtools/*)` and `mcp(*)`.
+2. **The rule string is the identity agy logs on the denial**, verbatim —
+   `kcap-flow-result/submit_review_result`. Unlike the `view_file`/`read_file` disagreement in §3,
+   the MCP kind names the same thing on both sides.
+3. **The binary ships a string that contradicts this, and it is not the MCP path:** *"the %s tool(s)
+   required approval that headless mode cannot prompt for, so they were auto-denied. Settings
+   allow-rules do not apply; re-run with --dangerously-skip-permissions to auto-approve all tools."*
+   The measurement above supersedes it for MCP — the allow-rule demonstrably applies. Do not act on
+   that string without re-measuring.
+
 ---
 
 ## 4. Two falsified premises

--- a/src/Capacitor.Cli.Core/Antigravity/AntigravityPaths.cs
+++ b/src/Capacitor.Cli.Core/Antigravity/AntigravityPaths.cs
@@ -41,6 +41,20 @@ public static class AntigravityPaths {
     public static string McpConfigJson(string? home = null, string? geminiCliHome = null)
         => Path.Combine(GuiConfigRoot(home, geminiCliHome), "mcp_config.json");
 
+    /// <summary>The <c>agy</c> CLI's OWN config root: <c>&lt;gemini-root&gt;/antigravity-cli</c>. The GUI
+    /// does NOT read it (see this type's header), so it is the wrong place for capture hooks and the
+    /// right place for anything scoped to a CLI invocation.</summary>
+    public static string CliConfigRoot(string? home = null, string? geminiCliHome = null)
+        => Path.Combine(GeminiPaths.Root(home, geminiCliHome), "antigravity-cli");
+
+    /// <summary>The <c>agy</c> CLI's settings file: <c>&lt;cli-config&gt;/settings.json</c>. A DIFFERENT
+    /// file from both <see cref="McpConfigJson"/> (Antigravity's MCP server list) and the Gemini CLI's
+    /// <c>~/.gemini/settings.json</c>. Holds the CLI's own preferences plus the <c>permissions.allow</c>
+    /// rules headless (<c>agy -p</c>) runs are evaluated against — headless cannot prompt, so a tool
+    /// with no matching allow-rule is auto-denied.</summary>
+    public static string CliSettingsJson(string? home = null, string? geminiCliHome = null)
+        => Path.Combine(CliConfigRoot(home, geminiCliHome), "settings.json");
+
     /// <summary>Global steering/context file the IDE loads: <c>&lt;gemini-root&gt;/GEMINI.md</c> —
     /// SHARED with the Gemini CLI (both hardcode <c>~/.gemini/GEMINI.md</c>), so kcap's single
     /// marker-delimited block serves both. Honors <c>GEMINI_CLI_HOME</c> via <see cref="GeminiPaths.Root"/>.</summary>

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerHome.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerHome.cs
@@ -111,18 +111,36 @@ internal static class AntigravityReviewerHome {
               + "launch that could not be removed. Refusing rather than handing a reviewer another "
               + "review's conversation state.");
 
-        WriteMcpConfig(home, injected);
+        // Everything from the first WRITE onward is all-or-nothing. The caller binds this home's
+        // disposal to the runtime it creates AFTER Create returns, so a throw from in here leaves a
+        // home with no disposal path armed at all — and the first thing written, mcp_config.json,
+        // carries the launch's live loopback capability URL. The daemon-epoch sweep would eventually
+        // reclaim it, but that is the crash backstop, not a licence to leak on an ordinary refusal.
+        // WriteSettings' fail-closed throw for an unclassifiable server makes this reachable by
+        // configuration rather than only by IO failure.
+        //
+        // Scoped to start here deliberately: the emptiness refusal above keeps its existing
+        // behaviour of leaving the previous launch's undeletable content alone, and nothing
+        // capability-bearing exists before this point.
+        try {
+            WriteMcpConfig(home, injected);
 
-        // Injecting a server is only half of a usable reviewer — see WriteSettings.
-        if (grantInjectedMcpTools) WriteSettings(home, injected);
+            // Injecting a server is only half of a usable reviewer — see WriteSettings.
+            if (grantInjectedMcpTools) WriteSettings(home, injected);
 
-        // The kcap plugin dir is what lets agy's OWN capture hooks fire (job 1) — its absence is
-        // the whole mechanism, so it is checked rather than trusted to follow from "we never wrote
-        // it". A future change that seeds a fuller home must trip this, not silently double-capture.
-        if (Directory.Exists(AntigravityPaths.PluginDir(home)))
-            throw new InvalidOperationException(
-                $"antigravity_reviewer_home_not_isolated: '{home}' carries a kcap plugin directory, "
-              + "which would let this reviewer's own capture hooks fire against its conversation.");
+            // The kcap plugin dir is what lets agy's OWN capture hooks fire (job 1) — its absence is
+            // the whole mechanism, so it is checked rather than trusted to follow from "we never wrote
+            // it". A future change that seeds a fuller home must trip this, not silently double-capture.
+            if (Directory.Exists(AntigravityPaths.PluginDir(home)))
+                throw new InvalidOperationException(
+                    $"antigravity_reviewer_home_not_isolated: '{home}' carries a kcap plugin directory, "
+                  + "which would let this reviewer's own capture hooks fire against its conversation.");
+        } catch {
+            // Best-effort, and never allowed to replace the real reason: a cleanup fault here would
+            // otherwise mask the fail-closed refusal the caller needs to see.
+            Delete(home, stateDir, log ?? NullLogger.Instance);
+            throw;
+        }
 
         return home;
     }

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerHome.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerHome.cs
@@ -37,6 +37,14 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// plugin directory job 1 depends on must still never exist, and creation verifies that rather than
 /// assuming it.</para>
 ///
+/// <para><b>And a review home carries a second file, for the same reason.</b> Kiro trusts its injected
+/// tools through launch argv (<see cref="KiroReviewerTrustList"/>); <c>agy</c> has no such flag, and
+/// <c>agy -p</c> auto-denies every tool confirmation it cannot prompt a human for — so a home that
+/// injects the result channel and grants nothing produces a reviewer that reads, reasons, and can never
+/// report. The <c>settings.json</c> written into <c>.gemini/antigravity-cli/</c> (a DIFFERENT file from
+/// the <c>mcp_config.json</c> above) carries the <c>permissions.allow</c> rules that close it; see
+/// <see cref="WriteSettings"/> and <see cref="AntigravityReviewerPermissions"/>.</para>
+///
 /// <para><b>Why disposal is a security requirement, not hygiene.</b> The reviewer's own conversation
 /// JSONL (<c>brain/&lt;id&gt;/.system_generated/logs/transcript_full.jsonl</c>, see
 /// <see cref="AntigravityPaths"/>) carries the caller's diff, source excerpts and findings. The home
@@ -59,12 +67,25 @@ internal static class AntigravityReviewerHome {
         $"{Prefix}{Sanitize(daemonEpoch)}-{Sanitize(launchId)}";
 
     /// <summary>
-    /// Creates an owner-only home carrying only a fresh <c>mcp_config.json</c> for
-    /// <paramref name="injected"/>. Never seeds the kcap plugin directory — that absence is what job
+    /// Creates an owner-only home carrying a fresh <c>mcp_config.json</c> for
+    /// <paramref name="injected"/>, and — for an unattended review — the <c>settings.json</c> that
+    /// grants those servers' tools. Never seeds the kcap plugin directory — that absence is what job
     /// 1 above depends on, so it is verified after writing rather than assumed.
     /// </summary>
+    /// <param name="grantInjectedMcpTools">Whether this launch's injected MCP tools need
+    /// <c>permissions.allow</c> rules — true for an unattended review, false for a hosted agent.
+    ///
+    /// <para><b>A parameter rather than "grant whatever was injected".</b> A hosted launch already
+    /// passes <c>--dangerously-skip-permissions</c>, so a rule for it would be dead config; and its
+    /// injected list is <c>ctx.McpServers</c>, whose contents are a caller's rather than a review
+    /// definition's — deriving rules from it would put an unclassifiable server through
+    /// <see cref="AntigravityReviewerPermissions"/>'s fail-closed throw and refuse a launch that was
+    /// never asking for a grant. Deliberately not defaulted: a caller that omits it would get a
+    /// reviewer that starts, runs, and is auto-denied on the one call the round waits for — the exact
+    /// defect this parameter exists to fix.</para></param>
     internal static string Create(string stateDir, string daemonEpoch, string launchId,
-                                  IReadOnlyList<AcpMcpServerSpec> injected, ILogger? log = null) {
+                                  IReadOnlyList<AcpMcpServerSpec> injected, bool grantInjectedMcpTools,
+                                  ILogger? log = null) {
         var root = RootFor(stateDir);
         CreateOwnerOnly(root);
 
@@ -92,6 +113,9 @@ internal static class AntigravityReviewerHome {
 
         WriteMcpConfig(home, injected);
 
+        // Injecting a server is only half of a usable reviewer — see WriteSettings.
+        if (grantInjectedMcpTools) WriteSettings(home, injected);
+
         // The kcap plugin dir is what lets agy's OWN capture hooks fire (job 1) — its absence is
         // the whole mechanism, so it is checked rather than trusted to follow from "we never wrote
         // it". A future change that seeds a fuller home must trip this, not silently double-capture.
@@ -112,23 +136,7 @@ internal static class AntigravityReviewerHome {
     /// — the latter lower to a generic <c>Add&lt;T&gt;</c> that trips NativeAOT (IL3050), the same
     /// rule <c>ClaudeLauncher.BuildReviewFlowMcpConfig</c> and <c>ReviewLaunchBuilder</c> follow.</summary>
     static void WriteMcpConfig(string home, IReadOnlyList<AcpMcpServerSpec> injected) {
-        var path = AntigravityPaths.McpConfigJson(home);
-
-        // AntigravityPaths.McpConfigJson → GeminiPaths.Root honors THIS PROCESS's own
-        // GEMINI_CLI_HOME when set, falling back to `home` only when it is not — so on a daemon
-        // that happens to run with GEMINI_CLI_HOME set, the resolved path would escape `home`
-        // entirely, writing the reviewer's result channel outside the isolated home job 3 exists
-        // to guarantee (and potentially into the operator's own Gemini tree). Not something to fix
-        // in AntigravityPaths (that fallback is correct for its other, non-isolated callers) — this
-        // class's whole purpose is isolation, so it is verified here rather than assumed.
-        var homeFull = Path.TrimEndingDirectorySeparator(Path.GetFullPath(home));
-        var pathFull = Path.GetFullPath(path);
-
-        if (!pathFull.StartsWith(homeFull + Path.DirectorySeparatorChar, StringComparison.Ordinal))
-            throw new InvalidOperationException(
-                $"antigravity_reviewer_home_escaped_root: mcp_config.json resolved to '{pathFull}', "
-              + $"outside the isolated home '{homeFull}' (likely GEMINI_CLI_HOME set in the daemon's "
-              + "own environment). Refusing to write a reviewer's result channel outside its isolated home.");
+        var pathFull = ResolveInsideHome(home, AntigravityPaths.McpConfigJson(home), "mcp_config.json");
 
         Directory.CreateDirectory(Path.GetDirectoryName(pathFull)!);
 
@@ -150,6 +158,64 @@ internal static class AntigravityReviewerHome {
 
         var root = new JsonObject { ["mcpServers"] = mcpServers };
         File.WriteAllText(pathFull, root.ToJsonString());
+    }
+
+    /// <summary>
+    /// Writes <c>{home}/.gemini/antigravity-cli/settings.json</c> — the <c>agy</c> CLI's OWN settings
+    /// file, a different file from the <c>mcp_config.json</c> above — carrying nothing but the
+    /// <c>permissions.allow</c> rules for <paramref name="injected"/>.
+    ///
+    /// <para><b>Injecting a server is only half of a usable reviewer.</b> <c>agy -p</c> has no human to
+    /// answer a tool confirmation, so it auto-denies every one it raises — and the reviewer's result
+    /// channel IS an MCP tool, which made the one call each round depends on the one call print mode
+    /// refused. Measured: the conversation stopped at <c>PLANNER_RESPONSE</c> with no <c>TOOL_CALL</c>,
+    /// agy logged <c>user denied permission for mcp</c>, and every round hung to the flow's timeout. See
+    /// <see cref="AntigravityReviewerPermissions"/> for the rule form and why not
+    /// <c>--dangerously-skip-permissions</c>.</para>
+    ///
+    /// <para>Same fresh-write-into-a-fresh-directory shape as <see cref="WriteMcpConfig"/>: the whole
+    /// file is this launch's content, so there is no operator config to merge with — which is also what
+    /// makes the grant exactly this launch's and not the operator's own rules plus it.</para>
+    /// </summary>
+    static void WriteSettings(string home, IReadOnlyList<AcpMcpServerSpec> injected) {
+        var pathFull = ResolveInsideHome(home, AntigravityPaths.CliSettingsJson(home), "settings.json");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(pathFull)!);
+
+        var allow = new JsonArray();
+
+        // Built BEFORE anything is written: an unclassifiable server throws, and a home left carrying a
+        // half-written grant would be worse than one carrying none.
+        foreach (var rule in AntigravityReviewerPermissions.AllowRulesFor(injected)) allow.Add((JsonNode?)rule);
+
+        var root = new JsonObject { ["permissions"] = new JsonObject { ["allow"] = allow } };
+        File.WriteAllText(pathFull, root.ToJsonString());
+    }
+
+    /// <summary>
+    /// The full path of a file this class means to write INSIDE <paramref name="home"/>, or a throw.
+    ///
+    /// <para><c>AntigravityPaths</c> → <c>GeminiPaths.Root</c> honors THIS PROCESS's own
+    /// <c>GEMINI_CLI_HOME</c> when set, falling back to <paramref name="home"/> only when it is not — so
+    /// on a daemon that happens to run with <c>GEMINI_CLI_HOME</c> set, the resolved path would escape
+    /// <paramref name="home"/> entirely, writing the reviewer's result channel (or its permission
+    /// grants) outside the isolated home job 3 exists to guarantee, and potentially into the operator's
+    /// own Gemini tree. Not something to fix in <c>AntigravityPaths</c> (that fallback is correct for
+    /// its other, non-isolated callers) — this class's whole purpose is isolation, so it is verified
+    /// here rather than assumed, once for every file the home writes.</para>
+    /// </summary>
+    static string ResolveInsideHome(string home, string path, string what) {
+        var homeFull = Path.TrimEndingDirectorySeparator(Path.GetFullPath(home));
+        var pathFull = Path.GetFullPath(path);
+
+        if (!pathFull.StartsWith(homeFull + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"antigravity_reviewer_home_escaped_root: {what} resolved to '{pathFull}', "
+              + $"outside the isolated home '{homeFull}' (likely GEMINI_CLI_HOME set in the daemon's "
+              + "own environment). Refusing to write a reviewer's result channel, or the grants that "
+              + "admit it, outside its isolated home.");
+
+        return pathFull;
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerPermissions.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerPermissions.cs
@@ -7,37 +7,23 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// The <c>permissions.allow</c> rules an unattended Antigravity reviewer's per-launch home grants —
 /// the settings-file half of <see cref="AntigravityReviewerHome"/>.
 ///
-/// <para><b>Why a reviewer needs any grant at all.</b> <c>agy -p</c> has no human to answer a tool
-/// confirmation, so it auto-denies every one it raises. The reviewer's result channel IS an MCP tool,
-/// which made the one call a round depends on the one call print mode refused: measured, the
-/// conversation stops at <c>PLANNER_RESPONSE</c> with no <c>TOOL_CALL</c>, agy's own log reads
-/// <c>permission check failed for mcp "kcap-flow-result/submit_review_result": user denied permission
-/// for mcp</c>, and the round then hangs until the flow times out. agy names the remedy itself: an
-/// allow-rule under <c>permissions.allow</c>.</para>
+/// <para><c>agy -p</c> auto-denies every tool confirmation it raises, and the reviewer's result channel
+/// IS an MCP tool — so the one call a round waits for was the one print mode refused, and the round hung
+/// to the flow timeout.</para>
 ///
-/// <para><b>Not <c>--dangerously-skip-permissions</c>.</b> That flag is the reviewer's whole read
-/// boundary — measured on agy 1.1.10, with it an absolute <c>view_file</c> OUTSIDE the workspace
-/// succeeds and without it the same read is refused with a typed error (see
-/// <c>AntigravityHostedAgentRuntimeFactory.BuildTurnPsi</c>). Passing it to buy delivery would trade a
-/// containment property for a delivery fix. An allow-rule is scoped to the named tool and moves
-/// nothing else.</para>
+/// <para><b>agy's binary ships a string saying this cannot work</b> — <c>"…auto-denied. Settings
+/// allow-rules do not apply; re-run with --dangerously-skip-permissions…"</c>. It does not describe the
+/// MCP path: probed on 1.1.13 under an isolated home, the exact rule below let the call through and its
+/// absence reproduced the denial. Believe the probe, not the string; the rule form is agy's own
+/// (<c>mcp(chrome-devtools/*)</c> ships in the binary).</para>
 ///
-/// <para><b>Measured, not inferred, and the binary carries a string that contradicts it.</b> agy also
-/// ships <c>"…auto-denied. Settings allow-rules do not apply; re-run with
-/// --dangerously-skip-permissions…"</c>. That notice is NOT the MCP path: a probe against agy 1.1.13
-/// under an isolated home with one stub MCP server ran the exact rule below and the tool call reached
-/// the server, while the same home without it produced the auto-denial. The rule form is agy's own —
-/// its binary ships <c>mcp(chrome_devtools/evaluate_script)</c> and <c>mcp(chrome-devtools/*)</c>.</para>
+/// <para>The flag is not the alternative: it is the reviewer's whole read boundary (measured on 1.1.10 —
+/// with it an absolute out-of-workspace <c>view_file</c> succeeds), so it would trade containment for
+/// delivery. Rules are exact pairs, never <c>mcp(server/*)</c>, since the narrow form was measured to
+/// work and the wide one would grant whatever the channel serves next.</para>
 ///
-/// <para><b>Exact pairs, never a wildcard.</b> <c>mcp(kcap-flow-result/*)</c> would grant whatever the
-/// channel serves next without a reviewed decision, and the exact pair was measured to work — so there
-/// is no "the narrow form does not function" case buying the wider one.</para>
-///
-/// <para><b>Where the tool names come from.</b> The same two authoritative tables every other
-/// unattended reviewer's approval surface is built from — <c>KcapMcpRegistry</c>'s
-/// <c>ReservedResultChannelUnattendedSafeTools</c> and <c>ReviewFlowUnattendedSafeTools</c>. Naming
-/// tools here instead would be a second classification of the same decision, and the one that drifts is
-/// silent: a reviewer granted a tool it may not call, or refused one it needs.</para>
+/// <para>Tool names come from <c>KcapMcpRegistry</c>'s tables rather than being listed here — a second
+/// list would drift silently, granting a tool the reviewer may not call or withholding one it needs.</para>
 /// </summary>
 internal static class AntigravityReviewerPermissions {
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerPermissions.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerPermissions.cs
@@ -1,0 +1,86 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+
+namespace Capacitor.Cli.Daemon.Acp;
+
+/// <summary>
+/// The <c>permissions.allow</c> rules an unattended Antigravity reviewer's per-launch home grants —
+/// the settings-file half of <see cref="AntigravityReviewerHome"/>.
+///
+/// <para><b>Why a reviewer needs any grant at all.</b> <c>agy -p</c> has no human to answer a tool
+/// confirmation, so it auto-denies every one it raises. The reviewer's result channel IS an MCP tool,
+/// which made the one call a round depends on the one call print mode refused: measured, the
+/// conversation stops at <c>PLANNER_RESPONSE</c> with no <c>TOOL_CALL</c>, agy's own log reads
+/// <c>permission check failed for mcp "kcap-flow-result/submit_review_result": user denied permission
+/// for mcp</c>, and the round then hangs until the flow times out. agy names the remedy itself: an
+/// allow-rule under <c>permissions.allow</c>.</para>
+///
+/// <para><b>Not <c>--dangerously-skip-permissions</c>.</b> That flag is the reviewer's whole read
+/// boundary — measured on agy 1.1.10, with it an absolute <c>view_file</c> OUTSIDE the workspace
+/// succeeds and without it the same read is refused with a typed error (see
+/// <c>AntigravityHostedAgentRuntimeFactory.BuildTurnPsi</c>). Passing it to buy delivery would trade a
+/// containment property for a delivery fix. An allow-rule is scoped to the named tool and moves
+/// nothing else.</para>
+///
+/// <para><b>Measured, not inferred, and the binary carries a string that contradicts it.</b> agy also
+/// ships <c>"…auto-denied. Settings allow-rules do not apply; re-run with
+/// --dangerously-skip-permissions…"</c>. That notice is NOT the MCP path: a probe against agy 1.1.13
+/// under an isolated home with one stub MCP server ran the exact rule below and the tool call reached
+/// the server, while the same home without it produced the auto-denial. The rule form is agy's own —
+/// its binary ships <c>mcp(chrome_devtools/evaluate_script)</c> and <c>mcp(chrome-devtools/*)</c>.</para>
+///
+/// <para><b>Exact pairs, never a wildcard.</b> <c>mcp(kcap-flow-result/*)</c> would grant whatever the
+/// channel serves next without a reviewed decision, and the exact pair was measured to work — so there
+/// is no "the narrow form does not function" case buying the wider one.</para>
+///
+/// <para><b>Where the tool names come from.</b> The same two authoritative tables every other
+/// unattended reviewer's approval surface is built from — <c>KcapMcpRegistry</c>'s
+/// <c>ReservedResultChannelUnattendedSafeTools</c> and <c>ReviewFlowUnattendedSafeTools</c>. Naming
+/// tools here instead would be a second classification of the same decision, and the one that drifts is
+/// silent: a reviewer granted a tool it may not call, or refused one it needs.</para>
+/// </summary>
+internal static class AntigravityReviewerPermissions {
+    /// <summary>
+    /// The ordered allow-rules for <paramref name="injected"/> — server order as injected, tools
+    /// ordinal-ordered, so the file a launch writes is deterministic.
+    ///
+    /// <para>Throws when an injected server has no entry in the authoritative tables, rather than
+    /// writing a home whose reviewer would be auto-denied on that server's first call. A wedged round
+    /// reports nothing an operator can act on; a refused launch names the server.</para>
+    /// </summary>
+    internal static IReadOnlyList<string> AllowRulesFor(IReadOnlyList<AcpMcpServerSpec> injected) {
+        var rules = new List<string>();
+
+        foreach (var server in injected) {
+            foreach (var tool in ToolsFor(server.Name)) rules.Add(Rule(server.Name, tool));
+        }
+
+        return rules;
+    }
+
+    /// <summary>One rule in agy's own syntax. The tool identity is exactly what agy logs on a denial
+    /// (<c>kcap-flow-result/submit_review_result</c>), so the rule and the thing it admits are the same
+    /// string.</summary>
+    internal static string Rule(string server, string tool) => $"mcp({server}/{tool})";
+
+    static IEnumerable<string> ToolsFor(string serverName) {
+        // The result channel serves more than the submit tool — send_flow_message is unattended-safe
+        // too, and a reviewer that cannot call it loses the out-of-band message lane silently. Ordinal:
+        // this feeds an auto-approve, so a case variant of a safe name is not the safe name.
+        if (string.Equals(serverName, KcapMcpRegistry.ReservedResultChannelId, StringComparison.Ordinal))
+            return KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools.Order(StringComparer.Ordinal);
+
+        if (KcapMcpRegistry.ReviewFlowUnattendedSafeTools.TryGetValue(serverName, out var tools))
+            return tools.Order(StringComparer.Ordinal);
+
+        // Reached by an injected server this vendor is not supposed to get: a borrowed-snapshot
+        // kcap-review-context (the factory refuses a borrowed workspace before any home is created), or
+        // a per-launch ALIASED name if this vendor ever starts aliasing — agy's MCP surface is the file
+        // the launch writes rather than a name-matched allowlist, so it deliberately does not today.
+        throw new InvalidOperationException(
+            $"antigravity_reviewer_permission_unknown_server: injected MCP server '{serverName}' has no "
+          + "entry in the review-flow unattended-safe tool table, so no allow-rule can be written for it. "
+          + "Failing the launch rather than handing a reviewer a server whose first tool call headless "
+          + "mode would auto-deny.");
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
@@ -24,14 +24,19 @@ internal static class AcpReviewFlowMcp {
         var channelName = ctx.LaunchIdentity?.ResultChannelWireName
                        ?? KcapMcpRegistry.ReservedResultChannelId;
 
-        // A borrowed launch delivers through a daemon capability, never KCAP_URL — that variable
-        // routes the channel at the token store, which its redirected HOME cannot reach. Mutually
+        // A launch whose HOME is not the daemon user's delivers through a daemon capability, never
+        // KCAP_URL — that variable routes the channel at a token store it cannot reach. Mutually
         // exclusive on purpose: passing both leaves the broken path reachable as a silent fallback.
-        if (ctx.IsBorrowedSnapshot && string.IsNullOrWhiteSpace(ctx.FlowResultCapabilityUrl))
+        //
+        // Read from the ONE derived flag rather than re-deriving the causes here. Borrowed-ness is
+        // only one of them (the Antigravity reviewer borrows nothing and still redirects HOME), and a
+        // second derivation would be free to disagree with the mint that produced the capability.
+        if (ctx.RequiresBrokeredResultDelivery && string.IsNullOrWhiteSpace(ctx.FlowResultCapabilityUrl))
             throw new InvalidOperationException(
-                "Borrowed-snapshot review cannot inject kcap-flow-result (missing result capability URL).");
+                "Review launch cannot inject kcap-flow-result (missing result capability URL): its "
+              + "HOME is redirected away from the token store, so the channel cannot authenticate.");
 
-        var resultEnv = ctx.IsBorrowedSnapshot
+        var resultEnv = ctx.RequiresBrokeredResultDelivery
             ? new AcpMcpServerEnvVar[] { new("KCAP_FLOW_CAPABILITY_URL", ctx.FlowResultCapabilityUrl!),
                                          new("KCAP_FLOW_AGENT_ID", ctx.AgentId) }
             : [new("KCAP_URL", ctx.ServerUrl!), new("KCAP_FLOW_AGENT_ID", ctx.AgentId)];

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1581,16 +1581,36 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             string? reviewContextCapabilityUrl = null;
             string? flowResultCapabilityUrl    = null;
 
-            // A token record is minted for the union of two independent authorities: Codex's
-            // unattended permission allowlist and a borrowed snapshot's immutable review context.
-            // Direct Codex keeps its permissions-only grant; non-Codex snapshot runtimes get an
-            // empty permission set plus context. One record means one revocation cannot drift.
+            // Whether this reviewer's kcap-flow-result channel must deliver through a daemon-brokered
+            // capability instead of authenticating for itself. The channel resolves its credential
+            // from PathHelpers.ConfigDir, which hangs off HOME — so the question is whether the launch
+            // runs under the daemon user's HOME, and there are two independent causes of its not doing
+            // so, one owned by the launch and one by the runtime:
+            //
+            //   • a borrowed snapshot, whose OS sandbox moves HOME into a per-launch state dir, and
+            //   • a runtime that isolates HOME on every review it serves (Antigravity), which borrows
+            //     nothing at all and is therefore unreachable through the first.
+            //
+            // The borrowed arm stays unconditional rather than being narrowed to the sandboxed vendors:
+            // the snapshot lane has delivered through the broker since #488, and a snapshot runtime that
+            // keeps its own HOME (Cursor) losing that is a behaviour change nothing here asks for.
+            //
+            // Computed ONCE and used for the mint, the forwarder and the context, so the grant that
+            // serves the submit path and the env the channel is launched with cannot disagree.
+            var brokeredResultDelivery = snapshotBorrow
+                                      || (isReviewFlow && runtimeFactory.ReviewFlowRedirectsHome);
+
+            // A token record is minted for the union of three independent authorities: Codex's
+            // unattended permission allowlist, a borrowed snapshot's immutable review context, and a
+            // brokered result channel's submit forwarder. Direct Codex keeps its permissions-only
+            // grant; every other reviewer here gets an empty permission set plus whichever capability
+            // it needs. One record means one revocation cannot drift.
             var codexReviewer = isReviewFlow &&
                 string.Equals(cmd.Vendor, "codex", StringComparison.OrdinalIgnoreCase);
-            if (codexReviewer || snapshotBorrow) {
+            if (codexReviewer || brokeredResultDelivery) {
                 if (daemonBridgeUrl is null)
                     throw new InvalidOperationException(
-                        "Borrowed review context requires the local permission bridge.");
+                        "An unattended reviewer's capabilities require the local permission bridge.");
 
                 string[] reviewerServers = [];
                 if (codexReviewer &&
@@ -1613,24 +1633,24 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     : null;
                 var reviewerUrl = _permissionBridge.RegisterReviewerToken(
                     reviewerServers, reviewGeneration, activityClock,
-                    // Only a borrowed snapshot gets a submit forwarder. Its sandbox redirects HOME,
-                    // so its result channel has no token store; every other reviewer authenticates
-                    // for itself and must NOT be handed a daemon-credentialed relay it has no need
-                    // for. Withholding it also keeps the endpoint 404 rather than merely unused.
-                    snapshotBorrow ? ForwardFlowSubmissionAsync : null);
+                    // Only a reviewer that cannot reach its own token store gets a submit forwarder.
+                    // Every other reviewer authenticates for itself and must NOT be handed a
+                    // daemon-credentialed relay it has no need for. Withholding it also keeps the
+                    // endpoint 404 rather than merely unused.
+                    brokeredResultDelivery ? ForwardFlowSubmissionAsync : null);
                 reviewerToken = reviewerUrl; // the URL doubles as the revoke handle
                 if (codexReviewer) {
                     daemonBridgeUrl = reviewerUrl;
                     effectiveAllowlist = reviewerServers;
                 }
-                if (snapshotBorrow) {
+                if (snapshotBorrow)
                     reviewContextCapabilityUrl = reviewerUrl +
                         "/review-context/workspace-mcp-configs";
-                    // Both capabilities hang off the SAME reviewer grant, so revoking that one token
-                    // closes the read path and the submit path together. A separately-minted token
-                    // could outlive the first and leave a live submit path after the reviewer is gone.
-                    flowResultCapabilityUrl = reviewerUrl;
-                }
+                // The capability IS the reviewer grant, so revoking that one token closes the submit
+                // path in the same operation that closes the read path a borrowed launch also holds.
+                // A separately-minted token could outlive the first and leave a live submit path
+                // after the reviewer is gone.
+                if (brokeredResultDelivery) flowResultCapabilityUrl = reviewerUrl;
             }
 
             var runtimeCtx = new RuntimeStartContext(
@@ -1663,6 +1683,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 IsBorrowedSnapshot: snapshotBorrow,
                 ReviewContextCapabilityUrl: reviewContextCapabilityUrl,
                 FlowResultCapabilityUrl: flowResultCapabilityUrl,
+                RequiresBrokeredResultDelivery: brokeredResultDelivery,
                 CodexPosture: cmd.CodexPosture,
                 // Handed to the factory so it can wire the clock onto the runtime BEFORE StartAsync —
                 // assigning it after that call returns silently defeats every handshake stage stamp.

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -403,6 +403,21 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// <b>non-retryable and names the ADC remedy</b> — a generic launch failure would send an operator
     /// looking at the daemon, the flow or the network, when the actual fix is three environment
     /// variables.
+    ///
+    /// <para><b>GOOGLE_APPLICATION_CREDENTIALS is one of the three, and naming it is load-bearing.</b>
+    /// ADC's default location is <c>$HOME/.config/gcloud/application_default_credentials.json</c>, and
+    /// this launch redirects <c>HOME</c> to a per-launch state directory — so the credential
+    /// <c>gcloud auth application-default login</c> just wrote is invisible to the child, and neither
+    /// <c>AGY_ADC_AUTH</c> nor <c>GOOGLE_CLOUD_PROJECT</c> carries a path that would find it. An earlier
+    /// revision of this message named only those two; measured, an operator following it exactly still
+    /// gets <c>authentication required. Run 'agy' to log in.</c> The remedy text has to be sufficient on
+    /// its own — a remedy that leaves the operator where they started reads as a broken feature.</para>
+    ///
+    /// <para>The daemon deliberately does NOT synthesize the path from its own <c>HOME</c>. Per the
+    /// borrowed-review auth design it never goes <i>looking</i> for a credential — it forwards what the
+    /// operator exported and nothing else — and reading a well-known credential location is exactly
+    /// that. <c>ServiceEnvironment</c> already carries this key into a supervised unit off-Windows, so
+    /// the export survives a service install without the daemon ever reading the file.</para>
     /// </summary>
     static InvalidOperationException DescribeLaunchFailure(
             Exception cause, IAgyTurnProcess? firstTurn, CancellationToken callerToken, CancellationToken launchToken) {
@@ -410,9 +425,13 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
             return new InvalidOperationException(
                 "antigravity_reviewer_auth_unavailable: agy could not authenticate, and a daemon-hosted "
               + "agy has no way to complete an interactive login (its stdin is closed). Give the "
-              + "daemon durable credentials: `gcloud auth application-default login`, then "
-              + "GOOGLE_CLOUD_PROJECT=<project> and AGY_ADC_AUTH=1 in the daemon's environment. A "
-              + "supervised daemon installed before this shipped must be reinstalled to capture them.",
+              + "daemon durable credentials: `gcloud auth application-default login`, then set ALL THREE "
+              + "of GOOGLE_CLOUD_PROJECT=<project>, AGY_ADC_AUTH=1 and "
+              + "GOOGLE_APPLICATION_CREDENTIALS=<absolute path to "
+              + "application_default_credentials.json> in the daemon's environment. The path is required "
+              + "even though ADC has a default location: a reviewer launch redirects HOME, so the "
+              + "default location is not visible to it. A supervised daemon installed before these were "
+              + "exported must be reinstalled to capture them.",
                 cause);
 
         if (launchToken.IsCancellationRequested && !callerToken.IsCancellationRequested)

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -275,8 +275,12 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         // its own watcher session, while this runtime is already the transcript source. An inherited
         // HOME would duplicate capture, not add it.
         var stateDir = ReviewerStateDir(config);
+        // The grant is review-only for the same reason the result channel is: a hosted launch already
+        // runs with --dangerously-skip-permissions, so an allow-rule for it would be dead config, and
+        // its injected servers are a caller's rather than a review definition's.
         var home     = AntigravityReviewerHome.Create(
-            stateDir, config.DaemonEpoch ?? "unpinned", ctx.AgentId, injected, _logger);
+            stateDir, config.DaemonEpoch ?? "unpinned", ctx.AgentId, injected,
+            grantInjectedMcpTools: ctx.IsReviewFlow, _logger);
 
         // Created here rather than left to agy: TMPDIR must exist before the child writes into it, and
         // it is inside the home precisely so it is removed with it.

--- a/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AntigravityHostedAgentRuntimeFactory.cs
@@ -118,6 +118,13 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
 
     public bool SupportsUnattended => DescribeUnattendedSupport().Supported;
 
+    /// <summary>Every launch this runtime serves runs under the per-launch isolated <c>HOME</c>
+    /// <see cref="StartAsync"/> creates, and an MCP server is spawned as the vendor's child, so the
+    /// result channel inherits it and finds no token store. Unconditional rather than borrowed-scoped:
+    /// this runtime refuses a borrowed workspace outright and redirects <c>HOME</c> regardless, which
+    /// is exactly why a borrowed-ness predicate could not reach it.</summary>
+    public bool ReviewFlowRedirectsHome => true;
+
     /// <summary>
     /// Advertisement keeps the FULL ladder, consent included, because advertising is specifically an
     /// offer to REVIEW unattended — the one thing the consent flag governs. A daemon that advertised
@@ -371,6 +378,17 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
             throw new InvalidOperationException(
                 "antigravity_reviewer_result_channel_incomplete: cannot inject the kcap-flow-result "
               + "channel (missing server url / kcap path / agent id).");
+
+        // This runtime DECLARES that its reviews redirect HOME (see ReviewFlowRedirectsHome), so a
+        // review reaching here without brokered delivery means that declaration was not honoured —
+        // the same code-level-invariant shape as AcpHostedAgentRuntimeFactory.ValidateBorrowedArtifact.
+        // The alternative to failing is a reviewer that reads its context, reasons, and can never
+        // report: the round then burns its whole timeout with no error anywhere.
+        if (!ctx.RequiresBrokeredResultDelivery)
+            throw new InvalidOperationException(
+                "antigravity_reviewer_result_delivery_unbrokered: this reviewer runs under a "
+              + "per-launch isolated HOME, so its result channel has no token store to authenticate "
+              + "from and must be launched with a daemon-brokered delivery capability.");
 
         if (!KcapMcpRegistry.TryResolveReviewFlowAllowlist(ctx.McpAllowlist, out var allowlistServerIds, out var rejected))
             throw new InvalidOperationException(

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -62,6 +62,28 @@ internal interface IHostedAgentRuntimeFactory {
     bool BorrowedReviewRequiresIndependentSnapshot => false;
 
     /// <summary>
+    /// Whether a review-flow launch this runtime serves runs the vendor — and therefore every MCP
+    /// child the vendor spawns — under a <c>HOME</c> that is not the daemon user's.
+    ///
+    /// <para>That is a delivery fact, not a containment one. The <c>kcap-flow-result</c> channel
+    /// resolves its credential from <see cref="Core.PathHelpers"/>' config dir, which hangs off
+    /// <c>HOME</c>, so a redirected launch's channel reads an empty directory and cannot authenticate.
+    /// Such a launch must be given the daemon-brokered delivery capability instead of
+    /// <c>KCAP_URL</c> — see <c>RuntimeStartContext.RequiresBrokeredResultDelivery</c>.</para>
+    ///
+    /// <para><b>Deliberately independent of borrowed-ness.</b> A borrowed snapshot is one CAUSE of a
+    /// redirected home (the Copilot sandbox moves it into a per-launch state dir), not the property
+    /// itself: Antigravity isolates <c>HOME</c> on every launch it serves and refuses a borrowed
+    /// workspace outright. Keying delivery on borrowed-ness alone therefore left that reviewer on the
+    /// path it cannot use — it produced a correct answer and then failed to submit it.</para>
+    ///
+    /// <para>Not a vendor test, and not an advertisement gate: a runtime that answers <c>true</c> is
+    /// simply promising that its review launches need brokered delivery, and the orchestrator mints
+    /// accordingly.</para>
+    /// </summary>
+    bool ReviewFlowRedirectsHome => false;
+
+    /// <summary>
     /// This runtime's reviewer MODEL override resolver, or <see langword="null"/> when the vendor has
     /// no authoritative resolver yet. PTY factories delegate to their launcher-owned policy; ACP /
     /// multi-provider factories return <see langword="null"/> (which does not remove their existing
@@ -170,12 +192,19 @@ internal sealed record RuntimeStartContext(
         // Exact loopback GET capability for the immutable Git-index review-context generation.
         // Present only for borrowed-snapshot review flows; never a backend or filesystem URL.
         string?            ReviewContextCapabilityUrl = null,
-        // Exact loopback POST capability the result channel submits through, so a borrowed
-        // reviewer can report without a credential inside the sandbox. Required — not merely
-        // permitted — for a borrowed snapshot: that launch's HOME is a per-launch state dir, so the
-        // channel's own token store is unreachable and the ambient-credential path cannot work.
-        // The daemon holds the authenticated connection and forwards; nothing here is a backend URL.
+        // Exact loopback POST capability the result channel submits through, so a reviewer whose HOME
+        // is not the daemon user's can report without a credential of its own. The daemon holds the
+        // authenticated connection and forwards; nothing here is a backend URL.
         string?            FlowResultCapabilityUrl = null,
+        // Whether this launch's result channel MUST deliver through FlowResultCapabilityUrl rather
+        // than authenticating for itself, in which case the capability is required — not merely
+        // permitted — and its absence fails the launch instead of falling back to KCAP_URL.
+        //
+        // Derived by the orchestrator, because neither party alone determines it: a borrowed snapshot
+        // is one cause (the sandbox redirects HOME) and IHostedAgentRuntimeFactory
+        // .ReviewFlowRedirectsHome is the other. The ONE thing AcpReviewFlowMcp reads, so the two
+        // causes cannot end up expressed differently at the two ends of the same launch.
+        bool               RequiresBrokeredResultDelivery = false,
         // Caller-selected Codex sandbox/approval posture, carried verbatim from
         // LaunchAgentCommand.CodexPosture through to LauncherContext.CodexPosture. Non-null only for
         // an interactive daemon-owned-worktree Codex launch that passed the orchestrator's guard.

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityContainmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityContainmentTests.cs
@@ -88,7 +88,8 @@ public class AntigravityContainmentTests {
 
             // Production home and production argv/env — an assertion over a re-derived spawn shape
             // would certify the test's idea of the launch, not the launch.
-            home = AntigravityReviewerHome.Create(stateDir, "containment-epoch", "containment-agent", []);
+            home = AntigravityReviewerHome.Create(
+                stateDir, "containment-epoch", "containment-agent", [], grantInjectedMcpTools: true);
 
             var psi = AntigravityHostedAgentRuntimeFactory.BuildTurnPsi(
                 config: new DaemonConfig {

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerHomeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerHomeTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
 using Capacitor.Cli.Daemon.Acp;
 
@@ -10,13 +12,15 @@ namespace Capacitor.Cli.Tests.Unit.Acp;
 /// when present), so that absence is asserted directly rather than inferred from "we wrote nothing".
 /// </summary>
 public class AntigravityReviewerHomeTests {
+    static readonly AcpMcpServerSpec ResultChannel =
+        new("kcap-flow-result", "kcap", ["mcp", "flow-result"], []);
+
     [Test]
     public async Task The_home_carries_only_the_injected_mcp_server() {
         if (OperatingSystem.IsWindows()) return;
         using var root = new TempDir();
         var home = AntigravityReviewerHome.Create(
-            root.Path, "epoch1", "agent1",
-            [new AcpMcpServerSpec("kcap-flow-result", "kcap", ["mcp", "flow-result"], [])]);
+            root.Path, "epoch1", "agent1", [ResultChannel], grantInjectedMcpTools: true);
 
         var mcp = Path.Combine(home, ".gemini", "config", "mcp_config.json");
         await Assert.That(File.Exists(mcp)).IsTrue();
@@ -31,7 +35,7 @@ public class AntigravityReviewerHomeTests {
     public async Task The_home_is_owner_only_from_creation() {
         if (OperatingSystem.IsWindows()) return;
         using var root = new TempDir();
-        var home = AntigravityReviewerHome.Create(root.Path, "epoch1", "agent1", []);
+        var home = AntigravityReviewerHome.Create(root.Path, "epoch1", "agent1", [], grantInjectedMcpTools: true);
         var mode = File.GetUnixFileMode(home);
 
         await Assert.That(mode.HasFlag(UnixFileMode.GroupRead)).IsFalse();
@@ -42,13 +46,183 @@ public class AntigravityReviewerHomeTests {
     public async Task Sweep_removes_foreign_epochs_and_keeps_the_current_one() {
         if (OperatingSystem.IsWindows()) return;
         using var root = new TempDir();
-        var stale   = AntigravityReviewerHome.Create(root.Path, "old",     "a1", []);
-        var current = AntigravityReviewerHome.Create(root.Path, "current", "a2", []);
+        var stale   = AntigravityReviewerHome.Create(root.Path, "old",     "a1", [], grantInjectedMcpTools: true);
+        var current = AntigravityReviewerHome.Create(root.Path, "current", "a2", [], grantInjectedMcpTools: true);
 
         AntigravityReviewerHome.SweepStale(root.Path, "current");
 
         await Assert.That(Directory.Exists(stale)).IsFalse();
         await Assert.That(Directory.Exists(current)).IsTrue();
+    }
+
+    // ── permissions.allow: the reviewer can still DO ITS JOB ───────────────────────────────────────
+    //
+    // Everything above certifies what the reviewer cannot do. That is perfectly consistent with a
+    // reviewer that never works: `agy -p` auto-denies every tool confirmation it raises, the result
+    // channel IS an MCP tool, and the shipped home granted nothing — so the one call a round depends
+    // on was the one call print mode refused, and every round hung until the flow timed out. These
+    // assert the home grants its own result channel.
+
+    /// <summary>Reads the launch's own settings.json by LITERAL path.
+    /// <c>AntigravityPaths.CliSettingsJson</c> honours the TEST PROCESS's <c>GEMINI_CLI_HOME</c>, so it
+    /// could read somewhere the launch never wrote.</summary>
+    static string[] AllowRulesIn(string home) {
+        var path = Path.Combine(home, ".gemini", "antigravity-cli", "settings.json");
+
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"The home wrote no settings.json under '{home}'.", path);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+
+        return [.. doc.RootElement.GetProperty("permissions").GetProperty("allow")
+                    .EnumerateArray().Select(e => e.GetString()!)];
+    }
+
+    static bool HasSettings(string home) =>
+        File.Exists(Path.Combine(home, ".gemini", "antigravity-cli", "settings.json"));
+
+    /// <summary>
+    /// The regression this whole section exists for. Named exactly as agy names it on the denial —
+    /// <c>kcap-flow-result/submit_review_result</c> — so the rule and the identity it admits are the
+    /// same string.
+    /// </summary>
+    [Test]
+    public async Task The_home_grants_the_reviewers_own_result_channel() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root = new TempDir();
+
+        var home = AntigravityReviewerHome.Create(
+            root.Path, "epoch1", "agent1", [ResultChannel], grantInjectedMcpTools: true);
+
+        await Assert.That(AllowRulesIn(home)).Contains("mcp(kcap-flow-result/submit_review_result)");
+    }
+
+    /// <summary>The channel serves more than the submit tool, and a reviewer that cannot call
+    /// <c>send_flow_message</c> loses the out-of-band message lane the same silent way.</summary>
+    [Test]
+    public async Task The_grant_covers_every_unattended_safe_tool_the_channel_serves() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root = new TempDir();
+
+        var home = AntigravityReviewerHome.Create(
+            root.Path, "epoch1", "agent1", [ResultChannel], grantInjectedMcpTools: true);
+
+        var rules = AllowRulesIn(home);
+
+        foreach (var tool in KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools)
+            await Assert.That(rules).Contains($"mcp(kcap-flow-result/{tool})");
+    }
+
+    /// <summary>
+    /// The narrowest thing that works, asserted as an EXACT set rather than a containment: a
+    /// <c>mcp(kcap-flow-result/*)</c> or <c>mcp(*)</c> would satisfy every "contains" assertion above
+    /// while granting whatever the channel serves next with no reviewed decision. The exact pair was
+    /// measured to work against a real agy, so nothing buys the wider form.
+    /// </summary>
+    [Test]
+    public async Task The_grant_is_exactly_the_classified_tools_and_never_a_wildcard() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root = new TempDir();
+
+        var home = AntigravityReviewerHome.Create(
+            root.Path, "epoch1", "agent1", [ResultChannel], grantInjectedMcpTools: true);
+
+        var expected = KcapMcpRegistry.ReservedResultChannelUnattendedSafeTools
+            .Select(t => $"mcp(kcap-flow-result/{t})")
+            .OrderBy(r => r, StringComparer.Ordinal)
+            .ToArray();
+
+        await Assert.That(AllowRulesIn(home).OrderBy(r => r, StringComparer.Ordinal).ToArray())
+                    .IsEquivalentTo(expected);
+
+        foreach (var rule in AllowRulesIn(home))
+            await Assert.That(rule).DoesNotContain("*");
+    }
+
+    /// <summary>
+    /// A reviewer given a read-only server it can never call is the same bug in a second place — the
+    /// allowlist servers are injected into the same mcp_config.json and hit the same auto-deny.
+    /// </summary>
+    [Test]
+    public async Task An_allowlisted_read_only_server_is_granted_its_own_tools_too() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root = new TempDir();
+
+        var home = AntigravityReviewerHome.Create(
+            root.Path, "epoch1", "agent1",
+            [ResultChannel, new AcpMcpServerSpec("kcap-review", "kcap", ["mcp", "review"], [])],
+            grantInjectedMcpTools: true);
+
+        var rules = AllowRulesIn(home);
+
+        foreach (var tool in KcapMcpRegistry.ReviewFlowUnattendedSafeTools["kcap-review"])
+            await Assert.That(rules).Contains($"mcp(kcap-review/{tool})");
+
+        // Still the channel's own, so granting the allowlist cannot have replaced it.
+        await Assert.That(rules).Contains("mcp(kcap-flow-result/submit_review_result)");
+    }
+
+    /// <summary>A hosted launch already runs with <c>--dangerously-skip-permissions</c>, so a rule for
+    /// it would be dead config — and its injected list is a CALLER's, which the fail-closed classifier
+    /// below would refuse outright.</summary>
+    [Test]
+    public async Task A_hosted_launch_home_carries_no_permission_grants() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root = new TempDir();
+
+        var home = AntigravityReviewerHome.Create(
+            root.Path, "epoch1", "agent1",
+            [new AcpMcpServerSpec("caller-supplied", "/bin/echo", ["hi"], [])],
+            grantInjectedMcpTools: false);
+
+        await Assert.That(HasSettings(home)).IsFalse();
+    }
+
+    /// <summary>Fail closed: a server with no classified tools would produce a reviewer auto-denied on
+    /// its first call — a wedged round with nothing an operator can act on. The refusal names it.</summary>
+    [Test]
+    public async Task A_review_grant_for_an_unclassified_server_refuses_the_launch() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root = new TempDir();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => AntigravityReviewerHome.Create(
+            root.Path, "epoch1", "agent1",
+            [ResultChannel, new AcpMcpServerSpec("kcap-review-context", "kcap", ["mcp", "review"], [])],
+            grantInjectedMcpTools: true));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_permission_unknown_server");
+        await Assert.That(ex.Message).Contains("kcap-review-context");
+    }
+
+    /// <summary>
+    /// Both files this home writes resolve through <c>AntigravityPaths</c> → <c>GeminiPaths.Root</c>,
+    /// which honours the DAEMON PROCESS's own <c>GEMINI_CLI_HOME</c> ahead of the home it was handed —
+    /// so on a daemon that happens to run with it set, an unguarded write would land the reviewer's
+    /// result channel and its permission grants in the operator's own Gemini tree instead of the
+    /// isolated home. The guard is shared, and settings.json is the file it was extended to cover.
+    /// </summary>
+    [Test]
+    [NotInParallel("HomeEnvVarMutation")]
+    public async Task A_daemon_wide_gemini_cli_home_cannot_redirect_the_homes_writes() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root     = new TempDir();
+        using var elsewhere = new TempDir();
+
+        var previous = Environment.GetEnvironmentVariable("GEMINI_CLI_HOME");
+
+        try {
+            Environment.SetEnvironmentVariable("GEMINI_CLI_HOME", elsewhere.Path);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => AntigravityReviewerHome.Create(
+                root.Path, "epoch1", "agent1", [ResultChannel], grantInjectedMcpTools: true));
+
+            await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_home_escaped_root");
+
+            // Refused, not merely reported: nothing was written into the operator's tree.
+            await Assert.That(Directory.Exists(Path.Combine(elsewhere.Path, ".gemini"))).IsFalse();
+        } finally {
+            Environment.SetEnvironmentVariable("GEMINI_CLI_HOME", previous);
+        }
     }
 
     sealed class TempDir : IDisposable {

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerHomeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerHomeTests.cs
@@ -31,6 +31,57 @@ public class AntigravityReviewerHomeTests {
         await Assert.That(Directory.Exists(Path.Combine(home, ".gemini", "config", "plugins"))).IsFalse();
     }
 
+    /// <summary>
+    /// A refused Create must leave NOTHING behind. The caller binds this home's disposal to the
+    /// runtime it builds only after Create returns, so a throw from inside Create escapes with no
+    /// disposal path armed — and the first file written, <c>mcp_config.json</c>, carries the launch's
+    /// live loopback capability URL. The epoch sweep is the crash backstop, not a licence to leak on
+    /// an ordinary refusal.
+    ///
+    /// <para>Driven through the permissions layer's fail-closed throw rather than a simulated IO
+    /// fault, because that is the reachable-by-configuration path: an injected server this vendor
+    /// cannot classify. The assertion is on the home's ABSENCE, not on the exception — the throw is
+    /// the precondition, and asserting it alone would pass just as well with the directory left
+    /// sitting there.</para>
+    /// </summary>
+    [Test]
+    public async Task A_refused_create_leaves_no_home_behind() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root = new TempDir();
+
+        var unclassifiable = new AcpMcpServerSpec("not-a-known-kcap-server", "kcap", ["mcp", "nope"], []);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => {
+            AntigravityReviewerHome.Create(
+                root.Path, "epoch1", "agent1", [unclassifiable], grantInjectedMcpTools: true);
+            return Task.CompletedTask;
+        });
+
+        var home = Path.Combine(
+            AntigravityReviewerHome.RootFor(root.Path),
+            AntigravityReviewerHome.NameFor("epoch1", "agent1"));
+
+        await Assert.That(Directory.Exists(home)).IsFalse();
+    }
+
+    /// <summary>
+    /// The control: the same call with a classifiable server DOES leave a home, so the assertion
+    /// above is measuring the refusal and not something that never creates a directory at all.
+    /// </summary>
+    [Test]
+    public async Task An_accepted_create_does_leave_a_home() {
+        if (OperatingSystem.IsWindows()) return;
+        using var root = new TempDir();
+
+        var home = AntigravityReviewerHome.Create(
+            root.Path, "epoch1", "agent1", [ResultChannel], grantInjectedMcpTools: true);
+
+        await Assert.That(Directory.Exists(home)).IsTrue();
+        await Assert.That(home).IsEqualTo(Path.Combine(
+            AntigravityReviewerHome.RootFor(root.Path),
+            AntigravityReviewerHome.NameFor("epoch1", "agent1")));
+    }
+
     [Test]
     public async Task The_home_is_owner_only_from_creation() {
         if (OperatingSystem.IsWindows()) return;

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorReviewerTokenTests.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Services;
 
 namespace Capacitor.Cli.Tests.Unit;
@@ -168,6 +169,109 @@ public partial class AgentOrchestratorVendorTests {
                 // Failed fast: no PTY spawned, no agent registered, no reviewer token left behind.
                 await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
                 await Assert.That(orch.GetAgentForTest("rev-bad")).IsNull();
+                await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(0);
+            } finally {
+                await bridge.DisposeAsync();
+            }
+        } finally {
+            cleanup();
+        }
+    }
+
+    /// <summary>
+    /// A runtime that declares <c>ReviewFlowRedirectsHome</c> gets the daemon-brokered delivery
+    /// capability even though it borrows NOTHING — the case a borrowed-ness predicate cannot reach.
+    /// Its result channel resolves the token store from HOME, and this launch's HOME is a per-launch
+    /// isolated directory, so the ambient-credential path fails at delivery with "Not logged in"
+    /// after the reviewer has already done the work.
+    ///
+    /// <para>The URL identity assertion is the load-bearing half: the capability must be the reviewer
+    /// GRANT's own URL, so revoking the reviewer closes the submit path in the same operation.</para>
+    /// </summary>
+    [Test, NotInParallel("LocalPermissionBridgeTests")]
+    public async Task ReviewFlow_home_redirecting_runtime_is_minted_a_delivery_capability_without_borrowing() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server  = new CaptureServerConnection();
+            var factory = new SpyHostedAgentRuntimeFactory("antigravity") {
+                SupportsUnattended      = true,
+                ReviewFlowRedirectsHome = true
+            };
+
+            await using var orch = BuildOrchestrator(
+                server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+            var bridge = orch.PermissionBridgeForTest;
+            await bridge.StartAsync(CancellationToken.None);
+
+            try {
+                await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                    AgentId: "rev-agy", Prompt: "review", Model: "default", Effort: null,
+                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "antigravity",
+                    Kind: LaunchKind.ReviewFlow, McpAllowlist: ["kcap-review"]));
+
+                var ctx = factory.LastContext;
+                await Assert.That(ctx).IsNotNull();
+                // Borrows nothing — this is exactly the launch shape #488's predicate misses.
+                await Assert.That(ctx!.IsBorrowedSnapshot).IsFalse();
+                await Assert.That(ctx.Work).IsEqualTo(WorkLocation.OwnedWorktree);
+
+                await Assert.That(ctx.RequiresBrokeredResultDelivery).IsTrue();
+                await Assert.That(ctx.FlowResultCapabilityUrl).IsNotNull();
+
+                var agent = orch.GetAgentForTest("rev-agy");
+                await Assert.That(agent!.ReviewerBridgeToken).IsEqualTo(ctx.FlowResultCapabilityUrl);
+                await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(1);
+
+                // The grant carries a SUBMIT FORWARDER, not merely a URL. A grant minted without one
+                // 404s that endpoint by design, so a not-404 is the only thing that distinguishes a
+                // capability that can deliver from a URL that can only fail. It is not a 200 either:
+                // this orchestrator's ServerUrl is an unreachable loopback port, so the forwarder
+                // runs and faults — which is the bridge's 500, and is proof it ran at all.
+                using var client = new HttpClient();
+                var submit = await client.PostAsync($"{ctx.FlowResultCapabilityUrl}/flow-result",
+                    new StringContent("{\"kind\":\"clean\"}", System.Text.Encoding.UTF8, "application/json"));
+                await Assert.That(submit.StatusCode).IsNotEqualTo(System.Net.HttpStatusCode.NotFound);
+
+                // The capability dies with the reviewer: one revocation closes the submit path.
+                await orch.CleanupAgentForTest("rev-agy");
+                await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(0);
+            } finally {
+                await bridge.DisposeAsync();
+            }
+        } finally {
+            cleanup();
+        }
+    }
+
+    /// <summary>The negative control for the broadening: a runtime that does NOT redirect HOME keeps
+    /// the ambient-credential path and is minted nothing. Same vendor-neutral spy as above, so the
+    /// only difference between the two is the declaration itself.</summary>
+    [Test, NotInParallel("LocalPermissionBridgeTests")]
+    public async Task ReviewFlow_runtime_that_keeps_its_home_is_minted_no_delivery_capability() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server  = new CaptureServerConnection();
+            var factory = new SpyHostedAgentRuntimeFactory("antigravity") { SupportsUnattended = true };
+
+            await using var orch = BuildOrchestrator(
+                server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+            var bridge = orch.PermissionBridgeForTest;
+            await bridge.StartAsync(CancellationToken.None);
+
+            try {
+                await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                    AgentId: "rev-plain", Prompt: "review", Model: "default", Effort: null,
+                    RepoPath: repoPath, Tools: null, AttachmentIds: null, Vendor: "antigravity",
+                    Kind: LaunchKind.ReviewFlow, McpAllowlist: ["kcap-review"]));
+
+                var ctx = factory.LastContext;
+                await Assert.That(ctx).IsNotNull();
+                await Assert.That(ctx!.RequiresBrokeredResultDelivery).IsFalse();
+                await Assert.That(ctx.FlowResultCapabilityUrl).IsNull();
                 await Assert.That(bridge.ReviewerTokenCountForTest).IsEqualTo(0);
             } finally {
                 await bridge.DisposeAsync();

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -2034,6 +2034,11 @@ public partial class AgentOrchestratorVendorTests {
         public bool   SupportsBorrowedReviewFlow { get; init; }
         public bool   BorrowedReviewRequiresIndependentSnapshot { get; init; }
 
+        /// <summary>Stands in for a runtime that isolates HOME on every review it serves (Antigravity
+        /// today). Independent of borrowed-ness on purpose — that is the whole point of the
+        /// declaration, and a test that could only set it alongside a borrow would prove nothing.</summary>
+        public bool   ReviewFlowRedirectsHome { get; init; }
+
         /// <summary>Task 8: lets a test give this factory a reviewer-model resolver so the
         /// orchestrator's ResolveReviewerModel preflight handler can resolve against it.</summary>
         public IReviewerModelResolver? ReviewerModelResolver { get; init; }

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpReviewFlowMcpContextTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpReviewFlowMcpContextTests.cs
@@ -26,11 +26,16 @@ public class AcpReviewFlowMcpContextTests {
     /// <summary>A borrowed reviewer's HOME is redirected to a per-launch state dir, so the
     /// result channel cannot load the token store — it must be handed a daemon-minted capability
     /// instead. KCAP_URL is the thing that drives the ambient-credential path, so its ABSENCE is the
-    /// load-bearing half of this assertion, not decoration.</summary>
+    /// load-bearing half of this assertion, not decoration.
+    ///
+    /// <para>Pins the borrowed lane against the broadening that follows it: brokered delivery is now
+    /// keyed on <c>RequiresBrokeredResultDelivery</c>, and the orchestrator derives that from a
+    /// superset of borrowed-ness — a borrowed snapshot must still land here.</para></summary>
     [Test]
     public async Task Borrowed_snapshot_result_channel_uses_capability_not_ambient_credential() {
         var servers = AcpReviewFlowMcp.Build(Context() with {
             IsBorrowedSnapshot = true,
+            RequiresBrokeredResultDelivery = true,
             ReviewContextCapabilityUrl =
                 "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/review-context/workspace-mcp-configs",
             FlowResultCapabilityUrl =
@@ -44,9 +49,37 @@ public class AcpReviewFlowMcpContextTests {
             .IsEqualTo("http://127.0.0.1:1234/0123456789abcdef0123456789abcdef");
     }
 
-    /// <summary>The non-borrowed launch keeps the ambient-credential path: its HOME is the real one,
-    /// the token store resolves, and nothing about the sandboxed case applies. Pins that the fix is scoped to
-    /// the sandboxed case rather than silently rerouting every reviewer.</summary>
+    /// <summary>
+    /// The reviewer this broadening exists for: it borrows nothing (its workspace is a daemon-owned
+    /// worktree) and yet its HOME is a per-launch isolated directory, so its result channel resolves
+    /// PathHelpers.ConfigDir at an empty tree and cannot authenticate. Keying delivery on
+    /// borrowed-ness left this launch on the KCAP_URL path, which fails at the delivery step with
+    /// "Not logged in" after the reviewer has already done its work.
+    ///
+    /// <para>The ABSENCE of KCAP_URL is again the load-bearing half — the two are mutually exclusive
+    /// so the broken ambient-credential path is not reachable as a silent fallback.</para>
+    /// </summary>
+    [Test]
+    public async Task Home_redirected_launch_uses_capability_even_though_it_borrows_nothing() {
+        var servers = AcpReviewFlowMcp.Build(Context() with {
+            RequiresBrokeredResultDelivery = true,
+            FlowResultCapabilityUrl =
+                "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef"
+        }, []);
+
+        var channel = servers.Single(server => server.Name == "kcap-flow-result");
+        await Assert.That(channel.Env.Select(pair => pair.Name))
+            .IsEquivalentTo(["KCAP_FLOW_CAPABILITY_URL", "KCAP_FLOW_AGENT_ID"]);
+        await Assert.That(channel.Env.Single(pair => pair.Name == "KCAP_FLOW_CAPABILITY_URL").Value)
+            .IsEqualTo("http://127.0.0.1:1234/0123456789abcdef0123456789abcdef");
+        // Not a borrowed launch, so no review-context server either: the broadening moves delivery
+        // only, and must not drag the snapshot's read capability along with it.
+        await Assert.That(servers.Any(server => server.Name == "kcap-review-context")).IsFalse();
+    }
+
+    /// <summary>The reviewer whose HOME is the daemon user's own keeps the ambient-credential path:
+    /// its token store resolves, and nothing about the redirected case applies. Pins that the fix is
+    /// scoped rather than silently rerouting every reviewer through the daemon.</summary>
     [Test]
     public async Task Direct_review_result_channel_keeps_server_url() {
         var servers = AcpReviewFlowMcp.Build(Context(), []);
@@ -64,9 +97,21 @@ public class AcpReviewFlowMcpContextTests {
         var ex = Assert.Throws<InvalidOperationException>(() =>
             AcpReviewFlowMcp.Build(Context() with {
                 IsBorrowedSnapshot = true,
+                RequiresBrokeredResultDelivery = true,
                 ReviewContextCapabilityUrl =
                     "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef/review-context/workspace-mcp-configs"
             }, []));
+        await Assert.That(ex.Message).Contains("missing result capability URL");
+    }
+
+    /// <summary>The fail-closed shape survives the broadening: a HOME-redirected launch with no
+    /// capability must fail loudly rather than fall back to KCAP_URL, which is precisely the path it
+    /// cannot use. Non-borrowed, so it can only be reached through the broadened condition.</summary>
+    [Test]
+    public async Task Home_redirected_launch_without_result_capability_fails_before_launch() {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            AcpReviewFlowMcp.Build(Context() with { RequiresBrokeredResultDelivery = true }, []));
+
         await Assert.That(ex.Message).Contains("missing result capability URL");
     }
 
@@ -86,6 +131,7 @@ public class AcpReviewFlowMcpContextTests {
                 IsBorrowedSnapshot = true,
                 // Supplied so the result-capability guard passes and this test still
                 // exercises the CONTEXT guard it was written for, rather than the new one.
+                RequiresBrokeredResultDelivery = true,
                 FlowResultCapabilityUrl =
                     "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef"
             }, []));

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -915,6 +915,68 @@ public class AntigravityReviewerLaunchTests {
         await Assert.That(config).Contains("\"kcap-flow-result\"");
     }
 
+    // ── the launch's permissions.allow ─────────────────────────────────────────────────────────────
+    //
+    // Injecting the result channel is only half of a working reviewer. `agy -p` auto-denies every tool
+    // confirmation it raises, and the channel IS an MCP tool — so a launch that injects it and grants
+    // nothing produces a reviewer that reads its context, reasons, and can never report. Measured: the
+    // conversation stops at PLANNER_RESPONSE with no TOOL_CALL and the round hangs to the flow's
+    // timeout. The mcp_config assertions above all pass in exactly that state.
+
+    /// <summary>Reads the settings.json the launch actually wrote, from the home the child was handed.
+    /// Literal path, for the same reason <see cref="McpConfigOf"/> uses one.</summary>
+    static async Task<string?> SettingsOf(SpyTurnSource spy) {
+        var path = Path.Combine(spy.Spawns[0].Environment["HOME"]!, ".gemini", "antigravity-cli", "settings.json");
+
+        return File.Exists(path) ? await WatchCommand.ReadAllTextSharedAsync(path) : null;
+    }
+
+    /// <summary>The delivery half of a review launch, asserted at the launch boundary rather than only
+    /// on the home builder — the grant has to reach the same HOME the child is spawned under, and
+    /// nothing else in this file would notice if it did not.</summary>
+    [Test]
+    public async Task A_review_launch_grants_its_own_result_channel() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy = new SpyTurnSource();
+
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(isReviewFlow: true), CancellationToken.None).WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        var settings = await SettingsOf(spy);
+
+        await Assert.That(settings).IsNotNull();
+        await Assert.That(settings!).Contains("mcp(kcap-flow-result/submit_review_result)");
+
+        // Never the blunt instrument: a wildcard would satisfy the assertion above while granting
+        // whatever the channel serves next, and --dangerously-skip-permissions stays off this arm.
+        await Assert.That(settings).DoesNotContain("*");
+        await Assert.That(spy.Spawns[0].ArgumentList).DoesNotContain("--dangerously-skip-permissions");
+    }
+
+    /// <summary>The other half of the split: a hosted launch already runs with
+    /// <c>--dangerously-skip-permissions</c>, so a grant would be dead config — and its injected
+    /// servers are a caller's, which the reviewer classifier refuses outright.</summary>
+    [Test]
+    public async Task A_hosted_launch_is_granted_nothing_and_is_not_refused_for_a_caller_supplied_server() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy = new SpyTurnSource();
+
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(isReviewFlow: false,
+                            mcpServers: [new AcpMcpServerSpec("caller-supplied", "/bin/echo", ["hi"], null)]),
+                        CancellationToken.None)
+            .WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        await Assert.That(await SettingsOf(spy)).IsNull();
+        await Assert.That(spy.Spawns[0].ArgumentList).Contains("--dangerously-skip-permissions");
+    }
+
     /// <summary>The hosted arm forwards <c>ctx.McpServers</c> verbatim, mirroring
     /// <c>AcpHostedAgentRuntimeFactory</c>'s hosted arm. <b>No production caller populates that field
     /// today</b>, so this pins a contract rather than a live path — the point being that a hosted agy

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -1110,7 +1110,19 @@ public class AntigravityReviewerLaunchTests {
             factory.StartAsync(Ctx(), CancellationToken.None).WaitAsync(HangGuard));
 
         await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_auth_unavailable");
+
+        // ALL THREE, and the third is the one that regressed: an earlier revision named only the
+        // switch and the project, and an operator following it exactly still got
+        // `authentication required` — because ADC's default location is under the HOME this launch
+        // redirects, and neither of those two carries a path. A remedy that leaves the operator
+        // where they started is worse than no remedy, so the message is pinned, not just its code.
         await Assert.That(ex.Message).Contains("AGY_ADC_AUTH");
+        await Assert.That(ex.Message).Contains("GOOGLE_CLOUD_PROJECT");
+        await Assert.That(ex.Message).Contains("GOOGLE_APPLICATION_CREDENTIALS");
+
+        // And it must say WHY the path is needed despite ADC having a default — without that an
+        // operator reasonably deletes it as redundant.
+        await Assert.That(ex.Message).Contains("HOME");
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityReviewerLaunchTests.cs
@@ -68,11 +68,19 @@ public class AntigravityReviewerLaunchTests {
     /// to pin which arm forwards it.</param>
     /// <param name="isReview">The PR-review launch kind (<c>LaunchKind.Review</c>) — a THIRD shape,
     /// distinct from both arms above and refused outright; see the test that pins it.</param>
+    /// <param name="brokeredResultDelivery">Defaults to <paramref name="isReviewFlow"/>, which is
+    /// exactly what the orchestrator derives for this runtime: it declares
+    /// <c>ReviewFlowRedirectsHome</c>, so every review it serves is brokered and no hosted launch is.
+    /// A test passes <see langword="false"/> on a review to reach the wiring guard.</param>
+    /// <param name="flowResultCapabilityUrl">The loopback capability the brokered channel delivers
+    /// through, minted on the reviewer grant. Defaulted to a real-shaped value because production
+    /// always has one here.</param>
     static RuntimeStartContext Ctx(
             bool isReviewFlow = true, AgentActivityClock? clock = null, string? model = null,
             string? serverUrl = "http://kcap.test", string capacitorPath = "/usr/local/bin/kcap",
             string[]? mcpAllowlist = null, IReadOnlyList<AcpMcpServerSpec>? mcpServers = null,
-            bool isReview = false) => new(
+            bool isReview = false, bool? brokeredResultDelivery = null,
+            string? flowResultCapabilityUrl = CapabilityUrl) => new(
         AgentId: "agent-1", Vendor: "antigravity", SourceRepoPath: "/repo",
         Worktree: new WorktreeInfo(Path: "/abs/wt", Branch: "b", SourceRepo: "/repo"),
         Prompt: "review this",
@@ -84,7 +92,13 @@ public class AntigravityReviewerLaunchTests {
         McpAllowlist: mcpAllowlist,
         DaemonId: "daemon-1", DaemonEpoch: "epoch-1",
         McpServers: mcpServers,
+        RequiresBrokeredResultDelivery: brokeredResultDelivery ?? isReviewFlow,
+        FlowResultCapabilityUrl: flowResultCapabilityUrl,
         ActivityClock: clock);
+
+    /// <summary>Shape-accurate stand-in for the reviewer grant's own URL (loopback + 32 hex chars),
+    /// so nothing here passes on a value the bridge would never mint.</summary>
+    const string CapabilityUrl = "http://127.0.0.1:1234/0123456789abcdef0123456789abcdef";
 
     static ProcessStartInfo BuildPsi(
             DaemonConfig config, string? conversationId = null, bool isReviewFlow = true) =>
@@ -804,8 +818,70 @@ public class AntigravityReviewerLaunchTests {
         await Assert.That(config).Contains("\"/usr/local/bin/kcap\"");
         await Assert.That(config).Contains("\"KCAP_FLOW_AGENT_ID\"");
         await Assert.That(config).Contains("\"agent-1\"");
-        await Assert.That(config).Contains("\"KCAP_URL\"");
+        await Assert.That(config).Contains("\"KCAP_FLOW_CAPABILITY_URL\"");
         await Assert.That(config).DoesNotContain("caller-supplied");
+    }
+
+    /// <summary>
+    /// <b>The delivery credential, at the launch boundary.</b> This runtime hands the child a
+    /// per-launch isolated <c>HOME</c>, and the result channel is spawned as that child's child — so
+    /// it inherits the isolated home and resolves <c>PathHelpers.ConfigDir</c> at an empty directory.
+    /// Measured live: the channel failed with <c>Not logged in. Run 'kcap login' on the host shell.</c>
+    /// after the reviewer had already produced its answer.
+    ///
+    /// <para>The ABSENCE of <c>KCAP_URL</c> on the channel is the load-bearing half: that variable is
+    /// what routes delivery at the unreachable token store, so leaving it alongside the capability
+    /// would keep the broken path reachable as a silent fallback. Asserted on the mcp_config the
+    /// launch actually WROTE, not on a builder's return value — the file the child loads is the only
+    /// thing that decides this.</para>
+    /// </summary>
+    [Test]
+    public async Task A_review_launch_delivers_through_the_capability_and_never_the_token_store() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "POSIX-only: the per-launch home cannot be owner-only on Windows.");
+
+        var spy = new SpyTurnSource();
+
+        var start = await Factory(EnabledConfig(), spy.SpawnAsync)
+            .StartAsync(Ctx(isReviewFlow: true), CancellationToken.None).WaitAsync(HangGuard);
+
+        await using var runtime = start.Runtime;
+
+        var config = await McpConfigOf(spy);
+
+        await Assert.That(config).Contains($"\"KCAP_FLOW_CAPABILITY_URL\":\"{CapabilityUrl}\"");
+        await Assert.That(config).DoesNotContain("KCAP_URL");
+    }
+
+    /// <summary>
+    /// The wiring guard, in the shape of <c>AcpHostedAgentRuntimeFactory.ValidateBorrowedArtifact</c>:
+    /// this runtime DECLARES that every review it serves redirects HOME, so a review reaching it
+    /// without the brokered capability means the orchestrator did not honour that declaration. The
+    /// alternative to failing here is a reviewer that starts, reads, reasons and then silently cannot
+    /// report — which burns the round's whole timeout and is the exact failure this whole path exists
+    /// to remove.
+    /// </summary>
+    [Test]
+    public async Task A_review_launch_that_was_not_given_brokered_delivery_is_refused() {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            Factory(EnabledConfig(), new SpyTurnSource().SpawnAsync)
+                .StartAsync(Ctx(isReviewFlow: true, brokeredResultDelivery: false),
+                            CancellationToken.None));
+
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_result_delivery_unbrokered");
+    }
+
+    /// <summary>
+    /// The declaration itself, read through the interface — the only surface the orchestrator
+    /// consults. It is deliberately NOT borrowed-ness: this runtime refuses a borrowed workspace
+    /// outright (see above) and still redirects HOME, which is precisely why keying delivery on a
+    /// borrowed snapshot left this reviewer unable to report.
+    /// </summary>
+    [Test]
+    public async Task The_runtime_declares_that_its_reviews_redirect_home() {
+        IHostedAgentRuntimeFactory factory = Factory(EnabledConfig());
+
+        await Assert.That(factory.ReviewFlowRedirectsHome).IsTrue();
+        await Assert.That(factory.SupportsBorrowedReviewFlow).IsFalse();
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

An unattended `agy` reviewer could read and reason perfectly and then **could not deliver its result**. Three `submit_review_result` calls returned an internal error and the round burned its full timeout. Two independent causes, both live-verified.

**1. Print mode auto-denied the MCP tool.** `permission check failed for mcp "kcap-flow-result/submit_review_result": user denied permission for mcp`. A `-p` launch has no one to approve a confirmation, so every call to the one channel that exists was denied.

**2. The result channel had no usable credential.** A reviewer launch redirects `HOME` for single-lane capture, so the `kcap mcp flow-result` child — spawned by the vendor, inheriting that `HOME` — found no token store and reported `Not logged in`.

## What this does

**Grants the two flow-result tools** in the per-launch `settings.json`, built from the injected MCP specs rather than a fixed list, so the grant cannot drift from what is actually injected.

**Broadens brokered result delivery from "borrowed" to "this launch redirects `HOME`".** #488 solved cause 2 for borrowed reviewers, and its own comment gives the reason as the `HOME` redirect — but it keyed on `IsBorrowedSnapshot`. `agy` is never borrowed, so it took the `else` branch and got the credential path it cannot use.

The predicate is now an **OR of two clauses with genuinely different owners**, computed once into one local that drives the mint gate, the forwarder and the context together:

```csharp
var brokeredResultDelivery = snapshotBorrow
                          || (isReviewFlow && runtimeFactory.ReviewFlowRedirectsHome);
```

Both halves are load-bearing, and *not* for symmetric reasons — worth knowing before anyone simplifies this:

- Dropping `snapshotBorrow` breaks **Cursor**, whose borrowed snapshot does *not* redirect `HOME` (`RequiresProcessSandbox: false`). #488's predicate was already broader than its stated property in that direction, so replacing it outright would have silently withdrawn the broker from a shipped vendor.
- Dropping the second clause is exactly the #488 shape, and leaves `agy` broken.

`ReviewFlowRedirectsHome` is a factory-level declaration alongside the existing `SupportsBorrowedReviewFlow`, not a vendor check. A review reaching a runtime that *declares* the redirect without brokered delivery is a wiring bug and fails closed with a coded reason, rather than silently falling back and burning the timeout.

**Names the credential path in the auth remedy.** The coded `antigravity_reviewer_auth_unavailable` message and the README recipe both named only `GOOGLE_CLOUD_PROJECT` and `AGY_ADC_AUTH`. An operator following either exactly still fails: ADC's default location lives under the `HOME` this launch redirects, and neither variable carries a path. Isolated with a three-cell table — real `HOME` ✅, redirected ❌, redirected + absolute `GOOGLE_APPLICATION_CREDENTIALS` ✅.

The daemon deliberately does **not** synthesize that path from its own `HOME`. Per the borrowed-review auth design it never goes *looking* for a credential; reading a well-known credential location is precisely that. `ServiceEnvironment` already carries the key into a supervised unit off-Windows, so the export survives a service install without the daemon ever reading the file.

## Verification

Live, against a real daemon and a real `agy` 1.1.11 — a denial suite proves what a reviewer *cannot* do, and something has to prove it can still do its job:

- **Round 1** returned `status: findings` with real findings, synchronously. Zero denial lines.
- **Round 2** resumed correctly and **recalled both prior findings from memory** — the load-bearing check for an exec-per-turn runtime, where round 2 is a different process resumed via `--conversation`.
- The certified run's `mcp_config.json` carries `KCAP_FLOW_CAPABILITY_URL`, not `KCAP_URL`.

One trap cost two false failures and is worth recording: the daemon spawns the MCP child as bare `kcap`, resolved from `PATH`, so it was the *installed* 0.11.13 — built before the capability reader existed. It reproduced the pre-fix symptom exactly while the fix was working.

Seven new tests; every mutant listed in the branch was verified red. `*Antigravity*` 265 (260/5 skipped), `*Reviewer*` 438, `*Orchestrator*` 209, `*Acp*` 419. Clean AOT publish.

Fixes AI-1414

Closes #487
