### PR TITLE
Consent prompt window, Activity feed, tray attention (desktop supervisor)

### DIFF
--- a/docs/superpowers/plans/2026-08-08-ai1652-consent-prompt-activity-feed.md
+++ b/docs/superpowers/plans/2026-08-08-ai1652-consent-prompt-activity-feed.md
@@ -1,0 +1,1310 @@
+# Consent Prompt Window + Activity Feed (AI-1652) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the desktop consent UX: an auto-raised prompt window resolving daemon launch-consent requests, an Activity tab rendering the consent decision log, and pending-consent wired into the tray's Attention state — on a hardened v2 consent wire (daemon-minted `prompt_id` identity, `rule_saved` disclosure, structurally fail-closed v2 frames).
+
+**Architecture:** Daemon side: `LaunchConsentGate` mints a GUID `prompt_id` per prompt; `LaunchConsentBroker.TryResolve` atomically claims by identity echo; two new append-only frame types (`ConsentSubscribeV2 = 17`, `ConsentResolveV2 = 18`) carry the consent surface so a v1 daemon fails closed at its codec. App side: a `ConsentService` owns the pending cache (status-driven subscription, identity-guarded removals, service-lifetime tombstones, `PruneAfter` hygiene), a coordinator-owned topmost prompt window renders the queue, and an `ActivityViewModel` polls the decision-log file through a shared Core reader.
+
+**Tech Stack:** .NET 10 NativeAOT, Avalonia + ReactiveUI (`RxSchedulers.MainThreadScheduler` — `RxApp` scheduler properties do NOT exist in this ReactiveUI version) + DynamicData, System.Text.Json source-gen, TUnit on Microsoft Testing Platform, `Avalonia.Headless` for VM/window tests.
+
+**Spec:** `docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md` (referenced as "spec §N" throughout). The spec survived a 7-round hosted-Codex review; its exact contracts are load-bearing — do not "simplify" a guard you don't understand.
+
+## Global Constraints
+
+- **AOT:** `dotnet build` does NOT surface trimming warnings. After wire/JSON changes run `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` — must print nothing.
+- **JSON:** all new serialization goes through source-gen contexts (`ConsentIpcJsonContext`, `ConsentDecisionJsonContext`). Never `JsonSerializer` without a `JsonTypeInfo`. Use `JsonElementExtensions` instead of checking JSON value kind.
+- **DTO convention (positional-required):** trailing nullable members get NO C# default value; nulls are always written on serialize. `ConsentPendingDto` final positional order: `…, RequesterDisplay, PromptId` (spec §4.1).
+- **FrameType is append-only:** `ConsentSubscribeV2 = 17`, `ConsentResolveV2 = 18`. No other new values (spec §3).
+- **Copy strings verbatim from spec §6:** button labels `Allow once`, `Allow & remember`, `Deny`; tooltip `Saves a rule allowing future launches from this requester. Existing deny rules — including Pause — take precedence until removed.`; terminal texts `Already decided`, `Response time elapsed — unanswered requests are denied by the daemon`, `Expiring…`; disclosure variants in Task 9.
+- **Scheduling:** marshal to the UI thread with `.ObserveOn(RxSchedulers.MainThreadScheduler)` / `Dispatcher.UIThread.Post`. Never subscribe `Observable.Interval` off the UI thread (orphan-dispatcher bug — see `MainWindowViewModel._ticker` comment).
+- **File sharing:** every read of the daemon-written decision log opens with `FileShare.ReadWrite | FileShare.Delete` (spec §4.4; Windows mandatory sharing — AI-1629 bug class).
+- **No Linear IDs in C# comments** (CI lint). Use GitHub issue numbers if needed.
+- **TUnit:** run one class with `--treenode-filter "/*/*/ClassName/*"` (bare `"*Name*"` matches zero tests). Unit suites: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj`, `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj`.
+- **Windows CI:** never assert paths built with `/` against `Path.Combine` output; tests touching real daemon dirs must set `DaemonLockPaths` override (`KCAP_DAEMONS_DIR` seam / `SetTestOverride`) so they can't touch the developer's live daemon.
+- **README:** this slice adds no CLI surface (no new commands/flags) — README stays untouched; do not "helpfully" edit it.
+
+---
+
+## File Structure (whole slice)
+
+**Core (`src/Capacitor.Cli.Core/LocalIpc/`):**
+- `FrameType.cs`, `FrameCodec.cs` — v2 frame values + codec text-group entries (Task 1)
+- `ConsentIpc.cs` — trailing DTO fields (Task 1)
+- `ConsentDecisionLog.cs` — NEW: `ConsentDecisionRecord` + `ConsentDecisionJsonContext` (Task 1), `ConsentLogReadResult` + `ConsentDecisionLogReader` (Task 6)
+- `LocalControlOps.cs` — `ResolveConsentAsync` (Task 4)
+- `ConsentSubscription.cs` — NEW: `ConsentStreamEvent` + subscription client (Task 5)
+
+**Daemon (`src/Capacitor.Cli.Daemon/Services/`):**
+- `LaunchConsentEngine.cs` (`LaunchConsentInput` + display), `LaunchConsentGate.cs` (mint + threading + Core record), `LaunchConsentBroker.cs` (echo claim), `LaunchConsentDecisionLog.cs` (Core record), `AgentOrchestrator.cs` (pass display) — Task 2
+- `LaunchConsentIpc.cs` (rule_saved + echo + v2 validation), `LocalControlServer.cs` (route 17/18), `LocalControlCapabilities.cs` (consent/2) — Task 3
+
+**App (`src/Capacitor.App/`):**
+- `Services/UiTicker.cs` — NEW: hoisted app-lifetime ticker (Task 7)
+- `Services/ConsentService.cs` + `Services/IConsentService.cs` — NEW (Task 8)
+- `ViewModels/ConsentPromptViewModel.cs`, `Views/ConsentPromptWindow.axaml(.cs)`, `Services/ConsentPromptCoordinator.cs` — NEW (Task 9)
+- `ViewModels/ActivityViewModel.cs` — NEW; `Views/MainWindow.axaml` tabs (Task 10)
+- `ViewModels/TrayViewModel.cs`, `ViewModels/TrayModels.cs`, `Views/TrayMenuBuilder.cs` (Task 11)
+- `App.axaml.cs` — composition + shutdown order (Task 9)
+
+Dependency order: Task 1 → {2 → 3, 4, 5, 6} → 7 → 8 → 9 → 10 → 11. Tasks 4/5/6 depend only on Task 1. Task 10 depends on 6 + 7; Task 11 on 8 + 9.
+
+---
+
+### Task 1: Wire contracts — v2 frame types, DTO extensions, hoisted decision record
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/FrameType.cs`
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs` (Encode + Decode switches)
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/ConsentIpc.cs`
+- Create: `src/Capacitor.Cli.Core/LocalIpc/ConsentDecisionLog.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/ConsentWireContractsTests.cs` (new)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces (later tasks rely on these EXACT shapes):
+  - `FrameType.ConsentSubscribeV2 = 17`, `FrameType.ConsentResolveV2 = 18` (client→daemon)
+  - `ConsentPendingDto(string RequestId, string? Requester, string Kind, string RepoPath, string Vendor, string RequestedAt, int TimeoutSeconds, string? RequesterDisplay, string? PromptId)`
+  - `ConsentResolveDto(string RequestId, string Decision, ConsentRuleDto? SaveRule, string? PromptId)`
+  - `ConsentAckDto(bool Ok, string? Error, bool? RuleSaved)`
+  - `ConsentDecisionRecord(string DecidedAt, string AgentId, string? Requester, bool RequesterIsOwner, string Kind, string RepoPath, string Vendor, string Outcome, string Source, string? RequesterDisplay)` + `ConsentDecisionJsonContext`
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using System.Text.Json;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// Wire-shape pins for the AI-1652 consent v2 contracts (spec §4.1, §4.4): trailing nullable
+/// members with no C# default, nulls always written, snake_case names byte-compatible with
+/// existing daemons' output.
+public class ConsentWireContractsTests {
+    [Test]
+    public async Task Pending_dto_roundtrips_with_trailing_fields() {
+        var dto = new ConsentPendingDto("a1", "github:1", "agent", "/r", "codex", "2026-08-08T10:00:00.0000000+00:00", 45, "Mathias", "p1");
+        var json = JsonSerializer.Serialize(dto, ConsentIpcJsonContext.Default.ConsentPendingDto);
+        await Assert.That(json).Contains("\"requester_display\":\"Mathias\"");
+        await Assert.That(json).Contains("\"prompt_id\":\"p1\"");
+        var back = JsonSerializer.Deserialize(json, ConsentIpcJsonContext.Default.ConsentPendingDto);
+        await Assert.That(back).IsEqualTo(dto);
+    }
+
+    [Test]
+    public async Task Pending_dto_from_v1_daemon_reads_null_display_and_prompt_id() {
+        // A pre-AI-1652 daemon's exact serialization (no requester_display, no prompt_id).
+        const string v1 = "{\"request_id\":\"a1\",\"requester\":\"github:1\",\"kind\":\"agent\",\"repo_path\":\"/r\",\"vendor\":\"codex\",\"requested_at\":\"t\",\"timeout_seconds\":45}";
+        var dto = JsonSerializer.Deserialize(v1, ConsentIpcJsonContext.Default.ConsentPendingDto)!;
+        await Assert.That(dto.RequesterDisplay).IsNull();
+        await Assert.That(dto.PromptId).IsNull();
+    }
+
+    [Test]
+    public async Task Resolve_dto_carries_prompt_id_and_ack_carries_rule_saved_with_nulls_written() {
+        var resolve = new ConsentResolveDto("a1", "allow", null, "p1");
+        var rjson = JsonSerializer.Serialize(resolve, ConsentIpcJsonContext.Default.ConsentResolveDto);
+        await Assert.That(rjson).Contains("\"prompt_id\":\"p1\"");
+
+        var ack = new ConsentAckDto(true, null, null);
+        var ajson = JsonSerializer.Serialize(ack, ConsentIpcJsonContext.Default.ConsentAckDto);
+        await Assert.That(ajson).Contains("\"rule_saved\":null"); // nulls-always-written convention
+
+        // Old-format ack (no rule_saved member) → null, not an error.
+        var old = JsonSerializer.Deserialize("{\"ok\":false,\"error\":\"x\"}", ConsentIpcJsonContext.Default.ConsentAckDto)!;
+        await Assert.That(old.RuleSaved).IsNull();
+    }
+
+    [Test]
+    public async Task Decision_record_matches_existing_on_disk_field_names_verbatim() {
+        var rec = new ConsentDecisionRecord("t", "a1", "github:1", false, "agent", "/r", "codex", "allowed", "rule[0]", null);
+        var json = JsonSerializer.Serialize(rec, ConsentDecisionJsonContext.Default.ConsentDecisionRecord);
+        foreach (var name in new[] { "\"decided_at\"", "\"agent_id\"", "\"requester\"", "\"requester_is_owner\"",
+                                     "\"kind\"", "\"repo_path\"", "\"vendor\"", "\"outcome\"", "\"source\"", "\"requester_display\"" })
+            await Assert.That(json).Contains(name);
+
+        // Old log line (pre-AI-1652, no requester_display) parses; missing bool reads false.
+        const string oldLine = "{\"decided_at\":\"t\",\"agent_id\":\"a1\",\"requester\":null,\"requester_is_owner\":true,\"kind\":\"agent\",\"repo_path\":\"/r\",\"vendor\":\"codex\",\"outcome\":\"allowed\",\"source\":\"owner\"}";
+        var back = JsonSerializer.Deserialize(oldLine, ConsentDecisionJsonContext.Default.ConsentDecisionRecord)!;
+        await Assert.That(back.RequesterDisplay).IsNull();
+        await Assert.That(back.RequesterIsOwner).IsTrue();
+    }
+
+    [Test]
+    public async Task V2_frame_values_are_pinned_and_codec_roundtrips_them() {
+        await Assert.That((byte)FrameType.ConsentSubscribeV2).IsEqualTo((byte)17);
+        await Assert.That((byte)FrameType.ConsentResolveV2).IsEqualTo((byte)18);
+
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(ms, LocalFrame.ConsentJson(FrameType.ConsentResolveV2, "{\"x\":1}"), CancellationToken.None);
+        await FrameCodec.WriteAsync(ms, new LocalFrame(FrameType.ConsentSubscribeV2), CancellationToken.None);
+        ms.Position = 0;
+        var f1 = (await FrameCodec.ReadAsync(ms, CancellationToken.None))!;
+        var f2 = (await FrameCodec.ReadAsync(ms, CancellationToken.None))!;
+        await Assert.That(f1.Type).IsEqualTo(FrameType.ConsentResolveV2);
+        await Assert.That(f1.Text).IsEqualTo("{\"x\":1}");
+        await Assert.That(f2.Type).IsEqualTo(FrameType.ConsentSubscribeV2);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/ConsentWireContractsTests/*"`
+Expected: compile errors (`ConsentSubscribeV2` undefined, ctor arity mismatches).
+
+- [ ] **Step 3: Implement**
+
+`FrameType.cs` — append to the client→daemon block (after `StatusSubscribe = 16`):
+
+```csharp
+    // AI-1652 v2 consent frames (append-only). A v1 daemon's codec throws on these bytes
+    // before routing — that codec-level rejection IS the down-level fail-closed contract.
+    ConsentSubscribeV2 = 17, // long-lived: v2 subscribe (same reply stream as ConsentSubscribe)
+    ConsentResolveV2   = 18, // one-shot: resolve requiring the prompt_id identity echo
+```
+
+(Keep the "no Linear IDs" rule: the comment says "v2 consent frames", not the issue number — reference the spec file if a pointer is needed.)
+
+`FrameCodec.cs` — add `FrameType.ConsentSubscribeV2 or FrameType.ConsentResolveV2` to the **text-payload group** in BOTH `Encode` (the `or FrameType.ConsentSubscribe or FrameType.ConsentResolve` line) and `Decode` (same group).
+
+`ConsentIpc.cs` — extend the records (no defaults on new members):
+
+```csharp
+public sealed record ConsentPendingDto(
+    string RequestId, string? Requester, string Kind, string RepoPath, string Vendor,
+    string RequestedAt, int TimeoutSeconds, string? RequesterDisplay, string? PromptId);
+
+public sealed record ConsentResolveDto(string RequestId, string Decision, ConsentRuleDto? SaveRule, string? PromptId);
+
+/// Ok = did the resolution apply. RuleSaved: null when the resolve carried no save_rule;
+/// true/false = the rule write succeeded/failed — populated on BOTH Ok branches (spec §4.1),
+/// because save_rule is deliberately persisted before the resolution is attempted.
+public sealed record ConsentAckDto(bool Ok, string? Error, bool? RuleSaved);
+```
+
+`ConsentDecisionLog.cs` (new file):
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// The consent decision log's single write/read shape (spec §4.4): the daemon appends one of
+/// these per decision to consent-decisions.jsonl; the CLI `log` verb prints raw lines; the app
+/// parses them for the Activity feed. Field names are the pre-AI-1652 on-disk names verbatim —
+/// existing log files remain readable. Outcome: "allowed"|"denied". Source: "owner"|"rule[i]"|
+/// "default"|"prompt_no_ui"|"prompt_user"|"prompt_timeout".
+public sealed record ConsentDecisionRecord(
+    string DecidedAt, string AgentId, string? Requester, bool RequesterIsOwner,
+    string Kind, string RepoPath, string Vendor, string Outcome, string Source,
+    string? RequesterDisplay);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(ConsentDecisionRecord))]
+public partial class ConsentDecisionJsonContext : JsonSerializerContext;
+```
+
+Callers of the changed ctors elsewhere in the tree will now fail to compile (daemon's `ToDto`, `LaunchConsentIpc` rule handling, existing tests constructing `ConsentAckDto`/`ConsentPendingDto`). Fix each call site **mechanically** by appending the new arguments (`null` / `null` for pending display+prompt, `null` for resolve PromptId, `null` for ack RuleSaved) — behavioral rewiring is Tasks 2–3, not this task. Search: `rg -n "new ConsentAckDto|new ConsentPendingDto|new ConsentResolveDto|ConsentAckDto\(|ConsentPendingDto\(" src test`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: full unit suite `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj`
+Expected: PASS (incl. pre-existing consent tests with mechanically-appended args).
+
+- [ ] **Step 5: AOT check + commit**
+
+Run: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` → no output.
+
+```bash
+git add -A && git commit -m "feat: consent v2 wire contracts — frame types 17/18, prompt_id/rule_saved/requester_display DTO fields, hoisted decision record"
+```
+
+---
+
+### Task 2: Daemon — prompt identity, requester display threading, atomic broker claim
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/LaunchConsentEngine.cs` (`LaunchConsentInput`)
+- Modify: `src/Capacitor.Cli.Daemon/Services/LaunchConsentGate.cs` (`LaunchConsentPromptRequest`, mint, `Done()`)
+- Modify: `src/Capacitor.Cli.Daemon/Services/LaunchConsentBroker.cs` (`TryResolve` echo overload)
+- Modify: `src/Capacitor.Cli.Daemon/Services/LaunchConsentDecisionLog.cs` (write Core record; delete internal record+ctx)
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (~line 1328: pass `cmd.RequesterDisplay`)
+- Test: extend `test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentGateTests.cs`, `LaunchConsentBrokerTests.cs`, `LaunchConsentEngineTests.cs`, `LaunchConsentDecisionLogTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1 types (`ConsentDecisionRecord`, `ConsentDecisionJsonContext`).
+- Produces:
+  - `LaunchConsentInput(string? RequesterUserId, bool RequesterIsOwner, string Kind, string RepoPath, string Vendor, string? RequesterDisplay)` (readonly record struct)
+  - `LaunchConsentPromptRequest(string RequestId, string? Requester, string Kind, string RepoPath, string Vendor, string RequestedAt, int TimeoutSeconds, string? RequesterDisplay, string PromptId)` (internal record — PromptId non-nullable here: the gate always mints)
+  - `LaunchConsentBroker.TryResolve(string requestId, bool allow, string? promptIdEcho)` — null echo = legacy by-id; non-null must match exactly; lost claim → false, never retries
+  - `LaunchConsentDecisionLog.Record(ConsentDecisionRecord rec)`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `LaunchConsentGateTests.cs` add (using that file's existing fake prompter/store/log harness — read it first; reuse its builders):
+
+```csharp
+[Test]
+public async Task Gate_mints_distinct_prompt_ids_under_a_frozen_clock_and_threads_display() {
+    // Frozen TimeProvider: RequestedAt identical for both prompts — PromptId must still differ
+    // (the failure mode a timestamp identity would have had, spec §4.1).
+    var prompter = new CapturingPrompter(answer: true); // captures every LaunchConsentPromptRequest
+    var gate = BuildPromptModeGate(prompter, frozenClock: true);
+    var input = new LaunchConsentInput("github:1", false, "agent", "/r", "codex", "Mathias");
+
+    await gate.DecideAsync("agent-1", input, CancellationToken.None);
+    await gate.DecideAsync("agent-1", input, CancellationToken.None);
+
+    var (a, b) = (prompter.Requests[0], prompter.Requests[1]);
+    await Assert.That(a.RequestedAt).IsEqualTo(b.RequestedAt);        // clock frozen
+    await Assert.That(a.PromptId).IsNotEqualTo(b.PromptId);           // identity is not the clock
+    await Assert.That(a.PromptId).IsNotEmpty();
+    await Assert.That(a.RequesterDisplay).IsEqualTo("Mathias");
+}
+
+[Test]
+public async Task Done_records_requester_display_in_the_decision_record() {
+    // Rule-allowed path (no prompter needed): input display lands in the log record.
+    var log = new CapturingLog(); // or read the real file — follow the file's existing pattern
+    var gate = BuildAllowByDefaultGate(log);
+    await gate.DecideAsync("agent-1", new LaunchConsentInput("github:1", false, "agent", "/r", "codex", "Mathias"), CancellationToken.None);
+    await Assert.That(log.Records[0].RequesterDisplay).IsEqualTo("Mathias");
+    await Assert.That(log.Records[0].Source).IsEqualTo("default");
+}
+```
+
+In `LaunchConsentBrokerTests.cs` add:
+
+```csharp
+[Test]
+public async Task TryResolve_with_matching_echo_resolves_and_mismatch_leaves_pending_untouched() {
+    var broker = new LaunchConsentBroker();
+    var (id, reader) = broker.Subscribe();
+    var promptTask = broker.PromptAsync(ReqWithPromptId("agent-1", "p-A"), TimeSpan.FromMinutes(1), TimeProvider.System, CancellationToken.None);
+
+    await Assert.That(broker.TryResolve("agent-1", true, "WRONG")).IsFalse();   // mismatch: no claim
+    await Assert.That(promptTask.IsCompleted).IsFalse();                        // A still pending
+    await Assert.That(broker.TryResolve("agent-1", true, "p-A")).IsTrue();      // exact echo claims
+    await Assert.That(await promptTask).IsTrue();
+    broker.Unsubscribe(id);
+}
+
+[Test]
+public async Task Stale_echo_for_a_superseded_request_never_decides_the_successor() {
+    // A times out; successor B reuses the id; A's late resolve must answer false and leave B live.
+    var broker = new LaunchConsentBroker();
+    var (id, _) = broker.Subscribe();
+    var a = broker.PromptAsync(ReqWithPromptId("agent-1", "p-A"), TimeSpan.Zero, TimeProvider.System, CancellationToken.None);
+    await Assert.That(await a).IsNull(); // timeout claimed A
+    var b = broker.PromptAsync(ReqWithPromptId("agent-1", "p-B"), TimeSpan.FromMinutes(1), TimeProvider.System, CancellationToken.None);
+
+    await Assert.That(broker.TryResolve("agent-1", true, "p-A")).IsFalse(); // stale identity: refused
+    await Assert.That(b.IsCompleted).IsFalse();                             // B untouched
+    await Assert.That(broker.TryResolve("agent-1", false, "p-B")).IsTrue(); // B decided on its own terms
+    await Assert.That(await b).IsFalse();
+    broker.Unsubscribe(id);
+}
+
+[Test]
+public async Task Null_echo_preserves_legacy_resolve_by_id() {
+    var broker = new LaunchConsentBroker();
+    var (id, _) = broker.Subscribe();
+    var a = broker.PromptAsync(ReqWithPromptId("agent-1", "p-A"), TimeSpan.FromMinutes(1), TimeProvider.System, CancellationToken.None);
+    await Assert.That(broker.TryResolve("agent-1", true, null)).IsTrue();
+    await Assert.That(await a).IsTrue();
+    broker.Unsubscribe(id);
+}
+```
+
+(`ReqWithPromptId` is a local helper building `LaunchConsentPromptRequest` with all fields; adapt the file's existing request builder.)
+
+In `LaunchConsentEngineTests.cs` add:
+
+```csharp
+[Test]
+public async Task Earlier_wildcard_deny_shadows_a_later_appended_allow() {
+    // First-match-wins pins the "Allow & remember shadowed by pause" contract (spec §4.1).
+    var policy = new LaunchConsentPolicy(LaunchConsentDefault.Prompt, 45, [
+        new LaunchConsentRule("deny", null, null, null, null),          // pause at rules[0]
+        new LaunchConsentRule("allow", "github:1", null, null, null),   // appended by Allow & remember
+    ]);
+    var d = LaunchConsentEngine.Evaluate(policy, new LaunchConsentInput("github:1", false, "agent", "/r", "codex", null));
+    await Assert.That(d.Verdict).IsEqualTo(LaunchConsentVerdict.Deny);
+    await Assert.That(d.Source).IsEqualTo("rule[0]");
+}
+```
+
+In `LaunchConsentDecisionLogTests.cs`: update record construction to `ConsentDecisionRecord` and add one assertion that a written line contains `"requester_display"`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/LaunchConsent*/*"`
+Expected: compile errors (new members/overloads missing).
+
+- [ ] **Step 3: Implement**
+
+`LaunchConsentEngine.cs`:
+
+```csharp
+internal readonly record struct LaunchConsentInput(
+    string? RequesterUserId,
+    bool RequesterIsOwner,
+    string Kind,
+    string RepoPath,
+    string Vendor,
+    string? RequesterDisplay);
+```
+
+(Matching is untouched — `Matches` never reads `RequesterDisplay`.)
+
+`LaunchConsentGate.cs`:
+
+```csharp
+internal sealed record LaunchConsentPromptRequest(
+    string RequestId, string? Requester, string Kind, string RepoPath, string Vendor,
+    string RequestedAt, int TimeoutSeconds, string? RequesterDisplay, string PromptId);
+```
+
+In `DecideAsync`, the request construction becomes (mint the identity where the request is built — no clock involvement, spec §4.1):
+
+```csharp
+var req = new LaunchConsentPromptRequest(agentId, input.RequesterUserId, input.Kind,
+    input.RepoPath, input.Vendor, requestedAt, policy.PromptTimeoutSeconds,
+    input.RequesterDisplay, Guid.NewGuid().ToString("N"));
+```
+
+`Done()` writes the Core record:
+
+```csharp
+log.Record(new ConsentDecisionRecord(
+    DateTimeOffset.UtcNow.ToString("O"), agentId, input.RequesterUserId, input.RequesterIsOwner,
+    input.Kind, input.RepoPath, input.Vendor, allowed ? "allowed" : "denied", source,
+    input.RequesterDisplay));
+```
+
+(add `using Capacitor.Cli.Core.LocalIpc;`).
+
+`LaunchConsentBroker.cs` — replace `TryResolve` with:
+
+```csharp
+    public bool TryResolve(string requestId, bool allow) => TryResolve(requestId, allow, null);
+
+    /// Non-null echo: resolve succeeds only for the pending entry whose PromptId matches
+    /// exactly, and match+removal is ONE atomic claim — the KeyValuePair-conditional remove is
+    /// the same ABA primitive the timeout/cleanup paths use (class doc). A lost claim (the
+    /// matched instance replaced between lookup and removal) returns false and NEVER retries
+    /// against the successor. Null echo: legacy resolve-by-id (v1 frame callers).
+    public bool TryResolve(string requestId, bool allow, string? promptIdEcho) {
+        if (!_pending.TryGetValue(requestId, out var p)) return false;
+        if (promptIdEcho is not null &&
+            !string.Equals(promptIdEcho, p.Request.PromptId, StringComparison.Ordinal)) return false;
+        if (!_pending.TryRemove(new KeyValuePair<string, Pending>(requestId, p))) return false;
+        return p.Tcs.TrySetResult(allow);
+    }
+```
+
+`LaunchConsentDecisionLog.cs` — delete `LaunchConsentRecord` and `LaunchConsentDecisionJsonCtx`; `Record` takes `ConsentDecisionRecord` and serializes via `ConsentDecisionJsonContext.Default.ConsentDecisionRecord` (add the `using`). Writer behavior (0600, rotation, append) unchanged.
+
+`AgentOrchestrator.cs` (~line 1328): append the display argument:
+
+```csharp
+var consentInput = new LaunchConsentInput(
+    cmd.RequesterUserId, cmd.RequesterIsOwner ?? false,
+    LaunchConsentEngine.KindToken(cmd.Kind), cmd.RepoPath, cmd.Vendor, cmd.RequesterDisplay);
+```
+
+Fix remaining compile errors from the renamed record (`LaunchConsentIpc.ToDto` — stamp the new fields now: `new(r.RequestId, r.Requester, r.Kind, r.RepoPath, r.Vendor, r.RequestedAt, r.TimeoutSeconds, r.RequesterDisplay, r.PromptId)`; existing test builders gain the two new args).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: full `Capacitor.Cli.Tests.Unit` suite. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: daemon-minted prompt_id identity with atomic broker claim + requester_display threading"
+```
+
+---
+
+### Task 3: Daemon — v2 IPC handlers, rule_saved on both branches, consent/2 capability
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/LaunchConsentIpc.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs` (routing)
+- Modify: `src/Capacitor.Cli.Daemon/Services/LocalControlCapabilities.cs`
+- Test: extend `test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentIpcTests.cs`, `test/Capacitor.Cli.Tests.Unit/Daemon/LocalControlHelloTests.cs`
+
+**Interfaces:**
+- Consumes: Task 2's `TryResolve(id, allow, echo)`, Task 1 DTOs.
+- Produces: `LaunchConsentIpc.HandleResolveAsync(string payload, Stream stream, CancellationToken ct, bool requireEcho)`; server routes 17 → subscribe handler, 18 → resolve with `requireEcho: true`, 11/12 unchanged (`requireEcho: false`); `LocalControlCapabilities.Current == ["consent/1", "consent/2", "status/1"]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`LaunchConsentIpcTests.cs` uses an in-memory stream + real broker/store harness — follow its existing arrange helpers. Add:
+
+```csharp
+[Test]
+public async Task V2_resolve_without_prompt_id_acks_invalid_payload() {
+    // requireEcho: a v2 resolve missing/empty prompt_id never reaches the broker.
+    var ack = await ResolveAsync(ipc, "{\"request_id\":\"a1\",\"decision\":\"allow\"}", requireEcho: true);
+    await Assert.That(ack.Ok).IsFalse();
+    await Assert.That(ack.Error).Contains("prompt_id");
+}
+
+[Test]
+public async Task Rule_saved_is_populated_on_both_ok_branches() {
+    // (1) save_rule + live pending + matching echo → Ok=true, RuleSaved=true.
+    // (2) save_rule + NO pending → rule still persisted (save-before-resolve is deliberate),
+    //     Ok=false, RuleSaved=true — the disclosure the app renders (spec §4.1).
+    // (3) save_rule rejected by the store (drive TryReplace failure the way the file's existing
+    //     save_rule-rejection test does) → RuleSaved=false on both branches.
+    // (4) no save_rule → RuleSaved=null.
+    var okAck = await ResolveAsync(ipc, ResolveJson("a1", "allow", saveRule: true, promptId: livePromptId), requireEcho: true);
+    await Assert.That(okAck.Ok).IsTrue();
+    await Assert.That(okAck.RuleSaved).IsEqualTo(true);
+
+    var nopAck = await ResolveAsync(ipc, ResolveJson("ghost", "allow", saveRule: true, promptId: "p-x"), requireEcho: true);
+    await Assert.That(nopAck.Ok).IsFalse();
+    await Assert.That(nopAck.RuleSaved).IsEqualTo(true);
+    await Assert.That(StoreRules()).Contains(r => r.Requester == "github:1"); // persisted despite Ok=false
+
+    var plainAck = await ResolveAsync(ipc, ResolveJson("a1", "deny", saveRule: false, promptId: otherLivePromptId), requireEcho: true);
+    await Assert.That(plainAck.RuleSaved).IsNull();
+}
+
+[Test]
+public async Task V2_resolve_with_mismatching_echo_acks_no_pending_and_leaves_the_request_live() {
+    var ack = await ResolveAsync(ipc, ResolveJson("a1", "allow", saveRule: false, promptId: "WRONG"), requireEcho: true);
+    await Assert.That(ack.Ok).IsFalse();
+    await Assert.That(PendingStillLive("a1")).IsTrue();
+}
+
+[Test]
+public async Task Subscribe_pushes_prompt_id_and_requester_display_on_pending_frames() {
+    // ToDto stamping: the pushed ConsentPendingDto carries the request's PromptId + display.
+    var dto = await FirstPendingFrom(subscribeStream);
+    await Assert.That(dto.PromptId).IsEqualTo(livePromptId);
+    await Assert.That(dto.RequesterDisplay).IsEqualTo("Mathias");
+}
+```
+
+(Write `ResolveAsync`/`ResolveJson`/`StoreRules`/`PendingStillLive`/`FirstPendingFrom` as small local helpers over the file's existing harness — the file already round-trips resolve payloads and subscribe streams; mirror its mechanics, don't invent new plumbing.)
+
+`LocalControlHelloTests.cs`: update the capability assertion to `["consent/1", "consent/2", "status/1"]`.
+
+- [ ] **Step 2: Run to verify failure** — same filter as Task 2 plus `LocalControlHelloTests`. Expected: FAIL/compile errors.
+
+- [ ] **Step 3: Implement**
+
+`LaunchConsentIpc.HandleResolveAsync` — new signature `(string payload, Stream stream, CancellationToken ct, bool requireEcho = false)`; body changes:
+
+```csharp
+if (dto is null || string.IsNullOrEmpty(dto.RequestId) || dto.Decision is not ("allow" or "deny")
+        || (dto.SaveRule is { } saveRuleShape && saveRuleShape.Action is null)) {
+    ack = new ConsentAckDto(false, "invalid resolve payload (decision must be allow|deny)", null);
+} else if (requireEcho && string.IsNullOrEmpty(dto.PromptId)) {
+    // V2 contract: the identity echo is mandatory — an id-only resolve is exactly the stale-
+    // resolve hazard the v2 frame exists to close (spec §4.1).
+    ack = new ConsentAckDto(false, "invalid resolve payload (prompt_id required)", null);
+} else {
+    string? saveError = null;
+    bool? ruleSaved = null;
+    if (dto.SaveRule is { } r) {
+        var current = store.Current;
+        var next = current with {
+            Rules = [.. current.Rules, new LaunchConsentRule(r.Action, r.Requester, r.Kind, r.Repo, r.Vendor)] };
+        if (!store.TryReplace(next, out saveError))
+            logger.LogWarning("Consent save_rule rejected: {Error}", saveError);
+        ruleSaved = saveError is null;
+    }
+    var resolved = broker.TryResolve(dto.RequestId, dto.Decision == "allow", dto.PromptId);
+    ack = resolved
+        ? new ConsentAckDto(true, saveError, ruleSaved)
+        : new ConsentAckDto(false, "no pending consent request with that id", ruleSaved);
+}
+```
+
+(The `JsonException` catch's ack gains the third `null` arg. The pre-existing comment about Ok-vs-Error stays; extend it with one line: RuleSaved reports the save outcome on BOTH branches.)
+
+`LocalControlServer.cs` — add to the switch (after the ConsentRulesPut case):
+
+```csharp
+case FrameType.ConsentSubscribeV2: await consentIpc.HandleSubscribeAsync(stream, ct); break;
+case FrameType.ConsentResolveV2:   await consentIpc.HandleResolveAsync(first.Text, stream, ct, requireEcho: true); break;
+```
+
+and extend the default-arm error text's frame list with `/ConsentSubscribeV2/ConsentResolveV2`.
+
+`LocalControlCapabilities.cs`:
+
+```csharp
+public static readonly IReadOnlyList<string> Current = ["consent/1", "consent/2", "status/1"];
+```
+
+(Extend the file's existing doc comment: `consent/2` = identity-checked resolution (`prompt_id` echo), `rule_saved` acks, `prompt_id`/`requester_display`-stamped pendings — advertised only because the v2 routes above exist; discovery only, enforcement is the v2 frames themselves.)
+
+- [ ] **Step 4: Run to verify pass** — full `Capacitor.Cli.Tests.Unit` suite. Expected: PASS.
+
+- [ ] **Step 5: AOT check + commit**
+
+```bash
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'  # no output
+git add -A && git commit -m "feat: v2 consent IPC — identity-required resolve, rule_saved disclosure, consent/2 capability"
+```
+
+---
+
+### Task 4: Core — `ResolveConsentAsync` one-shot op
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs`
+- Test: extend `test/Capacitor.Cli.Tests.Unit/LocalControlOpsTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1 DTOs/frames.
+- Produces: `Task<ConsentAckDto> ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct)` on `ILocalControlOps` — throws `LocalControlOpsException` with reason `daemon_unreachable | daemon_rejected | unexpected_reply | timed_out`; caller OCE propagates.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `LocalControlOpsTests` (reuse `ScriptedOpsServer`, the short-socket-path arrangement, and the existing script helpers — read the whole file first):
+
+```csharp
+static ConnScript ConsentResolveV2Ack(string json) => async (_, s, ct) => {
+    var f = await FrameCodec.ReadAsync(s, ct);
+    if (f?.Type == FrameType.ConsentResolveV2)
+        await FrameCodec.WriteAsync(s, LocalFrame.ConsentJson(FrameType.ConsentAck, json), ct);
+};
+
+/// A faithful v1 daemon: reads the raw 5-byte header, sees a type byte its codec has no case
+/// for, and closes without writing ANY frame (FrameCodec.Decode throws InvalidDataException →
+/// HandleConnectionAsync catches/logs/closes). NOT a routing-default Error reply — no deployed
+/// v1 daemon produces one for byte 18 (spec §4.1).
+static ConnScript V1CodecReject() => async (_, s, ct) => {
+    var head = new byte[5];
+    var read = 0;
+    while (read < 5) {
+        var n = await s.ReadAsync(head.AsMemory(read), ct);
+        if (n == 0) return;
+        read += n;
+    }
+    // v1 FrameCodec would throw here — the server closes the socket, writing nothing.
+};
+
+[Test]
+public async Task Resolve_sends_v2_frame_with_prompt_id_and_returns_the_ack_shapes() {
+    // Ok=true/null-error/null-rule_saved; Ok=true+error+rule_saved=false; Ok=false+rule_saved=true;
+    // old-format ack (no rule_saved member) → RuleSaved null. Assert the WRITTEN frame carried
+    // prompt_id by echoing the request payload back through the script (capture f.Text).
+}
+
+[Test]
+public async Task Resolve_maps_error_frame_to_daemon_rejected() {
+    // ErrorThen("nope") → LocalControlOpsException with Reason "daemon_rejected", message "nope".
+}
+
+[Test]
+public async Task Resolve_against_a_v1_codec_observes_eof_as_unexpected_reply_and_nothing_was_resolved() {
+    // V1CodecReject() script → LocalControlOpsException Reason "unexpected_reply"
+    // ("daemon closed the connection without replying"). The incarnation-swap pin (spec §9/§10):
+    // no ack, no resolution — fail closed.
+}
+
+[Test]
+public async Task Resolve_timeout_eof_malformed_and_cancellation_classify_like_existing_ops() {
+    // Mirror the file's existing GetConsentPolicyAsync classification tests for the new op:
+    // Eof() → unexpected_reply; no-reply + short ConsentReplyTimeout via fake TimeProvider →
+    // timed_out; malformed ack JSON → unexpected_reply; pre-cancelled ct → OCE propagates.
+}
+```
+
+Flesh these out to real `[Test]` methods following the file's existing per-case shape (each existing classification case already has a sibling to copy the arrangement from — keep one test per failure class, same as the file does for stop/policy ops).
+
+- [ ] **Step 2: Run to verify failure** — `--treenode-filter "/*/*/LocalControlOpsTests/*"`. Expected: compile error (`ResolveConsentAsync` missing).
+
+- [ ] **Step 3: Implement** — add to the interface and class:
+
+```csharp
+Task<ConsentAckDto> ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct);
+```
+
+```csharp
+    public async Task<ConsentAckDto> ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct) {
+        var json = JsonSerializer.Serialize(resolve, ConsentIpcJsonContext.Default.ConsentResolveDto);
+        // ConsentResolveV2, never the v1 frame: a v1 daemon must fail closed at its codec rather
+        // than resolve by id without the identity check (spec §4.1).
+        var reply = await ExchangeAsync(LocalFrame.ConsentJson(FrameType.ConsentResolveV2, json), ConsentReplyTimeout, ct);
+        switch (reply.Type) {
+            case FrameType.ConsentAck:
+                var ack = DeserializeOrThrow(reply.Text, ConsentIpcJsonContext.Default.ConsentAckDto, "malformed consent ack reply");
+                if (ack is null) throw new LocalControlOpsException(UnexpectedReply, "malformed consent ack reply");
+                return ack;
+            case FrameType.Error:
+                throw new LocalControlOpsException(DaemonRejected, reply.Text);
+            default:
+                throw new LocalControlOpsException(UnexpectedReply, $"unexpected daemon response to consent resolve ({reply.Type})");
+        }
+    }
+```
+
+Also update `test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs` (the app-test fake implementing `ILocalControlOps`) with a scriptable `ResolveConsentAsync` following its existing per-method scripting shape — Task 8's tests drive it.
+
+- [ ] **Step 4: Run to verify pass** — both unit suites (Cli + App, the latter for the fake's compile). Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: ResolveConsentAsync one-shot op with v2 frame and pinned failure taxonomy"
+```
+
+---
+
+### Task 5: Core — consent subscription client
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/LocalIpc/ConsentSubscription.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/ConsentSubscriptionTests.cs` (new; copy the socket-path harness conventions from `LocalControlOpsTests` — short paths, Windows guard, `[NotInParallel]`)
+
+**Interfaces:**
+- Produces:
+
+```csharp
+public abstract record ConsentStreamEvent {
+    public sealed record Subscribed : ConsentStreamEvent;
+    public sealed record Pending(ConsentPendingDto Request) : ConsentStreamEvent;
+}
+public static class ConsentSubscription {
+    public static IAsyncEnumerable<ConsentStreamEvent> RunAsync(string daemonName, CancellationToken ct);
+}
+```
+
+- [ ] **Step 1: Write the failing tests** — scripted server (same `ScriptedOpsServer` shape), cases:
+
+1. `Subscribed_is_yielded_after_the_write_and_before_any_frame` — script reads the ConsentSubscribeV2 frame then blocks (await a TCS): first `MoveNextAsync` completes with `Subscribed` even though no reply exists (the empty-replay boundary, spec §4.2).
+2. `Replay_and_push_frames_yield_pending_events_in_order` — script writes two valid `ConsentPending` frames; enumeration yields `Subscribed`, `Pending(a)`, `Pending(b)`, then EOF ends it.
+3. `Failed_connect_ends_without_subscribed` — no listener at the socket path: enumeration completes empty (SocketException absorbed; `Subscribed` NOT yielded).
+4. `Unexpected_frame_type_ends_the_enumeration` — script writes a `ConsentRules` frame → stream ends after `Subscribed` (protocol confusion).
+5. `Undecodable_json_ends_the_enumeration` — `ConsentPending` frame with `not-json` text.
+6. `Structurally_invalid_pending_is_skipped_and_the_stream_continues` — `{}` frame followed by a valid frame → only the valid one yields.
+7. `Prompt_id_requirement_is_isolated` — three v1-shaped frames (every pre-existing field valid; `prompt_id` separately **absent**, **null**, **empty**) each yield nothing, stream continues to a final valid frame (a `{}` frame alone would stay green with the PromptId check forgotten — spec §10).
+8. `V1_codec_daemon_yields_subscribed_then_ends` — script reads the raw 5-byte header (type byte 17) and closes without writing (the `V1CodecReject` shape from Task 4): `Subscribed` then end, no `Pending`.
+9. `Cancellation_propagates` — cancel mid-read → `OperationCanceledException` from the enumeration.
+
+- [ ] **Step 2: Run to verify failure** — compile error.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// One consent subscription attempt as a typed stream (spec §4.2). `Subscribed` is a
+/// CLIENT-LOCAL boundary — emitted right after the subscribe write flushes, before any read,
+/// because an async iterator exposes no other observable point between "dialing" and
+/// "subscribed" (with an empty replay the first read never completes). It does not prove the
+/// daemon registered the subscription. The enumeration ENDING (for any reason but caller
+/// cancellation) means "this attempt is over" — the consumer decides whether to go again.
+public abstract record ConsentStreamEvent {
+    public sealed record Subscribed : ConsentStreamEvent;
+    public sealed record Pending(ConsentPendingDto Request) : ConsentStreamEvent;
+}
+
+public static class ConsentSubscription {
+    public static async IAsyncEnumerable<ConsentStreamEvent> RunAsync(
+            string daemonName, [EnumeratorCancellation] CancellationToken ct = default) {
+        using var sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        NetworkStream? stream = null;
+        try {
+            // Dial + subscribe write. ConsentSubscribeV2: a v1 daemon's codec rejects the byte
+            // before routing and closes without replying — we yield Subscribed (the write
+            // flushed) and then end on EOF, never registering a subscriber there (spec §4.1).
+            try {
+                await sock.ConnectAsync(new UnixDomainSocketEndPoint(LocalSocketPaths.Socket(daemonName)), ct);
+                stream = new NetworkStream(sock, ownsSocket: false);
+                await FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.ConsentSubscribeV2), ct);
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                throw;
+            } catch (Exception ex) when (ex is IOException or SocketException) {
+                yield break; // failed dial/write: attempt over, no Subscribed, no clear (spec §5)
+            }
+
+            yield return new ConsentStreamEvent.Subscribed();
+
+            while (true) {
+                LocalFrame? frame;
+                try {
+                    frame = await FrameCodec.ReadAsync(stream!, ct);
+                } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                    throw;
+                } catch (Exception ex) when (ex is IOException or SocketException or InvalidDataException) {
+                    yield break; // transport death / undecodable frame: attempt over
+                }
+                if (frame is null || frame.Type != FrameType.ConsentPending) yield break; // EOF / protocol confusion
+
+                ConsentPendingDto? dto;
+                try { dto = JsonSerializer.Deserialize(frame.Text, ConsentIpcJsonContext.Default.ConsentPendingDto); }
+                catch (JsonException) { yield break; } // undecodable payload: dead connection
+
+                // Structurally invalid (STJ leaves missing members null; `{}` decodes fine) is
+                // SKIPPED, not fatal — ending here would thrash: the resubscribe replay would
+                // redeliver the same invalid entry forever (spec §4.2).
+                if (!IsStructurallyValid(dto)) continue;
+                yield return new ConsentStreamEvent.Pending(dto!);
+            }
+        } finally {
+            if (stream is not null) await stream.DisposeAsync();
+        }
+    }
+
+    static bool IsStructurallyValid(ConsentPendingDto? dto) =>
+        dto is not null
+        && !string.IsNullOrEmpty(dto.RequestId)
+        && !string.IsNullOrEmpty(dto.PromptId)   // consent/2 daemons always stamp it (spec §4.2)
+        && !string.IsNullOrEmpty(dto.Kind)
+        && !string.IsNullOrEmpty(dto.RepoPath)
+        && !string.IsNullOrEmpty(dto.Vendor)
+        && !string.IsNullOrEmpty(dto.RequestedAt)
+        && dto.TimeoutSeconds > 0;
+}
+```
+
+(If `yield` placement fights the compiler on the connect block, hoist the dial into a private `static async Task<NetworkStream?> DialAsync(...)` returning null on absorbed failure — keep the classification identical.)
+
+- [ ] **Step 4: Run to verify pass** — full Cli unit suite. Expected: PASS.
+- [ ] **Step 5: Commit** — `git commit -m "feat: consent subscription client with typed Subscribed boundary and fail-closed validation"`
+
+---
+
+### Task 6: Core — decision-log reader
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/ConsentDecisionLog.cs` (append reader types)
+- Test: `test/Capacitor.Cli.Tests.Unit/ConsentDecisionLogReaderTests.cs` (new)
+
+**Interfaces:**
+- Produces:
+
+```csharp
+public sealed record ConsentLogReadResult(IReadOnlyList<ConsentDecisionRecord> Records, bool Complete);
+public static class ConsentDecisionLogReader {
+    public static string PathFor(string daemonName);
+    public static ConsentLogReadResult ReadTail(string daemonName, int max);
+}
+```
+
+- [ ] **Step 1: Write the failing tests** — every test redirects `DaemonLockPaths` to a temp dir (use the existing test override seam other daemon-dir tests use — find it via `rg -n "SetTestOverride|KCAP_DAEMONS_DIR" test/`; never touch the real `~/.config/kcap/daemons`). Cases:
+
+1. `Tail_merges_rotation_pair_newest_first_capped` — write 3 records to `{path}.1` and 3 newer to `{path}`; `ReadTail(name, 4)` → 4 records, newest first (the current file's last record first), `Complete=true`.
+2. `Undecodable_and_structurally_invalid_lines_are_skipped` — interleave `not-json`, `{}` (parses, but `decided_at`/`agent_id`/… null → invalid), and valid lines → only valid returned, `Complete=true`.
+3. `Absent_files_are_a_complete_empty_read` — no files → `([], Complete=true)` (clean absence — the feed's empty state, spec §4.4).
+4. `Unreadable_file_flips_complete_false_with_partial_records` — valid `.1`, then make `{path}` unreadable (open it exclusively with `FileShare.None` on Windows semantics; cross-platform: create `{path}` as a DIRECTORY so the file open throws `UnauthorizedAccessException`/`IOException`) → `.1` records returned, `Complete=false`.
+5. `Old_format_lines_parse_with_null_display` — a line without `requester_display` → record with null.
+6. `Duplicate_records_across_the_rotation_boundary_are_deduped` — same line present in both files → one record (value equality `Distinct`).
+7. `Reader_share_mode_never_blocks_the_writer` — the sharing regression guard (spec §10): hold a reader handle open with the READER's share mode (open via a stream the same way `ReadTail` does — extract `OpenShared(path)` as `internal static FileStream` so the test uses the production open), and while it is open: (a) append via a `FileStream(path, FileMode.Append, FileAccess.Write)` (the daemon writer's mode) — must succeed; (b) rotate via `File.Move(path, path + ".1", overwrite: true)` — must succeed (this is what `FileShare.Delete` buys); (c) a concurrent `ReadTail` succeeds. Trivially green on Unix; load-bearing on the Windows CI leg.
+
+- [ ] **Step 2: Run to verify failure** — compile error.
+
+- [ ] **Step 3: Implement** — append to `ConsentDecisionLog.cs`:
+
+```csharp
+/// Complete=false means at least one file existed but could not be read (I/O failure) — the
+/// records list may be partial and the consumer must not mistake it for a genuinely shorter
+/// log. Clean absence (file not found) is Complete=true (spec §4.4).
+public sealed record ConsentLogReadResult(IReadOnlyList<ConsentDecisionRecord> Records, bool Complete);
+
+public static class ConsentDecisionLogReader {
+    public static string PathFor(string daemonName) =>
+        Path.Combine(DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(daemonName), "consent-decisions.jsonl");
+
+    public static ConsentLogReadResult ReadTail(string daemonName, int max) {
+        var path = PathFor(daemonName);
+        var complete = true;
+        var lines = new List<string>();
+        foreach (var file in new[] { path + ".1", path }) {         // .1 first: its lines are older
+            if (!TryReadLines(file, lines)) complete = false;
+        }
+
+        var seen = new HashSet<ConsentDecisionRecord>();            // value equality — rotation-race dedup
+        var records = new List<ConsentDecisionRecord>();
+        for (var i = lines.Count - 1; i >= 0 && records.Count < max; i--) {
+            var rec = ParseValid(lines[i]);
+            if (rec is not null && seen.Add(rec)) records.Add(rec); // newest first
+        }
+        return new(records, complete);
+    }
+
+    // The reader's open — ReadWrite so the daemon's live appends are never blocked, Delete so
+    // its File.Move rotation is never blocked (Windows mandatory sharing; AI-1629 bug class).
+    internal static FileStream OpenShared(string path) =>
+        new(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+
+    /// True = read cleanly OR cleanly absent; false = existed-but-unreadable (I/O failure).
+    static bool TryReadLines(string path, List<string> into) {
+        try {
+            using var fs = OpenShared(path);
+            using var reader = new StreamReader(fs);
+            while (reader.ReadLine() is { } line) into.Add(line);
+            return true;
+        } catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
+            return true;  // clean absence
+        } catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) {
+            return false; // exists (or vanished mid-read) but unreadable — partial/incomplete
+        }
+    }
+
+    static ConsentDecisionRecord? ParseValid(string line) {
+        ConsentDecisionRecord? rec;
+        try { rec = JsonSerializer.Deserialize(line, ConsentDecisionJsonContext.Default.ConsentDecisionRecord); }
+        catch (JsonException) { return null; }
+        if (rec is null || string.IsNullOrEmpty(rec.DecidedAt) || string.IsNullOrEmpty(rec.AgentId)
+            || string.IsNullOrEmpty(rec.Kind) || string.IsNullOrEmpty(rec.RepoPath)
+            || string.IsNullOrEmpty(rec.Vendor) || string.IsNullOrEmpty(rec.Outcome)
+            || string.IsNullOrEmpty(rec.Source)) return null;
+        return rec;
+    }
+}
+```
+
+(Add `using System.Text.Json;` and whatever `DaemonLockPaths` needs. If `DaemonLockPaths.Sanitize` has different casing/visibility, mirror exactly what `DaemonConsentCommand.LogAsync` calls — that path derivation must match the CLI verb's byte-for-byte.)
+
+- [ ] **Step 4: Run to verify pass.** Expected: PASS.
+- [ ] **Step 5: Commit** — `git commit -m "feat: consent decision-log reader with Complete flag and writer-safe sharing"`
+
+---
+
+### Task 7: App — hoist the shared ticker into an app-lifetime service
+
+**Files:**
+- Create: `src/Capacitor.App/Services/UiTicker.cs`
+- Modify: `src/Capacitor.App/ViewModels/MainWindowViewModel.cs` (delete the private `_ticker`, take `ITicker`)
+- Modify: `src/Capacitor.App/App.axaml.cs` (construct one `UiTicker` in `StartAsync`, thread it through `BuildAndShowMainWindow`)
+- Test: `test/Capacitor.App.Tests.Unit/UiTickerTests.cs` (new); update every `new MainWindowViewModel(` call site in `MainWindowViewModelTests.cs`, `AgentGridTests.cs`, `MainWindowSmokeTests.cs`, `AppStartupTests.cs` (find all: `rg -n "new MainWindowViewModel" test src`)
+
+**Interfaces:**
+- Produces:
+
+```csharp
+public interface ITicker { IObservable<long> Ticks { get; } }
+public sealed class UiTicker : ITicker;   // production; construct ON the UI thread
+public sealed class FakeTicker : ITicker; // test helper (Subject-backed), lives in the test project
+```
+- `MainWindowViewModel(IDaemonClientService service, AgentActionService actions, ITicker ticker, CancellationToken shutdownToken, TimeProvider? time = null)`
+
+- [ ] **Step 1: Write the failing tests**
+
+`UiTickerTests.cs`: port `AppStartupTests`' existing real-ticker seam test (the one that exercises `MainWindowViewModel.Ticker` producing real ticks from a background subscription thread — find it via `rg -n "Ticker" test/Capacitor.App.Tests.Unit/AppStartupTests.cs`) to target `new UiTicker().Ticks` instead; assert ≥1 tick observed within the test's existing timeout when subscribed from a non-UI thread inside the headless session.
+
+- [ ] **Step 2: Run to verify failure** — compile error.
+
+- [ ] **Step 3: Implement**
+
+`UiTicker.cs` — move the exact pipeline (comment included, updated to name this class) from `MainWindowViewModel._ticker`:
+
+```csharp
+using System.Reactive.Linq;
+
+namespace Capacitor.App.Services;
+
+public interface ITicker {
+    /// Shared 1 Hz heartbeat. HOT via Publish().RefCount(); ticks are delivered on the UI
+    /// thread. Construct the production implementation ON the UI thread (App.StartAsync) —
+    /// an off-UI-thread Observable.Interval subscription binds an orphan thread-local
+    /// dispatcher that never ticks (the AI-1651 uptime bug; see the pipeline comment).
+    IObservable<long> Ticks { get; }
+}
+
+public sealed class UiTicker : ITicker {
+    // [move MainWindowViewModel's full _ticker pipeline comment + construction here verbatim]
+    public IObservable<long> Ticks { get; } = Observable
+        .Interval(TimeSpan.FromSeconds(1), RxSchedulers.MainThreadScheduler)
+        .SubscribeOn(RxSchedulers.MainThreadScheduler)
+        .Publish()
+        .RefCount();
+}
+```
+
+`MainWindowViewModel`: delete the `_ticker` field and `internal Ticker` seam (its hazard test moves to `UiTickerTests`); add the `ITicker ticker` ctor param (position 3); the row `Transform` uses `ticker.Ticks`.
+
+`App.axaml.cs` `StartAsync`: `var ticker = new UiTicker();` right after `notifier`; pass through `BuildAndShowMainWindow(service, actions, notifier, ticker, _shutdown.Token)` → `new MainWindowViewModel(service, actions, ticker, shutdownToken)`. Store it in a field `UiTicker? _ticker` for Tasks 8–10 to consume (no disposal needed — RefCount tears down with its subscribers).
+
+Test call sites: add a `FakeTicker` (Subject-backed) to `test/Capacitor.App.Tests.Unit/` and pass it everywhere `MainWindowViewModel` is constructed; tests that previously injected a `Subject<long>` ticker into rows keep doing so via `FakeTicker`.
+
+```csharp
+public sealed class FakeTicker : ITicker {
+    public readonly System.Reactive.Subjects.Subject<long> Subject = new();
+    public IObservable<long> Ticks => Subject;
+    public void Tick(long n = 0) => Subject.OnNext(n);
+}
+```
+
+- [ ] **Step 4: Run to verify pass** — full App unit suite. Expected: PASS.
+- [ ] **Step 5: Commit** — `git commit -m "refactor: hoist the shared 1Hz ticker into an app-lifetime UiTicker service"`
+
+---
+
+### Task 8: App — `ConsentService` (pending cache, tombstones, lifecycle, resolve lane, prune)
+
+**Files:**
+- Create: `src/Capacitor.App/Services/IConsentService.cs`
+- Create: `src/Capacitor.App/Services/ConsentService.cs`
+- Test: `test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs` (new)
+
+**Interfaces:**
+- Consumes: `ILocalControlOps.ResolveConsentAsync` (Task 4), `ConsentStreamEvent`/`ConsentSubscription` shape (Task 5 — injected as a delegate), `ITicker` (Task 7), `IDaemonClientService.Status`.
+- Produces (Tasks 9/11 rely on these exact names):
+
+```csharp
+public enum ConsentResolveKind { Applied, AppliedRuleRejected, AlreadyDecided, RuleSkippedNoRequester, TransportFailure }
+public enum ConsentRuleOutcome { NotRequested, Saved, Rejected, Unknown, SkippedNoRequester }
+public sealed record ConsentResolveOutcome(ConsentResolveKind Kind, ConsentRuleOutcome RuleOutcome, string? Error);
+
+public sealed class PendingConsent {
+    public ConsentPendingDto Dto { get; }
+    public string RequestId { get; }          // = Dto.RequestId (cache key / per-agent queue identity)
+    public string PromptId { get; }           // = Dto.PromptId! (structural validation guarantees it)
+    public DateTimeOffset DeadlineHint { get; }
+    public DateTimeOffset PruneAfter { get; internal set; }
+}
+
+public interface IConsentService : IDisposable {
+    IObservable<IChangeSet<PendingConsent, string>> Pending { get; } // background-thread mutations; consumers ObserveOn
+    IObservable<int> PendingCount { get; }
+    IObservable<Unit> EntryAdded { get; }                            // unconditional; the coordinator filters by visibility
+    Task<ConsentResolveOutcome> ResolveAsync(PendingConsent target, bool allow, bool saveRule, CancellationToken ct);
+}
+```
+
+- Constructor (all seams injectable for tests):
+
+```csharp
+public ConsentService(
+    IDaemonClientService service,
+    ILocalControlOps ops,
+    ITicker ticker,
+    Func<CancellationToken, IAsyncEnumerable<ConsentStreamEvent>> subscribe, // prod: ct => ConsentSubscription.RunAsync(service.DaemonName, ct)
+    TimeProvider time,
+    CancellationToken shutdownToken)
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Test harness: a `FakeDaemonClientService`-style status subject (reuse/extend the existing fake), `ScriptedLocalControlOps` for acks, a controllable fake subscription:
+
+```csharp
+sealed class FakeConsentStream {
+    readonly Channel<ConsentStreamEvent> _ch = Channel.CreateUnbounded<ConsentStreamEvent>();
+    public int Attempts; // incremented per RunAsync call — asserts retry cadence
+    public async IAsyncEnumerable<ConsentStreamEvent> RunAsync([EnumeratorCancellation] CancellationToken ct) {
+        Interlocked.Increment(ref Attempts);
+        await foreach (var e in _ch.Reader.ReadAllAsync(ct)) {
+            if (e is EndMarker) yield break;
+            yield return e;
+        }
+    }
+    // helpers: EmitSubscribed(), EmitPending(dto), EndAttempt() (yield-breaks the current enumeration)
+}
+```
+
+Use `Microsoft.Extensions.Time.Testing.FakeTimeProvider` if already referenced (check the csproj; otherwise a manual fake time provider consistent with the repo's existing pattern — `rg -n "FakeTimeProvider|TimeProvider" test/` first).
+
+Test cases (each a `[Test]`; exact expectations):
+
+1. `Subscribes_only_with_consent2_capability` — status Connected + `["consent/1"]` → `Attempts == 0` and cache cleared; Connected + `["consent/1","consent/2"]` → `Attempts == 1`.
+2. `Clear_happens_at_subscribed_not_before_dial` — pre-seed cache (via a first subscribe round), end attempt, emit nothing on the next attempt (dial "fails": `EndAttempt` before `Subscribed`) → cache retains entries; then `EmitSubscribed()` on a later attempt → cache empty.
+3. `Replay_upserts_by_request_id_and_entryadded_fires_on_new_keys_only` — two pendings with distinct ids → 2 EntryAdded; a re-push of the same id+promptId → no EntryAdded, count stays 2.
+4. `Tombstoned_prompt_id_is_dropped_and_survives_resubscribe` — resolve a pending to conclusion (ack Ok=true), then: `EmitPending(same identity)` → dropped; `EndAttempt` + new `Subscribed` + `EmitPending(same identity)` → STILL dropped (service-lifetime, spec §5 — the snapshot-before-ack/Subscribed-after-ack ordering); `EmitPending(different PromptId, same RequestId)` → admitted.
+5. `Conclusive_ack_evicts_by_identity_including_a_replayed_fresh_instance` — pending A admitted; a fresh DTO instance with A's identity re-admitted after a resubscribe clear; resolve the ORIGINAL `PendingConsent` object → ack concludes → the replayed instance (same PromptId) is evicted too.
+6. `Successor_with_same_request_id_survives_predecessors_ack` — A in cache; upsert B (same RequestId, different PromptId — replaces the cache slot); complete A's in-flight resolve with `Ok=false` → B still cached, 1 entry.
+7. `Resolve_outcome_mapping` — table-drive the ack → outcome mapping:
+   - `Ok=true, Error=null, RuleSaved=null`, saveRule:false → `(Applied, NotRequested)`
+   - `Ok=true, Error=null, RuleSaved=true`, saveRule:true → `(Applied, Saved)`
+   - `Ok=true, Error="store full", RuleSaved=false`, saveRule:true → `(AppliedRuleRejected, Rejected)`
+   - `Ok=true, Error=null, RuleSaved=null (old-format ack)`, saveRule:true → `(Applied, Saved)` (spec §4.1's Ok=true+Error=null carve-out)
+   - `Ok=false, RuleSaved=true`, saveRule:true → `(AlreadyDecided, Saved)`
+   - `Ok=false, RuleSaved=null`, saveRule:true → `(AlreadyDecided, Unknown)`
+   - `Ok=false, RuleSaved=null`, saveRule:false → `(AlreadyDecided, NotRequested)`
+8. `Save_rule_guard_null_and_empty_requester` — target with `Requester: null` and another with `""`, `ResolveAsync(..., saveRule: true)` → the sent `ConsentResolveDto.SaveRule` is NULL (assert via ScriptedLocalControlOps capture), outcome `(RuleSkippedNoRequester, SkippedNoRequester)`; a non-empty requester sends `("allow", requester, null, null, null)`.
+9. `Resolve_sends_the_targets_exact_prompt_id` — captured DTO's `PromptId == target.PromptId`, `RequestId == target.RequestId`.
+10. `Transport_failure_keeps_the_entry_and_refreshes_prune_after` — scripted `LocalControlOpsException("daemon_unreachable", …)` → outcome `TransportFailure`, entry still cached, `PruneAfter == now + 5s`.
+11. `Cancellation_propagates_and_keeps_the_entry` — pre-cancelled ct → `OperationCanceledException` from `ResolveAsync`, entry cached, no tombstone.
+12. `Prune_removes_past_prune_after_but_skips_the_inflight_target` — entry with `DeadlineHint` in the past: advance fake time past `PruneAfter`, tick → removed. Second entry mid-resolve (ScriptedLocalControlOps holds the call on a TCS): advance past `PruneAfter`, tick → NOT removed; complete the ack → evicted by conclusion (never double-removed).
+13. `Stream_end_while_connected_retries_after_1s` — `EndAttempt()`; fake-time advance 1s → `Attempts == 2` (and NOT before the advance).
+14. `Leaving_connected_cancels_the_loop_and_retains_entries` — status → Unreachable: entries stay; `Attempts` stops growing.
+15. `Deadline_hint_falls_back_on_unparseable_requested_at` — DTO with `RequestedAt: "garbage"` → `DeadlineHint ≈ now + TimeoutSeconds` (fake clock exact).
+
+- [ ] **Step 2: Run to verify failure** — compile errors.
+
+- [ ] **Step 3: Implement `ConsentService`**
+
+Key mechanics (full file — implementer writes it with these exact behaviors):
+
+```csharp
+public sealed class ConsentService : IConsentService {
+    readonly SourceCache<PendingConsent, string> _cache = new(p => p.RequestId);
+    readonly HashSet<string> _tombstones = [];       // concluded PromptIds — service lifetime, no cap (spec §5)
+    readonly Lock _lock = new();                     // guards _tombstones + _inFlightPromptId
+    readonly SemaphoreSlim _lane = new(1, 1);        // one resolve at a time (PauseController discipline)
+    string? _inFlightPromptId;                       // prune skip (spec §5)
+    // + injected fields, a CompositeDisposable, loop CTS management
+```
+
+- **Status subscription** (constructor-scoped): on each `AttachStatus`:
+  - Connected && caps contains `"consent/2"` → start the loop if not running (new CTS linked to `shutdownToken`).
+  - Connected && caps lack `consent/2` → stop the loop AND `_cache.Clear()` (stale incarnation, spec §5).
+  - Connecting/Unreachable → stop the loop; entries retained.
+- **Loop**: `while (!ct.IsCancellationRequested) { await foreach (evt in subscribe(ct)) { Subscribed → _cache.Clear(); Pending(dto) → Upsert(dto); } await Task.Delay(1s, time, ct); }` — OCE exits; any other exception from the enumeration is contained (log to `Console.Error`) and falls through to the delay.
+- **Upsert**: `lock` tombstone check → drop if `_tombstones.Contains(dto.PromptId)`; build `PendingConsent` (`DeadlineHint` = parse `RequestedAt` (`DateTimeOffset.TryParse`, round-trip style) + `TimeoutSeconds`, falling back to `time.GetUtcNow() + TimeoutSeconds`; `PruneAfter = DeadlineHint + 5s`); `var added = !_cache.Lookup(dto.RequestId).HasValue; _cache.AddOrUpdate(pc); if (added) _entryAdded.OnNext(Unit.Default);`
+- **ResolveAsync**: `await _lane.WaitAsync(ct)` (OCE propagates); build DTO (guard: `sendRule = saveRule && !string.IsNullOrEmpty(target.Dto.Requester)`); set `_inFlightPromptId = target.PromptId` under lock; call ops; on `LocalControlOpsException` → clear in-flight, `target.PruneAfter = time.GetUtcNow() + 5s`, re-`AddOrUpdate(target)` if still the cached identity, return `TransportFailure`; on ack → `Conclude(target)` then map (mapping per test 7 exactly; `AppliedRuleRejected` when `Ok && ruleOutcome is Rejected or Unknown`; `RuleSkippedNoRequester` when the guard skipped; `AlreadyDecided` when `!Ok`); `finally { _inFlightPromptId = null; _lane.Release(); }`.
+- **Conclude(target)**: `lock { _tombstones.Add(target.PromptId); }` then identity-guarded evict: `_cache.Edit(u => { var cur = u.Lookup(target.RequestId); if (cur.HasValue && cur.Value.PromptId == target.PromptId) u.Remove(target.RequestId); });` — the lookup-compare-remove inside ONE `Edit` is the atomicity (spec §5's "atomically records and evicts").
+- **Prune** (ticker subscription, constructor-scoped): `var now = time.GetUtcNow(); _cache.Edit(u => { foreach (var p in u.Items.Where(p => now > p.PruneAfter && p.PromptId != Volatile.Read(ref _inFlightPromptId)).ToList()) { var cur = u.Lookup(p.RequestId); if (cur.HasValue && cur.Value.PromptId == p.PromptId) u.Remove(p.RequestId); } });`
+- **Exposed**: `Pending => _cache.Connect()`, `PendingCount => _cache.CountChanged`, `EntryAdded`, `Dispose` (cancel loop CTS, dispose cache/subjects/lane).
+
+Add class doc comments carrying the spec's WHY for: service-lifetime tombstones (never retired — a client-local `Subscribed` is not ordered against a concurrent ack; PromptIds are never-reused GUIDs so retention is free), clear-at-`Subscribed` (failed dial must not erase an actionable queue), and the prune's in-flight skip + transport refresh.
+
+- [ ] **Step 4: Run to verify pass** — full App unit suite. Expected: PASS.
+- [ ] **Step 5: Commit** — `git commit -m "feat: ConsentService — status-driven subscription, identity-guarded cache, lifetime tombstones, prune hygiene"`
+
+---
+
+### Task 9: App — prompt window, ViewModel, coordinator, composition & shutdown
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs`
+- Create: `src/Capacitor.App/Views/ConsentPromptWindow.axaml` + `.axaml.cs`
+- Create: `src/Capacitor.App/Services/ConsentPromptCoordinator.cs`
+- Modify: `src/Capacitor.App/App.axaml.cs` (compose ConsentService + coordinator; shutdown order)
+- Test: `test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs`, `ConsentPromptCoordinatorTests.cs` (new)
+
+**Interfaces:**
+- Consumes: `IConsentService` (Task 8), `ITicker`, `IAppNotifier`.
+- Produces: `ConsentPromptCoordinator.ShowPromptWindow()` (Task 11's tray menu target); `App` fields `_consent`, `_promptCoordinator` in the disposal lists.
+
+- [ ] **Step 1: Write the failing VM tests** (headless via `AvaloniaSession`, fake ticker, fake `IConsentService` — a small `FakeConsentService` exposing a `SourceCache` + scriptable `ResolveAsync` results):
+
+VM behavior contract (spec §6) the tests pin:
+
+1. `Current_is_oldest_by_requested_at_then_id_and_position_text_reads_1_of_n` — 3 pendings → `Current` = oldest; `PositionText == "1 of 3"`, visible only when N > 1.
+2. `Pin_survives_cache_changes_while_resolving_or_in_terminal_hold` — start resolve (scripted hold) → add a new older entry → `Current` unchanged.
+3. `Requester_falls_back_display_then_id_then_unknown`; kind labels `agent→Agent, review→Review, review-flow→Review flow`; repo leaf via `RepoLabel.Leaf` with full path tooltip property.
+4. `Countdown_ticks_and_expiry_is_not_a_verdict` — fake time past `DeadlineHint`, tick → `CountdownText == "Response time elapsed — unanswered requests are denied by the daemon"` AND buttons remain enabled (spec §6); a subsequent Allow click that acks `Ok=true` → `Applied` (the wall-clock-step case); one acking `Ok=false` → AlreadyDecided path.
+5. `Buttons_send_the_pinned_targets_prompt_id` — each of the three commands → `FakeConsentService` captured `(target.PromptId, allow, saveRule)` = (`AllowOnce`: allow=true saveRule=false; `AllowRemember`: true/true; `Deny`: false/false).
+6. `Allow_remember_hidden_for_null_and_empty_requester` — `AllowRememberVisible` false for both; true otherwise.
+7. `Already_decided_holds_2_ticks_then_advances` — scripted `(AlreadyDecided, NotRequested)` → `PhaseText == "Already decided"`, buttons hidden; 2 fake ticks → advances to next pending.
+8. `Already_decided_discloses_rule_outcome_after_allow_remember` — scripted `(AlreadyDecided, Saved)` → text `Already decided — your allow rule for {requester} was still saved.`; `(AlreadyDecided, Rejected)` → `Already decided — no rule was saved.`; `(AlreadyDecided, Unknown)` → `Already decided — this daemon version doesn't report whether your allow rule was saved.`
+9. `Applied_advances_immediately_and_rule_warnings_toast` — `(Applied, Saved)` → no toast, advance; `(AppliedRuleRejected, Rejected)` → notifier received `Decision applied — rule not saved: {reason}`; `(Applied→RuleSkippedNoRequester …)` → warning; `(AppliedRuleRejected, Unknown)` → `Decision applied — this daemon version doesn't report whether the rule was saved`.
+10. `Transport_failure_reenables_buttons_and_keeps_current` — scripted `TransportFailure` → toast `Daemon unreachable — the request is still pending`, buttons enabled, same `Current`.
+11. `Expiry_never_preempts_inflight_resolve` — resolve held; fake time past deadline + tick → `CountdownText == "Expiring…"`, no advance; ack `Ok=true` → Applied.
+12. `Advance_on_pinned_removal_in_expired_state` — expired display (no resolve); service prune removes the pinned entry → VM advances/closes-empty.
+13. `Resolving_disables_all_buttons` (no double-submit).
+14. `Cancellation_is_a_silent_abort` — scripted OCE → no toast, entry kept, buttons re-enabled.
+
+Coordinator tests:
+
+15. `Raise_on_entry_added_while_window_not_visible_marshals_to_ui_thread` — EntryAdded fired from a background thread → window created+shown (headless lifetime); fired again while visible → no second window, no re-activation call.
+16. `Close_is_defer_reopen_via_show` — close the window (no decision) → cache untouched; `ShowPromptWindow()` → a fresh window instance shows the same queue.
+17. `Dispose_closes_the_window` — for the shutdown path.
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement**
+
+`ConsentPromptViewModel` (constructor: `IConsentService consent, IAppNotifier notifier, ITicker ticker, TimeProvider time, CancellationToken shutdownToken`): activation-scoped (`WhenActivated`) subscription to `consent.Pending` sorted by (`RequestedAt`, `RequestId` ordinal) into a stable `ObservableCollectionExtended` (the AI-1651 stable-collection lesson), OAPH projections for all display text, `enum Phase { Ready, Resolving, AlreadyDecided, Expired }` state machine, 2-tick terminal holds driven by `ticker.Ticks`, commands calling `consent.ResolveAsync(pinned, …)` with the OCE-silent catch. Copy strings exactly as listed in Global Constraints + step 1. Pin logic: `_pinned` field set when `Current` first renders or after each advance; advance = clear pin, take current sorted head.
+
+`ConsentPromptWindow.axaml`: `rxui:ReactiveWindow x:TypeArguments="vm:ConsentPromptViewModel"`, `Width="460" Height="260"`, `CanResize="False"`, `Topmost="True"`, `WindowStartupLocation="CenterScreen"`, `Icon` same as MainWindow. Layout: requester (bold, 16pt), kind · vendor row, repo leaf with `ToolTip.Tip`, countdown line, phase text, button row (`Allow once` / `Allow & remember` with the verbatim tooltip / `Deny`), position text top-right. Code-behind mirrors `MainWindow.axaml.cs`'s notifier attachment: a `WindowNotificationManager` created in `OnLoaded` with `Notifier` property wiring (extend `AppNotifier` usage exactly the way MainWindow does — read `MainWindow.axaml.cs` first and copy its subscription discipline).
+
+`ConsentPromptCoordinator`:
+
+```csharp
+/// Owns the single consent prompt window (spec §6): at most one instance at a time; closing
+/// releases it (an explicit defer — the queue is untouched) and a later raise re-creates it.
+/// The service knows nothing about windows — THIS class filters the unconditional EntryAdded
+/// signal by visibility and marshals to the UI thread.
+public sealed class ConsentPromptCoordinator : IDisposable {
+    readonly Func<ConsentPromptWindow> _windowFactory;
+    readonly IDisposable _subscription;
+    ConsentPromptWindow? _window;
+
+    public ConsentPromptCoordinator(IConsentService consent, Func<ConsentPromptWindow> windowFactory) {
+        _windowFactory = windowFactory;
+        _subscription = consent.EntryAdded.Subscribe(_ =>
+            Dispatcher.UIThread.Post(() => { if (_window is not { IsVisible: true }) ShowPromptWindow(); }));
+    }
+
+    public void ShowPromptWindow() {
+        if (_window is null) {
+            var w = _windowFactory();
+            w.Closed += (_, _) => { if (ReferenceEquals(_window, w)) _window = null; };
+            _window = w;
+            w.Show();
+        }
+        _window.Show();
+        _window.Activate();
+    }
+
+    public void Dispose() {
+        _subscription.Dispose();
+        _window?.Close();
+        _window = null;
+    }
+}
+```
+
+`App.axaml.cs` `StartAsync` additions (after `actions`):
+
+```csharp
+_consent = new ConsentService(service, ops, ticker,
+    ct => ConsentSubscription.RunAsync(service.DaemonName, ct), TimeProvider.System, _shutdown.Token);
+_promptCoordinator = new ConsentPromptCoordinator(_consent,
+    () => new ConsentPromptWindow {
+        DataContext = new ConsentPromptViewModel(_consent, notifier, ticker, TimeProvider.System, _shutdown.Token),
+        Notifier = notifier,
+    });
+```
+
+Disposal lists (BOTH the shutdown list in `DisposeAndShutdownAsync` and the startup-failure list) become `[_tray, _trayVm, _promptCoordinator, _consent, _pause]` — coordinator before service before the daemon client (spec §5 shutdown order); the corresponding null-out lines on the failure path gain the two new fields. `AppStartupTests`' disposal-order recording tests get the two new entries asserted in order.
+
+- [ ] **Step 4: Run to verify pass** — full App suite (including the updated AppStartupTests). Expected: PASS.
+- [ ] **Step 5: Commit** — `git commit -m "feat: consent prompt window — pinned queue, honest terminal states, coordinator-owned raise"`
+
+---
+
+### Task 10: App — Activity tab
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/ActivityViewModel.cs`
+- Modify: `src/Capacitor.App/Views/MainWindow.axaml` (+ `.axaml.cs` if control lookups change)
+- Test: `test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs` (new); run `MainWindowSmokeTests`/`AgentGridTests` to prove the tab restructure broke nothing
+
+**Interfaces:**
+- Consumes: `ConsentDecisionLogReader.ReadTail` (Task 6 — injected as `Func<int, ConsentLogReadResult>` for tests), `ITicker`, stat provider seam `Func<(DateTime? mtime, long? length)[]>` or simpler: inject `Func<string?>` — see below.
+- Produces: `ActivityViewModel` with `ReadOnlyObservableCollection<ActivityRow> Rows`, `bool IsEmpty`, `void OnTabVisibleChanged(bool visible)`, `void OnOwnResolution()` (Task 9's VM calls it? No — keep decoupled: MainWindowViewModel wires `consent` acks? Simplest per spec: the prompt VM's conclusive ack path calls `IActivityRefresh.RequestRefresh()`; implement as an interface on ActivityViewModel registered at composition. See Step 3.)
+
+- [ ] **Step 1: Write the failing tests**
+
+`ActivityRow` mapping + refresh semantics (spec §7):
+
+1. `Rows_map_records_with_fallbacks_and_source_labels` — record → row: local time `yyyy-MM-dd HH:mm:ss` (unparseable `decided_at` renders verbatim); requester fallback chain; kind labels; repo leaf + full tooltip; source labels `owner→owner, rule[7]→rule, default→default policy, prompt_user→you, prompt_timeout→timeout, prompt_no_ui→no UI attached, weird→weird` (verbatim); outcome `allowed`/`denied` drives `IsAllowed` for the badge.
+2. `Complete_read_replaces_rows_including_to_empty` — first read 2 records; second scripted read `([], Complete=true)` → rows empty, `IsEmpty` true.
+3. `Incomplete_read_keeps_last_good_rows` — `(1 record, Complete=false)` after a good 2-record read → still the 2 rows; with NO previous rows → shows the 1 partial row.
+4. `Stat_poll_rereads_only_on_change_every_2_ticks_while_visible` — scripted stat function; tick × 2 with unchanged stats → no re-read (count the injected read calls); change stats → re-read on the next 2nd tick; `OnTabVisibleChanged(false)` → no polling.
+5. `Tab_visible_triggers_immediate_refresh`.
+6. `Own_resolution_refresh_is_eventual` — `RequestRefresh()` → one immediate read; the record "appears no later than the next poll" (second read after stat change on a later tick).
+7. `Poll_survives_a_throwing_stat_or_read` — a stat/read that throws once → swallowed, polling continues next tick.
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement**
+
+`ActivityViewModel` (constructor: `Func<ConsentLogReadResult> read` — prod `() => ConsentDecisionLogReader.ReadTail(daemonName, 200)`; `Func<(DateTime?, long?), (DateTime?, long?)>`? Keep it simple and testable: `Func<string>` **statKey** — prod computes `$"{mtime.Ticks}:{length}"` for both files via `File.GetLastWriteTimeUtc`/`FileInfo.Length` inside try/catch returning `"absent"` on failure; the VM re-reads when the key differs from the last poll's; `ITicker ticker`): every-2nd-tick gate via a counter while `_visible`; `RequestRefresh()` public (immediate read). Rows in a stable `ObservableCollectionExtended<ActivityRow>` replaced only on `Complete || Rows.Count == 0` per spec §7. All mutations marshalled with `ObserveOn(RxSchedulers.MainThreadScheduler)` where sourced from the ticker (already UI-thread) — direct is fine, document it.
+
+`ActivityRow` (plain record): `Time, Outcome ("allowed"/"denied"), IsAllowed, Requester, KindLabel, RepoLeaf, RepoFull, Vendor, SourceLabel`.
+
+`MainWindow.axaml` restructure: keep the header StackPanel (identity/status/buttons) as-is above a `TabControl` occupying the `*` row:
+
+```xml
+<TabControl Grid.Row="1" Margin="0,8,0,0">
+    <TabItem Header="Agents">
+        <!-- the ENTIRE existing agents block (divider, title, empty state, ScrollViewer+grid)
+             moves here unchanged — control names preserved so existing smoke tests keep finding
+             them in the window's name scope -->
+    </TabItem>
+    <TabItem Header="Activity">
+        <Grid RowDefinitions="Auto,*">
+            <TextBlock x:Name="ActivityEmptyText" Text="No decisions yet"
+                       IsVisible="{Binding Activity.IsEmpty}" HorizontalAlignment="Center" Margin="0,24,0,0" />
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                <StackPanel>
+                    <Grid x:Name="ActivityHeader" ColumnDefinitions="150,70,120,90,140,90,110" Margin="0,0,0,4"
+                          IsVisible="{Binding !Activity.IsEmpty}">
+                        <!-- Time / Outcome / Requester / Kind / Repo / Vendor / Source bold headers,
+                             same style as AgentsGridHeader -->
+                    </Grid>
+                    <ItemsControl ItemsSource="{Binding Activity.Rows}">
+                        <!-- one Grid row per ActivityRow, same column widths; Outcome TextBlock
+                             Foreground green (#2E7D32) when IsAllowed else red (#D32F2F) -->
+                    </ItemsControl>
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </TabItem>
+</TabControl>
+```
+
+`MainWindowViewModel` gains `public ActivityViewModel Activity { get; }` (constructor-injected). Tab visibility: bind `TabControl.SelectionChanged` in `MainWindow.axaml.cs` to `Activity.OnTabVisibleChanged(activityTabSelected && windowVisible)`; also window `IsVisible` changes (`Opened`/`Hidden` — hook the same events the window already handles). Own-resolution refresh: `App.axaml.cs` composition passes the SAME `ActivityViewModel` instance's `RequestRefresh` as an `Action` into `ConsentPromptViewModel` (add an optional `Action? onConcluded = null` ctor param there, invoked after every conclusive ack) — one composition-root wire, no service coupling.
+
+Update `App.BuildAndShowMainWindow` and every VM-construction call site accordingly.
+
+- [ ] **Step 4: Run to verify pass** — full App suite (smoke tests prove the tab move). Expected: PASS.
+- [ ] **Step 5: Commit** — `git commit -m "feat: Activity tab — decision-log feed with stat-poll refresh and last-good display"`
+
+---
+
+### Task 11: App — tray Attention row + Review menu item; final sweep
+
+**Files:**
+- Modify: `src/Capacitor.App/ViewModels/TrayModels.cs`, `TrayViewModel.cs`, `Views/TrayMenuBuilder.cs`
+- Modify: `src/Capacitor.App/App.axaml.cs` (pass consent + coordinator into `TrayViewModel`)
+- Test: extend `test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs`, `TrayAdapterTests.cs`
+
+**Interfaces:**
+- Consumes: `IConsentService.PendingCount` (Task 8), `ConsentPromptCoordinator.ShowPromptWindow` (Task 9).
+- Produces: `TrayMenuModel(TrayState State, int RunningCount, string Header, IReadOnlyList<TrayAgentEntry> Agents, TrayPauseItem Pause, int PendingConsent)`; `TrayViewModel.ReviewPendingCommand`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`TrayViewModelTests` additions (follow the file's existing Build/Project-driving patterns):
+
+1. `Pending_consent_asserts_attention_over_idle_and_running` — Connected+idle with pendingCount 1 → `State == Attention`, header `"{daemonName}: 1 launch awaiting approval"`; Connected+2 agents running with pendingCount 3 → `Attention`, header `"{daemonName}: 3 launches awaiting approval"`, `RunningCount` still 2 (the badge keeps the agent count).
+2. `Connection_trouble_rows_keep_precedence` — Unreachable/unreachable-reason with pendingCount 5 → still `Stopped` (row 1); Connected+`reconnecting` with pending → `Attention` with the RECONNECTING header (row 5 wins the copy).
+3. `Review_item_visible_only_with_pending` — `MenuModel.PendingConsent == 0` → builder emits no review item; `> 0` → item present between the agents section and the pause item, invoking `ReviewPendingCommand` calls the injected open action (assert via recorded delegate).
+
+`TrayAdapterTests`: extend the menu-shape assertions for the new item (label `Review pending launches…`, placement).
+
+- [ ] **Step 2: Run to verify failure.**
+
+- [ ] **Step 3: Implement**
+
+`TrayModels.cs`: append `int PendingConsent` to `TrayMenuModel`.
+
+`TrayViewModel`: ctor gains `IConsentService consent, Action? openReviewPrompts = null`; `ReviewPendingCommand = ReactiveCommand.Create(openReviewPrompts ?? (() => { }));` combine stream becomes `service.Status.CombineLatest(snapshots, pause.State, actions.StopsInFlight, consent.PendingCount.StartWith(0), (status, snap, pauseState, inFlight, pending) => Build(...))`. In `Build`/`Project`: after the existing ten-row projection, apply the new rule (spec §8):
+
+```csharp
+// Row 11 (spec §8): pending consent asserts Attention only while Connected — a launch is
+// awaiting the owner. Connection-trouble rows above keep precedence; the running-count badge
+// keeps the agent count.
+if (status.State == AttachState.Connected && pendingConsent > 0 && state is TrayState.Idle or TrayState.Running)
+    return BuildWithAttention(...); // state = Attention, header body $"{pendingConsent} launch{(pendingConsent == 1 ? "" : "es")} awaiting approval"
+```
+
+(Restructure `Build`/`HeaderText` minimally: pass `pendingConsent` down; the pending header wins only when the row-11 rule fired.)
+
+`TrayMenuBuilder`: between the agents section and the pause toggle, when `model.PendingConsent > 0`, add a `NativeMenuItem { Header = "Review pending launches…" }` wired to `ReviewPendingCommand` following the file's existing item-construction pattern (mind the AI-1651 lesson comment in that file: `IsEnabled` assigned LAST after `Command`).
+
+`App.axaml.cs`: `_trayVm = new TrayViewModel(service, _pause, actions, _consent, openMainWindow: …, quit: …, openReviewPrompts: _promptCoordinator.ShowPromptWindow);` (adjust parameter order to taste; update `TrayViewModel` test constructions with a `FakeConsentService`).
+
+- [ ] **Step 4: Run to verify pass** — full App suite.
+
+- [ ] **Step 5: Final sweep + commit**
+
+```bash
+dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj
+dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj
+dotnet run --project test/Capacitor.Cli.Tests.Integration/Capacitor.Cli.Tests.Integration.csproj
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'  # no output
+git add -A && git commit -m "feat: tray Attention on pending consent + Review pending launches menu item"
+```
+
+Spec-conformance spot-check before hand-off: §6 copy strings verbatim in the built XAML/VM, §9 table rows each traceable to a test, disposal order `[tray, trayVm, promptCoordinator, consent, pause]` asserted.
+
+---
+
+## Self-Review Notes (already applied)
+
+- **Spec coverage:** §4.1 → Tasks 1–4; §4.2 → Task 5; §4.3 → Task 2; §4.4 → Tasks 1+6; §5 → Task 8; §6 → Task 9; §7 → Task 10; §8 → Task 11; §9/§10 rows distributed to their owning tasks' test lists.
+- **Deliberate exclusions:** no README change (no CLI surface); no new `kcap daemon consent` verbs (spec §11); dock/notification work stays in AI-1653.
+- **Type consistency:** `ConsentResolveOutcome`/`PendingConsent`/`IConsentService` names identical across Tasks 8–11; `ITicker` identical across 7–10; DTO shapes identical across 1–5.
+- **Known churn points for implementers:** Task 1 intentionally leaves call sites mechanically null-extended (Tasks 2–3 rewire them); Task 7 touches many test files but only constructor arity; Task 10's XAML move must preserve control names for the existing smoke tests.

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -35,10 +35,11 @@ in Core; decision-record hoisting to Core (shared write/read shape); `requester_
 threading through the consent pipeline (additive); `rule_saved` reporting on `ConsentAckDto`
 (additive) so a rule installed for an already-decided request is disclosed, not hidden; a
 daemon-minted `prompt_id` request identity on `ConsentPendingDto` echoed on
-`ConsentResolveDto` and atomically claimed by the broker, advertised as a new `consent/2`
-capability the app requires, so a stale resolve can never decide a different launch that
-reused the id; hoisting the AI-1651 per-window ticker into an app-lifetime service; headless
-ViewModel tests for the full prompt matrix.
+`ConsentResolveDto` and atomically claimed by the broker, carried on **new v2 consent frame
+types** an old daemon structurally cannot decode (fail-closed on the wire) and advertised as
+a new `consent/2` capability for discovery, so a stale resolve can never decide a different
+launch that reused the id; hoisting the AI-1651 per-window ticker into an app-lifetime
+service; headless ViewModel tests for the full prompt matrix.
 
 **Out:** macOS system notification (AI-1653); consent-rules editor UI (slice 4); any change to
 engine matching, rule ordering/precedence, policy storage, or prompt timeout semantics; new
@@ -46,7 +47,8 @@ IPC frame types; Windows/Linux app packaging.
 
 ## 4. Wire & Core changes
 
-No new frame types and no protocol version change. Everything below is additive.
+Everything below is additive: two new append-only `FrameType` values (§4.1) and trailing
+DTO fields; no protocol version change and no change to any existing frame's semantics.
 
 ### 4.1 `ResolveConsentAsync` on `ILocalControlOps`, and `rule_saved` on the ack
 
@@ -55,8 +57,8 @@ Task<ConsentAckDto> ResolveConsentAsync(ConsentResolveDto resolve, CancellationT
 ```
 
 One-shot, exactly the existing `LocalControlOps` pattern (connect → send → single reply →
-close): writes `FrameType.ConsentResolve` with the `ConsentResolveDto` JSON as `Text`, expects
-exactly one `ConsentAck` frame, deserializes `ConsentAckDto`. Per-phase timeouts and failure
+close): writes `FrameType.ConsentResolveV2` (below) with the `ConsentResolveDto` JSON as
+`Text`, expects exactly one `ConsentAck` frame, deserializes `ConsentAckDto`. Per-phase timeouts and failure
 classification are identical to the existing ops — caller-cancellation propagates
 (`OperationCanceledException` checked first), `EndOfStreamException` before `IOException`
 (derivation order) → `unexpected_reply`, transport → `daemon_unreachable`, phase timeout →
@@ -126,15 +128,28 @@ value the daemon mints:
 guards and tombstones (§5) key on it, `RequestId` remains only the cache/broker key and the
 per-agent queue identity.
 
-**Capability `consent/2`.** The identity guarantee is only real when the daemon enforces it —
-a pre-AI-1652 daemon deserializes the resolve while silently dropping the unmapped `prompt_id`
-and resolves by id alone. `LocalControlCapabilities.Current` therefore appends **`consent/2`**
-(advertised, per the AI-1648 convention, only because the live handler enforces
-identity-checked resolution, populates `rule_saved`, and stamps `prompt_id`/
-`requester_display` on pendings). The app treats a daemon advertising `consent/1` without
-`consent/2` exactly like one with no consent capability at all: no subscription, no prompts,
-no resolves (§5) — mixed-version consent fails closed rather than degrading to the unguarded
+**V2 frames: enforcement is structural, not negotiated.** The identity guarantee is only real
+when the daemon enforces it — a pre-AI-1652 daemon deserializes the v1 resolve while silently
+dropping the unmapped `prompt_id` and resolves by id alone. A capability check cannot close
+this: capabilities are learned on one socket while consent ops travel on fresh bare-frame
+connections, so a daemon restart/downgrade between them (TOCTOU) would route a v2-shaped
+resolve into the v1 handler. The v2 operations therefore ride **new append-only frame
+types** — `ConsentSubscribeV2 = 17` and `ConsentResolveV2 = 18` — which the app uses
+exclusively. A v1 daemon's routing switch answers any unknown frame type with an `Error`
+frame (`LocalControlServer` default arm), so against a v1 incarnation the v2 resolve draws
+`daemon_rejected` (no resolution occurred — the cached prompt is *structurally impossible* to
+resolve through the v1 id-only handler, whichever incarnation answers the socket) and the v2
+subscribe ends without registering a subscriber (the v1 daemon keeps its fast `prompt_no_ui`
+denials instead of waiting on a subscriber that renders nothing). On a v2 daemon, frame 17
+routes to the same subscribe handler as frame 11, and frame 18 routes to a resolve path that
+**requires** `prompt_id` (missing/empty → `Ok=false` "invalid resolve payload"); the v1
+frames 11/12 remain routed unchanged for legacy callers, served by `TryResolve`'s null-echo
 path.
+
+**Capability `consent/2`** is appended to `LocalControlCapabilities.Current` as the
+*discovery* signal (advertised, per the AI-1648 convention, only because the live v2 handlers
+exist): §5 uses it to decide whether to run the consent loop and to surface the down-level
+condition. Security does not rest on it — the frames fail closed on their own.
 
 ### 4.2 Consent subscription client (Core)
 
@@ -150,9 +165,10 @@ public static async IAsyncEnumerable<ConsentStreamEvent> RunAsync(
     string daemonName, [EnumeratorCancellation] CancellationToken ct)
 ```
 
-Connects to the daemon's socket, writes `FrameType.ConsentSubscribe` (empty text), **yields
-`Subscribed` once** immediately after that write succeeds, then reads frames and yields one
-`Pending` per `ConsentPending` frame. The `Subscribed` event exists because an async iterator
+Connects to the daemon's socket, writes `FrameType.ConsentSubscribeV2` (empty text; §4.1 —
+a v1 daemon answers the unknown frame with `Error`, ending the enumeration without
+registering a subscriber), **yields `Subscribed` once** immediately after that write
+succeeds, then reads frames and yields one `Pending` per `ConsentPending` frame. The `Subscribed` event exists because an async iterator
 exposes no other observable boundary between "dialing" and "subscribed": with an empty replay
 the first read never completes, so a consumer that must act at the subscribe boundary (the §5
 cache clear) would otherwise have no signal. The daemon replays the full pending set
@@ -311,14 +327,18 @@ delivery latency. On every conclusive ack the service atomically (1) records the
 ghost-admitted-before-ack ordering, which a guard keyed on the original instance alone would
 miss. An incoming `Pending` whose `PromptId` is tombstoned is dropped; by the §4.1 identity
 contract a matching frame *is* the concluded request — never a distinct successor — so
-dropping is always correct. **Tombstones are scoped to the subscription connection, with no
-TTL**: they are retired in bulk at each `Subscribed` boundary, because a fresh replay provably
-cannot contain a concluded request (`TryResolve` removes the entry before the ack exists, and
-`Subscribe` snapshots the current map) — a time-based TTL would reopen the window for a frame
-delayed past it. Within one connection the set grows only with conclusions on that connection;
-a defensive FIFO cap of 1024 bounds pathological lifetimes and is documented as such. Expiry/
-prune do **not** tombstone: a request the app merely gave up on locally is still live
-daemon-side (the clock-step case) and must be allowed to reappear.
+dropping is always correct — **forever**. Tombstones therefore live for the
+**`ConsentService` lifetime: no TTL, no per-connection retirement, no size cap.** Any time-
+or boundary-based retirement reopens a window: a client-local `Subscribed` is not ordered
+against a concurrent ack (the daemon can snapshot a replay *before* a resolve concludes while
+the app processes the ack *before* its local `Subscribed` — retiring there would admit the
+still-in-flight snapshotted frame), and any cap's eviction re-admits a frame delayed past it.
+None of that trades against anything real: a `PromptId` is a GUID that is never reused, so a
+lifetime tombstone can never wrongly suppress a future request, and the memory cost is ~50
+bytes per *concluded human decision* — thousands of conclusions in one app session amount to
+hundreds of kilobytes, accepted and documented. Expiry/prune do **not** tombstone: a request
+the app merely gave up on locally is still live daemon-side (the clock-step case) and must be
+allowed to reappear.
 
 **Subscription lifecycle — status-driven.** The service observes
 `DaemonClientService.Status`:
@@ -551,12 +571,12 @@ cadence picks up count changes through the model stream — no new refresh machi
 | Failure | Surface | Behavior |
 |---|---|---|
 | Daemon unreachable (no subscription) | Tray | Existing AI-1651 rows; no prompts possible; feed still renders from file |
-| Daemon without `consent/2` (incl. `consent/1`-only) | Tray | No subscription, prompts, or resolves — identity check can't be enforced; cache cleared; existing down-level surfacing |
+| Daemon without `consent/2` (incl. `consent/1`-only) | Tray | No subscription, prompts, or resolves; cache cleared; down-level surfacing. Enforcement doesn't depend on the check: a v1 incarnation answering a v2 frame (restart TOCTOU) errors it — structurally unable to resolve or subscribe (§4.1) |
 | Consent dial fails while status Connected | none (self-heal) | Cache NOT cleared (clear sits at the `Subscribed` boundary); 1s delay → retry |
 | Daemon dies between subscribe write and replay | none (self-heal) | Cache cleared but restored by the next successful replay (~1s cadence); bounded, UI-only (§5) |
 | Consent stream dies while Connected | none (self-heal) | 1s delay → resubscribe (fresh replay reconciles at the `Subscribed` boundary) |
 | Structurally invalid pending frame | none | Skipped (ending the stream would thrash the resubscribe loop) |
-| Ghost replay of a just-concluded request | none | Arrives after the ack → connection-scoped tombstone drops it (no TTL — arbitrarily delayed frames stay dropped); admitted before the ack → the ack's identity-matched eviction removes it — no second prompt either way |
+| Ghost replay of a just-concluded request | none | Arrives after the ack → service-lifetime tombstone drops it (no TTL, no retirement, no cap — arbitrarily delayed frames stay dropped, across resubscribes); admitted before the ack → the ack's identity-matched eviction removes it — no second prompt either way |
 | Wall-clock step vs. daemon's monotonic deadline | Prompt window | Hint expiry is never a verdict: non-authoritative copy, buttons stay active, ack governs |
 | Resolve transport failure | Prompt toast | Entry kept; buttons re-enable |
 | Resolve cancelled (shutdown) | none | OCE propagates; silent abort — never rendered as transport failure |
@@ -585,8 +605,11 @@ throughout — no real sleeps).
   yield `Pending` events in order; EOF ends enumeration; failed connect (`SocketException`)
   ends enumeration without yielding `Subscribed`; unexpected frame type ends enumeration;
   undecodable JSON ends enumeration; **decodable-but-structurally-invalid pending (null
-  request_id via `{}`) is skipped and the stream continues**; `ct` propagates OCE. Absent
-  `requester_display` deserializes to null.
+  request_id via `{}`) is skipped and the stream continues**; **the `PromptId` requirement is
+  isolated: a v1-shaped pending with every pre-existing field valid and `prompt_id`
+  separately absent, null, and empty yields no `Pending` event and the stream continues** (a
+  `{}` frame alone would stay green with the PromptId check forgotten); `ct` propagates OCE.
+  Absent `requester_display` deserializes to null.
 - `ConsentDecisionLogReader`: tail across the rotation pair (order, cap, newest-first);
   undecodable-line skip; **parseable-but-structurally-invalid line (`{}`) skip**;
   `Distinct()` dedup; absent files → `([], Complete=true)`; **one file unreadable (I/O
@@ -622,6 +645,13 @@ throughout — no real sleeps).
 - Capability: `LocalControlCapabilities.Current` advertises `consent/2` alongside
   `consent/1`; mixed-version acceptance — an app facing a `consent/1`-only capability set
   starts no subscription and sends no resolve.
+- Incarnation swap (the restart TOCTOU): against a v1-routing server (routes frames 11/12,
+  answers 17/18 with the shipped `default`-arm `Error` frame), a cached v2 prompt's resolve
+  via `ConsentResolveV2` draws `daemon_rejected` — **no resolution occurs and a same-id
+  pending on that daemon is untouched**; `ConsentSubscribeV2` against the same server ends
+  the enumeration without registering a subscriber. V2-daemon side: frame 18 with a
+  missing/empty `prompt_id` acks `Ok=false` "invalid resolve payload"; frames 11/12 still
+  route for legacy callers.
 
 **App (the "full prompt matrix" from the issue):**
 - Allow once / Deny → correct `ConsentResolveDto`, entry removed, queue advances.
@@ -637,11 +667,13 @@ throughout — no real sleeps).
   prompted; **B arrives after A's `Ok=true` ack** → A was evicted, B is admitted and
   prompted. In both, the successor is decided only on its own terms.
 - Ghost replay (both orderings): a ghost `Pending` arriving *after* A's conclusive ack is
-  dropped by the tombstone — **including one delayed arbitrarily long within the same
-  subscription connection** (no TTL to outlive); a ghost admitted *before* the ack (reconnect
-  replay raced the resolve — a fresh instance with A's identity) is evicted by the ack's
-  identity-matched removal — no second raise either way. Tombstones are retired at the
-  `Subscribed` boundary: after a resubscribe, a fresh replay's entries are admitted normally.
+  dropped by the tombstone — **including one delayed arbitrarily long, and including the
+  snapshot-before-ack / `Subscribed`-after-ack interleaving** (daemon snapshots the replay,
+  the resolve concludes and tombstones A, the local `Subscribed` fires, THEN the snapshotted
+  A frame arrives — still dropped: tombstones survive the boundary); a ghost admitted
+  *before* the ack (replay raced the resolve — a fresh instance with A's identity) is evicted
+  by the ack's identity-matched removal — no second raise either way. Entries never concluded
+  are admitted normally after any resubscribe (their `PromptId`s are not tombstoned).
 - Hint expiry with no resolve in flight → non-authoritative copy, **buttons remain active**;
   a click after hint-zero that acks `Ok=true` is `Applied` (the wall-clock-step case: hint
   fired early, request was still live); one that acks `Ok=false` runs "Already decided"; the

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -1,0 +1,371 @@
+# Consent prompt window + Activity feed (desktop supervisor, AI-1652)
+
+Umbrella: `2026-07-31-desktop-supervisor-app-design.md` §5–6. Builds on the AI-1650 app shell,
+the AI-1651 tray/agents/stop slice, and the AI-1623/AI-1648 consent IPC. One PR.
+
+## 1. Problem
+
+The daemon-side consent machinery is complete: a `prompt`-mode launch parks at
+`LaunchConsentGate`, the broker replays/pushes `ConsentPending` frames to local-socket
+subscribers, and `ConsentResolve` settles the launch. But nothing subscribes. On a machine
+running the app, a `prompt` policy currently burns the AI-1648 subscriber grace and denies as
+`prompt_no_ui` — the original "daemon launches without asking" complaint is only answerable
+once the app raises a prompt. Separately, every decision (rule-matched and human) is appended
+to `consent-decisions.jsonl`, but no UI renders it.
+
+This slice ships the consent UX: an auto-raised prompt window, an Activity tab rendering the
+decision log, and pending-consent wired into the tray's existing `Attention` state.
+
+## 2. Decisions (settled in brainstorming, 2026-08-08)
+
+| Decision | Choice |
+|---|---|
+| Activity feed read surface | **Direct file read** of `consent-decisions.jsonl` (+ `.1`), formalized as a documented read-only contract with a shared record type in Core. No new IPC frames. Precedent: `kcap daemon consent log` already reads the file and works with the daemon stopped. |
+| "Always allow" rule scope | **Requester-only**: `(action: allow, requester: <id>, kind: null, repo: null, vendor: null)`. The trust decision is about the person. Finer grain arrives with the Settings rules editor (umbrella slice 4). |
+| macOS system notification | **Deferred to AI-1653.** `UNUserNotificationCenter` needs a signed bundle identity; the auto-raised prompt window is the always-works path (umbrella §11). |
+| Main window layout | **Tabs**: Agents \| Activity. Settings slots in as a third tab in slice 4. |
+| Multiple pending requests | **One window, queued**: shows the oldest pending with a "1 of N" indicator; deciding or expiry advances. |
+
+## 3. Scope
+
+**In:** consent subscription service in the app; prompt window (Allow once / Always allow /
+Deny, countdown, queue); Activity tab; tray `Attention` on pending consent + "Review pending
+launches…" menu item; `ResolveConsentAsync` on `ILocalControlOps`; consent subscription client
+in Core; decision-record hoisting to Core (shared write/read shape); `requester_display`
+threading through the consent pipeline (additive); headless ViewModel tests for the full
+prompt matrix.
+
+**Out:** macOS system notification (AI-1653); consent-rules editor UI (slice 4); any daemon
+policy/engine behavior change; new IPC frame types; Windows/Linux app packaging.
+
+## 4. Wire & Core changes
+
+No new frame types and no protocol version change. Everything below is additive.
+
+### 4.1 `ResolveConsentAsync` on `ILocalControlOps`
+
+```csharp
+Task<ConsentAckDto> ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct);
+```
+
+One-shot, exactly the existing `LocalControlOps` pattern (connect → send → single reply →
+close): writes `FrameType.ConsentResolve` with the `ConsentResolveDto` JSON as `Text`, expects
+exactly one `ConsentAck` frame, deserializes `ConsentAckDto`. Per-phase timeouts and failure
+classification are identical to the existing ops — caller-cancellation propagates
+(`OperationCanceledException` checked first), `EndOfStreamException` before `IOException`
+(derivation order) → `unexpected_reply`, transport → `daemon_unreachable`, phase timeout →
+`timed_out`; a null/malformed ack or a non-`ConsentAck` frame → `unexpected_reply`. The
+`ConsentAckDto` is returned as-is: `Ok` reflects the resolution outcome, `Error` carries either
+the failure detail or the partial-failure warning on `Ok=true` (rejected `save_rule`).
+
+The daemon handler exists (`LaunchConsentIpc.HandleResolveAsync`); this is client plumbing only.
+No hello is needed on one-shot connections (hello is optional; the CLI consent verbs already
+send bare frames).
+
+### 4.2 Consent subscription client (Core)
+
+`ConsentSubscription` in `Capacitor.Cli.Core/LocalIpc/`:
+
+```csharp
+public static async IAsyncEnumerable<ConsentPendingDto> RunAsync(
+    string daemonName, [EnumeratorCancellation] CancellationToken ct)
+```
+
+Connects to the daemon's socket, writes `FrameType.ConsentSubscribe` (empty text), then reads
+frames and yields one `ConsentPendingDto` per `ConsentPending` frame. The daemon replays the
+full pending set immediately, then pushes new requests (broker contract: exactly-once per
+subscriber, no withdrawal push).
+
+Termination contract: EOF and transport `IOException` end the enumeration normally (an ended
+stream means "disconnected" — the consumer decides whether to resubscribe). A frame of any
+other type, or a `ConsentPending` frame whose JSON does not deserialize, also ends the
+enumeration — protocol confusion is treated as a dead connection, not skipped, and the
+consumer's resubscribe gets a fresh replay. Only `OperationCanceledException` (the caller's
+`ct`) propagates.
+
+### 4.3 `requester_display` threading (additive)
+
+The consent pipeline predates AI-1791's `RequesterDisplay` on `LaunchAgentCommand` and still
+carries only the requester *id* — the prompt and the feed would show `github:2821205`, which
+the grid work already established is unacceptable. Thread the display name through, additively:
+
+- `LaunchConsentInput` gains trailing `string? RequesterDisplay`. Engine matching is untouched
+  — rules match on `RequesterUserId` only.
+- `LaunchConsentPromptRequest` gains trailing `string? RequesterDisplay`.
+- `ConsentPendingDto` gains trailing `string? RequesterDisplay` (wire `requester_display`,
+  positional-required convention: no C# default, nulls always written). A pre-AI-1652 daemon
+  never sends it; STJ source-gen leaves the member null on absence, and the app falls back to
+  the id.
+- The hoisted decision record (§4.4) gains trailing `string? RequesterDisplay`
+  (`requester_display`); old log lines lack the field and read back as null.
+- `AgentOrchestrator` passes `cmd.RequesterDisplay` into `LaunchConsentInput` at the gate call
+  site; `LaunchConsentGate` threads it into the prompt request and into `Done()`'s record.
+
+Presentation rule everywhere (prompt, feed): `RequesterDisplay ?? Requester ?? "unknown"` —
+same fallback chain as `AgentRowViewModel.Requester`.
+
+### 4.4 Decision-log read contract (record hoisting)
+
+The daemon's internal `LaunchConsentRecord` + private JSON context move to Core as the single
+write/read shape — the "documented read-only contract" is a shared type, not prose:
+
+```csharp
+// Capacitor.Cli.Core/LocalIpc/ConsentDecisionLog.cs
+public sealed record ConsentDecisionRecord(
+    string DecidedAt, string AgentId, string? Requester, bool RequesterIsOwner,
+    string Kind, string RepoPath, string Vendor, string Outcome, string Source,
+    string? RequesterDisplay);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(ConsentDecisionRecord))]
+public partial class ConsentDecisionJsonContext : JsonSerializerContext;
+```
+
+Field names are the existing snake_case wire names verbatim (`decided_at`, `agent_id`,
+`requester`, `requester_is_owner`, `kind`, `repo_path`, `vendor`, `outcome`, `source`) plus the
+new trailing `requester_display` — existing log files remain readable byte-for-byte.
+`Outcome` is `allowed | denied`; `Source` is `owner | rule[i] | default | prompt_no_ui |
+prompt_user | prompt_timeout` (engine + gate, recorded verbatim). `Kind` is the engine token
+`agent | review | review-flow`.
+
+The daemon's `LaunchConsentDecisionLog` writes this Core type via this Core context (its
+internal record and private context are deleted); its writer behavior — append-only, 0600 from
+first byte, 1MB rotation to `.1` via `File.Move` — is unchanged. The CLI `log` verb prints raw
+lines and is unaffected.
+
+**Reader** (Core, same file):
+
+```csharp
+public static class ConsentDecisionLogReader {
+    public static string PathFor(string daemonName);   // DaemonLockPaths.Directory / Sanitize(name) / consent-decisions.jsonl
+    public static IReadOnlyList<ConsentDecisionRecord> ReadTail(string daemonName, int max);
+}
+```
+
+`ReadTail` reads `{path}.1` then `{path}` (each may be absent), keeps the last `max` parseable
+records, newest first. Rules:
+
+- **Sharing:** every open is `FileAccess.Read` with `FileShare.ReadWrite | FileShare.Delete` —
+  the daemon appends and rotates (`File.Move`) this file live; a default write-denying or
+  delete-denying open would block the daemon's own writer on Windows (the AI-1629 bug class).
+- **Malformed lines** (torn tail write, hand-edited file) are skipped, not fatal.
+- **Rotation race:** a rotation between the two reads can transiently duplicate or miss lines.
+  Records have value equality — the merged list is `Distinct()`-ed, and a miss self-heals on
+  the next refresh (§7). Accepted: this is a display feed, not an audit query.
+- Absent files → empty list (the feed renders its empty state; no error).
+
+## 5. `ConsentService` (app)
+
+`src/Capacitor.App/Services/ConsentService.cs` (+ `IConsentService`): owns the consent
+subscription, the pending queue, and resolution. Single instance, created at startup beside
+`DaemonClientService`.
+
+**State:** `SourceCache<PendingConsent, string>` keyed by `RequestId`. `PendingConsent` wraps
+the `ConsentPendingDto` plus a computed `DeadlineHint = RequestedAt + TimeoutSeconds`
+(`DateTimeOffset` parse of the daemon's ISO stamp; same machine, so no clock-skew handling; an
+unparseable `RequestedAt` falls back to arrival time + `TimeoutSeconds`).
+The deadline is a *hint* — AI-1648's subscriber grace means the daemon's real deadline can
+differ slightly; the authoritative outcome is only ever a resolve ack.
+
+**Subscription lifecycle — status-driven.** The service observes
+`DaemonClientService.Status`:
+
+- On `Connected` with capabilities containing `"consent/1"` → start the subscription loop.
+- On leaving `Connected` (Connecting/Unreachable) → cancel the loop. Pending entries are NOT
+  cleared on disconnect — the daemon may still be alive holding live prompts; entries expire
+  via their own deadline hints, and a resubscribe reconciles (below).
+- `Connected` without `consent/1` (down-level daemon) → no subscription, no prompts; the
+  existing shell surfaces the daemon-outdated condition.
+
+**Loop:** while in the connected state: clear the pending cache, then enumerate
+`ConsentSubscription.RunAsync(daemonName, ct)`, upserting each DTO by `RequestId`. The clear
+immediately precedes each connection attempt — the daemon's replay is the authoritative
+pending set, and there is no end-of-replay marker, so reset-then-rebuild is the only honest
+reconciliation. If the enumeration ends while status still reports Connected (protocol
+confusion, half-dead socket), delay 1s and go around. Loop cancellation stops cleanly.
+
+**Pruning:** on the shared 1-second ticker, entries with `now > DeadlineHint + 5s` are removed
+from the cache. This bounds ghost entries from requests that expired daemon-side (there is no
+withdrawal push) and from disconnected periods. The prompt VM shows the expired state before
+the prune fires (§6).
+
+**Resolution:**
+
+```csharp
+Task<ConsentResolveOutcome> ResolveAsync(string requestId, bool allow, bool saveRule, CancellationToken ct);
+```
+
+Builds the `ConsentResolveDto` (`decision: allow|deny`; when `saveRule`, a requester-only
+`save_rule` from the pending entry's `Requester`) and calls
+`ILocalControlOps.ResolveConsentAsync`. One resolve in flight at a time — serialized on one
+lane, same discipline as `PauseController`. Outcome mapping:
+
+| Result | Cache effect | Meaning |
+|---|---|---|
+| `Ok=true, Error=null` | remove entry | applied |
+| `Ok=true, Error!=null` | remove entry | applied; rule save rejected — warn |
+| `Ok=false` | remove entry | already decided (daemon timeout / raced) |
+| `LocalControlOpsException` / OCE | keep entry | transport failure — request may still be pending daemon-side |
+
+**Exposed:** the pending cache (`IObservable` via DynamicData `.Connect()`),
+`IObservable<int> PendingCount`, `ResolveAsync`, and a raise signal: an event/observable that
+fires when an entry is added while the prompt window is not visible (drives auto-raise, §6).
+The count feeds `TrayViewModel` (§8).
+
+## 6. Prompt window
+
+`ConsentPromptWindow` + `ConsentPromptViewModel`. One instance ever, owned by a coordinator
+(pattern of `MainWindowCoordinator`): open-or-activate; closing hides/releases but a later
+raise re-creates. Fixed compact size (460×260 starting point, subject to live-acceptance
+polish; non-resizable), `Topmost = true`, centered.
+
+**Raise policy:** the window opens and the app activates when a pending entry is added while
+the window is not visible — this covers both the 0→1 transition and a new request arriving
+after the user closed the window. Closing the window without deciding is an explicit *defer*:
+the queue is untouched, the tray stays in `Attention`, and the tray menu's "Review pending
+launches…" reopens it. Additions while the window is already visible just update the queue
+indicator — no re-activation (no focus stealing mid-interaction).
+
+**Content** — the oldest pending request (sort: `RequestedAt`, then `RequestId` ordinal for
+determinism):
+
+- Requester: `RequesterDisplay ?? Requester ?? "unknown"`, prominent.
+- Kind label: `agent` → "Agent", `review` → "Review", `review-flow` → "Review flow".
+- Repo: `RepoLabel.Leaf`, full path as tooltip. Vendor as-is.
+- Countdown: "Expires in 37s", ticked by the shared UI-thread ticker from `DeadlineHint`.
+- Queue indicator "1 of 3" when more than one pending.
+
+**Buttons:**
+
+| Button | Wire | Notes |
+|---|---|---|
+| Allow once | `ConsentResolve{decision: "allow"}` | |
+| Always allow | `ConsentResolve{decision: "allow", save_rule: {action: "allow", requester: <id>, kind: null, repo: null, vendor: null}}` | Atomic — daemon stays the single rule writer. **Hidden when `Requester` is null**: a requester-only rule with a null requester would be a wildcard allow-everything rule. |
+| Deny | `ConsentResolve{decision: "deny"}` | |
+
+While a resolve is in flight all three disable (no double-submit); the countdown keeps
+ticking.
+
+**Terminal states (per request):**
+
+- **Decided (`Ok=true`)** → entry removed, window advances to the next pending or closes when
+  the queue empties. A non-null `Error` on `Ok=true` additionally shows a warning toast over
+  the prompt window: "Decision applied — rule not saved: {error}".
+- **Already decided (`Ok=false`)** → buttons are replaced by "Already decided" for 2 seconds
+  (ticker-driven), then the entry is removed and the window advances. Never a silent success:
+  the user always sees that their click did not decide this launch.
+- **Expired (countdown ≤ 0)** → buttons are replaced by "Expired — denied by timeout" for
+  2 seconds, then the entry is removed (the §5 prune is the backstop). If the user's click races the
+  daemon's timeout, the ack (`Ok=false`) wins the display — same "Already decided" path.
+- **Transport failure** → toast over the prompt window ("Daemon unreachable — the request is
+  still pending"), buttons re-enable, entry stays. The daemon may still be waiting.
+
+Toasts use `AppNotifier` extended to attach a `WindowNotificationManager` to the prompt window
+— the main window may be closed, so prompt-related warnings must surface on the prompt window
+itself.
+
+**Pause interplay:** none needed. Pause is a wildcard deny rule at `rules[0]`, so paused
+launches are rule-denied without prompting and simply appear in the Activity feed as denials.
+
+## 7. Activity tab
+
+The main window becomes a two-tab layout — **Agents** | **Activity** — with the AI-1651 agents
+grid unchanged inside its tab. `ActivityViewModel` renders the decision log, newest first,
+capped at 200 records.
+
+**Refresh triggers** (no `FileSystemWatcher` — platform quirks, untestable timing):
+
+- The Activity tab becomes visible (also covers window open on that tab).
+- A stat poll on the shared ticker, every 2s while the tab is visible: compare
+  (`LastWriteTimeUtc`, `Length`) of both files against the previous poll; re-read on change.
+- A local resolve reached a conclusive ack (the user's own decision should appear
+  immediately).
+
+The reader is `ConsentDecisionLogReader.ReadTail(daemonName, 200)` — pure file I/O, so the
+feed works with the daemon stopped or unreachable.
+
+**Row rendering:** local timestamp (`yyyy-MM-dd HH:mm:ss` from `decided_at`), outcome badge
+(`allowed` green / `denied` red), requester (`requester_display ?? requester ?? "unknown"`),
+kind label (as §6), repo leaf (`RepoLabel`, full path tooltip), vendor, and a human source
+label: `owner` → "owner", `rule[i]` → "rule", `default` → "default policy", `prompt_user` →
+"you", `prompt_timeout` → "timeout", `prompt_no_ui` → "no UI attached" (unrecognized values
+render verbatim). Empty state mirrors the Agents tab: centered "No decisions yet", no column
+headers.
+
+## 8. Tray integration
+
+**State derivation.** `TrayViewModel` gains a `PendingConsentCount` input (from
+`IConsentService.PendingCount`, combined into the existing derivation stream). New rule,
+appended to the AI-1651 state table: when the connection-derived state is `Idle` or `Running`
+and `PendingConsentCount > 0`, the state becomes `Attention` with header
+"{N} launch(es) awaiting approval" — e.g. "1 launch awaiting approval". All
+connection-trouble rows keep precedence: pending consent asserts `Attention` only while
+Connected (which is also the only state where the subscription runs). The icon shows the
+existing `Attention` rendering; the running-count badge continues to reflect the agent count.
+
+**Menu.** A "Review pending launches…" `NativeMenuItem`, visible only when
+`PendingConsentCount > 0`, placed between the agents section and the pause toggle. Click →
+open/activate the prompt window via the coordinator. The existing `NeedsUpdate` rebuild
+cadence picks up count changes through the model stream — no new refresh machinery.
+
+## 9. Error handling summary
+
+| Failure | Surface | Behavior |
+|---|---|---|
+| Daemon unreachable (no subscription) | Tray | Existing AI-1651 rows; no prompts possible; feed still renders from file |
+| Daemon without `consent/1` | Tray | No subscription; existing down-level surfacing |
+| Consent stream dies while Connected | none (self-heal) | 1s delay → resubscribe (fresh replay reconciles) |
+| Resolve transport failure | Prompt toast | Entry kept; buttons re-enable |
+| Resolve `Ok=false` | Prompt window | "Already decided" — never a silent success |
+| Rule save rejected on `Ok=true` | Prompt toast | Decision applied; warning shown |
+| Request expired (no withdrawal push) | Prompt window / prune | Countdown shows expiry; cache prune at hint+5s |
+| Decision log absent/malformed lines | Activity tab | Empty state / lines skipped |
+| Rotation race during read | Activity tab | `Distinct()` merge; miss self-heals next poll |
+
+## 10. Testing
+
+All headless (TUnit; `Avalonia.Headless` for VM/window behavior; fake `TimeProvider`
+throughout — no real sleeps).
+
+**Core:**
+- `ResolveConsentAsync` against an in-proc fake server (pattern of existing `LocalControlOps`
+  tests): ack round-trip (all four `Ok`/`Error` shapes), malformed ack → `unexpected_reply`,
+  EOF → `unexpected_reply`, transport → `daemon_unreachable`, phase timeout → `timed_out`,
+  caller-cancellation propagates.
+- `ConsentSubscription`: replay + push frames yield DTOs in order; EOF ends enumeration;
+  unexpected frame type ends enumeration; malformed pending JSON ends enumeration; `ct`
+  propagates OCE. Absent `requester_display` deserializes to null.
+- `ConsentDecisionLogReader`: tail across the rotation pair (order, cap, newest-first);
+  malformed-line skip; `Distinct()` dedup; absent files → empty; old-format lines (no
+  `requester_display`) parse with null; **a read succeeding while a writer holds an open
+  append handle** (`FileShare` regression guard — the test that would have caught AI-1629).
+
+**Daemon:**
+- Gate threads `RequesterDisplay` into the prompt request and the decision record (extend
+  existing gate tests); log writer round-trips through the hoisted Core type unchanged
+  (existing files' snake_case field names asserted verbatim).
+
+**App (the "full prompt matrix" from the issue):**
+- Allow once / Deny → correct `ConsentResolveDto`, entry removed, queue advances.
+- Always allow → `save_rule` is requester-only; button hidden when `Requester` is null.
+- Countdown expiry → "Expired — denied by timeout", entry removed; prune removes ghost
+  entries at hint+5s.
+- `Ok=false` → "Already decided" state, then advance — never silent.
+- `Ok=true` + `Error` → warning surfaced, entry removed.
+- Transport failure → entry kept, buttons re-enable.
+- Queue: "1 of N" indicator; oldest-first ordering; additions while visible don't re-raise;
+  addition while closed raises.
+- Subscription lifecycle: clear-before-(re)subscribe reconciliation; no subscription without
+  `consent/1`; stream-end-while-Connected retries.
+- `ActivityViewModel`: rows map records (fallback chains, source labels, unrecognized source
+  verbatim); refresh on tab-visible / stat-change / own-resolution; empty state.
+- `TrayViewModel`: new Attention row (pending>0 while Idle/Running → Attention + header);
+  connection-trouble precedence unchanged; menu item visibility.
+
+## 11. Deferred / out of scope
+
+- macOS system notification → AI-1653 (needs bundle identity).
+- Consent rules editor UI → umbrella slice 4.
+- Attach/approve from the CLI (`kcap daemon consent` gains no resolve verb — the app is the
+  approval surface; the CLI keeps rules + log only).
+- Any change to engine matching, policy storage, or prompt timeout semantics.

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -34,10 +34,11 @@ launches…" menu item; `ResolveConsentAsync` on `ILocalControlOps`; consent sub
 in Core; decision-record hoisting to Core (shared write/read shape); `requester_display`
 threading through the consent pipeline (additive); `rule_saved` reporting on `ConsentAckDto`
 (additive) so a rule installed for an already-decided request is disclosed, not hidden; a
-request-identity echo on `ConsentResolveDto` (additive `requested_at`, verified by the broker)
-so a stale resolve can never decide a different launch that reused the id; hoisting the
-AI-1651 per-window ticker into an app-lifetime service; headless ViewModel tests for the full
-prompt matrix.
+daemon-minted `prompt_id` request identity on `ConsentPendingDto` echoed on
+`ConsentResolveDto` and atomically claimed by the broker, advertised as a new `consent/2`
+capability the app requires, so a stale resolve can never decide a different launch that
+reused the id; hoisting the AI-1651 per-window ticker into an app-lifetime service; headless
+ViewModel tests for the full prompt matrix.
 
 **Out:** macOS system notification (AI-1653); consent-rules editor UI (slice 4); any change to
 engine matching, rule ordering/precedence, policy storage, or prompt timeout semantics; new
@@ -72,14 +73,14 @@ installed rule. The handler change: populate `RuleSaved` on **both** ack branche
 no-pending branch drops the save outcome entirely). `Ok`'s meaning is unchanged: it reflects
 the resolution outcome only.
 
-**Down-level disambiguation is the caller's job.** A pre-AI-1652 daemon advertises the same
-`consent/1` capability but omits `rule_saved`, which deserializes as null — the same value a
-new daemon uses for "no save requested". The wire cannot distinguish these, but the *service*
-can: it knows whether it sent `save_rule`. Client-side interpretation, pinned in §5: when the
-service sent `save_rule` and the ack's `RuleSaved` is null, the rule outcome is **unknown
-(down-level daemon)** — except on `Ok=true` with `Error=null`, where the shipped daemon's own
-contract (it reports a rejected save via `Error` even when `Ok=true`) already implies the
-save succeeded.
+**Down-level daemons are gated out, not disambiguated.** A pre-AI-1652 daemon advertises the
+same `consent/1` capability, omits `rule_saved` (deserializes as null), and — critically —
+silently ignores unmapped members on `ConsentResolveDto`, so it would resolve by id alone and
+void the identity guarantee below. The app therefore requires the new **`consent/2`**
+capability (below) before subscribing or resolving at all; behind that gate `RuleSaved` is
+always present. The service still keeps a *defensive* mapping (§5): `save_rule` sent but
+`RuleSaved` null → rule outcome unknown — unreachable behind the gate, honest if it ever
+fires.
 
 **Rule ordering is deliberately untouched.** The handler appends the saved rule at the end
 and `LaunchConsentEngine` is first-match-wins, so an earlier matching rule — the pause
@@ -93,28 +94,47 @@ The daemon resolve handler otherwise exists (`LaunchConsentIpc.HandleResolveAsyn
 is needed on one-shot connections (hello is optional; the CLI consent verbs already send bare
 frames).
 
-**Request identity: the `requested_at` echo.** `ConsentResolveDto` carries only `request_id`
-today, and the broker's `TryResolve` resolves whichever pending entry currently holds that
-key. A request id is the agent id, and the daemon explicitly makes **no id-non-reuse
-assumption** (`SequencedCommandProcessor` treats two launches for one id as distinct
-instances, and the orchestrator builds consent input afresh from each command) — so a
-successor B under A's id can carry a *different* requester, kind, repo, or vendor, and a
-delayed resolve for A must never decide B. Close this on the wire:
+**Request identity: the daemon-minted `prompt_id`.** `ConsentResolveDto` carries only
+`request_id` today, and the broker's `TryResolve` resolves whichever pending entry currently
+holds that key. A request id is the agent id, and the daemon explicitly makes **no
+id-non-reuse assumption** (`SequencedCommandProcessor` treats two launches for one id as
+distinct instances, and the orchestrator builds consent input afresh from each command) — so
+a successor B under A's id can carry a *different* requester, kind, repo, or vendor, and a
+delayed resolve for A must never decide B. Wall-clock stamps cannot serve as the
+discriminator (`RequestedAt` comes from `GetUtcNow()` — clock steps can revisit an earlier
+exact value, and OS clock resolution can repeat across calls), so the identity is an opaque
+value the daemon mints:
 
-- `ConsentResolveDto` gains trailing `string? RequestedAt` (wire `requested_at`,
-  positional-required convention: no C# default, nulls always written) — an echo of the
-  pending request's `RequestedAt` stamp.
-- `LaunchConsentBroker.TryResolve` gains the echo parameter: with a null echo (a caller that
-  never saw the stamp) behavior is unchanged; with a non-null echo the resolve succeeds only
-  if it matches the pending entry's `RequestedAt` exactly (ordinal). A mismatch is treated as
-  no-pending: `Ok=false`, the honest already-decided path.
+- `LaunchConsentGate` mints a fresh **`PromptId`** (`Guid.NewGuid().ToString("N")` —
+  process-lifetime unique by construction, no clock involvement) for every prompt entry;
+  `LaunchConsentPromptRequest` carries it.
+- `ConsentPendingDto` gains trailing `string? PromptId` (wire `prompt_id`,
+  positional-required convention: no C# default, nulls always written), appended **after**
+  §4.3's `RequesterDisplay` — final positional order: …, `RequesterDisplay`, `PromptId`.
+- `ConsentResolveDto` gains trailing `string? PromptId` (wire `prompt_id`) — the echo.
+- `LaunchConsentBroker.TryResolve` gains the echo parameter, and for a non-null echo the
+  match and removal are **one atomic claim**: look up the pending entry, compare the echo to
+  its `PromptId`, then conditionally remove the exact captured `Pending` *object* via the
+  `KeyValuePair`-conditional overload — the same primitive the broker's timeout/cleanup paths
+  already use — before completing its TCS. A mismatch, or a lost claim (the entry was
+  replaced between match and removal), returns false and **never retries against the
+  successor**; the handler acks `Ok=false`, the honest already-decided path. A null echo (a
+  caller that never saw the id) preserves legacy resolve-by-key behavior.
 - The app always sends the echo (§5).
 
-`(RequestId, RequestedAt)` is thereby the **request identity**, enforced end-to-end — the
-client's cache guards (§5) use the same pair. Identity collision would require two prompts of
-the same agent id stamped at the same 100 ns wall-clock tick, with a full launch round-trip
-between them — not physically achievable in production; tests that freeze the clock must
-fabricate distinct stamps.
+`PromptId` is thereby the **request identity**, enforced end-to-end — the client's cache
+guards and tombstones (§5) key on it, `RequestId` remains only the cache/broker key and the
+per-agent queue identity.
+
+**Capability `consent/2`.** The identity guarantee is only real when the daemon enforces it —
+a pre-AI-1652 daemon deserializes the resolve while silently dropping the unmapped `prompt_id`
+and resolves by id alone. `LocalControlCapabilities.Current` therefore appends **`consent/2`**
+(advertised, per the AI-1648 convention, only because the live handler enforces
+identity-checked resolution, populates `rule_saved`, and stamps `prompt_id`/
+`requester_display` on pendings). The app treats a daemon advertising `consent/1` without
+`consent/2` exactly like one with no consent capability at all: no subscription, no prompts,
+no resolves (§5) — mixed-version consent fails closed rather than degrading to the unguarded
+path.
 
 ### 4.2 Consent subscription client (Core)
 
@@ -151,9 +171,9 @@ write and the replay. §5 states the accepted consequence.
 - A frame of any type other than `ConsentPending`, or a frame whose JSON does not
   *deserialize*, also ends the enumeration — protocol confusion is a dead connection.
 - A frame that deserializes but is **structurally invalid** — null root, or null/empty
-  `RequestId`, `Kind`, `RepoPath`, `Vendor`, `RequestedAt`, or `TimeoutSeconds <= 0` (STJ
-  source-gen does not enforce non-nullable members; `{}` decodes "successfully") — is
-  **skipped**, not fatal. Ending the enumeration here would be a thrash loop: the resubscribe
+  `RequestId`, `PromptId` (a `consent/2` daemon always stamps it — §4.1), `Kind`, `RepoPath`,
+  `Vendor`, `RequestedAt`, or `TimeoutSeconds <= 0` (STJ source-gen does not enforce
+  non-nullable members; `{}` decodes "successfully") — is **skipped**, not fatal. Ending the enumeration here would be a thrash loop: the resubscribe
   replay would redeliver the same invalid entry forever.
 - Only `OperationCanceledException` (the caller's `ct`) propagates.
 
@@ -271,42 +291,47 @@ explicitly documents that a successor prompt can reuse a predecessor's id. The s
 and resolve travel on separate connections, so successor B can be upserted (replacing A's
 cache slot by key) before predecessor A's ack is processed — an unconditional remove-by-key
 would then evict B, and with no withdrawal push nothing would restore it. Therefore **every**
-removal is guarded by the §4.1 request identity: it captures the `(RequestId, RequestedAt)`
-pair it is acting on and removes only if the entry currently cached under that key carries the
-same pair. B differs in `RequestedAt` by the §4.1 identity contract, so a stale removal for A
-can never evict B — while a *replayed instance of A itself* (same pair, fresh object) is
-correctly evicted. A removal that finds a different pair is a no-op. Because the resolve
-carries the echo, the ack verifiably concerns exactly the identity the app targeted: whether B
-replaced A in the daemon before the resolve arrived (mismatch → `Ok=false`) or B arrived
-after A's resolution (`Ok=true` for A), B's cache entry survives either way and is prompted on
-its own terms.
+removal is guarded by the §4.1 request identity: it captures the `PromptId` it is acting on
+and removes only if the entry currently cached under that `RequestId` carries the same
+`PromptId`. B carries a different daemon-minted `PromptId` by construction, so a stale removal
+for A can never evict B — while a *replayed instance of A itself* (same `PromptId`, fresh
+object) is correctly evicted. A removal that finds a different `PromptId` is a no-op. Because
+the resolve carries the echo, the ack verifiably concerns exactly the identity the app
+targeted: whether B replaced A in the daemon before the resolve arrived (mismatch/lost claim
+→ `Ok=false`) or B arrived after A's resolution (`Ok=true` for A), B's cache entry survives
+either way and is prompted on its own terms.
 
 **Conclusion tombstones (ghost-replay defense).** The broker's `Subscribe` snapshots pending
-entries without synchronizing against a concurrent `TryResolve`, so a resubscribe replay can
-redeliver a request the app is just concluding — and the orderings differ: the ghost `Pending`
-can arrive *before* the conclusive ack (a reconnect's replay raced the resolve) or *after* it.
-On every conclusive ack the service atomically (1) records a tombstone for the request
-identity `(RequestId, RequestedAt)` and (2) evicts any currently cached entry matching that
-identity — closing the replay-ghost-admitted-before-ack ordering, which a guard keyed on the
-original instance alone would miss. An incoming `Pending` matching a live tombstone is
-dropped. By the §4.1 identity contract a matching frame *is* the concluded request — never a
-distinct successor — so dropping is always correct and no delayed admission is needed; the
-10-second TTL is purely a memory bound (ghost frames only arise from replay snapshots taken
-within the milliseconds-wide resolve race, never seconds later). Expiry/prune do **not**
-tombstone: a request the app merely gave up on locally is still live daemon-side (the
-clock-step case) and must be allowed to reappear.
+entries without synchronizing against a concurrent `TryResolve`, and a snapshotted frame can
+sit in the unbounded per-subscriber channel arbitrarily long (backpressure, suspension, a
+large replay) — so a `Pending` for a request the app already concluded can arrive *before*
+the conclusive ack (a reconnect's replay raced the resolve) or *after* it, with no bounded
+delivery latency. On every conclusive ack the service atomically (1) records the concluded
+`PromptId` as a tombstone and (2) evicts any currently cached entry carrying it — closing the
+ghost-admitted-before-ack ordering, which a guard keyed on the original instance alone would
+miss. An incoming `Pending` whose `PromptId` is tombstoned is dropped; by the §4.1 identity
+contract a matching frame *is* the concluded request — never a distinct successor — so
+dropping is always correct. **Tombstones are scoped to the subscription connection, with no
+TTL**: they are retired in bulk at each `Subscribed` boundary, because a fresh replay provably
+cannot contain a concluded request (`TryResolve` removes the entry before the ack exists, and
+`Subscribe` snapshots the current map) — a time-based TTL would reopen the window for a frame
+delayed past it. Within one connection the set grows only with conclusions on that connection;
+a defensive FIFO cap of 1024 bounds pathological lifetimes and is documented as such. Expiry/
+prune do **not** tombstone: a request the app merely gave up on locally is still live
+daemon-side (the clock-step case) and must be allowed to reappear.
 
 **Subscription lifecycle — status-driven.** The service observes
 `DaemonClientService.Status`:
 
-- On `Connected` with capabilities containing `"consent/1"` → start the subscription loop.
+- On `Connected` with capabilities containing `"consent/2"` → start the subscription loop.
 - On leaving `Connected` (Connecting/Unreachable) → cancel the loop. Pending entries are NOT
   cleared on disconnect — the daemon may still be alive holding live prompts; entries expire
   via their own deadline hints, and a successful resubscribe reconciles (below).
-- On `Connected` **without** `"consent/1"` (a down-level daemon incarnation) → no
-  subscription, and the cache **is** cleared: any retained entries belong to a previous
-  incarnation and can never be resolved against this one. The existing shell surfaces the
-  daemon-outdated condition.
+- On `Connected` **without** `"consent/2"` — including a daemon advertising only `consent/1`
+  (§4.1: it would resolve without the identity check) → no subscription, no prompts, no
+  resolves, and the cache **is** cleared: any retained entries belong to a previous
+  incarnation and can never be safely resolved against this one. The existing shell surfaces
+  the daemon-outdated condition.
 
 **Loop:** while in the connected state: enumerate `ConsentSubscription.RunAsync`; on the
 `Subscribed` event clear the pending cache; on each `Pending` event upsert by `RequestId`
@@ -343,7 +368,7 @@ Task<ConsentResolveOutcome> ResolveAsync(PendingConsent target, bool allow, bool
 ```
 
 `ResolveAsync` builds the `ConsentResolveDto` (`decision: allow|deny`; **always** the
-`requested_at` echo from `target` — the §4.1 identity check; when `saveRule`, a requester-only
+`prompt_id` echo from `target` — the §4.1 identity check; when `saveRule`, a requester-only
 `save_rule` from `target.Requester`) and calls `ILocalControlOps.ResolveConsentAsync`. One
 resolve in flight at a time — serialized on one lane, same discipline as `PauseController`. **Null-requester guard lives here, not only on the
 button:** when `saveRule` is requested but `target.Requester` is null or empty, the service
@@ -353,9 +378,8 @@ is the safety boundary, and it is tested directly.
 
 `ConsentResolveOutcome` (cache effects identity-guarded on `target`; `RuleOutcome` is the
 service's disambiguation — it knows whether it sent `save_rule` (§4.1): `Saved`, `Rejected`,
-`Unknown` (save requested, `RuleSaved` null, i.e. down-level daemon — except `Ok=true` +
-`Error=null`, which implies `Saved` on the shipped daemon's own contract), `NotRequested`,
-`SkippedNoRequester`):
+`Unknown` (save requested but `RuleSaved` null — unreachable behind the `consent/2` gate,
+kept as a defensive mapping), `NotRequested`, `SkippedNoRequester`):
 
 | Outcome | Ack | Cache effect | Meaning |
 |---|---|---|---|
@@ -527,12 +551,12 @@ cadence picks up count changes through the model stream — no new refresh machi
 | Failure | Surface | Behavior |
 |---|---|---|
 | Daemon unreachable (no subscription) | Tray | Existing AI-1651 rows; no prompts possible; feed still renders from file |
-| Daemon without `consent/1` | Tray | No subscription; cache cleared (stale incarnation); existing down-level surfacing |
+| Daemon without `consent/2` (incl. `consent/1`-only) | Tray | No subscription, prompts, or resolves — identity check can't be enforced; cache cleared; existing down-level surfacing |
 | Consent dial fails while status Connected | none (self-heal) | Cache NOT cleared (clear sits at the `Subscribed` boundary); 1s delay → retry |
 | Daemon dies between subscribe write and replay | none (self-heal) | Cache cleared but restored by the next successful replay (~1s cadence); bounded, UI-only (§5) |
 | Consent stream dies while Connected | none (self-heal) | 1s delay → resubscribe (fresh replay reconciles at the `Subscribed` boundary) |
 | Structurally invalid pending frame | none | Skipped (ending the stream would thrash the resubscribe loop) |
-| Ghost replay of a just-concluded request | none | Arrives after the ack → tombstone drops it; admitted before the ack → the ack's identity-matched eviction removes it — no second prompt either way |
+| Ghost replay of a just-concluded request | none | Arrives after the ack → connection-scoped tombstone drops it (no TTL — arbitrarily delayed frames stay dropped); admitted before the ack → the ack's identity-matched eviction removes it — no second prompt either way |
 | Wall-clock step vs. daemon's monotonic deadline | Prompt window | Hint expiry is never a verdict: non-authoritative copy, buttons stay active, ack governs |
 | Resolve transport failure | Prompt toast | Entry kept; buttons re-enable |
 | Resolve cancelled (shutdown) | none | OCE propagates; silent abort — never rendered as transport failure |
@@ -540,7 +564,7 @@ cadence picks up count changes through the model stream — no new refresh machi
 | Rule save rejected / unknown / skipped (no requester) | Prompt toast | Decision applied; warning shown |
 | Request expired (no withdrawal push) | Prompt window / prune | Non-authoritative expiry display; cache prune at `PruneAfter` (identity-guarded, skips the in-flight resolve target, refreshed on transport failure) |
 | Same-id successor while ack in flight | none | Identity-pair removal guard — a stale ack/prune never evicts the successor |
-| Stale resolve reaching the daemon after id reuse | daemon | Closed: the `requested_at` echo mismatches and the broker answers no-pending (`Ok=false`) — a verdict for A can never decide B (§4.1) |
+| Stale resolve reaching the daemon after id reuse | daemon | Closed: the `prompt_id` echo mismatches (or the atomic claim is lost) and the broker answers no-pending (`Ok=false`) — a verdict for A can never decide B (§4.1) |
 | Decision log absent / IO failure / bad lines | Activity tab | Clean absence → `Complete` empty read → empty state; I/O failure → `Complete=false` → last-good rows kept; invalid lines skipped |
 | Rotation race during read | Activity tab | `Distinct()` merge; miss self-heals next poll |
 
@@ -552,7 +576,7 @@ throughout — no real sleeps).
 **Core:**
 - `ResolveConsentAsync` against an in-proc fake server (pattern of existing `LocalControlOps`
   tests): ack round-trip (`Ok`/`Error`/`RuleSaved` shapes, including an old-format ack with no
-  `rule_saved` member → null; the sent `ConsentResolveDto` carries the `requested_at` echo),
+  `rule_saved` member → null; the sent `ConsentResolveDto` carries the `prompt_id` echo),
   decodable `Error` frame → `daemon_rejected`, malformed ack → `unexpected_reply`, EOF →
   `unexpected_reply`, transport → `daemon_unreachable`, phase timeout → `timed_out`,
   caller-cancellation propagates.
@@ -583,12 +607,21 @@ throughout — no real sleeps).
   `save_rule` → `RuleSaved=null` (written as JSON null).
 - Engine: an earlier matching deny (index 0 wildcard) shadows a later appended allow —
   first-match-wins pinned by test.
-- Broker identity check: `TryResolve` with a matching `requested_at` echo resolves; a
+- Prompt identity: every prompt entry gets a fresh `PromptId` — two same-agent-id prompts
+  under a **frozen clock** (identical `RequestedAt`) still carry distinct identities, and all
+  guards discriminate them (the failure mode a timestamp identity would have).
+- Broker identity check: `TryResolve` with a matching `prompt_id` echo resolves; a
   mismatching echo returns false (and the handler acks `Ok=false`) leaving the pending entry
-  untouched; a null echo preserves legacy resolve-by-id behavior. The two orderings the echo
-  exists for, end to end through the handler: **B replaces A in the broker before A's resolve
-  arrives** → A's resolve mismatches, `Ok=false`, B stays pending; **A resolved, then A's ack
-  raced by B's arrival** → `Ok=true` concerned only A, B stays pending.
+  untouched; a null echo preserves legacy resolve-by-id behavior; **a lost claim — the
+  captured `Pending` replaced between match and conditional removal — returns false and the
+  successor is untouched** (exercised deterministically against the claim primitive with a
+  stale captured instance). The two orderings the echo exists for, end to end through the
+  handler: **B replaces A in the broker before A's resolve arrives** → A's resolve
+  mismatches, `Ok=false`, B stays pending; **A resolved, then A's ack raced by B's arrival**
+  → `Ok=true` concerned only A, B stays pending.
+- Capability: `LocalControlCapabilities.Current` advertises `consent/2` alongside
+  `consent/1`; mixed-version acceptance — an app facing a `consent/1`-only capability set
+  starts no subscription and sends no resolve.
 
 **App (the "full prompt matrix" from the issue):**
 - Allow once / Deny → correct `ConsentResolveDto`, entry removed, queue advances.
@@ -604,10 +637,11 @@ throughout — no real sleeps).
   prompted; **B arrives after A's `Ok=true` ack** → A was evicted, B is admitted and
   prompted. In both, the successor is decided only on its own terms.
 - Ghost replay (both orderings): a ghost `Pending` arriving *after* A's conclusive ack is
-  dropped by the tombstone; a ghost admitted *before* the ack (reconnect replay raced the
-  resolve — a fresh instance with A's identity) is evicted by the ack's identity-matched
-  removal — no second raise either way. A tombstone past its TTL no longer filters (memory
-  bound, not a correctness window).
+  dropped by the tombstone — **including one delayed arbitrarily long within the same
+  subscription connection** (no TTL to outlive); a ghost admitted *before* the ack (reconnect
+  replay raced the resolve — a fresh instance with A's identity) is evicted by the ack's
+  identity-matched removal — no second raise either way. Tombstones are retired at the
+  `Subscribed` boundary: after a resubscribe, a fresh replay's entries are admitted normally.
 - Hint expiry with no resolve in flight → non-authoritative copy, **buttons remain active**;
   a click after hint-zero that acks `Ok=true` is `Applied` (the wall-clock-step case: hint
   fired early, request was still live); one that acks `Ok=false` runs "Already decided"; the
@@ -631,8 +665,8 @@ throughout — no real sleeps).
   entries — no `Subscribed`, no clear); reconnect-with-empty-replay leaves an empty cache
   (the `Subscribed` boundary makes this observable); stream death after `Subscribed` but
   before any replay frame → cache cleared, restored by the next attempt's replay; `Connected`
-  without `consent/1` clears the cache and never subscribes; stream-end-while-Connected
-  retries.
+  without `consent/2` (including `consent/1`-only) clears the cache and never subscribes;
+  stream-end-while-Connected retries.
 - Shutdown: app quits with the prompt window open and a resolve in flight → clean disposal in
   the §5 order, OCE path exercised.
 - `ActivityViewModel`: rows map records (fallback chains, source labels, unrecognized source

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -28,8 +28,8 @@ decision log, and pending-consent wired into the tray's existing `Attention` sta
 
 ## 3. Scope
 
-**In:** consent subscription service in the app; prompt window (Allow once / Always allow /
-Deny, countdown, queue); Activity tab; tray `Attention` on pending consent + "Review pending
+**In:** consent subscription service in the app; prompt window (Allow once / Allow & remember
+/ Deny, countdown, queue); Activity tab; tray `Attention` on pending consent + "Review pending
 launches…" menu item; `ResolveConsentAsync` on `ILocalControlOps`; consent subscription client
 in Core; decision-record hoisting to Core (shared write/read shape); `requester_display`
 threading through the consent pipeline (additive); `rule_saved` reporting on `ConsentAckDto`
@@ -61,38 +61,73 @@ classification are identical to the existing ops — caller-cancellation propaga
 ops), any other frame type or a null/malformed ack → `unexpected_reply`.
 
 **`ConsentAckDto` gains trailing `bool? RuleSaved`** (wire `rule_saved`, positional-required
-convention: no C# default, nulls always written). Semantics: null when the resolve carried no
-`save_rule`; `true`/`false` = the rule write succeeded/failed. The daemon's
+convention: no C# default, nulls always written). Daemon semantics: null when the resolve
+carried no `save_rule`; `true`/`false` = the rule write succeeded/failed. The daemon's
 `HandleResolveAsync` deliberately persists `save_rule` *before* attempting the resolution —
-"Always allow" expresses durable trust in the requester, which stands even when this
+"Allow & remember" expresses durable trust in the requester, which stands even when this
 particular launch has already been decided — so today an `Ok=false` ack can silently hide an
 installed rule. The handler change: populate `RuleSaved` on **both** ack branches (today the
 no-pending branch drops the save outcome entirely). `Ok`'s meaning is unchanged: it reflects
 the resolution outcome only.
 
+**Down-level disambiguation is the caller's job.** A pre-AI-1652 daemon advertises the same
+`consent/1` capability but omits `rule_saved`, which deserializes as null — the same value a
+new daemon uses for "no save requested". The wire cannot distinguish these, but the *service*
+can: it knows whether it sent `save_rule`. Client-side interpretation, pinned in §5: when the
+service sent `save_rule` and the ack's `RuleSaved` is null, the rule outcome is **unknown
+(down-level daemon)** — except on `Ok=true` with `Error=null`, where the shipped daemon's own
+contract (it reports a rejected save via `Error` even when `Ok=true`) already implies the
+save succeeded.
+
 **Rule ordering is deliberately untouched.** The handler appends the saved rule at the end
 and `LaunchConsentEngine` is first-match-wins, so an earlier matching rule — the pause
 wildcard deny at `rules[0]`, or any manual deny — takes precedence over an appended allow
-until that earlier rule is removed. This is correct: "Always allow" must never silently
-override pause or an explicit deny. The UI copy carries the consequence honestly (§6).
+until that earlier rule is removed. This is correct: a remembered allow must never silently
+override pause or an explicit deny. The UI copy carries the consequence honestly (§6: the
+button says "Allow & remember", not "Always allow" — the label must not promise what
+precedence may withhold).
 
 The daemon resolve handler otherwise exists (`LaunchConsentIpc.HandleResolveAsync`); no hello
 is needed on one-shot connections (hello is optional; the CLI consent verbs already send bare
 frames).
+
+**Stale resolve vs. same-id successor — accepted, with rationale.** `ConsentResolveDto`
+carries only `request_id`, and the broker's `TryResolve` resolves whichever pending entry
+currently holds that key. If request A times out, a successor B reuses the id, and A's delayed
+resolve then arrives, it decides B. This is deliberately accepted rather than closed with a
+wire generation check: a request id is the agent id, and a same-id successor is by
+construction a **retry of the same launch** — same requester, kind, repo, and vendor (the
+server retries the same command). The user's verdict was about that content, and applying it
+to the retry honors their intent. (A future wire generation echo — an additive `requested_at`
+on `ConsentResolveDto` verified by the broker — remains open to a later slice if this
+assumption ever breaks.)
 
 ### 4.2 Consent subscription client (Core)
 
 `ConsentSubscription` in `Capacitor.Cli.Core/LocalIpc/`:
 
 ```csharp
-public static async IAsyncEnumerable<ConsentPendingDto> RunAsync(
+public abstract record ConsentStreamEvent {
+    public sealed record Subscribed : ConsentStreamEvent;               // connect + subscribe write succeeded
+    public sealed record Pending(ConsentPendingDto Request) : ConsentStreamEvent;
+}
+
+public static async IAsyncEnumerable<ConsentStreamEvent> RunAsync(
     string daemonName, [EnumeratorCancellation] CancellationToken ct)
 ```
 
-Connects to the daemon's socket, writes `FrameType.ConsentSubscribe` (empty text), then reads
-frames and yields one `ConsentPendingDto` per `ConsentPending` frame. The daemon replays the
-full pending set immediately, then pushes new requests (broker contract: exactly-once per
-subscriber, no withdrawal push).
+Connects to the daemon's socket, writes `FrameType.ConsentSubscribe` (empty text), **yields
+`Subscribed` once** immediately after that write succeeds, then reads frames and yields one
+`Pending` per `ConsentPending` frame. The `Subscribed` event exists because an async iterator
+exposes no other observable boundary between "dialing" and "subscribed": with an empty replay
+the first read never completes, so a consumer that must act at the subscribe boundary (the §5
+cache clear) would otherwise have no signal. The daemon replays the full pending set
+immediately after the subscribe registers, then pushes new requests (broker contract:
+exactly-once per subscriber, no withdrawal push).
+
+**`Subscribed` is a client-local boundary, not a server acknowledgment.** A flushed subscribe
+write does not prove the daemon registered the subscription — the peer can die between the
+write and the replay. §5 states the accepted consequence.
 
 **Termination and validation contract:**
 
@@ -161,14 +196,22 @@ lines and is unaffected.
 **Reader** (Core, same file):
 
 ```csharp
+public sealed record ConsentLogReadResult(IReadOnlyList<ConsentDecisionRecord> Records, bool Complete);
+
 public static class ConsentDecisionLogReader {
     public static string PathFor(string daemonName);   // DaemonLockPaths.Directory / Sanitize(name) / consent-decisions.jsonl
-    public static IReadOnlyList<ConsentDecisionRecord> ReadTail(string daemonName, int max);
+    public static ConsentLogReadResult ReadTail(string daemonName, int max);
 }
 ```
 
 `ReadTail` reads `{path}.1` then `{path}` (each may be absent), keeps the last `max` valid
-records, newest first. Rules:
+records, newest first. `Complete` distinguishes what a bare list cannot: a **clean absence**
+(the file does not exist — `FileNotFoundException`/`DirectoryNotFoundException` on open)
+counts as complete, while an **I/O failure** (`IOException`, `UnauthorizedAccessException`,
+including a file vanishing mid-read) makes that file contribute nothing and flips
+`Complete=false`. `ReadTail` itself never throws for any of these; worst case is
+`([], false)`. The consumer contract (§7) needs exactly this bit: an incomplete read must not
+be mistaken for a genuinely shorter/empty log. Rules:
 
 - **Sharing:** every open is `FileAccess.Read` with `FileShare.ReadWrite | FileShare.Delete` —
   the daemon appends and rotates (`File.Move`) this file live; on Windows a write-denying open
@@ -178,10 +221,6 @@ records, newest first. Rules:
   write), and lines that parse but are structurally invalid — null root, or null `DecidedAt`,
   `AgentId`, `Kind`, `RepoPath`, `Vendor`, `Outcome`, or `Source` (`Requester`,
   `RequesterDisplay` stay nullable; a missing `requester_is_owner` reads as `false`).
-- **Per-file I/O failure = absent:** `FileNotFoundException`, `DirectoryNotFoundException`,
-  `IOException`, and `UnauthorizedAccessException` on either file (races with rotation or
-  daemon-state-dir deletion between stat and open, or between the two reads) make that file
-  contribute nothing. `ReadTail` never throws for these; worst case it returns an empty list.
 - **Rotation race:** a rotation between the two reads can transiently duplicate or miss lines.
   Records have value equality — the merged list is `Distinct()`-ed, and a miss self-heals on
   the next refresh (§7). Accepted: this is a display feed, not an audit query.
@@ -191,8 +230,8 @@ records, newest first. Rules:
 `src/Capacitor.App/Services/ConsentService.cs` (+ `IConsentService`): owns the consent
 subscription, the pending queue, and resolution. Single instance, created at startup beside
 `DaemonClientService`. **The service is the sole owner of the pending cache** — every
-insertion and removal happens here; ViewModels only read (§6 pins *displayed* items
-separately).
+insertion and removal happens here (removals occur only on conclusive acks and via the prune;
+§6's ViewModel never removes, it only reads and pins).
 
 **Shared ticker (infrastructure, in scope):** the AI-1651 1-second ticker currently lives as a
 private observable inside `MainWindowViewModel`. It hoists into an app-lifetime `ITicker`
@@ -204,19 +243,36 @@ holds), and `ActivityViewModel` (stat poll) consume the same instance.
 
 **State:** `SourceCache<PendingConsent, string>` keyed by `RequestId`. `PendingConsent` wraps
 the `ConsentPendingDto` plus a computed `DeadlineHint = RequestedAt + TimeoutSeconds`
-(`DateTimeOffset` parse of the daemon's ISO stamp; same machine, so no clock-skew handling; an
-unparseable `RequestedAt` falls back to arrival time + `TimeoutSeconds`). The deadline is a
-*hint* — AI-1648's subscriber grace means the daemon's real deadline can differ slightly; the
-authoritative outcome is only ever a resolve ack.
+(`DateTimeOffset` parse of the daemon's ISO stamp; an unparseable `RequestedAt` falls back to
+arrival time + `TimeoutSeconds`). **The deadline is a heuristic, never an outcome.** The
+daemon enforces its timeout on a *monotonic* clock anchored at prompt entry; `RequestedAt` is
+wall-clock metadata, so an NTP/manual clock step can make the hint disagree with the daemon's
+real deadline in either direction. Nothing in the app treats hint expiry as a decision: the
+authoritative outcome is only ever a resolve ack (§6 renders expiry accordingly), and the
+prune below is availability hygiene, not settlement — a prematurely pruned still-live request
+simply times out daemon-side exactly as if no UI were attached.
 
 **Instance-guarded removal (ABA defense).** `RequestId` is the agent id, and the broker
 explicitly documents that a successor prompt can reuse a predecessor's id (retry of the same
 agent). The subscription and resolve travel on separate connections, so successor B can be
 upserted before predecessor A's ack is processed — an unconditional remove-by-key would then
-evict B, and with no withdrawal/replay push nothing would restore it. Therefore **every**
-removal (conclusive ack, dismiss, prune) captures the exact `PendingConsent` it is acting on
-and removes only if the cache still holds that value (record value-equality; A and B differ at
-least in `RequestedAt`). A removal that finds a different value is a no-op.
+evict B, and with no withdrawal push nothing would restore it. Therefore **every** removal
+(conclusive ack, prune) captures the exact `PendingConsent` *instance* it is acting on and
+removes only if the cache still holds that same instance — **reference identity, not value
+equality**: each received frame materializes a fresh instance, whereas DTO field values
+(including `RequestedAt`, a wall-clock stamp) can legitimately collide between a predecessor
+and its retry. A removal that finds a different instance is a no-op.
+
+**Conclusion tombstones (ghost-replay defense).** The broker's `Subscribe` snapshots pending
+entries without synchronizing against a concurrent `TryResolve`, so a resubscribe replay can
+redeliver a request the app just concluded — re-adding a ghost and auto-raising a second
+prompt whose answer can only be "already decided". On every conclusive ack the service records
+a tombstone `(RequestId, RequestedAt)` with a 10-second TTL; an incoming `Pending` matching a
+live tombstone is dropped. The TTL bounds the risk of suppressing a genuine same-id successor
+to the case where it also carries an identical wall-clock stamp *within the window* —
+accepted as vanishingly unlikely, and self-healing (the next resubscribe replays it after the
+TTL). Expiry/prune do **not** tombstone: a request the app merely gave up on locally is still
+live daemon-side (the clock-step case) and must be allowed to reappear.
 
 **Subscription lifecycle — status-driven.** The service observes
 `DaemonClientService.Status`:
@@ -230,27 +286,31 @@ least in `RequestedAt`). A removal that finds a different value is a no-op.
   incarnation and can never be resolved against this one. The existing shell surfaces the
   daemon-outdated condition.
 
-**Loop:** while in the connected state: dial and write the `ConsentSubscribe` frame; **only
-after that write succeeds** clear the pending cache, then upsert each incoming DTO by
-`RequestId`. The clear sits at the subscribe-write boundary, not before the dial: a failed
-dial while the status socket still reports Connected must not erase a still-actionable queue
-— retained entries keep the tray attention and their countdowns alive through the transient.
-After the boundary, the daemon's replay is authoritative by construction: anything the daemon
-no longer holds is gone from the cache (accepted tradeoff: an entry resolved while
-disconnected vanishes without a terminal display; the Activity feed carries its outcome). If
-the enumeration ends while status still reports Connected (protocol confusion, half-dead
-socket, failed dial), delay 1s and go around. Loop cancellation stops cleanly.
+**Loop:** while in the connected state: enumerate `ConsentSubscription.RunAsync`; on the
+`Subscribed` event clear the pending cache; on each `Pending` event upsert by `RequestId`
+(tombstones filtering, above). The clear sits at the `Subscribed` boundary, not before the
+dial: a failed dial while the status socket still reports Connected must not erase a
+still-actionable queue — retained entries keep the tray attention and their countdowns alive
+through the transient. After the boundary the daemon's replay is authoritative: anything it no
+longer holds is gone from the cache by construction.
+
+**Accepted post-`Subscribed` window:** `Subscribed` is client-local (§4.2) — if the daemon
+dies between the subscribe write and the replay, the cache has been cleared and no replay
+restores it until the next successful attempt (~1s cadence). The loss is bounded and
+UI-only: the daemon-side prompts were never dismissed, and the next successful replay
+restores them; if no daemon comes back, the entries were unanswerable anyway. If the
+enumeration ends while status still reports Connected (protocol confusion, half-dead socket,
+failed dial), delay 1s and go around. Loop cancellation stops cleanly.
 
 **Pruning:** on the shared ticker, entries with `now > DeadlineHint + 5s` are removed
 (instance-guarded). This bounds ghost entries from requests that expired daemon-side (there is
-no withdrawal push) and from disconnected periods. The prompt VM shows the expired state and
-dismisses before the prune fires (§6); the prune is the backstop.
+no withdrawal push) and from disconnected periods. Under a clock step the prune inherits the
+hint's heuristic nature (above) — accepted.
 
 **Resolution:**
 
 ```csharp
 Task<ConsentResolveOutcome> ResolveAsync(PendingConsent target, bool allow, bool saveRule, CancellationToken ct);
-void Dismiss(PendingConsent target);   // instance-guarded removal; used by the VM's terminal-state advance
 ```
 
 `ResolveAsync` builds the `ConsentResolveDto` (`decision: allow|deny`; when `saveRule`, a
@@ -262,23 +322,28 @@ sends the resolve *without* `save_rule` (a null requester would serialize into a
 allow-everything rule) and reports it in the outcome; the §6 button-hiding is UX, this guard
 is the safety boundary, and it is tested directly.
 
-`ConsentResolveOutcome` (all cache effects instance-guarded on `target`):
+`ConsentResolveOutcome` (cache effects instance-guarded on `target`; `RuleOutcome` is the
+service's disambiguation — it knows whether it sent `save_rule` (§4.1): `Saved`, `Rejected`,
+`Unknown` (save requested, `RuleSaved` null, i.e. down-level daemon — except `Ok=true` +
+`Error=null`, which implies `Saved` on the shipped daemon's own contract), `NotRequested`,
+`SkippedNoRequester`):
 
 | Outcome | Ack | Cache effect | Meaning |
 |---|---|---|---|
-| `Applied` | `Ok=true, Error=null` | remove | applied (`RuleSaved` carried along: null/true/false) |
-| `AppliedRuleRejected` | `Ok=true, Error!=null` or `RuleSaved=false` | remove | decision applied; rule not saved — warn |
-| `AlreadyDecided` | `Ok=false` | remove | decided elsewhere (daemon timeout / race); `RuleSaved` carried along — a rule may still have been installed (§4.1) and the UI must disclose it |
-| `RuleSkippedNoRequester` | `Ok=true` (no save_rule sent) | remove | applied; rule not saved because the request had no requester identity |
+| `Applied` | `Ok=true`, rule outcome `Saved`/`NotRequested` | remove + tombstone | applied |
+| `AppliedRuleRejected` | `Ok=true`, rule outcome `Rejected` or `Unknown` | remove + tombstone | decision applied; rule not saved (or outcome unknown on a down-level daemon) — warn |
+| `AlreadyDecided` | `Ok=false` | remove + tombstone | decided elsewhere (daemon timeout / race); carries `RuleOutcome` — a rule may still have been installed (§4.1) and §6 must disclose saved / not saved / unknown |
+| `RuleSkippedNoRequester` | `Ok=true` (no save_rule sent) | remove + tombstone | applied; rule not saved because the request had no requester identity |
 | `TransportFailure` | `LocalControlOpsException` | keep | daemon unreachable/timeout — request may still be pending daemon-side |
 | *(propagates)* | `OperationCanceledException` | keep | caller/app-shutdown cancellation is its own path — never rendered as a transport failure; the VM treats it as a silent abort |
 
 **Exposed:** the pending cache (`IObservable` via DynamicData `.Connect()` — mutated on
-background continuations; consumers marshal with `ObserveOn(RxApp.MainThreadScheduler)`),
-`IObservable<int> PendingCount`, `ResolveAsync`, `Dismiss`, and an **unconditional**
-entry-added signal. The service knows nothing about windows: the prompt-window *coordinator*
-subscribes to the added signal, filters by window visibility, and marshals to the UI thread
-(§6). The count feeds `TrayViewModel` (§8).
+background continuations; consumers marshal with
+`ObserveOn(RxSchedulers.MainThreadScheduler)`, the app's existing scheduler seam),
+`IObservable<int> PendingCount`, `ResolveAsync`, and an **unconditional** entry-added signal.
+The service knows nothing about windows: the prompt-window *coordinator* subscribes to the
+added signal, filters by window visibility, and marshals to the UI thread (§6). The count
+feeds `TrayViewModel` (§8).
 
 **Shutdown:** app shutdown disposes in order: prompt-window coordinator (closes the window,
 cancelling any in-flight resolve via the OCE path above) → `ConsentService` (cancels the
@@ -306,9 +371,10 @@ stealing mid-interaction).
 `RequestId` ordinal for determinism) and pins the head as `Current`. While `Current` is in a
 terminal display or has a resolve in flight, cache changes (new arrivals, prune, replay
 reconciliation) do **not** swap the displayed item out from under the user — the pin releases
-only on advance. Removal is never the VM's job directly: it calls `ResolveAsync`/`Dismiss` on
-the pinned instance and the service's instance guard makes a stale removal a no-op (a
-successor with the same id is untouched).
+only on advance (or, in the hint-expired state, when the service's prune removes the pinned
+instance — below). The VM never removes cache entries; conclusive acks and the prune do (§5),
+and the instance guard makes any stale action a no-op that can never touch a same-id
+successor.
 
 **Content** — for the pinned current request:
 
@@ -323,30 +389,37 @@ successor with the same id is untouched).
 | Button | Wire | Notes |
 |---|---|---|
 | Allow once | `ConsentResolve{decision: "allow"}` | |
-| Always allow | `ConsentResolve{decision: "allow", save_rule: {action: "allow", requester: <id>, kind: null, repo: null, vendor: null}}` | Daemon stays the single rule writer. **Hidden when `Requester` is null** (§5 holds the real guard). Tooltip carries the precedence honestly: "Saves a rule allowing future launches from this requester. Existing deny rules — including Pause — take precedence until removed." No stronger promise is made anywhere in the UI (§4.1: the appended rule is first-match-shadowed by earlier denies). |
+| Allow & remember | `ConsentResolve{decision: "allow", save_rule: {action: "allow", requester: <id>, kind: null, repo: null, vendor: null}}` | Daemon stays the single rule writer. Label is deliberately not "Always allow" — an appended rule is first-match-shadowed by earlier denies (§4.1), so the label must not promise "always". **Hidden when `Requester` is null *or empty*** — the same predicate as §5's service guard, which remains the real safety boundary. Tooltip: "Saves a rule allowing future launches from this requester. Existing deny rules — including Pause — take precedence until removed." |
 | Deny | `ConsentResolve{decision: "deny"}` | |
 
 While a resolve is in flight all three disable (no double-submit); the countdown keeps
 ticking, but **hint expiry never preempts an in-flight resolve**: if the countdown reaches
 zero mid-resolve, the display shows "Expiring…" and waits for the ack — the ack is
-authoritative and governs the terminal state. Expiry acts on its own only when no resolve is
-in flight.
+authoritative and governs the terminal state.
 
-**Terminal states (per pinned request; each holds for 2 seconds, ticker-driven, then the VM
-dismisses/advances — the pin guarantees the display survives concurrent cache changes):**
+**Hint expiry (no resolve in flight) is not a verdict.** When the countdown reaches zero the
+window does *not* claim a denial — the hint is wall-clock and the daemon's deadline is
+monotonic (§5), so the request may in fact still be live. The countdown is replaced by
+"Response time elapsed — unanswered requests are denied by the daemon", and **the buttons
+stay active**: a click still resolves normally (if the daemon really did time out, the ack
+comes back `Ok=false` and the honest "Already decided" path runs; after a backward clock step,
+the click simply works). The entry stays in the cache until the §5 prune removes it (hint+5s,
+instance-guarded); the VM advances when its pinned instance leaves the cache in this state.
+
+**Terminal states (per pinned request):**
 
 - **Decided (`Applied`)** → advance immediately (no hold): window shows the next pending or
   closes when the queue empties. `AppliedRuleRejected` and `RuleSkippedNoRequester`
   additionally show a warning toast over the prompt window: "Decision applied — rule not
-  saved: {reason}".
-- **Already decided (`AlreadyDecided`)** → buttons are replaced by "Already decided" for the
-  2-second hold, then `Dismiss` + advance. Never a silent success: the user always sees that
-  their click did not decide this launch. When the click was **Always allow** and the ack's
-  `RuleSaved=true`, the text discloses the side effect: "Already decided — your always-allow
-  rule for {requester} was still saved."
-- **Expired (countdown ≤ 0, no resolve in flight)** → buttons are replaced by "Expired —
-  denied by timeout" for the 2-second hold, then `Dismiss` + advance (the §5 prune is the
-  backstop).
+  saved: {reason}" (for rule outcome `Unknown`: "Decision applied — this daemon version
+  doesn't report whether the rule was saved").
+- **Already decided (`AlreadyDecided`)** → buttons are replaced by "Already decided" for a
+  2-second hold (ticker-driven), then advance (the cache entry is already gone — the pin is
+  what the user is looking at). Never a silent success. After an **Allow & remember** click
+  the text discloses the §4.1 side effect per `RuleOutcome`: `Saved` → "Already decided —
+  your allow rule for {requester} was still saved."; `Rejected` → "Already decided — no rule
+  was saved."; `Unknown` → "Already decided — this daemon version doesn't report whether your
+  allow rule was saved."
 - **Transport failure (`TransportFailure`)** → toast over the prompt window ("Daemon
   unreachable — the request is still pending"), buttons re-enable, entry stays. The daemon
   may still be waiting.
@@ -362,7 +435,7 @@ itself.
 
 **Pause interplay:** none needed for prompting. Pause is a wildcard deny rule at `rules[0]`,
 so paused launches are rule-denied without prompting and simply appear in the Activity feed as
-denials. (Its interaction with "Always allow" is the §4.1 precedence note.)
+denials. (Its interaction with "Allow & remember" is the §4.1 precedence note.)
 
 ## 7. Activity tab
 
@@ -384,9 +457,12 @@ capped at 200 records.
   immediately on the ack *and* relies on the regular 2s stat poll to converge — the spec
   promise is "your decision appears no later than the next poll", not "immediately".
 
-Read failures never blank the feed: a `ReadTail` that returns empty (or a refresh that
-throws) while a previous read had rows keeps the last-good rows on display; the empty state
-renders only when the log is genuinely absent/empty on a clean read.
+**Display rule, keyed off `ConsentLogReadResult.Complete` (§4.4):** a `Complete` read
+replaces the rows — including replacing them with the empty state when it is genuinely empty
+(legitimate log deletion must be able to empty the feed). An **incomplete** read (any per-file
+I/O failure) never replaces existing rows: last-good rows stay on display and the next poll
+retries; if there are no previous rows, the partial records are shown as best-effort. The
+empty state therefore renders only on a clean empty read.
 
 The reader is `ConsentDecisionLogReader.ReadTail(daemonName, 200)` — pure file I/O, so the
 feed works with the daemon stopped or unreachable.
@@ -422,16 +498,20 @@ cadence picks up count changes through the model stream — no new refresh machi
 |---|---|---|
 | Daemon unreachable (no subscription) | Tray | Existing AI-1651 rows; no prompts possible; feed still renders from file |
 | Daemon without `consent/1` | Tray | No subscription; cache cleared (stale incarnation); existing down-level surfacing |
-| Consent dial fails while status Connected | none (self-heal) | Cache NOT cleared (clear sits after the subscribe-write boundary); 1s delay → retry |
-| Consent stream dies while Connected | none (self-heal) | 1s delay → resubscribe (fresh replay reconciles after the write boundary) |
+| Consent dial fails while status Connected | none (self-heal) | Cache NOT cleared (clear sits at the `Subscribed` boundary); 1s delay → retry |
+| Daemon dies between subscribe write and replay | none (self-heal) | Cache cleared but restored by the next successful replay (~1s cadence); bounded, UI-only (§5) |
+| Consent stream dies while Connected | none (self-heal) | 1s delay → resubscribe (fresh replay reconciles at the `Subscribed` boundary) |
 | Structurally invalid pending frame | none | Skipped (ending the stream would thrash the resubscribe loop) |
+| Ghost replay of a just-concluded request | none | Conclusion tombstone (10s TTL) drops it — no second prompt |
+| Wall-clock step vs. daemon's monotonic deadline | Prompt window | Hint expiry is never a verdict: non-authoritative copy, buttons stay active, ack governs |
 | Resolve transport failure | Prompt toast | Entry kept; buttons re-enable |
 | Resolve cancelled (shutdown) | none | OCE propagates; silent abort — never rendered as transport failure |
-| Resolve `Ok=false` | Prompt window | "Already decided" — never a silent success; `RuleSaved=true` disclosed |
-| Rule save rejected / skipped (no requester) | Prompt toast | Decision applied; warning shown |
-| Request expired (no withdrawal push) | Prompt window / prune | Countdown expiry display (never preempting an in-flight resolve); cache prune at hint+5s |
-| Same-id successor while ack in flight | none | Instance-guarded removals — a stale ack/dismiss/prune never evicts the successor |
-| Decision log absent / IO failure / bad lines | Activity tab | Absent → empty contribution; last-good rows kept on failed refresh; invalid lines skipped |
+| Resolve `Ok=false` | Prompt window | "Already decided" — never a silent success; rule outcome disclosed as saved / not saved / unknown (down-level) |
+| Rule save rejected / unknown / skipped (no requester) | Prompt toast | Decision applied; warning shown |
+| Request expired (no withdrawal push) | Prompt window / prune | Non-authoritative expiry display; cache prune at hint+5s (instance-guarded) |
+| Same-id successor while ack in flight | none | Reference-identity removal guard — a stale ack/prune never evicts the successor |
+| Stale resolve reaching the daemon after id reuse | daemon | Accepted: a same-id successor is a retry of the same launch content; the verdict transfers honestly (§4.1) |
+| Decision log absent / IO failure / bad lines | Activity tab | Clean absence → `Complete` empty read → empty state; I/O failure → `Complete=false` → last-good rows kept; invalid lines skipped |
 | Rotation race during read | Activity tab | `Distinct()` merge; miss self-heals next poll |
 
 ## 10. Testing
@@ -441,22 +521,27 @@ throughout — no real sleeps).
 
 **Core:**
 - `ResolveConsentAsync` against an in-proc fake server (pattern of existing `LocalControlOps`
-  tests): ack round-trip (`Ok`/`Error`/`RuleSaved` shapes), decodable `Error` frame →
-  `daemon_rejected`, malformed ack → `unexpected_reply`, EOF → `unexpected_reply`, transport
-  → `daemon_unreachable`, phase timeout → `timed_out`, caller-cancellation propagates.
-- `ConsentSubscription`: replay + push frames yield DTOs in order; EOF ends enumeration;
-  failed connect (`SocketException`) ends enumeration (no daemon listening); unexpected frame
-  type ends enumeration; undecodable JSON ends enumeration; **decodable-but-structurally-
-  invalid pending (null request_id via `{}`) is skipped and the stream continues**; `ct`
-  propagates OCE. Absent `requester_display` deserializes to null.
+  tests): ack round-trip (`Ok`/`Error`/`RuleSaved` shapes, including an old-format ack with no
+  `rule_saved` member → null), decodable `Error` frame → `daemon_rejected`, malformed ack →
+  `unexpected_reply`, EOF → `unexpected_reply`, transport → `daemon_unreachable`, phase
+  timeout → `timed_out`, caller-cancellation propagates.
+- `ConsentSubscription`: `Subscribed` yielded after connect+write and **before any read**
+  (observable with an empty replay — first `MoveNextAsync` completes); replay + push frames
+  yield `Pending` events in order; EOF ends enumeration; failed connect (`SocketException`)
+  ends enumeration without yielding `Subscribed`; unexpected frame type ends enumeration;
+  undecodable JSON ends enumeration; **decodable-but-structurally-invalid pending (null
+  request_id via `{}`) is skipped and the stream continues**; `ct` propagates OCE. Absent
+  `requester_display` deserializes to null.
 - `ConsentDecisionLogReader`: tail across the rotation pair (order, cap, newest-first);
   undecodable-line skip; **parseable-but-structurally-invalid line (`{}`) skip**;
-  `Distinct()` dedup; absent files → empty; file vanishing between stat and open → empty, no
-  throw; old-format lines (no `requester_display`) parse with null; **a reader holding an
-  open handle (the reader's own share mode) does not block the writer's actual operations —
-  append AND `File.Move` rotation — while a concurrent `ReadTail` succeeds** (the sharing
-  regression guard; trivially green on Unix, load-bearing on the Windows CI leg — both
-  directions and both operations covered, since `FileShare.Delete` is what rotation needs).
+  `Distinct()` dedup; absent files → `([], Complete=true)`; **one file unreadable (I/O
+  failure) → partial records with `Complete=false`**; file vanishing between stat and open →
+  clean absence, no throw; old-format lines (no `requester_display`) parse with null; **a
+  reader holding an open handle (the reader's own share mode) does not block the writer's
+  actual operations — append AND `File.Move` rotation — while a concurrent `ReadTail`
+  succeeds** (the sharing regression guard; trivially green on Unix, load-bearing on the
+  Windows CI leg — both directions and both operations covered, since `FileShare.Delete` is
+  what rotation needs).
 
 **Daemon:**
 - Gate threads `RequesterDisplay` into the prompt request and the decision record (extend
@@ -470,34 +555,45 @@ throughout — no real sleeps).
 
 **App (the "full prompt matrix" from the issue):**
 - Allow once / Deny → correct `ConsentResolveDto`, entry removed, queue advances.
-- Always allow → `save_rule` is requester-only; button hidden when `Requester` is null; **the
-  service guard: `ResolveAsync(saveRule: true)` on a null/empty-requester target sends NO
-  `save_rule` and reports `RuleSkippedNoRequester`** (tested directly, not via the button).
+- Allow & remember → `save_rule` is requester-only; button hidden when `Requester` is null
+  **and** when it is empty (same predicate as the service guard); **the service guard:
+  `ResolveAsync(saveRule: true)` on a null/empty-requester target sends NO `save_rule` and
+  reports `RuleSkippedNoRequester`** (tested directly, not via the button).
+- Rule-outcome disambiguation: after an Allow & remember click, `AlreadyDecided` with
+  `RuleSaved=true` / `false` / absent (old-format ack) shows the saved / not-saved /
+  unknown-down-level disclosure respectively.
 - ABA: successor with the same `RequestId` upserted while predecessor's resolve is in flight
-  → the predecessor's ack removes nothing; the successor survives and is displayed next.
-- Countdown expiry with no resolve in flight → "Expired — denied by timeout", 2s hold
-  (ticker-driven), `Dismiss`, advance; prune removes ghost entries at hint+5s
-  (instance-guarded).
-- Countdown reaches zero while a resolve is in flight → no expiry preemption; `Ok=true` after
-  zero → `Applied`; `Ok=false` after zero → "Already decided"; the next request is unaffected.
-- `AlreadyDecided` → 2s hold, then advance — never silent; with `RuleSaved=true` after an
-  Always-allow click, the disclosure text is shown.
-- `AppliedRuleRejected` → warning surfaced, entry removed.
+  → the predecessor's ack removes nothing; the successor survives and is displayed next —
+  **including when both carry an identical `RequestedAt`** (reference identity, not value
+  equality).
+- Ghost replay: a `Pending` for a request concluded within the tombstone TTL is dropped — no
+  re-add, no second raise; one arriving after the TTL is admitted.
+- Hint expiry with no resolve in flight → non-authoritative copy, **buttons remain active**;
+  a click after hint-zero that acks `Ok=true` is `Applied` (the wall-clock-step case: hint
+  fired early, request was still live); one that acks `Ok=false` runs "Already decided"; the
+  prune removes the entry at hint+5s (instance-guarded) and the VM advances on that removal.
+- Countdown reaches zero while a resolve is in flight → no expiry preemption; the ack
+  governs; the next request is unaffected.
+- `AlreadyDecided` → 2s hold, then advance — never silent.
+- `AppliedRuleRejected` (including rule outcome `Unknown`) → warning surfaced, entry removed.
 - Transport failure → entry kept, buttons re-enable. Cancellation (lane-queued and
   in-flight) → silent abort, entry kept, no toast.
 - Queue: "1 of N" indicator; oldest-first ordering; the pinned display does not swap while a
   terminal hold or in-flight resolve is active; additions while visible don't re-raise;
   addition while closed raises (coordinator-filtered, marshalled to the UI thread — the add
   originates off the UI thread in the test).
-- Subscription lifecycle: clear happens only after the subscribe write succeeds (failed dial
-  retains entries); reconnect-with-empty-replay leaves an empty cache; `Connected` without
-  `consent/1` clears the cache and never subscribes; stream-end-while-Connected retries.
+- Subscription lifecycle: clear happens at the `Subscribed` event (failed dial retains
+  entries — no `Subscribed`, no clear); reconnect-with-empty-replay leaves an empty cache
+  (the `Subscribed` boundary makes this observable); stream death after `Subscribed` but
+  before any replay frame → cache cleared, restored by the next attempt's replay; `Connected`
+  without `consent/1` clears the cache and never subscribes; stream-end-while-Connected
+  retries.
 - Shutdown: app quits with the prompt window open and a resolve in flight → clean disposal in
   the §5 order, OCE path exercised.
 - `ActivityViewModel`: rows map records (fallback chains, source labels, unrecognized source
   verbatim, unparseable timestamp verbatim); refresh on tab-visible / stat-change /
-  own-resolution (eventual — asserted via the next poll tick, not instant); last-good rows
-  kept when a refresh fails; empty state only on clean-empty read.
+  own-resolution (eventual — asserted via the next poll tick, not instant); **`Complete=false`
+  read keeps last-good rows; `Complete=true` empty read shows the empty state**.
 - `TrayViewModel`: new Attention row (pending>0 while Idle/Running → Attention + header);
   connection-trouble precedence unchanged; menu item visibility.
 
@@ -507,5 +603,7 @@ throughout — no real sleeps).
 - Consent rules editor UI → umbrella slice 4.
 - Attach/approve from the CLI (`kcap daemon consent` gains no resolve verb — the app is the
   approval surface; the CLI keeps rules + log only).
+- A wire generation echo on `ConsentResolveDto` (§4.1's accepted stale-resolve tradeoff notes
+  it as a future option).
 - Any change to engine matching, rule ordering/precedence, policy storage, or prompt timeout
   semantics.

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -492,7 +492,12 @@ this state.
   closes when the queue empties. `AppliedRuleRejected` and `RuleSkippedNoRequester`
   additionally show a warning toast over the prompt window: "Decision applied — rule not
   saved: {reason}" (for rule outcome `Unknown`: "Decision applied — this daemon version
-  doesn't report whether the rule was saved").
+  doesn't report whether the rule was saved"). **Exception (implementation-discovered
+  contradiction, resolved for disclosure):** when a rule warning must be shown AND the queue
+  would empty, the window holds for the 2-second terminal beat displaying the warning
+  in-window before closing — a toast "over the prompt window" cannot render on a window that
+  closes synchronously, and "never a silent success" outranks "advance immediately". A clean
+  `Applied` with an empty queue still closes immediately.
 - **Already decided (`AlreadyDecided`)** → buttons are replaced by "Already decided" for a
   2-second hold (ticker-driven), then advance (the cache entry is already gone — the pin is
   what the user is looking at). Never a silent success. After an **Allow & remember** click

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -424,6 +424,23 @@ The service knows nothing about windows: the prompt-window *coordinator* subscri
 added signal, filters by window visibility, and marshals to the UI thread (§6). The count
 feeds `TrayViewModel` (§8).
 
+**Entry-added identity — the signal is the FIRST SURFACING of a `PromptId`
+(implementation-discovered refinement).** "Unconditional" above means only "not filtered by
+window state". Keyed on the cache KEY the signal was wrong in both directions, and both
+directions were shipped defects. A successor B under A's `RequestId` — the id-reuse case this
+whole section is built around, and the likeliest second prompt there is — replaced A's cache
+slot in silence, so a deferred or hidden window never raised for the retry. And the
+`Subscribed` clear re-admits every replayed entry into an *empty* cache, so every replayed
+request looked new and re-raised a window the user had explicitly deferred (§6). The service
+therefore keeps a `_surfaced` PromptId set beside the tombstones, with the same lifetime and
+the same argument behind it: a never-reused GUID can never suppress a future request, at ~50
+bytes per request ever seen. `EntryAdded` fires when, and only when, an upsert introduces a
+PromptId that set has not seen. Tombstones are a subset of it and stay separate because they do
+a different job — a tombstone *drops* the frame, `_surfaced` only keeps it *quiet*. The
+down-level `Connected` cache clear joins the tombstone test and the insert under the one lock
+for the same reason they already share it: an upsert that had passed its tombstone test would
+otherwise land after that clear and resurrect a previous incarnation's entry.
+
 **Shutdown:** app shutdown disposes in order: prompt-window coordinator (closes the window,
 cancelling any in-flight resolve via the OCE path above) → `ConsentService` (cancels the
 subscription loop and the resolve lane) → `DaemonClientService` (existing). Quitting with the
@@ -445,6 +462,20 @@ without deciding is an explicit *defer*: the queue is untouched, the tray stays 
 `Attention`, and the tray menu's "Review pending launches…" reopens it. Additions while the
 window is already visible just update the queue indicator — no re-activation (no focus
 stealing mid-interaction).
+
+**Raise identity and the close debounce (implementation-discovered refinement).** "A new
+request" above is a `PromptId` the service has never surfaced (§5), not a new cache key: a
+same-`RequestId` successor raises, and a resubscribe's replay of an already-surfaced request
+does not — which is what makes the defer survive a reconnect blip instead of being undone by
+it. Symmetrically, "closes when the queue empties" (below) applies *on the spot* only to a
+**decision** — an ack, or the end of its terminal hold. A queue the CACHE emptied waits one
+ticker beat before closing, because the clear and its replay arrive as two separate changesets
+and closing on the intermediate one flickered the window shut and rebuilt it with a fresh
+ViewModel, a reset pin and stolen focus; a replay landing inside that beat cancels the close
+outright. The pin releases immediately either way — nothing that left the cache stays on
+screen. Accepted consequence: a replay more than a beat late does close the window, and its
+already-surfaced requests do not raise a new one — the tray keeps `Attention` and "Review
+pending launches…" is the way back.
 
 **Displayed item is a pinned snapshot.** The VM sorts the cache (by `RequestedAt`, then
 `RequestId` ordinal for determinism) and pins the head as `Current`. While `Current` is in a
@@ -596,6 +627,7 @@ cadence picks up count changes through the model stream — no new refresh machi
 | Rule save rejected / unknown / skipped (no requester) | Prompt toast | Decision applied; warning shown |
 | Request expired (no withdrawal push) | Prompt window / prune | Non-authoritative expiry display; cache prune at `PruneAfter` (identity-guarded, skips the in-flight resolve target, refreshed on transport failure) |
 | Same-id successor while ack in flight | none | Identity-pair removal guard — a stale ack/prune never evicts the successor |
+| Resubscribe replay while the window is deferred or open | none | No re-raise (the replayed identities were already surfaced, §5) and no flicker close (a cache-caused close waits a beat and the replay cancels it, §6) |
 | Stale resolve reaching the daemon after id reuse | daemon | Closed: the `prompt_id` echo mismatches (or the atomic claim is lost) and the broker answers no-pending (`Ok=false`) — a verdict for A can never decide B (§4.1) |
 | Decision log absent / IO failure / bad lines | Activity tab | Clean absence → `Complete` empty read → empty state; I/O failure → `Complete=false` → last-good rows kept; invalid lines skipped |
 | Rotation race during read | Activity tab | `Distinct()` merge; miss self-heals next poll |
@@ -709,6 +741,13 @@ throughout — no real sleeps).
   terminal hold or in-flight resolve is active; additions while visible don't re-raise;
   addition while closed raises (coordinator-filtered, marshalled to the UI thread — the add
   originates off the UI thread in the test).
+- Raise identity and the close debounce (the §5/§6 refinements): a same-`RequestId` successor
+  carrying a fresh `PromptId` fires the added signal and raises a hidden window; a
+  resubscribe's replay of already-surfaced identities fires nothing (a deferred window stays
+  closed, the tray count is still restored) while a genuinely new request pushed after the same
+  reconnect still fires; an OPEN window survives a clear+replay without closing or being
+  rebuilt (ticker-driven, deterministic); a cache-caused emptiness with no replay still closes
+  it on the next beat, and an ack-emptied queue still closes it immediately.
 - Subscription lifecycle: clear happens at the `Subscribed` event (failed dial retains
   entries — no `Subscribed`, no clear); reconnect-with-empty-replay leaves an empty cache
   (the `Subscribed` boundary makes this observable); stream death after `Subscribed` but

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -42,8 +42,8 @@ launch that reused the id; hoisting the AI-1651 per-window ticker into an app-li
 service; headless ViewModel tests for the full prompt matrix.
 
 **Out:** macOS system notification (AI-1653); consent-rules editor UI (slice 4); any change to
-engine matching, rule ordering/precedence, policy storage, or prompt timeout semantics; new
-IPC frame types; Windows/Linux app packaging.
+engine matching, rule ordering/precedence, policy storage, or prompt timeout semantics; any
+frame types beyond the two §4.1 v2 values; Windows/Linux app packaging.
 
 ## 4. Wire & Core changes
 
@@ -135,16 +135,21 @@ this: capabilities are learned on one socket while consent ops travel on fresh b
 connections, so a daemon restart/downgrade between them (TOCTOU) would route a v2-shaped
 resolve into the v1 handler. The v2 operations therefore ride **new append-only frame
 types** — `ConsentSubscribeV2 = 17` and `ConsentResolveV2 = 18` — which the app uses
-exclusively. A v1 daemon's routing switch answers any unknown frame type with an `Error`
-frame (`LocalControlServer` default arm), so against a v1 incarnation the v2 resolve draws
-`daemon_rejected` (no resolution occurred — the cached prompt is *structurally impossible* to
-resolve through the v1 id-only handler, whichever incarnation answers the socket) and the v2
-subscribe ends without registering a subscriber (the v1 daemon keeps its fast `prompt_no_ui`
-denials instead of waiting on a subscriber that renders nothing). On a v2 daemon, frame 17
-routes to the same subscribe handler as frame 11, and frame 18 routes to a resolve path that
-**requires** `prompt_id` (missing/empty → `Ok=false` "invalid resolve payload"); the v1
-frames 11/12 remain routed unchanged for legacy callers, served by `TryResolve`'s null-echo
-path.
+exclusively. A shipped v1 daemon never even routes these bytes: its `FrameCodec.Decode`
+throws `InvalidDataException` for a type absent from its enum/switch *before* the routing
+arm, and `LocalControlServer.HandleConnectionAsync` catches, logs, and closes the socket
+without writing any frame. The observable contract against a v1 incarnation is therefore
+**EOF**: the v2 resolve reads end-of-stream and classifies as `unexpected_reply`; the v2
+subscribe yields its client-local `Subscribed` and then ends — never registering a subscriber
+(the v1 daemon keeps its fast `prompt_no_ui` denials instead of waiting on a subscriber that
+renders nothing). Either failure shape (EOF today; a decodable `Error` from any future
+decode-but-don't-route daemon → `daemon_rejected`) is a `LocalControlOpsException` the app
+maps to a kept entry (§5) — and in every shape the cached prompt is *structurally impossible*
+to resolve through the v1 id-only handler, whichever incarnation answers the socket. On a v2
+daemon, frame 17 routes to the same subscribe handler as frame 11, and frame 18 routes to a
+resolve path that **requires** `prompt_id` (missing/empty → `Ok=false` "invalid resolve
+payload"); the v1 frames 11/12 remain routed unchanged for legacy callers, served by
+`TryResolve`'s null-echo path.
 
 **Capability `consent/2`** is appended to `LocalControlCapabilities.Current` as the
 *discovery* signal (advertised, per the AI-1648 convention, only because the live v2 handlers
@@ -166,7 +171,8 @@ public static async IAsyncEnumerable<ConsentStreamEvent> RunAsync(
 ```
 
 Connects to the daemon's socket, writes `FrameType.ConsentSubscribeV2` (empty text; §4.1 —
-a v1 daemon answers the unknown frame with `Error`, ending the enumeration without
+a v1 daemon's codec rejects the unknown byte before routing and the server closes without
+replying, so the enumeration yields its client-local `Subscribed` and then ends on EOF, never
 registering a subscriber), **yields `Subscribed` once** immediately after that write
 succeeds, then reads frames and yields one `Pending` per `ConsentPending` frame. The `Subscribed` event exists because an async iterator
 exposes no other observable boundary between "dialing" and "subscribed": with an empty replay
@@ -571,7 +577,7 @@ cadence picks up count changes through the model stream — no new refresh machi
 | Failure | Surface | Behavior |
 |---|---|---|
 | Daemon unreachable (no subscription) | Tray | Existing AI-1651 rows; no prompts possible; feed still renders from file |
-| Daemon without `consent/2` (incl. `consent/1`-only) | Tray | No subscription, prompts, or resolves; cache cleared; down-level surfacing. Enforcement doesn't depend on the check: a v1 incarnation answering a v2 frame (restart TOCTOU) errors it — structurally unable to resolve or subscribe (§4.1) |
+| Daemon without `consent/2` (incl. `consent/1`-only) | Tray | No subscription, prompts, or resolves; cache cleared; down-level surfacing. Enforcement doesn't depend on the check: a v1 incarnation's codec rejects a v2 frame before routing and closes without replying (restart TOCTOU) — the resolve observes EOF → `unexpected_reply`, no resolution occurs (§4.1) |
 | Consent dial fails while status Connected | none (self-heal) | Cache NOT cleared (clear sits at the `Subscribed` boundary); 1s delay → retry |
 | Daemon dies between subscribe write and replay | none (self-heal) | Cache cleared but restored by the next successful replay (~1s cadence); bounded, UI-only (§5) |
 | Consent stream dies while Connected | none (self-heal) | 1s delay → resubscribe (fresh replay reconciles at the `Subscribed` boundary) |
@@ -645,13 +651,15 @@ throughout — no real sleeps).
 - Capability: `LocalControlCapabilities.Current` advertises `consent/2` alongside
   `consent/1`; mixed-version acceptance — an app facing a `consent/1`-only capability set
   starts no subscription and sends no resolve.
-- Incarnation swap (the restart TOCTOU): against a v1-routing server (routes frames 11/12,
-  answers 17/18 with the shipped `default`-arm `Error` frame), a cached v2 prompt's resolve
-  via `ConsentResolveV2` draws `daemon_rejected` — **no resolution occurs and a same-id
-  pending on that daemon is untouched**; `ConsentSubscribeV2` against the same server ends
-  the enumeration without registering a subscriber. V2-daemon side: frame 18 with a
-  missing/empty `prompt_id` acks `Ok=false` "invalid resolve payload"; frames 11/12 still
-  route for legacy callers.
+- Incarnation swap (the restart TOCTOU): against a faithful v1 fake — a server whose
+  *decoder* rejects frame bytes 17/18 before routing and closes the connection without
+  writing a frame, mirroring the shipped v1 `FrameCodec.Decode`/`HandleConnectionAsync`
+  behavior (NOT a routing-default `Error` reply, which no deployed v1 daemon produces) — a
+  cached v2 prompt's resolve via `ConsentResolveV2` observes EOF → `unexpected_reply` and
+  **no resolution occurs; a same-id pending on that daemon is untouched**;
+  `ConsentSubscribeV2` against the same fake yields `Subscribed` then ends on EOF without
+  registering a subscriber. V2-daemon side: frame 18 with a missing/empty `prompt_id` acks
+  `Ok=false` "invalid resolve payload"; frames 11/12 still route for legacy callers.
 
 **App (the "full prompt matrix" from the issue):**
 - Allow once / Deny → correct `ConsentResolveDto`, entry removed, queue advances.

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -689,10 +689,15 @@ throughout — no real sleeps).
 - Capability: `LocalControlCapabilities.Current` advertises `consent/2` alongside
   `consent/1`; mixed-version acceptance — an app facing a `consent/1`-only capability set
   starts no subscription and sends no resolve.
-- Incarnation swap (the restart TOCTOU): against a faithful v1 fake — a server whose
-  *decoder* rejects frame bytes 17/18 before routing and closes the connection without
-  writing a frame, mirroring the shipped v1 `FrameCodec.Decode`/`HandleConnectionAsync`
-  behavior (NOT a routing-default `Error` reply, which no deployed v1 daemon produces) — a
+- Incarnation swap (the restart TOCTOU): against a faithful v1 fake — a server that consumes
+  the full frame (5-byte header, then exactly the declared payload length) before its
+  *decoder* rejects frame bytes 17/18 and closes the connection without writing a frame,
+  mirroring the shipped v1 `FrameCodec.ReadAsync`/`Decode`/`HandleConnectionAsync` behavior:
+  `ReadAsync` always reads header **and** payload off the wire before `Decode` ever throws on
+  the unknown type byte, so the fake must too — a header-only close would leave a non-empty
+  request payload (e.g. `ConsentResolveV2`'s JSON) unread in the kernel buffer, and closing
+  with unread bytes sends RST on Linux (ECONNRESET, not clean EOF) even though it doesn't on
+  macOS (NOT a routing-default `Error` reply, which no deployed v1 daemon produces) — a
   cached v2 prompt's resolve via `ConsentResolveV2` observes EOF → `unexpected_reply` and
   **no resolution occurs; a same-id pending on that daemon is untouched**;
   `ConsentSubscribeV2` against the same fake yields `Subscribed` then ends on EOF without

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -32,17 +32,20 @@ decision log, and pending-consent wired into the tray's existing `Attention` sta
 Deny, countdown, queue); Activity tab; tray `Attention` on pending consent + "Review pending
 launches…" menu item; `ResolveConsentAsync` on `ILocalControlOps`; consent subscription client
 in Core; decision-record hoisting to Core (shared write/read shape); `requester_display`
-threading through the consent pipeline (additive); headless ViewModel tests for the full
-prompt matrix.
+threading through the consent pipeline (additive); `rule_saved` reporting on `ConsentAckDto`
+(additive) so a rule installed for an already-decided request is disclosed, not hidden;
+hoisting the AI-1651 per-window ticker into an app-lifetime service; headless ViewModel tests
+for the full prompt matrix.
 
-**Out:** macOS system notification (AI-1653); consent-rules editor UI (slice 4); any daemon
-policy/engine behavior change; new IPC frame types; Windows/Linux app packaging.
+**Out:** macOS system notification (AI-1653); consent-rules editor UI (slice 4); any change to
+engine matching, rule ordering/precedence, policy storage, or prompt timeout semantics; new
+IPC frame types; Windows/Linux app packaging.
 
 ## 4. Wire & Core changes
 
 No new frame types and no protocol version change. Everything below is additive.
 
-### 4.1 `ResolveConsentAsync` on `ILocalControlOps`
+### 4.1 `ResolveConsentAsync` on `ILocalControlOps`, and `rule_saved` on the ack
 
 ```csharp
 Task<ConsentAckDto> ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct);
@@ -54,13 +57,28 @@ exactly one `ConsentAck` frame, deserializes `ConsentAckDto`. Per-phase timeouts
 classification are identical to the existing ops — caller-cancellation propagates
 (`OperationCanceledException` checked first), `EndOfStreamException` before `IOException`
 (derivation order) → `unexpected_reply`, transport → `daemon_unreachable`, phase timeout →
-`timed_out`; a null/malformed ack or a non-`ConsentAck` frame → `unexpected_reply`. The
-`ConsentAckDto` is returned as-is: `Ok` reflects the resolution outcome, `Error` carries either
-the failure detail or the partial-failure warning on `Ok=true` (rejected `save_rule`).
+`timed_out`, a decodable `Error` frame → `daemon_rejected` (matching the existing consent
+ops), any other frame type or a null/malformed ack → `unexpected_reply`.
 
-The daemon handler exists (`LaunchConsentIpc.HandleResolveAsync`); this is client plumbing only.
-No hello is needed on one-shot connections (hello is optional; the CLI consent verbs already
-send bare frames).
+**`ConsentAckDto` gains trailing `bool? RuleSaved`** (wire `rule_saved`, positional-required
+convention: no C# default, nulls always written). Semantics: null when the resolve carried no
+`save_rule`; `true`/`false` = the rule write succeeded/failed. The daemon's
+`HandleResolveAsync` deliberately persists `save_rule` *before* attempting the resolution —
+"Always allow" expresses durable trust in the requester, which stands even when this
+particular launch has already been decided — so today an `Ok=false` ack can silently hide an
+installed rule. The handler change: populate `RuleSaved` on **both** ack branches (today the
+no-pending branch drops the save outcome entirely). `Ok`'s meaning is unchanged: it reflects
+the resolution outcome only.
+
+**Rule ordering is deliberately untouched.** The handler appends the saved rule at the end
+and `LaunchConsentEngine` is first-match-wins, so an earlier matching rule — the pause
+wildcard deny at `rules[0]`, or any manual deny — takes precedence over an appended allow
+until that earlier rule is removed. This is correct: "Always allow" must never silently
+override pause or an explicit deny. The UI copy carries the consequence honestly (§6).
+
+The daemon resolve handler otherwise exists (`LaunchConsentIpc.HandleResolveAsync`); no hello
+is needed on one-shot connections (hello is optional; the CLI consent verbs already send bare
+frames).
 
 ### 4.2 Consent subscription client (Core)
 
@@ -76,12 +94,19 @@ frames and yields one `ConsentPendingDto` per `ConsentPending` frame. The daemon
 full pending set immediately, then pushes new requests (broker contract: exactly-once per
 subscriber, no withdrawal push).
 
-Termination contract: EOF and transport `IOException` end the enumeration normally (an ended
-stream means "disconnected" — the consumer decides whether to resubscribe). A frame of any
-other type, or a `ConsentPending` frame whose JSON does not deserialize, also ends the
-enumeration — protocol confusion is treated as a dead connection, not skipped, and the
-consumer's resubscribe gets a fresh replay. Only `OperationCanceledException` (the caller's
-`ct`) propagates.
+**Termination and validation contract:**
+
+- EOF, transport `IOException`, and `SocketException` (a failed *connect* throws
+  `SocketException` directly — it is not an `IOException`) end the enumeration normally: an
+  ended stream means "this attempt is over", and the consumer decides whether to resubscribe.
+- A frame of any type other than `ConsentPending`, or a frame whose JSON does not
+  *deserialize*, also ends the enumeration — protocol confusion is a dead connection.
+- A frame that deserializes but is **structurally invalid** — null root, or null/empty
+  `RequestId`, `Kind`, `RepoPath`, `Vendor`, `RequestedAt`, or `TimeoutSeconds <= 0` (STJ
+  source-gen does not enforce non-nullable members; `{}` decodes "successfully") — is
+  **skipped**, not fatal. Ending the enumeration here would be a thrash loop: the resubscribe
+  replay would redeliver the same invalid entry forever.
+- Only `OperationCanceledException` (the caller's `ct`) propagates.
 
 ### 4.3 `requester_display` threading (additive)
 
@@ -142,30 +167,56 @@ public static class ConsentDecisionLogReader {
 }
 ```
 
-`ReadTail` reads `{path}.1` then `{path}` (each may be absent), keeps the last `max` parseable
+`ReadTail` reads `{path}.1` then `{path}` (each may be absent), keeps the last `max` valid
 records, newest first. Rules:
 
 - **Sharing:** every open is `FileAccess.Read` with `FileShare.ReadWrite | FileShare.Delete` —
-  the daemon appends and rotates (`File.Move`) this file live; a default write-denying or
-  delete-denying open would block the daemon's own writer on Windows (the AI-1629 bug class).
-- **Malformed lines** (torn tail write, hand-edited file) are skipped, not fatal.
+  the daemon appends and rotates (`File.Move`) this file live; on Windows a write-denying open
+  would block the daemon's appends and a delete-denying open would fail its rotation (the
+  AI-1629 bug class; `FileShare.Delete` is specifically what `File.Move` needs).
+- **Invalid lines are skipped, never fatal:** lines that do not parse as JSON (torn tail
+  write), and lines that parse but are structurally invalid — null root, or null `DecidedAt`,
+  `AgentId`, `Kind`, `RepoPath`, `Vendor`, `Outcome`, or `Source` (`Requester`,
+  `RequesterDisplay` stay nullable; a missing `requester_is_owner` reads as `false`).
+- **Per-file I/O failure = absent:** `FileNotFoundException`, `DirectoryNotFoundException`,
+  `IOException`, and `UnauthorizedAccessException` on either file (races with rotation or
+  daemon-state-dir deletion between stat and open, or between the two reads) make that file
+  contribute nothing. `ReadTail` never throws for these; worst case it returns an empty list.
 - **Rotation race:** a rotation between the two reads can transiently duplicate or miss lines.
   Records have value equality — the merged list is `Distinct()`-ed, and a miss self-heals on
   the next refresh (§7). Accepted: this is a display feed, not an audit query.
-- Absent files → empty list (the feed renders its empty state; no error).
 
 ## 5. `ConsentService` (app)
 
 `src/Capacitor.App/Services/ConsentService.cs` (+ `IConsentService`): owns the consent
 subscription, the pending queue, and resolution. Single instance, created at startup beside
-`DaemonClientService`.
+`DaemonClientService`. **The service is the sole owner of the pending cache** — every
+insertion and removal happens here; ViewModels only read (§6 pins *displayed* items
+separately).
+
+**Shared ticker (infrastructure, in scope):** the AI-1651 1-second ticker currently lives as a
+private observable inside `MainWindowViewModel`. It hoists into an app-lifetime `ITicker`
+service — a shared 1 Hz `IObservable<long>`, created and subscribed on the UI thread at
+startup (the AI-1651 lesson: an off-UI-thread `Observable.Interval` subscription binds an
+orphan thread-local dispatcher and never ticks). `MainWindowViewModel` consumes it instead of
+owning it; `ConsentService` (prune), `ConsentPromptViewModel` (countdown, terminal-state
+holds), and `ActivityViewModel` (stat poll) consume the same instance.
 
 **State:** `SourceCache<PendingConsent, string>` keyed by `RequestId`. `PendingConsent` wraps
 the `ConsentPendingDto` plus a computed `DeadlineHint = RequestedAt + TimeoutSeconds`
 (`DateTimeOffset` parse of the daemon's ISO stamp; same machine, so no clock-skew handling; an
-unparseable `RequestedAt` falls back to arrival time + `TimeoutSeconds`).
-The deadline is a *hint* — AI-1648's subscriber grace means the daemon's real deadline can
-differ slightly; the authoritative outcome is only ever a resolve ack.
+unparseable `RequestedAt` falls back to arrival time + `TimeoutSeconds`). The deadline is a
+*hint* — AI-1648's subscriber grace means the daemon's real deadline can differ slightly; the
+authoritative outcome is only ever a resolve ack.
+
+**Instance-guarded removal (ABA defense).** `RequestId` is the agent id, and the broker
+explicitly documents that a successor prompt can reuse a predecessor's id (retry of the same
+agent). The subscription and resolve travel on separate connections, so successor B can be
+upserted before predecessor A's ack is processed — an unconditional remove-by-key would then
+evict B, and with no withdrawal/replay push nothing would restore it. Therefore **every**
+removal (conclusive ack, dismiss, prune) captures the exact `PendingConsent` it is acting on
+and removes only if the cache still holds that value (record value-equality; A and B differ at
+least in `RequestedAt`). A removal that finds a different value is a no-op.
 
 **Subscription lifecycle — status-driven.** The service observes
 `DaemonClientService.Status`:
@@ -173,66 +224,98 @@ differ slightly; the authoritative outcome is only ever a resolve ack.
 - On `Connected` with capabilities containing `"consent/1"` → start the subscription loop.
 - On leaving `Connected` (Connecting/Unreachable) → cancel the loop. Pending entries are NOT
   cleared on disconnect — the daemon may still be alive holding live prompts; entries expire
-  via their own deadline hints, and a resubscribe reconciles (below).
-- `Connected` without `consent/1` (down-level daemon) → no subscription, no prompts; the
-  existing shell surfaces the daemon-outdated condition.
+  via their own deadline hints, and a successful resubscribe reconciles (below).
+- On `Connected` **without** `"consent/1"` (a down-level daemon incarnation) → no
+  subscription, and the cache **is** cleared: any retained entries belong to a previous
+  incarnation and can never be resolved against this one. The existing shell surfaces the
+  daemon-outdated condition.
 
-**Loop:** while in the connected state: clear the pending cache, then enumerate
-`ConsentSubscription.RunAsync(daemonName, ct)`, upserting each DTO by `RequestId`. The clear
-immediately precedes each connection attempt — the daemon's replay is the authoritative
-pending set, and there is no end-of-replay marker, so reset-then-rebuild is the only honest
-reconciliation. If the enumeration ends while status still reports Connected (protocol
-confusion, half-dead socket), delay 1s and go around. Loop cancellation stops cleanly.
+**Loop:** while in the connected state: dial and write the `ConsentSubscribe` frame; **only
+after that write succeeds** clear the pending cache, then upsert each incoming DTO by
+`RequestId`. The clear sits at the subscribe-write boundary, not before the dial: a failed
+dial while the status socket still reports Connected must not erase a still-actionable queue
+— retained entries keep the tray attention and their countdowns alive through the transient.
+After the boundary, the daemon's replay is authoritative by construction: anything the daemon
+no longer holds is gone from the cache (accepted tradeoff: an entry resolved while
+disconnected vanishes without a terminal display; the Activity feed carries its outcome). If
+the enumeration ends while status still reports Connected (protocol confusion, half-dead
+socket, failed dial), delay 1s and go around. Loop cancellation stops cleanly.
 
-**Pruning:** on the shared 1-second ticker, entries with `now > DeadlineHint + 5s` are removed
-from the cache. This bounds ghost entries from requests that expired daemon-side (there is no
-withdrawal push) and from disconnected periods. The prompt VM shows the expired state before
-the prune fires (§6).
+**Pruning:** on the shared ticker, entries with `now > DeadlineHint + 5s` are removed
+(instance-guarded). This bounds ghost entries from requests that expired daemon-side (there is
+no withdrawal push) and from disconnected periods. The prompt VM shows the expired state and
+dismisses before the prune fires (§6); the prune is the backstop.
 
 **Resolution:**
 
 ```csharp
-Task<ConsentResolveOutcome> ResolveAsync(string requestId, bool allow, bool saveRule, CancellationToken ct);
+Task<ConsentResolveOutcome> ResolveAsync(PendingConsent target, bool allow, bool saveRule, CancellationToken ct);
+void Dismiss(PendingConsent target);   // instance-guarded removal; used by the VM's terminal-state advance
 ```
 
-Builds the `ConsentResolveDto` (`decision: allow|deny`; when `saveRule`, a requester-only
-`save_rule` from the pending entry's `Requester`) and calls
+`ResolveAsync` builds the `ConsentResolveDto` (`decision: allow|deny`; when `saveRule`, a
+requester-only `save_rule` from `target.Requester`) and calls
 `ILocalControlOps.ResolveConsentAsync`. One resolve in flight at a time — serialized on one
-lane, same discipline as `PauseController`. Outcome mapping:
+lane, same discipline as `PauseController`. **Null-requester guard lives here, not only on the
+button:** when `saveRule` is requested but `target.Requester` is null or empty, the service
+sends the resolve *without* `save_rule` (a null requester would serialize into a wildcard
+allow-everything rule) and reports it in the outcome; the §6 button-hiding is UX, this guard
+is the safety boundary, and it is tested directly.
 
-| Result | Cache effect | Meaning |
-|---|---|---|
-| `Ok=true, Error=null` | remove entry | applied |
-| `Ok=true, Error!=null` | remove entry | applied; rule save rejected — warn |
-| `Ok=false` | remove entry | already decided (daemon timeout / raced) |
-| `LocalControlOpsException` / OCE | keep entry | transport failure — request may still be pending daemon-side |
+`ConsentResolveOutcome` (all cache effects instance-guarded on `target`):
 
-**Exposed:** the pending cache (`IObservable` via DynamicData `.Connect()`),
-`IObservable<int> PendingCount`, `ResolveAsync`, and a raise signal: an event/observable that
-fires when an entry is added while the prompt window is not visible (drives auto-raise, §6).
-The count feeds `TrayViewModel` (§8).
+| Outcome | Ack | Cache effect | Meaning |
+|---|---|---|---|
+| `Applied` | `Ok=true, Error=null` | remove | applied (`RuleSaved` carried along: null/true/false) |
+| `AppliedRuleRejected` | `Ok=true, Error!=null` or `RuleSaved=false` | remove | decision applied; rule not saved — warn |
+| `AlreadyDecided` | `Ok=false` | remove | decided elsewhere (daemon timeout / race); `RuleSaved` carried along — a rule may still have been installed (§4.1) and the UI must disclose it |
+| `RuleSkippedNoRequester` | `Ok=true` (no save_rule sent) | remove | applied; rule not saved because the request had no requester identity |
+| `TransportFailure` | `LocalControlOpsException` | keep | daemon unreachable/timeout — request may still be pending daemon-side |
+| *(propagates)* | `OperationCanceledException` | keep | caller/app-shutdown cancellation is its own path — never rendered as a transport failure; the VM treats it as a silent abort |
+
+**Exposed:** the pending cache (`IObservable` via DynamicData `.Connect()` — mutated on
+background continuations; consumers marshal with `ObserveOn(RxApp.MainThreadScheduler)`),
+`IObservable<int> PendingCount`, `ResolveAsync`, `Dismiss`, and an **unconditional**
+entry-added signal. The service knows nothing about windows: the prompt-window *coordinator*
+subscribes to the added signal, filters by window visibility, and marshals to the UI thread
+(§6). The count feeds `TrayViewModel` (§8).
+
+**Shutdown:** app shutdown disposes in order: prompt-window coordinator (closes the window,
+cancelling any in-flight resolve via the OCE path above) → `ConsentService` (cancels the
+subscription loop and the resolve lane) → `DaemonClientService` (existing). Quitting with the
+prompt window open is a tested path.
 
 ## 6. Prompt window
 
-`ConsentPromptWindow` + `ConsentPromptViewModel`. One instance ever, owned by a coordinator
-(pattern of `MainWindowCoordinator`): open-or-activate; closing hides/releases but a later
-raise re-creates. Fixed compact size (460×260 starting point, subject to live-acceptance
-polish; non-resizable), `Topmost = true`, centered.
+`ConsentPromptWindow` + `ConsentPromptViewModel`. At most one instance at a time, owned by a
+coordinator (pattern of `MainWindowCoordinator`): open-or-activate; closing releases the
+instance and a later raise creates a fresh one. Fixed compact size (460×260 starting point,
+subject to live-acceptance polish; non-resizable), `Topmost = true`, centered. All window
+open/activate calls are marshalled to the UI thread by the coordinator
+(`Dispatcher.UIThread.Post`) — the trigger originates on a socket continuation.
 
-**Raise policy:** the window opens and the app activates when a pending entry is added while
-the window is not visible — this covers both the 0→1 transition and a new request arriving
-after the user closed the window. Closing the window without deciding is an explicit *defer*:
-the queue is untouched, the tray stays in `Attention`, and the tray menu's "Review pending
-launches…" reopens it. Additions while the window is already visible just update the queue
-indicator — no re-activation (no focus stealing mid-interaction).
+**Raise policy:** the coordinator opens the window and activates the app when the service's
+entry-added signal fires while the window is not visible — this covers both the 0→1
+transition and a new request arriving after the user closed the window. Closing the window
+without deciding is an explicit *defer*: the queue is untouched, the tray stays in
+`Attention`, and the tray menu's "Review pending launches…" reopens it. Additions while the
+window is already visible just update the queue indicator — no re-activation (no focus
+stealing mid-interaction).
 
-**Content** — the oldest pending request (sort: `RequestedAt`, then `RequestId` ordinal for
-determinism):
+**Displayed item is a pinned snapshot.** The VM sorts the cache (by `RequestedAt`, then
+`RequestId` ordinal for determinism) and pins the head as `Current`. While `Current` is in a
+terminal display or has a resolve in flight, cache changes (new arrivals, prune, replay
+reconciliation) do **not** swap the displayed item out from under the user — the pin releases
+only on advance. Removal is never the VM's job directly: it calls `ResolveAsync`/`Dismiss` on
+the pinned instance and the service's instance guard makes a stale removal a no-op (a
+successor with the same id is untouched).
+
+**Content** — for the pinned current request:
 
 - Requester: `RequesterDisplay ?? Requester ?? "unknown"`, prominent.
 - Kind label: `agent` → "Agent", `review` → "Review", `review-flow` → "Review flow".
 - Repo: `RepoLabel.Leaf`, full path as tooltip. Vendor as-is.
-- Countdown: "Expires in 37s", ticked by the shared UI-thread ticker from `DeadlineHint`.
+- Countdown: "Expires in 37s", ticked by the shared ticker from `DeadlineHint`.
 - Queue indicator "1 of 3" when more than one pending.
 
 **Buttons:**
@@ -240,32 +323,46 @@ determinism):
 | Button | Wire | Notes |
 |---|---|---|
 | Allow once | `ConsentResolve{decision: "allow"}` | |
-| Always allow | `ConsentResolve{decision: "allow", save_rule: {action: "allow", requester: <id>, kind: null, repo: null, vendor: null}}` | Atomic — daemon stays the single rule writer. **Hidden when `Requester` is null**: a requester-only rule with a null requester would be a wildcard allow-everything rule. |
+| Always allow | `ConsentResolve{decision: "allow", save_rule: {action: "allow", requester: <id>, kind: null, repo: null, vendor: null}}` | Daemon stays the single rule writer. **Hidden when `Requester` is null** (§5 holds the real guard). Tooltip carries the precedence honestly: "Saves a rule allowing future launches from this requester. Existing deny rules — including Pause — take precedence until removed." No stronger promise is made anywhere in the UI (§4.1: the appended rule is first-match-shadowed by earlier denies). |
 | Deny | `ConsentResolve{decision: "deny"}` | |
 
 While a resolve is in flight all three disable (no double-submit); the countdown keeps
-ticking.
+ticking, but **hint expiry never preempts an in-flight resolve**: if the countdown reaches
+zero mid-resolve, the display shows "Expiring…" and waits for the ack — the ack is
+authoritative and governs the terminal state. Expiry acts on its own only when no resolve is
+in flight.
 
-**Terminal states (per request):**
+**Terminal states (per pinned request; each holds for 2 seconds, ticker-driven, then the VM
+dismisses/advances — the pin guarantees the display survives concurrent cache changes):**
 
-- **Decided (`Ok=true`)** → entry removed, window advances to the next pending or closes when
-  the queue empties. A non-null `Error` on `Ok=true` additionally shows a warning toast over
-  the prompt window: "Decision applied — rule not saved: {error}".
-- **Already decided (`Ok=false`)** → buttons are replaced by "Already decided" for 2 seconds
-  (ticker-driven), then the entry is removed and the window advances. Never a silent success:
-  the user always sees that their click did not decide this launch.
-- **Expired (countdown ≤ 0)** → buttons are replaced by "Expired — denied by timeout" for
-  2 seconds, then the entry is removed (the §5 prune is the backstop). If the user's click races the
-  daemon's timeout, the ack (`Ok=false`) wins the display — same "Already decided" path.
-- **Transport failure** → toast over the prompt window ("Daemon unreachable — the request is
-  still pending"), buttons re-enable, entry stays. The daemon may still be waiting.
+- **Decided (`Applied`)** → advance immediately (no hold): window shows the next pending or
+  closes when the queue empties. `AppliedRuleRejected` and `RuleSkippedNoRequester`
+  additionally show a warning toast over the prompt window: "Decision applied — rule not
+  saved: {reason}".
+- **Already decided (`AlreadyDecided`)** → buttons are replaced by "Already decided" for the
+  2-second hold, then `Dismiss` + advance. Never a silent success: the user always sees that
+  their click did not decide this launch. When the click was **Always allow** and the ack's
+  `RuleSaved=true`, the text discloses the side effect: "Already decided — your always-allow
+  rule for {requester} was still saved."
+- **Expired (countdown ≤ 0, no resolve in flight)** → buttons are replaced by "Expired —
+  denied by timeout" for the 2-second hold, then `Dismiss` + advance (the §5 prune is the
+  backstop).
+- **Transport failure (`TransportFailure`)** → toast over the prompt window ("Daemon
+  unreachable — the request is still pending"), buttons re-enable, entry stays. The daemon
+  may still be waiting.
+- **Cancellation (OCE)** → silent abort: no toast, no removal; on app shutdown the window is
+  closing anyway.
+
+A late ack for a request the VM already advanced past updates nothing: the service's
+instance-guarded removal already ran or no-ops, and the VM only renders its pin.
 
 Toasts use `AppNotifier` extended to attach a `WindowNotificationManager` to the prompt window
 — the main window may be closed, so prompt-related warnings must surface on the prompt window
 itself.
 
-**Pause interplay:** none needed. Pause is a wildcard deny rule at `rules[0]`, so paused
-launches are rule-denied without prompting and simply appear in the Activity feed as denials.
+**Pause interplay:** none needed for prompting. Pause is a wildcard deny rule at `rules[0]`,
+so paused launches are rule-denied without prompting and simply appear in the Activity feed as
+denials. (Its interaction with "Always allow" is the §4.1 precedence note.)
 
 ## 7. Activity tab
 
@@ -277,20 +374,30 @@ capped at 200 records.
 
 - The Activity tab becomes visible (also covers window open on that tab).
 - A stat poll on the shared ticker, every 2s while the tab is visible: compare
-  (`LastWriteTimeUtc`, `Length`) of both files against the previous poll; re-read on change.
-- A local resolve reached a conclusive ack (the user's own decision should appear
-  immediately).
+  (`LastWriteTimeUtc`, `Length`) of both files against the previous poll; re-read on change. A
+  stat failure (file/directory absent, transient IO) counts as "no stats" — compared as a
+  change when stats reappear — and is swallowed: the poll subscription never terminates on an
+  exception.
+- A local resolve reached a conclusive ack. **Own decisions are eventual, not instant:** the
+  daemon appends the log record *after* completing the resolution TCS
+  (`RunContinuationsAsynchronously`), so the ack can beat the append. The VM refreshes
+  immediately on the ack *and* relies on the regular 2s stat poll to converge — the spec
+  promise is "your decision appears no later than the next poll", not "immediately".
+
+Read failures never blank the feed: a `ReadTail` that returns empty (or a refresh that
+throws) while a previous read had rows keeps the last-good rows on display; the empty state
+renders only when the log is genuinely absent/empty on a clean read.
 
 The reader is `ConsentDecisionLogReader.ReadTail(daemonName, 200)` — pure file I/O, so the
 feed works with the daemon stopped or unreachable.
 
-**Row rendering:** local timestamp (`yyyy-MM-dd HH:mm:ss` from `decided_at`), outcome badge
-(`allowed` green / `denied` red), requester (`requester_display ?? requester ?? "unknown"`),
-kind label (as §6), repo leaf (`RepoLabel`, full path tooltip), vendor, and a human source
-label: `owner` → "owner", `rule[i]` → "rule", `default` → "default policy", `prompt_user` →
-"you", `prompt_timeout` → "timeout", `prompt_no_ui` → "no UI attached" (unrecognized values
-render verbatim). Empty state mirrors the Agents tab: centered "No decisions yet", no column
-headers.
+**Row rendering:** local timestamp (`yyyy-MM-dd HH:mm:ss` from `decided_at`; an unparseable
+stamp renders the raw string verbatim), outcome badge (`allowed` green / `denied` red),
+requester (`requester_display ?? requester ?? "unknown"`), kind label (as §6), repo leaf
+(`RepoLabel`, full path tooltip), vendor, and a human source label: `owner` → "owner",
+`rule[i]` → "rule", `default` → "default policy", `prompt_user` → "you", `prompt_timeout` →
+"timeout", `prompt_no_ui` → "no UI attached" (unrecognized values render verbatim). Empty
+state mirrors the Agents tab: centered "No decisions yet", no column headers.
 
 ## 8. Tray integration
 
@@ -300,8 +407,9 @@ appended to the AI-1651 state table: when the connection-derived state is `Idle`
 and `PendingConsentCount > 0`, the state becomes `Attention` with header
 "{N} launch(es) awaiting approval" — e.g. "1 launch awaiting approval". All
 connection-trouble rows keep precedence: pending consent asserts `Attention` only while
-Connected (which is also the only state where the subscription runs). The icon shows the
-existing `Attention` rendering; the running-count badge continues to reflect the agent count.
+Connected. (Retained entries can outlive a disconnect (§5); the connection-trouble row wins
+the display during it.) The icon shows the existing `Attention` rendering; the running-count
+badge continues to reflect the agent count.
 
 **Menu.** A "Review pending launches…" `NativeMenuItem`, visible only when
 `PendingConsentCount > 0`, placed between the agents section and the pause toggle. Click →
@@ -313,52 +421,83 @@ cadence picks up count changes through the model stream — no new refresh machi
 | Failure | Surface | Behavior |
 |---|---|---|
 | Daemon unreachable (no subscription) | Tray | Existing AI-1651 rows; no prompts possible; feed still renders from file |
-| Daemon without `consent/1` | Tray | No subscription; existing down-level surfacing |
-| Consent stream dies while Connected | none (self-heal) | 1s delay → resubscribe (fresh replay reconciles) |
+| Daemon without `consent/1` | Tray | No subscription; cache cleared (stale incarnation); existing down-level surfacing |
+| Consent dial fails while status Connected | none (self-heal) | Cache NOT cleared (clear sits after the subscribe-write boundary); 1s delay → retry |
+| Consent stream dies while Connected | none (self-heal) | 1s delay → resubscribe (fresh replay reconciles after the write boundary) |
+| Structurally invalid pending frame | none | Skipped (ending the stream would thrash the resubscribe loop) |
 | Resolve transport failure | Prompt toast | Entry kept; buttons re-enable |
-| Resolve `Ok=false` | Prompt window | "Already decided" — never a silent success |
-| Rule save rejected on `Ok=true` | Prompt toast | Decision applied; warning shown |
-| Request expired (no withdrawal push) | Prompt window / prune | Countdown shows expiry; cache prune at hint+5s |
-| Decision log absent/malformed lines | Activity tab | Empty state / lines skipped |
+| Resolve cancelled (shutdown) | none | OCE propagates; silent abort — never rendered as transport failure |
+| Resolve `Ok=false` | Prompt window | "Already decided" — never a silent success; `RuleSaved=true` disclosed |
+| Rule save rejected / skipped (no requester) | Prompt toast | Decision applied; warning shown |
+| Request expired (no withdrawal push) | Prompt window / prune | Countdown expiry display (never preempting an in-flight resolve); cache prune at hint+5s |
+| Same-id successor while ack in flight | none | Instance-guarded removals — a stale ack/dismiss/prune never evicts the successor |
+| Decision log absent / IO failure / bad lines | Activity tab | Absent → empty contribution; last-good rows kept on failed refresh; invalid lines skipped |
 | Rotation race during read | Activity tab | `Distinct()` merge; miss self-heals next poll |
 
 ## 10. Testing
 
-All headless (TUnit; `Avalonia.Headless` for VM/window behavior; fake `TimeProvider`
+All headless (TUnit; `Avalonia.Headless` for VM/window behavior; fake `TimeProvider`/ticker
 throughout — no real sleeps).
 
 **Core:**
 - `ResolveConsentAsync` against an in-proc fake server (pattern of existing `LocalControlOps`
-  tests): ack round-trip (all four `Ok`/`Error` shapes), malformed ack → `unexpected_reply`,
-  EOF → `unexpected_reply`, transport → `daemon_unreachable`, phase timeout → `timed_out`,
-  caller-cancellation propagates.
+  tests): ack round-trip (`Ok`/`Error`/`RuleSaved` shapes), decodable `Error` frame →
+  `daemon_rejected`, malformed ack → `unexpected_reply`, EOF → `unexpected_reply`, transport
+  → `daemon_unreachable`, phase timeout → `timed_out`, caller-cancellation propagates.
 - `ConsentSubscription`: replay + push frames yield DTOs in order; EOF ends enumeration;
-  unexpected frame type ends enumeration; malformed pending JSON ends enumeration; `ct`
+  failed connect (`SocketException`) ends enumeration (no daemon listening); unexpected frame
+  type ends enumeration; undecodable JSON ends enumeration; **decodable-but-structurally-
+  invalid pending (null request_id via `{}`) is skipped and the stream continues**; `ct`
   propagates OCE. Absent `requester_display` deserializes to null.
 - `ConsentDecisionLogReader`: tail across the rotation pair (order, cap, newest-first);
-  malformed-line skip; `Distinct()` dedup; absent files → empty; old-format lines (no
-  `requester_display`) parse with null; **a read succeeding while a writer holds an open
-  append handle** (`FileShare` regression guard — the test that would have caught AI-1629).
+  undecodable-line skip; **parseable-but-structurally-invalid line (`{}`) skip**;
+  `Distinct()` dedup; absent files → empty; file vanishing between stat and open → empty, no
+  throw; old-format lines (no `requester_display`) parse with null; **a reader holding an
+  open handle (the reader's own share mode) does not block the writer's actual operations —
+  append AND `File.Move` rotation — while a concurrent `ReadTail` succeeds** (the sharing
+  regression guard; trivially green on Unix, load-bearing on the Windows CI leg — both
+  directions and both operations covered, since `FileShare.Delete` is what rotation needs).
 
 **Daemon:**
 - Gate threads `RequesterDisplay` into the prompt request and the decision record (extend
   existing gate tests); log writer round-trips through the hoisted Core type unchanged
   (existing files' snake_case field names asserted verbatim).
+- `HandleResolveAsync`: `save_rule` + no pending request → rule IS persisted and the ack is
+  `Ok=false, RuleSaved=true`; rejected save → `RuleSaved=false` on both `Ok` branches; no
+  `save_rule` → `RuleSaved=null` (written as JSON null).
+- Engine: an earlier matching deny (index 0 wildcard) shadows a later appended allow —
+  first-match-wins pinned by test.
 
 **App (the "full prompt matrix" from the issue):**
 - Allow once / Deny → correct `ConsentResolveDto`, entry removed, queue advances.
-- Always allow → `save_rule` is requester-only; button hidden when `Requester` is null.
-- Countdown expiry → "Expired — denied by timeout", entry removed; prune removes ghost
-  entries at hint+5s.
-- `Ok=false` → "Already decided" state, then advance — never silent.
-- `Ok=true` + `Error` → warning surfaced, entry removed.
-- Transport failure → entry kept, buttons re-enable.
-- Queue: "1 of N" indicator; oldest-first ordering; additions while visible don't re-raise;
-  addition while closed raises.
-- Subscription lifecycle: clear-before-(re)subscribe reconciliation; no subscription without
-  `consent/1`; stream-end-while-Connected retries.
+- Always allow → `save_rule` is requester-only; button hidden when `Requester` is null; **the
+  service guard: `ResolveAsync(saveRule: true)` on a null/empty-requester target sends NO
+  `save_rule` and reports `RuleSkippedNoRequester`** (tested directly, not via the button).
+- ABA: successor with the same `RequestId` upserted while predecessor's resolve is in flight
+  → the predecessor's ack removes nothing; the successor survives and is displayed next.
+- Countdown expiry with no resolve in flight → "Expired — denied by timeout", 2s hold
+  (ticker-driven), `Dismiss`, advance; prune removes ghost entries at hint+5s
+  (instance-guarded).
+- Countdown reaches zero while a resolve is in flight → no expiry preemption; `Ok=true` after
+  zero → `Applied`; `Ok=false` after zero → "Already decided"; the next request is unaffected.
+- `AlreadyDecided` → 2s hold, then advance — never silent; with `RuleSaved=true` after an
+  Always-allow click, the disclosure text is shown.
+- `AppliedRuleRejected` → warning surfaced, entry removed.
+- Transport failure → entry kept, buttons re-enable. Cancellation (lane-queued and
+  in-flight) → silent abort, entry kept, no toast.
+- Queue: "1 of N" indicator; oldest-first ordering; the pinned display does not swap while a
+  terminal hold or in-flight resolve is active; additions while visible don't re-raise;
+  addition while closed raises (coordinator-filtered, marshalled to the UI thread — the add
+  originates off the UI thread in the test).
+- Subscription lifecycle: clear happens only after the subscribe write succeeds (failed dial
+  retains entries); reconnect-with-empty-replay leaves an empty cache; `Connected` without
+  `consent/1` clears the cache and never subscribes; stream-end-while-Connected retries.
+- Shutdown: app quits with the prompt window open and a resolve in flight → clean disposal in
+  the §5 order, OCE path exercised.
 - `ActivityViewModel`: rows map records (fallback chains, source labels, unrecognized source
-  verbatim); refresh on tab-visible / stat-change / own-resolution; empty state.
+  verbatim, unparseable timestamp verbatim); refresh on tab-visible / stat-change /
+  own-resolution (eventual — asserted via the next poll tick, not instant); last-good rows
+  kept when a refresh fails; empty state only on clean-empty read.
 - `TrayViewModel`: new Attention row (pending>0 while Idle/Running → Attention + header);
   connection-trouble precedence unchanged; menu item visibility.
 
@@ -368,4 +507,5 @@ throughout — no real sleeps).
 - Consent rules editor UI → umbrella slice 4.
 - Attach/approve from the CLI (`kcap daemon consent` gains no resolve verb — the app is the
   approval surface; the CLI keeps rules + log only).
-- Any change to engine matching, policy storage, or prompt timeout semantics.
+- Any change to engine matching, rule ordering/precedence, policy storage, or prompt timeout
+  semantics.

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -465,11 +465,11 @@ successor.
 
 **Buttons:**
 
-| Button | Wire | Notes |
+| Button | Wire (all via `ConsentResolveV2`, always carrying the pinned target's `request_id` **and** `prompt_id` — the v2 daemon rejects a missing/empty `prompt_id`, §4.1) | Notes |
 |---|---|---|
-| Allow once | `ConsentResolve{decision: "allow"}` | |
-| Allow & remember | `ConsentResolve{decision: "allow", save_rule: {action: "allow", requester: <id>, kind: null, repo: null, vendor: null}}` | Daemon stays the single rule writer. Label is deliberately not "Always allow" — an appended rule is first-match-shadowed by earlier denies (§4.1), so the label must not promise "always". **Hidden when `Requester` is null *or empty*** — the same predicate as §5's service guard, which remains the real safety boundary. Tooltip: "Saves a rule allowing future launches from this requester. Existing deny rules — including Pause — take precedence until removed." |
-| Deny | `ConsentResolve{decision: "deny"}` | |
+| Allow once | `ConsentResolveV2{request_id, prompt_id, decision: "allow"}` | |
+| Allow & remember | `ConsentResolveV2{request_id, prompt_id, decision: "allow", save_rule: {action: "allow", requester: <id>, kind: null, repo: null, vendor: null}}` | Daemon stays the single rule writer. Label is deliberately not "Always allow" — an appended rule is first-match-shadowed by earlier denies (§4.1), so the label must not promise "always". **Hidden when `Requester` is null *or empty*** — the same predicate as §5's service guard, which remains the real safety boundary. Tooltip: "Saves a rule allowing future launches from this requester. Existing deny rules — including Pause — take precedence until removed." |
+| Deny | `ConsentResolveV2{request_id, prompt_id, decision: "deny"}` | |
 
 While a resolve is in flight all three disable (no double-submit); the countdown keeps
 ticking, but **hint expiry never preempts an in-flight resolve**: if the countdown reaches
@@ -507,7 +507,8 @@ this state.
   closing anyway.
 
 A late ack for a request the VM already advanced past updates nothing: the service's
-instance-guarded removal already ran or no-ops, and the VM only renders its pin.
+identity-guarded (`PromptId`-matched) removal already ran or no-ops, and the VM only renders
+its pin.
 
 Toasts use `AppNotifier` extended to attach a `WindowNotificationManager` to the prompt window
 — the main window may be closed, so prompt-related warnings must surface on the prompt window
@@ -662,7 +663,9 @@ throughout — no real sleeps).
   `Ok=false` "invalid resolve payload"; frames 11/12 still route for legacy callers.
 
 **App (the "full prompt matrix" from the issue):**
-- Allow once / Deny → correct `ConsentResolveDto`, entry removed, queue advances.
+- Allow once / Deny / Allow & remember → the sent `ConsentResolveDto` carries **the pinned
+  target's exact `PromptId`** (asserted per button at the service/VM boundary, not just DTO
+  serialization) plus its `RequestId` and decision; entry removed, queue advances.
 - Allow & remember → `save_rule` is requester-only; button hidden when `Requester` is null
   **and** when it is empty (same predicate as the service guard); **the service guard:
   `ResolveAsync(saveRule: true)` on a null/empty-requester target sends NO `save_rule` and

--- a/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
+++ b/docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md
@@ -33,9 +33,11 @@ decision log, and pending-consent wired into the tray's existing `Attention` sta
 launches…" menu item; `ResolveConsentAsync` on `ILocalControlOps`; consent subscription client
 in Core; decision-record hoisting to Core (shared write/read shape); `requester_display`
 threading through the consent pipeline (additive); `rule_saved` reporting on `ConsentAckDto`
-(additive) so a rule installed for an already-decided request is disclosed, not hidden;
-hoisting the AI-1651 per-window ticker into an app-lifetime service; headless ViewModel tests
-for the full prompt matrix.
+(additive) so a rule installed for an already-decided request is disclosed, not hidden; a
+request-identity echo on `ConsentResolveDto` (additive `requested_at`, verified by the broker)
+so a stale resolve can never decide a different launch that reused the id; hoisting the
+AI-1651 per-window ticker into an app-lifetime service; headless ViewModel tests for the full
+prompt matrix.
 
 **Out:** macOS system notification (AI-1653); consent-rules editor UI (slice 4); any change to
 engine matching, rule ordering/precedence, policy storage, or prompt timeout semantics; new
@@ -91,16 +93,28 @@ The daemon resolve handler otherwise exists (`LaunchConsentIpc.HandleResolveAsyn
 is needed on one-shot connections (hello is optional; the CLI consent verbs already send bare
 frames).
 
-**Stale resolve vs. same-id successor — accepted, with rationale.** `ConsentResolveDto`
-carries only `request_id`, and the broker's `TryResolve` resolves whichever pending entry
-currently holds that key. If request A times out, a successor B reuses the id, and A's delayed
-resolve then arrives, it decides B. This is deliberately accepted rather than closed with a
-wire generation check: a request id is the agent id, and a same-id successor is by
-construction a **retry of the same launch** — same requester, kind, repo, and vendor (the
-server retries the same command). The user's verdict was about that content, and applying it
-to the retry honors their intent. (A future wire generation echo — an additive `requested_at`
-on `ConsentResolveDto` verified by the broker — remains open to a later slice if this
-assumption ever breaks.)
+**Request identity: the `requested_at` echo.** `ConsentResolveDto` carries only `request_id`
+today, and the broker's `TryResolve` resolves whichever pending entry currently holds that
+key. A request id is the agent id, and the daemon explicitly makes **no id-non-reuse
+assumption** (`SequencedCommandProcessor` treats two launches for one id as distinct
+instances, and the orchestrator builds consent input afresh from each command) — so a
+successor B under A's id can carry a *different* requester, kind, repo, or vendor, and a
+delayed resolve for A must never decide B. Close this on the wire:
+
+- `ConsentResolveDto` gains trailing `string? RequestedAt` (wire `requested_at`,
+  positional-required convention: no C# default, nulls always written) — an echo of the
+  pending request's `RequestedAt` stamp.
+- `LaunchConsentBroker.TryResolve` gains the echo parameter: with a null echo (a caller that
+  never saw the stamp) behavior is unchanged; with a non-null echo the resolve succeeds only
+  if it matches the pending entry's `RequestedAt` exactly (ordinal). A mismatch is treated as
+  no-pending: `Ok=false`, the honest already-decided path.
+- The app always sends the echo (§5).
+
+`(RequestId, RequestedAt)` is thereby the **request identity**, enforced end-to-end — the
+client's cache guards (§5) use the same pair. Identity collision would require two prompts of
+the same agent id stamped at the same 100 ns wall-clock tick, with a full launch round-trip
+between them — not physically achievable in production; tests that freeze the clock must
+fabricate distinct stamps.
 
 ### 4.2 Consent subscription client (Core)
 
@@ -252,27 +266,35 @@ authoritative outcome is only ever a resolve ack (§6 renders expiry accordingly
 prune below is availability hygiene, not settlement — a prematurely pruned still-live request
 simply times out daemon-side exactly as if no UI were attached.
 
-**Instance-guarded removal (ABA defense).** `RequestId` is the agent id, and the broker
-explicitly documents that a successor prompt can reuse a predecessor's id (retry of the same
-agent). The subscription and resolve travel on separate connections, so successor B can be
-upserted before predecessor A's ack is processed — an unconditional remove-by-key would then
-evict B, and with no withdrawal push nothing would restore it. Therefore **every** removal
-(conclusive ack, prune) captures the exact `PendingConsent` *instance* it is acting on and
-removes only if the cache still holds that same instance — **reference identity, not value
-equality**: each received frame materializes a fresh instance, whereas DTO field values
-(including `RequestedAt`, a wall-clock stamp) can legitimately collide between a predecessor
-and its retry. A removal that finds a different instance is a no-op.
+**Identity-guarded removal (ABA defense).** `RequestId` is the agent id, and the broker
+explicitly documents that a successor prompt can reuse a predecessor's id. The subscription
+and resolve travel on separate connections, so successor B can be upserted (replacing A's
+cache slot by key) before predecessor A's ack is processed — an unconditional remove-by-key
+would then evict B, and with no withdrawal push nothing would restore it. Therefore **every**
+removal is guarded by the §4.1 request identity: it captures the `(RequestId, RequestedAt)`
+pair it is acting on and removes only if the entry currently cached under that key carries the
+same pair. B differs in `RequestedAt` by the §4.1 identity contract, so a stale removal for A
+can never evict B — while a *replayed instance of A itself* (same pair, fresh object) is
+correctly evicted. A removal that finds a different pair is a no-op. Because the resolve
+carries the echo, the ack verifiably concerns exactly the identity the app targeted: whether B
+replaced A in the daemon before the resolve arrived (mismatch → `Ok=false`) or B arrived
+after A's resolution (`Ok=true` for A), B's cache entry survives either way and is prompted on
+its own terms.
 
 **Conclusion tombstones (ghost-replay defense).** The broker's `Subscribe` snapshots pending
 entries without synchronizing against a concurrent `TryResolve`, so a resubscribe replay can
-redeliver a request the app just concluded — re-adding a ghost and auto-raising a second
-prompt whose answer can only be "already decided". On every conclusive ack the service records
-a tombstone `(RequestId, RequestedAt)` with a 10-second TTL; an incoming `Pending` matching a
-live tombstone is dropped. The TTL bounds the risk of suppressing a genuine same-id successor
-to the case where it also carries an identical wall-clock stamp *within the window* —
-accepted as vanishingly unlikely, and self-healing (the next resubscribe replays it after the
-TTL). Expiry/prune do **not** tombstone: a request the app merely gave up on locally is still
-live daemon-side (the clock-step case) and must be allowed to reappear.
+redeliver a request the app is just concluding — and the orderings differ: the ghost `Pending`
+can arrive *before* the conclusive ack (a reconnect's replay raced the resolve) or *after* it.
+On every conclusive ack the service atomically (1) records a tombstone for the request
+identity `(RequestId, RequestedAt)` and (2) evicts any currently cached entry matching that
+identity — closing the replay-ghost-admitted-before-ack ordering, which a guard keyed on the
+original instance alone would miss. An incoming `Pending` matching a live tombstone is
+dropped. By the §4.1 identity contract a matching frame *is* the concluded request — never a
+distinct successor — so dropping is always correct and no delayed admission is needed; the
+10-second TTL is purely a memory bound (ghost frames only arise from replay snapshots taken
+within the milliseconds-wide resolve race, never seconds later). Expiry/prune do **not**
+tombstone: a request the app merely gave up on locally is still live daemon-side (the
+clock-step case) and must be allowed to reappear.
 
 **Subscription lifecycle — status-driven.** The service observes
 `DaemonClientService.Status`:
@@ -302,10 +324,17 @@ restores them; if no daemon comes back, the entries were unanswerable anyway. If
 enumeration ends while status still reports Connected (protocol confusion, half-dead socket,
 failed dial), delay 1s and go around. Loop cancellation stops cleanly.
 
-**Pruning:** on the shared ticker, entries with `now > DeadlineHint + 5s` are removed
-(instance-guarded). This bounds ghost entries from requests that expired daemon-side (there is
-no withdrawal push) and from disconnected periods. Under a clock step the prune inherits the
-hint's heuristic nature (above) — accepted.
+**Pruning:** each entry carries `PruneAfter`, initialized to `DeadlineHint + 5s`. On the
+shared ticker, entries with `now > PruneAfter` are removed (identity-guarded) — bounding ghost
+entries from requests that expired daemon-side (there is no withdrawal push) and from
+disconnected periods. Two qualifications keep the prune from contradicting §6's interaction
+guarantees: the prune **skips the entry currently targeted by the in-flight resolve** (a user
+clicking just before the boundary must not have the entry vanish mid-call; the lane's
+settlement disposes of it — a conclusive ack evicts, and the skip ends), and a
+`TransportFailure` settlement **refreshes the target's `PruneAfter` to `now + 5s`** so the
+promised entry-stays-interactive state actually exists for a beat instead of being pruned on
+the next tick. Under a clock step the prune inherits the hint's heuristic nature (above) —
+accepted.
 
 **Resolution:**
 
@@ -313,16 +342,16 @@ hint's heuristic nature (above) — accepted.
 Task<ConsentResolveOutcome> ResolveAsync(PendingConsent target, bool allow, bool saveRule, CancellationToken ct);
 ```
 
-`ResolveAsync` builds the `ConsentResolveDto` (`decision: allow|deny`; when `saveRule`, a
-requester-only `save_rule` from `target.Requester`) and calls
-`ILocalControlOps.ResolveConsentAsync`. One resolve in flight at a time — serialized on one
-lane, same discipline as `PauseController`. **Null-requester guard lives here, not only on the
+`ResolveAsync` builds the `ConsentResolveDto` (`decision: allow|deny`; **always** the
+`requested_at` echo from `target` — the §4.1 identity check; when `saveRule`, a requester-only
+`save_rule` from `target.Requester`) and calls `ILocalControlOps.ResolveConsentAsync`. One
+resolve in flight at a time — serialized on one lane, same discipline as `PauseController`. **Null-requester guard lives here, not only on the
 button:** when `saveRule` is requested but `target.Requester` is null or empty, the service
 sends the resolve *without* `save_rule` (a null requester would serialize into a wildcard
 allow-everything rule) and reports it in the outcome; the §6 button-hiding is UX, this guard
 is the safety boundary, and it is tested directly.
 
-`ConsentResolveOutcome` (cache effects instance-guarded on `target`; `RuleOutcome` is the
+`ConsentResolveOutcome` (cache effects identity-guarded on `target`; `RuleOutcome` is the
 service's disambiguation — it knows whether it sent `save_rule` (§4.1): `Saved`, `Rejected`,
 `Unknown` (save requested, `RuleSaved` null, i.e. down-level daemon — except `Ok=true` +
 `Error=null`, which implies `Saved` on the shipped daemon's own contract), `NotRequested`,
@@ -332,7 +361,7 @@ service's disambiguation — it knows whether it sent `save_rule` (§4.1): `Save
 |---|---|---|---|
 | `Applied` | `Ok=true`, rule outcome `Saved`/`NotRequested` | remove + tombstone | applied |
 | `AppliedRuleRejected` | `Ok=true`, rule outcome `Rejected` or `Unknown` | remove + tombstone | decision applied; rule not saved (or outcome unknown on a down-level daemon) — warn |
-| `AlreadyDecided` | `Ok=false` | remove + tombstone | decided elsewhere (daemon timeout / race); carries `RuleOutcome` — a rule may still have been installed (§4.1) and §6 must disclose saved / not saved / unknown |
+| `AlreadyDecided` | `Ok=false` | remove + tombstone | decided elsewhere or superseded (daemon timeout, or the §4.1 identity check found a different request under this id); carries `RuleOutcome` — a rule may still have been installed (§4.1) and §6 must disclose saved / not saved / unknown |
 | `RuleSkippedNoRequester` | `Ok=true` (no save_rule sent) | remove + tombstone | applied; rule not saved because the request had no requester identity |
 | `TransportFailure` | `LocalControlOpsException` | keep | daemon unreachable/timeout — request may still be pending daemon-side |
 | *(propagates)* | `OperationCanceledException` | keep | caller/app-shutdown cancellation is its own path — never rendered as a transport failure; the VM treats it as a silent abort |
@@ -372,8 +401,8 @@ stealing mid-interaction).
 terminal display or has a resolve in flight, cache changes (new arrivals, prune, replay
 reconciliation) do **not** swap the displayed item out from under the user — the pin releases
 only on advance (or, in the hint-expired state, when the service's prune removes the pinned
-instance — below). The VM never removes cache entries; conclusive acks and the prune do (§5),
-and the instance guard makes any stale action a no-op that can never touch a same-id
+entry — below). The VM never removes cache entries; conclusive acks and the prune do (§5),
+and the identity guard makes any stale action a no-op that can never touch a same-id
 successor.
 
 **Content** — for the pinned current request:
@@ -403,8 +432,9 @@ monotonic (§5), so the request may in fact still be live. The countdown is repl
 "Response time elapsed — unanswered requests are denied by the daemon", and **the buttons
 stay active**: a click still resolves normally (if the daemon really did time out, the ack
 comes back `Ok=false` and the honest "Already decided" path runs; after a backward clock step,
-the click simply works). The entry stays in the cache until the §5 prune removes it (hint+5s,
-instance-guarded); the VM advances when its pinned instance leaves the cache in this state.
+the click simply works). The entry stays in the cache until the §5 prune removes it
+(`PruneAfter`, identity-guarded); the VM advances when its pinned entry leaves the cache in
+this state.
 
 **Terminal states (per pinned request):**
 
@@ -502,15 +532,15 @@ cadence picks up count changes through the model stream — no new refresh machi
 | Daemon dies between subscribe write and replay | none (self-heal) | Cache cleared but restored by the next successful replay (~1s cadence); bounded, UI-only (§5) |
 | Consent stream dies while Connected | none (self-heal) | 1s delay → resubscribe (fresh replay reconciles at the `Subscribed` boundary) |
 | Structurally invalid pending frame | none | Skipped (ending the stream would thrash the resubscribe loop) |
-| Ghost replay of a just-concluded request | none | Conclusion tombstone (10s TTL) drops it — no second prompt |
+| Ghost replay of a just-concluded request | none | Arrives after the ack → tombstone drops it; admitted before the ack → the ack's identity-matched eviction removes it — no second prompt either way |
 | Wall-clock step vs. daemon's monotonic deadline | Prompt window | Hint expiry is never a verdict: non-authoritative copy, buttons stay active, ack governs |
 | Resolve transport failure | Prompt toast | Entry kept; buttons re-enable |
 | Resolve cancelled (shutdown) | none | OCE propagates; silent abort — never rendered as transport failure |
 | Resolve `Ok=false` | Prompt window | "Already decided" — never a silent success; rule outcome disclosed as saved / not saved / unknown (down-level) |
 | Rule save rejected / unknown / skipped (no requester) | Prompt toast | Decision applied; warning shown |
-| Request expired (no withdrawal push) | Prompt window / prune | Non-authoritative expiry display; cache prune at hint+5s (instance-guarded) |
-| Same-id successor while ack in flight | none | Reference-identity removal guard — a stale ack/prune never evicts the successor |
-| Stale resolve reaching the daemon after id reuse | daemon | Accepted: a same-id successor is a retry of the same launch content; the verdict transfers honestly (§4.1) |
+| Request expired (no withdrawal push) | Prompt window / prune | Non-authoritative expiry display; cache prune at `PruneAfter` (identity-guarded, skips the in-flight resolve target, refreshed on transport failure) |
+| Same-id successor while ack in flight | none | Identity-pair removal guard — a stale ack/prune never evicts the successor |
+| Stale resolve reaching the daemon after id reuse | daemon | Closed: the `requested_at` echo mismatches and the broker answers no-pending (`Ok=false`) — a verdict for A can never decide B (§4.1) |
 | Decision log absent / IO failure / bad lines | Activity tab | Clean absence → `Complete` empty read → empty state; I/O failure → `Complete=false` → last-good rows kept; invalid lines skipped |
 | Rotation race during read | Activity tab | `Distinct()` merge; miss self-heals next poll |
 
@@ -522,9 +552,10 @@ throughout — no real sleeps).
 **Core:**
 - `ResolveConsentAsync` against an in-proc fake server (pattern of existing `LocalControlOps`
   tests): ack round-trip (`Ok`/`Error`/`RuleSaved` shapes, including an old-format ack with no
-  `rule_saved` member → null), decodable `Error` frame → `daemon_rejected`, malformed ack →
-  `unexpected_reply`, EOF → `unexpected_reply`, transport → `daemon_unreachable`, phase
-  timeout → `timed_out`, caller-cancellation propagates.
+  `rule_saved` member → null; the sent `ConsentResolveDto` carries the `requested_at` echo),
+  decodable `Error` frame → `daemon_rejected`, malformed ack → `unexpected_reply`, EOF →
+  `unexpected_reply`, transport → `daemon_unreachable`, phase timeout → `timed_out`,
+  caller-cancellation propagates.
 - `ConsentSubscription`: `Subscribed` yielded after connect+write and **before any read**
   (observable with an empty replay — first `MoveNextAsync` completes); replay + push frames
   yield `Pending` events in order; EOF ends enumeration; failed connect (`SocketException`)
@@ -552,6 +583,12 @@ throughout — no real sleeps).
   `save_rule` → `RuleSaved=null` (written as JSON null).
 - Engine: an earlier matching deny (index 0 wildcard) shadows a later appended allow —
   first-match-wins pinned by test.
+- Broker identity check: `TryResolve` with a matching `requested_at` echo resolves; a
+  mismatching echo returns false (and the handler acks `Ok=false`) leaving the pending entry
+  untouched; a null echo preserves legacy resolve-by-id behavior. The two orderings the echo
+  exists for, end to end through the handler: **B replaces A in the broker before A's resolve
+  arrives** → A's resolve mismatches, `Ok=false`, B stays pending; **A resolved, then A's ack
+  raced by B's arrival** → `Ok=true` concerned only A, B stays pending.
 
 **App (the "full prompt matrix" from the issue):**
 - Allow once / Deny → correct `ConsentResolveDto`, entry removed, queue advances.
@@ -562,16 +599,24 @@ throughout — no real sleeps).
 - Rule-outcome disambiguation: after an Allow & remember click, `AlreadyDecided` with
   `RuleSaved=true` / `false` / absent (old-format ack) shows the saved / not-saved /
   unknown-down-level disclosure respectively.
-- ABA: successor with the same `RequestId` upserted while predecessor's resolve is in flight
-  → the predecessor's ack removes nothing; the successor survives and is displayed next —
-  **including when both carry an identical `RequestedAt`** (reference identity, not value
-  equality).
-- Ghost replay: a `Pending` for a request concluded within the tombstone TTL is dropped — no
-  re-add, no second raise; one arriving after the TTL is admitted.
+- ABA (both orderings, distinct cache outcomes asserted): **B replaces A's cache slot before
+  A's ack is processed** → the ack's identity-guarded eviction no-ops, B survives and is
+  prompted; **B arrives after A's `Ok=true` ack** → A was evicted, B is admitted and
+  prompted. In both, the successor is decided only on its own terms.
+- Ghost replay (both orderings): a ghost `Pending` arriving *after* A's conclusive ack is
+  dropped by the tombstone; a ghost admitted *before* the ack (reconnect replay raced the
+  resolve — a fresh instance with A's identity) is evicted by the ack's identity-matched
+  removal — no second raise either way. A tombstone past its TTL no longer filters (memory
+  bound, not a correctness window).
 - Hint expiry with no resolve in flight → non-authoritative copy, **buttons remain active**;
   a click after hint-zero that acks `Ok=true` is `Applied` (the wall-clock-step case: hint
   fired early, request was still live); one that acks `Ok=false` runs "Already decided"; the
-  prune removes the entry at hint+5s (instance-guarded) and the VM advances on that removal.
+  prune removes the entry at `PruneAfter` (identity-guarded) and the VM advances on that
+  removal.
+- Prune vs. in-flight resolve (spanning the `PruneAfter` boundary): the prune skips the
+  resolve target while the call is pending; a **transport-failure** settlement retains the
+  entry with `PruneAfter` refreshed to now+5s (interactive for a beat, not pruned on the next
+  tick); a **conclusive ack** settlement evicts it normally.
 - Countdown reaches zero while a resolve is in flight → no expiry preemption; the ack
   governs; the next request is unaffected.
 - `AlreadyDecided` → 2s hold, then advance — never silent.
@@ -603,7 +648,5 @@ throughout — no real sleeps).
 - Consent rules editor UI → umbrella slice 4.
 - Attach/approve from the CLI (`kcap daemon consent` gains no resolve verb — the app is the
   approval surface; the CLI keeps rules + log only).
-- A wire generation echo on `ConsentResolveDto` (§4.1's accepted stale-resolve tradeoff notes
-  it as a future option).
 - Any change to engine matching, rule ordering/precedence, policy storage, or prompt timeout
   semantics.

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -26,6 +26,10 @@ public partial class App : Application {
     PauseController? _pause;
     ConsentService? _consent;
     ConsentPromptCoordinator? _promptCoordinator;
+    // No disposal needed — a plain ticker subscription (ActivityViewModel's class doc comment),
+    // same as _ticker below. Held so it survives StartAsync's own stack frame: the prompt window
+    // factory and BuildAndShowMainWindow both close over the SAME instance.
+    ActivityViewModel? _activity;
     TrayViewModel? _trayVm;
     TrayIconManager? _tray;
     // No disposal needed — RefCount tears its Interval down with its last subscriber. Held for
@@ -79,6 +83,14 @@ public partial class App : Application {
             // nothing can trigger a protected-kind stop before ShowMainWindow below assigns it.
             var actions = new AgentActionService(ops, notifier, new ShellUrlOpener(), service.Snapshots, _shutdown.Token, ConfirmForceStopAsync);
 
+            // Constructed once here, like the ticker and consent service (spec §7): the prompt
+            // window factory below and MainWindowViewModel both need the SAME instance — the
+            // former to nudge it on every conclusive ack, the latter to render it.
+            var activity = new ActivityViewModel(
+                () => ConsentDecisionLogReader.ReadTail(service.DaemonName, 200),
+                () => ActivityStatKey(service.DaemonName), ticker);
+            _activity = activity;
+
             // The prompt window is built per raise, never here: the coordinator owns its lifetime
             // and each window gets its own ViewModel over the one shared service (spec §6).
             var consent = new ConsentService(
@@ -86,11 +98,12 @@ public partial class App : Application {
                 TimeProvider.System, _shutdown.Token);
             _consent = consent;
             _promptCoordinator = new ConsentPromptCoordinator(consent, () => new ConsentPromptWindow {
-                DataContext = new ConsentPromptViewModel(consent, notifier, ticker, TimeProvider.System, _shutdown.Token),
+                DataContext = new ConsentPromptViewModel(
+                    consent, notifier, ticker, TimeProvider.System, _shutdown.Token, activity.RequestRefresh),
                 Notifier = notifier,
             });
 
-            _coordinator = new MainWindowCoordinator(() => BuildAndShowMainWindow(service, actions, notifier, ticker, _shutdown.Token));
+            _coordinator = new MainWindowCoordinator(() => BuildAndShowMainWindow(service, actions, notifier, ticker, _shutdown.Token, activity));
             // A shutdown that started before this continuation resumed already ran its first
             // pass against a null coordinator, so a window built now must never be
             // close-protected (BeginShutdownPass's rule 1 is the general defense; this is the
@@ -122,6 +135,7 @@ public partial class App : Application {
             _promptCoordinator = null;
             _consent = null;
             _pause = null;
+            _activity = null;
         }
     }
 
@@ -216,14 +230,33 @@ public partial class App : Application {
     // timing such that ShowMainWindow() DOES still see a non-null MainWindow.
     internal static MainWindow BuildAndShowMainWindow(
             IDaemonClientService service, AgentActionService actions, IAppNotifier notifier, ITicker ticker,
-            CancellationToken shutdownToken) {
+            CancellationToken shutdownToken, ActivityViewModel activity) {
         // Notifier is set on the WINDOW (spec §11 toast overlay), not the ViewModel — the toast
         // is a View-level concern (WindowNotificationManager lives on MainWindow) independent of
         // the VM's WhenActivated-scoped projections.
-        var window = new MainWindow { DataContext = new MainWindowViewModel(service, actions, ticker, shutdownToken), Notifier = notifier };
+        var window = new MainWindow {
+            DataContext = new MainWindowViewModel(service, actions, ticker, shutdownToken, activity), Notifier = notifier,
+        };
         window.Show();
         return window;
     }
+
+    // Combines both log files' (LastWriteTimeUtc, Length) into one comparison key for
+    // ActivityViewModel's stat poll (spec §7) — a single try/catch, since either file being
+    // absent or transiently unreadable is "no stats" for the pair as a whole, not per file.
+    // FileInfo.Length throws FileNotFoundException on a missing file (unlike
+    // File.GetLastWriteTimeUtc, which returns a sentinel instead) — that throw is what carries a
+    // clean absence into the caught "absent" branch.
+    internal static string ActivityStatKey(string daemonName) {
+        try {
+            var path = ConsentDecisionLogReader.PathFor(daemonName);
+            return $"{StatOf(path + ".1")}|{StatOf(path)}";
+        } catch {
+            return "absent";
+        }
+    }
+
+    static string StatOf(string path) => $"{File.GetLastWriteTimeUtc(path).Ticks}:{new FileInfo(path).Length}";
 
     // Composed here (not inside AgentActionService, spec decision 5): the service only awaits the
     // seam; every UI concern — the dialog itself, choosing an owner, marshaling onto the UI

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -115,7 +115,8 @@ public partial class App : Application {
             // LAST, deliberately (spec §9): anything above throwing lands in the catch with no
             // tray icon ever created, leaving the error window as the only surface.
             _trayVm = new TrayViewModel(
-                service, _pause, actions, openMainWindow: _coordinator.ShowMainWindow, quit: () => desktop.TryShutdown());
+                service, _pause, actions, consent, openMainWindow: _coordinator.ShowMainWindow,
+                quit: () => desktop.TryShutdown(), openReviewPrompts: _promptCoordinator.ShowPromptWindow);
             _tray = new TrayIconManager(this, _trayVm);
         } catch (Exception ex) {
             // BEFORE any await: a shutdown request can arrive while cleanup below is still

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -26,14 +26,17 @@ public partial class App : Application {
     PauseController? _pause;
     ConsentService? _consent;
     ConsentPromptCoordinator? _promptCoordinator;
-    // No disposal needed — a plain ticker subscription (ActivityViewModel's class doc comment),
-    // same as _ticker below. Held so it survives StartAsync's own stack frame: the prompt window
-    // factory and BuildAndShowMainWindow both close over the SAME instance.
+    // Disposed with the other UI services below: it holds a constructor-scoped subscription to
+    // the shared ticker, which is RefCount'd — an undisposed subscriber keeps the Interval (and
+    // this object) running past teardown. Held as a field so it survives StartAsync's own stack
+    // frame: the prompt window factory and BuildAndShowMainWindow both close over the SAME
+    // instance.
     ActivityViewModel? _activity;
     TrayViewModel? _trayVm;
     TrayIconManager? _tray;
-    // No disposal needed — RefCount tears its Interval down with its last subscriber. Held for
-    // later tasks (consent prompt / activity feed) to share the same 1 Hz heartbeat.
+    // No disposal needed — RefCount tears its Interval down with its last subscriber, and every
+    // subscriber above IS disposed. Held so the consent prompt and the activity feed share the
+    // same 1 Hz heartbeat.
     UiTicker? _ticker;
     bool _shutdownStarted;
     bool _shutdownConfirmed;
@@ -127,7 +130,7 @@ public partial class App : Application {
             // must not intercept anything from here on — every close on this path is a real one.
             if (_coordinator is not null) _coordinator.QuitInProgress = true;
             Console.Error.WriteLine($"kcap app failed to start: {ex}");
-            await HandleStartupFailureAsync(desktop, ex, _service, _shutdown, [_tray, _trayVm, _promptCoordinator, _consent, _pause]);
+            await HandleStartupFailureAsync(desktop, ex, _service, _shutdown, [_tray, _trayVm, _promptCoordinator, _consent, _activity, _pause]);
             // all already disposed above — never let a later OnShutdownRequested (e.g. Cmd+Q
             // while the error window is up) dispose any of them a second time
             _service = null;
@@ -373,7 +376,7 @@ public partial class App : Application {
             // disposed one. A resolve already in flight was cancelled by _shutdown at the top of
             // OnShutdownRequested and settles on the ViewModel's silent-abort path.
             await DisposeUiThenConfirmShutdownAsync(
-                [_tray, _trayVm, _promptCoordinator, _consent, _pause],
+                [_tray, _trayVm, _promptCoordinator, _consent, _activity, _pause],
                 _service is null ? null : _service.DisposeAsync, () => _shutdownConfirmed = true, desktop, _exitCode);
         } else {
             if (_service is not null) await _service.DisposeAsync();

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -26,6 +26,9 @@ public partial class App : Application {
     PauseController? _pause;
     TrayViewModel? _trayVm;
     TrayIconManager? _tray;
+    // No disposal needed — RefCount tears its Interval down with its last subscriber. Held for
+    // later tasks (consent prompt / activity feed) to share the same 1 Hz heartbeat.
+    UiTicker? _ticker;
     bool _shutdownStarted;
     bool _shutdownConfirmed;
     // 0 = normal shutdown. Set to 1 on a startup failure so the DEFERRED shutdown path (Cmd+Q /
@@ -66,13 +69,15 @@ public partial class App : Application {
             // toast/stderr channel (spec §11).
             var ops = new LocalControlOps(service.DaemonName);
             var notifier = new AppNotifier();
+            var ticker = new UiTicker();
+            _ticker = ticker;
             _pause = new PauseController(ops, notifier.Notify, _shutdown.Token);
             // ConfirmForceStopAsync reads _coordinator at INVOCATION time (a captured field, not
             // a captured value) — safe even though _coordinator is still null right here, because
             // nothing can trigger a protected-kind stop before ShowMainWindow below assigns it.
             var actions = new AgentActionService(ops, notifier, new ShellUrlOpener(), service.Snapshots, _shutdown.Token, ConfirmForceStopAsync);
 
-            _coordinator = new MainWindowCoordinator(() => BuildAndShowMainWindow(service, actions, notifier, _shutdown.Token));
+            _coordinator = new MainWindowCoordinator(() => BuildAndShowMainWindow(service, actions, notifier, ticker, _shutdown.Token));
             // A shutdown that started before this continuation resumed already ran its first
             // pass against a null coordinator, so a window built now must never be
             // close-protected (BeginShutdownPass's rule 1 is the general defense; this is the
@@ -195,12 +200,12 @@ public partial class App : Application {
     // already-visible window is a no-op, so this stays correct even if a future edit changes the
     // timing such that ShowMainWindow() DOES still see a non-null MainWindow.
     internal static MainWindow BuildAndShowMainWindow(
-            IDaemonClientService service, AgentActionService actions, IAppNotifier notifier,
+            IDaemonClientService service, AgentActionService actions, IAppNotifier notifier, ITicker ticker,
             CancellationToken shutdownToken) {
         // Notifier is set on the WINDOW (spec §11 toast overlay), not the ViewModel — the toast
         // is a View-level concern (WindowNotificationManager lives on MainWindow) independent of
         // the VM's WhenActivated-scoped projections.
-        var window = new MainWindow { DataContext = new MainWindowViewModel(service, actions, shutdownToken), Notifier = notifier };
+        var window = new MainWindow { DataContext = new MainWindowViewModel(service, actions, ticker, shutdownToken), Notifier = notifier };
         window.Show();
         return window;
     }

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -245,22 +245,30 @@ public partial class App : Application {
         return window;
     }
 
-    // Combines both log files' (LastWriteTimeUtc, Length) into one comparison key for
-    // ActivityViewModel's stat poll (spec §7) — a single try/catch, since either file being
-    // absent or transiently unreadable is "no stats" for the pair as a whole, not per file.
-    // FileInfo.Length throws FileNotFoundException on a missing file (unlike
-    // File.GetLastWriteTimeUtc, which returns a sentinel instead) — that throw is what carries a
-    // clean absence into the caught "absent" branch.
     internal static string ActivityStatKey(string daemonName) {
+        var path = ConsentDecisionLogReader.PathFor(daemonName);
+        return ActivityStatKey(path + ".1", path);
+    }
+
+    // Combines both log files' (LastWriteTimeUtc, Length) into one comparison key for
+    // ActivityViewModel's stat poll (spec §7). Each file gets its OWN try/catch: `.1` is absent
+    // on every fresh install until the first 1MB rotation, and a single shared catch around both
+    // files would collapse the WHOLE joined key to the "absent" constant whenever `.1` throws —
+    // appends to the live file would then never change the key, and the Activity tab would go
+    // stale until the tab is reselected. FileInfo.Length throws FileNotFoundException on a
+    // missing file (unlike File.GetLastWriteTimeUtc, which returns a sentinel instead) — that
+    // throw is what carries a clean per-file absence into that file's own "absent" branch. Takes
+    // both paths directly (rather than a daemon name) so a test can point it at a temp directory
+    // without redirecting any real daemon-dir resolution.
+    internal static string ActivityStatKey(string p1Path, string livePath) => $"{StatOf(p1Path)}|{StatOf(livePath)}";
+
+    static string StatOf(string path) {
         try {
-            var path = ConsentDecisionLogReader.PathFor(daemonName);
-            return $"{StatOf(path + ".1")}|{StatOf(path)}";
+            return $"{File.GetLastWriteTimeUtc(path).Ticks}:{new FileInfo(path).Length}";
         } catch {
             return "absent";
         }
     }
-
-    static string StatOf(string path) => $"{File.GetLastWriteTimeUtc(path).Ticks}:{new FileInfo(path).Length}";
 
     // Composed here (not inside AgentActionService, spec decision 5): the service only awaits the
     // seam; every UI concern — the dialog itself, choosing an owner, marshaling onto the UI

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -24,6 +24,8 @@ public partial class App : Application {
     // first, so a quit never strands a dead icon in the menu bar (spec §9).
     MainWindowCoordinator? _coordinator;
     PauseController? _pause;
+    ConsentService? _consent;
+    ConsentPromptCoordinator? _promptCoordinator;
     TrayViewModel? _trayVm;
     TrayIconManager? _tray;
     // No disposal needed — RefCount tears its Interval down with its last subscriber. Held for
@@ -77,6 +79,17 @@ public partial class App : Application {
             // nothing can trigger a protected-kind stop before ShowMainWindow below assigns it.
             var actions = new AgentActionService(ops, notifier, new ShellUrlOpener(), service.Snapshots, _shutdown.Token, ConfirmForceStopAsync);
 
+            // The prompt window is built per raise, never here: the coordinator owns its lifetime
+            // and each window gets its own ViewModel over the one shared service (spec §6).
+            var consent = new ConsentService(
+                service, ops, ticker, ct => ConsentSubscription.RunAsync(service.DaemonName, ct),
+                TimeProvider.System, _shutdown.Token);
+            _consent = consent;
+            _promptCoordinator = new ConsentPromptCoordinator(consent, () => new ConsentPromptWindow {
+                DataContext = new ConsentPromptViewModel(consent, notifier, ticker, TimeProvider.System, _shutdown.Token),
+                Notifier = notifier,
+            });
+
             _coordinator = new MainWindowCoordinator(() => BuildAndShowMainWindow(service, actions, notifier, ticker, _shutdown.Token));
             // A shutdown that started before this continuation resumed already ran its first
             // pass against a null coordinator, so a window built now must never be
@@ -100,12 +113,14 @@ public partial class App : Application {
             // must not intercept anything from here on — every close on this path is a real one.
             if (_coordinator is not null) _coordinator.QuitInProgress = true;
             Console.Error.WriteLine($"kcap app failed to start: {ex}");
-            await HandleStartupFailureAsync(desktop, ex, _service, _shutdown, [_tray, _trayVm, _pause]);
+            await HandleStartupFailureAsync(desktop, ex, _service, _shutdown, [_tray, _trayVm, _promptCoordinator, _consent, _pause]);
             // all already disposed above — never let a later OnShutdownRequested (e.g. Cmd+Q
             // while the error window is up) dispose any of them a second time
             _service = null;
             _tray = null;
             _trayVm = null;
+            _promptCoordinator = null;
+            _consent = null;
             _pause = null;
         }
     }
@@ -319,8 +334,12 @@ public partial class App : Application {
 
     async Task DisposeAndShutdownAsync() {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
+            // Prompt coordinator BEFORE the consent service (spec §5): the window and its
+            // ViewModel are gone before the service they resolve against, so no click can reach a
+            // disposed one. A resolve already in flight was cancelled by _shutdown at the top of
+            // OnShutdownRequested and settles on the ViewModel's silent-abort path.
             await DisposeUiThenConfirmShutdownAsync(
-                [_tray, _trayVm, _pause],
+                [_tray, _trayVm, _promptCoordinator, _consent, _pause],
                 _service is null ? null : _service.DisposeAsync, () => _shutdownConfirmed = true, desktop, _exitCode);
         } else {
             if (_service is not null) await _service.DisposeAsync();

--- a/src/Capacitor.App/Services/ConsentPromptCoordinator.cs
+++ b/src/Capacitor.App/Services/ConsentPromptCoordinator.cs
@@ -1,0 +1,53 @@
+using Avalonia.Threading;
+using Capacitor.App.Views;
+
+namespace Capacitor.App.Services;
+
+/// Owns the single consent prompt window (spec §6): at most one instance at a time; closing
+/// releases it (an explicit defer — the queue is untouched) and a later raise re-creates it.
+/// The service knows nothing about windows — THIS class filters the unconditional EntryAdded
+/// signal by visibility and marshals to the UI thread, because the signal originates on a socket
+/// continuation. Additions while the window is already visible never re-activate it: no focus
+/// stealing mid-interaction.
+public sealed class ConsentPromptCoordinator : IDisposable {
+    readonly Func<ConsentPromptWindow> _windowFactory;
+    readonly IDisposable _subscription;
+    ConsentPromptWindow? _window;
+
+    public ConsentPromptCoordinator(IConsentService consent, Func<ConsentPromptWindow> windowFactory) {
+        _windowFactory = windowFactory;
+        _subscription  = consent.EntryAdded.Subscribe(_ => Dispatcher.UIThread.Post(RaiseIfHidden));
+    }
+
+    /// Every open-or-activate pass, including the one the tray menu drives — the "no re-activation
+    /// while visible" rule is only assertable if the raise itself is countable.
+    internal int Raises { get; private set; }
+
+    /// The tray menu's "Review pending launches…" target, and the coordinator's own raise path.
+    /// Must run on the UI thread.
+    public void ShowPromptWindow() {
+        Raises++;
+        if (_window is null) {
+            var window = _windowFactory();
+            // Only the identity check keeps a late event from a superseded window from clearing a
+            // newer one (MainWindowCoordinator's same guard).
+            window.Closed += (_, _) => {
+                if (ReferenceEquals(_window, window)) _window = null;
+            };
+            _window = window;
+        }
+
+        _window.Show();
+        _window.Activate();
+    }
+
+    public void Dispose() {
+        _subscription.Dispose();
+        _window?.Close();
+        _window = null;
+    }
+
+    void RaiseIfHidden() {
+        if (_window is not { IsVisible: true }) ShowPromptWindow();
+    }
+}

--- a/src/Capacitor.App/Services/ConsentPromptCoordinator.cs
+++ b/src/Capacitor.App/Services/ConsentPromptCoordinator.cs
@@ -13,6 +13,7 @@ public sealed class ConsentPromptCoordinator : IDisposable {
     readonly Func<ConsentPromptWindow> _windowFactory;
     readonly IDisposable _subscription;
     ConsentPromptWindow? _window;
+    bool _disposed;
 
     public ConsentPromptCoordinator(IConsentService consent, Func<ConsentPromptWindow> windowFactory) {
         _windowFactory = windowFactory;
@@ -26,6 +27,10 @@ public sealed class ConsentPromptCoordinator : IDisposable {
     /// The tray menu's "Review pending launches…" target, and the coordinator's own raise path.
     /// Must run on the UI thread.
     public void ShowPromptWindow() {
+        // A click racing shutdown must never rebuild a window during teardown (Dispose below runs
+        // first in App's disposal order, but the tray's command delegate is still reachable until
+        // the tray icon itself is gone).
+        if (_disposed) return;
         Raises++;
         if (_window is null) {
             var window = _windowFactory();
@@ -42,6 +47,7 @@ public sealed class ConsentPromptCoordinator : IDisposable {
     }
 
     public void Dispose() {
+        _disposed = true;
         _subscription.Dispose();
         _window?.Close();
         _window = null;

--- a/src/Capacitor.App/Services/ConsentService.cs
+++ b/src/Capacitor.App/Services/ConsentService.cs
@@ -1,0 +1,276 @@
+using System.Globalization;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+
+namespace Capacitor.App.Services;
+
+/// Sole owner of the pending-consent cache (spec §5): it subscribes to the daemon's consent
+/// stream, holds the pending queue, and is the only place entries are inserted or removed —
+/// ViewModels read and pin, never mutate.
+///
+/// Three guards carry the reviewed reasoning:
+///
+/// * <b>Tombstones live for the service lifetime</b> — no TTL, no per-connection retirement, no
+///   size cap. The broker snapshots its pending set without synchronizing against a concurrent
+///   resolve, and a snapshotted frame can sit in the per-subscriber channel arbitrarily long, so a
+///   ghost for an already-concluded request can arrive before OR after its own ack. Any retirement
+///   boundary reopens that window — in particular a client-local <c>Subscribed</c> is not ordered
+///   against a concurrent ack. Nothing is traded away: a PromptId is a never-reused GUID, so a
+///   lifetime tombstone can never suppress a future request, at ~50 bytes per human decision.
+/// * <b>The cache clear sits at the <c>Subscribed</c> boundary, never before the dial</b> — a
+///   failed dial while the status socket still reports Connected must not erase a still-actionable
+///   queue; retained entries keep the tray attention and their countdowns alive through the
+///   transient. After the boundary the daemon's replay is authoritative.
+/// * <b>The prune skips the in-flight resolve target and a transport failure refreshes it</b> — a
+///   user clicking just before the prune boundary must not have the entry vanish mid-call (the
+///   lane's settlement disposes of it instead), and the promised entry-stays-interactive state
+///   after an unreachable daemon has to actually exist for a beat.
+///
+/// Nothing here marshals to the UI thread: cache mutations land on the loop's thread-pool
+/// continuations, and consumers ObserveOn(RxSchedulers.MainThreadScheduler).
+public sealed class ConsentService : IConsentService {
+    const string ConsentV2Capability = "consent/2";
+
+    static readonly TimeSpan PruneGrace = TimeSpan.FromSeconds(5);
+    static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
+
+    readonly SourceCache<PendingConsent, string> _cache = new(p => p.RequestId);
+    readonly HashSet<string> _tombstones = [];
+    readonly Lock _lock = new();          // guards _tombstones, _inFlightPromptId, _loopCts, _disposed
+    readonly SemaphoreSlim _lane = new(1, 1); // one resolve in flight (PauseController discipline)
+    readonly Subject<Unit> _entryAdded = new();
+
+    readonly ILocalControlOps _ops;
+    readonly Func<CancellationToken, IAsyncEnumerable<ConsentStreamEvent>> _subscribe;
+    readonly TimeProvider _time;
+    readonly CancellationToken _shutdownToken;
+    readonly IDisposable _statusSub;
+    readonly IDisposable _tickSub;
+
+    string? _inFlightPromptId;
+    CancellationTokenSource? _loopCts;
+    bool _disposed;
+
+    public ConsentService(
+            IDaemonClientService service, ILocalControlOps ops, ITicker ticker,
+            Func<CancellationToken, IAsyncEnumerable<ConsentStreamEvent>> subscribe,
+            TimeProvider time, CancellationToken shutdownToken) {
+        _ops           = ops;
+        _subscribe     = subscribe;
+        _time          = time;
+        _shutdownToken = shutdownToken;
+        _tickSub       = ticker.Ticks.Subscribe(_ => Prune());
+        _statusSub     = service.Status.Subscribe(OnStatus);
+    }
+
+    public IObservable<IChangeSet<PendingConsent, string>> Pending => _cache.Connect();
+    public IObservable<int> PendingCount => _cache.CountChanged;
+    public IObservable<Unit> EntryAdded => _entryAdded.AsObservable();
+
+    public async Task<ConsentResolveOutcome> ResolveAsync(
+            PendingConsent target, bool allow, bool saveRule, CancellationToken ct) {
+        await _lane.WaitAsync(ct).ConfigureAwait(false); // OCE propagates: entry kept, no tombstone
+        try {
+            // Safety boundary, not UX: a null/empty requester would serialize into a wildcard
+            // allow-everything rule, so the save is dropped and reported instead of sent.
+            var sendRule = saveRule && !string.IsNullOrEmpty(target.Dto.Requester);
+            var skipped  = saveRule && !sendRule;
+            var resolve  = new ConsentResolveDto(
+                target.RequestId, allow ? "allow" : "deny",
+                sendRule ? new ConsentRuleDto("allow", target.Dto.Requester, null, null, null) : null,
+                target.PromptId); // ALWAYS the echo — the daemon's identity check (spec §4.1)
+
+            lock (_lock) _inFlightPromptId = target.PromptId;
+
+            ConsentAckDto ack;
+            try {
+                ack = await _ops.ResolveConsentAsync(resolve, ct).ConfigureAwait(false);
+            } catch (LocalControlOpsException ex) {
+                return Unsettled(ex.Reason);
+            } catch (Exception ex) when (ex is not OperationCanceledException) {
+                // An unmapped failure (LocalControlOps does not classify every socket-construction
+                // error) must never reach a UI command — and it settled nothing, so it keeps the
+                // entry exactly like a transport failure does.
+                Console.Error.WriteLine($"kcap: consent resolve failed unexpectedly: {ex.Message}");
+                return Unsettled(ex.Message);
+            }
+
+            Conclude(target);
+            var ruleOutcome = RuleOf(ack);
+            var kind =
+                !ack.Ok    ? ConsentResolveKind.AlreadyDecided
+                : skipped  ? ConsentResolveKind.RuleSkippedNoRequester
+                : ruleOutcome is ConsentRuleOutcome.Rejected or ConsentRuleOutcome.Unknown
+                    ? ConsentResolveKind.AppliedRuleRejected
+                    : ConsentResolveKind.Applied;
+            return new ConsentResolveOutcome(kind, ruleOutcome, ack.Error);
+
+            ConsentResolveOutcome Unsettled(string reason) {
+                RefreshPrune(target);
+                return new ConsentResolveOutcome(ConsentResolveKind.TransportFailure, RuleOf(null), reason);
+            }
+
+            ConsentRuleOutcome RuleOf(ConsentAckDto? a) =>
+                skipped      ? ConsentRuleOutcome.SkippedNoRequester
+                : !sendRule  ? ConsentRuleOutcome.NotRequested
+                : a?.RuleSaved switch {
+                    true  => ConsentRuleOutcome.Saved,
+                    false => ConsentRuleOutcome.Rejected,
+                    // A pre-rule_saved ack that applied cleanly reported success the only way it
+                    // could: Ok with no warning (spec §4.1's carve-out).
+                    _     => a is { Ok: true, Error: null } ? ConsentRuleOutcome.Saved : ConsentRuleOutcome.Unknown,
+                };
+        } finally {
+            lock (_lock) _inFlightPromptId = null;
+            try { _lane.Release(); } catch (ObjectDisposedException) { } // disposed mid-resolve
+        }
+    }
+
+    public void Dispose() {
+        lock (_lock) {
+            if (_disposed) return;
+            _disposed = true;
+        }
+        _statusSub.Dispose();
+        _tickSub.Dispose();
+        StopLoop();
+        _entryAdded.OnCompleted();
+        _entryAdded.Dispose();
+        _cache.Dispose();
+        _lane.Dispose();
+    }
+
+    void OnStatus(AttachStatus status) {
+        if (status is { State: AttachState.Connected, Capabilities: not null } &&
+            status.Capabilities.Contains(ConsentV2Capability)) {
+            StartLoop();
+            return;
+        }
+        StopLoop();
+        // A daemon that answers without consent/2 is a different incarnation than the one those
+        // entries came from, and it would resolve without the identity check — they can never be
+        // safely answered against it. Disconnected states retain instead: the daemon may still be
+        // alive holding live prompts.
+        if (status.State == AttachState.Connected) _cache.Clear();
+    }
+
+    void StartLoop() {
+        CancellationTokenSource cts;
+        lock (_lock) {
+            if (_disposed || _loopCts is not null) return;
+            cts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownToken);
+            _loopCts = cts;
+        }
+        _ = Task.Run(() => RunLoopAsync(cts));
+    }
+
+    void StopLoop() {
+        CancellationTokenSource? cts;
+        lock (_lock) {
+            cts = _loopCts;
+            _loopCts = null;
+        }
+        if (cts is null) return;
+        try { cts.Cancel(); } catch (ObjectDisposedException) { } // already unwound and self-disposed
+    }
+
+    async Task RunLoopAsync(CancellationTokenSource cts) {
+        var ct = cts.Token;
+        try {
+            while (!ct.IsCancellationRequested) {
+                try {
+                    await foreach (var evt in _subscribe(ct).WithCancellation(ct).ConfigureAwait(false)) {
+                        ct.ThrowIfCancellationRequested(); // a superseded loop never touches the cache
+                        switch (evt) {
+                            case ConsentStreamEvent.Subscribed:  _cache.Clear();  break;
+                            case ConsentStreamEvent.Pending p:   Upsert(p.Request); break;
+                        }
+                    }
+                } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                    break;
+                } catch (Exception ex) {
+                    // Never kill the loop: the enumeration ending badly is just "this attempt is
+                    // over" — the retry below is the whole recovery story.
+                    Console.Error.WriteLine($"kcap: consent subscription attempt failed: {ex.Message}");
+                }
+
+                try {
+                    await Task.Delay(RetryDelay, _time, ct).ConfigureAwait(false);
+                } catch (OperationCanceledException) {
+                    break;
+                }
+            }
+        } finally {
+            cts.Dispose();
+        }
+    }
+
+    void Upsert(ConsentPendingDto dto) {
+        var deadline = DeadlineFor(dto);
+        var entry    = new PendingConsent(dto, deadline, deadline + PruneGrace);
+        bool added;
+        // The tombstone test and the insert share one critical section with Conclude's
+        // record-and-evict, so a ghost can never slip in between an ack's two halves.
+        lock (_lock) {
+            if (_tombstones.Contains(entry.PromptId)) return;
+            added = false;
+            _cache.Edit(u => {
+                added = !u.Lookup(entry.RequestId).HasValue;
+                u.AddOrUpdate(entry);
+            });
+        }
+        if (added) _entryAdded.OnNext(Unit.Default);
+    }
+
+    /// Records the concluded identity and evicts it in one critical section. The eviction compares
+    /// PromptIds, not object references, so a REPLAYED instance of the same request goes too — while
+    /// a successor sharing only the RequestId survives (spec §5's ABA defense).
+    void Conclude(PendingConsent target) {
+        lock (_lock) {
+            _tombstones.Add(target.PromptId);
+            _cache.Edit(u => {
+                if (u.Lookup(target.RequestId) is { HasValue: true, Value.PromptId: var id } && id == target.PromptId)
+                    u.Remove(target.RequestId);
+            });
+        }
+    }
+
+    void RefreshPrune(PendingConsent target) {
+        target.PruneAfter = _time.GetUtcNow() + PruneGrace;
+        _cache.Edit(u => {
+            if (u.Lookup(target.RequestId) is { HasValue: true, Value.PromptId: var id } && id == target.PromptId)
+                u.AddOrUpdate(target);
+        });
+    }
+
+    // Availability hygiene, not settlement — and deliberately NOT a tombstone: a request the app
+    // merely gave up on locally is still live daemon-side (the clock-step case) and must be allowed
+    // to reappear.
+    void Prune() {
+        var now      = _time.GetUtcNow();
+        var inFlight = Volatile.Read(ref _inFlightPromptId);
+        try {
+            _cache.Edit(u => {
+                foreach (var stale in u.Items.Where(p => now > p.PruneAfter && p.PromptId != inFlight).ToList()) {
+                    if (u.Lookup(stale.RequestId) is { HasValue: true, Value.PromptId: var id } && id == stale.PromptId)
+                        u.Remove(stale.RequestId);
+                }
+            });
+        } catch (Exception ex) {
+            // The ticker is SHARED (tray, rows, countdowns): a throw from this handler would tear
+            // down everyone's 1 Hz heartbeat, e.g. on a tick racing shutdown's cache disposal.
+            Console.Error.WriteLine($"kcap: consent prune failed: {ex.Message}");
+        }
+    }
+
+    DateTimeOffset DeadlineFor(ConsentPendingDto dto) {
+        var anchor = DateTimeOffset.TryParse(
+            dto.RequestedAt, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var stamped)
+            ? stamped
+            : _time.GetUtcNow();
+        return anchor + TimeSpan.FromSeconds(dto.TimeoutSeconds);
+    }
+}

--- a/src/Capacitor.App/Services/ConsentService.cs
+++ b/src/Capacitor.App/Services/ConsentService.cs
@@ -11,8 +11,18 @@ namespace Capacitor.App.Services;
 /// stream, holds the pending queue, and is the only place entries are inserted or removed —
 /// ViewModels read and pin, never mutate.
 ///
-/// Three guards carry the reviewed reasoning:
+/// Four guards carry the reviewed reasoning:
 ///
+/// * <b>EntryAdded is the FIRST SURFACING of a PromptId, never a new cache key</b> — the signal
+///   is the raise trigger (spec §6), so it has to mean "a request the user has not been offered
+///   yet". Keyed on the cache key it was wrong in both directions: a successor B under A's
+///   RequestId (a relaunch — the likeliest second prompt there is) replaced the slot in silence
+///   and never raised, while a resubscribe's clear+replay made every replayed entry look new and
+///   re-raised a window the user had explicitly deferred. `_surfaced` is therefore a
+///   service-lifetime PromptId set with the tombstone argument behind it — never-reused GUIDs, so
+///   it can never suppress a future request, at ~50 bytes per request ever seen. Tombstones are a
+///   subset of it (a concluded request was surfaced first) and stay separate because they do a
+///   different job: a tombstone DROPS the frame, `_surfaced` only keeps it quiet.
 /// * <b>Tombstones live for the service lifetime</b> — no TTL, no per-connection retirement, no
 ///   size cap. The broker snapshots its pending set without synchronizing against a concurrent
 ///   resolve, and a snapshotted frame can sit in the per-subscriber channel arbitrarily long, so a
@@ -39,7 +49,8 @@ public sealed class ConsentService : IConsentService {
 
     readonly SourceCache<PendingConsent, string> _cache = new(p => p.RequestId);
     readonly HashSet<string> _tombstones = [];
-    readonly Lock _lock = new();          // guards _tombstones, _inFlightPromptId, _loopCts, _disposed
+    readonly HashSet<string> _surfaced = [];
+    readonly Lock _lock = new();          // guards _tombstones, _surfaced, _inFlightPromptId, _loopCts, _disposed
     readonly SemaphoreSlim _lane = new(1, 1); // one resolve in flight (PauseController discipline)
     readonly Subject<Unit> _entryAdded = new();
 
@@ -154,7 +165,11 @@ public sealed class ConsentService : IConsentService {
         // entries came from, and it would resolve without the identity check — they can never be
         // safely answered against it. Disconnected states retain instead: the daemon may still be
         // alive holding live prompts.
-        if (status.State == AttachState.Connected) _cache.Clear();
+        //
+        // Under the same lock Upsert holds: this runs on the status thread, so an Upsert that had
+        // already passed its tombstone test would otherwise land its insert AFTER the clear and
+        // resurrect a previous incarnation's entry into a cache that must be empty.
+        if (status.State == AttachState.Connected) lock (_lock) _cache.Clear();
     }
 
     void StartLoop() {
@@ -216,11 +231,8 @@ public sealed class ConsentService : IConsentService {
         // record-and-evict, so a ghost can never slip in between an ack's two halves.
         lock (_lock) {
             if (_tombstones.Contains(entry.PromptId)) return;
-            added = false;
-            _cache.Edit(u => {
-                added = !u.Lookup(entry.RequestId).HasValue;
-                u.AddOrUpdate(entry);
-            });
+            added = _surfaced.Add(entry.PromptId);
+            _cache.Edit(u => u.AddOrUpdate(entry));
         }
         if (added) _entryAdded.OnNext(Unit.Default);
     }

--- a/src/Capacitor.App/Services/ConsentService.cs
+++ b/src/Capacitor.App/Services/ConsentService.cs
@@ -250,15 +250,20 @@ public sealed class ConsentService : IConsentService {
     // merely gave up on locally is still live daemon-side (the clock-step case) and must be allowed
     // to reappear.
     void Prune() {
-        var now      = _time.GetUtcNow();
-        var inFlight = Volatile.Read(ref _inFlightPromptId);
+        var now = _time.GetUtcNow();
         try {
-            _cache.Edit(u => {
-                foreach (var stale in u.Items.Where(p => now > p.PruneAfter && p.PromptId != inFlight).ToList()) {
-                    if (u.Lookup(stale.RequestId) is { HasValue: true, Value.PromptId: var id } && id == stale.PromptId)
-                        u.Remove(stale.RequestId);
-                }
-            });
+            // The in-flight marker is read INSIDE the section that edits: snapshotting it first
+            // would let a resolve claim its target in the gap and still lose it mid-call, after
+            // which a TransportFailure's refresh finds nothing cached and cannot re-add it.
+            lock (_lock) {
+                var inFlight = _inFlightPromptId;
+                _cache.Edit(u => {
+                    foreach (var stale in u.Items.Where(p => now > p.PruneAfter && p.PromptId != inFlight).ToList()) {
+                        if (u.Lookup(stale.RequestId) is { HasValue: true, Value.PromptId: var id } && id == stale.PromptId)
+                            u.Remove(stale.RequestId);
+                    }
+                });
+            }
         } catch (Exception ex) {
             // The ticker is SHARED (tray, rows, countdowns): a throw from this handler would tear
             // down everyone's 1 Hz heartbeat, e.g. on a tick racing shutdown's cache disposal.

--- a/src/Capacitor.App/Services/IConsentService.cs
+++ b/src/Capacitor.App/Services/IConsentService.cs
@@ -48,10 +48,14 @@ public interface IConsentService : IDisposable {
     /// consumers marshal with ObserveOn(RxSchedulers.MainThreadScheduler).
     IObservable<IChangeSet<PendingConsent, string>> Pending { get; }
 
+    /// Replays the current count on subscribe (DynamicData's CountChanged) — TrayViewModel's
+    /// derivation stream relies on that seed to emit synchronously rather than starting null.
     IObservable<int> PendingCount { get; }
 
-    /// Fires once per newly-keyed entry, unconditionally: the service knows nothing about windows,
-    /// so the prompt-window coordinator is what filters by visibility (spec §5/§6).
+    /// Fires once per request identity, on its FIRST surfacing — a PromptId not already cached
+    /// under its key and never surfaced before (so a same-RequestId successor DOES fire and a
+    /// resubscribe's replay does NOT). Unconditional beyond that: the service knows nothing about
+    /// windows, so the prompt-window coordinator is what filters by visibility (spec §5/§6).
     IObservable<Unit> EntryAdded { get; }
 
     Task<ConsentResolveOutcome> ResolveAsync(PendingConsent target, bool allow, bool saveRule, CancellationToken ct);

--- a/src/Capacitor.App/Services/IConsentService.cs
+++ b/src/Capacitor.App/Services/IConsentService.cs
@@ -1,0 +1,58 @@
+using System.Reactive;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+
+namespace Capacitor.App.Services;
+
+/// How a resolve settled. Only <see cref="TransportFailure"/> leaves the request pending; every
+/// other value is conclusive (the entry is removed and its identity tombstoned). Caller
+/// cancellation is not a value here — it propagates as OperationCanceledException (spec §5).
+public enum ConsentResolveKind { Applied, AppliedRuleRejected, AlreadyDecided, RuleSkippedNoRequester, TransportFailure }
+
+/// What became of the optional "remember this requester" rule. The service disambiguates because
+/// only it knows whether a `save_rule` was actually sent: <see cref="Unknown"/> is a save that was
+/// sent but not reported (unreachable behind the consent/2 gate, honest if it ever fires) and
+/// <see cref="SkippedNoRequester"/> is a save the service refused to send at all.
+public enum ConsentRuleOutcome { NotRequested, Saved, Rejected, Unknown, SkippedNoRequester }
+
+/// <param name="Error">The ack's warning/failure detail, or the coded transport reason
+/// (e.g. <c>daemon_unreachable</c>) on <see cref="ConsentResolveKind.TransportFailure"/>.</param>
+public sealed record ConsentResolveOutcome(ConsentResolveKind Kind, ConsentRuleOutcome RuleOutcome, string? Error);
+
+/// One pending consent request. <see cref="RequestId"/> is the cache key and the per-agent queue
+/// identity (the daemon reuses it across launches); <see cref="PromptId"/> is the daemon-minted
+/// REQUEST identity every cache guard and the resolve echo key on (spec §4.1).
+public sealed class PendingConsent {
+    internal PendingConsent(ConsentPendingDto dto, DateTimeOffset deadlineHint, DateTimeOffset pruneAfter) {
+        Dto          = dto;
+        RequestId    = dto.RequestId;
+        PromptId     = dto.PromptId!; // ConsentSubscription's structural validation guarantees it
+        DeadlineHint = deadlineHint;
+        PruneAfter   = pruneAfter;
+    }
+
+    public ConsentPendingDto Dto { get; }
+    public string RequestId { get; }
+    public string PromptId { get; }
+
+    /// `RequestedAt + TimeoutSeconds` — a HEURISTIC, never an outcome. The daemon enforces its
+    /// timeout on a monotonic clock; this is wall-clock metadata, so a clock step can make the two
+    /// disagree in either direction. Only a resolve ack settles a request.
+    public DateTimeOffset DeadlineHint { get; }
+
+    public DateTimeOffset PruneAfter { get; internal set; }
+}
+
+public interface IConsentService : IDisposable {
+    /// Mutated on background continuations (the subscription loop and resolve completions) —
+    /// consumers marshal with ObserveOn(RxSchedulers.MainThreadScheduler).
+    IObservable<IChangeSet<PendingConsent, string>> Pending { get; }
+
+    IObservable<int> PendingCount { get; }
+
+    /// Fires once per newly-keyed entry, unconditionally: the service knows nothing about windows,
+    /// so the prompt-window coordinator is what filters by visibility (spec §5/§6).
+    IObservable<Unit> EntryAdded { get; }
+
+    Task<ConsentResolveOutcome> ResolveAsync(PendingConsent target, bool allow, bool saveRule, CancellationToken ct);
+}

--- a/src/Capacitor.App/Services/UiTicker.cs
+++ b/src/Capacitor.App/Services/UiTicker.cs
@@ -28,7 +28,7 @@ public sealed class UiTicker : ITicker {
     // (AgentRowViewModel), so a StartWith would only re-emit the identical string. The scheduler is
     // captured NOW (Rx operators take a scheduler by value, not a live reference to
     // RxSchedulers.MainThreadScheduler) and RefCount defers the connection until a row subscribes —
-    // which is what lets a test construct this VM inside AvaloniaSession.WithImmediateRxScheduler
+    // which is what lets a test construct this ticker inside AvaloniaSession.WithImmediateRxScheduler
     // WITHOUT ever subscribing a row: subscribing an Interval under an immediate scheduler would
     // block/spin forever, since Interval never completes.
     public IObservable<long> Ticks { get; } = Observable

--- a/src/Capacitor.App/Services/UiTicker.cs
+++ b/src/Capacitor.App/Services/UiTicker.cs
@@ -1,0 +1,39 @@
+using System.Reactive.Linq;
+using ReactiveUI;
+
+namespace Capacitor.App.Services;
+
+public interface ITicker {
+    /// Shared 1 Hz heartbeat. HOT via Publish().RefCount(); ticks are delivered on the UI thread.
+    /// Construct the production implementation ON the UI thread (App.StartAsync) — an off-UI-
+    /// thread Observable.Interval subscription binds an orphan thread-local dispatcher that never
+    /// ticks (a real production bug; see UiTicker's pipeline comment).
+    IObservable<long> Ticks { get; }
+}
+
+/// ONE shared ticker for every row (spec §8): Publish().RefCount() makes it HOT, so all rows
+/// observe the same Interval and tick in lockstep instead of each cold-subscribing its own.
+public sealed class UiTicker : ITicker {
+    // SubscribeOn is load-bearing. Rows are built inside DynamicData's Transform, which runs on
+    // whatever thread mutates the SourceCache — in production DaemonClientService's socket pump
+    // thread, never the UI thread. AvaloniaScheduler's non-zero-dueTime path does NOT marshal: it
+    // calls DispatcherTimer.RunOnce, which resolves Dispatcher.CurrentDispatcher — a THREAD-LOCAL
+    // lookup that, off the UI thread, silently constructs a brand-new dispatcher for that thread
+    // which nothing ever pumps. Its Tick never fires, so the Interval produces no value at all and
+    // every row's Uptime freezes at its seed forever, with no exception and no log. SubscribeOn
+    // forces the subscription — and therefore Interval's first Schedule call — onto the real UI
+    // dispatcher via AvaloniaScheduler's zero-dueTime Dispatcher.UIThread.Post path.
+    //
+    // No StartWith: a row's immediate first value is the OAPH's initialUptime argument
+    // (AgentRowViewModel), so a StartWith would only re-emit the identical string. The scheduler is
+    // captured NOW (Rx operators take a scheduler by value, not a live reference to
+    // RxSchedulers.MainThreadScheduler) and RefCount defers the connection until a row subscribes —
+    // which is what lets a test construct this VM inside AvaloniaSession.WithImmediateRxScheduler
+    // WITHOUT ever subscribing a row: subscribing an Interval under an immediate scheduler would
+    // block/spin forever, since Interval never completes.
+    public IObservable<long> Ticks { get; } = Observable
+        .Interval(TimeSpan.FromSeconds(1), RxSchedulers.MainThreadScheduler)
+        .SubscribeOn(RxSchedulers.MainThreadScheduler)
+        .Publish()
+        .RefCount();
+}

--- a/src/Capacitor.App/ViewModels/ActivityViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ActivityViewModel.cs
@@ -1,0 +1,124 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData.Binding;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+/// One row of the decision log, projected for display (spec §7). Time is local
+/// ("yyyy-MM-dd HH:mm:ss"); an unparseable decided_at renders verbatim rather than throwing.
+/// IsAllowed drives the outcome badge color; Outcome carries the raw wire value.
+public sealed record ActivityRow(
+    string Time, string Outcome, bool IsAllowed, string Requester, string KindLabel,
+    string RepoLeaf, string RepoFull, string Vendor, string SourceLabel);
+
+/// Renders the consent decision log as the Activity tab (spec §7): pure file I/O via the injected
+/// `read`, so the feed works with the daemon stopped or unreachable. No FileSystemWatcher —
+/// refreshed on tab visibility, a 2-tick stat poll while visible, and an own-resolution nudge (App
+/// wires RequestRefresh into ConsentPromptViewModel's onConcluded callback).
+///
+/// Constructed once at the composition root and lives for the app's lifetime, like ConsentService
+/// — it subscribes to the SHARED ticker directly in the constructor rather than through
+/// WhenActivated/window activation, since the prompt-window factory must capture this same
+/// instance independently of MainWindowViewModel's own construction. The ticker already delivers
+/// on the UI thread (UiTicker's doc comment), so no ObserveOn is needed here.
+public sealed class ActivityViewModel : ReactiveObject {
+    readonly Func<ConsentLogReadResult> _read;
+    readonly Func<string> _statKey;
+
+    readonly ObservableCollectionExtended<ActivityRow> _rowsSource = new();
+    public ReadOnlyObservableCollection<ActivityRow> Rows { get; }
+
+    bool _isEmpty = true;
+    public bool IsEmpty {
+        get => _isEmpty;
+        private set => this.RaiseAndSetIfChanged(ref _isEmpty, value);
+    }
+
+    bool _visible;
+    int _tickCount;
+    string? _lastStatKey;
+
+    public ActivityViewModel(Func<ConsentLogReadResult> read, Func<string> statKey, ITicker ticker) {
+        _read = read;
+        _statKey = statKey;
+        Rows = new ReadOnlyObservableCollection<ActivityRow>(_rowsSource);
+
+        ticker.Ticks.Subscribe(_ => OnTick());
+    }
+
+    /// Tab-visibility trigger (spec §7): a true transition (tab selected AND window visible, per
+    /// MainWindow.axaml.cs) does an immediate read and primes the poll's stat baseline so the very
+    /// next tick doesn't immediately re-read the same unchanged content. A no-op on a repeated call
+    /// with the same value.
+    public void OnTabVisibleChanged(bool visible) {
+        if (visible == _visible) return;
+        _visible = visible;
+        _tickCount = 0;
+        if (!visible) return;
+
+        try { _lastStatKey = _statKey(); } catch { _lastStatKey = "absent"; }
+        SafeRefresh();
+    }
+
+    /// Own-resolution nudge (spec §7): an immediate read now — the daemon appends the log record
+    /// AFTER completing the resolve (RunContinuationsAsynchronously), so this ack-triggered read
+    /// can beat the append. Eventual consistency relies on the next stat-poll tick, not on this
+    /// call firing a second time.
+    public void RequestRefresh() => SafeRefresh();
+
+    void OnTick() {
+        if (!_visible) return;
+        if (++_tickCount < 2) return;
+        _tickCount = 0;
+
+        string key;
+        try { key = _statKey(); } catch { key = "absent"; }
+        if (key == _lastStatKey) return;
+        _lastStatKey = key;
+        SafeRefresh();
+    }
+
+    void SafeRefresh() {
+        ConsentLogReadResult result;
+        try { result = _read(); } catch { return; } // swallowed — last-good rows stay on display
+        Apply(result);
+    }
+
+    /// Display rule keyed off Complete (spec §7): a Complete read replaces the rows, including
+    /// replacing them with the empty state when it is genuinely empty. An incomplete read never
+    /// replaces existing rows — unless there are none yet, where the partial records are shown
+    /// best-effort rather than leaving the feed with nothing at all.
+    void Apply(ConsentLogReadResult result) {
+        if (!result.Complete && _rowsSource.Count > 0) return;
+
+        _rowsSource.Load(result.Records.Select(ToRow));
+        IsEmpty = _rowsSource.Count == 0;
+    }
+
+    static ActivityRow ToRow(ConsentDecisionRecord r) => new(
+        FormatTime(r.DecidedAt), r.Outcome, r.Outcome == "allowed", RequesterOf(r),
+        ConsentPromptViewModel.KindLabelOf(r.Kind), RepoLabel.Leaf(r.RepoPath), r.RepoPath, r.Vendor,
+        SourceLabelOf(r.Source));
+
+    static string RequesterOf(ConsentDecisionRecord r) =>
+        !string.IsNullOrWhiteSpace(r.RequesterDisplay) ? r.RequesterDisplay
+        : !string.IsNullOrWhiteSpace(r.Requester)      ? r.Requester
+        : "unknown";
+
+    static string FormatTime(string decidedAt) =>
+        DateTimeOffset.TryParse(decidedAt, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+            ? parsed.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
+            : decidedAt; // unparseable — rendered verbatim rather than thrown
+
+    internal static string SourceLabelOf(string source) => source switch {
+        "owner"          => "owner",
+        "default"        => "default policy",
+        "prompt_user"    => "you",
+        "prompt_timeout" => "timeout",
+        "prompt_no_ui"   => "no UI attached",
+        _ => source.StartsWith("rule[", StringComparison.Ordinal) && source.EndsWith(']') ? "rule" : source,
+    };
+}

--- a/src/Capacitor.App/ViewModels/ActivityViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ActivityViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Globalization;
+using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData.Binding;
@@ -47,6 +48,15 @@ public sealed class ActivityViewModel : ReactiveObject, IDisposable {
     bool _visible;
     int _tickCount;
     string? _lastStatKey;
+    bool _refreshInFlight;
+    bool _disposed;
+
+    enum RefreshMode { Gated, PrimeAndRead, ReadOnly }
+
+    /// Test-only seam: the in-flight off-UI-thread stat+read hop this VM is currently awaiting, so
+    /// a test can await the exact completion the single-flight guard below watches instead of a
+    /// fixed delay. Null when idle.
+    internal Task? PendingRefreshForTesting { get; private set; }
 
     public ActivityViewModel(Func<ConsentLogReadResult> read, Func<string> statKey, ITicker ticker) {
         _read = read;
@@ -56,7 +66,10 @@ public sealed class ActivityViewModel : ReactiveObject, IDisposable {
         _tickSub = ticker.Ticks.Subscribe(_ => OnTick());
     }
 
-    public void Dispose() => _tickSub.Dispose();
+    public void Dispose() {
+        _disposed = true;
+        _tickSub.Dispose();
+    }
 
     /// Tab-visibility trigger (spec §7): a true transition (tab selected AND window visible, per
     /// MainWindow.axaml.cs) does an immediate read and primes the poll's stat baseline so the very
@@ -68,32 +81,66 @@ public sealed class ActivityViewModel : ReactiveObject, IDisposable {
         _tickCount = 0;
         if (!visible) return;
 
-        try { _lastStatKey = _statKey(); } catch { _lastStatKey = "absent"; }
-        SafeRefresh();
+        TriggerRefresh(RefreshMode.PrimeAndRead);
     }
 
     /// Own-resolution nudge (spec §7): an immediate read now — the daemon appends the log record
     /// AFTER completing the resolve (RunContinuationsAsynchronously), so this ack-triggered read
     /// can beat the append. Eventual consistency relies on the next stat-poll tick, not on this
-    /// call firing a second time.
-    public void RequestRefresh() => SafeRefresh();
+    /// call firing a second time — including when the single-flight guard drops this call because
+    /// another refresh is already in flight.
+    public void RequestRefresh() => TriggerRefresh(RefreshMode.ReadOnly);
 
     void OnTick() {
         if (!_visible) return;
         if (++_tickCount < 2) return;
         _tickCount = 0;
+        TriggerRefresh(RefreshMode.Gated);
+    }
+
+    /// Single-flight: a trigger arriving while a stat+read is already running is dropped, never
+    /// queued — latest-wins isn't needed because the next tick/refresh re-checks on its own. Both
+    /// the stat call and the log read are blocking file I/O, so they run off the UI thread
+    /// (Task.Run); only the resulting state mutation and Apply (Rows is a bound collection) run
+    /// back on the UI thread, via an explicit Dispatcher hop rather than relying on an ambient
+    /// SynchronizationContext capture.
+    void TriggerRefresh(RefreshMode mode) {
+        if (_refreshInFlight) return;
+        _refreshInFlight = true;
+        PendingRefreshForTesting = RunRefreshAsync(mode);
+    }
+
+    async Task RunRefreshAsync(RefreshMode mode) {
+        try {
+            var previousKey = _lastStatKey;
+            var (nextKey, result) = await Task.Run(() => ComputeOffUiThread(mode, previousKey)).ConfigureAwait(false);
+            await Dispatcher.UIThread.InvokeAsync(() => ApplyOutcome(nextKey, result));
+        } finally {
+            _refreshInFlight = false;
+        }
+    }
+
+    // Gated (OnTick): re-reads only when the stat key changed since the previous check — the key
+    // still advances even if the read that follows throws, same as before this moved off-thread.
+    // PrimeAndRead (OnTabVisibleChanged true) always reads and always primes the baseline.
+    // ReadOnly (RequestRefresh) never touches the stat key at all.
+    (string? key, ConsentLogReadResult? result) ComputeOffUiThread(RefreshMode mode, string? previousKey) {
+        if (mode == RefreshMode.ReadOnly) return (null, SafeRead());
 
         string key;
         try { key = _statKey(); } catch { key = "absent"; }
-        if (key == _lastStatKey) return;
-        _lastStatKey = key;
-        SafeRefresh();
+        if (mode == RefreshMode.Gated && key == previousKey) return (null, null);
+        return (key, SafeRead());
     }
 
-    void SafeRefresh() {
-        ConsentLogReadResult result;
-        try { result = _read(); } catch { return; } // swallowed — last-good rows stay on display
-        Apply(result);
+    ConsentLogReadResult? SafeRead() {
+        try { return _read(); } catch { return null; } // swallowed — last-good rows stay on display
+    }
+
+    void ApplyOutcome(string? key, ConsentLogReadResult? result) {
+        if (_disposed) return;
+        if (key is not null) _lastStatKey = key;
+        if (result is not null) Apply(result);
     }
 
     /// Display rule keyed off Complete (spec §7): a Complete read replaces the rows, including

--- a/src/Capacitor.App/ViewModels/ActivityViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ActivityViewModel.cs
@@ -116,7 +116,7 @@ public sealed class ActivityViewModel : ReactiveObject, IDisposable {
             var (nextKey, result) = await Task.Run(() => ComputeOffUiThread(mode, previousKey)).ConfigureAwait(false);
             await Dispatcher.UIThread.InvokeAsync(() => ApplyOutcome(nextKey, result));
         } finally {
-            _refreshInFlight = false;
+            _refreshInFlight = false; // runs on the UI thread (InvokeAsync's continuation), but a plain bool write is safe either way
         }
     }
 

--- a/src/Capacitor.App/ViewModels/ActivityViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ActivityViewModel.cs
@@ -24,9 +24,16 @@ public sealed record ActivityRow(
 /// WhenActivated/window activation, since the prompt-window factory must capture this same
 /// instance independently of MainWindowViewModel's own construction. The ticker already delivers
 /// on the UI thread (UiTicker's doc comment), so no ObserveOn is needed here.
-public sealed class ActivityViewModel : ReactiveObject {
+///
+/// That constructor-scoped subscription is why this is IDisposable: the shared ticker is
+/// Publish().RefCount(), so its Interval only tears down when the LAST subscriber goes — a
+/// subscriber nobody disposes keeps a 1 Hz timer (and this object) alive past teardown, including
+/// the startup-failure path where the app lingers on an error window. App disposes it in reverse
+/// creation order with the other UI services.
+public sealed class ActivityViewModel : ReactiveObject, IDisposable {
     readonly Func<ConsentLogReadResult> _read;
     readonly Func<string> _statKey;
+    readonly IDisposable _tickSub;
 
     readonly ObservableCollectionExtended<ActivityRow> _rowsSource = new();
     public ReadOnlyObservableCollection<ActivityRow> Rows { get; }
@@ -46,8 +53,10 @@ public sealed class ActivityViewModel : ReactiveObject {
         _statKey = statKey;
         Rows = new ReadOnlyObservableCollection<ActivityRow>(_rowsSource);
 
-        ticker.Ticks.Subscribe(_ => OnTick());
+        _tickSub = ticker.Ticks.Subscribe(_ => OnTick());
     }
+
+    public void Dispose() => _tickSub.Dispose();
 
     /// Tab-visibility trigger (spec §7): a true transition (tab selected AND window visible, per
     /// MainWindow.axaml.cs) does an immediate read and primes the poll's stat baseline so the very
@@ -108,8 +117,10 @@ public sealed class ActivityViewModel : ReactiveObject {
         : !string.IsNullOrWhiteSpace(r.Requester)      ? r.Requester
         : "unknown";
 
+    // RoundtripKind, matching ConsentService.DeadlineFor: both parse the same daemon-written ISO
+    // stamps, and one parse style across the app is one behavior to reason about.
     static string FormatTime(string decidedAt) =>
-        DateTimeOffset.TryParse(decidedAt, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+        DateTimeOffset.TryParse(decidedAt, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed)
             ? parsed.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
             : decidedAt; // unparseable — rendered verbatim rather than thrown
 

--- a/src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs
@@ -62,6 +62,7 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
     readonly IAppNotifier _notifier;
     readonly TimeProvider _time;
     readonly CancellationToken _shutdownToken;
+    readonly Action? _onConcluded;
     readonly Subject<Unit> _closeRequested = new();
 
     // ONE stable collection, created once and never replaced (the lesson recorded on
@@ -154,13 +155,20 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
     public ReactiveCommand<Unit, Unit> AllowRememberCommand { get; }
     public ReactiveCommand<Unit, Unit> DenyCommand { get; }
 
+    /// <param name="onConcluded">
+    /// Invoked after every conclusive ack (AlreadyDecided or a landed decision — never a
+    /// TransportFailure, which settles nothing). Composition wires this to the app's single
+    /// ActivityViewModel's RequestRefresh (spec §7): own decisions are eventual, not instant — see
+    /// that method's own doc comment.
+    /// </param>
     public ConsentPromptViewModel(
             IConsentService consent, IAppNotifier notifier, ITicker ticker, TimeProvider time,
-            CancellationToken shutdownToken) {
+            CancellationToken shutdownToken, Action? onConcluded = null) {
         _consent       = consent;
         _notifier      = notifier;
         _time          = time;
         _shutdownToken = shutdownToken;
+        _onConcluded   = onConcluded;
         Queue          = new ReadOnlyObservableCollection<PendingConsent>(_queueSource);
 
         var current = this.WhenAnyValue(x => x.Current);
@@ -333,12 +341,14 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
 
             case ConsentResolveKind.AlreadyDecided:
                 _settled = Current;
+                _onConcluded?.Invoke();
                 Hold(DecidedText(outcome.RuleOutcome));
                 break;
 
             // Applied / AppliedRuleRejected / RuleSkippedNoRequester: the decision landed.
             default:
                 _settled = Current;
+                _onConcluded?.Invoke();
                 var warning = RuleWarning(outcome);
                 if (warning is not null) _notifier.Notify(warning);
 

--- a/src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs
@@ -37,6 +37,10 @@ public enum ConsentPromptPhase { Ready, Resolving, Concluded, Expired }
 /// * <b>A warning outlives the decision that raised it.</b> A toast posted on the same beat the
 ///   window closes is never seen, so a rule-not-saved disclosure with nothing left to advance to
 ///   holds the window for the terminal hold instead of closing under its own toast.
+/// * <b>Only a DECISION closes the window on the spot.</b> A queue the cache emptied — a
+///   resubscribe's clear, whose replay arrives as a separate changeset — waits one beat before
+///   closing, so a reconnect blip can no longer flicker the window shut and rebuild it (see
+///   Advance).
 public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewModel {
     const string ExpiredCopy     = "Response time elapsed — unanswered requests are denied by the daemon";
     const string ExpiringCopy    = "Expiring…";
@@ -76,6 +80,10 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
     // and the ack's continuation are two independently posted jobs and their order is not ours to
     // assume. Skipping the settled identity makes the advance correct under either one.
     PendingConsent? _settled;
+
+    // Armed when the CACHE emptied the queue (a resubscribe's clear, a prune) rather than a local
+    // settle; disarmed by the next entry to arrive. See Advance.
+    bool _closeDeferred;
 
     int _heldTicks;
 
@@ -204,6 +212,7 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
             // without this Clear a reactivation's initial replay would insert a second copy of
             // everything currently cached (MainWindowViewModel's identical note).
             _queueSource.Clear();
+            _closeDeferred = false; // a close armed under the previous activation is not this one's
 
             // ObserveOn BEFORE the binding operator: the cache is mutated on the service's
             // background continuations (spec §5).
@@ -248,12 +257,21 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
             return;
         }
 
-        if (Current is null || !StillQueued(Current)) Advance(); else UpdatePosition();
+        if (Current is null || !StillQueued(Current)) Advance(settled: false); else UpdatePosition();
     }
 
     void OnTick() {
         if (Phase == ConsentPromptPhase.Concluded) {
-            if (++_heldTicks >= TerminalHoldTicks) Advance();
+            if (++_heldTicks >= TerminalHoldTicks) Advance(settled: true);
+            return;
+        }
+
+        // Still empty a beat after the cache emptied it: the emptiness was real, not a
+        // resubscribe's clear with its replay in flight. One-shot — a queue that stays empty
+        // never re-fires it.
+        if (_closeDeferred) {
+            _closeDeferred = false;
+            _closeRequested.OnNext(Unit.Default);
             return;
         }
 
@@ -262,7 +280,14 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
 
     /// Releases the pin and takes the sorted head — or signals empty. Nothing here removes: the
     /// service evicts a concluded entry, and _settled covers the beat before that eviction shows up.
-    void Advance() {
+    ///
+    /// <paramref name="settled"/> marks the LOCAL paths — an ack, or the end of its terminal hold —
+    /// which close on this very beat (spec §6). An emptiness the CACHE caused waits one ticker beat
+    /// instead: a resubscribe clears and replays as two separate changesets, and closing on the
+    /// intermediate one flickered the window shut and rebuilt it a moment later with a fresh
+    /// ViewModel, a reset pin and stolen focus. The pin still releases immediately either way —
+    /// nothing that left the cache stays on screen.
+    void Advance(bool settled) {
         var wasPinned = Current is not null;
 
         _heldTicks = 0;
@@ -272,9 +297,17 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
         Phase      = RestingPhase();
         UpdatePosition();
 
+        if (Current is not null) {
+            _closeDeferred = false; // the queue came back: a deferred close is off
+            return;
+        }
+
         // Only a released pin can empty the window. A ViewModel activating before its first
-        // changeset arrives (ObserveOn POSTS the initial replay) has nothing to close over yet.
-        if (Current is null && wasPinned) _closeRequested.OnNext(Unit.Default);
+        // changeset arrives (ObserveOn POSTS the initial replay) has nothing to close over yet —
+        // and neither does a second empty changeset arriving while a close is already armed.
+        if (!wasPinned) return;
+
+        if (settled) _closeRequested.OnNext(Unit.Default); else _closeDeferred = true;
     }
 
     ConsentPromptPhase RestingPhase() =>
@@ -357,7 +390,7 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
                 // very beat, and a posted toast over a closed window is no disclosure at all — so
                 // the warning takes the same terminal hold "Already decided" gets, and the close
                 // follows it.
-                if (warning is not null && NextAfterSettled() is null) Hold(warning); else Advance();
+                if (warning is not null && NextAfterSettled() is null) Hold(warning); else Advance(settled: true);
                 break;
         }
     }

--- a/src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs
@@ -1,0 +1,358 @@
+using System.Collections.ObjectModel;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using DynamicData;
+using DynamicData.Binding;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+/// Ready/Expired are the two INTERACTIVE states — hint expiry is not a verdict (spec §6), so the
+/// buttons behave identically in both and only the countdown line differs.
+public enum ConsentPromptPhase { Ready, Resolving, AlreadyDecided, Expired }
+
+/// Renders ONE pinned consent request at a time (spec §6). The pin is what the user is looking at:
+/// it is taken from the sorted queue head and released only on an advance — never swapped out from
+/// under a click by an arrival, a prune, or a replay. The ViewModel NEVER removes a cache entry;
+/// conclusive acks and the prune do that inside ConsentService (spec §5), and its identity guard
+/// makes any stale action a no-op.
+///
+/// Three honesty rules carry the reviewed reasoning:
+///
+/// * <b>Expiry is never a verdict.</b> The deadline hint is wall-clock and the daemon's deadline is
+///   monotonic, so a hint that reached zero proves nothing. The countdown line says so and the
+///   buttons stay ACTIVE — a click after zero either applies normally (backward clock step) or
+///   comes back Ok=false and runs the honest "Already decided" path.
+/// * <b>An in-flight resolve outranks the clock.</b> Past zero mid-call the line reads "Expiring…"
+///   and the phase stays Resolving: the ack, not the hint, settles the request.
+/// * <b>A transport failure discloses nothing about the rule.</b> Its outcome carries a rule value
+///   that was never sent, so this path shows only the transport toast, re-enables the buttons and
+///   keeps the entry.
+public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewModel {
+    const string ExpiredCopy     = "Response time elapsed — unanswered requests are denied by the daemon";
+    const string ExpiringCopy    = "Expiring…";
+    const string DecidedCopy     = "Already decided";
+    const string TransportCopy   = "Daemon unreachable — the request is still pending";
+    const string UnknownRuleCopy = "Decision applied — this daemon version doesn't report whether the rule was saved";
+
+    // 1 Hz ticker (spec §6: a 2-second hold), counted in ticks so no test ever sleeps.
+    const int TerminalHoldTicks = 2;
+
+    static readonly IComparer<PendingConsent> QueueComparer = Comparer<PendingConsent>.Create((a, b) => {
+        var byRequested = RequestedAt(a).CompareTo(RequestedAt(b));
+        return byRequested != 0 ? byRequested : string.CompareOrdinal(a.RequestId, b.RequestId);
+    });
+
+    // RequestedAt as the SERVICE resolved it: DeadlineHint is anchor + TimeoutSeconds, where the
+    // anchor is the parsed stamp or — unparseable — arrival time. Deriving it back out keeps the
+    // sort key and the countdown on one value, with no second parse and no second fallback rule.
+    static DateTimeOffset RequestedAt(PendingConsent entry) =>
+        entry.DeadlineHint - TimeSpan.FromSeconds(entry.Dto.TimeoutSeconds);
+
+    readonly IConsentService _consent;
+    readonly IAppNotifier _notifier;
+    readonly TimeProvider _time;
+    readonly CancellationToken _shutdownToken;
+    readonly Subject<Unit> _closeRequested = new();
+
+    // ONE stable collection, created once and never replaced (the AI-1651 lesson — see
+    // MainWindowViewModel._agentsSource): WhenActivated re-runs on every window, and SortAndBind's
+    // IList overload mutates THIS instance in place.
+    readonly ObservableCollectionExtended<PendingConsent> _queueSource = new();
+
+    // The pin's own conclusion, held until the next advance. The service evicts a concluded entry
+    // inside ResolveAsync, but this ViewModel sees the cache through an ObserveOn — so the eviction
+    // and the ack's continuation are two independently posted jobs and their order is not ours to
+    // assume. Skipping the settled identity makes the advance correct under either one.
+    PendingConsent? _settled;
+
+    int _heldTicks;
+
+    public ViewModelActivator Activator { get; } = new();
+
+    public ReadOnlyObservableCollection<PendingConsent> Queue { get; }
+
+    /// Fires when an advance finds nothing left to show. The window closes itself on this (spec
+    /// §6: "the next pending or closes when the queue empties"); the ViewModel owns no window.
+    public IObservable<Unit> CloseRequested => _closeRequested.AsObservable();
+
+    PendingConsent? _current;
+    /// The pinned request — the ONLY thing rendered. Null when the queue is empty.
+    public PendingConsent? Current {
+        get => _current;
+        private set => this.RaiseAndSetIfChanged(ref _current, value);
+    }
+
+    ConsentPromptPhase _phase;
+    public ConsentPromptPhase Phase {
+        get => _phase;
+        private set => this.RaiseAndSetIfChanged(ref _phase, value);
+    }
+
+    string? _phaseText;
+    /// Terminal-state line ("Already decided", plus the §4.1 rule-side-effect disclosure). Null
+    /// while the request is still answerable.
+    public string? PhaseText {
+        get => _phaseText;
+        private set => this.RaiseAndSetIfChanged(ref _phaseText, value);
+    }
+
+    string _positionText = "";
+    public string PositionText {
+        get => _positionText;
+        private set => this.RaiseAndSetIfChanged(ref _positionText, value);
+    }
+
+    bool _positionVisible;
+    public bool PositionVisible {
+        get => _positionVisible;
+        private set => this.RaiseAndSetIfChanged(ref _positionVisible, value);
+    }
+
+    readonly ObservableAsPropertyHelper<string> _requesterText;
+    public string RequesterText => _requesterText.Value;
+
+    readonly ObservableAsPropertyHelper<string> _kindLabel;
+    public string KindLabel => _kindLabel.Value;
+
+    readonly ObservableAsPropertyHelper<string> _vendorText;
+    public string VendorText => _vendorText.Value;
+
+    readonly ObservableAsPropertyHelper<string> _repoLeaf;
+    public string RepoLeaf => _repoLeaf.Value;
+
+    readonly ObservableAsPropertyHelper<string> _repoFull;
+    public string RepoFull => _repoFull.Value;
+
+    // Hidden when the requester is null OR empty — the same predicate as ConsentService's save
+    // guard, which stays the real safety boundary (a wildcard allow-everything rule, spec §6).
+    readonly ObservableAsPropertyHelper<bool> _allowRememberVisible;
+    public bool AllowRememberVisible => _allowRememberVisible.Value;
+
+    readonly ObservableAsPropertyHelper<bool> _buttonsEnabled;
+    public bool ButtonsEnabled => _buttonsEnabled.Value;
+
+    readonly ObservableAsPropertyHelper<bool> _buttonsVisible;
+    public bool ButtonsVisible => _buttonsVisible.Value;
+
+    // Activation-scoped, unlike the projections above: this one subscribes to the SHARED,
+    // app-lifetime ticker, so a closed window's ViewModel must stop recomputing on every beat.
+    ObservableAsPropertyHelper<string>? _countdownText;
+    public string CountdownText => _countdownText?.Value ?? "";
+
+    public ReactiveCommand<Unit, Unit> AllowOnceCommand { get; }
+    public ReactiveCommand<Unit, Unit> AllowRememberCommand { get; }
+    public ReactiveCommand<Unit, Unit> DenyCommand { get; }
+
+    public ConsentPromptViewModel(
+            IConsentService consent, IAppNotifier notifier, ITicker ticker, TimeProvider time,
+            CancellationToken shutdownToken) {
+        _consent       = consent;
+        _notifier      = notifier;
+        _time          = time;
+        _shutdownToken = shutdownToken;
+        Queue          = new ReadOnlyObservableCollection<PendingConsent>(_queueSource);
+
+        var current = this.WhenAnyValue(x => x.Current);
+
+        _requesterText = current.Select(RequesterOf).ToProperty(this, x => x.RequesterText, "");
+        _kindLabel     = current.Select(c => c is null ? "" : KindLabelOf(c.Dto.Kind)).ToProperty(this, x => x.KindLabel, "");
+        _vendorText    = current.Select(c => c?.Dto.Vendor ?? "").ToProperty(this, x => x.VendorText, "");
+        _repoLeaf      = current.Select(c => c is null ? "" : RepoLabel.Leaf(c.Dto.RepoPath)).ToProperty(this, x => x.RepoLeaf, "");
+        _repoFull      = current.Select(c => c?.Dto.RepoPath ?? "").ToProperty(this, x => x.RepoFull, "");
+
+        _allowRememberVisible = current
+            .Select(c => c is not null && !string.IsNullOrEmpty(c.Dto.Requester))
+            .ToProperty(this, x => x.AllowRememberVisible, initialValue: false);
+
+        // Constructor-scoped, exactly like MainWindowViewModel's Start/RetryVisible: the commands
+        // must exist and be assertable before any window activates, and these observables only
+        // ever observe THIS object's own property changes (always raised on the UI thread).
+        var canResolve = this
+            .WhenAnyValue(x => x.Current, x => x.Phase,
+                (target, phase) => target is not null && phase is ConsentPromptPhase.Ready or ConsentPromptPhase.Expired);
+
+        _buttonsEnabled = canResolve.ToProperty(this, x => x.ButtonsEnabled, initialValue: false);
+        _buttonsVisible = this
+            .WhenAnyValue(x => x.Current, x => x.Phase, (target, phase) => target is not null && phase != ConsentPromptPhase.AlreadyDecided)
+            .ToProperty(this, x => x.ButtonsVisible, initialValue: false);
+
+        AllowOnceCommand     = ReactiveCommand.CreateFromTask(() => RunResolveAsync(allow: true, saveRule: false), canResolve);
+        AllowRememberCommand = ReactiveCommand.CreateFromTask(() => RunResolveAsync(allow: true, saveRule: true), canResolve);
+        DenyCommand          = ReactiveCommand.CreateFromTask(() => RunResolveAsync(allow: false, saveRule: false), canResolve);
+
+        this.WhenActivated(disposables => {
+            // The pipeline below is brand new on every activation while _queueSource is reused —
+            // without this Clear a reactivation's initial replay would insert a second copy of
+            // everything currently cached (MainWindowViewModel's identical note).
+            _queueSource.Clear();
+
+            // ObserveOn BEFORE the binding operator: the cache is mutated on the service's
+            // background continuations (spec §5).
+            consent.Pending
+                .ObserveOn(RxSchedulers.MainThreadScheduler)
+                .SortAndBind(_queueSource, QueueComparer)
+                .Subscribe(_ => OnQueueChanged())
+                .DisposeWith(disposables);
+
+            ticker.Ticks
+                .Subscribe(_ => OnTick())
+                .DisposeWith(disposables);
+
+            _countdownText = ticker.Ticks.Select(_ => Unit.Default)
+                .Merge(this.WhenAnyValue(x => x.Current).Select(_ => Unit.Default))
+                .Merge(this.WhenAnyValue(x => x.Phase).Select(_ => Unit.Default))
+                .Select(_ => Countdown())
+                .ToProperty(this, x => x.CountdownText, Countdown())
+                .DisposeWith(disposables);
+        });
+    }
+
+    internal static string KindLabelOf(string kind) => kind switch {
+        "agent"       => "Agent",
+        "review"      => "Review",
+        "review-flow" => "Review flow",
+        _             => kind, // an unrecognized kind renders verbatim rather than as a wrong label
+    };
+
+    static string RequesterOf(PendingConsent? entry) =>
+        entry is null                                              ? ""
+        : !string.IsNullOrWhiteSpace(entry.Dto.RequesterDisplay)   ? entry.Dto.RequesterDisplay
+        : !string.IsNullOrWhiteSpace(entry.Dto.Requester)          ? entry.Dto.Requester
+        : "unknown";
+
+    /// Cache changes never swap the display while the pinned request is being resolved or is
+    /// holding a terminal state; otherwise the pin survives until it leaves the cache (the
+    /// hint-expired prune, spec §6).
+    void OnQueueChanged() {
+        if (Phase is ConsentPromptPhase.Resolving or ConsentPromptPhase.AlreadyDecided) {
+            UpdatePosition();
+            return;
+        }
+
+        if (Current is null || !StillQueued(Current)) Advance(); else UpdatePosition();
+    }
+
+    void OnTick() {
+        if (Phase == ConsentPromptPhase.AlreadyDecided) {
+            if (++_heldTicks >= TerminalHoldTicks) Advance();
+            return;
+        }
+
+        if (Phase != ConsentPromptPhase.Resolving) Phase = RestingPhase();
+    }
+
+    /// Releases the pin and takes the sorted head — or signals empty. Nothing here removes: the
+    /// service evicts a concluded entry, and _settled covers the beat before that eviction shows up.
+    void Advance() {
+        var wasPinned = Current is not null;
+
+        _heldTicks = 0;
+        PhaseText  = null;
+        Current    = _queueSource.FirstOrDefault(p => _settled is null || p.PromptId != _settled.PromptId);
+        _settled   = null;
+        Phase      = RestingPhase();
+        UpdatePosition();
+
+        // Only a released pin can empty the window. A ViewModel activating before its first
+        // changeset arrives (ObserveOn POSTS the initial replay) has nothing to close over yet.
+        if (Current is null && wasPinned) _closeRequested.OnNext(Unit.Default);
+    }
+
+    ConsentPromptPhase RestingPhase() =>
+        Current is not null && _time.GetUtcNow() >= Current.DeadlineHint
+            ? ConsentPromptPhase.Expired
+            : ConsentPromptPhase.Ready;
+
+    bool StillQueued(PendingConsent target) =>
+        _queueSource.Any(p => p.RequestId == target.RequestId && p.PromptId == target.PromptId);
+
+    void UpdatePosition() {
+        var count = _queueSource.Count;
+        var index = Current is null ? -1 : _queueSource.IndexOf(Current);
+        PositionText    = $"{Math.Max(index, 0) + 1} of {count}";
+        PositionVisible = count > 1;
+    }
+
+    string Countdown() {
+        var target = Current;
+        if (target is null || Phase == ConsentPromptPhase.AlreadyDecided) return "";
+
+        var remaining = target.DeadlineHint - _time.GetUtcNow();
+        if (remaining > TimeSpan.Zero) return $"Expires in {(int)Math.Ceiling(remaining.TotalSeconds)}s";
+
+        // Past the hint: an in-flight resolve owns the outcome, otherwise the non-authoritative
+        // copy — and the buttons stay live either way (spec §6).
+        return Phase == ConsentPromptPhase.Resolving ? ExpiringCopy : ExpiredCopy;
+    }
+
+    async Task RunResolveAsync(bool allow, bool saveRule) {
+        var target = Current;
+        if (target is null || Phase is ConsentPromptPhase.Resolving or ConsentPromptPhase.AlreadyDecided) return;
+
+        Phase = ConsentPromptPhase.Resolving;
+        try {
+            Settle(await _consent.ResolveAsync(target, allow, saveRule, _shutdownToken));
+        } catch (OperationCanceledException) {
+            // Shutdown (or a cancelled lane wait): a silent abort — no toast, no removal, and the
+            // window is closing anyway. Nothing was decided, so the request stays answerable.
+            Phase = RestingPhase();
+        } catch (Exception ex) {
+            // ResolveAsync already contains its own unmapped failures; anything still escaping
+            // (e.g. a disposed service, which the §5 shutdown order makes unreachable) must not
+            // reach ReactiveCommand.ThrownExceptions, whose default handler rethrows on the
+            // dispatcher and takes the app down.
+            Console.Error.WriteLine($"kcap: consent resolve failed unexpectedly: {ex.Message}");
+            Phase = RestingPhase();
+        }
+    }
+
+    void Settle(ConsentResolveOutcome outcome) {
+        switch (outcome.Kind) {
+            case ConsentResolveKind.TransportFailure:
+                // Deliberately NO rule disclosure: nothing was sent, so the outcome's rule value
+                // (possibly Unknown) says nothing about a rule and must not be rendered.
+                _notifier.Notify(TransportCopy);
+                Phase = RestingPhase();
+                break;
+
+            case ConsentResolveKind.AlreadyDecided:
+                _settled   = Current;
+                PhaseText  = DecidedText(outcome.RuleOutcome);
+                _heldTicks = 0;
+                Phase      = ConsentPromptPhase.AlreadyDecided;
+                break;
+
+            // Applied / AppliedRuleRejected / RuleSkippedNoRequester: the decision landed.
+            default:
+                _settled = Current;
+                if (RuleWarning(outcome) is { } warning) _notifier.Notify(warning);
+                Advance();
+                break;
+        }
+    }
+
+    /// Never a silent success (spec §6) — and after an Allow &amp; remember the §4.1 side effect is
+    /// disclosed: the daemon persists a rule BEFORE it attempts the resolution, so a request that
+    /// was already decided elsewhere can still have installed one.
+    string DecidedText(ConsentRuleOutcome rule) => rule switch {
+        ConsentRuleOutcome.Saved    => $"Already decided — your allow rule for {RequesterText} was still saved.",
+        ConsentRuleOutcome.Rejected or ConsentRuleOutcome.SkippedNoRequester => "Already decided — no rule was saved.",
+        ConsentRuleOutcome.Unknown  => "Already decided — this daemon version doesn't report whether your allow rule was saved.",
+        _                           => DecidedCopy,
+    };
+
+    static string? RuleWarning(ConsentResolveOutcome outcome) =>
+        outcome.Kind is not (ConsentResolveKind.AppliedRuleRejected or ConsentResolveKind.RuleSkippedNoRequester) ? null
+        : outcome.RuleOutcome == ConsentRuleOutcome.Unknown ? UnknownRuleCopy
+        : $"Decision applied — rule not saved: {RuleFailureReason(outcome)}";
+
+    static string RuleFailureReason(ConsentResolveOutcome outcome) =>
+        !string.IsNullOrEmpty(outcome.Error)                                ? outcome.Error
+        : outcome.RuleOutcome == ConsentRuleOutcome.SkippedNoRequester      ? "the request had no requester identity"
+        : "the daemon didn't say why";
+}

--- a/src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs
@@ -12,8 +12,10 @@ using ReactiveUI;
 namespace Capacitor.App.ViewModels;
 
 /// Ready/Expired are the two INTERACTIVE states — hint expiry is not a verdict (spec §6), so the
-/// buttons behave identically in both and only the countdown line differs.
-public enum ConsentPromptPhase { Ready, Resolving, AlreadyDecided, Expired }
+/// buttons behave identically in both and only the countdown line differs. Concluded is the
+/// 2-second terminal hold: the pinned request is settled and its disclosure is on screen — either
+/// "Already decided" or an applied decision whose rule did not save.
+public enum ConsentPromptPhase { Ready, Resolving, Concluded, Expired }
 
 /// Renders ONE pinned consent request at a time (spec §6). The pin is what the user is looking at:
 /// it is taken from the sorted queue head and released only on an advance — never swapped out from
@@ -21,7 +23,7 @@ public enum ConsentPromptPhase { Ready, Resolving, AlreadyDecided, Expired }
 /// conclusive acks and the prune do that inside ConsentService (spec §5), and its identity guard
 /// makes any stale action a no-op.
 ///
-/// Three honesty rules carry the reviewed reasoning:
+/// Four honesty rules carry the reviewed reasoning:
 ///
 /// * <b>Expiry is never a verdict.</b> The deadline hint is wall-clock and the daemon's deadline is
 ///   monotonic, so a hint that reached zero proves nothing. The countdown line says so and the
@@ -32,6 +34,9 @@ public enum ConsentPromptPhase { Ready, Resolving, AlreadyDecided, Expired }
 /// * <b>A transport failure discloses nothing about the rule.</b> Its outcome carries a rule value
 ///   that was never sent, so this path shows only the transport toast, re-enables the buttons and
 ///   keeps the entry.
+/// * <b>A warning outlives the decision that raised it.</b> A toast posted on the same beat the
+///   window closes is never seen, so a rule-not-saved disclosure with nothing left to advance to
+///   holds the window for the terminal hold instead of closing under its own toast.
 public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewModel {
     const string ExpiredCopy     = "Response time elapsed — unanswered requests are denied by the daemon";
     const string ExpiringCopy    = "Expiring…";
@@ -59,9 +64,10 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
     readonly CancellationToken _shutdownToken;
     readonly Subject<Unit> _closeRequested = new();
 
-    // ONE stable collection, created once and never replaced (the AI-1651 lesson — see
-    // MainWindowViewModel._agentsSource): WhenActivated re-runs on every window, and SortAndBind's
-    // IList overload mutates THIS instance in place.
+    // ONE stable collection, created once and never replaced (the lesson recorded on
+    // MainWindowViewModel._agentsSource — a swapped instance leaves the view bound to a dead
+    // collection): WhenActivated re-runs on every window, and SortAndBind's IList overload mutates
+    // THIS instance in place.
     readonly ObservableCollectionExtended<PendingConsent> _queueSource = new();
 
     // The pin's own conclusion, held until the next advance. The service evicts a concluded entry
@@ -94,8 +100,8 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
     }
 
     string? _phaseText;
-    /// Terminal-state line ("Already decided", plus the §4.1 rule-side-effect disclosure). Null
-    /// while the request is still answerable.
+    /// Terminal-state line: "Already decided" with its §4.1 rule-side-effect disclosure, or a
+    /// rule-not-saved warning being held on screen. Null while the request is still answerable.
     public string? PhaseText {
         get => _phaseText;
         private set => this.RaiseAndSetIfChanged(ref _phaseText, value);
@@ -178,7 +184,7 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
 
         _buttonsEnabled = canResolve.ToProperty(this, x => x.ButtonsEnabled, initialValue: false);
         _buttonsVisible = this
-            .WhenAnyValue(x => x.Current, x => x.Phase, (target, phase) => target is not null && phase != ConsentPromptPhase.AlreadyDecided)
+            .WhenAnyValue(x => x.Current, x => x.Phase, (target, phase) => target is not null && phase != ConsentPromptPhase.Concluded)
             .ToProperty(this, x => x.ButtonsVisible, initialValue: false);
 
         AllowOnceCommand     = ReactiveCommand.CreateFromTask(() => RunResolveAsync(allow: true, saveRule: false), canResolve);
@@ -229,7 +235,7 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
     /// holding a terminal state; otherwise the pin survives until it leaves the cache (the
     /// hint-expired prune, spec §6).
     void OnQueueChanged() {
-        if (Phase is ConsentPromptPhase.Resolving or ConsentPromptPhase.AlreadyDecided) {
+        if (Phase is ConsentPromptPhase.Resolving or ConsentPromptPhase.Concluded) {
             UpdatePosition();
             return;
         }
@@ -238,7 +244,7 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
     }
 
     void OnTick() {
-        if (Phase == ConsentPromptPhase.AlreadyDecided) {
+        if (Phase == ConsentPromptPhase.Concluded) {
             if (++_heldTicks >= TerminalHoldTicks) Advance();
             return;
         }
@@ -253,7 +259,7 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
 
         _heldTicks = 0;
         PhaseText  = null;
-        Current    = _queueSource.FirstOrDefault(p => _settled is null || p.PromptId != _settled.PromptId);
+        Current    = NextAfterSettled();
         _settled   = null;
         Phase      = RestingPhase();
         UpdatePosition();
@@ -268,6 +274,11 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
             ? ConsentPromptPhase.Expired
             : ConsentPromptPhase.Ready;
 
+    /// What an advance would land on: the sorted head, skipping the identity this pin just
+    /// concluded (see _settled). Null means the window has nothing left to show.
+    PendingConsent? NextAfterSettled() =>
+        _queueSource.FirstOrDefault(p => _settled is null || p.PromptId != _settled.PromptId);
+
     bool StillQueued(PendingConsent target) =>
         _queueSource.Any(p => p.RequestId == target.RequestId && p.PromptId == target.PromptId);
 
@@ -280,7 +291,7 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
 
     string Countdown() {
         var target = Current;
-        if (target is null || Phase == ConsentPromptPhase.AlreadyDecided) return "";
+        if (target is null || Phase == ConsentPromptPhase.Concluded) return "";
 
         var remaining = target.DeadlineHint - _time.GetUtcNow();
         if (remaining > TimeSpan.Zero) return $"Expires in {(int)Math.Ceiling(remaining.TotalSeconds)}s";
@@ -292,7 +303,7 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
 
     async Task RunResolveAsync(bool allow, bool saveRule) {
         var target = Current;
-        if (target is null || Phase is ConsentPromptPhase.Resolving or ConsentPromptPhase.AlreadyDecided) return;
+        if (target is null || Phase is ConsentPromptPhase.Resolving or ConsentPromptPhase.Concluded) return;
 
         Phase = ConsentPromptPhase.Resolving;
         try {
@@ -321,19 +332,32 @@ public sealed class ConsentPromptViewModel : ReactiveObject, IActivatableViewMod
                 break;
 
             case ConsentResolveKind.AlreadyDecided:
-                _settled   = Current;
-                PhaseText  = DecidedText(outcome.RuleOutcome);
-                _heldTicks = 0;
-                Phase      = ConsentPromptPhase.AlreadyDecided;
+                _settled = Current;
+                Hold(DecidedText(outcome.RuleOutcome));
                 break;
 
             // Applied / AppliedRuleRejected / RuleSkippedNoRequester: the decision landed.
             default:
                 _settled = Current;
-                if (RuleWarning(outcome) is { } warning) _notifier.Notify(warning);
-                Advance();
+                var warning = RuleWarning(outcome);
+                if (warning is not null) _notifier.Notify(warning);
+
+                // With something else queued the advance keeps the window up and the toast lands
+                // over the next request. On the LAST one the advance closes the window on this
+                // very beat, and a posted toast over a closed window is no disclosure at all — so
+                // the warning takes the same terminal hold "Already decided" gets, and the close
+                // follows it.
+                if (warning is not null && NextAfterSettled() is null) Hold(warning); else Advance();
                 break;
         }
+    }
+
+    /// The 2-tick terminal hold: the pin stays on screen carrying its disclosure, the buttons go
+    /// (there is nothing left to click), and OnTick advances out of it.
+    void Hold(string disclosure) {
+        PhaseText  = disclosure;
+        _heldTicks = 0;
+        Phase      = ConsentPromptPhase.Concluded;
     }
 
     /// Never a silent success (spec §6) — and after an Allow &amp; remember the §4.1 side effect is

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -133,37 +133,6 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     readonly ObservableAsPropertyHelper<bool> _retryVisible;
     public bool RetryVisible => _retryVisible.Value;
 
-    // ONE shared ticker for every row (spec §8): Publish().RefCount() makes it HOT, so all rows
-    // observe the same Interval and tick in lockstep instead of each cold-subscribing its own.
-    //
-    // SubscribeOn is load-bearing. Rows are built inside DynamicData's Transform, which runs on
-    // whatever thread mutates the SourceCache — in production DaemonClientService's socket pump
-    // thread, never the UI thread. AvaloniaScheduler's non-zero-dueTime path does NOT marshal: it
-    // calls DispatcherTimer.RunOnce, which resolves Dispatcher.CurrentDispatcher — a THREAD-LOCAL
-    // lookup that, off the UI thread, silently constructs a brand-new dispatcher for that thread
-    // which nothing ever pumps. Its Tick never fires, so the Interval produces no value at all and
-    // every row's Uptime freezes at its seed forever, with no exception and no log. SubscribeOn
-    // forces the subscription — and therefore Interval's first Schedule call — onto the real UI
-    // dispatcher via AvaloniaScheduler's zero-dueTime Dispatcher.UIThread.Post path.
-    //
-    // No StartWith: a row's immediate first value is the OAPH's initialUptime argument
-    // (AgentRowViewModel), so a StartWith would only re-emit the identical string. The scheduler is
-    // captured NOW (Rx operators take a scheduler by value, not a live reference to
-    // RxSchedulers.MainThreadScheduler) and RefCount defers the connection until a row subscribes —
-    // which is what lets a test construct this VM inside AvaloniaSession.WithImmediateRxScheduler
-    // WITHOUT ever subscribing a row: subscribing an Interval under an immediate scheduler would
-    // block/spin forever, since Interval never completes.
-    readonly IObservable<long> _ticker = Observable
-        .Interval(TimeSpan.FromSeconds(1), RxSchedulers.MainThreadScheduler)
-        .SubscribeOn(RxSchedulers.MainThreadScheduler)
-        .Publish()
-        .RefCount();
-
-    // Test seam: the only way to exercise the REAL ticker (real 1s Interval on the real
-    // AvaloniaScheduler) from the production subscription thread — the row-level tests inject a
-    // Subject and so cannot observe the off-UI-thread hazard the SubscribeOn above exists for.
-    internal IObservable<long> Ticker => _ticker;
-
     readonly TimeProvider _time;
 
     /// <param name="shutdownToken">
@@ -172,7 +141,7 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     /// unbounded wait would survive app exit).
     /// </param>
     public MainWindowViewModel(
-            IDaemonClientService service, AgentActionService actions,
+            IDaemonClientService service, AgentActionService actions, ITicker ticker,
             CancellationToken shutdownToken, TimeProvider? time = null) {
         _service = service;
         _time = time ?? TimeProvider.System;
@@ -299,7 +268,7 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
             // whatever rows are still live at that point — DisposeMany disposes its full current
             // set on teardown, not just on per-item Remove/Update.
             service.Agents.Connect()
-                .Transform(dto => new AgentRowViewModel(dto, actions, _ticker, _time, connected, stopsInFlight))
+                .Transform(dto => new AgentRowViewModel(dto, actions, ticker.Ticks, _time, connected, stopsInFlight))
                 .DisposeMany()
                 .ObserveOn(RxSchedulers.MainThreadScheduler)
                 .SortAndBind(_agentsSource, RowComparer)

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -108,6 +108,11 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     readonly ObservableCollectionExtended<AgentRowViewModel> _agentsSource = new();
     public ReadOnlyObservableCollection<AgentRowViewModel> Agents { get; }
 
+    /// The Activity tab (spec §7) — constructed once at the composition root, same instance the
+    /// prompt window's onConcluded callback nudges, so this is a plain ctor-injected reference,
+    /// not something built here.
+    public ActivityViewModel Activity { get; }
+
     ObservableAsPropertyHelper<bool>? _gridEnabled;
     public bool GridEnabled => _gridEnabled?.Value ?? false;
 
@@ -142,10 +147,11 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     /// </param>
     public MainWindowViewModel(
             IDaemonClientService service, AgentActionService actions, ITicker ticker,
-            CancellationToken shutdownToken, TimeProvider? time = null) {
+            CancellationToken shutdownToken, ActivityViewModel activity, TimeProvider? time = null) {
         _service = service;
         _time = time ?? TimeProvider.System;
         Agents = new ReadOnlyObservableCollection<AgentRowViewModel>(_agentsSource);
+        Activity = activity;
 
         // ReactiveCommand's own CanExecute observable already ANDs the supplied canExecute with
         // "not currently executing" (confirmed against the installed ReactiveUI 23.2.28 API

--- a/src/Capacitor.App/ViewModels/TrayModels.cs
+++ b/src/Capacitor.App/ViewModels/TrayModels.cs
@@ -27,4 +27,4 @@ public sealed record TrayAgentEntry(string Id, string Label, string Kind, bool S
 public sealed record TrayPauseItem(bool Enabled, bool Checked);
 public sealed record TrayMenuModel(
     TrayState State, int RunningCount, string Header,
-    IReadOnlyList<TrayAgentEntry> Agents, TrayPauseItem Pause);
+    IReadOnlyList<TrayAgentEntry> Agents, TrayPauseItem Pause, int PendingConsent);

--- a/src/Capacitor.App/ViewModels/TrayViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TrayViewModel.cs
@@ -9,9 +9,9 @@ using ReactiveUI;
 namespace Capacitor.App.ViewModels;
 
 /// Projects IDaemonClientService.Status/Snapshots + IPauseController.State +
-/// AgentActionService.StopsInFlight into the tray's menu model (spec §4, §5, §7). Constructor-
-/// scoped, not WhenActivated: the tray icon exists before any window is shown, so MenuModel must
-/// be live from construction, not gated on activation.
+/// AgentActionService.StopsInFlight + IConsentService.PendingCount into the tray's menu model
+/// (spec §4, §5, §7, §8). Constructor-scoped, not WhenActivated: the tray icon exists before any
+/// window is shown, so MenuModel must be live from construction, not gated on activation.
 public sealed class TrayViewModel : ReactiveObject, IDisposable {
     const string IncompatibleReason = "daemon_incompatible";
     const string UnreachableReason  = "daemon_unreachable";
@@ -50,9 +50,14 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
     public ReactiveCommand<Unit, Unit> OpenMainWindowCommand { get; }
     public ReactiveCommand<Unit, Unit> QuitCommand { get; }
 
+    // The tray menu's "Review pending launches…" target (spec §8); the coordinator itself
+    // filters/marshals the raise, so this command is a plain delegate call, same shape as
+    // OpenMainWindowCommand/QuitCommand above.
+    public ReactiveCommand<Unit, Unit> ReviewPendingCommand { get; }
+
     public TrayViewModel(
-            IDaemonClientService service, IPauseController pause, AgentActionService actions,
-            Action? openMainWindow = null, Action? quit = null) {
+            IDaemonClientService service, IPauseController pause, AgentActionService actions, IConsentService consent,
+            Action? openMainWindow = null, Action? quit = null, Action? openReviewPrompts = null) {
         _pause = pause;
 
         TogglePauseCommand = ReactiveCommand.Create<bool>(pause.RequestToggle);
@@ -63,28 +68,33 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
         OpenInWebCommand = ReactiveCommand.Create<string>(actions.OpenInWeb);
         OpenMainWindowCommand = ReactiveCommand.Create(openMainWindow ?? (() => { }));
         QuitCommand = ReactiveCommand.Create(quit ?? (() => { }));
+        ReviewPendingCommand = ReactiveCommand.Create(openReviewPrompts ?? (() => { }));
 
         var snapshots = service.Snapshots
             .Select(s => (DaemonStatusDto?)s)
             .StartWith((DaemonStatusDto?)null);
 
-        var projected = service.Status.CombineLatest(snapshots, pause.State, actions.StopsInFlight,
-            (status, snap, pauseState, inFlight) => Build(service.DaemonName, status, snap, pauseState, inFlight));
+        // consent.PendingCount is DynamicData's CountChanged, which seeds the current count on
+        // subscribe (decompile-verified) — deliberately NOT StartWith(0)'d, which would inject a
+        // spurious extra 0 ahead of that seed and could flicker Attention at startup.
+        var projected = service.Status.CombineLatest(snapshots, pause.State, actions.StopsInFlight, consent.PendingCount,
+            (status, snap, pauseState, inFlight, pending) => Build(service.DaemonName, status, snap, pauseState, inFlight, pending));
 
-        // Status, snapshots (seeded above), and pause.State are all replay-1, so CombineLatest
-        // emits synchronously on subscribe — captured here as the OAPH's initial value so
-        // MenuModel is never default(TrayMenuModel) (null) before RxSchedulers.MainThreadScheduler
-        // delivers the ObserveOn'd copy below. The synchronous-emission assumption rests on
-        // IPauseController.State's documented replay-1 contract, which a future implementation
-        // could violate — defended below rather than left to surface as an unexplained NRE on
-        // first MenuModel access.
+        // Status, snapshots (seeded above), pause.State, and consent.PendingCount are all
+        // replay-1-shaped (seed on subscribe), so CombineLatest emits synchronously on subscribe —
+        // captured here as the OAPH's initial value so MenuModel is never default(TrayMenuModel)
+        // (null) before RxSchedulers.MainThreadScheduler delivers the ObserveOn'd copy below. The
+        // synchronous-emission assumption rests on IPauseController.State's and
+        // IConsentService.PendingCount's documented replay-on-subscribe contracts, which a future
+        // implementation could violate — defended below rather than left to surface as an
+        // unexplained NRE on first MenuModel access.
         TrayMenuModel? seed = null;
         using (projected.Subscribe(v => seed = v)) { }
 
         _menuModel = projected
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .ToProperty(this, x => x.MenuModel, seed ?? throw new InvalidOperationException(
-                "IPauseController.State must replay a value on subscribe (contract in IPauseController)."))
+                "IPauseController.State and IConsentService.PendingCount must replay a value on subscribe."))
             .DisposeWith(_disposables);
 
         // Edge-triggered passive refresh (spec §6): fired once on the attach-state transition
@@ -109,11 +119,20 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
 
     static TrayMenuModel Build(
             string daemonName, AttachStatus status, DaemonStatusDto? snap, PauseState pauseState,
-            IReadOnlySet<string> stopsInFlight) {
+            IReadOnlySet<string> stopsInFlight, int pendingConsent) {
         var (state, count) = Project(status, snap);
+
+        // Row 11 (spec §8): pending consent asserts Attention only while Connected — a launch is
+        // awaiting the owner. Connection-trouble rows above already left state at something other
+        // than Idle/Running, so they keep precedence for free; the running-count badge (count)
+        // keeps the agent count regardless.
+        var pendingAttention = status.State == AttachState.Connected && pendingConsent > 0
+            && state is TrayState.Idle or TrayState.Running;
+        if (pendingAttention) state = TrayState.Attention;
+
         return new TrayMenuModel(
-            state, count, HeaderText(daemonName, status, snap, state, count),
-            BuildEntries(status, snap, stopsInFlight), BuildPause(status, pauseState));
+            state, count, HeaderText(daemonName, status, snap, state, count, pendingAttention, pendingConsent),
+            BuildEntries(status, snap, stopsInFlight), BuildPause(status, pauseState), pendingConsent);
     }
 
     /// Pure ten-row mapping (spec §4), precedence top-down.
@@ -145,18 +164,22 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
         return (TrayState.Attention, 0); // row 9 — unrecognized connection value
     }
 
-    static string HeaderText(string daemonName, AttachStatus status, DaemonStatusDto? snap, TrayState state, int count) {
+    static string HeaderText(
+            string daemonName, AttachStatus status, DaemonStatusDto? snap, TrayState state, int count,
+            bool pendingAttention, int pendingConsent) {
         if (state == TrayState.Attention && status.State == AttachState.Unreachable && status.Reason == IncompatibleReason)
             return SkewMessage; // no daemon-name prefix
 
-        var body = state switch {
-            TrayState.Stopped    => "not running",
-            TrayState.Connecting => "connecting…",
-            TrayState.Idle       => "connected — no agents",
-            TrayState.Running    => $"connected — {count} agent(s) running",
-            TrayState.Attention  => AttentionBody(status, snap),
-            _                    => "needs attention",
-        };
+        var body = pendingAttention
+            ? $"{pendingConsent} launch{(pendingConsent == 1 ? "" : "es")} awaiting approval"
+            : state switch {
+                TrayState.Stopped    => "not running",
+                TrayState.Connecting => "connecting…",
+                TrayState.Idle       => "connected — no agents",
+                TrayState.Running    => $"connected — {count} agent(s) running",
+                TrayState.Attention  => AttentionBody(status, snap),
+                _                    => "needs attention",
+            };
         return $"{daemonName}: {body}";
     }
 

--- a/src/Capacitor.App/Views/ConsentPromptWindow.axaml
+++ b/src/Capacitor.App/Views/ConsentPromptWindow.axaml
@@ -1,0 +1,50 @@
+<rxui:ReactiveWindow xmlns="https://github.com/avaloniaui"
+                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                     xmlns:rxui="clr-namespace:ReactiveUI.Avalonia;assembly=ReactiveUI.Avalonia"
+                     xmlns:vm="clr-namespace:Capacitor.App.ViewModels"
+                     x:Class="Capacitor.App.Views.ConsentPromptWindow"
+                     x:TypeArguments="vm:ConsentPromptViewModel"
+                     x:DataType="vm:ConsentPromptViewModel"
+                     Title="Kurrent Capacitor — launch approval"
+                     Icon="avares://Kurrent Capacitor/Assets/kcap-icon.png"
+                     Width="460" Height="260"
+                     CanResize="False" Topmost="True" WindowStartupLocation="CenterScreen">
+    <Grid Margin="20" RowDefinitions="Auto,Auto,Auto,Auto,*,Auto">
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+            <TextBlock Grid.Column="0" x:Name="RequesterText" Text="{Binding RequesterText}"
+                       FontSize="16" FontWeight="Bold" TextTrimming="CharacterEllipsis" />
+            <TextBlock Grid.Column="1" x:Name="PositionText" Text="{Binding PositionText}"
+                       IsVisible="{Binding PositionVisible}" Opacity="0.7" VerticalAlignment="Center" />
+        </Grid>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
+            <TextBlock x:Name="KindText" Text="{Binding KindLabel}" />
+            <TextBlock Text="·" />
+            <TextBlock x:Name="VendorText" Text="{Binding VendorText}" />
+        </StackPanel>
+
+        <TextBlock Grid.Row="2" x:Name="RepoText" Text="{Binding RepoLeaf}" ToolTip.Tip="{Binding RepoFull}"
+                   TextTrimming="CharacterEllipsis" Opacity="0.7" Margin="0,4,0,0" />
+
+        <!-- Both lines collapse when empty (the countdown goes quiet during a terminal hold, the
+             phase line exists only in one) so neither reserves dead space. -->
+        <TextBlock Grid.Row="3" x:Name="CountdownText" Text="{Binding CountdownText}" TextWrapping="Wrap" Margin="0,14,0,0"
+                   IsVisible="{Binding CountdownText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
+        <TextBlock Grid.Row="4" x:Name="PhaseText" Text="{Binding PhaseText}" TextWrapping="Wrap"
+                   VerticalAlignment="Top" Margin="0,14,0,0"
+                   IsVisible="{Binding PhaseText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
+        <StackPanel Grid.Row="5" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right"
+                    IsVisible="{Binding ButtonsVisible}">
+            <Button x:Name="AllowOnceButton" Content="Allow once"
+                    Command="{Binding AllowOnceCommand}" IsEnabled="{Binding ButtonsEnabled}" />
+            <Button x:Name="AllowRememberButton" Content="Allow &amp; remember"
+                    Command="{Binding AllowRememberCommand}" IsEnabled="{Binding ButtonsEnabled}"
+                    IsVisible="{Binding AllowRememberVisible}"
+                    ToolTip.Tip="Saves a rule allowing future launches from this requester. Existing deny rules — including Pause — take precedence until removed." />
+            <Button x:Name="DenyButton" Content="Deny"
+                    Command="{Binding DenyCommand}" IsEnabled="{Binding ButtonsEnabled}" />
+        </StackPanel>
+    </Grid>
+</rxui:ReactiveWindow>

--- a/src/Capacitor.App/Views/ConsentPromptWindow.axaml.cs
+++ b/src/Capacitor.App/Views/ConsentPromptWindow.axaml.cs
@@ -1,0 +1,54 @@
+using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
+using System.Reactive.Linq;
+using Avalonia.Controls.Notifications;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using ReactiveUI;
+using ReactiveUI.Avalonia;
+
+namespace Capacitor.App.Views;
+
+// ReactiveWindow<T> ties ViewModel.Activator to THIS window's Loaded/Unloaded lifecycle, so
+// Show() starts the ViewModel's queue/ticker projections and Close() stops them — which is also
+// why a deferred (closed) prompt costs nothing until the coordinator builds the next one.
+public partial class ConsentPromptWindow : ReactiveWindow<ConsentPromptViewModel> {
+    WindowNotificationManager? _notifications;
+    IDisposable? _notifierSubscription;
+    IAppNotifier? _notifier;
+
+    /// Assigned by App's window factory (spec §6): prompt warnings must surface on THIS window —
+    /// the main window may be closed. Same shape as MainWindow.Notifier, with one difference that
+    /// matters here: a prompt window is transient (a fresh instance per raise), so the
+    /// app-lifetime notifier subscription is dropped on close instead of living forever.
+    public IAppNotifier? Notifier {
+        get => _notifier;
+        set {
+            _notifier = value;
+            _notifierSubscription?.Dispose();
+            _notifierSubscription = value?.Messages
+                .ObserveOn(RxSchedulers.MainThreadScheduler)
+                .Subscribe(ShowToast);
+        }
+    }
+
+    public ConsentPromptWindow() {
+        InitializeComponent();
+
+        // Built on Loaded, not in the constructor: WindowNotificationManager self-installs into
+        // the TopLevel's AdornerLayer once the template is applied (MainWindow's same note).
+        Loaded += (_, _) => _notifications ??= new WindowNotificationManager(this) {
+            Position = NotificationPosition.TopRight,
+        };
+        Closed += (_, _) => _notifierSubscription?.Dispose();
+
+        // The queue emptying is the ONE close this window performs on its own; a user close is an
+        // explicit defer and leaves the queue untouched (spec §6).
+        this.WhenActivated(disposables => {
+            ViewModel?.CloseRequested.Subscribe(_ => Close()).DisposeWith(disposables);
+        });
+    }
+
+    void ShowToast(string message) =>
+        _notifications?.Show(new Notification("Kurrent Capacitor", message, NotificationType.Warning, TimeSpan.FromSeconds(4)));
+}

--- a/src/Capacitor.App/Views/Converters.cs
+++ b/src/Capacitor.App/Views/Converters.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Avalonia.Data.Converters;
+using Avalonia.Media;
 
 namespace Capacitor.App.Views;
 
@@ -34,6 +35,20 @@ public sealed class HeaderRowVisibleConverter : IValueConverter {
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         value is int count && count > 0;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// Activity row outcome badge (spec §7): green for allowed, red for denied. ActivityRow stays a
+/// plain record (no Avalonia types, so its mapping can construct off any thread) — the color
+/// lives here rather than as a cached Brush field, for the same UI-thread-affinity reason
+/// MainWindowViewModel.DotBrush documents.
+public sealed class OutcomeBrushConverter : IValueConverter {
+    public static readonly OutcomeBrushConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        new SolidColorBrush(Color.Parse(value is true ? "#2E7D32" : "#D32F2F"));
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.App/Views/MainWindow.axaml
+++ b/src/Capacitor.App/Views/MainWindow.axaml
@@ -39,61 +39,113 @@
                 <TextBlock x:Name="ReasonText" Text="{Binding Reason}"
                            IsVisible="{Binding Reason, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
             </StackPanel>
-
-            <StackPanel Spacing="8">
-                <Border Height="1" Background="{DynamicResource SystemControlForegroundBaseHighBrush}" Opacity="0.7" />
-                <TextBlock Text="Agents" FontSize="14" FontWeight="Bold" />
-
-                <TextBlock x:Name="EmptyStateText" Text="No agents running">
-                    <TextBlock.IsVisible>
-                        <MultiBinding Converter="{x:Static views:EmptyStateVisibleConverter.Instance}">
-                            <Binding Path="GridEnabled" />
-                            <Binding Path="Agents.Count" />
-                        </MultiBinding>
-                    </TextBlock.IsVisible>
-                </TextBlock>
-            </StackPanel>
         </StackPanel>
 
-        <!-- Row "*" (bounded height, unlike a StackPanel child which Avalonia always measures
-             with infinite height) is what lets this ScrollViewer's VerticalScrollBarVisibility
-             actually engage. Fixed column widths total ~770px — wider than the default window's
-             content area — so both scrollbars are Auto: horizontal reaches the Actions column
-             when the window is narrower than the grid, vertical reaches every row when there are
-             more than fit the window's height. -->
-        <ScrollViewer Grid.Row="1" Margin="0,8,0,0"
-                      VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
-            <StackPanel x:Name="AgentsGrid" Opacity="{Binding GridEnabled, Converter={x:Static views:GridEnabledOpacityConverter.Instance}}">
-                <Grid x:Name="AgentsGridHeader" ColumnDefinitions="80,140,140,100,90,70,150" Margin="0,0,0,4"
-                      IsVisible="{Binding Agents.Count, Converter={x:Static views:HeaderRowVisibleConverter.Instance}}">
-                    <TextBlock Grid.Column="0" Text="Kind" FontWeight="Bold" Opacity="0.7" />
-                    <TextBlock Grid.Column="1" Text="Vendor" FontWeight="Bold" Opacity="0.7" />
-                    <TextBlock Grid.Column="2" Text="Repo" FontWeight="Bold" Opacity="0.7" />
-                    <TextBlock Grid.Column="3" Text="Requester" FontWeight="Bold" Opacity="0.7" />
-                    <TextBlock Grid.Column="4" Text="Status" FontWeight="Bold" Opacity="0.7" />
-                    <TextBlock Grid.Column="5" Text="Uptime" FontWeight="Bold" Opacity="0.7" />
-                    <TextBlock Grid.Column="6" Text="Actions" FontWeight="Bold" Opacity="0.7" />
-                </Grid>
+        <!-- Tabs (spec §7): Agents | Activity. Settings joins as a third tab in slice 4.
+             SelectionChanged is wired in code-behind (MainWindow.axaml.cs) so the Activity tab's
+             refresh cadence tracks both tab selection and the window's own on-screen state. -->
+        <TabControl Grid.Row="1" x:Name="MainTabs" Margin="0,8,0,0" SelectionChanged="OnTabSelectionChanged">
+            <TabItem Header="Agents">
+                <!-- The ENTIRE pre-existing agents block, unchanged: control names preserved so
+                     the existing smoke tests keep finding them in the window's name scope. -->
+                <Grid RowDefinitions="Auto,*">
+                    <StackPanel Grid.Row="0" Spacing="8">
+                        <Border Height="1" Background="{DynamicResource SystemControlForegroundBaseHighBrush}" Opacity="0.7" />
+                        <TextBlock Text="Agents" FontSize="14" FontWeight="Bold" />
 
-                <ItemsControl x:Name="AgentsItems" ItemsSource="{Binding Agents}">
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="vm:AgentRowViewModel">
-                            <Grid ColumnDefinitions="80,140,140,100,90,70,150" Margin="0,2">
-                                <TextBlock Grid.Column="0" Text="{Binding Kind}" TextTrimming="CharacterEllipsis" />
-                                <TextBlock Grid.Column="1" Text="{Binding VendorDisplay}" TextTrimming="CharacterEllipsis" />
-                                <TextBlock Grid.Column="2" Text="{Binding RepoLeaf}" ToolTip.Tip="{Binding RepoFull}" TextTrimming="CharacterEllipsis" />
-                                <TextBlock Grid.Column="3" Text="{Binding Requester}" TextTrimming="CharacterEllipsis" />
-                                <TextBlock Grid.Column="4" Text="{Binding StatusText}" TextTrimming="CharacterEllipsis" />
-                                <TextBlock Grid.Column="5" Text="{Binding Uptime}" TextTrimming="CharacterEllipsis" />
-                                <StackPanel Grid.Column="6" Orientation="Horizontal" Spacing="4">
-                                    <Button Content="Stop" Command="{Binding StopCommand}" IsEnabled="{Binding ActionsEnabled}" Padding="8,2" FontSize="12" />
-                                    <Button Content="Open in web" Command="{Binding OpenInWebCommand}" IsEnabled="{Binding ActionsEnabled}" Padding="8,2" FontSize="12" />
-                                </StackPanel>
+                        <TextBlock x:Name="EmptyStateText" Text="No agents running">
+                            <TextBlock.IsVisible>
+                                <MultiBinding Converter="{x:Static views:EmptyStateVisibleConverter.Instance}">
+                                    <Binding Path="GridEnabled" />
+                                    <Binding Path="Agents.Count" />
+                                </MultiBinding>
+                            </TextBlock.IsVisible>
+                        </TextBlock>
+                    </StackPanel>
+
+                    <!-- Row "*" (bounded height, unlike a StackPanel child which Avalonia always
+                         measures with infinite height) is what lets this ScrollViewer's
+                         VerticalScrollBarVisibility actually engage. Fixed column widths total
+                         ~770px — wider than the default window's content area — so both
+                         scrollbars are Auto: horizontal reaches the Actions column when the
+                         window is narrower than the grid, vertical reaches every row when there
+                         are more than fit the window's height. -->
+                    <ScrollViewer Grid.Row="1" Margin="0,8,0,0"
+                                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                        <StackPanel x:Name="AgentsGrid" Opacity="{Binding GridEnabled, Converter={x:Static views:GridEnabledOpacityConverter.Instance}}">
+                            <Grid x:Name="AgentsGridHeader" ColumnDefinitions="80,140,140,100,90,70,150" Margin="0,0,0,4"
+                                  IsVisible="{Binding Agents.Count, Converter={x:Static views:HeaderRowVisibleConverter.Instance}}">
+                                <TextBlock Grid.Column="0" Text="Kind" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="1" Text="Vendor" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="2" Text="Repo" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="3" Text="Requester" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="4" Text="Status" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="5" Text="Uptime" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="6" Text="Actions" FontWeight="Bold" Opacity="0.7" />
                             </Grid>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </StackPanel>
-        </ScrollViewer>
+
+                            <ItemsControl x:Name="AgentsItems" ItemsSource="{Binding Agents}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:AgentRowViewModel">
+                                        <Grid ColumnDefinitions="80,140,140,100,90,70,150" Margin="0,2">
+                                            <TextBlock Grid.Column="0" Text="{Binding Kind}" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="1" Text="{Binding VendorDisplay}" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="2" Text="{Binding RepoLeaf}" ToolTip.Tip="{Binding RepoFull}" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="3" Text="{Binding Requester}" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="4" Text="{Binding StatusText}" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="5" Text="{Binding Uptime}" TextTrimming="CharacterEllipsis" />
+                                            <StackPanel Grid.Column="6" Orientation="Horizontal" Spacing="4">
+                                                <Button Content="Stop" Command="{Binding StopCommand}" IsEnabled="{Binding ActionsEnabled}" Padding="8,2" FontSize="12" />
+                                                <Button Content="Open in web" Command="{Binding OpenInWebCommand}" IsEnabled="{Binding ActionsEnabled}" Padding="8,2" FontSize="12" />
+                                            </StackPanel>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </ScrollViewer>
+                </Grid>
+            </TabItem>
+
+            <TabItem x:Name="ActivityTabItem" Header="Activity">
+                <Grid RowDefinitions="Auto,*">
+                    <TextBlock x:Name="ActivityEmptyText" Text="No decisions yet"
+                               IsVisible="{Binding Activity.IsEmpty}" HorizontalAlignment="Center" Margin="0,24,0,0" />
+
+                    <ScrollViewer Grid.Row="1" Margin="0,8,0,0"
+                                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                        <StackPanel>
+                            <Grid x:Name="ActivityHeader" ColumnDefinitions="150,70,120,90,140,90,110" Margin="0,0,0,4"
+                                  IsVisible="{Binding !Activity.IsEmpty}">
+                                <TextBlock Grid.Column="0" Text="Time" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="1" Text="Outcome" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="2" Text="Requester" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="3" Text="Kind" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="4" Text="Repo" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="5" Text="Vendor" FontWeight="Bold" Opacity="0.7" />
+                                <TextBlock Grid.Column="6" Text="Source" FontWeight="Bold" Opacity="0.7" />
+                            </Grid>
+
+                            <ItemsControl x:Name="ActivityItems" ItemsSource="{Binding Activity.Rows}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:ActivityRow">
+                                        <Grid ColumnDefinitions="150,70,120,90,140,90,110" Margin="0,2">
+                                            <TextBlock Grid.Column="0" Text="{Binding Time}" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="1" Text="{Binding Outcome}" TextTrimming="CharacterEllipsis"
+                                                       Foreground="{Binding IsAllowed, Converter={x:Static views:OutcomeBrushConverter.Instance}}" />
+                                            <TextBlock Grid.Column="2" Text="{Binding Requester}" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="3" Text="{Binding KindLabel}" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="4" Text="{Binding RepoLeaf}" ToolTip.Tip="{Binding RepoFull}" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="5" Text="{Binding Vendor}" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Grid.Column="6" Text="{Binding SourceLabel}" TextTrimming="CharacterEllipsis" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </ScrollViewer>
+                </Grid>
+            </TabItem>
+        </TabControl>
     </Grid>
 </rxui:ReactiveWindow>

--- a/src/Capacitor.App/Views/MainWindow.axaml.cs
+++ b/src/Capacitor.App/Views/MainWindow.axaml.cs
@@ -1,4 +1,6 @@
 using System.Reactive.Linq;
+using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
@@ -20,6 +22,10 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel> {
     WindowNotificationManager? _notifications;
     IDisposable? _notifierSubscription;
     IAppNotifier? _notifier;
+
+    // Defaults to false — the Agents TabItem is selected first (MainWindow.axaml), so Activity
+    // starts unselected regardless of the window's own visibility.
+    bool _activityTabSelected;
 
     /// Assigned by App.BuildAndShowMainWindow (spec §11) — the SAME IAppNotifier instance
     /// AgentActionService pushes into, so the toast overlay and stderr mirroring are always in
@@ -60,4 +66,29 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel> {
     // banner it replaces (spec §11).
     void ShowToast(string message) =>
         _notifications?.Show(new Notification("Kurrent Capacitor", message, NotificationType.Warning, TimeSpan.FromSeconds(4)));
+
+    // Wired from MainWindow.axaml's TabControl (spec §7): the Activity tab's refresh cadence
+    // needs to know it is ACTUALLY on screen, which is the AND of tab selection and the window's
+    // own visibility below — a background window with Activity selected must not poll.
+    void OnTabSelectionChanged(object? sender, SelectionChangedEventArgs e) {
+        _activityTabSelected = e.AddedItems.Count > 0 && ReferenceEquals(e.AddedItems[0], ActivityTabItem);
+        UpdateActivityVisibility();
+    }
+
+    // IsVisible is decompile-verified to be exactly what Show()/Hide() toggle (see
+    // App.ShowConfirmForceStopDialogAsync's owner check) — hide-to-tray never fires Closed/Opened
+    // (MainWindowCoordinator's own doc comment: it "never detaches this window from the visual
+    // tree"), so this property is the one signal that actually tracks on-screen state across a
+    // hide/reopen cycle.
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change) {
+        base.OnPropertyChanged(change);
+        // DataContextProperty too — defensive: production always assigns DataContext before the
+        // first Show(), but this keeps the check correct even if a caller (a test) does it the
+        // other way around.
+        if (change.Property == IsVisibleProperty || change.Property == DataContextProperty) UpdateActivityVisibility();
+    }
+
+    void UpdateActivityVisibility() {
+        if (DataContext is MainWindowViewModel vm) vm.Activity.OnTabVisibleChanged(_activityTabSelected && IsVisible);
+    }
 }

--- a/src/Capacitor.App/Views/TrayMenuBuilder.cs
+++ b/src/Capacitor.App/Views/TrayMenuBuilder.cs
@@ -20,6 +20,11 @@ public sealed class TrayMenuBuilder(TrayViewModel vm) {
             menu.Items.Add(new NativeMenuItemSeparator());
         }
 
+        // Between the agents section and the pause toggle (spec §8), visible only while a launch
+        // is actually awaiting the owner.
+        if (model.PendingConsent > 0)
+            menu.Items.Add(new NativeMenuItem("Review pending launches…") { Command = vm.ReviewPendingCommand });
+
         menu.Items.Add(BuildPauseItem(model.Pause));
         menu.Items.Add(new NativeMenuItem("Open Kurrent Capacitor") { Command = vm.OpenMainWindowCommand });
         menu.Items.Add(new NativeMenuItemSeparator());

--- a/src/Capacitor.Cli.Core/LocalIpc/ConsentDecisionLog.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/ConsentDecisionLog.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Capacitor.Cli.Core.LocalIpc;
@@ -15,3 +16,60 @@ public sealed record ConsentDecisionRecord(
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(ConsentDecisionRecord))]
 public partial class ConsentDecisionJsonContext : JsonSerializerContext;
+
+/// Complete=false means at least one file existed but could not be read (I/O failure) — the
+/// records list may be partial and the consumer must not mistake it for a genuinely shorter
+/// log. Clean absence (file not found) is Complete=true (spec §4.4).
+public sealed record ConsentLogReadResult(IReadOnlyList<ConsentDecisionRecord> Records, bool Complete);
+
+public static class ConsentDecisionLogReader {
+    public static string PathFor(string daemonName) =>
+        Path.Combine(DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(daemonName), "consent-decisions.jsonl");
+
+    public static ConsentLogReadResult ReadTail(string daemonName, int max) {
+        var path = PathFor(daemonName);
+        var complete = true;
+        var lines = new List<string>();
+        foreach (var file in new[] { path + ".1", path }) {         // .1 first: its lines are older
+            if (!TryReadLines(file, lines)) complete = false;
+        }
+
+        var seen = new HashSet<ConsentDecisionRecord>();            // value equality — rotation-race dedup
+        var records = new List<ConsentDecisionRecord>();
+        for (var i = lines.Count - 1; i >= 0 && records.Count < max; i--) {
+            var rec = ParseValid(lines[i]);
+            if (rec is not null && seen.Add(rec)) records.Add(rec); // newest first
+        }
+        return new(records, complete);
+    }
+
+    // The reader's open — ReadWrite so the daemon's live appends are never blocked, Delete so
+    // its File.Move rotation is never blocked (Windows mandatory sharing is otherwise exclusive).
+    internal static FileStream OpenShared(string path) =>
+        new(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+
+    /// True = read cleanly OR cleanly absent; false = existed-but-unreadable (I/O failure).
+    static bool TryReadLines(string path, List<string> into) {
+        try {
+            using var fs = OpenShared(path);
+            using var reader = new StreamReader(fs);
+            while (reader.ReadLine() is { } line) into.Add(line);
+            return true;
+        } catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
+            return true;  // clean absence
+        } catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) {
+            return false; // exists (or vanished mid-read) but unreadable — partial/incomplete
+        }
+    }
+
+    static ConsentDecisionRecord? ParseValid(string line) {
+        ConsentDecisionRecord? rec;
+        try { rec = JsonSerializer.Deserialize(line, ConsentDecisionJsonContext.Default.ConsentDecisionRecord); }
+        catch (JsonException) { return null; }
+        if (rec is null || string.IsNullOrEmpty(rec.DecidedAt) || string.IsNullOrEmpty(rec.AgentId)
+            || string.IsNullOrEmpty(rec.Kind) || string.IsNullOrEmpty(rec.RepoPath)
+            || string.IsNullOrEmpty(rec.Vendor) || string.IsNullOrEmpty(rec.Outcome)
+            || string.IsNullOrEmpty(rec.Source)) return null;
+        return rec;
+    }
+}

--- a/src/Capacitor.Cli.Core/LocalIpc/ConsentDecisionLog.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/ConsentDecisionLog.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// The consent decision log's single write/read shape (spec §4.4): the daemon appends one of
+/// these per decision to consent-decisions.jsonl; the CLI `log` verb prints raw lines; the app
+/// parses them for the Activity feed. Field names are the pre-existing on-disk names verbatim —
+/// existing log files remain readable. Outcome: "allowed"|"denied". Source: "owner"|"rule[i]"|
+/// "default"|"prompt_no_ui"|"prompt_user"|"prompt_timeout".
+public sealed record ConsentDecisionRecord(
+    string DecidedAt, string AgentId, string? Requester, bool RequesterIsOwner,
+    string Kind, string RepoPath, string Vendor, string Outcome, string Source,
+    string? RequesterDisplay);
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(ConsentDecisionRecord))]
+public partial class ConsentDecisionJsonContext : JsonSerializerContext;

--- a/src/Capacitor.Cli.Core/LocalIpc/ConsentIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/ConsentIpc.cs
@@ -6,9 +6,9 @@ namespace Capacitor.Cli.Core.LocalIpc;
 /// verbatim by the daemon, the CLI, and the future desktop app.
 public sealed record ConsentPendingDto(
     string RequestId, string? Requester, string Kind, string RepoPath, string Vendor,
-    string RequestedAt, int TimeoutSeconds);
+    string RequestedAt, int TimeoutSeconds, string? RequesterDisplay, string? PromptId);
 
-public sealed record ConsentResolveDto(string RequestId, string Decision, ConsentRuleDto? SaveRule);
+public sealed record ConsentResolveDto(string RequestId, string Decision, ConsentRuleDto? SaveRule, string? PromptId);
 
 public sealed record ConsentRuleDto(string Action, string? Requester, string? Kind, string? Repo, string? Vendor);
 
@@ -17,7 +17,10 @@ public sealed record ConsentPolicyDto(string Default, int PromptTimeoutSeconds, 
 /// Ok = did the primary operation apply; Error = failure detail, OR a partial-failure warning
 /// when Ok=true (e.g. ConsentResolve's decision was applied but its optional save_rule was
 /// rejected — the resolution itself is not conflated with that secondary failure).
-public sealed record ConsentAckDto(bool Ok, string? Error);
+/// RuleSaved: null when the resolve carried no save_rule; true/false = the rule write
+/// succeeded/failed — populated on BOTH Ok branches, because save_rule is deliberately
+/// persisted before the resolution is attempted.
+public sealed record ConsentAckDto(bool Ok, string? Error, bool? RuleSaved);
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(ConsentPendingDto))]

--- a/src/Capacitor.Cli.Core/LocalIpc/ConsentSubscription.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/ConsentSubscription.cs
@@ -1,0 +1,74 @@
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// One consent subscription attempt as a typed stream (spec §4.2). `Subscribed` is a
+/// CLIENT-LOCAL boundary — emitted right after the subscribe write flushes, before any read,
+/// because an async iterator exposes no other observable point between "dialing" and
+/// "subscribed" (with an empty replay the first read never completes). It does not prove the
+/// daemon registered the subscription. The enumeration ENDING (for any reason but caller
+/// cancellation) means "this attempt is over" — the consumer decides whether to go again.
+public abstract record ConsentStreamEvent {
+    public sealed record Subscribed : ConsentStreamEvent;
+    public sealed record Pending(ConsentPendingDto Request) : ConsentStreamEvent;
+}
+
+public static class ConsentSubscription {
+    public static async IAsyncEnumerable<ConsentStreamEvent> RunAsync(
+            string daemonName, [EnumeratorCancellation] CancellationToken ct = default) {
+        using var sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        NetworkStream? stream = null;
+        try {
+            // Dial + subscribe write. ConsentSubscribeV2: a v1 daemon's codec rejects the byte
+            // before routing and closes without replying — we yield Subscribed (the write
+            // flushed) and then end on EOF, never registering a subscriber there (spec §4.1).
+            try {
+                await sock.ConnectAsync(new UnixDomainSocketEndPoint(LocalSocketPaths.Socket(daemonName)), ct);
+                stream = new NetworkStream(sock, ownsSocket: false);
+                await FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.ConsentSubscribeV2), ct);
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                throw;
+            } catch (Exception ex) when (ex is IOException or SocketException) {
+                yield break; // failed dial/write: attempt over, no Subscribed, no clear (spec §5)
+            }
+
+            yield return new ConsentStreamEvent.Subscribed();
+
+            while (true) {
+                LocalFrame? frame;
+                try {
+                    frame = await FrameCodec.ReadAsync(stream!, ct);
+                } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                    throw;
+                } catch (Exception ex) when (ex is IOException or SocketException or InvalidDataException) {
+                    yield break; // transport death / undecodable frame: attempt over
+                }
+                if (frame is null || frame.Type != FrameType.ConsentPending) yield break; // EOF / protocol confusion
+
+                ConsentPendingDto? dto;
+                try { dto = JsonSerializer.Deserialize(frame.Text, ConsentIpcJsonContext.Default.ConsentPendingDto); }
+                catch (JsonException) { yield break; } // undecodable payload: dead connection
+
+                // Structurally invalid (STJ leaves missing members null; `{}` decodes fine) is
+                // SKIPPED, not fatal — ending here would thrash: the resubscribe replay would
+                // redeliver the same invalid entry forever (spec §4.2).
+                if (!IsStructurallyValid(dto)) continue;
+                yield return new ConsentStreamEvent.Pending(dto!);
+            }
+        } finally {
+            if (stream is not null) await stream.DisposeAsync();
+        }
+    }
+
+    static bool IsStructurallyValid(ConsentPendingDto? dto) =>
+        dto is not null
+        && !string.IsNullOrEmpty(dto.RequestId)
+        && !string.IsNullOrEmpty(dto.PromptId)   // consent/2 daemons always stamp it (spec §4.2)
+        && !string.IsNullOrEmpty(dto.Kind)
+        && !string.IsNullOrEmpty(dto.RepoPath)
+        && !string.IsNullOrEmpty(dto.Vendor)
+        && !string.IsNullOrEmpty(dto.RequestedAt)
+        && dto.TimeoutSeconds > 0;
+}

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
@@ -52,6 +52,7 @@ public static class FrameCodec {
             or FrameType.Stop or FrameType.StopAck
             or FrameType.Hello or FrameType.HelloReply
             or FrameType.ConsentSubscribe or FrameType.ConsentResolve
+            or FrameType.ConsentSubscribeV2 or FrameType.ConsentResolveV2
             or FrameType.ConsentRulesGet or FrameType.ConsentRulesPut
             or FrameType.ConsentPending or FrameType.ConsentRules
             or FrameType.ConsentAck or FrameType.DaemonStatus => Encoding.UTF8.GetBytes(f.Text),
@@ -70,6 +71,7 @@ public static class FrameCodec {
             or FrameType.Stop or FrameType.StopAck
             or FrameType.Hello or FrameType.HelloReply
             or FrameType.ConsentSubscribe or FrameType.ConsentResolve
+            or FrameType.ConsentSubscribeV2 or FrameType.ConsentResolveV2
             or FrameType.ConsentRulesGet or FrameType.ConsentRulesPut
             or FrameType.ConsentPending or FrameType.ConsentRules
             or FrameType.ConsentAck or FrameType.DaemonStatus => new(t) { Text = Encoding.UTF8.GetString(p) },

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
@@ -15,6 +15,10 @@ public enum FrameType : byte {
     StopV2  = 10,  // stop with a force flag (see FrameCodec.StopV2); supersedes Stop
     Hello   = 15,  // optional one-shot: client info (Text = ClientHelloDto JSON; empty valid)
     StatusSubscribe = 16, // long-lived: push DaemonStatus snapshots (immediate + on change)
+    // v2 consent frames (append-only). A v1 daemon's codec throws on these bytes
+    // before routing — that codec-level rejection IS the down-level fail-closed contract.
+    ConsentSubscribeV2 = 17, // long-lived: v2 subscribe (same reply stream as ConsentSubscribe)
+    ConsentResolveV2   = 18, // one-shot: resolve requiring the prompt_id identity echo
     // Consent control frames — values append-only
     ConsentSubscribe = 11, // long-lived: replay pending + push new ConsentPending frames
     ConsentResolve   = 12, // one-shot: resolve a pending request (Text = ConsentResolveDto JSON)

--- a/src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs
@@ -18,6 +18,7 @@ public interface ILocalControlOps {
     Task<StopAgentResult>  StopAgentAsync(string agentId, bool force, CancellationToken ct);
     Task<ConsentPolicyDto> GetConsentPolicyAsync(CancellationToken ct);
     Task<ConsentAckDto>    PutConsentPolicyAsync(ConsentPolicyDto policy, CancellationToken ct);
+    Task<ConsentAckDto>    ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct);
 }
 
 /// One-shot Core IPC operations behind a fresh socket per call — no Hello negotiation (callers
@@ -79,6 +80,23 @@ public sealed class LocalControlOps(string daemonName, TimeProvider? time = null
                 throw new LocalControlOpsException(DaemonRejected, reply.Text);
             default:
                 throw new LocalControlOpsException(UnexpectedReply, $"unexpected daemon response to consent rules put ({reply.Type})");
+        }
+    }
+
+    public async Task<ConsentAckDto> ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct) {
+        var json = JsonSerializer.Serialize(resolve, ConsentIpcJsonContext.Default.ConsentResolveDto);
+        // ConsentResolveV2, never the v1 frame: a v1 daemon must fail closed at its codec rather
+        // than resolve by id without the identity check (spec §4.1).
+        var reply = await ExchangeAsync(LocalFrame.ConsentJson(FrameType.ConsentResolveV2, json), ConsentReplyTimeout, ct);
+        switch (reply.Type) {
+            case FrameType.ConsentAck:
+                var ack = DeserializeOrThrow(reply.Text, ConsentIpcJsonContext.Default.ConsentAckDto, "malformed consent ack reply");
+                if (ack is null) throw new LocalControlOpsException(UnexpectedReply, "malformed consent ack reply");
+                return ack;
+            case FrameType.Error:
+                throw new LocalControlOpsException(DaemonRejected, reply.Text);
+            default:
+                throw new LocalControlOpsException(UnexpectedReply, $"unexpected daemon response to consent resolve ({reply.Type})");
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1327,7 +1327,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // messages to this daemon queue behind the prompt for the same window.
         var consentInput = new LaunchConsentInput(
             cmd.RequesterUserId, cmd.RequesterIsOwner ?? false,
-            LaunchConsentEngine.KindToken(cmd.Kind), cmd.RepoPath, cmd.Vendor);
+            LaunchConsentEngine.KindToken(cmd.Kind), cmd.RepoPath, cmd.Vendor, cmd.RequesterDisplay);
         var consent = await _consentGate.DecideAsync(cmd.AgentId, consentInput, _shutdownCts.Token);
         if (!consent.Allowed) {
             _logger.LogWarning("Launch {AgentId} denied by consent policy ({Source})", cmd.AgentId, consent.Source);

--- a/src/Capacitor.Cli.Daemon/Services/LaunchConsentBroker.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LaunchConsentBroker.cs
@@ -139,8 +139,20 @@ internal sealed class LaunchConsentBroker : ILaunchConsentPrompter {
         }
     }
 
-    public bool TryResolve(string requestId, bool allow) =>
-        _pending.TryRemove(requestId, out var p) && p.Tcs.TrySetResult(allow);
+    public bool TryResolve(string requestId, bool allow) => TryResolve(requestId, allow, null);
+
+    /// Non-null echo: resolve succeeds only for the pending entry whose PromptId matches
+    /// exactly, and match+removal is ONE atomic claim — the KeyValuePair-conditional remove is
+    /// the same ABA primitive the timeout/cleanup paths use (class doc). A lost claim (the
+    /// matched instance replaced between lookup and removal) returns false and NEVER retries
+    /// against the successor. Null echo: legacy resolve-by-id (v1 frame callers).
+    public bool TryResolve(string requestId, bool allow, string? promptIdEcho) {
+        if (!_pending.TryGetValue(requestId, out var p)) return false;
+        if (promptIdEcho is not null &&
+            !string.Equals(promptIdEcho, p.Request.PromptId, StringComparison.Ordinal)) return false;
+        if (!_pending.TryRemove(new KeyValuePair<string, Pending>(requestId, p))) return false;
+        return p.Tcs.TrySetResult(allow);
+    }
 
     public IReadOnlyList<LaunchConsentPromptRequest> PendingSnapshot() =>
         _pending.Values.Select(p => p.Request).ToList();

--- a/src/Capacitor.Cli.Daemon/Services/LaunchConsentBroker.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LaunchConsentBroker.cs
@@ -18,7 +18,8 @@ namespace Capacitor.Cli.Daemon.Services;
 /// it first; expiry surfaces as TryResolve returning false. Never persisted — a daemon restart
 /// clears pending prompts (the server retries or fails the launch with the coded timeout denial).
 ///
-/// All cleanup removals (the OCE-catch claim attempt and the outer finally) are INSTANCE-scoped
+/// EVERY removal — PromptAsync's timeout claim, its OCE-catch claim attempt, its outer finally,
+/// and TryResolve's own claim (echo-matched or legacy) — is INSTANCE-scoped
 /// via the ConcurrentDictionary KeyValuePair-conditional overload, keyed on the exact `Pending`
 /// object PromptAsync added — never a plain key-based remove. This closes an ABA race: if a new
 /// prompt B reuses the same RequestId (agent-id retry, legacy/sequenced lane overlap) and TryAdds

--- a/src/Capacitor.Cli.Daemon/Services/LaunchConsentDecisionLog.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LaunchConsentDecisionLog.cs
@@ -1,26 +1,21 @@
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
+using Capacitor.Cli.Core.LocalIpc;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Services;
-
-/// Hoisted decision record for serialization and external consumption (e.g., Task 5).
-internal sealed record LaunchConsentRecord(
-    string DecidedAt, string AgentId, string? Requester, bool RequesterIsOwner,
-    string Kind, string RepoPath, string Vendor, string Outcome, string Source);
 
 /// Append-only JSONL audit of every consent decision (rule-matched and human), rendered by the
 /// desktop app as the Activity feed and by `kcap daemon consent log`. Best-effort: an I/O fault
 /// is logged and swallowed — audit must never fail a launch decision. On Unix, files are created
 /// 0600 from the first byte (UnixCreateMode) to avoid a world-readable window after umask-default
 /// creation; the directory is owner-only (0700) to restrict traversal.
-internal sealed partial class LaunchConsentDecisionLog(string stateDir, ILogger logger, long maxBytes = 1_048_576) {
+internal sealed class LaunchConsentDecisionLog(string stateDir, ILogger logger, long maxBytes = 1_048_576) {
     readonly string _path = Path.Combine(stateDir, "consent-decisions.jsonl");
     readonly object _gate = new();
     bool _dirCreated;
 
-    public void Record(LaunchConsentRecord rec) {
+    public void Record(ConsentDecisionRecord rec) {
         lock (_gate) {
             try {
                 // Lazy directory creation + mode setting: only when first needed, not on every Record() call.
@@ -31,7 +26,7 @@ internal sealed partial class LaunchConsentDecisionLog(string stateDir, ILogger 
                     _dirCreated = true;
                 }
 
-                var line = JsonSerializer.Serialize(rec, LaunchConsentDecisionJsonCtx.Default.LaunchConsentRecord) + "\n";
+                var line = JsonSerializer.Serialize(rec, ConsentDecisionJsonContext.Default.ConsentDecisionRecord) + "\n";
                 var incoming = Encoding.UTF8.GetByteCount(line);
                 if (File.Exists(_path) && new FileInfo(_path).Length + incoming > maxBytes)
                     File.Move(_path, _path + ".1", overwrite: true);
@@ -51,8 +46,4 @@ internal sealed partial class LaunchConsentDecisionLog(string stateDir, ILogger 
             }
         }
     }
-
-    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
-    [JsonSerializable(typeof(LaunchConsentRecord))]
-    partial class LaunchConsentDecisionJsonCtx : JsonSerializerContext;
 }

--- a/src/Capacitor.Cli.Daemon/Services/LaunchConsentEngine.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LaunchConsentEngine.cs
@@ -7,7 +7,8 @@ internal readonly record struct LaunchConsentInput(
     bool RequesterIsOwner,
     string Kind,
     string RepoPath,
-    string Vendor);
+    string Vendor,
+    string? RequesterDisplay);
 
 internal enum LaunchConsentVerdict { Allow, Deny, Prompt }
 

--- a/src/Capacitor.Cli.Daemon/Services/LaunchConsentGate.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LaunchConsentGate.cs
@@ -1,10 +1,11 @@
+using Capacitor.Cli.Core.LocalIpc;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Services;
 
 internal sealed record LaunchConsentPromptRequest(
     string RequestId, string? Requester, string Kind, string RepoPath, string Vendor,
-    string RequestedAt, int TimeoutSeconds);
+    string RequestedAt, int TimeoutSeconds, string? RequesterDisplay, string PromptId);
 
 /// Implemented by LaunchConsentBroker (Task 6). Null answer = timeout / subscriber vanished.
 internal interface ILaunchConsentPrompter {
@@ -62,7 +63,8 @@ internal sealed class LaunchConsentGate(
                 detail: $"owner approval required and no approval UI attached within {wait.TotalSeconds:0.0}s grace");
 
         var req = new LaunchConsentPromptRequest(agentId, input.RequesterUserId, input.Kind,
-            input.RepoPath, input.Vendor, requestedAt, policy.PromptTimeoutSeconds);
+            input.RepoPath, input.Vendor, requestedAt, policy.PromptTimeoutSeconds,
+            input.RequesterDisplay, Guid.NewGuid().ToString("N"));
         logger.LogInformation("Launch {AgentId} awaiting owner consent (timeout {Timeout}s)", agentId, req.TimeoutSeconds);
         // Recomputed (zero allowed — a subscriber arriving exactly at the deadline still gets a
         // single fail-closed settlement via PromptAsync's own timeout, never a special case here).
@@ -76,9 +78,10 @@ internal sealed class LaunchConsentGate(
     }
 
     LaunchConsentOutcome Done(string agentId, in LaunchConsentInput input, bool allowed, string source, string detail) {
-        log.Record(new LaunchConsentRecord(
+        log.Record(new ConsentDecisionRecord(
             DateTimeOffset.UtcNow.ToString("O"), agentId, input.RequesterUserId, input.RequesterIsOwner,
-            input.Kind, input.RepoPath, input.Vendor, allowed ? "allowed" : "denied", source));
+            input.Kind, input.RepoPath, input.Vendor, allowed ? "allowed" : "denied", source,
+            input.RequesterDisplay));
         return new LaunchConsentOutcome(allowed, source, detail);
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/LaunchConsentIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LaunchConsentIpc.cs
@@ -34,7 +34,7 @@ internal sealed class LaunchConsentIpc(
         }
     }
 
-    public async Task HandleResolveAsync(string payload, Stream stream, CancellationToken ct) {
+    public async Task HandleResolveAsync(string payload, Stream stream, CancellationToken ct, bool requireEcho = false) {
         ConsentAckDto ack;
         try {
             var dto = JsonSerializer.Deserialize(payload, ConsentIpcJsonContext.Default.ConsentResolveDto);
@@ -47,23 +47,31 @@ internal sealed class LaunchConsentIpc(
             if (dto is null || string.IsNullOrEmpty(dto.RequestId) || dto.Decision is not ("allow" or "deny")
                     || (dto.SaveRule is { } saveRuleShape && saveRuleShape.Action is null)) {
                 ack = new ConsentAckDto(false, "invalid resolve payload (decision must be allow|deny)", null);
+            } else if (requireEcho && string.IsNullOrEmpty(dto.PromptId)) {
+                // V2 contract: the identity echo is mandatory — an id-only resolve is exactly the
+                // stale-resolve hazard the v2 frame exists to close.
+                ack = new ConsentAckDto(false, "invalid resolve payload (prompt_id required)", null);
             } else {
                 string? saveError = null;
+                bool? ruleSaved = null;
                 if (dto.SaveRule is { } r) {
                     var current = store.Current;
                     var next = current with {
                         Rules = [.. current.Rules, new LaunchConsentRule(r.Action, r.Requester, r.Kind, r.Repo, r.Vendor)] };
                     if (!store.TryReplace(next, out saveError))
                         logger.LogWarning("Consent save_rule rejected: {Error}", saveError);
+                    ruleSaved = saveError is null;
                 }
                 // Ok reflects the RESOLUTION outcome only — whether the caller's decision was
                 // applied to a still-pending request. A rejected save_rule is a secondary,
                 // partial failure: it must not be conflated with "no pending request with that
                 // id" (Ok=false), so it rides along as Error even when Ok=true. See ConsentAckDto.
-                var resolved = broker.TryResolve(dto.RequestId, dto.Decision == "allow");
+                // RuleSaved reports the save outcome on BOTH branches — save_rule is persisted
+                // before the resolution is attempted, so a no-pending Ok=false ack must not hide it.
+                var resolved = broker.TryResolve(dto.RequestId, dto.Decision == "allow", dto.PromptId);
                 ack = resolved
-                    ? new ConsentAckDto(true, saveError, null)
-                    : new ConsentAckDto(false, "no pending consent request with that id", null);
+                    ? new ConsentAckDto(true, saveError, ruleSaved)
+                    : new ConsentAckDto(false, "no pending consent request with that id", ruleSaved);
             }
         } catch (JsonException) {
             ack = new ConsentAckDto(false, "malformed resolve payload", null);

--- a/src/Capacitor.Cli.Daemon/Services/LaunchConsentIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LaunchConsentIpc.cs
@@ -46,7 +46,7 @@ internal sealed class LaunchConsentIpc(
             // (an uncaught exception here drops the connection with no ConsentAck at all).
             if (dto is null || string.IsNullOrEmpty(dto.RequestId) || dto.Decision is not ("allow" or "deny")
                     || (dto.SaveRule is { } saveRuleShape && saveRuleShape.Action is null)) {
-                ack = new ConsentAckDto(false, "invalid resolve payload (decision must be allow|deny)");
+                ack = new ConsentAckDto(false, "invalid resolve payload (decision must be allow|deny)", null);
             } else {
                 string? saveError = null;
                 if (dto.SaveRule is { } r) {
@@ -62,11 +62,11 @@ internal sealed class LaunchConsentIpc(
                 // id" (Ok=false), so it rides along as Error even when Ok=true. See ConsentAckDto.
                 var resolved = broker.TryResolve(dto.RequestId, dto.Decision == "allow");
                 ack = resolved
-                    ? new ConsentAckDto(true, saveError)
-                    : new ConsentAckDto(false, "no pending consent request with that id");
+                    ? new ConsentAckDto(true, saveError, null)
+                    : new ConsentAckDto(false, "no pending consent request with that id", null);
             }
         } catch (JsonException) {
-            ack = new ConsentAckDto(false, "malformed resolve payload");
+            ack = new ConsentAckDto(false, "malformed resolve payload", null);
         }
         await WriteAck(stream, ack, ct);
     }
@@ -93,29 +93,29 @@ internal sealed class LaunchConsentIpc(
             // still deserializes without throwing — so check for a null element before touching
             // r.Action on it, or this throws an uncaught NullReferenceException instead.
             if (dto is null || dto.Default is null || dto.Rules is null || dto.Rules.Any(r => r is null || r.Action is null)) {
-                ack = new ConsentAckDto(false, "malformed policy payload");
+                ack = new ConsentAckDto(false, "malformed policy payload", null);
             } else {
                 var def = dto.Default switch {
                     "deny" => LaunchConsentDefault.Deny, "prompt" => LaunchConsentDefault.Prompt,
                     "allow" => LaunchConsentDefault.Allow,
                     _ => (LaunchConsentDefault?)null };
                 if (def is null) {
-                    ack = new ConsentAckDto(false, "invalid default (allow|deny|prompt)");
+                    ack = new ConsentAckDto(false, "invalid default (allow|deny|prompt)", null);
                 } else {
                     var next = new LaunchConsentPolicy(def.Value, dto.PromptTimeoutSeconds,
                         dto.Rules.Select(r => new LaunchConsentRule(r.Action, r.Requester, r.Kind, r.Repo, r.Vendor)).ToList());
                     ack = store.TryReplace(next, out var error)
-                        ? new ConsentAckDto(true, null) : new ConsentAckDto(false, error);
+                        ? new ConsentAckDto(true, null, null) : new ConsentAckDto(false, error, null);
                 }
             }
         } catch (JsonException) {
-            ack = new ConsentAckDto(false, "malformed policy payload");
+            ack = new ConsentAckDto(false, "malformed policy payload", null);
         }
         await WriteAck(stream, ack, ct);
     }
 
     static ConsentPendingDto ToDto(LaunchConsentPromptRequest r) =>
-        new(r.RequestId, r.Requester, r.Kind, r.RepoPath, r.Vendor, r.RequestedAt, r.TimeoutSeconds);
+        new(r.RequestId, r.Requester, r.Kind, r.RepoPath, r.Vendor, r.RequestedAt, r.TimeoutSeconds, null, null);
 
     static Task WriteAck(Stream stream, ConsentAckDto ack, CancellationToken ct) {
         var json = JsonSerializer.Serialize(ack, ConsentIpcJsonContext.Default.ConsentAckDto);

--- a/src/Capacitor.Cli.Daemon/Services/LaunchConsentIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LaunchConsentIpc.cs
@@ -115,7 +115,7 @@ internal sealed class LaunchConsentIpc(
     }
 
     static ConsentPendingDto ToDto(LaunchConsentPromptRequest r) =>
-        new(r.RequestId, r.Requester, r.Kind, r.RepoPath, r.Vendor, r.RequestedAt, r.TimeoutSeconds, null, null);
+        new(r.RequestId, r.Requester, r.Kind, r.RepoPath, r.Vendor, r.RequestedAt, r.TimeoutSeconds, r.RequesterDisplay, r.PromptId);
 
     static Task WriteAck(Stream stream, ConsentAckDto ack, CancellationToken ct) {
         var json = JsonSerializer.Serialize(ack, ConsentIpcJsonContext.Default.ConsentAckDto);

--- a/src/Capacitor.Cli.Daemon/Services/LocalControlCapabilities.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalControlCapabilities.cs
@@ -5,10 +5,14 @@ namespace Capacitor.Cli.Daemon.Services;
 /// INVARIANT: an entry may exist here ONLY if <see cref="LocalControlServer"/> actually
 /// routes the corresponding frame(s) to a real handler — this list is assembled right next
 /// to that routing switch so a capability can never be advertised without behavior behind
-/// it. Both entries' handlers are live in this build: <c>"consent/1"</c> routes
-/// ConsentSubscribe/ConsentResolve/ConsentRulesGet/ConsentRulesPut to <see cref="LaunchConsentIpc"/>,
-/// and <c>"status/1"</c> routes StatusSubscribe to <see cref="DaemonStatusIpc"/>.
+/// it. All three entries' handlers are live in this build: <c>"consent/1"</c> routes
+/// ConsentSubscribe/ConsentResolve/ConsentRulesGet/ConsentRulesPut to <see cref="LaunchConsentIpc"/>;
+/// <c>"consent/2"</c> routes ConsentSubscribeV2/ConsentResolveV2 to the same handler with
+/// identity-checked resolution (mandatory <c>prompt_id</c> echo), <c>rule_saved</c> acks, and
+/// <c>prompt_id</c>/<c>requester_display</c>-stamped pendings — this list entry is discovery
+/// only, enforcement lives in the v2 frames themselves; and <c>"status/1"</c> routes
+/// StatusSubscribe to <see cref="DaemonStatusIpc"/>.
 /// </summary>
 internal static class LocalControlCapabilities {
-    public static readonly IReadOnlyList<string> Current = ["consent/1", "status/1"];
+    public static readonly IReadOnlyList<string> Current = ["consent/1", "consent/2", "status/1"];
 }

--- a/src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs
@@ -56,9 +56,11 @@ internal sealed partial class LocalControlServer(
                 case FrameType.ConsentResolve:   await consentIpc.HandleResolveAsync(first.Text, stream, ct); break;
                 case FrameType.ConsentRulesGet:  await consentIpc.HandleRulesGetAsync(stream, ct); break;
                 case FrameType.ConsentRulesPut:  await consentIpc.HandleRulesPutAsync(first.Text, stream, ct); break;
+                case FrameType.ConsentSubscribeV2: await consentIpc.HandleSubscribeAsync(stream, ct); break;
+                case FrameType.ConsentResolveV2:   await consentIpc.HandleResolveAsync(first.Text, stream, ct, requireEcho: true); break;
                 case FrameType.Hello: await HandleHelloAsync(first.Text, stream, ct); break;
                 case FrameType.StatusSubscribe: await statusIpc.HandleSubscribeAsync(stream, ct); break;
-                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List/Stop/StopV2/Restart/ConsentSubscribe/ConsentResolve/ConsentRulesGet/ConsentRulesPut/Hello/StatusSubscribe, got {first.Type}"), ct); break;
+                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List/Stop/StopV2/Restart/ConsentSubscribe/ConsentResolve/ConsentRulesGet/ConsentRulesPut/ConsentSubscribeV2/ConsentResolveV2/Hello/StatusSubscribe, got {first.Type}"), ct); break;
             }
         } catch (Exception ex) when (ex is not OperationCanceledException) {
             LogConnectionError(ex);

--- a/test/Capacitor.App.Tests.Unit/ActivityStatKeyTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ActivityStatKeyTests.cs
@@ -1,0 +1,63 @@
+using AppUnderTest = Capacitor.App.App;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Regression coverage for a Critical bug found in review: the original
+/// ActivityStatKey wrapped BOTH log files in one try/catch, so a missing `.1` rotation file
+/// (every fresh install, until the first 1MB rotation) collapsed the WHOLE key to the "absent"
+/// constant — appends to the live file never changed it, and the Activity tab went stale until
+/// the tab was reselected. Drives the two-path testable overload directly against a temp
+/// directory; never touches the real daemon-dir resolution under ~/.config/kcap/daemons.
+public class ActivityStatKeyTests {
+    [Test]
+    public async Task Live_file_append_changes_the_key_even_when_the_rotation_file_is_absent() {
+        var dir = Directory.CreateTempSubdirectory("kcap-ask-");
+        try {
+            var p1 = Path.Combine(dir.FullName, "consent-decisions.jsonl.1");
+            var live = Path.Combine(dir.FullName, "consent-decisions.jsonl");
+            File.WriteAllText(live, "one\n");
+
+            var before = AppUnderTest.ActivityStatKey(p1, live);
+            File.AppendAllText(live, "two\n");
+            var after = AppUnderTest.ActivityStatKey(p1, live);
+
+            await Assert.That(after).IsNotEqualTo(before);
+        } finally {
+            Directory.Delete(dir.FullName, true);
+        }
+    }
+
+    [Test]
+    public async Task Key_is_stable_when_neither_file_exists() {
+        var dir = Directory.CreateTempSubdirectory("kcap-ask-");
+        try {
+            var p1 = Path.Combine(dir.FullName, "consent-decisions.jsonl.1");
+            var live = Path.Combine(dir.FullName, "consent-decisions.jsonl");
+
+            var first = AppUnderTest.ActivityStatKey(p1, live);
+            var second = AppUnderTest.ActivityStatKey(p1, live);
+
+            await Assert.That(second).IsEqualTo(first);
+        } finally {
+            Directory.Delete(dir.FullName, true);
+        }
+    }
+
+    [Test]
+    public async Task Key_changes_when_the_rotation_file_appears() {
+        var dir = Directory.CreateTempSubdirectory("kcap-ask-");
+        try {
+            var p1 = Path.Combine(dir.FullName, "consent-decisions.jsonl.1");
+            var live = Path.Combine(dir.FullName, "consent-decisions.jsonl");
+            File.WriteAllText(live, "one\n");
+
+            var before = AppUnderTest.ActivityStatKey(p1, live);
+            File.WriteAllText(p1, "rotated\n");
+            var after = AppUnderTest.ActivityStatKey(p1, live);
+
+            await Assert.That(after).IsNotEqualTo(before);
+        } finally {
+            Directory.Delete(dir.FullName, true);
+        }
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
@@ -248,7 +248,7 @@ public class ActivityViewModelTests {
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Tab_visible_triggers_immediate_refresh() {
-        var (readCalls, count) = await AvaloniaSession.DispatchAsync(async () => {
+        var (readCallsBefore, readCallsAfter, count) = await AvaloniaSession.DispatchAsync(async () => {
             var reader = new ScriptedReader();
             reader.Set(new ConsentLogReadResult([Rec()], true));
             var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
@@ -257,10 +257,11 @@ public class ActivityViewModelTests {
             vm.OnTabVisibleChanged(true);
             await vm.PendingRefreshForTesting!;
 
-            return (readCallsBefore, vm.Rows.Count);
+            return (readCallsBefore, reader.ReadCalls, vm.Rows.Count);
         });
 
-        await Assert.That(readCalls).IsEqualTo(0);
+        await Assert.That(readCallsBefore).IsEqualTo(0);
+        await Assert.That(readCallsAfter).IsEqualTo(1); // exactly one read — guards against an accidental double-read
         await Assert.That(count).IsEqualTo(1);
     }
 

--- a/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
@@ -260,4 +260,29 @@ public class ActivityViewModelTests {
         vm.RequestRefresh();
         await Assert.That(vm.Rows.Count).IsEqualTo(1); // recovers on the next call
     }
+
+    // ---- 8: disposal releases the shared ticker ----
+
+    /// The subscription is constructor-scoped (no WhenActivated), and the shared ticker is
+    /// Publish().RefCount() — an undisposed subscriber keeps its Interval, and this object,
+    /// running past app teardown.
+    [Test]
+    public async Task Dispose_stops_the_stat_poll() {
+        var reader = new ScriptedReader();
+        reader.Set(new ConsentLogReadResult([Rec()], true));
+        var stat = new ScriptedStat { Key = "k0" };
+        var ticker = new FakeTicker();
+        var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
+
+        vm.OnTabVisibleChanged(true);
+        await Assert.That(reader.ReadCalls).IsEqualTo(1);
+
+        vm.Dispose();
+
+        stat.Key = "k1";
+        ticker.Tick();
+        ticker.Tick();
+        await Assert.That(reader.ReadCalls).IsEqualTo(1);
+        await Assert.That(ticker.Subject.HasObservers).IsFalse();
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
@@ -37,11 +37,34 @@ sealed class ScriptedStat {
     }
 }
 
-/// Covers ActivityViewModel's row mapping and refresh semantics (spec §7, task-10-brief's 7
-/// cases). No AvaloniaSession/RxSchedulers wrapping needed: the VM subscribes to the injected
-/// ITicker directly with no ObserveOn (the ticker already delivers on the UI thread in
-/// production — see ActivityViewModel's class doc comment), so a plain Subject-backed FakeTicker
-/// delivers synchronously on the calling thread, same as AgentRowViewModel's tests.
+/// A `Func&lt;ConsentLogReadResult&gt;` that blocks on a caller-controlled gate — lets a test hold a
+/// read genuinely "in flight" on the thread pool, deterministically and without a sleep, to
+/// exercise ActivityViewModel's single-flight guard (test 9).
+sealed class GatedReader {
+    public int ReadCalls { get; private set; }
+    readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    ConsentLogReadResult _result = new([], true);
+
+    public Task Started => _started.Task;
+    public void Set(ConsentLogReadResult result) => _result = result;
+    public void Release() => _release.SetResult();
+
+    public ConsentLogReadResult Read() {
+        ReadCalls++;
+        _started.TrySetResult();
+        _release.Task.GetAwaiter().GetResult(); // blocks the background thread, never the UI thread
+        return _result;
+    }
+}
+
+/// Covers ActivityViewModel's row mapping and refresh semantics (spec §7, task-10-brief's 7 cases),
+/// including the stat+read hop off the UI thread. The VM now hops through Task.Run and back via
+/// Dispatcher.UIThread.InvokeAsync, so every test that triggers a refresh
+/// runs under AvaloniaSession (the real headless dispatcher) and awaits
+/// ActivityViewModel.PendingRefreshForTesting — the same completion the production single-flight
+/// guard watches — instead of guessing at a delay. A plain Subject-backed FakeTicker still delivers
+/// Tick() synchronously on the calling thread; only the VM's OWN work moved off-thread.
 public class ActivityViewModelTests {
     static ConsentDecisionRecord Rec(
             string decidedAt = "2026-08-08T12:00:00.0000000+00:00", string agentId = "a1", string? requester = "github:1",
@@ -53,6 +76,7 @@ public class ActivityViewModelTests {
     // ---- 1: row mapping ----
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Rows_map_records_with_fallbacks_and_source_labels() {
         const string decidedAt = "2026-08-08T12:34:56.0000000+00:00";
         var expectedTime = DateTimeOffset.Parse(decidedAt, CultureInfo.InvariantCulture)
@@ -66,12 +90,16 @@ public class ActivityViewModelTests {
                 kind: "agent", repoPath: "/repos/kcap-cli", vendor: "claude", outcome: "denied", source: "prompt_timeout"),
         };
 
-        var reader = new ScriptedReader();
-        reader.Set(new ConsentLogReadResult(records, true));
-        var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
-        vm.OnTabVisibleChanged(true);
+        var (first, second) = await AvaloniaSession.DispatchAsync(async () => {
+            var reader = new ScriptedReader();
+            reader.Set(new ConsentLogReadResult(records, true));
+            var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
+            vm.OnTabVisibleChanged(true);
+            await vm.PendingRefreshForTesting!;
 
-        var first = vm.Rows[0];
+            return (vm.Rows[0], vm.Rows[1]);
+        });
+
         await Assert.That(first.Time).IsEqualTo(expectedTime);
         await Assert.That(first.Requester).IsEqualTo("Ada Lovelace");
         await Assert.That(first.KindLabel).IsEqualTo("Review flow");
@@ -82,7 +110,6 @@ public class ActivityViewModelTests {
         await Assert.That(first.IsAllowed).IsTrue();
         await Assert.That(first.SourceLabel).IsEqualTo("rule");
 
-        var second = vm.Rows[1];
         await Assert.That(second.Time).IsEqualTo("not-a-timestamp"); // unparseable -> verbatim
         await Assert.That(second.Requester).IsEqualTo("unknown"); // both requester and display absent
         await Assert.That(second.KindLabel).IsEqualTo("Agent");
@@ -106,159 +133,230 @@ public class ActivityViewModelTests {
     // ---- 2: Complete replaces, including to empty ----
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Complete_read_replaces_rows_including_to_empty() {
-        var reader = new ScriptedReader();
-        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
-        var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
+        var (countAfterFirst, emptyAfterFirst, countAfterSecond, emptyAfterSecond) = await AvaloniaSession.DispatchAsync(async () => {
+            var reader = new ScriptedReader();
+            reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
+            var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
 
-        vm.OnTabVisibleChanged(true);
-        await Assert.That(vm.Rows.Count).IsEqualTo(2);
-        await Assert.That(vm.IsEmpty).IsFalse();
+            vm.OnTabVisibleChanged(true);
+            await vm.PendingRefreshForTesting!;
+            var countAfterFirst = vm.Rows.Count;
+            var emptyAfterFirst = vm.IsEmpty;
 
-        reader.Set(new ConsentLogReadResult([], true));
-        vm.RequestRefresh();
+            reader.Set(new ConsentLogReadResult([], true));
+            vm.RequestRefresh();
+            await vm.PendingRefreshForTesting!;
 
-        await Assert.That(vm.Rows.Count).IsEqualTo(0);
-        await Assert.That(vm.IsEmpty).IsTrue();
+            return (countAfterFirst, emptyAfterFirst, vm.Rows.Count, vm.IsEmpty);
+        });
+
+        await Assert.That(countAfterFirst).IsEqualTo(2);
+        await Assert.That(emptyAfterFirst).IsFalse();
+        await Assert.That(countAfterSecond).IsEqualTo(0);
+        await Assert.That(emptyAfterSecond).IsTrue();
     }
 
     // ---- 3: Incomplete keeps last-good; best-effort with nothing previous ----
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Incomplete_read_keeps_last_good_rows() {
-        var reader = new ScriptedReader();
-        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
-        var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
+        var count = await AvaloniaSession.DispatchAsync(async () => {
+            var reader = new ScriptedReader();
+            reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
+            var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
 
-        vm.OnTabVisibleChanged(true);
-        await Assert.That(vm.Rows.Count).IsEqualTo(2);
+            vm.OnTabVisibleChanged(true);
+            await vm.PendingRefreshForTesting!;
 
-        reader.Set(new ConsentLogReadResult([Rec(agentId: "a3")], false));
-        vm.RequestRefresh();
+            reader.Set(new ConsentLogReadResult([Rec(agentId: "a3")], false));
+            vm.RequestRefresh();
+            await vm.PendingRefreshForTesting!;
 
-        await Assert.That(vm.Rows.Count).IsEqualTo(2); // last-good kept, the partial read discarded
+            return vm.Rows.Count;
+        });
+
+        await Assert.That(count).IsEqualTo(2); // last-good kept, the partial read discarded
     }
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Incomplete_read_with_no_previous_rows_shows_partial_best_effort() {
-        var reader = new ScriptedReader();
-        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], false));
-        var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
+        var (count, isEmpty) = await AvaloniaSession.DispatchAsync(async () => {
+            var reader = new ScriptedReader();
+            reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], false));
+            var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
 
-        vm.RequestRefresh(); // nothing displayed yet
+            vm.RequestRefresh(); // nothing displayed yet
+            await vm.PendingRefreshForTesting!;
 
-        await Assert.That(vm.Rows.Count).IsEqualTo(1);
-        await Assert.That(vm.IsEmpty).IsFalse();
+            return (vm.Rows.Count, vm.IsEmpty);
+        });
+
+        await Assert.That(count).IsEqualTo(1);
+        await Assert.That(isEmpty).IsFalse();
     }
 
     // ---- 4: stat-gated poll, every 2nd tick while visible ----
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Stat_poll_rereads_only_on_change_every_2_ticks_while_visible() {
-        var reader = new ScriptedReader();
-        reader.Set(new ConsentLogReadResult([Rec()], true));
-        var stat = new ScriptedStat { Key = "k0" };
-        var ticker = new FakeTicker();
-        var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
+        var (afterVisible, afterUnchanged, afterChanged, afterInvisible) = await AvaloniaSession.DispatchAsync(async () => {
+            var reader = new ScriptedReader();
+            reader.Set(new ConsentLogReadResult([Rec()], true));
+            var stat = new ScriptedStat { Key = "k0" };
+            var ticker = new FakeTicker();
+            var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
 
-        vm.OnTabVisibleChanged(true); // immediate read
-        await Assert.That(reader.ReadCalls).IsEqualTo(1);
+            vm.OnTabVisibleChanged(true); // immediate read
+            await vm.PendingRefreshForTesting!;
+            var afterVisible = reader.ReadCalls;
 
-        ticker.Tick();
-        ticker.Tick(); // unchanged stat across the 2-tick window -> no re-read
-        await Assert.That(reader.ReadCalls).IsEqualTo(1);
+            ticker.Tick();
+            ticker.Tick(); // unchanged stat across the 2-tick window -> no re-read
+            await vm.PendingRefreshForTesting!;
+            var afterUnchanged = reader.ReadCalls;
 
-        stat.Key = "k1";
-        ticker.Tick();
-        ticker.Tick(); // changed stat, checked on the 2nd tick -> re-read
-        await Assert.That(reader.ReadCalls).IsEqualTo(2);
+            stat.Key = "k1";
+            ticker.Tick();
+            ticker.Tick(); // changed stat, checked on the 2nd tick -> re-read
+            await vm.PendingRefreshForTesting!;
+            var afterChanged = reader.ReadCalls;
 
-        vm.OnTabVisibleChanged(false);
-        stat.Key = "k2";
-        ticker.Tick();
-        ticker.Tick();
-        ticker.Tick();
-        ticker.Tick();
-        await Assert.That(reader.ReadCalls).IsEqualTo(2); // invisible -> polling stopped entirely
+            vm.OnTabVisibleChanged(false);
+            stat.Key = "k2";
+            ticker.Tick();
+            ticker.Tick();
+            ticker.Tick();
+            ticker.Tick();
+            var afterInvisible = reader.ReadCalls;
+
+            return (afterVisible, afterUnchanged, afterChanged, afterInvisible);
+        });
+
+        await Assert.That(afterVisible).IsEqualTo(1);
+        await Assert.That(afterUnchanged).IsEqualTo(1);
+        await Assert.That(afterChanged).IsEqualTo(2);
+        await Assert.That(afterInvisible).IsEqualTo(2); // invisible -> polling stopped entirely
     }
 
     // ---- 5: visibility triggers an immediate refresh ----
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Tab_visible_triggers_immediate_refresh() {
-        var reader = new ScriptedReader();
-        reader.Set(new ConsentLogReadResult([Rec()], true));
-        var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
+        var (readCalls, count) = await AvaloniaSession.DispatchAsync(async () => {
+            var reader = new ScriptedReader();
+            reader.Set(new ConsentLogReadResult([Rec()], true));
+            var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
 
-        await Assert.That(reader.ReadCalls).IsEqualTo(0);
-        vm.OnTabVisibleChanged(true);
+            var readCallsBefore = reader.ReadCalls;
+            vm.OnTabVisibleChanged(true);
+            await vm.PendingRefreshForTesting!;
 
-        await Assert.That(reader.ReadCalls).IsEqualTo(1);
-        await Assert.That(vm.Rows.Count).IsEqualTo(1);
+            return (readCallsBefore, vm.Rows.Count);
+        });
+
+        await Assert.That(readCalls).IsEqualTo(0);
+        await Assert.That(count).IsEqualTo(1);
     }
 
     // ---- 6: own-resolution refresh is an immediate read, eventual display ----
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Own_resolution_refresh_is_eventual() {
-        var reader = new ScriptedReader();
-        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], true));
-        var stat = new ScriptedStat { Key = "k0" };
-        var ticker = new FakeTicker();
-        var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
+        var (countAfterVisible, readCallsAfterRequest, countAfterRequest, countAfterTick) = await AvaloniaSession.DispatchAsync(async () => {
+            var reader = new ScriptedReader();
+            reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], true));
+            var stat = new ScriptedStat { Key = "k0" };
+            var ticker = new FakeTicker();
+            var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
 
-        vm.OnTabVisibleChanged(true);
-        await Assert.That(vm.Rows.Count).IsEqualTo(1);
+            vm.OnTabVisibleChanged(true);
+            await vm.PendingRefreshForTesting!;
+            var countAfterVisible = vm.Rows.Count;
 
-        // The ack fires RequestRefresh, but the daemon's own append hasn't landed yet — a stale
-        // read is still what an immediate refresh can see.
-        vm.RequestRefresh();
-        await Assert.That(reader.ReadCalls).IsEqualTo(2);
-        await Assert.That(vm.Rows.Count).IsEqualTo(1);
+            // The ack fires RequestRefresh, but the daemon's own append hasn't landed yet — a stale
+            // read is still what an immediate refresh can see.
+            vm.RequestRefresh();
+            await vm.PendingRefreshForTesting!;
+            var readCallsAfterRequest = reader.ReadCalls;
+            var countAfterRequest = vm.Rows.Count;
 
-        // The append lands; the next stat-poll tick converges (spec: "no later than the next
-        // poll", not "immediately").
-        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
-        stat.Key = "k1";
-        ticker.Tick();
-        ticker.Tick();
+            // The append lands; the next stat-poll tick converges (spec: "no later than the next
+            // poll", not "immediately").
+            reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
+            stat.Key = "k1";
+            ticker.Tick();
+            ticker.Tick();
+            await vm.PendingRefreshForTesting!;
 
-        await Assert.That(vm.Rows.Count).IsEqualTo(2);
+            return (countAfterVisible, readCallsAfterRequest, countAfterRequest, vm.Rows.Count);
+        });
+
+        await Assert.That(countAfterVisible).IsEqualTo(1);
+        await Assert.That(readCallsAfterRequest).IsEqualTo(2);
+        await Assert.That(countAfterRequest).IsEqualTo(1);
+        await Assert.That(countAfterTick).IsEqualTo(2);
     }
 
     // ---- 7: a throwing stat or read is swallowed; polling keeps going ----
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Poll_survives_a_throwing_stat_or_read() {
-        var reader = new ScriptedReader();
-        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], true));
-        var stat = new ScriptedStat { Key = "k0" };
-        var ticker = new FakeTicker();
-        var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
+        var (countAfterVisible, caughtFromThrowingStat, countAfterThrowingStat, countAfterRecoveredTick,
+                caughtFromThrowingRead, countAfterThrowingRead, countAfterRecoveredRequest) = await AvaloniaSession.DispatchAsync(async () => {
+            var reader = new ScriptedReader();
+            reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], true));
+            var stat = new ScriptedStat { Key = "k0" };
+            var ticker = new FakeTicker();
+            var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
 
-        vm.OnTabVisibleChanged(true);
-        await Assert.That(vm.Rows.Count).IsEqualTo(1);
+            vm.OnTabVisibleChanged(true);
+            await vm.PendingRefreshForTesting!;
+            var countAfterVisible = vm.Rows.Count;
 
-        stat.ThrowOnce = true;
-        Exception? caught = null;
-        try { ticker.Tick(); ticker.Tick(); } catch (Exception ex) { caught = ex; }
-        await Assert.That(caught).IsNull();
+            stat.ThrowOnce = true;
+            Exception? caughtFromThrowingStat = null;
+            ticker.Tick();
+            ticker.Tick();
+            try { await vm.PendingRefreshForTesting!; } catch (Exception ex) { caughtFromThrowingStat = ex; }
+            var countAfterThrowingStat = vm.Rows.Count; // unaffected: the read behind it still succeeded
 
-        // A later, healthy tick still drives the poll.
-        stat.Key = "k1";
-        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
-        ticker.Tick();
-        ticker.Tick();
-        await Assert.That(vm.Rows.Count).IsEqualTo(2);
+            // A later, healthy tick still drives the poll.
+            stat.Key = "k1";
+            reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
+            ticker.Tick();
+            ticker.Tick();
+            await vm.PendingRefreshForTesting!;
+            var countAfterRecoveredTick = vm.Rows.Count;
 
-        reader.ThrowOnce = true;
-        try { vm.RequestRefresh(); } catch (Exception ex) { caught = ex; }
-        await Assert.That(caught).IsNull();
-        await Assert.That(vm.Rows.Count).IsEqualTo(2); // unaffected by the swallowed throw
+            reader.ThrowOnce = true;
+            Exception? caughtFromThrowingRead = null;
+            vm.RequestRefresh();
+            try { await vm.PendingRefreshForTesting!; } catch (Exception ex) { caughtFromThrowingRead = ex; }
+            var countAfterThrowingRead = vm.Rows.Count; // unaffected by the swallowed throw
 
-        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], true));
-        vm.RequestRefresh();
-        await Assert.That(vm.Rows.Count).IsEqualTo(1); // recovers on the next call
+            reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], true));
+            vm.RequestRefresh();
+            await vm.PendingRefreshForTesting!;
+
+            return (countAfterVisible, caughtFromThrowingStat, countAfterThrowingStat, countAfterRecoveredTick,
+                caughtFromThrowingRead, countAfterThrowingRead, vm.Rows.Count);
+        });
+
+        await Assert.That(countAfterVisible).IsEqualTo(1);
+        await Assert.That(caughtFromThrowingStat).IsNull();
+        await Assert.That(countAfterThrowingStat).IsEqualTo(1);
+        await Assert.That(countAfterRecoveredTick).IsEqualTo(2);
+        await Assert.That(caughtFromThrowingRead).IsNull();
+        await Assert.That(countAfterThrowingRead).IsEqualTo(2);
+        await Assert.That(countAfterRecoveredRequest).IsEqualTo(1); // recovers on the next call
     }
 
     // ---- 8: disposal releases the shared ticker ----
@@ -267,22 +365,64 @@ public class ActivityViewModelTests {
     /// Publish().RefCount() — an undisposed subscriber keeps its Interval, and this object,
     /// running past app teardown.
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Dispose_stops_the_stat_poll() {
-        var reader = new ScriptedReader();
-        reader.Set(new ConsentLogReadResult([Rec()], true));
-        var stat = new ScriptedStat { Key = "k0" };
-        var ticker = new FakeTicker();
-        var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
+        var (readCallsAfterVisible, readCallsAfterDispose, hasObservers) = await AvaloniaSession.DispatchAsync(async () => {
+            var reader = new ScriptedReader();
+            reader.Set(new ConsentLogReadResult([Rec()], true));
+            var stat = new ScriptedStat { Key = "k0" };
+            var ticker = new FakeTicker();
+            var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
 
-        vm.OnTabVisibleChanged(true);
-        await Assert.That(reader.ReadCalls).IsEqualTo(1);
+            vm.OnTabVisibleChanged(true);
+            await vm.PendingRefreshForTesting!;
+            var readCallsAfterVisible = reader.ReadCalls;
 
-        vm.Dispose();
+            vm.Dispose();
 
-        stat.Key = "k1";
-        ticker.Tick();
-        ticker.Tick();
-        await Assert.That(reader.ReadCalls).IsEqualTo(1);
-        await Assert.That(ticker.Subject.HasObservers).IsFalse();
+            stat.Key = "k1";
+            ticker.Tick();
+            ticker.Tick();
+
+            return (readCallsAfterVisible, reader.ReadCalls, ticker.Subject.HasObservers);
+        });
+
+        await Assert.That(readCallsAfterVisible).IsEqualTo(1);
+        await Assert.That(readCallsAfterDispose).IsEqualTo(1);
+        await Assert.That(hasObservers).IsFalse();
+    }
+
+    // ---- 9: single-flight — a tick during an in-flight read is dropped, not queued ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Tick_during_an_in_flight_read_is_dropped_not_queued() {
+        var (readCallsWhileBlocked, readCallsAfterRelease, rowsAfterRelease) = await AvaloniaSession.DispatchAsync(async () => {
+            var reader = new GatedReader();
+            reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], true));
+            var stat = new ScriptedStat { Key = "k0" };
+            var ticker = new FakeTicker();
+            var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
+
+            vm.OnTabVisibleChanged(true); // kicks off the read; GatedReader blocks it in flight
+            var inFlight = vm.PendingRefreshForTesting!;
+            await reader.Started; // the background read is now blocked, provably in flight
+
+            // The stat genuinely changed, so this tick WOULD warrant a fresh read if it ran — the
+            // single-flight guard must still drop it because a read is already in flight.
+            stat.Key = "k1";
+            ticker.Tick();
+            ticker.Tick();
+            var readCallsWhileBlocked = reader.ReadCalls;
+
+            reader.Release();
+            await inFlight;
+
+            return (readCallsWhileBlocked, reader.ReadCalls, vm.Rows.Count);
+        });
+
+        await Assert.That(readCallsWhileBlocked).IsEqualTo(1); // the dropped tick never started a 2nd read
+        await Assert.That(readCallsAfterRelease).IsEqualTo(1);
+        await Assert.That(rowsAfterRelease).IsEqualTo(1);
     }
 }

--- a/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
@@ -1,0 +1,263 @@
+using System.Globalization;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Scripted `Func&lt;ConsentLogReadResult&gt;`: counts calls, can be reprogrammed between calls, and
+/// can be armed to throw exactly once (test 7 — a throwing read must never escape the VM).
+sealed class ScriptedReader {
+    public int ReadCalls { get; private set; }
+    public bool ThrowOnce;
+    ConsentLogReadResult _result = new([], true);
+
+    public void Set(ConsentLogReadResult result) => _result = result;
+
+    public ConsentLogReadResult Read() {
+        ReadCalls++;
+        if (ThrowOnce) {
+            ThrowOnce = false;
+            throw new IOException("scripted read failure");
+        }
+        return _result;
+    }
+}
+
+/// Scripted `Func&lt;string&gt;` stat key: settable between calls, can be armed to throw exactly once.
+sealed class ScriptedStat {
+    public string Key = "k0";
+    public bool ThrowOnce;
+
+    public string Get() {
+        if (ThrowOnce) {
+            ThrowOnce = false;
+            throw new IOException("scripted stat failure");
+        }
+        return Key;
+    }
+}
+
+/// Covers ActivityViewModel's row mapping and refresh semantics (spec §7, task-10-brief's 7
+/// cases). No AvaloniaSession/RxSchedulers wrapping needed: the VM subscribes to the injected
+/// ITicker directly with no ObserveOn (the ticker already delivers on the UI thread in
+/// production — see ActivityViewModel's class doc comment), so a plain Subject-backed FakeTicker
+/// delivers synchronously on the calling thread, same as AgentRowViewModel's tests.
+public class ActivityViewModelTests {
+    static ConsentDecisionRecord Rec(
+            string decidedAt = "2026-08-08T12:00:00.0000000+00:00", string agentId = "a1", string? requester = "github:1",
+            bool requesterIsOwner = false, string kind = "agent", string repoPath = "/repos/kcap-cli",
+            string vendor = "claude", string outcome = "allowed", string source = "owner",
+            string? requesterDisplay = null) =>
+        new(decidedAt, agentId, requester, requesterIsOwner, kind, repoPath, vendor, outcome, source, requesterDisplay);
+
+    // ---- 1: row mapping ----
+
+    [Test]
+    public async Task Rows_map_records_with_fallbacks_and_source_labels() {
+        const string decidedAt = "2026-08-08T12:34:56.0000000+00:00";
+        var expectedTime = DateTimeOffset.Parse(decidedAt, CultureInfo.InvariantCulture)
+            .ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+
+        var records = new[] {
+            Rec(decidedAt: decidedAt, requester: "github:1", requesterDisplay: "Ada Lovelace",
+                kind: "review-flow", repoPath: "/repos/kcap-cli/.claude/worktrees/tender-honking-pebble",
+                vendor: "codex", outcome: "allowed", source: "rule[7]"),
+            Rec(decidedAt: "not-a-timestamp", requester: null, requesterDisplay: null,
+                kind: "agent", repoPath: "/repos/kcap-cli", vendor: "claude", outcome: "denied", source: "prompt_timeout"),
+        };
+
+        var reader = new ScriptedReader();
+        reader.Set(new ConsentLogReadResult(records, true));
+        var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
+        vm.OnTabVisibleChanged(true);
+
+        var first = vm.Rows[0];
+        await Assert.That(first.Time).IsEqualTo(expectedTime);
+        await Assert.That(first.Requester).IsEqualTo("Ada Lovelace");
+        await Assert.That(first.KindLabel).IsEqualTo("Review flow");
+        await Assert.That(first.RepoLeaf).IsEqualTo("kcap-cli"); // worktree leaf stripped, RepoLabel
+        await Assert.That(first.RepoFull).IsEqualTo("/repos/kcap-cli/.claude/worktrees/tender-honking-pebble");
+        await Assert.That(first.Vendor).IsEqualTo("codex");
+        await Assert.That(first.Outcome).IsEqualTo("allowed");
+        await Assert.That(first.IsAllowed).IsTrue();
+        await Assert.That(first.SourceLabel).IsEqualTo("rule");
+
+        var second = vm.Rows[1];
+        await Assert.That(second.Time).IsEqualTo("not-a-timestamp"); // unparseable -> verbatim
+        await Assert.That(second.Requester).IsEqualTo("unknown"); // both requester and display absent
+        await Assert.That(second.KindLabel).IsEqualTo("Agent");
+        await Assert.That(second.Outcome).IsEqualTo("denied");
+        await Assert.That(second.IsAllowed).IsFalse();
+        await Assert.That(second.SourceLabel).IsEqualTo("timeout");
+    }
+
+    [Test]
+    [Arguments("owner", "owner")]
+    [Arguments("rule[7]", "rule")]
+    [Arguments("default", "default policy")]
+    [Arguments("prompt_user", "you")]
+    [Arguments("prompt_timeout", "timeout")]
+    [Arguments("prompt_no_ui", "no UI attached")]
+    [Arguments("something-weird", "something-weird")] // unrecognized renders verbatim
+    public async Task Source_labels(string source, string expected) {
+        await Assert.That(ActivityViewModel.SourceLabelOf(source)).IsEqualTo(expected);
+    }
+
+    // ---- 2: Complete replaces, including to empty ----
+
+    [Test]
+    public async Task Complete_read_replaces_rows_including_to_empty() {
+        var reader = new ScriptedReader();
+        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
+        var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
+
+        vm.OnTabVisibleChanged(true);
+        await Assert.That(vm.Rows.Count).IsEqualTo(2);
+        await Assert.That(vm.IsEmpty).IsFalse();
+
+        reader.Set(new ConsentLogReadResult([], true));
+        vm.RequestRefresh();
+
+        await Assert.That(vm.Rows.Count).IsEqualTo(0);
+        await Assert.That(vm.IsEmpty).IsTrue();
+    }
+
+    // ---- 3: Incomplete keeps last-good; best-effort with nothing previous ----
+
+    [Test]
+    public async Task Incomplete_read_keeps_last_good_rows() {
+        var reader = new ScriptedReader();
+        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
+        var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
+
+        vm.OnTabVisibleChanged(true);
+        await Assert.That(vm.Rows.Count).IsEqualTo(2);
+
+        reader.Set(new ConsentLogReadResult([Rec(agentId: "a3")], false));
+        vm.RequestRefresh();
+
+        await Assert.That(vm.Rows.Count).IsEqualTo(2); // last-good kept, the partial read discarded
+    }
+
+    [Test]
+    public async Task Incomplete_read_with_no_previous_rows_shows_partial_best_effort() {
+        var reader = new ScriptedReader();
+        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], false));
+        var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
+
+        vm.RequestRefresh(); // nothing displayed yet
+
+        await Assert.That(vm.Rows.Count).IsEqualTo(1);
+        await Assert.That(vm.IsEmpty).IsFalse();
+    }
+
+    // ---- 4: stat-gated poll, every 2nd tick while visible ----
+
+    [Test]
+    public async Task Stat_poll_rereads_only_on_change_every_2_ticks_while_visible() {
+        var reader = new ScriptedReader();
+        reader.Set(new ConsentLogReadResult([Rec()], true));
+        var stat = new ScriptedStat { Key = "k0" };
+        var ticker = new FakeTicker();
+        var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
+
+        vm.OnTabVisibleChanged(true); // immediate read
+        await Assert.That(reader.ReadCalls).IsEqualTo(1);
+
+        ticker.Tick();
+        ticker.Tick(); // unchanged stat across the 2-tick window -> no re-read
+        await Assert.That(reader.ReadCalls).IsEqualTo(1);
+
+        stat.Key = "k1";
+        ticker.Tick();
+        ticker.Tick(); // changed stat, checked on the 2nd tick -> re-read
+        await Assert.That(reader.ReadCalls).IsEqualTo(2);
+
+        vm.OnTabVisibleChanged(false);
+        stat.Key = "k2";
+        ticker.Tick();
+        ticker.Tick();
+        ticker.Tick();
+        ticker.Tick();
+        await Assert.That(reader.ReadCalls).IsEqualTo(2); // invisible -> polling stopped entirely
+    }
+
+    // ---- 5: visibility triggers an immediate refresh ----
+
+    [Test]
+    public async Task Tab_visible_triggers_immediate_refresh() {
+        var reader = new ScriptedReader();
+        reader.Set(new ConsentLogReadResult([Rec()], true));
+        var vm = new ActivityViewModel(reader.Read, new ScriptedStat().Get, new FakeTicker());
+
+        await Assert.That(reader.ReadCalls).IsEqualTo(0);
+        vm.OnTabVisibleChanged(true);
+
+        await Assert.That(reader.ReadCalls).IsEqualTo(1);
+        await Assert.That(vm.Rows.Count).IsEqualTo(1);
+    }
+
+    // ---- 6: own-resolution refresh is an immediate read, eventual display ----
+
+    [Test]
+    public async Task Own_resolution_refresh_is_eventual() {
+        var reader = new ScriptedReader();
+        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], true));
+        var stat = new ScriptedStat { Key = "k0" };
+        var ticker = new FakeTicker();
+        var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
+
+        vm.OnTabVisibleChanged(true);
+        await Assert.That(vm.Rows.Count).IsEqualTo(1);
+
+        // The ack fires RequestRefresh, but the daemon's own append hasn't landed yet — a stale
+        // read is still what an immediate refresh can see.
+        vm.RequestRefresh();
+        await Assert.That(reader.ReadCalls).IsEqualTo(2);
+        await Assert.That(vm.Rows.Count).IsEqualTo(1);
+
+        // The append lands; the next stat-poll tick converges (spec: "no later than the next
+        // poll", not "immediately").
+        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
+        stat.Key = "k1";
+        ticker.Tick();
+        ticker.Tick();
+
+        await Assert.That(vm.Rows.Count).IsEqualTo(2);
+    }
+
+    // ---- 7: a throwing stat or read is swallowed; polling keeps going ----
+
+    [Test]
+    public async Task Poll_survives_a_throwing_stat_or_read() {
+        var reader = new ScriptedReader();
+        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], true));
+        var stat = new ScriptedStat { Key = "k0" };
+        var ticker = new FakeTicker();
+        var vm = new ActivityViewModel(reader.Read, stat.Get, ticker);
+
+        vm.OnTabVisibleChanged(true);
+        await Assert.That(vm.Rows.Count).IsEqualTo(1);
+
+        stat.ThrowOnce = true;
+        Exception? caught = null;
+        try { ticker.Tick(); ticker.Tick(); } catch (Exception ex) { caught = ex; }
+        await Assert.That(caught).IsNull();
+
+        // A later, healthy tick still drives the poll.
+        stat.Key = "k1";
+        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1"), Rec(agentId: "a2")], true));
+        ticker.Tick();
+        ticker.Tick();
+        await Assert.That(vm.Rows.Count).IsEqualTo(2);
+
+        reader.ThrowOnce = true;
+        try { vm.RequestRefresh(); } catch (Exception ex) { caught = ex; }
+        await Assert.That(caught).IsNull();
+        await Assert.That(vm.Rows.Count).IsEqualTo(2); // unaffected by the swallowed throw
+
+        reader.Set(new ConsentLogReadResult([Rec(agentId: "a1")], true));
+        vm.RequestRefresh();
+        await Assert.That(vm.Rows.Count).IsEqualTo(1); // recovers on the next call
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/AgentGridTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AgentGridTests.cs
@@ -331,7 +331,7 @@ public class AgentGridTests {
         var ids = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
             var t0 = new DateTime(2026, 8, 6, 10, 0, 0, DateTimeKind.Utc);
@@ -352,7 +352,7 @@ public class AgentGridTests {
         var (beforeCount, afterIds) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
             var t0 = DateTime.UtcNow;
@@ -383,7 +383,7 @@ public class AgentGridTests {
         var (sameInstance, oldDisposed, newDisposed, newStatus, agentsCountAfter) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
             var t0 = DateTime.UtcNow;
@@ -414,7 +414,7 @@ public class AgentGridTests {
         var row = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             var activation = vm.Activator.Activate();
 
             service.Agents.AddOrUpdate(Dto(id: "a"));
@@ -441,7 +441,7 @@ public class AgentGridTests {
         var (sameReference, idsAfterReactivation) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
 
             var activation1 = vm.Activator.Activate();
             service.Agents.AddOrUpdate(Dto(id: "a"));
@@ -476,7 +476,7 @@ public class AgentGridTests {
         var (whileConnected, whileUnreachable) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
@@ -500,7 +500,7 @@ public class AgentGridTests {
         var (idsWhileConnected, idsWhileDisconnected, actionsEnabledWhileDisconnected) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
@@ -532,7 +532,7 @@ public class AgentGridTests {
         var (beforeStop, whileInFlight) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service, ops);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));

--- a/test/Capacitor.App.Tests.Unit/AgentGridTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AgentGridTests.cs
@@ -25,15 +25,13 @@ sealed class MutableTimeProvider : TimeProvider {
 /// pipeline (sort order, EditDiff removal, GridEnabled) driven through
 /// AvaloniaSession.DispatchAsync with the REAL dispatcher scheduler.
 ///
-/// The full-pipeline tests deliberately do NOT use AvaloniaSession.WithImmediateRxScheduler:
-/// MainWindowViewModel's shared ticker is a real Observable.Interval(1s, RxSchedulers.
-/// MainThreadScheduler), and subscribing an Interval to ImmediateScheduler.Instance blocks/spins
-/// the calling thread forever (Rx's ImmediateScheduler executes a relative-time Schedule by
-/// SLEEPING for the real due time rather than truly firing "immediately" — verified against the
-/// installed System.Reactive 6.1.0 before writing this comment). Any test that populates
-/// service.Agents and exercises the resulting rows must run under the real (non-blocking)
-/// AvaloniaScheduler instead. (The toast overlay this VM used to drive via a Banner property now
-/// lives entirely in the View — see MainWindow.axaml.cs and AppNotifierTests.)
+/// The full-pipeline tests pass a FakeTicker (never a real Interval — UiTickerTests owns the real
+/// one, including the off-UI-thread hazard) but still run under AvaloniaSession.DispatchAsync's
+/// REAL dispatcher scheduler rather than WithImmediateRxScheduler: that's the scheduler
+/// production's WhenActivated pipeline actually runs under (ObserveOn(RxSchedulers.
+/// MainThreadScheduler) on status/snapshots), so this stays closest to the real thing. (The toast
+/// overlay this VM used to drive via a Banner property now lives entirely in the View — see
+/// MainWindow.axaml.cs and AppNotifierTests.)
 public class AgentGridTests {
     // ---- UptimeFormat (spec §8) ----
 
@@ -333,7 +331,7 @@ public class AgentGridTests {
         var ids = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             using var activation = vm.Activator.Activate();
 
             var t0 = new DateTime(2026, 8, 6, 10, 0, 0, DateTimeKind.Utc);
@@ -354,7 +352,7 @@ public class AgentGridTests {
         var (beforeCount, afterIds) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             using var activation = vm.Activator.Activate();
 
             var t0 = DateTime.UtcNow;
@@ -385,7 +383,7 @@ public class AgentGridTests {
         var (sameInstance, oldDisposed, newDisposed, newStatus, agentsCountAfter) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             using var activation = vm.Activator.Activate();
 
             var t0 = DateTime.UtcNow;
@@ -416,7 +414,7 @@ public class AgentGridTests {
         var row = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             var activation = vm.Activator.Activate();
 
             service.Agents.AddOrUpdate(Dto(id: "a"));
@@ -428,46 +426,6 @@ public class AgentGridTests {
         });
 
         await Assert.That(row.IsDisposed).IsTrue();
-    }
-
-    /// Regression coverage for the frozen-Uptime bug: rows are constructed inside DynamicData's
-    /// Transform, which runs on whatever thread mutates the SourceCache — in production
-    /// DaemonClientService's socket pump thread, never the UI thread. Subscribing the shared ticker
-    /// from there used to bind its DispatcherTimer to a per-thread dispatcher nothing pumps, so the
-    /// Interval produced no value at all and Uptime stayed at its seed forever. This drives the VM's
-    /// REAL ticker (real 1s Interval on the real AvaloniaScheduler) from a background thread — the
-    /// row-level uptime tests inject a Subject and are blind to the whole hazard.
-    [Test]
-    [NotInParallel("AvaloniaSession")]
-    public async Task Ticker_subscribed_off_the_ui_thread_still_ticks_on_the_dispatcher() {
-        var (ticks, everyTickOnUiThread) = await AvaloniaSession.DispatchAsync(async () => {
-            var service = new FakeDaemonClientService();
-            var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
-
-            var count = 0;
-            var onUiThread = true;
-            IDisposable? subscription = null;
-            await Task.Run(() => subscription = vm.Ticker.Subscribe(_ => {
-                onUiThread &= Dispatcher.UIThread.CheckAccess();
-                Interlocked.Increment(ref count);
-            }));
-
-            // Baseline excludes anything the ticker delivers SYNCHRONOUSLY on subscribe (a
-            // StartWith-style seed), so the wait below can only be satisfied by a genuine periodic
-            // tick — the exact thing the broken version never produced.
-            var seedOnSubscribe = Volatile.Read(ref count);
-
-            // DispatchAsync's async overload pumps a DispatcherFrame around this body, which is
-            // what lets the dispatcher's own timers run while we wait.
-            await WaitUntilAsync(() => Volatile.Read(ref count) > seedOnSubscribe, what: "a periodic ticker tick");
-            subscription!.Dispose();
-
-            return (Volatile.Read(ref count) - seedOnSubscribe, onUiThread);
-        });
-
-        await Assert.That(ticks).IsGreaterThan(0);
-        await Assert.That(everyTickOnUiThread).IsTrue();
     }
 
     /// Regression coverage for a P1 bug found in review: SortAndBind(out _agents, ...) replaced
@@ -483,7 +441,7 @@ public class AgentGridTests {
         var (sameReference, idsAfterReactivation) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
 
             var activation1 = vm.Activator.Activate();
             service.Agents.AddOrUpdate(Dto(id: "a"));
@@ -518,7 +476,7 @@ public class AgentGridTests {
         var (whileConnected, whileUnreachable) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             using var activation = vm.Activator.Activate();
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
@@ -542,7 +500,7 @@ public class AgentGridTests {
         var (idsWhileConnected, idsWhileDisconnected, actionsEnabledWhileDisconnected) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             using var activation = vm.Activator.Activate();
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
@@ -574,7 +532,7 @@ public class AgentGridTests {
         var (beforeStop, whileInFlight) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service, ops);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             using var activation = vm.Activator.Activate();
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));

--- a/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
@@ -259,10 +259,12 @@ public class AppStartupTests {
         public void Dispose() => onDispose();
     }
 
-    /// Ordering pin for spec §9's "quit never strands a menu-bar icon": the UI-thread-owned
-    /// disposables run, in the order given (tray icon first), BEFORE the service dispose /
-    /// markConfirmed / TryShutdown pass. Driven through a recording list rather than the real
-    /// App fields, which no test can populate (StartAsync's composition needs a real daemon).
+    /// Ordering pin for spec §9's "quit never strands a menu-bar icon" and spec §5's consent
+    /// shutdown order: the UI-thread-owned disposables run, in the order given (tray icon first,
+    /// then the prompt coordinator BEFORE the consent service it resolves against), all BEFORE the
+    /// service dispose / markConfirmed / TryShutdown pass. Driven through a recording list rather
+    /// than the real App fields, which no test can populate (StartAsync's composition needs a real
+    /// daemon).
     [Test]
     public async Task DisposeUiThenConfirmShutdownAsync_disposes_ui_services_before_the_confirm_pass() {
         var (desktop, fake) = FakeClassicDesktopLifetime.Create();
@@ -271,13 +273,16 @@ public class AppStartupTests {
         await AppUnderTest.DisposeUiThenConfirmShutdownAsync(
             [new RecordingDisposable(() => order.Add("tray")),
              new RecordingDisposable(() => order.Add("trayVm")),
+             new RecordingDisposable(() => order.Add("promptCoordinator")),
+             new RecordingDisposable(() => order.Add("consent")),
              new RecordingDisposable(() => order.Add("pause"))],
             disposeAsync: () => { order.Add("service"); return ValueTask.CompletedTask; },
             markConfirmed: () => order.Add("confirm"),
             desktop,
             exitCode: 0);
 
-        await Assert.That(order).IsEquivalentTo(["tray", "trayVm", "pause", "service", "confirm"], CollectionOrdering.Matching);
+        await Assert.That(order).IsEquivalentTo(
+            ["tray", "trayVm", "promptCoordinator", "consent", "pause", "service", "confirm"], CollectionOrdering.Matching);
         await Assert.That(fake.ShutdownCalls).IsEquivalentTo([0], CollectionOrdering.Matching);
     }
 
@@ -294,13 +299,15 @@ public class AppStartupTests {
         await AppUnderTest.DisposeUiThenConfirmShutdownAsync(
             [new RecordingDisposable(() => throw new InvalidOperationException("tray-boom")),
              null,
+             new RecordingDisposable(() => order.Add("promptCoordinator")),
+             new RecordingDisposable(() => order.Add("consent")),
              new RecordingDisposable(() => order.Add("pause"))],
             disposeAsync: null,
             markConfirmed: () => order.Add("confirm"),
             desktop,
             exitCode: 1);
 
-        await Assert.That(order).IsEquivalentTo(["pause", "confirm"], CollectionOrdering.Matching);
+        await Assert.That(order).IsEquivalentTo(["promptCoordinator", "consent", "pause", "confirm"], CollectionOrdering.Matching);
         await Assert.That(fake.ShutdownCalls).IsEquivalentTo([1], CollectionOrdering.Matching);
     }
 

--- a/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
@@ -520,7 +520,7 @@ public class AppStartupTests {
                 var (desktop, fake) = FakeClassicDesktopLifetime.Create();
                 var daemon = new FakeDaemonClientService();
                 var (actions, _) = NewActions(daemon);
-                var trayVm = new TrayViewModel(daemon, new FakePauseController(), actions);
+                var trayVm = new TrayViewModel(daemon, new FakePauseController(), actions, new FakeConsentService());
                 var app = Application.Current!;
                 var tray = new TrayIconManager(app, trayVm);
 

--- a/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
@@ -32,7 +32,7 @@ public class AppStartupTests {
         var isVisible = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, notifier) = NewActions(service);
-            var window = AppUnderTest.BuildAndShowMainWindow(service, actions, notifier, new FakeTicker(), CancellationToken.None);
+            var window = AppUnderTest.BuildAndShowMainWindow(service, actions, notifier, new FakeTicker(), CancellationToken.None, TestActivity.New());
             Dispatcher.UIThread.RunJobs(); // flush the deferred Loaded post (diagnostic parity with the smoke test)
 
             var visible = window.IsVisible;

--- a/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
@@ -32,7 +32,7 @@ public class AppStartupTests {
         var isVisible = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, notifier) = NewActions(service);
-            var window = AppUnderTest.BuildAndShowMainWindow(service, actions, notifier, CancellationToken.None);
+            var window = AppUnderTest.BuildAndShowMainWindow(service, actions, notifier, new FakeTicker(), CancellationToken.None);
             Dispatcher.UIThread.RunJobs(); // flush the deferred Loaded post (diagnostic parity with the smoke test)
 
             var visible = window.IsVisible;

--- a/test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj
+++ b/test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj
@@ -12,5 +12,6 @@
     <ItemGroup>
         <PackageReference Include="TUnit" />
         <PackageReference Include="Avalonia.Headless" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     </ItemGroup>
 </Project>

--- a/test/Capacitor.App.Tests.Unit/ConsentPromptCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentPromptCoordinatorTests.cs
@@ -241,4 +241,30 @@ public class ConsentPromptCoordinatorTests {
         await Assert.That(windows).IsEqualTo(1);
         await Assert.That(raisesAfterDispose).IsEqualTo(1);
     }
+
+    /// The gap Dispose_closes_the_window doesn't cover: that test's post-dispose signal travels
+    /// through the (already-torn-down) EntryAdded subscription, never reaching ShowPromptWindow.
+    /// The tray's "Review pending launches…" item (spec §8) calls ShowPromptWindow directly — a
+    /// click racing shutdown must not rebuild a window during teardown.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task ShowPromptWindow_after_dispose_is_a_no_op() {
+        var (windowsAfterDispose, raisesAfterDispose) = await AvaloniaSession.DispatchAsync(() => {
+            using var f = new Fixture();
+            f.Consent.Add(Entry("a1", "p1"));
+            f.Coordinator.ShowPromptWindow();
+            Dispatcher.UIThread.RunJobs();
+
+            f.Coordinator.Dispose();
+            Dispatcher.UIThread.RunJobs();
+
+            f.Coordinator.ShowPromptWindow();
+            Dispatcher.UIThread.RunJobs();
+
+            return (f.Windows.Count, f.Coordinator.Raises);
+        });
+
+        await Assert.That(windowsAfterDispose).IsEqualTo(1);
+        await Assert.That(raisesAfterDispose).IsEqualTo(1);
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/ConsentPromptCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentPromptCoordinatorTests.cs
@@ -140,6 +140,43 @@ public class ConsentPromptCoordinatorTests {
         await Assert.That(reopenedVisible).IsTrue();
     }
 
+    /// Regression coverage for an Important defect found in review: on the LAST pending request —
+    /// the common single-prompt case — the rule-not-saved warning was notified and then thrown
+    /// away, because the advance emptied the queue and closed the window on the same beat, before
+    /// the posted toast ever rendered. Exactly the disclosure spec §6's "never a silent success"
+    /// exists for. Asserted on what the user can observe: the window still up, with the warning on
+    /// screen.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Rule_warning_on_the_last_pending_request_is_actually_shown() {
+        var (visibleAfterAck, rendered, visibleAfterHold, builds) = await AvaloniaSession.DispatchAsync(async () => {
+            using var f = new Fixture();
+            f.Consent.Add(Entry("a1", "p1")); // the ONLY pending request
+            f.Coordinator.ShowPromptWindow();
+            Dispatcher.UIThread.RunJobs();
+            var window = f.Last;
+            var vm = (ConsentPromptViewModel)window.DataContext!;
+
+            f.Consent.Queue(ConsentResolveKind.AppliedRuleRejected, ConsentRuleOutcome.Rejected, "store full");
+            await vm.AllowRememberCommand.Execute().ToTask();
+            Dispatcher.UIThread.RunJobs();
+
+            var visible = window.IsVisible;
+            var texts = string.Join('\n', window.GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text ?? ""));
+
+            f.Ticker.Tick();
+            f.Ticker.Tick();
+            Dispatcher.UIThread.RunJobs();
+
+            return (visible, texts, window.IsVisible, f.Windows.Count);
+        });
+
+        await Assert.That(visibleAfterAck).IsTrue();
+        await Assert.That(rendered).Contains("Decision applied — rule not saved: store full");
+        await Assert.That(visibleAfterHold).IsFalse(); // disclosed for the hold, then closed
+        await Assert.That(builds).IsEqualTo(1);
+    }
+
     /// Rendering acceptance for the §6 copy: the bound text actually reaches the screen (a
     /// mistyped binding path renders empty), including the toast overlay this window owns because
     /// the main window may be closed.

--- a/test/Capacitor.App.Tests.Unit/ConsentPromptCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentPromptCoordinatorTests.cs
@@ -1,0 +1,207 @@
+using System.Reactive.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.App.Views;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.ConsentEntries;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The window-lifetime half of spec §6: at most one prompt window, raised only when it is not
+/// already visible, and always from the UI thread — the entry-added signal originates on a socket
+/// continuation. Real headless ConsentPromptWindows over a real ConsentPromptViewModel, so this
+/// also exercises the production composition App's factory builds.
+public class ConsentPromptCoordinatorTests {
+    sealed class Fixture : IDisposable {
+        public readonly FakeConsentService Consent = new();
+        public readonly AppNotifier Notifier = new();
+        public readonly FakeTicker Ticker = new();
+        public readonly List<ConsentPromptWindow> Windows = [];
+        public readonly ConsentPromptCoordinator Coordinator;
+
+        public Fixture() {
+            Coordinator = new ConsentPromptCoordinator(Consent, () => {
+                var window = new ConsentPromptWindow {
+                    DataContext = new ConsentPromptViewModel(
+                        Consent, Notifier, Ticker, new FakeTimeProvider(T0), CancellationToken.None),
+                    Notifier = Notifier,
+                };
+                Windows.Add(window);
+                return window;
+            });
+        }
+
+        public ConsentPromptWindow Last => Windows[^1];
+
+        public void Dispose() {
+            Coordinator.Dispose();
+            Dispatcher.UIThread.RunJobs();
+            Consent.Dispose();
+        }
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Raise_on_entry_added_while_window_not_visible_marshals_to_ui_thread() {
+        var (builds, visible, raises, buildsAfterSecond, raisesAfterSecond, stillVisible) =
+            await AvaloniaSession.DispatchAsync(async () => {
+                using var f = new Fixture();
+
+                // The real signal arrives on a socket continuation, never the UI thread.
+                await Task.Run(() => f.Consent.Add(Entry("a1", "p1")));
+                Dispatcher.UIThread.RunJobs();
+
+                var first = (f.Windows.Count, f.Last.IsVisible, f.Coordinator.Raises);
+
+                await Task.Run(() => f.Consent.Add(Entry("a2", "p2", requestedAt: T0.AddSeconds(5))));
+                Dispatcher.UIThread.RunJobs();
+
+                return (first.Count, first.IsVisible, first.Raises,
+                        f.Windows.Count, f.Coordinator.Raises, f.Last.IsVisible);
+            });
+
+        await Assert.That(builds).IsEqualTo(1);
+        await Assert.That(visible).IsTrue();
+        await Assert.That(raises).IsEqualTo(1);
+        // Already visible: no second window and no re-activation — never steal focus mid-decision.
+        await Assert.That(buildsAfterSecond).IsEqualTo(1);
+        await Assert.That(raisesAfterSecond).IsEqualTo(1);
+        await Assert.That(stillVisible).IsTrue();
+    }
+
+    /// Closing without deciding is an explicit defer: the queue is untouched and the tray keeps
+    /// its attention state. A later ShowPromptWindow (the tray menu item) builds a fresh window —
+    /// Avalonia refuses to Show() a closed one — over the same, still-pending queue.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Close_is_defer_reopen_via_show() {
+        var (pendingAfterClose, resolves, builds, differentInstance, visible, reopenedRequestId) =
+            await AvaloniaSession.DispatchAsync(() => {
+                using var f = new Fixture();
+                f.Consent.Add(Entry("a1", "p1"));
+                f.Coordinator.ShowPromptWindow();
+                Dispatcher.UIThread.RunJobs();
+                var deferred = f.Last;
+
+                deferred.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                var cacheCount = f.Consent.Cache.Count;
+                var resolveCount = f.Consent.Resolved.Count;
+
+                f.Coordinator.ShowPromptWindow();
+                Dispatcher.UIThread.RunJobs();
+
+                var reopened = f.Last;
+                var vm = (ConsentPromptViewModel)reopened.DataContext!;
+                return (cacheCount, resolveCount, f.Windows.Count, !ReferenceEquals(deferred, reopened),
+                        reopened.IsVisible, vm.Current?.RequestId);
+            });
+
+        await Assert.That(pendingAfterClose).IsEqualTo(1); // a defer decides nothing
+        await Assert.That(resolves).IsEqualTo(0);
+        await Assert.That(builds).IsEqualTo(2);
+        await Assert.That(differentInstance).IsTrue();
+        await Assert.That(visible).IsTrue();
+        await Assert.That(reopenedRequestId).IsEqualTo("a1"); // the same queue, still pending
+    }
+
+    /// The window's own close: an advance that finds nothing left (spec §6). Proves the
+    /// ViewModel→window wiring, and that the coordinator releases the instance so the next
+    /// arrival raises a fresh one rather than trying to Show() a closed window.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Window_closes_itself_when_the_queue_empties() {
+        var (visibleAfterDecision, builds, reopenedVisible) = await AvaloniaSession.DispatchAsync(async () => {
+            using var f = new Fixture();
+            f.Consent.Add(Entry("a1", "p1"));
+            f.Coordinator.ShowPromptWindow();
+            Dispatcher.UIThread.RunJobs();
+            var window = f.Last;
+            var vm = (ConsentPromptViewModel)window.DataContext!;
+
+            f.Consent.Queue(ConsentResolveKind.Applied, ConsentRuleOutcome.NotRequested);
+            await vm.AllowOnceCommand.Execute().ToTask();
+            Dispatcher.UIThread.RunJobs();
+
+            var closed = window.IsVisible;
+
+            await Task.Run(() => f.Consent.Add(Entry("a2", "p2", requestedAt: T0.AddSeconds(5))));
+            Dispatcher.UIThread.RunJobs();
+
+            return (closed, f.Windows.Count, f.Last.IsVisible);
+        });
+
+        await Assert.That(visibleAfterDecision).IsFalse();
+        await Assert.That(builds).IsEqualTo(2);
+        await Assert.That(reopenedVisible).IsTrue();
+    }
+
+    /// Rendering acceptance for the §6 copy: the bound text actually reaches the screen (a
+    /// mistyped binding path renders empty), including the toast overlay this window owns because
+    /// the main window may be closed.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Window_renders_the_request_the_countdown_and_the_three_buttons() {
+        var (texts, buttons, tooltip) = await AvaloniaSession.DispatchAsync(() => {
+            using var f = new Fixture();
+            f.Consent.Add(Entry("a1", "p1", kind: "review-flow", repoPath: "/repos/kcap-cli"));
+            f.Consent.Add(Entry("a2", "p2", requestedAt: T0.AddSeconds(5)));
+            f.Coordinator.ShowPromptWindow();
+            Dispatcher.UIThread.RunJobs();
+
+            f.Notifier.Notify("Daemon unreachable — the request is still pending");
+            Dispatcher.UIThread.RunJobs();
+
+            var rendered = string.Join('\n', f.Last.GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text ?? ""));
+            var labels = f.Last.GetVisualDescendants().OfType<Button>().Select(b => b.Content as string).ToArray();
+            var remember = f.Last.GetVisualDescendants().OfType<Button>().First(b => Equals(b.Content, "Allow & remember"));
+            return (rendered, labels, ToolTip.GetTip(remember) as string);
+        });
+
+        await Assert.That(texts).Contains("Alice");
+        await Assert.That(texts).Contains("Review flow");
+        await Assert.That(texts).Contains("claude");
+        await Assert.That(texts).Contains("kcap-cli");
+        await Assert.That(texts).Contains("Expires in 30s");
+        await Assert.That(texts).Contains("1 of 2");
+        await Assert.That(texts).Contains("Daemon unreachable — the request is still pending"); // the toast overlay
+        await Assert.That(buttons).Contains("Allow once");
+        await Assert.That(buttons).Contains("Allow & remember");
+        await Assert.That(buttons).Contains("Deny");
+        await Assert.That(tooltip).IsEqualTo(
+            "Saves a rule allowing future launches from this requester. Existing deny rules — including Pause — take precedence until removed.");
+    }
+
+    /// Shutdown (spec §5): the coordinator is disposed BEFORE ConsentService, so the window — and
+    /// any resolve it has in flight — is gone before the service it would call into.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Dispose_closes_the_window() {
+        var (visibleBefore, visibleAfter, windows, raisesAfterDispose) = await AvaloniaSession.DispatchAsync(() => {
+            using var f = new Fixture();
+            f.Consent.Add(Entry("a1", "p1"));
+            f.Coordinator.ShowPromptWindow();
+            Dispatcher.UIThread.RunJobs();
+
+            var before = f.Last.IsVisible;
+            f.Coordinator.Dispose();
+            Dispatcher.UIThread.RunJobs();
+            var after = f.Last.IsVisible;
+
+            // A signal arriving after disposal must not resurrect a window.
+            f.Consent.Add(Entry("a2", "p2", requestedAt: T0.AddSeconds(5)));
+            Dispatcher.UIThread.RunJobs();
+
+            return (before, after, f.Windows.Count, f.Coordinator.Raises);
+        });
+
+        await Assert.That(visibleBefore).IsTrue();
+        await Assert.That(visibleAfter).IsFalse();
+        await Assert.That(windows).IsEqualTo(1);
+        await Assert.That(raisesAfterDispose).IsEqualTo(1);
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ConsentPromptCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentPromptCoordinatorTests.cs
@@ -109,6 +109,75 @@ public class ConsentPromptCoordinatorTests {
         await Assert.That(reopenedRequestId).IsEqualTo("a1"); // the same queue, still pending
     }
 
+    /// A defer must survive a reconnect blip: the stream drops, the resubscribe clears and the
+    /// daemon replays the SAME requests — nothing the user has not already dismissed, so no
+    /// window comes back uninvited. A genuinely new request still raises one.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Deferred_window_is_not_reraised_by_a_resubscribe_replay() {
+        var (buildsAfterReplay, raisesAfterReplay, buildsAfterNew, visibleAfterNew, pinnedAfterNew) =
+            await AvaloniaSession.DispatchAsync(async () => {
+                using var f = new Fixture();
+                f.Consent.Add(Entry("a1", "p1"));
+                f.Coordinator.ShowPromptWindow();
+                Dispatcher.UIThread.RunJobs();
+                f.Last.Close(); // the explicit defer
+                Dispatcher.UIThread.RunJobs();
+
+                await Task.Run(() => {
+                    f.Consent.Clear();
+                    f.Consent.Add(Entry("a1", "p1"));
+                });
+                Dispatcher.UIThread.RunJobs();
+                var afterReplay = (f.Windows.Count, f.Coordinator.Raises);
+
+                await Task.Run(() => f.Consent.Add(Entry("a2", "p2", requestedAt: T0.AddSeconds(5))));
+                Dispatcher.UIThread.RunJobs();
+
+                var vm = (ConsentPromptViewModel)f.Last.DataContext!;
+                return (afterReplay.Count, afterReplay.Raises, f.Windows.Count, f.Last.IsVisible, vm.Current?.RequestId);
+            });
+
+        await Assert.That(buildsAfterReplay).IsEqualTo(1); // the replay raised nothing
+        await Assert.That(raisesAfterReplay).IsEqualTo(1);
+        await Assert.That(buildsAfterNew).IsEqualTo(2);    // a new request still does
+        await Assert.That(visibleAfterNew).IsTrue();
+        await Assert.That(pinnedAfterNew).IsEqualTo("a1"); // over the whole still-pending queue
+    }
+
+    /// The window-level half of the same defect: an OPEN window used to close on the clear's
+    /// empty changeset and be rebuilt by the replay — a fresh ViewModel, the pin reset, focus
+    /// stolen mid-decision. The same window survives, still pinned on the same request.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Open_window_survives_a_resubscribe_clear_and_replay() {
+        var (builds, raises, visible, sameWindow, pinned) = await AvaloniaSession.DispatchAsync(async () => {
+            using var f = new Fixture();
+            f.Consent.Add(Entry("a1", "p1"));
+            f.Coordinator.ShowPromptWindow();
+            Dispatcher.UIThread.RunJobs();
+            var open = f.Last;
+
+            await Task.Run(() => f.Consent.Clear());
+            Dispatcher.UIThread.RunJobs();
+
+            await Task.Run(() => f.Consent.Add(Entry("a1", "p1")));
+            Dispatcher.UIThread.RunJobs();
+            f.Ticker.Tick();
+            f.Ticker.Tick();
+            Dispatcher.UIThread.RunJobs();
+
+            var vm = (ConsentPromptViewModel)f.Last.DataContext!;
+            return (f.Windows.Count, f.Coordinator.Raises, open.IsVisible, ReferenceEquals(open, f.Last), vm.Current?.RequestId);
+        });
+
+        await Assert.That(builds).IsEqualTo(1);
+        await Assert.That(raises).IsEqualTo(1);
+        await Assert.That(visible).IsTrue();
+        await Assert.That(sameWindow).IsTrue();
+        await Assert.That(pinned).IsEqualTo("a1");
+    }
+
     /// The window's own close: an advance that finds nothing left (spec §6). Proves the
     /// ViewModel→window wiring, and that the coordinator releases the instance so the next
     /// arrival raises a fresh one rather than trying to Show() a closed window.

--- a/test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs
@@ -440,25 +440,90 @@ public class ConsentPromptViewModelTests {
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Advance_on_pinned_removal_in_expired_state() {
-        var (phase, afterFirstPrune, currentAfterSecond, closed) = await AvaloniaSession.DispatchAsync(() => {
-            var first = Entry("a1", "p1");
-            var second = Entry("a2", "p2", requestedAt: T0.AddSeconds(5));
-            using var h = new PromptHarness(first, second);
-            h.Activate();
-            h.Tick(TimeSpan.FromSeconds(40));
+        var (phase, afterFirstPrune, currentAfterSecond, closedOnPrune, closedAfterBeat) =
+            await AvaloniaSession.DispatchAsync(() => {
+                var first = Entry("a1", "p1");
+                var second = Entry("a2", "p2", requestedAt: T0.AddSeconds(5));
+                using var h = new PromptHarness(first, second);
+                h.Activate();
+                h.Tick(TimeSpan.FromSeconds(40));
 
-            var expiredPhase = h.Vm.Phase;
-            h.Prune(first);
-            var advanced = h.Vm.Current!.RequestId;
+                var expiredPhase = h.Vm.Phase;
+                h.Prune(first);
+                var advanced = h.Vm.Current!.RequestId;
 
-            h.Prune(second);
-            return (expiredPhase, advanced, h.Vm.Current, h.CloseRequests);
-        });
+                h.Prune(second);
+                var onPrune = (h.Vm.Current, h.CloseRequests);
+
+                h.Tick();
+                return (expiredPhase, advanced, onPrune.Current, onPrune.CloseRequests, h.CloseRequests);
+            });
 
         await Assert.That(phase).IsEqualTo(ConsentPromptPhase.Expired);
         await Assert.That(afterFirstPrune).IsEqualTo("a2");
         await Assert.That(currentAfterSecond).IsNull();
-        await Assert.That(closed).IsEqualTo(1);
+        // The pin releases at once (nothing dishonest stays on screen) but the CLOSE waits one
+        // beat: a cache-caused emptiness may be a resubscribe's clear with its replay in flight.
+        await Assert.That(closedOnPrune).IsEqualTo(0);
+        await Assert.That(closedAfterBeat).IsEqualTo(1); // still empty a beat later: really empty
+    }
+
+    // ---- 12b: clear+replay must not flicker the window shut ----
+
+    /// A resubscribe clears the cache and the daemon replays into it as two separate changesets,
+    /// so an OPEN window saw the intermediate empty state, closed itself, and was then re-raised
+    /// as a fresh window — pin reset, focus stolen, mid-decision. The close waits one beat, and
+    /// a replay landing inside it cancels the close outright.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Clear_and_replay_within_a_beat_never_closes_the_window() {
+        var (currentWhileEmpty, closedWhileEmpty, currentAfterReplay, closedAfterBeats, position) =
+            await AvaloniaSession.DispatchAsync(() => {
+                var first = Entry("a1", "p1");
+                var second = Entry("a2", "p2", requestedAt: T0.AddSeconds(5));
+                using var h = new PromptHarness(first, second);
+                h.Activate();
+
+                h.Clear();
+                var empty = (h.Vm.Current, h.CloseRequests);
+
+                h.Add(Entry("a1", "p1"));                                  // the replay: same
+                h.Add(Entry("a2", "p2", requestedAt: T0.AddSeconds(5)));   // identities, fresh objects
+                h.Tick();
+                h.Tick();
+
+                return (empty.Current, empty.CloseRequests, h.Vm.Current, h.CloseRequests, h.Vm.PositionText);
+            });
+
+        await Assert.That(currentWhileEmpty).IsNull();
+        await Assert.That(closedWhileEmpty).IsEqualTo(0);
+        await Assert.That(currentAfterReplay!.RequestId).IsEqualTo("a1"); // re-pinned on the head
+        await Assert.That(closedAfterBeats).IsEqualTo(0);                 // and never closed
+        await Assert.That(position).IsEqualTo("1 of 2");
+    }
+
+    /// The other half of the same rule: an emptiness that is REAL still closes the window — one
+    /// beat later, not never.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Clear_with_no_replay_closes_the_window_on_the_next_beat() {
+        var (closedOnClear, closedAfterBeat, closedAfterTwoBeats) = await AvaloniaSession.DispatchAsync(() => {
+            using var h = new PromptHarness(Entry("a1", "p1"));
+            h.Activate();
+
+            h.Clear();
+            var onClear = h.CloseRequests;
+
+            h.Tick();
+            var afterBeat = h.CloseRequests;
+
+            h.Tick(); // the close is one-shot: a still-empty queue never re-fires it
+            return (onClear, afterBeat, h.CloseRequests);
+        });
+
+        await Assert.That(closedOnClear).IsEqualTo(0);
+        await Assert.That(closedAfterBeat).IsEqualTo(1);
+        await Assert.That(closedAfterTwoBeats).IsEqualTo(1);
     }
 
     // ---- 13: no double-submit ----
@@ -552,6 +617,14 @@ sealed class PromptHarness : IDisposable {
 
     public void Prune(PendingConsent entry) {
         Consent.Prune(entry);
+        Pump();
+    }
+
+    /// The §5 Subscribed boundary: the cache is emptied and the daemon's replay re-adds. Pumped
+    /// separately from the replay, because that IS the production shape — the clear and each
+    /// replayed entry are independently posted changesets.
+    public void Clear() {
+        Consent.Clear();
         Pump();
     }
 

--- a/test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs
@@ -349,6 +349,36 @@ public class ConsentPromptViewModelTests {
         await Assert.That(afterEviction).IsEqualTo("a2");
     }
 
+    /// The ViewModel half of the same defect: a warning that has nowhere to advance to must hold
+    /// the pin (and the window) rather than close on the beat it was raised. The multi-entry test
+    /// above pins the other half — a queue with somewhere to go still advances immediately.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Rule_warning_holds_the_window_when_the_queue_would_empty() {
+        var (phaseText, pinned, buttonsVisible, closedDuringHold, afterHold, closedAfterHold) =
+            await AvaloniaSession.DispatchAsync(async () => {
+                using var h = new PromptHarness(Entry("a1", "p1"));
+                h.Activate();
+
+                h.Consent.Queue(ConsentResolveKind.AppliedRuleRejected, ConsentRuleOutcome.Rejected, "store full");
+                await h.Vm.AllowRememberCommand.Execute().ToTask();
+                PromptHarness.Pump();
+
+                var held = (h.Vm.PhaseText, h.Vm.Current is not null, h.Vm.ButtonsVisible, h.CloseRequests);
+
+                h.Tick();
+                h.Tick();
+                return (held.PhaseText, held.Item2, held.ButtonsVisible, held.CloseRequests, h.Vm.Current, h.CloseRequests);
+            });
+
+        await Assert.That(phaseText).IsEqualTo("Decision applied — rule not saved: store full");
+        await Assert.That(pinned).IsTrue();
+        await Assert.That(buttonsVisible).IsFalse(); // the request is settled: nothing left to click
+        await Assert.That(closedDuringHold).IsEqualTo(0);
+        await Assert.That(afterHold).IsNull();
+        await Assert.That(closedAfterHold).IsEqualTo(1);
+    }
+
     // ---- 10: transport failure ----
 
     /// The outcome's rule value on this path describes a rule that was never sent, so it must NOT

--- a/test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs
@@ -1,0 +1,542 @@
+using System.Reactive.Linq;
+using ReactiveUnit = System.Reactive.Unit;
+using System.Reactive.Threading.Tasks;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Microsoft.Extensions.Time.Testing;
+using ReactiveUI;
+using TUnit.Assertions.Enums;
+using static Capacitor.App.Tests.Unit.ConsentEntries;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The full prompt matrix (spec §6/§10). Everything runs on the headless session's REAL dispatcher
+/// scheduler — that is what production's ObserveOn(RxSchedulers.MainThreadScheduler) actually runs
+/// under, and the resolve continuation's ordering against the cache eviction only exists there.
+/// Time is a FakeTimeProvider and the heartbeat a FakeTicker: no test sleeps, and the 2-second
+/// terminal hold is counted in ticks.
+public class ConsentPromptViewModelTests {
+    // ---- 1: queue order + position indicator ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Current_is_oldest_by_requested_at_then_id_and_position_text_reads_1_of_n() {
+        var (currentId, positionText, positionVisible, soloVisible) = await AvaloniaSession.DispatchAsync(() => {
+            using var h = new PromptHarness(
+                Entry("c", "pc", requestedAt: T0.AddSeconds(10)),
+                Entry("b", "pb"),
+                Entry("a", "pa")); // ties with "b" on RequestedAt: ordinal tiebreak wins
+            h.Activate();
+
+            using var solo = new PromptHarness(Entry("only", "ponly"));
+            solo.Activate();
+
+            return (h.Vm.Current!.RequestId, h.Vm.PositionText, h.Vm.PositionVisible, solo.Vm.PositionVisible);
+        });
+
+        await Assert.That(currentId).IsEqualTo("a");
+        await Assert.That(positionText).IsEqualTo("1 of 3");
+        await Assert.That(positionVisible).IsTrue();
+        await Assert.That(soloVisible).IsFalse(); // "1 of 1" is noise
+    }
+
+    // ---- 2: the pin ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Pin_survives_cache_changes_while_resolving_or_in_terminal_hold() {
+        var (whileResolving, whileHolding, afterHold) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"));
+            h.Activate();
+
+            var gate = h.Consent.Arm();
+            var exec = h.Vm.DenyCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            h.Add(Entry("older", "p-older", requestedAt: T0.AddSeconds(-60))); // sorts ahead of the pin
+            var resolving = h.Vm.Current!.RequestId;
+
+            gate.SetResult(new ConsentResolveOutcome(ConsentResolveKind.AlreadyDecided, ConsentRuleOutcome.NotRequested, null));
+            await exec;
+            PromptHarness.Pump();
+
+            h.Add(Entry("older2", "p-older2", requestedAt: T0.AddSeconds(-120)));
+            var holding = h.Vm.Current!.RequestId;
+
+            h.Tick();
+            h.Tick();
+            return (resolving, holding, h.Vm.Current!.RequestId);
+        });
+
+        await Assert.That(whileResolving).IsEqualTo("a1");
+        await Assert.That(whileHolding).IsEqualTo("a1");
+        await Assert.That(afterHold).IsEqualTo("older2"); // the advance releases the pin to the head
+    }
+
+    // ---- 3: content projection ----
+
+    [Test]
+    [Arguments("agent", "Agent")]
+    [Arguments("review", "Review")]
+    [Arguments("review-flow", "Review flow")]
+    [Arguments("something-new", "something-new")] // unrecognized renders verbatim, never a wrong label
+    public async Task Kind_labels(string kind, string expected) {
+        await Assert.That(ConsentPromptViewModel.KindLabelOf(kind)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Requester_falls_back_display_then_id_then_unknown() {
+        var (display, id, unknown, kindLabel, repoLeaf, repoFull, vendor) = await AvaloniaSession.DispatchAsync(() => {
+            static string Requester(string? requesterDisplay, string? requester) {
+                using var h = new PromptHarness(Entry(requesterDisplay: requesterDisplay, requester: requester));
+                h.Activate();
+                return h.Vm.RequesterText;
+            }
+
+            using var main = new PromptHarness(Entry(
+                kind: "review-flow", repoPath: "/repos/kcap-cli/.claude/worktrees/tender-honking-pebble", vendor: "codex"));
+            main.Activate();
+
+            return (Requester("Alice", "github:1"), Requester(null, "github:1"), Requester(null, null),
+                    main.Vm.KindLabel, main.Vm.RepoLeaf, main.Vm.RepoFull, main.Vm.VendorText);
+        });
+
+        await Assert.That(display).IsEqualTo("Alice");
+        await Assert.That(id).IsEqualTo("github:1");
+        await Assert.That(unknown).IsEqualTo("unknown");
+        await Assert.That(kindLabel).IsEqualTo("Review flow");
+        await Assert.That(repoLeaf).IsEqualTo("kcap-cli"); // the worktree leaf is noise (RepoLabel)
+        await Assert.That(repoFull).IsEqualTo("/repos/kcap-cli/.claude/worktrees/tender-honking-pebble");
+        await Assert.That(vendor).IsEqualTo("codex");
+    }
+
+    // ---- 4: countdown, and expiry as a non-verdict ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Countdown_ticks_and_expiry_is_not_a_verdict() {
+        var (initial, ticked, expired, enabledWhileExpired, phase) = await AvaloniaSession.DispatchAsync(() => {
+            using var h = new PromptHarness(Entry("a1", "p1"));
+            h.Activate();
+
+            var start = h.Vm.CountdownText;
+            h.Tick(TimeSpan.FromSeconds(10));
+            var mid = h.Vm.CountdownText;
+            h.Tick(TimeSpan.FromSeconds(25)); // past DeadlineHint (T0 + 30s)
+
+            return (start, mid, h.Vm.CountdownText, h.Vm.ButtonsEnabled, h.Vm.Phase);
+        });
+
+        await Assert.That(initial).IsEqualTo("Expires in 30s");
+        await Assert.That(ticked).IsEqualTo("Expires in 20s");
+        await Assert.That(expired).IsEqualTo("Response time elapsed — unanswered requests are denied by the daemon");
+        await Assert.That(enabledWhileExpired).IsTrue(); // expiry is never a verdict (spec §6)
+        await Assert.That(phase).IsEqualTo(ConsentPromptPhase.Expired);
+    }
+
+    /// The wall-clock-step case: the hint fired early, the request was still live daemon-side.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Click_after_hint_zero_applies_when_the_daemon_still_had_the_request() {
+        var (resolved, currentAfter, phaseText) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"), Entry("a2", "p2", requestedAt: T0.AddSeconds(5)));
+            h.Activate();
+            h.Tick(TimeSpan.FromSeconds(40));
+
+            h.Consent.Queue(ConsentResolveKind.Applied, ConsentRuleOutcome.NotRequested);
+            await h.Vm.AllowOnceCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            return (h.Consent.Resolved.ToArray(), h.Vm.Current!.RequestId, h.Vm.PhaseText);
+        });
+
+        await Assert.That(resolved).IsEquivalentTo([("p1", true, false)], CollectionOrdering.Matching);
+        await Assert.That(currentAfter).IsEqualTo("a2"); // applied and advanced, not "expired"
+        await Assert.That(phaseText).IsNull();
+    }
+
+    /// The other half: the daemon really did time out, so the honest already-decided path runs.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Click_after_hint_zero_runs_already_decided_when_the_daemon_timed_out() {
+        var (phaseText, buttonsVisible) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"));
+            h.Activate();
+            h.Tick(TimeSpan.FromSeconds(40));
+
+            h.Consent.Queue(ConsentResolveKind.AlreadyDecided, ConsentRuleOutcome.NotRequested);
+            await h.Vm.AllowOnceCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            return (h.Vm.PhaseText, h.Vm.ButtonsVisible);
+        });
+
+        await Assert.That(phaseText).IsEqualTo("Already decided");
+        await Assert.That(buttonsVisible).IsFalse();
+    }
+
+    // ---- 5: the three buttons ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Buttons_send_the_pinned_targets_prompt_id() {
+        var resolved = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(
+                Entry("a1", "p1"),
+                Entry("a2", "p2", requestedAt: T0.AddSeconds(5)),
+                Entry("a3", "p3", requestedAt: T0.AddSeconds(10)));
+            h.Activate();
+
+            h.Consent.Queue(ConsentResolveKind.Applied, ConsentRuleOutcome.NotRequested);
+            await h.Vm.AllowOnceCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            h.Consent.Queue(ConsentResolveKind.Applied, ConsentRuleOutcome.Saved);
+            await h.Vm.AllowRememberCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            h.Consent.Queue(ConsentResolveKind.Applied, ConsentRuleOutcome.NotRequested);
+            await h.Vm.DenyCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            return h.Consent.Resolved.ToArray();
+        });
+
+        await Assert.That(resolved).IsEquivalentTo(
+            [("p1", true, false), ("p2", true, true), ("p3", false, false)], CollectionOrdering.Matching);
+    }
+
+    // ---- 6: the save-rule button predicate ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Allow_remember_hidden_for_null_and_empty_requester() {
+        var (nullRequester, emptyRequester, named) = await AvaloniaSession.DispatchAsync(() => {
+            static bool Visible(string? requester) {
+                using var h = new PromptHarness(Entry(requester: requester, requesterDisplay: "Alice"));
+                h.Activate();
+                return h.Vm.AllowRememberVisible;
+            }
+
+            return (Visible(null), Visible(""), Visible("github:1"));
+        });
+
+        // A display name is not an identity: only Requester can key a rule (spec §6).
+        await Assert.That(nullRequester).IsFalse();
+        await Assert.That(emptyRequester).IsFalse();
+        await Assert.That(named).IsTrue();
+    }
+
+    // ---- 7/8: already decided ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Already_decided_holds_2_ticks_then_advances() {
+        var (phaseText, buttonsVisible, afterOneTick, afterTwoTicks) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"), Entry("a2", "p2", requestedAt: T0.AddSeconds(5)));
+            h.Activate();
+
+            h.Consent.Queue(ConsentResolveKind.AlreadyDecided, ConsentRuleOutcome.NotRequested);
+            await h.Vm.DenyCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            var text = h.Vm.PhaseText;
+            var visible = h.Vm.ButtonsVisible;
+
+            h.Tick();
+            var one = h.Vm.Current!.RequestId;
+            h.Tick();
+            return (text, visible, one, h.Vm.Current!.RequestId);
+        });
+
+        await Assert.That(phaseText).IsEqualTo("Already decided");
+        await Assert.That(buttonsVisible).IsFalse();
+        await Assert.That(afterOneTick).IsEqualTo("a1"); // still held
+        await Assert.That(afterTwoTicks).IsEqualTo("a2");
+    }
+
+    [Test]
+    [Arguments(ConsentRuleOutcome.Saved, "Already decided — your allow rule for Alice was still saved.")]
+    [Arguments(ConsentRuleOutcome.Rejected, "Already decided — no rule was saved.")]
+    [Arguments(ConsentRuleOutcome.Unknown, "Already decided — this daemon version doesn't report whether your allow rule was saved.")]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Already_decided_discloses_rule_outcome_after_allow_remember(ConsentRuleOutcome rule, string expected) {
+        var (phaseText, notified) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"));
+            h.Activate();
+
+            h.Consent.Queue(ConsentResolveKind.AlreadyDecided, rule);
+            await h.Vm.AllowRememberCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            return (h.Vm.PhaseText, h.Notifier.Notified.ToArray());
+        });
+
+        await Assert.That(phaseText).IsEqualTo(expected);
+        await Assert.That(notified).IsEmpty(); // the disclosure is the window's, not a toast
+    }
+
+    // ---- 9: applied + rule warnings ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Applied_advances_immediately_without_a_toast() {
+        var (notified, current, closed) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"));
+            h.Activate();
+
+            h.Consent.Queue(ConsentResolveKind.Applied, ConsentRuleOutcome.Saved);
+            await h.Vm.AllowRememberCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            return (h.Notifier.Notified.ToArray(), h.Vm.Current, h.CloseRequests);
+        });
+
+        await Assert.That(notified).IsEmpty();
+        await Assert.That(current).IsNull();
+        await Assert.That(closed).IsEqualTo(1); // the queue emptied: the window closes itself
+    }
+
+    [Test]
+    [Arguments(ConsentResolveKind.AppliedRuleRejected, ConsentRuleOutcome.Rejected, "store full", "Decision applied — rule not saved: store full")]
+    [Arguments(ConsentResolveKind.RuleSkippedNoRequester, ConsentRuleOutcome.SkippedNoRequester, null, "Decision applied — rule not saved: the request had no requester identity")]
+    [Arguments(ConsentResolveKind.AppliedRuleRejected, ConsentRuleOutcome.Unknown, null, "Decision applied — this daemon version doesn't report whether the rule was saved")]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Rule_warnings_toast_and_still_advance(
+            ConsentResolveKind kind, ConsentRuleOutcome rule, string? error, string expected) {
+        var (notified, current) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"), Entry("a2", "p2", requestedAt: T0.AddSeconds(5)));
+            h.Activate();
+
+            h.Consent.Queue(kind, rule, error);
+            await h.Vm.AllowRememberCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            return (h.Notifier.Notified.ToArray(), h.Vm.Current!.RequestId);
+        });
+
+        await Assert.That(notified).IsEquivalentTo([expected], CollectionOrdering.Matching);
+        await Assert.That(current).IsEqualTo("a2");
+    }
+
+    /// The eviction and the ack's continuation are two independently posted jobs, so the advance
+    /// must not depend on the queue view having caught up: the request it just concluded is never
+    /// re-pinned, and a late eviction changes nothing afterwards.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Advance_never_repins_the_request_it_just_concluded() {
+        var (afterAck, queuedAtAck, afterEviction) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"), Entry("a2", "p2", requestedAt: T0.AddSeconds(5)));
+            h.Activate();
+            h.Consent.ConcludeLate = true;
+
+            h.Consent.Queue(ConsentResolveKind.Applied, ConsentRuleOutcome.NotRequested);
+            await h.Vm.AllowOnceCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            var pinned = h.Vm.Current!.RequestId;
+            var queued = h.Vm.Queue.Count; // the concluded entry is still in view
+
+            h.Consent.FlushConclusions();
+            PromptHarness.Pump();
+            return (pinned, queued, h.Vm.Current!.RequestId);
+        });
+
+        await Assert.That(afterAck).IsEqualTo("a2");
+        await Assert.That(queuedAtAck).IsEqualTo(2);
+        await Assert.That(afterEviction).IsEqualTo("a2");
+    }
+
+    // ---- 10: transport failure ----
+
+    /// The outcome's rule value on this path describes a rule that was never sent, so it must NOT
+    /// be rendered: an Unknown here would otherwise produce the down-level-daemon copy.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Transport_failure_reenables_buttons_and_keeps_current() {
+        var (notified, current, enabled, phaseText, queued) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"));
+            h.Activate();
+
+            h.Consent.Queue(ConsentResolveKind.TransportFailure, ConsentRuleOutcome.Unknown, "daemon_unreachable");
+            await h.Vm.AllowRememberCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            return (h.Notifier.Notified.ToArray(), h.Vm.Current!.RequestId, h.Vm.ButtonsEnabled, h.Vm.PhaseText, h.Vm.Queue.Count);
+        });
+
+        await Assert.That(notified).IsEquivalentTo(["Daemon unreachable — the request is still pending"], CollectionOrdering.Matching);
+        await Assert.That(current).IsEqualTo("a1");
+        await Assert.That(enabled).IsTrue();
+        await Assert.That(phaseText).IsNull();
+        await Assert.That(queued).IsEqualTo(1);
+    }
+
+    // ---- 11: expiry never preempts an in-flight resolve ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Expiry_never_preempts_inflight_resolve() {
+        var (countdown, pinned, phase, afterAck) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"), Entry("a2", "p2", requestedAt: T0.AddSeconds(5)));
+            h.Activate();
+
+            var gate = h.Consent.Arm();
+            var exec = h.Vm.AllowOnceCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            h.Tick(TimeSpan.FromSeconds(40)); // past both hints, mid-call
+            var text = h.Vm.CountdownText;
+            var stillPinned = h.Vm.Current!.RequestId;
+            var duringPhase = h.Vm.Phase;
+
+            gate.SetResult(new ConsentResolveOutcome(ConsentResolveKind.Applied, ConsentRuleOutcome.NotRequested, null));
+            await exec;
+            PromptHarness.Pump();
+
+            return (text, stillPinned, duringPhase, h.Vm.Current!.RequestId);
+        });
+
+        await Assert.That(countdown).IsEqualTo("Expiring…");
+        await Assert.That(pinned).IsEqualTo("a1");
+        await Assert.That(phase).IsEqualTo(ConsentPromptPhase.Resolving);
+        await Assert.That(afterAck).IsEqualTo("a2"); // the ack governed, not the clock
+    }
+
+    // ---- 12: the expired-state prune advance ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Advance_on_pinned_removal_in_expired_state() {
+        var (phase, afterFirstPrune, currentAfterSecond, closed) = await AvaloniaSession.DispatchAsync(() => {
+            var first = Entry("a1", "p1");
+            var second = Entry("a2", "p2", requestedAt: T0.AddSeconds(5));
+            using var h = new PromptHarness(first, second);
+            h.Activate();
+            h.Tick(TimeSpan.FromSeconds(40));
+
+            var expiredPhase = h.Vm.Phase;
+            h.Prune(first);
+            var advanced = h.Vm.Current!.RequestId;
+
+            h.Prune(second);
+            return (expiredPhase, advanced, h.Vm.Current, h.CloseRequests);
+        });
+
+        await Assert.That(phase).IsEqualTo(ConsentPromptPhase.Expired);
+        await Assert.That(afterFirstPrune).IsEqualTo("a2");
+        await Assert.That(currentAfterSecond).IsNull();
+        await Assert.That(closed).IsEqualTo(1);
+    }
+
+    // ---- 13: no double-submit ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Resolving_disables_all_buttons() {
+        var (enabled, allowOnce, allowRemember, deny, resolveCalls) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"));
+            h.Activate();
+
+            var gate = h.Consent.Arm();
+            var exec = h.Vm.AllowOnceCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            var state = (h.Vm.ButtonsEnabled, CanExecute(h.Vm.AllowOnceCommand), CanExecute(h.Vm.AllowRememberCommand),
+                CanExecute(h.Vm.DenyCommand), h.Consent.Resolved.Count);
+
+            gate.SetResult(new ConsentResolveOutcome(ConsentResolveKind.Applied, ConsentRuleOutcome.NotRequested, null));
+            await exec;
+            PromptHarness.Pump();
+            return state;
+        });
+
+        await Assert.That(enabled).IsFalse();
+        await Assert.That(allowOnce).IsFalse();
+        await Assert.That(allowRemember).IsFalse();
+        await Assert.That(deny).IsFalse();
+        await Assert.That(resolveCalls).IsEqualTo(1);
+    }
+
+    // ---- 14: cancellation ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Cancellation_is_a_silent_abort() {
+        var (notified, current, enabled, queued, phaseText) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new PromptHarness(Entry("a1", "p1"));
+            h.Activate();
+
+            h.Consent.QueueCancellation();
+            await h.Vm.DenyCommand.Execute().ToTask();
+            PromptHarness.Pump();
+
+            return (h.Notifier.Notified.ToArray(), h.Vm.Current!.RequestId, h.Vm.ButtonsEnabled, h.Vm.Queue.Count, h.Vm.PhaseText);
+        });
+
+        await Assert.That(notified).IsEmpty();
+        await Assert.That(current).IsEqualTo("a1");
+        await Assert.That(enabled).IsTrue();
+        await Assert.That(queued).IsEqualTo(1);
+        await Assert.That(phaseText).IsNull();
+    }
+
+    static bool CanExecute(ReactiveCommand<ReactiveUnit, ReactiveUnit> command) {
+        var value = false;
+        using var subscription = command.CanExecute.Subscribe(v => value = v); // replayed on subscribe
+        return value;
+    }
+}
+
+/// One ConsentPromptViewModel with every seam scripted, activated the way a window activates it.
+/// Must be constructed and driven ON the headless UI thread (AvaloniaSession.DispatchAsync).
+sealed class PromptHarness : IDisposable {
+    public readonly FakeConsentService Consent = new();
+    public readonly RecordingNotifier Notifier = new();
+    public readonly FakeTicker Ticker = new();
+    public readonly FakeTimeProvider Clock = new(ConsentEntries.T0);
+    public readonly ConsentPromptViewModel Vm;
+
+    readonly IDisposable _closeSub;
+    IDisposable? _activation;
+
+    public int CloseRequests { get; private set; }
+
+    public PromptHarness(params PendingConsent[] entries) {
+        Vm = new ConsentPromptViewModel(Consent, Notifier, Ticker, Clock, CancellationToken.None);
+        _closeSub = Vm.CloseRequested.Subscribe(_ => CloseRequests++);
+        foreach (var entry in entries) Consent.Add(entry);
+    }
+
+    public void Activate() {
+        _activation = Vm.Activator.Activate();
+        Pump();
+    }
+
+    public void Add(PendingConsent entry) {
+        Consent.Add(entry);
+        Pump();
+    }
+
+    public void Prune(PendingConsent entry) {
+        Consent.Prune(entry);
+        Pump();
+    }
+
+    public void Tick(TimeSpan? advance = null) {
+        if (advance is { } step) Clock.Advance(step);
+        Ticker.Tick();
+        Pump();
+    }
+
+    /// Drains the dispatcher — every cache change reaches the ViewModel through an ObserveOn post.
+    public static void Pump() => Dispatcher.UIThread.RunJobs();
+
+    public void Dispose() {
+        _activation?.Dispose();
+        _closeSub.Dispose();
+        Consent.Dispose();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs
@@ -1,0 +1,501 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Plain TUnit tests — ConsentService is scheduler-free (a SourceCache plus a plain Subject, no
+/// Avalonia globals), so no AvaloniaSession is needed. Every settle is driven by a FIFO barrier on
+/// the scripted stream, a ScriptedLocalControlOps TaskCompletionSource gate, or WaitUntilAsync
+/// polling (PauseControllerTests idiom); every clock-dependent behavior is driven by
+/// FakeTimeProvider — never Task.Delay-based ordering.
+public class ConsentServiceTests {
+    static readonly DateTimeOffset T0 = new(2026, 8, 8, 10, 0, 0, TimeSpan.Zero);
+
+    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    static ConsentPendingDto Dto(
+            string requestId = "a1", string promptId = "p1", string? requester = "github:1",
+            string? requestedAt = null, int timeoutSeconds = 30) =>
+        new(requestId, requester, "agent", "/repo", "claude", requestedAt ?? T0.ToString("O"), timeoutSeconds,
+            "Alice", promptId);
+
+    // ---- 1: subscription gate ----
+
+    [Test]
+    public async Task Subscribes_only_with_consent2_capability() {
+        using var h = new ConsentHarness();
+
+        h.Connect("consent/1");
+        await Task.Delay(50); // a negative: give a would-be loop every chance to dial
+        await Assert.That(h.Stream.Attempts).IsEqualTo(0);
+
+        h.Connect("consent/1", "consent/2");
+        await WaitUntilAsync(() => h.Stream.Attempts == 1, what: "the consent/2 subscribe attempt");
+        h.Stream.EmitSubscribed();
+        await h.EmitAsync(Dto());
+        await Assert.That(h.View.Count).IsEqualTo(1);
+
+        // Down-level incarnation: no loop AND the retained entries (a previous incarnation's) go.
+        h.Connect("consent/1");
+        await WaitUntilAsync(() => h.View.Count == 0, what: "cache cleared on a down-level daemon");
+        await Assert.That(h.Stream.Attempts).IsEqualTo(1);
+    }
+
+    // ---- 2: clear boundary ----
+
+    [Test]
+    public async Task Clear_happens_at_subscribed_not_before_dial() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        await h.EmitAsync(Dto());
+
+        // Attempt 2 "fails to dial": it ends without ever reaching Subscribed.
+        await h.DrainAsync();
+        await h.RetryAsync();
+        await h.DrainAsync();
+        await Assert.That(h.View.Count).IsEqualTo(1); // still actionable — nothing was erased
+
+        await h.RetryAsync();
+        h.Stream.EmitSubscribed();
+        await WaitUntilAsync(() => h.View.Count == 0, what: "cache cleared at the Subscribed boundary");
+    }
+
+    // ---- 3: upsert + added signal ----
+
+    [Test]
+    public async Task Replay_upserts_by_request_id_and_entryadded_fires_on_new_keys_only() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+
+        await h.EmitAsync(Dto("a1", "p1"));
+        await h.EmitAsync(Dto("a2", "p2"));
+        await Assert.That(h.View.Count).IsEqualTo(2);
+        await WaitUntilAsync(() => h.Added == 2, what: "two added signals");
+
+        h.Stream.EmitPending(Dto("a1", "p1"));
+        await h.DrainAsync(); // FIFO barrier: the re-push has been processed
+        await Assert.That(h.View.Count).IsEqualTo(2);
+        await Assert.That(h.Added).IsEqualTo(2);
+    }
+
+    // ---- 4: tombstones ----
+
+    [Test]
+    public async Task Tombstoned_prompt_id_is_dropped_and_survives_resubscribe() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto("a1", "p1"));
+
+        h.Ops.QueueResolve(ok: true, error: null);
+        var outcome = await h.Service.ResolveAsync(entry, allow: true, saveRule: false, CancellationToken.None);
+        await Assert.That(outcome.Kind).IsEqualTo(ConsentResolveKind.Applied);
+        await Assert.That(h.View.Count).IsEqualTo(0);
+
+        h.Stream.EmitPending(Dto("a1", "p1"));
+        await h.DrainAsync();
+        await Assert.That(h.View.Count).IsEqualTo(0); // ghost replay dropped
+
+        await h.RetryAsync();
+        h.Stream.EmitSubscribed();
+        h.Stream.EmitPending(Dto("a1", "p1"));
+        await h.DrainAsync();
+        await Assert.That(h.View.Count).IsEqualTo(0); // STILL dropped: tombstones are service-lifetime
+
+        await h.RetryAsync();
+        h.Stream.EmitSubscribed();
+        var successor = await h.EmitAsync(Dto("a1", "p2")); // different identity under the same key
+        await Assert.That(successor.PromptId).IsEqualTo("p2");
+        await Assert.That(h.View.Count).IsEqualTo(1);
+    }
+
+    // ---- 5: identity-guarded eviction ----
+
+    [Test]
+    public async Task Conclusive_ack_evicts_by_identity_including_a_replayed_fresh_instance() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var original = await h.EmitAsync(Dto("a1", "p1"));
+
+        var gate = h.Ops.ArmResolve();
+        var resolve = h.Service.ResolveAsync(original, allow: true, saveRule: false, CancellationToken.None);
+        await WaitUntilAsync(() => h.Ops.ResolveCalls == 1, what: "the resolve to reach the ops layer");
+
+        // A reconnect clears and replays the SAME identity as a brand-new object.
+        await h.DrainAsync();
+        await h.RetryAsync();
+        h.Stream.EmitSubscribed();
+        await WaitUntilAsync(() => h.View.Count == 0, what: "the Subscribed clear");
+        var replayed = await h.EmitAsync(Dto("a1", "p1"));
+        await Assert.That(ReferenceEquals(replayed, original)).IsFalse();
+
+        gate.SetResult(new ConsentAckDto(true, null, null));
+        var outcome = await resolve;
+
+        await Assert.That(outcome.Kind).IsEqualTo(ConsentResolveKind.Applied);
+        await Assert.That(h.View.Count).IsEqualTo(0);
+    }
+
+    // ---- 6: ABA defense ----
+
+    [Test]
+    public async Task Successor_with_same_request_id_survives_predecessors_ack() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var predecessor = await h.EmitAsync(Dto("a1", "p1"));
+
+        var gate = h.Ops.ArmResolve();
+        var resolve = h.Service.ResolveAsync(predecessor, allow: true, saveRule: false, CancellationToken.None);
+        await WaitUntilAsync(() => h.Ops.ResolveCalls == 1, what: "the resolve to reach the ops layer");
+
+        var successor = await h.EmitAsync(Dto("a1", "p2"));
+
+        gate.SetResult(new ConsentAckDto(false, "already decided", null));
+        var outcome = await resolve;
+
+        await Assert.That(outcome.Kind).IsEqualTo(ConsentResolveKind.AlreadyDecided);
+        await Assert.That(h.View.Count).IsEqualTo(1);
+        await Assert.That(h.View.Lookup("a1").Value.PromptId).IsEqualTo(successor.PromptId);
+    }
+
+    // ---- 7: ack -> outcome mapping ----
+
+    [Test]
+    [Arguments(true, null, null, false, ConsentResolveKind.Applied, ConsentRuleOutcome.NotRequested)]
+    [Arguments(true, null, true, true, ConsentResolveKind.Applied, ConsentRuleOutcome.Saved)]
+    [Arguments(true, "store full", false, true, ConsentResolveKind.AppliedRuleRejected, ConsentRuleOutcome.Rejected)]
+    [Arguments(true, null, null, true, ConsentResolveKind.Applied, ConsentRuleOutcome.Saved)] // old-format ack carve-out
+    [Arguments(false, null, true, true, ConsentResolveKind.AlreadyDecided, ConsentRuleOutcome.Saved)]
+    [Arguments(false, null, null, true, ConsentResolveKind.AlreadyDecided, ConsentRuleOutcome.Unknown)]
+    [Arguments(false, null, null, false, ConsentResolveKind.AlreadyDecided, ConsentRuleOutcome.NotRequested)]
+    public async Task Resolve_outcome_mapping(
+            bool ok, string? error, bool? ruleSaved, bool saveRule,
+            ConsentResolveKind expectedKind, ConsentRuleOutcome expectedRule) {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto());
+
+        h.Ops.QueueResolve(ok, error, ruleSaved);
+        var outcome = await h.Service.ResolveAsync(entry, allow: true, saveRule, CancellationToken.None);
+
+        await Assert.That(outcome.Kind).IsEqualTo(expectedKind);
+        await Assert.That(outcome.RuleOutcome).IsEqualTo(expectedRule);
+        await Assert.That(outcome.Error).IsEqualTo(error);
+        await Assert.That(h.View.Count).IsEqualTo(0); // every ack is conclusive: remove + tombstone
+    }
+
+    // ---- 8: save_rule guard ----
+
+    [Test]
+    public async Task Save_rule_guard_null_and_empty_requester() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var noRequester = await h.EmitAsync(Dto("a1", "p1", requester: null));
+        var emptyRequester = await h.EmitAsync(Dto("a2", "p2", requester: ""));
+        var named = await h.EmitAsync(Dto("a3", "p3", requester: "github:2821205"));
+
+        h.Ops.QueueResolve(ok: true, error: null);
+        var first = await h.Service.ResolveAsync(noRequester, allow: true, saveRule: true, CancellationToken.None);
+        h.Ops.QueueResolve(ok: true, error: null);
+        var second = await h.Service.ResolveAsync(emptyRequester, allow: true, saveRule: true, CancellationToken.None);
+        h.Ops.QueueResolve(ok: true, error: null, ruleSaved: true);
+        var third = await h.Service.ResolveAsync(named, allow: true, saveRule: true, CancellationToken.None);
+
+        // A null requester would serialize into a wildcard allow-everything rule: never sent.
+        await Assert.That(h.Ops.ResolvePayloads[0].SaveRule).IsNull();
+        await Assert.That(h.Ops.ResolvePayloads[1].SaveRule).IsNull();
+        await Assert.That(first.Kind).IsEqualTo(ConsentResolveKind.RuleSkippedNoRequester);
+        await Assert.That(first.RuleOutcome).IsEqualTo(ConsentRuleOutcome.SkippedNoRequester);
+        await Assert.That(second.Kind).IsEqualTo(ConsentResolveKind.RuleSkippedNoRequester);
+        await Assert.That(second.RuleOutcome).IsEqualTo(ConsentRuleOutcome.SkippedNoRequester);
+
+        await Assert.That(h.Ops.ResolvePayloads[2].SaveRule)
+            .IsEqualTo(new ConsentRuleDto("allow", "github:2821205", null, null, null));
+        await Assert.That(third.Kind).IsEqualTo(ConsentResolveKind.Applied);
+        await Assert.That(third.RuleOutcome).IsEqualTo(ConsentRuleOutcome.Saved);
+    }
+
+    // ---- 9: identity echo ----
+
+    [Test]
+    public async Task Resolve_sends_the_targets_exact_prompt_id() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto("agent-7", "prompt-7"));
+
+        h.Ops.QueueResolve(ok: true, error: null);
+        await h.Service.ResolveAsync(entry, allow: false, saveRule: false, CancellationToken.None);
+
+        var sent = h.Ops.ResolvePayloads[0];
+        await Assert.That(sent.PromptId).IsEqualTo(entry.PromptId);
+        await Assert.That(sent.RequestId).IsEqualTo(entry.RequestId);
+        await Assert.That(sent.Decision).IsEqualTo("deny");
+    }
+
+    // ---- 10: transport failure ----
+
+    [Test]
+    public async Task Transport_failure_keeps_the_entry_and_refreshes_prune_after() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto());
+
+        h.Ops.QueueResolveFailure("daemon_unreachable");
+        var outcome = await h.Service.ResolveAsync(entry, allow: true, saveRule: false, CancellationToken.None);
+
+        await Assert.That(outcome.Kind).IsEqualTo(ConsentResolveKind.TransportFailure);
+        await Assert.That(outcome.Error).IsEqualTo("daemon_unreachable");
+        await Assert.That(h.View.Count).IsEqualTo(1);
+        await Assert.That(h.View.Lookup("a1").Value.PruneAfter)
+            .IsEqualTo(h.Clock.GetUtcNow() + TimeSpan.FromSeconds(5));
+    }
+
+    // An unmapped exception (LocalControlOps does not classify every socket-construction failure)
+    // must not reach the UI command, must keep the unsettled entry, and must free the lane —
+    // the PauseController/AgentActionService discipline.
+    [Test]
+    public async Task Unmapped_exception_is_contained_and_keeps_the_entry() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto());
+
+        h.Ops.QueueResolveUnmappedFailure(new InvalidOperationException("boom"));
+        var outcome = await h.Service.ResolveAsync(entry, allow: true, saveRule: false, CancellationToken.None);
+
+        await Assert.That(outcome.Kind).IsEqualTo(ConsentResolveKind.TransportFailure);
+        await Assert.That(outcome.Error).IsEqualTo("boom");
+        await Assert.That(h.View.Count).IsEqualTo(1);
+
+        h.Ops.QueueResolve(ok: true, error: null);
+        var retry = await h.Service.ResolveAsync(entry, allow: true, saveRule: false, CancellationToken.None);
+        await Assert.That(retry.Kind).IsEqualTo(ConsentResolveKind.Applied); // lane freed
+    }
+
+    // ---- 11: cancellation ----
+
+    [Test]
+    public async Task Cancellation_propagates_and_keeps_the_entry() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto());
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => h.Service.ResolveAsync(entry, allow: true, saveRule: false, cts.Token));
+
+        await Assert.That(h.View.Count).IsEqualTo(1);
+
+        // No tombstone: after a clearing resubscribe the same identity is admitted again.
+        await h.DrainAsync();
+        await h.RetryAsync();
+        h.Stream.EmitSubscribed();
+        await WaitUntilAsync(() => h.View.Count == 0, what: "the Subscribed clear");
+        await h.EmitAsync(Dto());
+        await Assert.That(h.View.Count).IsEqualTo(1);
+    }
+
+    // ---- 12: prune ----
+
+    [Test]
+    public async Task Prune_removes_past_prune_after_but_skips_the_inflight_target() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var expired = await h.EmitAsync(Dto("a1", "p1", requestedAt: h.Clock.GetUtcNow().ToString("O")));
+        var inFlight = await h.EmitAsync(Dto("a2", "p2", requestedAt: h.Clock.GetUtcNow().ToString("O")));
+        await Assert.That(expired.PruneAfter).IsEqualTo(T0 + TimeSpan.FromSeconds(35));
+
+        var gate = h.Ops.ArmResolve();
+        var resolve = h.Service.ResolveAsync(inFlight, allow: true, saveRule: false, CancellationToken.None);
+        await WaitUntilAsync(() => h.Ops.ResolveCalls == 1, what: "the resolve to reach the ops layer");
+
+        h.Clock.Advance(TimeSpan.FromSeconds(40)); // both entries are now past PruneAfter
+        h.Ticker.Tick();
+
+        await Assert.That(h.View.Count).IsEqualTo(1);
+        await Assert.That(h.View.Lookup("a2").HasValue).IsTrue(); // the in-flight target is skipped
+
+        gate.SetResult(new ConsentAckDto(true, null, null));
+        await resolve;
+        await Assert.That(h.View.Count).IsEqualTo(0); // evicted by conclusion, never double-removed
+    }
+
+    // ---- 13/14: loop lifecycle ----
+
+    [Test]
+    public async Task Stream_end_while_connected_retries_after_1s() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        await h.DrainAsync();
+
+        await WaitUntilAsync(() => h.Time.TimersCreated == 1, what: "the 1s retry delay to be armed");
+        await Assert.That(h.Stream.Attempts).IsEqualTo(1); // no retry before the clock moves
+
+        h.Clock.Advance(TimeSpan.FromSeconds(1));
+        await WaitUntilAsync(() => h.Stream.Attempts == 2, what: "the resubscribe");
+    }
+
+    [Test]
+    public async Task Leaving_connected_cancels_the_loop_and_retains_entries() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        await h.EmitAsync(Dto());
+
+        h.Daemon.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+        await WaitUntilAsync(() => h.Stream.Ended == 1, what: "the loop to unwind");
+
+        h.Clock.Advance(TimeSpan.FromSeconds(30));
+        await Task.Delay(50);
+
+        await Assert.That(h.Stream.Attempts).IsEqualTo(1); // no resubscribe while disconnected
+        await Assert.That(h.View.Count).IsEqualTo(1);      // the daemon may still hold live prompts
+    }
+
+    // ---- 15: deadline hint ----
+
+    [Test]
+    public async Task Deadline_hint_falls_back_on_unparseable_requested_at() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+
+        var garbage = await h.EmitAsync(Dto("a1", "p1", requestedAt: "garbage", timeoutSeconds: 45));
+        await Assert.That(garbage.DeadlineHint).IsEqualTo(T0 + TimeSpan.FromSeconds(45)); // arrival + timeout
+
+        var stamped = await h.EmitAsync(
+            Dto("a2", "p2", requestedAt: (T0 - TimeSpan.FromSeconds(10)).ToString("O"), timeoutSeconds: 45));
+        await Assert.That(stamped.DeadlineHint).IsEqualTo(T0 + TimeSpan.FromSeconds(35));
+    }
+}
+
+/// One scripted consent subscription attempt per RunAsync call, fed from one FIFO channel that
+/// outlives the attempts. `Attempts`/`Ended` make the loop's retry cadence and its unwinding
+/// observable; a null item is the end-of-attempt marker, which doubles as a barrier proving every
+/// earlier item was processed.
+sealed class FakeConsentStream {
+    readonly Channel<ConsentStreamEvent?> _channel = Channel.CreateUnbounded<ConsentStreamEvent?>();
+
+    int _attempts;
+    int _ended;
+
+    public int Attempts => Volatile.Read(ref _attempts);
+    public int Ended    => Volatile.Read(ref _ended);
+
+    public async IAsyncEnumerable<ConsentStreamEvent> RunAsync([EnumeratorCancellation] CancellationToken ct) {
+        Interlocked.Increment(ref _attempts);
+        try {
+            await foreach (var evt in _channel.Reader.ReadAllAsync(ct)) {
+                if (evt is null) yield break;
+                yield return evt;
+            }
+        } finally {
+            Interlocked.Increment(ref _ended);
+        }
+    }
+
+    public void EmitSubscribed() => _channel.Writer.TryWrite(new ConsentStreamEvent.Subscribed());
+    public void EmitPending(ConsentPendingDto dto) => _channel.Writer.TryWrite(new ConsentStreamEvent.Pending(dto));
+    public void EndAttempt() => _channel.Writer.TryWrite(null);
+}
+
+/// Delegates to a FakeTimeProvider while counting CreateTimer calls, so a test can wait for the
+/// loop's retry delay to be ARMED before advancing the clock — advancing first would leave the
+/// timer scheduled a second into a future that already passed (LaunchConsentGateTests idiom).
+sealed class TimerCountingTimeProvider(FakeTimeProvider inner) : TimeProvider {
+    int _timersCreated;
+    public int TimersCreated => Volatile.Read(ref _timersCreated);
+
+    public override DateTimeOffset GetUtcNow()   => inner.GetUtcNow();
+    public override long GetTimestamp()          => inner.GetTimestamp();
+    public override TimeZoneInfo LocalTimeZone   => inner.LocalTimeZone;
+    public override long TimestampFrequency      => inner.TimestampFrequency;
+
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period) {
+        Interlocked.Increment(ref _timersCreated);
+        return inner.CreateTimer(callback, state, dueTime, period);
+    }
+}
+
+/// One ConsentService with every seam scripted, plus an observable-cache view of the pending
+/// cache and a counter for the added signal.
+sealed class ConsentHarness : IDisposable {
+    public static readonly DateTimeOffset Start = new(2026, 8, 8, 10, 0, 0, TimeSpan.Zero);
+
+    public readonly FakeDaemonClientService Daemon = new();
+    public readonly ScriptedLocalControlOps Ops    = new();
+    public readonly FakeTicker Ticker              = new();
+    public readonly FakeConsentStream Stream       = new();
+    public readonly FakeTimeProvider Clock         = new(Start);
+    public readonly TimerCountingTimeProvider Time;
+    public readonly ConsentService Service;
+    public readonly IObservableCache<PendingConsent, string> View;
+
+    readonly IDisposable _addedSub;
+    int _added;
+    int _timersSeen;
+
+    public ConsentHarness() {
+        Time      = new TimerCountingTimeProvider(Clock);
+        Service   = new ConsentService(Daemon, Ops, Ticker, Stream.RunAsync, Time, CancellationToken.None);
+        View      = Service.Pending.AsObservableCache();
+        _addedSub = Service.EntryAdded.Subscribe(_ => Interlocked.Increment(ref _added));
+    }
+
+    public int Added => Volatile.Read(ref _added);
+
+    public void Connect(params string[] capabilities) =>
+        Daemon.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, capabilities));
+
+    /// Connect with consent/2, wait for the dial, and cross the Subscribed boundary.
+    public async Task StartAsync() {
+        Connect("consent/1", "consent/2");
+        await WaitAsync(() => Stream.Attempts == 1, "the first subscribe attempt");
+        Stream.EmitSubscribed();
+    }
+
+    public async Task<PendingConsent> EmitAsync(ConsentPendingDto dto) {
+        Stream.EmitPending(dto);
+        await WaitAsync(
+            () => View.Lookup(dto.RequestId) is { HasValue: true, Value.PromptId: var id } && id == dto.PromptId,
+            $"pending {dto.RequestId}/{dto.PromptId} to be cached");
+        return View.Lookup(dto.RequestId).Value;
+    }
+
+    /// Ends the current attempt — a FIFO barrier proving every earlier emission was processed.
+    public async Task DrainAsync() {
+        var ended = Stream.Ended;
+        Stream.EndAttempt();
+        await WaitAsync(() => Stream.Ended > ended, "the attempt to end");
+    }
+
+    /// Fires the loop's 1s retry delay once the delay is actually armed, then waits for the dial.
+    public async Task RetryAsync() {
+        var attempts = Stream.Attempts;
+        await WaitAsync(() => Time.TimersCreated > _timersSeen, "the retry delay to be armed");
+        _timersSeen = Time.TimersCreated;
+        Clock.Advance(TimeSpan.FromSeconds(1));
+        await WaitAsync(() => Stream.Attempts > attempts, "the resubscribe");
+    }
+
+    static async Task WaitAsync(Func<bool> condition, string what) {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    public void Dispose() {
+        _addedSub.Dispose();
+        Service.Dispose();
+        View.Dispose();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs
@@ -304,6 +304,33 @@ public class ConsentServiceTests {
         await Assert.That(h.View.Count).IsEqualTo(1);
     }
 
+    // The OTHER cancellation shape: cancelled while the ops call is in flight, so the OCE surfaces
+    // from INSIDE the resolve's try — the one place the unmapped-exception arm could swallow it and
+    // fabricate a TransportFailure settlement out of a caller's abort.
+    [Test]
+    public async Task Cancellation_in_flight_propagates_and_keeps_the_entry() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto());
+        using var cts = new CancellationTokenSource();
+
+        h.Ops.ArmResolve(); // never completed: the token, not the ack, ends this call
+        var resolve = h.Service.ResolveAsync(entry, allow: true, saveRule: false, cts.Token);
+        await WaitUntilAsync(() => h.Ops.ResolveCalls == 1, what: "the resolve to reach the ops layer");
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => resolve);
+        await Assert.That(h.View.Count).IsEqualTo(1);
+
+        // No tombstone: after a clearing resubscribe the same identity is admitted again.
+        await h.DrainAsync();
+        await h.RetryAsync();
+        h.Stream.EmitSubscribed();
+        await WaitUntilAsync(() => h.View.Count == 0, what: "the Subscribed clear");
+        await h.EmitAsync(Dto());
+        await Assert.That(h.View.Count).IsEqualTo(1);
+    }
+
     // ---- 12: prune ----
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs
@@ -73,7 +73,7 @@ public class ConsentServiceTests {
     // ---- 3: upsert + added signal ----
 
     [Test]
-    public async Task Replay_upserts_by_request_id_and_entryadded_fires_on_new_keys_only() {
+    public async Task Replay_upserts_by_request_id_and_entryadded_fires_once_per_identity() {
         using var h = new ConsentHarness();
         await h.StartAsync();
 
@@ -86,6 +86,50 @@ public class ConsentServiceTests {
         await h.DrainAsync(); // FIFO barrier: the re-push has been processed
         await Assert.That(h.View.Count).IsEqualTo(2);
         await Assert.That(h.Added).IsEqualTo(2);
+    }
+
+    /// A successor sharing the RequestId but carrying a fresh PromptId is a NEW request — the
+    /// likeliest second prompt there is (a relaunch under the same agent id) — so a hidden or
+    /// deferred window has to be raised for it. A signal keyed on the cache KEY missed exactly
+    /// this: the successor replaced the slot silently and nothing ever prompted for it.
+    [Test]
+    public async Task Entryadded_fires_for_a_same_key_successor_identity() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+
+        await h.EmitAsync(Dto("a1", "p1"));
+        await WaitUntilAsync(() => h.Added == 1, what: "the first added signal");
+
+        await h.EmitAsync(Dto("a1", "p2")); // same key, different request
+        await WaitUntilAsync(() => h.Added == 2, what: "the successor's added signal");
+        await Assert.That(h.View.Count).IsEqualTo(1);
+        await Assert.That(h.View.Lookup("a1").Value.PromptId).IsEqualTo("p2");
+    }
+
+    /// A resubscribe clears at the Subscribed boundary and the daemon replays everything, so every
+    /// replayed entry re-enters an EMPTY cache — a key-keyed signal fired for all of them and
+    /// re-raised a window the user had explicitly deferred. First-surfacing is per PromptId and
+    /// survives the boundary (like a tombstone), while a genuinely new request still signals.
+    [Test]
+    public async Task Entryadded_is_silent_on_a_resubscribe_replay_and_fires_for_a_new_request() {
+        using var h = new ConsentHarness();
+        await h.StartAsync();
+        await h.EmitAsync(Dto("a1", "p1"));
+        await h.EmitAsync(Dto("a2", "p2"));
+        await WaitUntilAsync(() => h.Added == 2, what: "two added signals");
+
+        await h.DrainAsync();
+        await h.RetryAsync();
+        h.Stream.EmitSubscribed();
+        await WaitUntilAsync(() => h.View.Count == 0, what: "the Subscribed clear");
+
+        h.Stream.EmitPending(Dto("a1", "p1")); // the replay: same identities, fresh objects
+        h.Stream.EmitPending(Dto("a2", "p2"));
+        h.Stream.EmitPending(Dto("a3", "p3")); // ...and one request the service has never seen
+        await h.DrainAsync();                  // FIFO barrier: all three have been processed
+
+        await Assert.That(h.Added).IsEqualTo(3);      // exactly one signal, for the new request
+        await Assert.That(h.View.Count).IsEqualTo(3); // the replay still restored the tray count
     }
 
     // ---- 4: tombstones ----
@@ -104,18 +148,22 @@ public class ConsentServiceTests {
         h.Stream.EmitPending(Dto("a1", "p1"));
         await h.DrainAsync();
         await Assert.That(h.View.Count).IsEqualTo(0); // ghost replay dropped
+        await Assert.That(h.Added).IsEqualTo(1);      // ...and never raised a second prompt
 
         await h.RetryAsync();
         h.Stream.EmitSubscribed();
         h.Stream.EmitPending(Dto("a1", "p1"));
         await h.DrainAsync();
         await Assert.That(h.View.Count).IsEqualTo(0); // STILL dropped: tombstones are service-lifetime
+        await Assert.That(h.Added).IsEqualTo(1);
 
         await h.RetryAsync();
         h.Stream.EmitSubscribed();
         var successor = await h.EmitAsync(Dto("a1", "p2")); // different identity under the same key
+        await h.DrainAsync();
         await Assert.That(successor.PromptId).IsEqualTo("p2");
         await Assert.That(h.View.Count).IsEqualTo(1);
+        await Assert.That(h.Added).IsEqualTo(2); // a never-concluded identity: prompted on its own terms
     }
 
     // ---- 5: identity-guarded eviction ----
@@ -136,7 +184,9 @@ public class ConsentServiceTests {
         h.Stream.EmitSubscribed();
         await WaitUntilAsync(() => h.View.Count == 0, what: "the Subscribed clear");
         var replayed = await h.EmitAsync(Dto("a1", "p1"));
+        await h.DrainAsync();
         await Assert.That(ReferenceEquals(replayed, original)).IsFalse();
+        await Assert.That(h.Added).IsEqualTo(1); // a replayed identity is not a new request
 
         gate.SetResult(new ConsentAckDto(true, null, null));
         var outcome = await resolve;
@@ -158,6 +208,8 @@ public class ConsentServiceTests {
         await WaitUntilAsync(() => h.Ops.ResolveCalls == 1, what: "the resolve to reach the ops layer");
 
         var successor = await h.EmitAsync(Dto("a1", "p2"));
+        await h.DrainAsync();
+        await Assert.That(h.Added).IsEqualTo(2); // the successor is a request of its own: raise for it
 
         gate.SetResult(new ConsentAckDto(false, "already decided", null));
         var outcome = await resolve;

--- a/test/Capacitor.App.Tests.Unit/FakeConsentService.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeConsentService.cs
@@ -30,11 +30,13 @@ static class ConsentEntries {
 /// Two behaviors deliberately mirror the real service (spec §5), because the ViewModel's advance
 /// rules are only honest against them: a conclusive outcome evicts its target from the cache
 /// (identity-guarded) BEFORE the awaiting caller resumes, and a transport failure keeps it.
-/// EntryAdded fires on genuinely new keys only, from whatever thread Add is called on.
+/// EntryAdded fires on the FIRST SURFACING of a PromptId — a same-key successor fires, a replay
+/// after <see cref="Clear"/> does not — from whatever thread Add is called on.
 sealed class FakeConsentService : IConsentService {
     public readonly SourceCache<PendingConsent, string> Cache = new(p => p.RequestId);
 
     readonly Subject<ReactiveUnit> _entryAdded = new();
+    readonly HashSet<string> _surfaced = [];
     readonly Queue<TaskCompletionSource<ConsentResolveOutcome>> _outcomes = new();
     readonly List<PendingConsent> _deferredConclusions = [];
 
@@ -51,13 +53,18 @@ sealed class FakeConsentService : IConsentService {
     public IObservable<ReactiveUnit> EntryAdded => _entryAdded;
 
     public void Add(PendingConsent entry) {
-        var isNew = !Cache.Lookup(entry.RequestId).HasValue;
+        bool isNew;
+        lock (_surfaced) isNew = _surfaced.Add(entry.PromptId);
         Cache.AddOrUpdate(entry);
         if (isNew) _entryAdded.OnNext(ReactiveUnit.Default);
     }
 
     /// The §5 prune: an entry disappearing under the ViewModel with no ack involved.
     public void Prune(PendingConsent entry) => Cache.Remove(entry.RequestId);
+
+    /// The §5 Subscribed boundary: the cache is emptied, the daemon's replay re-adds through
+    /// <see cref="Add"/>. Surfaced identities survive it, exactly as in the real service.
+    public void Clear() => Cache.Clear();
 
     public TaskCompletionSource<ConsentResolveOutcome> Arm() {
         var tcs = new TaskCompletionSource<ConsentResolveOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/test/Capacitor.App.Tests.Unit/FakeConsentService.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeConsentService.cs
@@ -1,0 +1,100 @@
+using ReactiveUnit = System.Reactive.Unit;
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// PendingConsent fixtures shared by the prompt ViewModel and coordinator suites. DeadlineHint /
+/// PruneAfter are computed exactly as ConsentService computes them (anchor + timeout, + 5s grace),
+/// so the ViewModel's sort key (which derives the anchor back out of the hint) stays truthful.
+static class ConsentEntries {
+    public static readonly DateTimeOffset T0 = new(2026, 8, 8, 10, 0, 0, TimeSpan.Zero);
+
+    public static PendingConsent Entry(
+            string requestId = "a1", string promptId = "p1", string? requester = "github:1",
+            string? requesterDisplay = "Alice", string kind = "agent", string repoPath = "/repos/kcap-cli",
+            string vendor = "claude", DateTimeOffset? requestedAt = null, int timeoutSeconds = 30) {
+        var anchor = requestedAt ?? T0;
+        var dto = new ConsentPendingDto(
+            requestId, requester, kind, repoPath, vendor, anchor.ToString("O"), timeoutSeconds,
+            requesterDisplay, promptId);
+        var deadline = anchor + TimeSpan.FromSeconds(timeoutSeconds);
+        return new PendingConsent(dto, deadline, deadline + TimeSpan.FromSeconds(5));
+    }
+}
+
+/// Scripted IConsentService: a real SourceCache plus a per-call TaskCompletionSource queue for
+/// ResolveAsync, so a test arms the NEXT resolve's outcome (or holds it open) before clicking.
+/// Two behaviors deliberately mirror the real service (spec §5), because the ViewModel's advance
+/// rules are only honest against them: a conclusive outcome evicts its target from the cache
+/// (identity-guarded) BEFORE the awaiting caller resumes, and a transport failure keeps it.
+/// EntryAdded fires on genuinely new keys only, from whatever thread Add is called on.
+sealed class FakeConsentService : IConsentService {
+    public readonly SourceCache<PendingConsent, string> Cache = new(p => p.RequestId);
+
+    readonly Subject<ReactiveUnit> _entryAdded = new();
+    readonly Queue<TaskCompletionSource<ConsentResolveOutcome>> _outcomes = new();
+    readonly List<PendingConsent> _deferredConclusions = [];
+
+    public readonly List<(string PromptId, bool Allow, bool SaveRule)> Resolved = [];
+
+    /// Withholds the conclusive eviction until <see cref="FlushConclusions"/>, modelling the
+    /// ordering the ViewModel cannot assume away: the cache edit and the ack's continuation are
+    /// two independently posted jobs, so the ack can be observed while the queue view still holds
+    /// the concluded entry.
+    public bool ConcludeLate;
+
+    public IObservable<IChangeSet<PendingConsent, string>> Pending => Cache.Connect();
+    public IObservable<int> PendingCount => Cache.CountChanged;
+    public IObservable<ReactiveUnit> EntryAdded => _entryAdded;
+
+    public void Add(PendingConsent entry) {
+        var isNew = !Cache.Lookup(entry.RequestId).HasValue;
+        Cache.AddOrUpdate(entry);
+        if (isNew) _entryAdded.OnNext(ReactiveUnit.Default);
+    }
+
+    /// The §5 prune: an entry disappearing under the ViewModel with no ack involved.
+    public void Prune(PendingConsent entry) => Cache.Remove(entry.RequestId);
+
+    public TaskCompletionSource<ConsentResolveOutcome> Arm() {
+        var tcs = new TaskCompletionSource<ConsentResolveOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _outcomes.Enqueue(tcs);
+        return tcs;
+    }
+
+    public void Queue(ConsentResolveKind kind, ConsentRuleOutcome rule, string? error = null) =>
+        Arm().SetResult(new ConsentResolveOutcome(kind, rule, error));
+
+    public void QueueCancellation() => Arm().SetCanceled();
+
+    public async Task<ConsentResolveOutcome> ResolveAsync(
+            PendingConsent target, bool allow, bool saveRule, CancellationToken ct) {
+        Resolved.Add((target.PromptId, allow, saveRule));
+        if (_outcomes.Count == 0) throw new InvalidOperationException("FakeConsentService: unscripted resolve call");
+
+        var outcome = await _outcomes.Dequeue().Task; // cancellation propagates as OCE, same as the real lane
+        if (outcome.Kind == ConsentResolveKind.TransportFailure) return outcome;
+
+        if (ConcludeLate) _deferredConclusions.Add(target); else Conclude(target);
+        return outcome;
+    }
+
+    public void FlushConclusions() {
+        foreach (var target in _deferredConclusions) Conclude(target);
+        _deferredConclusions.Clear();
+    }
+
+    public void Dispose() {
+        Cache.Dispose();
+        _entryAdded.Dispose();
+    }
+
+    void Conclude(PendingConsent target) =>
+        Cache.Edit(u => {
+            if (u.Lookup(target.RequestId) is { HasValue: true, Value.PromptId: var id } && id == target.PromptId)
+                u.Remove(target.RequestId);
+        });
+}

--- a/test/Capacitor.App.Tests.Unit/FakeTicker.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeTicker.cs
@@ -1,0 +1,13 @@
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Subject-backed ITicker: MainWindowViewModel construction across this project needs SOME
+/// ticker, and most tests never care whether it ticks at all (UiTickerTests owns the real
+/// Interval/off-UI-thread hazard) — Tick() is here for the few that inject ticks directly.
+sealed class FakeTicker : ITicker {
+    public readonly Subject<long> Subject = new();
+    public IObservable<long> Ticks => Subject;
+    public void Tick(long n = 0) => Subject.OnNext(n);
+}

--- a/test/Capacitor.App.Tests.Unit/FakeTicker.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeTicker.cs
@@ -1,5 +1,7 @@
 using System.Reactive.Subjects;
 using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -10,4 +12,11 @@ sealed class FakeTicker : ITicker {
     public readonly Subject<long> Subject = new();
     public IObservable<long> Ticks => Subject;
     public void Tick(long n = 0) => Subject.OnNext(n);
+}
+
+/// Harmless ActivityViewModel for the many MainWindowViewModel construction sites that don't
+/// exercise the Activity tab at all — ActivityViewModelTests owns its own behavior.
+static class TestActivity {
+    public static ActivityViewModel New() =>
+        new(() => new ConsentLogReadResult([], true), () => "unused", new FakeTicker());
 }

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -38,7 +38,7 @@ public class MainWindowSmokeTests {
                 service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
 
                 var (actions, _) = NewActions(service);
-                var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+                var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
                 var window = new MainWindow { DataContext = vm };
                 window.Show();
                 // Control.Loaded is POSTED at DispatcherPriority.Loaded (Avalonia defers it, it
@@ -84,7 +84,7 @@ public class MainWindowSmokeTests {
         var (thrown, startEnabledAfter) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             var window = new MainWindow { DataContext = vm };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -139,7 +139,7 @@ public class MainWindowSmokeTests {
 
             var shutdown = new CancellationTokenSource();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), shutdown.Token);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), shutdown.Token, TestActivity.New());
             var window = new MainWindow { DataContext = vm };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -195,7 +195,7 @@ public class MainWindowSmokeTests {
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
 
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             var window = new MainWindow { DataContext = vm };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -227,7 +227,7 @@ public class MainWindowSmokeTests {
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
 
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             var window = new MainWindow { DataContext = vm };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -261,7 +261,7 @@ public class MainWindowSmokeTests {
             await AvaloniaSession.DispatchAsync(async () => {
                 var service = new FakeDaemonClientService();
                 var (actions, _) = NewActions(service);
-                var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+                var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
                 var window = new MainWindow { DataContext = vm };
                 window.Show();
                 Dispatcher.UIThread.RunJobs();
@@ -304,7 +304,7 @@ public class MainWindowSmokeTests {
         var rendered = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, notifier) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             var window = new MainWindow { DataContext = vm, Notifier = notifier };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -322,5 +322,55 @@ public class MainWindowSmokeTests {
 
         await Assert.That(rendered).Contains("Kurrent Capacitor");
         await Assert.That(rendered).Contains("Couldn't stop agent-a");
+    }
+
+    // ---- Activity tab visibility wiring (spec §7) ----
+    //
+    // Proves the real production wiring end to end — MainWindow.axaml's TabControl selection and
+    // the window's own IsVisible (Show()/Hide()) both drive ActivityViewModel.OnTabVisibleChanged
+    // through the code-behind, not just that the ViewModel reacts correctly in isolation
+    // (ActivityViewModelTests already covers that). Selecting Agents leaves the read count
+    // unchanged; each TRUE transition (select Activity, then re-Show after a Hide) issues exactly
+    // one more immediate read; Hide is a FALSE transition and reads nothing.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Activity_tab_visibility_follows_selection_and_window_IsVisible() {
+        var (afterAgents, afterActivity, afterHide, afterReshow) = await AvaloniaSession.DispatchAsync(() => {
+            var service = new FakeDaemonClientService();
+            var (actions, _) = NewActions(service);
+            var reader = new ScriptedReader();
+            reader.Set(new ConsentLogReadResult([], true));
+            var activity = new ActivityViewModel(reader.Read, () => "k", new FakeTicker());
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, activity);
+            var window = new MainWindow { DataContext = vm };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var readsAgents = reader.ReadCalls; // Agents tab selected by default — no Activity read
+
+            var tabs = window.GetVisualDescendants().OfType<TabControl>().First(t => t.Name == "MainTabs");
+            var activityTab = window.GetVisualDescendants().OfType<TabItem>().First(t => t.Name == "ActivityTabItem");
+            tabs.SelectedItem = activityTab;
+            Dispatcher.UIThread.RunJobs();
+            var readsActivity = reader.ReadCalls;
+
+            window.Hide();
+            Dispatcher.UIThread.RunJobs();
+            var readsHidden = reader.ReadCalls;
+
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            var readsReshown = reader.ReadCalls;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return (readsAgents, readsActivity, readsHidden, readsReshown);
+        });
+
+        await Assert.That(afterAgents).IsEqualTo(0);
+        await Assert.That(afterActivity).IsEqualTo(1); // selecting Activity: one immediate read
+        await Assert.That(afterHide).IsEqualTo(1); // hiding is a FALSE transition — no read
+        await Assert.That(afterReshow).IsEqualTo(2); // re-showing: another TRUE transition
     }
 }

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -38,7 +38,7 @@ public class MainWindowSmokeTests {
                 service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
 
                 var (actions, _) = NewActions(service);
-                var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+                var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
                 var window = new MainWindow { DataContext = vm };
                 window.Show();
                 // Control.Loaded is POSTED at DispatcherPriority.Loaded (Avalonia defers it, it
@@ -84,7 +84,7 @@ public class MainWindowSmokeTests {
         var (thrown, startEnabledAfter) = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             var window = new MainWindow { DataContext = vm };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -139,7 +139,7 @@ public class MainWindowSmokeTests {
 
             var shutdown = new CancellationTokenSource();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, shutdown.Token);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), shutdown.Token);
             var window = new MainWindow { DataContext = vm };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -183,9 +183,9 @@ public class MainWindowSmokeTests {
 
     /// Spec §8 empty state: "No agents running" renders only while Connected AND the Agents
     /// cache is empty. Deliberately NOT wrapped in WithImmediateRxScheduler: no agent is ever
-    /// added to service.Agents here, so the real shared ticker inside MainWindowViewModel is
-    /// never subscribed either way — but the real dispatcher is what MainWindowViewModel's own
-    /// production ctor is meant to run under, so this stays close to that path.
+    /// added to service.Agents here, so the injected FakeTicker is never subscribed either way —
+    /// but the real dispatcher is what MainWindowViewModel's own production ctor is meant to run
+    /// under, so this stays close to that path.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Empty_agents_grid_shows_no_agents_running_while_connected() {
@@ -195,7 +195,7 @@ public class MainWindowSmokeTests {
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
 
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             var window = new MainWindow { DataContext = vm };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -227,7 +227,7 @@ public class MainWindowSmokeTests {
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
 
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             var window = new MainWindow { DataContext = vm };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -261,7 +261,7 @@ public class MainWindowSmokeTests {
             await AvaloniaSession.DispatchAsync(async () => {
                 var service = new FakeDaemonClientService();
                 var (actions, _) = NewActions(service);
-                var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+                var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
                 var window = new MainWindow { DataContext = vm };
                 window.Show();
                 Dispatcher.UIThread.RunJobs();
@@ -304,7 +304,7 @@ public class MainWindowSmokeTests {
         var rendered = await AvaloniaSession.DispatchAsync(() => {
             var service = new FakeDaemonClientService();
             var (actions, notifier) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             var window = new MainWindow { DataContext = vm, Notifier = notifier };
             window.Show();
             Dispatcher.UIThread.RunJobs();

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -331,11 +331,13 @@ public class MainWindowSmokeTests {
     // through the code-behind, not just that the ViewModel reacts correctly in isolation
     // (ActivityViewModelTests already covers that). Selecting Agents leaves the read count
     // unchanged; each TRUE transition (select Activity, then re-Show after a Hide) issues exactly
-    // one more immediate read; Hide is a FALSE transition and reads nothing.
+    // one more immediate read; Hide is a FALSE transition and reads nothing. Each TRUE transition
+    // is awaited via PendingRefreshForTesting — the VM's stat+read now hops off the UI thread,
+    // so RunJobs() alone no longer guarantees the read has landed.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Activity_tab_visibility_follows_selection_and_window_IsVisible() {
-        var (afterAgents, afterActivity, afterHide, afterReshow) = await AvaloniaSession.DispatchAsync(() => {
+        var (afterAgents, afterActivity, afterHide, afterReshow) = await AvaloniaSession.DispatchAsync(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
             var reader = new ScriptedReader();
@@ -352,6 +354,7 @@ public class MainWindowSmokeTests {
             var activityTab = window.GetVisualDescendants().OfType<TabItem>().First(t => t.Name == "ActivityTabItem");
             tabs.SelectedItem = activityTab;
             Dispatcher.UIThread.RunJobs();
+            await activity.PendingRefreshForTesting!;
             var readsActivity = reader.ReadCalls;
 
             window.Hide();
@@ -360,6 +363,7 @@ public class MainWindowSmokeTests {
 
             window.Show();
             Dispatcher.UIThread.RunJobs();
+            await activity.PendingRefreshForTesting!;
             var readsReshown = reader.ReadCalls;
 
             window.Close();

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -27,7 +27,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             using var activation = vm.Activator.Activate();
 
             service.SnapshotsSubject.OnNext(Snap(daemon: "daemon-a", version: "1.2.3", serverUrl: "http://localhost:9999", connection: "connected"));
@@ -95,7 +95,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
 
             foreach (var reason in new[] { "daemon_unreachable", "daemon_incompatible" }) {
                 service.StatusSubject.OnNext(new AttachStatus(AttachState.Connecting, null, null));
@@ -119,7 +119,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
 
@@ -147,7 +147,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             using var activation = vm.Activator.Activate();
 
             service.SnapshotsSubject.OnNext(Snap(active: 2, max: 5));
@@ -167,7 +167,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
 
             var startCanExecute = false;
             var retryCanExecute = false;
@@ -215,7 +215,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             using var activation = vm.Activator.Activate();
 
             var startCanExecute = false;
@@ -238,7 +238,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
             using var activation = vm.Activator.Activate();
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
@@ -277,7 +277,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
 
             var activation = vm.Activator.Activate();
             service.SnapshotsSubject.OnNext(Snap(daemon: "daemon-a", active: 1, max: 5));

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -27,7 +27,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
             service.SnapshotsSubject.OnNext(Snap(daemon: "daemon-a", version: "1.2.3", serverUrl: "http://localhost:9999", connection: "connected"));
@@ -95,7 +95,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
 
             foreach (var reason in new[] { "daemon_unreachable", "daemon_incompatible" }) {
                 service.StatusSubject.OnNext(new AttachStatus(AttachState.Connecting, null, null));
@@ -119,7 +119,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
 
@@ -147,7 +147,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
             service.SnapshotsSubject.OnNext(Snap(active: 2, max: 5));
@@ -167,7 +167,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
 
             var startCanExecute = false;
             var retryCanExecute = false;
@@ -215,7 +215,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
             var startCanExecute = false;
@@ -238,7 +238,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
@@ -277,7 +277,7 @@ public class MainWindowViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
-            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
 
             var activation = vm.Activator.Activate();
             service.SnapshotsSubject.OnNext(Snap(daemon: "daemon-a", active: 1, max: 5));

--- a/test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs
+++ b/test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs
@@ -37,7 +37,7 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
         return tcs;
     }
 
-    public void QueueAck(bool ok, string? error) => ArmPut().SetResult(new ConsentAckDto(ok, error));
+    public void QueueAck(bool ok, string? error) => ArmPut().SetResult(new ConsentAckDto(ok, error, null));
 
     public TaskCompletionSource<StopAgentResult> ArmStop() {
         var tcs = new TaskCompletionSource<StopAgentResult>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs
+++ b/test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs
@@ -14,12 +14,15 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
     readonly Queue<TaskCompletionSource<ConsentPolicyDto>> _gets = new();
     readonly Queue<TaskCompletionSource<ConsentAckDto>> _puts = new();
     readonly Queue<TaskCompletionSource<StopAgentResult>> _stops = new();
+    readonly Queue<TaskCompletionSource<ConsentAckDto>> _resolves = new();
 
     public int GetCalls;
     public int PutCalls;
     public int StopCalls;
+    public int ResolveCalls;
     public readonly List<ConsentPolicyDto> PutPayloads = [];
     public readonly List<(string AgentId, bool Force)> StopPayloads = [];
+    public readonly List<ConsentResolveDto> ResolvePayloads = [];
 
     public TaskCompletionSource<ConsentPolicyDto> ArmGet() {
         var tcs = new TaskCompletionSource<ConsentPolicyDto>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -49,6 +52,16 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
     public void QueueStopFailure(string reason) => ArmStop().SetException(new LocalControlOpsException(reason, reason));
     public void QueueStopUnmappedFailure(Exception ex) => ArmStop().SetException(ex);
 
+    public TaskCompletionSource<ConsentAckDto> ArmResolve() {
+        var tcs = new TaskCompletionSource<ConsentAckDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _resolves.Enqueue(tcs);
+        return tcs;
+    }
+
+    public void QueueResolve(bool ok, string? error, bool? ruleSaved = null) => ArmResolve().SetResult(new ConsentAckDto(ok, error, ruleSaved));
+    public void QueueResolveFailure(string reason) => ArmResolve().SetException(new LocalControlOpsException(reason, reason));
+    public void QueueResolveUnmappedFailure(Exception ex) => ArmResolve().SetException(ex);
+
     public Task<ConsentPolicyDto> GetConsentPolicyAsync(CancellationToken ct) {
         Interlocked.Increment(ref GetCalls);
         if (ct.IsCancellationRequested) return Task.FromCanceled<ConsentPolicyDto>(ct);
@@ -74,6 +87,16 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
         if (ct.IsCancellationRequested) return Task.FromCanceled<StopAgentResult>(ct);
         if (_stops.Count == 0) throw new InvalidOperationException("ScriptedLocalControlOps: unscripted Stop call");
         var tcs = _stops.Dequeue();
+        ct.Register(() => tcs.TrySetCanceled(ct));
+        return tcs.Task;
+    }
+
+    public Task<ConsentAckDto> ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct) {
+        Interlocked.Increment(ref ResolveCalls);
+        ResolvePayloads.Add(resolve);
+        if (ct.IsCancellationRequested) return Task.FromCanceled<ConsentAckDto>(ct);
+        if (_resolves.Count == 0) throw new InvalidOperationException("ScriptedLocalControlOps: unscripted Resolve call");
+        var tcs = _resolves.Dequeue();
         ct.Register(() => tcs.TrySetCanceled(ct));
         return tcs.Task;
     }

--- a/test/Capacitor.App.Tests.Unit/TrayAdapterTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TrayAdapterTests.cs
@@ -19,8 +19,8 @@ public class TrayAdapterTests {
 
     static TrayMenuModel Model(
             TrayState state = TrayState.Idle, int count = 0, string header = "hdr",
-            IReadOnlyList<TrayAgentEntry>? agents = null, TrayPauseItem? pause = null) =>
-        new(state, count, header, agents ?? [], pause ?? new TrayPauseItem(Enabled: true, Checked: false));
+            IReadOnlyList<TrayAgentEntry>? agents = null, TrayPauseItem? pause = null, int pendingConsent = 0) =>
+        new(state, count, header, agents ?? [], pause ?? new TrayPauseItem(Enabled: true, Checked: false), pendingConsent);
 
     // ---- CountBadge (pure) ----
 
@@ -141,7 +141,8 @@ public class TrayAdapterTests {
             var (headerText, headerEnabled) = await AvaloniaSession.DispatchAsync(() => {
                 var service = new FakeDaemonClientService();
                 var pause = new FakePauseController();
-                using var vm = new TrayViewModel(service, pause, NewActions(service));
+                var consent = new FakeConsentService();
+                using var vm = new TrayViewModel(service, pause, NewActions(service), consent);
                 var builder = new TrayMenuBuilder(vm);
                 var menu = new NativeMenu();
 
@@ -163,7 +164,8 @@ public class TrayAdapterTests {
             var (itemCount, separatorCount) = await AvaloniaSession.DispatchAsync(() => {
                 var service = new FakeDaemonClientService();
                 var pause = new FakePauseController();
-                using var vm = new TrayViewModel(service, pause, NewActions(service));
+                var consent = new FakeConsentService();
+                using var vm = new TrayViewModel(service, pause, NewActions(service), consent);
                 var builder = new TrayMenuBuilder(vm);
                 var menu = new NativeMenu();
 
@@ -185,7 +187,8 @@ public class TrayAdapterTests {
             var result = await AvaloniaSession.DispatchAsync(() => {
                 var service = new FakeDaemonClientService();
                 var pause = new FakePauseController();
-                using var vm = new TrayViewModel(service, pause, NewActions(service));
+                var consent = new FakeConsentService();
+                using var vm = new TrayViewModel(service, pause, NewActions(service), consent);
                 var builder = new TrayMenuBuilder(vm);
                 var menu = new NativeMenu();
 
@@ -224,6 +227,60 @@ public class TrayAdapterTests {
         });
     }
 
+    // ---- Review pending launches item (spec §8) ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Rebuild_omits_the_review_item_when_no_pending_consent() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var hasReviewItem = await AvaloniaSession.DispatchAsync(() => {
+                var service = new FakeDaemonClientService();
+                var pause = new FakePauseController();
+                var consent = new FakeConsentService();
+                using var vm = new TrayViewModel(service, pause, NewActions(service), consent);
+                var builder = new TrayMenuBuilder(vm);
+                var menu = new NativeMenu();
+
+                builder.Rebuild(menu, Model(agents: [], pendingConsent: 0));
+
+                return menu.Items.OfType<NativeMenuItem>().Any(i => i.Header == "Review pending launches…");
+            });
+
+            await Assert.That(hasReviewItem).IsFalse();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Rebuild_includes_review_item_between_agents_and_pause_when_pending_consent_positive() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (header, reviewIndex, pauseIndex, commandMatches) = await AvaloniaSession.DispatchAsync(() => {
+                var service = new FakeDaemonClientService();
+                var pause = new FakePauseController();
+                var consent = new FakeConsentService();
+                using var vm = new TrayViewModel(service, pause, NewActions(service), consent);
+                var builder = new TrayMenuBuilder(vm);
+                var menu = new NativeMenu();
+
+                var agents = new List<TrayAgentEntry> {
+                    new("a1", "agent · claude · repo-one", "agent", StopEnabled: true),
+                };
+                builder.Rebuild(menu, Model(agents: agents, pendingConsent: 3));
+
+                var items = menu.Items.OfType<NativeMenuItem>().ToList();
+                var review = items.First(i => i.Header == "Review pending launches…");
+                var pauseItem = items.First(i => i.Header == "Pause new launches");
+
+                return (review.Header, menu.Items.IndexOf(review), menu.Items.IndexOf(pauseItem),
+                    ReferenceEquals(review.Command, vm.ReviewPendingCommand));
+            });
+
+            await Assert.That(header).IsEqualTo("Review pending launches…");
+            await Assert.That(reviewIndex).IsEqualTo(pauseIndex - 1); // immediately before the pause toggle
+            await Assert.That(commandMatches).IsTrue();
+        });
+    }
+
     // Regression coverage (review Critical 1): NativeMenuItem.OnPropertyChanged recomputes
     // IsEnabled from Command.CanExecute(CommandParameter) whenever Command is (re)assigned
     // (decompiler-verified) — so IsEnabled must be the LAST property set in BuildPauseItem's
@@ -242,7 +299,8 @@ public class TrayAdapterTests {
             var (toggleType, isChecked, isEnabled, parameter, commandMatches) = await AvaloniaSession.DispatchAsync(() => {
                 var service = new FakeDaemonClientService();
                 var pause = new FakePauseController();
-                using var vm = new TrayViewModel(service, pause, NewActions(service));
+                var consent = new FakeConsentService();
+                using var vm = new TrayViewModel(service, pause, NewActions(service), consent);
                 var builder = new TrayMenuBuilder(vm);
                 var menu = new NativeMenu();
 
@@ -268,7 +326,8 @@ public class TrayAdapterTests {
             var (openHeader, openMatches, quitHeader, quitMatches) = await AvaloniaSession.DispatchAsync(() => {
                 var service = new FakeDaemonClientService();
                 var pause = new FakePauseController();
-                using var vm = new TrayViewModel(service, pause, NewActions(service));
+                var consent = new FakeConsentService();
+                using var vm = new TrayViewModel(service, pause, NewActions(service), consent);
                 var builder = new TrayMenuBuilder(vm);
                 var menu = new NativeMenu();
 
@@ -311,7 +370,8 @@ public class TrayAdapterTests {
             var (icon, tooltip, itemCountBeforeNeedsUpdate) = await AvaloniaSession.DispatchAsync(() => {
                 var service = new FakeDaemonClientService();
                 var pause = new FakePauseController();
-                using var vm = new TrayViewModel(service, pause, NewActions(service));
+                var consent = new FakeConsentService();
+                using var vm = new TrayViewModel(service, pause, NewActions(service), consent);
                 service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
                 service.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: "connected", active: 2));
 
@@ -335,7 +395,8 @@ public class TrayAdapterTests {
             var iconChanged = await AvaloniaSession.DispatchAsync(() => {
                 var service = new FakeDaemonClientService();
                 var pause = new FakePauseController();
-                using var vm = new TrayViewModel(service, pause, NewActions(service));
+                var consent = new FakeConsentService();
+                using var vm = new TrayViewModel(service, pause, NewActions(service), consent);
 
                 var app = Application.Current!;
                 using var manager = new TrayIconManager(app, vm);
@@ -361,7 +422,8 @@ public class TrayAdapterTests {
             var iconsAfterDispose = await AvaloniaSession.DispatchAsync(() => {
                 var service = new FakeDaemonClientService();
                 var pause = new FakePauseController();
-                using var vm = new TrayViewModel(service, pause, NewActions(service));
+                var consent = new FakeConsentService();
+                using var vm = new TrayViewModel(service, pause, NewActions(service), consent);
 
                 var app = Application.Current!;
                 var manager = new TrayIconManager(app, vm);

--- a/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
@@ -4,6 +4,7 @@ using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
 using Capacitor.Cli.Core.LocalIpc;
 using TUnit.Assertions.Enums;
+using static Capacitor.App.Tests.Unit.ConsentEntries;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -47,7 +48,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, reason, null));
 
@@ -63,7 +65,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             await Assert.That(vm.MenuModel.State).IsEqualTo(TrayState.Connecting);
             await Assert.That(vm.MenuModel.RunningCount).IsEqualTo(0);
@@ -85,7 +88,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap(connection, active));
@@ -102,7 +106,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             // No snapshot pushed — cannot happen per the client pin, but Project must stay total.
@@ -118,7 +123,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap("connected", 3));
@@ -142,7 +148,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
 
@@ -157,7 +164,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: connecting…");
         });
@@ -170,7 +178,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_incompatible", null));
 
@@ -186,7 +195,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap("reconnecting"));
@@ -202,7 +212,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap("disconnected"));
@@ -218,7 +229,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap("connected", 0));
@@ -234,7 +246,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap("connected", 4));
@@ -250,7 +263,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap("weird"));
@@ -266,7 +280,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
             service.SnapshotsSubject.OnNext(Snap("connected", -1));
@@ -282,7 +297,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "future_reason", null));
 
@@ -299,7 +315,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             var t0 = new DateTime(2026, 8, 6, 10, 0, 0, DateTimeKind.Utc);
             var agents = new List<AgentStatusDto> {
@@ -326,7 +343,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             var t0 = new DateTime(2026, 8, 6, 10, 0, 0, DateTimeKind.Utc);
             var agents = new List<AgentStatusDto> {
@@ -350,7 +368,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             var agents = new List<AgentStatusDto> {
                 new("r", "review-flow", "codex", null, "Running", null, null, null, DateTime.UtcNow, null, null),
@@ -370,7 +389,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             var agents = new List<AgentStatusDto> {
                 new("a", "agent", "claude", "/Users/alexey/dev/kcap-server/.claude/worktrees/hazy-sleeping-plum", "Running", null, null, null, DateTime.UtcNow, null, null),
@@ -390,7 +410,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             var agents = new List<AgentStatusDto> {
                 new("a", "agent", "claude", null, "Running", null, null, null, DateTime.UtcNow, null, null),
@@ -414,7 +435,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             pause.StateSubject.OnNext(new PauseState(Checked: false, Verified: true, Busy: false));
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, [])); // no consent/1
@@ -431,7 +453,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             pause.StateSubject.OnNext(new PauseState(Checked: false, Verified: true, Busy: false));
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
@@ -454,7 +477,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["consent/1"]));
             service.SnapshotsSubject.OnNext(Snap());
@@ -477,7 +501,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["consent/1"]));
             service.SnapshotsSubject.OnNext(Snap());
@@ -494,7 +519,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["consent/1"]));
             service.SnapshotsSubject.OnNext(Snap());
@@ -511,7 +537,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["consent/1"]));
             service.SnapshotsSubject.OnNext(Snap());
@@ -529,7 +556,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["consent/1"]));
             service.SnapshotsSubject.OnNext(Snap());
@@ -549,7 +577,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             vm.RequestPauseRefresh();
 
@@ -568,7 +597,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             // Connecting -> Connected(with capability): exactly one refresh from the edge.
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["consent/1"]));
@@ -600,7 +630,8 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             await vm.TogglePauseCommand.Execute(desired).ToTask();
 
@@ -626,7 +657,8 @@ public class TrayViewModelTests {
             var pause = new FakePauseController();
             var ops = new ScriptedLocalControlOps();
             var actions = new AgentActionService(ops, new RecordingNotifier(), new RecordingOpener(), service.SnapshotsSubject, CancellationToken.None, NeverConfirm.Confirm);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             var agents = new List<AgentStatusDto> {
                 new("a", "agent", "claude", null, "Running", null, null, null, DateTime.UtcNow, null, null),
@@ -656,7 +688,8 @@ public class TrayViewModelTests {
             var ops = new ScriptedLocalControlOps();
             var notifier = new RecordingNotifier();
             var actions = new AgentActionService(ops, notifier, new RecordingOpener(), service.SnapshotsSubject, CancellationToken.None, NeverConfirm.Confirm);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             var agents = new List<AgentStatusDto> {
                 new("a", "agent", "claude", "/repos/kcap-cli", "Running", null, null, null, DateTime.UtcNow, null, null),
@@ -685,7 +718,8 @@ public class TrayViewModelTests {
             var ops = new ScriptedLocalControlOps();
             var confirmer = new RecordingConfirmer();
             var actions = new AgentActionService(ops, new RecordingNotifier(), new RecordingOpener(), service.SnapshotsSubject, CancellationToken.None, confirmer.Confirm);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             var agents = new List<AgentStatusDto> {
                 new("a", "review-flow", "codex", "/repos/kcap-cli", "Running", null, null, null, DateTime.UtcNow, null, null),
@@ -712,7 +746,8 @@ public class TrayViewModelTests {
             var ops = new ScriptedLocalControlOps();
             var opener = new RecordingOpener();
             var actions = new AgentActionService(ops, new RecordingNotifier(), opener, service.SnapshotsSubject, CancellationToken.None, NeverConfirm.Confirm);
-            using var vm = new TrayViewModel(service, pause, actions);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
 
             service.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(serverUrl: "https://x.kcap.ai"));
 
@@ -732,7 +767,8 @@ public class TrayViewModelTests {
             var pause = new FakePauseController();
             var actions = NewActions(service);
             var calls = 0;
-            using var vm = new TrayViewModel(service, pause, actions, openMainWindow: () => calls++);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent, openMainWindow: () => calls++);
 
             await vm.OpenMainWindowCommand.Execute().ToTask();
 
@@ -748,7 +784,8 @@ public class TrayViewModelTests {
             var pause = new FakePauseController();
             var actions = NewActions(service);
             var calls = 0;
-            using var vm = new TrayViewModel(service, pause, actions, quit: () => calls++);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent, quit: () => calls++);
 
             await vm.QuitCommand.Execute().ToTask();
 
@@ -763,10 +800,86 @@ public class TrayViewModelTests {
             var service = new FakeDaemonClientService();
             var pause = new FakePauseController();
             var actions = NewActions(service);
-            using var vm = new TrayViewModel(service, pause, actions); // no delegates injected
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent); // no delegates injected
 
             await vm.OpenMainWindowCommand.Execute().ToTask();
             await vm.QuitCommand.Execute().ToTask();
+            await vm.ReviewPendingCommand.Execute().ToTask();
+        });
+    }
+
+    // ---- §8 pending-consent Attention row + Review menu item ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Pending_consent_asserts_attention_over_idle_and_running() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var pause = new FakePauseController();
+            var actions = NewActions(service);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
+            service.SnapshotsSubject.OnNext(Snap("connected", 0));
+            consent.Add(Entry("a1", "p1"));
+
+            await Assert.That(vm.MenuModel.State).IsEqualTo(TrayState.Attention);
+            await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: 1 launch awaiting approval");
+            await Assert.That(vm.MenuModel.RunningCount).IsEqualTo(0);
+            await Assert.That(vm.MenuModel.PendingConsent).IsEqualTo(1);
+
+            // 2 agents running + pendingCount 3 -> still Attention, plural copy, badge keeps 2.
+            service.SnapshotsSubject.OnNext(Snap("connected", 2));
+            consent.Add(Entry("a2", "p2", requestedAt: T0.AddSeconds(1)));
+            consent.Add(Entry("a3", "p3", requestedAt: T0.AddSeconds(2)));
+
+            await Assert.That(vm.MenuModel.State).IsEqualTo(TrayState.Attention);
+            await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: 3 launches awaiting approval");
+            await Assert.That(vm.MenuModel.RunningCount).IsEqualTo(2);
+            await Assert.That(vm.MenuModel.PendingConsent).IsEqualTo(3);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Connection_trouble_rows_keep_precedence() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var pause = new FakePauseController();
+            var actions = NewActions(service);
+            var consent = new FakeConsentService();
+            using var vm = new TrayViewModel(service, pause, actions, consent);
+
+            for (var i = 0; i < 5; i++) consent.Add(Entry($"a{i}", $"p{i}", requestedAt: T0.AddSeconds(i)));
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+            await Assert.That(vm.MenuModel.State).IsEqualTo(TrayState.Stopped); // row 1 still wins
+            await Assert.That(vm.MenuModel.PendingConsent).IsEqualTo(5);
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
+            service.SnapshotsSubject.OnNext(Snap("reconnecting"));
+
+            await Assert.That(vm.MenuModel.State).IsEqualTo(TrayState.Attention);
+            await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: reconnecting to server"); // row 5's copy wins
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task ReviewPendingCommand_invokes_the_injected_delegate() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var pause = new FakePauseController();
+            var actions = NewActions(service);
+            var consent = new FakeConsentService();
+            var calls = 0;
+            using var vm = new TrayViewModel(service, pause, actions, consent, openReviewPrompts: () => calls++);
+
+            await vm.ReviewPendingCommand.Execute().ToTask();
+
+            await Assert.That(calls).IsEqualTo(1);
         });
     }
 }

--- a/test/Capacitor.App.Tests.Unit/UiTickerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/UiTickerTests.cs
@@ -1,0 +1,54 @@
+using Avalonia.Threading;
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Regression coverage for the frozen-Uptime bug (moved here from AgentGridTests, which used to
+/// drive it through MainWindowViewModel's internal `Ticker` test seam): a row's shared ticker
+/// used to be subscribed inside DynamicData's Transform, which runs on whatever thread mutates
+/// the SourceCache — in production DaemonClientService's socket pump thread, never the UI thread.
+/// Subscribing the shared ticker from there bound its DispatcherTimer to a per-thread dispatcher
+/// nothing pumps, so the Interval produced no value at all and Uptime stayed at its seed forever.
+/// This drives UiTicker's REAL ticker (real 1s Interval on the real AvaloniaScheduler) from a
+/// background thread — the row-level uptime tests inject a Subject and are blind to the whole
+/// hazard.
+public class UiTickerTests {
+    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Ticker_subscribed_off_the_ui_thread_still_ticks_on_the_dispatcher() {
+        var (ticks, everyTickOnUiThread) = await AvaloniaSession.DispatchAsync(async () => {
+            var ticker = new UiTicker(); // construct ON the UI thread, per the production contract
+
+            var count = 0;
+            var onUiThread = true;
+            IDisposable? subscription = null;
+            await Task.Run(() => subscription = ticker.Ticks.Subscribe(_ => {
+                onUiThread &= Dispatcher.UIThread.CheckAccess();
+                Interlocked.Increment(ref count);
+            }));
+
+            // Baseline excludes anything the ticker delivers SYNCHRONOUSLY on subscribe (a
+            // StartWith-style seed), so the wait below can only be satisfied by a genuine periodic
+            // tick — the exact thing the broken version never produced.
+            var seedOnSubscribe = Volatile.Read(ref count);
+
+            // DispatchAsync's async overload pumps a DispatcherFrame around this body, which is
+            // what lets the dispatcher's own timers run while we wait.
+            await WaitUntilAsync(() => Volatile.Read(ref count) > seedOnSubscribe, what: "a periodic ticker tick");
+            subscription!.Dispose();
+
+            return (Volatile.Read(ref count) - seedOnSubscribe, onUiThread);
+        });
+
+        await Assert.That(ticks).IsGreaterThan(0);
+        await Assert.That(everyTickOnUiThread).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ConsentDecisionLogReaderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConsentDecisionLogReaderTests.cs
@@ -1,0 +1,181 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// Every test redirects <see cref="DaemonLockPaths"/> to a throwaway temp directory via
+/// <see cref="DaemonLockPaths.OverrideDirectoryForTesting"/> — never touch the real
+/// ~/.config/kcap/daemons (a stray read there can resolve the developer's live daemon).
+[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+public class ConsentDecisionLogReaderTests {
+    const string DaemonName = "test-daemon";
+
+    // requesterDisplay: null omits the field entirely — the true old-format shape (spec §4.4's
+    // field predates requester_display), distinct from an explicit JSON null.
+    static string Record(string decidedAt, string agentId = "agent-1", string? requesterDisplay = "Alexey") {
+        var displayField = requesterDisplay is null ? "" : $",\"requester_display\":\"{requesterDisplay}\"";
+        return "{\"decided_at\":\"" + decidedAt + "\",\"agent_id\":\"" + agentId + "\"," +
+               "\"requester\":\"alexey\",\"requester_is_owner\":true,\"kind\":\"agent\"," +
+               "\"repo_path\":\"/repo\",\"vendor\":\"claude\",\"outcome\":\"allowed\"," +
+               "\"source\":\"owner\"" + displayField + "}";
+    }
+
+    static DirectoryInfo SetUp() {
+        var dir = Directory.CreateTempSubdirectory("kcap-consent-decision-log-");
+        DaemonLockPaths.OverrideDirectoryForTesting(dir.FullName);
+        return dir;
+    }
+
+    static void TearDown(DirectoryInfo dir) {
+        DaemonLockPaths.OverrideDirectoryForTesting(null);
+        dir.Delete(true);
+    }
+
+    static void WriteLines(string path, params string[] lines) {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, string.Join('\n', lines) + '\n');
+    }
+
+    [Test]
+    public async Task Tail_merges_rotation_pair_newest_first_capped() {
+        var dir = SetUp();
+        try {
+            var path = ConsentDecisionLogReader.PathFor(DaemonName);
+            WriteLines(path + ".1", Record("2026-01-01T00:00:00Z", "old-0"), Record("2026-01-01T00:00:01Z", "old-1"), Record("2026-01-01T00:00:02Z", "old-2"));
+            WriteLines(path, Record("2026-01-01T00:01:00Z", "new-0"), Record("2026-01-01T00:01:01Z", "new-1"), Record("2026-01-01T00:01:02Z", "new-2"));
+
+            var result = ConsentDecisionLogReader.ReadTail(DaemonName, 4);
+
+            await Assert.That(result.Complete).IsTrue();
+            await Assert.That(result.Records.Count).IsEqualTo(4);
+            await Assert.That(result.Records[0].AgentId).IsEqualTo("new-2"); // current file's last record first
+            await Assert.That(result.Records[1].AgentId).IsEqualTo("new-1");
+            await Assert.That(result.Records[2].AgentId).IsEqualTo("new-0");
+            await Assert.That(result.Records[3].AgentId).IsEqualTo("old-2");
+        } finally {
+            TearDown(dir);
+        }
+    }
+
+    [Test]
+    public async Task Undecodable_and_structurally_invalid_lines_are_skipped() {
+        var dir = SetUp();
+        try {
+            var path = ConsentDecisionLogReader.PathFor(DaemonName);
+            WriteLines(path,
+                "not-json",
+                Record("2026-01-01T00:00:00Z", "valid-1"),
+                "{}",
+                Record("2026-01-01T00:00:01Z", "valid-2"));
+
+            var result = ConsentDecisionLogReader.ReadTail(DaemonName, 10);
+
+            await Assert.That(result.Complete).IsTrue();
+            await Assert.That(result.Records.Count).IsEqualTo(2);
+            await Assert.That(result.Records[0].AgentId).IsEqualTo("valid-2");
+            await Assert.That(result.Records[1].AgentId).IsEqualTo("valid-1");
+        } finally {
+            TearDown(dir);
+        }
+    }
+
+    [Test]
+    public async Task Absent_files_are_a_complete_empty_read() {
+        var dir = SetUp();
+        try {
+            var result = ConsentDecisionLogReader.ReadTail(DaemonName, 10);
+
+            await Assert.That(result.Records).IsEmpty();
+            await Assert.That(result.Complete).IsTrue();
+        } finally {
+            TearDown(dir);
+        }
+    }
+
+    [Test]
+    public async Task Unreadable_file_flips_complete_false_with_partial_records() {
+        var dir = SetUp();
+        try {
+            var path = ConsentDecisionLogReader.PathFor(DaemonName);
+            WriteLines(path + ".1", Record("2026-01-01T00:00:00Z", "backup-0"));
+
+            // Cross-platform stand-in for "unreadable": a directory at the exact file path makes
+            // the production FileStream open throw UnauthorizedAccessException/IOException,
+            // without relying on Windows-only exclusive-sharing semantics.
+            Directory.CreateDirectory(path);
+
+            var result = ConsentDecisionLogReader.ReadTail(DaemonName, 10);
+
+            await Assert.That(result.Complete).IsFalse();
+            await Assert.That(result.Records.Count).IsEqualTo(1);
+            await Assert.That(result.Records[0].AgentId).IsEqualTo("backup-0");
+        } finally {
+            TearDown(dir);
+        }
+    }
+
+    [Test]
+    public async Task Old_format_lines_parse_with_null_display() {
+        var dir = SetUp();
+        try {
+            var path = ConsentDecisionLogReader.PathFor(DaemonName);
+            WriteLines(path, Record("2026-01-01T00:00:00Z", "no-display", requesterDisplay: null));
+
+            var result = ConsentDecisionLogReader.ReadTail(DaemonName, 10);
+
+            await Assert.That(result.Complete).IsTrue();
+            await Assert.That(result.Records.Count).IsEqualTo(1);
+            await Assert.That(result.Records[0].RequesterDisplay).IsNull();
+        } finally {
+            TearDown(dir);
+        }
+    }
+
+    [Test]
+    public async Task Duplicate_records_across_the_rotation_boundary_are_deduped() {
+        var dir = SetUp();
+        try {
+            var path = ConsentDecisionLogReader.PathFor(DaemonName);
+            var shared = Record("2026-01-01T00:00:00Z", "shared");
+            WriteLines(path + ".1", shared);
+            WriteLines(path, shared);
+
+            var result = ConsentDecisionLogReader.ReadTail(DaemonName, 10);
+
+            await Assert.That(result.Complete).IsTrue();
+            await Assert.That(result.Records.Count).IsEqualTo(1);
+            await Assert.That(result.Records[0].AgentId).IsEqualTo("shared");
+        } finally {
+            TearDown(dir);
+        }
+    }
+
+    [Test]
+    public async Task Reader_share_mode_never_blocks_the_writer() {
+        var dir = SetUp();
+        try {
+            var path = ConsentDecisionLogReader.PathFor(DaemonName);
+            WriteLines(path, Record("2026-01-01T00:00:00Z", "initial"));
+
+            using var readerHandle = ConsentDecisionLogReader.OpenShared(path);
+
+            // (a) the daemon writer's append mode must not be blocked by the open reader handle.
+            var appendLine = Record("2026-01-01T00:00:01Z", "appended") + '\n';
+            await using (var writer = new FileStream(path, FileMode.Append, FileAccess.Write)) {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(appendLine);
+                await writer.WriteAsync(bytes);
+            }
+
+            // (b) the daemon's rotation (File.Move) must not be blocked either — this is what
+            // FileShare.Delete buys.
+            File.Move(path, path + ".1", overwrite: true);
+
+            // (c) a concurrent ReadTail must succeed while the original handle is still open.
+            var result = ConsentDecisionLogReader.ReadTail(DaemonName, 10);
+            await Assert.That(result.Complete).IsTrue();
+            await Assert.That(result.Records.Count).IsEqualTo(2);
+        } finally {
+            TearDown(dir);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ConsentSubscriptionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConsentSubscriptionTests.cs
@@ -76,7 +76,9 @@ public class ConsentSubscriptionTests {
 
     /// A faithful v1 daemon: reads the raw 5-byte header, sees a type byte its codec has no case
     /// for, and closes without writing ANY frame — never a routing-default Error reply (spec §4.1,
-    /// the V1CodecReject shape from Task 4).
+    /// the V1CodecReject shape from Task 4). Header-only is the full frame here ONLY because
+    /// ConsentSubscribeV2 carries an empty payload (len=0, see ConsentSubscription.RunAsync); a
+    /// non-empty request would need the payload read too (see LocalControlOpsTests.V1CodecReject).
     static ConnScript V1CodecReject() => async (_, s, ct) => {
         var head = new byte[5];
         var read = 0;

--- a/test/Capacitor.Cli.Tests.Unit/ConsentSubscriptionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConsentSubscriptionTests.cs
@@ -1,0 +1,259 @@
+using System.Net.Sockets;
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// ConsentSubscription.RunAsync over a REAL Unix socket driven by a scripted server (spec §4.2).
+/// Harness conventions (short socket paths for the macOS sockaddr_un ~104-byte limit, Windows
+/// guard, [NotInParallel], daemon-name→socket-path arrangement, the ScriptedOpsServer shape) are
+/// copied from <see cref="LocalControlOpsTests"/>.
+/// </summary>
+public class ConsentSubscriptionTests {
+    delegate Task ConnScript(Socket raw, NetworkStream s, CancellationToken ct);
+
+    sealed class ScriptedOpsServer : IAsyncDisposable {
+        readonly Socket _listener = new(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        readonly CancellationTokenSource _cts = new();
+        readonly ConnScript[] _scripts;
+        volatile int _served;
+        readonly Task _accept;
+
+        public ScriptedOpsServer(string sockPath, params ConnScript[] scripts) {
+            _scripts = scripts;
+            _listener.Bind(new UnixDomainSocketEndPoint(sockPath));
+            _listener.Listen(8);
+            _accept = Task.Run(async () => {
+                try {
+                    while (!_cts.IsCancellationRequested) {
+                        var conn = await _listener.AcceptAsync(_cts.Token);
+                        var script = _scripts[Math.Min(_served++, _scripts.Length - 1)];
+                        _ = Task.Run(async () => {
+                            using var c = conn;
+                            await using var s = new NetworkStream(c, ownsSocket: false);
+                            try { await script(c, s, _cts.Token); } catch { /* scripted teardown */ }
+                        }, _cts.Token);
+                    }
+                } catch { /* shutdown */ }
+            });
+        }
+
+        public async ValueTask DisposeAsync() {
+            _cts.Cancel();
+            _listener.Dispose();
+            if (_accept is { } a) { try { await a; } catch { } }
+        }
+    }
+
+    // ---- script building blocks ----
+
+    /// Reads the ConsentSubscribeV2 frame then parks on an awaited TaskCompletionSource so no
+    /// reply EVER arrives — the empty-replay boundary (spec §4.2). Only server teardown (the
+    /// script's own ct, cancelled by ScriptedOpsServer.DisposeAsync) unblocks this.
+    static ConnScript SubscribeThenPark() => async (_, s, ct) => {
+        var f = await FrameCodec.ReadAsync(s, ct);
+        if (f?.Type != FrameType.ConsentSubscribeV2) return;
+        var tcs = new TaskCompletionSource();
+        await tcs.Task.WaitAsync(ct);
+    };
+
+    static ConnScript SubscribePush(params string[] pendingJsons) => async (_, s, ct) => {
+        var f = await FrameCodec.ReadAsync(s, ct);
+        if (f?.Type != FrameType.ConsentSubscribeV2) return;
+        foreach (var json in pendingJsons)
+            await FrameCodec.WriteAsync(s, LocalFrame.ConsentJson(FrameType.ConsentPending, json), ct);
+    };
+
+    /// Answers the subscribe with a decodable but wrong frame type — protocol confusion,
+    /// distinct from an undecodable frame type (FrameCodec's own InvalidDataException path).
+    static ConnScript SubscribeThenWrongFrameType() => async (_, s, ct) => {
+        var f = await FrameCodec.ReadAsync(s, ct);
+        if (f?.Type != FrameType.ConsentSubscribeV2) return;
+        await FrameCodec.WriteAsync(s, LocalFrame.ConsentJson(FrameType.ConsentRules, "{}"), ct);
+    };
+
+    /// A faithful v1 daemon: reads the raw 5-byte header, sees a type byte its codec has no case
+    /// for, and closes without writing ANY frame — never a routing-default Error reply (spec §4.1,
+    /// the V1CodecReject shape from Task 4).
+    static ConnScript V1CodecReject() => async (_, s, ct) => {
+        var head = new byte[5];
+        var read = 0;
+        while (read < 5) {
+            var n = await s.ReadAsync(head.AsMemory(read), ct);
+            if (n == 0) return;
+            read += n;
+        }
+    };
+
+    static string ValidPendingJson(string requestId, string promptId) =>
+        JsonSerializer.Serialize(
+            new ConsentPendingDto(requestId, null, "tool", "/repo", "claude", "2026-08-08T00:00:00Z", 30, null, promptId),
+            ConsentIpcJsonContext.Default.ConsentPendingDto);
+
+    /// Builds a v1-shaped payload (every field besides prompt_id is valid) with the given
+    /// literal fragment appended for the prompt_id member — "" omits the member entirely.
+    static string PendingJsonWithPromptIdFragment(string requestId, string promptIdFragment) =>
+        $$"""{"request_id":"{{requestId}}","requester":null,"kind":"tool","repo_path":"/repo","vendor":"claude","requested_at":"2026-08-08T00:00:00Z","timeout_seconds":30,"requester_display":null{{promptIdFragment}}}""";
+
+    /// Runs `body` against an isolated socket dir with a scripted server listening for `name`.
+    static async Task WithServerAsync(ConnScript[] scripts, Func<string, Task> body) {
+        var sockDir = Directory.CreateTempSubdirectory("kcap-csx-");
+        DaemonLockPaths.OverrideDirectoryForTesting(sockDir.FullName);
+        try {
+            var name = "csx-" + Guid.NewGuid().ToString("N")[..6];
+            await using var server = new ScriptedOpsServer(LocalSocketPaths.Socket(name), scripts);
+            await body(name);
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(sockDir.FullName, true); } catch { }
+        }
+    }
+
+    static async Task<List<ConsentStreamEvent>> CollectAsync(string daemonName, TimeSpan timeout) {
+        using var cts = new CancellationTokenSource(timeout);
+        var events = new List<ConsentStreamEvent>();
+        await foreach (var e in ConsentSubscription.RunAsync(daemonName, cts.Token)) events.Add(e);
+        return events;
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Subscribed_is_yielded_after_the_write_and_before_any_frame() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithServerAsync([SubscribeThenPark()], async name => {
+            using var cts = new CancellationTokenSource();
+            var enumerator = ConsentSubscription.RunAsync(name, cts.Token).GetAsyncEnumerator();
+            try {
+                var moved = await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+                await Assert.That(moved).IsTrue();
+                await Assert.That(enumerator.Current).IsTypeOf<ConsentStreamEvent.Subscribed>();
+            } finally {
+                await enumerator.DisposeAsync();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Replay_and_push_frames_yield_pending_events_in_order() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var a = ValidPendingJson("r1", "p1");
+        var b = ValidPendingJson("r2", "p2");
+        await WithServerAsync([SubscribePush(a, b)], async name => {
+            var events = await CollectAsync(name, TimeSpan.FromSeconds(5));
+
+            await Assert.That(events.Count).IsEqualTo(3);
+            await Assert.That(events[0]).IsTypeOf<ConsentStreamEvent.Subscribed>();
+            var p0 = (ConsentStreamEvent.Pending)events[1];
+            await Assert.That(p0.Request.RequestId).IsEqualTo("r1");
+            var p1 = (ConsentStreamEvent.Pending)events[2];
+            await Assert.That(p1.Request.RequestId).IsEqualTo("r2");
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Failed_connect_ends_without_subscribed() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var sockDir = Directory.CreateTempSubdirectory("kcap-csx-");
+        DaemonLockPaths.OverrideDirectoryForTesting(sockDir.FullName);
+        try {
+            var events = await CollectAsync("csx-none", TimeSpan.FromSeconds(5));
+            await Assert.That(events.Count).IsEqualTo(0);
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(sockDir.FullName, true); } catch { }
+        }
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Unexpected_frame_type_ends_the_enumeration() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithServerAsync([SubscribeThenWrongFrameType()], async name => {
+            var events = await CollectAsync(name, TimeSpan.FromSeconds(5));
+            await Assert.That(events.Count).IsEqualTo(1);
+            await Assert.That(events[0]).IsTypeOf<ConsentStreamEvent.Subscribed>();
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Undecodable_json_ends_the_enumeration() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithServerAsync([SubscribePush("not-json")], async name => {
+            var events = await CollectAsync(name, TimeSpan.FromSeconds(5));
+            await Assert.That(events.Count).IsEqualTo(1);
+            await Assert.That(events[0]).IsTypeOf<ConsentStreamEvent.Subscribed>();
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Structurally_invalid_pending_is_skipped_and_the_stream_continues() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var valid = ValidPendingJson("r1", "p1");
+        await WithServerAsync([SubscribePush("{}", valid)], async name => {
+            var events = await CollectAsync(name, TimeSpan.FromSeconds(5));
+            await Assert.That(events.Count).IsEqualTo(2);
+            await Assert.That(events[0]).IsTypeOf<ConsentStreamEvent.Subscribed>();
+            var pending = (ConsentStreamEvent.Pending)events[1];
+            await Assert.That(pending.Request.RequestId).IsEqualTo("r1");
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Prompt_id_requirement_is_isolated() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var absent = PendingJsonWithPromptIdFragment("r1", "");
+        var nullValue = PendingJsonWithPromptIdFragment("r2", ",\"prompt_id\":null");
+        var empty = PendingJsonWithPromptIdFragment("r3", ",\"prompt_id\":\"\"");
+        var final = ValidPendingJson("r4", "p4");
+
+        await WithServerAsync([SubscribePush(absent, nullValue, empty, final)], async name => {
+            var events = await CollectAsync(name, TimeSpan.FromSeconds(5));
+            await Assert.That(events.Count).IsEqualTo(2);
+            await Assert.That(events[0]).IsTypeOf<ConsentStreamEvent.Subscribed>();
+            var pending = (ConsentStreamEvent.Pending)events[1];
+            await Assert.That(pending.Request.RequestId).IsEqualTo("r4");
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task V1_codec_daemon_yields_subscribed_then_ends() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithServerAsync([V1CodecReject()], async name => {
+            var events = await CollectAsync(name, TimeSpan.FromSeconds(5));
+            await Assert.That(events.Count).IsEqualTo(1);
+            await Assert.That(events[0]).IsTypeOf<ConsentStreamEvent.Subscribed>();
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Cancellation_propagates() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithServerAsync([SubscribeThenPark()], async name => {
+            using var cts = new CancellationTokenSource();
+            var enumTask = Task.Run(async () => {
+                await foreach (var _ in ConsentSubscription.RunAsync(name, cts.Token)) { }
+            });
+            await Task.Delay(50); // let connect+write+Subscribed land so cancellation hits the pending read
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await enumTask);
+        });
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ConsentWireContractsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ConsentWireContractsTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// Wire-shape pins for the consent v2 contracts (spec §4.1, §4.4): trailing nullable
+/// members with no C# default, nulls always written, snake_case names byte-compatible with
+/// existing daemons' output.
+public class ConsentWireContractsTests {
+    [Test]
+    public async Task Pending_dto_roundtrips_with_trailing_fields() {
+        var dto = new ConsentPendingDto("a1", "github:1", "agent", "/r", "codex", "2026-08-08T10:00:00.0000000+00:00", 45, "Mathias", "p1");
+        var json = JsonSerializer.Serialize(dto, ConsentIpcJsonContext.Default.ConsentPendingDto);
+        await Assert.That(json).Contains("\"requester_display\":\"Mathias\"");
+        await Assert.That(json).Contains("\"prompt_id\":\"p1\"");
+        var back = JsonSerializer.Deserialize(json, ConsentIpcJsonContext.Default.ConsentPendingDto);
+        await Assert.That(back).IsEqualTo(dto);
+    }
+
+    [Test]
+    public async Task Pending_dto_from_v1_daemon_reads_null_display_and_prompt_id() {
+        // A pre-v2 daemon's exact serialization (no requester_display, no prompt_id).
+        const string v1 = "{\"request_id\":\"a1\",\"requester\":\"github:1\",\"kind\":\"agent\",\"repo_path\":\"/r\",\"vendor\":\"codex\",\"requested_at\":\"t\",\"timeout_seconds\":45}";
+        var dto = JsonSerializer.Deserialize(v1, ConsentIpcJsonContext.Default.ConsentPendingDto)!;
+        await Assert.That(dto.RequesterDisplay).IsNull();
+        await Assert.That(dto.PromptId).IsNull();
+    }
+
+    [Test]
+    public async Task Resolve_dto_carries_prompt_id_and_ack_carries_rule_saved_with_nulls_written() {
+        var resolve = new ConsentResolveDto("a1", "allow", null, "p1");
+        var rjson = JsonSerializer.Serialize(resolve, ConsentIpcJsonContext.Default.ConsentResolveDto);
+        await Assert.That(rjson).Contains("\"prompt_id\":\"p1\"");
+
+        var ack = new ConsentAckDto(true, null, null);
+        var ajson = JsonSerializer.Serialize(ack, ConsentIpcJsonContext.Default.ConsentAckDto);
+        await Assert.That(ajson).Contains("\"rule_saved\":null"); // nulls-always-written convention
+
+        // Old-format ack (no rule_saved member) → null, not an error.
+        var old = JsonSerializer.Deserialize("{\"ok\":false,\"error\":\"x\"}", ConsentIpcJsonContext.Default.ConsentAckDto)!;
+        await Assert.That(old.RuleSaved).IsNull();
+    }
+
+    [Test]
+    public async Task Decision_record_matches_existing_on_disk_field_names_verbatim() {
+        var rec = new ConsentDecisionRecord("t", "a1", "github:1", false, "agent", "/r", "codex", "allowed", "rule[0]", null);
+        var json = JsonSerializer.Serialize(rec, ConsentDecisionJsonContext.Default.ConsentDecisionRecord);
+        foreach (var name in new[] { "\"decided_at\"", "\"agent_id\"", "\"requester\"", "\"requester_is_owner\"",
+                                     "\"kind\"", "\"repo_path\"", "\"vendor\"", "\"outcome\"", "\"source\"", "\"requester_display\"" })
+            await Assert.That(json).Contains(name);
+
+        // Old log line (pre-v2, no requester_display) parses; missing bool reads false.
+        const string oldLine = "{\"decided_at\":\"t\",\"agent_id\":\"a1\",\"requester\":null,\"requester_is_owner\":true,\"kind\":\"agent\",\"repo_path\":\"/r\",\"vendor\":\"codex\",\"outcome\":\"allowed\",\"source\":\"owner\"}";
+        var back = JsonSerializer.Deserialize(oldLine, ConsentDecisionJsonContext.Default.ConsentDecisionRecord)!;
+        await Assert.That(back.RequesterDisplay).IsNull();
+        await Assert.That(back.RequesterIsOwner).IsTrue();
+    }
+
+    [Test]
+    public async Task V2_frame_values_are_pinned_and_codec_roundtrips_them() {
+        await Assert.That((byte)FrameType.ConsentSubscribeV2).IsEqualTo((byte)17);
+        await Assert.That((byte)FrameType.ConsentResolveV2).IsEqualTo((byte)18);
+
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(ms, LocalFrame.ConsentJson(FrameType.ConsentResolveV2, "{\"x\":1}"), CancellationToken.None);
+        await FrameCodec.WriteAsync(ms, new LocalFrame(FrameType.ConsentSubscribeV2), CancellationToken.None);
+        ms.Position = 0;
+        var f1 = (await FrameCodec.ReadAsync(ms, CancellationToken.None))!;
+        var f2 = (await FrameCodec.ReadAsync(ms, CancellationToken.None))!;
+        await Assert.That(f1.Type).IsEqualTo(FrameType.ConsentResolveV2);
+        await Assert.That(f1.Text).IsEqualTo("{\"x\":1}");
+        await Assert.That(f2.Type).IsEqualTo(FrameType.ConsentSubscribeV2);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentBrokerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentBrokerTests.cs
@@ -15,8 +15,10 @@ public class LaunchConsentBrokerTests {
         return await task;
     }
 
-    static LaunchConsentPromptRequest Req(string id = "a1") =>
-        new(id, "user_x", "agent", "/tmp/repo", "claude", DateTimeOffset.UtcNow.ToString("O"), 5);
+    static LaunchConsentPromptRequest Req(string id = "a1", string promptId = "p1") =>
+        new(id, "user_x", "agent", "/tmp/repo", "claude", DateTimeOffset.UtcNow.ToString("O"), 5, null, promptId);
+
+    static LaunchConsentPromptRequest ReqWithPromptId(string id, string promptId) => Req(id, promptId);
 
     [Test]
     public async Task No_subscriber_reports_HasSubscriber_false() {
@@ -253,5 +255,46 @@ public class LaunchConsentBrokerTests {
 
         await Assert.That(async () => await promptTask).Throws<OperationCanceledException>();
         await Assert.That(broker.TryResolve("a-external-cancel", allow: true)).IsFalse();
+    }
+
+    // ══ TryResolve promptId-echo claim (spec §4.1) — the atomic identity-checked overload. ═════
+
+    [Test]
+    public async Task TryResolve_with_matching_echo_resolves_and_mismatch_leaves_pending_untouched() {
+        var broker = new LaunchConsentBroker();
+        var (id, _) = broker.Subscribe();
+        var promptTask = broker.PromptAsync(ReqWithPromptId("agent-1", "p-A"), TimeSpan.FromMinutes(1), TimeProvider.System, CancellationToken.None);
+
+        await Assert.That(broker.TryResolve("agent-1", true, "WRONG")).IsFalse();   // mismatch: no claim
+        await Assert.That(promptTask.IsCompleted).IsFalse();                        // A still pending
+        await Assert.That(broker.TryResolve("agent-1", true, "p-A")).IsTrue();      // exact echo claims
+        await Assert.That(await promptTask).IsTrue();
+        broker.Unsubscribe(id);
+    }
+
+    [Test]
+    public async Task Stale_echo_for_a_superseded_request_never_decides_the_successor() {
+        // A times out; successor B reuses the id; A's late resolve must answer false and leave B live.
+        var broker = new LaunchConsentBroker();
+        var (id, _) = broker.Subscribe();
+        var a = broker.PromptAsync(ReqWithPromptId("agent-1", "p-A"), TimeSpan.Zero, TimeProvider.System, CancellationToken.None);
+        await Assert.That(await a).IsNull(); // timeout claimed A
+        var b = broker.PromptAsync(ReqWithPromptId("agent-1", "p-B"), TimeSpan.FromMinutes(1), TimeProvider.System, CancellationToken.None);
+
+        await Assert.That(broker.TryResolve("agent-1", true, "p-A")).IsFalse(); // stale identity: refused
+        await Assert.That(b.IsCompleted).IsFalse();                             // B untouched
+        await Assert.That(broker.TryResolve("agent-1", false, "p-B")).IsTrue(); // B decided on its own terms
+        await Assert.That(await b).IsFalse();
+        broker.Unsubscribe(id);
+    }
+
+    [Test]
+    public async Task Null_echo_preserves_legacy_resolve_by_id() {
+        var broker = new LaunchConsentBroker();
+        var (id, _) = broker.Subscribe();
+        var a = broker.PromptAsync(ReqWithPromptId("agent-1", "p-A"), TimeSpan.FromMinutes(1), TimeProvider.System, CancellationToken.None);
+        await Assert.That(broker.TryResolve("agent-1", true, null)).IsTrue();
+        await Assert.That(await a).IsTrue();
+        broker.Unsubscribe(id);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentDecisionLogTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentDecisionLogTests.cs
@@ -1,13 +1,14 @@
 using System.Text.Json;
+using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 public class LaunchConsentDecisionLogTests {
-    static LaunchConsentRecord Rec(string agent = "a1") => new(
+    static ConsentDecisionRecord Rec(string agent = "a1") => new(
         DateTimeOffset.UtcNow.ToString("O"), agent, "user_x", false,
-        "agent", "/tmp/repo", "claude", "denied", "default");
+        "agent", "/tmp/repo", "claude", "denied", "default", "Mathias");
 
     [Test]
     public async Task Records_append_as_parseable_snake_case_jsonl() {
@@ -20,6 +21,7 @@ public class LaunchConsentDecisionLogTests {
         using var parsed = JsonDocument.Parse(lines[0]);
         await Assert.That(parsed.RootElement.GetProperty("agent_id").GetString()).IsEqualTo("a1");
         await Assert.That(parsed.RootElement.GetProperty("outcome").GetString()).IsEqualTo("denied");
+        await Assert.That(lines[0]).Contains("\"requester_display\":\"Mathias\"");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentEngineTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentEngineTests.cs
@@ -6,8 +6,8 @@ namespace Capacitor.Cli.Tests.Unit.Daemon;
 internal class LaunchConsentEngineTests {
     static LaunchConsentInput Input(
         string? requester = "user_abc", bool owner = false, string kind = "agent",
-        string repo = "/Users/me/dev/proj", string vendor = "claude")
-        => new(requester, owner, kind, repo, vendor);
+        string repo = "/Users/me/dev/proj", string vendor = "claude", string? requesterDisplay = null)
+        => new(requester, owner, kind, repo, vendor, requesterDisplay);
 
     static LaunchConsentPolicy Policy(
         LaunchConsentDefault def = LaunchConsentDefault.Allow, params LaunchConsentRule[] rules)
@@ -121,6 +121,17 @@ internal class LaunchConsentEngineTests {
         var d = LaunchConsentEngine.Evaluate(policy, Input(owner: true));
         await Assert.That(d.Verdict).IsEqualTo(LaunchConsentVerdict.Allow);
         await Assert.That(d.Source).IsEqualTo("owner");
+    }
+
+    [Test] // first-match-wins pins the "Allow & remember shadowed by pause" contract (spec §4.1).
+    public async Task Earlier_wildcard_deny_shadows_a_later_appended_allow() {
+        var policy = new LaunchConsentPolicy(LaunchConsentDefault.Prompt, 45, [
+            new LaunchConsentRule("deny", null, null, null, null),          // pause at rules[0]
+            new LaunchConsentRule("allow", "github:1", null, null, null),   // appended by Allow & remember
+        ]);
+        var d = LaunchConsentEngine.Evaluate(policy, Input(requester: "github:1"));
+        await Assert.That(d.Verdict).IsEqualTo(LaunchConsentVerdict.Deny);
+        await Assert.That(d.Source).IsEqualTo("rule[0]");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentGateTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentGateTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
@@ -16,8 +17,8 @@ public class LaunchConsentGateTests {
         return (gate, store, dir);
     }
 
-    static LaunchConsentInput Input(bool owner = false) =>
-        new("user_x", owner, "agent", "/tmp/repo", "claude");
+    static LaunchConsentInput Input(bool owner = false, string? requesterDisplay = null) =>
+        new("user_x", owner, "agent", "/tmp/repo", "claude", requesterDisplay);
 
     sealed class FakePrompter(bool? answer, bool hasSubscriber = true) : ILaunchConsentPrompter {
         public LaunchConsentPromptRequest? Seen;
@@ -26,6 +27,19 @@ public class LaunchConsentGateTests {
             Task.FromResult(hasSubscriber);
         public Task<bool?> PromptAsync(LaunchConsentPromptRequest req, TimeSpan timeout, TimeProvider time, CancellationToken ct) {
             Seen = req;
+            return Task.FromResult(answer);
+        }
+    }
+
+    /// Like FakePrompter, but accumulates every request it is asked to prompt — for pinning
+    /// per-call identity (e.g. distinct minted PromptIds across repeated DecideAsync calls).
+    sealed class CapturingPrompter(bool? answer) : ILaunchConsentPrompter {
+        public readonly List<LaunchConsentPromptRequest> Requests = [];
+        public bool HasSubscriber => true;
+        public Task<bool> WaitForSubscriberAsync(TimeSpan wait, TimeProvider time, CancellationToken ct) =>
+            Task.FromResult(true);
+        public Task<bool?> PromptAsync(LaunchConsentPromptRequest req, TimeSpan timeout, TimeProvider time, CancellationToken ct) {
+            Requests.Add(req);
             return Task.FromResult(answer);
         }
     }
@@ -83,6 +97,37 @@ public class LaunchConsentGateTests {
     [Test]
     public async Task Denied_reason_prefix_is_the_public_wire_literal() {
         await Assert.That(LaunchConsentGate.DeniedReasonPrefix).IsEqualTo("launch_denied_by_owner");
+    }
+
+    [Test]
+    public async Task Gate_mints_distinct_prompt_ids_under_a_frozen_clock_and_threads_display() {
+        // Frozen TimeProvider (never advanced): RequestedAt is identical for both prompts —
+        // PromptId must still differ (the failure mode a timestamp identity would have had).
+        var prompter = new CapturingPrompter(answer: true);
+        var (gate, _, _) = Build(LaunchConsentDefault.Prompt, prompter, time: new FakeTimeProvider());
+        var input = new LaunchConsentInput("github:1", false, "agent", "/r", "codex", "Mathias");
+
+        await gate.DecideAsync("agent-1", input, CancellationToken.None);
+        await gate.DecideAsync("agent-1", input, CancellationToken.None);
+
+        var (a, b) = (prompter.Requests[0], prompter.Requests[1]);
+        await Assert.That(a.RequestedAt).IsEqualTo(b.RequestedAt);        // clock frozen
+        await Assert.That(a.PromptId).IsNotEqualTo(b.PromptId);          // identity is not the clock
+        await Assert.That(a.PromptId).IsNotEmpty();
+        await Assert.That(a.RequesterDisplay).IsEqualTo("Mathias");
+    }
+
+    [Test]
+    public async Task Done_records_requester_display_in_the_decision_record() {
+        // Rule-allowed path (no prompter needed): input display lands in the log record.
+        var (gate, _, dir) = Build(LaunchConsentDefault.Allow);
+        var o = await gate.DecideAsync("a1",
+            new LaunchConsentInput("github:1", false, "agent", "/r", "codex", "Mathias"), CancellationToken.None);
+        await Assert.That(o.Source).IsEqualTo("default");
+
+        var lines = File.ReadAllLines(Path.Combine(dir, "consent-decisions.jsonl"));
+        using var parsed = JsonDocument.Parse(lines[0]);
+        await Assert.That(parsed.RootElement.GetProperty("requester_display").GetString()).IsEqualTo("Mathias");
     }
 
     // ══ Deadline discipline (spec §3.2) — grace + monotonic deadline + TimeProvider plumbing.

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentIpcTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentIpcTests.cs
@@ -191,7 +191,7 @@ public class LaunchConsentIpcTests {
             await FrameCodec.WriteAsync(subscriber, new LocalFrame(FrameType.ConsentSubscribe), ct);
             await SpinUntilSubscribedAsync(h.Broker, ct);
 
-            var input = new LaunchConsentInput("user_x", RequesterIsOwner: false, "agent", "/tmp/repo", "claude");
+            var input = new LaunchConsentInput("user_x", RequesterIsOwner: false, "agent", "/tmp/repo", "claude", null);
             var decideTask = h.Gate.DecideAsync("a9", input, ct);
 
             var pending = await FrameCodec.ReadAsync(subscriber, ct);
@@ -224,7 +224,7 @@ public class LaunchConsentIpcTests {
             await FrameCodec.WriteAsync(subscriber, new LocalFrame(FrameType.ConsentSubscribe), ct);
             await SpinUntilSubscribedAsync(h.Broker, ct);
 
-            var input = new LaunchConsentInput("user_x", RequesterIsOwner: false, "review-flow", "/tmp/repo", "claude");
+            var input = new LaunchConsentInput("user_x", RequesterIsOwner: false, "review-flow", "/tmp/repo", "claude", null);
             var decideTask = h.Gate.DecideAsync("a10", input, ct);
 
             var pending = await FrameCodec.ReadAsync(subscriber, ct);
@@ -347,7 +347,7 @@ public class LaunchConsentIpcTests {
             await FrameCodec.WriteAsync(subscriber, new LocalFrame(FrameType.ConsentSubscribe), ct);
             await SpinUntilSubscribedAsync(h.Broker, ct);
 
-            var input = new LaunchConsentInput("user_x", RequesterIsOwner: false, "agent", "/tmp/repo", "claude");
+            var input = new LaunchConsentInput("user_x", RequesterIsOwner: false, "agent", "/tmp/repo", "claude", null);
             var decideTask = h.Gate.DecideAsync("a11", input, ct);
 
             var pending = await FrameCodec.ReadAsync(subscriber, ct);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentIpcTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LaunchConsentIpcTests.cs
@@ -133,6 +133,38 @@ public class LaunchConsentIpcTests {
         while (!broker.HasSubscriber && DateTime.UtcNow < deadline) await Task.Delay(10, ct);
     }
 
+    // ══ v2 helpers: a fresh connection per resolve (mirrors the file's existing one-shot-resolve
+    // tests), routed through the real LocalControlServer switch so the ConsentResolveV2/
+    // ConsentSubscribeV2 routing added for the v2 consent surface is exercised, not bypassed. ═════
+
+    static async Task<ConsentAckDto> ResolveAsync(Harness h, string json, bool requireEcho, CancellationToken ct) {
+        await using var s = await ConnectAsync(h.SockPath, ct);
+        var frameType = requireEcho ? FrameType.ConsentResolveV2 : FrameType.ConsentResolve;
+        await FrameCodec.WriteAsync(s, LocalFrame.ConsentJson(frameType, json), ct);
+        var resp = await FrameCodec.ReadAsync(s, ct);
+        return JsonSerializer.Deserialize(resp!.Text, ConsentIpcJsonContext.Default.ConsentAckDto)!;
+    }
+
+    /// Builds a ConsentResolveDto payload via the shared source-gen context (rather than a
+    /// hand-typed literal) so the helper can't drift from the wire shape it's meant to exercise.
+    /// `action` overrides the save_rule's action independently of `decision` — needed to drive a
+    /// store-side rejection (an invalid action) while still resolving a valid allow/deny.
+    static string ResolveJson(string requestId, string decision, bool saveRule, string? promptId, string? action = null) {
+        var rule = saveRule ? new ConsentRuleDto(action ?? decision, "github:1", "agent", null, null) : null;
+        return JsonSerializer.Serialize(new ConsentResolveDto(requestId, decision, rule, promptId),
+            ConsentIpcJsonContext.Default.ConsentResolveDto);
+    }
+
+    static IReadOnlyList<LaunchConsentRule> StoreRules(Harness h) => h.Store.Current.Rules;
+
+    static bool PendingStillLive(Harness h, string requestId) =>
+        h.Broker.PendingSnapshot().Any(p => p.RequestId == requestId);
+
+    static async Task<ConsentPendingDto> FirstPendingFrom(Stream subscribeStream, CancellationToken ct) {
+        var frame = await FrameCodec.ReadAsync(subscribeStream, ct);
+        return JsonSerializer.Deserialize(frame!.Text, ConsentIpcJsonContext.Default.ConsentPendingDto)!;
+    }
+
     [Test]
     [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
     public async Task RulesGet_returns_current_policy_and_RulesPut_replaces_it() {
@@ -372,6 +404,137 @@ public class LaunchConsentIpcTests {
             var outcome = await decideTask;
             await Assert.That(outcome.Allowed).IsTrue();
             await Assert.That(outcome.Source).IsEqualTo("prompt_user");
+        });
+    }
+
+    // ══ v2 consent surface (ConsentSubscribeV2/ConsentResolveV2): a mandatory prompt_id identity
+    // echo, rule_saved reported on both ack branches, and ToDto stamping pinned against the
+    // broker's own ground-truth PromptId/RequesterDisplay. ═══════════════════════════════════════
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task V2_resolve_without_prompt_id_acks_invalid_payload() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("v2-resolve-noecho", LaunchConsentDefault.Allow, 45, async (h, ct) => {
+            // A v2 resolve missing prompt_id entirely never reaches the broker.
+            await using (var s1 = await ConnectAsync(h.SockPath, ct)) {
+                await FrameCodec.WriteAsync(s1, LocalFrame.ConsentJson(FrameType.ConsentResolveV2,
+                    """{"request_id":"a1","decision":"allow","save_rule":null}"""), ct);
+                var resp = await FrameCodec.ReadAsync(s1, ct);
+                var ack = JsonSerializer.Deserialize(resp!.Text, ConsentIpcJsonContext.Default.ConsentAckDto)!;
+                await Assert.That(ack.Ok).IsFalse();
+                await Assert.That(ack.Error).Contains("prompt_id");
+            }
+
+            // Nor does an empty-string prompt_id.
+            var emptyEchoAck = await ResolveAsync(h, ResolveJson("a1", "allow", saveRule: false, ""), requireEcho: true, ct);
+            await Assert.That(emptyEchoAck.Ok).IsFalse();
+            await Assert.That(emptyEchoAck.Error).Contains("prompt_id");
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Rule_saved_is_populated_on_both_ok_branches() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("v2-rule-saved", LaunchConsentDefault.Prompt, 30, async (h, ct) => {
+            await using var subscriber = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(subscriber, new LocalFrame(FrameType.ConsentSubscribeV2), ct);
+            await SpinUntilSubscribedAsync(h.Broker, ct);
+
+            var input = new LaunchConsentInput("user_x", RequesterIsOwner: false, "agent", "/tmp/repo", "claude", null);
+
+            // (1) save_rule + live pending + matching echo → Ok=true, RuleSaved=true.
+            var decideTask1 = h.Gate.DecideAsync("a1", input, ct);
+            var pending1 = await FirstPendingFrom(subscriber, ct);
+            var okAck = await ResolveAsync(h, ResolveJson("a1", "allow", saveRule: true, pending1.PromptId), requireEcho: true, ct);
+            await Assert.That(okAck.Ok).IsTrue();
+            await Assert.That(okAck.RuleSaved).IsEqualTo(true);
+            await decideTask1;
+
+            // (2) save_rule + NO pending → the rule is still persisted (save-before-resolve is
+            // deliberate — "Allow & remember" is a durable trust statement, not conditioned on this
+            // particular launch still being live), Ok=false, RuleSaved=true.
+            var nopAck = await ResolveAsync(h, ResolveJson("ghost", "allow", saveRule: true, "p-x"), requireEcho: true, ct);
+            await Assert.That(nopAck.Ok).IsFalse();
+            await Assert.That(nopAck.RuleSaved).IsEqualTo(true);
+            await Assert.That(StoreRules(h).Any(r => r.Requester == "github:1")).IsTrue(); // persisted despite Ok=false
+
+            // (3) save_rule rejected by the store (invalid action) → RuleSaved=false on BOTH the
+            // still-resolves-fine branch and the no-pending branch.
+            var decideTask3 = h.Gate.DecideAsync("a1", input, ct); // successor prompt reusing "a1" — case (1)'s was already claimed
+            var pending3 = await FirstPendingFrom(subscriber, ct);
+            var rejectedButLiveAck = await ResolveAsync(
+                h, ResolveJson("a1", "allow", saveRule: true, pending3.PromptId, action: "bogus"), requireEcho: true, ct);
+            await Assert.That(rejectedButLiveAck.Ok).IsTrue(); // the resolution itself still applies
+            await Assert.That(rejectedButLiveAck.RuleSaved).IsEqualTo(false);
+            await decideTask3;
+
+            var rejectedNoPendingAck = await ResolveAsync(
+                h, ResolveJson("ghost2", "allow", saveRule: true, "p-y", action: "bogus"), requireEcho: true, ct);
+            await Assert.That(rejectedNoPendingAck.Ok).IsFalse();
+            await Assert.That(rejectedNoPendingAck.RuleSaved).IsEqualTo(false);
+
+            // (4) no save_rule → RuleSaved=null.
+            var decideTask4 = h.Gate.DecideAsync("a1", input, ct);
+            var pending4 = await FirstPendingFrom(subscriber, ct);
+            var plainAck = await ResolveAsync(h, ResolveJson("a1", "deny", saveRule: false, pending4.PromptId), requireEcho: true, ct);
+            await Assert.That(plainAck.RuleSaved).IsNull();
+            await decideTask4;
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task V2_resolve_with_mismatching_echo_acks_no_pending_and_leaves_the_request_live() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("v2-resolve-mismatch", LaunchConsentDefault.Prompt, 30, async (h, ct) => {
+            await using var subscriber = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(subscriber, new LocalFrame(FrameType.ConsentSubscribeV2), ct);
+            await SpinUntilSubscribedAsync(h.Broker, ct);
+
+            var input = new LaunchConsentInput("user_x", RequesterIsOwner: false, "agent", "/tmp/repo", "claude", null);
+            var decideTask = h.Gate.DecideAsync("a1", input, ct);
+            var pending = await FirstPendingFrom(subscriber, ct);
+
+            var ack = await ResolveAsync(h, ResolveJson("a1", "allow", saveRule: false, "WRONG"), requireEcho: true, ct);
+            await Assert.That(ack.Ok).IsFalse();
+            await Assert.That(PendingStillLive(h, "a1")).IsTrue();
+
+            // Resolve for real with the correct echo, so the DecideAsync task doesn't outlive the test.
+            var cleanupAck = await ResolveAsync(h, ResolveJson("a1", "allow", saveRule: false, pending.PromptId), requireEcho: true, ct);
+            await Assert.That(cleanupAck.Ok).IsTrue();
+            await decideTask;
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Subscribe_pushes_prompt_id_and_requester_display_on_pending_frames() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("v2-subscribe-stamped", LaunchConsentDefault.Prompt, 30, async (h, ct) => {
+            await using var subscriber = await ConnectAsync(h.SockPath, ct);
+            await FrameCodec.WriteAsync(subscriber, new LocalFrame(FrameType.ConsentSubscribeV2), ct);
+            await SpinUntilSubscribedAsync(h.Broker, ct);
+
+            var input = new LaunchConsentInput("user_x", RequesterIsOwner: false, "agent", "/tmp/repo", "claude", "Mathias");
+            var decideTask = h.Gate.DecideAsync("a1", input, ct);
+
+            var dto = await FirstPendingFrom(subscriber, ct);
+            // Assert against the broker's own ground-truth request, not just a non-null check —
+            // this is the pin for ToDto's stamping (previously untested).
+            var live = h.Broker.PendingSnapshot().Single(p => p.RequestId == "a1");
+            await Assert.That(dto.PromptId).IsEqualTo(live.PromptId);
+            await Assert.That(dto.RequesterDisplay).IsEqualTo(live.RequesterDisplay);
+            await Assert.That(dto.RequesterDisplay).IsEqualTo("Mathias");
+
+            var ack = await ResolveAsync(h, ResolveJson("a1", "allow", saveRule: false, dto.PromptId), requireEcho: true, ct);
+            await Assert.That(ack.Ok).IsTrue();
+            await decideTask;
         });
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/LocalControlHelloTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/LocalControlHelloTests.cs
@@ -133,7 +133,7 @@ public class LocalControlHelloTests {
             await Assert.That(dto!.ProtocolVersion).IsEqualTo(1);
             await Assert.That(dto.DaemonVersion).IsNotEmpty();
             await Assert.That(dto.DaemonName).IsEqualTo(h.Config.Name);
-            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "status/1" });
+            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "consent/2", "status/1" });
         });
     }
 
@@ -152,7 +152,7 @@ public class LocalControlHelloTests {
             await Assert.That(dto!.ProtocolVersion).IsEqualTo(1);
             await Assert.That(dto.DaemonVersion).IsNotEmpty();
             await Assert.That(dto.DaemonName).IsEqualTo(h.Config.Name);
-            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "status/1" });
+            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "consent/2", "status/1" });
         });
     }
 
@@ -174,7 +174,7 @@ public class LocalControlHelloTests {
             await Assert.That(dto!.ProtocolVersion).IsEqualTo(1);
             await Assert.That(dto.DaemonVersion).IsNotEmpty();
             await Assert.That(dto.DaemonName).IsEqualTo(h.Config.Name);
-            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "status/1" });
+            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "consent/2", "status/1" });
         });
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/LocalControlOpsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalControlOpsTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Net.Sockets;
 using System.Text.Json;
 using Capacitor.Cli.Core;
@@ -88,10 +89,15 @@ public class LocalControlOpsTests {
             await FrameCodec.WriteAsync(s, LocalFrame.ConsentJson(FrameType.ConsentAck, json), ct);
         }
     };
-    /// A faithful v1 daemon: reads the raw 5-byte header, sees a type byte its codec has no case
-    /// for, and closes without writing ANY frame (FrameCodec.Decode throws InvalidDataException →
-    /// HandleConnectionAsync catches/logs/closes). NOT a routing-default Error reply — no deployed
-    /// v1 daemon produces one for byte 18 (spec §4.1).
+    /// A faithful v1 daemon: reads the raw 5-byte header AND the full payload it declares — the
+    /// real FrameCodec.ReadAsync (src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs) always consumes
+    /// header+payload before Decode ever runs, so it only throws InvalidDataException (unknown
+    /// type byte) once the whole frame is off the wire. HandleConnectionAsync then catches/logs/
+    /// closes, writing nothing. A header-only close would leave the ConsentResolveV2 JSON payload
+    /// unread in the kernel socket buffer; closing with unread bytes sends RST on Linux (not on
+    /// macOS), so CI would observe ECONNRESET (daemon_unreachable) instead of the intended clean
+    /// EOF (unexpected_reply) — this is the ubuntu-latest-only CI failure this script fixes. NOT a
+    /// routing-default Error reply — no deployed v1 daemon produces one for byte 18 (spec §4.1).
     static ConnScript V1CodecReject() => async (_, s, ct) => {
         var head = new byte[5];
         var read = 0;
@@ -100,7 +106,16 @@ public class LocalControlOpsTests {
             if (n == 0) return;
             read += n;
         }
-        // v1 FrameCodec would throw here — the server closes the socket, writing nothing.
+        var len = BinaryPrimitives.ReadInt32BigEndian(head.AsSpan(1));
+        var payload = new byte[len];
+        var got = 0;
+        while (got < len) {
+            var n = await s.ReadAsync(payload.AsMemory(got), ct);
+            if (n == 0) return;
+            got += n;
+        }
+        // v1 FrameCodec would throw here (Decode sees an unmapped type byte) — the server closes
+        // the socket, writing nothing.
     };
     static ConnScript Eof() => async (_, s, ct) => { await FrameCodec.ReadAsync(s, ct); }; // read, close silently
     static ConnScript TruncatedHeader() => async (_, s, ct) => {

--- a/test/Capacitor.Cli.Tests.Unit/LocalControlOpsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalControlOpsTests.cs
@@ -1,4 +1,5 @@
 using System.Net.Sockets;
+using System.Text.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 
@@ -71,6 +72,35 @@ public class LocalControlOpsTests {
         var f = await FrameCodec.ReadAsync(s, ct);                       // expect ConsentRulesPut
         if (f?.Type == FrameType.ConsentRulesPut)
             await FrameCodec.WriteAsync(s, LocalFrame.ConsentJson(FrameType.ConsentAck, json), ct);
+    };
+    static ConnScript ConsentResolveV2Ack(string json) => async (_, s, ct) => {
+        var f = await FrameCodec.ReadAsync(s, ct);                       // expect ConsentResolveV2
+        if (f?.Type == FrameType.ConsentResolveV2)
+            await FrameCodec.WriteAsync(s, LocalFrame.ConsentJson(FrameType.ConsentAck, json), ct);
+    };
+    /// Same as <see cref="ConsentResolveV2Ack"/> but hands the request's raw Text to the caller
+    /// before replying, so a test can assert what was actually written on the wire (the
+    /// prompt_id echo) rather than just the parsed reply.
+    static ConnScript ConsentResolveV2AckCapturing(string json, Action<string> captureRequestText) => async (_, s, ct) => {
+        var f = await FrameCodec.ReadAsync(s, ct);
+        if (f?.Type == FrameType.ConsentResolveV2) {
+            captureRequestText(f.Text);
+            await FrameCodec.WriteAsync(s, LocalFrame.ConsentJson(FrameType.ConsentAck, json), ct);
+        }
+    };
+    /// A faithful v1 daemon: reads the raw 5-byte header, sees a type byte its codec has no case
+    /// for, and closes without writing ANY frame (FrameCodec.Decode throws InvalidDataException →
+    /// HandleConnectionAsync catches/logs/closes). NOT a routing-default Error reply — no deployed
+    /// v1 daemon produces one for byte 18 (spec §4.1).
+    static ConnScript V1CodecReject() => async (_, s, ct) => {
+        var head = new byte[5];
+        var read = 0;
+        while (read < 5) {
+            var n = await s.ReadAsync(head.AsMemory(read), ct);
+            if (n == 0) return;
+            read += n;
+        }
+        // v1 FrameCodec would throw here — the server closes the socket, writing nothing.
     };
     static ConnScript Eof() => async (_, s, ct) => { await FrameCodec.ReadAsync(s, ct); }; // read, close silently
     static ConnScript TruncatedHeader() => async (_, s, ct) => {
@@ -322,6 +352,118 @@ public class LocalControlOpsTests {
             await Assert.That(ex!.Reason).IsEqualTo("daemon_rejected");
             await Assert.That(ex.Message).IsEqualTo("not authorized");
         });
+    }
+
+    // ---- ResolveConsentAsync ----
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    [Arguments("""{"ok":true,"error":null,"rule_saved":null}""", true, null, null)]
+    [Arguments("""{"ok":true,"error":"partial rule save failure","rule_saved":false}""", true, "partial rule save failure", false)]
+    [Arguments("""{"ok":false,"error":"no pending consent request with that id","rule_saved":true}""", false, "no pending consent request with that id", true)]
+    [Arguments("""{"ok":false,"error":"x"}""", false, "x", null)] // old-format ack: no rule_saved member at all
+    public async Task Resolve_ack_shapes(string json, bool ok, string? error, bool? ruleSaved) {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithOpsAsync([ConsentResolveV2Ack(json)], async ops => {
+            var ack = await ops.ResolveConsentAsync(new ConsentResolveDto("r1", "allow", null, "p1"), CancellationToken.None);
+            await Assert.That(ack.Ok).IsEqualTo(ok);
+            await Assert.That(ack.Error).IsEqualTo(error);
+            await Assert.That(ack.RuleSaved).IsEqualTo(ruleSaved);
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Resolve_echoes_prompt_id_on_the_written_frame() {
+        if (OperatingSystem.IsWindows()) return;
+
+        string? sentText = null;
+        await WithOpsAsync(
+            [ConsentResolveV2AckCapturing("""{"ok":true,"error":null,"rule_saved":null}""", t => sentText = t)],
+            async ops => await ops.ResolveConsentAsync(new ConsentResolveDto("r1", "allow", null, "prompt-xyz"), CancellationToken.None));
+
+        var sent = JsonSerializer.Deserialize(sentText!, ConsentIpcJsonContext.Default.ConsentResolveDto);
+        await Assert.That(sent!.PromptId).IsEqualTo("prompt-xyz");
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Resolve_maps_error_frame_to_daemon_rejected() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithOpsAsync([ErrorThen("nope")], async ops => {
+            var ex = await Assert.ThrowsAsync<LocalControlOpsException>(
+                async () => await ops.ResolveConsentAsync(new ConsentResolveDto("r1", "allow", null, "p1"), CancellationToken.None));
+            await Assert.That(ex!.Reason).IsEqualTo("daemon_rejected");
+            await Assert.That(ex.Message).IsEqualTo("nope");
+        });
+    }
+
+    /// The incarnation-swap pin (spec §9/§10): a v1 daemon fails closed at its own codec rather
+    /// than resolving by request id without the identity check, so the caller must see this as
+    /// "nothing was resolved", never as a successful ack.
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Resolve_against_a_v1_codec_observes_eof_as_unexpected_reply_and_nothing_was_resolved() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithOpsAsync([V1CodecReject()], async ops => {
+            var ex = await Assert.ThrowsAsync<LocalControlOpsException>(
+                async () => await ops.ResolveConsentAsync(new ConsentResolveDto("r1", "allow", null, "p1"), CancellationToken.None));
+            await Assert.That(ex!.Reason).IsEqualTo("unexpected_reply");
+            await Assert.That(ex.Message).IsEqualTo("daemon closed the connection without replying");
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Resolve_clean_eof() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithOpsAsync([Eof()], async ops => {
+            var ex = await Assert.ThrowsAsync<LocalControlOpsException>(
+                async () => await ops.ResolveConsentAsync(new ConsentResolveDto("r1", "allow", null, "p1"), CancellationToken.None));
+            await Assert.That(ex!.Reason).IsEqualTo("unexpected_reply");
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Resolve_malformed_ack() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithOpsAsync([ConsentResolveV2Ack("not json")], async ops => {
+            var ex = await Assert.ThrowsAsync<LocalControlOpsException>(
+                async () => await ops.ResolveConsentAsync(new ConsentResolveDto("r1", "allow", null, "p1"), CancellationToken.None));
+            await Assert.That(ex!.Reason).IsEqualTo("unexpected_reply");
+        });
+    }
+
+    [Test] // real short timeout, matching this file's existing choice of real time over FakeTimeProvider for socket tests
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Resolve_reply_timeout() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithOpsAsync([Stall()], async ops => {
+            var ex = await Assert.ThrowsAsync<LocalControlOpsException>(
+                async () => await ops.ResolveConsentAsync(new ConsentResolveDto("r1", "allow", null, "p1"), CancellationToken.None));
+            await Assert.That(ex!.Reason).IsEqualTo("timed_out");
+        }, configure: ops => ops.ConsentReplyTimeout = TimeSpan.FromMilliseconds(100));
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Resolve_caller_cancellation() {
+        if (OperatingSystem.IsWindows()) return;
+
+        await WithOpsAsync([Stall()], async ops => {
+            using var cts = new CancellationTokenSource();
+            var task = ops.ResolveConsentAsync(new ConsentResolveDto("r1", "allow", null, "p1"), cts.Token);
+            await Task.Delay(50); // let connect+write land so cancellation is observed during the reply wait
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
+        }, configure: ops => ops.ConsentReplyTimeout = TimeSpan.FromSeconds(30));
     }
 
     // ---- shared transport classification (exercised via StopAgentAsync) ----


### PR DESCRIPTION
Closes #503. AI-1652.

The consent UX for the desktop supervisor app — the piece that answers the original "daemon launches without asking" complaint on machines running the app.

## What's in here

**App (`src/Capacitor.App`)**
- **Consent prompt window**, auto-raised when a launch parks at the daemon's consent gate: requester (display name), kind, repo, vendor, countdown from the daemon's deadline hint; **Allow once / Allow & remember / Deny**; "1 of N" queue. Closing without deciding is an explicit defer — the tray keeps Attention and "Review pending launches…" reopens it. Expiry is never fabricated as a verdict: past the hint the buttons stay live and the daemon's ack decides.
- **Activity tab** in the main window (now tabbed Agents | Activity): the consent decision log, newest first — outcome badge, requester, kind, repo, vendor, source ("you", "rule", "timeout", …). Reads the daemon's JSONL directly (writer-safe sharing), works with the daemon down, keeps last-good rows on partial reads.
- **Tray**: pending consent asserts the Attention state ("N launches awaiting approval") while connected; new menu item between the agents section and pause.
- `ConsentService`: status-driven subscription gated on the new `consent/2` capability, identity-guarded pending cache, service-lifetime tombstones (ghost-replay defense), prune hygiene, one-resolve-at-a-time lane. The shared 1 Hz ticker is hoisted into an app-lifetime `UiTicker`.

**Wire/daemon hardening (all additive)**
- Daemon-minted **`prompt_id`** request identity on pendings, echoed on resolves, **atomically claimed** by the broker — a stale resolve can never decide a different launch that reused the agent id (the daemon makes no id-non-reuse guarantee).
- **V2 consent frames** (`ConsentSubscribeV2 = 17`, `ConsentResolveV2 = 18`): a pre-upgrade daemon's codec rejects them before routing, so mixed-version consent fails closed on the wire — no capability-check TOCTOU across daemon restarts. `consent/2` is advertised for discovery only.
- **`rule_saved`** on consent acks: the handler deliberately persists an "Allow & remember" rule before resolving (durable trust), so an already-decided outcome now *discloses* the installed rule instead of hiding it. The button says "Allow & remember" — not "Always allow" — because earlier deny rules (including Pause) shadow the appended allow.
- **`requester_display`** threaded through the consent pipeline (gate input → prompt request → pending DTO → decision record) so prompts and the feed show names, not `github:…` ids.

## Process

Spec survived a 7-round hosted-Codex review (`docs/superpowers/specs/2026-08-08-ai1652-consent-prompt-activity-feed-design.md`); implemented as 11 SDD tasks with per-task reviews, two task-level fix rounds, and a whole-branch final review whose one must-fix (identity-aware raise signal) landed in the final fix wave. App suite 307/307; consent-focused CLI suites green; AOT publish clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)