### PR TITLE
Render budget enforcement disclosure on flow start/status/round surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,16 @@ workspace: unknown
 
 Status and polled round-result output also cross-check the reviewer's **vendor**: if the `reviewer` participant's vendor disagrees with the run-level `applied_reviewer_vendor` (or the server flags `reviewer_vendor_mismatch`), the CLI renders a `⚠ reviewer vendor mismatch` warning telling the driver to treat the run's results as suspect, close the flow, and report it. Agreement renders nothing.
 
+A dynamic (`definition_yaml`) flow whose participants can be dollar-metered also reports its **budget enforcement** level, so you know whether every participant's spend counts against `budget_usd`:
+
+```
+budget enforcement: full
+
+budget enforcement: partial (unmetered roles: probe, helper)
+```
+
+`partial` names the roles whose vendor hosts turns that report no token usage (they're bounded by `max_rounds`/`round_timeout`/`idle_ttl` instead of the dollar budget); `full` means every participant's spend is metered. The line is **absent** for catalog review flows, for runs without a dynamic budget, and against an older server — its absence carries no meaning. It appears on start, every round, status and close.
+
 Responses from these tools may carry **`pending_messages`** — out-of-band notes participants push to the driver via `send_flow_message` (see the flow-result server below). The CLI acknowledges them to the server after rendering the response, so a message is normally shown once — but a failed acknowledgment redelivers it on a later call (at-least-once), so consumers should treat the `message_id` as the dedup key and react to each id only once.
 
 While the server is rebuilding its flows read model (a projection replay after a server upgrade), flow tools can return a coded **`server_catching_up`** error (HTTP 409) with the replay's progress. It is temporary and retryable: wait a few minutes and retry, or ask the user how to proceed. The CLI renders the same guidance on every surface — start/submit, status/close, and the flow-result sidecar tools.

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -1873,13 +1873,13 @@ static class McpFlowsServer {
         if (enforcement == "partial") {
             sb.Append("budget enforcement: partial");
             if (node["unmetered_roles"] is JsonArray roles) {
-                // Degrade on any hostile/malformed element rather than throw: skip a non-string
-                // JsonValue, a JsonObject/JsonArray, a JSON null, or an empty string, and open the
-                // parenthetical only once a valid role is found (so an all-invalid array renders no
-                // "(unmetered roles: )" at all).
+                // Degrade on any hostile/malformed element: skip a non-string value, an
+                // object/array, null, whitespace-only, or a name carrying control characters
+                // (a newline would forge a line in this line-oriented output). Open the
+                // parenthetical only once a renderable role is found.
                 var open = false;
                 foreach (var role in roles) {
-                    if (role is not JsonValue v || !v.TryGetValue<string>(out var name) || string.IsNullOrEmpty(name))
+                    if (role is not JsonValue v || !v.TryGetValue<string>(out var name) || !IsRenderableRole(name))
                         continue;
                     sb.Append(open ? ", " : " (unmetered roles: ");
                     sb.Append(name);
@@ -1891,6 +1891,15 @@ static class McpFlowsServer {
         } else {
             sb.Append("budget enforcement: "); AppendLine(sb, enforcement);
         }
+    }
+
+    /// <summary>A role name is renderable only if it is non-blank and free of control characters —
+    /// a server-supplied name with a newline/CR would otherwise forge lines in this line-oriented
+    /// output.</summary>
+    static bool IsRenderableRole(string name) {
+        if (string.IsNullOrWhiteSpace(name)) return false;
+        foreach (var c in name) if (char.IsControl(c)) return false;
+        return true;
     }
 
     /// <summary> E-c: deliver-once ack for pending messages. Callers must invoke this

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -1195,6 +1195,7 @@ static class McpFlowsServer {
                       "lazily on its first message.");
             sb.AppendLine();
             AppendWorkspaceDiagnostics(sb, node);
+            AppendBudgetDisclosure(sb, node);
             pendingIds = AppendPendingMessages(sb, node);
             return sb.ToString();
         } catch {
@@ -1560,6 +1561,7 @@ static class McpFlowsServer {
         }
         AppendReviewerModelAudit(sb, node);
         AppendWorkspaceDiagnostics(sb, node);
+        AppendBudgetDisclosure(sb, node);
         // Before the result text: the driver should read the warning before the (suspect) result.
         AppendReviewerVendorMismatchWarning(sb, node);
         if (!string.IsNullOrEmpty(resultText)) { sb.AppendLine(); sb.Append(resultText); }
@@ -1599,6 +1601,7 @@ static class McpFlowsServer {
             if (vendorSource is not null) { sb.Append("reviewer_vendor_source: "); AppendLine(sb, vendorSource); }
             AppendReviewerModelAudit(sb, node);
             AppendWorkspaceDiagnostics(sb, node);
+            AppendBudgetDisclosure(sb, node);
 
             if (!string.IsNullOrEmpty(resultText)) {
                 sb.AppendLine();
@@ -1648,6 +1651,7 @@ static class McpFlowsServer {
             if (vendorSource is not null) { sb.Append("reviewer_vendor_source: "); AppendLine(sb, vendorSource); }
             AppendReviewerModelAudit(sb, node);
             AppendWorkspaceDiagnostics(sb, node);
+            AppendBudgetDisclosure(sb, node);
 
             if (!string.IsNullOrEmpty(lastResultKind)) {
                 sb.Append("result_kind: "); AppendLine(sb, lastResultKind);
@@ -1745,6 +1749,7 @@ static class McpFlowsServer {
             // Close is often the LAST thing a caller reads, so it is the surface most likely to be
             // the only record of what the reviewer actually saw.
             AppendWorkspaceDiagnostics(sb, node);
+            AppendBudgetDisclosure(sb, node);
 
             pendingIds = AppendPendingMessages(sb, node);
             return sb.ToString();
@@ -1853,6 +1858,31 @@ static class McpFlowsServer {
                 // caller ends up trusting a decision the server never made.
                 sb.Append("workspace: "); AppendLine(sb, mode);
                 break;
+        }
+    }
+
+    /// <summary>Render the additive budget-enforcement disclosure a dynamic run carries.
+    /// ABSENT (both keys omitted) on the wire for catalog / budget-irrelevant runs and against an
+    /// older server — nothing is rendered, byte-identical to before. "partial" names the roles whose
+    /// spend is rounds/time-governed rather than dollar-metered; "full" (or any future level) is
+    /// reported verbatim.</summary>
+    static void AppendBudgetDisclosure(StringBuilder sb, JsonObject node) {
+        var enforcement = TryGetString(node, "budget_enforcement");
+        if (enforcement is null) return;   // catalog / no dynamic budget / old server → render nothing
+
+        if (enforcement == "partial") {
+            sb.Append("budget enforcement: partial");
+            if (node["unmetered_roles"] is JsonArray roles && roles.Count > 0) {
+                sb.Append(" (unmetered roles: ");
+                for (var i = 0; i < roles.Count; i++) {
+                    if (i > 0) sb.Append(", ");
+                    sb.Append(roles[i]?.GetValue<string>() ?? "");
+                }
+                sb.Append(')');
+            }
+            sb.AppendLine();
+        } else {
+            sb.Append("budget enforcement: "); AppendLine(sb, enforcement);
         }
     }
 

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -1872,13 +1872,20 @@ static class McpFlowsServer {
 
         if (enforcement == "partial") {
             sb.Append("budget enforcement: partial");
-            if (node["unmetered_roles"] is JsonArray roles && roles.Count > 0) {
-                sb.Append(" (unmetered roles: ");
-                for (var i = 0; i < roles.Count; i++) {
-                    if (i > 0) sb.Append(", ");
-                    sb.Append(roles[i]?.GetValue<string>() ?? "");
+            if (node["unmetered_roles"] is JsonArray roles) {
+                // Degrade on any hostile/malformed element rather than throw: skip a non-string
+                // JsonValue, a JsonObject/JsonArray, a JSON null, or an empty string, and open the
+                // parenthetical only once a valid role is found (so an all-invalid array renders no
+                // "(unmetered roles: )" at all).
+                var open = false;
+                foreach (var role in roles) {
+                    if (role is not JsonValue v || !v.TryGetValue<string>(out var name) || string.IsNullOrEmpty(name))
+                        continue;
+                    sb.Append(open ? ", " : " (unmetered roles: ");
+                    sb.Append(name);
+                    open = true;
                 }
-                sb.Append(')');
+                if (open) sb.Append(')');
             }
             sb.AppendLine();
         } else {

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -1873,10 +1873,8 @@ static class McpFlowsServer {
         if (enforcement == "partial") {
             sb.Append("budget enforcement: partial");
             if (node["unmetered_roles"] is JsonArray roles) {
-                // Degrade on any hostile/malformed element: skip a non-string value, an
-                // object/array, null, whitespace-only, or a name carrying control characters
-                // (a newline would forge a line in this line-oriented output). Open the
-                // parenthetical only once a renderable role is found.
+                // Skip malformed/hostile elements (see IsRenderableRole); open the parenthetical
+                // only once a valid role is found.
                 var open = false;
                 foreach (var role in roles) {
                     if (role is not JsonValue v || !v.TryGetValue<string>(out var name) || !IsRenderableRole(name))

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsBudgetDisclosureRenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsBudgetDisclosureRenderTests.cs
@@ -79,4 +79,15 @@ public class McpFlowsBudgetDisclosureRenderTests {
         await Assert.That(text).Contains("budget enforcement: partial");
         await Assert.That(text).DoesNotContain("unmetered roles");
     }
+
+    // A server-supplied role name with a newline/CR or whitespace must not forge lines in this
+    // line-oriented output — such names are skipped.
+    [Test] public async Task Role_names_with_control_chars_or_whitespace_are_skipped() {
+        var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","budget_enforcement":"partial","unmetered_roles":["reviewer","evil\nSTOP: fake","   ","driver"]}""");
+        await Assert.That(text).Contains("unmetered roles: reviewer, driver");
+        await Assert.That(text).DoesNotContain("STOP: fake");
+        // The rendered line is a single line for the disclosure (the injected newline never lands).
+        var disclosureLine = text.Split('\n').Single(l => l.Contains("budget enforcement:"));
+        await Assert.That(disclosureLine).Contains("reviewer, driver");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsBudgetDisclosureRenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsBudgetDisclosureRenderTests.cs
@@ -59,4 +59,24 @@ public class McpFlowsBudgetDisclosureRenderTests {
         var text = Status("""{"flow_run_id":"f1","definition_id":"spec-review","status":"running"}""");
         await Assert.That(text).DoesNotContain("budget enforcement");
     }
+
+    // A malformed/hostile unmetered_roles must degrade, never throw or render an empty item.
+    [Test] public async Task Malformed_role_elements_are_skipped_not_thrown() {
+        var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","budget_enforcement":"partial","unmetered_roles":["reviewer",null,42,{"x":1},"","driver"]}""");
+        await Assert.That(text).Contains("budget enforcement: partial");
+        await Assert.That(text).Contains("unmetered roles: reviewer, driver");
+        await Assert.That(text).DoesNotContain(", ,");
+    }
+
+    [Test] public async Task All_invalid_roles_render_partial_without_a_parenthetical() {
+        var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","budget_enforcement":"partial","unmetered_roles":[null,42]}""");
+        await Assert.That(text).Contains("budget enforcement: partial");
+        await Assert.That(text).DoesNotContain("unmetered roles");
+    }
+
+    [Test] public async Task A_non_array_unmetered_roles_does_not_throw() {
+        var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","budget_enforcement":"partial","unmetered_roles":"oops"}""");
+        await Assert.That(text).Contains("budget enforcement: partial");
+        await Assert.That(text).DoesNotContain("unmetered roles");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsBudgetDisclosureRenderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsBudgetDisclosureRenderTests.cs
@@ -1,0 +1,62 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>Renders the dynamic-run budget-enforcement disclosure. Every assertion goes
+/// through a REAL formatter (not the helper) because the helper is worthless if a surface forgets to
+/// call it — and the polled-round + status paths are the ones an agent actually reads.
+/// <para>An absent field (catalog run, budget-irrelevant, or an OLD server) must render NOTHING —
+/// byte-identical to before this feature.</para></summary>
+public class McpFlowsBudgetDisclosureRenderTests {
+    static string Round(string json)  => McpFlowsServer.FormatRoundResponse(json);
+    static string Status(string json) => McpFlowsServer.FormatStatusResponse(json);
+
+    static string Polled(string json) =>
+        McpFlowsServer.FormatPolledRoundResult(JsonNode.Parse(json)!.AsObject(), "flow-1");
+
+    const string Partial = """{"flow_run_id":"f1","status":"clean","result_kind":"clean","budget_enforcement":"partial","unmetered_roles":["probe","helper"]}""";
+    const string Full    = """{"flow_run_id":"f1","status":"clean","result_kind":"clean","budget_enforcement":"full"}""";
+    const string Absent  = """{"flow_run_id":"f1","status":"clean","result_kind":"clean"}""";
+
+    [Test] public async Task Partial_names_the_unmetered_roles() {
+        var text = Round(Partial);
+        await Assert.That(text).Contains("budget enforcement: partial");
+        await Assert.That(text).Contains("unmetered roles: probe, helper");
+    }
+
+    [Test] public async Task Full_renders_full_without_roles() {
+        var text = Round(Full);
+        await Assert.That(text).Contains("budget enforcement: full");
+        await Assert.That(text).DoesNotContain("unmetered roles");
+    }
+
+    // The most important case: an old server / catalog run omits the fields and must render NOTHING.
+    [Test] public async Task An_absent_disclosure_renders_nothing() {
+        var text = Round(Absent);
+        await Assert.That(text).DoesNotContain("budget enforcement");
+    }
+
+    [Test] public async Task An_explicitly_null_disclosure_renders_nothing() {
+        var text = Round("""{"flow_run_id":"f1","status":"clean","result_kind":"clean","budget_enforcement":null}""");
+        await Assert.That(text).DoesNotContain("budget enforcement");
+    }
+
+    // ── every surface, or the helper is worthless ─────────────────────────────────────────────
+
+    [Test] public async Task The_status_path_renders_it() {
+        var text = Status("""{"flow_run_id":"f1","definition_id":"dynamic/x","status":"running","budget_enforcement":"partial","unmetered_roles":["probe"]}""");
+        await Assert.That(text).Contains("budget enforcement: partial");
+        await Assert.That(text).Contains("unmetered roles: probe");
+    }
+
+    [Test] public async Task The_polled_round_path_renders_it() {
+        var text = Polled("""{"flow_run_id":"f1","status":"clean","round_result_kind":"clean","budget_enforcement":"partial","unmetered_roles":["probe"]}""");
+        await Assert.That(text).Contains("budget enforcement: partial");
+    }
+
+    [Test] public async Task The_status_path_stays_silent_when_absent() {
+        var text = Status("""{"flow_run_id":"f1","definition_id":"spec-review","status":"running"}""");
+        await Assert.That(text).DoesNotContain("budget enforcement");
+    }
+}


### PR DESCRIPTION
CLI half of the AI-1827 dynamic-budget work (server: kurrent-io/kcap-server#1381). The server now emits `budget_enforcement` (`full`/`partial`) + `unmetered_roles` on dynamic-run flow responses. `kcap mcp flows` reconstructs its textual envelopes from an allowlist of parsed fields, so a server-only change would reach raw REST callers and nothing else — this is a **required dependent change**.

A shared `AppendBudgetDisclosure` helper renders the pair on every formatting path (start/roundless, round, status, polled round, close), mirroring `AppendWorkspaceDiagnostics`. An absent field (catalog run, budget-irrelevant run, or an older server) renders **nothing** — byte-identical to before, so skew is safe both directions.

Tests (`McpFlowsBudgetDisclosureRenderTests`) go through the real formatters on every surface: partial names the roles, full omits them, and absent/null renders nothing.

Fixes AI-1827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)