### PR TITLE
[AI-1826] Freeze the terminal sequenced-command ack + re-deliver unretired answers on reconnect/tick

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1065,6 +1065,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal async Task SendDaemonStatusReportOnceAsync() {
         try { await _server.DaemonStatusReportAsync(BuildStatusReport()); }
         catch (Exception ex) { _logger.LogDebug(ex, "DaemonStatusReport send failed — ignoring"); }
+        // Settlement lost-ack redelivery (D1): after advertising the watermarks, re-deliver any UNRETIRED terminal acks — a lost
+        // ack in a reconnect window is re-elicited here instead of waiting for the server to retransmit
+        // the whole command (the server tolerates the duplicate per D2″). No-op when nothing is
+        // unretired; sends are contained + one-way, so this can never fault the report path. This covers
+        // the periodic tick, the server's on-request report, and the activity-triggered report — every
+        // status-report moment is also a re-sync moment. A validated AckProcessedPrefix stops the re-sends.
+        Processor?.RedeliverUnretiredProcessedAcks();
     }
 
     /// <summary>The out-of-cycle report fired on a launch-stage transition, wired in
@@ -3103,7 +3110,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// The bounded ownership-retry in <see cref="ServerConnection.RequestPermissionAsync"/> is the
     /// final safety net for the residual case.
     /// </summary>
-    async Task ReRegisterAgentsAsync() {
+    internal async Task ReRegisterAgentsAsync() {
         // PrivateLocal agents are never registered with the server, so never re-register them.
         foreach (var agent in _agents.Values.Where(a => (a.Status is "Starting" or "Running") && !a.IsPrivate)) {
             for (var attempt = 1; ; attempt++) {
@@ -3149,6 +3156,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 }
             }
         }
+
+        // Settlement lost-ack redelivery (D1): a reconnect is the highest-value re-sync moment — the terminal ack most likely to
+        // have been lost is one that settled while the transport was down. Re-deliver every unretired
+        // terminal ack now that registration is back, rather than waiting up to a full status-report
+        // interval. Fires regardless of agent count (an ack can be unretired after its agent is gone) and
+        // is a contained, one-way no-op when nothing is unretired.
+        Processor?.RedeliverUnretiredProcessedAcks();
     }
 
     static readonly TimeSpan StartupTimeout     = TimeSpan.FromSeconds(90);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -516,6 +516,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         _server.OnSendSpecialKey         += HandleSendSpecialKey;
         _server.OnResizeTerminal         += HandleResizeTerminal;
         _server.ReRegisterAgentsHook          =  ReRegisterAgentsAsync;
+        // Settlement lost-ack redelivery (D1): re-deliver unretired terminal acks POST-registration
+        // (readiness restored) — inside ReRegisterAgentsHook the CommandAckAsync IsReady gate would drop
+        // them. Fires on every (re)connect + heartbeat re-register.
+        _server.OnRegisteredHook              =  () => { Processor?.RedeliverUnretiredProcessedAcks(); return Task.CompletedTask; };
         _server.FindRepoForRemoteHandler      =  HandleFindRepoForRemote;
         _server.ProbeBorrowSourceHandler      =  HandleProbeBorrowSource;
         // Task 8: the side-effect-free reviewer-model preflight. Pure resolution over the
@@ -3156,13 +3160,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 }
             }
         }
-
-        // Settlement lost-ack redelivery (D1): a reconnect is the highest-value re-sync moment — the terminal ack most likely to
-        // have been lost is one that settled while the transport was down. Re-deliver every unretired
-        // terminal ack now that registration is back, rather than waiting up to a full status-report
-        // interval. Fires regardless of agent count (an ack can be unretired after its agent is gone) and
-        // is a contained, one-way no-op when nothing is unretired.
-        Processor?.RedeliverUnretiredProcessedAcks();
+        // NOTE: the settlement lost-ack re-delivery is deliberately NOT here — this hook runs inside the
+        // registration bracket BEFORE readiness is restored, so CommandAckAsync would drop every ack. It
+        // is wired to OnRegisteredHook instead, which runs post-MarkRegistered (IsReady == true).
     }
 
     static readonly TimeSpan StartupTimeout     = TimeSpan.FromSeconds(90);

--- a/src/Capacitor.Cli.Daemon/Services/RegistrationGate.cs
+++ b/src/Capacitor.Cli.Daemon/Services/RegistrationGate.cs
@@ -39,10 +39,16 @@ internal sealed class RegistrationGate {
     /// If <paramref name="daemonConnect"/> throws (e.g. name-in-use), the exception propagates
     /// and readiness stays cleared — re-registration is skipped and MarkRegistered never runs.
     /// </summary>
-    public async Task RunRegistrationAsync(Func<Task> daemonConnect, Func<Task> reRegisterAgents) {
+    public async Task RunRegistrationAsync(
+            Func<Task> daemonConnect, Func<Task> reRegisterAgents, Func<Task>? postRegister = null) {
         MarkUnregistered();
         await daemonConnect();
         await reRegisterAgents();
         MarkRegistered();
+        // postRegister runs with IsReady == true — for work that must reach the server on the freshly
+        // ready transport (e.g. re-delivering unretired terminal acks, which CommandAckAsync drops while
+        // readiness is still cleared inside this bracket). Its failure must not un-register the daemon,
+        // so it is the caller's job to contain it.
+        if (postRegister is not null) await postRegister();
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/RegistrationGate.cs
+++ b/src/Capacitor.Cli.Daemon/Services/RegistrationGate.cs
@@ -53,7 +53,12 @@ internal sealed class RegistrationGate {
         // The hook owns its diagnostics; this gate has no logger and deliberately swallows.
         if (postRegister is not null) {
             try { await postRegister(); }
-            catch { /* deliberately empty — readiness stays set; best-effort post-register work */ }
+            // Cancellation is a shutdown signal, not a hook failure — it must propagate, never be
+            // swallowed as success.
+            catch (OperationCanceledException) { throw; }
+            // A genuine hook FAILURE is best-effort: MarkRegistered already ran, so it must not un-set
+            // readiness or fault the reconnect path.
+            catch { /* deliberately empty — see summary */ }
         }
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/RegistrationGate.cs
+++ b/src/Capacitor.Cli.Daemon/Services/RegistrationGate.cs
@@ -47,8 +47,13 @@ internal sealed class RegistrationGate {
         MarkRegistered();
         // postRegister runs with IsReady == true — for work that must reach the server on the freshly
         // ready transport (e.g. re-delivering unretired terminal acks, which CommandAckAsync drops while
-        // readiness is still cleared inside this bracket). Its failure must not un-register the daemon,
-        // so it is the caller's job to contain it.
-        if (postRegister is not null) await postRegister();
+        // readiness is still cleared inside this bracket). It is CONTAINED here: MarkRegistered has already
+        // run, so a throw from the hook — including from a throwing ILogger inside its OWN error handling,
+        // a supported input in this codebase — must never un-set readiness or fault the reconnect path.
+        // The hook owns its diagnostics; this gate has no logger and deliberately swallows.
+        if (postRegister is not null) {
+            try { await postRegister(); }
+            catch { /* deliberately empty — readiness stays set; best-effort post-register work */ }
+        }
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
@@ -63,18 +63,15 @@ internal readonly record struct CommandOutcome(
 internal sealed class SequencedCommandProcessor : IAsyncDisposable {
     sealed class CacheEntry {
         public required string CommandId;
-        // Settlement lost-ack redelivery (D1): the item's own identity, retained so a settled entry can build/re-send its
-        // terminal ack at status-tick / reconnect time without the original SequencedItem in hand.
-        // Epoch is the processor-wide _epoch; Seq is also the cache key, kept here for self-contained
-        // rebuilds.
+        // Lost-ack redelivery (D1): the item's own identity, so a settled entry can re-send its terminal
+        // ack at tick/reconnect time without the SequencedItem (Epoch is _epoch; Seq is also the key).
         public required long Seq;
         public required string AgentId;
         public bool Processed;
         public CommandOutcome Outcome;
-        // Settlement lost-ack redelivery (D1): the SINGLE published terminal ack. Frozen once (get-or-freeze) so the proactive
-        // send, a duplicate-replay, and every tick re-delivery all carry byte-identical liveness — a
-        // live-liveness read that changed between two sends can never make two acks for one command
-        // disagree. Null until the first successful freeze (a throwing liveness read defers it).
+        // Lost-ack redelivery (D1): the SINGLE published terminal ack — frozen once (get-or-freeze) so the
+        // proactive send, a duplicate-replay, and every re-delivery carry byte-identical liveness. Null
+        // until the first successful freeze (a throwing liveness read defers it).
         public CommandAck? FrozenAck;
     }
 
@@ -591,13 +588,12 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
             SendContained(() => _sendAck(ack), item.Seq, "settled ack");
     }
 
-    /// <summary>Settlement lost-ack redelivery (D1) (re-deliver unretired outcomes): re-send the terminal ack of every unretired
-    /// Processed command, freezing any winner-less entry first (a freeze deferred by a throwing liveness
-    /// read now retries). The orchestrator calls this after every successful (re)connect + registration and
-    /// on each status-report tick while any unretired processed entry remains, so a terminal ack lost in a
-    /// reconnect window is re-elicited without waiting for the server to retransmit the command. Sends are
-    /// contained + one-way and never block the lane; a validated <see cref="AckProcessedPrefix"/> evicts
-    /// retired entries, which is what makes the re-sends stop.</summary>
+    /// <summary>Lost-ack redelivery (D1): re-send the terminal ack of every unretired Processed command,
+    /// freezing any winner-less entry first (a freeze deferred by a throwing liveness read now retries).
+    /// The orchestrator calls this post-registration and on each status-report tick, so a terminal ack lost
+    /// in a reconnect window is re-elicited without a server retransmit. Sends are contained + one-way and
+    /// never block the lane; a validated <see cref="AckProcessedPrefix"/> evicts retired entries, stopping
+    /// the re-sends.</summary>
     public void RedeliverUnretiredProcessedAcks() {
         foreach (var (seq, commandId, agentId, outcome, frozen) in EnumerateUnretiredProcessedEntries()) {
             var ack = frozen ?? TryGetOrFreezeAck(seq, commandId, agentId, outcome);

--- a/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
@@ -61,7 +61,22 @@ internal readonly record struct CommandOutcome(
 /// before the write and never touched again.</para>
 /// </summary>
 internal sealed class SequencedCommandProcessor : IAsyncDisposable {
-    sealed class CacheEntry { public required string CommandId; public bool Processed; public CommandOutcome Outcome; }
+    sealed class CacheEntry {
+        public required string CommandId;
+        // Settlement lost-ack redelivery (D1): the item's own identity, retained so a settled entry can build/re-send its
+        // terminal ack at status-tick / reconnect time without the original SequencedItem in hand.
+        // Epoch is the processor-wide _epoch; Seq is also the cache key, kept here for self-contained
+        // rebuilds.
+        public required long Seq;
+        public required string AgentId;
+        public bool Processed;
+        public CommandOutcome Outcome;
+        // Settlement lost-ack redelivery (D1): the SINGLE published terminal ack. Frozen once (get-or-freeze) so the proactive
+        // send, a duplicate-replay, and every tick re-delivery all carry byte-identical liveness — a
+        // live-liveness read that changed between two sends can never make two acks for one command
+        // disagree. Null until the first successful freeze (a throwing liveness read defers it).
+        public CommandAck? FrozenAck;
+    }
 
     /// <summary>One lane entry. EXACTLY ONE shape is populated — sequenced (identity + terminal-answer
     /// machinery + a per-item execution-completion task) or un-sequenced (a bare delegate, no reply
@@ -231,7 +246,7 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
 
         // ACCEPT + lane-item, atomically under _lock.
         _highestAcceptedSeq = item.Seq;
-        _cache[item.Seq] = new CacheEntry { CommandId = item.CommandId, Processed = false };
+        _cache[item.Seq] = new CacheEntry { CommandId = item.CommandId, Seq = item.Seq, AgentId = item.AgentId, Processed = false };
         var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var lane = LaneItem.ForSequenced(item, execute, done);
 
@@ -495,12 +510,62 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
     /// command reaches this — holding the lock across it would put that read on the critical path of
     /// concurrent <see cref="SubmitAsync"/>/<see cref="AckPrefix"/> callers. Both callers commit the
     /// outcome to the cache first, so an ack can never advertise an outcome the cache lacks.</para></summary>
-    CommandAck BuildProcessedAck(SequencedItem item, CommandOutcome outcome) {
-        var live   = _readLiveness(outcome.AgentId ?? item.AgentId);
+    CommandAck BuildProcessedAck(SequencedItem item, CommandOutcome outcome) =>
+        BuildProcessedAck(item.Seq, item.CommandId, item.AgentId, outcome);
+
+    /// <summary>Settlement lost-ack redelivery (D1): the primitive builder, so a re-delivery can rebuild an entry's terminal ack
+    /// from the cached identity (Seq/CommandId/AgentId + Outcome) without the original SequencedItem. Same
+    /// live <c>_readLiveness</c> read and lock-scope contract as the item overload.</summary>
+    CommandAck BuildProcessedAck(long seq, string commandId, string agentId, CommandOutcome outcome) {
+        var live   = _readLiveness(outcome.AgentId ?? agentId);
         var reason = outcome.RejectReason is { } r ? RejectReasonWireToken(r) : null;
 
-        return new CommandAck(_epoch, item.Seq, item.CommandId, CommandAckState.Processed,
-            outcome.Kind, live, outcome.AgentId ?? item.AgentId, outcome.SessionId, reason);
+        return new CommandAck(_epoch, seq, commandId, CommandAckState.Processed,
+            outcome.Kind, live, outcome.AgentId ?? agentId, outcome.SessionId, reason);
+    }
+
+    /// <summary>Settlement lost-ack redelivery (D1) (freeze the terminal ack): get-or-freeze the SINGLE terminal ack for a settled
+    /// command. The candidate is built OUTSIDE <c>_lock</c> (readLiveness walks lifecycle collections and
+    /// must never run under the lock), then published under <c>_lock</c> IFF the entry has no frozen ack
+    /// yet — a single winner. Every sender (proactive settle, duplicate-replay, tick/reconnect
+    /// re-delivery) sends the RETURNED winner, so a liveness value that changed between two sends can never
+    /// make two terminal acks for one command disagree.
+    /// <para>Returns <c>null</c> when the entry is gone (retired) OR the build threw: a throwing
+    /// readLiveness must not abandon the item — the outcome stays committed <c>Processed</c>, the freeze is
+    /// simply deferred, and a later tick/reconnect re-attempts it. This is the exact containment
+    /// <see cref="SendSettledAck"/> used to apply to the inline build.</para></summary>
+    CommandAck? TryGetOrFreezeAck(long seq, string commandId, string agentId, CommandOutcome outcome) {
+        lock (_lock) {
+            if (!_cache.TryGetValue(seq, out var current)) return null;      // retired
+            if (current.FrozenAck is { } already) return already;            // fast path: winner exists
+        }
+        CommandAck candidate;
+        try {
+            candidate = BuildProcessedAck(seq, commandId, agentId, outcome);
+        } catch (Exception ex) {
+            // Leave FrozenAck null so a later re-delivery retries; the outcome is already committed.
+            _logger.LogDebug(ex, "Deferring terminal-ack freeze for seq {Seq}: liveness read threw.", seq);
+            return null;
+        }
+        lock (_lock) {
+            if (!_cache.TryGetValue(seq, out var entry)) return null;        // retired during the build
+            return entry.FrozenAck ??= candidate;                            // publish iff unset; losers take the winner
+        }
+    }
+
+    /// <summary>Settlement lost-ack redelivery (D1) (re-deliver unretired outcomes): every Processed cache entry the server has NOT
+    /// confirmed via a validated <c>AckProcessedPrefix</c> (retirement evicts the entry, so presence in the
+    /// cache IS the unretired predicate). Snapshotted under <c>_lock</c> so the caller iterates without
+    /// holding it. Each carries what a re-send needs: the frozen ack if already published, else the
+    /// identity+outcome to (re)freeze at send time.</summary>
+    internal IReadOnlyList<(long Seq, string CommandId, string AgentId, CommandOutcome Outcome, CommandAck? FrozenAck)>
+        EnumerateUnretiredProcessedEntries() {
+        lock (_lock) {
+            var result = new List<(long, string, string, CommandOutcome, CommandAck?)>();
+            foreach (var e in _cache.Values)
+                if (e.Processed) result.Add((e.Seq, e.CommandId, e.AgentId, e.Outcome, e.FrozenAck));
+            return result;
+        }
     }
 
     /// <summary>Build AND fire a settled command's terminal ack without ever letting it fault the caller.
@@ -515,8 +580,27 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
     /// <see cref="SubmitAsync"/> it escapes into the hub handler. Both callers reach this only AFTER the
     /// outcome is recorded in the cache, so swallowing the ack costs at most one status-report interval
     /// of slot latency — never a wrong or missing terminal fact.</para></summary>
-    void SendSettledAck(SequencedItem item, CommandOutcome outcome) =>
-        SendContained(() => _sendAck(BuildProcessedAck(item, outcome)), item.Seq, "settled ack");
+    void SendSettledAck(SequencedItem item, CommandOutcome outcome) {
+        // Settlement lost-ack redelivery (D1): send the FROZEN winner (get-or-freeze), never a freshly-built ack — so the proactive
+        // send and any later duplicate-replay/re-delivery are byte-identical. A deferred freeze (liveness
+        // read threw) sends nothing now; a later tick/reconnect re-delivery retries it.
+        if (TryGetOrFreezeAck(item.Seq, item.CommandId, item.AgentId, outcome) is { } ack)
+            SendContained(() => _sendAck(ack), item.Seq, "settled ack");
+    }
+
+    /// <summary>Settlement lost-ack redelivery (D1) (re-deliver unretired outcomes): re-send the terminal ack of every unretired
+    /// Processed command, freezing any winner-less entry first (a freeze deferred by a throwing liveness
+    /// read now retries). The orchestrator calls this after every successful (re)connect + registration and
+    /// on each status-report tick while any unretired processed entry remains, so a terminal ack lost in a
+    /// reconnect window is re-elicited without waiting for the server to retransmit the command. Sends are
+    /// contained + one-way and never block the lane; a validated <see cref="AckProcessedPrefix"/> evicts
+    /// retired entries, which is what makes the re-sends stop.</summary>
+    public void RedeliverUnretiredProcessedAcks() {
+        foreach (var (seq, commandId, agentId, outcome, frozen) in EnumerateUnretiredProcessedEntries()) {
+            var ack = frozen ?? TryGetOrFreezeAck(seq, commandId, agentId, outcome);
+            if (ack is { } resend) SendContained(() => _sendAck(resend), seq, "re-delivered settled ack");
+        }
+    }
 
     /// <summary>Phase B2-b (sequenced-settlement design §5.5): the wire token a cached
     /// <see cref="CommandRejectedReason"/> carries on a processed-duplicate <see cref="CommandAck"/> —
@@ -587,7 +671,7 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
         // would (a) advertise a non-contiguous prefix and (b) be regressed below when the earlier item's
         // consumer later advances to N-1. AdvanceWatermarkLocked is monotonic + contiguous by construction.
         _cache[item.Seq] = new CacheEntry {
-            CommandId = item.CommandId, Processed = true,
+            CommandId = item.CommandId, Seq = item.Seq, AgentId = item.AgentId, Processed = true,
             Outcome = new CommandOutcome(CommandOutcomeKind.InternalError, item.AgentId) };
         AdvanceWatermarkLocked();
         rejection = new CommandRejected(item.Epoch, item.Seq, item.CommandId, CommandRejectedReason.InternalError, item.AgentId);

--- a/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SequencedCommandProcessor.cs
@@ -543,8 +543,11 @@ internal sealed class SequencedCommandProcessor : IAsyncDisposable {
         try {
             candidate = BuildProcessedAck(seq, commandId, agentId, outcome);
         } catch (Exception ex) {
-            // Leave FrozenAck null so a later re-delivery retries; the outcome is already committed.
-            _logger.LogDebug(ex, "Deferring terminal-ack freeze for seq {Seq}: liveness read threw.", seq);
+            // Leave FrozenAck null so a later re-delivery retries; the outcome is already committed. The
+            // diagnostic goes through LogQuietly because a throwing ILogger provider is a supported input
+            // here — logging must not become the failure and let the exception escape the containment
+            // (which would fault SubmitAsync into the hub, or fault a tick/reconnect re-delivery).
+            LogQuietly(ex, "{What} freeze for seq {Seq}: liveness read threw — deferred for re-delivery", "terminal-ack", seq);
             return null;
         }
         lock (_lock) {

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -574,7 +574,12 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             // IsReady gate. Contained so a failing re-delivery never un-registers the daemon.
             postRegister: async () => {
                 try { await (OnRegisteredHook?.Invoke() ?? Task.CompletedTask); }
-                catch (Exception ex) { _logger.LogDebug(ex, "post-registration hook failed — ignoring"); }
+                catch (Exception ex) {
+                    // The log itself is contained: a throwing ILogger provider is a supported input, so a
+                    // bare LogDebug here could re-throw and defeat this very containment.
+                    try { _logger.LogDebug(ex, "post-registration hook failed — ignoring"); }
+                    catch { /* logger provider threw — swallow so post-register containment holds */ }
+                }
             }
         );
 

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -568,7 +568,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     internal virtual Task RegisterDaemonAsync() =>
         _gate.RunRegistrationAsync(
             daemonConnect: DaemonConnectAsync,
-            reRegisterAgents: ReRegisterAgentsAndAcpBindingsAsync
+            reRegisterAgents: ReRegisterAgentsAndAcpBindingsAsync,
+            // Runs AFTER MarkRegistered, i.e. with IsReady == true, so a re-delivery here actually reaches
+            // the server — inside reRegisterAgents it would be silently dropped by the CommandAckAsync
+            // IsReady gate. Contained so a failing re-delivery never un-registers the daemon.
+            postRegister: async () => {
+                try { await (OnRegisteredHook?.Invoke() ?? Task.CompletedTask); }
+                catch (Exception ex) { _logger.LogDebug(ex, "post-registration hook failed — ignoring"); }
+            }
         );
 
     /// <summary>
@@ -672,6 +679,14 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// Null until wired (early startup / tests) — treated as a no-op.
     /// </summary>
     internal Func<Task>? ReRegisterAgentsHook { get; set; }
+
+    /// <summary>Invoked inside <see cref="RegisterDaemonAsync"/> AFTER readiness is restored
+    /// (post-<c>MarkRegistered</c>), unlike <see cref="ReRegisterAgentsHook"/>. For work that must reach
+    /// the server on the freshly ready transport — the settlement lost-ack re-delivery lives here because
+    /// <see cref="CommandAckAsync"/> silently drops sends while <see cref="IsReady"/> is still false inside
+    /// the registration bracket. Null until wired (early startup / tests) — a no-op; failures are contained
+    /// by the caller so they never un-register the daemon.</summary>
+    internal Func<Task>? OnRegisteredHook { get; set; }
 
     async Task<string[]> MergeRepoPathsAsync() {
         var persisted = await RepoPathStore.GetSortedPathsAsync();

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -574,6 +574,8 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             // IsReady gate. Contained so a failing re-delivery never un-registers the daemon.
             postRegister: async () => {
                 try { await (OnRegisteredHook?.Invoke() ?? Task.CompletedTask); }
+                // Cancellation (shutdown) propagates — never contained as a hook failure.
+                catch (OperationCanceledException) { throw; }
                 catch (Exception ex) {
                     // The log itself is contained: a throwing ILogger provider is a supported input, so a
                     // bare LogDebug here could re-throw and defeat this very containment.

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
@@ -448,6 +448,34 @@ public class SequencedCommandProcessorTests {
         await Assert.That(p.LastProcessedSeq).IsEqualTo(2L);
     }
 
+    // Settlement lost-ack redelivery (D1) deferred-freeze containment: a throwing liveness read AND a
+    // throwing logger TOGETHER must still not fault SubmitAsync. The deferred-freeze diagnostic routes
+    // through the contained LogQuietly, so a throwing logger provider (a supported input) cannot let the
+    // exception escape; the outcome stays committed with no ack, and a later re-delivery (liveness
+    // recovered) completes the freeze and sends.
+    [Test] public async Task A_throwing_liveness_and_a_throwing_logger_together_still_defer_without_faulting() {
+        var throwLiveness = 1;
+        var acks = new List<CommandAck>();
+        await using var p = new SequencedCommandProcessor(
+            "e1",
+            _ => { if (Interlocked.Exchange(ref throwLiveness, 0) == 1) throw new InvalidOperationException("liveness blip"); return AgentLiveness.Live; },
+            a => { lock (acks) acks.Add(a); return Task.CompletedTask; },
+            _ => Task.CompletedTask,
+            new ThrowingLogger());
+
+        // Proactive freeze: liveness throws → the deferred-freeze catch logs through the THROWING logger.
+        // Neither the lane nor the submitter may fault.
+        await p.SubmitAsync(new SequencedItem(SequencedKind.Launch, "e1", 1, "cmd1", "a1"),
+            () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a1", "sess")));
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(1L);   // committed despite the double throw
+        await Assert.That(acks).IsEmpty();                     // freeze deferred, no ack
+
+        // Liveness recovered: a re-delivery completes the freeze and sends (the success path logs nothing).
+        p.RedeliverUnretiredProcessedAcks();
+        await Assert.That(acks).HasCount().EqualTo(1);
+        await Assert.That(acks[0].State).IsEqualTo(CommandAckState.Processed);
+    }
+
     // Rejections are captured under _lock and sent after release, so no transport delegate runs inside
     // the processor's critical section. Asserted directly rather than by timing.
     [Test] public async Task Rejection_sends_do_not_run_inside_the_processor_lock() {

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SequencedCommandProcessorTests.cs
@@ -143,14 +143,16 @@ public class SequencedCommandProcessorTests {
         await p.SubmitAsync(item, () => { runs++; return Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)); });
         await Assert.That(runs).IsEqualTo(1);                                    // no re-execution
 
-        // Two acks now: [0] the proactive settle ack from the lane, [1] the duplicate-replay ack.
-        // Both are Processed and carry the SAME cached outcome — the duplicate path is unchanged.
+        // Two acks: [0] the proactive settle ack from the lane, [1] the duplicate-replay ack. Both are
+        // Processed and carry the SAME cached outcome. Settlement lost-ack redelivery (D1): [1] is now the FROZEN ack [0] published
+        // (get-or-freeze), not a fresh build — so it is byte-identical rather than merely equal-by-value.
         await Assert.That(h.Acks).HasCount().EqualTo(2);
         await Assert.That(h.Acks[0].State).IsEqualTo(CommandAckState.Processed);  // proactive
         var ack = h.Acks[1];                                                      // duplicate replay
         await Assert.That(ack.State).IsEqualTo(CommandAckState.Processed);
         await Assert.That(ack.OutcomeKind).IsEqualTo(CommandOutcomeKind.LaunchExecuted);
-        await Assert.That(ack.CurrentState).IsEqualTo(AgentLiveness.Live);       // read live at ack time
+        await Assert.That(ack.CurrentState).IsEqualTo(AgentLiveness.Live);       // the frozen liveness
+        await Assert.That(ack).IsEqualTo(h.Acks[0]);                            // D1: the same frozen value
     }
 
     [Test] public async Task Different_command_id_at_an_accepted_seq_is_a_duplicate_collision() {
@@ -257,8 +259,10 @@ public class SequencedCommandProcessorTests {
         await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a1", "sess")));
         await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
 
-        await Assert.That(reads).IsEqualTo(2);          // proactive settle ack + duplicate replay ack
-        await Assert.That(readsUnderLock).IsEqualTo(0); // neither one held _lock
+        // Settlement lost-ack redelivery (D1): the terminal ack is FROZEN once (get-or-freeze), so the duplicate replay reuses the
+        // published ack instead of reading liveness again — one read total, not two.
+        await Assert.That(reads).IsEqualTo(1);          // the single freeze read; the duplicate reused it
+        await Assert.That(readsUnderLock).IsEqualTo(0); // and it did NOT hold _lock
     }
 
     // The ordering the lock move must NOT break: the cache records the outcome BEFORE the ack is built, so
@@ -507,5 +511,116 @@ public class SequencedCommandProcessorTests {
         await Assert.That(h.Acks).HasCount().EqualTo(2);                              // proactive + duplicate replay
         await Assert.That(h.Acks[0].RejectionReason).IsNull();
         await Assert.That(h.Acks[1].RejectionReason).IsNull();
+    }
+
+    // ── Settlement lost-ack redelivery (D1): freeze the terminal ack + re-deliver unretired outcomes ──────────────────────────
+
+    /// <summary>Task 6 (the freeze proof): the terminal ack is published ONCE. A duplicate replay reuses
+    /// the frozen value, so a liveness that CHANGED between the two sends can never make them disagree —
+    /// the whole point of the freeze, and what lets the server tolerate duplicate acks (D2″).</summary>
+    [Test] public async Task The_terminal_ack_is_frozen_so_a_replay_never_reflects_a_changed_liveness() {
+        var livenesses = new Queue<AgentLiveness>([AgentLiveness.Live, AgentLiveness.Dead, AgentLiveness.NotFound]);
+        var acks = new List<CommandAck>();
+        await using var p = new SequencedCommandProcessor(
+            "e1",
+            _ => livenesses.Count > 0 ? livenesses.Dequeue() : AgentLiveness.NotFound,
+            a => { lock (acks) acks.Add(a); return Task.CompletedTask; },
+            _ => Task.CompletedTask, NullLogger.Instance);
+
+        var item = new SequencedItem(SequencedKind.Launch, "e1", 1, "cmd1", "a1");
+        await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a1", "sess")));
+        // The proactive freeze dequeued Live. A duplicate would dequeue Dead next IF it re-read — but it
+        // reuses the winner, so Dead is never consumed.
+        await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+
+        await Assert.That(acks).HasCount().EqualTo(2);
+        await Assert.That(acks[0].CurrentState).IsEqualTo(AgentLiveness.Live);   // proactive freeze
+        await Assert.That(acks[1].CurrentState).IsEqualTo(AgentLiveness.Live);   // duplicate: FROZEN, not Dead
+        await Assert.That(acks[0]).IsEqualTo(acks[1]);                            // byte-identical DTO
+        await Assert.That(livenesses.Count).IsEqualTo(2);                        // only ONE liveness read total
+    }
+
+    /// <summary>Task 6 (deferred freeze) + Task 7 (retry on re-delivery): a throwing liveness read must not
+    /// abandon the item — the outcome stays committed Processed with NO ack, and a later re-delivery
+    /// completes the freeze and sends. A second re-delivery re-sends the SAME frozen value verbatim.</summary>
+    [Test] public async Task A_throwing_liveness_defers_the_freeze_and_a_later_redelivery_completes_it() {
+        var throwOnce = 1;
+        var acks = new List<CommandAck>();
+        await using var p = new SequencedCommandProcessor(
+            "e1",
+            _ => { if (Interlocked.Exchange(ref throwOnce, 0) == 1) throw new InvalidOperationException("liveness blip"); return AgentLiveness.Live; },
+            a => { lock (acks) acks.Add(a); return Task.CompletedTask; },
+            _ => Task.CompletedTask, NullLogger.Instance);
+
+        var item = new SequencedItem(SequencedKind.Launch, "e1", 1, "cmd1", "a1");
+        await p.SubmitAsync(item, () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a1", "sess")));
+
+        // Proactive freeze threw → deferred: outcome committed (watermark advanced), but NO ack sent.
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(1L);
+        await Assert.That(acks).IsEmpty();
+
+        // A later status tick / reconnect re-delivers: the freeze now succeeds and the ack goes out.
+        p.RedeliverUnretiredProcessedAcks();
+        await Assert.That(acks).HasCount().EqualTo(1);
+        await Assert.That(acks[0].State).IsEqualTo(CommandAckState.Processed);
+        await Assert.That(acks[0].CurrentState).IsEqualTo(AgentLiveness.Live);
+
+        // A subsequent re-delivery re-sends the SAME frozen value verbatim (no further liveness read).
+        p.RedeliverUnretiredProcessedAcks();
+        await Assert.That(acks).HasCount().EqualTo(2);
+        await Assert.That(acks[1]).IsEqualTo(acks[0]);
+    }
+
+    /// <summary>Task 7 (re-deliver only the unretired suffix; a validated prefix stops it): a re-delivery
+    /// re-sends every unretired terminal ack; a validated AckProcessedPrefix evicts the retired entries so
+    /// their re-sends stop, leaving only the unretired suffix.</summary>
+    [Test] public async Task Redelivery_re_sends_the_unretired_suffix_and_a_validated_prefix_stops_it() {
+        var h = new Harness(); await using var p = h.P();
+        await p.SubmitAsync(h.Launch(1), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await p.SubmitAsync(h.Launch(2), () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(h.Acks).HasCount().EqualTo(2);                 // two proactive settle acks
+
+        // A re-delivery re-sends BOTH unretired terminal acks.
+        p.RedeliverUnretiredProcessedAcks();
+        await Assert.That(h.Acks).HasCount().EqualTo(4);
+
+        // The server confirms the prefix up to 1 → seq 1 is retired (evicted); only seq 2 remains.
+        p.AckPrefix(new AckProcessedPrefix("e1", 1));
+        p.RedeliverUnretiredProcessedAcks();
+        await Assert.That(h.Acks).HasCount().EqualTo(5);                 // +1, only the unretired suffix
+        await Assert.That(h.Acks[4].Seq).IsEqualTo(2L);
+
+        // Confirm the full prefix → nothing left to re-deliver.
+        p.AckPrefix(new AckProcessedPrefix("e1", 2));
+        p.RedeliverUnretiredProcessedAcks();
+        await Assert.That(h.Acks).HasCount().EqualTo(5);                 // no change
+    }
+
+    /// <summary>Task 7 (re-delivery never blocks the lane under a send fault): a throwing sendAck is
+    /// contained both on the proactive settle and on re-delivery, so neither faults; once the transport
+    /// recovers, the next re-delivery lands the frozen ack.</summary>
+    [Test] public async Task Redelivery_swallows_a_send_fault_and_never_throws() {
+        var acks = new List<CommandAck>();
+        var fail = true;
+        await using var p = new SequencedCommandProcessor(
+            "e1", _ => AgentLiveness.Live,
+            a => { if (Volatile.Read(ref fail)) throw new InvalidOperationException("transport down"); lock (acks) acks.Add(a); return Task.CompletedTask; },
+            _ => Task.CompletedTask, NullLogger.Instance);
+
+        // Proactive settle: the send throws but is contained, so the submit completes and the ack freezes.
+        await p.SubmitAsync(new SequencedItem(SequencedKind.Launch, "e1", 1, "cmd1", "a1"),
+            () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted)));
+        await Assert.That(p.LastProcessedSeq).IsEqualTo(1L);
+        await Assert.That(acks).IsEmpty();
+
+        // A re-delivery while the transport is still down must not throw either.
+        p.RedeliverUnretiredProcessedAcks();                            // no throw
+        await Assert.That(acks).IsEmpty();
+
+        // Transport recovers; the next re-delivery lands the frozen ack.
+        Volatile.Write(ref fail, false);
+        p.RedeliverUnretiredProcessedAcks();
+        await Assert.That(acks).HasCount().EqualTo(1);
+        await Assert.That(acks[0].State).IsEqualTo(CommandAckState.Processed);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SettlementAckRedeliveryWiringTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SettlementAckRedeliveryWiringTests.cs
@@ -38,12 +38,18 @@ public partial class AgentOrchestratorVendorTests {
     }
 
     [Test]
-    public async Task Reconnect_reregistration_redelivers_unretired_terminal_acks() {
+    public async Task Reconnect_redelivers_unretired_terminal_acks_only_AFTER_readiness_is_restored() {
         var (orch, server, proactive) = await OrchestratorWithOneSettledCommandAsync();
         await using var _ = orch;
 
-        await orch.ReRegisterAgentsAsync();                 // the reconnect hook (no agents to re-register)
+        // The PRE-READY re-register hook must NOT re-deliver: it runs inside the registration bracket
+        // before MarkRegistered, where CommandAckAsync silently drops sends (IsReady still false). If the
+        // re-delivery were (wrongly) here, this would add an ack.
+        await orch.ReRegisterAgentsAsync();
+        await Assert.That(server.Acks.Count).IsEqualTo(proactive);   // unchanged — not re-delivered here
 
+        // The POST-REGISTER hook (fires with IsReady == true) is where re-delivery is wired.
+        await server.OnRegisteredHook!.Invoke();
         await Assert.That(server.Acks.Count).IsEqualTo(proactive + 1);
         await Assert.That(server.Acks[^1].Seq).IsEqualTo(1L);
         await Assert.That(server.Acks[^1].State).IsEqualTo(CommandAckState.Processed);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/SettlementAckRedeliveryWiringTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/SettlementAckRedeliveryWiringTests.cs
@@ -1,0 +1,51 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+// Settlement lost-ack redelivery (D1) (Task 7 wiring): the orchestrator re-delivers unretired terminal acks on a status-report
+// tick AND on reconnect (re-registration). The freeze + re-delivery MECHANISM is pinned at the processor
+// level (SequencedCommandProcessorTests); these pin that the orchestrator actually invokes it end-to-end
+// — processor -> _server.CommandAckAsync. Reuses the AgentOrchestratorVendorTests harness
+// (BuildOrchestrator / SpyPtyProcessFactory / SeqCaptureServerConnection / WaitBoundedAsync).
+public partial class AgentOrchestratorVendorTests {
+    // A published processor with exactly one SETTLED (Processed, unretired) sequenced command, so the
+    // server has captured its single proactive terminal ack and a re-delivery has something to re-send.
+    static async Task<(AgentOrchestrator Orch, SeqCaptureServerConnection Server, int ProactiveAcks)>
+        OrchestratorWithOneSettledCommandAsync() {
+        var server = new SeqCaptureServerConnection();
+        var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher>());
+        orch.PublishSequencedProcessorForTest();
+        await orch.ProcessorForTest!.SubmitAsync(
+            new SequencedItem(SequencedKind.Launch, orch.DaemonEpochForTest, 1, "cmd1", "a1"),
+            () => Task.FromResult(new CommandOutcome(CommandOutcomeKind.LaunchExecuted, "a1", "sess")));
+        await WaitBoundedAsync(orch.DrainLaneForTest(), "the lane never settled the command");
+        return (orch, server, server.Acks.Count);
+    }
+
+    [Test]
+    public async Task Status_report_tick_redelivers_unretired_terminal_acks() {
+        var (orch, server, proactive) = await OrchestratorWithOneSettledCommandAsync();
+        await using var _ = orch;
+        await Assert.That(proactive).IsGreaterThanOrEqualTo(1);
+
+        await orch.SendDaemonStatusReportOnceAsync();       // the periodic / on-request tick
+
+        await Assert.That(server.Acks.Count).IsEqualTo(proactive + 1);
+        await Assert.That(server.Acks[^1].Seq).IsEqualTo(1L);
+        await Assert.That(server.Acks[^1].State).IsEqualTo(CommandAckState.Processed);
+    }
+
+    [Test]
+    public async Task Reconnect_reregistration_redelivers_unretired_terminal_acks() {
+        var (orch, server, proactive) = await OrchestratorWithOneSettledCommandAsync();
+        await using var _ = orch;
+
+        await orch.ReRegisterAgentsAsync();                 // the reconnect hook (no agents to re-register)
+
+        await Assert.That(server.Acks.Count).IsEqualTo(proactive + 1);
+        await Assert.That(server.Acks[^1].Seq).IsEqualTo(1L);
+        await Assert.That(server.Acks[^1].State).IsEqualTo(CommandAckState.Processed);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/RegistrationGateTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RegistrationGateTests.cs
@@ -130,4 +130,20 @@ public class RegistrationGateTests {
         await Assert.That(reRegistered).IsFalse();
         await Assert.That(gate.IsReady(HubConnectionState.Connected)).IsFalse();
     }
+
+    // Settlement lost-ack redelivery (D1): postRegister runs AFTER MarkRegistered, so a throw there
+    // (including from a throwing ILogger inside the hook's own error handling — a supported input) must
+    // be contained: RunRegistrationAsync must not fault the reconnect path, and readiness stays set.
+    [Test]
+    public async Task A_throwing_post_register_hook_is_contained_and_readiness_stays_set() {
+        var gate = new RegistrationGate();
+
+        await gate.RunRegistrationAsync(
+            daemonConnect:    () => Task.CompletedTask,
+            reRegisterAgents: () => Task.CompletedTask,
+            postRegister:     () => throw new InvalidOperationException("hook and its logger both blew up"));
+
+        // The daemon is registered despite the post-register throw — the bracket completed cleanly.
+        await Assert.That(gate.IsReady(HubConnectionState.Connected)).IsTrue();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/RegistrationGateTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/RegistrationGateTests.cs
@@ -146,4 +146,19 @@ public class RegistrationGateTests {
         // The daemon is registered despite the post-register throw — the bracket completed cleanly.
         await Assert.That(gate.IsReady(HubConnectionState.Connected)).IsTrue();
     }
+
+    // Cancellation is a shutdown signal, NOT a hook failure: it must propagate out of the bracket rather
+    // than be swallowed as success (readiness still set, since MarkRegistered ran first).
+    [Test]
+    public async Task A_cancelled_post_register_hook_propagates_the_cancellation() {
+        var gate = new RegistrationGate();
+
+        await Assert.That(async () => await gate.RunRegistrationAsync(
+                daemonConnect:    () => Task.CompletedTask,
+                reRegisterAgents: () => Task.CompletedTask,
+                postRegister:     () => throw new OperationCanceledException()))
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(gate.IsReady(HubConnectionState.Connected)).IsTrue();
+    }
 }


### PR DESCRIPTION
## Incident

A flow wedged ~5.5h on a stable daemon link: a foreground reviewer launch kept returning `flow_settlement_busy` and only a daemon restart cleared it. Root cause — a sequenced-command answer (`CommandAck`) can be lost in a reconnect/disconnect window, leaving the daemon's single settlement slot occupied by a command whose terminal outcome the server never learns.

This is the **D1 (daemon)** half. The server half (D2 recovery + D3 blocker-honest busy) is `kurrent-io/kcap-server#1383`.

Fixes AI-1826.

## This PR

**Freeze (Task 6).** The terminal `CommandAck` is now published **once** per command via a get-or-freeze on the cache entry: the candidate is built *outside* the lock (`readLiveness` walks lifecycle collections and must never run under the lock), then published under the lock iff no ack is frozen yet — a single winner. The proactive settle, a duplicate-replay, and every re-delivery send that one frozen DTO, so a liveness value that changed between two sends can never make two acks for one command disagree (which is exactly what lets the server tolerate the duplicate). A throwing `readLiveness` **defers** the freeze — the outcome stays committed `Processed` with no ack — and a later re-delivery completes it.

**Re-deliver (Task 7).** After every successful (re)connect + re-registration and on each status-report tick, the daemon re-sends the frozen ack of every **unretired** `Processed` entry (retirement evicts the entry, so cache presence *is* the unretired predicate). Sends are contained + one-way and never block the lane; a validated `AckProcessedPrefix` evicts the retired entries, which is what makes the re-sends stop. This re-elicits a lost terminal answer without waiting for the server to retransmit the whole command.

## Tests

- `SequencedCommandProcessorTests` — the freeze under a changed liveness (one read, byte-identical DTO), the deferred-freeze-then-redelivery path, the unretired-suffix re-delivery + prefix-stops-it, and send-fault containment. Updated the two existing duplicate tests that encoded the old "read live at ack time" behaviour.
- `SettlementAckRedeliveryWiringTests` — end-to-end: a status-report tick AND a reconnect re-registration each re-deliver the unretired terminal ack through `_server.CommandAckAsync`.
- Full `SequencedCommandProcessorTests` (30) + `AgentOrchestratorVendorTests` (211) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)