### PR TITLE
Docs: multi-vendor hosted agents + reviewer choice (CLI)

### DIFF
--- a/kcap/README.md
+++ b/kcap/README.md
@@ -79,7 +79,8 @@ Each hook pipes its JSON payload through the `kcap` CLI, which enriches it with 
 - `validate-plan` / `kcap-validate-plan` — Verify that all planned items were completed
 - `disable` / `kcap-disable` — Stop recording and delete all server data for the current session
 - `hide` / `kcap-hide` — Hide the current session (owner-only visibility)
-- `review-flows` / `kcap-review-flows` — Run structured, iterative spec/code review loops
+- `review-flows` / `kcap-review-flows` — Run structured, iterative spec/code review loops; the reviewer vendor is chosen independently of the driver (pass a lowercase token like `claude`/`codex`/`cursor`)
+- `agent-flows` / `kcap-agent-flows` — Run structured multi-participant agent flows (catalog `definition_id` or an inline `definition_yaml`), each participant declaring its own vendor/model
 - `guided-tour` / `kcap-guided-tour` — Onboarding tour: what Capacitor has recorded for your team, then per-use-case tutorials (evals, session recall, PR review, analytics)
 
 In Claude they're invoked as `/kcap:recap`, `/kcap:errors`, `/kcap:guided-tour`, etc.

--- a/kcap/skills/agent-flows/SKILL.md
+++ b/kcap/skills/agent-flows/SKILL.md
@@ -72,7 +72,7 @@ explicitly ask you to proceed with whatever vendor the definition or saved prefe
 Canonical reviewer aliases for reserved review flows: Claude / Claude Code → `claude`; Codex /
 OpenAI Codex → `codex`; Cursor / cursor-agent → `cursor`; GitHub Copilot / Copilot CLI → `copilot`;
 Gemini / Gemini CLI → `gemini`; Kiro / Kiro CLI → `kiro`; Pi → `pi`; OpenCode → `opencode`;
-Antigravity / agy → `agy`. Normalize only names bound to the reviewer role, honor negation and
+Antigravity / agy → `antigravity`. Normalize only names bound to the reviewer role, honor negation and
 positive contrast, and ask rather than guessing when two reviewer candidates remain.
 
 For the reserved `spec-review`/`code-review` aliases only, `start_flow` also accepts a top-level

--- a/kcap/skills/review-flows/SKILL.md
+++ b/kcap/skills/review-flows/SKILL.md
@@ -60,7 +60,7 @@ candidates remain after negation, ask the user to choose; never guess.
 
 Canonical reviewer aliases: Claude / Claude Code → `claude`; Codex / OpenAI Codex → `codex`;
 Cursor / cursor-agent → `cursor`; GitHub Copilot / Copilot CLI → `copilot`; Gemini / Gemini CLI →
-`gemini`; Kiro / Kiro CLI → `kiro`; Pi → `pi`; OpenCode → `opencode`; Antigravity / agy → `agy`.
+`gemini`; Kiro / Kiro CLI → `kiro`; Pi → `pi`; OpenCode → `opencode`; Antigravity / agy → `antigravity`.
 Normalize only the reviewer-role mention. Positive contrast (for example, “from Codex, ask Claude”)
 selects Claude; negated names are removed; two remaining reviewer candidates are ambiguous.
 

--- a/src/Capacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-mcp.txt
@@ -41,17 +41,40 @@ mcp sessions:
   cd into your project before spawning. Requires `kcap login`.
 
 mcp flows:
-  Exposes four tools — start_review_flow, submit_review_round,
-  get_review_flow_status, close_review_flow — for agents to start and
-  interact with review flows. Requester context (session ID, cwd, repo
+  Exposes the review-flow and generic-flow tools for agents to start and
+  interact with hosted flows. Requester context (session ID, cwd, repo
   root, owner/name) is resolved automatically at startup. Requires
   `kcap login`.
 
-    Tools:
-      start_review_flow      Start a new AI-powered review flow.
-      submit_review_round    Submit a follow-up round with updated context.
+    Review-flow tools (reserved spec-review / code-review aliases):
+      start_review_flow      Start a review flow. Optional `vendor` picks the
+                             reviewer harness (lowercase token: claude, codex,
+                             cursor, copilot, gemini, kiro, opencode, antigravity, pi) —
+                             independent of the driver; omit to use the definition's
+                             authored vendor or your saved preference. Optional
+                             `model` pins the reviewer's model (REQUIRES `vendor`).
+                             Optional `mode: context-only` reviews without a workspace.
+      submit_review_round    Submit a follow-up round (reuses the pinned vendor/model).
       get_review_flow_status Get the status and last result of a flow.
       close_review_flow      Close a completed review flow.
+
+    Generic-flow tools (catalog + dynamic definitions):
+      start_flow             Start a catalog flow by `definition_id`, or an inline
+                             `definition_yaml` dynamic flow. `vendor`/`model` apply to
+                             single-participant catalog definitions only (rejected for
+                             multi-participant and definition_yaml).
+      send_to_participant    Address a message to a named participant role.
+      get_flow_status        Get status, rounds, and pending messages.
+      close_flow             Close a flow run.
+
+  The reviewer vendor is chosen independently of the driver harness. Pass the
+  lowercase canonical token; naming a reviewer is never inferred from the driver.
+  The tokens above are the protocol vocabulary — availability is per daemon: the
+  server rejects a vendor no connected daemon advertises as an unattended reviewer
+  with `reviewer_vendor_unavailable`, rather than silently substituting another.
+  A `model` override requires a server on the v3 flow-start protocol and a daemon
+  advertising a runtime model resolver for that vendor; otherwise the reviewer runs
+  on the vendor's default model. `default`/`auto` are rejected as model values.
 
   Claude Code auto-registers `kcap-flows` via the plugin's `.mcp.json`.
   `kcap setup` / `kcap plugin install --codex` register it conservatively


### PR DESCRIPTION
CLI-side documentation for the multi-vendor hosted-agent and reviewer-choice epics (kcap-server AI-1415 / AI-1416). Docs only — no code. The `review-flows`/`agent-flows` skills and the `mcp flows` tool schemas already carried the `vendor`/`model` args; this rounds out the stale reference docs around them.

## Changes
- **README daemon section** — replace the "Claude, Codex, or Cursor" opener with a full **hosted-vendor matrix** (mechanism / platforms / CLI path knob) covering all 8 hosted vendors; add the missing `KCAP_ANTIGRAVITY_PATH`/`KCAP_ANTIGRAVITY_MODEL` config knob + the exec-per-turn note; fix the stale "`KCAP_OPENCODE_PATH` reserved / not-yet-hosted" line and the stale "Kiro cannot be an unattended reviewer" limitation.
- **help-mcp.txt** — rewrite the `mcp flows` section (was only the four review tools, no `vendor`/`model`) to cover the review + generic-flow tools and the reviewer vendor/model selection contract.
- **kcap/README.md** (plugin) — add the `agent-flows` skill row; note reviewer-vendor independence on `review-flows`.

`check-linear-ids.sh` passes clean.

Part of kcap-server **AI-1415** and **AI-1416** (multi-repo docs). Not a closing PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
