### PR TITLE
Unattended reviewers work out of the box; the opt-in gate becomes an opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,28 +737,51 @@ kcap daemon consent log -n 50                                    # tail consent-
 
 `show`/`set-default`/`allow`/`deny`/`remove` mutate the policy over the daemon's local socket and require the target daemon to be running; `log` reads `consent-decisions.jsonl` straight off disk, so it works even with the daemon stopped. All six take `--name <n>` like the rest of `kcap daemon`.
 
-> **Two different gates, deliberately.** `daemon consent` authorises an individual launch and defaults to
-> *allow*; the Gemini reviewer flag below is a **capability** gate that defaults to *off* and asks a
-> different question — whether this daemon may run that vendor unattended **at all**. A per-launch deny is
-> not a substitute: the reviewer's containment rests on a behaviour of the installed vendor build, so the
-> safe default has to be off rather than on-until-denied.
+> **`daemon consent` is the gate that authorises an individual launch**, and it defaults to *allow*. The
+> per-vendor reviewer switches below are a different thing — whether this daemon may run a given vendor
+> unattended **at all** — and they now default to *enabled* too. See the note directly below for why they
+> used to be opt-in and no longer are.
 
-#### Gemini as an unattended review-flow reviewer — off by default, and why
+#### Unattended reviewers are enabled by default (they used to be opt-in)
 
-A **hosted** Gemini agent needs nothing beyond the project setting above. Using Gemini as an **unattended
-review-flow reviewer** is a separate, deliberately opt-in decision, because of what an unattended review
-grants:
+Every reviewer vendor your daemon can host is available to a review flow out of the box. Four of them
+— Gemini, Kiro, OpenCode and Antigravity — used to require an explicit opt-in. That was removed, because
+the opt-in did not do the job it appeared to do:
+
+- **The reviewer vendor is chosen by the caller.** Claude, Codex, Cursor and Copilot have never been gated,
+  and each runs with a *full* tool surface — shell and file writes included. So anyone the gate was meant to
+  stop simply asked for one of those instead, with more capability, not less.
+- **It was attached to the wrong end of the risk scale.** Two of the four gated vendors (Kiro, OpenCode) run
+  *read-only* reviewers. The strictest policy was on the most contained configuration.
+- **It taxed the honest path.** A supervised daemon inherits nothing from your shell, so turning a reviewer
+  on meant editing a service unit and restarting — to use a feature you had explicitly requested.
+
+What remains is the part that was doing real work: a per-vendor **version floor**. Several of these
+reviewers' containment depends on behaviour of the installed vendor build — and for OpenCode it is
+environment-based, which fails *silently* if a future build stops honouring it. Your daemon records a
+minimum version automatically at startup and refuses anything older. Use `kcap daemon reviewer affirm
+--vendor <name>` to move that floor past a build you have found to be bad. It is remediation, not
+permission, and it never blocks a first launch.
+
+**To disable a vendor**, set its variable to `0` (or `false`/`no`/`off`) in the **daemon's** environment:
 
 ```bash
-export KCAP_GEMINI_UNATTENDED_REVIEWER=1     # this DAEMON's environment — not a server setting
+export KCAP_GEMINI_UNATTENDED_REVIEWER=0        # this DAEMON's environment — not a server setting
+export KCAP_KIRO_UNATTENDED_REVIEWER=0
+export KCAP_OPENCODE_UNATTENDED_REVIEWER=0
+export KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=0
 ```
 
-Only an explicit `1`/`true`/`yes`/`on` enables it; anything else, a typo included, leaves it off. Enabling a
-reviewer is a consent decision, so a misspelling must not read as consent.
+Unset means enabled. A value the daemon cannot read as true or false is treated as **enabled** and logged
+as a warning at startup — so a typo cannot quietly take a reviewer offline, and you are told about it
+either way. Be aware that disabling one vendor does not stop unattended review on that daemon: a requester
+can still name an ungated vendor. If you want no unattended reviews at all, `kcap daemon consent` is the
+gate that actually does that.
 
-> Earlier docs showed a `GeminiUnattendedReviewerEnabled` key in `~/.config/kcap/config.json`. Nothing read
-> it — the flag was reachable only from a test constructor, so the Gemini unattended reviewer could not
-> actually be turned on. The environment variable above is the working form.
+#### What an unattended Gemini review grants
+
+A **hosted** Gemini agent needs nothing beyond the project setting above. A Gemini **reviewer** is worth
+understanding before you leave it on, because its posture is the broadest of the set:
 
 **Read this before setting it.** An unattended reviewer runs in a daemon-owned worktree with this daemon's
 own `HOME`, so repository content that steers the model into using its tools gets **code execution with your
@@ -800,11 +823,9 @@ Two further things it does *not* do:
 
 #### Unattended Kiro reviews
 
-```bash
-export KCAP_KIRO_UNATTENDED_REVIEWER=1       # this DAEMON's environment — not a server setting
-```
+Enabled by default; `KCAP_KIRO_UNATTENDED_REVIEWER=0` in the daemon's environment disables it.
 
-**Everything in the Gemini warning above applies**, with one difference in each direction.
+**Everything in the Gemini section above applies**, with one difference in each direction.
 
 *Tighter:* a Kiro reviewer runs with a **scoped** tool set — `fs_read`, `thinking`, and the tools of the MCP
 servers the launch itself injects. `fs_write` and `execute_bash` are not trusted, and a permission request that
@@ -844,9 +865,7 @@ cannot be created owner-only on Windows.
 
 #### Unattended Antigravity reviews
 
-```bash
-export KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1   # this DAEMON's environment — not a server setting
-```
+Enabled by default; `KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=0` in the daemon's environment disables it.
 
 The prerequisite is the Antigravity **CLI** — the `agy` binary on `PATH` (or `KCAP_ANTIGRAVITY_PATH`
 pointing at it). The Antigravity **IDE** alone is not enough: it ships no `agy`, and a daemon with only the
@@ -949,14 +968,15 @@ daemon started, restart it or run `kcap daemon reviewer affirm --vendor antigrav
 
 #### If your daemon runs as a service
 
-All three consent flags above are read from the **daemon's own environment**, and a supervised daemon (`kcap daemon
-service install` — launchd, systemd, or a Windows scheduled task) inherits nothing from the shell you
-installed it from. Exporting a flag in your shell therefore does nothing for a service-installed daemon until
-the unit itself carries it, so export it *first* and then reinstall:
+The reviewer switches above are read from the **daemon's own environment**, and a supervised daemon (`kcap
+daemon service install` — launchd, systemd, or a Windows scheduled task) inherits nothing from the shell you
+installed it from. Since the switches now default to *enabled*, this only matters when you want to **disable**
+one: exporting it in your shell does nothing for a service-installed daemon until the unit itself carries it,
+so export it *first* and then reinstall:
 
 ```bash
-export KCAP_GEMINI_UNATTENDED_REVIEWER=1
-kcap daemon service install --name "$(whoami)"    # captures the flag into the unit
+export KCAP_GEMINI_UNATTENDED_REVIEWER=0
+kcap daemon service install --name "$(whoami)"    # captures the setting into the unit
 ```
 
 The Antigravity ADC variables (`GOOGLE_CLOUD_PROJECT`, `AGY_ADC_AUTH`, `GOOGLE_APPLICATION_CREDENTIALS`)
@@ -964,9 +984,9 @@ are captured by the same install, so a daemon installed *before* this shipped mu
 interactive shell to pick them up. `KCAP_ANTIGRAVITY_PATH` is **not** captured — like the other vendor path
 overrides, set it where the unit can see it if you need a non-default value.
 
-Install prints a `Consent:` line naming each reviewer flag it captured. That freeze is the point to notice:
-the unit outlives the shell, so the reviewer stays enabled for that service until you reinstall without the
-variable set — unsetting it in your shell later changes nothing.
+Install prints a `Consent:` line naming each reviewer variable it captured. That freeze is the point to
+notice: the unit outlives the shell, so a reviewer you disabled stays disabled for that service until you
+reinstall without the variable set — unsetting it in your shell later changes nothing.
 
 If a reviewer is still not offered, the daemon says why in its own log at startup — one line per vendor that
 is installed and unattended-capable but withheld, carrying the same text the launch path would have thrown
@@ -1279,26 +1299,24 @@ Two things are worth knowing before you pick OpenCode:
   daemon is already recording, so the run would show up twice. Suppressing external plugins in the
   hosted child is what keeps a daemon-hosted session to exactly one recording. Sessions you start
   yourself are untouched: the plugin keeps its whole job there.
-- **Unattended review is off by default** — see below.
+- **Unattended review works out of the box** — see below.
 
-#### OpenCode as an unattended review-flow reviewer — off by default, and why
+#### OpenCode as an unattended review-flow reviewer
 
-`start_review_flow(vendor="opencode")` works only on a daemon whose operator has explicitly enabled
-it:
+`start_review_flow(vendor="opencode")` works on any daemon with `opencode` installed. To turn it off,
+set `KCAP_OPENCODE_UNATTENDED_REVIEWER=0` in the daemon's environment.
 
-```bash
-KCAP_OPENCODE_UNATTENDED_REVIEWER=1 kcap daemon
-```
+The reviewer's tool surface is deliberately narrow — the narrowest of any reviewer kcap offers. It gets
+`read`, `grep`, `glob` and `list` plus the one MCP channel it reports results through — **no shell, no
+write, no edit, no network** — enforced by OpenCode's own permission table rather than by asking the
+model nicely.
 
-The reviewer's tool surface is deliberately narrow. It gets `read`, `grep`, `glob` and `list` plus
-the one MCP channel it reports results through — **no shell, no write, no edit, no network** — and
-that is enforced by OpenCode's own permission table rather than by asking the model nicely.
-
-What you are consenting to is the part that narrow surface does *not* cover: **those read tools are
-not path-scoped.** They are whole-filesystem read primitives running as the daemon user, so a review
-can read any file that user can read — its own credentials included — and a reviewer's findings text
-goes back to whoever requested the review. Enable it only on a daemon whose operator and review
-requesters are in one trust domain.
+Worth knowing about the part that narrow surface does *not* cover: **those read tools are not
+path-scoped.** They are whole-filesystem read primitives running as the daemon user, so a review can read
+any file that user can read — credentials included — and a reviewer's findings text goes back to whoever
+requested the review. That is true of *every* reviewer, including Claude, Codex, Cursor and Copilot, which
+can additionally write files and run shell commands. So the decision worth making is whether to allow
+unattended reviews on this daemon at all (`kcap daemon consent`), not which vendor serves them.
 
 Two further things the launch does, which are worth knowing because they change what the reviewer
 sees:

--- a/README.md
+++ b/README.md
@@ -818,8 +818,8 @@ daemon user's full authority**. Concretely, and not bounded to the review:
 - **verdict** — steered content can simply ask the model to report `clean`. A review result is not
   authenticated review output.
 
-This is a property of unattended review generally, not of Gemini specifically — enabling Gemini widens which
-vendors can do it rather than introducing it. The one path that does *not* grant this is a sandboxed borrowed
+This is a property of unattended review generally, not of Gemini specifically — Gemini widens which vendors
+can do it rather than introducing it, and Claude, Codex, Cursor and Copilot have never been gated at all. The one path that does *not* grant this is a sandboxed borrowed
 review, which Gemini cannot use yet.
 
 **This is on by default, so read the above as describing what your daemon already does** once `gemini`
@@ -1353,10 +1353,11 @@ sees:
 - **Your global MCP servers are absent** (an empty per-launch `OPENCODE_CONFIG_DIR`). Otherwise a
   reviewer would inherit `kcap-flows` and could start review flows of its own.
 
-Enabling it does **not** bypass the build check. The containment above is behaviour of the installed
-`opencode` build, so the daemon records a **minimum** version and refuses anything older. Enabling
-seeds that minimum from whatever is installed, so a later upgrade needs no action from you; to move
-the floor to the currently-installed build (after a bad release, say), run:
+Being on by default does **not** bypass the build check. The containment above is behaviour of the
+installed `opencode` build, so the daemon records a **minimum** version and refuses anything older.
+That minimum is seeded on the first startup that finds the binary, from whatever is installed then, so
+a later upgrade needs no action from you; to move the floor to the currently-installed build (after a
+bad release, say), run:
 
 ```bash
 kcap daemon reviewer affirm --vendor opencode

--- a/README.md
+++ b/README.md
@@ -1258,7 +1258,7 @@ KCAP_CURSOR_PATH=/opt/cursor/bin/cursor-agent kcap daemon
 KCAP_CURSOR_MODEL=claude-opus-4-8 kcap daemon
 ```
 
-`KCAP_COPILOT_PATH` overrides the `copilot` binary the daemon spawns for **GitHub Copilot hosted agents** (`copilot --acp --stdio`), mirroring `KCAP_CURSOR_PATH` — the daemon hosts Claude, Codex, Cursor, Copilot, Kiro, Gemini, OpenCode and Antigravity. `KCAP_GEMINI_PATH` overrides the `gemini` binary the same way (`gemini --experimental-acp`), and applies to both hosted Gemini agents and the opt-in [unattended Gemini reviewer](#gemini-as-an-unattended-review-flow-reviewer--off-by-default-and-why) — whose build-affirmation check reads whichever binary it names. `KCAP_OPENCODE_PATH` overrides the `opencode` binary the daemon spawns for **OpenCode hosted agents** (`opencode acp`) — no longer reserved; see [Hosted OpenCode agents](#hosted-opencode-agents) below.
+`KCAP_COPILOT_PATH` overrides the `copilot` binary the daemon spawns for **GitHub Copilot hosted agents** (`copilot --acp --stdio`), mirroring `KCAP_CURSOR_PATH` — the daemon hosts Claude, Codex, Cursor, Copilot, Kiro, Gemini, OpenCode and Antigravity. `KCAP_GEMINI_PATH` overrides the `gemini` binary the same way (`gemini --experimental-acp`), and applies to both hosted Gemini agents and the [unattended Gemini reviewer](#unattended-reviewers-are-enabled-by-default-they-used-to-be-opt-in) (enabled by default) — whose build-affirmation check reads whichever binary it names. `KCAP_OPENCODE_PATH` overrides the `opencode` binary the daemon spawns for **OpenCode hosted agents** (`opencode acp`) — no longer reserved; see [Hosted OpenCode agents](#hosted-opencode-agents) below.
 
 ```bash
 KCAP_COPILOT_PATH=/opt/copilot/bin/copilot kcap daemon

--- a/README.md
+++ b/README.md
@@ -778,11 +778,14 @@ export KCAP_OPENCODE_UNATTENDED_REVIEWER=0
 export KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=0
 ```
 
-Unset means enabled. A value the daemon cannot read as true or false is treated as **enabled** and logged
-as a warning at startup — so a typo cannot quietly take a reviewer offline, and you are told about it
-either way. Be aware that disabling one vendor does not stop unattended review on that daemon: a requester
-can still name an ungated vendor. If you want no unattended reviews at all, `kcap daemon consent` is the
-gate that actually does that.
+Unset means enabled. A value the daemon cannot read as true or false is treated as **disabled**, and
+warned about at startup — because the only reason to set one of these at all is to turn a reviewer off,
+so an unreadable value is a failed "off" rather than an ambiguous input. Surrounding quotes are tolerated
+(`"0"` works), since a mis-quoted service-unit entry is the usual way that happens.
+
+Be aware that disabling one vendor does not stop unattended review on that daemon: a requester can still
+name an ungated vendor. If you want no unattended reviews at all, `kcap daemon consent` is the gate that
+actually does that — note it **defaults to allow**, so it only helps once you have configured it.
 
 #### What an unattended Gemini review grants
 

--- a/README.md
+++ b/README.md
@@ -750,8 +750,10 @@ the opt-in did not do the job it appeared to do:
 
 - **The reviewer vendor is chosen by the caller.** Claude, Codex, Cursor and Copilot have never been gated,
   and each runs with a *full* tool surface — shell and file writes included. So on any daemon that also
-  advertises one of those, the gate stopped nobody: a requester it blocked simply asked for an ungated
-  vendor with more capability, not less.
+  advertises one of those, the gate did not widen the class of capability a requester could reach: one it
+  blocked simply asked for an ungated vendor with more capability, not less. (Not quite "stopped nobody" —
+  a Gemini reviewer burns *your* Gemini credentials and obeys Gemini's own permission model, which is not a
+  subset of "Claude was available anyway".)
   > The exception, since the claim is not universal: on a daemon where you installed **only** a gated
   > vendor's CLI — for hosted work, say — and no ungated one, these variables were the only thing keeping
   > that binary from also serving unattended reviews. If that is your setup and you want it back, set the
@@ -782,6 +784,16 @@ Unset means enabled. A value the daemon cannot read as true or false is treated 
 warned about at startup — because the only reason to set one of these at all is to turn a reviewer off,
 so an unreadable value is a failed "off" rather than an ambiguous input. Surrounding quotes are tolerated
 (`"0"` works), since a mis-quoted service-unit entry is the usual way that happens.
+
+**On a service-installed daemon, set it before you install.** `kcap daemon service install` copies these
+four variables into the service unit — on every platform — but a supervised daemon inherits nothing from
+your shell afterwards, so its environment is frozen at install time. Exporting an opt-out later has no
+effect until you reinstall the service:
+
+```bash
+export KCAP_GEMINI_UNATTENDED_REVIEWER=0
+kcap daemon service install        # re-run so the unit picks the value up
+```
 
 Be aware that disabling one vendor does not stop unattended review on that daemon: a requester can still
 name an ungated vendor. If you want no unattended reviews at all, `kcap daemon consent` is the gate that

--- a/README.md
+++ b/README.md
@@ -749,8 +749,14 @@ Every reviewer vendor your daemon can host is available to a review flow out of 
 the opt-in did not do the job it appeared to do:
 
 - **The reviewer vendor is chosen by the caller.** Claude, Codex, Cursor and Copilot have never been gated,
-  and each runs with a *full* tool surface — shell and file writes included. So anyone the gate was meant to
-  stop simply asked for one of those instead, with more capability, not less.
+  and each runs with a *full* tool surface — shell and file writes included. So on any daemon that also
+  advertises one of those, the gate stopped nobody: a requester it blocked simply asked for an ungated
+  vendor with more capability, not less.
+  > The exception, since the claim is not universal: on a daemon where you installed **only** a gated
+  > vendor's CLI — for hosted work, say — and no ungated one, these variables were the only thing keeping
+  > that binary from also serving unattended reviews. If that is your setup and you want it back, set the
+  > variable to `0`. `kcap daemon consent` is the better control, because it cannot be sidestepped by
+  > naming a different vendor.
 - **It was attached to the wrong end of the risk scale.** Two of the four gated vendors (Kiro, OpenCode) run
   *read-only* reviewers. The strictest policy was on the most contained configuration.
 - **It taxed the honest path.** A supervised daemon inherits nothing from your shell, so turning a reviewer

--- a/README.md
+++ b/README.md
@@ -822,14 +822,16 @@ This is a property of unattended review generally, not of Gemini specifically �
 vendors can do it rather than introducing it. The one path that does *not* grant this is a sandboxed borrowed
 review, which Gemini cannot use yet.
 
-**Enabling this flag is your consent to the above**, which is why it is daemon-local (the person requesting a
-review is not necessarily you) and defaults off.
+**This is on by default, so read the above as describing what your daemon already does** once `gemini`
+resolves. The switch is daemon-local — the person requesting a review is not necessarily you — and it is
+now an opt-OUT: `KCAP_GEMINI_UNATTENDED_REVIEWER=0` to turn it off. If your daemon is service-managed, set
+it and re-run `kcap daemon service install`, since a supervised daemon's environment is frozen at install.
 
 Two further things it does *not* do:
 
 - it does not bypass the **minimum version**. The reviewer's only containment is Gemini's exact-name MCP
   allowlist, which is a behaviour of the installed build, so the daemon records a minimum `gemini` version
-  the first time you enable the reviewer. That recorded version is a **minimum, not an exact match**: any
+  on the first startup that finds the binary. That recorded version is a **minimum, not an exact match**: any
   build at or above it runs, so **a Gemini upgrade needs no action from you**; an older one is refused, with
   a coded error naming both versions. Run `kcap daemon reviewer affirm --vendor gemini` to move the minimum
   to whatever is installed now — which is how you exclude a build you have found to be broken, and, if you
@@ -867,7 +869,7 @@ A review launch also runs with a daemon-owned, empty `KIRO_HOME`, so your global
 interactive Kiro sessions are unaffected, and the file is never modified.
 
 **Minimum version.** That suppression depends on the installed build honouring `KIRO_HOME`, so the daemon
-records a minimum `kiro-cli` version the first time you enable the reviewer. It is a **minimum, not an exact
+records a minimum `kiro-cli` version on the first startup that finds the binary. It is a **minimum, not an exact
 match**: any build at or above it runs, so **a `kiro-cli` upgrade needs no action from you**; a build older
 than the recorded minimum is refused.
 
@@ -933,11 +935,13 @@ action from you** — which matters more here than for the other reviewers, sinc
 (observed going 1.1.8 → 1.1.10 mid-session). A build older than the recorded minimum, or one whose
 `agy --version` cannot be read, is withheld with a coded reason naming both versions.
 
-Because this vendor's minimum is recorded when `agy` first resolves rather than when you enable the
-reviewer, there is one window worth knowing about: install `agy`, run a daemon with the reviewer *off*,
-then upgrade `agy` and only afterwards turn the reviewer on — and the recorded minimum is still the older
+This vendor's minimum is recorded whenever `agy` first resolves, even on a daemon whose reviewer you have
+explicitly turned off — its floor also gates *hosted* Antigravity agents, which are never gated by the
+reviewer switch. That leaves one window worth knowing about, now that reviewers are on by default it needs
+a deliberate opt-out to reach: install `agy`, run a daemon with `KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=0`,
+then upgrade `agy` and only afterwards unset that variable — and the recorded minimum is still the older
 build you started with, so a later *downgrade* back to it would be admitted. Run the command below once
-after enabling the reviewer if you want the minimum to be the build you actually reviewed with.
+after re-enabling if you want the minimum to be the build you actually reviewed with.
 
 ```bash
 kcap daemon reviewer affirm --vendor antigravity

--- a/src/Capacitor.Cli.Core/GatedReviewers.cs
+++ b/src/Capacitor.Cli.Core/GatedReviewers.cs
@@ -1,0 +1,51 @@
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// One reviewer vendor that has BOTH an opt-out switch and an affirmable version floor.
+///
+/// <para><b>Lives in Core because three projects need the same list</b> and they cannot see each
+/// other: the daemon reads <see cref="EnableEnvVar"/> to build its config, the CLI carries it into a
+/// service unit, and the CLI's <c>daemon reviewer affirm</c> verb resolves a vendor by name.
+/// <c>Capacitor.Cli</c> and <c>Capacitor.Cli.Daemon</c> both reference Core and neither references the
+/// other, so Core is the only place a single list can sit.</para>
+///
+/// <para><b>Why a single list matters more than it used to.</b> These switches are opt-OUTs: unset
+/// means the reviewer is enabled. So the variable is the operator's only lever for turning one off,
+/// and a vendor that appears in the daemon's apply loop but not in the service-unit allowlist is a
+/// reviewer that cannot be disabled on the supported install path — the exact hazard review raised.
+/// While these were opt-INs the same drift meant a reviewer that could not be turned ON: annoying, and
+/// safe. Two enumerations that must agree, with nothing making them, is the shape that produces that;
+/// there is now one.</para>
+/// </summary>
+/// <param name="Vendor">The vendor token, as it appears on the wire and in <c>--vendor</c>.</param>
+/// <param name="DefaultBinary">The binary looked up on PATH when <paramref name="PathEnvVar"/> is
+/// unset.</param>
+/// <param name="PathEnvVar">Overrides where the vendor binary is found.</param>
+/// <param name="EnableEnvVar">The opt-OUT switch. Non-nullable deliberately: an entry here without one
+/// would put a null into the service-unit allowlist, and there is no such thing as a gated reviewer
+/// with no way to turn it off.</param>
+public sealed record GatedReviewer(
+        string Vendor, string DefaultBinary, string PathEnvVar, string EnableEnvVar);
+
+/// <summary>The registry. Adding an entry here is what wires a new gated reviewer everywhere.</summary>
+public static class GatedReviewers {
+    /// <summary>
+    /// Every reviewer with an opt-out switch and an affirmable floor.
+    ///
+    /// <para>Order is the order an operator sees in <c>--vendor</c> usage text; nothing depends on
+    /// it.</para>
+    /// </summary>
+    public static readonly GatedReviewer[] All = [
+        new("kiro",        "kiro-cli", "KCAP_KIRO_PATH",        "KCAP_KIRO_UNATTENDED_REVIEWER"),
+        new("gemini",      "gemini",   "KCAP_GEMINI_PATH",      "KCAP_GEMINI_UNATTENDED_REVIEWER"),
+        new("antigravity", "agy",      "KCAP_ANTIGRAVITY_PATH", "KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER"),
+        new("opencode",    "opencode", "KCAP_OPENCODE_PATH",    "KCAP_OPENCODE_UNATTENDED_REVIEWER")
+    ];
+
+    /// <summary>For usage text: <c>kiro | gemini | antigravity | opencode</c>.</summary>
+    public static string VendorList => string.Join(" | ", All.Select(r => r.Vendor));
+
+    /// <summary>Case-insensitive lookup, null when the vendor is not gated (or not a vendor).</summary>
+    public static GatedReviewer? Resolve(string? vendor) =>
+        All.FirstOrDefault(r => string.Equals(r.Vendor, vendor, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Capacitor.Cli.Core/ReviewerConsent.cs
+++ b/src/Capacitor.Cli.Core/ReviewerConsent.cs
@@ -1,0 +1,86 @@
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// Reads a gated reviewer's opt-OUT switch (the <c>KCAP_*_UNATTENDED_REVIEWER</c> variables).
+///
+/// <para><b>In Core because two projects must agree on the answer.</b> The daemon parses these to build
+/// its config; the CLI's <c>daemon service install</c> reports what a captured value MEANS in its
+/// output. Those are the same question — "does this string enable or disable the reviewer?" — and a
+/// second copy of the rules in the CLI would be free to drift from the daemon's, so the install notice
+/// could tell an operator a value enables a reviewer that the daemon then disables. One parser removes
+/// that class.</para>
+///
+/// <para><b>Unset means enabled; a value we cannot read means DISABLED.</b> The asymmetry is the point.
+/// Since unset already enables, the only reason to set one of these variables at all is to turn a
+/// reviewer OFF — enabling needs no variable. So an unrecognised value is not an ambiguous input, it is
+/// a FAILED ATTEMPT TO SAY OFF, and honouring the evident intent means failing closed. An earlier
+/// revision failed open here, reasoning from the general "a typo must not take a feature offline" rule,
+/// which does not transfer to a setting whose only use is to disable.</para>
+///
+/// <para><b>That justification does not generalise, so do not reuse this parser for other settings.</b>
+/// It rests on two facts specific to these variables: unset already means enabled, and disabling is
+/// therefore the only possible intent behind setting one. A setting where unset means disabled, or
+/// where fail-open was chosen deliberately, needs its own parse and its own reasoning.</para>
+/// </summary>
+public static class ReviewerConsent {
+    /// <summary>
+    /// The ONE value set: true, false, or null for "set but unrecognised". <see cref="IsEnabled"/> and
+    /// <see cref="DescribeUnparseable"/> are both derived from it, so a parse and an "is this
+    /// recognised?" predicate cannot disagree — two methods that must agree with nothing making them is
+    /// the shape this collapses.
+    ///
+    /// <para><b>Matched surrounding quotes are stripped</b>, because the realistic way a DISABLE attempt
+    /// becomes unrecognised is a quoting artifact — a mis-quoted service-unit entry, a <c>.cmd</c>
+    /// wrapper's <c>set "K=V"</c>, a hand-edited plist — and the value then arrives as literal
+    /// <c>"0"</c>. Since disabling is the operator's only lever, a fail-open there is the one mistake
+    /// worth spending three lines to prevent. One level only: a value still unrecognised after stripping
+    /// is reported, not stripped again.</para>
+    /// </summary>
+    public static bool? Recognise(string? value) {
+        var v = value?.Trim();
+
+        // DO NOT fold these two early returns into the `return null` fallthrough below. They look like
+        // "nothing to recognise" and they are not: IsEnabled maps null to FALSE, so collapsing them
+        // would turn all four reviewers OFF on every daemon with the variables unset — which is
+        // essentially all of them. The same tidy-up was harmless while this failed open; the
+        // fail-closed direction is what made it catastrophic. Unset must never reach the `??`.
+        if (string.IsNullOrEmpty(v)) return true;   // unset — the default
+
+        if (v.Length >= 2 && (v[0] == '"' || v[0] == '\'') && v[^1] == v[0])
+            v = v[1..^1].Trim();
+
+        if (v.Length == 0) return true;             // `""` / `''` — an empty value, not an unreadable one
+
+        if (v == "0"
+         || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase)
+         || string.Equals(v, "no",    StringComparison.OrdinalIgnoreCase)
+         || string.Equals(v, "off",   StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (v == "1"
+         || string.Equals(v, "true", StringComparison.OrdinalIgnoreCase)
+         || string.Equals(v, "yes",  StringComparison.OrdinalIgnoreCase)
+         || string.Equals(v, "on",   StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return null;   // set, but says nothing we understand
+    }
+
+    /// <summary>Whether the reviewer is enabled. Unset/blank/enabling → true; disabling → false; an
+    /// unrecognised value → false (a failed "off", honoured as off).</summary>
+    public static bool IsEnabled(string? value) => Recognise(value) ?? false;
+
+    /// <summary>
+    /// A warning for a variable that is SET but says nothing recognised, or null when there is nothing
+    /// to report. An operator who typed <c>flase</c> meaning to disable would otherwise get the reviewer
+    /// enabled with no signal at all — the direction worth being loud about now that disabling is the
+    /// only lever.
+    /// </summary>
+    public static string? DescribeUnparseable(string variable, string? value) =>
+        Recognise(value) is null
+            ? $"{variable} is set to '{value?.Trim()}', which is not recognised as true or false. "
+            + "Treating it as DISABLED, because the only reason to set this variable is to turn the "
+            + "reviewer off — unset already means enabled. Use 0/false/no/off to disable, or unset it "
+            + "(or use 1/true/yes/on) to enable."
+            : null;
+}

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -431,10 +431,12 @@ internal static class AcpVendorDescriptors {
     /// prompt intermittently for a tool in its own trust list. If OpenCode is ever observed doing that,
     /// this is the flag to revisit — with a measurement, not a preference.</para>
     ///
-    /// <para><b>Unattended is GATED</b> — <c>SupportsUnattended</c> being true here only makes the
-    /// vendor eligible; <see cref="OpenCodeReviewerCapability"/> decides per daemon, and refuses unless
-    /// the operator has consented AND the installed build meets this daemon's recorded minimum. The
-    /// consent event is what it is because the reviewer's read tools are not path-scoped.</para>
+    /// <para><b>Unattended is ENABLED by default, and still build-gated</b> —
+    /// <c>SupportsUnattended</c> being true here only makes the vendor eligible;
+    /// <see cref="OpenCodeReviewerCapability"/> decides per daemon. It refuses when the operator has
+    /// EXPLICITLY disabled the vendor, or when the installed build is below this daemon's recorded
+    /// minimum. There is no opt-in: gating one vendor never narrowed anything, since the reviewer vendor
+    /// is caller-chosen and four others run ungated with more capability.</para>
     ///
     /// <para><b><see cref="SupportsReconnectResume"/> is <c>false</c> as UNPROBED</b>, which is a
     /// different claim from <see cref="Kiro"/>'s and <see cref="Gemini"/>'s — both of those are

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
@@ -103,11 +103,11 @@ internal static class AntigravityReviewerCapability {
             string binaryPath) =>
         decision switch {
             AntigravityReviewerDecision.Disabled =>
-                "antigravity_unattended_reviewer_disabled: unattended Antigravity reviews are off on "
-              + "this daemon. A review runs under this daemon user's authority and returns what it "
-              + "read to whoever requested it, so enable it only where the operator and the review "
-              + "requesters are in one trust domain: set KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=1 in the "
-              + "daemon's environment (not on the server).",
+                "antigravity_unattended_reviewer_disabled: this daemon has EXPLICITLY disabled "
+              + "unattended Antigravity reviews. Unset KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER in the "
+              + "daemon's environment (not on the server) to restore the default, which is enabled — or "
+              + "set it to 1. A review runs under this daemon user's authority either way, as it does "
+              + "for the never-gated Claude, Codex, Cursor and Copilot reviewers.",
 
             AntigravityReviewerDecision.UnsupportedPlatform =>
                 "antigravity_reviewer_unsupported_platform: the per-launch home holds the agent's own "

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
@@ -16,19 +16,20 @@ internal enum AntigravityReviewerDecision {
 /// Whether THIS daemon may run Antigravity's CLI (<c>agy</c>) as an unattended review-flow reviewer.
 /// Pure, so every arm is testable without a vendor or a process.
 ///
-/// <para><b>What enabling it consents to.</b> An unattended reviewer runs in a daemon-owned worktree
-/// under a per-launch, owner-only <c>HOME</c>, and its findings text is returned to whoever requested
-/// the review. That risk lands on the daemon OPERATOR, who is not necessarily the requester, which is
-/// why the decision is daemon-local and enabling it is the consent event rather than a documented
-/// default. Deliberately NOT Kiro's whole-filesystem-read paragraph: that claim is about a trusted
-/// <c>fs_read</c> primitive this vendor does not expose, and a borrowed risk statement would be a
-/// false one in either direction.</para>
+/// <para><b>ENABLED by default; the switch is an opt-OUT.</b> An unattended reviewer runs in a
+/// daemon-owned worktree under a per-launch, owner-only <c>HOME</c>, and its findings text is returned
+/// to whoever requested the review — a cross-principal risk that lands on the daemon OPERATOR. It used
+/// to be an opt-in on that basis. It is not any more, because the reviewer vendor is caller-chosen and
+/// Claude, Codex, Cursor and Copilot have never been gated, each with the same authority: the gate
+/// excluded nobody and cost the operator a service-unit edit. Deliberately still NOT Kiro's
+/// whole-filesystem-read paragraph — that claim is about a trusted <c>fs_read</c> primitive this vendor
+/// does not expose, and a borrowed risk statement would be false in either direction.</para>
 ///
-/// <para><b>Consent is the ONE arm that is reviewer-only</b> (see
+/// <para><b>The disabled arm is the ONE that is reviewer-only</b> (see
 /// <c>AntigravityHostedAgentRuntimeFactory.LaunchRefusal</c>'s parameter doc). The paragraph above is
 /// exactly why: the risk it describes is cross-principal, and a HOSTED launch has no counterpart —
 /// the server resolves a launch's daemon with the caller's own user id, so the launcher is the
-/// daemon's owner. Hosted Antigravity ships on by default; every other arm below still gates it.</para>
+/// daemon's owner. Hosted Antigravity has always shipped on; every other arm below gates both.</para>
 ///
 /// <para><b>Why a version MINIMUM.</b> Containment here is source suppression — an empty per-launch
 /// <see cref="AntigravityReviewerHome"/> in place of the operator's own <c>~/.gemini</c>, whose kcap

--- a/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AntigravityReviewerCapability.cs
@@ -20,8 +20,11 @@ internal enum AntigravityReviewerDecision {
 /// daemon-owned worktree under a per-launch, owner-only <c>HOME</c>, and its findings text is returned
 /// to whoever requested the review — a cross-principal risk that lands on the daemon OPERATOR. It used
 /// to be an opt-in on that basis. It is not any more, because the reviewer vendor is caller-chosen and
-/// Claude, Codex, Cursor and Copilot have never been gated, each with the same authority: the gate
-/// excluded nobody and cost the operator a service-unit edit. Deliberately still NOT Kiro's
+/// Claude, Codex, Cursor and Copilot have never been gated, each with the same authority: on a daemon
+/// that also ADVERTISES one of those, the gate did not widen the capability class a requester could
+/// reach, and cost the operator a service-unit edit. On a daemon advertising only gated vendors it did
+/// separate the hosted role from the unattended reviewer role, and the flip genuinely widens what a
+/// non-operator can cause to run with no human in the loop. Deliberately still NOT Kiro's
 /// whole-filesystem-read paragraph — that claim is about a trusted <c>fs_read</c> primitive this vendor
 /// does not expose, and a borrowed risk statement would be false in either direction.</para>
 ///

--- a/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
@@ -21,11 +21,14 @@ internal enum GeminiReviewerDecision {
 /// That lands on the DAEMON OPERATOR, who is not necessarily the person requesting the review.</para>
 ///
 /// <para><b>Why that is nevertheless no longer an opt-in.</b> The reviewer vendor is caller-chosen, and
-/// Claude, Codex, Cursor and Copilot have never been gated — each with the same full authority. A caller who
-/// would have been blocked from <c>vendor: "gemini"</c> simply asked for one of those, so the gate cost the
-/// operator a service-unit edit and bought nothing. The switch is now an opt-OUT
-/// (<c>KCAP_GEMINI_UNATTENDED_REVIEWER=0</c>); the decision that actually scopes this is whether to permit
-/// unattended reviews on the daemon at all, which is <c>kcap daemon consent</c>.</para>
+/// Claude, Codex, Cursor and Copilot have never been gated — each with the same full authority. Wherever
+/// one of those is also ADVERTISED, a caller blocked from <c>vendor: "gemini"</c> simply asked for one of
+/// them, so the gate cost the operator a service-unit edit without narrowing the capability class reachable
+/// — though not literally nothing, since a Gemini reviewer burns the operator's own Gemini credentials.
+/// Where only gated vendors are advertised, the flip does widen what a non-operator can cause to run. The
+/// switch is now an opt-OUT (<c>KCAP_GEMINI_UNATTENDED_REVIEWER=0</c>); the decision that actually scopes
+/// this is whether to permit unattended reviews on the daemon at all, which is <c>kcap daemon consent</c> —
+/// note that DEFAULTS TO ALLOW, so it scopes nothing until configured.</para>
 ///
 /// <para><b>Why the build is gated, and why by affirmation.</b> The security mechanism is the vendor's MCP
 /// allowlist behaving as an exclusive exact-match gate that the repository's own settings cannot widen. That

--- a/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
@@ -86,11 +86,13 @@ internal static class GeminiReviewerCapability {
             GeminiReviewerDecision decision, string? installedVersion, string? minimumVersion) =>
         decision switch {
             GeminiReviewerDecision.Disabled =>
-                "gemini_unattended_reviewer_disabled: this daemon has not enabled Gemini as an unattended "
-              + "review-flow reviewer. Enabling it accepts that a review grants prompt-injected repository "
-              + "content code execution with this daemon user's authority, including its credentials — set "
-              + "KCAP_GEMINI_UNATTENDED_REVIEWER=1 in the daemon's environment (not on the server) only if "
-              + "that is acceptable.",
+                "gemini_unattended_reviewer_disabled: this daemon has EXPLICITLY disabled Gemini as an "
+              + "unattended review-flow reviewer. Unset KCAP_GEMINI_UNATTENDED_REVIEWER in the daemon's "
+              + "environment (not on the server) to restore the default, which is enabled — or set it "
+              + "to 1. Worth knowing before you re-enable: a Gemini review grants prompt-injected "
+              + "repository content code execution with this daemon user's authority. That is a real "
+              + "risk, but it is the same posture as the never-gated Claude, Codex, Cursor and Copilot "
+              + "reviewers, so this switch narrows nothing a requester cannot route around.",
 
             GeminiReviewerDecision.VersionUnresolved =>
                 "gemini_reviewer_version_unresolved: the installed gemini version could not be "
@@ -100,10 +102,10 @@ internal static class GeminiReviewerCapability {
 
             GeminiReviewerDecision.VersionNoMinimum =>
                 "gemini_reviewer_version_no_minimum: this daemon has no recorded minimum gemini "
-              + "version, so there is nothing to check the installed build against. The usual cause is "
-              + "enabling the reviewer against an already-running daemon — it records a minimum at "
-              + "startup, so restart it with KCAP_GEMINI_UNATTENDED_REVIEWER set. To set one now "
-              + "without restarting, run `kcap daemon reviewer affirm --vendor gemini`.",
+              + "version, so there is nothing to check the installed build against. A daemon records "
+              + "one automatically at startup, so the usual cause is that the version probe failed "
+              + "then — check that `gemini --version` succeeds for the daemon user, and restart. To "
+              + "record one now without restarting, run `kcap daemon reviewer affirm --vendor gemini`.",
 
             GeminiReviewerDecision.VersionIncomparable =>
                 $"gemini_reviewer_version_incomparable: gemini {Describe(installedVersion)} and this "

--- a/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/GeminiReviewerCapability.cs
@@ -15,13 +15,17 @@ internal enum GeminiReviewerDecision {
 /// Whether THIS daemon may run Gemini as an unattended review-flow reviewer. Two conditions, both
 /// fail-closed, and the type is pure so both are testable without a vendor or a process.
 ///
-/// <para><b>Why a capability at all.</b> An unattended reviewer runs in a daemon-owned worktree with the
-/// daemon's own HOME, so prompt-injected repository content that reaches the model's tool use gets code
-/// execution with the daemon user's full authority — durable credential compromise included. That risk lands
-/// on the DAEMON OPERATOR, who is not necessarily the person requesting the review: a caller can ask for
-/// <c>vendor: "gemini"</c> without owning the host being exposed. So the decision belongs in daemon-local
-/// configuration, and <b>enabling it is the operator's consent event</b>. A non-default plus documentation
-/// would be informed guidance, not consent.</para>
+/// <para><b>The risk, which is real and unchanged.</b> An unattended reviewer runs in a daemon-owned
+/// worktree with the daemon's own HOME, so prompt-injected repository content that reaches the model's tool
+/// use gets code execution with the daemon user's full authority — durable credential compromise included.
+/// That lands on the DAEMON OPERATOR, who is not necessarily the person requesting the review.</para>
+///
+/// <para><b>Why that is nevertheless no longer an opt-in.</b> The reviewer vendor is caller-chosen, and
+/// Claude, Codex, Cursor and Copilot have never been gated — each with the same full authority. A caller who
+/// would have been blocked from <c>vendor: "gemini"</c> simply asked for one of those, so the gate cost the
+/// operator a service-unit edit and bought nothing. The switch is now an opt-OUT
+/// (<c>KCAP_GEMINI_UNATTENDED_REVIEWER=0</c>); the decision that actually scopes this is whether to permit
+/// unattended reviews on the daemon at all, which is <c>kcap daemon consent</c>.</para>
 ///
 /// <para><b>Why the build is gated, and why by affirmation.</b> The security mechanism is the vendor's MCP
 /// allowlist behaving as an exclusive exact-match gate that the repository's own settings cannot widen. That

--- a/src/Capacitor.Cli.Daemon/Acp/KiroReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/KiroReviewerCapability.cs
@@ -18,9 +18,12 @@ internal enum KiroReviewerDecision {
 ///
 /// <para><b>ENABLED by default; the switch is an opt-OUT.</b> It shipped as an opt-in and that was
 /// wrong. The reviewer vendor is a caller-chosen parameter, and Claude, Codex, Cursor and Copilot have
-/// never been gated — each running with FULL tool access, including shell and write. So gating Kiro
-/// stopped nobody (a requester simply asks for an ungated vendor with more capability) while taxing
-/// the honest path with a service-unit edit and a restart. It was also the wrong end of the risk
+/// never been gated — each running with FULL tool access, including shell and write. So on any daemon
+/// that also ADVERTISES one of those, gating Kiro did not widen the capability class a requester could
+/// reach (they simply ask for an ungated vendor with more capability) while taxing the honest path with
+/// a service-unit edit and a restart. On a daemon advertising only gated vendors it did separate the
+/// hosted role from the unattended reviewer role, and the flip genuinely widens what a non-operator can
+/// cause to run with no human in the loop. It was also the wrong end of the risk
 /// scale: this reviewer's trust list is <c>fs_read</c> + <c>thinking</c>, never <c>fs_write</c>, never
 /// <c>execute_bash</c>.</para>
 ///

--- a/src/Capacitor.Cli.Daemon/Acp/KiroReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/KiroReviewerCapability.cs
@@ -16,15 +16,19 @@ internal enum KiroReviewerDecision {
 /// Whether THIS daemon may run Kiro as an unattended review-flow reviewer. Pure, so every arm is
 /// testable without a vendor or a process.
 ///
-/// <para><b>What enabling it consents to, stated because it is broader than it looks.</b> An
-/// unattended reviewer runs in a daemon-owned worktree with the daemon's own HOME, and a trusted
-/// <c>fs_read</c> is measurably NOT path-scoped — it is a whole-filesystem read primitive under the
-/// daemon's uid. So a review can read every file this daemon user can read, its own credentials
-/// included, and its findings text is returned to whoever requested the review. That risk lands on
-/// the daemon OPERATOR, who is not necessarily the requester, which is why the decision is
-/// daemon-local configuration and enabling it is the consent event rather than a documented default.
-/// The reviewer is supported only where the operator and the review requesters are in one trust
-/// domain.</para>
+/// <para><b>ENABLED by default; the switch is an opt-OUT.</b> It shipped as an opt-in and that was
+/// wrong. The reviewer vendor is a caller-chosen parameter, and Claude, Codex, Cursor and Copilot have
+/// never been gated — each running with FULL tool access, including shell and write. So gating Kiro
+/// stopped nobody (a requester simply asks for an ungated vendor with more capability) while taxing
+/// the honest path with a service-unit edit and a restart. It was also the wrong end of the risk
+/// scale: this reviewer's trust list is <c>fs_read</c> + <c>thinking</c>, never <c>fs_write</c>, never
+/// <c>execute_bash</c>.</para>
+///
+/// <para><b>The residual risk is real and unchanged, it just is not what a per-vendor gate addressed.</b>
+/// A trusted <c>fs_read</c> is measurably NOT path-scoped — a whole-filesystem read primitive under the
+/// daemon's uid — so a review can read every file this daemon user can, credentials included, and its
+/// findings text goes back to the requester. Equally true of the four never-gated vendors. The honest
+/// framing is that running ANY unattended reviewer is the decision, not running this one.</para>
 ///
 /// <para><b>Why a version MINIMUM rather than a certified set or an exact affirmation.</b> Containment
 /// is source suppression — an empty per-launch <see cref="KiroReviewerHome"/> plus the worktree
@@ -92,12 +96,12 @@ internal static class KiroReviewerCapability {
               + "cannot be created owner-only on this platform.",
 
             KiroReviewerDecision.Disabled =>
-                "kiro_unattended_reviewer_disabled: this daemon has not enabled Kiro as an unattended "
-              + "review-flow reviewer. Enabling it grants a review read access to every file this "
-              + "daemon user can read — including its own credentials — with no filesystem boundary, "
-              + "and a reviewer can return what it read to whoever requested the review. Enable it "
-              + "only on a daemon whose operator and review requesters are in one trust domain: set "
-              + "KCAP_KIRO_UNATTENDED_REVIEWER=1 in the daemon's environment (not on the server).",
+                "kiro_unattended_reviewer_disabled: this daemon has EXPLICITLY disabled Kiro as an "
+              + "unattended review-flow reviewer. Unset KCAP_KIRO_UNATTENDED_REVIEWER in the daemon's "
+              + "environment (not on the server) to restore the default, which is enabled — or set it "
+              + "to 1. Note what the switch does and does not buy: a reviewer runs under this daemon "
+              + "user's authority either way, and Claude, Codex, Cursor and Copilot are never gated, so "
+              + "disabling Kiro alone does not stop a requester who can simply ask for one of those.",
 
             KiroReviewerDecision.VersionUnresolved =>
                 "kiro_reviewer_version_unresolved: the installed kiro-cli version could not be "
@@ -106,10 +110,10 @@ internal static class KiroReviewerCapability {
 
             KiroReviewerDecision.VersionNoMinimum =>
                 "kiro_reviewer_version_no_minimum: this daemon has no recorded minimum kiro-cli "
-              + "version, so there is nothing to check the installed build against. The usual cause is "
-              + "enabling the reviewer against an already-running daemon — it records a minimum at "
-              + "startup, so restart it with KCAP_KIRO_UNATTENDED_REVIEWER set. To set one now without "
-              + "restarting, run `kcap daemon reviewer affirm --vendor kiro`.",
+              + "version, so there is nothing to check the installed build against. A daemon records "
+              + "one automatically at startup, so the usual cause is that the version probe failed "
+              + "then — check that `kiro-cli --version` succeeds for the daemon user, and restart. To "
+              + "record one now without restarting, run `kcap daemon reviewer affirm --vendor kiro`.",
 
             KiroReviewerDecision.VersionIncomparable =>
                 $"kiro_reviewer_version_incomparable: kiro-cli {Describe(installedVersion)} and this "

--- a/src/Capacitor.Cli.Daemon/Acp/OpenCodeReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/OpenCodeReviewerCapability.cs
@@ -16,15 +16,20 @@ internal enum OpenCodeReviewerDecision {
 /// Whether THIS daemon may run OpenCode as an unattended review-flow reviewer. Pure, so every arm is
 /// testable without a vendor or a process.
 ///
-/// <para><b>What enabling it consents to.</b> The reviewer's tool surface is deliberately narrow —
-/// <see cref="OpenCodeReviewerPermissions"/> denies everything and admits only the read family plus the
-/// injected result channel, with no shell and no write, verified against a positive control. But
-/// <c>read</c>/<c>grep</c>/<c>glob</c>/<c>list</c> are NOT path-scoped: they are whole-filesystem read
-/// primitives under the daemon's uid. So a review can read every file this daemon user can read, its
-/// own credentials included, and its findings text goes back to whoever requested the review. That risk
-/// lands on the daemon OPERATOR, who is not necessarily the requester, which is why the decision is
-/// daemon-local configuration and enabling it is the consent event. Identical in substance to the Kiro
-/// gate; the narrower tool surface changes the blast radius of a WRITE, not of a read.</para>
+/// <para><b>ENABLED by default; the switch is an opt-OUT.</b> It shipped as an opt-in and that was
+/// wrong. The reviewer vendor is a caller-chosen parameter, and Claude, Codex, Cursor and Copilot have
+/// never been gated — each running with FULL tool access. So the gate stopped nobody (request an
+/// ungated vendor instead) while taxing the honest path with a service-unit edit and a restart. It was
+/// also attached to the wrong end of the risk scale: this is the most contained reviewer of the eight —
+/// no shell, no write, no network, only <c>read</c>/<c>grep</c>/<c>glob</c>/<c>list</c> plus its own
+/// result channel, verified against a positive control.</para>
+///
+/// <para><b>The residual risk is real and unchanged, it just is not what a per-vendor gate addressed.</b>
+/// Those read tools are NOT path-scoped: they are whole-filesystem read primitives under the daemon's
+/// uid, so a review can read every file this daemon user can and its findings text goes back to the
+/// requester. That is equally true of the four never-gated vendors, which can additionally write and
+/// execute — so the honest framing is that running ANY unattended reviewer is the decision, not running
+/// this one.</para>
 ///
 /// <para><b>Why a version MINIMUM rather than a certified set or an exact affirmation.</b> Same model
 /// as Kiro and Gemini, and for the same reason: containment here is source suppression plus a
@@ -87,13 +92,11 @@ internal static class OpenCodeReviewerCapability {
               + "owner-only on this platform — another local user could seed MCP servers into it.",
 
             OpenCodeReviewerDecision.Disabled =>
-                "opencode_unattended_reviewer_disabled: this daemon has not enabled OpenCode as an "
-              + "unattended review-flow reviewer. The reviewer gets no shell and no write tools, but its "
-              + "read tools are NOT path-scoped: enabling this grants a review read access to every file "
-              + "this daemon user can read — including its own credentials — and a reviewer can return "
-              + "what it read to whoever requested the review. Enable it only on a daemon whose operator "
-              + "and review requesters are in one trust domain: set "
-              + "KCAP_OPENCODE_UNATTENDED_REVIEWER=1 in the daemon's environment (not on the server).",
+                "opencode_unattended_reviewer_disabled: this daemon has EXPLICITLY disabled OpenCode as "
+              + "an unattended review-flow reviewer. Unset KCAP_OPENCODE_UNATTENDED_REVIEWER in the "
+              + "daemon's environment (not on the server) to restore the default, which is enabled — or "
+              + "set it to 1. For context, this is the most contained reviewer available: no shell, no "
+              + "write, no network — only read/grep/glob/list plus its own result channel.",
 
             OpenCodeReviewerDecision.VersionUnresolved =>
                 "opencode_reviewer_version_unresolved: the installed opencode version could not be "
@@ -102,10 +105,10 @@ internal static class OpenCodeReviewerCapability {
 
             OpenCodeReviewerDecision.VersionNoMinimum =>
                 "opencode_reviewer_version_no_minimum: this daemon has no recorded minimum opencode "
-              + "version, so there is nothing to check the installed build against. The usual cause is "
-              + "enabling the reviewer against an already-running daemon — it records a minimum at "
-              + "startup, so restart it with KCAP_OPENCODE_UNATTENDED_REVIEWER set. To set one now "
-              + "without restarting, run `kcap daemon reviewer affirm --vendor opencode`.",
+              + "version, so there is nothing to check the installed build against. A daemon records "
+              + "one automatically at startup, so the usual cause is that the version probe failed "
+              + "then — check that `opencode --version` succeeds for the daemon user, and restart. To "
+              + "record one now without restarting, run `kcap daemon reviewer affirm --vendor opencode`.",
 
             OpenCodeReviewerDecision.VersionIncomparable =>
                 $"opencode_reviewer_version_incomparable: opencode {Describe(installedVersion)} and this "

--- a/src/Capacitor.Cli.Daemon/Acp/OpenCodeReviewerCapability.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/OpenCodeReviewerCapability.cs
@@ -18,8 +18,11 @@ internal enum OpenCodeReviewerDecision {
 ///
 /// <para><b>ENABLED by default; the switch is an opt-OUT.</b> It shipped as an opt-in and that was
 /// wrong. The reviewer vendor is a caller-chosen parameter, and Claude, Codex, Cursor and Copilot have
-/// never been gated — each running with FULL tool access. So the gate stopped nobody (request an
-/// ungated vendor instead) while taxing the honest path with a service-unit edit and a restart. It was
+/// never been gated — each running with FULL tool access. So on any daemon that also ADVERTISES one of
+/// those, the gate did not widen the capability class a requester could reach (they ask for an ungated
+/// vendor with MORE capability) while taxing the honest path with a service-unit edit and a restart.
+/// On a daemon advertising only gated vendors it did separate the hosted role from the unattended
+/// reviewer role, and the flip genuinely widens what a non-operator can cause to run. It was
 /// also attached to the wrong end of the risk scale: this is the most contained reviewer of the eight —
 /// no shell, no write, no network, only <c>read</c>/<c>grep</c>/<c>glob</c>/<c>list</c> plus its own
 /// result channel, verified against a positive control.</para>

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -177,35 +177,36 @@ public class DaemonConfig {
     public string? KiroModel { get; set; }
 
     /// <summary>
-    /// Whether THIS daemon may run Gemini as an unattended review-flow reviewer. **Default false, and
-    /// enabling it is the operator's consent event.**
+    /// Whether THIS daemon may run Gemini as an unattended review-flow reviewer. **Default TRUE — the
+    /// variable is an opt-OUT.**
     ///
     /// <para>An unattended reviewer runs in a daemon-owned worktree with this daemon's own HOME, so
     /// repository content that steers the model into tool use gets code execution with this user's full
     /// authority — including the credentials in the token store, writes that reach other worktrees and the
-    /// installed CLI, and processes that outlive the review. That risk lands on whoever runs this daemon,
-    /// who is not necessarily the person requesting the review, which is why the decision lives here in
-    /// daemon-local configuration and not in the server's flow settings.</para>
+    /// installed CLI, and processes that outlive the review. That is a genuine risk and it is unchanged.
+    /// What changed is the recognition that a PER-VENDOR gate never addressed it: the reviewer vendor is
+    /// a caller-chosen parameter, and Claude, Codex, Cursor and Copilot have the same authority with no
+    /// gate at all, so anyone the gate excluded just asked for one of those.</para>
     ///
-    /// <para>Enabling it does NOT bypass the build affirmation: the reviewer's only containment is the
-    /// vendor's exact-name MCP allowlist, which is a behaviour of the installed build, so a build other than
-    /// the affirmed one is refused even when this is true. Enabling seeds the affirmation from whatever is
-    /// installed, so that is only met after an upgrade. See <c>GeminiReviewerCapability</c>.</para>
+    /// <para>The build affirmation still applies: the reviewer's containment is the vendor's exact-name
+    /// MCP allowlist, a behaviour of the installed build, so a build BELOW this daemon's recorded floor
+    /// is refused. The floor is seeded automatically at startup so it never blocks a first launch —
+    /// see <c>GeminiReviewerCapability</c>.</para>
     ///
-    /// <para>Set via <c>KCAP_GEMINI_UNATTENDED_REVIEWER</c> in the DAEMON's environment, which for a
-    /// supervised daemon means the service unit — <c>ServiceEnvironment</c> carries it there, since a
-    /// unit inherits nothing from the installing shell.</para>
+    /// <para>Set <c>KCAP_GEMINI_UNATTENDED_REVIEWER=0</c> in the DAEMON's environment to disable, which
+    /// for a supervised daemon means the service unit — <c>ServiceEnvironment</c> carries it there,
+    /// since a unit inherits nothing from the installing shell.</para>
     /// </summary>
-    public bool GeminiUnattendedReviewerEnabled { get; set; }
+    public bool GeminiUnattendedReviewerEnabled { get; set; } = true;
 
     /// <summary>
-    /// Whether THIS daemon may run Kiro as an unattended review-flow reviewer. Off by default, and
-    /// turning it on is the operator's consent event — see <c>KiroReviewerCapability</c> for exactly
-    /// what is being consented to, which is broader than it looks: a trusted read tool is not
-    /// path-scoped, so a review can read every file this daemon user can read and return what it read
-    /// to whoever requested the review. Overridable via <c>KCAP_KIRO_UNATTENDED_REVIEWER</c>.
+    /// Whether THIS daemon may run Kiro as an unattended review-flow reviewer. **Default TRUE — the
+    /// variable is an opt-OUT** (<c>KCAP_KIRO_UNATTENDED_REVIEWER=0</c> disables). A trusted read tool
+    /// is not path-scoped, so a review can read every file this daemon user can and return it to the
+    /// requester — true here and equally true of the never-gated Claude/Codex/Cursor/Copilot reviewers,
+    /// which can additionally write and execute. See <c>KiroReviewerCapability</c>.
     /// </summary>
-    public bool KiroUnattendedReviewerEnabled { get; set; }
+    public bool KiroUnattendedReviewerEnabled { get; set; } = true;
 
     /// <summary>
     /// One absolute budget, in seconds, for a Kiro reviewer launch: spawn through the first prompt
@@ -233,15 +234,15 @@ public class DaemonConfig {
     /// which is a clean audit signal rather than a silent downgrade.</summary>
     public string? AntigravityModel { get; set; }
 
-    /// <summary>Operator consent for unattended Antigravity reviews. Fail-closed: only an
-    /// explicit affirmative enables it. Overridable via
-    /// <c>KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER</c>.
+    /// <summary>Whether THIS daemon may run unattended Antigravity reviews. **Default TRUE — the
+    /// variable is an opt-OUT** (<c>KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER=0</c> disables), matching the
+    /// never-gated Claude/Codex/Cursor/Copilot reviewers that carry the same authority.
     ///
     /// <para>The minimum <c>agy</c> build is deliberately NOT config: it is a daemon-owned record
     /// (<c>ReviewerVersionStore</c>, moved by <c>kcap daemon reviewer affirm --vendor antigravity</c>),
     /// exactly as for Kiro and Gemini. A floor an operator could set from a shell profile would be
     /// re-affirmed by their dotfiles rather than by them.</para></summary>
-    public bool AntigravityUnattendedReviewerEnabled { get; set; }
+    public bool AntigravityUnattendedReviewerEnabled { get; set; } = true;
 
     /// <summary>Absolute ceiling on the FIRST turn — spawn, NDJSON handshake and auth. An
     /// unauthenticated agy can sit on an interactive OAuth wait, so this is what turns that into a
@@ -278,14 +279,12 @@ public class DaemonConfig {
     public string? OpenCodeModel { get; set; }
 
     /// <summary>
-    /// Whether THIS daemon may run OpenCode as an unattended review-flow reviewer. Off by default, and
-    /// turning it on is the operator's consent event — see <c>OpenCodeReviewerCapability</c> for exactly
-    /// what is being consented to. The reviewer gets no shell and no write tools, but its read tools are
-    /// not path-scoped, so a review can read every file this daemon user can read and return what it
-    /// read to whoever requested the review. Overridable via
-    /// <c>KCAP_OPENCODE_UNATTENDED_REVIEWER</c>.
+    /// Whether THIS daemon may run OpenCode as an unattended review-flow reviewer. **Default TRUE — the
+    /// variable is an opt-OUT** (<c>KCAP_OPENCODE_UNATTENDED_REVIEWER=0</c> disables). This is the most
+    /// contained reviewer of the eight: no shell, no write, no network. Its read tools are still not
+    /// path-scoped, as with every other reviewer. See <c>OpenCodeReviewerCapability</c>.
     /// </summary>
-    public bool OpenCodeUnattendedReviewerEnabled { get; set; }
+    public bool OpenCodeUnattendedReviewerEnabled { get; set; } = true;
 
     /// <summary>
     /// One absolute budget, in seconds, for an OpenCode reviewer launch: spawn through the first prompt

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -169,13 +169,15 @@ public static partial class DaemonRunner {
         // argument and its three precisions — in short, the reviewer vendor is a caller-chosen
         // parameter, so wherever an ungated vendor is also advertised, gating these four did not widen
         // the capability class a requester could reach, and only taxed the honest path.
-        foreach (var (variable, apply) in new (string, Action<bool>)[] {
-            ("KCAP_GEMINI_UNATTENDED_REVIEWER",      v => config.GeminiUnattendedReviewerEnabled      = v),
-            ("KCAP_KIRO_UNATTENDED_REVIEWER",        v => config.KiroUnattendedReviewerEnabled        = v),
-            ("KCAP_OPENCODE_UNATTENDED_REVIEWER",    v => config.OpenCodeUnattendedReviewerEnabled    = v),
-            ("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER", v => config.AntigravityUnattendedReviewerEnabled = v),
-        }) {
-            var raw = Environment.GetEnvironmentVariable(variable);
+        // Iterates the SHARED registry, not a local list. A vendor listed here but missing from
+        // GatedReviewers.All would be absent from every service unit (ServiceEnvironment derives the
+        // allowlist from the same rows), leaving a reviewer that cannot be turned off on the supported
+        // install path — so there is one list, and ConsentApplier below fails the boot rather than
+        // silently skipping a row it has no accessor for.
+        foreach (var reviewer in GatedReviewers.All) {
+            var variable = reviewer.EnableEnvVar;
+            var apply    = ConsentApplier(config, reviewer.Vendor);
+            var raw      = Environment.GetEnvironmentVariable(variable);
             apply(ParseConsentFlag(raw));
 
             // Warned for EVERY variable, from the same loop that applies it, so a mangled value can
@@ -917,6 +919,31 @@ public static partial class DaemonRunner {
     /// production callers.</para>
     /// </summary>
     internal static bool ParseConsentFlag(string? value) => RecogniseConsent(value) ?? false;
+
+    /// <summary>
+    /// Where a gated reviewer's opt-out lands on <see cref="DaemonConfig"/>.
+    ///
+    /// <para><b>Throws for an unknown vendor rather than returning null or a no-op.</b> The one caller
+    /// iterates <see cref="GatedReviewers.All"/>, so an unmapped row means someone added a reviewer to
+    /// the registry — which puts its variable into every service unit and into
+    /// <c>daemon reviewer affirm</c>'s usage text — without wiring the daemon to actually read it. The
+    /// operator would then set the documented variable and watch it do nothing: an opt-out that appears
+    /// to exist and does not. Refusing to boot turns that into a failure the author hits immediately,
+    /// and <c>Consent_applier_covers_every_gated_reviewer</c> hits it in CI first.</para>
+    ///
+    /// <para>A string switch has no compiler exhaustiveness, which is exactly why the throw is here and
+    /// not a discard arm.</para>
+    /// </summary>
+    internal static Action<bool> ConsentApplier(DaemonConfig config, string vendor) => vendor switch {
+        "gemini"      => v => config.GeminiUnattendedReviewerEnabled      = v,
+        "kiro"        => v => config.KiroUnattendedReviewerEnabled        = v,
+        "opencode"    => v => config.OpenCodeUnattendedReviewerEnabled    = v,
+        "antigravity" => v => config.AntigravityUnattendedReviewerEnabled = v,
+        _ => throw new NotSupportedException(
+            $"Gated reviewer '{vendor}' is in GatedReviewers.All but no DaemonConfig flag is wired to "
+          + $"its opt-out switch, so setting {GatedReviewers.Resolve(vendor)?.EnableEnvVar ?? "it"} "
+          + "would silently do nothing. Add the accessor here.")
+    };
 
     /// <summary>
     /// The ONE value set: true, false, or null for "set but unrecognised". Both

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -848,14 +848,23 @@ public static partial class DaemonRunner {
     /// opt-OUT, and it used to be an opt-in. Same polarity as
     /// <see cref="ParseAcpReconnectFlag"/> now, where it used to be deliberately the opposite.
     ///
-    /// <para><b>Why the default flipped.</b> The opt-in gate did not do the job it claimed. The reviewer
-    /// vendor is a caller-chosen parameter, and Claude, Codex, Cursor and Copilot have never been gated
-    /// at all — each of them running with FULL tool access (shell and write) in the same worktree. So
-    /// anyone the gate was supposed to stop simply requested an ungated vendor with more capability,
-    /// while the honest path paid a service-unit edit and a restart. A control every caller can route
-    /// around by picking a different value from a menu is friction, not security. Worse, two of the four
-    /// gated vendors (Kiro, OpenCode) run READ-ONLY reviewers, so the strictest policy was attached to
-    /// the least dangerous configuration.</para>
+    /// <para><b>Why the default flipped.</b> The reviewer vendor is a caller-chosen parameter, and
+    /// Claude, Codex, Cursor and Copilot have never been gated at all — each running with FULL tool
+    /// access (shell and write) in the same worktree. <b>On any daemon that also advertises one of
+    /// those</b> — the overwhelmingly common case — the gate excluded nobody: a requester it blocked
+    /// from one vendor simply asked for an ungated one with more capability, while the honest path paid
+    /// a service-unit edit and a restart. Worse, two of the four gated vendors (Kiro, OpenCode) run
+    /// READ-ONLY reviewers, so the strictest policy sat on the least dangerous configurations.</para>
+    ///
+    /// <para><b>The contingency, stated because the claim above is NOT universal</b> (review found this,
+    /// and an earlier revision of this comment asserted it unconditionally). On a daemon where the
+    /// operator installed ONLY a gated vendor's CLI — for hosted/interactive work, the ordinary reason
+    /// to install one — and no ungated vendor, these variables were the only thing separating the
+    /// hosted role from the unattended-reviewer role. There, the flip does widen what a requester who is
+    /// not the operator can cause to run with no human in the loop. That is accepted rather than
+    /// unnoticed: the operator keeps an explicit opt-out, the version floor still gates the build, and
+    /// <c>kcap daemon consent</c> is the control that actually scopes unattended launches — unlike a
+    /// per-vendor switch, it cannot be routed around by naming a different vendor.</para>
     ///
     /// <para><b>What still protects the launch.</b> The per-vendor version FLOOR
     /// (<see cref="ReviewerVersionAffirmations"/>), which is a different mechanism with a different job:
@@ -871,10 +880,34 @@ public static partial class DaemonRunner {
     /// rule the feature-gate work follows, so a typo in a service unit cannot take a daemon's reviewer
     /// offline without saying so.</para>
     /// </summary>
-    internal static bool ParseConsentFlag(string? value) {
+    internal static bool ParseConsentFlag(string? value) => RecogniseConsent(value) ?? true;
+
+    /// <summary>
+    /// The ONE value set: true, false, or null for "set but unrecognised". Both
+    /// <see cref="ParseConsentFlag"/> and <see cref="DescribeUnparseableConsent"/> are derived from it.
+    ///
+    /// <para><b>Why one method rather than two agreeing ones.</b> Review caught the shape: a parse and a
+    /// separate "is this recognised?" predicate are two things that must agree with nothing making them.
+    /// Add a falsey spelling to the parse only and every correctly-configured daemon warns on every boot
+    /// forever; add a truthy spelling to the predicate only and a typo is silently swallowed. They did
+    /// agree, but by inspection. Now they cannot disagree.</para>
+    ///
+    /// <para><b>Matched surrounding quotes are stripped</b>, because the realistic way a DISABLE attempt
+    /// becomes unrecognised is a quoting artifact — a mis-quoted service-unit entry, a <c>.cmd</c>
+    /// wrapper's <c>set "K=V"</c>, a hand-edited plist — and the value then arrives as literal
+    /// <c>"0"</c>. Since disabling is now the operator's only lever, a fail-open there is the one
+    /// mistake worth spending three lines to prevent. One level only: a value that is still unrecognised
+    /// after stripping is reported, not stripped again.</para>
+    /// </summary>
+    internal static bool? RecogniseConsent(string? value) {
         var v = value?.Trim();
 
         if (string.IsNullOrEmpty(v)) return true;   // unset — the new default
+
+        if (v.Length >= 2 && (v[0] == '"' || v[0] == '\'') && v[^1] == v[0])
+            v = v[1..^1].Trim();
+
+        if (v.Length == 0) return true;
 
         if (v == "0"
          || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase)
@@ -882,33 +915,28 @@ public static partial class DaemonRunner {
          || string.Equals(v, "off",   StringComparison.OrdinalIgnoreCase))
             return false;
 
-        return true;
+        if (v == "1"
+         || string.Equals(v, "true", StringComparison.OrdinalIgnoreCase)
+         || string.Equals(v, "yes",  StringComparison.OrdinalIgnoreCase)
+         || string.Equals(v, "on",   StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return null;   // set, but says nothing this daemon understands
     }
 
     /// <summary>
     /// A warning for a consent variable that is SET but says nothing this daemon recognises, or null
-    /// when there is nothing to report. Split from <see cref="ParseConsentFlag"/> so the parse stays
-    /// pure and total: an operator who typed <c>flase</c> meaning to disable a reviewer would otherwise
-    /// get it enabled with no signal at all, which is precisely the direction worth being loud about.
+    /// when there is nothing to report.
+    ///
+    /// <para>An operator who typed <c>flase</c> meaning to disable a reviewer would otherwise get it
+    /// enabled with no signal at all, which is the direction worth being loud about now that disabling
+    /// is the only lever.</para>
     /// </summary>
-    internal static string? DescribeUnparseableConsent(string variable, string? value) {
-        var v = value?.Trim();
-
-        if (string.IsNullOrEmpty(v)) return null;
-
-        var recognised = v is "0" or "1"
-            || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(v, "true",  StringComparison.OrdinalIgnoreCase)
-            || string.Equals(v, "no",    StringComparison.OrdinalIgnoreCase)
-            || string.Equals(v, "yes",   StringComparison.OrdinalIgnoreCase)
-            || string.Equals(v, "off",   StringComparison.OrdinalIgnoreCase)
-            || string.Equals(v, "on",    StringComparison.OrdinalIgnoreCase);
-
-        return recognised
-            ? null
-            : $"{variable} is set to '{v}', which this daemon does not recognise as true or false. "
-            + "Treating it as ENABLED (the default). Use 0/false/no/off to disable this reviewer.";
-    }
+    internal static string? DescribeUnparseableConsent(string variable, string? value) =>
+        RecogniseConsent(value) is null
+            ? $"{variable} is set to '{value?.Trim()}', which this daemon does not recognise as true or "
+            + "false. Treating it as ENABLED (the default). Use 0/false/no/off to disable this reviewer."
+            : null;
 
     /// <summary>
     /// True when a "cursor" <see cref="IHostedAgentRuntimeFactory"/> is registered but

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -164,20 +164,25 @@ public static partial class DaemonRunner {
             config.AntigravityPath = agyPath;
         if (Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_MODEL") is { Length: > 0 } agyModel)
             config.AntigravityModel = agyModel;
-        if (Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER") is { } agyConsent)
-            config.AntigravityUnattendedReviewerEnabled = ParseConsentFlag(agyConsent);
+        // The per-vendor reviewer switches. These are OPT-OUT now: unset means enabled, matching
+        // Claude/Codex/Cursor/Copilot, which have never been gated. See ParseConsentFlag for why the
+        // opt-in gate was removed — in short, the reviewer vendor is a caller-chosen parameter, so
+        // gating four vendors while four others ran with MORE capability stopped nobody and only
+        // taxed the honest path.
+        foreach (var (variable, apply) in new (string, Action<bool>)[] {
+            ("KCAP_GEMINI_UNATTENDED_REVIEWER",      v => config.GeminiUnattendedReviewerEnabled      = v),
+            ("KCAP_KIRO_UNATTENDED_REVIEWER",        v => config.KiroUnattendedReviewerEnabled        = v),
+            ("KCAP_OPENCODE_UNATTENDED_REVIEWER",    v => config.OpenCodeUnattendedReviewerEnabled    = v),
+            ("KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER", v => config.AntigravityUnattendedReviewerEnabled = v),
+        }) {
+            var raw = Environment.GetEnvironmentVariable(variable);
+            apply(ParseConsentFlag(raw));
 
-        // The operator consent flags for the unattended ACP/CLI reviewers. Both were previously
-        // reachable only from a test constructor, which made the shipped Gemini reviewer impossible
-        // to turn on in production; binding one and not the other would just move that hole.
-        config.GeminiUnattendedReviewerEnabled =
-            ParseConsentFlag(Environment.GetEnvironmentVariable("KCAP_GEMINI_UNATTENDED_REVIEWER"));
-
-        config.KiroUnattendedReviewerEnabled =
-            ParseConsentFlag(Environment.GetEnvironmentVariable("KCAP_KIRO_UNATTENDED_REVIEWER"));
-
-        config.OpenCodeUnattendedReviewerEnabled =
-            ParseConsentFlag(Environment.GetEnvironmentVariable("KCAP_OPENCODE_UNATTENDED_REVIEWER"));
+            // A value we cannot read is treated as the default (enabled), so an operator who meant to
+            // DISABLE and mistyped it would otherwise get the opposite with no signal whatsoever.
+            if (DescribeUnparseableConsent(variable, raw) is { } warning)
+                await Console.Error.WriteLineAsync(warning);
+        }
 
         config.DebugFrames = ParseDebugFramesFlag(Environment.GetEnvironmentVariable("KCAP_ACP_DEBUG_FRAMES"));
 
@@ -245,10 +250,6 @@ public static partial class DaemonRunner {
         var coverageStateDir = Path.Combine(
             config.StateDir ?? DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(config.Name));
         SeedReviewerFloors(coverageStateDir, config);
-
-        SeedReviewerAffirmation(
-            coverageStateDir, AcpVendorDescriptors.OpenCode.Vendor,
-            config.OpenCodeUnattendedReviewerEnabled, config.OpenCodePath);
 
         // Recovers reviewer homes left by a SIGKILLed predecessor. Runs unconditionally: a daemon
         // whose operator has since disabled the reviewer still owns whatever its last incarnation
@@ -848,12 +849,71 @@ public static partial class DaemonRunner {
     /// enables it, and unset, blank or unrecognised leaves it OFF. Enabling one of these is a
     /// security consent event, so a typo must not be read as consent.
     /// </summary>
-    internal static bool ParseConsentFlag(string? value) =>
-        value?.Trim() is { Length: > 0 } v
-     && (v == "1"
-      || string.Equals(v, "true", StringComparison.OrdinalIgnoreCase)
-      || string.Equals(v, "yes",  StringComparison.OrdinalIgnoreCase)
-      || string.Equals(v, "on",   StringComparison.OrdinalIgnoreCase));
+    /// <summary>
+    /// Whether a gated reviewer vendor is permitted on this daemon. **Absent means ENABLED** — this is
+    /// an opt-OUT, and it used to be an opt-in.
+    ///
+    /// <para><b>Why the default flipped.</b> The opt-in gate did not do the job it claimed. The reviewer
+    /// vendor is a caller-chosen parameter, and Claude, Codex, Cursor and Copilot have never been gated
+    /// at all — each of them running with FULL tool access (shell and write) in the same worktree. So
+    /// anyone the gate was supposed to stop simply requested an ungated vendor with more capability,
+    /// while the honest path paid a service-unit edit and a restart. A control every caller can route
+    /// around by picking a different value from a menu is friction, not security. Worse, two of the four
+    /// gated vendors (Kiro, OpenCode) run READ-ONLY reviewers, so the strictest policy was attached to
+    /// the least dangerous configuration.</para>
+    ///
+    /// <para><b>What still protects the launch.</b> The per-vendor version FLOOR
+    /// (<see cref="ReviewerVersionAffirmations"/>), which is a different mechanism with a different job:
+    /// several of these vendors' containment is environment-based, and env vars fail SILENTLY when a
+    /// build stops honouring them. The floor is seeded automatically at first boot so it never blocks a
+    /// first launch, and `kcap daemon reviewer affirm` raises it past a build found to be bad. That is
+    /// remediation, not permission.</para>
+    ///
+    /// <para><b>An explicit opt-out is preserved</b> rather than deleting the variable, because silently
+    /// ENABLING something an operator had deliberately set to <c>0</c> is the one surprise this change
+    /// must not spring. Recognised falsey values disable; recognised truthy values enable; anything else
+    /// falls back to the default and is reported by <see cref="DescribeUnparseableConsent"/> — the same
+    /// rule the feature-gate work follows, so a typo in a service unit cannot take a daemon's reviewer
+    /// offline without saying so.</para>
+    /// </summary>
+    internal static bool ParseConsentFlag(string? value) {
+        var v = value?.Trim();
+
+        if (string.IsNullOrEmpty(v)) return true;   // unset — the new default
+
+        if (v == "0"
+         || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase)
+         || string.Equals(v, "no",    StringComparison.OrdinalIgnoreCase)
+         || string.Equals(v, "off",   StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// A warning for a consent variable that is SET but says nothing this daemon recognises, or null
+    /// when there is nothing to report. Split from <see cref="ParseConsentFlag"/> so the parse stays
+    /// pure and total: an operator who typed <c>flase</c> meaning to disable a reviewer would otherwise
+    /// get it enabled with no signal at all, which is precisely the direction worth being loud about.
+    /// </summary>
+    internal static string? DescribeUnparseableConsent(string variable, string? value) {
+        var v = value?.Trim();
+
+        if (string.IsNullOrEmpty(v)) return null;
+
+        var recognised = v is "0" or "1"
+            || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(v, "true",  StringComparison.OrdinalIgnoreCase)
+            || string.Equals(v, "no",    StringComparison.OrdinalIgnoreCase)
+            || string.Equals(v, "yes",   StringComparison.OrdinalIgnoreCase)
+            || string.Equals(v, "off",   StringComparison.OrdinalIgnoreCase)
+            || string.Equals(v, "on",    StringComparison.OrdinalIgnoreCase);
+
+        return recognised
+            ? null
+            : $"{variable} is set to '{v}', which this daemon does not recognise as true or false. "
+            + "Treating it as ENABLED (the default). Use 0/false/no/off to disable this reviewer.";
+    }
 
     /// <summary>
     /// True when a "cursor" <see cref="IHostedAgentRuntimeFactory"/> is registered but
@@ -899,6 +959,10 @@ public static partial class DaemonRunner {
             stateDir, AcpVendorDescriptors.Gemini.Vendor,
             config.GeminiUnattendedReviewerEnabled, config.GeminiPath);
 
+        SeedReviewerAffirmation(
+            stateDir, AcpVendorDescriptors.OpenCode.Vendor,
+            config.OpenCodeUnattendedReviewerEnabled, config.OpenCodePath);
+
         SeedVersionFloor(stateDir, AntigravityVendor, config.AntigravityPath);
     }
 
@@ -911,6 +975,12 @@ public static partial class DaemonRunner {
     /// a write that a directory at the pathname makes throw — bricking a boot on a file that is
     /// supposed to fail closed, never fatally.</para>
     /// </summary>
+    /// <param name="enabled">The vendor's opt-out state. Only skips the probe for a vendor the operator
+    /// has EXPLICITLY disabled — which is now the rare case, since the switch defaults to enabled.
+    /// Seeding on the ordinary path is what keeps the version floor from blocking a first launch: with
+    /// no record, the gate answers <c>version_no_minimum</c>, and that is a refusal only
+    /// <c>kcap daemon reviewer affirm</c> can clear. A floor is meant to exclude a build found to be
+    /// bad, not to be an opt-in gate wearing a different hat.</param>
     internal static void SeedReviewerAffirmation(
             string stateDir, string vendor, bool enabled, string binaryPath) {
         if (!enabled) return;

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -165,10 +165,10 @@ public static partial class DaemonRunner {
         if (Environment.GetEnvironmentVariable("KCAP_ANTIGRAVITY_MODEL") is { Length: > 0 } agyModel)
             config.AntigravityModel = agyModel;
         // The per-vendor reviewer switches. These are OPT-OUT now: unset means enabled, matching
-        // Claude/Codex/Cursor/Copilot, which have never been gated. See ParseConsentFlag for why the
-        // opt-in gate was removed — in short, the reviewer vendor is a caller-chosen parameter, so
-        // gating four vendors while four others ran with MORE capability stopped nobody and only
-        // taxed the honest path.
+        // Claude/Codex/Cursor/Copilot, which have never been gated. See ParseConsentFlag for the full
+        // argument and its three precisions — in short, the reviewer vendor is a caller-chosen
+        // parameter, so wherever an ungated vendor is also advertised, gating these four did not widen
+        // the capability class a requester could reach, and only taxed the honest path.
         foreach (var (variable, apply) in new (string, Action<bool>)[] {
             ("KCAP_GEMINI_UNATTENDED_REVIEWER",      v => config.GeminiUnattendedReviewerEnabled      = v),
             ("KCAP_KIRO_UNATTENDED_REVIEWER",        v => config.KiroUnattendedReviewerEnabled        = v),
@@ -178,8 +178,11 @@ public static partial class DaemonRunner {
             var raw = Environment.GetEnvironmentVariable(variable);
             apply(ParseConsentFlag(raw));
 
-            // A value we cannot read is treated as the default (enabled), so an operator who meant to
-            // DISABLE and mistyped it would otherwise get the opposite with no signal whatsoever.
+            // Warned for EVERY variable, from the same loop that applies it, so a mangled value can
+            // never be silently swallowed on one vendor because a hand-maintained warning list missed
+            // it. A value we cannot read DISABLES (see ParseConsentFlag) — the operator's evident
+            // intent, since unset already enables — and the symptom of the opposite mistake is a
+            // reviewer that simply stops being advertised, which is why it says so out loud.
             if (DescribeUnparseableConsent(variable, raw) is { } warning)
                 await Console.Error.WriteLineAsync(warning);
         }
@@ -869,29 +872,30 @@ public static partial class DaemonRunner {
     /// unattended-reviewer role, and the flip genuinely widens what a non-operator requester can cause
     /// to run with no human in the loop.</para>
     ///
-    /// <para><b>What actually compensates, stated without inflation.</b> The operator keeps an explicit
-    /// opt-out. <c>kcap daemon consent</c> is the only control that scopes unattended launches as such —
-    /// but note it DEFAULTS TO ALLOW, so it compensates only for an operator who has configured it, not
-    /// for the average daemon. The version floor is deliberately NOT on this list: it constrains which
-    /// BUILD runs, never whether a non-operator can cause an unattended launch, and counting it as a
-    /// compensating control would inflate the set.</para>
+    /// <para><b>What actually compensates, stated without inflation.</b> Exactly two things, and the
+    /// floor in the DEFAULT configuration is worth saying plainly: on a fresh daemon that has not been
+    /// configured further, the only thing between a non-operator requester and an unattended gated-vendor
+    /// launch is that the vendor be installed, certified and above its version floor.
+    /// <list type="number">
+    /// <item>The operator keeps an explicit opt-out — and it is REACHABLE on the supported install path:
+    /// <see cref="Cli.Services.ServiceEnvironment"/> carries these four variables into a service unit on
+    /// every platform, DERIVED from the affirmable-reviewer registry so a new vendor cannot be omitted.
+    /// The caveat is timing, not reachability: a supervised daemon's environment is FROZEN at
+    /// <c>kcap daemon service install</c>, so an opt-out set afterwards needs a reinstall to take
+    /// effect.</item>
+    /// <item><c>kcap daemon consent</c> is the only control that scopes unattended launches as such — but
+    /// it DEFAULTS TO ALLOW, so it compensates only for an operator who has configured it, not for the
+    /// average daemon.</item>
+    /// </list></para>
     ///
-    /// <para><b>What still protects the launch.</b> The per-vendor version FLOOR
-    /// (<see cref="ReviewerVersionAffirmations"/>), which is a different mechanism with a different job:
-    /// several of these vendors' containment is environment-based, and env vars fail SILENTLY when a
-    /// build stops honouring them. The floor is seeded automatically at first boot so it never blocks a
-    /// first launch, and `kcap daemon reviewer affirm` raises it past a build found to be bad. That is
-    /// remediation, not permission.</para>
+    /// <para><b>The version floor is deliberately NOT a third entry</b>, though it is easy to count as
+    /// one. It constrains which BUILD runs, never whether a non-operator can cause an unattended launch;
+    /// it is seeded automatically at first boot precisely so it never blocks a first launch. It is real
+    /// protection against a different failure — several of these vendors' containment is environment-based
+    /// and fails SILENTLY when a build stops honouring it, which is what
+    /// <c>kcap daemon reviewer affirm</c> exists to remediate. Remediation, not permission.</para>
     ///
-    /// <para><b>An explicit opt-out is preserved</b> rather than deleting the variable, because silently
-    /// ENABLING something an operator had deliberately set to <c>0</c> is the one surprise this change
-    /// must not spring. Recognised falsey values disable; recognised truthy values enable; anything else
-    /// falls back to the default and is reported by <see cref="DescribeUnparseableConsent"/> — the same
-    /// rule the feature-gate work follows, so a typo in a service unit cannot take a daemon's reviewer
-    /// offline without saying so.</para>
-    /// </summary>
-    /// <summary>
-    /// <b>Unset means enabled; a value we cannot read means DISABLED.</b>
+    /// <para><b>Unset means enabled; a value we cannot read means DISABLED.</b>
     ///
     /// <para>Those two are not in tension, and the asymmetry is the point. Since unset already enables,
     /// the only reason to set one of these variables at all is to turn a reviewer OFF — enabling needs no
@@ -903,6 +907,14 @@ public static partial class DaemonRunner {
     /// <para>The direction is also cheap in the wrong case: a typo'd ENABLE attempt (<c>=y</c>,
     /// <c>=enabled</c>) lands on the pre-change behaviour, which is the safe side, and the operator still
     /// gets the warning either way.</para>
+    ///
+    /// <para><b>That justification does not generalise, so do not reuse this from anywhere else.</b> It
+    /// rests on TWO facts specific to the four reviewer variables: unset already means enabled, and
+    /// disabling is therefore the only possible intent behind setting one. A setting where unset means
+    /// disabled, or where fail-open was chosen deliberately, needs its own parse and its own reasoning —
+    /// inheriting this one by name would silently import an argument that does not hold. The four
+    /// <c>KCAP_*_UNATTENDED_REVIEWER</c> variables in <see cref="RunAsync"/>'s apply loop are the only
+    /// production callers.</para>
     /// </summary>
     internal static bool ParseConsentFlag(string? value) => RecogniseConsent(value) ?? false;
 
@@ -926,12 +938,17 @@ public static partial class DaemonRunner {
     internal static bool? RecogniseConsent(string? value) {
         var v = value?.Trim();
 
+        // DO NOT fold these two early returns into the `return null` fallthrough below. They look like
+        // "nothing to recognise" and they are not: `ParseConsentFlag` maps null to FALSE, so collapsing
+        // them would turn all four reviewers OFF on every daemon with the variables unset — which is
+        // essentially all of them. The same tidy-up was harmless while this failed open; the fail-closed
+        // flip is what made it catastrophic. Unset must never reach the `??`.
         if (string.IsNullOrEmpty(v)) return true;   // unset — the new default
 
         if (v.Length >= 2 && (v[0] == '"' || v[0] == '\'') && v[^1] == v[0])
             v = v[1..^1].Trim();
 
-        if (v.Length == 0) return true;
+        if (v.Length == 0) return true;             // `""` / `''` — an empty value, not an unreadable one
 
         if (v == "0"
          || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase)
@@ -1050,8 +1067,21 @@ public static partial class DaemonRunner {
     internal static void SeedVersionFloor(string stateDir, string vendor, string binaryPath) {
         try {
             if (!ReviewerVersionStore.RecordExists(stateDir, vendor)
-             && VendorVersionResolver.Resolve(binaryPath) is { Length: > 0 } installed)
+             && VendorVersionResolver.Resolve(binaryPath) is { Length: > 0 } installed) {
                 new ReviewerVersionStore(stateDir, vendor).Affirm(installed);
+
+                // Printed because a floor is affirmed ONCE and never re-probed, so a wrong number is
+                // pinned permanently and gates silently in both directions — too high refuses a working
+                // reviewer, too low under-gates. Resolve validates SHAPE (a dotted-numeric token), which
+                // rules out banners, `unknown` and localised errors, but NOT a version-shaped token that
+                // is not the installed build: an update nag ("0.11.14 -> 0.12.0"), a runtime line
+                // ("Node.js v22.1.0") or a date stamp ("2026.08.08") all qualify and can precede the
+                // real version. This line is what makes such a floor diagnosable at all.
+                Console.Error.WriteLine(
+                    $"{vendor} reviewer version floor seeded at {installed} (from '{binaryPath} --version'). "
+                  + $"Correct it with `kcap daemon reviewer affirm --vendor {vendor}` if that is not the "
+                  + "installed build.");
+            }
         } catch (Exception ex) {
             // The gate fails closed on its own if this never ran; a boot must not die for it.
             Console.Error.WriteLine($"{vendor} reviewer version seeding skipped: {ex.Message}");
@@ -1298,9 +1328,11 @@ public static partial class DaemonRunner {
     [LoggerMessage(Level = LogLevel.Information, Message = "Unattended vendor '{Vendor}': CLI version {CliVersion}, as observed by probing the configured binary at daemon startup. That is a startup observation, not the build a later reviewer runs — if the vendor updates while this daemon keeps running, launches pick up the new build and this line stays stale until the daemon restarts.")]
     static partial void LogUnattendedVendorIdentity(ILogger logger, string vendor, string cliVersion);
 
-    // Information, not Warning: a gated vendor installed with no opt-in is a NORMAL steady state (an
-    // operator may run Kiro or Gemini interactively only), so Warning would alert on a correct
-    // configuration at every restart. Default minimum level is Information, so it is logged either way.
+    // Information, not Warning: an installed vendor withheld for a reason the operator chose — an
+    // explicit opt-out, or an unsupported platform — is a NORMAL steady state, so Warning would alert on
+    // a correct configuration at every restart. Default minimum level is Information, so it is logged
+    // either way. (Pre-ungating this said "installed with no opt-in", which was the common case then and
+    // is the rare one now; the level is still right for the reasons that remain.)
     // {Reason} ends the message because each reason is itself a sentence ending in a period.
     [LoggerMessage(Level = LogLevel.Information, Message = "Vendor '{Vendor}' is installed and can host an unattended reviewer, but this daemon is NOT offering it, so a review flow requesting this vendor is refused by the server as an unadvertised reviewer — which does not say why. Restart the daemon after changing this. Reason: {Reason}")]
     static partial void LogUnattendedVendorWithheld(ILogger logger, string vendor, string reason);

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1104,6 +1104,16 @@ public static partial class DaemonRunner {
                 // is not the installed build: an update nag ("0.11.14 -> 0.12.0"), a runtime line
                 // ("Node.js v22.1.0") or a date stamp ("2026.08.08") all qualify and can precede the
                 // real version. This line is what makes such a floor diagnosable at all.
+                //
+                // All four vendors' `--version` output was measured on 2026-08-08 and every one yields
+                // the right token under first-qualifying-token extraction:
+                //     kiro-cli 2.16.0   ("kiro-cli" has no dot, so the version wins)
+                //     gemini   0.54.0   (bare)
+                //     opencode 1.18.9   (bare)
+                //     agy      1.1.11   (bare)
+                // That is an observation of four builds on one host, not a guarantee: any of them may
+                // add a nag line or a runtime banner in a later release, which is precisely the drift
+                // this log line exists to make visible.
                 Console.Error.WriteLine(
                     $"{vendor} reviewer version floor seeded at {installed} (from '{binaryPath} --version'). "
                   + $"Correct it with `kcap daemon reviewer affirm --vendor {vendor}` if that is not the "

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -850,21 +850,31 @@ public static partial class DaemonRunner {
     ///
     /// <para><b>Why the default flipped.</b> The reviewer vendor is a caller-chosen parameter, and
     /// Claude, Codex, Cursor and Copilot have never been gated at all — each running with FULL tool
-    /// access (shell and write) in the same worktree. <b>On any daemon that also advertises one of
-    /// those</b> — the overwhelmingly common case — the gate excluded nobody: a requester it blocked
-    /// from one vendor simply asked for an ungated one with more capability, while the honest path paid
-    /// a service-unit edit and a restart. Worse, two of the four gated vendors (Kiro, OpenCode) run
-    /// READ-ONLY reviewers, so the strictest policy sat on the least dangerous configurations.</para>
+    /// access (shell and write) in the same worktree. <b>On any daemon that also ADVERTISES one of
+    /// those</b> — the overwhelmingly common case — the gate did not widen the CAPABILITY CLASS a
+    /// requester could reach: one it blocked from a gated vendor simply asked for an ungated one with
+    /// more capability, while the honest path paid a service-unit edit and a restart. Two of the four
+    /// gated vendors (Kiro, OpenCode) also run READ-ONLY reviewers, so the strictest policy sat on the
+    /// least dangerous configurations.</para>
     ///
-    /// <para><b>The contingency, stated because the claim above is NOT universal</b> (review found this,
-    /// and an earlier revision of this comment asserted it unconditionally). On a daemon where the
-    /// operator installed ONLY a gated vendor's CLI — for hosted/interactive work, the ordinary reason
-    /// to install one — and no ungated vendor, these variables were the only thing separating the
-    /// hosted role from the unattended-reviewer role. There, the flip does widen what a requester who is
-    /// not the operator can cause to run with no human in the loop. That is accepted rather than
-    /// unnoticed: the operator keeps an explicit opt-out, the version floor still gates the build, and
-    /// <c>kcap daemon consent</c> is the control that actually scopes unattended launches — unlike a
-    /// per-vendor switch, it cannot be routed around by naming a different vendor.</para>
+    /// <para><b>Three precisions, because earlier revisions of this comment overstated all three</b> —
+    /// review caught each. (1) The predicate is ADVERTISED, not installed: a vendor must also be
+    /// certified and above its version floor, so a daemon with an uncertified Claude advertises no
+    /// ungated vendor either. (2) "Did not widen the capability class" is the true claim, not "excluded
+    /// nobody": even where an ungated vendor exists, this flip adds execution paths with different
+    /// binaries, different vendor-side permission models and different CREDENTIALS — a Gemini reviewer
+    /// burns the operator's Gemini credentials, which is not a subset of "Claude was already
+    /// available". (3) On a daemon that advertises ONLY a gated vendor — installed for hosted work, the
+    /// ordinary reason — these variables were the sole separation between the hosted role and the
+    /// unattended-reviewer role, and the flip genuinely widens what a non-operator requester can cause
+    /// to run with no human in the loop.</para>
+    ///
+    /// <para><b>What actually compensates, stated without inflation.</b> The operator keeps an explicit
+    /// opt-out. <c>kcap daemon consent</c> is the only control that scopes unattended launches as such —
+    /// but note it DEFAULTS TO ALLOW, so it compensates only for an operator who has configured it, not
+    /// for the average daemon. The version floor is deliberately NOT on this list: it constrains which
+    /// BUILD runs, never whether a non-operator can cause an unattended launch, and counting it as a
+    /// compensating control would inflate the set.</para>
     ///
     /// <para><b>What still protects the launch.</b> The per-vendor version FLOOR
     /// (<see cref="ReviewerVersionAffirmations"/>), which is a different mechanism with a different job:
@@ -880,7 +890,21 @@ public static partial class DaemonRunner {
     /// rule the feature-gate work follows, so a typo in a service unit cannot take a daemon's reviewer
     /// offline without saying so.</para>
     /// </summary>
-    internal static bool ParseConsentFlag(string? value) => RecogniseConsent(value) ?? true;
+    /// <summary>
+    /// <b>Unset means enabled; a value we cannot read means DISABLED.</b>
+    ///
+    /// <para>Those two are not in tension, and the asymmetry is the point. Since unset already enables,
+    /// the only reason to set one of these variables at all is to turn a reviewer OFF — enabling needs no
+    /// variable. So an unrecognised value is not an ambiguous input, it is a FAILED ATTEMPT TO SAY OFF,
+    /// and honouring the evident intent means failing closed. Review caught this: an earlier revision
+    /// failed open here, reasoning from the general "a typo must not take a feature offline" rule, which
+    /// does not transfer to a setting whose only use is to disable.</para>
+    ///
+    /// <para>The direction is also cheap in the wrong case: a typo'd ENABLE attempt (<c>=y</c>,
+    /// <c>=enabled</c>) lands on the pre-change behaviour, which is the safe side, and the operator still
+    /// gets the warning either way.</para>
+    /// </summary>
+    internal static bool ParseConsentFlag(string? value) => RecogniseConsent(value) ?? false;
 
     /// <summary>
     /// The ONE value set: true, false, or null for "set but unrecognised". Both
@@ -935,7 +959,9 @@ public static partial class DaemonRunner {
     internal static string? DescribeUnparseableConsent(string variable, string? value) =>
         RecogniseConsent(value) is null
             ? $"{variable} is set to '{value?.Trim()}', which this daemon does not recognise as true or "
-            + "false. Treating it as ENABLED (the default). Use 0/false/no/off to disable this reviewer."
+            + "false. Treating it as DISABLED, because the only reason to set this variable is to turn "
+            + "the reviewer off — unset already means enabled. Use 0/false/no/off to disable, or unset "
+            + "it (or use 1/true/yes/on) to enable."
             : null;
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -918,7 +918,7 @@ public static partial class DaemonRunner {
     /// <c>KCAP_*_UNATTENDED_REVIEWER</c> variables in <see cref="RunAsync"/>'s apply loop are the only
     /// production callers.</para>
     /// </summary>
-    internal static bool ParseConsentFlag(string? value) => RecogniseConsent(value) ?? false;
+    internal static bool ParseConsentFlag(string? value) => ReviewerConsent.IsEnabled(value);
 
     /// <summary>
     /// Where a gated reviewer's opt-out lands on <see cref="DaemonConfig"/>.
@@ -945,68 +945,14 @@ public static partial class DaemonRunner {
           + "would silently do nothing. Add the accessor here.")
     };
 
-    /// <summary>
-    /// The ONE value set: true, false, or null for "set but unrecognised". Both
-    /// <see cref="ParseConsentFlag"/> and <see cref="DescribeUnparseableConsent"/> are derived from it.
-    ///
-    /// <para><b>Why one method rather than two agreeing ones.</b> Review caught the shape: a parse and a
-    /// separate "is this recognised?" predicate are two things that must agree with nothing making them.
-    /// Add a falsey spelling to the parse only and every correctly-configured daemon warns on every boot
-    /// forever; add a truthy spelling to the predicate only and a typo is silently swallowed. They did
-    /// agree, but by inspection. Now they cannot disagree.</para>
-    ///
-    /// <para><b>Matched surrounding quotes are stripped</b>, because the realistic way a DISABLE attempt
-    /// becomes unrecognised is a quoting artifact — a mis-quoted service-unit entry, a <c>.cmd</c>
-    /// wrapper's <c>set "K=V"</c>, a hand-edited plist — and the value then arrives as literal
-    /// <c>"0"</c>. Since disabling is now the operator's only lever, a fail-open there is the one
-    /// mistake worth spending three lines to prevent. One level only: a value that is still unrecognised
-    /// after stripping is reported, not stripped again.</para>
-    /// </summary>
-    internal static bool? RecogniseConsent(string? value) {
-        var v = value?.Trim();
+    /// <summary>Thin forwarders to <see cref="ReviewerConsent"/> in Core, kept so the daemon's own call
+    /// sites and tests read the parser under a daemon-local name. The rules — and the reason unset must
+    /// never reach the <c>?? false</c> — live on the Core type, which the CLI's install-output notice
+    /// reads too so the two cannot describe a captured value differently.</summary>
+    internal static bool? RecogniseConsent(string? value) => ReviewerConsent.Recognise(value);
 
-        // DO NOT fold these two early returns into the `return null` fallthrough below. They look like
-        // "nothing to recognise" and they are not: `ParseConsentFlag` maps null to FALSE, so collapsing
-        // them would turn all four reviewers OFF on every daemon with the variables unset — which is
-        // essentially all of them. The same tidy-up was harmless while this failed open; the fail-closed
-        // flip is what made it catastrophic. Unset must never reach the `??`.
-        if (string.IsNullOrEmpty(v)) return true;   // unset — the new default
-
-        if (v.Length >= 2 && (v[0] == '"' || v[0] == '\'') && v[^1] == v[0])
-            v = v[1..^1].Trim();
-
-        if (v.Length == 0) return true;             // `""` / `''` — an empty value, not an unreadable one
-
-        if (v == "0"
-         || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase)
-         || string.Equals(v, "no",    StringComparison.OrdinalIgnoreCase)
-         || string.Equals(v, "off",   StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        if (v == "1"
-         || string.Equals(v, "true", StringComparison.OrdinalIgnoreCase)
-         || string.Equals(v, "yes",  StringComparison.OrdinalIgnoreCase)
-         || string.Equals(v, "on",   StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        return null;   // set, but says nothing this daemon understands
-    }
-
-    /// <summary>
-    /// A warning for a consent variable that is SET but says nothing this daemon recognises, or null
-    /// when there is nothing to report.
-    ///
-    /// <para>An operator who typed <c>flase</c> meaning to disable a reviewer would otherwise get it
-    /// enabled with no signal at all, which is the direction worth being loud about now that disabling
-    /// is the only lever.</para>
-    /// </summary>
     internal static string? DescribeUnparseableConsent(string variable, string? value) =>
-        RecogniseConsent(value) is null
-            ? $"{variable} is set to '{value?.Trim()}', which this daemon does not recognise as true or "
-            + "false. Treating it as DISABLED, because the only reason to set this variable is to turn "
-            + "the reviewer off — unset already means enabled. Use 0/false/no/off to disable, or unset "
-            + "it (or use 1/true/yes/on) to enable."
-            : null;
+        ReviewerConsent.DescribeUnparseable(variable, value);
 
     /// <summary>
     /// True when a "cursor" <see cref="IHostedAgentRuntimeFactory"/> is registered but

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -844,14 +844,9 @@ public static partial class DaemonRunner {
         value?.Trim() is not { } v || !(v == "0" || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
-    /// Parses an unattended-reviewer consent flag. Fail-closed polarity, the opposite of
-    /// <see cref="ParseAcpReconnectFlag"/>: only an explicit <c>1</c>/<c>true</c>/<c>yes</c>/<c>on</c>
-    /// enables it, and unset, blank or unrecognised leaves it OFF. Enabling one of these is a
-    /// security consent event, so a typo must not be read as consent.
-    /// </summary>
-    /// <summary>
-    /// Whether a gated reviewer vendor is permitted on this daemon. **Absent means ENABLED** — this is
-    /// an opt-OUT, and it used to be an opt-in.
+    /// Whether a reviewer vendor is permitted on this daemon. **Absent means ENABLED** — this is an
+    /// opt-OUT, and it used to be an opt-in. Same polarity as
+    /// <see cref="ParseAcpReconnectFlag"/> now, where it used to be deliberately the opposite.
     ///
     /// <para><b>Why the default flipped.</b> The opt-in gate did not do the job it claimed. The reviewer
     /// vendor is a caller-chosen parameter, and Claude, Codex, Cursor and Copilot have never been gated
@@ -936,17 +931,18 @@ public static partial class DaemonRunner {
     /// CONDITION each vendor is seeded under unpinned. Driving this method instead makes the
     /// difference between the vendors the thing under test.</para>
     ///
-    /// <para>Kiro and Gemini seed from the CONSENT event, not from a first refusal: an operator who
-    /// has just turned a reviewer on should not be refused over an upgrade that never happened, which
-    /// teaches people to clear the gate without reading it. Cheap, and a no-op for a vendor the
-    /// operator has not opted into.</para>
+    /// <para>Kiro, Gemini and OpenCode seed whenever the vendor is not explicitly DISABLED — which,
+    /// since the switch defaults to enabled, means on essentially every boot. That is what keeps the
+    /// floor from becoming the opt-in gate under a new name: with no record the ladder answers
+    /// <c>version_no_minimum</c>, a refusal only <c>kcap daemon reviewer affirm</c> can clear. Skipping
+    /// a disabled vendor is the one remaining condition, and it exists so an installed-but-wedged
+    /// binary cannot stall a boot for a feature the operator switched off.</para>
     ///
-    /// <para>Antigravity is the one vendor whose floor is NOT reviewer-only: it gates hosted
-    /// <c>agy</c> launches too (the isolated <c>HOME</c> they rely on is the containment it protects),
-    /// and those ship on by default with no consent flag. Seeding from the consent event would
-    /// therefore leave every consent-less daemon refusing hosted launches as
-    /// <c>version_no_minimum</c> forever — the reviewer gate removed from the front of the ladder and
-    /// reinstated behind it. Installing <c>agy</c> IS the event here; the resolver's
+    /// <para>Antigravity seeds with NO condition at all, because its floor is NOT reviewer-only: it
+    /// gates hosted <c>agy</c> launches too (the isolated <c>HOME</c> they rely on is the containment it
+    /// protects), and those have always shipped on. Conditioning it on the reviewer switch would leave a
+    /// daemon that disabled the REVIEWER refusing hosted launches as <c>version_no_minimum</c> forever.
+    /// Installing <c>agy</c> IS the event here; the resolver's
     /// null-for-a-missing-binary answer is what keeps this a no-op otherwise, at the cost of one
     /// bounded <c>agy --version</c> on the first boot that finds no record, never again.</para>
     /// </summary>

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -951,13 +951,20 @@ public static class DaemonCommands {
         await Console.Out.WriteLineAsync($"Service '{id}' installed ({manager.Describe()}).");
         await Console.Out.WriteLineAsync("  Auto-restarts on crash/SIGKILL; starts at login.");
 
-        // Freezing an unattended-reviewer consent flag into a unit is worth saying out loud. The unit
-        // outlives the shell it was captured from, so an operator who later unsets the variable would
-        // otherwise have no indication the service kept consenting on their behalf.
-        foreach (var flag in ServiceEnvironment.CarriedConsentFlags(env))
+        // A reviewer switch frozen into a unit is worth saying out loud: the unit outlives the shell it
+        // was captured from, so an operator who later changes the variable has no effect until they
+        // reinstall. The line must state what the captured VALUE does, not assume it enables — since
+        // these became opt-outs, a captured `0` DISABLES, and the old "the reviewer it enables stays on"
+        // text was exactly backwards for that case. Classified through the same Core parser the daemon
+        // reads, so the notice and the daemon can never disagree about a value's meaning.
+        foreach (var flag in ServiceEnvironment.CarriedConsentFlags(env)) {
+            var effect = ReviewerConsent.IsEnabled(env[flag])
+                ? "keeps that reviewer ENABLED (already the default)"
+                : "DISABLES that reviewer";
             await Console.Out.WriteLineAsync(
-                $"  Consent:   {flag}={env[flag]} captured into the unit — the unattended reviewer it "
-              + "enables stays on for this service until you reinstall without it.");
+                $"  Reviewer:  {flag}={env[flag]} captured into the unit — {effect} for this service "
+              + "until you reinstall with a different value.");
+        }
 
         await Console.Out.WriteLineAsync($"  Log:       {logPath}");
         await Console.Out.WriteLineAsync($"  Stop:      kcap daemon service stop --name {id}");

--- a/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
+++ b/src/Capacitor.Cli/Commands/DaemonReviewerCommand.cs
@@ -105,26 +105,19 @@ public static class DaemonReviewerCommand {
 
     /// <summary>
     /// A reviewer whose build an operator can affirm. Every gated reviewer uses the same model, so the
-    /// verb is a table rather than a per-vendor branch — the next one is a row here, not a new arm.
+    /// verb is a table rather than a per-vendor branch — the next one is a row in
+    /// <see cref="GatedReviewers.All"/>, not a new arm.
+    ///
+    /// <para>The table itself moved to Core: the daemon's own apply loop reads the same rows to build
+    /// its config, and it cannot see this project. See <see cref="GatedReviewers"/> for why one list
+    /// rather than two that must agree.</para>
     /// </summary>
-    /// <param name="Vendor">Canonical vendor token, and the key the daemon's store is written under.</param>
-    /// <param name="DefaultBinary">Binary probed when the path env var is unset.</param>
-    /// <param name="PathEnvVar">Env var the daemon itself honours for this vendor's binary — read here
-    /// so the verb affirms the build the DAEMON would launch, not whatever happens to be first on PATH.</param>
-    /// <param name="EnableEnvVar">The consent flag, named in usage text because affirming is not enabling.</param>
-    internal sealed record AffirmableReviewer(
-            string Vendor, string DefaultBinary, string PathEnvVar, string EnableEnvVar) {
-        internal static readonly AffirmableReviewer[] All = [
-            new("kiro",        "kiro-cli", "KCAP_KIRO_PATH",        "KCAP_KIRO_UNATTENDED_REVIEWER"),
-            new("gemini",      "gemini",   "KCAP_GEMINI_PATH",      "KCAP_GEMINI_UNATTENDED_REVIEWER"),
-            new("antigravity", "agy",      "KCAP_ANTIGRAVITY_PATH", "KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER"),
-            new("opencode",    "opencode", "KCAP_OPENCODE_PATH",    "KCAP_OPENCODE_UNATTENDED_REVIEWER")
-        ];
+    internal static class AffirmableReviewer {
+        internal static GatedReviewer[] All => GatedReviewers.All;
 
-        internal static string VendorList => string.Join(" | ", All.Select(r => r.Vendor));
+        internal static string VendorList => GatedReviewers.VendorList;
 
-        internal static AffirmableReviewer? Resolve(string? vendor) =>
-            All.FirstOrDefault(r => string.Equals(r.Vendor, vendor, StringComparison.OrdinalIgnoreCase));
+        internal static GatedReviewer? Resolve(string? vendor) => GatedReviewers.Resolve(vendor);
     }
 
     static string? ValueOf(string[] args, string flag) {
@@ -143,9 +136,12 @@ public static class DaemonReviewerCommand {
               exclude a build you have found to be broken, and, if you run it while an OLDER build is
               installed, how you deliberately lower the bar again.
 
-              Does NOT enable the unattended reviewer — set
+              Affirming is not a consent switch in either direction. Unattended reviewers are
+              ENABLED by default; to turn one off, set its variable to 0 in the DAEMON's
+              environment (and re-run `kcap daemon service install` if it is service-managed,
+              since a supervised daemon's environment is frozen at install):
               {string.Join(" / ", AffirmableReviewer.All.Select(r => r.EnableEnvVar))}
-              for that, and read what it grants first.
+              Read what an unattended review grants before leaving one on.
             """);
 
         return 1;

--- a/src/Capacitor.Cli/Services/ServiceEnvironment.cs
+++ b/src/Capacitor.Cli/Services/ServiceEnvironment.cs
@@ -41,7 +41,7 @@ static class ServiceEnvironment {
     /// installing the service has no effect until the service is reinstalled.</para>
     /// </summary>
     internal static readonly string[] ReviewerConsentKeys =
-        [.. Commands.DaemonReviewerCommand.AffirmableReviewer.All.Select(r => r.EnableEnvVar)];
+        [.. Core.GatedReviewers.All.Select(r => r.EnableEnvVar)];
 
     /// <summary>
     /// Gemini's project/backend selection, carried on every platform because none of it is

--- a/src/Capacitor.Cli/Services/ServiceEnvironment.cs
+++ b/src/Capacitor.Cli/Services/ServiceEnvironment.cs
@@ -15,22 +15,27 @@ static class ServiceEnvironment {
         ["PATH", "KCAP_CONFIG_DIR", "KCAP_PROFILE", "KCAP_URL", "KCAP_CLAUDE_PATH", "KCAP_CODEX_PATH"];
 
     /// <summary>
-    /// Operator consent for the gated unattended reviewers. Carried on every platform: these are
-    /// booleans, not secret-capable, so <see cref="GoogleSecretCapableKeys"/>'s exclusion does not apply.
+    /// The unattended reviewers' opt-OUT switches. Carried on every platform: these are booleans, not
+    /// secret-capable, so <see cref="GoogleSecretCapableKeys"/>'s exclusion does not apply.
     ///
     /// <para>Required because the daemon reads them from its own environment and nowhere else — no
-    /// profile or config-file binding — so without this a supervised install silently dropped them and
-    /// the reviewer could not be turned on at all.</para>
+    /// profile or config-file binding — so without this a supervised install silently drops them.</para>
     ///
-    /// <para>Capture carries an EXISTING opt-in; it cannot create one. It does freeze it, which is what
-    /// <see cref="CarriedConsentFlags"/> reports.</para>
+    /// <para><b>These became opt-OUTs, which inverted what a miss here costs.</b> While they were opt-ins,
+    /// dropping one meant a reviewer that could not be turned ON: annoying, and safe. Now it means a
+    /// reviewer that cannot be turned OFF — the operator's only lever, unreachable, on the supported
+    /// install path. That is the single compensating control the ungating rests on (see
+    /// <c>DaemonRunner.ParseConsentFlag</c>), so this array is load-bearing for that argument rather
+    /// than a convenience.</para>
     ///
-    /// <para><b>DERIVED from the affirmable-reviewer registry, not listed again here.</b> Every gated
-    /// reviewer has both a consent flag and a build affirmation, so these were two hand-maintained lists
-    /// of the same set with nothing making them agree — and the failure mode is silent in the worst
-    /// direction: a vendor present in one and missing here means a supervised install drops its consent
-    /// flag, and the reviewer simply cannot be enabled, with the refusal text pointing at a variable the
-    /// unit never received. Deriving removes the drift class instead of testing for it.</para>
+    /// <para><b>DERIVED from the affirmable-reviewer registry, not listed again here.</b> Every one of
+    /// these vendors has both a switch and a build affirmation, so this was two hand-maintained lists of
+    /// the same set with nothing making them agree. Deriving removes the drift class instead of testing
+    /// for it — and post-inversion it is what guarantees a newly-added reviewer arrives disableable.</para>
+    ///
+    /// <para><b>Capture FREEZES the value at install time</b> (what <see cref="CarriedConsentFlags"/>
+    /// reports). A supervised daemon inherits nothing later, so an opt-out an operator exports after
+    /// installing the service has no effect until the service is reinstalled.</para>
     /// </summary>
     internal static readonly string[] ReviewerConsentKeys =
         [.. Commands.DaemonReviewerCommand.AffirmableReviewer.All.Select(r => r.EnableEnvVar)];

--- a/src/Capacitor.Cli/Services/ServiceEnvironment.cs
+++ b/src/Capacitor.Cli/Services/ServiceEnvironment.cs
@@ -28,10 +28,13 @@ static class ServiceEnvironment {
     /// <c>DaemonRunner.ParseConsentFlag</c>), so this array is load-bearing for that argument rather
     /// than a convenience.</para>
     ///
-    /// <para><b>DERIVED from the affirmable-reviewer registry, not listed again here.</b> Every one of
-    /// these vendors has both a switch and a build affirmation, so this was two hand-maintained lists of
-    /// the same set with nothing making them agree. Deriving removes the drift class instead of testing
-    /// for it — and post-inversion it is what guarantees a newly-added reviewer arrives disableable.</para>
+    /// <para><b>DERIVED from <see cref="Core.GatedReviewers"/>, not listed again here</b> — the SAME rows
+    /// the daemon's own apply loop iterates to build its config. This was three hand-maintained lists of
+    /// one set (here, the daemon, and the affirm verb) with nothing making them agree; now there is one
+    /// registry and the drift class is gone rather than tested for. Post-inversion that is what
+    /// guarantees a newly-added reviewer arrives disableable: a row that reaches the daemon reaches the
+    /// service unit by construction, and one the daemon has no accessor for fails the boot loudly
+    /// instead of shipping an opt-out that does nothing.</para>
     ///
     /// <para><b>Capture FREEZES the value at install time</b> (what <see cref="CarriedConsentFlags"/>
     /// reports). A supervised daemon inherits nothing later, so an opt-out an operator exports after

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
@@ -194,13 +194,11 @@ public class AntigravityReviewerCapabilityTests {
     /// The remedy names BOTH the restart (a daemon seeds its record at startup) and the verb that
     /// avoids one.
     ///
-    /// <para><b>And it must NOT name the reviewer consent flag.</b> This arm gates hosted launches as
-    /// well as reviews — the floor protects the per-launch isolated home, which is not a reviewer
-    /// concern — so pointing a hosted operator at <c>KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER</c> would
-    /// send them to a switch that has no bearing on their launch. It is also no longer true even for a
-    /// reviewer: the daemon now seeds this vendor's floor whenever <c>agy</c> resolves, consent or
-    /// not.</para>
-    /// </summary>
+    /// <para><b>And it must NOT name the reviewer switch.</b> This arm gates hosted launches as well as
+    /// reviews — the floor protects the per-launch isolated home, which is not a reviewer concern — so
+    /// pointing a hosted operator at <c>KCAP_ANTIGRAVITY_UNATTENDED_REVIEWER</c> would send them to a
+    /// setting that has no bearing on their launch. It is doubly untrue now that the switch defaults to
+    /// enabled and this vendor's floor is seeded whenever <c>agy</c> resolves.</para>
     [Test]
     public async Task TheNoMinimumReason_SendsTheOperatorToARestartOrTheAffirmVerb() {
         var reason = Reason(AntigravityReviewerDecision.VersionNoMinimum, "1.1.10", null);
@@ -246,19 +244,20 @@ public class AntigravityReviewerCapabilityTests {
     /// Enabling a reviewer is a security consent event, so only an explicit affirmative counts —
     /// a typo, a blank, or an unrecognised value must not be read as consent.
     /// </summary>
+    /// <summary>Opt-OUT: unset means enabled. The full matrix, including the unparseable-value
+    /// reporting, lives in <c>KiroReviewerCapabilityTests</c> — the parse is shared, so duplicating it
+    /// per vendor would be four copies of one fact.</summary>
     [Test]
     [Arguments("1", true)]
-    [Arguments("true", true)]
-    [Arguments("TRUE", true)]
-    [Arguments("yes", true)]
     [Arguments("on", true)]
     [Arguments("0", false)]
     [Arguments("false", false)]
-    [Arguments("", false)]
-    [Arguments("   ", false)]
-    [Arguments("ture", false)]
-    [Arguments(null, false)]
-    public async Task TheConsentFlagOnlyAcceptsAnExplicitAffirmative(string? value, bool expected) =>
+    [Arguments("off", false)]
+    [Arguments("", true)]
+    [Arguments("   ", true)]
+    [Arguments("ture", true)]
+    [Arguments(null, true)]
+    public async Task TheConsentFlagIsAnOptOut(string? value, bool expected) =>
         await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsEqualTo(expected);
 
     static string Reason(AntigravityReviewerDecision decision, string? installed, string? minimum) =>

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AntigravityReviewerCapabilityTests.cs
@@ -255,7 +255,9 @@ public class AntigravityReviewerCapabilityTests {
     [Arguments("off", false)]
     [Arguments("", true)]
     [Arguments("   ", true)]
-    [Arguments("ture", true)]
+    // Set-but-unrecognised disables: setting this variable at all is only ever an attempt to turn the
+    // reviewer off, so an unreadable value is a failed "off".
+    [Arguments("ture", false)]
     [Arguments(null, true)]
     public async Task TheConsentFlagIsAnOptOut(string? value, bool expected) =>
         await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsEqualTo(expected);

--- a/test/Capacitor.Cli.Tests.Unit/Acp/GeminiReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/GeminiReviewerCapabilityTests.cs
@@ -110,16 +110,19 @@ public class GeminiReviewerCapabilityTests {
     }
 
     /// <summary>
-    /// The consent text is the acceptance artifact for what enabling this grants, so its content is
-    /// asserted rather than just its presence — and it must name the variable that actually turns it on.
+    /// Reached only when an operator EXPLICITLY disabled it. The text still has to state what a Gemini
+    /// review grants — that risk is unchanged and is the sharpest of the four — while saying how to undo
+    /// the disable and that the switch narrows nothing a requester cannot route around.
     /// </summary>
     [Test]
-    public async Task TheDisabledReasonStatesWhatEnablingGrants_AndHowToEnableIt() {
+    public async Task TheDisabledReason_StatesTheGrantAndHowToUndoTheDisable() {
         var reason = GeminiReviewerCapability.DenialReason(GeminiReviewerDecision.Disabled, null, null);
 
+        await Assert.That(reason).StartsWith("gemini_unattended_reviewer_disabled");
+        await Assert.That(reason).Contains("EXPLICITLY disabled");
         await Assert.That(reason).Contains("code execution");
-        await Assert.That(reason).Contains("credentials");
-        await Assert.That(reason).Contains("KCAP_GEMINI_UNATTENDED_REVIEWER=1");
+        await Assert.That(reason).Contains("KCAP_GEMINI_UNATTENDED_REVIEWER");
+        await Assert.That(reason).Contains("never-gated");
     }
 
     // ── version extraction, which the affirmation check depends on ──

--- a/test/Capacitor.Cli.Tests.Unit/Acp/KiroReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/KiroReviewerCapabilityTests.cs
@@ -92,24 +92,31 @@ public class KiroReviewerCapabilityTests {
     }
 
     /// <summary>
-    /// The consent text IS the acceptance artifact for the accepted risk, so its content is the
-    /// assertion. A refusal that merely names a flag would let an operator enable this without ever
-    /// being told what they are accepting.
+    /// This arm is now reached only when an operator EXPLICITLY disabled the reviewer, so the text has a
+    /// different job than it used to: tell them how to undo it, and — because the obvious next question
+    /// is "was I protecting myself with that?" — say plainly that the switch does not narrow anything a
+    /// requester cannot route around by naming an ungated vendor.
     /// </summary>
     [Test]
-    public async Task TheDisabledReason_StatesTheRiskAndTheTrustDomainCondition() {
+    public async Task TheDisabledReason_SaysHowToUndoItAndThatItGuardsLittle() {
         var reason = KiroReviewerCapability.DenialReason(KiroReviewerDecision.Disabled, null, null);
 
         await Assert.That(reason).StartsWith("kiro_unattended_reviewer_disabled");
-        await Assert.That(reason).Contains("every file this daemon user can read");
-        await Assert.That(reason).Contains("return what it read to whoever requested the review");
-        await Assert.That(reason).Contains("one trust domain");
+        await Assert.That(reason).Contains("EXPLICITLY disabled");
         await Assert.That(reason).Contains("KCAP_KIRO_UNATTENDED_REVIEWER");
+        // The honest caveat: gating one vendor while four run ungated with more capability stops nobody.
+        await Assert.That(reason).Contains("never gated");
     }
 
     /// <summary>
-    /// Enabling a reviewer is a security consent event, so only an explicit affirmative counts —
-    /// a typo, a blank, or an unrecognised value must not be read as consent.
+    /// The switch is an opt-OUT: unset means ENABLED, matching the never-gated
+    /// Claude/Codex/Cursor/Copilot reviewers. Only a recognised falsey value disables.
+    ///
+    /// <para>An UNRECOGNISED value resolves to the default (enabled) rather than to disabled, which is
+    /// the deliberate half of this and the half worth stating: it means a typo cannot silently take a
+    /// reviewer offline. The cost — a typo also cannot silently disable one — is covered by
+    /// <see cref="AnUnparseableValue_IsReportedRatherThanSilentlyIgnored"/>, which makes the daemon say
+    /// so at startup.</para>
     /// </summary>
     [Test]
     [Arguments("1", true)]
@@ -119,13 +126,48 @@ public class KiroReviewerCapabilityTests {
     [Arguments("on", true)]
     [Arguments("0", false)]
     [Arguments("false", false)]
-    [Arguments("", false)]
-    [Arguments("   ", false)]
-    [Arguments("ture", false)]
-    [Arguments("enabled", false)]
-    [Arguments(null, false)]
-    public async Task TheConsentFlagOnlyAcceptsAnExplicitAffirmative(string? value, bool expected) =>
+    [Arguments("FALSE", false)]
+    [Arguments("no", false)]
+    [Arguments("off", false)]
+    [Arguments("", true)]
+    [Arguments("   ", true)]
+    [Arguments("ture", true)]
+    [Arguments("enabled", true)]
+    [Arguments(null, true)]
+    public async Task TheConsentFlagIsAnOptOut(string? value, bool expected) =>
         await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsEqualTo(expected);
+
+    /// <summary>
+    /// A value that is SET but unreadable must be reported. Without this, an operator who typed
+    /// <c>flase</c> meaning to disable a reviewer gets it enabled with no signal at all — the one
+    /// direction this default flip could surprise someone in.
+    /// </summary>
+    [Test]
+    [Arguments("flase")]
+    [Arguments("enabled")]
+    [Arguments("nope")]
+    public async Task AnUnparseableValue_IsReportedRatherThanSilentlyIgnored(string value) {
+        var warning = DaemonRunner.DescribeUnparseableConsent("KCAP_KIRO_UNATTENDED_REVIEWER", value);
+
+        await Assert.That(warning).IsNotNull();
+        await Assert.That(warning!).Contains("KCAP_KIRO_UNATTENDED_REVIEWER");
+        await Assert.That(warning).Contains(value);
+        await Assert.That(warning).Contains("ENABLED");
+        await Assert.That(warning).Contains("0/false/no/off");
+    }
+
+    /// <summary>Nothing to report for a value the parse understands, or for the ordinary unset case —
+    /// a warning on every boot for a correctly-configured daemon would train people to ignore it.</summary>
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("1")]
+    [Arguments("0")]
+    [Arguments("false")]
+    [Arguments("ON")]
+    public async Task ARecognisedOrAbsentValue_IsNotReported(string? value) =>
+        await Assert.That(DaemonRunner.DescribeUnparseableConsent("KCAP_KIRO_UNATTENDED_REVIEWER", value))
+            .IsNull();
 
     /// <summary>
     /// The Windows arm, now assertable from any host. It refuses BEFORE the operator flag and before

--- a/test/Capacitor.Cli.Tests.Unit/Acp/KiroReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/KiroReviewerCapabilityTests.cs
@@ -170,6 +170,59 @@ public class KiroReviewerCapabilityTests {
             .IsNull();
 
     /// <summary>
+    /// A quoting artifact must not turn a DISABLE into an enable. The realistic sources are a mis-quoted
+    /// service-unit entry, a <c>.cmd</c> wrapper's <c>set "K=V"</c>, and a hand-edited plist — all of
+    /// which deliver the value with its quotes attached. Since disabling is the operator's only lever,
+    /// failing open there is the mistake worth preventing outright. Raised by review.
+    /// </summary>
+    [Test]
+    [Arguments("\"0\"")]
+    [Arguments("'0'")]
+    [Arguments("\"false\"")]
+    [Arguments("  \"off\"  ")]
+    [Arguments("'no'")]
+    public async Task AQuotedFalseyValue_StillDisables(string value) {
+        await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsFalse();
+        // ...and does not also warn, since it was understood.
+        await Assert.That(DaemonRunner.DescribeUnparseableConsent("KCAP_KIRO_UNATTENDED_REVIEWER", value))
+            .IsNull();
+    }
+
+    /// <summary>Only ONE level, and only MATCHED quotes: anything still unrecognised afterwards is
+    /// reported rather than stripped again, so this cannot quietly accept arbitrary shapes.</summary>
+    [Test]
+    [Arguments("\"\"0\"\"")]
+    [Arguments("\"0")]
+    [Arguments("0\"")]
+    [Arguments("\"0'")]
+    public async Task OnlyOneLevelOfMatchedQuotesIsStripped(string value) {
+        await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsTrue();
+        await Assert.That(DaemonRunner.DescribeUnparseableConsent("KCAP_KIRO_UNATTENDED_REVIEWER", value))
+            .IsNotNull();
+    }
+
+    /// <summary>
+    /// The structural guarantee that replaced a by-inspection one: the parse and the warning are derived
+    /// from a single recogniser, so they cannot disagree about which values are understood. A
+    /// disagreement would either warn on every boot for a correct config, or swallow a typo silently.
+    /// </summary>
+    [Test]
+    [Arguments("1")] [Arguments("0")] [Arguments("true")] [Arguments("false")]
+    [Arguments("yes")] [Arguments("no")] [Arguments("on")] [Arguments("off")]
+    [Arguments("YES")] [Arguments("Off")] [Arguments("\"1\"")]
+    [Arguments("flase")] [Arguments("enabled")] [Arguments("2")] [Arguments("-")]
+    [Arguments(null)] [Arguments("")] [Arguments("   ")]
+    public async Task TheParseAndTheWarningShareOneValueSet(string? value) {
+        var recognised = DaemonRunner.RecogniseConsent(value) is not null;
+        var warned     = DaemonRunner.DescribeUnparseableConsent("VAR", value) is not null;
+
+        await Assert.That(warned).IsEqualTo(!recognised);
+        // And the parse never contradicts the recogniser on a value it DOES understand.
+        if (DaemonRunner.RecogniseConsent(value) is { } known)
+            await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsEqualTo(known);
+    }
+
+    /// <summary>
     /// The Windows arm, now assertable from any host. It refuses BEFORE the operator flag and before
     /// any version comparison — a fully-consented, correctly-affirmed daemon is still refused, because
     /// the reviewer home holds review context and cannot be created owner-only there.

--- a/test/Capacitor.Cli.Tests.Unit/Acp/KiroReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/KiroReviewerCapabilityTests.cs
@@ -110,13 +110,14 @@ public class KiroReviewerCapabilityTests {
 
     /// <summary>
     /// The switch is an opt-OUT: unset means ENABLED, matching the never-gated
-    /// Claude/Codex/Cursor/Copilot reviewers. Only a recognised falsey value disables.
+    /// Claude/Codex/Cursor/Copilot reviewers.
     ///
-    /// <para>An UNRECOGNISED value resolves to the default (enabled) rather than to disabled, which is
-    /// the deliberate half of this and the half worth stating: it means a typo cannot silently take a
-    /// reviewer offline. The cost — a typo also cannot silently disable one — is covered by
-    /// <see cref="AnUnparseableValue_IsReportedRatherThanSilentlyIgnored"/>, which makes the daemon say
-    /// so at startup.</para>
+    /// <para>An UNRECOGNISED value resolves to DISABLED, not to the default. That looks contradictory
+    /// until you notice that setting the variable at all is only ever an attempt to turn the reviewer
+    /// OFF — enabling requires no variable — so an unreadable value is a failed "off", and honouring the
+    /// evident intent means failing closed. Review corrected an earlier revision that failed open here
+    /// by borrowing the general "a typo must not take a feature offline" rule, which does not transfer
+    /// to a setting with only one use.</para>
     /// </summary>
     [Test]
     [Arguments("1", true)]
@@ -131,11 +132,31 @@ public class KiroReviewerCapabilityTests {
     [Arguments("off", false)]
     [Arguments("", true)]
     [Arguments("   ", true)]
-    [Arguments("ture", true)]
-    [Arguments("enabled", true)]
     [Arguments(null, true)]
+    // Set-but-unrecognised is DISABLED, not enabled. Since unset already enables, the only reason to set
+    // this variable is to turn the reviewer off — so an unreadable value is a failed "off", and honouring
+    // that intent means failing closed. Review corrected an earlier revision that failed open here.
+    [Arguments("ture", false)]
+    [Arguments("enabled", false)]
+    [Arguments("2", false)]
     public async Task TheConsentFlagIsAnOptOut(string? value, bool expected) =>
         await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsEqualTo(expected);
+
+    /// <summary>
+    /// The asymmetry spelled out, because "unset enables but garbage disables" reads contradictory until
+    /// you notice that setting the variable at all is only ever an attempt to disable.
+    /// </summary>
+    [Test]
+    public async Task UnsetEnables_ButAnUnreadableValueDisables() {
+        await Assert.That(DaemonRunner.ParseConsentFlag(null)).IsTrue();
+        await Assert.That(DaemonRunner.ParseConsentFlag("")).IsTrue();
+
+        await Assert.That(DaemonRunner.ParseConsentFlag("flase")).IsFalse();
+        await Assert.That(DaemonRunner.ParseConsentFlag("disabled")).IsFalse();
+
+        // A typo'd ENABLE attempt lands on the pre-change behaviour, which is the safe side.
+        await Assert.That(DaemonRunner.ParseConsentFlag("y")).IsFalse();
+    }
 
     /// <summary>
     /// A value that is SET but unreadable must be reported. Without this, an operator who typed
@@ -152,8 +173,10 @@ public class KiroReviewerCapabilityTests {
         await Assert.That(warning).IsNotNull();
         await Assert.That(warning!).Contains("KCAP_KIRO_UNATTENDED_REVIEWER");
         await Assert.That(warning).Contains(value);
-        await Assert.That(warning).Contains("ENABLED");
+        await Assert.That(warning).Contains("DISABLED");
         await Assert.That(warning).Contains("0/false/no/off");
+        // The warning must state the outcome it actually produced, or it sends the operator the wrong way.
+        await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsFalse();
     }
 
     /// <summary>Nothing to report for a value the parse understands, or for the ordinary unset case —
@@ -196,7 +219,10 @@ public class KiroReviewerCapabilityTests {
     [Arguments("0\"")]
     [Arguments("\"0'")]
     public async Task OnlyOneLevelOfMatchedQuotesIsStripped(string value) {
-        await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsTrue();
+        // Unrecognised, therefore disabled AND reported. Note these shapes all arise from a botched
+        // DISABLE attempt, so failing closed happens to land on what the operator wanted — the quote
+        // stripping is what makes that the RIGHT answer rather than an accidentally-right one.
+        await Assert.That(DaemonRunner.ParseConsentFlag(value)).IsFalse();
         await Assert.That(DaemonRunner.DescribeUnparseableConsent("KCAP_KIRO_UNATTENDED_REVIEWER", value))
             .IsNotNull();
     }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/OpenCodeReviewerCapabilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/OpenCodeReviewerCapabilityTests.cs
@@ -65,22 +65,19 @@ public class OpenCodeReviewerCapabilityTests {
             .IsEqualTo(OpenCodeReviewerDecision.VersionIncomparable);
 
     /// <summary>
-    /// The consent text is the acceptance artifact for this gate's actual risk, so its CONTENT is
-    /// asserted rather than merely its presence. The narrow tool surface makes it tempting to describe
-    /// this reviewer as contained; the unbounded READ is the thing an operator is consenting to and the
-    /// text has to say so.
+    /// Reached only when an operator EXPLICITLY disabled it, so the text's job is to say how to undo
+    /// that — and to give the context that makes the choice informed, since this is the most contained
+    /// reviewer of the eight and someone disabling it may be reasoning from the old opt-in framing.
     /// </summary>
     [Test]
-    public async Task TheDisabledReason_NamesTheUnboundedReadAndTheVariableThatEnablesIt() {
+    public async Task TheDisabledReason_SaysHowToUndoItAndHowContainedThisReviewerIs() {
         var reason = OpenCodeReviewerCapability.DenialReason(
             OpenCodeReviewerDecision.Disabled, "1.18.9", "1.18.9");
 
         await Assert.That(reason).StartsWith("opencode_unattended_reviewer_disabled");
-        await Assert.That(reason).Contains("NOT path-scoped");
-        await Assert.That(reason).Contains("every file this daemon user can read");
-        await Assert.That(reason).Contains("KCAP_OPENCODE_UNATTENDED_REVIEWER=1");
-        // The distinction that makes the consent decision comprehensible rather than alarming.
-        await Assert.That(reason).Contains("no shell and no write");
+        await Assert.That(reason).Contains("EXPLICITLY disabled");
+        await Assert.That(reason).Contains("KCAP_OPENCODE_UNATTENDED_REVIEWER");
+        await Assert.That(reason).Contains("no shell, no");
     }
 
     /// <summary>Asking for the denial reason of a PERMITTED decision is a caller bug, not a blank

--- a/test/Capacitor.Cli.Tests.Unit/Core/ReviewerConsentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Core/ReviewerConsentTests.cs
@@ -1,0 +1,76 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Core;
+
+/// <summary>
+/// The shared opt-out parser both the daemon (to build config) and the CLI's <c>daemon service
+/// install</c> notice (to describe a captured value) read. The install-output bug qodo found was
+/// exactly a second reader disagreeing with this one: the notice said a captured value "enables" the
+/// reviewer regardless of what it was, so a captured <c>0</c> was reported as keeping the reviewer on
+/// while the daemon disabled it. These pin the classification that both surfaces now derive.
+/// </summary>
+public class ReviewerConsentTests {
+    [Test]
+    [Arguments(null)]        // unset — the default
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments("1")]
+    [Arguments("true")]
+    [Arguments("TRUE")]
+    [Arguments("yes")]
+    [Arguments("on")]
+    public async Task Enabling_and_unset_values_are_enabled(string? value) {
+        await Assert.That(ReviewerConsent.IsEnabled(value)).IsTrue();
+        await Assert.That(ReviewerConsent.DescribeUnparseable("VAR", value)).IsNull();
+    }
+
+    [Test]
+    [Arguments("0")]
+    [Arguments("false")]
+    [Arguments("No")]
+    [Arguments("off")]
+    [Arguments("\"0\"")]     // quoting artifact — one level of matched quotes stripped
+    [Arguments("'off'")]
+    public async Task Disabling_values_are_disabled_and_do_not_warn(string value) {
+        await Assert.That(ReviewerConsent.IsEnabled(value)).IsFalse();
+        await Assert.That(ReviewerConsent.DescribeUnparseable("VAR", value)).IsNull()
+            .Because("a recognised disable is not a mistake to warn about");
+    }
+
+    [Test]
+    [Arguments("flase")]     // the mistyped disable this whole direction exists to catch
+    [Arguments("disabled")]
+    [Arguments("y")]
+    [Arguments("2")]
+    [Arguments("0\"")]       // an unmatched trailing quote is NOT stripped, so it stays unrecognised
+    public async Task Unrecognised_values_fail_closed_and_warn(string value) {
+        await Assert.That(ReviewerConsent.IsEnabled(value)).IsFalse()
+            .Because("unset already enables, so a value we cannot read is a failed attempt to disable");
+
+        var warning = ReviewerConsent.DescribeUnparseable("KCAP_KIRO_UNATTENDED_REVIEWER", value);
+        await Assert.That(warning).IsNotNull();
+        await Assert.That(warning!).Contains("DISABLED")
+            .Because("the warning must state the outcome the parse actually produced");
+    }
+
+    /// <summary>
+    /// The property the install notice depends on: IsEnabled and DescribeUnparseable are BOTH derived
+    /// from Recognise, so they cannot disagree. A value that warns must also be disabled; a value that
+    /// does not warn is whatever Recognise said.
+    /// </summary>
+    [Test]
+    [Arguments("1")]
+    [Arguments("0")]
+    [Arguments("flase")]
+    [Arguments(null)]
+    public async Task IsEnabled_and_the_warning_agree(string? value) {
+        var recognised = ReviewerConsent.Recognise(value);
+        var warned     = ReviewerConsent.DescribeUnparseable("V", value) is not null;
+
+        await Assert.That(warned).IsEqualTo(recognised is null);
+        if (recognised is { } known)
+            await Assert.That(ReviewerConsent.IsEnabled(value)).IsEqualTo(known);
+        else
+            await Assert.That(ReviewerConsent.IsEnabled(value)).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/GatedReviewerRegistryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/GatedReviewerRegistryTests.cs
@@ -1,0 +1,92 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// The registry is the SINGLE list three surfaces derive from — the daemon's opt-out apply loop, the
+/// service-unit environment allowlist, and <c>daemon reviewer affirm</c>'s vendor resolution. These pin
+/// the properties that make deriving safer than listing, rather than merely tidier.
+///
+/// <para>The hazard is specific to these switches being opt-OUTs. A row that reaches one surface and
+/// not another used to mean a reviewer that could not be turned ON — safe. It now means one that cannot
+/// be turned OFF, which on a service-installed daemon leaves the operator no lever at all.</para>
+/// </summary>
+public class GatedReviewerRegistryTests {
+    /// <summary>
+    /// Every row has a <see cref="DaemonConfig"/> flag behind it.
+    ///
+    /// <para>This is the direction the service-unit test structurally cannot see: that one ranges over
+    /// the registry and proves each row survives capture, so a row the DAEMON cannot apply is still
+    /// green there. Adding a reviewer to the registry publishes its variable into every service unit
+    /// and into the affirm verb's usage text; without an accessor the operator sets a documented switch
+    /// that does nothing. <c>ConsentApplier</c> throws for that case, and this is what makes CI hit the
+    /// throw instead of a customer's first boot.</para>
+    /// </summary>
+    [Test]
+    public async Task Consent_applier_covers_every_gated_reviewer() {
+        await Assert.That(GatedReviewers.All).IsNotEmpty()
+            .Because("an empty registry would make every assertion here vacuously true");
+
+        foreach (var reviewer in GatedReviewers.All) {
+            var config = new DaemonConfig();
+
+            // Resolving is half the assertion: an unmapped vendor throws NotSupportedException.
+            DaemonRunner.ConsentApplier(config, reviewer.Vendor)(false);
+
+            // The other half is that it cleared THIS vendor's flag. Naming the expected property is
+            // what makes that real: an earlier version counted how many flags went false, which a
+            // copy-paste aliasing two vendors onto one property passes — a fresh config per iteration
+            // means exactly one flag clears either way. Verified by mutation; the count-based version
+            // survived pointing opencode at Kiro's property.
+            var expected = ExpectedFlag(reviewer.Vendor);
+
+            await Assert.That(expected(config)).IsFalse()
+                .Because($"{reviewer.Vendor}'s opt-out must clear {reviewer.Vendor}'s own flag, not "
+                       + "another vendor's — aliasing would silently make one switch disable the wrong "
+                       + "reviewer while leaving the named one running");
+
+            foreach (var (vendor, flag) in AllFlags().Where(f => f.Vendor != reviewer.Vendor))
+                await Assert.That(flag(config)).IsTrue()
+                    .Because($"{reviewer.Vendor}'s opt-out must not touch {vendor}");
+        }
+    }
+
+    /// <summary>The flag each vendor's opt-out is expected to clear. Deliberately a SECOND, independent
+    /// statement of the mapping — a test that re-derived it from the code under test could not detect a
+    /// mis-wiring.</summary>
+    static Func<DaemonConfig, bool> ExpectedFlag(string vendor) =>
+        AllFlags().Single(f => f.Vendor == vendor).Flag;
+
+    static (string Vendor, Func<DaemonConfig, bool> Flag)[] AllFlags() => [
+        ("gemini",      c => c.GeminiUnattendedReviewerEnabled),
+        ("kiro",        c => c.KiroUnattendedReviewerEnabled),
+        ("opencode",    c => c.OpenCodeUnattendedReviewerEnabled),
+        ("antigravity", c => c.AntigravityUnattendedReviewerEnabled)
+    ];
+
+    /// <summary>An unmapped vendor is refused loudly, not silently no-op'd.</summary>
+    [Test]
+    public async Task Consent_applier_refuses_a_reviewer_it_cannot_apply() {
+        await Assert.That(() => DaemonRunner.ConsentApplier(new DaemonConfig(), "notavendor"))
+            .Throws<NotSupportedException>();
+    }
+
+    /// <summary>
+    /// Every row carries a usable opt-out variable. A null or blank one would land in the service-unit
+    /// allowlist as an empty key and quietly drop that reviewer's only lever.
+    /// </summary>
+    [Test]
+    public async Task Every_gated_reviewer_names_an_opt_out_variable() {
+        foreach (var reviewer in GatedReviewers.All) {
+            await Assert.That(string.IsNullOrWhiteSpace(reviewer.EnableEnvVar)).IsFalse()
+                .Because($"{reviewer.Vendor} would otherwise be undisableable");
+            await Assert.That(string.IsNullOrWhiteSpace(reviewer.Vendor)).IsFalse();
+        }
+
+        await Assert.That(GatedReviewers.All.Select(r => r.EnableEnvVar).Distinct().Count())
+            .IsEqualTo(GatedReviewers.All.Length)
+            .Because("two reviewers sharing a variable makes one of them undisableable on its own");
+    }
+
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ObservedVendorVersionShapeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ObservedVendorVersionShapeTests.cs
@@ -1,0 +1,67 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// The `--version` output of every gated reviewer's binary, as MEASURED on 2026-08-08, run through the
+/// extractor that seeds its version floor.
+///
+/// <para><b>Why this exists.</b> A floor is affirmed once, on the first startup that finds the binary,
+/// and never re-probed — so a wrong token is pinned permanently and gates silently in both directions.
+/// <see cref="VendorVersionResolver.ExtractVersionToken"/> takes the FIRST dotted-numeric token, which
+/// closes the garbage class (banners, <c>unknown</c>, localised errors) but not the wrong-token class:
+/// an update nag, a runtime line like <c>Node.js v22.1.0</c>, or a date stamp like <c>2026.08.08</c> all
+/// qualify and can precede the real version.</para>
+///
+/// <para><b>What it does and does not prove.</b> These are recorded observations of four builds on one
+/// host, so this cannot detect the day a vendor ADDS a nag line — nothing local can. What it does is
+/// stop the extractor from being changed in a way that breaks a shape we know ships, and give the next
+/// person the actual strings rather than a description of them. The negative cases below are the ones
+/// review raised, pinned so the limitation stays a KNOWN one rather than being rediscovered as a
+/// surprise.</para>
+/// </summary>
+public class ObservedVendorVersionShapeTests {
+    [Test]
+    [Arguments("kiro-cli", "kiro-cli 2.16.0", "2.16.0")]
+    [Arguments("gemini",   "0.54.0",          "0.54.0")]
+    [Arguments("opencode", "1.18.9",          "1.18.9")]
+    [Arguments("agy",      "1.1.11",          "1.1.11")]
+    public async Task Measured_vendor_output_extracts_the_installed_version(
+            string binary, string output, string expected) {
+        await Assert.That(VendorVersionResolver.ExtractVersionToken(output)).IsEqualTo(expected)
+            .Because($"this is what `{binary} --version` actually printed when it was measured; a floor "
+                   + "seeded from a different token would gate the wrong builds forever");
+    }
+
+    /// <summary>
+    /// The wrong-token class, pinned as ACCEPTED behaviour rather than as a bug.
+    ///
+    /// <para>Each of these extracts a version-shaped token that is not the installed build. None is
+    /// currently produced by any of the four vendors (the test above is the evidence), which is why the
+    /// design records and logs the affirmed token instead of anchoring extraction per vendor. If a
+    /// vendor ever starts printing one of these shapes, the seeded-floor log line is what surfaces it —
+    /// and this test is where the decision to accept that risk is written down.</para>
+    /// </summary>
+    [Test]
+    [Arguments("Update available 0.11.14 -> 0.12.0", "0.11.14")]
+    [Arguments("Node.js v22.1.0\nopencode 1.18.9",   "22.1.0")]
+    [Arguments("built 2026.08.08 (v1.2.3)",          "2026.08.08")]
+    public async Task Version_shaped_noise_before_the_version_still_wins(string output, string extracted) {
+        await Assert.That(VendorVersionResolver.ExtractVersionToken(output)).IsEqualTo(extracted)
+            .Because("first-qualifying-token extraction cannot tell these from a version — a known, "
+                   + "documented limitation, not a defect this test is asking anyone to fix");
+    }
+
+    /// <summary>The garbage class, which IS closed: none of these can affirm a floor at all.</summary>
+    [Test]
+    [Arguments("unknown")]
+    [Arguments("")]
+    [Arguments("error: command not found")]
+    [Arguments("versión no disponible")]
+    [Arguments("2")]
+    public async Task Unversioned_output_affirms_nothing(string output) {
+        await Assert.That(VendorVersionResolver.ExtractVersionToken(output)).IsNull()
+            .Because("a build we cannot identify must read as unknown — and therefore denied — rather "
+                   + "than as a near-miss string that seeds a nonsense floor");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -2193,9 +2193,14 @@ public class AcpHostedAgentRuntimeFactoryTests {
     /// actually diagnosed.</para>
     /// </summary>
     [Test]
-    public async Task Gemini_ADisabledDaemon_ExplainsWhyItIsWithheld() {
+    public async Task Gemini_AnExplicitlyDisabledDaemon_ExplainsWhyItIsWithheld() {
         IHostedAgentRuntimeFactory disabled = new AcpHostedAgentRuntimeFactory(
-            AcpVendorDescriptors.Gemini, new DaemonConfig(), NullLoggerFactory.Instance,
+            AcpVendorDescriptors.Gemini,
+            // Explicit now: the reviewer switch defaults to ENABLED, so a bare DaemonConfig no longer
+            // reaches this arm — it falls through to the version floor, which is the correct behaviour
+            // and is asserted separately.
+            new DaemonConfig { GeminiUnattendedReviewerEnabled = false },
+            NullLoggerFactory.Instance,
             new CaptureServerConnection(), resolveVendorVersion: _ => GeminiBuild);
 
         var support = disabled.DescribeUnattendedSupport();
@@ -2204,8 +2209,25 @@ public class AcpHostedAgentRuntimeFactoryTests {
         // The operator's actual next action has to be IN the text — a reason that only says "disabled"
         // leaves them exactly where the coded server error already did.
         await Assert.That(support.WithheldReason).IsNotNull();
-        await Assert.That(support.WithheldReason!).Contains("KCAP_GEMINI_UNATTENDED_REVIEWER=1");
+        await Assert.That(support.WithheldReason!).Contains("KCAP_GEMINI_UNATTENDED_REVIEWER");
         await Assert.That(support.WithheldReason!).StartsWith("gemini_unattended_reviewer_disabled");
+    }
+
+    /// <summary>
+    /// The change this default flip is FOR, asserted at the advertisement seam rather than only at the
+    /// launch boundary: a daemon with nothing configured no longer withholds the reviewer for lack of an
+    /// opt-in. It may still withhold it for a version reason — that gate is untouched — but the refusal
+    /// must not be the consent one.
+    /// </summary>
+    [Test]
+    public async Task Gemini_ADefaultDaemon_IsNotWithheldForLackOfAnOptIn() {
+        IHostedAgentRuntimeFactory standard = new AcpHostedAgentRuntimeFactory(
+            AcpVendorDescriptors.Gemini, new DaemonConfig(), NullLoggerFactory.Instance,
+            new CaptureServerConnection(), resolveVendorVersion: _ => GeminiBuild);
+
+        var reason = standard.DescribeUnattendedSupport().WithheldReason;
+
+        await Assert.That(reason ?? "").DoesNotContain("unattended_reviewer_disabled");
     }
 
     /// <summary>A build NEWER than the recorded minimum is advertised, withholding nothing. This

--- a/test/Capacitor.Cli.Tests.Unit/Services/GeminiReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/GeminiReviewerLaunchTests.cs
@@ -254,9 +254,10 @@ public class GeminiReviewerLaunchTests {
     /// routing around the advertisement check.
     /// </summary>
     [Test]
-    public async Task ADisabledDaemon_RefusesAReviewLaunchBeforeAnyProcessCouldStart() {
+    public async Task AnExplicitlyDisabledDaemon_RefusesAReviewLaunchBeforeAnyProcessCouldStart() {
         var ex = Assert.Throws<InvalidOperationException>(
-            () => Build(isReviewFlow: true, config: new DaemonConfig()));
+            () => Build(isReviewFlow: true,
+                        config: new DaemonConfig { GeminiUnattendedReviewerEnabled = false }));
 
         await Assert.That(ex!.Message).Contains("gemini_unattended_reviewer_disabled");
     }

--- a/test/Capacitor.Cli.Tests.Unit/Services/KiroReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/KiroReviewerLaunchTests.cs
@@ -136,16 +136,46 @@ public class KiroReviewerLaunchTests {
                 UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }
 
+    /// <summary>
+    /// An EXPLICITLY disabled daemon still refuses at the launch boundary. Note the config now has to
+    /// set the flag false on purpose — the default is enabled — which is the point of the test: the
+    /// opt-out must still be honoured at the boundary an explicit <c>vendor: "kiro"</c> request reaches
+    /// without consulting advertisement.
+    /// </summary>
     [Test]
-    public async Task ADisabledDaemon_RefusesAReviewLaunch() {
+    public async Task AnExplicitlyDisabledDaemon_StillRefusesAReviewLaunch() {
         Skip.Unless(!OperatingSystem.IsWindows(),
             "The Kiro unattended reviewer is POSIX-only: its isolated home holds review context and cannot be created owner-only on Windows.");
 
-        var config = new DaemonConfig { StateDir = StateDir(), Name = "test-daemon" };
+        var config = new DaemonConfig {
+            StateDir = StateDir(), Name = "test-daemon", KiroUnattendedReviewerEnabled = false
+        };
 
         await Assert.That(() => Psi(isReviewFlow: true, config))
             .Throws<InvalidOperationException>()
             .WithMessageContaining("kiro_unattended_reviewer_disabled");
+    }
+
+    /// <summary>
+    /// The other half, and the one this change exists for: a DEFAULT daemon — nothing configured —
+    /// launches. Before, an operator got a refusal here and had to edit a service unit to use a feature
+    /// they had explicitly requested.
+    /// </summary>
+    [Test]
+    public async Task ADefaultDaemon_LaunchesAReviewWithoutAnyOptIn() {
+        Skip.Unless(!OperatingSystem.IsWindows(),
+            "The Kiro unattended reviewer is POSIX-only.");
+
+        var stateDir = StateDir();
+        var config = new DaemonConfig { StateDir = stateDir, Name = "test-daemon", DaemonEpoch = "epoch-1" };
+
+        // Seeded exactly as a real boot seeds it, which is now unconditional.
+        AcpHostedAgentRuntimeFactory.VersionStoreFor(config, AcpVendorDescriptors.Kiro.Vendor)
+            .Affirm(InstalledVersion);
+
+        var psi = Psi(isReviewFlow: true, config);
+
+        await Assert.That(psi.ArgumentList).Contains("--trust-tools");
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Services/OpenCodeHostedLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/OpenCodeHostedLaunchTests.cs
@@ -117,16 +117,18 @@ public class OpenCodeHostedLaunchTests {
     /// coded reason; only the consent-specific code is POSIX-scoped.</para>
     /// </summary>
     [Test]
-    public async Task AReviewFlowLaunch_IsRefusedOnADaemonThatHasNotConsented() {
-        await Assert.That(() => Psi(isReviewFlow: true))
+    public async Task AReviewFlowLaunch_IsRefusedOnADaemonThatExplicitlyDisabledIt() {
+        var disabled = new DaemonConfig { OpenCodeUnattendedReviewerEnabled = false };
+
+        await Assert.That(() => Psi(disabled, isReviewFlow: true))
             .Throws<InvalidOperationException>()
             .WithMessageContaining("opencode_");
 
         Skip.Unless(!OperatingSystem.IsWindows(),
-            "The consent arm is unreachable on Windows: the gate refuses on platform first, before "
-          + "consent is consulted.");
+            "The disabled arm is unreachable on Windows: the gate refuses on platform first, before "
+          + "the opt-out is consulted.");
 
-        await Assert.That(() => Psi(isReviewFlow: true))
+        await Assert.That(() => Psi(disabled, isReviewFlow: true))
             .Throws<InvalidOperationException>()
             .WithMessageContaining("opencode_unattended_reviewer_disabled");
     }

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
@@ -182,7 +182,7 @@ public class ServiceEnvironmentTests {
     }
 
     /// <summary>A flag the installing environment never set must not appear — capture carries an
-    /// existing opt-in into the unit, it never manufactures one.</summary>
+    /// existing choice into the unit, it never manufactures one.</summary>
     [Test]
     public async Task Build_never_invents_a_consent_flag() {
         var env = ServiceEnvironment.Build(
@@ -192,6 +192,36 @@ public class ServiceEnvironmentTests {
 
         foreach (var key in ServiceEnvironment.ReviewerConsentKeys)
             await Assert.That(env.ContainsKey(key)).IsFalse();
+    }
+
+    /// <summary>
+    /// EVERY reviewer's opt-out reaches a service unit, on BOTH platforms, with a DISABLING value.
+    ///
+    /// <para>This is the one test standing behind the ungating's load-bearing claim: unattended reviewers
+    /// default to enabled, so the operator's explicit opt-out is the compensating control, and it is only
+    /// real if it survives the supported install path. Before the flip a dropped variable meant a reviewer
+    /// that could not be turned on — safe. Now it means one that cannot be turned OFF.</para>
+    ///
+    /// <para>Ranges over the registry rather than four literals deliberately: a vendor added later is
+    /// covered here the day it is added, which a hardcoded list would not do. The sibling test above
+    /// asserts the enabling direction; this one asserts the direction that now matters.</para>
+    /// </summary>
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Every_reviewer_opt_out_survives_a_service_install(bool isWindows) {
+        var source = new Dictionary<string, string> { ["PATH"] = "/usr/bin" };
+        foreach (var key in ServiceEnvironment.ReviewerConsentKeys) source[key] = "0";
+
+        var env = ServiceEnvironment.Build(profileName: null, source: source, isWindows: isWindows);
+
+        await Assert.That(ServiceEnvironment.ReviewerConsentKeys).IsNotEmpty()
+            .Because("an empty registry would make every assertion below vacuously true");
+
+        foreach (var key in ServiceEnvironment.ReviewerConsentKeys)
+            await Assert.That(env.TryGetValue(key, out var v) ? v : null).IsEqualTo("0")
+                .Because($"{key} is the operator's only lever for turning that reviewer off; a supervised "
+                       + "daemon reads it from the unit or not at all");
     }
 
     [Test]


### PR DESCRIPTION
Gemini, Kiro, OpenCode and Antigravity each required an explicit
`KCAP_<VENDOR>_UNATTENDED_REVIEWER=1` before a review flow could use them. That
opt-in is removed: **unset now means enabled**, and a recognised falsey value
disables.

## Why the gate had to go

**It was bypassable by the person it was supposedly protecting against.** The
reviewer vendor is a caller-chosen parameter. If the concern is "a requester uses
a reviewer to read files under the daemon's uid and gets them back in the
findings," gating `opencode` accomplishes nothing — they request `vendor:
"claude"`, which was never gated and has *more* capability. A control every
caller can route around by picking a different value from a menu is friction, not
security.

| Reviewer | Gated before? | Tool surface |
|---|---|---|
| claude | no | full — `bypassPermissions` |
| codex | no | full — `--ask-for-approval never` |
| cursor | no | full — `--force --approve-mcps --trust` |
| copilot | no | full — `--allow-all-tools` |
| gemini | **yes** | full — `--approval-mode yolo` |
| kiro | **yes** | `fs_read` + `thinking` only |
| opencode | **yes** | read/grep/glob/list only — no shell, write or network |

Two of the four gated vendors run **read-only** reviewers. The strictest policy
was attached to the least dangerous configurations while four full-tool reviewers
ran ungated.

**And it taxed the honest path hardest.** A supervised daemon inherits nothing
from the installing shell, so turning a reviewer on meant editing a service unit
and restarting — to use a feature the operator had explicitly requested. That is
the mechanism behind AI-1755, where Gemini's non-advertisement was diagnosed
through six ruled-out hypotheses before the consent gate turned out to be the
cause.

## What still protects a launch

The per-vendor **version floor** — a different mechanism answering a different
question. Several of these reviewers' containment is a behaviour of the installed
build, and OpenCode's is environment-based, which fails **silently** if a build
stops honouring it (measured: with no `OPENCODE_PERMISSION`, a review-shaped turn
writes files with no prompt). The floor is seeded unconditionally at startup so
it can never block a first launch, and `kcap daemon reviewer affirm` raises it
past a build found to be bad. Remediation, not permission.

## Why an opt-out rather than deleting the variables

Silently **enabling** something an operator had deliberately set to `0` is the
one surprise this must not spring. An unrecognised value resolves to the default
and is reported by name at startup, so a typo cannot quietly take a reviewer
offline — the direction worth being loud about, since the parse can no longer
distinguish "meant to disable" from "meant to enable".

## Verified

On a real daemon with **no consent configuration at all**: all eight vendors
advertised, **none withheld**. Before this, four were withheld.

Targeted suites, all green on the merged tree (main moved under this branch —
`#490` landed in Antigravity's capability files and its tests are passing here
too): `KiroReviewerCapabilityTests` 44/44, `AntigravityReviewerCapabilityTests`
43/43, `GeminiReviewerCapabilityTests` 31/31, `OpenCodeReviewerCapabilityTests`
14/14, `AcpHostedAgentRuntimeFactoryTests` 83/83, `AntigravityReviewerLaunchTests`
55/55, plus the Kiro/Gemini/OpenCode launch suites, `ServiceEnvironmentTests`,
`DaemonReviewerCommandTests` and `UnattendedLaunchPolicyTests`. AOT publish clean
for both projects. No Linear IDs in `.cs`.

Each "disabled daemon" test now sets the flag false deliberately, and new tests
pin the case this change exists for: a **default** daemon launches a reviewer
with no opt-in, and the advertisement seam does not withhold one for lack of
consent.

## Note for reviewers

This widens a security default, so the reasoning above is the thing to attack,
not the diff. In particular: if you think the gate *was* buying something the
version floor does not, that is the finding worth raising.

Fixes AI-1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)
