### PR TITLE
Host Pi agents over pi --mode rpc (PR-1: interactive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1262,7 +1262,7 @@ KCAP_CURSOR_PATH=/opt/cursor/bin/cursor-agent kcap daemon
 KCAP_CURSOR_MODEL=claude-opus-4-8 kcap daemon
 ```
 
-`KCAP_COPILOT_PATH` overrides the `copilot` binary the daemon spawns for **GitHub Copilot hosted agents** (`copilot --acp --stdio`), mirroring `KCAP_CURSOR_PATH` — the daemon hosts Claude, Codex, Cursor, Copilot, Kiro, Gemini, OpenCode and Antigravity. `KCAP_GEMINI_PATH` overrides the `gemini` binary the same way (`gemini --experimental-acp`), and applies to both hosted Gemini agents and the [unattended Gemini reviewer](#unattended-reviewers-are-enabled-by-default-they-used-to-be-opt-in) (enabled by default) — whose build-affirmation check reads whichever binary it names. `KCAP_OPENCODE_PATH` overrides the `opencode` binary the daemon spawns for **OpenCode hosted agents** (`opencode acp`) — no longer reserved; see [Hosted OpenCode agents](#hosted-opencode-agents) below.
+`KCAP_COPILOT_PATH` overrides the `copilot` binary the daemon spawns for **GitHub Copilot hosted agents** (`copilot --acp --stdio`), mirroring `KCAP_CURSOR_PATH` — the daemon hosts Claude, Codex, Cursor, Copilot, Kiro, Gemini, Pi, OpenCode and Antigravity. `KCAP_GEMINI_PATH` overrides the `gemini` binary the same way (`gemini --experimental-acp`), and applies to both hosted Gemini agents and the [unattended Gemini reviewer](#unattended-reviewers-are-enabled-by-default-they-used-to-be-opt-in) (enabled by default) — whose build-affirmation check reads whichever binary it names. `KCAP_OPENCODE_PATH` overrides the `opencode` binary the daemon spawns for **OpenCode hosted agents** (`opencode acp`) — no longer reserved; see [Hosted OpenCode agents](#hosted-opencode-agents) below. `KCAP_PI_PATH` overrides the `pi` binary the daemon spawns for **Pi hosted agents** (`pi --mode rpc`) — interactive hosting only in this release; see [Hosted Pi agents](#hosted-pi-agents) below.
 
 ```bash
 KCAP_COPILOT_PATH=/opt/copilot/bin/copilot kcap daemon
@@ -1408,6 +1408,34 @@ verbatim, exactly like every other agent, with no Cursor/ACP-specific redaction.
 | `KCAP_CODEX_IDLE_MINUTES` | `60` | How long a Codex rollout file may be idle (no new rollout lines and no Codex tool call in flight) before the `kcap watch` background watcher ends the session (`reason: idle_timeout`). Increase for very long thinking/compute turns; decrease for faster cleanup of abandoned sessions. Invalid or non-positive values fall back to the 60-minute default. |
 | `KCAP_PARENT_DEAD_CEILING_MINUTES` | `360` | Staged recovery ceiling for a watcher whose parent coding-agent PID was already dead at startup (a resolution glitch) and can't be re-resolved. The watcher first periodically re-resolves and re-arms the parent-exit watchdog; only if that keeps failing AND the transcript makes no progress for this long does it post `session-end` (`reason: parent_dead_ceiling`). Deliberately far above the idle timeout so a user parked at a Kiro/OpenCode prompt is never ended prematurely. Invalid or non-positive values fall back to 360 minutes (6h). |
 | `KCAP_CURSOR_IDLE_CEILING_MINUTES` | `60` | How long a Cursor session's transcript watcher may go idle before it exits (AI-1382). Unlike Codex/Antigravity, this exit does NOT itself POST `session-end` — Cursor's end-of-session synthesis stays owned by the `sessionEnd` hook or, as a backstop, a server-side lease-gated sweep; the next hook for that session reactivates a fresh watcher. Invalid or non-positive values fall back to the 60-minute default. |
+
+### Hosted Pi agents
+
+`KCAP_PI_MODEL` overrides the model a `pi` hosted agent runs, mirroring `KCAP_OPENCODE_MODEL` —
+including the same deliberate absence of a built-in default: with nothing set (and no per-launch
+model from the dashboard, which takes precedence) the agent runs whatever Pi's own configured
+default is and kcap reports none. The value is passed verbatim as `--model <value>` on the spawned
+`pi --mode rpc` child's argv; kcap does not query or validate it against Pi's available models, so
+an unrecognized value is Pi's own error to report.
+
+```bash
+KCAP_PI_MODEL=claude-opus-4-5 kcap daemon
+```
+
+Two things are worth knowing before you pick Pi:
+
+- **Your Pi extension does not load in a hosted agent.** kcap's global Pi live-ingest extension
+  (`~/.pi/agent/extensions/kcap.ts`) auto-loads inside every `pi` process on the machine, hosted or
+  not, so the daemon spawns the hosted child with `KCAP_PI_PURE=1` — read by the extension at the
+  top of its exported function, which then returns immediately and registers no handlers. Without
+  it a hosted session would be captured twice: once over the RPC wire this runtime already speaks,
+  and once by the extension's own `session_start`/`session_shutdown` hooks. Sessions you start
+  yourself are untouched: the extension keeps its whole job there.
+- **Interactive hosting only, in an owned worktree only, in this release.** Pi has no reviewer lane
+  yet — `start_review_flow(vendor="pi")` and a Pi PR review (`kcap review <pr>` / the dashboard's
+  Review PR action) are both refused, the latter because that surface needs the `kcap mcp review`
+  tool set only the PTY-backed vendors are given. There is also no borrowed-workspace containment
+  for Pi, so a hosted Pi launch always runs in a daemon-owned worktree, never your own checkout.
 
 #### Review-flow reviewer backstops & crash-survivor reaping
 

--- a/src/Capacitor.Cli.Core/JsonElementExtensions.cs
+++ b/src/Capacitor.Cli.Core/JsonElementExtensions.cs
@@ -10,6 +10,13 @@ static class JsonElementExtensions {
         // to a raw ValueKind comparison instead.
         public bool IsObject => el.ValueKind == JsonValueKind.Object;
 
+        // Same shape as IsObject, for callers that already have an element in hand (e.g. a property
+        // value pulled via TryGetProperty) and need to branch on ITS kind rather than a named
+        // property of it — the accessors below only ever answer about a property BY NAME.
+        public bool IsString => el.ValueKind == JsonValueKind.String;
+        public bool IsArray  => el.ValueKind == JsonValueKind.Array;
+        public bool IsNull   => el.ValueKind == JsonValueKind.Null;
+
         public string? Str(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
 
         // Guard the ValueKind before TryGetInt64: it THROWS on a non-Number element (string,
@@ -18,6 +25,12 @@ static class JsonElementExtensions {
         // Same defensive contract as Str/Obj/Arr above — a wrong-typed field reads as absent.
         // A fractional number still returns null via TryGetInt64 rather than truncating.
         public long? Num(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var n) ? n : null;
+
+        // Only True/False resolve; anything else (missing, wrong-typed) reads as absent — same
+        // defensive contract as Str/Num/Obj/Arr, and the nullable result lets a caller that only
+        // cares about an explicit `true` write `el.Bool("x") == true` without conflating "false" with
+        // "absent".
+        public bool? Bool(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.ValueKind is JsonValueKind.True or JsonValueKind.False ? v.GetBoolean() : null;
 
         public JsonElement? Obj(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.IsObject ? v : null;
 

--- a/src/Capacitor.Cli.Core/Pi/PiExtensionInstaller.cs
+++ b/src/Capacitor.Cli.Core/Pi/PiExtensionInstaller.cs
@@ -35,6 +35,11 @@ public static class PiExtensionInstaller {
         // pi session.
 
         export default function (pi: any) {
+          // Hosted launches set KCAP_PI_PURE=1: the daemon owns capture there, and this
+          // extension standing down is what prevents the session being recorded twice.
+          // Mirrors OPENCODE_PURE.
+          if (typeof process !== "undefined" && process?.env?.KCAP_PI_PURE === "1") return;
+
           // Team-memory fragment for the CURRENT session file, or null. Keyed by file
           // because that is Pi's stable session identity: resume reuses the file,
           // fork/switch mint a different one (which must never inherit this fragment).

--- a/src/Capacitor.Cli.Daemon/Acp/IPiRpcProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/IPiRpcProcess.cs
@@ -48,6 +48,11 @@ internal interface IPiRpcProcess : IAsyncDisposable {
     /// <summary>OS exit code once <see cref="HasExited"/>; null while running or if unknown.</summary>
     int? ExitCode { get; }
 
+    /// <summary>A bounded capture of whatever the child wrote to stderr, or null if it wrote
+    /// nothing. Read on a failed launch (see <c>PiRpcHostedAgentRuntimeFactory</c>'s post-spawn
+    /// catch) or an unexpected exit, to turn silence into a reason an operator can act on.</summary>
+    string? Diagnostics { get; }
+
     /// <summary>
     /// Reads this child's stdout, LF-framed, one JSONL line at a time, ending when stdout hits EOF
     /// (the process exited, or is about to). Must not throw for a normal EOF — the sequence simply

--- a/src/Capacitor.Cli.Daemon/Acp/IPiRpcProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/IPiRpcProcess.cs
@@ -1,0 +1,289 @@
+// src/Capacitor.Cli.Daemon/Acp/IPiRpcProcess.cs
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Acp;
+
+/// <summary>
+/// Minimal process-lifecycle abstraction for a hosted Pi <c>pi</c> child speaking the stdio JSONL
+/// RPC protocol (see <c>PiRpc</c>). Unlike <see cref="IAgyTurnProcess"/> — an exec-per-turn child
+/// whose stdin is closed the instant it is spawned — a Pi RPC child is LONG-LIVED: one process backs
+/// the whole hosted session, and its stdin stays open for that entire lifetime so the runtime can
+/// keep sending <c>prompt</c>/<c>abort</c>/<c>get_state</c>/<c>set_model</c> commands to it turn
+/// after turn. That is exactly the capability this interface adds over <see cref="IAgyTurnProcess"/>:
+/// <see cref="WriteLineAsync"/>.
+///
+/// <para>Exists so a Pi hosted-agent runtime is testable without spawning a real process; a later
+/// task's factory implements this over <see cref="System.Diagnostics.Process"/> (<see cref="PiRpcProcess"/>,
+/// this file).</para>
+///
+/// <para><b>Two contracts a real implementation must honor — copied verbatim from
+/// <see cref="IAgyTurnProcess"/>, because the same runtime shapes (a turn worker's own
+/// <c>finally</c> racing the runtime's own teardown) apply here too:</b></para>
+/// <para>0. <see cref="IAsyncDisposable.DisposeAsync"/> MAY terminate a still-running child, and an
+/// implementation over a real process does. It is therefore NOT a source of exit evidence: a caller
+/// that needs to know whether a child exited must terminate it explicitly and read
+/// <see cref="HasExited"/> while the handle is still valid, BEFORE disposing — a disposed process
+/// object reports exited whether or not it is.</para>
+/// <para>1. <see cref="IAsyncDisposable.DisposeAsync"/> MUST be idempotent. A second call on the same
+/// instance must be a safe no-op, never throw.</para>
+/// <para>2. <see cref="TerminateAsync"/> MUST be safe to call AFTER
+/// <see cref="IAsyncDisposable.DisposeAsync"/> has already run — this must degrade gracefully (a
+/// no-op, or a caught/logged failure internally), never throw an exception a caller doesn't already
+/// catch.</para>
+/// <para>3. <see cref="WriteLineAsync"/> calls MUST be serialized against each other so that two
+/// concurrent writers can never interleave partial lines on the child's stdin — a torn line is
+/// unparseable JSON on the other end, and unlike a read race (which just ends the enumerable early),
+/// a write race corrupts the wire for every command after it.</para>
+/// </summary>
+internal interface IPiRpcProcess : IAsyncDisposable {
+    /// <summary>OS process id of the hosted <c>pi</c> child.</summary>
+    int Pid { get; }
+
+    /// <summary>True once the process has exited.</summary>
+    bool HasExited { get; }
+
+    /// <summary>OS exit code once <see cref="HasExited"/>; null while running or if unknown.</summary>
+    int? ExitCode { get; }
+
+    /// <summary>
+    /// Reads this child's stdout, LF-framed, one JSONL line at a time, ending when stdout hits EOF
+    /// (the process exited, or is about to). Must not throw for a normal EOF — the sequence simply
+    /// ends; it throws <see cref="OperationCanceledException"/> if <paramref name="ct"/> is
+    /// cancelled first.
+    /// </summary>
+    IAsyncEnumerable<string> ReadLinesAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Writes <paramref name="json"/> followed by a single <c>\n</c> to the child's stdin and
+    /// flushes, so the line is on the wire before this returns. Concurrent callers are serialized
+    /// against each other (contract 3 on this interface's class doc) — never call this expecting an
+    /// implementation to accept interleaved writes.
+    /// </summary>
+    Task WriteLineAsync(string json, CancellationToken ct);
+
+    /// <summary>Wait up to <paramref name="timeout"/> for the process to exit (returns silently on timeout).</summary>
+    Task WaitForExitAsync(TimeSpan? timeout = null);
+
+    /// <summary>Terminate the process (SIGTERM then SIGKILL) within <paramref name="timeout"/>. Must
+    /// be safe to call even after <see cref="IAsyncDisposable.DisposeAsync"/> has already run — see
+    /// this interface's class doc.</summary>
+    Task TerminateAsync(TimeSpan? timeout = null);
+}
+
+/// <summary>
+/// <see cref="IPiRpcProcess"/> over a real <see cref="Process"/> — the long-lived <c>pi</c> child
+/// backing one hosted Pi session for its whole lifetime. Mirrors <c>AgyTurnProcess</c>'s
+/// terminate/wait/dispose semantics (SIGTERM-then-kill via <see cref="Process.Kill(bool)"/>, bounded
+/// waits that return silently on timeout, idempotent dispose, terminate-safe-after-dispose) and its
+/// bounded stderr diagnostics capture, but differs in the one place the two runtimes differ: stdin.
+/// <c>AgyTurnProcess</c> closes it the instant the child spawns (a fresh exec-per-turn process that
+/// never needs a second write); this type deliberately leaves it open and adds
+/// <see cref="WriteLineAsync"/>, serialized under a <see cref="SemaphoreSlim"/> so two commands fired
+/// close together (e.g. a user prompt racing an operator-initiated abort) can never tear each other's
+/// line in half on the wire.
+///
+/// <para><b>Identity is captured at construction</b>, not read on demand: <see cref="Process.Id"/>
+/// throws once the process object is disposed, and the PID is exactly what an orphan reaper needs
+/// most after the fact.</para>
+/// </summary>
+internal sealed partial class PiRpcProcess : IPiRpcProcess {
+    /// <summary>Enough to carry a startup/auth error and the context around it, and small enough
+    /// that a chatty long-lived child cannot grow the daemon's heap over a session's whole
+    /// lifetime. Over-cap output is dropped, never rotated — this exists to explain a FAILED launch
+    /// or an unexpected exit, and that explanation is at the start.</summary>
+    const int DiagnosticsCap = 4096;
+
+    readonly Process                 _process;
+    readonly ILogger                 _logger;
+    readonly CancellationTokenSource _stderrDrainCts = new();
+    readonly Task                    _stderrDrainTask;
+    readonly Lock                    _diagnosticsGate = new();
+    readonly StringBuilder           _diagnostics     = new();
+    readonly SemaphoreSlim           _stdinGate       = new(1, 1);
+
+    int _disposed;
+
+    internal PiRpcProcess(ProcessStartInfo psi, ILogger logger)
+        : this(Process.Start(psi) ?? throw new InvalidOperationException(
+                   $"pi_rpc_spawn_failed: '{psi.FileName}' did not start (Process.Start returned null)."),
+               logger) { }
+
+    internal PiRpcProcess(Process process, ILogger logger) {
+        _process = process;
+        _logger  = logger;
+        Pid      = SafePid(process);
+
+        // Deliberately NOT closed — unlike AgyTurnProcess's exec-per-turn child, this process backs
+        // the whole hosted session and must keep receiving commands (prompt/abort/get_state/
+        // set_model) on stdin for its entire lifetime.
+        _stderrDrainTask = DrainStderrAsync(_stderrDrainCts.Token);
+    }
+
+    public int  Pid       { get; }
+    public bool HasExited { get { try { return _process.HasExited; } catch { return true; } } }
+
+    public int? ExitCode {
+        get {
+            try {
+                return _process.HasExited ? _process.ExitCode : null;
+            } catch {
+                return null;
+            }
+        }
+    }
+
+    /// <summary>A bounded capture of whatever the child wrote to stderr, or null if it wrote
+    /// nothing. Read on a failed launch or an unexpected exit, to turn silence into a reason an
+    /// operator can act on. Mirrors <c>AgyTurnProcess.Diagnostics</c>'s shape and naming.</summary>
+    public string? Diagnostics {
+        get { lock (_diagnosticsGate) return _diagnostics.Length == 0 ? null : _diagnostics.ToString(); }
+    }
+
+    /// <summary>This child's stdout, LF-framed, one JSONL line at a time, ending at EOF.</summary>
+    public async IAsyncEnumerable<string> ReadLinesAsync([EnumeratorCancellation] CancellationToken ct) {
+        while (true) {
+            string? line;
+
+            try {
+                line = await _process.StandardOutput.ReadLineAsync(ct).ConfigureAwait(false);
+            } catch (IOException) {
+                break;   // pipe torn down (the child was killed mid-read) — EOF, per this method's contract
+            } catch (ObjectDisposedException) {
+                break;   // stream disposed under us by a racing DisposeAsync — likewise EOF
+            }
+
+            if (line is null) break;
+
+            yield return line;
+        }
+    }
+
+    /// <summary>
+    /// Writes <paramref name="json"/> + <c>\n</c> to stdin and flushes, serialized under
+    /// <see cref="_stdinGate"/> so concurrent callers never interleave partial lines on the wire.
+    /// </summary>
+    public async Task WriteLineAsync(string json, CancellationToken ct) {
+        await _stdinGate.WaitAsync(ct).ConfigureAwait(false);
+
+        try {
+            await _process.StandardInput.WriteAsync((json + "\n").AsMemory(), ct).ConfigureAwait(false);
+            await _process.StandardInput.FlushAsync(ct).ConfigureAwait(false);
+        } finally {
+            _stdinGate.Release();
+        }
+    }
+
+    /// <summary>Keeps the stderr pipe drained — an undrained one fills at ~64KB and blocks the child
+    /// on its next write, which for a long-lived RPC process would wedge every future turn, not just
+    /// one. Never logs the text itself: a hosted agent's stderr can carry prompt fragments, paths,
+    /// or auth detail.</summary>
+    async Task DrainStderrAsync(CancellationToken ct) {
+        try {
+            while (!ct.IsCancellationRequested) {
+                var line = await _process.StandardError.ReadLineAsync(ct).ConfigureAwait(false);
+
+                if (line is null) break;      // EOF — the child exited and closed the stream
+                if (line.Length == 0) continue;
+
+                Capture(line);
+                LogStderrShape(line.Length);
+            }
+        } catch (OperationCanceledException) {
+            // Disposal asked the drain to stop — expected.
+        } catch (IOException) {
+            // Pipe torn down on teardown — expected.
+        } catch (ObjectDisposedException) {
+            // Stream disposed out from under the read — expected.
+        }
+    }
+
+    void Capture(string line) {
+        lock (_diagnosticsGate) {
+            if (_diagnostics.Length >= DiagnosticsCap) return;
+
+            _diagnostics.Append(line).Append('\n');
+        }
+    }
+
+    public async Task WaitForExitAsync(TimeSpan? timeout = null) {
+        try {
+            if (timeout is { } t) {
+                using var cts = new CancellationTokenSource(t);
+
+                try {
+                    await _process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+                } catch (OperationCanceledException) {
+                    // Timed out — return silently, per this method's contract.
+                }
+            } else {
+                await _process.WaitForExitAsync().ConfigureAwait(false);
+            }
+        } catch {
+            // Already exited or disposed — nothing left to wait for.
+        }
+    }
+
+    public async Task TerminateAsync(TimeSpan? timeout = null) {
+        try {
+            if (_process.HasExited) return;
+
+            _process.Kill(entireProcessTree: true);
+        } catch {
+            // Already exited, already disposed (the contract explicitly permits this call after
+            // DisposeAsync), or the kill raced the exit — nothing left to terminate either way.
+            return;
+        }
+
+        await WaitForExitAsync(timeout ?? TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync() {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;   // idempotent, per the interface contract
+
+        // No bounded wait after the kill, deliberately — see AgyTurnProcess's identical comment.
+        // Kill(entireProcessTree: true) is SIGKILL on POSIX, which no child can catch or defer, so
+        // the death is already effectively synchronous with the call. Callers that need a CONFIRMED
+        // exit terminate first and read HasExited while the handle is still valid.
+        try {
+            if (!_process.HasExited) _process.Kill(entireProcessTree: true);
+        } catch {
+            // Best-effort — already exited or inaccessible.
+        }
+
+        try {
+            await _stderrDrainCts.CancelAsync().ConfigureAwait(false);
+        } catch {
+            // Best-effort.
+        }
+
+        try {
+            await _stderrDrainTask.WaitAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+        } catch {
+            // DrainStderrAsync already swallows its expected exceptions; never let a stuck drain hang
+            // or fault a dispose.
+        }
+
+        _stderrDrainCts.Dispose();
+        _stdinGate.Dispose();
+
+        try {
+            _process.Dispose();
+        } catch {
+            // Best-effort.
+        }
+    }
+
+    static int SafePid(Process process) {
+        try {
+            return process.Id;
+        } catch {
+            return 0;
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Pi RPC stderr: {Length} chars")]
+    partial void LogStderrShape(int length);
+}

--- a/src/Capacitor.Cli.Daemon/Acp/IPiRpcProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/IPiRpcProcess.cs
@@ -67,7 +67,8 @@ internal interface IPiRpcProcess : IAsyncDisposable {
     /// <summary>Wait up to <paramref name="timeout"/> for the process to exit (returns silently on timeout).</summary>
     Task WaitForExitAsync(TimeSpan? timeout = null);
 
-    /// <summary>Terminate the process (SIGTERM then SIGKILL) within <paramref name="timeout"/>. Must
+    /// <summary>Terminate the process — an immediate kill of the whole process tree, matching
+    /// <c>AgyTurnProcess</c> (not a graceful signal first) — within <paramref name="timeout"/>. Must
     /// be safe to call even after <see cref="IAsyncDisposable.DisposeAsync"/> has already run — see
     /// this interface's class doc.</summary>
     Task TerminateAsync(TimeSpan? timeout = null);
@@ -76,9 +77,10 @@ internal interface IPiRpcProcess : IAsyncDisposable {
 /// <summary>
 /// <see cref="IPiRpcProcess"/> over a real <see cref="Process"/> — the long-lived <c>pi</c> child
 /// backing one hosted Pi session for its whole lifetime. Mirrors <c>AgyTurnProcess</c>'s
-/// terminate/wait/dispose semantics (SIGTERM-then-kill via <see cref="Process.Kill(bool)"/>, bounded
-/// waits that return silently on timeout, idempotent dispose, terminate-safe-after-dispose) and its
-/// bounded stderr diagnostics capture, but differs in the one place the two runtimes differ: stdin.
+/// terminate/wait/dispose semantics (an immediate kill of the whole process tree via
+/// <see cref="Process.Kill(bool)"/> — not a graceful signal first — bounded waits that return
+/// silently on timeout, idempotent dispose, terminate-safe-after-dispose) and its bounded stderr
+/// diagnostics capture, but differs in the one place the two runtimes differ: stdin.
 /// <c>AgyTurnProcess</c> closes it the instant the child spawns (a fresh exec-per-turn process that
 /// never needs a second write); this type deliberately leaves it open and adds
 /// <see cref="WriteLineAsync"/>, serialized under a <see cref="SemaphoreSlim"/> so two commands fired
@@ -105,6 +107,12 @@ internal sealed partial class PiRpcProcess : IPiRpcProcess {
     readonly SemaphoreSlim           _stdinGate       = new(1, 1);
 
     int _disposed;
+
+    /// <summary>Read wherever a caller needs to know disposal has started WITHOUT racing
+    /// <see cref="DisposeAsync"/>'s own idempotency check — <see cref="_disposed"/> is set via
+    /// <see cref="Interlocked.Exchange(ref int, int)"/> the instant <see cref="DisposeAsync"/>
+    /// begins, so a plain volatile read here is already coherent with that write.</summary>
+    bool IsDisposed => Volatile.Read(ref _disposed) != 0;
 
     internal PiRpcProcess(ProcessStartInfo psi, ILogger logger)
         : this(Process.Start(psi) ?? throw new InvalidOperationException(
@@ -164,11 +172,24 @@ internal sealed partial class PiRpcProcess : IPiRpcProcess {
     /// <summary>
     /// Writes <paramref name="json"/> + <c>\n</c> to stdin and flushes, serialized under
     /// <see cref="_stdinGate"/> so concurrent callers never interleave partial lines on the wire.
+    ///
+    /// <para>Checked for disposal BOTH before and after acquiring the gate. The pre-check is the
+    /// fast path once disposal has already finished (no need to queue behind a gate nobody will
+    /// ever signal again); the post-check catches a writer that was already queued in
+    /// <c>WaitAsync</c> when <see cref="DisposeAsync"/> ran and only got the gate because the
+    /// PREVIOUS holder's own <c>finally</c> released it — without this second check that writer
+    /// would go on to write into a process <see cref="DisposeAsync"/> just killed. Either check
+    /// throws <see cref="ObjectDisposedException"/>, matching the type this method's contract
+    /// promises for a call after disposal.</para>
     /// </summary>
     public async Task WriteLineAsync(string json, CancellationToken ct) {
+        if (IsDisposed) throw new ObjectDisposedException(nameof(PiRpcProcess));
+
         await _stdinGate.WaitAsync(ct).ConfigureAwait(false);
 
         try {
+            if (IsDisposed) throw new ObjectDisposedException(nameof(PiRpcProcess));
+
             await _process.StandardInput.WriteAsync((json + "\n").AsMemory(), ct).ConfigureAwait(false);
             await _process.StandardInput.FlushAsync(ct).ConfigureAwait(false);
         } finally {
@@ -243,10 +264,18 @@ internal sealed partial class PiRpcProcess : IPiRpcProcess {
     public async ValueTask DisposeAsync() {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;   // idempotent, per the interface contract
 
+        // The kill happens FIRST, before anything else in this method, and that ordering is load
+        // bearing for WriteLineAsync's post-dispose behaviour: a writer already inside the
+        // `_stdinGate` critical section (mid WriteAsync/FlushAsync on stdin) is not cancelled by
+        // disposal — killing the child here breaks its pipe out from under it instead, so that
+        // in-flight write fails fast (IOException/ObjectDisposedException) rather than hanging on a
+        // dead pipe that will never accept more bytes.
+        //
         // No bounded wait after the kill, deliberately — see AgyTurnProcess's identical comment.
-        // Kill(entireProcessTree: true) is SIGKILL on POSIX, which no child can catch or defer, so
-        // the death is already effectively synchronous with the call. Callers that need a CONFIRMED
-        // exit terminate first and read HasExited while the handle is still valid.
+        // Kill(entireProcessTree: true) is an immediate kill (SIGKILL on POSIX), which no child can
+        // catch or defer, so the death is already effectively synchronous with the call. Callers
+        // that need a CONFIRMED exit terminate first and read HasExited while the handle is still
+        // valid.
         try {
             if (!_process.HasExited) _process.Kill(entireProcessTree: true);
         } catch {
@@ -267,8 +296,16 @@ internal sealed partial class PiRpcProcess : IPiRpcProcess {
         }
 
         _stderrDrainCts.Dispose();
-        _stdinGate.Dispose();
 
+        // _stdinGate is deliberately left undisposed. Disposing a SemaphoreSlim does NOT release
+        // outstanding async waiters — a WriteLineAsync already blocked in WaitAsync when this method
+        // ran would then hang forever, and the holder that eventually releases it would have its
+        // `finally { Release() }` throw ObjectDisposedException on top of whatever it was already
+        // unwinding, potentially masking the real failure. A SemaphoreSlim holds no unmanaged state
+        // unless its AvailableWaitHandle is touched (never is, here), so leaving it undisposed is
+        // accepted .NET practice. WriteLineAsync's own IsDisposed checks (before AND after acquiring
+        // the gate) are what actually turn a post-dispose writer away — cleanly, and without ever
+        // waiting on a signal that would otherwise never come.
         try {
             _process.Dispose();
         } catch {

--- a/src/Capacitor.Cli.Daemon/Acp/PiLaunchEnvironment.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/PiLaunchEnvironment.cs
@@ -1,0 +1,36 @@
+namespace Capacitor.Cli.Daemon.Acp;
+
+/// <summary>
+/// The environment every daemon-spawned <c>pi --mode rpc</c> child gets.
+///
+/// <para><b>Why this exists.</b> Pi has no shell hooks, so kcap's live-ingest capture for a user's
+/// OWN interactive Pi sessions works by installing a TypeScript extension
+/// (<c>~/.pi/agent/extensions/kcap.ts</c> — see <c>PiExtensionInstaller</c>) that Pi auto-discovers
+/// and loads in-process for EVERY <c>pi</c> invocation on the machine, hosted or not. A daemon-hosted
+/// Pi child is spawned under that same operator <c>HOME</c>, so without a way to tell the extension
+/// to stand down, its <c>session_start</c>/<c>session_shutdown</c> handlers would start a SECOND,
+/// independent capture (a lifecycle POST plus a spawned watcher) for the very session this runtime is
+/// already recording over the RPC wire — the same dual-capture failure mode
+/// <c>OpenCodeLaunchEnvironment</c> documents at length for OpenCode's own global plugin.</para>
+///
+/// <para><b>The precedence this pins:</b> for a daemon-hosted session, the runtime's own RPC
+/// transcript (<c>PiRpcHostedAgentRuntime</c>) is the ONLY capture path. The extension keeps its whole
+/// job for every session the user starts themselves — this suppresses it only inside a child the
+/// daemon owns and is already recording.</para>
+///
+/// <para>Unconditional for EVERY hosted launch (there is no reviewer-only carve-out here, unlike
+/// <c>OpenCodeLaunchEnvironment.ApplyReviewer</c>'s three settings): an interactive hosted Pi agent is
+/// double-captured exactly as an unattended one would be, so there is no launch shape this should ever
+/// be omitted from.</para>
+/// </summary>
+internal static class PiLaunchEnvironment {
+    /// <summary>Read by the kcap.ts extension (see <c>PiExtensionInstaller.ExtensionContent</c>) at
+    /// the top of its exported function — when set to <c>"1"</c> the extension returns immediately
+    /// and registers no handlers at all.</summary>
+    internal const string PureVariable = "KCAP_PI_PURE";
+
+    /// <summary>Applies the one setting every hosted Pi launch needs.</summary>
+    internal static void Apply(IDictionary<string, string?> environment) {
+        environment[PureVariable] = "1";
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
@@ -1,0 +1,273 @@
+// src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
+using System.Text.Json;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Daemon.Acp;
+
+/// <summary>
+/// Discriminator for <see cref="PiRpcFrame.Kind"/> — Pi's JSONL-RPC protocol has exactly one
+/// top-level frame shape carrying <c>"type":"response"</c> (a reply to a command this daemon sent,
+/// correlated by <see cref="PiRpcFrame.Id"/>); every other object carrying a non-empty string
+/// <c>"type"</c> is an <see cref="Event"/> (Pi-initiated, unsolicited); an object with no
+/// recognizable string <c>"type"</c> field is <see cref="Unknown"/> — schema drift, never thrown on.
+/// </summary>
+internal enum PiRpcFrameKind {
+    Response,
+    Event,
+    Unknown,
+}
+
+/// <summary>
+/// One parsed line of Pi's JSONL-RPC wire protocol — mirrors <c>AntigravityEvent</c>'s role for agy's
+/// NDJSON. <see cref="Root"/> is a CLONED <see cref="JsonElement"/> (the backing
+/// <see cref="JsonDocument"/> is disposed inside <see cref="PiRpc.TryParseLine"/>), so it stays valid
+/// for however long the caller holds this frame — callers read shape-specific fields off it directly
+/// (e.g. <see cref="PiRpcFrame.Type"/>-specific payload fields for a <see cref="PiRpcFrameKind.Event"/>,
+/// or <c>"data"</c>/<c>"error"</c> for a <see cref="PiRpcFrameKind.Response"/>) rather than this
+/// record duplicating every possible field.
+/// </summary>
+internal sealed record PiRpcFrame(
+    PiRpcFrameKind Kind,
+    string         Type,
+    string?        Id,
+    bool?          Success,
+    JsonElement    Root
+);
+
+/// <summary>
+/// Pure protocol layer for hosted Pi: parses one JSONL-RPC line into a <see cref="PiRpcFrame"/>,
+/// translates an event frame into the daemon's canonical <see cref="AcpEventEnvelope"/> transcript
+/// events, and builds the JSON text for the four commands this daemon sends to Pi. No process, no
+/// I/O, no state — see <c>AntigravityNdjson</c> for the structural template this mirrors.
+///
+/// Commands are hand-built as JSON text (never reflection-based serialization — this runs AOT) using
+/// <see cref="System.Text.Json.Nodes.JsonObject"/>, matching <c>AcpRpc.cs</c>'s idiom of keeping the
+/// wire shape explicit rather than riding a shared source-gen context whose property-naming policy
+/// would need to special-case this one vendor's camelCase field names
+/// (<c>streamingBehavior</c>/<c>set_model</c>'s own <c>model</c>) against the rest of the codebase's
+/// snake_case <see cref="CapacitorJsonContext"/>.
+/// </summary>
+internal static class PiRpc {
+    const int ExtensionErrorTextCap = 500;
+
+    /// <summary>
+    /// Parses one JSONL-RPC line. Returns <see langword="null"/> for a blank/whitespace-only line or
+    /// malformed JSON — never throws. A trailing <c>\r</c> (CRLF line endings) is tolerated. A parsed
+    /// JSON value that is not an object also returns <see langword="null"/> (Pi's protocol has no
+    /// bare-array or bare-scalar frame).
+    /// </summary>
+    public static PiRpcFrame? TryParseLine(string line) {
+        if (string.IsNullOrWhiteSpace(line)) return null;
+
+        var trimmed = line.AsSpan().TrimEnd('\r');
+
+        JsonDocument doc;
+        try {
+            doc = JsonDocument.Parse(trimmed.ToString());
+        } catch (JsonException) {
+            return null;
+        }
+
+        using (doc) {
+            var root = doc.RootElement;
+            if (!root.IsObject) return null;
+
+            var type = root.Str("type");
+            var kind = type switch {
+                "response"           => PiRpcFrameKind.Response,
+                { Length: > 0 }      => PiRpcFrameKind.Event,
+                _                    => PiRpcFrameKind.Unknown,
+            };
+
+            return new PiRpcFrame(
+                Kind: kind,
+                Type: type ?? "",
+                Id: root.Str("id"),
+                Success: root.TryGetProperty("success", out var s) && s.ValueKind is JsonValueKind.True or JsonValueKind.False
+                    ? s.GetBoolean()
+                    : null,
+                // Clone: `doc` is disposed at the end of this `using` block, and JsonElement values
+                // sourced from a disposed JsonDocument throw on access.
+                Root: root.Clone());
+        }
+    }
+
+    /// <summary>
+    /// Translates ONE event <paramref name="frame"/> into zero or more <see cref="AcpEventEnvelope"/>s.
+    /// A <see cref="PiRpcFrameKind.Response"/> or <see cref="PiRpcFrameKind.Unknown"/> frame always
+    /// yields <c>[]</c> — a response is command-correlation plumbing the runtime layer consumes
+    /// directly, not transcript content.
+    ///
+    /// <list type="bullet">
+    /// <item><description><c>message_end</c> with an assistant message maps each content item, IN
+    /// ORDER, to <c>assistant_text</c> / <c>assistant_thinking</c> / <c>tool_call</c>, then appends
+    /// ONE trailing <c>usage</c> envelope when the message carries a <c>usage</c> block. Every
+    /// envelope's <see cref="AcpEventEnvelope.Model"/> is the message's own <c>"model"</c> field, else
+    /// <paramref name="fallbackModel"/>.</description></item>
+    /// <item><description><c>message_end</c> with a user message maps to ONE <c>user_message</c>
+    /// envelope carrying the concatenated text — content may be a plain string or a content-part
+    /// array (only <c>text</c> parts contribute; a user message has no thinking/toolCall parts).</description></item>
+    /// <item><description><c>tool_execution_end</c> maps to ONE <c>tool_result</c>. The result is
+    /// best-effort text: a JSON string is used verbatim, anything else (object/array/number/etc.) is
+    /// serialized back to compact JSON text — this never throws on an unexpected shape.</description></item>
+    /// <item><description><c>extension_error</c> maps to ONE <c>system_note</c>, its text capped at
+    /// <see cref="ExtensionErrorTextCap"/> characters.</description></item>
+    /// <item><description>Every other known event (<c>agent_start</c>/<c>agent_end</c>/
+    /// <c>agent_settled</c>/<c>turn_start</c>/<c>turn_end</c>/<c>message_start</c>/
+    /// <c>message_update</c>/<c>bash_execution_update</c>) and any unrecognized type yield
+    /// <c>[]</c> — deliberately no <c>system_note</c> spam for known-but-untranslated events; the
+    /// runtime logs unknown types separately.</description></item>
+    /// </list>
+    /// </summary>
+    public static IReadOnlyList<AcpEventEnvelope> ToEnvelopes(PiRpcFrame frame, string? fallbackModel) {
+        if (frame.Kind != PiRpcFrameKind.Event) return [];
+
+        return frame.Type switch {
+            "message_end"        => TranslateMessageEnd(frame.Root, fallbackModel),
+            "tool_execution_end" => TranslateToolExecutionEnd(frame.Root),
+            "extension_error"    => TranslateExtensionError(frame.Root),
+            _                    => [],
+        };
+    }
+
+    static IReadOnlyList<AcpEventEnvelope> TranslateMessageEnd(JsonElement root, string? fallbackModel) {
+        if (root.Obj("message") is not { } message) return [];
+
+        var role = message.Str("role");
+        return role switch {
+            "assistant" => TranslateAssistantMessage(message, fallbackModel),
+            "user"      => TranslateUserMessage(message),
+            _           => [],
+        };
+    }
+
+    static IReadOnlyList<AcpEventEnvelope> TranslateAssistantMessage(JsonElement message, string? fallbackModel) {
+        var model = message.Str("model") ?? fallbackModel;
+
+        List<AcpEventEnvelope>? envelopes = null;
+        if (message.Arr("content") is { } content) {
+            foreach (var item in content.EnumerateArray()) {
+                if (!item.IsObject) continue;
+
+                switch (item.Str("type")) {
+                    case "text":
+                        if (item.Str("text") is { } text) {
+                            (envelopes ??= []).Add(new AcpEventEnvelope(
+                                Kind: AcpEventKind.AssistantText,
+                                Text: text,
+                                Model: model));
+                        }
+                        break;
+
+                    case "thinking":
+                        if (item.Str("thinking") is { } thinking) {
+                            (envelopes ??= []).Add(new AcpEventEnvelope(
+                                Kind: AcpEventKind.AssistantThinking,
+                                Text: thinking,
+                                Model: model));
+                        }
+                        break;
+
+                    case "toolCall":
+                        (envelopes ??= []).Add(new AcpEventEnvelope(
+                            Kind: AcpEventKind.ToolCall,
+                            ToolCallId: item.Str("id"),
+                            ToolName: item.Str("name"),
+                            ToolInputJson: item.Obj("arguments")?.GetRawText()));
+                        break;
+                }
+            }
+        }
+
+        if (message.Obj("usage") is not null) {
+            var usage = message.Obj("usage")!.Value;
+            (envelopes ??= []).Add(new AcpEventEnvelope(
+                Kind: AcpEventKind.Usage,
+                Model: model,
+                ContextUsedTokens: usage.Num("input")));
+        }
+
+        return envelopes ?? [];
+    }
+
+    static IReadOnlyList<AcpEventEnvelope> TranslateUserMessage(JsonElement message) {
+        if (!message.TryGetProperty("content", out var content)) return [];
+
+        string text;
+        if (content.ValueKind == JsonValueKind.String) {
+            text = content.GetString() ?? "";
+        } else if (content.ValueKind == JsonValueKind.Array) {
+            var sb = new System.Text.StringBuilder();
+            foreach (var item in content.EnumerateArray()) {
+                if (item.IsObject && item.Str("type") == "text" && item.Str("text") is { } t) sb.Append(t);
+            }
+            text = sb.ToString();
+        } else {
+            return [];
+        }
+
+        return [new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: text)];
+    }
+
+    static IReadOnlyList<AcpEventEnvelope> TranslateToolExecutionEnd(JsonElement root) {
+        var toolCallId = root.Str("toolCallId");
+        var isError    = root.TryGetProperty("isError", out var e) && e.ValueKind == JsonValueKind.True;
+
+        string? resultText = null;
+        if (root.TryGetProperty("result", out var result)) {
+            resultText = result.ValueKind switch {
+                JsonValueKind.String => result.GetString(),
+                JsonValueKind.Null   => null,
+                _                    => result.GetRawText(),
+            };
+        }
+
+        return [new AcpEventEnvelope(
+            Kind: AcpEventKind.ToolResult,
+            ToolCallId: toolCallId,
+            ToolResult: resultText,
+            ToolIsError: isError)];
+    }
+
+    static IReadOnlyList<AcpEventEnvelope> TranslateExtensionError(JsonElement root) {
+        var error = root.Str("error");
+        if (error is null) return [];
+
+        var bounded = error.Length > ExtensionErrorTextCap ? error[..ExtensionErrorTextCap] : error;
+        return [new AcpEventEnvelope(Kind: AcpEventKind.SystemNote, Text: bounded)];
+    }
+
+    // ---- Command builders ----
+    //
+    // Hand-built via JsonObject rather than a source-gen context: these four shapes are small, fixed,
+    // and vendor-specific (camelCase, unlike the rest of this codebase's snake_case wire contracts),
+    // so a one-off object literal is clearer than teaching a shared JsonSerializerContext a
+    // per-command naming exception.
+
+    public static string PromptCommand(string id, string message) =>
+        new System.Text.Json.Nodes.JsonObject {
+            ["id"]                 = id,
+            ["type"]               = "prompt",
+            ["message"]            = message,
+            ["streamingBehavior"]  = "followUp",
+        }.ToJsonString();
+
+    public static string AbortCommand(string id) =>
+        new System.Text.Json.Nodes.JsonObject {
+            ["id"]   = id,
+            ["type"] = "abort",
+        }.ToJsonString();
+
+    public static string GetStateCommand(string id) =>
+        new System.Text.Json.Nodes.JsonObject {
+            ["id"]   = id,
+            ["type"] = "get_state",
+        }.ToJsonString();
+
+    public static string SetModelCommand(string id, string model) =>
+        new System.Text.Json.Nodes.JsonObject {
+            ["id"]    = id,
+            ["type"]  = "set_model",
+            ["model"] = model,
+        }.ToJsonString();
+}

--- a/src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
@@ -85,9 +85,7 @@ internal static class PiRpc {
                 Kind: kind,
                 Type: type ?? "",
                 Id: root.Str("id"),
-                Success: root.TryGetProperty("success", out var s) && s.ValueKind is JsonValueKind.True or JsonValueKind.False
-                    ? s.GetBoolean()
-                    : null,
+                Success: root.Bool("success"),
                 // Clone: `doc` is disposed at the end of this `using` block, and JsonElement values
                 // sourced from a disposed JsonDocument throw on access.
                 Root: root.Clone());
@@ -212,9 +210,9 @@ internal static class PiRpc {
         if (!message.TryGetProperty("content", out var content)) return [];
 
         string text;
-        if (content.ValueKind == JsonValueKind.String) {
+        if (content.IsString) {
             text = content.GetString() ?? "";
-        } else if (content.ValueKind == JsonValueKind.Array) {
+        } else if (content.IsArray) {
             var sb = new System.Text.StringBuilder();
             foreach (var item in content.EnumerateArray()) {
                 if (item.IsObject && item.Str("type") == "text" && item.Str("text") is { } t) sb.Append(t);
@@ -229,7 +227,7 @@ internal static class PiRpc {
 
     static IReadOnlyList<AcpEventEnvelope> TranslateToolExecutionEnd(JsonElement root) {
         var toolCallId = root.Str("toolCallId");
-        var isError    = root.TryGetProperty("isError", out var e) && e.ValueKind == JsonValueKind.True;
+        var isError    = root.Bool("isError") == true;
 
         string? resultText = null;
         if (root.TryGetProperty("result", out var result)) resultText = ExtractToolResultText(result);
@@ -247,10 +245,10 @@ internal static class PiRpc {
     /// anything else (an object with no <c>content</c> array, an array, a number, …) falls back to
     /// <c>GetRawText()</c> so a result is never silently dropped.</summary>
     static string? ExtractToolResultText(JsonElement result) {
-        if (result.ValueKind == JsonValueKind.String) return result.GetString();
-        if (result.ValueKind == JsonValueKind.Null) return null;
+        if (result.IsString) return result.GetString();
+        if (result.IsNull) return null;
 
-        if (result.ValueKind == JsonValueKind.Object && result.Arr("content") is { } content) {
+        if (result.IsObject && result.Arr("content") is { } content) {
             var sb = new System.Text.StringBuilder();
             foreach (var item in content.EnumerateArray()) {
                 if (item.IsObject && item.Str("type") == "text" && item.Str("text") is { } t) sb.Append(t);

--- a/src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
@@ -173,14 +173,14 @@ internal static class PiRpc {
                             Kind: AcpEventKind.ToolCall,
                             ToolCallId: item.Str("id"),
                             ToolName: item.Str("name"),
-                            ToolInputJson: item.Obj("arguments")?.GetRawText()));
+                            ToolInputJson: item.Obj("arguments")?.GetRawText(),
+                            Model: model));
                         break;
                 }
             }
         }
 
-        if (message.Obj("usage") is not null) {
-            var usage = message.Obj("usage")!.Value;
+        if (message.Obj("usage") is { } usage) {
             (envelopes ??= []).Add(new AcpEventEnvelope(
                 Kind: AcpEventKind.Usage,
                 Model: model,

--- a/src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
@@ -269,7 +269,13 @@ internal static class PiRpc {
     /// <summary>See the <see cref="ToEnvelopes"/> class doc's <c>extension_ui_request</c> item: a
     /// dialog method blocks the child waiting for an <c>extension_ui_response</c> this daemon never
     /// sends, so a hosted turn that hits one stalls with no other signal anywhere in the
-    /// transcript.</summary>
+    /// transcript.
+    ///
+    /// <para><b>Recovery.</b> A dialog method (<c>select</c>/<c>confirm</c>/<c>input</c>/
+    /// <c>editor</c>) leaves the child BLOCKED on stdin waiting for an <c>extension_ui_response</c>
+    /// this daemon never sends; this note is the only signal anywhere that it happened. The runtime
+    /// does not synthesize a response or auto-abort in PR-1 — the only way out is termination
+    /// (graceful stop → abort → terminate).</para></summary>
     static IReadOnlyList<AcpEventEnvelope> TranslateExtensionUiRequest(JsonElement root) {
         var method = root.Str("method") ?? "unknown";
 

--- a/src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/PiRpc.cs
@@ -37,18 +37,20 @@ internal sealed record PiRpcFrame(
 /// <summary>
 /// Pure protocol layer for hosted Pi: parses one JSONL-RPC line into a <see cref="PiRpcFrame"/>,
 /// translates an event frame into the daemon's canonical <see cref="AcpEventEnvelope"/> transcript
-/// events, and builds the JSON text for the four commands this daemon sends to Pi. No process, no
-/// I/O, no state — see <c>AntigravityNdjson</c> for the structural template this mirrors.
+/// events, and builds the JSON text for the three commands this daemon sends to Pi in PR-1
+/// (<c>prompt</c>/<c>abort</c>/<c>get_state</c> — <c>set_model</c> is PR-2's, see the reviewer/model
+/// lane). No process, no I/O, no state — see <c>AntigravityNdjson</c> for the structural template
+/// this mirrors.
 ///
 /// Commands are hand-built as JSON text (never reflection-based serialization — this runs AOT) using
 /// <see cref="System.Text.Json.Nodes.JsonObject"/>, matching <c>AcpRpc.cs</c>'s idiom of keeping the
 /// wire shape explicit rather than riding a shared source-gen context whose property-naming policy
 /// would need to special-case this one vendor's camelCase field names
-/// (<c>streamingBehavior</c>/<c>set_model</c>'s own <c>model</c>) against the rest of the codebase's
-/// snake_case <see cref="CapacitorJsonContext"/>.
+/// (<c>streamingBehavior</c>) against the rest of the codebase's snake_case
+/// <see cref="CapacitorJsonContext"/>.
 /// </summary>
 internal static class PiRpc {
-    const int ExtensionErrorTextCap = 500;
+    const int ExtensionNoteTextCap = 500;
 
     /// <summary>
     /// Parses one JSONL-RPC line. Returns <see langword="null"/> for a blank/whitespace-only line or
@@ -107,26 +109,42 @@ internal static class PiRpc {
     /// <item><description><c>message_end</c> with a user message maps to ONE <c>user_message</c>
     /// envelope carrying the concatenated text — content may be a plain string or a content-part
     /// array (only <c>text</c> parts contribute; a user message has no thinking/toolCall parts).</description></item>
-    /// <item><description><c>tool_execution_end</c> maps to ONE <c>tool_result</c>. The result is
-    /// best-effort text: a JSON string is used verbatim, anything else (object/array/number/etc.) is
-    /// serialized back to compact JSON text — this never throws on an unexpected shape.</description></item>
+    /// <item><description><c>tool_execution_end</c> maps to ONE <c>tool_result</c>. Upstream's
+    /// <c>result</c> is an OBJECT — <c>{"content":[{"type":"text","text":".."}],"details":{..}}</c> —
+    /// so the text is the concatenation of its <c>content[]</c> items' <c>text</c> fields (the same
+    /// content-part concatenation <see cref="TranslateUserMessage"/> uses). A plain string
+    /// <c>result</c> is used verbatim (schema drift, tolerated); anything else — an object with no
+    /// <c>content</c> array, or any other shape — falls back to <c>GetRawText()</c> rather than
+    /// dropping the result, so this never throws on an unexpected shape.</description></item>
     /// <item><description><c>extension_error</c> maps to ONE <c>system_note</c>, its text capped at
-    /// <see cref="ExtensionErrorTextCap"/> characters.</description></item>
+    /// <see cref="ExtensionNoteTextCap"/> characters.</description></item>
+    /// <item><description><c>extension_ui_request</c> — a dialog or fire-and-forget UI call from a
+    /// user's OWN Pi extension (<c>KCAP_PI_PURE</c> only stands down kcap's own extension) — maps to
+    /// ONE <c>system_note</c> naming the request's <c>method</c>, capped at
+    /// <see cref="ExtensionNoteTextCap"/> characters. A dialog method (<c>select</c>/<c>confirm</c>/
+    /// <c>input</c>/<c>editor</c>) blocks the child on stdin for an <c>extension_ui_response</c> this
+    /// daemon never sends, so without this the turn stalls silently; the note is emitted for every
+    /// method, not just the blocking ones, since a hosted viewer has no way to tell them apart
+    /// either.</description></item>
     /// <item><description>Every other known event (<c>agent_start</c>/<c>agent_end</c>/
     /// <c>agent_settled</c>/<c>turn_start</c>/<c>turn_end</c>/<c>message_start</c>/
     /// <c>message_update</c>/<c>bash_execution_update</c>) and any unrecognized type yield
-    /// <c>[]</c> — deliberately no <c>system_note</c> spam for known-but-untranslated events; the
-    /// runtime logs unknown types separately.</description></item>
+    /// <c>[]</c> — deliberately no <c>system_note</c> spam for known-but-untranslated events, and no
+    /// debug logging either; the only place this protocol layer's caller logs anything is the read
+    /// pump, and only for a frame with no recognizable string <c>type</c> at all (see
+    /// <see cref="PiRpcFrameKind.Unknown"/>) — a known-or-unknown EVENT type that yields
+    /// <c>[]</c> here is silent by design.</description></item>
     /// </list>
     /// </summary>
     public static IReadOnlyList<AcpEventEnvelope> ToEnvelopes(PiRpcFrame frame, string? fallbackModel) {
         if (frame.Kind != PiRpcFrameKind.Event) return [];
 
         return frame.Type switch {
-            "message_end"        => TranslateMessageEnd(frame.Root, fallbackModel),
-            "tool_execution_end" => TranslateToolExecutionEnd(frame.Root),
-            "extension_error"    => TranslateExtensionError(frame.Root),
-            _                    => [],
+            "message_end"          => TranslateMessageEnd(frame.Root, fallbackModel),
+            "tool_execution_end"   => TranslateToolExecutionEnd(frame.Root),
+            "extension_error"      => TranslateExtensionError(frame.Root),
+            "extension_ui_request" => TranslateExtensionUiRequest(frame.Root),
+            _                      => [],
         };
     }
 
@@ -214,13 +232,7 @@ internal static class PiRpc {
         var isError    = root.TryGetProperty("isError", out var e) && e.ValueKind == JsonValueKind.True;
 
         string? resultText = null;
-        if (root.TryGetProperty("result", out var result)) {
-            resultText = result.ValueKind switch {
-                JsonValueKind.String => result.GetString(),
-                JsonValueKind.Null   => null,
-                _                    => result.GetRawText(),
-            };
-        }
+        if (root.TryGetProperty("result", out var result)) resultText = ExtractToolResultText(result);
 
         return [new AcpEventEnvelope(
             Kind: AcpEventKind.ToolResult,
@@ -229,20 +241,54 @@ internal static class PiRpc {
             ToolIsError: isError)];
     }
 
+    /// <summary>Upstream's <c>result</c> is normally an object carrying <c>content[]</c> — the same
+    /// content-part shape <see cref="TranslateUserMessage"/> concatenates, so this reuses that
+    /// approach rather than a second copy of it. A plain string is schema drift, tolerated verbatim;
+    /// anything else (an object with no <c>content</c> array, an array, a number, …) falls back to
+    /// <c>GetRawText()</c> so a result is never silently dropped.</summary>
+    static string? ExtractToolResultText(JsonElement result) {
+        if (result.ValueKind == JsonValueKind.String) return result.GetString();
+        if (result.ValueKind == JsonValueKind.Null) return null;
+
+        if (result.ValueKind == JsonValueKind.Object && result.Arr("content") is { } content) {
+            var sb = new System.Text.StringBuilder();
+            foreach (var item in content.EnumerateArray()) {
+                if (item.IsObject && item.Str("type") == "text" && item.Str("text") is { } t) sb.Append(t);
+            }
+            return sb.ToString();
+        }
+
+        return result.GetRawText();
+    }
+
     static IReadOnlyList<AcpEventEnvelope> TranslateExtensionError(JsonElement root) {
         var error = root.Str("error");
         if (error is null) return [];
 
-        var bounded = error.Length > ExtensionErrorTextCap ? error[..ExtensionErrorTextCap] : error;
-        return [new AcpEventEnvelope(Kind: AcpEventKind.SystemNote, Text: bounded)];
+        return [new AcpEventEnvelope(Kind: AcpEventKind.SystemNote, Text: Cap(error))];
     }
+
+    /// <summary>See the <see cref="ToEnvelopes"/> class doc's <c>extension_ui_request</c> item: a
+    /// dialog method blocks the child waiting for an <c>extension_ui_response</c> this daemon never
+    /// sends, so a hosted turn that hits one stalls with no other signal anywhere in the
+    /// transcript.</summary>
+    static IReadOnlyList<AcpEventEnvelope> TranslateExtensionUiRequest(JsonElement root) {
+        var method = root.Str("method") ?? "unknown";
+
+        return [new AcpEventEnvelope(
+            Kind: AcpEventKind.SystemNote,
+            Text: Cap($"Pi extension requested interactive input ({method}); hosted sessions cannot "
+                    + "answer, the turn may stall."))];
+    }
+
+    static string Cap(string text) => text.Length > ExtensionNoteTextCap ? text[..ExtensionNoteTextCap] : text;
 
     // ---- Command builders ----
     //
-    // Hand-built via JsonObject rather than a source-gen context: these four shapes are small, fixed,
-    // and vendor-specific (camelCase, unlike the rest of this codebase's snake_case wire contracts),
-    // so a one-off object literal is clearer than teaching a shared JsonSerializerContext a
-    // per-command naming exception.
+    // Hand-built via JsonObject rather than a source-gen context: these shapes are small, fixed, and
+    // vendor-specific (camelCase, unlike the rest of this codebase's snake_case wire contracts), so a
+    // one-off object literal is clearer than teaching a shared JsonSerializerContext a per-command
+    // naming exception.
 
     public static string PromptCommand(string id, string message) =>
         new System.Text.Json.Nodes.JsonObject {
@@ -262,12 +308,5 @@ internal static class PiRpc {
         new System.Text.Json.Nodes.JsonObject {
             ["id"]   = id,
             ["type"] = "get_state",
-        }.ToJsonString();
-
-    public static string SetModelCommand(string id, string model) =>
-        new System.Text.Json.Nodes.JsonObject {
-            ["id"]    = id,
-            ["type"]  = "set_model",
-            ["model"] = model,
         }.ToJsonString();
 }

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -297,6 +297,25 @@ public class DaemonConfig {
     /// </summary>
     public int OpenCodeReviewerLaunchTimeoutSeconds { get; set; } = 120;
 
+    /// <summary>Path or bare command for Pi's RPC entry point, spawned as
+    /// <c>{PiPath} --mode rpc</c> by <c>PiRpcHostedAgentRuntimeFactory</c>. Interactive hosting only
+    /// in PR-1 — the reviewer lane is not implemented yet. Availability is
+    /// <c>CliResolver.Exists(PiPath)</c>. Overridable via <c>KCAP_PI_PATH</c>.</summary>
+    public string PiPath { get; set; } = "pi";
+
+    /// <summary>
+    /// Optional daemon-wide default model for hosted Pi agents, passed as <c>--model</c> on the
+    /// spawned <c>pi --mode rpc</c> child. Overridable via <c>KCAP_PI_MODEL</c>, mirroring
+    /// <see cref="OpenCodeModel"/>.
+    ///
+    /// <para>Like <see cref="OpenCodeModel"/> and <see cref="KiroModel"/> the default is NULL,
+    /// deliberately: a zero-configuration launch keeps Pi's own configured default and reports no
+    /// model. A per-launch <c>RuntimeStartContext.Model</c> takes precedence over this daemon-wide
+    /// default (the <c>"default"</c> sentinel falls through to it, same convention as every other
+    /// vendor's <c>ResolveModel</c>).</para>
+    /// </summary>
+    public string? PiModel { get; set; }
+
     /// <summary>Path or bare command for Google Gemini CLI's ACP entry point, spawned as
     /// <c>{GeminiPath} --experimental-acp …</c> by <c>AcpHostedAgentRuntimeFactory</c>. No longer
     /// reserved: it drives interactive hosting AND the gated unattended reviewer, whose build-affirmation

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -157,6 +157,12 @@ public static partial class DaemonRunner {
         if (Environment.GetEnvironmentVariable("KCAP_OPENCODE_MODEL") is { Length: > 0 } envOpenCodeModel)
             config.OpenCodeModel = envOpenCodeModel;
 
+        if (Environment.GetEnvironmentVariable("KCAP_PI_PATH") is { Length: > 0 } envPiPath)
+            config.PiPath = envPiPath;
+
+        if (Environment.GetEnvironmentVariable("KCAP_PI_MODEL") is { Length: > 0 } envPiModel)
+            config.PiModel = envPiModel;
+
         if (Environment.GetEnvironmentVariable("KCAP_GEMINI_PATH") is { Length: > 0 } envGeminiPath)
             config.GeminiPath = envGeminiPath;
 
@@ -425,6 +431,17 @@ public static partial class DaemonRunner {
         // per turn process, not a single typed logger.
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
             new AntigravityHostedAgentRuntimeFactory(
+                sp.GetRequiredService<DaemonConfig>(),
+                sp.GetRequiredService<ILoggerFactory>()
+            )
+        );
+
+        // Not an ACP factory either: pi speaks its own LF-framed JSONL-RPC over one LONG-LIVED
+        // process for the whole hosted session (see IPiRpcProcess), unlike Antigravity's
+        // exec-per-turn shape above. PR-1 only — interactive hosting; the reviewer lane
+        // (SupportsUnattended) is not implemented yet.
+        builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
+            new PiRpcHostedAgentRuntimeFactory(
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>()
             )

--- a/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
@@ -290,7 +290,13 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
     /// <summary>Rule (c): true when this frame is Pi echoing back a prompt we sent, in which case
     /// the whole frame is dropped (we already emitted the <c>user_message</c> at send time). Only
     /// ever true for a single-envelope user-message frame — an assistant frame, or a user frame
-    /// whose text matches nothing we sent, is real transcript.</summary>
+    /// whose text matches nothing we sent, is real transcript.
+    ///
+    /// <para><b>Known cosmetic hole, not worth solving in PR-1.</b> Pi expands a <c>/skill:name</c>
+    /// or <c>/template</c> input before echoing it back (rpc.md ~73) — the echoed
+    /// <c>message_end</c> carries the EXPANDED text, not what this daemon literally sent, so
+    /// <see cref="TryConsumeSentPrompt"/> finds no match and the slash-command message renders
+    /// twice (once from the send-time envelope, once from the un-deduped echo).</para></summary>
     bool IsOurOwnEcho(PiRpcFrame frame, IReadOnlyList<AcpEventEnvelope> envelopes) =>
         frame.Type == "message_end"
         && envelopes is [{ Kind: AcpEventKind.UserMessage, Text: { } text }]

--- a/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
@@ -286,6 +286,9 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
                 return;
         }
 
+        // Display fallback only — NOT the authoritative ResolvedModel (see ApplyState's comment on
+        // _resolvedModel = ExtractModelId(...)): this feeds envelope.Model for rendering, never the
+        // confirmed-applied-model signal the orchestrator reads off ResolvedModel.
         var envelopes = PiRpc.ToEnvelopes(frame, _resolvedModel ?? _requestedModel);
         if (envelopes.Count == 0) return;
 
@@ -393,7 +396,10 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
         // signal (see the ResolvedModel property doc), so when get_state omits a model, null is the
         // only truthful value — the IAcpTranscriptSource contract's "null ⇒ vendor default applies".
         // Reporting the merely-requested model here would be an attribution lie: it claims Pi
-        // confirmed a model it never mentioned.
+        // confirmed a model it never mentioned. ResolvedModel is deliberately null in that case — it
+        // is never backfilled from _requestedModel. The transcript ENVELOPE fallback below (see
+        // HandleEvent's `_resolvedModel ?? _requestedModel`) is a SEPARATE, intentional concern: a
+        // display fallback for envelope.Model, not the authoritative ResolvedModel this field feeds.
         _resolvedModel = ExtractModelId(data.Value);
 
         // Pi may already be mid-turn when we attach (a resumed session), so the initial busy state
@@ -479,7 +485,10 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
         // Observed in the background: Pi's response to `prompt` acknowledges acceptance, and a
         // refusal (e.g. a prompt that raced an in-flight turn) is only ever visible to the person
         // who typed the message as a transcript note. Never awaited here — a prompt that queues
-        // behind a long turn must not block the daemon's command lane.
+        // behind a long turn must not block the daemon's command lane. No lifetime leak: this
+        // fire-and-forget task always completes because its pending waiter is faulted by
+        // EnterTerminal, and _pumpTask (whose finally calls EnterTerminal) is created in the
+        // constructor before it returns, so DisposeAsync always has it to join.
         _ = ObservePromptResponseAsync(waiter.Task);
     }
 
@@ -530,12 +539,24 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
     // ---- Echo memory (rule (c)) ----
 
     void RememberSentPrompt(string text) {
+        var evicted = false;
+
         lock (_echoGate) {
             _sentPrompts.Add(text);
 
             // Oldest-first eviction: an entry that has waited this long was never echoed.
-            while (_sentPrompts.Count > SentPromptMemory) _sentPrompts.RemoveAt(0);
+            while (_sentPrompts.Count > SentPromptMemory) {
+                _sentPrompts.RemoveAt(0);
+                evicted = true;
+            }
         }
+
+        // Debug, not Warning: unreachable in normal turn-based interactive use (a caller waits for
+        // idle between sends), so this is detectability for the live cert, not an operational
+        // alarm — logged outside the lock, and only when eviction actually dropped an entry, to
+        // avoid flooding.
+        if (evicted)
+            _logger.LogDebug("Pi: evicted an un-echoed sent-prompt at the cap (agentId={AgentId}).", _agentId);
     }
 
     /// <summary>Most-recent-first, consume-on-match — see rule (c) on why consuming (rather than
@@ -558,7 +579,13 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
     /// <summary>Completes immediately when Pi is not streaming, else on the next
     /// <c>agent_settled</c>. Entering terminal releases every waiter (via
     /// <see cref="EnterTerminal"/>'s <c>SetBusy(false)</c>) — a waiter parked on a settle that can
-    /// never arrive is a hang, not a stop.</summary>
+    /// never arrive is a hang, not a stop.
+    ///
+    /// <para>A caller that may need to stop waiting on a wedged turn (e.g. a child blocked on an
+    /// <c>extension_ui_request</c> that never settles — see <see cref="PiRpc"/>'s
+    /// <c>TranslateExtensionUiRequest</c>) MUST pass a cancellable token: with
+    /// <see cref="CancellationToken.None"/> the waiter only completes on the next
+    /// <c>agent_settled</c> or on <see cref="EnterTerminal"/>.</para></summary>
     public Task WaitForTurnIdleAsync(CancellationToken ct) {
         TaskCompletionSource waiter;
 
@@ -667,6 +694,10 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
             $"Pi: the hosted session ended before its identity handshake completed (agentId={_agentId}).",
             inner: null);
 
+        // Releasing idle waiters here can wake a caller that then attempts SendUserInputAsync during
+        // teardown; that write fails fast (dead pipe → caught → "could not be delivered" note) — i.e.
+        // "idle after EnterTerminal" does NOT mean the agent is accepting input. Accepted fail-open
+        // behavior, not a bug.
         SetBusy(false);
 
         _transcript.Writer.TryComplete();

--- a/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
@@ -33,9 +33,16 @@ namespace Capacitor.Cli.Daemon.Services;
 /// documents at length). The barrier is only usable because it resolves on EVERY path: the
 /// response arrives (success), the response says <c>success:false</c> or carries no
 /// <c>sessionId</c> (fault — fail closed rather than bind <c>""</c>), the child exits or its stdout
-/// EOFs (fault, via <see cref="EnterTerminal"/>), the write itself fails (fault), or the optional
-/// <c>readyDeadline</c> elapses (fault). A hanging barrier wedges the launch path; a faulted one
-/// merely fails a launch.</para>
+/// EOFs (fault, via <see cref="EnterTerminal"/>), the write itself fails (fault), or the deadline
+/// elapses (fault). A hanging barrier wedges the launch path; a faulted one merely fails a launch.</para>
+///
+/// <para>That last path is why the deadline is NOT optional. A caller may override it, but it
+/// always applies — <see cref="DefaultReadyDeadline"/> backs an omitted one. Every other path
+/// needs the child to DO something (answer, refuse, or die); an alive-but-silent child — spawned,
+/// hung before its first read, never exiting — does none of them, so a null deadline would leave
+/// that one shape with no resolver at all. A launch path that hangs only when a callsite forgot to
+/// pass a timeout is the exact failure this barrier exists to prevent, arriving through the
+/// barrier's own configuration.</para>
 ///
 /// <para><b>(b) <see cref="ReadOutputAsync"/> parks on one signal, created once.</b> Same rule as
 /// Antigravity's (c): the orchestrator drives <c>FinalizeAgentRunAsync</c> from that stream's
@@ -74,12 +81,20 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
 
     static readonly TimeSpan DefaultStopGrace = TimeSpan.FromSeconds(3);
 
+    /// <summary>Backs an omitted <c>readyDeadline</c> — see rule (a) on why the deadline is never
+    /// allowed to be absent. Generous rather than tight: it bounds a PATHOLOGY (a child that
+    /// spawned but never speaks), not normal startup, and a healthy <c>pi</c> answers
+    /// <c>get_state</c> in milliseconds. The cost of it being too long is a slow failed launch; the
+    /// cost of it being too short is a launch that fails on a cold, loaded machine that would have
+    /// succeeded.</summary>
+    internal static readonly TimeSpan DefaultReadyDeadline = TimeSpan.FromSeconds(30);
+
     readonly IPiRpcProcess _process;
     readonly ILogger       _logger;
     readonly string        _agentId;
     readonly string?       _requestedModel;
     readonly string        _cwd;
-    readonly TimeSpan?     _readyDeadline;
+    readonly TimeSpan      _readyDeadline;
     readonly TimeSpan      _stopGrace;
     readonly Action?       _onDisposed;
 
@@ -110,7 +125,12 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
 
     /// <summary>In-flight commands awaiting their correlated <c>response</c> frame, keyed by the
     /// <c>id</c> this runtime stamped on them. Faulted wholesale by <see cref="EnterTerminal"/> —
-    /// a response that can never arrive must never leave a waiter parked.</summary>
+    /// a response that can never arrive must never leave a waiter parked.
+    ///
+    /// <para><b>Bound:</b> one entry per in-flight user message, released on its response or at
+    /// terminal — so this is bounded by USER INPUT RATE, not by wire traffic. Pi's event stream can
+    /// be arbitrarily chatty without adding a single entry here, since only commands this runtime
+    /// SENDS are ever registered.</para></summary>
     readonly ConcurrentDictionary<string, TaskCompletionSource<PiRpcFrame>> _pending = new();
 
     readonly Lock         _echoGate    = new();
@@ -155,7 +175,7 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
         _agentId        = agentId;
         _requestedModel = requestedModel;
         _cwd            = cwd;
-        _readyDeadline  = readyDeadline;
+        _readyDeadline  = readyDeadline ?? DefaultReadyDeadline;   // never absent — rule (a)
         _stopGrace      = stopGrace ?? DefaultStopGrace;
         _onDisposed     = onDisposed;
         _ownerToken     = _ownerCts.Token;
@@ -276,18 +296,51 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
         && envelopes is [{ Kind: AcpEventKind.UserMessage, Text: { } text }]
         && TryConsumeSentPrompt(text);
 
+    // ---- Command correlation ----
+
+    /// <summary>
+    /// Registers a command's response waiter — the ONLY way an entry enters <see cref="_pending"/>.
+    ///
+    /// <para><b>The post-registration re-check is the whole point.</b>
+    /// <see cref="EnterTerminal"/>'s fault loop iterates a SNAPSHOT of the keys, so a waiter
+    /// registered after that snapshot was taken is never faulted by it, and the terminal flag is
+    /// already set so nothing will fault it later either — the entry parks forever. Two real
+    /// callers hit that window: a viewer's <see cref="SendUserInputAsync"/> racing a stop (its
+    /// <see cref="ObservePromptResponseAsync"/> would never complete), and the constructor's own
+    /// handshake racing a child that died synchronously (which would then burn the whole
+    /// <see cref="DisposeAsync"/> join budget on a task that can never finish). Re-checking here,
+    /// AFTER the entry is visible, means the two orderings cover each other: either
+    /// <see cref="EnterTerminal"/>'s snapshot sees this entry, or this check sees the flag it
+    /// set.</para>
+    /// </summary>
+    TaskCompletionSource<PiRpcFrame> RegisterPending(string id) {
+        var waiter = new TaskCompletionSource<PiRpcFrame>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _pending[id] = waiter;
+
+        if (Volatile.Read(ref _terminal) != 0) FaultPending(id);
+
+        return waiter;
+    }
+
+    void FaultPending(string id) {
+        if (_pending.TryRemove(id, out var waiter))
+            waiter.TrySetException(new InvalidOperationException(
+                $"Pi: the hosted session ended before command {id} was answered."));
+    }
+
+    /// <summary>Test/diagnostic view of the correlation table — see <see cref="RegisterPending"/>
+    /// for the race this makes observable.</summary>
+    internal int PendingCommandCount => _pending.Count;
+
     // ---- Handshake ----
 
     async Task RunHandshakeAsync() {
-        var waiter = new TaskCompletionSource<PiRpcFrame>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _pending[InitStateCommandId] = waiter;
+        var waiter = RegisterPending(InitStateCommandId);
 
         try {
             await _process.WriteLineAsync(PiRpc.GetStateCommand(InitStateCommandId), _ownerToken).ConfigureAwait(false);
 
-            var response = _readyDeadline is { } deadline
-                ? await waiter.Task.WaitAsync(deadline).ConfigureAwait(false)
-                : await waiter.Task.ConfigureAwait(false);
+            var response = await waiter.Task.WaitAsync(_readyDeadline).ConfigureAwait(false);
 
             ApplyState(response);
         } catch (Exception ex) {
@@ -377,13 +430,28 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
         EmitLocalEnvelope(new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: text));
 
         var id     = NextCommandId();
-        var waiter = new TaskCompletionSource<PiRpcFrame>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _pending[id] = waiter;
+        var waiter = RegisterPending(id);
 
         try {
             await _process.WriteLineAsync(PiRpc.PromptCommand(id, text), _ownerToken).ConfigureAwait(false);
         } catch {
             _pending.TryRemove(id, out _);
+
+            // Undo the echo memory: this message never reached Pi, so its echo can never arrive —
+            // and a stale entry is not inert. It would silently swallow the NEXT genuine user
+            // message with identical text (a retry of exactly what just failed is the likeliest
+            // thing to happen next), which is the dedupe misfiring on real content.
+            TryConsumeSentPrompt(text);
+
+            // Best-effort: dropped when the channel is already completed (the common case if the
+            // write failed BECAUSE the session is ending), which is fine — the session ending is
+            // itself the user-visible signal. Worth emitting for the case the write failed while
+            // the session is otherwise healthy, where this note is the only feedback the person who
+            // typed the message gets; the rethrow below only reaches the daemon log.
+            EmitLocalEnvelope(new AcpEventEnvelope(
+                Kind: AcpEventKind.SystemNote,
+                Text: "Your message could not be delivered to the agent."));
+
             throw;
         }
 
@@ -480,7 +548,30 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
             _idleWaiters.Add(waiter);
         }
 
-        return waiter.Task.WaitAsync(ct);
+        return ct.CanBeCanceled ? AwaitTurnIdleAsync(waiter, ct) : waiter.Task;
+    }
+
+    /// <summary>Waits, and on CANCELLATION removes its own waiter from
+    /// <see cref="_idleWaiters"/> — the list is the one unbounded collection in this runtime, and a
+    /// cancelled caller that leaves its entry behind leaks until the next settle (which may never
+    /// come). The live caller that makes this real rather than theoretical is the orchestrator's
+    /// periodic borrowed-snapshot refresh, which waits under a timeout every cycle: a slow leak,
+    /// one entry per cancelled cycle, for as long as a turn stays in flight.</summary>
+    async Task AwaitTurnIdleAsync(TaskCompletionSource waiter, CancellationToken ct) {
+        try {
+            await waiter.Task.WaitAsync(ct).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            // Harmless if a concurrent SetBusy(false) already drained it — Remove on an absent
+            // item is a no-op, and the waiter itself is unreferenced after this.
+            lock (_turnGate) _idleWaiters.Remove(waiter);
+            throw;
+        }
+    }
+
+    /// <summary>Test/diagnostic view — see <see cref="AwaitTurnIdleAsync"/> for the leak this makes
+    /// observable.</summary>
+    internal int TurnIdleWaiterCount {
+        get { lock (_turnGate) return _idleWaiters.Count; }
     }
 
     void SetBusy(bool busy) {
@@ -547,11 +638,9 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
 
         _terminalTcs.TrySetResult();
 
-        foreach (var id in _pending.Keys) {
-            if (_pending.TryRemove(id, out var waiter))
-                waiter.TrySetException(new InvalidOperationException(
-                    $"Pi: the hosted session ended before command {id} was answered."));
-        }
+        // A snapshot of the keys, deliberately — see RegisterPending, which covers the entries
+        // registered after this loop reads them (the flag set above is what that check observes).
+        foreach (var id in _pending.Keys) FaultPending(id);
 
         FaultSessionReadyIfUnresolved(
             $"Pi: the hosted session ended before its identity handshake completed (agentId={_agentId}).",

--- a/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
@@ -152,7 +152,11 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
     /// orchestrator reads it the instant a launch returns).</summary>
     volatile string? _sessionId;
 
-    /// <summary>See <see cref="_sessionId"/> — same cross-thread reasoning.</summary>
+    /// <summary>See <see cref="_sessionId"/> — same cross-thread reasoning. Null means the
+    /// handshake's <c>get_state</c> did not carry a model (see <see cref="ExtractModelId"/>) — NEVER
+    /// backfilled with <see cref="_requestedModel"/>, since <see cref="ResolvedModel"/> is read as a
+    /// CONFIRMED-applied-model signal, and a requested-but-unconfirmed model would be an attribution
+    /// lie.</summary>
     volatile string? _resolvedModel;
 
     /// <summary>Liveness-supervision clock, assigned by the factory BEFORE the first input. Every
@@ -201,6 +205,12 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
 
     public string  AcpSessionId  => _sessionId ?? "";
     public string  Cwd           => _cwd;
+
+    /// <summary>The CONFIRMED-applied model, per the <see cref="IAcpTranscriptSource"/> contract:
+    /// null means the vendor's own default applies, never "we don't know yet". Sourced solely from
+    /// <see cref="_resolvedModel"/> (set once, from the handshake's <c>get_state</c> — see
+    /// <see cref="ApplyState"/>) — deliberately NOT backfilled with the merely-requested model, since
+    /// the orchestrator reads this as confirmation Pi actually applied it.</summary>
     public string? ResolvedModel => _resolvedModel;
 
     public ChannelReader<AcpEventEnvelope> Envelopes => _transcript.Reader;
@@ -377,13 +387,19 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
             return;
         }
 
-        _sessionId     = sessionId;
-        _resolvedModel = ExtractModelId(data.Value) ?? _requestedModel;
+        _sessionId = sessionId;
+
+        // NOT `?? _requestedModel`: ResolvedModel is the orchestrator's CONFIRMED-applied-model
+        // signal (see the ResolvedModel property doc), so when get_state omits a model, null is the
+        // only truthful value — the IAcpTranscriptSource contract's "null ⇒ vendor default applies".
+        // Reporting the merely-requested model here would be an attribution lie: it claims Pi
+        // confirmed a model it never mentioned.
+        _resolvedModel = ExtractModelId(data.Value);
 
         // Pi may already be mid-turn when we attach (a resumed session), so the initial busy state
         // comes from the handshake, not from having observed an agent_start we were never running
         // to see.
-        if (data.Value.TryGetProperty("isStreaming", out var streaming) && streaming.ValueKind == JsonValueKind.True)
+        if (data.Value.Bool("isStreaming") == true)
             SetBusy(true);
 
         ActivityClock?.SetLaunchStage("session_created");
@@ -392,17 +408,16 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
     }
 
     /// <summary>Pi's <c>model</c> is a full object, not a string — <c>id</c> is its identity. A
-    /// bare string is tolerated as schema drift rather than dropped, and anything else reads as
-    /// absent (the caller then falls back to the requested model, whose only consumer is
-    /// attribution).</summary>
+    /// bare string is tolerated as schema drift rather than dropped, and anything else — missing
+    /// entirely, or an unrecognized shape — reads as absent (null): <see cref="ApplyState"/> assigns
+    /// this straight to <see cref="_resolvedModel"/> with NO requested-model fallback, since a null
+    /// here means Pi never confirmed a model at all.</summary>
     static string? ExtractModelId(JsonElement data) {
         if (!data.TryGetProperty("model", out var model)) return null;
+        if (model.IsString) return model.GetString();
+        if (model.IsObject) return model.Str("id") ?? model.Str("name");
 
-        return model.ValueKind switch {
-            JsonValueKind.String => model.GetString(),
-            JsonValueKind.Object => model.Str("id") ?? model.Str("name"),
-            _                    => null,
-        };
+        return null;
     }
 
     void FaultSessionReadyIfUnresolved(string message, Exception? inner) {

--- a/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
@@ -1,0 +1,632 @@
+// src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntime.cs
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// <see cref="IHostedAgentRuntime"/> for Pi's CLI (<c>pi --mode rpc</c>) as an interactive hosted
+/// agent, speaking Pi's LF-framed JSONL-RPC over stdio (see <see cref="PiRpc"/> for the pure
+/// protocol layer).
+///
+/// <para><b>Why this is much simpler than <see cref="AntigravityHostedAgentRuntime"/>.</b> agy has
+/// no process between turns, which is why it needs an explicit phase machine to answer "is this
+/// runtime alive". Pi's child is LONG-LIVED — ONE <c>pi</c> process backs the whole hosted session,
+/// its stdin stays open for that session's whole life — so liveness is REAL:
+/// <see cref="HasExited"/>/<see cref="ExitCode"/>/<see cref="Pid"/> all delegate straight to the
+/// process, and there is no phase to keep in sync with it. What this class owns instead is the
+/// stdio protocol: one read pump, command/response correlation by <c>id</c>, and the transcript
+/// translation.</para>
+///
+/// <para><b>(a) The ready barrier is the load-bearing invariant.</b> The constructor sends
+/// <c>get_state</c> (id <see cref="InitStateCommandId"/>) and
+/// <see cref="WaitForSessionReadyAsync"/> completes when its response resolves
+/// <see cref="AcpSessionId"/> and <see cref="ResolvedModel"/>. A factory MUST await it before
+/// returning control to the orchestrator, which reads <see cref="AcpSessionId"/> synchronously the
+/// moment a launch returns — binding a transcript to <c>""</c> is a silent, permanent correlation
+/// break, not a flaky race (the same rule <see cref="AntigravityHostedAgentRuntime"/>'s rule (e)
+/// documents at length). The barrier is only usable because it resolves on EVERY path: the
+/// response arrives (success), the response says <c>success:false</c> or carries no
+/// <c>sessionId</c> (fault — fail closed rather than bind <c>""</c>), the child exits or its stdout
+/// EOFs (fault, via <see cref="EnterTerminal"/>), the write itself fails (fault), or the optional
+/// <c>readyDeadline</c> elapses (fault). A hanging barrier wedges the launch path; a faulted one
+/// merely fails a launch.</para>
+///
+/// <para><b>(b) <see cref="ReadOutputAsync"/> parks on one signal, created once.</b> Same rule as
+/// Antigravity's (c): the orchestrator drives <c>FinalizeAgentRunAsync</c> from that stream's
+/// <c>await foreach</c> ending, so <see cref="_terminalTcs"/> is a single constructor-owned
+/// <see cref="TaskCompletionSource"/> completed exactly once, on entry to terminal — never a
+/// per-turn signal. Pi's stdout is protocol traffic, never terminal bytes, so
+/// <see cref="EmitsTerminalOutput"/> is <see langword="false"/> and this stream yields no bytes at
+/// all.</para>
+///
+/// <para><b>(c) The user-echo dedupe.</b> <see cref="SendUserInputAsync"/> emits the
+/// <c>user_message</c> envelope itself, at send time, so the viewer sees their message immediately
+/// rather than only once Pi echoes it back. Pi then ALSO reports that same text as a user-role
+/// <c>message_end</c>, so without a dedupe every hosted message renders twice. Sent prompts are
+/// remembered in a bounded (<see cref="SentPromptMemory"/>), most-recent-first, CONSUME-on-match
+/// list, and the match is applied BEFORE the envelope reaches the channel. Consume-on-match (rather
+/// than a contains-check) is what keeps a genuinely repeated message renderable: sending "again"
+/// twice must show two user messages, and a non-consuming filter would swallow the second
+/// forever.</para>
+///
+/// <para><b>Never emits <c>session_ended</c></b> — the server's <c>EndAgentSession</c> owns that
+/// transition, exactly as for every other <see cref="IAcpTranscriptSource"/> runtime.</para>
+/// </summary>
+internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscriptSource {
+    /// <summary>The correlation id of the constructor's handshake <c>get_state</c> — fixed rather
+    /// than sequenced so a test (and a log reader) can name it.</summary>
+    internal const string InitStateCommandId = "init-state";
+
+    const int DefaultTranscriptCapacity = 2000;
+
+    /// <summary>How many recently-sent prompts are held for echo matching. Bounded because the
+    /// list only exists to absorb Pi's echo of a message we JUST sent — an unmatched entry is
+    /// evidence Pi never echoed it, not something to keep forever. Small enough that a session's
+    /// whole history never accumulates here, large enough to cover a burst of queued input that
+    /// Pi echoes only when it finishes the current turn.</summary>
+    const int SentPromptMemory = 16;
+
+    static readonly TimeSpan DefaultStopGrace = TimeSpan.FromSeconds(3);
+
+    readonly IPiRpcProcess _process;
+    readonly ILogger       _logger;
+    readonly string        _agentId;
+    readonly string?       _requestedModel;
+    readonly string        _cwd;
+    readonly TimeSpan?     _readyDeadline;
+    readonly TimeSpan      _stopGrace;
+    readonly Action?       _onDisposed;
+
+    readonly Channel<AcpEventEnvelope> _transcript;
+
+    /// <summary>Cancelled by <see cref="TerminateAsync"/>/<see cref="DisposeAsync"/>; the pump's
+    /// read token and every command write rides it.
+    ///
+    /// <para>Deliberately NEVER disposed. Its token is handed to <see cref="IPiRpcProcess"/> calls
+    /// that can still be in flight on other threads when disposal runs (a viewer's
+    /// <see cref="SendUserInputAsync"/> racing a stop), and both reading <c>.Token</c> and
+    /// registering on it throw once the source is disposed — turning a benign teardown race into a
+    /// thrown <see cref="ObjectDisposedException"/> from a caller that did nothing wrong. It owns
+    /// no timer and no unmanaged state, so leaving it undisposed costs nothing; the same reasoning
+    /// <see cref="PiRpcProcess"/> applies to its stdin semaphore.</para></summary>
+    readonly CancellationTokenSource _ownerCts = new();
+
+    /// <summary>Captured once, in the constructor — see <see cref="_ownerCts"/>. Reading a
+    /// previously-captured token is safe regardless of what happens to its source.</summary>
+    readonly CancellationToken _ownerToken;
+
+    /// <summary>Completed exactly once, on entry to terminal — see rule (b).</summary>
+    readonly TaskCompletionSource _terminalTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Rule (a)'s barrier. Resolved by a good <c>get_state</c> response; faulted on every
+    /// other ending.</summary>
+    readonly TaskCompletionSource _sessionReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>In-flight commands awaiting their correlated <c>response</c> frame, keyed by the
+    /// <c>id</c> this runtime stamped on them. Faulted wholesale by <see cref="EnterTerminal"/> —
+    /// a response that can never arrive must never leave a waiter parked.</summary>
+    readonly ConcurrentDictionary<string, TaskCompletionSource<PiRpcFrame>> _pending = new();
+
+    readonly Lock         _echoGate    = new();
+    readonly List<string> _sentPrompts = [];
+
+    readonly Lock                         _turnGate    = new();
+    readonly List<TaskCompletionSource>   _idleWaiters = [];
+    bool                                  _busy;
+
+    readonly Task _pumpTask;
+    readonly Task _handshakeTask;
+
+    int _commandSeq;
+    int _terminal;
+    int _disposed;
+
+    /// <summary>Resolved from the handshake and never changed after. <see langword="volatile"/>
+    /// because the pump thread writes it and <see cref="AcpSessionId"/> is read cross-thread (the
+    /// orchestrator reads it the instant a launch returns).</summary>
+    volatile string? _sessionId;
+
+    /// <summary>See <see cref="_sessionId"/> — same cross-thread reasoning.</summary>
+    volatile string? _resolvedModel;
+
+    /// <summary>Liveness-supervision clock, assigned by the factory BEFORE the first input. Every
+    /// stamp is a no-op guard rather than a throw so a direct construction (tests, a caller that
+    /// does not care about liveness) keeps working — which is exactly why a clock assigned LATE
+    /// fails silently.</summary>
+    internal AgentActivityClock? ActivityClock { get; set; }
+
+    public PiRpcHostedAgentRuntime(
+            IPiRpcProcess process,
+            ILogger       logger,
+            string        agentId,
+            string?       requestedModel,
+            string        cwd,
+            TimeSpan?     readyDeadline = null,
+            TimeSpan?     stopGrace     = null,
+            Action?       onDisposed    = null) {
+        _process        = process;
+        _logger         = logger;
+        _agentId        = agentId;
+        _requestedModel = requestedModel;
+        _cwd            = cwd;
+        _readyDeadline  = readyDeadline;
+        _stopGrace      = stopGrace ?? DefaultStopGrace;
+        _onDisposed     = onDisposed;
+        _ownerToken     = _ownerCts.Token;
+
+        // DropOldest with SingleWriter=false: the pump is the only writer that matters for
+        // ordering, but EnterTerminal's TryComplete and a caller's own send-time user_message emit
+        // both race it. Same shape as AntigravityHostedAgentRuntime's transcript channel.
+        _transcript = Channel.CreateBounded<AcpEventEnvelope>(
+            new BoundedChannelOptions(DefaultTranscriptCapacity)
+                { SingleReader = true, SingleWriter = false, FullMode = BoundedChannelFullMode.DropOldest });
+
+        // The pump starts FIRST: the handshake's response can only be observed by a running pump,
+        // and Pi may answer before WriteLineAsync's continuation even resumes.
+        _pumpTask      = RunPumpAsync();
+        _handshakeTask = RunHandshakeAsync();
+    }
+
+    public string Vendor              => "pi";
+    public int    Pid                 => _process.Pid;
+    public bool   HasExited           => _process.HasExited;
+    public int?   ExitCode            => _process.ExitCode;
+    public bool   EmitsTerminalOutput => false;
+
+    public string  AcpSessionId  => _sessionId ?? "";
+    public string  Cwd           => _cwd;
+    public string? ResolvedModel => _resolvedModel;
+
+    public ChannelReader<AcpEventEnvelope> Envelopes => _transcript.Reader;
+
+    /// <summary>Rule (a). A factory MUST await this after constructing the runtime and BEFORE
+    /// returning control to the orchestrator. Faults — never hangs — on every path that cannot
+    /// produce a session identity.</summary>
+    internal Task WaitForSessionReadyAsync(CancellationToken ct) => _sessionReady.Task.WaitAsync(ct);
+
+    // ---- Read pump ----
+
+    /// <summary>The single reader of the child's stdout. Response frames complete their correlated
+    /// pending command; event frames become transcript envelopes. Its ENDING — EOF, cancellation,
+    /// or an unexpected fault — is this runtime's terminal signal, which is why
+    /// <see cref="EnterTerminal"/> runs in a <c>finally</c> covering every one of them.</summary>
+    async Task RunPumpAsync() {
+        try {
+            await foreach (var line in _process.ReadLinesAsync(_ownerToken).ConfigureAwait(false)) {
+                var frame = PiRpc.TryParseLine(line);
+                if (frame is null) continue;
+
+                switch (frame.Kind) {
+                    case PiRpcFrameKind.Response:
+                        CompletePending(frame);
+                        break;
+
+                    case PiRpcFrameKind.Event:
+                        HandleEvent(frame);
+                        break;
+
+                    default:
+                        _logger.LogDebug("Pi: ignoring an unrecognized frame shape (agentId={AgentId}).", _agentId);
+                        break;
+                }
+            }
+        } catch (OperationCanceledException) when (_ownerToken.IsCancellationRequested) {
+            // Normal teardown — EnterTerminal has already run (or runs in the finally below).
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "Pi: the read pump ended unexpectedly (agentId={AgentId}).", _agentId);
+        } finally {
+            EnterTerminal();
+        }
+    }
+
+    void CompletePending(PiRpcFrame frame) {
+        if (frame.Id is not { Length: > 0 } id) {
+            _logger.LogDebug("Pi: dropped an uncorrelated response frame (agentId={AgentId}).", _agentId);
+            return;
+        }
+
+        if (_pending.TryRemove(id, out var waiter)) waiter.TrySetResult(frame);
+        else _logger.LogDebug("Pi: response {Id} matched no in-flight command (agentId={AgentId}).", id, _agentId);
+    }
+
+    /// <summary>
+    /// Translates one event frame. Busy tracking rides <c>agent_start</c>/<c>agent_settled</c> —
+    /// neither produces an envelope (see the plan's translation table), they only drive
+    /// <see cref="WaitForTurnIdleAsync"/>.
+    ///
+    /// <para>The user-echo filter (rule (c)) is applied HERE, before the channel write, and it
+    /// consults <see cref="PiRpc.ToEnvelopes"/>'s own output for the text rather than
+    /// re-implementing the content-part concatenation — a second copy of that logic would drift
+    /// from the translator and silently stop matching.</para>
+    /// </summary>
+    void HandleEvent(PiRpcFrame frame) {
+        switch (frame.Type) {
+            case "agent_start":
+                SetBusy(true);
+                return;
+
+            case "agent_settled":
+                SetBusy(false);
+                return;
+        }
+
+        var envelopes = PiRpc.ToEnvelopes(frame, _resolvedModel ?? _requestedModel);
+        if (envelopes.Count == 0) return;
+
+        if (IsOurOwnEcho(frame, envelopes)) {
+            _logger.LogDebug("Pi: dropped the echo of a prompt this daemon sent (agentId={AgentId}).", _agentId);
+            return;
+        }
+
+        foreach (var env in envelopes) EmitAgentEnvelope(env);
+    }
+
+    /// <summary>Rule (c): true when this frame is Pi echoing back a prompt we sent, in which case
+    /// the whole frame is dropped (we already emitted the <c>user_message</c> at send time). Only
+    /// ever true for a single-envelope user-message frame — an assistant frame, or a user frame
+    /// whose text matches nothing we sent, is real transcript.</summary>
+    bool IsOurOwnEcho(PiRpcFrame frame, IReadOnlyList<AcpEventEnvelope> envelopes) =>
+        frame.Type == "message_end"
+        && envelopes is [{ Kind: AcpEventKind.UserMessage, Text: { } text }]
+        && TryConsumeSentPrompt(text);
+
+    // ---- Handshake ----
+
+    async Task RunHandshakeAsync() {
+        var waiter = new TaskCompletionSource<PiRpcFrame>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _pending[InitStateCommandId] = waiter;
+
+        try {
+            await _process.WriteLineAsync(PiRpc.GetStateCommand(InitStateCommandId), _ownerToken).ConfigureAwait(false);
+
+            var response = _readyDeadline is { } deadline
+                ? await waiter.Task.WaitAsync(deadline).ConfigureAwait(false)
+                : await waiter.Task.ConfigureAwait(false);
+
+            ApplyState(response);
+        } catch (Exception ex) {
+            // EVERY failure lands here — a failed write, the deadline, the child exiting (which
+            // faults `waiter` via EnterTerminal), or a malformed/refused state response. Rule (a):
+            // fault, never hang.
+            FaultSessionReadyIfUnresolved(
+                $"Pi: the hosted session's identity handshake failed (agentId={_agentId}).", ex);
+        } finally {
+            _pending.TryRemove(InitStateCommandId, out _);
+        }
+    }
+
+    /// <summary>Applies a <c>get_state</c> response. Fails CLOSED on a refused response or a
+    /// missing <c>sessionId</c>: reporting <c>""</c> as the session identity would bind the
+    /// transcript to nothing, permanently and silently.</summary>
+    void ApplyState(PiRpcFrame response) {
+        if (response.Success == false) {
+            FaultSessionReadyIfUnresolved($"Pi: get_state was refused (agentId={_agentId}).", inner: null);
+            return;
+        }
+
+        var data = response.Root.Obj("data");
+
+        if (data?.Str("sessionId") is not { Length: > 0 } sessionId) {
+            FaultSessionReadyIfUnresolved(
+                $"Pi: get_state answered without a sessionId (agentId={_agentId}).", inner: null);
+            return;
+        }
+
+        _sessionId     = sessionId;
+        _resolvedModel = ExtractModelId(data.Value) ?? _requestedModel;
+
+        // Pi may already be mid-turn when we attach (a resumed session), so the initial busy state
+        // comes from the handshake, not from having observed an agent_start we were never running
+        // to see.
+        if (data.Value.TryGetProperty("isStreaming", out var streaming) && streaming.ValueKind == JsonValueKind.True)
+            SetBusy(true);
+
+        ActivityClock?.SetLaunchStage("session_created");
+
+        _sessionReady.TrySetResult();
+    }
+
+    /// <summary>Pi's <c>model</c> is a full object, not a string — <c>id</c> is its identity. A
+    /// bare string is tolerated as schema drift rather than dropped, and anything else reads as
+    /// absent (the caller then falls back to the requested model, whose only consumer is
+    /// attribution).</summary>
+    static string? ExtractModelId(JsonElement data) {
+        if (!data.TryGetProperty("model", out var model)) return null;
+
+        return model.ValueKind switch {
+            JsonValueKind.String => model.GetString(),
+            JsonValueKind.Object => model.Str("id") ?? model.Str("name"),
+            _                    => null,
+        };
+    }
+
+    void FaultSessionReadyIfUnresolved(string message, Exception? inner) {
+        // TrySetException is a no-op against an already-resolved barrier, so this can never clobber
+        // a real identity that arrived first.
+        if (!_sessionReady.TrySetException(
+                inner is null ? new InvalidOperationException(message)
+                              : new InvalidOperationException(message, inner)))
+            return;
+
+        _logger.LogWarning(inner, "{Message}", message);
+
+        // Observe the fault we just caused: nothing requires a caller to await this barrier (only a
+        // factory does), and an unobserved faulted Task risks TaskScheduler.UnobservedTaskException
+        // once the GC finalizes it. A real awaiter still sees the exception through its own await.
+        _sessionReady.Task.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    // ---- Input ----
+
+    public async Task SendUserInputAsync(string text) {
+        // Ordering is load-bearing on both halves. The echo memory is written BEFORE the command
+        // goes on the wire, because Pi's echo can be read back by the pump before this method's
+        // own continuation resumes. The envelope is emitted first so the viewer sees their message
+        // immediately, rather than only when Pi gets round to echoing it.
+        RememberSentPrompt(text);
+        EmitLocalEnvelope(new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: text));
+
+        var id     = NextCommandId();
+        var waiter = new TaskCompletionSource<PiRpcFrame>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _pending[id] = waiter;
+
+        try {
+            await _process.WriteLineAsync(PiRpc.PromptCommand(id, text), _ownerToken).ConfigureAwait(false);
+        } catch {
+            _pending.TryRemove(id, out _);
+            throw;
+        }
+
+        // Observed in the background: Pi's response to `prompt` acknowledges acceptance, and a
+        // refusal (e.g. a prompt that raced an in-flight turn) is only ever visible to the person
+        // who typed the message as a transcript note. Never awaited here — a prompt that queues
+        // behind a long turn must not block the daemon's command lane.
+        _ = ObservePromptResponseAsync(waiter.Task);
+    }
+
+    async Task ObservePromptResponseAsync(Task<PiRpcFrame> response) {
+        try {
+            var frame = await response.ConfigureAwait(false);
+            if (frame.Success != false) return;
+
+            var reason = frame.Root.Str("error") ?? "pi rejected the message";
+            EmitLocalEnvelope(new AcpEventEnvelope(
+                Kind: AcpEventKind.SystemNote,
+                Text: $"Your message was not accepted: {reason}"));
+        } catch (Exception ex) {
+            // The runtime went terminal before Pi answered — the session ending is itself the
+            // user-visible signal, and the transcript channel is already completed.
+            _logger.LogDebug(ex, "Pi: a prompt's response never arrived (agentId={AgentId}).", _agentId);
+        }
+    }
+
+    public Task SendUserInputAndWaitForWriteAsync(string text) => SendUserInputAsync(text);
+
+    /// <summary>Pi has no key surface — the ONE mapping that means anything is escape, which is
+    /// Pi's <c>abort</c> (interrupt the current turn). Everything else is logged and dropped
+    /// rather than guessed at.</summary>
+    public async Task SendSpecialKeyAsync(string key) {
+        if (!string.Equals(key, "escape", StringComparison.OrdinalIgnoreCase)) {
+            _logger.LogDebug("Pi runtime ignoring SendSpecialKeyAsync({Key}) — no equivalent command.", key);
+            return;
+        }
+
+        try {
+            await _process.WriteLineAsync(PiRpc.AbortCommand(NextCommandId()), _ownerToken).ConfigureAwait(false);
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "Pi: failed to send an abort command (agentId={AgentId}).", _agentId);
+        }
+    }
+
+    public Task SendRawInputAsync(byte[] data) =>
+        throw new NotSupportedException(
+            "Local-attach raw input is a PTY-only surface; the Pi runtime has no equivalent channel.");
+
+    public void Resize(ushort cols, ushort rows) {
+        // No terminal capability — pi --mode rpc's stdout is protocol traffic, not a terminal.
+    }
+
+    string NextCommandId() => $"kcap-{Interlocked.Increment(ref _commandSeq)}";
+
+    // ---- Echo memory (rule (c)) ----
+
+    void RememberSentPrompt(string text) {
+        lock (_echoGate) {
+            _sentPrompts.Add(text);
+
+            // Oldest-first eviction: an entry that has waited this long was never echoed.
+            while (_sentPrompts.Count > SentPromptMemory) _sentPrompts.RemoveAt(0);
+        }
+    }
+
+    /// <summary>Most-recent-first, consume-on-match — see rule (c) on why consuming (rather than
+    /// merely testing membership) is what keeps a genuinely repeated message renderable.</summary>
+    bool TryConsumeSentPrompt(string text) {
+        lock (_echoGate) {
+            for (var i = _sentPrompts.Count - 1; i >= 0; i--) {
+                if (!string.Equals(_sentPrompts[i], text, StringComparison.Ordinal)) continue;
+
+                _sentPrompts.RemoveAt(i);
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    // ---- Turn idleness ----
+
+    /// <summary>Completes immediately when Pi is not streaming, else on the next
+    /// <c>agent_settled</c>. Entering terminal releases every waiter (via
+    /// <see cref="EnterTerminal"/>'s <c>SetBusy(false)</c>) — a waiter parked on a settle that can
+    /// never arrive is a hang, not a stop.</summary>
+    public Task WaitForTurnIdleAsync(CancellationToken ct) {
+        TaskCompletionSource waiter;
+
+        lock (_turnGate) {
+            if (!_busy) return Task.CompletedTask;
+
+            waiter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _idleWaiters.Add(waiter);
+        }
+
+        return waiter.Task.WaitAsync(ct);
+    }
+
+    void SetBusy(bool busy) {
+        TaskCompletionSource[]? release = null;
+
+        lock (_turnGate) {
+            _busy = busy;
+
+            if (!busy && _idleWaiters.Count > 0) {
+                release = [.. _idleWaiters];
+                _idleWaiters.Clear();
+            }
+        }
+
+        // Both effects OUTSIDE the lock: the clock takes its own lock, and a waiter's continuation
+        // can run inline. Neither belongs under a lock this runtime's own pump re-enters.
+        ActivityClock?.SetTurnInFlight(busy);
+
+        if (release is null) return;
+
+        foreach (var waiter in release) waiter.TrySetResult();
+    }
+
+    // ---- Transcript ----
+
+    /// <summary>An envelope the AGENT produced — advances the activity clock, which is what makes
+    /// this runtime's output the liveness signal a supervisor reads.</summary>
+    void EmitAgentEnvelope(AcpEventEnvelope env) => Write(env, agentActivity: true);
+
+    /// <summary>An envelope this daemon authored: the send-time user echo and the rejected-prompt
+    /// note. Reaches the transcript identically but does NOT advance the clock — neither is
+    /// evidence the agent produced anything, and counting a user's retries against a wedged agent
+    /// as activity is exactly how an agent becomes un-reapable.</summary>
+    void EmitLocalEnvelope(AcpEventEnvelope env) => Write(env, agentActivity: false);
+
+    void Write(AcpEventEnvelope env, bool agentActivity) {
+        // Advance BEFORE the channel write: a reader can wake the instant TryWrite makes the item
+        // visible, on another thread, so the reverse order is a race a fast reader wins.
+        if (agentActivity) ActivityClock?.Advance();
+
+        if (_transcript.Writer.TryWrite(env)) return;
+
+        // Debug, not Warning: an envelope arriving after the channel closed is the ORDINARY shape
+        // of teardown (the pump is draining Pi's last lines while terminal is entered).
+        _logger.LogDebug("Pi: dropped a transcript envelope — the channel is already completed.");
+    }
+
+    /// <summary>Rule (b): parks on the single constructor-owned <see cref="_terminalTcs"/> and
+    /// yields no bytes ever. Its ENDING is what drives the orchestrator's finalize.</summary>
+    public async IAsyncEnumerable<byte[]> ReadOutputAsync(
+            [EnumeratorCancellation] CancellationToken ct = default) {
+        await _terminalTcs.Task.WaitAsync(ct).ConfigureAwait(false);
+        yield break;
+    }
+
+    // ---- Terminal / teardown ----
+
+    /// <summary>Idempotent. Completes the park, faults every waiter that can no longer be answered
+    /// (pending commands, the ready barrier, turn-idle waiters), and closes the transcript —
+    /// deliberately LAST, so a note written by one of those faults still has somewhere to go.
+    /// Never emits <c>session_ended</c>.</summary>
+    bool EnterTerminal() {
+        if (Interlocked.Exchange(ref _terminal, 1) != 0) return false;
+
+        _terminalTcs.TrySetResult();
+
+        foreach (var id in _pending.Keys) {
+            if (_pending.TryRemove(id, out var waiter))
+                waiter.TrySetException(new InvalidOperationException(
+                    $"Pi: the hosted session ended before command {id} was answered."));
+        }
+
+        FaultSessionReadyIfUnresolved(
+            $"Pi: the hosted session ended before its identity handshake completed (agentId={_agentId}).",
+            inner: null);
+
+        SetBusy(false);
+
+        _transcript.Writer.TryComplete();
+
+        return true;
+    }
+
+    /// <summary>Best-effort <c>abort</c> so Pi can wind the current turn down itself, then a
+    /// bounded wait, then terminate — the interface's documented "the orchestrator falls through
+    /// to terminate" contract, performed here so a clean stop is attempted first.</summary>
+    public async Task RequestGracefulStopAsync() {
+        try {
+            await _process.WriteLineAsync(PiRpc.AbortCommand(NextCommandId()), _ownerToken).ConfigureAwait(false);
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "Pi: failed to send the graceful-stop abort (agentId={AgentId}).", _agentId);
+        }
+
+        await _process.WaitForExitAsync(_stopGrace).ConfigureAwait(false);
+
+        if (_process.HasExited) return;
+
+        await TerminateAsync(_stopGrace).ConfigureAwait(false);
+    }
+
+    /// <summary>Delegates to the child — unlike Antigravity, "exited" here is a real process fact,
+    /// not a logical phase. Returns silently on timeout, per the interface contract.</summary>
+    public Task WaitForExitAsync(TimeSpan? timeout = null) => _process.WaitForExitAsync(timeout);
+
+    public async Task TerminateAsync(TimeSpan? timeout = null) {
+        EnterTerminal();
+
+        await _ownerCts.CancelAsync().ConfigureAwait(false);
+
+        try {
+            await _process.TerminateAsync(timeout).ConfigureAwait(false);
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "Pi: failed to terminate the hosted child (agentId={AgentId}).", _agentId);
+        }
+    }
+
+    public async ValueTask DisposeAsync() {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;   // idempotent; _onDisposed fires once
+
+        EnterTerminal();
+
+        await _ownerCts.CancelAsync().ConfigureAwait(false);
+
+        // Both bounded and both swallowed — a stuck pump or an unanswered handshake must never hang
+        // a dispose. The handshake is joined too so its own `finally` cannot run against a disposed
+        // process.
+        try {
+            await Task.WhenAll(_pumpTask, _handshakeTask).WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "Pi: the read pump did not join within the dispose budget (agentId={AgentId}).", _agentId);
+        }
+
+        try {
+            await _process.DisposeAsync().ConfigureAwait(false);
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "Pi: failed to dispose the hosted child (agentId={AgentId}).", _agentId);
+        }
+
+        // _ownerCts is deliberately not disposed — see its field remarks.
+
+        if (_onDisposed is null) return;
+
+        try {
+            _onDisposed();
+        } catch (Exception ex) {
+            _logger.LogWarning(ex, "Pi: the runtime's disposal callback failed (agentId={AgentId}).", _agentId);
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntimeFactory.cs
@@ -161,10 +161,9 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
             // A genuine shutdown propagates AS a cancellation — do not dress it up as a launch failure.
             if (ex is OperationCanceledException && ct.IsCancellationRequested) throw;
 
-            // An unauthenticated or misconfigured pi should surface its real stderr rather than just
-            // the generic handshake-failed message the runtime already throws — mirrors
-            // AntigravityHostedAgentRuntimeFactory.DescribeLaunchFailure in spirit (this vendor has no
-            // auth-specific cases to distinguish yet, so there is no case ladder, just the append).
+            // The child's captured stderr is logged LOCALLY (never embedded in the exception message
+            // — see DescribeLaunchFailure's doc) and this exception is what AgentOrchestrator forwards
+            // verbatim to the server via LaunchFailedAsync.
             //
             // Bare `throw;` when there's nothing to add: it preserves ex's original stack trace,
             // where re-throwing ex itself (`throw ex;`) would reset it to here. Wrapping only
@@ -240,21 +239,44 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
     }
 
     /// <summary>
-    /// Wraps <paramref name="cause"/> with its child's captured stderr appended, or
-    /// <see langword="null"/> when there is none to add — in spirit with
-    /// <c>AntigravityHostedAgentRuntimeFactory.DescribeLaunchFailure</c>, but without that method's
-    /// auth/timeout case ladder: this vendor has no equivalent well-known failure shapes to
-    /// distinguish yet, so there is nothing to branch on beyond "did the child say anything on the
-    /// way out". <paramref name="cause"/> is preserved as <see cref="Exception.InnerException"/>,
-    /// stack trace and all, when this returns non-null; the caller falls back to a bare
-    /// <c>throw;</c> of <paramref name="cause"/> itself when this returns <see langword="null"/>, so
-    /// that unadorned case never has its stack trace reset.
+    /// Logs the child's captured stderr to the DAEMON'S OWN log — never into the exception message
+    /// that propagates out of this factory — and returns a safe wrapper around
+    /// <paramref name="cause"/>, or <see langword="null"/> when there is no stderr to log.
+    ///
+    /// <para><b>Why stderr must never reach the returned exception.</b>
+    /// <see cref="PiRpcProcess.Diagnostics"/> is a bounded capture of whatever the child wrote to
+    /// stderr, and <c>PiRpcProcess.DrainStderrAsync</c> deliberately never logs that text itself
+    /// because it can carry prompt fragments, paths, or auth detail. This exception, however, is
+    /// what <c>AgentOrchestrator</c>'s launch catch forwards verbatim to the server via
+    /// <c>LaunchFailedAsync</c> — an off-host sink. Embedding the raw capture in the message would
+    /// defeat the exact boundary <c>DrainStderrAsync</c> exists to hold, so it is logged at Warning
+    /// here (the daemon log is the access-controlled local sink) and the returned exception carries
+    /// only <paramref name="cause"/>'s own generic reason plus an indicator that stderr was
+    /// captured — never the stderr text. This mirrors the SAFER of the two vendor factories:
+    /// <c>AntigravityHostedAgentRuntimeFactory.DescribeLaunchFailure</c> only ever uses its
+    /// diagnostics capture to CLASSIFY a known failure shape (auth, via
+    /// <c>LooksLikeAuthFailure</c>) and picks one of a few fixed, non-sensitive message templates —
+    /// it never appends the raw capture either.</para>
+    ///
+    /// <para><paramref name="cause"/> is preserved as <see cref="Exception.InnerException"/>, stack
+    /// trace and all, when this returns non-null; the caller falls back to a bare <c>throw;</c> of
+    /// <paramref name="cause"/> itself when this returns <see langword="null"/>, so that unadorned
+    /// case never has its stack trace reset.</para>
     /// </summary>
-    static Exception? DescribeLaunchFailure(Exception cause, string? diagnostics) =>
-        diagnostics is { Length: > 0 }
-            ? new InvalidOperationException($"{cause.Message} (pi stderr: {diagnostics})", cause)
-            : null;
+    Exception? DescribeLaunchFailure(Exception cause, string? diagnostics) {
+        if (diagnostics is not { Length: > 0 }) return null;
+
+        LogPiLaunchStderr(diagnostics);
+
+        return new InvalidOperationException($"{cause.Message} (stderr captured in daemon log)", cause);
+    }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Pi launch: agentId={AgentId} cwd={Cwd}")]
     partial void LogLaunching(string agentId, string cwd);
+
+    /// <summary>The daemon-local-only sink for a failed launch's captured stderr — see
+    /// <see cref="DescribeLaunchFailure"/>'s class doc for why this text must never reach the
+    /// exception that propagates to the orchestrator/server.</summary>
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Pi launch failed; captured stderr follows (not sent to server): {Diagnostics}")]
+    partial void LogPiLaunchStderr(string diagnostics);
 }

--- a/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntimeFactory.cs
@@ -1,5 +1,6 @@
 // src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntimeFactory.cs
 using System.Diagnostics;
+using System.Text;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Acp;
 using Microsoft.Extensions.Logging;
@@ -11,9 +12,10 @@ namespace Capacitor.Cli.Daemon.Services;
 /// hosted agent over the LONG-LIVED <see cref="PiRpcHostedAgentRuntime"/>.
 ///
 /// <para><b>PR-1 scope: interactive hosting only.</b> <see cref="SupportsUnattended"/> is
-/// unconditionally <see langword="false"/> — the reviewer lane is a later PR — so
-/// <see cref="DescribeUnattendedSupport"/> always carries the same withheld reason and this factory
-/// never needs to spawn <c>pi</c> to answer either question.</para>
+/// unconditionally <see langword="false"/> — the reviewer lane is a later PR. Pi never claimed
+/// unattended support at all, so the default <see cref="IHostedAgentRuntimeFactory.DescribeUnattendedSupport"/>
+/// (a null <see cref="UnattendedSupport.WithheldReason"/>) is correct, and this factory never needs
+/// to spawn <c>pi</c> to answer either question.</para>
 ///
 /// <para><b>Not an ACP factory.</b> Pi speaks its own LF-framed JSONL-RPC over stdio for ONE
 /// long-lived child that backs the whole hosted session (see <see cref="IPiRpcProcess"/>'s class doc
@@ -42,11 +44,16 @@ namespace Capacitor.Cli.Daemon.Services;
 /// the same builder a real launch uses.</param>
 /// <param name="binaryExists">Test seam ONLY, for <see cref="IsAvailable"/>. Production passes null,
 /// which resolves the real binary through <c>PATH</c> via <see cref="CliResolver.Exists"/>.</param>
+/// <param name="readyDeadline">Test seam ONLY, threaded verbatim into every
+/// <see cref="PiRpcHostedAgentRuntime"/> this factory constructs. Production passes null, which
+/// falls through to <see cref="PiRpcHostedAgentRuntime.DefaultReadyDeadline"/> — so a test can bound
+/// a silent-child launch to milliseconds instead of burning the real 30s default.</param>
 internal sealed partial class PiRpcHostedAgentRuntimeFactory(
         DaemonConfig                                                 config,
         ILoggerFactory                                                loggerFactory,
         Func<ProcessStartInfo, CancellationToken, Task<IPiRpcProcess>>? processSource = null,
-        Func<string, bool>?                                           binaryExists = null
+        Func<string, bool>?                                           binaryExists = null,
+        TimeSpan?                                                     readyDeadline = null
     ) : IHostedAgentRuntimeFactory {
     readonly ILogger _logger = loggerFactory.CreateLogger<PiRpcHostedAgentRuntimeFactory>();
 
@@ -60,12 +67,14 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
 
     public bool IsAvailable() => _binaryExists(config.PiPath);
 
-    /// <summary>PR-1 only — the reviewer lane is not implemented yet. See
-    /// <see cref="DescribeUnattendedSupport"/> for the reason surfaced to an operator.</summary>
+    /// <summary>PR-1 only — the reviewer lane is not implemented yet. Pi never claimed unattended
+    /// support in the first place, so the default <see cref="IHostedAgentRuntimeFactory.DescribeUnattendedSupport"/>
+    /// (<c>new(SupportsUnattended, null)</c>) is correct as-is: <see cref="UnattendedSupport.WithheldReason"/>
+    /// is reserved for a vendor this daemon's OWN configuration is refusing to offer, not for one that
+    /// simply doesn't support it yet. An earlier revision overrode this with a non-null reason, which
+    /// made every daemon with <c>pi</c> installed log a false "restart to enable" operator
+    /// instruction at boot.</summary>
     public bool SupportsUnattended => false;
-
-    public UnattendedSupport DescribeUnattendedSupport() =>
-        new(false, "pi reviewer lane not yet implemented");
 
     /// <summary>Pi's model rides argv (<c>--model</c>), applied on every launch that resolves one —
     /// unlike a vendor whose model-selection hook is unverified.</summary>
@@ -111,7 +120,8 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
                 loggerFactory.CreateLogger<PiRpcHostedAgentRuntime>(),
                 ctx.AgentId,
                 ResolveModel(config, ctx),
-                ctx.Worktree.Path);
+                ctx.Worktree.Path,
+                readyDeadline: readyDeadline);
         } catch {
             // Construction itself failing (it should not, in practice) still leaves a spawned child —
             // no orphan pi processes.
@@ -121,6 +131,18 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
 
         // MUST precede the first input: a clock assigned later makes every stamp inside the launch a
         // silent no-op, and a liveness sweep would then judge this agent from an empty record.
+        //
+        // Deferred, not fixed: the runtime's constructor starts its read pump and handshake tasks
+        // immediately (before this line runs), so a response that arrives between construction and
+        // this assignment would stamp the clock's SetLaunchStage against a still-null ActivityClock —
+        // the identical race AntigravityHostedAgentRuntimeFactory's own post-construction
+        // `runtime.ActivityClock = ctx.ActivityClock;` assignment carries, unfixed, today. Threading
+        // the clock through the runtime's constructor instead (set before RunPumpAsync/
+        // RunHandshakeAsync start) would close it, but would also touch every direct-construction
+        // test site (PiRpcRuntimeFakes.NewRuntime, PiRpcHostedAgentRuntimeTests) for a window that
+        // requires the real child to answer get_state before this single assignment statement runs —
+        // sub-millisecond in practice. Left as-is, matching the sibling factory's accepted risk;
+        // revisit both together if this is ever observed rather than theorized.
         runtime.ActivityClock = ctx.ActivityClock;
 
         try {
@@ -139,6 +161,16 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
             // A genuine shutdown propagates AS a cancellation — do not dress it up as a launch failure.
             if (ex is OperationCanceledException && ct.IsCancellationRequested) throw;
 
+            // An unauthenticated or misconfigured pi should surface its real stderr rather than just
+            // the generic handshake-failed message the runtime already throws — mirrors
+            // AntigravityHostedAgentRuntimeFactory.DescribeLaunchFailure in spirit (this vendor has no
+            // auth-specific cases to distinguish yet, so there is no case ladder, just the append).
+            //
+            // Bare `throw;` when there's nothing to add: it preserves ex's original stack trace,
+            // where re-throwing ex itself (`throw ex;`) would reset it to here. Wrapping only
+            // happens in the branch that actually adds information, and ex's own stack trace
+            // survives intact as the wrapper's InnerException.
+            if (DescribeLaunchFailure(ex, process.Diagnostics) is { } wrapped) throw wrapped;
             throw;
         }
 
@@ -177,11 +209,20 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
             argv.Add(model);
         }
 
+        // No-BOM UTF-8, matching AcpConnection's wire encoding: a BOM emitted before the first JSON
+        // line would break pi's line parser, and the platform-default encoding these three
+        // properties would otherwise fall back to is not guaranteed to be UTF-8 (nor BOM-free) on
+        // every OS this daemon runs on.
+        var noBomUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
         var psi = new ProcessStartInfo(config.PiPath, argv) {
             WorkingDirectory       = ctx.Worktree.Path,
             RedirectStandardInput  = true,
             RedirectStandardOutput = true,
             RedirectStandardError  = true,
+            StandardInputEncoding  = noBomUtf8,
+            StandardOutputEncoding = noBomUtf8,
+            StandardErrorEncoding  = noBomUtf8,
             UseShellExecute        = false,
             CreateNoWindow         = true
         };
@@ -197,6 +238,22 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
 
         return psi;
     }
+
+    /// <summary>
+    /// Wraps <paramref name="cause"/> with its child's captured stderr appended, or
+    /// <see langword="null"/> when there is none to add — in spirit with
+    /// <c>AntigravityHostedAgentRuntimeFactory.DescribeLaunchFailure</c>, but without that method's
+    /// auth/timeout case ladder: this vendor has no equivalent well-known failure shapes to
+    /// distinguish yet, so there is nothing to branch on beyond "did the child say anything on the
+    /// way out". <paramref name="cause"/> is preserved as <see cref="Exception.InnerException"/>,
+    /// stack trace and all, when this returns non-null; the caller falls back to a bare
+    /// <c>throw;</c> of <paramref name="cause"/> itself when this returns <see langword="null"/>, so
+    /// that unadorned case never has its stack trace reset.
+    /// </summary>
+    static Exception? DescribeLaunchFailure(Exception cause, string? diagnostics) =>
+        diagnostics is { Length: > 0 }
+            ? new InvalidOperationException($"{cause.Message} (pi stderr: {diagnostics})", cause)
+            : null;
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Pi launch: agentId={AgentId} cwd={Cwd}")]
     partial void LogLaunching(string agentId, string cwd);

--- a/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntimeFactory.cs
@@ -1,0 +1,203 @@
+// src/Capacitor.Cli.Daemon/Services/PiRpcHostedAgentRuntimeFactory.cs
+using System.Diagnostics;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// <see cref="IHostedAgentRuntimeFactory"/> for Pi's CLI (<c>pi --mode rpc</c>) as an interactive
+/// hosted agent over the LONG-LIVED <see cref="PiRpcHostedAgentRuntime"/>.
+///
+/// <para><b>PR-1 scope: interactive hosting only.</b> <see cref="SupportsUnattended"/> is
+/// unconditionally <see langword="false"/> — the reviewer lane is a later PR — so
+/// <see cref="DescribeUnattendedSupport"/> always carries the same withheld reason and this factory
+/// never needs to spawn <c>pi</c> to answer either question.</para>
+///
+/// <para><b>Not an ACP factory.</b> Pi speaks its own LF-framed JSONL-RPC over stdio for ONE
+/// long-lived child that backs the whole hosted session (see <see cref="IPiRpcProcess"/>'s class doc
+/// for the contrast with Antigravity's exec-per-turn shape), so this factory owns its own PSI builder
+/// and process seam rather than reusing <see cref="AcpHostedAgentRuntimeFactory"/>.</para>
+///
+/// <para><b>The dual-capture gate.</b> Every launch this factory serves carries
+/// <c>KCAP_PI_PURE=1</c> via <see cref="PiLaunchEnvironment.Apply"/> — see its class doc for why an
+/// unconditional gate (not a reviewer-only one) is required: kcap's global Pi extension
+/// (<c>~/.pi/agent/extensions/kcap.ts</c>) loads inside every <c>pi</c> process on the machine,
+/// hosted or not, and would otherwise start a SECOND capture of a session this runtime already
+/// records over the RPC wire.</para>
+///
+/// <para><b>No isolated <c>HOME</c>, unlike Antigravity/Kiro/Copilot.</b> Dual capture here is closed
+/// by the PURE env var alone, so this launch inherits the daemon's own <c>HOME</c> — there is no
+/// per-launch state directory to create or sweep.</para>
+///
+/// <para><b>Refusal ordering mirrors <see cref="AntigravityHostedAgentRuntimeFactory.StartAsync"/>:</b>
+/// a PR review (<c>ctx.IsReview</c>) first, since no config or consent could make that shape work;
+/// then the review-flow refusal (PR-1 has no reviewer at all); then the borrowed-worktree refusal —
+/// this runtime has no containment strategy for a workspace it does not own.</para>
+/// </summary>
+/// <param name="processSource">Test seam ONLY. Production passes null, which spawns the real
+/// <see cref="PiRpcProcess"/> from the <see cref="ProcessStartInfo"/> <see cref="BuildPsi"/> built —
+/// so the seam changes nothing about production behaviour, and the argv/env assertions run against
+/// the same builder a real launch uses.</param>
+/// <param name="binaryExists">Test seam ONLY, for <see cref="IsAvailable"/>. Production passes null,
+/// which resolves the real binary through <c>PATH</c> via <see cref="CliResolver.Exists"/>.</param>
+internal sealed partial class PiRpcHostedAgentRuntimeFactory(
+        DaemonConfig                                                 config,
+        ILoggerFactory                                                loggerFactory,
+        Func<ProcessStartInfo, CancellationToken, Task<IPiRpcProcess>>? processSource = null,
+        Func<string, bool>?                                           binaryExists = null
+    ) : IHostedAgentRuntimeFactory {
+    readonly ILogger _logger = loggerFactory.CreateLogger<PiRpcHostedAgentRuntimeFactory>();
+
+    readonly Func<ProcessStartInfo, CancellationToken, Task<IPiRpcProcess>> _processSource =
+        processSource ?? ((psi, _) => Task.FromResult<IPiRpcProcess>(
+            new PiRpcProcess(psi, loggerFactory.CreateLogger<PiRpcProcess>())));
+
+    readonly Func<string, bool> _binaryExists = binaryExists ?? CliResolver.Exists;
+
+    public string Vendor => "pi";
+
+    public bool IsAvailable() => _binaryExists(config.PiPath);
+
+    /// <summary>PR-1 only — the reviewer lane is not implemented yet. See
+    /// <see cref="DescribeUnattendedSupport"/> for the reason surfaced to an operator.</summary>
+    public bool SupportsUnattended => false;
+
+    public UnattendedSupport DescribeUnattendedSupport() =>
+        new(false, "pi reviewer lane not yet implemented");
+
+    /// <summary>Pi's model rides argv (<c>--model</c>), applied on every launch that resolves one —
+    /// unlike a vendor whose model-selection hook is unverified.</summary>
+    public bool SupportsModelSelection => true;
+
+    public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+        // FIRST, ahead of every other refusal: no install or config makes a PR review work here — this
+        // runtime hosts interactive agents only, and a PR review needs the `kcap mcp review` tool
+        // surface only the PTY launchers build.
+        if (ctx.IsReview)
+            throw new InvalidOperationException(
+                "pi_pr_review_unsupported: this runtime hosts interactive agents only. A PR review "
+              + "needs the `kcap mcp review` tool surface and review prompt, which only the PTY "
+              + "launchers build — launch the PR review with Claude.");
+
+        // PR-1 has no reviewer lane at all — SupportsUnattended is unconditionally false, so the
+        // orchestrator's own gate should already have refused this before reaching a factory. This is
+        // defence in depth for an explicit `vendor: "pi"` review-flow request that reaches a factory
+        // without consulting advertisement.
+        if (ctx.IsReviewFlow)
+            throw new InvalidOperationException(
+                "pi_reviewer_not_implemented: the Pi reviewer lane is not implemented yet — this "
+              + "runtime hosts interactive agents only.");
+
+        // A property of this runtime, not of reviews: there is no sandbox substrate here, so nothing
+        // bounds what a launch could read out of a checkout it does not own.
+        if (ctx.Work != WorkLocation.OwnedWorktree)
+            throw new InvalidOperationException(
+                "pi_requires_owned_worktree: this runtime has no containment strategy for a borrowed "
+              + "workspace, so it runs only in a daemon-owned worktree.");
+
+        var psi = BuildPsi(config, ctx);
+
+        LogLaunching(ctx.AgentId, ctx.Worktree.Path);
+
+        var process = await _processSource(psi, ct).ConfigureAwait(false);
+
+        PiRpcHostedAgentRuntime runtime;
+
+        try {
+            runtime = new PiRpcHostedAgentRuntime(
+                process,
+                loggerFactory.CreateLogger<PiRpcHostedAgentRuntime>(),
+                ctx.AgentId,
+                ResolveModel(config, ctx),
+                ctx.Worktree.Path);
+        } catch {
+            // Construction itself failing (it should not, in practice) still leaves a spawned child —
+            // no orphan pi processes.
+            await process.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+
+        // MUST precede the first input: a clock assigned later makes every stamp inside the launch a
+        // silent no-op, and a liveness sweep would then judge this agent from an empty record.
+        runtime.ActivityClock = ctx.ActivityClock;
+
+        try {
+            if (!string.IsNullOrEmpty(ctx.Prompt))
+                await runtime.SendUserInputAsync(ctx.Prompt).ConfigureAwait(false);
+
+            // The ordering guarantee: the orchestrator reads transcript.AcpSessionId synchronously the
+            // moment this method returns, so the barrier must resolve BEFORE that — see
+            // PiRpcHostedAgentRuntime's rule (a).
+            await runtime.WaitForSessionReadyAsync(ct).ConfigureAwait(false);
+        } catch (Exception ex) {
+            // The launch is over either way; leaving the child alive would leave an unreapable agent
+            // holding a daemon slot. DisposeAsync terminates the child and joins the pump/handshake.
+            await runtime.DisposeAsync().ConfigureAwait(false);
+
+            // A genuine shutdown propagates AS a cancellation — do not dress it up as a launch failure.
+            if (ex is OperationCanceledException && ct.IsCancellationRequested) throw;
+
+            throw;
+        }
+
+        // The runtime IS the transcript source, so the orchestrator binds and forwards without
+        // downcasting Runtime. McpConfigPath stays null: this launch writes no temp mcp-config file.
+        return new HostedRuntimeStart(runtime, McpConfigPath: null, Transcript: runtime);
+    }
+
+    /// <summary>The effective model — the launch's own override, else the daemon-wide default. Same
+    /// <c>"default"</c>-sentinel convention as <see cref="AntigravityHostedAgentRuntimeFactory.ResolveModel"/>
+    /// and every other vendor's resolver.</summary>
+    internal static string? ResolveModel(DaemonConfig config, RuntimeStartContext ctx) =>
+        !string.IsNullOrEmpty(ctx.Model) && !string.Equals(ctx.Model, "default", StringComparison.OrdinalIgnoreCase)
+            ? ctx.Model
+            : config.PiModel;
+
+    /// <summary>
+    /// PURE builder for the whole launch — no process, no filesystem side effects. The real spawn
+    /// path and the launch tests both go through it, so an assertion here certifies the vector the OS
+    /// actually receives.
+    ///
+    /// <para>Argv is exactly <c>--mode rpc</c> plus <c>--model &lt;m&gt;</c> when
+    /// <see cref="ResolveModel"/> yields one. Env carries <see cref="PiLaunchEnvironment.Apply"/>'s
+    /// <c>KCAP_PI_PURE=1</c> (never omitted — see that type's doc) plus the same daemon-identity
+    /// stamps <see cref="AntigravityHostedAgentRuntimeFactory.BuildTurnPsi"/> carries:
+    /// <c>KCAP_URL</c>, <c>KCAP_AGENT_ID</c>, <c>KCAP_DAEMON_ID</c>, <c>KCAP_DAEMON_EPOCH</c> — the
+    /// last two are what makes a surviving child visible to <c>OrphanReaper</c>'s env-marker pass
+    /// after a daemon restart, and are omitted (never stamped empty) when the context does not carry
+    /// them, matching Antigravity's convention.</para>
+    /// </summary>
+    internal static ProcessStartInfo BuildPsi(DaemonConfig config, RuntimeStartContext ctx) {
+        var argv = new List<string> { "--mode", "rpc" };
+
+        if (ResolveModel(config, ctx) is { Length: > 0 } model) {
+            argv.Add("--model");
+            argv.Add(model);
+        }
+
+        var psi = new ProcessStartInfo(config.PiPath, argv) {
+            WorkingDirectory       = ctx.Worktree.Path,
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+            CreateNoWindow         = true
+        };
+
+        // The dual-capture gate — unconditional, see PiLaunchEnvironment's doc.
+        PiLaunchEnvironment.Apply(psi.Environment);
+
+        if (!string.IsNullOrEmpty(ctx.ServerUrl)) psi.Environment["KCAP_URL"] = ctx.ServerUrl;
+
+        psi.Environment["KCAP_AGENT_ID"] = ctx.AgentId;
+        if (!string.IsNullOrEmpty(ctx.DaemonId))    psi.Environment["KCAP_DAEMON_ID"]    = ctx.DaemonId;
+        if (!string.IsNullOrEmpty(ctx.DaemonEpoch)) psi.Environment["KCAP_DAEMON_EPOCH"] = ctx.DaemonEpoch;
+
+        return psi;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Pi launch: agentId={AgentId} cwd={Cwd}")]
+    partial void LogLaunching(string agentId, string cwd);
+}

--- a/test/Capacitor.Cli.Tests.Unit/PiExtensionMemoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PiExtensionMemoryTests.cs
@@ -57,4 +57,12 @@ public class PiExtensionMemoryTests {
     public async Task shutdown_clears_the_cache() {
         await Assert.That(Ts).Contains("memFragment = null");
     }
+
+    // Dual-capture gate: a hosted launch sets KCAP_PI_PURE=1 (PiLaunchEnvironment.Apply) and this
+    // extension must stand down entirely rather than registering handlers that would double-record
+    // the session the daemon's own RPC runtime already captures.
+    [Test]
+    public async Task hosted_launches_stand_down_via_kcap_pi_pure() {
+        await Assert.That(Ts).Contains("process?.env?.KCAP_PI_PURE === \"1\"");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiHostedLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiHostedLaunchTests.cs
@@ -1,0 +1,377 @@
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// Pi's hosted-launch invariants, asserted on the LAUNCH ARTIFACT — the
+/// <see cref="System.Diagnostics.ProcessStartInfo"/> <see cref="PiRpcHostedAgentRuntimeFactory.BuildPsi"/>
+/// actually produces — plus the factory's refusal ladder and DI registration.
+/// </summary>
+public class PiHostedLaunchTests {
+    static RuntimeStartContext Ctx(
+            string? model = null, string? prompt = "", bool isReview = false, bool isReviewFlow = false,
+            WorkLocation work = WorkLocation.OwnedWorktree, string? serverUrl = "http://kcap.test",
+            string daemonId = "", string daemonEpoch = "") => new(
+        AgentId: "agent-1", Vendor: "pi", SourceRepoPath: "/repo",
+        Worktree: new WorktreeInfo(Path: "/abs/wt", Branch: "b", SourceRepo: "/repo"), Prompt: prompt,
+        Model: model, Effort: null, Tools: null,
+        IsReview: isReview, IsReviewFlow: isReviewFlow, Review: null,
+        Cols: 80, Rows: 24,
+        ServerUrl: serverUrl, DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap",
+        Work: work, DaemonId: daemonId, DaemonEpoch: daemonEpoch);
+
+    // ── BuildPsi: argv ──
+
+    [Test]
+    public async Task BuildPsi_NoModel_ArgvIsExactlyModeRpc() {
+        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig(), Ctx());
+
+        await Assert.That(string.Join(" ", psi.ArgumentList)).IsEqualTo("--mode rpc");
+    }
+
+    [Test]
+    public async Task BuildPsi_WithCallerModel_ArgvAppendsModelFlag() {
+        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig(), Ctx(model: "claude-opus"));
+
+        await Assert.That(string.Join(" ", psi.ArgumentList)).IsEqualTo("--mode rpc --model claude-opus");
+    }
+
+    [Test]
+    public async Task BuildPsi_WithConfigDefaultModel_ArgvAppendsModelFlag() {
+        var config = new DaemonConfig { PiModel = "config-default" };
+        var psi    = PiRpcHostedAgentRuntimeFactory.BuildPsi(config, Ctx());
+
+        await Assert.That(string.Join(" ", psi.ArgumentList)).IsEqualTo("--mode rpc --model config-default");
+    }
+
+    [Test]
+    public async Task BuildPsi_UsesConfiguredPiPath() {
+        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig { PiPath = "/opt/pi/bin/pi" }, Ctx());
+
+        await Assert.That(psi.FileName).IsEqualTo("/opt/pi/bin/pi");
+    }
+
+    // ── BuildPsi: cwd ──
+
+    [Test]
+    public async Task BuildPsi_WorkingDirectoryIsExactlyTheWorktreePath() {
+        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig(), Ctx());
+
+        await Assert.That(psi.WorkingDirectory).IsEqualTo("/abs/wt");
+    }
+
+    // ── BuildPsi: env — all five vars, exact ──
+
+    [Test]
+    public async Task BuildPsi_EnvCarriesTheDualCaptureGate() {
+        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig(), Ctx());
+
+        await Assert.That(psi.Environment[PiLaunchEnvironment.PureVariable]).IsEqualTo("1");
+    }
+
+    [Test]
+    public async Task BuildPsi_EnvCarriesAllFiveVarsExactly() {
+        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(
+            new DaemonConfig(),
+            Ctx(serverUrl: "http://kcap.test", daemonId: "daemon-1", daemonEpoch: "epoch-1"));
+
+        await Assert.That(psi.Environment["KCAP_PI_PURE"]).IsEqualTo("1");
+        await Assert.That(psi.Environment["KCAP_URL"]).IsEqualTo("http://kcap.test");
+        await Assert.That(psi.Environment["KCAP_AGENT_ID"]).IsEqualTo("agent-1");
+        await Assert.That(psi.Environment["KCAP_DAEMON_ID"]).IsEqualTo("daemon-1");
+        await Assert.That(psi.Environment["KCAP_DAEMON_EPOCH"]).IsEqualTo("epoch-1");
+    }
+
+    [Test]
+    public async Task BuildPsi_OmitsDaemonIdAndEpoch_WhenContextCarriesNone() {
+        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig(), Ctx(daemonId: "", daemonEpoch: ""));
+
+        await Assert.That(psi.Environment.ContainsKey("KCAP_DAEMON_ID")).IsFalse();
+        await Assert.That(psi.Environment.ContainsKey("KCAP_DAEMON_EPOCH")).IsFalse();
+    }
+
+    [Test]
+    public async Task BuildPsi_OmitsServerUrl_WhenContextCarriesNone() {
+        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig(), Ctx(serverUrl: null));
+
+        await Assert.That(psi.Environment.ContainsKey("KCAP_URL")).IsFalse();
+    }
+
+    [Test]
+    public async Task BuildPsi_RedirectsAllThreeStandardStreams() {
+        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig(), Ctx());
+
+        await Assert.That(psi.RedirectStandardInput).IsTrue();
+        await Assert.That(psi.RedirectStandardOutput).IsTrue();
+        await Assert.That(psi.RedirectStandardError).IsTrue();
+    }
+
+    // ── ResolveModel matrix ──
+
+    [Test]
+    public async Task ResolveModel_CtxModelWins_OverConfigDefault() {
+        var config = new DaemonConfig { PiModel = "config-default" };
+
+        await Assert.That(PiRpcHostedAgentRuntimeFactory.ResolveModel(config, Ctx(model: "caller-choice")))
+            .IsEqualTo("caller-choice");
+    }
+
+    [Test]
+    [Arguments("default")]
+    [Arguments("DEFAULT")]
+    [Arguments("Default")]
+    public async Task ResolveModel_DefaultSentinel_FallsThroughToConfig(string sentinel) {
+        var config = new DaemonConfig { PiModel = "config-default" };
+
+        await Assert.That(PiRpcHostedAgentRuntimeFactory.ResolveModel(config, Ctx(model: sentinel)))
+            .IsEqualTo("config-default");
+    }
+
+    [Test]
+    public async Task ResolveModel_BothNull_ResolvesNull() {
+        await Assert.That(PiRpcHostedAgentRuntimeFactory.ResolveModel(new DaemonConfig(), Ctx(model: null))).IsNull();
+    }
+
+    [Test]
+    public async Task ResolveModel_EmptyCtxModel_FallsThroughToConfig() {
+        var config = new DaemonConfig { PiModel = "config-default" };
+
+        await Assert.That(PiRpcHostedAgentRuntimeFactory.ResolveModel(config, Ctx(model: ""))).IsEqualTo("config-default");
+    }
+
+    // ── IsAvailable seam ──
+
+    [Test]
+    public async Task IsAvailable_ProbesConfiguredPiPath_ThroughTheSeam() {
+        string? probed = null;
+        var factory = new PiRpcHostedAgentRuntimeFactory(
+            new DaemonConfig { PiPath = "/opt/pi/bin/pi" }, NullLoggerFactory.Instance,
+            binaryExists: p => { probed = p; return true; });
+
+        var result = factory.IsAvailable();
+
+        await Assert.That(result).IsTrue();
+        await Assert.That(probed).IsEqualTo("/opt/pi/bin/pi");
+    }
+
+    [Test]
+    public async Task IsAvailable_FalseWhenSeamReportsMissing() {
+        var factory = new PiRpcHostedAgentRuntimeFactory(
+            new DaemonConfig(), NullLoggerFactory.Instance, binaryExists: _ => false);
+
+        await Assert.That(factory.IsAvailable()).IsFalse();
+    }
+
+    // ── Vendor / unattended-support surface ──
+
+    [Test]
+    public async Task Vendor_IsPi() {
+        var factory = new PiRpcHostedAgentRuntimeFactory(new DaemonConfig(), NullLoggerFactory.Instance);
+
+        await Assert.That(factory.Vendor).IsEqualTo("pi");
+    }
+
+    [Test]
+    public async Task SupportsUnattended_IsFalse_InPr1() {
+        var factory = new PiRpcHostedAgentRuntimeFactory(new DaemonConfig(), NullLoggerFactory.Instance);
+
+        await Assert.That(factory.SupportsUnattended).IsFalse();
+    }
+
+    [Test]
+    public async Task DescribeUnattendedSupport_CarriesTheNotImplementedReason() {
+        var factory = new PiRpcHostedAgentRuntimeFactory(new DaemonConfig(), NullLoggerFactory.Instance);
+
+        var support = factory.DescribeUnattendedSupport();
+
+        await Assert.That(support.Supported).IsFalse();
+        await Assert.That(support.WithheldReason).IsEqualTo("pi reviewer lane not yet implemented");
+    }
+
+    [Test]
+    public async Task SupportsModelSelection_IsTrue() {
+        var factory = new PiRpcHostedAgentRuntimeFactory(new DaemonConfig(), NullLoggerFactory.Instance);
+
+        await Assert.That(factory.SupportsModelSelection).IsTrue();
+    }
+
+    // ── StartAsync refusals — none of these may reach a spawn ──
+
+    [Test]
+    public async Task StartAsync_RefusesAPrReview() {
+        var factory = new PiRpcHostedAgentRuntimeFactory(
+            new DaemonConfig(), NullLoggerFactory.Instance,
+            processSource: (_, _) => throw new InvalidOperationException("must not spawn"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => factory.StartAsync(Ctx(isReview: true), CancellationToken.None));
+
+        await Assert.That(ex!.Message).Contains("pi_pr_review_unsupported");
+    }
+
+    [Test]
+    public async Task StartAsync_RefusesAReviewFlowLaunch() {
+        var factory = new PiRpcHostedAgentRuntimeFactory(
+            new DaemonConfig(), NullLoggerFactory.Instance,
+            processSource: (_, _) => throw new InvalidOperationException("must not spawn"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => factory.StartAsync(Ctx(isReviewFlow: true), CancellationToken.None));
+
+        await Assert.That(ex!.Message).Contains("pi_reviewer_not_implemented");
+    }
+
+    [Test]
+    public async Task StartAsync_RefusesABorrowedWorkspace() {
+        var factory = new PiRpcHostedAgentRuntimeFactory(
+            new DaemonConfig(), NullLoggerFactory.Instance,
+            processSource: (_, _) => throw new InvalidOperationException("must not spawn"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => factory.StartAsync(Ctx(work: WorkLocation.BorrowedCwd), CancellationToken.None));
+
+        await Assert.That(ex!.Message).Contains("pi_requires_owned_worktree");
+    }
+
+    // ── StartAsync: the happy path against a fake process ──
+
+    /// <summary>Minimal <see cref="IPiRpcProcess"/> stand-in that answers <c>get_state</c> immediately
+    /// with a fixed session id, so <c>WaitForSessionReadyAsync</c> resolves without a real child.</summary>
+    sealed class FakeProcess : IPiRpcProcess {
+        readonly System.Threading.Channels.Channel<string> _lines =
+            System.Threading.Channels.Channel.CreateUnbounded<string>();
+
+        public int    Pid       => 4242;
+        public bool   HasExited => false;
+        public int?   ExitCode  => null;
+
+        public List<string> Written { get; } = [];
+
+        public IAsyncEnumerable<string> ReadLinesAsync(CancellationToken ct) => _lines.Reader.ReadAllAsync(ct);
+
+        public Task WriteLineAsync(string json, CancellationToken ct) {
+            Written.Add(json);
+
+            // Answer the handshake's get_state with a fixed session id the instant it's sent, so the
+            // ready barrier resolves without any real child process.
+            if (json.Contains("\"get_state\"") && json.Contains(PiRpcHostedAgentRuntime.InitStateCommandId)) {
+                _lines.Writer.TryWrite(
+                    "{\"type\":\"response\",\"id\":\"" + PiRpcHostedAgentRuntime.InitStateCommandId
+                  + "\",\"success\":true,\"data\":{\"sessionId\":\"sess-1\"}}");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan? timeout = null)   => Task.CompletedTask;
+        public ValueTask DisposeAsync()                        => ValueTask.CompletedTask;
+    }
+
+    [Test]
+    public async Task StartAsync_HappyPath_ReturnsARuntimeBoundToTheResolvedSession() {
+        var fake = new FakeProcess();
+        var factory = new PiRpcHostedAgentRuntimeFactory(
+            new DaemonConfig(), NullLoggerFactory.Instance,
+            processSource: (_, _) => Task.FromResult<IPiRpcProcess>(fake));
+
+        var start = await factory.StartAsync(Ctx(prompt: "hello"), CancellationToken.None);
+
+        try {
+            await Assert.That(start.Transcript!.AcpSessionId).IsEqualTo("sess-1");
+            await Assert.That(start.McpConfigPath).IsNull();
+            await Assert.That(fake.Written.Any(w => w.Contains("\"prompt\""))).IsTrue();
+        } finally {
+            await start.Runtime.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task StartAsync_DoesNotSendAnEmptyPrompt() {
+        var fake = new FakeProcess();
+        var factory = new PiRpcHostedAgentRuntimeFactory(
+            new DaemonConfig(), NullLoggerFactory.Instance,
+            processSource: (_, _) => Task.FromResult<IPiRpcProcess>(fake));
+
+        var start = await factory.StartAsync(Ctx(prompt: ""), CancellationToken.None);
+
+        try {
+            await Assert.That(fake.Written.Any(w => w.Contains("\"prompt\""))).IsFalse();
+        } finally {
+            await start.Runtime.DisposeAsync();
+        }
+    }
+
+    /// <summary>A process whose handshake never answers — <c>WaitForSessionReadyAsync</c> must fault
+    /// (bounded by the runtime's own internal ready deadline) and the factory must dispose the runtime
+    /// rather than leak it.</summary>
+    sealed class SilentProcess : IPiRpcProcess {
+        public int  Pid       => 9999;
+        public bool HasExited => false;
+        public int? ExitCode  => null;
+        public bool Disposed  { get; private set; }
+
+        public IAsyncEnumerable<string> ReadLinesAsync(CancellationToken ct) =>
+            System.Threading.Channels.Channel.CreateUnbounded<string>().Reader.ReadAllAsync(ct);
+
+        public Task WriteLineAsync(string json, CancellationToken ct) => Task.CompletedTask;
+        public Task WaitForExitAsync(TimeSpan? timeout = null)        => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan? timeout = null)          => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() {
+            Disposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Test]
+    [Timeout(35_000)]
+    public async Task StartAsync_ASilentChild_FaultsAndDisposesRatherThanHanging() {
+        var silent  = new SilentProcess();
+        var factory = new PiRpcHostedAgentRuntimeFactory(
+            new DaemonConfig(), NullLoggerFactory.Instance,
+            processSource: (_, _) => Task.FromResult<IPiRpcProcess>(silent));
+
+        await Assert.ThrowsAsync<Exception>(() => factory.StartAsync(Ctx(), CancellationToken.None));
+
+        await Assert.That(silent.Disposed).IsTrue();
+    }
+
+    // ── DI registration: after DaemonRunner's registration shape, "pi" resolves ──
+
+    /// <summary>
+    /// Mirrors the exact registration DaemonRunner uses (one <c>IHostedAgentRuntimeFactory</c>
+    /// singleton per vendor projected into the vendor-keyed dictionary
+    /// <c>AgentOrchestrator</c> resolves by), without booting the full daemon host — proving the
+    /// wiring rather than re-asserting DaemonRunner's own source text.
+    /// </summary>
+    [Test]
+    public async Task DaemonRunnerRegistrationShape_ResolvesPiFromTheVendorDictionary() {
+        var services = new ServiceCollection();
+        services.AddSingleton(new DaemonConfig());
+        services.AddSingleton<Microsoft.Extensions.Logging.ILoggerFactory>(NullLoggerFactory.Instance);
+
+        services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
+            new PiRpcHostedAgentRuntimeFactory(
+                sp.GetRequiredService<DaemonConfig>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>()
+            )
+        );
+
+        services.AddSingleton<IReadOnlyDictionary<string, IHostedAgentRuntimeFactory>>(sp =>
+            sp.GetServices<IHostedAgentRuntimeFactory>().ToDictionary(f => f.Vendor)
+        );
+
+        await using var provider = services.BuildServiceProvider();
+
+        var factories = provider.GetRequiredService<IReadOnlyDictionary<string, IHostedAgentRuntimeFactory>>();
+
+        await Assert.That(factories.ContainsKey("pi")).IsTrue();
+        await Assert.That(factories["pi"].Vendor).IsEqualTo("pi");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiHostedLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiHostedLaunchTests.cs
@@ -3,6 +3,7 @@ using Capacitor.Cli.Daemon;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit.Services;
@@ -353,17 +354,53 @@ public class PiHostedLaunchTests {
         await Assert.That(silent.Disposed).IsTrue();
     }
 
+    /// <summary>Security regression: the child's captured stderr must stay DAEMON-LOCAL. Stderr can
+    /// carry prompt fragments, paths, or auth detail — the same reason
+    /// <c>PiRpcProcess.DrainStderrAsync</c> never logs it either — and the thrown exception's
+    /// <c>Message</c> is exactly what <c>AgentOrchestrator</c> forwards, verbatim, off-host to the
+    /// server via <c>LaunchFailedAsync</c>. So the message must carry only a generic, non-sensitive
+    /// indicator, while the raw stderr text lands in the daemon's own log instead.</summary>
     [Test]
-    public async Task StartAsync_ASilentChildWithDiagnostics_AppendsThemToTheThrownError() {
-        var silent = new SilentProcess { Diagnostics = "authentication required: run `pi login`" };
+    public async Task StartAsync_ASilentChildWithDiagnostics_KeepsStderrOutOfTheThrownMessage() {
+        var silent        = new SilentProcess { Diagnostics = "authentication required: run `pi login`" };
+        var loggerFactory = new CaptureLoggerFactory();
         var factory = new PiRpcHostedAgentRuntimeFactory(
-            new DaemonConfig(), NullLoggerFactory.Instance,
+            new DaemonConfig(), loggerFactory,
             processSource: (_, _) => Task.FromResult<IPiRpcProcess>(silent),
             readyDeadline: TimeSpan.FromMilliseconds(500));
 
         var ex = await Assert.ThrowsAsync<Exception>(() => factory.StartAsync(Ctx(), CancellationToken.None));
 
-        await Assert.That(ex!.Message).Contains("authentication required");
+        await Assert.That(ex!.Message).DoesNotContain("authentication required");
+        await Assert.That(ex.Message).Contains("stderr captured in daemon log");
+
+        // The raw text must still be RECOVERABLE — just from the access-controlled local sink, not
+        // from the exception that left the daemon.
+        await Assert.That(loggerFactory.Logger.Entries
+            .Any(e => e.Level == LogLevel.Warning && e.Message.Contains("authentication required")))
+            .IsTrue();
+    }
+
+    /// <summary>Records every log call across every category (one instance shared by every
+    /// <c>CreateLogger&lt;T&gt;()</c> call) — mirrors <c>AcpHostedAgentRuntimeFactoryTests.CaptureLogger</c>'s
+    /// established pattern, wrapped in a minimal <see cref="ILoggerFactory"/> so it can be handed to
+    /// the factory's real constructor.</summary>
+    sealed class CaptureLogger : ILogger {
+        public readonly List<(LogLevel Level, string Message)> Entries = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool         IsEnabled(LogLevel logLevel)                            => true;
+
+        public void Log<TState>(LogLevel level, EventId id, TState state, Exception? ex, Func<TState, Exception?, string> formatter)
+            => Entries.Add((level, formatter(state, ex)));
+    }
+
+    sealed class CaptureLoggerFactory : ILoggerFactory {
+        public readonly CaptureLogger Logger = new();
+
+        public ILogger CreateLogger(string categoryName) => Logger;
+        public void    AddProvider(ILoggerProvider provider) { }
+        public void    Dispose() { }
     }
 
     // ── DI registration: after DaemonRunner's registration shape, "pi" resolves ──

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiHostedLaunchTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiHostedLaunchTests.cs
@@ -184,13 +184,20 @@ public class PiHostedLaunchTests {
     }
 
     [Test]
-    public async Task DescribeUnattendedSupport_CarriesTheNotImplementedReason() {
-        var factory = new PiRpcHostedAgentRuntimeFactory(new DaemonConfig(), NullLoggerFactory.Instance);
+    public async Task DescribeUnattendedSupport_WithheldReasonIsNull_PiNeverClaimedUnattendedSupport() {
+        // WithheldReason is reserved for a vendor this daemon's OWN config is refusing to offer —
+        // Pi simply doesn't support it yet, so the default IHostedAgentRuntimeFactory implementation
+        // (no override here) must report null, not a reason. A prior revision's override reported a
+        // non-null reason, which made every daemon with pi installed log a false "restart to enable"
+        // operator instruction at boot.
+        IHostedAgentRuntimeFactory factory = new PiRpcHostedAgentRuntimeFactory(new DaemonConfig(), NullLoggerFactory.Instance);
 
+        // A default interface member is only reachable through the interface type — there is no
+        // override on the concrete class to call directly, which is the whole point of this fix.
         var support = factory.DescribeUnattendedSupport();
 
         await Assert.That(support.Supported).IsFalse();
-        await Assert.That(support.WithheldReason).IsEqualTo("pi reviewer lane not yet implemented");
+        await Assert.That(support.WithheldReason).IsNull();
     }
 
     [Test]
@@ -246,9 +253,10 @@ public class PiHostedLaunchTests {
         readonly System.Threading.Channels.Channel<string> _lines =
             System.Threading.Channels.Channel.CreateUnbounded<string>();
 
-        public int    Pid       => 4242;
-        public bool   HasExited => false;
-        public int?   ExitCode  => null;
+        public int     Pid         => 4242;
+        public bool    HasExited   => false;
+        public int?    ExitCode    => null;
+        public string? Diagnostics => null;
 
         public List<string> Written { get; } = [];
 
@@ -311,10 +319,11 @@ public class PiHostedLaunchTests {
     /// (bounded by the runtime's own internal ready deadline) and the factory must dispose the runtime
     /// rather than leak it.</summary>
     sealed class SilentProcess : IPiRpcProcess {
-        public int  Pid       => 9999;
-        public bool HasExited => false;
-        public int? ExitCode  => null;
-        public bool Disposed  { get; private set; }
+        public int     Pid         => 9999;
+        public bool    HasExited   => false;
+        public int?    ExitCode    => null;
+        public bool    Disposed    { get; private set; }
+        public string? Diagnostics { get; set; }
 
         public IAsyncEnumerable<string> ReadLinesAsync(CancellationToken ct) =>
             System.Threading.Channels.Channel.CreateUnbounded<string>().Reader.ReadAllAsync(ct);
@@ -330,16 +339,31 @@ public class PiHostedLaunchTests {
     }
 
     [Test]
-    [Timeout(35_000)]
     public async Task StartAsync_ASilentChild_FaultsAndDisposesRatherThanHanging() {
         var silent  = new SilentProcess();
         var factory = new PiRpcHostedAgentRuntimeFactory(
             new DaemonConfig(), NullLoggerFactory.Instance,
-            processSource: (_, _) => Task.FromResult<IPiRpcProcess>(silent));
+            processSource: (_, _) => Task.FromResult<IPiRpcProcess>(silent),
+            // A short test-only deadline (see the factory ctor's readyDeadline param) instead of
+            // burning the real 30s DefaultReadyDeadline this launch would otherwise wait out.
+            readyDeadline: TimeSpan.FromMilliseconds(500));
 
         await Assert.ThrowsAsync<Exception>(() => factory.StartAsync(Ctx(), CancellationToken.None));
 
         await Assert.That(silent.Disposed).IsTrue();
+    }
+
+    [Test]
+    public async Task StartAsync_ASilentChildWithDiagnostics_AppendsThemToTheThrownError() {
+        var silent = new SilentProcess { Diagnostics = "authentication required: run `pi login`" };
+        var factory = new PiRpcHostedAgentRuntimeFactory(
+            new DaemonConfig(), NullLoggerFactory.Instance,
+            processSource: (_, _) => Task.FromResult<IPiRpcProcess>(silent),
+            readyDeadline: TimeSpan.FromMilliseconds(500));
+
+        var ex = await Assert.ThrowsAsync<Exception>(() => factory.StartAsync(Ctx(), CancellationToken.None));
+
+        await Assert.That(ex!.Message).Contains("authentication required");
     }
 
     // ── DI registration: after DaemonRunner's registration shape, "pi" resolves ──

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiHostedRuntimeLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiHostedRuntimeLiveCertTests.cs
@@ -1,0 +1,219 @@
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// Gated live end-to-end certification that <see cref="PiRpcHostedAgentRuntimeFactory"/> and
+/// <see cref="PiRpcHostedAgentRuntime"/> actually work against a REAL <c>pi --mode rpc</c> child — no
+/// <c>FakeProcess</c>, no in-memory pipe (see <c>PiHostedLaunchTests</c> for that coverage of the same
+/// code path, including the exact PSI/argv/env this factory builds and the refusal ladder). This is
+/// the only place asserting the end-to-end claim: real process spawn (the factory's default
+/// <c>processSource</c>, i.e. <c>processSource: null</c>) → real LF-framed JSONL-RPC over stdio → a
+/// real <c>get_state</c> handshake resolving <see cref="PiRpcHostedAgentRuntime.AcpSessionId"/> → a
+/// real <c>prompt</c> turn whose <c>assistant_text</c> reply actually reaches
+/// <see cref="PiRpcHostedAgentRuntime.Envelopes"/> → a real <c>abort</c>-then-exit graceful stop.
+///
+/// <para><b>What this does NOT certify.</b> The <c>KCAP_PI_PURE=1</c> dual-capture gate this factory's
+/// <c>BuildPsi</c> stamps on every launch (see <see cref="PiLaunchEnvironment"/>) is pinned STATICALLY
+/// by <c>PiHostedLaunchTests.BuildPsi_EnvCarriesTheDualCaptureGate</c> — a PSI assertion, not a live
+/// one. Whether the installed <c>~/.pi/agent/extensions/kcap.ts</c> actually HONOURS that env var (i.e.
+/// that a real Pi process spawned with it set stands its own capture down rather than double-recording
+/// this session) is a claim about the extension's runtime behaviour under a live Pi build, and that is
+/// exactly what the memory-injection live cert covers — see
+/// <c>SessionStartMemory.PiMemoryIndexLiveCertTests</c>. Deliberately not duplicated here.</para>
+///
+/// <para><b>Gated</b> behind <c>KCAP_PI_HOSTED_LIVE=1</c> so CI (no <c>pi</c> binary, no authenticated
+/// provider) never runs this, and no ordinary local test run silently spends a real Pi turn. Requires:
+/// <c>pi</c> on <c>PATH</c> and authenticated for at least one provider. POSIX-gated: the daemon-owned
+/// worktree this factory requires (<c>WorkLocation.OwnedWorktree</c>) is a plain temp directory here,
+/// but a <c>git init</c> of it mirrors the real launch shape (an actual daemon-created worktree is
+/// always a git checkout) closely enough that skipping it on Windows costs nothing this cert needs to
+/// prove.</para>
+/// </summary>
+public class PiHostedRuntimeLiveCertTests {
+    const string LiveGateEnvVar = "KCAP_PI_HOSTED_LIVE";
+
+    static readonly TimeSpan ReadyTimeout = TimeSpan.FromSeconds(30);
+    static readonly TimeSpan TurnTimeout  = TimeSpan.FromSeconds(60);
+    static readonly TimeSpan StopTimeout  = TimeSpan.FromSeconds(15);
+
+    [Test]
+    public async Task StartAsync_AgainstRealPiRpc_ProducesThePromptedNonceAndStopsCleanly() {
+        Skip.Unless(
+            Environment.GetEnvironmentVariable(LiveGateEnvVar) == "1",
+            $"Gated live E2E against a real 'pi --mode rpc' process — set {LiveGateEnvVar}=1 to run "
+          + "(spends a real Pi turn; needs `pi` on PATH and authenticated for a provider — spawns one "
+          + "real `pi --mode rpc` session in a throwaway git worktree).");
+        Skip.Unless(
+            !OperatingSystem.IsWindows(),
+            "The gated probe git-inits a throwaway worktree with plain POSIX `git`; not exercised on Windows.");
+
+        var worktreeDir = Directory.CreateTempSubdirectory("kcap-pi-hosted-live-");
+        RunGit(worktreeDir.FullName, "init", "-q");
+        RunGit(worktreeDir.FullName, "config", "user.email", "test@example.com");
+        RunGit(worktreeDir.FullName, "config", "user.name", "Test");
+
+        // A real (console) logger factory rather than NullLoggerFactory — PiRpcHostedAgentRuntime logs
+        // at Warning/Debug on handshake and translation faults, so a real logger is the only way this
+        // test can surface those instead of silently swallowing them.
+        using var liveLoggerFactory = LoggerFactory.Create(b => b
+            .AddSimpleConsole(o => { o.SingleLine = true; o.TimestampFormat = "HH:mm:ss.fff "; })
+            .SetMinimumLevel(LogLevel.Debug));
+
+        var nonce  = Guid.NewGuid().ToString("N")[..8];
+        var prompt = $"Reply with exactly: PONG-{nonce}";
+
+        var config = new DaemonConfig {
+            PiPath = Environment.GetEnvironmentVariable("KCAP_PI_PATH") is { Length: > 0 } envPiPath
+                ? envPiPath
+                : "pi"
+        };
+
+        // Logged for the record — mirrors the memory-injection cert's RecordCertEnvironment spirit: a
+        // cert passing (or failing) against an unknown build is how earlier live-cert failures got
+        // misdiagnosed as code defects when the real cause was a stale/mismatched installed binary.
+        await LogPiVersionAsync(config.PiPath);
+
+        var factory = new PiRpcHostedAgentRuntimeFactory(
+            config: config,
+            loggerFactory: liveLoggerFactory,
+            processSource: null,  // real `pi --mode rpc` spawn — the production path
+            binaryExists: null);  // real CliResolver.Exists probe
+
+        try {
+            var ctx = new RuntimeStartContext(
+                AgentId: "ai-894-pi-hosted-live",
+                Vendor: "pi",
+                SourceRepoPath: worktreeDir.FullName,
+                Worktree: new WorktreeInfo(Path: worktreeDir.FullName, Branch: "", SourceRepo: worktreeDir.FullName),
+                Prompt: prompt,
+                Model: null,
+                Effort: null,
+                Tools: null,
+                IsReview: false,
+                IsReviewFlow: false,
+                Review: null,
+                Cols: 80,
+                Rows: 24,
+                ServerUrl: null,
+                DaemonBridgeUrl: null,
+                CapacitorPath: "/usr/local/bin/kcap");
+                // Work defaults to WorkLocation.OwnedWorktree — the only shape this factory serves.
+
+            using var startCts = new CancellationTokenSource();
+
+            var start = await factory.StartAsync(ctx, startCts.Token).WaitAsync(ReadyTimeout);
+            var runtime = (PiRpcHostedAgentRuntime)start.Runtime;
+
+            try {
+                // (a) The ordering guarantee StartAsync's own doc states: a factory MUST await the
+                // ready barrier before returning, so both of these must already be true the instant
+                // StartAsync's Task completed above — no further waiting here.
+                await Assert.That(start.Transcript).IsNotNull();
+                await Assert.That(runtime.AcpSessionId).IsNotEmpty();
+
+                Console.WriteLine($"[pi-hosted-live] AcpSessionId={runtime.AcpSessionId} ResolvedModel={runtime.ResolvedModel ?? "(none)"}");
+
+                // (b) The prompted turn's assistant_text reply must carry the nonce, observed over the
+                // SAME channel the daemon forwards to the server.
+                var (sawNonce, collected) = await CollectUntilNonceAsync(runtime.Envelopes, nonce, TurnTimeout);
+
+                Console.WriteLine($"[pi-hosted-live] observed {collected.Count} transcript envelope(s):");
+                foreach (var env in collected)
+                    Console.WriteLine($"[pi-hosted-live]   kind={env.Kind} text={env.Text}");
+
+                await Assert.That(sawNonce).IsTrue()
+                    .Because($"expected an assistant_text envelope containing '{nonce}' within {TurnTimeout} "
+                           + "of the prompted turn");
+            } finally {
+                // (c) Graceful stop first; TerminateAsync (inside DisposeAsync) is the backstop this
+                // factory's own doc describes for a launch that fails to wind down cleanly.
+                try {
+                    await runtime.RequestGracefulStopAsync().WaitAsync(StopTimeout);
+                    await runtime.WaitForExitAsync(StopTimeout);
+                } catch (Exception ex) {
+                    Console.WriteLine($"[pi-hosted-live] graceful stop did not complete cleanly: {ex.Message}");
+                }
+
+                startCts.Cancel();
+                await runtime.DisposeAsync();
+            }
+        } finally {
+            try { worktreeDir.Delete(recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    /// <summary>Drains <paramref name="envelopes"/> until an <c>assistant_text</c> envelope's
+    /// <see cref="AcpEventEnvelope.Text"/> contains <paramref name="nonce"/> (ordinal), or
+    /// <paramref name="timeout"/> elapses.</summary>
+    static async Task<(bool SawNonce, List<AcpEventEnvelope> Collected)> CollectUntilNonceAsync(
+            ChannelReader<AcpEventEnvelope> envelopes, string nonce, TimeSpan timeout) {
+        var collected = new List<AcpEventEnvelope>();
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+
+        try {
+            while (await envelopes.WaitToReadAsync(timeoutCts.Token)) {
+                while (envelopes.TryRead(out var env)) {
+                    collected.Add(env);
+
+                    if (env.Kind == AcpEventKind.AssistantText
+                            && env.Text is { Length: > 0 } text
+                            && text.Contains(nonce, StringComparison.Ordinal))
+                        return (true, collected);
+                }
+            }
+        } catch (OperationCanceledException) {
+            // Timed out waiting for the turn to produce the nonce — fall through and report what was
+            // observed either way.
+        }
+
+        return (false, collected);
+    }
+
+    /// <summary>Best-effort <c>pi --version</c> capture for the test log — never asserted on, purely
+    /// diagnostic (see the memory-injection cert's <c>RecordCertEnvironmentAsync</c> for the same
+    /// spirit: a cert result is meaningless without knowing which build it ran against).</summary>
+    static async Task LogPiVersionAsync(string piPath) {
+        try {
+            using var process = Process.Start(new ProcessStartInfo(piPath, ["--version"]) {
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true,
+                UseShellExecute        = false
+            });
+
+            if (process is null) {
+                Console.WriteLine("[pi-hosted-live] pi --version: could not start process");
+                return;
+            }
+
+            var stdout = await process.StandardOutput.ReadToEndAsync();
+            var stderr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+            Console.WriteLine($"[pi-hosted-live] pi --version: {stdout.Trim()}{stderr.Trim()}");
+        } catch (Exception ex) {
+            Console.WriteLine($"[pi-hosted-live] pi --version failed: {ex.Message}");
+        }
+    }
+
+    static void RunGit(string cwd, params string[] args) {
+        using var process = Process.Start(new ProcessStartInfo("git", args) {
+            WorkingDirectory = cwd,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        })!;
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(process.StandardError.ReadToEnd());
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcHostedAgentRuntimeTests.cs
@@ -92,6 +92,23 @@ public class PiRpcHostedAgentRuntimeTests {
             async () => await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard));
     }
 
+    /// <summary>The deadline is not optional — an alive-but-silent child (spawned, hung before its
+    /// first read, never exiting) trips NO other resolver, so an omitted deadline would leave that
+    /// shape with no way out of the barrier at all. This pins the constant rather than waiting it
+    /// out; the behavioural half is
+    /// <see cref="Ready_barrier_faults_when_the_deadline_elapses"/>, which injects a short one.</summary>
+    [Test]
+    public async Task A_ready_deadline_always_applies_even_when_the_caller_omits_one() {
+        await Assert.That(PiRpcHostedAgentRuntime.DefaultReadyDeadline).IsEqualTo(TimeSpan.FromSeconds(30));
+
+        // Constructing with no readyDeadline must not throw and must not resolve the barrier early;
+        // the fault itself arrives 30s later, which is deliberately not waited on here.
+        var (rt, _) = NewRuntime(answerGetState: false, readyDeadline: null);
+        await using var __ = rt;
+
+        await Assert.That(rt.WaitForSessionReadyAsync(CancellationToken.None).IsCompleted).IsFalse();
+    }
+
     [Test]
     public async Task Ready_barrier_faults_when_the_state_response_carries_no_session_id() {
         var (rt, _) = NewRuntime(stateResponse: GetStateResponse(sessionId: null));
@@ -241,6 +258,36 @@ public class PiRpcHostedAgentRuntimeTests {
         await Assert.That(third.Kind).IsEqualTo(AcpEventKind.AssistantText);
     }
 
+    /// <summary>A write that fails must not leave its text in the echo memory: the echo can never
+    /// arrive, and a stale entry would silently swallow the NEXT genuine user message with the same
+    /// text — a retry of exactly what just failed being the likeliest next thing to happen.</summary>
+    [Test]
+    public async Task A_failed_send_does_not_leave_a_stale_echo_entry_behind() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        proc.FailWrites = true;
+        await Assert.ThrowsAsync<IOException>(async () => await rt.SendUserInputAsync("retry me"));
+        proc.FailWrites = false;
+
+        var firstEcho = await NextEnvelopeAsync(rt);
+        await Assert.That(firstEcho.Kind).IsEqualTo(AcpEventKind.UserMessage);
+
+        var note = await NextEnvelopeAsync(rt);
+        await Assert.That(note.Kind).IsEqualTo(AcpEventKind.SystemNote);
+        await Assert.That(note.Text).Contains("could not be delivered");
+
+        // The stale entry, if any, would swallow this genuine user message.
+        proc.Push(UserMessage("retry me"));
+        proc.Push(AssistantText("sentinel"));
+
+        var kept = await NextEnvelopeAsync(rt);
+        await Assert.That(kept.Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(kept.Text).IsEqualTo("retry me");
+    }
+
     [Test]
     public async Task A_user_message_we_did_not_send_reaches_the_transcript() {
         var (rt, proc) = NewRuntime();
@@ -341,6 +388,49 @@ public class PiRpcHostedAgentRuntimeTests {
 
         // A waiter parked on a settle that will never come is a hang, not a stop.
         await idle.WaitAsync(HangGuard);
+    }
+
+    /// <summary>A cancelled waiter must not stay in the list — it is the one unbounded collection
+    /// here, and the orchestrator's periodic borrowed-snapshot refresh cancels one per cycle.</summary>
+    [Test]
+    public async Task A_cancelled_turn_idle_waiter_is_removed_from_the_list() {
+        var (rt, proc) = NewRuntime(stateResponse: GetStateResponse(isStreaming: true));
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        using var cts = new CancellationTokenSource();
+        var abandoned = rt.WaitForTurnIdleAsync(cts.Token);
+        await Assert.That(rt.TurnIdleWaiterCount).IsEqualTo(1);
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await abandoned.WaitAsync(HangGuard));
+
+        await Assert.That(rt.TurnIdleWaiterCount).IsEqualTo(0);
+
+        // A later settle must still work, and must not trip over the removed waiter.
+        var live = rt.WaitForTurnIdleAsync(CancellationToken.None);
+        proc.Push(AgentSettled);
+        await live.WaitAsync(HangGuard);
+    }
+
+    /// <summary>F3's race: a command registered AFTER <c>EnterTerminal</c> took its key snapshot
+    /// would park forever — the send's response observer never completes, and the handshake's own
+    /// registration racing a synchronously-dead child would burn the whole dispose join budget.</summary>
+    [Test]
+    public async Task A_command_registered_after_terminal_is_faulted_rather_than_parked() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        var read = Task.Run(async () => { await foreach (var _unused in rt.ReadOutputAsync()) { } });
+        proc.EndOfStream();
+        await read.WaitAsync(HangGuard);   // terminal has genuinely been entered
+
+        await rt.SendUserInputAsync("lands after the end").WaitAsync(HangGuard);
+
+        await Assert.That(rt.PendingCommandCount).IsEqualTo(0);
     }
 
     // ---- Stopping ----

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcHostedAgentRuntimeTests.cs
@@ -1,0 +1,437 @@
+// test/Capacitor.Cli.Tests.Unit/Services/PiRpcHostedAgentRuntimeTests.cs
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using static Capacitor.Cli.Tests.Unit.Services.PiRpcRuntimeFakes;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// Exercises <see cref="PiRpcHostedAgentRuntime"/> against <see cref="FakePiRpcProcess"/> — no real
+/// <c>pi</c> process is spawned.
+///
+/// <para>Unlike <c>AntigravityRuntimeLifecycleTests</c>, there is no phase machine to pin here: Pi's
+/// child is long-lived, so liveness is the process's own. What replaces it as the highest-risk
+/// surface is the <b>ready barrier</b> — <c>StartAsync</c> must not return before the session
+/// identity is real, and a barrier that can hang wedges the orchestrator instead of failing a
+/// launch. Every path that can end the handshake therefore gets its own test (answered, unanswered
+/// + process exit, unanswered + deadline), and two of them are mutation-pinned in the task report.</para>
+///
+/// <para><b>Ordering discipline in these tests.</b> The fake's stdout is a channel, so a
+/// <c>Push</c> is not observed synchronously. Nothing here asserts "not yet" against a bare delay
+/// where a FIFO fact is available instead: to prove the pump has consumed line N, the tests push a
+/// sentinel line N+1 whose envelope they then await — channel FIFO makes that a proof, a sleep does
+/// not.</para>
+/// </summary>
+public class PiRpcHostedAgentRuntimeTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    static async Task<AcpEventEnvelope> NextEnvelopeAsync(PiRpcHostedAgentRuntime runtime) {
+        using var cts = new CancellationTokenSource(HangGuard);
+
+        return await runtime.Envelopes.ReadAsync(cts.Token);
+    }
+
+    // ---- Ready barrier ----
+
+    [Test]
+    public async Task Ready_barrier_resolves_the_session_identity_from_get_state() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(rt.AcpSessionId).IsEqualTo(SessionId);
+        await Assert.That(rt.ResolvedModel).IsEqualTo(StateModelId);
+        await Assert.That(rt.Cwd).IsEqualTo("/w");
+
+        // The handshake command itself: sent by the constructor, correlated on the pinned id.
+        await Assert.That(FirstCommandId(proc, "get_state")).IsEqualTo("init-state");
+    }
+
+    [Test]
+    public async Task Ready_barrier_falls_back_to_the_requested_model_when_the_state_carries_none() {
+        var (rt, _) = NewRuntime(stateResponse: GetStateResponse(modelId: null));
+        await using var __ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(rt.AcpSessionId).IsEqualTo(SessionId);
+        await Assert.That(rt.ResolvedModel).IsEqualTo(RequestedModel);
+    }
+
+    /// <summary>MUTATION-PINNED (task report, guard (a)). A child that dies before answering
+    /// <c>get_state</c> must FAULT the barrier — a hang here wedges the factory's
+    /// <c>StartAsync</c>, and with it the orchestrator's whole launch path.</summary>
+    [Test]
+    public async Task Ready_barrier_faults_when_the_process_exits_before_answering() {
+        var (rt, proc) = NewRuntime(answerGetState: false);
+        await using var _ = rt;
+
+        proc.EndOfStream(exitCode: 3);
+
+        // InvalidOperationException, NOT a bare Exception: a barrier that HUNG would surface the
+        // hang guard's own TimeoutException, which a bare `Exception` assertion would happily
+        // accept — turning the one test that exists to prove "never hangs" into its opposite.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard));
+
+        await Assert.That(rt.AcpSessionId).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task Ready_barrier_faults_when_the_deadline_elapses() {
+        // The child stays alive and simply never answers — only the deadline can end this.
+        var (rt, _) = NewRuntime(answerGetState: false, readyDeadline: TimeSpan.FromMilliseconds(200));
+        await using var __ = rt;
+
+        // InvalidOperationException, NOT a bare Exception: a barrier that HUNG would surface the
+        // hang guard's own TimeoutException, which a bare `Exception` assertion would happily
+        // accept — turning the one test that exists to prove "never hangs" into its opposite.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard));
+    }
+
+    [Test]
+    public async Task Ready_barrier_faults_when_the_state_response_carries_no_session_id() {
+        var (rt, _) = NewRuntime(stateResponse: GetStateResponse(sessionId: null));
+        await using var __ = rt;
+
+        // Fail closed: binding a transcript to "" is a silent, permanent correlation break.
+        // InvalidOperationException, NOT a bare Exception: a barrier that HUNG would surface the
+        // hang guard's own TimeoutException, which a bare `Exception` assertion would happily
+        // accept — turning the one test that exists to prove "never hangs" into its opposite.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard));
+    }
+
+    // ---- Read pump ----
+
+    [Test]
+    public async Task Event_frames_become_transcript_envelopes() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        proc.Push(AssistantText("hello from pi"));
+
+        var env = await NextEnvelopeAsync(rt);
+
+        await Assert.That(env.Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(env.Text).IsEqualTo("hello from pi");
+        await Assert.That(env.Model).IsEqualTo(StateModelId);
+    }
+
+    [Test]
+    public async Task Agent_produced_envelopes_advance_the_activity_clock() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        var clock = new AgentActivityClock(TimeProvider.System);
+        rt.ActivityClock = clock;
+        var before = clock.ActivitySeq;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        proc.Push(AssistantText("working"));
+        await NextEnvelopeAsync(rt);
+
+        await Assert.That(clock.ActivitySeq).IsGreaterThan(before);
+    }
+
+    [Test]
+    public async Task Response_frames_never_reach_the_transcript() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // The handshake response has already been pumped by the time the barrier resolved; the
+        // sentinel after it proves the transcript's FIRST item is the assistant text, i.e. nothing
+        // from the response frame was ever written.
+        proc.Push(AssistantText("after the response"));
+
+        var env = await NextEnvelopeAsync(rt);
+
+        await Assert.That(env.Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(env.Text).IsEqualTo("after the response");
+    }
+
+    // ---- Sending input ----
+
+    [Test]
+    public async Task SendUserInputAsync_emits_a_user_message_then_writes_a_prompt_command() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.SendUserInputAsync("do the thing").WaitAsync(HangGuard);
+
+        var env = await NextEnvelopeAsync(rt);
+        await Assert.That(env.Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(env.Text).IsEqualTo("do the thing");
+
+        var prompt = proc.Writes.Single(w => w.Contains("\"type\":\"prompt\"", StringComparison.Ordinal));
+        await Assert.That(prompt).Contains("do the thing");
+        await Assert.That(prompt).Contains("\"streamingBehavior\":\"followUp\"");
+    }
+
+    [Test]
+    public async Task A_rejected_prompt_emits_a_system_note() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.SendUserInputAsync("do the thing").WaitAsync(HangGuard);
+
+        var promptId = FirstCommandId(proc, "prompt");
+        await Assert.That(promptId).IsNotNull();
+        proc.Push(PromptResponse(promptId!, success: false, error: "already streaming"));
+
+        var echo = await NextEnvelopeAsync(rt);
+        await Assert.That(echo.Kind).IsEqualTo(AcpEventKind.UserMessage);
+
+        var note = await NextEnvelopeAsync(rt);
+        await Assert.That(note.Kind).IsEqualTo(AcpEventKind.SystemNote);
+        await Assert.That(note.Text).Contains("already streaming");
+    }
+
+    /// <summary>MUTATION-PINNED (task report, guard (b)). Pi echoes our own prompt back as a
+    /// user-role <c>message_end</c>; without the dedupe the viewer sees every message they sent
+    /// twice.</summary>
+    [Test]
+    public async Task The_echo_of_a_prompt_we_sent_is_not_duplicated() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.SendUserInputAsync("do the thing").WaitAsync(HangGuard);
+
+        proc.Push(UserMessage("do the thing"));      // Pi's echo — must be dropped
+        proc.Push(AssistantText("on it"));           // sentinel: proves the echo was consumed, not merely late
+
+        var first = await NextEnvelopeAsync(rt);
+        await Assert.That(first.Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(first.Text).IsEqualTo("do the thing");
+
+        var second = await NextEnvelopeAsync(rt);
+        await Assert.That(second.Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(second.Text).IsEqualTo("on it");
+    }
+
+    [Test]
+    public async Task An_echo_is_consumed_once_so_a_repeated_prompt_still_renders_twice() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.SendUserInputAsync("again").WaitAsync(HangGuard);
+
+        proc.Push(UserMessage("again"));   // consumes the one remembered prompt
+        proc.Push(UserMessage("again"));   // nothing left to match — this is a genuine second message
+        proc.Push(AssistantText("done"));
+
+        var first = await NextEnvelopeAsync(rt);
+        await Assert.That(first.Kind).IsEqualTo(AcpEventKind.UserMessage);   // our own send-time emit
+
+        var second = await NextEnvelopeAsync(rt);
+        await Assert.That(second.Kind).IsEqualTo(AcpEventKind.UserMessage);  // the unmatched echo
+        await Assert.That(second.Text).IsEqualTo("again");
+
+        var third = await NextEnvelopeAsync(rt);
+        await Assert.That(third.Kind).IsEqualTo(AcpEventKind.AssistantText);
+    }
+
+    [Test]
+    public async Task A_user_message_we_did_not_send_reaches_the_transcript() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        proc.Push(UserMessage("typed straight into pi"));
+
+        var env = await NextEnvelopeAsync(rt);
+
+        await Assert.That(env.Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(env.Text).IsEqualTo("typed straight into pi");
+    }
+
+    // ---- Keys, raw input, resize ----
+
+    [Test]
+    public async Task Escape_sends_an_abort_command_and_other_keys_are_ignored() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.SendSpecialKeyAsync("escape").WaitAsync(HangGuard);
+        await rt.SendSpecialKeyAsync("ctrl-r").WaitAsync(HangGuard);
+
+        var aborts = proc.Writes.Count(w => w.Contains("\"type\":\"abort\"", StringComparison.Ordinal));
+
+        await Assert.That(aborts).IsEqualTo(1);
+        await Assert.That(proc.Writes.Count).IsEqualTo(2);   // get_state + the one abort
+    }
+
+    [Test]
+    public async Task Raw_input_is_unsupported_and_resize_is_a_no_op() {
+        var (rt, _) = NewRuntime();
+        await using var __ = rt;
+
+        await Assert.That(rt.EmitsTerminalOutput).IsFalse();
+        await Assert.That(rt.Vendor).IsEqualTo("pi");
+
+        await Assert.ThrowsAsync<NotSupportedException>(async () => await rt.SendRawInputAsync([1, 2, 3]));
+
+        rt.Resize(120, 40);   // no-op: must not throw
+    }
+
+    // ---- Turn idleness ----
+
+    [Test]
+    public async Task WaitForTurnIdleAsync_completes_immediately_when_the_agent_is_idle() {
+        var (rt, _) = NewRuntime();
+        await using var __ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+    }
+
+    [Test]
+    public async Task WaitForTurnIdleAsync_waits_for_the_next_agent_settled() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        proc.Push(AgentStart);
+        proc.Push(AssistantText("thinking"));         // FIFO sentinel: agent_start has been consumed
+        await NextEnvelopeAsync(rt);
+
+        var idle = rt.WaitForTurnIdleAsync(CancellationToken.None);
+        await Assert.That(idle.IsCompleted).IsFalse();
+
+        proc.Push(AgentSettled);
+        await idle.WaitAsync(HangGuard);
+    }
+
+    [Test]
+    public async Task An_already_streaming_session_is_busy_from_the_handshake() {
+        var (rt, proc) = NewRuntime(stateResponse: GetStateResponse(isStreaming: true));
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        var idle = rt.WaitForTurnIdleAsync(CancellationToken.None);
+        await Assert.That(idle.IsCompleted).IsFalse();
+
+        proc.Push(AgentSettled);
+        await idle.WaitAsync(HangGuard);
+    }
+
+    [Test]
+    public async Task Going_terminal_releases_a_turn_idle_waiter() {
+        var (rt, proc) = NewRuntime(stateResponse: GetStateResponse(isStreaming: true));
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        var idle = rt.WaitForTurnIdleAsync(CancellationToken.None);
+        proc.EndOfStream();
+
+        // A waiter parked on a settle that will never come is a hang, not a stop.
+        await idle.WaitAsync(HangGuard);
+    }
+
+    // ---- Stopping ----
+
+    [Test]
+    public async Task RequestGracefulStopAsync_aborts_then_terminates_after_the_grace() {
+        var (rt, proc) = NewRuntime(stopGrace: TimeSpan.FromMilliseconds(50));
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await rt.RequestGracefulStopAsync().WaitAsync(HangGuard);
+
+        await Assert.That(proc.Writes.Any(w => w.Contains("\"type\":\"abort\"", StringComparison.Ordinal))).IsTrue();
+        await Assert.That(proc.TerminateCalls).IsGreaterThanOrEqualTo(1);
+    }
+
+    // ---- Terminal ----
+
+    [Test]
+    public async Task ReadOutputAsync_parks_until_terminal_then_ends() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        var read = Task.Run(async () => { await foreach (var _unused in rt.ReadOutputAsync()) { } });
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        proc.Push(AssistantText("still going"));
+        await NextEnvelopeAsync(rt);
+
+        // Ending this stream is what drives the orchestrator's finalize — it must not end while live.
+        await Assert.That(read.IsCompleted).IsFalse();
+
+        proc.EndOfStream();
+
+        await read.WaitAsync(HangGuard);
+        await Assert.That(read.IsCompletedSuccessfully).IsTrue();
+    }
+
+    [Test]
+    public async Task Terminal_completes_the_transcript_and_never_emits_session_ended() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        proc.Push(AssistantText("last words"));
+        proc.EndOfStream();
+
+        var kinds = new List<string>();
+        using var cts = new CancellationTokenSource(HangGuard);
+
+        try {
+            await foreach (var env in rt.Envelopes.ReadAllAsync(cts.Token))
+                kinds.Add(env.Kind);
+        } catch (ChannelClosedException) {
+            // The reader completing IS the assertion below; ReadAllAsync ends normally on completion.
+        }
+
+        await Assert.That(kinds).Contains(AcpEventKind.AssistantText);
+        await Assert.That(kinds).DoesNotContain(AcpEventKind.SessionEnded);
+    }
+
+    [Test]
+    public async Task HasExited_and_ExitCode_delegate_to_the_process() {
+        var (rt, proc) = NewRuntime();
+        await using var _ = rt;
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(rt.HasExited).IsFalse();
+        await Assert.That(rt.ExitCode).IsNull();
+        await Assert.That(rt.Pid).IsEqualTo(proc.Pid);
+
+        proc.EndOfStream(exitCode: 7);
+
+        await Assert.That(rt.HasExited).IsTrue();
+        await Assert.That(rt.ExitCode).IsEqualTo(7);
+    }
+
+    // ---- Disposal ----
+
+    [Test]
+    public async Task DisposeAsync_is_idempotent_and_invokes_the_callback_exactly_once() {
+        var disposals = 0;
+        var (rt, proc) = NewRuntime(onDisposed: () => Interlocked.Increment(ref disposals));
+
+        await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await rt.DisposeAsync().AsTask().WaitAsync(HangGuard);
+        await rt.DisposeAsync().AsTask().WaitAsync(HangGuard);
+
+        await Assert.That(disposals).IsEqualTo(1);
+        await Assert.That(proc.DisposeCalls).IsEqualTo(1);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcHostedAgentRuntimeTests.cs
@@ -49,15 +49,20 @@ public class PiRpcHostedAgentRuntimeTests {
         await Assert.That(FirstCommandId(proc, "get_state")).IsEqualTo("init-state");
     }
 
+    /// <summary>Security/correctness regression: <see cref="PiRpcHostedAgentRuntime.ResolvedModel"/>
+    /// is read by the orchestrator as a CONFIRMED-applied-model signal, so a <c>get_state</c> that
+    /// carries no model must resolve to null — the <see cref="IAcpTranscriptSource"/> contract's
+    /// "null ⇒ vendor default applies" — NEVER the merely-requested model. Reporting the requested
+    /// model here would misrepresent an unconfirmed value as confirmed.</summary>
     [Test]
-    public async Task Ready_barrier_falls_back_to_the_requested_model_when_the_state_carries_none() {
+    public async Task Ready_barrier_resolves_null_model_when_the_state_carries_none() {
         var (rt, _) = NewRuntime(stateResponse: GetStateResponse(modelId: null));
         await using var __ = rt;
 
         await rt.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
 
         await Assert.That(rt.AcpSessionId).IsEqualTo(SessionId);
-        await Assert.That(rt.ResolvedModel).IsEqualTo(RequestedModel);
+        await Assert.That(rt.ResolvedModel).IsNull();
     }
 
     /// <summary>MUTATION-PINNED (task report, guard (a)). A child that dies before answering

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcProcessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcProcessTests.cs
@@ -22,6 +22,27 @@ public class PiRpcProcessTests {
             UseShellExecute        = false,
         })!;
 
+    /// <summary>A child that NEVER reads its stdin — unlike <c>/bin/cat</c>, which drains stdin as
+    /// fast as it's written, so a write to it can never fill the OS pipe buffer and block. Used only
+    /// by the dispose/write race test below, which needs a writer to be genuinely stuck mid-flush,
+    /// holding the stdin gate, for the race it exercises to be real rather than incidental.</summary>
+    static Process StartNonReadingChild() =>
+        Process.Start(new ProcessStartInfo("/bin/sh", "-c \"exec sleep 30\"") {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+        })!;
+
+    static async Task<Exception?> SwallowFault(Task task) {
+        try {
+            await task.ConfigureAwait(false);
+            return null;
+        } catch (Exception ex) {
+            return ex;
+        }
+    }
+
     /// <summary>
     /// The whole point of this abstraction over <c>AgyTurnProcess</c>: stdin is NOT closed at
     /// construction, so a line written after construction is still deliverable — and because the
@@ -140,54 +161,56 @@ public class PiRpcProcessTests {
 
     /// <summary>
     /// The regression this pins: <c>DisposeAsync</c> used to call <c>_stdinGate.Dispose()</c>, but
-    /// <see cref="SemaphoreSlim.Dispose()"/> does not release outstanding async waiters — a
-    /// <see cref="PiRpcProcess.WriteLineAsync"/> call blocked in <c>WaitAsync</c> when dispose ran
-    /// could hang FOREVER, and the racing writer's own <c>finally</c> release could throw
-    /// <see cref="ObjectDisposedException"/> over whatever it was already unwinding. Task 3's runtime
-    /// races exactly this shape — a send or abort racing teardown — so this test drives the real
-    /// race rather than just unit-testing the fixed code in isolation: a write in flight when
-    /// dispose runs, and a write issued strictly after dispose has completed, must both settle
-    /// promptly, never hang.
+    /// <see cref="SemaphoreSlim.Dispose()"/> does not release outstanding async waiters. That only
+    /// bites when a SECOND writer is genuinely queued in <c>WaitAsync</c> behind a first writer that
+    /// is itself still blocked holding the gate — a single unopposed <c>WriteLineAsync</c> acquires
+    /// the semaphore synchronously and never exercises the disposed-waiter path at all (an earlier
+    /// version of this test raced exactly one write against dispose and was proven vacuous by
+    /// mutation testing: reverting the fix left it green).
+    ///
+    /// <para>So this test manufactures the real precondition directly: A child that never reads its
+    /// stdin (<see cref="StartNonReadingChild"/>) lets writer A block mid-<c>WriteAsync</c>/
+    /// <c>FlushAsync</c> — <c>Process.StandardInput</c>'s <c>AutoFlush</c> is on by default, so
+    /// writing more than the OS pipe buffer can hold with nobody draining it blocks the write itself
+    /// — WHILE HOLDING <c>_stdinGate</c>. Writer B then queues behind A in <c>WaitAsync</c>. Only
+    /// with a real waiter parked on the gate does disposing it (the bug) or leaving it alone (the
+    /// fix) diverge. <c>DisposeAsync</c> then runs concurrently with both; the pre-fix code hangs B
+    /// forever, the fix lets everything settle (faulted is fine — the kill breaks A's pipe and B's
+    /// disposed-check throws) within the bounded wait below.</para>
     /// </summary>
     [Test]
-    public async Task DisposeAsync_racing_a_WriteLineAsync_never_hangs_and_leaves_writes_failing_fast() {
-        Skip.Unless(!OperatingSystem.IsWindows(), "Uses /bin/cat as a real long-lived RPC-shaped child; Pi hosting is POSIX-only anyway.");
+    public async Task DisposeAsync_racing_a_writer_queued_behind_a_blocked_write_never_hangs() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Uses /bin/sh as a real long-lived, non-reading child; Pi hosting is POSIX-only anyway.");
 
-        var proc = new PiRpcProcess(StartCat(), NullLogger<PiRpcProcess>.Instance);
+        var proc = new PiRpcProcess(StartNonReadingChild(), NullLogger<PiRpcProcess>.Instance);
 
-        // Race a write against dispose. This half of the test does not care whether the racing
-        // write succeeds (it may complete before the kill lands) or faults (if the kill wins) — the
-        // only claim it makes is that NEITHER task hangs waiting on the other, which is exactly what
-        // a disposed-out-from-under-it SemaphoreSlim would cause.
-        var racingWrite = proc.WriteLineAsync("""{"type":"prompt","id":"racing"}""", CancellationToken.None)
-            .ContinueWith(t => t.Exception, TaskContinuationOptions.ExecuteSynchronously);
+        // Bigger than any OS pipe buffer this test could plausibly run against (typically 16-64KB
+        // on macOS/Linux) — large enough that A is still mid-flush, holding the gate, when B tries
+        // to queue behind it.
+        var hugeLine = new string('a', 8 * 1024 * 1024);
+        var writeA   = SwallowFault(proc.WriteLineAsync(hugeLine, CancellationToken.None));
+
+        // Give A time to acquire the gate and actually block on the pipe write, rather than racing
+        // its own semaphore acquisition.
+        await Task.Delay(TimeSpan.FromMilliseconds(200));
+
+        await Assert.That(writeA.IsCompleted).IsFalse()
+            .Because("A must still be blocked mid-write, holding the gate, for B to queue behind it " +
+                      "— if A already finished (e.g. the OS pipe buffer absorbed the whole line) this " +
+                      "test proves nothing, exactly like the mutation-caught prior version");
+
+        // B queues in WaitAsync behind A. THIS is the state the pre-fix `_stdinGate.Dispose()` could
+        // strand forever.
+        var writeB = SwallowFault(proc.WriteLineAsync("""{"type":"prompt","id":"queued"}""", CancellationToken.None));
+
         var disposeTask = proc.DisposeAsync().AsTask();
 
-        var both   = Task.WhenAll(racingWrite, disposeTask);
-        var winner = await Task.WhenAny(both, Task.Delay(TimeSpan.FromSeconds(5)));
+        var all    = Task.WhenAll(writeA, writeB, disposeTask);
+        var winner = await Task.WhenAny(all, Task.Delay(TimeSpan.FromSeconds(5)));
 
-        await Assert.That(ReferenceEquals(winner, both)).IsTrue()
-            .Because("a write racing dispose must never hang — the defect under test was disposing " +
-                     "the stdin semaphore while a waiter was still queued on it");
-
-        // A write issued strictly AFTER dispose has already completed must fault immediately —
-        // never queue behind a gate that will never again be released.
-        var postDisposeWrite = proc.WriteLineAsync("""{"type":"prompt","id":"after-dispose"}""", CancellationToken.None);
-        var postWinner        = await Task.WhenAny(postDisposeWrite, Task.Delay(TimeSpan.FromSeconds(5)));
-
-        await Assert.That(ReferenceEquals(postWinner, postDisposeWrite)).IsTrue()
-            .Because("a write issued after dispose must fault promptly, not hang");
-
-        Exception? caught = null;
-
-        try {
-            await postDisposeWrite;
-        } catch (Exception ex) {
-            caught = ex;
-        }
-
-        await Assert.That(caught).IsNotNull();
-        await Assert.That(caught is ObjectDisposedException or IOException).IsTrue()
-            .Because($"expected ObjectDisposedException or IOException, got {caught?.GetType().FullName}");
+        await Assert.That(ReferenceEquals(winner, all)).IsTrue()
+            .Because("neither the blocked writer, the writer queued behind it, nor dispose itself " +
+                      "may hang — the defect under test was disposing the stdin semaphore while a " +
+                      "waiter was queued on it");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcProcessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcProcessTests.cs
@@ -1,0 +1,140 @@
+// test/Capacitor.Cli.Tests.Unit/Services/PiRpcProcessTests.cs
+using System.Diagnostics;
+using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// <see cref="PiRpcProcess"/> against a REAL child — <c>/bin/cat</c>, which echoes each stdin line
+/// back on stdout, so it doubles as a stand-in for Pi's stdio JSONL RPC without depending on the
+/// real binary being installed. Unlike <c>AgyTurnProcess</c> (one process per turn, stdin closed at
+/// spawn), a Pi RPC child is LONG-LIVED and its stdin stays open for the whole session — these tests
+/// pin exactly that difference, plus the lifecycle contracts shared with every other real-process
+/// wrapper in this daemon (idempotent dispose, terminate-after-dispose, confirmed exit after kill).
+/// </summary>
+public class PiRpcProcessTests {
+    static Process StartCat() =>
+        Process.Start(new ProcessStartInfo("/bin/cat") {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+        })!;
+
+    /// <summary>
+    /// The whole point of this abstraction over <c>AgyTurnProcess</c>: stdin is NOT closed at
+    /// construction, so a line written after construction is still deliverable — and because the
+    /// child is <c>cat</c>, the same line comes back out on stdout.
+    /// </summary>
+    [Test]
+    public async Task Written_line_is_echoed_back_through_ReadLinesAsync() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Uses /bin/cat as a real long-lived RPC-shaped child; Pi hosting is POSIX-only anyway.");
+
+        await using var proc = new PiRpcProcess(StartCat(), NullLogger<PiRpcProcess>.Instance);
+
+        await proc.WriteLineAsync("""{"type":"prompt","id":"req-1"}""", CancellationToken.None);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var enumerator = proc.ReadLinesAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+
+        await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+        await Assert.That(enumerator.Current).IsEqualTo("""{"type":"prompt","id":"req-1"}""");
+    }
+
+    /// <summary>
+    /// Two callers writing concurrently must never interleave — a torn line is unparseable JSON on
+    /// the other end. <c>WriteLineAsync</c> serializes writers under a semaphore, so both full lines
+    /// must arrive intact (order between them is unspecified; interleaving is not).
+    /// </summary>
+    [Test]
+    public async Task Concurrent_writers_never_interleave_partial_lines() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Uses /bin/cat as a real long-lived RPC-shaped child; Pi hosting is POSIX-only anyway.");
+
+        await using var proc = new PiRpcProcess(StartCat(), NullLogger<PiRpcProcess>.Instance);
+
+        var lineA = new string('a', 20_000);
+        var lineB = new string('b', 20_000);
+
+        var writeA = proc.WriteLineAsync(lineA, CancellationToken.None);
+        var writeB = proc.WriteLineAsync(lineB, CancellationToken.None);
+        await Task.WhenAll(writeA, writeB);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var enumerator = proc.ReadLinesAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+
+        await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+        var first = enumerator.Current;
+
+        await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+        var second = enumerator.Current;
+
+        var received = new[] { first, second }.OrderBy((string s) => s, StringComparer.Ordinal).ToArray();
+        var expected = new[] { lineA, lineB }.OrderBy((string s) => s, StringComparer.Ordinal).ToArray();
+
+        await Assert.That(received).IsEquivalentTo(expected);
+    }
+
+    /// <summary><see cref="IAsyncDisposable.DisposeAsync"/> must be idempotent — a second call on the
+    /// same instance is a safe no-op, never a throw.</summary>
+    [Test]
+    public async Task DisposeAsync_is_idempotent() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Uses /bin/cat as a real long-lived RPC-shaped child; Pi hosting is POSIX-only anyway.");
+
+        var proc = new PiRpcProcess(StartCat(), NullLogger<PiRpcProcess>.Instance);
+
+        await proc.DisposeAsync();
+        await proc.DisposeAsync();
+    }
+
+    /// <summary><see cref="PiRpcProcess.TerminateAsync"/> must be safe to call AFTER
+    /// <see cref="IAsyncDisposable.DisposeAsync"/> has already run.</summary>
+    [Test]
+    public async Task TerminateAsync_is_safe_after_dispose() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Uses /bin/cat as a real long-lived RPC-shaped child; Pi hosting is POSIX-only anyway.");
+
+        var proc = new PiRpcProcess(StartCat(), NullLogger<PiRpcProcess>.Instance);
+
+        await proc.DisposeAsync();
+        await proc.TerminateAsync();
+    }
+
+    /// <summary>Terminating a running child kills it: <see cref="PiRpcProcess.HasExited"/> flips true
+    /// and <see cref="PiRpcProcess.ExitCode"/> becomes observable once the OS confirms the exit.</summary>
+    [Test]
+    public async Task Terminate_kills_a_running_child_and_sets_HasExited_and_ExitCode() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Uses /bin/cat as a real long-lived RPC-shaped child; Pi hosting is POSIX-only anyway.");
+
+        var child = StartCat();
+        using var observer = Process.GetProcessById(child.Id);
+        var proc = new PiRpcProcess(child, NullLogger<PiRpcProcess>.Instance);
+
+        await Assert.That(proc.HasExited).IsFalse();
+
+        await proc.TerminateAsync();
+
+        await Assert.That(proc.HasExited).IsTrue();
+        await Assert.That(proc.ExitCode).IsNotNull();
+
+        observer.WaitForExit(milliseconds: 5000);
+        await Assert.That(observer.HasExited).IsTrue();
+
+        await proc.DisposeAsync();
+    }
+
+    /// <summary><see cref="PiRpcProcess.WaitForExitAsync"/> returns once a killed child's exit is
+    /// confirmed by the OS, rather than hanging or returning only on its own timeout.</summary>
+    [Test]
+    public async Task WaitForExitAsync_returns_after_kill() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Uses /bin/cat as a real long-lived RPC-shaped child; Pi hosting is POSIX-only anyway.");
+
+        var proc = new PiRpcProcess(StartCat(), NullLogger<PiRpcProcess>.Instance);
+
+        await proc.TerminateAsync();
+        await proc.WaitForExitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(proc.HasExited).IsTrue();
+
+        await proc.DisposeAsync();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcProcessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcProcessTests.cs
@@ -137,4 +137,57 @@ public class PiRpcProcessTests {
 
         await proc.DisposeAsync();
     }
+
+    /// <summary>
+    /// The regression this pins: <c>DisposeAsync</c> used to call <c>_stdinGate.Dispose()</c>, but
+    /// <see cref="SemaphoreSlim.Dispose()"/> does not release outstanding async waiters — a
+    /// <see cref="PiRpcProcess.WriteLineAsync"/> call blocked in <c>WaitAsync</c> when dispose ran
+    /// could hang FOREVER, and the racing writer's own <c>finally</c> release could throw
+    /// <see cref="ObjectDisposedException"/> over whatever it was already unwinding. Task 3's runtime
+    /// races exactly this shape — a send or abort racing teardown — so this test drives the real
+    /// race rather than just unit-testing the fixed code in isolation: a write in flight when
+    /// dispose runs, and a write issued strictly after dispose has completed, must both settle
+    /// promptly, never hang.
+    /// </summary>
+    [Test]
+    public async Task DisposeAsync_racing_a_WriteLineAsync_never_hangs_and_leaves_writes_failing_fast() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Uses /bin/cat as a real long-lived RPC-shaped child; Pi hosting is POSIX-only anyway.");
+
+        var proc = new PiRpcProcess(StartCat(), NullLogger<PiRpcProcess>.Instance);
+
+        // Race a write against dispose. This half of the test does not care whether the racing
+        // write succeeds (it may complete before the kill lands) or faults (if the kill wins) — the
+        // only claim it makes is that NEITHER task hangs waiting on the other, which is exactly what
+        // a disposed-out-from-under-it SemaphoreSlim would cause.
+        var racingWrite = proc.WriteLineAsync("""{"type":"prompt","id":"racing"}""", CancellationToken.None)
+            .ContinueWith(t => t.Exception, TaskContinuationOptions.ExecuteSynchronously);
+        var disposeTask = proc.DisposeAsync().AsTask();
+
+        var both   = Task.WhenAll(racingWrite, disposeTask);
+        var winner = await Task.WhenAny(both, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        await Assert.That(ReferenceEquals(winner, both)).IsTrue()
+            .Because("a write racing dispose must never hang — the defect under test was disposing " +
+                     "the stdin semaphore while a waiter was still queued on it");
+
+        // A write issued strictly AFTER dispose has already completed must fault immediately —
+        // never queue behind a gate that will never again be released.
+        var postDisposeWrite = proc.WriteLineAsync("""{"type":"prompt","id":"after-dispose"}""", CancellationToken.None);
+        var postWinner        = await Task.WhenAny(postDisposeWrite, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        await Assert.That(ReferenceEquals(postWinner, postDisposeWrite)).IsTrue()
+            .Because("a write issued after dispose must fault promptly, not hang");
+
+        Exception? caught = null;
+
+        try {
+            await postDisposeWrite;
+        } catch (Exception ex) {
+            caught = ex;
+        }
+
+        await Assert.That(caught).IsNotNull();
+        await Assert.That(caught is ObjectDisposedException or IOException).IsTrue()
+            .Because($"expected ObjectDisposedException or IOException, got {caught?.GetType().FullName}");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcRuntimeFakes.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcRuntimeFakes.cs
@@ -1,0 +1,213 @@
+// test/Capacitor.Cli.Tests.Unit/Services/PiRpcRuntimeFakes.cs
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Channels;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// Scripted <see cref="IPiRpcProcess"/> fake — the long-lived-child analogue of
+/// <c>FakeAgyTurnProcess</c>. Where agy's fake scripts ONE turn's canned line sequence and then EOFs,
+/// this one is driven interactively by the test: <see cref="Push"/> puts a protocol line on the
+/// child's "stdout" at any moment, <see cref="Writes"/> captures every command the runtime wrote to
+/// its "stdin", and <see cref="EndOfStream"/> is the explicit "the child exited" event. That
+/// difference is the whole point — Pi's runtime has one process for the session's whole life, so its
+/// interesting behaviours (a response correlating to a command sent earlier, an echo arriving after a
+/// prompt, a turn going busy then settling) are all ORDERING facts between reads and writes that a
+/// canned script cannot express.
+/// </summary>
+internal sealed class FakePiRpcProcess : IPiRpcProcess {
+    readonly Channel<string> _lines = Channel.CreateUnbounded<string>();
+    readonly Lock            _gate  = new();
+    readonly List<string>    _writes = [];
+
+    /// <summary>When non-null, a <c>get_state</c> command written by the runtime is answered
+    /// immediately with this literal line — the ordinary "Pi is healthy and answers its handshake"
+    /// setup. Set to <see langword="null"/> for the tests that need the handshake to go UNANSWERED
+    /// (the deadline and process-exit barrier faults).</summary>
+    public string? AutoStateResponse { get; set; } = PiRpcRuntimeFakes.GetStateResponse();
+
+    /// <summary>Observer for every written command line, invoked inside
+    /// <see cref="WriteLineAsync"/> — lets a test answer a correlated command (a <c>prompt</c>'s
+    /// response, say) at the exact moment it goes on the wire.</summary>
+    public Action<string>? OnWrite { get; set; }
+
+    /// <summary>When true, every <see cref="WriteLineAsync"/> fails — the "the child's stdin is
+    /// gone" shape.</summary>
+    public bool FailWrites { get; set; }
+
+    public int  Pid            { get; }              = 4242;
+    public bool HasExited      { get; private set; }
+    public int? ExitCode       { get; private set; }
+    public int  TerminateCalls { get; private set; }
+    public int  DisposeCalls   { get; private set; }
+
+    /// <summary>Every command line the runtime wrote, in order. A snapshot copy — the runtime writes
+    /// from its own threads while a test reads.</summary>
+    public IReadOnlyList<string> Writes {
+        get { lock (_gate) return _writes.ToArray(); }
+    }
+
+    /// <summary>Puts one line on the child's stdout.</summary>
+    public void Push(string line) => _lines.Writer.TryWrite(line);
+
+    /// <summary>The child exited: stdout hits EOF and the process reports the exit. This is the
+    /// event the runtime must translate into "terminal".</summary>
+    public void EndOfStream(int exitCode = 0) {
+        HasExited = true;
+        ExitCode  = exitCode;
+        _lines.Writer.TryComplete();
+    }
+
+    public async IAsyncEnumerable<string> ReadLinesAsync([EnumeratorCancellation] CancellationToken ct) {
+        while (await _lines.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            while (_lines.Reader.TryRead(out var line))
+                yield return line;
+    }
+
+    public Task WriteLineAsync(string json, CancellationToken ct) {
+        if (FailWrites) return Task.FromException(new IOException("fake pi stdin is gone"));
+
+        lock (_gate) _writes.Add(json);
+
+        if (AutoStateResponse is { } response && json.Contains("\"type\":\"get_state\"", StringComparison.Ordinal))
+            Push(response);
+
+        OnWrite?.Invoke(json);
+
+        return Task.CompletedTask;
+    }
+
+    public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+
+    public Task TerminateAsync(TimeSpan? timeout = null) {
+        TerminateCalls++;
+        HasExited = true;
+        ExitCode ??= -1;
+        _lines.Writer.TryComplete();
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() {
+        DisposeCalls++;
+        _lines.Writer.TryComplete();
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// <summary>Shared line builders and construction helpers for
+/// <see cref="PiRpcHostedAgentRuntime"/>'s tests. Every literal here is a Pi JSONL-RPC frame in the
+/// pinned upstream shape — kept in ONE place so a protocol correction lands once.</summary>
+internal static class PiRpcRuntimeFakes {
+    public const string SessionId      = "pi-session-abc123";
+    public const string StateModelId   = "anthropic/claude-sonnet-4";
+    public const string RequestedModel = "requested-model";
+
+    /// <summary>A <c>get_state</c> response frame. <paramref name="modelId"/> null omits the whole
+    /// <c>model</c> object (Pi's own "no model resolved yet" shape), which is what drives the
+    /// fallback to the requested model.</summary>
+    public static string GetStateResponse(
+            string  id          = "init-state",
+            string? sessionId   = SessionId,
+            string? modelId     = StateModelId,
+            bool    isStreaming = false,
+            bool    success     = true) {
+        var data = new JsonObject {
+            ["model"]        = modelId is null
+                ? null
+                : new JsonObject { ["id"] = modelId, ["provider"] = "anthropic" },
+            ["isStreaming"]  = isStreaming,
+            ["sessionFile"]  = "/tmp/s.jsonl",
+            ["messageCount"] = 3,
+        };
+
+        if (sessionId is not null) data["sessionId"] = sessionId;
+
+        return new JsonObject {
+            ["type"]    = "response",
+            ["command"] = "get_state",
+            ["id"]      = id,
+            ["success"] = success,
+            ["data"]    = data,
+        }.ToJsonString();
+    }
+
+    public static string PromptResponse(string id, bool success, string? error = null) {
+        var frame = new JsonObject {
+            ["type"]    = "response",
+            ["command"] = "prompt",
+            ["id"]      = id,
+            ["success"] = success,
+        };
+
+        if (success) frame["data"]  = new JsonObject();
+        else         frame["error"] = error ?? "prompt rejected";
+
+        return frame.ToJsonString();
+    }
+
+    public static string AssistantText(string text, string? model = null) =>
+        new JsonObject {
+            ["type"]    = "message_end",
+            ["message"] = new JsonObject {
+                ["role"]    = "assistant",
+                ["model"]   = model ?? StateModelId,
+                ["content"] = new JsonArray(new JsonObject { ["type"] = "text", ["text"] = text }),
+            },
+        }.ToJsonString();
+
+    public static string UserMessage(string text) =>
+        new JsonObject {
+            ["type"]    = "message_end",
+            ["message"] = new JsonObject {
+                ["role"]    = "user",
+                ["content"] = new JsonArray(new JsonObject { ["type"] = "text", ["text"] = text }),
+            },
+        }.ToJsonString();
+
+    public const string AgentStart   = """{"type":"agent_start"}""";
+    public const string AgentSettled = """{"type":"agent_settled"}""";
+
+    /// <summary>Builds a runtime over a fresh <see cref="FakePiRpcProcess"/>. The caller owns
+    /// disposing the runtime (which disposes the process).</summary>
+    public static (PiRpcHostedAgentRuntime Runtime, FakePiRpcProcess Process) NewRuntime(
+            string?    stateResponse  = null,
+            bool       answerGetState = true,
+            string?    requestedModel = RequestedModel,
+            TimeSpan?  readyDeadline  = null,
+            TimeSpan?  stopGrace      = null,
+            Action?    onDisposed     = null) {
+        var process = new FakePiRpcProcess {
+            AutoStateResponse = answerGetState ? stateResponse ?? GetStateResponse() : null,
+        };
+
+        var runtime = new PiRpcHostedAgentRuntime(
+            process:        process,
+            logger:         NullLogger.Instance,
+            agentId:        "agent-1",
+            requestedModel: requestedModel,
+            cwd:            "/w",
+            readyDeadline:  readyDeadline,
+            stopGrace:      stopGrace,
+            onDisposed:     onDisposed);
+
+        return (runtime, process);
+    }
+
+    /// <summary>The <c>id</c> the runtime stamped on the first command of the given
+    /// <paramref name="type"/> it wrote — how a test answers a correlated command without the
+    /// runtime having to expose its id generator.</summary>
+    public static string? FirstCommandId(FakePiRpcProcess process, string type) {
+        foreach (var line in process.Writes) {
+            using var doc = JsonDocument.Parse(line);
+            if (doc.RootElement.GetProperty("type").GetString() == type)
+                return doc.RootElement.GetProperty("id").GetString();
+        }
+
+        return null;
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcRuntimeFakes.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcRuntimeFakes.cs
@@ -46,6 +46,11 @@ internal sealed class FakePiRpcProcess : IPiRpcProcess {
     public int  TerminateCalls { get; private set; }
     public int  DisposeCalls   { get; private set; }
 
+    /// <summary>Settable so a test can simulate a child that left a stderr trail — the real
+    /// <c>PiRpcProcess</c>'s capture, faked here rather than replayed through a scripted stderr
+    /// stream this fake has no stdio pipes for.</summary>
+    public string? Diagnostics { get; set; }
+
     /// <summary>Every command line the runtime wrote, in order. A snapshot copy — the runtime writes
     /// from its own threads while a test reads.</summary>
     public IReadOnlyList<string> Writes {

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcTests.cs
@@ -1,0 +1,310 @@
+// test/Capacitor.Cli.Tests.Unit/Services/PiRpcTests.cs
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// Pure unit tests for <see cref="PiRpc"/> — no process/runtime involved. JSONL fixtures below are
+/// literal lines matching the pinned Pi protocol shapes from the task brief.
+/// </summary>
+public class PiRpcTests {
+    // ---- TryParseLine: response frames ----
+
+    [Test]
+    public async Task Response_frame_parses_with_id_echo_and_success_true() {
+        var frame = PiRpc.TryParseLine("""{"id":"abc-1","type":"response","command":"prompt","success":true}""");
+
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Kind).IsEqualTo(PiRpcFrameKind.Response);
+        await Assert.That(frame.Type).IsEqualTo("response");
+        await Assert.That(frame.Id).IsEqualTo("abc-1");
+        await Assert.That(frame.Success).IsEqualTo(true);
+    }
+
+    [Test]
+    public async Task Response_frame_parses_with_success_false() {
+        var frame = PiRpc.TryParseLine(
+            """{"id":"abc-2","type":"response","command":"prompt","success":false,"error":"boom"}""");
+
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Kind).IsEqualTo(PiRpcFrameKind.Response);
+        await Assert.That(frame.Id).IsEqualTo("abc-2");
+        await Assert.That(frame.Success).IsEqualTo(false);
+        await Assert.That(frame.Root.Str("error")).IsEqualTo("boom");
+    }
+
+    // ---- TryParseLine: event frames ----
+
+    [Test]
+    public async Task Event_frame_parses_as_Event_kind() {
+        var frame = PiRpc.TryParseLine("""{"type":"agent_start"}""");
+
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Kind).IsEqualTo(PiRpcFrameKind.Event);
+        await Assert.That(frame.Type).IsEqualTo("agent_start");
+        await Assert.That(frame.Id).IsNull();
+    }
+
+    [Test]
+    public async Task Object_with_no_type_field_parses_as_Unknown_kind() {
+        var frame = PiRpc.TryParseLine("""{"foo":"bar"}""");
+
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Kind).IsEqualTo(PiRpcFrameKind.Unknown);
+        await Assert.That(frame.Type).IsEqualTo("");
+    }
+
+    // ---- TryParseLine: null cases ----
+
+    [Test]
+    public async Task Blank_line_returns_null() {
+        await Assert.That(PiRpc.TryParseLine("")).IsNull();
+        await Assert.That(PiRpc.TryParseLine("   ")).IsNull();
+    }
+
+    [Test]
+    public async Task Garbage_json_returns_null() {
+        await Assert.That(PiRpc.TryParseLine("{not json")).IsNull();
+        await Assert.That(PiRpc.TryParseLine("not even close")).IsNull();
+    }
+
+    [Test]
+    public async Task Trailing_carriage_return_is_tolerated() {
+        var frame = PiRpc.TryParseLine("{\"type\":\"agent_start\"}\r");
+
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Kind).IsEqualTo(PiRpcFrameKind.Event);
+        await Assert.That(frame.Type).IsEqualTo("agent_start");
+    }
+
+    // ---- ToEnvelopes: assistant message_end ----
+
+    [Test]
+    public async Task Assistant_message_end_with_text_thinking_toolCall_and_usage_yields_four_envelopes() {
+        const string line = """
+            {"type":"message_end","message":{"role":"assistant","content":[
+                {"type":"text","text":"Hello there"},
+                {"type":"thinking","thinking":"pondering..."},
+                {"type":"toolCall","id":"call_123","name":"bash","arguments":{"cmd":"ls"}}
+            ],"model":"pi-large","usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"}}
+            """;
+
+        var frame = PiRpc.TryParseLine(line);
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Kind).IsEqualTo(PiRpcFrameKind.Event);
+
+        var envelopes = PiRpc.ToEnvelopes(frame, fallbackModel: "fallback-model");
+
+        await Assert.That(envelopes.Count).IsEqualTo(4);
+
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(envelopes[0].Text).IsEqualTo("Hello there");
+        await Assert.That(envelopes[0].Model).IsEqualTo("pi-large");
+
+        await Assert.That(envelopes[1].Kind).IsEqualTo(AcpEventKind.AssistantThinking);
+        await Assert.That(envelopes[1].Text).IsEqualTo("pondering...");
+        await Assert.That(envelopes[1].Model).IsEqualTo("pi-large");
+
+        await Assert.That(envelopes[2].Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(envelopes[2].ToolCallId).IsEqualTo("call_123");
+        await Assert.That(envelopes[2].ToolName).IsEqualTo("bash");
+        await Assert.That(envelopes[2].ToolInputJson).IsEqualTo("""{"cmd":"ls"}""");
+
+        await Assert.That(envelopes[3].Kind).IsEqualTo(AcpEventKind.Usage);
+        await Assert.That(envelopes[3].Model).IsEqualTo("pi-large");
+        await Assert.That(envelopes[3].ContextUsedTokens).IsEqualTo(100L);
+    }
+
+    [Test]
+    public async Task Assistant_message_end_falls_back_to_fallback_model_when_message_has_none() {
+        const string line = """
+            {"type":"message_end","message":{"role":"assistant","content":[
+                {"type":"text","text":"hi"}
+            ]}}
+            """;
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: "fallback-model");
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(envelopes[0].Model).IsEqualTo("fallback-model");
+    }
+
+    // ---- ToEnvelopes: user message_end ----
+
+    [Test]
+    public async Task User_message_end_with_content_array_yields_one_user_message_envelope() {
+        const string line = """{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"do the thing"}]}}""";
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(envelopes[0].Text).IsEqualTo("do the thing");
+    }
+
+    [Test]
+    public async Task User_message_end_with_plain_string_content_is_handled() {
+        const string line = """{"type":"message_end","message":{"role":"user","content":"do the other thing"}}""";
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(envelopes[0].Text).IsEqualTo("do the other thing");
+    }
+
+    // ---- ToEnvelopes: tool_execution_end ----
+
+    [Test]
+    public async Task Tool_execution_end_yields_tool_result_with_text_and_not_error() {
+        const string line = """{"type":"tool_execution_end","toolCallId":"call_123","toolName":"bash","result":{"stdout":"ok"},"isError":false}""";
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(envelopes[0].ToolCallId).IsEqualTo("call_123");
+        await Assert.That(envelopes[0].ToolIsError).IsEqualTo(false);
+        await Assert.That(envelopes[0].ToolResult).IsNotNull();
+    }
+
+    [Test]
+    public async Task Tool_execution_end_with_isError_true_is_marked_as_error() {
+        const string line = """{"type":"tool_execution_end","toolCallId":"call_456","toolName":"bash","result":"command not found","isError":true}""";
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(envelopes[0].ToolCallId).IsEqualTo("call_456");
+        await Assert.That(envelopes[0].ToolIsError).IsEqualTo(true);
+        await Assert.That(envelopes[0].ToolResult).IsEqualTo("command not found");
+    }
+
+    // ---- ToEnvelopes: extension_error ----
+
+    [Test]
+    public async Task Extension_error_yields_bounded_system_note() {
+        const string line = """{"type":"extension_error","error":"something went wrong"}""";
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.SystemNote);
+        await Assert.That(envelopes[0].Text).IsEqualTo("something went wrong");
+    }
+
+    [Test]
+    public async Task Extension_error_text_is_capped_at_500_characters() {
+        var longError = new string('x', 800);
+        var line = $$"""{"type":"extension_error","error":"{{longError}}"}""";
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.SystemNote);
+        await Assert.That(envelopes[0].Text!.Length).IsEqualTo(500);
+    }
+
+    // ---- ToEnvelopes: known-but-untranslated / unknown events ----
+
+    [Test]
+    public async Task Known_untranslated_events_yield_empty_envelope_list() {
+        string[] lines = [
+            """{"type":"agent_start"}""",
+            """{"type":"agent_end"}""",
+            """{"type":"agent_settled"}""",
+            """{"type":"turn_start"}""",
+            """{"type":"turn_end"}""",
+            """{"type":"message_start"}""",
+            """{"type":"message_update"}""",
+            """{"type":"bash_execution_update"}""",
+        ];
+
+        foreach (var line in lines) {
+            var frame = PiRpc.TryParseLine(line);
+            var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+            await Assert.That(envelopes.Count).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Unrecognized_event_type_yields_empty_envelope_list() {
+        var frame = PiRpc.TryParseLine("""{"type":"some_future_event","stuff":123}""");
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Response_frame_yields_empty_envelope_list() {
+        var frame = PiRpc.TryParseLine("""{"id":"x","type":"response","command":"prompt","success":true}""");
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(0);
+    }
+
+    // ---- Command builders ----
+
+    [Test]
+    public async Task PromptCommand_emits_streamingBehavior_followUp() {
+        var json = PiRpc.PromptCommand("req-1", "hello");
+
+        await Assert.That(json).Contains(""""streamingBehavior":"followUp"""");
+        await Assert.That(json).Contains(""""type":"prompt"""");
+        await Assert.That(json).Contains(""""id":"req-1"""");
+        await Assert.That(json).Contains(""""message":"hello"""");
+    }
+
+    [Test]
+    public async Task PromptCommand_round_trips_quotes_newlines_and_emoji_verbatim() {
+        const string message = "she said \"hi\"\nline two 🎉";
+        var json = PiRpc.PromptCommand("req-2", message);
+
+        var frame = PiRpc.TryParseLine(json);
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Root.Str("message")).IsEqualTo(message);
+        await Assert.That(frame.Root.Str("id")).IsEqualTo("req-2");
+        await Assert.That(frame.Root.Str("streamingBehavior")).IsEqualTo("followUp");
+    }
+
+    [Test]
+    public async Task AbortCommand_produces_exact_json() {
+        var json = PiRpc.AbortCommand("req-3");
+        var frame = PiRpc.TryParseLine(json);
+
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Root.Str("id")).IsEqualTo("req-3");
+        await Assert.That(frame.Root.Str("type")).IsEqualTo("abort");
+    }
+
+    [Test]
+    public async Task GetStateCommand_produces_exact_json() {
+        var json = PiRpc.GetStateCommand("req-4");
+        var frame = PiRpc.TryParseLine(json);
+
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Root.Str("id")).IsEqualTo("req-4");
+        await Assert.That(frame.Root.Str("type")).IsEqualTo("get_state");
+    }
+
+    [Test]
+    public async Task SetModelCommand_produces_exact_json() {
+        var json = PiRpc.SetModelCommand("req-5", "pi-large");
+        var frame = PiRpc.TryParseLine(json);
+
+        await Assert.That(frame).IsNotNull();
+        await Assert.That(frame!.Root.Str("id")).IsEqualTo("req-5");
+        await Assert.That(frame.Root.Str("type")).IsEqualTo("set_model");
+        await Assert.That(frame.Root.Str("model")).IsEqualTo("pi-large");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcTests.cs
@@ -163,7 +163,13 @@ public class PiRpcTests {
 
     [Test]
     public async Task Tool_execution_end_yields_tool_result_with_text_and_not_error() {
-        const string line = """{"type":"tool_execution_end","toolCallId":"call_123","toolName":"bash","result":{"stdout":"ok"},"isError":false}""";
+        // Upstream's `result` is an OBJECT carrying a content array (rpc.md ~1003) — not the bare
+        // "stdout" shape an earlier revision of this test assumed.
+        const string line = """
+            {"type":"tool_execution_end","toolCallId":"call_123","toolName":"bash",
+             "result":{"content":[{"type":"text","text":"total 48\ndrwxr-xr-x"}],"details":{"truncation":null}},
+             "isError":false}
+            """;
 
         var frame = PiRpc.TryParseLine(line);
         var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
@@ -172,11 +178,38 @@ public class PiRpcTests {
         await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.ToolResult);
         await Assert.That(envelopes[0].ToolCallId).IsEqualTo("call_123");
         await Assert.That(envelopes[0].ToolIsError).IsEqualTo(false);
-        await Assert.That(envelopes[0].ToolResult).IsNotNull();
+        await Assert.That(envelopes[0].ToolResult).IsEqualTo("total 48\ndrwxr-xr-x");
+    }
+
+    [Test]
+    public async Task Tool_execution_end_result_concatenates_multiple_content_text_items() {
+        const string line = """
+            {"type":"tool_execution_end","toolCallId":"call_999","toolName":"bash",
+             "result":{"content":[{"type":"text","text":"part one "},{"type":"text","text":"part two"}]},
+             "isError":false}
+            """;
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].ToolResult).IsEqualTo("part one part two");
+    }
+
+    [Test]
+    public async Task Tool_execution_end_result_falls_back_to_raw_json_when_no_content_array() {
+        const string line = """{"type":"tool_execution_end","toolCallId":"call_777","result":{"foo":"bar"},"isError":false}""";
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].ToolResult).IsEqualTo("""{"foo":"bar"}""");
     }
 
     [Test]
     public async Task Tool_execution_end_with_isError_true_is_marked_as_error() {
+        // A plain string result is schema drift, not the documented shape — tolerated verbatim.
         const string line = """{"type":"tool_execution_end","toolCallId":"call_456","toolName":"bash","result":"command not found","isError":true}""";
 
         var frame = PiRpc.TryParseLine(line);
@@ -214,6 +247,23 @@ public class PiRpcTests {
         await Assert.That(envelopes.Count).IsEqualTo(1);
         await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.SystemNote);
         await Assert.That(envelopes[0].Text!.Length).IsEqualTo(500);
+    }
+
+    // ---- ToEnvelopes: extension_ui_request ----
+
+    [Test]
+    public async Task Extension_ui_request_yields_one_system_note_naming_the_method() {
+        const string line = """
+            {"type":"extension_ui_request","id":"uuid-1","method":"select","title":"Allow dangerous command?","options":["Allow","Block"],"timeout":10000}
+            """;
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.SystemNote);
+        await Assert.That(envelopes[0].Text).Contains("select");
+        await Assert.That(envelopes[0].Text).Contains("hosted sessions cannot answer");
     }
 
     // ---- ToEnvelopes: known-but-untranslated / unknown events ----
@@ -298,14 +348,8 @@ public class PiRpcTests {
         await Assert.That(frame.Root.Str("type")).IsEqualTo("get_state");
     }
 
-    [Test]
-    public async Task SetModelCommand_produces_exact_json() {
-        var json = PiRpc.SetModelCommand("req-5", "pi-large");
-        var frame = PiRpc.TryParseLine(json);
-
-        await Assert.That(frame).IsNotNull();
-        await Assert.That(frame!.Root.Str("id")).IsEqualTo("req-5");
-        await Assert.That(frame.Root.Str("type")).IsEqualTo("set_model");
-        await Assert.That(frame.Root.Str("model")).IsEqualTo("pi-large");
-    }
+    // set_model is PR-2's — see PiRpc's class doc. Its correct upstream shape
+    // ({"type":"set_model","provider":..,"modelId":..}, rpc.md ~222) will be added with the reviewer
+    // / model-selection lane; PR-1 never called SetModelCommand, so it was dead code carrying the
+    // WRONG shape ({"model":..}) and has been removed along with this test.
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/PiRpcTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/PiRpcTests.cs
@@ -110,6 +110,7 @@ public class PiRpcTests {
         await Assert.That(envelopes[2].ToolCallId).IsEqualTo("call_123");
         await Assert.That(envelopes[2].ToolName).IsEqualTo("bash");
         await Assert.That(envelopes[2].ToolInputJson).IsEqualTo("""{"cmd":"ls"}""");
+        await Assert.That(envelopes[2].Model).IsEqualTo("pi-large");
 
         await Assert.That(envelopes[3].Kind).IsEqualTo(AcpEventKind.Usage);
         await Assert.That(envelopes[3].Model).IsEqualTo("pi-large");


### PR DESCRIPTION
Interactive hosting for the Pi coding agent (`pi --mode rpc`), the last supported harness with no daemon hosting. A bespoke JSONL-RPC runtime peer of the PTY / ACP / Antigravity runtimes — the shape the AI-894 spike recommended (upstream rejected an in-tree ACP mode; the third-party adapter is a capability/supply-chain dead end).

**Stacked on #494** (AI-1465 Pi memory injection) — review/merge that first; this PR's base is `claude-tyoung/ai-1465-pi-memory`, so its own diff is just the 10 hosting commits.

## What

- `PiRpc` — pure, AOT-safe JSONL-RPC protocol layer (parse frames, build `prompt`/`abort`/`get_state` commands, translate Pi events → vendor-neutral `AcpEventEnvelope`s). Wire shapes cross-checked against upstream `rpc.md`.
- `PiRpcProcess` / `IPiRpcProcess` — long-lived stdio child (unlike Antigravity's exec-per-turn): open stdin for the session's life, serialized line writes, bounded stderr diagnostics, safe dispose/terminate.
- `PiRpcHostedAgentRuntime` — `IHostedAgentRuntime` + `IAcpTranscriptSource`. Read pump → bounded transcript channel; a `get_state` ready barrier that resolves `AcpSessionId`/`ResolvedModel` and **always** faults (30s mandatory deadline) so a wedged child can't hang the orchestrator; queued input, escape→abort, turn-idle tracking, graceful stop, user-echo dedup. Never emits `session_ended` (the server owns it).
- `PiRpcHostedAgentRuntimeFactory` + `DaemonConfig.PiPath`/`PiModel` + `KCAP_PI_PATH`/`KCAP_PI_MODEL` + DaemonRunner registration. `SupportsUnattended=false` (reviewer lane is PR-2); refuses review / review-flow / borrowed-worktree launches before spawn.
- `KCAP_PI_PURE=1` dual-capture gate: the hosted spawn sets it and `kcap.ts` stands down, so the daemon-hosted session isn't also live-ingested by the global extension (the `OPENCODE_PURE` pattern).
- Gated hosted live cert (`KCAP_PI_HOSTED_LIVE=1`) — real spawn → ready barrier → live envelope translation → graceful stop — and README hosted-Pi docs.

## Reviews

TDD throughout; per-task reviews + a whole-branch opus review, all clean after fix rounds. Mutation-verified the load-bearing guards (dispose-vs-write race, ready-barrier fault, echo-dedup). AOT publish clean (both projects); no Linear ids in source. Copilot code-review flow: (running — will note result in a comment).

## Deliberate deferrals

- **Reviewer lane → PR-2** (`PiReviewerCapability`, `-e kcap-flow-result.ts` result channel, `--no-extensions --tools read,submit_review_result` clamp, seeded-defect cert). This is why the PR references AI-894 without a closing keyword.
- **kcap-server companion (before rollout):** add `pi` to `Vendors.NoTerminalSurface` or hosted Pi shows an empty Terminal tab (the Antigravity/AI-1412 precedent); likely also `Vendors.TurnScopedInput`.
- **Memory-injection parity:** `KCAP_PI_PURE` stands down the whole extension, so a hosted Pi session does not get AI-1465's SessionStart team-memory block (accepted; a hosted Claude still does via its hook).

## Before merge (human)

Run the live cert once (`KCAP_PI_HOSTED_LIVE=1` + an authenticated `pi`), ideally after extending its prompt to trigger one tool call (proves the tool-result text extraction end-to-end); record the observed `pi` version.

AI-894

🤖 Generated with [Claude Code](https://claude.com/claude-code)