### PR TITLE
[AI-1283] Deterministic update notice + version/preference headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,18 +1811,21 @@ kcap logout         # delete stored tokens
 > releases correspond to server versions rolled out to internal tenants first,
 > so most users should stay on stable.
 >
-> **Staying current, and turning it all off.** Beyond the stderr hint above,
-> every human-facing `kcap` command prints an "Update available" notice after
-> it finishes if a newer version exists, and `kcap status`'s **Version** line
-> shows the same thing inline. Every request `kcap` sends also carries its
-> version (and, if update checks are off, an explicit opt-out marker) to your
-> server, which is how the web dashboard's own out-of-date banner and
-> notification-centre entry — and the in-agent nudge Claude Code sessions can
-> see (above) — know to show up. `kcap config set update_check false` (or
-> `--no-update-check` for a single invocation) turns off **all** of it at
-> once: the stderr hint, the exit-time notice, the `kcap status` annotation,
-> the headers that drive the server-side banner/notification, and the
-> in-agent nudge. It defaults to on.
+> **Staying current, and turning it all off.** Every human-facing `kcap`
+> command prints an "Update available" notice after it finishes if a newer
+> version exists, and `kcap status`'s **Version** line shows the same thing
+> inline. Every request `kcap` sends also carries its version (and, if update
+> checks are off, an explicit opt-out marker) to your server, which is how the
+> web dashboard's own out-of-date banner and notification-centre entry — and
+> the in-agent nudge Claude Code sessions can see (above) — know to show up.
+> `kcap config set update_check false` is the full, persisted opt-out: it
+> disables the notice, the `kcap status` annotation, the headers that drive
+> the server-side banner/notification, and the in-agent nudge — everywhere,
+> until you turn it back on. `--no-update-check` is narrower and one-shot: it
+> only suppresses the notice and the `kcap status` annotation for that single
+> invocation — it doesn't change what gets sent to the server, so the banner,
+> notification, and in-agent nudge keep following whatever `update_check` is
+> persisted to. It defaults to on.
 
 The v1 config format stored `server_url` as a bare host name without a
 scheme. If `kcap` crashes with `An invalid request URI was provided`

--- a/README.md
+++ b/README.md
@@ -1829,9 +1829,11 @@ kcap logout         # delete stored tokens
 > web dashboard's own out-of-date banner and notification-centre entry — and
 > the in-agent nudge Claude Code sessions can see (above) — know to show up.
 > `kcap config set update_check false` is the full, persisted opt-out: it
-> disables the notice, the `kcap status` annotation, the headers that drive
-> the server-side banner/notification, and the in-agent nudge — everywhere,
-> until you turn it back on. `--no-update-check` is narrower and one-shot: it
+> disables the notice and the `kcap status` annotation, makes the server
+> suppress its own banner/notification for you via the transmitted opt-out
+> marker (the version is still sent — the opt-out is signaled, not omitted),
+> and drops the in-agent nudge — everywhere, until you turn it back on.
+> `--no-update-check` is narrower and one-shot: it
 > only suppresses the notice and the `kcap status` annotation for that single
 > invocation — it doesn't change what gets sent to the server, so the banner,
 > notification, and in-agent nudge keep following whatever `update_check` is

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ Verify with `kcap whoami` and `kcap status`. `kcap whoami` prints your identity 
 resolved, then asks the server whether it actually accepts your token — it exits non-zero if the
 server rejects it, or if the token was issued by a different server than the profile now targets
 (re-run `kcap login`). If the server can't be reached it says so and still exits 0, so it stays
-usable offline.
+usable offline. `kcap status` prints its own **Version** line — the installed CLI version, with an
+inline `(update available: …)` annotation when a newer one is out — see
+[`kcap update`](#other-commands) for the full opt-out story.
 
 Setup closes with a **Next steps** box. Each item opens with a question, because neither step is for
 everyone:
@@ -205,7 +207,7 @@ Once set up, Capacitor runs silently in the background. Every Claude Code (and C
 - **Tool usage** — every tool call with timing and results
 - **Token consumption** — input/output/cache token counts per interaction
 - **Repository context** — git repo, branch, and PR linkage
-- **In-agent upgrade prompts** — in Claude Code sessions, when the server is running a newer kcap release than the local CLI, additional context is injected into the session so the agent can offer the user an upgrade via `kcap update`. The stderr `kcap` update hint continues to fire for direct command-line use.
+- **In-agent upgrade prompts** — in Claude Code sessions, when the server is running a newer kcap release than the local CLI, additional context is injected into the session so the agent can offer the user an upgrade via `kcap update`. The stderr `kcap` update hint continues to fire for direct command-line use, and every request also carries the CLI's version to the server so it can surface its own out-of-date banner/notification (see [`kcap update`](#other-commands) for the full picture, including how `update_check: false` turns all of this off).
 - **SessionStart context injection** — at every session start the server injects top evaluation-derived fact clusters for the current repo into Claude's `additionalContext`. The injected block is split into two sections: `## Known patterns` (repo/project facts relevant to any reader) and `## Guidance from past sessions` (agent-targeted action items derived from prior eval suggestions with `audience: "agent"`). Opt out by setting `disable_session_guidelines: true` in `~/.config/kcap/config.json` or via `kcap config set disable_session_guidelines true`.
 - **SessionStart team-memory index** — at every session start (Claude Code, Codex CLI, GitHub Copilot CLI, Gemini CLI, AWS Kiro CLI, Google Antigravity, Pi, OpenCode, and Cursor CLI's `cursor-agent` — see the capability matrix below for the full per-harness rollout) `kcap` also fetches a compact index of durable [team memories](#memory-mcp-server-for-agents) visible for the current repo/machine and appends a `## Team memory` block to the session's injected context (`additionalContext` for Claude, Codex, Copilot, and Gemini, `additional_context` for Cursor, raw stdout for Kiro, `injectSteps`/`userMessage` for Antigravity, system-prompt append via the kcap Pi extension for Pi, and system-entry append via the kcap OpenCode plugin for OpenCode): one `slug: description` line per memory, grouped **Org / Team / Yours**, with a nudge to call `get_memory` / `search_memories` for full content. Only the index is injected — never the bodies — so the cost stays roughly flat as the pool grows (mirrors a local `MEMORY.md`). Best-effort and fail-open (a slow or failed fetch injects nothing, never blocking the hook), and only ever injected once per conversation. Opt out with `disable_memory_index: true` in `~/.config/kcap/config.json` or `kcap config set disable_memory_index true`.
 - **Crash resilience** — if a `kcap` command hits an unexpected error it records the exception (with stack trace) to `~/.config/kcap/crash.log` (honours `KCAP_CONFIG_DIR`; size-capped) and exits cleanly instead of aborting. Hook and detached-generator commands the coding agent spawns **fail open** (exit 0, nothing surfaced to the agent); other commands exit non-zero with a one-line stderr message pointing at the log.
@@ -1808,6 +1810,19 @@ kcap logout         # delete stored tokens
 > **stable** channel (npm dist-tag `latest`); beta is strictly opt-in. Beta
 > releases correspond to server versions rolled out to internal tenants first,
 > so most users should stay on stable.
+>
+> **Staying current, and turning it all off.** Beyond the stderr hint above,
+> every human-facing `kcap` command prints an "Update available" notice after
+> it finishes if a newer version exists, and `kcap status`'s **Version** line
+> shows the same thing inline. Every request `kcap` sends also carries its
+> version (and, if update checks are off, an explicit opt-out marker) to your
+> server, which is how the web dashboard's own out-of-date banner and
+> notification-centre entry — and the in-agent nudge Claude Code sessions can
+> see (above) — know to show up. `kcap config set update_check false` (or
+> `--no-update-check` for a single invocation) turns off **all** of it at
+> once: the stderr hint, the exit-time notice, the `kcap status` annotation,
+> the headers that drive the server-side banner/notification, and the
+> in-agent nudge. It defaults to on.
 
 The v1 config format stored `server_url` as a bare host name without a
 scheme. If `kcap` crashes with `An invalid request URI was provided`

--- a/kcap/hooks/hooks.json
+++ b/kcap/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "kcap hook --claude",
+            "command": "kcap hook --claude --no-update-check",
             "timeout": 5
           }
         ]
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "kcap hook --claude",
+            "command": "kcap hook --claude --no-update-check",
             "timeout": 15
           }
         ]
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "kcap hook --claude",
+            "command": "kcap hook --claude --no-update-check",
             "timeout": 5,
             "async": true
           }
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "kcap hook --claude",
+            "command": "kcap hook --claude --no-update-check",
             "timeout": 5,
             "async": true
           }
@@ -61,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "kcap hook --claude",
+            "command": "kcap hook --claude --no-update-check",
             "timeout": 5
           }
         ]
@@ -72,7 +72,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "kcap hook --claude",
+            "command": "kcap hook --claude --no-update-check",
             "timeout": 5
           }
         ]
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "kcap hook --claude",
+            "command": "kcap hook --claude --no-update-check",
             "timeout": 36000
           }
         ]

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -53,8 +53,24 @@ public static class HttpClientExtensions {
     /// <summary>
     /// Shared client construction. Returns the resolution alongside the client so callers that
     /// report a mismatch quote the issuing server from the same snapshot the decision used.
+    ///
+    /// <para>Every client this produces — regardless of which branch below built it — leaves here
+    /// carrying the observation headers the server's update-notification pipeline reads (see
+    /// <see cref="AttachObservationHeadersAsync"/>): this is the ONE choke point every authenticated
+    /// CLI request flows through, so it is the one place that can promise every request the server
+    /// sees is tagged. <see cref="WhoamiCommand.ProbeAsync"/> deliberately bypasses this method (it
+    /// must not mutate auth state) and attaches the same headers explicitly.</para>
     /// </summary>
     static async Task<(HttpClient Client, AuthStatus Status, TokenResolution? Resolution, string? MachineProblem)> CreateClientCoreAsync(
+        string? baseUrl, CancellationToken ct, bool allowAutoRedirect,
+        string? rejectedAccessToken, bool autoRetryUnauthorized) {
+        var result = await CreateClientCoreImplAsync(baseUrl, ct, allowAutoRedirect, rejectedAccessToken, autoRetryUnauthorized);
+        await AttachObservationHeadersAsync(result.Client, ct);
+
+        return result;
+    }
+
+    static async Task<(HttpClient Client, AuthStatus Status, TokenResolution? Resolution, string? MachineProblem)> CreateClientCoreImplAsync(
         string? baseUrl, CancellationToken ct, bool allowAutoRedirect,
         string? rejectedAccessToken, bool autoRetryUnauthorized) {
         baseUrl ??= AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
@@ -134,6 +150,43 @@ public static class HttpClientExtensions {
         }
 
         return (NewClient(), resolution.Status, resolution, null);
+    }
+
+    /// <summary>Wire header naming the installed CLI's display version (see <see cref="CapacitorVersion.CurrentDisplay"/>).</summary>
+    public const string CliVersionHeader = "X-Kcap-Cli-Version";
+
+    /// <summary>
+    /// Wire header sent ONLY to declare the active profile's update-check preference is off. Its
+    /// ABSENCE on a version-carrying request means the preference is on (the default) — never send
+    /// an "on" value, only omit the header.
+    /// </summary>
+    public const string UpdateCheckHeader = "X-Kcap-Update-Check";
+
+    /// <summary>Value <see cref="UpdateCheckHeader"/> carries when sent.</summary>
+    public const string UpdateCheckOffValue = "off";
+
+    /// <summary>
+    /// Attaches the two observation headers the server's CLI-update-notification pipeline reads to
+    /// <paramref name="client"/>. Always attaches <see cref="CliVersionHeader"/> — unless
+    /// <see cref="CapacitorVersion.CurrentDisplay"/> can't resolve a real version, in which case
+    /// sending "unknown" would be worse than omitting it. Attaches <see cref="UpdateCheckHeader"/>
+    /// only when the active profile has explicitly opted out, per the absence-means-on contract
+    /// above. Reads the profile via <see cref="AppConfig.GetActiveProfileAsync"/> — the same
+    /// accessor <c>UpdateNotice</c> uses — which is a cache hit (no disk I/O) whenever the process
+    /// already resolved a profile, so this stays cheap on the per-request hot path.
+    /// </summary>
+    internal static async Task AttachObservationHeadersAsync(HttpClient client, CancellationToken ct = default) {
+        var version = CapacitorVersion.CurrentDisplay();
+
+        if (!string.IsNullOrWhiteSpace(version) && !version.Equals("unknown", StringComparison.OrdinalIgnoreCase)) {
+            client.DefaultRequestHeaders.Add(CliVersionHeader, version);
+        }
+
+        var profile = await AppConfig.GetActiveProfileAsync();
+
+        if (profile?.UpdateCheck == false) {
+            client.DefaultRequestHeaders.Add(UpdateCheckHeader, UpdateCheckOffValue);
+        }
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Core/Resources/help-update.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-update.txt
@@ -26,3 +26,13 @@ Options:
 
 Beta releases correspond to server versions rolled out to internal
 tenants first. Most users should stay on the default stable channel.
+
+update_check (kcap config set update_check false):
+  Controls ALL kcap update nudging, not just the local stderr hint. With
+  it off, kcap: skips the passive "update available" hint printed after
+  human-facing commands; omits the X-Kcap-Cli-Version/X-Kcap-Update-Check
+  headers it would otherwise send with every server request (so your
+  server's own out-of-date banner and notification stay silent for you);
+  and drops the in-agent nudge it would otherwise inject into a Claude
+  Code session's context when the server reports a newer version. It
+  defaults to true (on) for a fresh profile.

--- a/src/Capacitor.Cli.Core/Resources/help-update.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-update.txt
@@ -30,9 +30,10 @@ tenants first. Most users should stay on the default stable channel.
 update_check (kcap config set update_check false):
   Controls ALL kcap update nudging, not just the local stderr hint. With
   it off, kcap: skips the passive "update available" hint printed after
-  human-facing commands; omits the X-Kcap-Cli-Version/X-Kcap-Update-Check
-  headers it would otherwise send with every server request (so your
-  server's own out-of-date banner and notification stay silent for you);
-  and drops the in-agent nudge it would otherwise inject into a Claude
-  Code session's context when the server reports a newer version. It
-  defaults to true (on) for a fresh profile.
+  human-facing commands (and the kcap status annotation); still sends
+  X-Kcap-Cli-Version but adds X-Kcap-Update-Check: off, so the server
+  suppresses its own out-of-date banner and notification for you (the
+  opt-out is a signal carried on the wire, not an omission — the server
+  still knows your version); and drops the in-agent nudge it would
+  otherwise inject into a Claude Code session's context when the server
+  reports a newer version. It defaults to true (on) for a fresh profile.

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -644,7 +644,13 @@ public static class ClaudeHookCommand {
                 try {
                     var disabled        = AppConfig.ResolvedProfile?.Profile?.DisableSessionGuidelines is true;
                     var lessonsFragment = SessionGuidelinesEmitter.BuildFragment(responseNode, disabled);
-                    var nudgeFragment   = VersionNudgeEmitter.BuildFragment(responseNode, CapacitorVersion.CurrentDisplay());
+                    // update_check=false opts out of ALL kcap update nudging, including the
+                    // in-agent one — skip emission entirely rather than let a server that still
+                    // sends `version` sneak the fragment past a locally-disabled preference.
+                    var updateCheckOff  = AppConfig.ResolvedProfile?.Profile?.UpdateCheck is false;
+                    var nudgeFragment   = updateCheckOff
+                        ? null
+                        : VersionNudgeEmitter.BuildFragment(responseNode, CapacitorVersion.CurrentDisplay());
                     // join the parallel memory-index fetch, bounded by the remaining
                     // hook budget so a slow fetch can't delay the hook (fail-open → null).
                     var memoryFragment = await AwaitMemoryFragmentAsync(memoryIndexTask, processStart);

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -24,24 +24,24 @@ public static class ClaudeHookCommand {
     // send the POST; the server's StopAndDrain + the "kcap import" hint recover the rest.
     static readonly TimeSpan PreHookDrainCap = TimeSpan.FromSeconds(8);
 
-    public static Task<int> Handle(string baseUrl, TextReader stdin, Task? updateCheckTask = null, long processStart = 0,
+    public static Task<int> Handle(string baseUrl, TextReader stdin, long processStart = 0,
             TextWriter? stdout = null) {
         var spool = new HookSpool(PathHelpers.ConfigPath("spool"));
         spool.ReapOlderThan(TimeSpan.FromDays(30));
         var ps = processStart == 0 ? Stopwatch.GetTimestamp() : processStart;
-        return HandleWithDeps(spool, ps, baseUrl, stdin, updateCheckTask, stdout);
+        return HandleWithDeps(spool, ps, baseUrl, stdin, stdout);
     }
 
     static Task<int> HandleWithDeps(HookSpool spool, long processStart, string baseUrl, TextReader stdin,
-            Task? updateCheckTask, TextWriter? stdout = null)
-        => HandleWithDeps(spool, processStart, baseUrl, stdin, updateCheckTask,
+            TextWriter? stdout = null)
+        => HandleWithDeps(spool, processStart, baseUrl, stdin,
             () => HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl),
             async (rejectedAccessToken, ct) => (await HttpClientExtensions.CreateClientWithAuthStatusAsync(
                 baseUrl, ct, allowAutoRedirect: false, rejectedAccessToken: rejectedAccessToken)).Client,
             stdout);
 
     internal static async Task<int> HandleWithDeps(
-            HookSpool spool, long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask,
+            HookSpool spool, long processStart, string baseUrl, TextReader stdin,
             Func<Task<(HttpClient Client, AuthStatus Status)>> clientFactory,
             Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
             TextWriter? stdout = null) {
@@ -112,7 +112,7 @@ public static class ClaudeHookCommand {
         var (client, authStatus) = created.Value;
         try {
             return await HandleCore(client, authStatus, spool, processStart, baseUrl, new StringReader(body),
-                updateCheckTask, memoryClientFactory, stdout: stdout);
+                memoryClientFactory, stdout: stdout);
         } catch (Exception ex) {
             await Console.Error.WriteLineAsync($"[kcap] claude hook failed (fail-open): {ex.Message}");
             return 0;
@@ -247,7 +247,7 @@ public static class ClaudeHookCommand {
     }
 
     internal static async Task<int> HandleCore(HttpClient client, AuthStatus authStatus, HookSpool spool,
-        long processStart, string baseUrl, TextReader stdin, Task? updateCheckTask = null,
+        long processStart, string baseUrl, TextReader stdin,
         Func<string?, CancellationToken, Task<HttpClient>>? memoryClientFactory = null,
         Func<SessionStartMemoryLeaseStore>? memoryStoreFactory = null,
         TextWriter? stdout = null) {

--- a/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/ClaudeHookCommand.cs
@@ -661,10 +661,6 @@ public static class ClaudeHookCommand {
 
             resp.Dispose();
 
-            if (updateCheckTask is not null) {
-                await updateCheckTask;
-            }
-
             return 0;
         }
 
@@ -814,10 +810,6 @@ public static class ClaudeHookCommand {
 
                 break;
             }
-        }
-
-        if (updateCheckTask is not null) {
-            await updateCheckTask;
         }
 
         return 0;

--- a/src/Capacitor.Cli/Commands/ConfigCommand.cs
+++ b/src/Capacitor.Cli/Commands/ConfigCommand.cs
@@ -140,7 +140,7 @@ public static class ConfigCommand {
         Console.Error.WriteLine("  daemon.max_agents           Max concurrent hosted coding agents");
         Console.Error.WriteLine("  daemon.claude_path          Path to claude binary (default: claude)");
         Console.Error.WriteLine("  daemon.codex_path           Path to codex binary (default: codex)");
-        Console.Error.WriteLine("  update_check                Enable update check (true/false)");
+        Console.Error.WriteLine("  update_check                All kcap update nudging: stderr hint, server headers (banner/notification), in-agent nudge (true/false)");
         Console.Error.WriteLine("  default_visibility          Default session visibility (private, project, org_public, public)");
         Console.Error.WriteLine("  disable_session_guidelines  Skip injecting recurring-lessons context at SessionStart (true/false)");
         Console.Error.WriteLine("  use_provider_api_key        Keep ANTHROPIC_API_KEY/OPENAI_API_KEY in headless agent spawns (true/false)");

--- a/src/Capacitor.Cli/Commands/StatusCommand.cs
+++ b/src/Capacitor.Cli/Commands/StatusCommand.cs
@@ -14,14 +14,8 @@ namespace Capacitor.Cli.Commands;
 
 public static class StatusCommand {
     public static async Task<int> HandleAsync(string? baseUrl, string[] args) {
-        // Version — reuses UpdateNotice's shared lazy update-check (Capacitor.Cli.UpdateNotice
-        // .GetSharedCheckAsync) rather than calling UpdateCommand.CheckForUpdateAsync directly, so
-        // this line and the exit-time footer (UpdateNotice.FlushAsync) never trigger two network
-        // round-trips for one invocation. When this line prints the inline annotation it calls
-        // UpdateNotice.MarkReported() so FlushAsync's own finally-block print is suppressed —
-        // the information must surface exactly once, not twice. Respects the same opt-outs
-        // FlushAsync does (--no-update-check, profile.UpdateCheck == false) by skipping the check
-        // entirely rather than forcing one the user disabled.
+        // Version line reuses UpdateNotice's shared check and marks-reported so the exit footer
+        // doesn't double-print; respects the same opt-outs.
         await WriteVersionLineAsync(args);
 
         // Server

--- a/src/Capacitor.Cli/Commands/StatusCommand.cs
+++ b/src/Capacitor.Cli/Commands/StatusCommand.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Antigravity;
 using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Copilot;
 using Capacitor.Cli.Core.Cursor;
 using Capacitor.Cli.Core.Gemini;
@@ -12,7 +13,17 @@ using Capacitor.Cli.Core.Pi;
 namespace Capacitor.Cli.Commands;
 
 public static class StatusCommand {
-    public static async Task<int> HandleAsync(string? baseUrl) {
+    public static async Task<int> HandleAsync(string? baseUrl, string[] args) {
+        // Version — reuses UpdateNotice's shared lazy update-check (Capacitor.Cli.UpdateNotice
+        // .GetSharedCheckAsync) rather than calling UpdateCommand.CheckForUpdateAsync directly, so
+        // this line and the exit-time footer (UpdateNotice.FlushAsync) never trigger two network
+        // round-trips for one invocation. When this line prints the inline annotation it calls
+        // UpdateNotice.MarkReported() so FlushAsync's own finally-block print is suppressed —
+        // the information must surface exactly once, not twice. Respects the same opt-outs
+        // FlushAsync does (--no-update-check, profile.UpdateCheck == false) by skipping the check
+        // entirely rather than forcing one the user disabled.
+        await WriteVersionLineAsync(args);
+
         // Server
         Console.Write("  Server:  ");
 
@@ -81,6 +92,51 @@ public static class StatusCommand {
 
         return 0;
     }
+
+    static async Task WriteVersionLineAsync(string[] args) {
+        Console.Write("  Version: ");
+
+        var current = CapacitorVersion.CurrentDisplay();
+
+        // Opt-out: an explicit --no-update-check flag or a disabled profile setting means no
+        // check is performed at all (never force one the user turned off) — the line still
+        // prints the bare version.
+        if (args.Contains("--no-update-check")) {
+            await Console.Out.WriteLineAsync(FormatVersionLine(current, null));
+
+            return;
+        }
+
+        var profile = await AppConfig.GetActiveProfileAsync();
+
+        if (profile?.UpdateCheck == false) {
+            await Console.Out.WriteLineAsync(FormatVersionLine(current, null));
+
+            return;
+        }
+
+        var channel = UpdateCommand.ResolveChannel(args, profile?.UpdateChannel);
+        var result  = await UpdateNotice.GetSharedCheckAsync(channel);
+
+        await Console.Out.WriteLineAsync(FormatVersionLine(current, result));
+
+        if (result is { Newer: true, Latest: not null }) {
+            // Surfaced inline already — the exit-time footer (UpdateNotice.FlushAsync) must not
+            // print the same information a second time.
+            UpdateNotice.MarkReported();
+        }
+    }
+
+    /// <summary>
+    /// Pure formatting for the Version line: <c>kcap {current}</c>, with an inline
+    /// <c>(update available: {latest})</c> annotation appended only when
+    /// <paramref name="result"/> reports a newer version. Split out from
+    /// <see cref="WriteVersionLineAsync"/> so the exact text is unit-testable without any I/O.
+    /// </summary>
+    internal static string FormatVersionLine(string current, UpdateCommand.UpdateCheckResult? result) =>
+        result is { Newer: true, Latest: not null }
+            ? $"kcap {current} (update available: {result.Latest})"
+            : $"kcap {current}";
 
     static async Task WriteAgentStatusAsync() {
         if (!Directory.Exists(DaemonLockPaths.Directory)) {

--- a/src/Capacitor.Cli/Commands/UpdateCommand.cs
+++ b/src/Capacitor.Cli/Commands/UpdateCommand.cs
@@ -18,8 +18,10 @@ public static class UpdateCommand {
     /// <summary>
     /// Version-transition arrow. ASCII on Windows: legacy console codepages
     /// (cp437/cp850) can't encode `→` and render it as `␦`/`?`.
+    /// Internal (not private): <see cref="Capacitor.Cli.UpdateNotice"/> renders the same hint
+    /// text from its own exit-time print path and must not drift from this formatting.
     /// </summary>
-    static readonly string Arrow = OperatingSystem.IsWindows() ? "->" : "→";
+    internal static readonly string Arrow = OperatingSystem.IsWindows() ? "->" : "→";
 
     /// <summary>
     /// Resolves the effective update channel (npm dist-tag): an explicit
@@ -125,25 +127,79 @@ public static class UpdateCommand {
     }
 
     /// <summary>
-    /// Print an update hint to stderr if a newer version is available.
-    /// Called on every CLI invocation (cached, max once per 24h).
+    /// Print an update hint to stderr if a newer version is available. Budget-aware
+    /// (<see cref="CheckForUpdateWithBudgetAsync"/>) so a slow/unreachable registry can't stall
+    /// the caller. Retained as a standalone, no-args entry point; the actual exit-time call site
+    /// is <see cref="Capacitor.Cli.UpdateNotice.FlushAsync"/>, which additionally applies the
+    /// human-facing suppression predicate and a cross-surface "already reported" gate so this
+    /// text is never printed twice for one invocation.
     /// </summary>
     public static async Task PrintUpdateHintIfAvailable() {
         try {
             var profile = await AppConfig.GetActiveProfileAsync();
             if (profile?.UpdateCheck == false) return;
-            var channel           = ResolveChannel([], profile?.UpdateChannel);
-            var checkResult       = await CheckForUpdateAsync(forceCheck: false, channel);
-            var (latest, current) = (checkResult.Latest, checkResult.Current);
+            var channel     = ResolveChannel([], profile?.UpdateChannel);
+            var checkResult = await CheckForUpdateWithBudgetAsync(channel);
 
-            if (latest is not null && current is not null && IsNewer(latest, current)) {
+            if (checkResult is { Newer: true, Latest: not null, Current: not null }) {
                 await Console.Error.WriteLineAsync();
-                await Console.Error.WriteLineAsync($"Update available: {current} {Arrow} {latest}");
+                await Console.Error.WriteLineAsync($"Update available: {checkResult.Current} {Arrow} {checkResult.Latest}");
                 await Console.Error.WriteLineAsync("Run `kcap update` to update");
             }
         } catch {
             // Best effort — never break the CLI for update checks
         }
+    }
+
+    /// <summary>
+    /// Two-tier budget over <see cref="CheckForUpdateAsync"/> for a passive, exit-time caller
+    /// (<see cref="Capacitor.Cli.UpdateNotice"/>): the common cache-fresh case (a local file
+    /// read, no network — see <see cref="UpdateCacheRecord.IsFresh"/>) is bound by a defensive
+    /// <paramref name="cacheFreshBudget"/> (default ~300ms); a stale/missing cache instead rides
+    /// the fetch's own cancellation deadline (<paramref name="networkCancelAfter"/>, default
+    /// ~3s, passed as the fetch's <c>ct</c>) plus a short <paramref name="cleanupGrace"/>
+    /// (default ~500ms) so the failure/backoff write — deliberately unbound by that token, see
+    /// <see cref="WriteCacheRecordAsync"/> — can still land on disk.
+    /// </summary>
+    /// <returns>
+    /// The completed result, or <c>null</c> if neither tier produced one in time. A still-running
+    /// check past that point is abandoned (never awaited further by the caller) but not orphaned:
+    /// a continuation disposes its <see cref="CancellationTokenSource"/> once it eventually
+    /// finishes and observes any fault so it can't surface as an unobserved task exception.
+    /// </returns>
+    internal static async Task<UpdateCheckResult?> CheckForUpdateWithBudgetAsync(
+            string channel,
+            TimeSpan? cacheFreshBudget = null,
+            TimeSpan? networkCancelAfter = null,
+            TimeSpan? cleanupGrace = null) {
+        var cacheFreshBudgetVal   = cacheFreshBudget ?? TimeSpan.FromMilliseconds(300);
+        var networkCancelAfterVal = networkCancelAfter ?? TimeSpan.FromSeconds(3);
+        var cleanupGraceVal       = cleanupGrace ?? TimeSpan.FromMilliseconds(500);
+
+        var cts       = new CancellationTokenSource(networkCancelAfterVal);
+        var checkTask = CheckForUpdateAsync(forceCheck: false, channel, cts.Token);
+
+        // Dispose only once the task reaches a terminal state — never synchronously here, since
+        // an abandoned check (either tier below giving up) may still be running past this method's
+        // own return. Also observes a fault so a late exception can't become unobserved.
+        _ = checkTask.ContinueWith(static (t, state) => {
+            ((CancellationTokenSource)state!).Dispose();
+            if (t.IsFaulted) _ = t.Exception;
+        }, cts, TaskScheduler.Default);
+
+        var firstWinner = await Task.WhenAny(checkTask, Task.Delay(cacheFreshBudgetVal));
+        if (firstWinner == checkTask) {
+            return checkTask.IsCompletedSuccessfully ? checkTask.Result : null;
+        }
+
+        // Cache was stale/missing (the fetch above didn't return from a local file read within
+        // the defensive bound) — a network refresh is in flight. Let the cancellation already
+        // armed on `cts` cut the HTTP request at networkCancelAfterVal, then allow cleanupGraceVal
+        // more for the CancellationToken.None-guarded backoff write to persist.
+        var remaining    = networkCancelAfterVal - cacheFreshBudgetVal + cleanupGraceVal;
+        var secondWinner = await Task.WhenAny(checkTask, Task.Delay(remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero));
+
+        return secondWinner == checkTask && checkTask.IsCompletedSuccessfully ? checkTask.Result : null;
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Commands/UpdateCommand.cs
+++ b/src/Capacitor.Cli/Commands/UpdateCommand.cs
@@ -67,7 +67,8 @@ public static class UpdateCommand {
             }
         }
 
-        var (latest, current) = await CheckForUpdateAsync(forceCheck: true, channel);
+        var checkResult       = await CheckForUpdateAsync(forceCheck: true, channel);
+        var (latest, current) = (checkResult.Latest, checkResult.Current);
 
         if (checkOnly) {
             // Machine-readable probe consumed by the npm launcher (kcap.js).
@@ -131,8 +132,9 @@ public static class UpdateCommand {
         try {
             var profile = await AppConfig.GetActiveProfileAsync();
             if (profile?.UpdateCheck == false) return;
-            var channel = ResolveChannel([], profile?.UpdateChannel);
-            var (latest, current) = await CheckForUpdateAsync(forceCheck: false, channel);
+            var channel           = ResolveChannel([], profile?.UpdateChannel);
+            var checkResult       = await CheckForUpdateAsync(forceCheck: false, channel);
+            var (latest, current) = (checkResult.Latest, checkResult.Current);
 
             if (latest is not null && current is not null && IsNewer(latest, current)) {
                 await Console.Error.WriteLineAsync();
@@ -151,61 +153,174 @@ public static class UpdateCommand {
     static string CachePathFor(string channel) =>
         PathHelpers.ConfigPath($"update-check-{channel}.json");
 
-    internal static async Task<(string? latest, string? current)> CheckForUpdateAsync(bool forceCheck, string channel) {
-        var current   = GetCurrentVersion();
-        var cachePath = CachePathFor(channel);
+    /// <summary>
+    /// On-disk shape of a per-channel update-check cache file. Two kinds of
+    /// record share the file: a <b>success</b> record (<see cref="CheckedAt"/>
+    /// set, <see cref="Failed"/> false) and a <b>backoff</b> record written
+    /// after a failed/cancelled fetch (<see cref="AttemptedAt"/> set,
+    /// <see cref="Failed"/> true) that still retains the last known
+    /// <see cref="LatestVersion"/> so a transient registry outage doesn't
+    /// regress an already-known "update available" result.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Parse"/> reads the legacy two-field shape
+    /// (<c>{latest_version, checked_at}</c>, written before backoff support
+    /// existed) as a plain success record — the missing <see cref="AttemptedAt"/>/
+    /// <see cref="Failed"/> fields default to null/false. That backward
+    /// compatibility is deliberate: an existing on-disk cache from an older
+    /// build must not be treated as corrupt.
+    /// </remarks>
+    internal sealed record UpdateCacheRecord(
+        string? LatestVersion,
+        DateTimeOffset? CheckedAt,
+        DateTimeOffset? AttemptedAt,
+        bool Failed) {
 
-        if (!forceCheck) {
-            // Check cache
-            if (File.Exists(cachePath)) {
-                try {
-                    var cacheJson     = await File.ReadAllTextAsync(cachePath);
-                    var cache         = JsonNode.Parse(cacheJson);
-                    var checkedAt     = cache?["checked_at"]?.GetValue<DateTimeOffset>();
-                    var cachedVersion = cache?["latest_version"]?.GetValue<string>();
+        /// <summary>
+        /// Parses a cache file's JSON. Returns null for anything unparseable
+        /// (corrupt/truncated file) so the caller can fall through to a fresh
+        /// fetch rather than throw.
+        /// </summary>
+        public static UpdateCacheRecord? Parse(string json) {
+            try {
+                var node = JsonNode.Parse(json);
+                if (node is null) return null;
 
-                    if (checkedAt is not null
-                     && DateTimeOffset.UtcNow - checkedAt.Value < TimeSpan.FromHours(24)
-                     && cachedVersion is not null) {
-                        return (cachedVersion, current);
-                    }
-                } catch {
-                    // Corrupted cache — re-check
-                }
+                var latestVersion = node["latest_version"]?.GetValue<string>();
+                var checkedAt     = node["checked_at"]?.GetValue<DateTimeOffset>();
+                var attemptedAt   = node["attempted_at"]?.GetValue<DateTimeOffset>();
+                var failed        = node["failed"]?.GetValue<bool>() ?? false;
+
+                return new UpdateCacheRecord(latestVersion, checkedAt, attemptedAt, failed);
+            } catch {
+                return null;
             }
         }
 
-        // Query npm registry
+        public string ToJson() {
+            var obj = new JsonObject {
+                ["latest_version"] = LatestVersion,
+                ["checked_at"]     = CheckedAt,
+                ["attempted_at"]   = AttemptedAt,
+                ["failed"]         = Failed,
+            };
+
+            return obj.ToJsonString();
+        }
+
+        /// <summary>True for a successful check still inside the cache TTL (24h in production).</summary>
+        public bool IsFresh(DateTimeOffset now, TimeSpan ttl) =>
+            !Failed && LatestVersion is not null && CheckedAt is not null && now - CheckedAt.Value < ttl;
+
+        /// <summary>
+        /// True for a failed/cancelled check still inside its backoff window
+        /// (1h in production) — the window during which a passive check
+        /// skips the network entirely and serves the retained
+        /// <see cref="LatestVersion"/> (which may itself be null if no check
+        /// has ever succeeded).
+        /// </summary>
+        public bool InFailureBackoff(DateTimeOffset now, TimeSpan backoff) =>
+            Failed && AttemptedAt is not null && now - AttemptedAt.Value < backoff;
+    }
+
+    /// <summary>Result of <see cref="CheckForUpdateAsync"/>.</summary>
+    /// <param name="FromCache">
+    /// True when <paramref name="Latest"/> came from a cached/retained value
+    /// (a fresh success record, or a retained version served during failure
+    /// backoff) rather than a network round-trip that just completed.
+    /// </param>
+    internal sealed record UpdateCheckResult(string? Current, string? Latest, bool Newer, bool FromCache);
+
+    static readonly TimeSpan CacheTtl       = TimeSpan.FromHours(24);
+    static readonly TimeSpan FailureBackoff = TimeSpan.FromHours(1);
+
+    /// <param name="ct">
+    /// Bounds the network fetch. <c>forceCheck</c> callers pass
+    /// <see cref="CancellationToken.None"/> and rely on the 5s
+    /// <see cref="HttpClient.Timeout"/> below; passive callers pass a short
+    /// (~3s) token so an unresponsive registry can't stall every CLI
+    /// invocation. Never used for the cache write itself — see
+    /// <see cref="WriteCacheRecordAsync"/>.
+    /// </param>
+    internal static async Task<UpdateCheckResult> CheckForUpdateAsync(bool forceCheck, string channel, CancellationToken ct = default) {
+        var current   = GetCurrentVersion();
+        var cachePath = CachePathFor(channel);
+        var now       = DateTimeOffset.UtcNow;
+
+        UpdateCacheRecord? cached = null;
+        if (File.Exists(cachePath)) {
+            try {
+                // Never bound this local read by the (possibly short, passive)
+                // request token — only the network fetch below should be.
+                cached = UpdateCacheRecord.Parse(await File.ReadAllTextAsync(cachePath, CancellationToken.None));
+            } catch {
+                // Corrupted/unreadable cache file — fall through to a fresh fetch.
+            }
+        }
+
+        if (!forceCheck && cached is not null
+         && (cached.IsFresh(now, CacheTtl) || cached.InFailureBackoff(now, FailureBackoff))) {
+            // Either a fresh success record, or a still-backed-off failure
+            // record — both cases serve the retained LatestVersion (which is
+            // null only if no check has ever succeeded) without touching the
+            // network.
+            return new UpdateCheckResult(current, cached.LatestVersion, IsNewer(cached.LatestVersion, current), FromCache: true);
+        }
+
+        // Query npm registry.
         using var http = new HttpClient();
         http.Timeout = TimeSpan.FromSeconds(5);
         http.DefaultRequestHeaders.Add("User-Agent", "kcap-cli");
 
         try {
-            var resp = await http.GetAsync($"{RegistryBaseUrl}/@kurrent/kcap/{channel}");
+            var resp = await http.GetAsync($"{RegistryBaseUrl}/@kurrent/kcap/{channel}", ct);
 
-            if (!resp.IsSuccessStatusCode) return (null, current);
+            if (!resp.IsSuccessStatusCode) {
+                await WriteBackoffRecordAsync(cachePath, cached?.LatestVersion, now);
+                return new UpdateCheckResult(current, cached?.LatestVersion, IsNewer(cached?.LatestVersion, current), FromCache: true);
+            }
 
-            var body   = await resp.Content.ReadAsStringAsync();
+            var body   = await resp.Content.ReadAsStringAsync(ct);
             var json   = JsonNode.Parse(body);
             var latest = json?["version"]?.GetValue<string>();
 
-            // Cache result
             if (latest is not null) {
-                var dir = Path.GetDirectoryName(cachePath)!;
-                Directory.CreateDirectory(dir);
-
-                var cacheObj = new JsonObject {
-                    ["latest_version"] = latest,
-                    ["checked_at"]     = DateTimeOffset.UtcNow
-                };
-                var tempPath = $"{cachePath}.tmp";
-                await File.WriteAllTextAsync(tempPath, cacheObj.ToJsonString());
-                File.Move(tempPath, cachePath, overwrite: true);
+                await WriteCacheRecordAsync(cachePath, new UpdateCacheRecord(latest, now, AttemptedAt: null, Failed: false));
             }
 
-            return (latest, current);
+            return new UpdateCheckResult(current, latest, IsNewer(latest, current), FromCache: false);
         } catch {
-            return (null, current);
+            // Network failure, non-2xx handled above, or cancellation (either
+            // the passive ct bound or the 5s HttpClient.Timeout). Pin a 1h
+            // backoff so a wedged/slow registry isn't re-hit on every
+            // invocation, but keep serving the last version we successfully
+            // saw (stale-while-backoff).
+            await WriteBackoffRecordAsync(cachePath, cached?.LatestVersion, now);
+            return new UpdateCheckResult(current, cached?.LatestVersion, IsNewer(cached?.LatestVersion, current), FromCache: true);
+        }
+    }
+
+    static Task WriteBackoffRecordAsync(string cachePath, string? retainedLatestVersion, DateTimeOffset attemptedAt) =>
+        WriteCacheRecordAsync(cachePath, new UpdateCacheRecord(retainedLatestVersion, CheckedAt: null, attemptedAt, Failed: true));
+
+    /// <summary>
+    /// Atomic tmp+<see cref="File.Move(string, string, bool)"/> write, same
+    /// pattern the rest of the config store uses. Deliberately never passed
+    /// the request's own <see cref="CancellationToken"/> — a cancelled fetch
+    /// must still be able to persist its backoff record — and never lets a
+    /// filesystem failure propagate: a best-effort cache write must not turn
+    /// an otherwise-successful check into a reported failure.
+    /// </summary>
+    static async Task WriteCacheRecordAsync(string cachePath, UpdateCacheRecord record) {
+        try {
+            var dir = Path.GetDirectoryName(cachePath)!;
+            Directory.CreateDirectory(dir);
+
+            var tempPath = $"{cachePath}.tmp";
+            await File.WriteAllTextAsync(tempPath, record.ToJson(), CancellationToken.None);
+            File.Move(tempPath, cachePath, overwrite: true);
+        } catch {
+            // Best-effort — never fail the check because the cache write did.
         }
     }
 

--- a/src/Capacitor.Cli/Commands/WhoamiCommand.cs
+++ b/src/Capacitor.Cli/Commands/WhoamiCommand.cs
@@ -88,6 +88,11 @@ public static class WhoamiCommand {
             using var http = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
             http.DefaultRequestHeaders.Authorization = new("Bearer", accessToken);
 
+            // This probe deliberately bypasses HttpClientExtensions' choke point (it must not
+            // mutate auth state), so it attaches the same observation headers explicitly rather
+            // than inheriting them for free.
+            await HttpClientExtensions.AttachObservationHeadersAsync(http);
+
             using var response = await http.GetOnceAsync(
                 $"{AppConfig.NormalizeUrl(baseUrl)}{ProbePath}", ProbeTimeout);
 

--- a/src/Capacitor.Cli/CrashReporter.cs
+++ b/src/Capacitor.Cli/CrashReporter.cs
@@ -17,8 +17,10 @@ namespace Capacitor.Cli;
 internal static class CrashReporter {
     // Commands the coding agent spawns as hooks or detached side-processes, where a
     // crash must never surface (no error banner, no crash report) — mirrors the
-    // hook handler's own fail-open behaviour.
-    static readonly HashSet<string> FailOpenCommands = new(StringComparer.Ordinal) {
+    // hook handler's own fail-open behaviour. Internal (not private): also consumed
+    // directly by UpdateNotice.IsHumanFacing — the same population never gets the
+    // exit-time update notice either, since nobody reads their stderr.
+    internal static readonly HashSet<string> FailOpenCommands = new(StringComparer.Ordinal) {
         "hook", "generate-whats-done", "set-title", "copilot-finalize",
     };
 

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -276,7 +276,7 @@ switch (command) {
     case "use":
         return await UseCommand.HandleAsync(args);
     case "status":
-        return await StatusCommand.HandleAsync(baseUrl);
+        return await StatusCommand.HandleAsync(baseUrl, args);
     case "config":
         return await ConfigCommand.HandleAsync(args);
     case "ignore":

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -77,18 +77,14 @@ ProcessUrlPolicy.Current = CrashReporter.IsFailOpenCommand(command)
 
 var baseUrl = await AppConfig.ResolveServerUrl(args, gitTimeoutMs: isHook ? 1000 : 5000);
 
-// Fire-and-forget update check (prints hint to stderr after command finishes).
-// Skipped for `uninstall` — the check writes ~/.config/kcap/update-check-{channel}.json
-// (e.g. update-check-latest.json), which would race with uninstall's `rm -rf`
-// of the config dir and recreate it after the command has reported success.
-// Skipped for `update` — nudging "run `kcap update`" from inside `kcap update`
-// is noise at best and lands mid-upgrade at worst.
-var   noUpdateCheck   = args.Contains("--no-update-check") || command is "uninstall" or "update";
-Task? updateCheckTask = null;
-
-if (!noUpdateCheck) {
-    updateCheckTask = Task.Run(UpdateCommand.PrintUpdateHintIfAvailable);
-}
+// Everything from here to the end of command dispatch — including the --help,
+// per-command-help, and no-server-configured early exits below — runs inside this
+// try/finally so the deterministic exit-time update notice (UpdateNotice.FlushAsync)
+// fires on every path out of the command, not just the ones that fall through the
+// switch. UpdateNotice.IsHumanFacing is the suppression predicate (hooks, mcp, watch,
+// the foreground daemon, update/uninstall themselves, --no-update-check) — it decides
+// per-invocation whether FlushAsync does anything at all.
+try {
 
 if (command is "--help" or "-h" or "help") {
     await PrintUsage();
@@ -713,7 +709,7 @@ switch (command) {
                 sessionId: null); // current session unknown here — reading stdin now would consume it
         }
         if (args.Contains("--claude")) {
-            return await ClaudeHookCommand.Handle(baseUrl!, Console.In, updateCheckTask, hookProcessStart);
+            return await ClaudeHookCommand.Handle(baseUrl!, Console.In, processStart: hookProcessStart);
         }
         if (args.Contains("--codex")) {
             return await CodexHookCommand.Handle(baseUrl!, Console.In, hookProcessStart);
@@ -764,6 +760,10 @@ return 1;
     CrashReporter.Record(command, topLevelEx);
 
     return CrashReporter.ExitCode(command);
+}
+
+} finally {
+    await UpdateNotice.FlushAsync(command, args);
 }
 
 static string? GetArg(string[] arguments, string flag) {

--- a/src/Capacitor.Cli/UpdateNotice.cs
+++ b/src/Capacitor.Cli/UpdateNotice.cs
@@ -1,0 +1,106 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli;
+
+/// <summary>
+/// Deterministic exit-time "update available" notice for human-facing invocations.
+///
+/// <para>Before this, the hint was printed by a fire-and-forget <c>Task.Run</c> launched near the
+/// top of <c>Program.cs</c> and never explicitly awaited on most paths — it only reliably resolved
+/// inside <see cref="ClaudeHookCommand"/>'s own two await sites, i.e. inside a Claude hook, where
+/// nobody reads stderr. Every other command — the ones a human is actually looking at — raced the
+/// process exit and usually lost. <see cref="FlushAsync"/> is the fix: <c>Program.cs</c> awaits it
+/// from a <c>finally</c> wrapping the whole command dispatch (including the <c>--help</c> and
+/// no-server-configured early exits), so it runs deterministically before the process exits.</para>
+///
+/// <para><see cref="IsHumanFacing"/> is the suppression predicate — nobody is watching stderr on a
+/// hook/MCP-server/watcher/foreground-daemon invocation, and printing on <c>update</c>/<c>uninstall</c>
+/// or a caller-passed <c>--no-update-check</c> would be actively wrong. Everything else counts.</para>
+///
+/// <para><see cref="MarkReported"/> plus the shared, lazily-started check task
+/// (<see cref="GetSharedCheckAsync"/>) let a second exit-time surface — <c>kcap status</c>'s own
+/// inline version line — reuse the same in-flight/completed check instead of triggering a second
+/// network round-trip, and suppress this class's own footer once it has already surfaced the
+/// information itself.</para>
+/// </summary>
+internal static class UpdateNotice {
+    static readonly object _gate = new();
+
+    static Task<UpdateCommand.UpdateCheckResult?>? _sharedCheck;
+
+    /// <summary>True once the notice has been surfaced (by <see cref="FlushAsync"/> itself, or by
+    /// another exit-time surface via <see cref="MarkReported"/>) for this process invocation.</summary>
+    static volatile bool _reported;
+
+    /// <summary>
+    /// The suppression predicate. False (suppressed) for:
+    /// <see cref="CrashReporter.FailOpenCommands"/> (<c>hook</c>, <c>generate-whats-done</c>,
+    /// <c>set-title</c>, <c>copilot-finalize</c> — agent-spawned, nobody reads their stderr);
+    /// <c>mcp</c> (a stdio JSON-RPC server — stderr is not a terminal) and <c>watch</c> (a
+    /// long-lived background process); <c>daemon run</c> (the foreground daemon process itself,
+    /// as opposed to e.g. <c>daemon status</c>); <c>update</c>/<c>uninstall</c> (nudging "run
+    /// kcap update" from inside one of those is noise at best, and uninstall's cache-file write
+    /// would race the command's own config-dir deletion); and an explicit <c>--no-update-check</c>
+    /// flag. Everything else is human-facing and returns true.
+    /// </summary>
+    public static bool IsHumanFacing(string command, string[] args) {
+        if (CrashReporter.FailOpenCommands.Contains(command)) return false;
+        if (command is "mcp" or "watch") return false;
+        if (command == "daemon" && args.Length > 1 && args[1] == "run") return false;
+        if (command is "update" or "uninstall") return false;
+        if (args.Contains("--no-update-check")) return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Marks the notice as already surfaced by another exit-time surface (e.g. <c>kcap status</c>'s
+    /// own inline version line), so a subsequent <see cref="FlushAsync"/> call for the same
+    /// invocation prints nothing.
+    /// </summary>
+    public static void MarkReported() => _reported = true;
+
+    /// <summary>
+    /// Lazily starts (or returns the already-started) budgeted check for <paramref name="channel"/>,
+    /// so at most one network round-trip happens per process no matter how many call sites
+    /// (<see cref="FlushAsync"/>, <c>kcap status</c>) ask for the result.
+    /// </summary>
+    internal static Task<UpdateCommand.UpdateCheckResult?> GetSharedCheckAsync(string channel) {
+        lock (_gate) {
+            return _sharedCheck ??= UpdateCommand.CheckForUpdateWithBudgetAsync(channel);
+        }
+    }
+
+    /// <summary>
+    /// The single exit-path helper: awaited from <c>Program.cs</c>'s outer <c>finally</c> for every
+    /// invocation. Does nothing (and touches neither disk nor network) unless
+    /// <see cref="IsHumanFacing"/> says the command is human-facing, the active profile's
+    /// <c>update_check</c> setting hasn't opted out, and nobody has already
+    /// <see cref="MarkReported"/> this invocation. Never throws — an update notice must never break
+    /// the command it's attached to.
+    /// </summary>
+    public static async Task FlushAsync(string command, string[] args) {
+        try {
+            if (_reported || !IsHumanFacing(command, args)) return;
+
+            var profile = await AppConfig.GetActiveProfileAsync();
+            if (profile?.UpdateCheck == false) return;
+
+            var channel = UpdateCommand.ResolveChannel(args, profile?.UpdateChannel);
+            var result  = await GetSharedCheckAsync(channel);
+
+            // Re-check after the await: `kcap status` may have won the race and already reported
+            // while this was in flight (both may share the same in-flight task via GetSharedCheckAsync).
+            if (_reported || result is not { Newer: true, Latest: not null, Current: not null }) return;
+
+            _reported = true;
+
+            await Console.Error.WriteLineAsync();
+            await Console.Error.WriteLineAsync($"Update available: {result.Current} {UpdateCommand.Arrow} {result.Latest}");
+            await Console.Error.WriteLineAsync("Run `kcap update` to update");
+        } catch {
+            // Best effort — an update notice must never break the command it's attached to.
+        }
+    }
+}

--- a/src/Capacitor.Cli/UpdateNotice.cs
+++ b/src/Capacitor.Cli/UpdateNotice.cs
@@ -38,16 +38,19 @@ internal static class UpdateNotice {
     /// <see cref="CrashReporter.FailOpenCommands"/> (<c>hook</c>, <c>generate-whats-done</c>,
     /// <c>set-title</c>, <c>copilot-finalize</c> — agent-spawned, nobody reads their stderr);
     /// <c>mcp</c> (a stdio JSON-RPC server — stderr is not a terminal) and <c>watch</c> (a
-    /// long-lived background process); <c>daemon run</c> (the foreground daemon process itself,
-    /// as opposed to e.g. <c>daemon status</c>); <c>update</c>/<c>uninstall</c> (nudging "run
-    /// kcap update" from inside one of those is noise at best, and uninstall's cache-file write
-    /// would race the command's own config-dir deletion); and an explicit <c>--no-update-check</c>
-    /// flag. Everything else is human-facing and returns true.
+    /// long-lived background process); the entire <c>daemon</c> command family (there is no
+    /// separate <c>run</c> subcommand — the foreground shape is plain <c>kcap daemon start</c>
+    /// without <c>-d</c>/<c>--detach</c>, which spawns the daemon child and blocks for its whole
+    /// lifetime, exactly what <c>Capacitor.AppHost</c> runs on every dev-loop restart; every other
+    /// <c>daemon</c> subcommand is infra/diagnostic and the "am I current?" nudge use-case is
+    /// already served by <c>kcap status</c>); <c>update</c>/<c>uninstall</c> (nudging "run kcap
+    /// update" from inside one of those is noise at best, and uninstall's cache-file write would
+    /// race the command's own config-dir deletion); and an explicit <c>--no-update-check</c> flag.
+    /// Everything else is human-facing and returns true.
     /// </summary>
     public static bool IsHumanFacing(string command, string[] args) {
         if (CrashReporter.FailOpenCommands.Contains(command)) return false;
-        if (command is "mcp" or "watch") return false;
-        if (command == "daemon" && args.Length > 1 && args[1] == "run") return false;
+        if (command is "mcp" or "watch" or "daemon") return false;
         if (command is "update" or "uninstall") return false;
         if (args.Contains("--no-update-check")) return false;
 

--- a/src/Capacitor.Cli/UpdateNotice.cs
+++ b/src/Capacitor.Cli/UpdateNotice.cs
@@ -4,25 +4,9 @@ using Capacitor.Cli.Core.Config;
 namespace Capacitor.Cli;
 
 /// <summary>
-/// Deterministic exit-time "update available" notice for human-facing invocations.
-///
-/// <para>Before this, the hint was printed by a fire-and-forget <c>Task.Run</c> launched near the
-/// top of <c>Program.cs</c> and never explicitly awaited on most paths — it only reliably resolved
-/// inside <see cref="ClaudeHookCommand"/>'s own two await sites, i.e. inside a Claude hook, where
-/// nobody reads stderr. Every other command — the ones a human is actually looking at — raced the
-/// process exit and usually lost. <see cref="FlushAsync"/> is the fix: <c>Program.cs</c> awaits it
-/// from a <c>finally</c> wrapping the whole command dispatch (including the <c>--help</c> and
-/// no-server-configured early exits), so it runs deterministically before the process exits.</para>
-///
-/// <para><see cref="IsHumanFacing"/> is the suppression predicate — nobody is watching stderr on a
-/// hook/MCP-server/watcher/foreground-daemon invocation, and printing on <c>update</c>/<c>uninstall</c>
-/// or a caller-passed <c>--no-update-check</c> would be actively wrong. Everything else counts.</para>
-///
-/// <para><see cref="MarkReported"/> plus the shared, lazily-started check task
-/// (<see cref="GetSharedCheckAsync"/>) let a second exit-time surface — <c>kcap status</c>'s own
-/// inline version line — reuse the same in-flight/completed check instead of triggering a second
-/// network round-trip, and suppress this class's own footer once it has already surfaced the
-/// information itself.</para>
+/// Deterministic exit-time "update available" notice for human-facing commands. Shares a single
+/// check (<see cref="GetSharedCheckAsync"/>) and a reported-once gate (<see cref="MarkReported"/>)
+/// with <c>kcap status</c>'s own version line so the two surfaces don't double-print.
 /// </summary>
 internal static class UpdateNotice {
     static readonly object _gate = new();

--- a/test/Capacitor.Cli.Tests.Integration/UpdateChannelQueryTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/UpdateChannelQueryTests.cs
@@ -37,9 +37,9 @@ public class UpdateChannelQueryTests : IDisposable {
     // tests in this class so they don't race each other's WireMock server.
     [Test, NotInParallel("UpdateCommand_RegistryBaseUrl")]
     public async Task Beta_channel_reports_beta_dist_tag_version() {
-        var (latest, _) = await UpdateCommand.CheckForUpdateAsync(forceCheck: true, "beta");
+        var result = await UpdateCommand.CheckForUpdateAsync(forceCheck: true, "beta");
 
-        await Assert.That(latest).IsEqualTo("0.9.0-beta.1");
+        await Assert.That(result.Latest).IsEqualTo("0.9.0-beta.1");
 
         var hits = _server.FindLogEntries(Request.Create().WithPath("/@kurrent/kcap/beta").UsingGet());
         await Assert.That(hits.Count).IsGreaterThanOrEqualTo(1);
@@ -47,11 +47,141 @@ public class UpdateChannelQueryTests : IDisposable {
 
     [Test, NotInParallel("UpdateCommand_RegistryBaseUrl")]
     public async Task Latest_channel_reports_latest_dist_tag_version() {
-        var (latest, _) = await UpdateCommand.CheckForUpdateAsync(forceCheck: true, "latest");
+        var result = await UpdateCommand.CheckForUpdateAsync(forceCheck: true, "latest");
 
-        await Assert.That(latest).IsEqualTo("0.8.0");
+        await Assert.That(result.Latest).IsEqualTo("0.8.0");
 
         var hits = _server.FindLogEntries(Request.Create().WithPath("/@kurrent/kcap/latest").UsingGet());
         await Assert.That(hits.Count).IsGreaterThanOrEqualTo(1);
+    }
+
+    /// <summary>
+    /// Two consecutive fresh coordinator runs (fresh HttpClient/coordinator
+    /// state each call, same on-disk <c>KCAP_CONFIG_DIR</c> cache) converge
+    /// via the 24h success cache: the response is slower than 300ms but well
+    /// inside the passive path's bound, so it completes; the second call
+    /// must not touch the network at all.
+    /// </summary>
+    [Test, NotInParallel("UpdateCommand_RegistryBaseUrl")]
+    public async Task Slow_but_completing_response_caches_and_second_run_skips_network() {
+        const string channel = "test-slow-success";
+        _server.Given(Request.Create().WithPath($"/@kurrent/kcap/{channel}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"version":"0.12.0"}""")
+                .WithDelay(TimeSpan.FromMilliseconds(400)));
+
+        var first = await UpdateCommand.CheckForUpdateAsync(forceCheck: false, channel);
+        await Assert.That(first.Latest).IsEqualTo("0.12.0");
+        await Assert.That(first.FromCache).IsFalse();
+
+        var second = await UpdateCommand.CheckForUpdateAsync(forceCheck: false, channel);
+        await Assert.That(second.Latest).IsEqualTo("0.12.0");
+        await Assert.That(second.FromCache).IsTrue();
+
+        var hits = _server.FindLogEntries(Request.Create().WithPath($"/@kurrent/kcap/{channel}").UsingGet());
+        await Assert.That(hits.Count).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// A response slower than the passive caller's own cancellation bound is
+    /// cancelled at that bound, not at the 5s <c>HttpClient.Timeout</c> — the
+    /// fetch is cut off, a backoff record is written, and a subsequent
+    /// within-1h passive run makes no further HTTP request.
+    /// </summary>
+    /// <remarks>
+    /// Verified via elapsed time, not <see cref="WireMockServer.FindLogEntries"/>:
+    /// WireMock.Net only appends a request log entry once it finishes
+    /// composing a response (including its configured delay), so a request
+    /// the client itself cancelled mid-flight never gets logged — a 0 hit
+    /// count would be true for a genuinely-skipped call AND a
+    /// cancelled-before-logging one, so it can't distinguish them. Elapsed
+    /// time can: if the second call incorrectly re-hit the network it would
+    /// take ~2s (the endpoint's configured delay, uncapped this time since no
+    /// short-lived token is passed), whereas a cache/backoff hit returns
+    /// near-instantly.
+    /// </remarks>
+    [Test, NotInParallel("UpdateCommand_RegistryBaseUrl")]
+    public async Task Response_slower_than_passive_token_is_cancelled_and_backs_off() {
+        const string channel = "test-passive-cancel";
+        _server.Given(Request.Create().WithPath($"/@kurrent/kcap/{channel}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"version":"0.13.0"}""")
+                .WithDelay(TimeSpan.FromSeconds(2)));
+
+        using var passiveBound = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        var firstSw = System.Diagnostics.Stopwatch.StartNew();
+        var first = await UpdateCommand.CheckForUpdateAsync(forceCheck: false, channel, passiveBound.Token);
+        firstSw.Stop();
+        await Assert.That(first.Latest).IsNull();
+        await Assert.That(first.FromCache).IsTrue();
+
+        // Cancelled at the ~200ms passive bound, not at the 2s response delay
+        // or the 5s HttpClient.Timeout — with slack for CI jitter.
+        await Assert.That(firstSw.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
+
+        var secondSw = System.Diagnostics.Stopwatch.StartNew();
+        var second = await UpdateCommand.CheckForUpdateAsync(forceCheck: false, channel);
+        secondSw.Stop();
+        await Assert.That(second.Latest).IsNull();
+        await Assert.That(second.FromCache).IsTrue();
+
+        // Well under the endpoint's 2s configured delay — proves the second
+        // call served the backoff record rather than re-hitting the network.
+        await Assert.That(secondSw.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
+    }
+
+    /// <summary>
+    /// Pins the 1h backoff policy itself: once a failure has written a
+    /// backoff record, even a NOW-fast endpoint is not queried again by a
+    /// passive caller inside the window — the skip is driven by the cached
+    /// record, not by the endpoint still being slow.
+    /// </summary>
+    [Test, NotInParallel("UpdateCommand_RegistryBaseUrl")]
+    public async Task Failure_pins_one_hour_backoff_even_once_endpoint_recovers() {
+        const string channel = "test-backoff-policy";
+        _server.Given(Request.Create().WithPath($"/@kurrent/kcap/{channel}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(503));
+
+        var first = await UpdateCommand.CheckForUpdateAsync(forceCheck: false, channel);
+        await Assert.That(first.Latest).IsNull();
+
+        // The endpoint "recovers" — but the backoff record, not the endpoint,
+        // is what should gate the second passive call.
+        _server.ResetMappings();
+        _server.ResetLogEntries();
+        _server.Given(Request.Create().WithPath($"/@kurrent/kcap/{channel}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"version":"0.14.0"}"""));
+
+        var second = await UpdateCommand.CheckForUpdateAsync(forceCheck: false, channel);
+        await Assert.That(second.Latest).IsNull();
+        await Assert.That(second.FromCache).IsTrue();
+
+        var hits = _server.FindLogEntries(Request.Create().WithPath($"/@kurrent/kcap/{channel}").UsingGet());
+        await Assert.That(hits.Count).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// <c>forceCheck: true</c> bypasses the backoff entirely — an explicit
+    /// <c>kcap update</c>/<c>--check</c> invocation must always hit the
+    /// network rather than silently reusing a retained failure result.
+    /// </summary>
+    [Test, NotInParallel("UpdateCommand_RegistryBaseUrl")]
+    public async Task ForceCheck_bypasses_backoff_and_hits_network() {
+        const string channel = "test-force-bypass";
+        _server.Given(Request.Create().WithPath($"/@kurrent/kcap/{channel}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(503));
+
+        var first = await UpdateCommand.CheckForUpdateAsync(forceCheck: false, channel);
+        await Assert.That(first.Latest).IsNull();
+
+        _server.ResetMappings();
+        _server.ResetLogEntries();
+        _server.Given(Request.Create().WithPath($"/@kurrent/kcap/{channel}").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"version":"0.15.0"}"""));
+
+        var forced = await UpdateCommand.CheckForUpdateAsync(forceCheck: true, channel);
+        await Assert.That(forced.Latest).IsEqualTo("0.15.0");
+        await Assert.That(forced.FromCache).IsFalse();
+
+        var hits = _server.FindLogEntries(Request.Create().WithPath($"/@kurrent/kcap/{channel}").UsingGet());
+        await Assert.That(hits.Count).IsEqualTo(1);
     }
 }

--- a/test/Capacitor.Cli.Tests.Integration/UpdateNoticeDeliveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/UpdateNoticeDeliveryTests.cs
@@ -131,6 +131,78 @@ public class UpdateNoticeDeliveryTests : IDisposable {
         await Assert.That(r.Stderr).DoesNotContain("Update available:");
     }
 
+    // --- kcap status: the Version line reuses the same shared check and single-reports ---
+
+    /// <summary>
+    /// <c>kcap status</c> is itself human-facing (it is not in the suppressed population), so
+    /// without the <see cref="Capacitor.Cli.UpdateNotice.MarkReported"/> wiring both the Version
+    /// line's own inline annotation AND <c>Program.cs</c>'s outer-<c>finally</c> footer would
+    /// print the "newer version available" information — once inline (stdout) and once as the
+    /// two-line footer (stderr). Counting case-insensitive occurrences of "update available"
+    /// across BOTH streams pins that it happens exactly once; checking only one stream would
+    /// miss a regression that moved (rather than duplicated) the print.
+    /// </summary>
+    [Test]
+    public async Task Status_PrintsInlineUpdateAnnotation_AndSuppressesTheExitFooter() {
+        var cfgDir = SeedFreshNewerCache();
+
+        var r = await RunAsync(["status"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+        await Assert.That(r.Stdout).Contains("kcap ");
+        await Assert.That(r.Stdout).Contains($"(update available: {NewerVersion})");
+        await Assert.That(r.Stderr).DoesNotContain("Update available:");
+
+        var combined  = r.Stdout + r.Stderr;
+        var occurrences = CountOccurrences(combined, "update available");
+        await Assert.That(occurrences).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// <c>--no-update-check</c> must skip the check entirely for the Version line too — not just
+    /// suppress the print of an already-performed check — so the line prints the bare version
+    /// with no annotation even though the seeded cache reports a newer version.
+    /// </summary>
+    [Test]
+    public async Task Status_NoUpdateCheckFlag_PrintsBareVersion_NoAnnotation() {
+        var cfgDir = SeedFreshNewerCache();
+
+        var r = await RunAsync(["status", "--no-update-check"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+        await Assert.That(r.Stdout).Contains("kcap ");
+        await Assert.That(r.Stdout).DoesNotContain("update available");
+        await Assert.That(r.Stderr).DoesNotContain("Update available:");
+    }
+
+    /// <summary>Same opt-out, via the profile's persisted <c>update_check: false</c> instead of the flag.</summary>
+    [Test]
+    public async Task Status_ProfileUpdateCheckDisabled_PrintsBareVersion_NoAnnotation() {
+        var cfgDir = SeedFreshNewerCache();
+        File.WriteAllText(Path.Combine(cfgDir, "config.json"), """
+            {"version":2,"active_profile":"default","profiles":{"default":{"update_check":false}},"profile_bindings":{},"cwd_remap":[]}
+            """);
+
+        var r = await RunAsync(["status"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+        await Assert.That(r.Stdout).Contains("kcap ");
+        await Assert.That(r.Stdout).DoesNotContain("update available");
+        await Assert.That(r.Stderr).DoesNotContain("Update available:");
+    }
+
+    static int CountOccurrences(string haystack, string needle) {
+        var count = 0;
+        var idx   = 0;
+
+        while ((idx = haystack.IndexOf(needle, idx, StringComparison.OrdinalIgnoreCase)) >= 0) {
+            count++;
+            idx += needle.Length;
+        }
+
+        return count;
+    }
+
     // --- helpers ---
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Integration/UpdateNoticeDeliveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/UpdateNoticeDeliveryTests.cs
@@ -1,0 +1,205 @@
+using System.Diagnostics;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage of the deterministic exit-time update notice
+/// (<c>Capacitor.Cli.UpdateNotice</c>): a human-facing invocation prints the hint on stderr
+/// before the process exits, the suppressed population (hooks, <c>mcp</c>, <c>watch</c>,
+/// <c>--no-update-check</c>, <c>update_check: false</c>) prints nothing, and the notice still
+/// fires on the <c>--help</c> and no-server-configured early exits — both of which return before
+/// the command dispatch <c>switch</c>, and must still fall through <c>Program.cs</c>'s outer
+/// <c>finally</c>.
+///
+/// <para>Each case runs the real compiled binary in an isolated child process with its own
+/// <c>KCAP_CONFIG_DIR</c> (mirroring <see cref="UnusableUrlHookMatrixTests"/>) rather than
+/// pointing <c>UpdateCommand.RegistryBaseUrl</c> at a WireMock server: that seam is an in-process
+/// static field of the PARENT test process and has no effect on a spawned child. Instead, each
+/// case pre-seeds the on-disk update-check cache file directly with a fresh, already-newer
+/// record — the exact on-disk shape <c>UpdateCommand.UpdateCacheRecord</c> reads via its
+/// <c>IsFresh</c> cache-hit path — so the child's check resolves from that local file without
+/// ever touching the network, keeping these tests fast and deterministic while still exercising
+/// the real process, the real cache-read path, and the real predicate wiring in
+/// <c>Program.cs</c>.</para>
+/// </summary>
+public class UpdateNoticeDeliveryTests : IDisposable {
+    const string NewerVersion = "999.0.0"; // deterministically newer than any real build's version.
+
+    readonly List<(string CfgDir, Process Process)> _spawned = [];
+
+    public void Dispose() {
+        foreach (var (cfgDir, p) in _spawned) {
+            try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { }
+            p.Dispose();
+            try { Directory.Delete(cfgDir, true); } catch { }
+        }
+    }
+
+    // --- Positive: a human-facing command prints the hint before exit ---
+
+    [Test]
+    public async Task HumanFacingCommand_PrintsTheTwoLineHint_WhenANewerVersionIsCached() {
+        var cfgDir = SeedFreshNewerCache();
+
+        var r = await RunAsync(["config", "show"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+        await Assert.That(r.Stderr).Contains($"Update available:");
+        await Assert.That(r.Stderr).Contains(NewerVersion);
+        await Assert.That(r.Stderr).Contains("Run `kcap update` to update");
+    }
+
+    // --- Structural: --help and the no-server path fall through the same finally ---
+
+    [Test]
+    public async Task HelpCommand_StillFlushesTheNotice() {
+        var cfgDir = SeedFreshNewerCache();
+
+        var r = await RunAsync(["--help"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+        await Assert.That(r.Stdout).Contains("kcap");
+        await Assert.That(r.Stderr).Contains("Update available:");
+    }
+
+    [Test]
+    public async Task NoServerConfigured_StillFlushesTheNotice() {
+        var cfgDir = SeedFreshNewerCache();
+
+        // "whoami" needs a server URL and is not in Program.cs's offlineCommands list, so with
+        // no KCAP_URL and no profile server_url it hits the early "No server configured" return
+        // — well before the command switch — and must still flush from the outer finally.
+        var r = await RunAsync(["whoami"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(1);
+        await Assert.That(r.Stderr).Contains("No server configured");
+        await Assert.That(r.Stderr).Contains("Update available:");
+    }
+
+    // --- Negative: the suppressed population prints nothing, even with the same newer-version cache ---
+
+    [Test]
+    public async Task Hook_PrintsNothing() {
+        var cfgDir = SeedFreshNewerCache();
+
+        var r = await RunAsync(["hook"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(1);
+        await Assert.That(r.Stderr).DoesNotContain("Update available:");
+    }
+
+    [Test]
+    public async Task Mcp_PrintsNothing() {
+        var cfgDir = SeedFreshNewerCache();
+
+        var r = await RunAsync(["mcp"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(1);
+        await Assert.That(r.Stderr).DoesNotContain("Update available:");
+    }
+
+    [Test]
+    public async Task Watch_PrintsNothing() {
+        var cfgDir = SeedFreshNewerCache();
+
+        var r = await RunAsync(["watch"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(1);
+        await Assert.That(r.Stderr).DoesNotContain("Update available:");
+    }
+
+    [Test]
+    public async Task NoUpdateCheckFlag_PrintsNothing() {
+        var cfgDir = SeedFreshNewerCache();
+
+        var r = await RunAsync(["config", "show", "--no-update-check"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+        await Assert.That(r.Stderr).DoesNotContain("Update available:");
+    }
+
+    [Test]
+    public async Task ProfileUpdateCheckDisabled_PrintsNothing() {
+        var cfgDir = SeedFreshNewerCache();
+        File.WriteAllText(Path.Combine(cfgDir, "config.json"), """
+            {"version":2,"active_profile":"default","profiles":{"default":{"update_check":false}},"profile_bindings":{},"cwd_remap":[]}
+            """);
+
+        var r = await RunAsync(["config", "show"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+        await Assert.That(r.Stderr).DoesNotContain("Update available:");
+    }
+
+    // --- helpers ---
+
+    /// <summary>
+    /// Creates a fresh isolated config dir and pre-seeds it with an already-newer,
+    /// just-checked cache record for the default ("latest") channel — the exact shape
+    /// <c>UpdateCommand.UpdateCacheRecord.ToJson()</c> writes — so the child process's check
+    /// resolves from the cache-fresh path (a local file read) without any network round-trip.
+    /// </summary>
+    static string SeedFreshNewerCache() {
+        var cfgDir = Path.Combine(Path.GetTempPath(), $"kcap-update-notice-cfg-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(cfgDir);
+
+        var checkedAt = DateTimeOffset.UtcNow.ToString("O");
+        File.WriteAllText(
+            Path.Combine(cfgDir, "update-check-latest.json"),
+            $$"""{"latest_version":"{{NewerVersion}}","checked_at":"{{checkedAt}}","attempted_at":null,"failed":false}""");
+
+        return cfgDir;
+    }
+
+    static string GetCliBinaryPath() {
+        var asmDir      = Path.GetDirectoryName(typeof(UpdateNoticeDeliveryTests).Assembly.Location)!;
+        var binDir      = Path.GetDirectoryName(asmDir)!;
+        var config      = Path.GetFileName(binDir);
+        var testBin     = Path.GetDirectoryName(binDir)!;
+        var testProjDir = Path.GetDirectoryName(testBin)!;
+        var testRoot    = Path.GetDirectoryName(testProjDir)!;
+        var repoRoot    = Path.GetDirectoryName(testRoot)!;
+        var binaryName  = OperatingSystem.IsWindows() ? "kcap.exe" : "kcap";
+
+        return Path.Combine(repoRoot, "src", "Capacitor.Cli", "bin", config, "net10.0", binaryName);
+    }
+
+    async Task<(int ExitCode, string Stdout, string Stderr)> RunAsync(string[] args, string cfgDir) {
+        var binary = GetCliBinaryPath();
+
+        if (!File.Exists(binary)) {
+            throw new FileNotFoundException(
+                $"kcap binary not found at {binary}. Build it first: dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj",
+                binary);
+        }
+
+        var psi = new ProcessStartInfo(binary) {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+            CreateNoWindow         = true,
+            WorkingDirectory       = cfgDir,
+            Environment = {
+                ["KCAP_URL"]        = "",
+                ["KCAP_CONFIG_DIR"] = cfgDir,
+                ["KCAP_SESSION_ID"] = "",
+            },
+        };
+
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        var process = Process.Start(psi) ?? throw new InvalidOperationException("failed to start kcap");
+        _spawned.Add((cfgDir, process));
+
+        try { process.StandardInput.Close(); } catch (IOException) { }
+
+        var stdout = await process.StandardOutput.ReadToEndAsync();
+        var stderr = await process.StandardError.ReadToEndAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await process.WaitForExitAsync(cts.Token);
+
+        return (process.ExitCode, stdout, stderr);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -54,6 +54,52 @@ public class ClaudeHookCommandTests {
         await Assert.That(fx.RouteOrder).Contains("session-start");
     }
 
+    // ── In-agent version nudge gated on update_check ────────────────────────────────────────
+
+    [Test, NotInParallel]
+    public async Task update_check_off_suppresses_the_in_agent_nudge_even_when_server_reports_a_newer_version() {
+        using var fx = new Fixture { RespondJson = """{"version": "999.0.0"}""" };
+        var stdout = new StringWriter();
+
+        var exit = await WithProfileAsync(new Profile { UpdateCheck = false }, () =>
+            ClaudeHookCommand.HandleCore(
+                fx.Client, AuthStatus.Ok, fx.Spool, System.Diagnostics.Stopwatch.GetTimestamp(),
+                "http://localhost", new StringReader(
+                    $$"""{"hook_event_name":"SessionStart","session_id":"{{Sid}}","cwd":"/tmp"}"""),
+                memoryStoreFactory: () => new SessionStartMemoryLeaseStore(
+                    Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))),
+                stdout: stdout));
+
+        await Assert.That(exit).IsEqualTo(0);
+        var ctx = stdout.ToString();
+        await Assert.That(ctx).DoesNotContain("999.0.0");
+        await Assert.That(ctx).DoesNotContain("kcap update");
+    }
+
+    /// <summary>Non-vacuous control for the test above: with update_check on (the default), the
+    /// same newer-version server response still produces the in-agent nudge fragment — proves the
+    /// gate suppresses the fragment specifically because of the opt-out, not because the fixture
+    /// never produces one.</summary>
+    [Test, NotInParallel]
+    public async Task update_check_on_still_emits_the_in_agent_nudge_for_a_newer_server_version() {
+        using var fx = new Fixture { RespondJson = """{"version": "999.0.0"}""" };
+        var stdout = new StringWriter();
+
+        var exit = await WithProfileAsync(new Profile { UpdateCheck = true }, () =>
+            ClaudeHookCommand.HandleCore(
+                fx.Client, AuthStatus.Ok, fx.Spool, System.Diagnostics.Stopwatch.GetTimestamp(),
+                "http://localhost", new StringReader(
+                    $$"""{"hook_event_name":"SessionStart","session_id":"{{Sid}}","cwd":"/tmp"}"""),
+                memoryStoreFactory: () => new SessionStartMemoryLeaseStore(
+                    Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))),
+                stdout: stdout));
+
+        await Assert.That(exit).IsEqualTo(0);
+        var ctx = stdout.ToString();
+        await Assert.That(ctx).Contains("999.0.0");
+        await Assert.That(ctx).Contains("kcap update");
+    }
+
     // ── SessionStart team-memory index: behavioral baseline ─────────────────────────────────
     // Characterizes today's byte-level SessionStart output on the shared
     // SessionStartMemoryOrchestrator/ContextProvider/LeaseStore foundation (StartMemoryIndexTask

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeHookCommandTests.cs
@@ -436,7 +436,7 @@ public class ClaudeHookCommandTests {
         var exit = await ClaudeHookCommand.HandleWithDeps(
             fx.Spool, processStart, "http://localhost",
             new StringReader($$"""{"hook_event_name":"SessionEnd","session_id":"{{Sid}}","transcript_path":"/none","cwd":"/tmp"}"""),
-            updateCheckTask: null, clientFactory: slowFactory);
+            clientFactory: slowFactory);
         sw.Stop();
 
         await Assert.That(exit).IsEqualTo(0);
@@ -538,7 +538,7 @@ public class ClaudeHookCommandTests {
         var exit = await ClaudeHookCommand.HandleWithDeps(
             fx.Spool, processStart, "http://localhost",
             new StringReader($$"""{"hook_event_name":"SubagentStop","session_id":"{{Sid}}","agent_id":"{{AgentId}}","transcript_path":"/none","cwd":"/tmp"}"""),
-            updateCheckTask: null, clientFactory: slowFactory);
+            clientFactory: slowFactory);
         sw.Stop();
         await Assert.That(exit).IsEqualTo(0);
         await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));

--- a/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Http/UnusableUrlGuardTests.cs
@@ -245,7 +245,6 @@ public class UnusableUrlGuardTests : IDisposable {
             processStart: Stopwatch.GetTimestamp(),
             baseUrl: BadUrl,
             stdin: new StringReader($$"""{"hook_event_name":"SessionStart","session_id":"{{Sid}}"}"""),
-            updateCheckTask: null,
             clientFactory: () => {
                 entered = true;
                 throw new InvalidOperationException("the claude guard did not run");

--- a/test/Capacitor.Cli.Tests.Unit/ObservationHeaderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ObservationHeaderTests.cs
@@ -1,0 +1,161 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The wire contract PR-2 (kcap-server) reads: every client built by
+/// <see cref="HttpClientExtensions"/>'s single choke point, and the raw client
+/// <see cref="WhoamiCommand"/> builds outside it, must carry the CLI's display version, and must
+/// carry the update-check opt-out header if and only if the active profile turned it off. Absence
+/// of the opt-out header on a version-carrying request is read by the server as "on" — so both the
+/// present and the absent case are asserted here, not just the header's shape when it does appear.
+///
+/// <para>Shares <c>TokenStoreProfileTests</c>'s serialization key: these tests touch the process-wide
+/// <see cref="AppConfig.ResolvedProfile"/> static and the shared <c>KCAP_CONFIG_DIR</c> config.json
+/// that other classes in this assembly also read and write.</para>
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class ObservationHeaderTests : IDisposable {
+    readonly WireMockServer _server = WireMockServer.Start();
+
+    [Before(Test)]
+    public void Cleanup() {
+        AppConfig.ResetResolvedStateForTesting();
+        HttpClientExtensions.ResetProviderCacheForTesting();
+
+        var cfg = AppConfig.GetConfigPath();
+        if (File.Exists(cfg)) File.Delete(cfg);
+    }
+
+    public void Dispose() {
+        _server.Stop();
+        AppConfig.ResetResolvedStateForTesting();
+        HttpClientExtensions.ResetProviderCacheForTesting();
+    }
+
+    void StubDiscovery(string provider = "None") =>
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{"provider":"{{provider}}"}"""));
+
+    // ── CreateClientCoreAsync (via CreateClientWithAuthStatusAsync) ────────────────────────────
+
+    [Test]
+    public async Task Client_always_carries_the_display_version_with_no_build_suffix() {
+        StubDiscovery();
+
+        var (client, status) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(_server.Urls[0]);
+
+        await Assert.That(status).IsEqualTo(AuthStatus.NoAuthRequired);
+        await Assert.That(client.DefaultRequestHeaders.Contains(HttpClientExtensions.CliVersionHeader)).IsTrue();
+
+        var value = client.DefaultRequestHeaders.GetValues(HttpClientExtensions.CliVersionHeader).Single();
+        await Assert.That(value).IsEqualTo(CapacitorVersion.CurrentDisplay());
+        await Assert.That(value).DoesNotContain("+");
+    }
+
+    [Test]
+    public async Task Off_header_is_sent_when_the_active_profile_disabled_update_check() {
+        StubDiscovery();
+        AppConfig.SetResolvedState(_server.Urls[0], "obs-headers-off", new Profile { UpdateCheck = false });
+
+        var (client, _) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(_server.Urls[0]);
+
+        await Assert.That(client.DefaultRequestHeaders.Contains(HttpClientExtensions.UpdateCheckHeader)).IsTrue();
+        await Assert.That(client.DefaultRequestHeaders.GetValues(HttpClientExtensions.UpdateCheckHeader).Single())
+            .IsEqualTo(HttpClientExtensions.UpdateCheckOffValue);
+    }
+
+    /// <summary>
+    /// The non-vacuous half of the pair above: update_check ON (the default) must NOT send the
+    /// header at all — a server that treats absence as "on" would misread a stray "on" value sent
+    /// defensively, so the implementation must omit it rather than send a truthy value.
+    /// </summary>
+    [Test]
+    public async Task Off_header_is_absent_when_the_active_profile_has_update_check_on() {
+        StubDiscovery();
+        AppConfig.SetResolvedState(_server.Urls[0], "obs-headers-on", new Profile { UpdateCheck = true });
+
+        var (client, _) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(_server.Urls[0]);
+
+        await Assert.That(client.DefaultRequestHeaders.Contains(HttpClientExtensions.UpdateCheckHeader)).IsFalse();
+    }
+
+    [Test]
+    public async Task Off_header_is_absent_when_no_profile_is_resolved_at_all() {
+        StubDiscovery();
+        // No AppConfig.SetResolvedState call, and Cleanup() above already cleared both the
+        // in-process resolved state and any stray config.json — GetActiveProfileAsync falls back
+        // to the built-in default profile, whose update_check defaults to true.
+        var (client, _) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(_server.Urls[0]);
+
+        await Assert.That(client.DefaultRequestHeaders.Contains(HttpClientExtensions.UpdateCheckHeader)).IsFalse();
+    }
+
+    // ── WhoamiCommand.ProbeAsync (the raw client that bypasses the choke point) ────────────────
+
+    /// <summary>
+    /// ProbeAsync is private (deliberately — it must send exactly the token whoami printed, with no
+    /// refresh). Driving it through the real <see cref="WhoamiCommand.HandleAsync"/> and capturing
+    /// the actual request WireMock received is the only way to prove the headers reached the wire,
+    /// as opposed to merely being attached to some client that HandleAsync doesn't end up using.
+    /// </summary>
+    [Test]
+    public async Task Whoami_probe_request_carries_both_headers_when_update_check_is_off() {
+        const string profileName = "obs-headers-whoami-off";
+        StubDiscovery(provider: "github_app");
+        _server.Given(Request.Create().WithPath(WhoamiCommand.ProbePath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        AppConfig.SetResolvedState(_server.Urls[0], profileName, new Profile { UpdateCheck = false });
+        await TokenStore.SaveAsync(profileName, new StoredTokens {
+            AccessToken    = "tok-whoami-off",
+            ExpiresAt      = DateTimeOffset.UtcNow.AddHours(1),
+            GitHubUsername = "alice",
+            Provider       = AuthProvider.GitHubApp,
+            ServerUrl      = _server.Urls[0],
+        });
+
+        await WhoamiCommand.HandleAsync(_server.Urls[0]);
+
+        var probe = _server.LogEntries.Single(e => e.RequestMessage.Path == WhoamiCommand.ProbePath);
+
+        await Assert.That(probe.RequestMessage.Headers![HttpClientExtensions.CliVersionHeader].Single())
+            .IsEqualTo(CapacitorVersion.CurrentDisplay());
+        await Assert.That(probe.RequestMessage.Headers![HttpClientExtensions.UpdateCheckHeader].Single())
+            .IsEqualTo(HttpClientExtensions.UpdateCheckOffValue);
+    }
+
+    /// <summary>Same probe, opposite preference: the off-header must not reach the wire either.</summary>
+    [Test]
+    public async Task Whoami_probe_request_omits_the_off_header_when_update_check_is_on() {
+        const string profileName = "obs-headers-whoami-on";
+        StubDiscovery(provider: "github_app");
+        _server.Given(Request.Create().WithPath(WhoamiCommand.ProbePath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        AppConfig.SetResolvedState(_server.Urls[0], profileName, new Profile { UpdateCheck = true });
+        await TokenStore.SaveAsync(profileName, new StoredTokens {
+            AccessToken    = "tok-whoami-on",
+            ExpiresAt      = DateTimeOffset.UtcNow.AddHours(1),
+            GitHubUsername = "alice",
+            Provider       = AuthProvider.GitHubApp,
+            ServerUrl      = _server.Urls[0],
+        });
+
+        await WhoamiCommand.HandleAsync(_server.Urls[0]);
+
+        var probe = _server.LogEntries.Single(e => e.RequestMessage.Path == WhoamiCommand.ProbePath);
+
+        await Assert.That(probe.RequestMessage.Headers![HttpClientExtensions.CliVersionHeader].Single())
+            .IsEqualTo(CapacitorVersion.CurrentDisplay());
+        await Assert.That(probe.RequestMessage.Headers!.ContainsKey(HttpClientExtensions.UpdateCheckHeader)).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/StatusVersionLineFormattingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/StatusVersionLineFormattingTests.cs
@@ -1,0 +1,43 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Pure formatting coverage for <see cref="StatusCommand.FormatVersionLine"/> — the I/O-free half
+/// of the Version line printed by <c>kcap status</c>. The stateful half (reusing
+/// <c>UpdateNotice</c>'s shared lazy check, calling <c>MarkReported()</c>, respecting the
+/// update-check opt-outs) is covered end-to-end by the spawned-process tests in
+/// <c>UpdateNoticeDeliveryTests</c>, since it needs a real profile config and the real
+/// cross-process static state <c>UpdateNotice</c> relies on.
+/// </summary>
+public class StatusVersionLineFormattingTests {
+    [Test]
+    public async Task NullResult_PrintsBareVersion() {
+        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", null)).IsEqualTo("kcap 0.11.12");
+    }
+
+    [Test]
+    public async Task NotNewer_PrintsBareVersion_NoAnnotation() {
+        var result = new UpdateCommand.UpdateCheckResult(Current: "0.11.12", Latest: "0.11.12", Newer: false, FromCache: true);
+
+        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", result)).IsEqualTo("kcap 0.11.12");
+    }
+
+    [Test]
+    public async Task Newer_AppendsInlineUpdateAvailableAnnotation() {
+        var result = new UpdateCommand.UpdateCheckResult(Current: "0.11.12", Latest: "0.11.14", Newer: true, FromCache: true);
+
+        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", result))
+            .IsEqualTo("kcap 0.11.12 (update available: 0.11.14)");
+    }
+
+    // Newer:true with a null Latest is a shape the current UpdateCheckResult never actually
+    // produces together, but the formatter defends against it anyway rather than trusting the
+    // flag alone — same discipline as UpdateNotice.FlushAsync's own pattern match.
+    [Test]
+    public async Task Newer_ButLatestNull_PrintsBareVersion() {
+        var result = new UpdateCommand.UpdateCheckResult(Current: "0.11.12", Latest: null, Newer: true, FromCache: true);
+
+        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", result)).IsEqualTo("kcap 0.11.12");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/UpdateCacheRecordTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UpdateCacheRecordTests.cs
@@ -1,0 +1,107 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Unit coverage for <see cref="UpdateCommand.UpdateCacheRecord"/>: legacy
+/// two-field on-disk compat, round-trip JSON, and the freshness/backoff
+/// arithmetic <see cref="UpdateCommand.CheckForUpdateAsync"/>'s decision
+/// ladder depends on. See <c>UpdateChannelQueryTests</c> for the end-to-end
+/// coverage of the coordinator itself.
+/// </summary>
+public class UpdateCacheRecordTests {
+    [Test]
+    public async Task LegacyTwoFieldCache_ReadsAsSuccessRecord() {
+        var json = """{"latest_version":"0.11.10","checked_at":"2026-08-08T10:00:00Z"}""";
+        var rec  = UpdateCommand.UpdateCacheRecord.Parse(json);
+
+        await Assert.That(rec).IsNotNull();
+        await Assert.That(rec!.LatestVersion).IsEqualTo("0.11.10");
+        await Assert.That(rec.Failed).IsFalse();
+        await Assert.That(rec.AttemptedAt).IsNull();
+    }
+
+    [Test]
+    public async Task LegacyTwoFieldCache_IsFresh_WithinTtl() {
+        var rec = UpdateCommand.UpdateCacheRecord.Parse(
+            """{"latest_version":"0.11.10","checked_at":"2026-08-08T10:00:00Z"}""");
+
+        await Assert.That(rec!.IsFresh(
+            DateTimeOffset.Parse("2026-08-08T10:00:00Z").AddHours(1),
+            TimeSpan.FromHours(24))).IsTrue();
+    }
+
+    [Test]
+    public async Task Parse_UnparseableJson_ReturnsNull() {
+        await Assert.That(UpdateCommand.UpdateCacheRecord.Parse("not json")).IsNull();
+        await Assert.That(UpdateCommand.UpdateCacheRecord.Parse("")).IsNull();
+    }
+
+    [Test]
+    public async Task ToJson_RoundTrips_ThroughParse() {
+        var now  = DateTimeOffset.Parse("2026-08-08T10:00:00Z");
+        var orig = new UpdateCommand.UpdateCacheRecord("0.11.10", now, AttemptedAt: null, Failed: false);
+        var rec  = UpdateCommand.UpdateCacheRecord.Parse(orig.ToJson());
+
+        await Assert.That(rec).IsNotNull();
+        await Assert.That(rec!.LatestVersion).IsEqualTo("0.11.10");
+        await Assert.That(rec.CheckedAt).IsEqualTo(now);
+        await Assert.That(rec.AttemptedAt).IsNull();
+        await Assert.That(rec.Failed).IsFalse();
+    }
+
+    [Test]
+    public async Task FailedRecord_ToJson_RoundTrips_RetainingLatestVersion() {
+        var attemptedAt = DateTimeOffset.Parse("2026-08-08T10:00:00Z");
+        var orig        = new UpdateCommand.UpdateCacheRecord("0.11.10", CheckedAt: null, attemptedAt, Failed: true);
+        var rec         = UpdateCommand.UpdateCacheRecord.Parse(orig.ToJson());
+
+        await Assert.That(rec).IsNotNull();
+        await Assert.That(rec!.LatestVersion).IsEqualTo("0.11.10");
+        await Assert.That(rec.CheckedAt).IsNull();
+        await Assert.That(rec.AttemptedAt).IsEqualTo(attemptedAt);
+        await Assert.That(rec.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task FailedRecord_WithinBackoffTtl_SkipsNetwork() {
+        var rec = new UpdateCommand.UpdateCacheRecord("0.11.10", CheckedAt: DateTimeOffset.UtcNow.AddHours(-30),
+                                        AttemptedAt: DateTimeOffset.UtcNow.AddMinutes(-10), Failed: true);
+
+        await Assert.That(rec.InFailureBackoff(DateTimeOffset.UtcNow, TimeSpan.FromHours(1))).IsTrue();
+        // stale-while-backoff: the retained last-known version is still served
+        await Assert.That(rec.LatestVersion).IsEqualTo("0.11.10");
+    }
+
+    [Test]
+    public async Task FailedRecord_PastBackoffTtl_NoLongerBacksOff() {
+        var rec = new UpdateCommand.UpdateCacheRecord("0.11.10", CheckedAt: null,
+                                        AttemptedAt: DateTimeOffset.UtcNow.AddHours(-2), Failed: true);
+
+        await Assert.That(rec.InFailureBackoff(DateTimeOffset.UtcNow, TimeSpan.FromHours(1))).IsFalse();
+    }
+
+    [Test]
+    public async Task SuccessRecord_NeverInFailureBackoff() {
+        var rec = new UpdateCommand.UpdateCacheRecord("0.11.10", CheckedAt: DateTimeOffset.UtcNow,
+                                        AttemptedAt: null, Failed: false);
+
+        await Assert.That(rec.InFailureBackoff(DateTimeOffset.UtcNow, TimeSpan.FromHours(1))).IsFalse();
+    }
+
+    [Test]
+    public async Task FailedRecord_NeverFresh_EvenWithoutCheckedAt() {
+        var rec = new UpdateCommand.UpdateCacheRecord("0.11.10", CheckedAt: null,
+                                        AttemptedAt: DateTimeOffset.UtcNow, Failed: true);
+
+        await Assert.That(rec.IsFresh(DateTimeOffset.UtcNow, TimeSpan.FromHours(24))).IsFalse();
+    }
+
+    [Test]
+    public async Task SuccessRecord_PastTtl_NoLongerFresh() {
+        var rec = new UpdateCommand.UpdateCacheRecord("0.11.10", CheckedAt: DateTimeOffset.UtcNow.AddHours(-25),
+                                        AttemptedAt: null, Failed: false);
+
+        await Assert.That(rec.IsFresh(DateTimeOffset.UtcNow, TimeSpan.FromHours(24))).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/UpdateNoticeIsHumanFacingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UpdateNoticeIsHumanFacingTests.cs
@@ -1,0 +1,107 @@
+using Capacitor.Cli;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Unit coverage for <see cref="UpdateNotice.IsHumanFacing"/> — the sync, I/O-free half of the
+/// suppression predicate (the async half, <c>profile.UpdateCheck == false</c>, is covered by
+/// <c>UpdateNoticeDeliveryTests</c> in the integration suite since it needs a real profile
+/// config file on disk). Asserts both directions of the matrix non-vacuously: every suppressed
+/// case is paired with the fact that ordinary human-facing commands are NOT suppressed, so a
+/// predicate hard-coded to <c>true</c> or <c>false</c> would fail here.
+/// </summary>
+public class UpdateNoticeIsHumanFacingTests {
+    static readonly string[] NoArgs = [];
+
+    // --- Suppressed: CrashReporter.FailOpenCommands (agent-spawned; nobody reads their stderr) ---
+
+    [Test]
+    [Arguments("hook")]
+    [Arguments("generate-whats-done")]
+    [Arguments("set-title")]
+    [Arguments("copilot-finalize")]
+    public async Task FailOpenCommands_AreSuppressed(string command) {
+        await Assert.That(UpdateNotice.IsHumanFacing(command, [command])).IsFalse();
+    }
+
+    // --- Suppressed: mcp / watch (stdio server / long-lived background process) ---
+
+    [Test]
+    public async Task Mcp_IsSuppressed_RegardlessOfSubcommand() {
+        await Assert.That(UpdateNotice.IsHumanFacing("mcp", ["mcp"])).IsFalse();
+        await Assert.That(UpdateNotice.IsHumanFacing("mcp", ["mcp", "flows"])).IsFalse();
+        await Assert.That(UpdateNotice.IsHumanFacing("mcp", ["mcp", "sessions"])).IsFalse();
+    }
+
+    [Test]
+    public async Task Watch_IsSuppressed() {
+        await Assert.That(UpdateNotice.IsHumanFacing("watch", ["watch", "sid", "/tmp/t.jsonl"])).IsFalse();
+    }
+
+    // --- Suppressed: `daemon run` specifically — NOT every daemon subcommand ---
+
+    [Test]
+    public async Task DaemonRun_IsSuppressed() {
+        await Assert.That(UpdateNotice.IsHumanFacing("daemon", ["daemon", "run"])).IsFalse();
+    }
+
+    [Test]
+    [Arguments("status")]
+    [Arguments("stop")]
+    [Arguments("install")]
+    public async Task DaemonOtherSubcommands_AreNotSuppressed(string subcommand) {
+        // Only `daemon run` (the foreground daemon process itself) is excluded — a bare `daemon`
+        // with no subcommand, or any other subcommand, is an ordinary human-facing CLI call.
+        await Assert.That(UpdateNotice.IsHumanFacing("daemon", ["daemon", subcommand])).IsTrue();
+    }
+
+    [Test]
+    public async Task BareDaemon_WithNoSubcommand_IsNotSuppressed() {
+        await Assert.That(UpdateNotice.IsHumanFacing("daemon", ["daemon"])).IsTrue();
+    }
+
+    // --- Suppressed: update / uninstall themselves ---
+
+    [Test]
+    public async Task Update_IsSuppressed() {
+        await Assert.That(UpdateNotice.IsHumanFacing("update", ["update"])).IsFalse();
+    }
+
+    [Test]
+    public async Task Uninstall_IsSuppressed() {
+        await Assert.That(UpdateNotice.IsHumanFacing("uninstall", ["uninstall"])).IsFalse();
+    }
+
+    // --- Suppressed: explicit --no-update-check flag, on an otherwise human-facing command ---
+
+    [Test]
+    public async Task NoUpdateCheckFlag_SuppressesAnOtherwiseHumanFacingCommand() {
+        await Assert.That(UpdateNotice.IsHumanFacing("config", ["config", "show", "--no-update-check"])).IsFalse();
+    }
+
+    // --- NOT suppressed: ordinary human-facing commands (the positive control) ---
+
+    [Test]
+    [Arguments("status")]
+    [Arguments("config")]
+    [Arguments("whoami")]
+    [Arguments("recap")]
+    [Arguments("errors")]
+    [Arguments("eval")]
+    [Arguments("import")]
+    [Arguments("--help")]
+    [Arguments("-h")]
+    [Arguments("help")]
+    [Arguments("--version")]
+    [Arguments("unknown-command")]
+    public async Task OrdinaryCommands_AreHumanFacing(string command) {
+        await Assert.That(UpdateNotice.IsHumanFacing(command, [command])).IsTrue();
+    }
+
+    [Test]
+    public async Task EmptyArgs_DoesNotThrow_AndIsHumanFacing() {
+        // args always contains at least the command itself in production (args[0] == command),
+        // but the predicate must not blow up on a caller that passes an empty array.
+        await Assert.That(UpdateNotice.IsHumanFacing("status", NoArgs)).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/UpdateNoticeIsHumanFacingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UpdateNoticeIsHumanFacingTests.cs
@@ -38,26 +38,29 @@ public class UpdateNoticeIsHumanFacingTests {
         await Assert.That(UpdateNotice.IsHumanFacing("watch", ["watch", "sid", "/tmp/t.jsonl"])).IsFalse();
     }
 
-    // --- Suppressed: `daemon run` specifically — NOT every daemon subcommand ---
+    // --- Suppressed: the whole `daemon` command family (there is no separate `run` subcommand —
+    // the foreground shape is plain `kcap daemon start`, which blocks for the daemon's lifetime) ---
 
     [Test]
-    public async Task DaemonRun_IsSuppressed() {
-        await Assert.That(UpdateNotice.IsHumanFacing("daemon", ["daemon", "run"])).IsFalse();
+    public async Task DaemonStart_IsSuppressed() {
+        // The real foreground shape: `daemon start` with no -d/--detach blocks for the daemon's
+        // whole lifetime (this is what Capacitor.AppHost runs on every dev-loop restart).
+        await Assert.That(UpdateNotice.IsHumanFacing("daemon", ["daemon", "start"])).IsFalse();
+        // The detached form is also suppressed — the whole family is, not just the blocking shape.
+        await Assert.That(UpdateNotice.IsHumanFacing("daemon", ["daemon", "start", "-d"])).IsFalse();
     }
 
     [Test]
     [Arguments("status")]
-    [Arguments("stop")]
-    [Arguments("install")]
-    public async Task DaemonOtherSubcommands_AreNotSuppressed(string subcommand) {
-        // Only `daemon run` (the foreground daemon process itself) is excluded — a bare `daemon`
-        // with no subcommand, or any other subcommand, is an ordinary human-facing CLI call.
-        await Assert.That(UpdateNotice.IsHumanFacing("daemon", ["daemon", subcommand])).IsTrue();
+    [Arguments("logs")]
+    [Arguments("doctor")]
+    public async Task AllDaemonSubcommands_AreSuppressed(string subcommand) {
+        await Assert.That(UpdateNotice.IsHumanFacing("daemon", ["daemon", subcommand])).IsFalse();
     }
 
     [Test]
-    public async Task BareDaemon_WithNoSubcommand_IsNotSuppressed() {
-        await Assert.That(UpdateNotice.IsHumanFacing("daemon", ["daemon"])).IsTrue();
+    public async Task BareDaemon_WithNoSubcommand_IsSuppressed() {
+        await Assert.That(UpdateNotice.IsHumanFacing("daemon", ["daemon"])).IsFalse();
     }
 
     // --- Suppressed: update / uninstall themselves ---


### PR DESCRIPTION
Part of AI-1283 — the kcap-cli half of "your kcap CLI is out of date" notifications. The kcap-server half (npm poller, per-user version registry, web banner, notification-centre kind, hook `version` field) already merged in kcap-server#1384. This PR makes the local update notice deterministic and starts transmitting the observation headers that server side consumes. Immediately useful on its own; the headers are inert until a server that reads them is deployed (and the server already ships that).

## What changed
- **Deterministic exit notice** — the existing npm update hint was fire-and-forget and only ever awaited inside Claude hooks (where nobody reads it). It now runs in a `try/finally` around the whole dispatch (covering `--help` and the no-server early exits) and prints after every *human-facing* command. Suppressed for agent-spawned/protocol/long-running commands (`hook`, `generate-whats-done`, `set-title`, `copilot-finalize`, `mcp *`, `watch`, the whole `daemon` family) and for `update`/`uninstall`/`--no-update-check`/`update_check=false`.
- **Cache + backoff** — `UpdateCacheRecord` adds failure/backoff fields (backward-compatible with the legacy two-field cache): a failed poll is retained with a 1h backoff so repeated quick commands don't re-hit the network, and the passive path runs under a bounded budget (300ms warm cache / 3s network with a 500ms cleanup grace) so a slow registry can't delay exit or livelock. `kcap update`/`--check` keep the 5s bound and bypass the backoff.
- **`kcap status`** now prints the installed CLI version, with an inline `(update available: X)` when behind — sharing one check with the exit notice (no double print, at most one network call).
- **Observation headers** — every authenticated request (via the `CreateClientCoreAsync` choke point, plus the `whoami` raw probe) carries `X-Kcap-Cli-Version`; `X-Kcap-Update-Check: off` is added only when the user has opted out. These let the server surface the banner / notification and honor the opt-out.
- **Opt-out** — `kcap config set update_check false` is now the full, persisted opt-out: it silences the local notice, the `kcap status` annotation, the transmitted headers (so the server-side banner/notification honor it), and the in-agent nudge. `--no-update-check` stays a one-shot local suppression.
- README + `help-update.txt` + `config` help updated.

## Notes
- Built TDD, task-by-task, each reviewed (incl. mutation-testing the wire-contract headers and the notice-suppression gate).
- No Linear IDs in any `.cs` file (repo lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
