### PR TITLE
Tolerate kiro-cli's repeated server_initialized for an injected reviewer server

### DIFF
--- a/src/Capacitor.Cli.Daemon/Acp/KiroMcpSurfaceMonitor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/KiroMcpSurfaceMonitor.cs
@@ -23,8 +23,14 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// a settle has a gap by construction: a server can initialize, be used, and be missed between two
 /// samples. Judging each notification on arrival closes it.</para>
 ///
-/// <para><b>Counting, not membership.</b> A duplicate of an injected name is INSIDE the injected set,
-/// so a membership test admits it. Each name is expected exactly once.</para>
+/// <para><b>Membership, not counting.</b> This originally required each injected name to initialize
+/// exactly once, reasoning that a duplicate could be a second server standing up under an injected
+/// name. But every injected name carries a per-launch GUID (Kiro aliases the result channel and the
+/// allowlist servers), so nothing in the operator's global config can be standing under one — a
+/// suppression failure surfaces as the operator's own server NAMES, which the membership arm catches.
+/// And kiro-cli 2.16.0 announces one injected server's initialization more than once as ordinary
+/// behaviour, so the count rule reaped every reviewer launch while the surface was exactly the
+/// injected set. A repeated announce of an injected name is therefore benign.</para>
 ///
 /// <para><b>Known residual, not mitigated:</b> a build that stopped emitting
 /// <c>server_initialized</c> for extra servers while still emitting it for injected ones defeats
@@ -90,11 +96,10 @@ internal sealed class KiroMcpSurfaceMonitor {
                 return;
             }
 
-            if (!_seen.Add(serverName))
-                _violation =
-                    $"kiro_reviewer_mcp_surface_unexpected: MCP server '{serverName}' initialized more "
-                  + "than once. An injected name is inside the expected set, so only counting catches a "
-                  + "second server standing up under it.";
+            // Recorded for readiness, never counted: kiro-cli (2.16.0) announces one injected server's
+            // initialization more than once, and an injected name is a per-launch GUID nothing else can
+            // stand up under — see the class doc.
+            _seen.Add(serverName);
         }
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Acp/KiroMcpSurfaceMonitorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/KiroMcpSurfaceMonitorTests.cs
@@ -7,7 +7,8 @@ namespace Capacitor.Cli.Tests.Unit.Acp;
 /// <summary>
 /// The tripwire detects a suppression failure. It is not the containment, so its residual (selective
 /// notification loss) degrades detection rather than the boundary — but everything it DOES claim to
-/// catch is pinned here, including the two shapes a membership-only check would miss.
+/// catch is pinned here, and so is what it deliberately tolerates (kiro-cli's benign re-announce of
+/// an injected server).
 /// </summary>
 public class KiroMcpSurfaceMonitorTests {
     const string Channel = "kcap-flow-result-abc";
@@ -39,14 +40,33 @@ public class KiroMcpSurfaceMonitorTests {
     }
 
     /// <summary>
-    /// The COUNT rule. A duplicate of an injected name is inside the injected set, so a
-    /// membership-only check admits it — this is the case that distinguishes the two.
+    /// kiro-cli 2.16.0 announces the injected result channel's initialization twice for one spawned
+    /// server, on every reviewer launch. Injected names carry per-launch GUIDs, so a repeat under one
+    /// cannot be the operator's global config standing a server up — treating it as a violation reaped
+    /// every reviewer while the surface was exactly the injected set.
     /// </summary>
     [Test]
-    public async Task ASecondInitializationOfAnInjectedName_IsAViolation() {
+    public async Task ARepeatedInitializationOfAnInjectedName_IsBenign() {
         var m = Monitor(Channel);
         m.Observe(Note(KiroMcpSurfaceMonitor.InitializedMethod, Channel));
         m.Observe(Note(KiroMcpSurfaceMonitor.InitializedMethod, Channel));
+
+        await Assert.That(m.Violation).IsNull();
+        await Assert.That(m.ResultChannelReady).IsTrue();
+    }
+
+    /// <summary>Tolerating repeats must not soften the actual boundary: a name outside the injected
+    /// set still trips after any number of benign re-announces.</summary>
+    [Test]
+    public async Task AnUnexpectedName_AfterABenignRepeat_StillTrips() {
+        var m = Monitor(Channel, "kcap-review-xyz");
+        m.Observe(Note(KiroMcpSurfaceMonitor.InitializedMethod, Channel));
+        m.Observe(Note(KiroMcpSurfaceMonitor.InitializedMethod, Channel));
+        m.Observe(Note(KiroMcpSurfaceMonitor.InitializedMethod, "kcap-review-xyz"));
+        m.Observe(Note(KiroMcpSurfaceMonitor.InitializedMethod, "kcap-review-xyz"));
+        await Assert.That(m.Violation).IsNull();          // control: healthy up to here
+
+        m.Observe(Note(KiroMcpSurfaceMonitor.InitializedMethod, "kcap-flows"));
 
         await Assert.That(m.Violation).IsNotNull();
         await Assert.That(m.Violation!).StartsWith("kiro_reviewer_mcp_surface_unexpected");


### PR DESCRIPTION
Every unattended **Kiro reviewer** launch on kiro-cli **2.16.0** is fail-closed reaped by kcap's own `KiroMcpSurfaceMonitor`, so `start_review_flow --vendor kiro` never produces a review (9/9 launches in the 2026-08-08 vendor-cert run; hosting unaffected). The flow surfaces a generic `ACP connection read loop ended with requests still pending` — the daemon log has the real reason: `kiro_reviewer_mcp_surface_unexpected: MCP server 'kcap-flow-result-<hash>' initialized more than once`.

Linear: **Fixes AI-1818**. No GitHub issue — filed directly in Linear (same as #471).

## Root cause

kiro-cli 2.16.0 emits `_kiro.dev/mcp/server_initialized` **twice** for the injected `kcap-flow-result` channel. The monitor's count rule required each injected name to initialize exactly once, so the second (benign) announce set a sticky violation, the daemon reaped the reviewer mid-handshake, and `AcpConnection.RequestAsync` faulted with the red-herring auth hint.

## Why dropping the count rule is sound

The count rule reasoned that a duplicate of an injected name could be "a second server standing up under it". But every injected name in a Kiro reviewer launch carries a **per-launch v4 GUID** — Kiro is an aliasing vendor (`AliasesResultChannel`), so the result channel is `kcap-flow-result-{guid:N}` and allowlist servers get `{id}-{allowlistSuffix:N}`. Nothing in the operator's global config can be standing under a name that didn't exist when that config was authored. A real suppression failure (KIRO_HOME no longer isolating) surfaces as the operator's own server **names**, which the unexpected-name arm — the actual containment boundary — still trips on, strictly and continuously.

## Changes

- `KiroMcpSurfaceMonitor.Observe`: a repeated `server_initialized` for an injected name is recorded (for `ResultChannelReady`) but no longer a violation. Unexpected-name arm and the result-channel `server_init_failure` arm unchanged.
- Class doc: "Counting, not membership" → "Membership, not counting", with the reasoning above.
- Tests: the count-rule test is inverted (`ARepeatedInitializationOfAnInjectedName_IsBenign`, failed red with the exact production violation string before the fix), plus `AnUnexpectedName_AfterABenignRepeat_StillTrips` pinning that tolerance does not soften the boundary.

## Verification

- TDD: new tests red on the old code (reproducing the field failure message verbatim), green after.
- All 854 ACP-namespace unit tests pass; daemon builds clean.

Not done here (deliberately): tightening `KiroReviewerVersionStore`'s affirmed-build window — the double-announce is a vendor notification-behavior change, not a containment regression, and the affirm flow already covers the build-change axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
