### PR TITLE
[AI-1828] Carry the daemon's reap verdict to the flow caller (launch-window reaps)

### DIFF
--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -18,6 +18,12 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// than taking a concrete <c>ServerConnection</c> dependency, so this class is unit-testable
 /// without a real SignalR connection (see <c>AcpInteractionBridgeTests</c>).
 ///
+/// <paramref name="unexpectedUnattendedInteraction"/> fires on every reap this bridge triggers, and
+/// carries the CODED REASON (design spec §3.1) that <c>AcpHostedAgentRuntime</c> forwards verbatim
+/// into its reap claim — never the bare JSON-RPC method: an unadmittable frame codes its own logged
+/// <c>why</c> (<c>unattended_frame_unadmittable: …</c>), everything else codes the method
+/// (<c>unattended_interaction_forbidden:{method}</c>) via <see cref="ForbiddenInteractionReason"/>.
+///
 /// Defensive-by-construction: every code path that can fail (missing/malformed params, the
 /// server call throwing, a decision that doesn't map to any offered option) returns a
 /// <c>"cancelled"</c>/safest-available-option result rather than propagating an exception —
@@ -41,15 +47,26 @@ internal sealed partial class AcpInteractionBridge(
     /// <see cref="AcpUnattendedInteractionPolicy.AllowlistedAutoApprove"/> it ALSO reaps, because a
     /// frame we cannot read is a frame we cannot admit — and "not admitted reaps exactly as Fail
     /// does" has to hold for the frames we understand least, not just the ones we understand.
+    ///
+    /// Publishes the FRAME-UNADMITTABLE coding of this method's own logged <paramref name="why"/> —
+    /// never the generic forbidden-method coding <see cref="ForbiddenInteractionReason"/> uses —
+    /// so a caller downstream (design spec §3.1) can tell "we couldn't even parse this" apart from
+    /// "we understood it and it wasn't allowed."
     /// </summary>
     JsonElement? UnadmittableFrame(AcpRequest request, string why) {
         if (unattendedPolicy == AcpUnattendedInteractionPolicy.AllowlistedAutoApprove) {
             logger.LogWarning("ACP: reaping unattended reviewer — {Why} (agent {AgentId})", why, agentId);
-            unexpectedUnattendedInteraction?.Invoke(request.Method);
+            unexpectedUnattendedInteraction?.Invoke($"unattended_frame_unadmittable: {why}");
         }
 
         return CancelledResult();
     }
+
+    /// <summary>The coded reason published for every FORBIDDEN-METHOD reap (as opposed to
+    /// <see cref="UnadmittableFrame"/>'s frame-unadmittable coding) — one formula shared by all
+    /// three call sites below, so they can never drift from each other or from the coded prefix a
+    /// caller downstream matches on.</summary>
+    static string ForbiddenInteractionReason(string method) => $"unattended_interaction_forbidden:{method}";
 
     /// <summary>
     /// Handles one inbound <see cref="AcpRequest"/>. Returns <see langword="null"/> for any method
@@ -81,7 +98,7 @@ internal sealed partial class AcpInteractionBridge(
         || (unattendedPolicy == AcpUnattendedInteractionPolicy.AllowlistedAutoApprove
             && request.Method != "session/request_permission")) {
             LogUnexpectedUnattendedInteraction(agentId, request.Method);
-            unexpectedUnattendedInteraction?.Invoke(request.Method);
+            unexpectedUnattendedInteraction?.Invoke(ForbiddenInteractionReason(request.Method));
 
             // Each method cancels in ITS OWN protocol's result shape — the stabilized
             // elicitation response is a different object from the permission outcome. The
@@ -150,7 +167,7 @@ internal sealed partial class AcpInteractionBridge(
         if (unattendedPolicy == AcpUnattendedInteractionPolicy.AllowlistedAutoApprove) {
             if (!UnattendedToolAdmission.IsAdmitted(parsed.ToolCall, admittedToolIds ?? EmptyAdmitted)) {
                 LogUnexpectedUnattendedInteraction(agentId, request.Method);
-                unexpectedUnattendedInteraction?.Invoke(request.Method);
+                unexpectedUnattendedInteraction?.Invoke(ForbiddenInteractionReason(request.Method));
 
                 return CancelledResult();
             }
@@ -167,7 +184,7 @@ internal sealed partial class AcpInteractionBridge(
             // Admitted tool, but no allow option we can identify. Reap rather than guess: an
             // unrecognised option set is exactly where a wrong pick grants something nobody asked for.
             LogUnexpectedUnattendedInteraction(agentId, request.Method);
-            unexpectedUnattendedInteraction?.Invoke(request.Method);
+            unexpectedUnattendedInteraction?.Invoke(ForbiddenInteractionReason(request.Method));
 
             return CancelledResult();
         }

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -409,6 +409,24 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     sealed class AcpProtocolVersionException(string message) : InvalidOperationException(message);
 
     /// <summary>
+    /// The initialize/session-new wrapper's failure, carrying the sanitized transport cause as a
+    /// SEPARATE property from the composed, hint-decorated <see cref="Exception.Message"/> (design
+    /// spec §3.2). <see cref="Message"/> is composed exactly as the plain
+    /// <see cref="InvalidOperationException"/> this replaces always was — byte-identical for the
+    /// no-verdict path — but <see cref="TransportMessage"/> lets a caller (the factory's
+    /// launch-failure reclassification) quote just the transport cause, so a reclassified suffix can
+    /// never smuggle the auth hint back in. <c>internal</c> (not the sibling exceptions' default
+    /// private) because the factory, in a different class, needs to pattern-match on it.
+    /// </summary>
+    internal sealed class AcpHandshakeFailedException(string stage, string transportMessage, string hint, Exception inner)
+        : InvalidOperationException(
+            $"ACP handshake ({stage}) failed: {transportMessage} — if this is an auth/subscription issue, {hint}.",
+            inner) {
+        /// <summary>The sanitized transport-level failure cause alone — no auth hint appended.</summary>
+        public string TransportMessage { get; } = transportMessage;
+    }
+
+    /// <summary>
     /// Makes an error message safe to fold into a forwarded launch-failure string: collapses line
     /// breaks to spaces and caps the length. The source can be an agent-controlled JSON-RPC
     /// <c>error.message</c> (via <see cref="AcpRpcException"/>), which could otherwise be arbitrarily
@@ -845,9 +863,8 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // Deliberately conservative: the exact wire shape of a logged-out/unsubscribed cursor-agent
             // failure is unverified, so this does NOT pattern-match specific error text (a live
             // logged-out probe is a follow-up). Never masks the original error, only annotates it.
-            throw new InvalidOperationException(
-                $"ACP handshake (initialize/session-new) failed: {SanitizeForForward(ex.Message)} — if this is an auth/subscription issue, {DiagnosticAuthHint}.",
-                ex);
+            throw new AcpHandshakeFailedException(
+                "initialize/session-new", SanitizeForForward(ex.Message), DiagnosticAuthHint, ex);
         }
 
         // Select the requested model (if any) BEFORE the first prompt fires. Awaited, but never
@@ -1714,14 +1731,22 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // Set false only when the child's exit could not be confirmed — see below.
         var cleanupSafe = true;
 
+        // UNCONDITIONAL, independent of _onDisposed: a claimed reap's Verdict is published
+        // synchronously at claim time (TryStartReap), but "post-disposal the verdict is final" also
+        // needs the reap's TASK to have settled before any caller (the factory's launch-failure
+        // catch) treats disposal as done — otherwise a no-hook (cursor-shaped) runtime could return
+        // from DisposeAsync while an in-flight reap is still tearing down the same process disposal
+        // is about to touch below. Design spec §3.2: this was previously gated on _onDisposed is not
+        // null, which is a Kiro/OpenCode-only concern (the isolated-home cleanup hook) that has
+        // nothing to do with whether a reap needs awaiting.
+        if (TakeReap() is { } reap) {
+            try { await reap.ConfigureAwait(false); } catch { /* already logged by the reap */ }
+        }
+
         // BEFORE disposing anything, when the child is still observable. AcpChildProcess.HasExited
         // reports true as soon as the underlying Process is disposed, so asking afterwards mistakes
         // "no longer observable" for "confirmed exited" — the opposite of what this gate is for.
         if (_onDisposed is not null) {
-            if (TakeReap() is { } reap) {
-                try { await reap.ConfigureAwait(false); } catch { /* already logged by the reap */ }
-            }
-
             try {
                 // Bounded HERE with WaitAsync rather than by trusting the timeout argument: the
                 // interface takes one but does not oblige an implementation to honour it, and the

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -470,6 +470,12 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// 2, round 3). Never touched by production code.</summary>
     internal Task RuntimeTerminalForTest => _runtimeTerminal.Task;
 
+    /// <summary>Test-only: the turn-worker task, so a test can assert DisposeAsync always SIGNALS the
+    /// worker to exit (channels completed / token cancelled) even when the early cancellation phase
+    /// faults — otherwise it parks forever while teardown disposes its resources (Bug 1). Never touched
+    /// by production code.</summary>
+    internal Task TurnWorkerTaskForTest => _turnWorkerTask;
+
     /// <summary>Test-only: installs a throwing owner CTS so <see cref="DisposeAsync"/>'s owner-cancel
     /// (the EARLY cancellation callback) faults. Never touched by production code.</summary>
     internal void SetOwnerCtsForTest(CancellationTokenSource cts) { lock (_reconnectLock) _ownerCts = cts; }
@@ -702,11 +708,13 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             return;
     }
 
-    async Task ReapUnexpectedInteractionAsync(string method) {
+    async Task ReapUnexpectedInteractionAsync(string reason) {
         try {
             await _installed.Process.TerminateAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
         } catch (Exception ex) {
-            _logger.LogDebug(ex, "ACP: failed to reap unattended reviewer after forbidden {Method} interaction.", method);
+            // Bug 4: callers now pass the full coded reap reason / monitor violation, not a bare
+            // JSON-RPC method — label it {Reason}, not {Method}.
+            _logger.LogDebug(ex, "ACP: failed to reap unattended reviewer after {Reason}.", reason);
         }
     }
 
@@ -1818,9 +1826,18 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // throwing owner callback can neither run under the lock nor strand waiters, and teardown still
         // runs against the successor-consistent `installed` captured above.
         try {
-            ownerCts?.Cancel();
+            // INDEPENDENTLY guarded (Bug 1): the owner cancel and _cts.CancelAsync() each run a
+            // cancellation callback that can throw (the whole reason finding 2 exists). Their faults
+            // must not skip the worker-unblock below — cancelling _cts AND completing _pendingTurns are
+            // exactly the two signals RunTurnWorkerAsync exits on (it parks on
+            // _pendingTurns.WaitToReadAsync(_cts.Token)); skipping them would leave the worker parked
+            // while the guaranteed teardown disposes its connection/process out from under it.
+            try { ownerCts?.Cancel(); }
+            catch (Exception ex) { _logger.LogDebug(ex, "ACP: owner cancel faulted during dispose for agent {AgentId}.", _agentId); }
 
-            await _cts.CancelAsync().ConfigureAwait(false);
+            try { await _cts.CancelAsync().ConfigureAwait(false); }
+            catch (Exception ex) { _logger.LogDebug(ex, "ACP: shutdown-token cancel faulted during dispose for agent {AgentId}.", _agentId); }
+
             _updates.Writer.TryComplete();
             _pendingTurns.Writer.TryComplete();
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -332,6 +332,41 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// </summary>
     internal TerminationVerdict? ReadVerdict() { lock (_reapLock) return Verdict; }
 
+    /// <summary>Test-only: invoked inside <see cref="TryInitiateNonFailureStatusSend"/> BETWEEN the
+    /// verdict check and the send initiation, while <see cref="_reapLock"/> is held — so a test can
+    /// prove a concurrent verdict publication cannot interleave there. Null in production.</summary>
+    internal Action? BeforeGatedSendHookForTest;
+
+    /// <summary>
+    /// ATOMICALLY, under <see cref="_reapLock"/> (the gate <see cref="TryStartReap"/> publishes the
+    /// verdict under): checks for a published launch-window verdict AND, if none, INITIATES
+    /// <paramref name="send"/> (finding-2 refinement). Verdict publication therefore cannot interleave
+    /// between the check and the send's initiation — either publication wins the lock first (this
+    /// returns <see langword="false"/>, nothing is sent), or <paramref name="send"/> is invoked before
+    /// the lock is released.
+    ///
+    /// <para><b>Ordering.</b> <paramref name="send"/> is <c>ServerConnection.AgentStatusChangedAsync</c>
+    /// → <c>HubConnection.InvokeAsync</c>, whose synchronous prefix enters the SignalR connection
+    /// send-semaphore (FIFO) before its first await — so the non-failure frame is queued while this
+    /// lock is still held, strictly before any <c>LaunchFailed</c> the finalizer can only send AFTER
+    /// publication (which needs this lock). On the single ordered hub connection the server processes
+    /// the non-failure status BEFORE the LaunchFailed and ends Failed+reason — never a non-failure
+    /// clear. <paramref name="sendTask"/> is the in-flight send so the caller can await COMPLETION
+    /// (the server round-trip) OUTSIDE the lock; the lock is only held across INITIATION.</para>
+    /// </summary>
+    internal bool TryInitiateNonFailureStatusSend(Func<Task> send, out Task sendTask) {
+        lock (_reapLock) {
+            if (Verdict is { ReapedInsideLaunchWindow: true }) {
+                sendTask = Task.CompletedTask;
+                return false;
+            }
+
+            BeforeGatedSendHookForTest?.Invoke();
+            sendTask = send();
+            return true;
+        }
+    }
+
     /// <summary>
     /// Claims the single reap slot and, on success, publishes the fused <see cref="TerminationVerdict"/>.
     /// The claim, the launch-window snapshot, and the publication all happen under ONE lock, and
@@ -417,6 +452,12 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// settle it directly — simulating a reap's own cancel — without driving a real turn through the
     /// connection. Never touched by production code.</summary>
     internal TaskCompletionSource FirstTurnSettledForTest => _firstTurnSettled;
+
+    /// <summary>Test-only: the runtime's shutdown token, so a test can register a THROWING
+    /// cancellation callback and fault <see cref="DisposeAsync"/>'s early cancellation phase
+    /// (<c>_cts.CancelAsync()</c>) — proving the guaranteed-teardown path still disposes the child
+    /// (finding 2). Never touched by production code.</summary>
+    internal CancellationToken RuntimeShutdownTokenForTest => _cts.Token;
 
     /// <summary>Agent capabilities negotiated by <see cref="StartAsync"/>'s <c>initialize</c> call; null before that.</summary>
     AgentCapabilities? _negotiatedCapabilities;
@@ -1696,78 +1737,97 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
+        // Captured up front so the GUARANTEED-TEARDOWN section below can reach the child even if the
+        // early cancellation phase faults (finding 2): _disposed is already latched, so a leaked
+        // child/streams could never be retried. _installed is refined under the lock for a consistent
+        // snapshot, but this top read is what keeps `installed` definitely-assigned on the fault path.
+        var installed = _installed;
+
         // Only emit the session-ended lifecycle event when a session actually started — a startup
         // failure (bad protocol version / handshake / session/new) disposes the runtime before
         // _sessionId is assigned, and pairing "ended" with a session that never started would make
-        // the lifecycle telemetry incoherent.
-        if (_sessionId is { Length: > 0 } endedSessionId)
-            LogSessionEnded(_agentId, endedSessionId);
-
-        // Intentional stop is marked FIRST (reconnect spec §9): a concurrent crash cannot
-        // resurrect a disposing runtime, an in-flight owner's next checkpoint unwinds, and the
-        // send gate opens into the terminal path so a parked worker never waits on a gate nobody
-        // will reopen.
-        Incarnation installed;
-        List<PendingInteraction>? swept;
-
-        lock (_reconnectLock) {
-            _intentionalStop = true;
-            _phase           = (int)RuntimePhase.Terminal;
-            _ownerCts?.Cancel();
-            swept     = MarkPendingInteractionsCancelledLocked();
-            installed = _installed;
-            _gateOpen.TrySetResult();
+        // the lifecycle telemetry incoherent. Contained: a logging fault must not skip teardown.
+        if (_sessionId is { Length: > 0 } endedSessionId) {
+            try { LogSessionEnded(_agentId, endedSessionId); }
+            catch (Exception ex) { _logger.LogDebug(ex, "ACP: session-ended log failed during dispose for agent {AgentId}.", _agentId); }
         }
 
-        ScheduleInteractionSweep(swept);
-        _runtimeTerminal.TrySetResult();
-
-        installed.Connection.OnNotification -= HandleNotification;
-
-        await _cts.CancelAsync().ConfigureAwait(false);
-        _updates.Writer.TryComplete();
-        _pendingTurns.Writer.TryComplete();
-
-        // Best-effort, bounded: the owner's own finally disposes any candidate it still holds; a
-        // stuck owner must never hang dispose.
-        try {
-            await _ownerTask.WaitAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
-        } catch {
-            // Best-effort.
-        }
-
-        // The turn worker's in-flight SendPromptAsync await is keyed off _cts.Token via
-        // AcpConnection.RequestAsync's own cancellation registration, so cancelling _cts above
-        // already unblocks it — ProcessAdmittedTurnAsync's own `finally` still runs a courtesy flush of that
-        // turn's partial buffer (see FlushOpenRun) before the worker loop observes the cancellation
-        // and returns. This is just a bounded wait for that to actually happen.
-        try {
-            await _turnWorkerTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-        } catch {
-            // Best-effort — a stuck turn worker must never hang dispose.
-        }
-
-        // Session-end flush: a belt-and-suspenders flush of any still-open aggregation run. In the
-        // normal shutdown path ProcessAdmittedTurnAsync's own finally already flushed the active turn's
-        // buffer above, making this a no-op — it only matters for the (currently unreachable in
-        // practice) case where the worker task itself never ran a turn to begin with.
-        FlushOpenRun();
-        _transcript.Writer.TryComplete();
-
-        try {
-            await installed.LoopTask.ConfigureAwait(false);
-        } catch (OperationCanceledException) {
-            // expected shutdown path
-        }
-
-        _cts.Dispose();
-
-        // In a finally, because _disposed is latched at the top: if connection or process disposal
-        // faults, a retry returns immediately and the callback would never run at all. For the Kiro
-        // reviewer that callback deletes the transcript-bearing home, so skipping it on a faulted
-        // teardown is precisely the leak this hook exists to close.
         // Set false only when the child's exit could not be confirmed — see below.
         var cleanupSafe = true;
+
+        // ── Early phase: mark terminal, cancel, drain workers ── CONTAINED (finding 2). A throwing
+        // cancellation callback on _ownerCts/_cts (cancellation callbacks can throw) would otherwise
+        // abort DisposeAsync here, BEFORE the reap wait + connection/process disposal below, leaking
+        // the child and its streams with no possible retry (the _disposed latch is already set).
+        try {
+            // Intentional stop is marked FIRST (reconnect spec §9): a concurrent crash cannot
+            // resurrect a disposing runtime, an in-flight owner's next checkpoint unwinds, and the
+            // send gate opens into the terminal path so a parked worker never waits on a gate nobody
+            // will reopen.
+            List<PendingInteraction>? swept;
+
+            lock (_reconnectLock) {
+                _intentionalStop = true;
+                _phase           = (int)RuntimePhase.Terminal;
+                _ownerCts?.Cancel();
+                swept     = MarkPendingInteractionsCancelledLocked();
+                installed = _installed;
+                _gateOpen.TrySetResult();
+            }
+
+            ScheduleInteractionSweep(swept);
+            _runtimeTerminal.TrySetResult();
+
+            installed.Connection.OnNotification -= HandleNotification;
+
+            await _cts.CancelAsync().ConfigureAwait(false);
+            _updates.Writer.TryComplete();
+            _pendingTurns.Writer.TryComplete();
+
+            // Best-effort, bounded: the owner's own finally disposes any candidate it still holds; a
+            // stuck owner must never hang dispose.
+            try {
+                await _ownerTask.WaitAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+            } catch {
+                // Best-effort.
+            }
+
+            // The turn worker's in-flight SendPromptAsync await is keyed off _cts.Token via
+            // AcpConnection.RequestAsync's own cancellation registration, so cancelling _cts above
+            // already unblocks it — ProcessAdmittedTurnAsync's own `finally` still runs a courtesy flush of that
+            // turn's partial buffer (see FlushOpenRun) before the worker loop observes the cancellation
+            // and returns. This is just a bounded wait for that to actually happen.
+            try {
+                await _turnWorkerTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            } catch {
+                // Best-effort — a stuck turn worker must never hang dispose.
+            }
+
+            // Session-end flush: a belt-and-suspenders flush of any still-open aggregation run. In the
+            // normal shutdown path ProcessAdmittedTurnAsync's own finally already flushed the active turn's
+            // buffer above, making this a no-op — it only matters for the (currently unreachable in
+            // practice) case where the worker task itself never ran a turn to begin with.
+            FlushOpenRun();
+            _transcript.Writer.TryComplete();
+
+            try {
+                await installed.LoopTask.ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+                // expected shutdown path
+            }
+
+            _cts.Dispose();
+        } catch (Exception ex) {
+            // The early cancellation/drain phase faulted — proceed to the guaranteed teardown below
+            // regardless, so the child and its streams are still disposed (finding 2).
+            _logger.LogDebug(ex, "ACP: dispose early phase faulted; proceeding to guaranteed teardown for agent {AgentId}.", _agentId);
+        }
+
+        // ── Guaranteed teardown: ALWAYS reached, even when the early phase above faulted (finding 2).
+        // In a finally-equivalent position because _disposed is latched at the top: if connection or
+        // process disposal faults, a retry returns immediately and the callback would never run at
+        // all. For the Kiro reviewer that callback deletes the transcript-bearing home, so skipping it
+        // on a faulted teardown is precisely the leak this hook exists to close.
 
         // UNCONDITIONAL, independent of _onDisposed: a claimed reap's Verdict is published
         // synchronously at claim time (TryStartReap), but "post-disposal the verdict is final" also

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -1762,10 +1762,13 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 // ignores its own timeout must not be able to wedge disposal outright. A reap that
                 // won't settle is a "didn't confirm" signal, not a reason to hang teardown.
                 await reap.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-            } catch {
-                // Already logged by the reap; a timeout here logs nothing further for the same reason
-                // the exit-confirmation wait below doesn't escalate past Debug — this is a bound, not
-                // a new failure class.
+            } catch (Exception ex) {
+                // The reap's OWN outcome is already logged; this is a SEPARATE, symmetric Debug
+                // line for the bound itself (matching the exit-confirmation wait below, which also
+                // never escalates past Debug) — a reap that hasn't settled within 5s during
+                // disposal is a real anomaly worth a daemon-log line, not a reason to hang or fault
+                // teardown.
+                _logger.LogDebug(ex, "ACP: reap task did not settle before disposal completed.");
             }
         }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -459,6 +459,37 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// (finding 2). Never touched by production code.</summary>
     internal CancellationToken RuntimeShutdownTokenForTest => _cts.Token;
 
+    /// <summary>Test-only: invoked in <see cref="DisposeAsync"/> IMMEDIATELY before it takes
+    /// <see cref="_reconnectLock"/> — the exact window a round-2 pre-lock incarnation read left open —
+    /// so a test can commit a reconnect successor there and prove the guaranteed teardown disposes the
+    /// SUCCESSOR (finding 2, round 3), not a stale predecessor. Null in production.</summary>
+    internal Action? BeforeReconnectLockOnDisposeForTest;
+
+    /// <summary>Test-only: the logical-terminal signal, so a test can assert it fired even when the
+    /// early cancellation phase faulted (parked read/finalizer waiters must not be stranded — finding
+    /// 2, round 3). Never touched by production code.</summary>
+    internal Task RuntimeTerminalForTest => _runtimeTerminal.Task;
+
+    /// <summary>Test-only: installs a throwing owner CTS so <see cref="DisposeAsync"/>'s owner-cancel
+    /// (the EARLY cancellation callback) faults. Never touched by production code.</summary>
+    internal void SetOwnerCtsForTest(CancellationTokenSource cts) { lock (_reconnectLock) _ownerCts = cts; }
+
+    /// <summary>Test-only: commits a reconnect SUCCESSOR incarnation (swaps <see cref="_installed"/> to
+    /// a fresh incarnation wrapping <paramref name="successorProcess"/>, reusing the current
+    /// connection), simulating a reconnect that committed between a pre-lock read and the lock. The
+    /// guaranteed teardown must dispose THIS successor, not the predecessor. Never touched by
+    /// production code.</summary>
+    internal void CommitSuccessorIncarnationForTest(IAcpProcess successorProcess) {
+        lock (_reconnectLock) {
+            _installed = new Incarnation {
+                Id         = Interlocked.Increment(ref _nextIncarnationId),
+                Connection = _installed.Connection,
+                Process    = successorProcess,
+                LoopCts    = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token)
+            };
+        }
+    }
+
     /// <summary>Agent capabilities negotiated by <see cref="StartAsync"/>'s <c>initialize</c> call; null before that.</summary>
     AgentCapabilities? _negotiatedCapabilities;
 
@@ -1737,12 +1768,6 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
-        // Captured up front so the GUARANTEED-TEARDOWN section below can reach the child even if the
-        // early cancellation phase faults (finding 2): _disposed is already latched, so a leaked
-        // child/streams could never be retried. _installed is refined under the lock for a consistent
-        // snapshot, but this top read is what keeps `installed` definitely-assigned on the fault path.
-        var installed = _installed;
-
         // Only emit the session-ended lifecycle event when a session actually started — a startup
         // failure (bad protocol version / handshake / session/new) disposes the runtime before
         // _sessionId is assigned, and pairing "ended" with a session that never started would make
@@ -1755,30 +1780,45 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // Set false only when the child's exit could not be confirmed — see below.
         var cleanupSafe = true;
 
-        // ── Early phase: mark terminal, cancel, drain workers ── CONTAINED (finding 2). A throwing
-        // cancellation callback on _ownerCts/_cts (cancellation callbacks can throw) would otherwise
-        // abort DisposeAsync here, BEFORE the reap wait + connection/process disposal below, leaking
-        // the child and its streams with no possible retry (the _disposed latch is already set).
+        BeforeReconnectLockOnDisposeForTest?.Invoke();
+
+        // Capture the CURRENT incarnation + owner AND publish the terminal/gate signals BEFORE any
+        // throwing cancellation callback (finding 2, round 3). A fault in the owner-cancel below must
+        // neither (a) select a STALE incarnation — leaking a reconnect successor committed since (a
+        // successor can no longer be committed once _intentionalStop is set here: TryCommit throws
+        // under this SAME lock) — nor (b) skip _gateOpen / the interaction sweep / _runtimeTerminal,
+        // which unpark parked send/read/finalizer work. So `installed` is assigned ONLY under the lock
+        // (never a pre-lock read that a Cancel throw could strand), and every signal fires before the
+        // cancel.
+        //
+        // Intentional stop is marked FIRST (reconnect spec §9): a concurrent crash cannot resurrect a
+        // disposing runtime, an in-flight owner's next checkpoint unwinds, and the send gate opens into
+        // the terminal path so a parked worker never waits on a gate nobody will reopen.
+        Incarnation installed;
+        CancellationTokenSource? ownerCts;
+        List<PendingInteraction>? swept;
+
+        lock (_reconnectLock) {
+            _intentionalStop = true;
+            _phase           = (int)RuntimePhase.Terminal;
+            installed        = _installed; // successor-consistent: the CURRENT incarnation, final under _intentionalStop
+            ownerCts         = _ownerCts;  // captured to cancel OUTSIDE the lock, below
+            swept            = MarkPendingInteractionsCancelledLocked();
+            _gateOpen.TrySetResult();
+        }
+
+        ScheduleInteractionSweep(swept);
+        _runtimeTerminal.TrySetResult();
+        installed.Connection.OnNotification -= HandleNotification;
+
+        // ── Early cancellation/drain phase ── CONTAINED (finding 2). The owner cancel and
+        // _cts.CancelAsync() run cancellation callbacks that can throw; a fault must not skip the
+        // guaranteed teardown below (the child/streams would leak with the _disposed latch set). The
+        // owner is cancelled here — OUTSIDE _reconnectLock and AFTER the terminal/gate signals — so a
+        // throwing owner callback can neither run under the lock nor strand waiters, and teardown still
+        // runs against the successor-consistent `installed` captured above.
         try {
-            // Intentional stop is marked FIRST (reconnect spec §9): a concurrent crash cannot
-            // resurrect a disposing runtime, an in-flight owner's next checkpoint unwinds, and the
-            // send gate opens into the terminal path so a parked worker never waits on a gate nobody
-            // will reopen.
-            List<PendingInteraction>? swept;
-
-            lock (_reconnectLock) {
-                _intentionalStop = true;
-                _phase           = (int)RuntimePhase.Terminal;
-                _ownerCts?.Cancel();
-                swept     = MarkPendingInteractionsCancelledLocked();
-                installed = _installed;
-                _gateOpen.TrySetResult();
-            }
-
-            ScheduleInteractionSweep(swept);
-            _runtimeTerminal.TrySetResult();
-
-            installed.Connection.OnNotification -= HandleNotification;
+            ownerCts?.Cancel();
 
             await _cts.CancelAsync().ConfigureAwait(false);
             _updates.Writer.TryComplete();

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -435,12 +435,21 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// <c>internal</c> (not the class's usual private default) so
     /// <see cref="AcpHostedAgentRuntimeFactory"/>, a different class in the same namespace, has ONE
     /// sanitizer to call for its own transport-cause truncation rather than a byte-for-byte
-    /// duplicate — the two must never drift, and a fix to this one (e.g. never splitting a Unicode
-    /// surrogate pair at the boundary) must reach every caller.
+    /// duplicate — the two must never drift, and this fix (never splitting a Unicode surrogate pair
+    /// at the boundary) reaches every caller.
     /// </summary>
     internal static string SanitizeForForward(string message, int maxLength = 500) {
         var oneLine = message.ReplaceLineEndings(" ").Trim();
-        return oneLine.Length <= maxLength ? oneLine : oneLine[..maxLength] + "…";
+        if (oneLine.Length <= maxLength) return oneLine;
+
+        // A raw code-unit slice at maxLength can land between a surrogate pair's two halves. Back
+        // off one position when that would happen so the cut only ever falls on a whole character —
+        // never grow past the cap to include the pair instead. cut > 0 guards the maxLength <= 0
+        // edge (nothing to back off from; falls through to the pre-fix substring behavior).
+        var cut = maxLength;
+        if (cut > 0 && char.IsHighSurrogate(oneLine[cut - 1])) cut--;
+
+        return oneLine[..cut] + "…";
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -297,17 +297,41 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     Task? _reapTask;
     readonly object _reapLock = new();
 
+    /// <summary>The reap claim's fused, immutable outcome: the writer's coded reason (sanitized —
+    /// see <see cref="TryStartReap"/>) plus whether the claim landed while the launch window
+    /// (<see cref="_firstTurnSettled"/>) was still open. Published at most once, by whichever reap
+    /// wins the claim.</summary>
+    public sealed record TerminationVerdict(string Reason, bool ReapedInsideLaunchWindow);
+
+    /// <summary>Null until a reap wins the claim (and forever null if none ever does, or the sole
+    /// claim's starter throws). Read by the orchestrator to reclassify a launch/registration failure
+    /// with the daemon's coded reason instead of surfacing as an unknown failure.</summary>
+    public TerminationVerdict? Verdict { get; private set; }
+
     /// <summary>
-    /// Claims the single reap slot. The claim and the later publication happen under ONE lock, and
+    /// Claims the single reap slot and, on success, publishes the fused <see cref="TerminationVerdict"/>.
+    /// The claim, the launch-window snapshot, and the publication all happen under ONE lock, and
     /// <see cref="TakeReap"/> waits on that same lock — so a disposal can no longer land in the gap
-    /// between "the guard flipped" and "the task exists" and conclude there is nothing to await.
-    /// An interlocked flag alone cannot express that, because the two steps are not one operation.
+    /// between "the guard flipped" and "the task/verdict exist" and conclude there is nothing to
+    /// await or classify. An interlocked flag alone cannot express that, because these are not one
+    /// operation.
+    ///
+    /// <para><paramref name="reason"/> is the writer's raw coded string — sanitized here (single-line
+    /// + length-capped via <see cref="SanitizeForForward"/>) before publication, since it can carry
+    /// agent-controlled text (e.g. a JSON-RPC method from an inbound frame). The window bit is
+    /// snapshotted from <see cref="_firstTurnSettled"/> BEFORE <paramref name="start"/> runs: the
+    /// reap's own <c>_cts.Cancel()</c> settles that marker in <see cref="ProcessAdmittedTurnAsync"/>'s
+    /// <c>finally</c>, so reading it after <paramref name="start"/> has run would be
+    /// self-contaminating — every claimed reap would read "settled" regardless of when it actually
+    /// fired.</para>
     /// </summary>
-    bool TryStartReap(Func<Task> start) {
+    internal bool TryStartReap(string reason, Func<Task> start) {
         lock (_reapLock) {
             if (_reapClaimed) return false;
 
             _reapClaimed = true;
+
+            var insideLaunchWindow = !_firstTurnSettled.Task.IsCompleted;
 
             // Started AND published inside the lock: claiming, releasing, then publishing leaves the
             // gap this exists to close — a disposal taking the lock in between sees a claim with no
@@ -316,7 +340,8 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // The callback runs SYNCHRONOUS work first (logging, _cts.Cancel()), so it can throw —
             // notably when a dispatched notification races disposal past _cts.Dispose(). Unwinding
             // out of here would release the lock with the slot claimed and no task published, which
-            // is precisely the prohibited state. So the claim is released on failure.
+            // is precisely the prohibited state. So the claim is released on failure — and the
+            // verdict below is never reached, so nothing is published for this claim.
             try {
                 _reapTask = start();
             } catch {
@@ -324,13 +349,15 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 throw;
             }
 
+            Verdict = new TerminationVerdict(SanitizeForForward(reason), insideLaunchWindow);
+
             return true;
         }
     }
 
     /// <summary>The in-flight reap, or null when none was ever claimed. A claim with no task yet
     /// published cannot be observed: the claimant publishes before releasing the caller.</summary>
-    Task? TakeReap() { lock (_reapLock) return _reapTask; }
+    internal Task? TakeReap() { lock (_reapLock) return _reapTask; }
 
     bool _reapClaimed;
 
@@ -356,8 +383,16 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     int _sawFirstUpdate;
 
     /// <summary>Completes when the first turn ends, however it ends — the other way to disarm the
-    /// first-output watchdog.</summary>
+    /// first-output watchdog. Also the launch-window marker <see cref="TryStartReap"/> snapshots
+    /// (design spec §3.3): the window is open from spawn until this settles. An empty/absent initial
+    /// prompt settles it directly at <see cref="StartAsync"/>'s completion (see that method's tail)
+    /// — a deterministic backstop, since no turn ever runs to settle it otherwise.</summary>
     readonly TaskCompletionSource _firstTurnSettled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Test-only: the SAME instance <see cref="TryStartReap"/> snapshots, so a test can
+    /// settle it directly — simulating a reap's own cancel — without driving a real turn through the
+    /// connection. Never touched by production code.</summary>
+    internal TaskCompletionSource FirstTurnSettledForTest => _firstTurnSettled;
 
     /// <summary>Agent capabilities negotiated by <see cref="StartAsync"/>'s <c>initialize</c> call; null before that.</summary>
     AgentCapabilities? _negotiatedCapabilities;
@@ -509,7 +544,8 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // TRACKED, not fire-and-forget. Disposal deletes the reviewer's transcript-bearing home, and
         // doing that while an in-flight reap has not confirmed the child is gone would leave a live
         // reviewer writing into a deleted path — and recreating it.
-        if (!TryStartReap(() => {
+        // The violation forwards VERBATIM as the published verdict's coded reason.
+        if (!TryStartReap(violation, () => {
                 _logger.LogError("ACP: reaping unattended reviewer — {Violation}", violation);
                 _cts.Cancel();
 
@@ -524,7 +560,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // Reap out-of-band and cancel both runtime workers immediately.
         // Same channel as the violation path: this is the SAME termination, so disposal must wait on
         // it too. Leaving either untracked would reintroduce the race for whichever path fired.
-        if (!TryStartReap(() => {
+        if (!TryStartReap($"unattended_interaction_forbidden:{method}", () => {
                 _cts.Cancel();
 
                 return ReapUnexpectedInteractionAsync(method);
@@ -834,6 +870,12 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         if (!string.IsNullOrEmpty(initialPrompt)) {
             _ = EnqueueTurn(initialPrompt, acknowledgeWrite: false);
             ArmFirstOutputWatchdog();
+        } else {
+            // Deterministic backstop (design spec §3.3): no turn will ever run to settle the marker
+            // via ProcessAdmittedTurnAsync when the launch carries no initial prompt — reviewer
+            // launches always carry one, but the window still needs a defined close for any launch
+            // that doesn't, or a later reap would misclassify as still inside it forever.
+            _firstTurnSettled.TrySetResult();
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -305,8 +305,32 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
     /// <summary>Null until a reap wins the claim (and forever null if none ever does, or the sole
     /// claim's starter throws). Read by the orchestrator to reclassify a launch/registration failure
-    /// with the daemon's coded reason instead of surfacing as an unknown failure.</summary>
+    /// with the daemon's coded reason instead of surfacing as an unknown failure.
+    ///
+    /// <para>The plain auto-property is safe only for a reader that CANNOT race a concurrent claim —
+    /// the factory's launch path, which reads it strictly after an ordered
+    /// <see cref="DisposeAsync"/> that already awaited the reap. The orchestrator's finalizer CAN race
+    /// the claim (the reap's own <c>_cts.Cancel()</c> drives finalization on another thread while the
+    /// claimant still holds <see cref="_reapLock"/> and this is still null), so it must read through
+    /// <see cref="ReadVerdict"/> instead.</para></summary>
     public TerminationVerdict? Verdict { get; private set; }
+
+    /// <summary>
+    /// The verdict, observed UNDER <see cref="_reapLock"/> — so a reader that can race a concurrent
+    /// claim blocks until the claimant has committed the publish (or observes the absence of any
+    /// claim), never the transient window where the slot is claimed but <see cref="Verdict"/> is not
+    /// yet assigned (finding 1). <see cref="TryStartReap"/> publishes the verdict at the tail of the
+    /// SAME critical section that claims the slot and runs the (connection-cancelling) starter, so a
+    /// finalizer reading the plain auto-property mid-claim would see null and skip
+    /// <c>LaunchFailed</c> permanently.
+    ///
+    /// <para><b>No deadlock:</b> the starter returns the reap Task WITHOUT awaiting termination (it
+    /// runs only synchronous log + <c>_cts.Cancel()</c> work before the first await inside
+    /// <see cref="ReapUnexpectedInteractionAsync"/>), so the claimant releases <see cref="_reapLock"/>
+    /// promptly and never itself waits on any finalizer — the lock is only ever held for that bounded
+    /// synchronous burst.</para>
+    /// </summary>
+    internal TerminationVerdict? ReadVerdict() { lock (_reapLock) return Verdict; }
 
     /// <summary>
     /// Claims the single reap slot and, on success, publishes the fused <see cref="TerminationVerdict"/>.

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -338,7 +338,14 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     internal Action? BeforeReadVerdictLockForTest;
 
     internal TerminationVerdict? ReadVerdict() {
-        BeforeReadVerdictLockForTest?.Invoke();
+        // GUARDED: the hook is a fire-and-forget TEST signal (null in production). ReadVerdict is a
+        // load-bearing PRODUCTION read — the finalizer calls it to decide whether to send LaunchFailed
+        // for a launch-window reap — so a throwing hook (test contamination / a stray assignment) must
+        // never make it throw and skip the verdict observation. It still FIRES before the lock (the
+        // barrier's happy-path hook never throws), it just can't break the read.
+        try { BeforeReadVerdictLockForTest?.Invoke(); }
+        catch (Exception ex) { _logger.LogDebug(ex, "ACP: BeforeReadVerdictLockForTest hook threw; continuing to read the verdict."); }
+
         lock (_reapLock) return Verdict;
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -330,7 +330,17 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// promptly and never itself waits on any finalizer — the lock is only ever held for that bounded
     /// synchronous burst.</para>
     /// </summary>
-    internal TerminationVerdict? ReadVerdict() { lock (_reapLock) return Verdict; }
+    /// <summary>Test-only: fires at the TOP of <see cref="ReadVerdict"/>, before the lock — lets the
+    /// finding-1 barrier detect, deterministically, that the finalizer took the SYNCHRONISED read path
+    /// and is about to block on <see cref="_reapLock"/> (vs. the regressed plain-<see cref="Verdict"/>
+    /// read, which never calls this). That removes any wall-clock hold from the barrier. Null in
+    /// production (a single null check per read).</summary>
+    internal Action? BeforeReadVerdictLockForTest;
+
+    internal TerminationVerdict? ReadVerdict() {
+        BeforeReadVerdictLockForTest?.Invoke();
+        lock (_reapLock) return Verdict;
+    }
 
     /// <summary>Test-only: invoked inside <see cref="TryInitiateNonFailureStatusSend"/> BETWEEN the
     /// verdict check and the send initiation, while <see cref="_reapLock"/> is held — so a test can
@@ -713,8 +723,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             await _installed.Process.TerminateAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
         } catch (Exception ex) {
             // Bug 4: callers now pass the full coded reap reason / monitor violation, not a bare
-            // JSON-RPC method — label it {Reason}, not {Method}.
-            _logger.LogDebug(ex, "ACP: failed to reap unattended reviewer after {Reason}.", reason);
+            // JSON-RPC method — label it {Reason}. Bug A: SANITIZED (single-line, length-bounded,
+            // surrogate-safe) because a coded reason embeds variable, agent-influenced content (MCP
+            // server names, a monitor's 'why' string) that can carry line breaks or run long and
+            // bloat this log line — the same normalization the forwarded verdict already uses.
+            _logger.LogDebug(ex, "ACP: failed to reap unattended reviewer after {Reason}.", SanitizeForForward(reason));
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -554,16 +554,22 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             return;
     }
 
-    void HandleUnexpectedUnattendedInteraction(string method) {
+    /// <summary>Wired as the bridge's reason-bearing reap callback (design spec §3.1) — <paramref
+    /// name="reason"/> arrives ALREADY CODED (<c>unattended_frame_unadmittable: …</c> or
+    /// <c>unattended_interaction_forbidden:{method}</c>; see <c>AcpInteractionBridge</c>'s
+    /// <c>unexpectedUnattendedInteraction</c> doc), so it forwards verbatim — same shape as <see
+    /// cref="HandleMcpSurfaceViolation"/> forwarding its own <c>violation</c> text, and no longer
+    /// re-derives the forbidden-method coding itself now that the bridge owns both codings.</summary>
+    void HandleUnexpectedUnattendedInteraction(string reason) {
         // Do not await process termination on AcpConnection's read loop: that loop is currently
         // handling the offending request, and the child may wait for its response before exiting.
         // Reap out-of-band and cancel both runtime workers immediately.
         // Same channel as the violation path: this is the SAME termination, so disposal must wait on
         // it too. Leaving either untracked would reintroduce the race for whichever path fired.
-        if (!TryStartReap($"unattended_interaction_forbidden:{method}", () => {
+        if (!TryStartReap(reason, () => {
                 _cts.Cancel();
 
-                return ReapUnexpectedInteractionAsync(method);
+                return ReapUnexpectedInteractionAsync(reason);
             }))
             return;
     }

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -432,8 +432,13 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// <c>error.message</c> (via <see cref="AcpRpcException"/>), which could otherwise be arbitrarily
     /// long or multi-line and degrade logs/UI downstream. The full original exception is retained as
     /// the thrown exception's <c>InnerException</c>, so nothing is lost for daemon-side diagnostics.
+    /// <c>internal</c> (not the class's usual private default) so
+    /// <see cref="AcpHostedAgentRuntimeFactory"/>, a different class in the same namespace, has ONE
+    /// sanitizer to call for its own transport-cause truncation rather than a byte-for-byte
+    /// duplicate — the two must never drift, and a fix to this one (e.g. never splitting a Unicode
+    /// surrogate pair at the boundary) must reach every caller.
     /// </summary>
-    static string SanitizeForForward(string message, int maxLength = 500) {
+    internal static string SanitizeForForward(string message, int maxLength = 500) {
         var oneLine = message.ReplaceLineEndings(" ").Trim();
         return oneLine.Length <= maxLength ? oneLine : oneLine[..maxLength] + "…";
     }
@@ -1740,7 +1745,19 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // null, which is a Kiro/OpenCode-only concern (the isolated-home cleanup hook) that has
         // nothing to do with whether a reap needs awaiting.
         if (TakeReap() is { } reap) {
-            try { await reap.ConfigureAwait(false); } catch { /* already logged by the reap */ }
+            try {
+                // Bounded defensively, same rationale and value as the exit-confirmation wait below:
+                // production reap tasks bottom out in AcpChildProcess.TerminateAsync, which is
+                // self-bounded (2-5s callers), so this isn't live today — but the await is now
+                // unconditional for every vendor, and a future/test IAcpProcess whose TerminateAsync
+                // ignores its own timeout must not be able to wedge disposal outright. A reap that
+                // won't settle is a "didn't confirm" signal, not a reason to hang teardown.
+                await reap.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            } catch {
+                // Already logged by the reap; a timeout here logs nothing further for the same reason
+                // the exit-confirmation wait below doesn't escalate past Debug — this is a bound, not
+                // a new failure class.
+            }
         }
 
         // BEFORE disposing anything, when the child is still observable. AcpChildProcess.HasExited

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -164,72 +164,89 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         var connLogger    = loggerFactory.CreateLogger<AcpConnection>();
 
         var (input, output, acpProcess) = _connectionSource(ctx);
-        var acpConnection = new AcpConnection(input, output, connLogger, config.DebugFrames);
 
-        // Reconnect eligibility (reconnect spec §4), decided at construction: probe-verified
-        // vendor AND an interactive launch AND the kill switch off. The remaining conjuncts
-        // (advertised loadSession, the resume cap) are runtime facts the runtime itself gates on
-        // per incident. The spawn closure re-invokes THIS launch's connection source, so a
-        // candidate is spawned by the same code path — argv, env, cwd — as the original child, and
-        // carries no registration/forwarder/slot side effects (§6.2's pure-spawn contract).
-        var reconnect = descriptor.SupportsReconnectResume && !ctx.IsReviewFlow && config.AcpReconnectEnabled
-            ? new AcpReconnectSupport { Spawn = () => _connectionSource(ctx) }
-            : null;
-        // PidCallbacks defaults to AcpPidRecordCallbacks.Unwired — FAIL-CLOSED (code-review r1/r2):
-        // a crash landing in the orchestrator's wiring window fails its attempts (§6.2's
-        // record-before-any-handshake MUST) rather than proceeding with an unrecorded candidate,
-        // and the orchestrator replaces recorder+clearer in ONE atomic reference assignment so no
-        // partially-wired state is ever observable.
+        // Nullable: a post-spawn/pre-StartAsync construction failure below (acpConnection or the
+        // runtime itself) must still be able to tear down what THIS launch already obtained, even
+        // though no AcpHostedAgentRuntime exists yet to own that ordered cleanup. Widened region —
+        // design spec §3.2's "post-spawn/pre-protected-region construction failure currently leaks
+        // the child" fix.
+        AcpConnection? acpConnection = null;
+        AcpHostedAgentRuntime runtime;
 
-        // Spec-review Finding 4: real production wiring — every launch now gets the
-        // permission/elicitation bridge, not the default MethodNotFound/decline.
-        var runtime = new AcpHostedAgentRuntime(
-            acpConnection,
-            acpProcess,
-            runtimeLogger,
-            agentId: ctx.AgentId,
-            requestInteraction: connection.RequestAcpInteractionAsync,
-            // Drives the handshake's per-stage caps (RunHandshakeStageAsync), so a test's
-            // FakeTimeProvider controls them without a real 90-second wait.
-            timeProvider: _timeProvider,
-            debugFrames: config.DebugFrames,
-            vendor: descriptor.Vendor,
-            modelSelector: descriptor.ModelSelector,
-            unattendedInteractionPolicy: unattendedInteractionPolicy,
-            reconnect: reconnect,
-            // Built from the SAME spec list session/new receives, so the expected set is what was
-            // actually sent rather than a re-derivation of it.
-            mcpSurfaceMonitor: KiroMcpSurfaceMonitor.For(
-                descriptor, ctx.IsReviewFlow, reviewMcp, ctx.LaunchIdentity),
-            // NULL for every launch with nothing to clean up, rather than a lambda that no-ops
-            // internally: the runtime keys its ordered-teardown path (await the reap, confirm child
-            // exit) on this being non-null, so an always-supplied callback made every ACP launch of
-            // every vendor pay that wait. The factory can only clean up launches that FAILED, so a
-            // successful review's home needs this hook — it holds review context, and would
-            // otherwise survive until a later daemon epoch swept it.
-            onDisposed: ReviewerLaunchTimeoutSeconds(descriptor, config, ctx) is not null
-                ? (Action)(() => DeleteReviewerIsolatedDirectory(descriptor, config, ctx, _logger))
-                : null,
-            // The second half of the launch bound. The deadline below covers spawn through the
-            // handshake; StartAsync deliberately does NOT await the first turn, so a peer that
-            // completes initialize and then wedges on the credential path would otherwise be
-            // unbounded. Time-to-first-OUTPUT, never turn completion — a real review runs long.
-            firstOutputDeadline: ReviewerLaunchTimeoutSeconds(descriptor, config, ctx) is { } firstOutputSeconds
-                ? TimeSpan.FromSeconds(firstOutputSeconds)
-                : null,
-            // The set AllowlistedAutoApprove admits, built from the SAME injected specs and identity
-            // the trust argv is built from. Two derivations would let the reviewer be TRUSTED to call
-            // a tool the policy then refuses to approve — a round that dies on its own result call.
-            admittedToolIds: descriptor.UnattendedInteractionPolicy
-                                 == AcpUnattendedInteractionPolicy.AllowlistedAutoApprove
-                          && ctx.IsReviewFlow && reviewMcp is { Count: > 0 } && ctx.LaunchIdentity is { } id
-                ? UnattendedToolAdmission.AdmittedFor(reviewMcp, id)
-                : null
-        );
+        try {
+            acpConnection = new AcpConnection(input, output, connLogger, config.DebugFrames);
 
-        // MUST precede StartAsync below: the handshake's SetLaunchStage stamps are no-ops against a
-        // null clock, so a later assignment silently defeats every stage stamp for the whole launch.
-        runtime.ActivityClock = ctx.ActivityClock;
+            // Reconnect eligibility (reconnect spec §4), decided at construction: probe-verified
+            // vendor AND an interactive launch AND the kill switch off. The remaining conjuncts
+            // (advertised loadSession, the resume cap) are runtime facts the runtime itself gates on
+            // per incident. The spawn closure re-invokes THIS launch's connection source, so a
+            // candidate is spawned by the same code path — argv, env, cwd — as the original child, and
+            // carries no registration/forwarder/slot side effects (§6.2's pure-spawn contract).
+            var reconnect = descriptor.SupportsReconnectResume && !ctx.IsReviewFlow && config.AcpReconnectEnabled
+                ? new AcpReconnectSupport { Spawn = () => _connectionSource(ctx) }
+                : null;
+            // PidCallbacks defaults to AcpPidRecordCallbacks.Unwired — FAIL-CLOSED (code-review r1/r2):
+            // a crash landing in the orchestrator's wiring window fails its attempts (§6.2's
+            // record-before-any-handshake MUST) rather than proceeding with an unrecorded candidate,
+            // and the orchestrator replaces recorder+clearer in ONE atomic reference assignment so no
+            // partially-wired state is ever observable.
+
+            // Spec-review Finding 4: real production wiring — every launch now gets the
+            // permission/elicitation bridge, not the default MethodNotFound/decline.
+            runtime = new AcpHostedAgentRuntime(
+                acpConnection,
+                acpProcess,
+                runtimeLogger,
+                agentId: ctx.AgentId,
+                requestInteraction: connection.RequestAcpInteractionAsync,
+                // Drives the handshake's per-stage caps (RunHandshakeStageAsync), so a test's
+                // FakeTimeProvider controls them without a real 90-second wait.
+                timeProvider: _timeProvider,
+                debugFrames: config.DebugFrames,
+                vendor: descriptor.Vendor,
+                modelSelector: descriptor.ModelSelector,
+                unattendedInteractionPolicy: unattendedInteractionPolicy,
+                reconnect: reconnect,
+                // Built from the SAME spec list session/new receives, so the expected set is what was
+                // actually sent rather than a re-derivation of it.
+                mcpSurfaceMonitor: KiroMcpSurfaceMonitor.For(
+                    descriptor, ctx.IsReviewFlow, reviewMcp, ctx.LaunchIdentity),
+                // NULL for every launch with nothing to clean up, rather than a lambda that no-ops
+                // internally: the runtime keys its ordered-teardown path (await the reap, confirm child
+                // exit) on this being non-null, so an always-supplied callback made every ACP launch of
+                // every vendor pay that wait. The factory can only clean up launches that FAILED, so a
+                // successful review's home needs this hook — it holds review context, and would
+                // otherwise survive until a later daemon epoch swept it.
+                onDisposed: ReviewerLaunchTimeoutSeconds(descriptor, config, ctx) is not null
+                    ? (Action)(() => DeleteReviewerIsolatedDirectory(descriptor, config, ctx, _logger))
+                    : null,
+                // The second half of the launch bound. The deadline below covers spawn through the
+                // handshake; StartAsync deliberately does NOT await the first turn, so a peer that
+                // completes initialize and then wedges on the credential path would otherwise be
+                // unbounded. Time-to-first-OUTPUT, never turn completion — a real review runs long.
+                firstOutputDeadline: ReviewerLaunchTimeoutSeconds(descriptor, config, ctx) is { } firstOutputSeconds
+                    ? TimeSpan.FromSeconds(firstOutputSeconds)
+                    : null,
+                // The set AllowlistedAutoApprove admits, built from the SAME injected specs and identity
+                // the trust argv is built from. Two derivations would let the reviewer be TRUSTED to call
+                // a tool the policy then refuses to approve — a round that dies on its own result call.
+                admittedToolIds: descriptor.UnattendedInteractionPolicy
+                                     == AcpUnattendedInteractionPolicy.AllowlistedAutoApprove
+                              && ctx.IsReviewFlow && reviewMcp is { Count: > 0 } && ctx.LaunchIdentity is { } id
+                    ? UnattendedToolAdmission.AdmittedFor(reviewMcp, id)
+                    : null
+            );
+
+            // MUST precede StartAsync below: the handshake's SetLaunchStage stamps are no-ops against
+            // a null clock, so a later assignment silently defeats every stage stamp for the launch.
+            runtime.ActivityClock = ctx.ActivityClock;
+        } catch {
+            // No AcpHostedAgentRuntime was ever built (a throw here means construction never reached
+            // its own assignment) — nothing owns ordered teardown, so tear down directly whatever this
+            // launch DID already obtain rather than leaking the spawned child.
+            await DisposeUnclaimedSpawnAsync(acpConnection, acpProcess).ConfigureAwait(false);
+            throw;
+        }
 
         // Review flow: the injected result channel + allowlist. Otherwise unchanged (null today).
         var mcpServers = ctx.IsReviewFlow
@@ -305,7 +322,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
                 ResolveRequestedModel(descriptor, config, ctx),
                 mcpServers
             ).ConfigureAwait(false);
-        } catch (OperationCanceledException) when (launchDeadline is { IsCancellationRequested: true }
+        } catch (OperationCanceledException ex) when (launchDeadline is { IsCancellationRequested: true }
                                                 && !ct.IsCancellationRequested) {
             LogSurfaceOnceIfEstablished();
 
@@ -315,8 +332,8 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             // rather than just the coded error.
             try {
                 await acpProcess.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
-            } catch (Exception ex) {
-                _logger.LogDebug(ex,
+            } catch (Exception termEx) {
+                _logger.LogDebug(termEx,
                     "ACP: failed to reap {Vendor} reviewer after its launch deadline expired.", descriptor.Vendor);
             }
 
@@ -324,21 +341,33 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             // unlinked path. The directory holds review state, so this is disposal, not disk hygiene.
             // No explicit delete here: runtime.DisposeAsync runs the ordered cleanup (await the
             // reap, confirm exit, then delete), and deleting again afterwards would bypass exactly
-            // the exit-confirmed gate that ordering exists to enforce.
+            // the exit-confirmed gate that ordering exists to enforce. DisposeAsync now unconditionally
+            // awaits any claimed reap, so a Verdict checked immediately afterward is final.
             await runtime.DisposeAsync().ConfigureAwait(false);
+
+            // Design spec §3.2: the deadline catch consults the verdict IDENTICALLY to the general
+            // catch below — a reap racing the launch deadline must not bypass reclassification and
+            // surface the generic timeout text instead of the coded reason.
+            if (ReclassifyIfReaped(runtime, ex) is { } deadlineReclassified) throw deadlineReclassified;
 
             throw new InvalidOperationException(
                 $"{descriptor.Vendor}_reviewer_launch_timeout: the reviewer did not complete its first "
               + $"prompt within {ReviewerLaunchTimeoutSeconds(descriptor, config, ctx)}s. The child was "
               + $"terminated and its isolated directory removed. {ReviewerLaunchTimeoutHint(descriptor)}");
-        } catch {
+        } catch (Exception ex) {
             // An established session is a fact the record must keep even though the launch failed.
             LogSurfaceOnceIfEstablished();
 
             // The runtime owns both the connection and the process; dispose on a failed handshake
             // so a half-started child process is never leaked.
-            // As above: disposal owns the exit-confirmed deletion.
+            // As above: disposal owns the exit-confirmed deletion, and now unconditionally awaits any
+            // claimed reap first, so the Verdict check right after is never racing it.
             await runtime.DisposeAsync().ConfigureAwait(false);
+
+            // Design spec §3.2: the single reclassification seam — a published Verdict means this
+            // launch was reaped, and its coded reason becomes the exception's headline instead of
+            // whatever StartAsync actually threw. No verdict ⇒ ex propagates byte-identically.
+            if (ReclassifyIfReaped(runtime, ex) is { } reclassified) throw reclassified;
 
             throw;
         }
@@ -350,6 +379,84 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         // bind + forward without downcasting Runtime.
         return new HostedRuntimeStart(runtime, McpConfigPath: null, Transcript: runtime);
     }
+
+    /// <summary>
+    /// A reviewer launch reaped by a containment tripwire during <see cref="StartAsync"/> (design
+    /// spec §3.2) — the daemon's coded <see cref="AcpHostedAgentRuntime.TerminationVerdict"/>
+    /// reclassified as the launch failure's headline, with the transport-level cause folded in
+    /// parenthetically rather than lost. <see cref="Exception.InnerException"/> is whatever
+    /// <see cref="AcpHostedAgentRuntime.StartAsync"/> (or the launch deadline) actually threw, so
+    /// daemon-side diagnostics keep everything.
+    /// </summary>
+    internal sealed class AcpReviewerReapedException(string message, Exception inner)
+        : InvalidOperationException(message, inner);
+
+    /// <summary>
+    /// The single reclassification seam (design spec §3.2): after ordered disposal — which now
+    /// unconditionally awaits any claimed reap (<see cref="AcpHostedAgentRuntime.DisposeAsync"/>) — a
+    /// published <see cref="AcpHostedAgentRuntime.Verdict"/> means this launch was reaped, and its
+    /// coded reason becomes the exception's headline instead of whatever the caller actually caught.
+    /// Returns <see langword="null"/> when no verdict was ever published, so the caller's own
+    /// exception propagates completely untouched (byte-identical no-verdict path).
+    /// </summary>
+    static AcpReviewerReapedException? ReclassifyIfReaped(AcpHostedAgentRuntime runtime, Exception ex) =>
+        runtime.Verdict is { } verdict
+            ? new AcpReviewerReapedException($"{verdict.Reason} (transport: {DescribeTransportCause(ex)})", ex)
+            : null;
+
+    /// <summary>
+    /// The reclassified message's transport half: the sanitized handshake cause when
+    /// <see cref="AcpHostedAgentRuntime.StartAsync"/>'s own wrapper produced one, else the caught
+    /// exception's own (separately sanitized) message — covers every stage the wrapper doesn't reach,
+    /// namely model selection (never wrapped at all) and a launch deadline firing mid-RPC (whose
+    /// <see cref="OperationCanceledException"/> the wrapper deliberately never touches either).
+    /// </summary>
+    static string DescribeTransportCause(Exception ex) =>
+        (ex as AcpHostedAgentRuntime.AcpHandshakeFailedException)?.TransportMessage ?? Sanitize(ex.Message);
+
+    /// <summary>Single-lined + length-capped, mirroring <c>AcpHostedAgentRuntime.SanitizeForForward</c>
+    /// — duplicated rather than shared because the message sanitized here may never have passed
+    /// through that type at all (e.g. a raw transport exception escaping model selection).</summary>
+    static string Sanitize(string message, int maxLength = 500) {
+        var oneLine = message.ReplaceLineEndings(" ").Trim();
+        return oneLine.Length <= maxLength ? oneLine : oneLine[..maxLength] + "…";
+    }
+
+    /// <summary>
+    /// Disposes whatever a launch already obtained when no <see cref="AcpHostedAgentRuntime"/> was
+    /// ever built to own ordered teardown — the widened pre-StartAsync construction-failure guard's
+    /// cleanup unit (design spec §3.2: "a post-spawn/pre-protected-region construction failure
+    /// currently leaks the child"). Best-effort throughout: a launch that already failed must not be
+    /// masked by a cleanup fault. <paramref name="process"/> is terminated before either is disposed,
+    /// mirroring <see cref="AcpHostedAgentRuntime.DisposeAsync"/>'s own ordering (a reap is not a
+    /// disposal — releasing handles under a still-alive child just leaves it running).
+    /// </summary>
+    internal static async Task DisposeUnclaimedSpawnAsync(AcpConnection? connection, IAcpProcess? process) {
+        if (process is not null) {
+            try {
+                await process.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+            } catch {
+                // Best-effort — the launch's own construction failure is the error that matters.
+            }
+        }
+
+        if (connection is not null)
+            await connection.DisposeAsync().ConfigureAwait(false);
+
+        if (process is not null)
+            await process.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Design spec §3.5's non-empty-reason fallback formula: <c>launch_failed:{exception type name}
+    /// — see daemon log</c> for a null/whitespace reason, else the reason verbatim. Task 4's
+    /// orchestrator mapping owns APPLYING this to whatever a launch failure ultimately reports, but a
+    /// pre-StartAsync factory failure — thrown before any runtime (hence any verdict) exists — is
+    /// exactly the case the fallback exists to cover, so the formula lives here rather than being
+    /// duplicated at every call site.
+    /// </summary>
+    internal static string DescribeLaunchFailure(Exception ex) =>
+        string.IsNullOrWhiteSpace(ex.Message) ? $"launch_failed:{ex.GetType().Name} — see daemon log" : ex.Message;
 
     /// <summary>
     /// Fail-closed validation + build of the review-flow MCP list, run as the FIRST thing in

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -407,20 +407,16 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// <summary>
     /// The reclassified message's transport half: the sanitized handshake cause when
     /// <see cref="AcpHostedAgentRuntime.StartAsync"/>'s own wrapper produced one, else the caught
-    /// exception's own (separately sanitized) message — covers every stage the wrapper doesn't reach,
-    /// namely model selection (never wrapped at all) and a launch deadline firing mid-RPC (whose
-    /// <see cref="OperationCanceledException"/> the wrapper deliberately never touches either).
+    /// exception's own message run through the SAME sanitizer — covers every stage the wrapper
+    /// doesn't reach, namely model selection (never wrapped at all) and a launch deadline firing
+    /// mid-RPC (whose <see cref="OperationCanceledException"/> the wrapper deliberately never
+    /// touches either). Calls <see cref="AcpHostedAgentRuntime.SanitizeForForward"/> directly rather
+    /// than a local copy, so a future fix to that sanitizer (e.g. Unicode-safe truncation) reaches
+    /// this call site too instead of silently missing it.
     /// </summary>
     static string DescribeTransportCause(Exception ex) =>
-        (ex as AcpHostedAgentRuntime.AcpHandshakeFailedException)?.TransportMessage ?? Sanitize(ex.Message);
-
-    /// <summary>Single-lined + length-capped, mirroring <c>AcpHostedAgentRuntime.SanitizeForForward</c>
-    /// — duplicated rather than shared because the message sanitized here may never have passed
-    /// through that type at all (e.g. a raw transport exception escaping model selection).</summary>
-    static string Sanitize(string message, int maxLength = 500) {
-        var oneLine = message.ReplaceLineEndings(" ").Trim();
-        return oneLine.Length <= maxLength ? oneLine : oneLine[..maxLength] + "…";
-    }
+        (ex as AcpHostedAgentRuntime.AcpHandshakeFailedException)?.TransportMessage
+            ?? AcpHostedAgentRuntime.SanitizeForForward(ex.Message);
 
     /// <summary>
     /// Disposes whatever a launch already obtained when no <see cref="AcpHostedAgentRuntime"/> was

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -342,8 +342,9 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             // No explicit delete here: runtime.DisposeAsync runs the ordered cleanup (await the
             // reap, confirm exit, then delete), and deleting again afterwards would bypass exactly
             // the exit-confirmed gate that ordering exists to enforce. DisposeAsync now unconditionally
-            // awaits any claimed reap, so a Verdict checked immediately afterward is final.
-            await runtime.DisposeAsync().ConfigureAwait(false);
+            // awaits any claimed reap, so a Verdict checked immediately afterward is final. Its
+            // teardown fault is contained (finding 3) so it cannot bypass reclassification below.
+            await DisposeRuntimeContainedAsync(runtime).ConfigureAwait(false);
 
             // Design spec §3.2: the deadline catch consults the verdict IDENTICALLY to the general
             // catch below — a reap racing the launch deadline must not bypass reclassification and
@@ -361,8 +362,9 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             // The runtime owns both the connection and the process; dispose on a failed handshake
             // so a half-started child process is never leaked.
             // As above: disposal owns the exit-confirmed deletion, and now unconditionally awaits any
-            // claimed reap first, so the Verdict check right after is never racing it.
-            await runtime.DisposeAsync().ConfigureAwait(false);
+            // claimed reap first, so the Verdict check right after is never racing it. Its teardown
+            // fault is contained (finding 3) so it cannot bypass reclassification below.
+            await DisposeRuntimeContainedAsync(runtime).ConfigureAwait(false);
 
             // Design spec §3.2: the single reclassification seam — a published Verdict means this
             // launch was reaped, and its coded reason becomes the exception's headline instead of
@@ -390,6 +392,23 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// </summary>
     internal sealed class AcpReviewerReapedException(string message, Exception inner)
         : InvalidOperationException(message, inner);
+
+    /// <summary>
+    /// Disposes the runtime with its teardown fault CONTAINED (design spec §3.2 / finding 3).
+    /// <see cref="AcpHostedAgentRuntime.DisposeAsync"/> can propagate a connection/process disposal
+    /// fault; letting that escape a launch-failure catch would skip <see cref="ReclassifyIfReaped"/>
+    /// and replace the coded verdict with a teardown exception. The published verdict is already final
+    /// by the time this runs (disposal awaits the reap first), so a disposal fault is pure teardown
+    /// noise — logged at Debug, never rethrown, so reclassification always runs.
+    /// </summary>
+    async Task DisposeRuntimeContainedAsync(AcpHostedAgentRuntime runtime) {
+        try {
+            await runtime.DisposeAsync().ConfigureAwait(false);
+        } catch (Exception disposeEx) {
+            _logger.LogDebug(disposeEx,
+                "ACP: runtime disposal faulted during launch-failure teardown; the coded verdict (if any) still governs reclassification.");
+        }
+    }
 
     /// <summary>
     /// The single reclassification seam (design spec §3.2): after ordered disposal — which now
@@ -428,6 +447,10 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// disposal — releasing handles under a still-alive child just leaves it running).
     /// </summary>
     internal static async Task DisposeUnclaimedSpawnAsync(AcpConnection? connection, IAcpProcess? process) {
+        // Each cleanup step is INDEPENDENTLY guarded (finding 4): a throwing connection disposal must
+        // neither skip the process disposal below it nor escape to mask the construction failure that
+        // brought us here — the "best-effort throughout" contract. The prior shape awaited
+        // connection.DisposeAsync with no guard, so a throwing stream disposal did both.
         if (process is not null) {
             try {
                 await process.TerminateAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
@@ -436,11 +459,21 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             }
         }
 
-        if (connection is not null)
-            await connection.DisposeAsync().ConfigureAwait(false);
+        if (connection is not null) {
+            try {
+                await connection.DisposeAsync().ConfigureAwait(false);
+            } catch {
+                // Best-effort — must not skip the process disposal below or mask the launch failure.
+            }
+        }
 
-        if (process is not null)
-            await process.DisposeAsync().ConfigureAwait(false);
+        if (process is not null) {
+            try {
+                await process.DisposeAsync().ConfigureAwait(false);
+            } catch {
+                // Best-effort — the same contract: a cleanup fault never replaces the real error.
+            }
+        }
     }
 
     /// <summary>
@@ -452,7 +485,17 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// duplicated at every call site.
     /// </summary>
     internal static string DescribeLaunchFailure(Exception ex) =>
-        string.IsNullOrWhiteSpace(ex.Message) ? $"launch_failed:{ex.GetType().Name} — see daemon log" : ex.Message;
+        string.IsNullOrWhiteSpace(ex.Message) ? FormatFallbackLaunchReason(ex.GetType().Name) : ex.Message;
+
+    /// <summary>
+    /// The SINGLE owner of the §3.5 fallback reason format (finding 5). Both the exception-backed
+    /// path (<see cref="DescribeLaunchFailure"/>) and the reason-backed path
+    /// (<see cref="AgentOrchestrator.MapLaunchFailureReason"/>) route their fallback through here, so
+    /// the two can never drift to different <c>launch_failed:…</c> shapes. <paramref name="token"/> is
+    /// the identifier for WHAT produced the empty reason — an exception type name, or a caller-supplied
+    /// source string.
+    /// </summary>
+    internal static string FormatFallbackLaunchReason(string token) => $"launch_failed:{token} — see daemon log";
 
     /// <summary>
     /// Fail-closed validation + build of the review-flow MCP list, run as the FIRST thing in

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2500,9 +2500,21 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         try {
             LogStopping(agentId);
 
+            // Design spec §3.3: StopAgentCoreAsync is the single funnel for every stop trigger —
+            // server StopAgent/StopAgentV2, a local-socket stop, AND the heartbeat's own
+            // TTL/idle/stuck-Starting reap sweep (HandleStopAgent's doc lists all three) — and any
+            // of them can race the finalizer having ALREADY reported a launch-window verdict (a
+            // reviewer that trips a containment tripwire is a plausible TTL/idle-reap candidate on
+            // the very same heartbeat tick). A published verdict has already forced terminal
+            // "Failed" and told the server via LaunchFailedAsync; a non-failure "Completed"
+            // transition here would clear the FailureReason that call just set server-side. Gated
+            // on the verdict-REPORTED flag specifically, not `Status == "Failed"` — an unrelated
+            // Failed state must not by itself block a legitimate Completed transition.
+            var verdictAlreadyReported = Volatile.Read(ref agent.LaunchFailureVerdictReported) != 0;
+
             // Set status BEFORE cancelling ReadCts so the read loop's finally
             // block sees "Completed" and skips its own status change / event append.
-            SetAgentStatus(agent, "Completed");
+            if (!verdictAlreadyReported) SetAgentStatus(agent, "Completed");
             // Mark this as a user-initiated stop so the read-loop's finally-block
             // EndAgentSessionAsync call uses "agent_stopped" if it ends up being
             // the only successful call (e.g., transient SignalR failure here).
@@ -2513,7 +2525,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             // An unregistered agent has no server-side row to update.
             if (!agent.IsPrivate) {
-                _ = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
+                if (!verdictAlreadyReported) _ = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
                 _ = _server.AppendAgentRunEventAsync(agentId, new AgentRunStopped("user", null));
             }
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2237,6 +2237,27 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (path is not null) LogFailedLaunchCaptured(agent.Id, path);
     }
 
+    /// <summary>
+    /// True when a published launch-window reap verdict (or its already-claimed report flag) forbids
+    /// any NON-failure <c>AgentStatusChanged</c> for this agent — such a transition clears the
+    /// <c>FailureReason</c> the verdict's <c>LaunchFailed</c> set server-side (design spec §3.3). The
+    /// single source of that rule, consulted by every non-failure status emitter that can race the
+    /// finalizer's report: the finalizer's own exit-code classification, the stop gate, and reconnect
+    /// re-registration (finding 2).
+    ///
+    /// <para>Both signals are read with proper cross-thread ordering — the flag via
+    /// <see cref="System.Threading.Volatile.Read(ref int)"/>, the verdict via the runtime's
+    /// lock-synchronised <see cref="AcpHostedAgentRuntime.ReadVerdict"/> — and ORed because the
+    /// verdict is PUBLISHED (at reap-claim time) strictly before the finalizer's CAS flips the flag,
+    /// so a same-tick emitter could otherwise read the flag as still 0 while the verdict already
+    /// exists. Post-window reaps leave both false, preserving byte-identical teardown for that
+    /// case.</para>
+    /// </summary>
+    static bool VerdictForbidsNonFailureStatus(AgentInstance agent) =>
+        Volatile.Read(ref agent.LaunchFailureVerdictReported) != 0
+     || (agent.Runtime is AcpHostedAgentRuntime runtime
+         && runtime.ReadVerdict() is { ReapedInsideLaunchWindow: true });
+
     async Task FinalizeAgentRunAsync(AgentInstance agent) {
         try {
             // Design spec §3.3: the registered-agent report seam, and the FIRST action here —
@@ -2246,8 +2267,21 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // Post-window reaps (ReapedInsideLaunchWindow == false) are deliberately NOT reported
             // here — today's teardown for that case must stay byte-identical (documented residual,
             // spec §1).
-            if (agent.Runtime is AcpHostedAgentRuntime { Verdict: { ReapedInsideLaunchWindow: true } verdict }
+            // ReadVerdict (not the plain Verdict property): the reap that produced this verdict can be
+            // racing us on another thread, publishing it at the tail of a critical section its own
+            // _cts.Cancel() drove us into — reading the plain property there sees null and skips the
+            // report permanently (finding 1). ReadVerdict blocks until the claim has committed.
+            if (agent.Runtime is AcpHostedAgentRuntime acpRuntime
+                && acpRuntime.ReadVerdict() is { ReapedInsideLaunchWindow: true } verdict
                 && Interlocked.CompareExchange(ref agent.LaunchFailureVerdictReported, 1, 0) == 0) {
+                // Force terminal Failed BEFORE the report await, not after (finding 2). A concurrent
+                // status emitter — a reconnect re-registration, a racing stop — must observe the
+                // failure state so it cannot emit a non-failure AgentStatusChanged that clears the
+                // FailureReason the LaunchFailed below is about to set server-side. Setting it here
+                // also makes the exit-code-driven classification further down a no-op for this agent.
+                // The CAS above (already committed) and this status are both visible before we await.
+                SetAgentStatus(agent, "Failed");
+
                 if (!agent.IsPrivate) {
                     // Own try/catch, deliberately separate from this method's own outer one below —
                     // a report fault must never skip CleanupAgentAsync or the normal unregister
@@ -2261,14 +2295,6 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                         LogVerdictReportFailed(ex, agent.Id);
                     }
                 }
-
-                // Force terminal Failed regardless of the child's exit code. This also makes the
-                // exit-code-driven classification below a no-op for this agent (agent.Status is
-                // already terminal), which is what keeps the daemon's status pipeline from ever
-                // emitting a non-failure AgentStatusChanged after a published verdict — a
-                // non-failure transition would clear the FailureReason the LaunchFailed call above
-                // just set server-side.
-                SetAgentStatus(agent, "Failed");
             }
 
             // PTY output can end before waitpid reports the child as exited.
@@ -2497,6 +2523,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         await StopAgentCoreAsync(agent);
     }
 
+    /// <summary>Test-only: invoked ONCE inside <see cref="StopAgentCoreAsync"/> immediately AFTER the
+    /// suppress-Completed snapshot and BEFORE the Completed send, so a test can publish a verdict in
+    /// exactly that TOCTOU window and prove the pre-send re-check suppresses it (finding 2). Null in
+    /// production (a single null check, no behavioural effect).</summary>
+    internal Action? StopGateAfterSnapshotHookForTest;
+
     /// <summary>
     /// The stop itself, with no caller-authorisation policy: graceful /exit, then terminate.
     /// Server-origin stops reach this through <see cref="HandleStopAgent"/> (which refuses
@@ -2529,9 +2561,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // false, preserving the byte-identical teardown for that case. Gated on these two
             // signals specifically, not `Status == "Failed"` — an unrelated Failed state must not
             // by itself block a legitimate Completed transition.
-            var suppressCompleted =
-                Volatile.Read(ref agent.LaunchFailureVerdictReported) != 0
-             || agent.Runtime is AcpHostedAgentRuntime { Verdict.ReapedInsideLaunchWindow: true };
+            var suppressCompleted = VerdictForbidsNonFailureStatus(agent);
+
+            // Test seam: lets a test publish a verdict in the TOCTOU window between this snapshot and
+            // the Completed send below. No-op in production.
+            StopGateAfterSnapshotHookForTest?.Invoke();
 
             // Set status BEFORE cancelling ReadCts so the read loop's finally
             // block sees "Completed" and skips its own status change / event append.
@@ -2546,7 +2580,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             // An unregistered agent has no server-side row to update.
             if (!agent.IsPrivate) {
-                if (!suppressCompleted) _ = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
+                // Re-check immediately before the send, not only at the snapshot (finding 2): a verdict
+                // PUBLISHED in the window between the snapshot above and here — the reap runs on another
+                // thread — must still suppress this non-failure transition, or it clears the
+                // FailureReason the finalizer's LaunchFailed set server-side.
+                if (!suppressCompleted && !VerdictForbidsNonFailureStatus(agent))
+                    _ = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
                 _ = _server.AppendAgentRunEventAsync(agentId, new AgentRunStopped("user", null));
             }
 
@@ -3192,6 +3231,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal async Task ReRegisterAgentsAsync() {
         // PrivateLocal agents are never registered with the server, so never re-register them.
         foreach (var agent in _agents.Values.Where(a => (a.Status is "Starting" or "Running") && !a.IsPrivate)) {
+            // A published launch-window verdict (or its reported flag) means this agent is terminally
+            // Failed and about to be unregistered by the finalizer — re-sending its (possibly stale
+            // "Running") non-failure Status would clear the FailureReason the verdict's LaunchFailed
+            // set server-side (finding 2). The outer Status filter can still admit it during the race
+            // where the finalizer has flipped the flag but not yet the Status field, so this inner
+            // re-check — on the properly-ordered flag/verdict, not the plain Status — is what closes
+            // it. Skip re-registration entirely; the finalizer owns this agent's terminal transition.
+            if (VerdictForbidsNonFailureStatus(agent)) continue;
+
             for (var attempt = 1; ; attempt++) {
                 try {
                     await _server.AgentRegisteredAsync(agent.Id, agent.Prompt, agent.Model, agent.Effort, agent.RepoPath, agent.SandboxPolicy, agent.ApprovalPolicy);
@@ -3263,7 +3311,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// the same mapping also covers a pre-<c>StartAsync</c> factory failure's plain exception message
     /// if a future call site adopts it.</summary>
     internal static string MapLaunchFailureReason(string? reason, string fallbackSource) =>
-        !string.IsNullOrWhiteSpace(reason) ? reason : $"launch_failed:{fallbackSource} — see daemon log";
+        !string.IsNullOrWhiteSpace(reason)
+            ? reason
+            : AcpHostedAgentRuntimeFactory.FormatFallbackLaunchReason(fallbackSource); // finding 5: single owner of the format
 
     static readonly HashSet<string> ValidEffortLevels = ["low", "medium", "high", "max"];
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -86,10 +86,13 @@ internal record AgentInstance(
     /// <summary>Design spec §3.3: single-flight guard for reporting a published ACP launch-window
     /// reap verdict to the server — claimed (0→1) by the FIRST path that reports it, via
     /// <see cref="System.Threading.Interlocked.CompareExchange(ref int,int,int)"/>, so dedupe is
-    /// structural rather than dependent on today's call-site ordering. Only
-    /// <see cref="AgentOrchestrator.FinalizeAgentRunAsync"/> consults this today (the factory's
-    /// pre-registration reclassification, design spec §3.2, has no <see cref="AgentInstance"/> to
-    /// share it with — see that method's remarks) but it is the canonical claim any future
+    /// structural rather than dependent on today's call-site ordering. Set by
+    /// <see cref="AgentOrchestrator.FinalizeAgentRunAsync"/>'s verdict arm; read (via a plain
+    /// <see cref="System.Threading.Volatile.Read(ref int)"/>, no claim) by
+    /// <see cref="AgentOrchestrator.StopAgentCoreAsync"/> to suppress a racing stop's non-failure
+    /// "Completed" transition once a verdict has already been reported — the factory's
+    /// pre-registration reclassification (design spec §3.2) has no <see cref="AgentInstance"/> to
+    /// share it with (see that method's remarks) — but it is the canonical claim any future
     /// verdict-reporting call site for this agent must take before sending.</summary>
     public int LaunchFailureVerdictReported;
 
@@ -1736,7 +1739,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 // CodexUnsupportedWindowsException: Windows build older than 10.0.17763, where
                 // Codex's Windows sandbox does not exist — carries the version + doc link.
                 // All map to the same cleanup path.
-                await _server.LaunchFailedAsync(agentId, ex.Message);
+                // §3.5: DescribeLaunchFailure covers a null/whitespace ex.Message with the typed
+                // fallback; these three exception types always carry a real message, but every
+                // LaunchFailed send site routes through the same fallback rather than assuming so.
+                await _server.LaunchFailedAsync(agentId, AcpHostedAgentRuntimeFactory.DescribeLaunchFailure(ex));
 
                 // No AgentInstance was created, so CleanupAgentAsync won't run — revoke the reviewer
                 // token here (if we minted one) so it doesn't leak into the live-token set.
@@ -1932,7 +1938,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // can't strand a live child; a pre-insert failure falls through to the transient cleanup below.
             if (_agents.ContainsKey(agentId)) {
                 await CleanupAgentAsync(agentId);
-                await _server.LaunchFailedAsync(agentId, ex.Message);
+                // §3.5: never forward a null/whitespace ex.Message raw.
+                await _server.LaunchFailedAsync(agentId, AcpHostedAgentRuntimeFactory.DescribeLaunchFailure(ex));
                 return new CommandOutcome(CommandOutcomeKind.LaunchFailedCleaned, agentId);
             }
 
@@ -1974,7 +1981,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 }
             }
 
-            await _server.LaunchFailedAsync(agentId, ex.Message);
+            // §3.5: this is the landing site for a factory pre-StartAsync failure — including a
+            // reclassified AcpReviewerReapedException (design spec §3.2) — thrown before any
+            // AgentInstance exists, so DescribeLaunchFailure's fallback is the ONLY cover a blank
+            // message gets here.
+            await _server.LaunchFailedAsync(agentId, AcpHostedAgentRuntimeFactory.DescribeLaunchFailure(ex));
 
             // Phase B2-b (sequenced-settlement design §4.2.2): a pre-insert failure — the worktree (if any)
             // was torn down and no agent was ever registered; terminal for the sequenced lane.
@@ -2507,14 +2518,24 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // reviewer that trips a containment tripwire is a plausible TTL/idle-reap candidate on
             // the very same heartbeat tick). A published verdict has already forced terminal
             // "Failed" and told the server via LaunchFailedAsync; a non-failure "Completed"
-            // transition here would clear the FailureReason that call just set server-side. Gated
-            // on the verdict-REPORTED flag specifically, not `Status == "Failed"` — an unrelated
-            // Failed state must not by itself block a legitimate Completed transition.
-            var verdictAlreadyReported = Volatile.Read(ref agent.LaunchFailureVerdictReported) != 0;
+            // transition here would clear the FailureReason that call just set server-side.
+            //
+            // Two independent reads, ORed, because the verdict is PUBLISHED at reap-claim time
+            // (TryStartReap) strictly before the finalizer's report runs — a same-tick sweep could
+            // otherwise read LaunchFailureVerdictReported in the instant BEFORE that CAS flips it
+            // and still emit the non-failure transition. Reading the runtime's own Verdict closes
+            // that window: it is suppressed the moment the verdict exists, not only once it has
+            // been reported. Post-window (ReapedInsideLaunchWindow == false) leaves both reads
+            // false, preserving the byte-identical teardown for that case. Gated on these two
+            // signals specifically, not `Status == "Failed"` — an unrelated Failed state must not
+            // by itself block a legitimate Completed transition.
+            var suppressCompleted =
+                Volatile.Read(ref agent.LaunchFailureVerdictReported) != 0
+             || agent.Runtime is AcpHostedAgentRuntime { Verdict.ReapedInsideLaunchWindow: true };
 
             // Set status BEFORE cancelling ReadCts so the read loop's finally
             // block sees "Completed" and skips its own status change / event append.
-            if (!verdictAlreadyReported) SetAgentStatus(agent, "Completed");
+            if (!suppressCompleted) SetAgentStatus(agent, "Completed");
             // Mark this as a user-initiated stop so the read-loop's finally-block
             // EndAgentSessionAsync call uses "agent_stopped" if it ends up being
             // the only successful call (e.g., transient SignalR failure here).
@@ -2525,7 +2546,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             // An unregistered agent has no server-side row to update.
             if (!agent.IsPrivate) {
-                if (!verdictAlreadyReported) _ = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
+                if (!suppressCompleted) _ = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
                 _ = _server.AppendAgentRunEventAsync(agentId, new AgentRunStopped("user", null));
             }
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2580,11 +2580,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             // An unregistered agent has no server-side row to update.
             if (!agent.IsPrivate) {
-                // Re-check immediately before the send, not only at the snapshot (finding 2): a verdict
-                // PUBLISHED in the window between the snapshot above and here — the reap runs on another
-                // thread — must still suppress this non-failure transition, or it clears the
-                // FailureReason the finalizer's LaunchFailed set server-side.
-                if (!suppressCompleted && !VerdictForbidsNonFailureStatus(agent))
+                // Atomic check + send-INITIATION under _reapLock for an ACP runtime (finding 1
+                // refinement): the round-1 second check narrowed but did not CLOSE the check-to-send
+                // race — a verdict could publish between the check and this send. The gate holds the
+                // publication lock across BOTH, so a Completed frame, if sent at all, is initiated
+                // before publication and is therefore ordered-before any LaunchFailed on the single
+                // hub connection. Non-ACP runtimes never carry a launch-window verdict, so the
+                // snapshot is authoritative for them.
+                if (agent.Runtime is AcpHostedAgentRuntime acpRuntime)
+                    acpRuntime.TryInitiateNonFailureStatusSend(
+                        () => _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId), out _);
+                else if (!suppressCompleted)
                     _ = _server.AgentStatusChangedAsync(agentId, "Completed", agent.SessionId);
                 _ = _server.AppendAgentRunEventAsync(agentId, new AgentRunStopped("user", null));
             }
@@ -3243,7 +3249,21 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             for (var attempt = 1; ; attempt++) {
                 try {
                     await _server.AgentRegisteredAsync(agent.Id, agent.Prompt, agent.Model, agent.Effort, agent.RepoPath, agent.SandboxPolicy, agent.ApprovalPolicy);
-                    await _server.AgentStatusChangedAsync(agent.Id, agent.Status, agent.SessionId);
+
+                    // Re-gate the status send atomically under _reapLock, per attempt (finding 1
+                    // refinement): the outer pre-check cannot cover a verdict published DURING the
+                    // AgentRegistered await above (or on a later retry). The gate suppresses the send
+                    // if a verdict is now published, else initiates it before publication can proceed
+                    // so it is ordered-before any LaunchFailed. Awaited OUTSIDE the lock (the gate only
+                    // holds it across initiation), preserving the retry-on-failure semantics.
+                    if (agent.Runtime is AcpHostedAgentRuntime acpRuntime) {
+                        if (!acpRuntime.TryInitiateNonFailureStatusSend(
+                                () => _server.AgentStatusChangedAsync(agent.Id, agent.Status, agent.SessionId), out var statusSend))
+                            break; // verdict published → terminal Failed; skip this agent's re-registration
+                        await statusSend;
+                    } else {
+                        await _server.AgentStatusChangedAsync(agent.Id, agent.Status, agent.SessionId);
+                    }
 
                     // Re-send the fixed PTY dims. The server stores them in memory, so a
                     // server restart (not just a daemon blip) wipes them — without this

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -83,6 +83,16 @@ internal record AgentInstance(
     /// one teardown runs even if the launch-catch and the read-loop's finally race.</summary>
     public int CleanupStarted;
 
+    /// <summary>Design spec §3.3: single-flight guard for reporting a published ACP launch-window
+    /// reap verdict to the server — claimed (0→1) by the FIRST path that reports it, via
+    /// <see cref="System.Threading.Interlocked.CompareExchange(ref int,int,int)"/>, so dedupe is
+    /// structural rather than dependent on today's call-site ordering. Only
+    /// <see cref="AgentOrchestrator.FinalizeAgentRunAsync"/> consults this today (the factory's
+    /// pre-registration reclassification, design spec §3.2, has no <see cref="AgentInstance"/> to
+    /// share it with — see that method's remarks) but it is the canonical claim any future
+    /// verdict-reporting call site for this agent must take before sending.</summary>
+    public int LaunchFailureVerdictReported;
+
     /// <summary>Phase B (D4): the child's exact start-identity captured ONCE at spawn (the
     /// <c>ProcessStartToken</c>). Teardown uses THIS stored token — never a freshly-recaptured one — so a
     /// pid recycled after the child exited can't be adopted and later killed. Null only when the pid was
@@ -2218,6 +2228,38 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     async Task FinalizeAgentRunAsync(AgentInstance agent) {
         try {
+            // Design spec §3.3: the registered-agent report seam, and the FIRST action here —
+            // strictly before the process-exit wait below. The runtime's Verdict is published at
+            // reap-CLAIM time (TryStartReap), not at process exit, so waiting on exit first would
+            // only widen the race against the server's reviewer-readiness wait for no benefit.
+            // Post-window reaps (ReapedInsideLaunchWindow == false) are deliberately NOT reported
+            // here — today's teardown for that case must stay byte-identical (documented residual,
+            // spec §1).
+            if (agent.Runtime is AcpHostedAgentRuntime { Verdict: { ReapedInsideLaunchWindow: true } verdict }
+                && Interlocked.CompareExchange(ref agent.LaunchFailureVerdictReported, 1, 0) == 0) {
+                if (!agent.IsPrivate) {
+                    // Own try/catch, deliberately separate from this method's own outer one below —
+                    // a report fault must never skip CleanupAgentAsync or the normal unregister
+                    // (capacity decrement + the durable death record ride AgentUnregistered and must
+                    // still run exactly once).
+                    try {
+                        await _server.LaunchFailedAsync(
+                            agent.Id,
+                            MapLaunchFailureReason(verdict.Reason, nameof(AcpHostedAgentRuntime.TerminationVerdict)));
+                    } catch (Exception ex) {
+                        LogVerdictReportFailed(ex, agent.Id);
+                    }
+                }
+
+                // Force terminal Failed regardless of the child's exit code. This also makes the
+                // exit-code-driven classification below a no-op for this agent (agent.Status is
+                // already terminal), which is what keeps the daemon's status pipeline from ever
+                // emitting a non-failure AgentStatusChanged after a published verdict — a
+                // non-failure transition would clear the FailureReason the LaunchFailed call above
+                // just set server-side.
+                SetAgentStatus(agent, "Failed");
+            }
+
             // PTY output can end before waitpid reports the child as exited.
             // Wait briefly for the process to finalize so we get a real exit code.
             await agent.Runtime.WaitForExitAsync(TimeSpan.FromSeconds(5));
@@ -3180,6 +3222,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal static bool IsStartupFailure(DateTime createdAt, DateTime lastOutputAt, bool hasReceivedOutput)
         => !hasReceivedOutput || lastOutputAt - createdAt < MinSessionLifespan;
 
+    /// <summary>Design spec §3.5: a <c>LaunchFailed</c> reason must never be forwarded empty. A
+    /// verdict's <c>Reason</c> should never be blank in practice — every writer
+    /// (<c>HandleMcpSurfaceViolation</c>, the bridge's reason-bearing reap callback) passes a coded
+    /// string — but this is the general, defensive cover, keyed off a caller-supplied identifier for
+    /// WHAT produced the blank reason (a type name today) rather than an exception specifically, so
+    /// the same mapping also covers a pre-<c>StartAsync</c> factory failure's plain exception message
+    /// if a future call site adopts it.</summary>
+    internal static string MapLaunchFailureReason(string? reason, string fallbackSource) =>
+        !string.IsNullOrWhiteSpace(reason) ? reason : $"launch_failed:{fallbackSource} — see daemon log";
+
     static readonly HashSet<string> ValidEffortLevels = ["low", "medium", "high", "max"];
 
     static readonly TimeSpan SessionIdPollInterval = TimeSpan.FromSeconds(2);
@@ -3636,6 +3688,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     [LoggerMessage(Level = LogLevel.Warning, Message = "Agent {AgentId} failed during startup (exit code {ExitCode}): {Reason}")]
     partial void LogStartupFailed(string agentId, int? exitCode, string reason);
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to report launch-window reap verdict for agent {AgentId} (continuing teardown)")]
+    partial void LogVerdictReportFailed(Exception ex, string agentId);
+
     [LoggerMessage(Level = LogLevel.Error, Message = "Agent {AgentId} wedged on an unattended consent/trust dialog — failing the launch fast: {Reason}")]
     partial void LogConsentDialogWedge(string agentId, string reason);
 
@@ -3766,6 +3821,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <c>_ = ReadAgentOutputAsync(agent)</c> in HandleLaunchAgent) so a seeded agent's consent-dialog
     /// fail-fast + tail-capture can be exercised without the full ReviewFlow launch gauntlet.</summary>
     internal Task ReadAgentOutputForTest(AgentInstance agent) => ReadAgentOutputAsync(agent);
+
+    /// <summary>Test-only: drive the read loop's finally-block teardown directly (mirrors what
+    /// <c>ReadAgentOutputAsync</c>'s own finally invokes) so the verdict-report arm, its ordering
+    /// against the process-exit wait, and the rest of teardown can be exercised without needing a
+    /// runtime whose <c>ReadOutputAsync</c> stream can be driven to completion.</summary>
+    internal Task FinalizeAgentRunForTest(AgentInstance agent) => FinalizeAgentRunAsync(agent);
 
     /// <summary>Test-only: the retained failed-launch log root, for asserting a capture landed.</summary>
     internal FailedLaunchLog? FailedLaunchLogForTest => _failedLaunchLog;

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
@@ -669,4 +669,67 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(claimed).IsTrue();
         await Assert.That(h.Runtime.Verdict!.ReapedInsideLaunchWindow).IsFalse();
     }
+
+    /// <summary>Reap reasons can embed agent-controlled text (e.g. a JSON-RPC method from an inbound
+    /// frame), which may contain non-BMP characters — a raw UTF-16 code-unit slice at the cap can
+    /// land between a surrogate pair's two halves, leaving a lone surrogate in the forwarded string
+    /// (design spec §3.1). Nine filler chars put "😀" (U+1F600, a high+low surrogate pair) exactly
+    /// astride the cut: its high half at index maxLength-1, low half at index maxLength — precisely
+    /// the boundary a naive <c>oneLine[..maxLength]</c> would slice through.</summary>
+    [Test]
+    public async Task Sanitize_never_splits_surrogate_at_boundary() {
+        const int maxLength = 10;
+        var oneLine = new string('a', maxLength - 1) + char.ConvertFromUtf32(0x1F600) + "-well-past-the-cap";
+
+        // Precondition: the pair really does straddle the cut this test means to exercise.
+        await Assert.That(char.IsHighSurrogate(oneLine[maxLength - 1])).IsTrue();
+        await Assert.That(char.IsLowSurrogate(oneLine[maxLength])).IsTrue();
+
+        var result = AcpHostedAgentRuntime.SanitizeForForward(oneLine, maxLength);
+
+        await Assert.That(result.All(c => !char.IsHighSurrogate(c) && !char.IsLowSurrogate(c))).IsTrue();
+        await Assert.That(result.Length).IsLessThanOrEqualTo(maxLength + 1); // +1 for the "…" suffix
+        await Assert.That(result).EndsWith("…");
+    }
+
+    /// <summary>Line breaks collapse to spaces (<c>ReplaceLineEndings</c>) before the cap is ever
+    /// applied, so a coded reason's prefix — e.g. the <c>unattended_interaction_forbidden:{method}</c>
+    /// shape writers use (design spec §3.1) — survives at the front and no raw line-break character
+    /// remains anywhere in the result.</summary>
+    [Test]
+    public async Task Sanitize_collapses_multiline_input_and_keeps_the_code_prefix() {
+        const string prefix = "unattended_interaction_forbidden:tools/call";
+        var input = $"{prefix}\nsecond line\r\nthird line";
+
+        var result = AcpHostedAgentRuntime.SanitizeForForward(input);
+
+        await Assert.That(result).StartsWith(prefix);
+        await Assert.That(result).DoesNotContain("\n");
+        await Assert.That(result).DoesNotContain("\r");
+    }
+
+    /// <summary>Truncation only ever trims the TAIL, so an oversized single-line reason keeps its
+    /// leading coded prefix intact — the reason a caller can rely on the prefix for classification
+    /// even when the full message got capped.</summary>
+    [Test]
+    public async Task Sanitize_of_an_oversized_reason_keeps_the_leading_coded_prefix() {
+        const string prefix = "unattended_interaction_forbidden:tools/call";
+        var input = prefix + new string('x', 600); // well past the 500-char default cap
+
+        var result = AcpHostedAgentRuntime.SanitizeForForward(input);
+
+        await Assert.That(result).StartsWith(prefix);
+        await Assert.That(result).EndsWith("…");
+        await Assert.That(result.Length).IsLessThanOrEqualTo(501); // default maxLength(500) + "…"
+    }
+
+    /// <summary>The back-off reads <c>oneLine[maxLength - 1]</c> — guards against a non-positive cap
+    /// underflowing that index instead of just falling through to the pre-fix (already-safe)
+    /// substring behavior.</summary>
+    [Test]
+    public async Task Sanitize_with_a_non_positive_cap_does_not_throw() {
+        var result = AcpHostedAgentRuntime.SanitizeForForward("anything at all", maxLength: 0);
+
+        await Assert.That(result).IsEqualTo("…");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
@@ -550,4 +550,123 @@ public class AcpHostedAgentRuntimeTests {
         // Release the fake's held response so the harness can tear down cleanly.
         h.Fake.HoldSetConfigOptionResponse.TrySetResult();
     }
+
+    // ── TerminationVerdict fused to the reap claim ─────────────────────────────────
+    // TryStartReap/TakeReap/FirstTurnSettledForTest are exercised directly (internal) rather than
+    // through HandleMcpSurfaceViolation/HandleUnexpectedUnattendedInteraction, so these tests can
+    // control claim/window timing deterministically instead of racing real ACP connection I/O.
+
+    /// <summary>A starter's synchronous prefix can throw (production: _cts.Cancel() racing a
+    /// disposed _cts). No verdict must survive that — and the claim must reopen for the next
+    /// caller, which then wins both the claim and the verdict.</summary>
+    [Test]
+    public async Task Verdict_published_only_on_successful_claim() {
+        await using var h = new Harness();
+
+        await Assert.That(() => h.Runtime.TryStartReap(
+                "first-reason", () => throw new InvalidOperationException("cancel failed")))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(h.Runtime.Verdict).IsNull();
+
+        var claimed = h.Runtime.TryStartReap("second-reason", () => Task.CompletedTask);
+
+        await Assert.That(claimed).IsTrue();
+        await Assert.That(h.Runtime.Verdict).IsNotNull();
+        await Assert.That(h.Runtime.Verdict!.Reason).IsEqualTo("second-reason");
+    }
+
+    /// <summary>The window bit must be read BEFORE the starter runs. Here the starter itself
+    /// settles the marker synchronously (standing in for production's _cts.Cancel() eventually
+    /// settling it via ProcessAdmittedTurnAsync's finally) — a snapshot taken anywhere other than
+    /// strictly before the starter runs would observe "settled" and misclassify.</summary>
+    [Test]
+    public async Task Window_bit_snapshotted_before_cancel() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        // Hold the prompt response so the first turn is genuinely still in flight when the reap is
+        // claimed below — nothing has settled the marker yet.
+        h.Fake.HoldPromptResponses = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await h.Runtime.StartAsync("/abs/worktree", "review this", h.Cts.Token).WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!h.Fake.ReceivedCalls.Any(c => c.Method == "session/prompt") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(h.Fake.ReceivedCalls.Any(c => c.Method == "session/prompt")).IsTrue();
+        await Assert.That(h.Runtime.FirstTurnSettledForTest.Task.IsCompleted).IsFalse();
+
+        var claimed = h.Runtime.TryStartReap("reap-reason", () => {
+            h.Runtime.FirstTurnSettledForTest.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        await Assert.That(claimed).IsTrue();
+        await Assert.That(h.Runtime.Verdict!.ReapedInsideLaunchWindow).IsTrue();
+
+        h.Fake.HoldPromptResponses.TrySetResult();
+    }
+
+    /// <summary>Barrier contention: the winner is held inside its synchronous starter, so the claim
+    /// + window snapshot + verdict publish are all still inside _reapLock. A concurrent TakeReap()
+    /// (disposal's seam) and a concurrent second TryStartReap() call (the loser) must both block on
+    /// that same lock — TakeReap can never observe a claim with no published verdict/task, and the
+    /// loser can neither publish nor overwrite once it does get in.</summary>
+    [Test]
+    public async Task Concurrent_loser_cannot_publish_or_overwrite() {
+        await using var h = new Harness();
+
+        var winnerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseWinner = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var winnerTask = Task.Run(() => h.Runtime.TryStartReap("winner-reason", () => {
+            winnerEntered.TrySetResult();
+            releaseWinner.Task.GetAwaiter().GetResult(); // synchronous block INSIDE _reapLock
+            return Task.CompletedTask;
+        }));
+
+        await winnerEntered.Task.WaitAsync(HangGuard);
+
+        // Explicit type argument: Task.Run would otherwise resolve TakeReap's Task? return via the
+        // Func<Task> "unwrap" overload (treating it as the work to await) instead of Func<Task?>
+        // (treating it as the RESULT), silently changing what takeTask represents.
+        var takeTask  = Task.Run<Task?>(() => h.Runtime.TakeReap());
+        var loserTask = Task.Run(() => h.Runtime.TryStartReap("loser-reason", () => Task.CompletedTask));
+
+        // Neither concurrent caller can have progressed past the lock yet.
+        await Task.Delay(200);
+        await Assert.That(takeTask.IsCompleted).IsFalse();
+        await Assert.That(loserTask.IsCompleted).IsFalse();
+
+        releaseWinner.TrySetResult();
+
+        await Assert.That(await winnerTask.WaitAsync(HangGuard)).IsTrue();
+        await Assert.That(await loserTask.WaitAsync(HangGuard)).IsFalse();
+
+        // A plain bool, not the Task value itself: TUnit's Assert.That special-cases a Task-typed
+        // value as something to further await, which collides with checking whether the reference
+        // came back null.
+        Task? takenReap = await takeTask.WaitAsync(HangGuard);
+        await Assert.That(takenReap is not null).IsTrue();
+
+        await Assert.That(h.Runtime.Verdict).IsNotNull();
+        await Assert.That(h.Runtime.Verdict!.Reason).IsEqualTo("winner-reason");
+    }
+
+    /// <summary>Reviewer launches always carry a prompt, but the window still needs a defined close
+    /// for a launch that doesn't — otherwise no turn ever runs, ProcessAdmittedTurnAsync's finally
+    /// never fires, and the marker (so the window) would stay open forever.</summary>
+    [Test]
+    public async Task Empty_initial_prompt_closes_window_at_handoff() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        await h.Runtime.StartAsync("/abs/worktree", "", h.Cts.Token).WaitAsync(HangGuard);
+
+        var claimed = h.Runtime.TryStartReap("reason", () => Task.CompletedTask);
+
+        await Assert.That(claimed).IsTrue();
+        await Assert.That(h.Runtime.Verdict!.ReapedInsideLaunchWindow).IsFalse();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
@@ -581,6 +581,22 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(h.Runtime.Verdict!.Reason).IsEqualTo("second-reason");
     }
 
+    /// <summary>ReadVerdict is a load-bearing PRODUCTION read (the finalizer decides LaunchFailed off
+    /// it), and its test-signal hook fires before the lock — a throwing hook must never make it throw
+    /// or skip the read. Asserts a faulting hook is swallowed and the current verdict still returns.</summary>
+    [Test]
+    public async Task ReadVerdict_swallows_a_throwing_test_hook_and_still_returns_the_verdict() {
+        await using var h = new Harness();
+
+        h.Runtime.TryStartReap("kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask);
+        h.Runtime.BeforeReadVerdictLockForTest = () => throw new InvalidOperationException("hook-fault");
+
+        var verdict = h.Runtime.ReadVerdict(); // must not throw despite the faulting hook
+
+        await Assert.That(verdict).IsNotNull();
+        await Assert.That(verdict!.Reason).Contains("kiro_reviewer_mcp_surface_unexpected");
+    }
+
     /// <summary>The window bit must be read BEFORE the starter runs. Here the starter itself
     /// settles the marker synchronously (standing in for production's _cts.Cancel() eventually
     /// settling it via ProcessAdmittedTurnAsync's finally) — a snapshot taken anywhere other than

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
@@ -31,6 +31,7 @@ public class AcpHostedAgentRuntimeTests {
         public bool HasExited      { get; private set; }
         public int? ExitCode       { get; private set; }
         public int  TerminateCalls { get; private set; }
+        public int  DisposeCalls   { get; private set; }
 
         /// <summary>Simulates the child process exiting on its own (no Terminate call).</summary>
         public void SignalExited(int exitCode = 0) {
@@ -54,7 +55,11 @@ public class AcpHostedAgentRuntimeTests {
             return Task.CompletedTask;
         }
 
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() {
+            DisposeCalls++;
+
+            return ValueTask.CompletedTask;
+        }
     }
 
     sealed class Harness : IAsyncDisposable {
@@ -652,6 +657,31 @@ public class AcpHostedAgentRuntimeTests {
 
         await Assert.That(h.Runtime.Verdict).IsNotNull();
         await Assert.That(h.Runtime.Verdict!.Reason).IsEqualTo("winner-reason");
+    }
+
+    /// <summary>Finding 2: DisposeAsync latches _disposed BEFORE its early cancellation phase, and
+    /// only reaches the reap wait + connection/process disposal much later. If a cancellation callback
+    /// on _cts throws (cancellation callbacks can throw), the early phase must NOT abort teardown —
+    /// the child/streams would leak with retry impossible (the latch is set). This registers a
+    /// throwing callback so _cts.CancelAsync() faults, then asserts the child is STILL disposed and
+    /// the coded verdict still surfaces.</summary>
+    [Test]
+    public async Task DisposeAsync_early_cancellation_fault_still_disposes_child_and_keeps_verdict() {
+        await using var h = new Harness();
+
+        // Faults DisposeAsync's early phase at `await _cts.CancelAsync()`. The no-op reap starter below
+        // does NOT cancel _cts, so this callback fires only during DisposeAsync.
+        h.Runtime.RuntimeShutdownTokenForTest.Register(() => throw new InvalidOperationException("early-cancel-fault"));
+
+        h.Runtime.TryStartReap("kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask);
+        await Assert.That(h.Runtime.ReadVerdict()).IsNotNull(); // precondition: a verdict exists to preserve
+
+        // Pre-fix: the early fault aborts DisposeAsync before the guaranteed teardown, so the child is
+        // never disposed (DisposeCalls == 0). Post-fix the early phase is contained and teardown runs.
+        try { await h.Runtime.DisposeAsync(); } catch { /* pre-fix: the early fault propagates */ }
+
+        await Assert.That(h.Process.DisposeCalls).IsGreaterThan(0);  // child disposed despite the fault
+        await Assert.That(h.Runtime.ReadVerdict()).IsNotNull();      // coded verdict still surfaces
     }
 
     /// <summary>Reviewer launches always carry a prompt, but the window still needs a defined close

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
@@ -684,6 +684,37 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(h.Runtime.ReadVerdict()).IsNotNull();      // coded verdict still surfaces
     }
 
+    /// <summary>Finding 2 (round 3): the EARLY owner-cancel (`_ownerCts.Cancel()`) can throw too, and
+    /// it ran BEFORE the incarnation was captured under the lock and BEFORE the terminal/gate signals.
+    /// If a reconnect commits a SUCCESSOR incarnation in the window before the lock, a throwing owner
+    /// cancel left the STALE predecessor selected (successor leaked) and skipped the signals that
+    /// unpark parked waiters. Commits a successor right before the lock, faults the owner cancel, and
+    /// asserts the LIVE successor is disposed (not the predecessor) and the terminal signal fired.</summary>
+    [Test]
+    public async Task DisposeAsync_owner_cancel_fault_disposes_the_successor_and_fires_terminal_signal() {
+        await using var h = new Harness();
+
+        // A throwing owner CTS — the EARLY cancellation callback, distinct from the _cts.CancelAsync()
+        // the previous test faults.
+        var ownerCts = new CancellationTokenSource();
+        ownerCts.Token.Register(() => throw new InvalidOperationException("owner-cancel-fault"));
+        h.Runtime.SetOwnerCtsForTest(ownerCts);
+
+        h.Runtime.TryStartReap("kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask);
+
+        // Commit a reconnect SUCCESSOR right before DisposeAsync takes _reconnectLock — the window the
+        // round-2 code read `installed` before, so a stale-incarnation dispose would leak this one.
+        var successorProcess = new FakeAcpProcess();
+        h.Runtime.BeforeReconnectLockOnDisposeForTest =
+            () => h.Runtime.CommitSuccessorIncarnationForTest(successorProcess);
+
+        try { await h.Runtime.DisposeAsync(); } catch { /* pre-fix: the owner-cancel fault propagates */ }
+
+        await Assert.That(successorProcess.DisposeCalls).IsGreaterThan(0);        // the LIVE successor disposed
+        await Assert.That(h.Process.DisposeCalls).IsEqualTo(0);                   // the stale predecessor NOT disposed
+        await Assert.That(h.Runtime.RuntimeTerminalForTest.IsCompleted).IsTrue(); // terminal signal fired despite the fault
+    }
+
     /// <summary>Reviewer launches always carry a prompt, but the window still needs a defined close
     /// for a launch that doesn't — otherwise no turn ever runs, ProcessAdmittedTurnAsync's finally
     /// never fires, and the marker (so the window) would stay open forever.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpHostedAgentRuntimeTests.cs
@@ -715,6 +715,32 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(h.Runtime.RuntimeTerminalForTest.IsCompleted).IsTrue(); // terminal signal fired despite the fault
     }
 
+    /// <summary>Bug 1: DisposeAsync's contained early phase must still SIGNAL the turn worker to exit
+    /// (cancel _cts AND complete _pendingTurns — the two things RunTurnWorkerAsync exits on) even when
+    /// `ownerCts.Cancel()` throws. Otherwise the worker parks forever on _pendingTurns.WaitToReadAsync
+    /// while teardown disposes its connection/process out from under it. Establishes a parked worker,
+    /// faults the owner cancel, and asserts the worker completed (not parked).</summary>
+    [Test]
+    public async Task DisposeAsync_owner_cancel_fault_still_unblocks_the_turn_worker() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        // No initial prompt → the single turn worker parks on _pendingTurns, still running.
+        await h.Runtime.StartAsync("/abs/worktree", initialPrompt: null, h.Cts.Token).WaitAsync(HangGuard);
+        await Assert.That(h.Runtime.TurnWorkerTaskForTest.IsCompleted).IsFalse(); // precondition: parked
+
+        var ownerCts = new CancellationTokenSource();
+        ownerCts.Token.Register(() => throw new InvalidOperationException("owner-cancel-fault"));
+        h.Runtime.SetOwnerCtsForTest(ownerCts);
+
+        try { await h.Runtime.DisposeAsync(); } catch { /* the fault is contained either way */ }
+
+        // Pre-fix: the owner-cancel throw skips _cts.CancelAsync() + both channel completions, so the
+        // worker stays parked (IsCompleted == false). Post-fix each cancel is independently guarded, so
+        // the worker is signaled and DisposeAsync's bounded wait sees it exit.
+        await Assert.That(h.Runtime.TurnWorkerTaskForTest.IsCompleted).IsTrue();
+    }
+
     /// <summary>Reviewer launches always carry a prompt, but the window still needs a defined close
     /// for a launch that doesn't — otherwise no turn ever runs, ProcessAdmittedTurnAsync's finally
     /// never fires, and the marker (so the window) would stay open forever.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -636,13 +636,60 @@ public class AcpInteractionBridgeTests {
         var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         await Assert.That(routed).IsEqualTo(0);
-        await Assert.That(reaped).IsEquivalentTo([method]);
+        // Task 2: the published reason is the forbidden-method CODING, not the bare method.
+        await Assert.That(reaped).IsEquivalentTo([$"unattended_interaction_forbidden:{method}"]);
         if (method == "vendor/unknown_interaction")
             await Assert.That(result).IsNull();
         else if (method == "elicitation/create")
             await Assert.That(result!.Value.GetRawText()).IsEqualTo("""{"action":"cancel"}""");
         else
             await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>The gap Task 2 closes: pre-fix, an unadmittable frame (params missing/malformed, or
+    /// no sessionId) invoked the SAME callback with just <c>request.Method</c> — the same shape a
+    /// forbidden-method reap uses — discarding the bridge's own precise <c>why</c> entirely. The
+    /// published reason must be the frame-unadmittable coding of `why`, never the bare method and
+    /// never the forbidden-method coding (which a caller could otherwise not distinguish from this
+    /// case).</summary>
+    [Test]
+    public async Task Unadmittable_frame_publishes_its_why_not_method() {
+        string? reason = null;
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => throw new InvalidOperationException("must not be called"),
+            agentId: AgentId,
+            logger: NullLogger.Instance,
+            unattendedPolicy: AcpUnattendedInteractionPolicy.AllowlistedAutoApprove,
+            unexpectedUnattendedInteraction: r => reason = r);
+
+        // Missing params is the simplest unadmittable frame — UnadmittableFrame's own logged `why`
+        // is "session/request_permission had no params" (see the bridge's first UnadmittableFrame
+        // call site).
+        var request = new AcpRequest(1, "session/request_permission", Params: null);
+        await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(reason).IsEqualTo("unattended_frame_unadmittable: session/request_permission had no params");
+        await Assert.That(reason).IsNotEqualTo(request.Method);
+        await Assert.That(reason).IsNotEqualTo($"unattended_interaction_forbidden:{request.Method}");
+    }
+
+    /// <summary>Contrasted against the unadmittable-frame case above: a FORBIDDEN-METHOD reap (here,
+    /// the Fail-policy branch) publishes the generic method-coded reason, not a `why`-shaped one —
+    /// the two reap causes must stay distinguishable downstream.</summary>
+    [Test]
+    public async Task Forbidden_method_publishes_method_coded_string() {
+        string? reason = null;
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => throw new InvalidOperationException("must not be called"),
+            agentId: AgentId,
+            logger: NullLogger.Instance,
+            unattendedPolicy: AcpUnattendedInteractionPolicy.Fail,
+            unexpectedUnattendedInteraction: r => reason = r);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionParamsWithOptions("[]"));
+        await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(reason).IsEqualTo("unattended_interaction_forbidden:session/request_permission");
     }
 
     static (AcpInteractionBridge Bridge, Func<int> Calls) AutoApproveBridge(ILogger? logger = null) {
@@ -1210,7 +1257,8 @@ public class AcpInteractionBridgeTests {
 
         await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString())
             .IsEqualTo("cancelled");
-        await Assert.That(reaped).IsEquivalentTo(["session/request_permission"]);
+        // Task 2: the published reason is the forbidden-method CODING, not the bare method.
+        await Assert.That(reaped).IsEquivalentTo(["unattended_interaction_forbidden:session/request_permission"]);
         await Assert.That(routed()).IsEqualTo(0);
     }
 
@@ -1225,7 +1273,7 @@ public class AcpInteractionBridgeTests {
                 PermissionParamsFor($"Running: {Admitted}", "[]")),
             CancellationToken.None);
 
-        await Assert.That(reaped).IsEquivalentTo(["session/request_permission"]);
+        await Assert.That(reaped).IsEquivalentTo(["unattended_interaction_forbidden:session/request_permission"]);
     }
 
     /// <summary>Every NON-permission method under this policy behaves exactly as Fail — the tool
@@ -1240,7 +1288,7 @@ public class AcpInteractionBridgeTests {
             new AcpRequest(1, method, PermissionParamsFor($"Running: {Admitted}", "[]")),
             CancellationToken.None);
 
-        await Assert.That(reaped).IsEquivalentTo([method]);
+        await Assert.That(reaped).IsEquivalentTo([$"unattended_interaction_forbidden:{method}"]);
         await Assert.That(routed()).IsEqualTo(0);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -38,8 +38,8 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     static readonly JsonElement DefaultPromptResult =
         JsonDocument.Parse("""{"stopReason":"end_turn"}""").RootElement.Clone();
 
-    readonly Pipe   _toAgent;            // connection writes here; fake reads here (simulated stdin)
-    readonly Pipe   _toClient = new();   // fake writes here; connection reads here (simulated stdout)
+    readonly Pipe   _toAgent  = new();  // connection writes here; fake reads here (simulated stdin)
+    readonly Pipe   _toClient = new();  // fake writes here; connection reads here (simulated stdout)
     readonly Stream _agentReadsFromConnection;
     readonly Stream _agentWritesToConnection;
 
@@ -140,30 +140,17 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     }
 
     readonly TaskCompletionSource _initializeReceived = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    readonly TaskCompletionSource _sessionNewReceived = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    /// <summary>Completes the instant the fake RECORDS an <c>initialize</c> call. A reap test awaits
-    /// this before triggering its reap/disposal, so the reap can never preempt the handshake's
-    /// <c>initialize</c> — the deterministic replacement for a wall-clock poll that a slower CI runner
-    /// races (windows). Pair with <c>inlineAgentReads: true</c> so recording is synchronous with the
-    /// connection's write (see the constructor), removing the pool-scheduling window entirely.</summary>
+    /// <summary>Completes the instant the fake RECORDS an <c>initialize</c> call — an awaitable,
+    /// deterministic replacement for a wall-clock poll of <see cref="ReceivedCalls"/>. A reap test
+    /// awaits this to prove the runtime actually reached (and the fake observed) the initialize stage
+    /// before it triggers the reap, so "reap DURING initialize" is a recorded fact rather than a timing
+    /// hope. On a POSIX host the runtime always sends initialize during a review launch, so this always
+    /// fires; a runtime that never sent it would hang the await, which is the regression the awaiting
+    /// tests still catch.</summary>
     public Task InitializeReceived => _initializeReceived.Task;
 
-    /// <summary>As <see cref="InitializeReceived"/>, for the <c>session/new</c> handshake stage.</summary>
-    public Task SessionNewReceived => _sessionNewReceived.Task;
-
-    /// <param name="inlineAgentReads">Run the fake's READ continuations INLINE on the connection's
-    /// write/flush thread rather than the thread pool. The connection writes <c>initialize</c>
-    /// synchronously inside StartAsync, so inline reads make the fake RECORD it synchronously too —
-    /// closing the pool-scheduling window in which a launch-deadline/disposal on a slow CI runner could
-    /// tear down the transport before <c>initialize</c> is ever read (the windows ordering race).
-    /// Opt-in: only the reap tests that need determinism pass true; every other fixture keeps the
-    /// default thread-pool scheduler and its established behaviour.</param>
-    public FakeAcpAgent(bool inlineAgentReads = false) {
-        _toAgent = inlineAgentReads
-            ? new Pipe(new PipeOptions(readerScheduler: PipeScheduler.Inline, useSynchronizationContext: false))
-            : new Pipe();
-
+    public FakeAcpAgent() {
         _agentReadsFromConnection = _toAgent.Reader.AsStream();
         _agentWritesToConnection  = _toClient.Writer.AsStream();
 
@@ -623,10 +610,10 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
         lock (_receivedCallsLock)
             _receivedCalls.Add((method, @params));
 
-        // Fire the per-stage handshake signals so a test can await a stage being provably RECEIVED
-        // instead of polling ReceivedCalls on a wall-clock bound (deterministic; windows-race-free).
-        if (method == "initialize")       _initializeReceived.TrySetResult();
-        else if (method == "session/new") _sessionNewReceived.TrySetResult();
+        // Fire the initialize signal so a test can await it being provably RECORDED instead of polling
+        // ReceivedCalls on a wall-clock bound. TrySetResult is idempotent — a second initialize (never
+        // sent in these fixtures) is harmless.
+        if (method == "initialize") _initializeReceived.TrySetResult();
     }
 
     // ---- probe-confirmed canned response shapes (docs/acp-probe-findings.md) ----

--- a/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -38,8 +38,8 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     static readonly JsonElement DefaultPromptResult =
         JsonDocument.Parse("""{"stopReason":"end_turn"}""").RootElement.Clone();
 
-    readonly Pipe   _toAgent  = new();  // connection writes here; fake reads here (simulated stdin)
-    readonly Pipe   _toClient = new();  // fake writes here; connection reads here (simulated stdout)
+    readonly Pipe   _toAgent;            // connection writes here; fake reads here (simulated stdin)
+    readonly Pipe   _toClient = new();   // fake writes here; connection reads here (simulated stdout)
     readonly Stream _agentReadsFromConnection;
     readonly Stream _agentWritesToConnection;
 
@@ -139,7 +139,31 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
         }
     }
 
-    public FakeAcpAgent() {
+    readonly TaskCompletionSource _initializeReceived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    readonly TaskCompletionSource _sessionNewReceived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>Completes the instant the fake RECORDS an <c>initialize</c> call. A reap test awaits
+    /// this before triggering its reap/disposal, so the reap can never preempt the handshake's
+    /// <c>initialize</c> — the deterministic replacement for a wall-clock poll that a slower CI runner
+    /// races (windows). Pair with <c>inlineAgentReads: true</c> so recording is synchronous with the
+    /// connection's write (see the constructor), removing the pool-scheduling window entirely.</summary>
+    public Task InitializeReceived => _initializeReceived.Task;
+
+    /// <summary>As <see cref="InitializeReceived"/>, for the <c>session/new</c> handshake stage.</summary>
+    public Task SessionNewReceived => _sessionNewReceived.Task;
+
+    /// <param name="inlineAgentReads">Run the fake's READ continuations INLINE on the connection's
+    /// write/flush thread rather than the thread pool. The connection writes <c>initialize</c>
+    /// synchronously inside StartAsync, so inline reads make the fake RECORD it synchronously too —
+    /// closing the pool-scheduling window in which a launch-deadline/disposal on a slow CI runner could
+    /// tear down the transport before <c>initialize</c> is ever read (the windows ordering race).
+    /// Opt-in: only the reap tests that need determinism pass true; every other fixture keeps the
+    /// default thread-pool scheduler and its established behaviour.</param>
+    public FakeAcpAgent(bool inlineAgentReads = false) {
+        _toAgent = inlineAgentReads
+            ? new Pipe(new PipeOptions(readerScheduler: PipeScheduler.Inline, useSynchronizationContext: false))
+            : new Pipe();
+
         _agentReadsFromConnection = _toAgent.Reader.AsStream();
         _agentWritesToConnection  = _toClient.Writer.AsStream();
 
@@ -598,6 +622,11 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     void Record(string method, JsonElement? @params) {
         lock (_receivedCallsLock)
             _receivedCalls.Add((method, @params));
+
+        // Fire the per-stage handshake signals so a test can await a stage being provably RECEIVED
+        // instead of polling ReceivedCalls on a wall-clock bound (deterministic; windows-race-free).
+        if (method == "initialize")       _initializeReceived.TrySetResult();
+        else if (method == "session/new") _sessionNewReceived.TrySetResult();
     }
 
     // ---- probe-confirmed canned response shapes (docs/acp-probe-findings.md) ----

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
@@ -557,9 +557,10 @@ public partial class AgentOrchestratorVendorTests {
         //     WaitForExitEntered signal fires, and the bound is never approached.
         //   • Post-fix (ReadVerdict): it blocks on _reapLock and never reaches WaitForExitAsync, so
         //     this falls to the bound. The bound is immaterial to post-fix correctness — the lock
-        //     guarantees the finalizer reads the published verdict once released — so a generous value
-        //     only costs this one test its tail; what it buys is a RELIABLE pre-fix null-read.
-        await Task.WhenAny(process.WaitForExitEntered.Task, Task.Delay(TimeSpan.FromSeconds(3)));
+        //     guarantees the finalizer reads the published verdict once released — so it is kept SHORT
+        //     (the dedicated finalizer thread blocks for it, and an oversubscribed windows runner must
+        //     not have it starve sibling barrier tests); the pre-fix null-read fires far inside 1s.
+        await Task.WhenAny(process.WaitForExitEntered.Task, Task.Delay(TimeSpan.FromSeconds(1)));
 
         // Close the claim section: verdict published, _reapLock released.
         releaseStarter.TrySetResult();

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
@@ -507,7 +507,7 @@ public partial class AgentOrchestratorVendorTests {
     /// ReadVerdict() until the publish and reports. No deadlock: the starter returns the reap task
     /// WITHOUT awaiting termination, so the claimant releases _reapLock promptly (here the starter is
     /// a no-op returning a completed task) and never waits on the finalizer.</summary>
-    [Test]
+    [Test, NotInParallel] // holds a pool thread blocked on _reapLock up to the bound; must not starve timing-sensitive peers
     public async Task Finalizer_verdict_read_synchronizes_with_the_claim() {
         var server = new CaptureServerConnection();
         await using var orch = BuildOrchestrator(
@@ -544,8 +544,12 @@ public partial class AgentOrchestratorVendorTests {
         await reaperInStarter.Task.WaitAsync(TimeSpan.FromSeconds(30));
 
         // Drive the finalizer concurrently — the production shape where the starter's own
-        // _cts.Cancel() terminalises the child and drives FinalizeAgentRunAsync on another thread.
-        var finalizeTask = Task.Run(() => orch.FinalizeAgentRunForTest(agent));
+        // _cts.Cancel() terminalises the child and drives FinalizeAgentRunAsync on another thread. On a
+        // DEDICATED thread (not the pool): post-fix it blocks synchronously on ReadVerdict/_reapLock
+        // until release, and a blocked pool thread would starve timing-sensitive sibling tests.
+        var finalizeTask = Task.Factory.StartNew(
+            () => orch.FinalizeAgentRunForTest(agent),
+            CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
 
         // Hold the claim section open until the finalizer has provably reached its verdict read while
         // the lock is held and the verdict is null:
@@ -665,5 +669,84 @@ public partial class AgentOrchestratorVendorTests {
 
         await Assert.That(server.StatusChangedCalls.Any(
             c => c.AgentId == "stop-toctou-1" && c.Status == "Completed")).IsFalse();
+    }
+
+    // ── Finding 1 refinement: the check and the send-initiation must be ATOMIC under _reapLock ─────
+    // Round-1's second VerdictForbidsNonFailureStatus check narrowed but did not CLOSE the window: a
+    // verdict published between the check and the send still permits a post-publication non-failure
+    // send. The fix holds the publication lock (_reapLock) across BOTH the check and the send's
+    // initiation, so publication cannot interleave there.
+
+    /// <summary>Stop gate: publish the verdict between the gate's verdict check and its Completed
+    /// send-initiation (via the runtime's between-check-and-send hook, on ANOTHER thread). Post-fix
+    /// the gate holds _reapLock, so the publish blocks and the Completed is initiated with no verdict
+    /// published; pre-fix it publishes and the Completed is initiated after publication.</summary>
+    [Test, NotInParallel] // the gate blocks the stop's pool thread on a Join up to the bound; keep it off peers
+    public async Task Stop_gate_atomically_serializes_a_publish_against_the_completed_send() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("stop-atomic-1");
+        await using var _ = fake;
+
+        var agent = SeedAcpAgent(orch, "stop-atomic-1", runtime, status: "Running");
+        process.SignalExited(0);
+        server.VerdictCaptureRuntime = runtime;
+
+        runtime.BeforeGatedSendHookForTest = () => {
+            // Dedicated thread (not the pool): the gate holds _reapLock, so TryStartReap blocks here
+            // post-fix — Join times out and the gate proceeds to send with no verdict published.
+            // Pre-fix (no gate) it publishes fast and Join returns, so the send follows publication.
+            var t = new Thread(() => runtime.TryStartReap(
+                "kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask)) { IsBackground = true };
+            t.Start();
+            t.Join(TimeSpan.FromMilliseconds(500));
+        };
+
+        // The stop runs on a DEDICATED thread (not the pool): the gate blocks it on the hook's Join,
+        // and a blocked pool thread would starve timing-sensitive sibling tests.
+        await Task.Factory.StartNew(
+            () => orch.HandleStopAgentForTest("stop-atomic-1"),
+            CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
+
+        await Assert.That(server.NonFailureStatusSentAfterVerdictPublished).IsFalse();
+    }
+
+    /// <summary>Re-registration: publish the verdict DURING the AgentRegistered await — the wider,
+    /// natural interleave round-1's single pre-loop check cannot cover. Post-fix the per-attempt gate
+    /// re-checks under _reapLock and suppresses the status send; pre-fix the status send proceeds after
+    /// publication.</summary>
+    [Test]
+    public async Task Reregistration_rechecks_a_verdict_published_during_the_agent_registered_await() {
+        var registeredEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRegistered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var server = new CaptureServerConnection {
+            AgentRegisteredEntered = registeredEntered,
+            AgentRegisteredGate    = releaseRegistered
+        };
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("rereg-await-1");
+        await using var _ = fake;
+
+        var agent = SeedAcpAgent(orch, "rereg-await-1", runtime, status: "Running");
+        server.VerdictCaptureRuntime = runtime;
+
+        var rereg = orch.ReRegisterAgentsForTestAsync();
+
+        // Re-registration is now blocked inside the AgentRegistered await.
+        await registeredEntered.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Publish the verdict during that await.
+        runtime.TryStartReap("kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask);
+
+        releaseRegistered.TrySetResult();
+        await rereg.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(server.NonFailureStatusSentAfterVerdictPublished).IsFalse();
+        await Assert.That(server.StatusChangedCalls.Any(
+            c => c.AgentId == "rereg-await-1" && c.Status is "Running" or "Starting")).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
@@ -1,0 +1,319 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Tests.Unit.Acp;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The orchestrator's finalizer verdict arm — the registered-agent report seam. When an ACP
+/// reviewer's launch-window reap verdict (published by
+/// <see cref="AcpHostedAgentRuntime.TryStartReap"/>) is observed by
+/// <see cref="AgentOrchestrator.FinalizeAgentRunAsync"/> for an agent that already registered
+/// (post-successful-<c>StartAsync</c>, so the factory's own reclassification never had the chance
+/// to fire — see <see cref="Report_sent_exactly_once_across_factory_and_finalizer"/>'s Part A),
+/// the finalizer reports it as its FIRST action — before the process-exit wait — exactly once,
+/// failure-contained, and forces terminal Failed regardless of the child's exit code. Post-window
+/// reaps are deliberately excluded: today's teardown for that case must stay byte-identical.
+///
+/// Partial of <see cref="AgentOrchestratorVendorTests"/> to reuse its BuildOrchestrator /
+/// CaptureServerConnection / CreateGitRepo / SpyHostedAgentRuntimeFactory harness.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    /// <summary>
+    /// Minimal <see cref="IAcpProcess"/> whose <see cref="WaitForExitAsync"/> is a SEPARATE,
+    /// test-controlled gate from <see cref="HasExited"/>/<see cref="ExitCode"/> — unlike
+    /// production (where "the process exited" and "WaitForExitAsync resolves" are the same
+    /// signal), this lets a test hold <c>FinalizeAgentRunAsync</c>'s process-exit wait open
+    /// independently of exit state, to prove the verdict report happens strictly BEFORE that wait
+    /// resolves.
+    /// </summary>
+    sealed class FinalizerTestAcpProcess : IAcpProcess {
+        readonly TaskCompletionSource _waitGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int  Pid            => 9191;
+        public bool HasExited      { get; private set; }
+        public int? ExitCode       { get; private set; }
+        public int  TerminateCalls { get; private set; }
+
+        /// <summary>Sets exit state AND releases the wait gate — the normal production coupling,
+        /// for tests that don't care about ordering.</summary>
+        public void SignalExited(int exitCode = 0) {
+            HasExited = true;
+            ExitCode  = exitCode;
+            _waitGate.TrySetResult();
+        }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => _waitGate.Task;
+
+        public Task TerminateAsync(TimeSpan? timeout = null) {
+            TerminateCalls++;
+            SignalExited(ExitCode ?? 0);
+
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Builds a REAL <see cref="AcpHostedAgentRuntime"/> — never <c>StartAsync</c>'d; these tests
+    /// publish a verdict directly via <c>TryStartReap</c>/<c>FirstTurnSettledForTest</c> rather
+    /// than driving a full handshake — backed by a controllable process and inert in-memory
+    /// connection streams (<see cref="FakeAcpAgent"/>, unstarted: no protocol traffic is ever
+    /// sent). A real runtime is required, not a fake <see cref="IHostedAgentRuntime"/>: the
+    /// orchestrator's verdict arm pattern-matches the CONCRETE <see cref="AcpHostedAgentRuntime"/>
+    /// type to reach <c>Verdict</c>.
+    /// </summary>
+    static (AcpHostedAgentRuntime Runtime, FinalizerTestAcpProcess Process, FakeAcpAgent Fake) BuildVerdictRuntime(
+            string agentId) {
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FinalizerTestAcpProcess();
+        var runtime = new AcpHostedAgentRuntime(conn, process, NullLogger.Instance, agentId: agentId);
+
+        return (runtime, process, fake);
+    }
+
+    /// <summary>Constructs an <see cref="AgentInstance"/> directly — <c>SeedAgentForTest</c> only
+    /// builds PTY runtimes — wrapping the given ACP runtime, and registers it via
+    /// <c>RegisterAgentForTest</c> so it is reachable exactly like a real launch's registration.</summary>
+    static AgentInstance SeedAcpAgent(
+            AgentOrchestrator orch, string agentId, IHostedAgentRuntime runtime, string status = "Running") {
+        var agent = new AgentInstance(
+            agentId, "review this", "default", null, "/repo", "cursor",
+            runtime,
+            new WorktreeInfo("/repo", "b", "/repo"),
+            new CancellationTokenSource()) {
+            Status = status
+        };
+
+        orch.RegisterAgentForTest(agent);
+
+        return agent;
+    }
+
+    [Test]
+    public async Task Report_sent_before_exit_wait() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("wedge-1");
+        await using var _ = fake;
+
+        var claimed = runtime.TryStartReap(
+            "kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask);
+        await Assert.That(claimed).IsTrue();
+        await Assert.That(runtime.Verdict!.ReapedInsideLaunchWindow).IsTrue();
+
+        var agent = SeedAcpAgent(orch, "wedge-1", runtime);
+
+        var finalizeTask = orch.FinalizeAgentRunForTest(agent);
+
+        // Poll for the report rather than assuming synchronous completion — the barrier assertion
+        // below is what actually proves ordering, deterministically, regardless of scheduling.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+        while (server.LaunchFailedCalls.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
+        await Assert.That(server.LaunchFailedCalls[0].AgentId).IsEqualTo("wedge-1");
+        await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("kiro_reviewer_mcp_surface_unexpected");
+
+        // The barrier: the process-exit wait is STILL held — finalize cannot have completed —
+        // proving the report really was sent BEFORE that wait, not merely before some later step.
+        await Assert.That(finalizeTask.IsCompleted).IsFalse();
+
+        process.SignalExited(0);
+
+        await finalizeTask.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(agent.Status).IsEqualTo("Failed");
+        await Assert.That(server.AgentUnregisteredCalls).Contains("wedge-1");
+    }
+
+    [Test]
+    public async Task Report_sent_exactly_once_across_factory_and_finalizer() {
+        // ── Part A: the factory path — a reap during StartAsync. No AgentInstance is ever
+        // created (StartAsync throws before PublishAgent runs in HandleLaunchAgentCore), so the
+        // finalizer's verdict arm structurally never gets a chance to ALSO fire for this launch
+        // attempt. This is what "the guard flag must be shared" is defending against — expressed
+        // here as: the factory path is independently exactly-once too, and produces no
+        // AgentInstance for the finalizer to duplicate against.
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var factoryServer  = new CaptureServerConnection();
+            var reapingFactory = new SpyHostedAgentRuntimeFactory("cursor") {
+                StartThrow = new InvalidOperationException(
+                    "kiro_reviewer_mcp_surface_unexpected: violation (transport: read loop ended)")
+            };
+
+            await using var factoryOrch = BuildOrchestrator(
+                factoryServer, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [reapingFactory]);
+
+            await factoryOrch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "factory-reap-1",
+                Prompt: "go",
+                Model: "",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "cursor"
+            ));
+
+            await Assert.That(factoryServer.LaunchFailedCalls.Count(c => c.AgentId == "factory-reap-1")).IsEqualTo(1);
+            await Assert.That(factoryServer.LaunchFailedCalls.Single(c => c.AgentId == "factory-reap-1").Reason)
+                .Contains("kiro_reviewer_mcp_surface_unexpected");
+            await Assert.That(factoryOrch.GetAgentForTest("factory-reap-1")).IsNull();
+        } finally {
+            cleanup();
+        }
+
+        // ── Part B: the finalizer path, invoked TWICE for the SAME agent — simulating a
+        // hypothetical re-entrant/racing call to prove the per-agent guard is structural, not
+        // merely a consequence of today's single-call-site shape.
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("finalizer-reap-1");
+        await using var _ = fake;
+
+        runtime.TryStartReap(
+            "unattended_interaction_forbidden:session/request_permission", () => Task.CompletedTask);
+        process.SignalExited(0);
+
+        var agent = SeedAcpAgent(orch, "finalizer-reap-1", runtime);
+
+        await orch.FinalizeAgentRunForTest(agent);
+        await orch.FinalizeAgentRunForTest(agent); // re-entrant call — must not double-report
+
+        await Assert.That(server.LaunchFailedCalls.Count(c => c.AgentId == "finalizer-reap-1")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Faulted_report_never_skips_cleanup_or_unregister() {
+        var server = new CaptureServerConnection {
+            LaunchFailedThrow = new InvalidOperationException("transient SignalR failure")
+        };
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("faulted-report-1");
+        await using var _ = fake;
+
+        runtime.TryStartReap("kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask);
+        process.SignalExited(0);
+
+        var agent = SeedAcpAgent(orch, "faulted-report-1", runtime);
+
+        // Must complete without throwing — a report fault must never propagate out of finalize.
+        await orch.FinalizeAgentRunForTest(agent).WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(server.LaunchFailedCalls.Count(c => c.AgentId == "faulted-report-1")).IsEqualTo(1); // attempted
+        await Assert.That(server.AgentUnregisteredCalls).Contains("faulted-report-1");                        // cleanup still ran
+        await Assert.That(agent.Status).IsEqualTo("Failed");                                                  // status force still applied
+        await Assert.That(orch.GetAgentForTest("faulted-report-1")).IsNull();                                 // unregistered
+    }
+
+    [Test]
+    public async Task Published_verdict_forces_terminal_failed_regardless_of_exit_code() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("clean-exit-reap-1");
+        await using var _ = fake;
+
+        runtime.TryStartReap("kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask);
+        process.SignalExited(0); // clean exit — would compute "Completed" absent the fix
+
+        var agent = SeedAcpAgent(orch, "clean-exit-reap-1", runtime);
+
+        await orch.FinalizeAgentRunForTest(agent).WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(agent.Status).IsEqualTo("Failed");
+
+        // No later status transition clears the reason: the finalizer's own exit-code-driven
+        // classification block is a structural no-op once Status is already terminal, so it must
+        // never have sent ANY AgentStatusChanged for this agent — not even a "Failed" one; the
+        // hub's LaunchFailed handling already marks the registry entry Failed with the reason, and
+        // a redundant AgentStatusChanged is exactly the seam a future edit could turn into a
+        // non-failure clear.
+        await Assert.That(server.StatusChangedCalls.Any(c => c.AgentId == "clean-exit-reap-1")).IsFalse();
+    }
+
+    [Test]
+    public async Task Post_window_reap_sends_no_launchfailed_teardown_byte_identical() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("post-window-1");
+        await using var _ = fake;
+
+        // Close the launch window BEFORE reaping (mirrors a real first turn settling) —
+        // TryStartReap then classifies OUTSIDE the window.
+        runtime.FirstTurnSettledForTest.TrySetResult();
+        var claimed = runtime.TryStartReap("some_later_administrative_reap", () => Task.CompletedTask);
+        await Assert.That(claimed).IsTrue();
+        await Assert.That(runtime.Verdict!.ReapedInsideLaunchWindow).IsFalse();
+
+        process.SignalExited(0);
+
+        var agent = SeedAcpAgent(orch, "post-window-1", runtime);
+
+        await orch.FinalizeAgentRunForTest(agent).WaitAsync(TimeSpan.FromSeconds(30));
+
+        // No LaunchFailed from the verdict arm.
+        await Assert.That(server.LaunchFailedCalls.Any(c => c.AgentId == "post-window-1")).IsFalse();
+
+        // Today's teardown, byte-identical: exit code 0 + EmitsTerminalOutput==false (ACP) means
+        // the existing startup-failure classification is skipped too (gated on
+        // EmitsTerminalOutput), status resolves to "Completed" via the plain exit-code path, and
+        // IS reported — exactly as it would be with no verdict machinery in the picture at all.
+        await Assert.That(agent.Status).IsEqualTo("Completed");
+        await Assert.That(server.StatusChangedCalls).Contains(("post-window-1", "Completed"));
+        await Assert.That(server.AgentUnregisteredCalls).Contains("post-window-1");
+    }
+
+    [Test]
+    public async Task Empty_reason_fallback_carries_exception_type() {
+        // Direct unit coverage of the mapping helper itself (the general-purpose fallback cover).
+        await Assert.That(AgentOrchestrator.MapLaunchFailureReason(null, "SomeSource"))
+            .IsEqualTo("launch_failed:SomeSource — see daemon log");
+        await Assert.That(AgentOrchestrator.MapLaunchFailureReason("   ", "SomeSource"))
+            .IsEqualTo("launch_failed:SomeSource — see daemon log");
+        await Assert.That(AgentOrchestrator.MapLaunchFailureReason("real-reason", "SomeSource"))
+            .IsEqualTo("real-reason");
+
+        // Integration: an (unrealistic — TryStartReap does not validate its reason — but
+        // reachable) empty verdict reason must still report something diagnosable, never a blank
+        // string that renders as "unknown failure" with no way to grep the daemon log.
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("empty-reason-1");
+        await using var _ = fake;
+
+        runtime.TryStartReap("", () => Task.CompletedTask);
+        await Assert.That(runtime.Verdict!.Reason).IsEmpty();
+
+        process.SignalExited(0);
+
+        var agent = SeedAcpAgent(orch, "empty-reason-1", runtime);
+
+        await orch.FinalizeAgentRunForTest(agent).WaitAsync(TimeSpan.FromSeconds(30));
+
+        var reported = server.LaunchFailedCalls.Single(c => c.AgentId == "empty-reason-1").Reason;
+        await Assert.That(reported).IsNotEmpty();
+        await Assert.That(reported).Contains("TerminationVerdict");
+        await Assert.That(reported).Contains("launch_failed:");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
@@ -316,4 +316,60 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(reported).Contains("TerminationVerdict");
         await Assert.That(reported).Contains("launch_failed:");
     }
+
+    // ── StopAgentCoreAsync must not walk a published verdict's Failed back to Completed ────────
+    // Design spec §3.3's "no non-failure AgentStatusChanged after a published verdict" guarantee
+    // has a second seam beyond the finalizer itself: StopAgentCoreAsync is the single funnel for
+    // EVERY stop trigger (HandleStopAgent's own doc comment: server StopAgent, sequenced
+    // StopAgentV2, and the heartbeat's own TTL/idle/stuck-Starting reap sweep — plus a
+    // local-socket stop, which calls it directly) and runs unconditionally while the agent is
+    // still published in _agents, which is exactly the window between the finalizer's report and
+    // CleanupAgentAsync's unpublish. A reviewer that trips a containment tripwire is a plausible
+    // candidate for the SAME heartbeat tick's TTL/idle reap, so this is a real race, not a
+    // hypothetical one. These two tests seed the guard state directly (rather than driving a full
+    // concurrent finalize+stop race, which the rest of this file's tests already show reports
+    // LaunchFailureVerdictReported=1 and Status="Failed" — see e.g.
+    // Published_verdict_forces_terminal_failed_regardless_of_exit_code) so the race window itself
+    // is exercised deterministically.
+
+    [Test]
+    public async Task Stop_after_published_verdict_does_not_clear_failed_status_or_reason() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = orch.SeedAgentForTest("stop-race-1", status: "Running");
+
+        // Simulate the finalizer's verdict arm having already run — it reports the coded reason
+        // then forces terminal Failed — BEFORE CleanupAgentAsync has unpublished this agent, i.e.
+        // the exact window a concurrent stop can land in.
+        agent.LaunchFailureVerdictReported = 1;
+        agent.Status                       = "Failed";
+
+        await orch.HandleStopAgentForTest("stop-race-1");
+
+        // No non-failure AgentStatusChanged at all — not even a REPEATED "Failed" one, since the
+        // gate suppresses the whole call, matching Published_verdict_forces_terminal_failed_regardless_of_exit_code's
+        // "zero calls" bar rather than merely "no Completed call".
+        await Assert.That(server.StatusChangedCalls.Any(c => c.AgentId == "stop-race-1")).IsFalse();
+        await Assert.That(agent.Status).IsEqualTo("Failed");
+    }
+
+    [Test]
+    public async Task Stop_without_a_published_verdict_still_transitions_to_completed_and_notifies() {
+        // Regression check: an ordinary stop (no verdict ever published — the overwhelmingly
+        // common case, e.g. every claude/codex PTY agent, and every ACP agent that never trips a
+        // containment tripwire) must still behave exactly as before this fix.
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = orch.SeedAgentForTest("stop-normal-1", status: "Running");
+        await Assert.That(agent.LaunchFailureVerdictReported).IsEqualTo(0); // precondition: no verdict
+
+        await orch.HandleStopAgentForTest("stop-normal-1");
+
+        await Assert.That(server.StatusChangedCalls).Contains(("stop-normal-1", "Completed"));
+        await Assert.That(agent.Status).IsEqualTo("Completed");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
@@ -507,7 +507,7 @@ public partial class AgentOrchestratorVendorTests {
     /// ReadVerdict() until the publish and reports. No deadlock: the starter returns the reap task
     /// WITHOUT awaiting termination, so the claimant releases _reapLock promptly (here the starter is
     /// a no-op returning a completed task) and never waits on the finalizer.</summary>
-    [Test, NotInParallel] // holds a pool thread blocked on _reapLock up to the bound; must not starve timing-sensitive peers
+    [Test, NotInParallel] // blocks two DEDICATED threads (reaper + finalizer) briefly, released deterministically; keep off timing-sensitive peers
     public async Task Finalizer_verdict_read_synchronizes_with_the_claim() {
         var server = new CaptureServerConnection();
         await using var orch = BuildOrchestrator(
@@ -543,32 +543,40 @@ public partial class AgentOrchestratorVendorTests {
 
         await reaperInStarter.Task.WaitAsync(TimeSpan.FromSeconds(30));
 
+        // Deterministic signal that the finalizer reached the SYNCHRONISED read (fires at the top of
+        // ReadVerdict, before it blocks on _reapLock). The regressed plain-Verdict read never calls it.
+        var readVerdictEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        runtime.BeforeReadVerdictLockForTest = () => readVerdictEntered.TrySetResult();
+
         // Drive the finalizer concurrently — the production shape where the starter's own
         // _cts.Cancel() terminalises the child and drives FinalizeAgentRunAsync on another thread. On a
-        // DEDICATED thread (not the pool): post-fix it blocks synchronously on ReadVerdict/_reapLock
-        // until release, and a blocked pool thread would starve timing-sensitive sibling tests.
+        // DEDICATED thread (not the pool) so a synchronous blocked read never occupies a pool thread.
         var finalizeTask = Task.Factory.StartNew(
             () => orch.FinalizeAgentRunForTest(agent),
             CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
 
-        // Hold the claim section open until the finalizer has provably reached its verdict read while
-        // the lock is held and the verdict is null:
-        //   • Pre-fix (plain read): it reads null, skips the arm and reaches WaitForExitAsync — the
-        //     WaitForExitEntered signal fires, and the bound is never approached.
-        //   • Post-fix (ReadVerdict): it blocks on _reapLock and never reaches WaitForExitAsync, so
-        //     this falls to the bound. The bound is immaterial to post-fix correctness — the lock
-        //     guarantees the finalizer reads the published verdict once released — so it is kept SHORT
-        //     (the dedicated finalizer thread blocks for it, and an oversubscribed windows runner must
-        //     not have it starve sibling barrier tests); the pre-fix null-read fires far inside 1s.
-        await Task.WhenAny(process.WaitForExitEntered.Task, Task.Delay(TimeSpan.FromSeconds(1)));
-
-        // Close the claim section: verdict published, _reapLock released.
-        releaseStarter.TrySetResult();
-        await Assert.That(await reaperResult.Task.WaitAsync(TimeSpan.FromSeconds(30))).IsTrue();
+        // DETERMINISTIC barrier — no wall-clock hold (Bug B). The reaper is NOT released until after the
+        // assertion below, so the verdict stays NULL throughout, and exactly one of these fires:
+        //   • readVerdictEntered — the finalizer reached the SYNCHRONISED ReadVerdict and is blocking on
+        //     _reapLock (the fixed path); OR
+        //   • WaitForExitEntered — the finalizer took the UNSYNCHRONISED plain-Verdict read, saw null,
+        //     skipped the arm and reached WaitForExitAsync (the regressed path).
+        // A slow/oversubscribed runner can only DELAY whichever fires, never swap it — so this can FAIL
+        // or hang, never false-pass. The 30s is a pure hang guard (yields a fail, never a pass).
+        var reached = await Task.WhenAny(readVerdictEntered.Task, process.WaitForExitEntered.Task)
+            .WaitAsync(TimeSpan.FromSeconds(30));
+        var blockedInReadVerdict = reached == readVerdictEntered.Task;
 
         try {
-            // Post-fix: the finalizer's ReadVerdict() unblocks and reports. Pre-fix: it already read
-            // null and skipped the arm, so no report ever lands and this times out at 0.
+            // The finalizer must be BLOCKED in the synchronised ReadVerdict (proven), not merely slow,
+            // and must NOT have taken the regressed plain-read path (which reaches WaitForExitAsync).
+            await Assert.That(blockedInReadVerdict).IsTrue();
+
+            // Close the claim section: verdict published, _reapLock released → the blocked ReadVerdict
+            // returns the published verdict and the finalizer reports.
+            releaseStarter.TrySetResult();
+            await Assert.That(await reaperResult.Task.WaitAsync(TimeSpan.FromSeconds(30))).IsTrue();
+
             var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
             while (server.LaunchFailedCalls.Count == 0 && DateTime.UtcNow < deadline)
                 await Task.Delay(10);
@@ -576,8 +584,9 @@ public partial class AgentOrchestratorVendorTests {
             await Assert.That(server.LaunchFailedCalls.Count(c => c.AgentId == "barrier-verdict-1")).IsEqualTo(1);
             await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("kiro_reviewer_mcp_surface_unexpected");
         } finally {
+            releaseStarter.TrySetResult(); // release the reaper even if the assertion above failed
             process.SignalExited(0);
-            try { await finalizeTask.WaitAsync(TimeSpan.FromSeconds(30)); } catch { /* pre-fix leaves it parked past the failed assertion */ }
+            try { await finalizeTask.WaitAsync(TimeSpan.FromSeconds(30)); } catch { /* regressed impl leaves it parked past the failed assertion */ }
         }
 
         await Assert.That(agent.Status).IsEqualTo("Failed");

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
@@ -372,4 +372,110 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(server.StatusChangedCalls).Contains(("stop-normal-1", "Completed"));
         await Assert.That(agent.Status).IsEqualTo("Completed");
     }
+
+    /// <summary>Part A final-review fix wave, item 2: the publish→report race. A same-tick
+    /// TTL/idle/stuck-Starting sweep can reach StopAgentCoreAsync in the instant AFTER
+    /// TryStartReap has published the verdict but BEFORE the finalizer's CAS has set
+    /// LaunchFailureVerdictReported — this seeds exactly that instant (verdict published, guard
+    /// flag still 0) rather than the fully-reported state
+    /// Stop_after_published_verdict_does_not_clear_failed_status_or_reason already covers.</summary>
+    [Test]
+    public async Task Stop_racing_a_published_but_not_yet_reported_verdict_does_not_emit_completed() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("stop-race-2");
+        await using var _ = fake;
+
+        var claimed = runtime.TryStartReap(
+            "kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask);
+        await Assert.That(claimed).IsTrue();
+        await Assert.That(runtime.Verdict!.ReapedInsideLaunchWindow).IsTrue();
+        process.SignalExited(0);
+
+        var agent = SeedAcpAgent(orch, "stop-race-2", runtime, status: "Running");
+        // Precondition: the verdict is published, but nothing has reported it yet — the finalizer
+        // never ran for this agent in this test.
+        await Assert.That(agent.LaunchFailureVerdictReported).IsEqualTo(0);
+
+        await orch.HandleStopAgentForTest("stop-race-2");
+
+        await Assert.That(server.StatusChangedCalls.Any(c => c.AgentId == "stop-race-2")).IsFalse();
+        await Assert.That(agent.Status).IsNotEqualTo("Completed");
+    }
+
+    // ── Part A final-review fix wave, item 1: §3.5 wired into the general launch-failure catch ──
+    // MapLaunchFailureReason/DescribeLaunchFailure previously covered ONLY the finalizer's verdict
+    // arm; the orchestrator's general catch (HandleLaunchAgentCore, the site a reclassified
+    // AcpReviewerReapedException — and any other pre-StartAsync factory failure — actually lands
+    // on) still forwarded ex.Message raw, so a blank/whitespace message reached LaunchFailed
+    // unmapped. These two tests exercise that general catch directly (SpyHostedAgentRuntimeFactory
+    // .StartThrow, no AgentInstance ever created — the same "pre-insert failure" landing zone
+    // Report_sent_exactly_once_across_factory_and_finalizer's Part A already proved is the sole
+    // reporter for this scenario).
+
+    [Test]
+    public async Task Factory_prespawn_failure_with_blank_message_reports_the_typed_fallback() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server = new CaptureServerConnection();
+            var blankMessageFactory = new SpyHostedAgentRuntimeFactory("cursor") {
+                StartThrow = new InvalidOperationException("   ")
+            };
+
+            await using var orch = BuildOrchestrator(
+                server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [blankMessageFactory]);
+
+            await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "blank-msg-1",
+                Prompt: "go",
+                Model: "",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "cursor"
+            ));
+
+            var reported = server.LaunchFailedCalls.Single(c => c.AgentId == "blank-msg-1").Reason;
+            await Assert.That(reported).IsEqualTo($"launch_failed:{nameof(InvalidOperationException)} — see daemon log");
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test]
+    public async Task Factory_prespawn_failure_with_a_real_message_passes_it_through_verbatim() {
+        var (repoPath, cleanup) = CreateGitRepo();
+
+        try {
+            var server = new CaptureServerConnection();
+            var realMessageFactory = new SpyHostedAgentRuntimeFactory("cursor") {
+                StartThrow = new InvalidOperationException("cursor-agent binary not found on PATH")
+            };
+
+            await using var orch = BuildOrchestrator(
+                server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [realMessageFactory]);
+
+            await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "real-msg-1",
+                Prompt: "go",
+                Model: "",
+                Effort: null,
+                RepoPath: repoPath,
+                Tools: null,
+                AttachmentIds: null,
+                Vendor: "cursor"
+            ));
+
+            var reported = server.LaunchFailedCalls.Single(c => c.AgentId == "real-msg-1").Reason;
+            await Assert.That(reported).IsEqualTo("cursor-agent binary not found on PATH");
+        } finally {
+            cleanup();
+        }
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
@@ -37,6 +37,15 @@ public partial class AgentOrchestratorVendorTests {
         public int? ExitCode       { get; private set; }
         public int  TerminateCalls { get; private set; }
 
+        /// <summary>Completed when the FINALIZER'S process-exit wait is entered — keyed on a NON-NULL
+        /// timeout, because the finalizer calls <c>WaitForExitAsync(5s)</c> while the runtime's own
+        /// construction-time watcher (<c>WatchProcessExitAsync</c>) calls the null-timeout overload;
+        /// firing on the null call would (wrongly) complete this at construction, before the finalizer
+        /// ever runs. The finalizer reaches this wait ONLY after passing (and skipping) the verdict
+        /// arm, so it fires exactly when a finalizer read the verdict as null and moved on — the
+        /// finding-1 barrier's deterministic proof the pre-fix (unsynchronized) read happened.</summary>
+        public readonly TaskCompletionSource WaitForExitEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         /// <summary>Sets exit state AND releases the wait gate — the normal production coupling,
         /// for tests that don't care about ordering.</summary>
         public void SignalExited(int exitCode = 0) {
@@ -45,7 +54,11 @@ public partial class AgentOrchestratorVendorTests {
             _waitGate.TrySetResult();
         }
 
-        public Task WaitForExitAsync(TimeSpan? timeout = null) => _waitGate.Task;
+        public Task WaitForExitAsync(TimeSpan? timeout = null) {
+            if (timeout is not null) WaitForExitEntered.TrySetResult(); // the finalizer's call, not the ctor watcher's
+
+            return _waitGate.Task;
+        }
 
         public Task TerminateAsync(TimeSpan? timeout = null) {
             TerminateCalls++;
@@ -477,5 +490,180 @@ public partial class AgentOrchestratorVendorTests {
         } finally {
             cleanup();
         }
+    }
+
+    // ── Finding 1: the finalizer's verdict observation must synchronise with the claim ──────────
+    // TryStartReap claims the slot, snapshots the window, runs the (connection-cancelling) starter,
+    // and publishes the verdict — ALL inside one _reapLock critical section. The starter's
+    // _cts.Cancel() can drive FinalizeAgentRunAsync onto another thread WHILE that section is still
+    // executing and the verdict is still null. A finalizer reading the plain Verdict auto-property
+    // there sees null and skips LaunchFailed permanently; reading through the lock-synchronised
+    // ReadVerdict() blocks until the claimant commits the publish.
+
+    /// <summary>Holds the claimant INSIDE its starter (lock held, verdict not yet published), drives
+    /// the finalizer concurrently, and asserts it still reports. WaitForExitEntered is deterministic
+    /// proof that a pre-fix (unsynchronised) finalizer already read null and moved past the verdict
+    /// arm — so pre-fix this test times out with zero reports; post-fix the finalizer blocks in
+    /// ReadVerdict() until the publish and reports. No deadlock: the starter returns the reap task
+    /// WITHOUT awaiting termination, so the claimant releases _reapLock promptly (here the starter is
+    /// a no-op returning a completed task) and never waits on the finalizer.</summary>
+    [Test]
+    public async Task Finalizer_verdict_read_synchronizes_with_the_claim() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("barrier-verdict-1");
+        await using var _ = fake;
+
+        var agent = SeedAcpAgent(orch, "barrier-verdict-1", runtime);
+
+        var reaperInStarter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStarter  = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reaperResult    = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // The claimant blocks inside its starter, so the whole claim section — _reapLock held, window
+        // snapshotted, verdict NOT yet published — stays open until the test releases it. It runs on a
+        // DEDICATED thread, never the thread pool: a blocked pool thread throttles the pool's thread
+        // injection, which would delay the finalizer's own Task.Run past the barrier and let it read
+        // the verdict only AFTER release (a false pass this test measured).
+        var reaperThread = new Thread(() => {
+            try {
+                reaperResult.SetResult(runtime.TryStartReap(
+                    "kiro_reviewer_mcp_surface_unexpected: violation", () => {
+                        reaperInStarter.TrySetResult();
+                        releaseStarter.Task.GetAwaiter().GetResult(); // synchronous block INSIDE _reapLock
+                        return Task.CompletedTask;
+                    }));
+            } catch (Exception ex) {
+                reaperResult.SetException(ex);
+            }
+        }) { IsBackground = true };
+        reaperThread.Start();
+
+        await reaperInStarter.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        // Drive the finalizer concurrently — the production shape where the starter's own
+        // _cts.Cancel() terminalises the child and drives FinalizeAgentRunAsync on another thread.
+        var finalizeTask = Task.Run(() => orch.FinalizeAgentRunForTest(agent));
+
+        // Hold the claim section open until the finalizer has provably reached its verdict read while
+        // the lock is held and the verdict is null:
+        //   • Pre-fix (plain read): it reads null, skips the arm and reaches WaitForExitAsync — the
+        //     WaitForExitEntered signal fires, and the bound is never approached.
+        //   • Post-fix (ReadVerdict): it blocks on _reapLock and never reaches WaitForExitAsync, so
+        //     this falls to the bound. The bound is immaterial to post-fix correctness — the lock
+        //     guarantees the finalizer reads the published verdict once released — so a generous value
+        //     only costs this one test its tail; what it buys is a RELIABLE pre-fix null-read.
+        await Task.WhenAny(process.WaitForExitEntered.Task, Task.Delay(TimeSpan.FromSeconds(3)));
+
+        // Close the claim section: verdict published, _reapLock released.
+        releaseStarter.TrySetResult();
+        await Assert.That(await reaperResult.Task.WaitAsync(TimeSpan.FromSeconds(30))).IsTrue();
+
+        try {
+            // Post-fix: the finalizer's ReadVerdict() unblocks and reports. Pre-fix: it already read
+            // null and skipped the arm, so no report ever lands and this times out at 0.
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+            while (server.LaunchFailedCalls.Count == 0 && DateTime.UtcNow < deadline)
+                await Task.Delay(10);
+
+            await Assert.That(server.LaunchFailedCalls.Count(c => c.AgentId == "barrier-verdict-1")).IsEqualTo(1);
+            await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("kiro_reviewer_mcp_surface_unexpected");
+        } finally {
+            process.SignalExited(0);
+            try { await finalizeTask.WaitAsync(TimeSpan.FromSeconds(30)); } catch { /* pre-fix leaves it parked past the failed assertion */ }
+        }
+
+        await Assert.That(agent.Status).IsEqualTo("Failed");
+    }
+
+    // ── Finding 2: a concurrent status sender must not clear the just-reported failure ──────────
+
+    /// <summary>The finalizer transitions the agent to Failed BEFORE awaiting the report, so a
+    /// reconnect re-registration racing that await sees the failure state and cannot re-send the
+    /// (pre-fix still "Running") non-failure status — which would clear the FailureReason the report
+    /// is setting server-side.</summary>
+    [Test]
+    public async Task Reregistration_during_the_verdict_report_await_does_not_emit_a_non_failure_status() {
+        var launchFailedEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var launchFailedGate    = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var server = new CaptureServerConnection {
+            LaunchFailedEntered = launchFailedEntered,
+            LaunchFailedGate    = launchFailedGate
+        };
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("rereg-race-1");
+        await using var _ = fake;
+
+        runtime.TryStartReap("kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask);
+
+        var agent = SeedAcpAgent(orch, "rereg-race-1", runtime, status: "Running");
+
+        var finalizeTask = orch.FinalizeAgentRunForTest(agent);
+
+        // The finalizer is now genuinely inside its verdict-report await.
+        await launchFailedEntered.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        // A reconnect re-registration racing that await must NOT re-send this agent's status.
+        await orch.ReRegisterAgentsForTestAsync();
+
+        await Assert.That(server.StatusChangedCalls.Any(
+            c => c.AgentId == "rereg-race-1" && c.Status is "Running" or "Starting")).IsFalse();
+
+        launchFailedGate.TrySetResult();
+        process.SignalExited(0);
+        await finalizeTask.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(agent.Status).IsEqualTo("Failed");
+        await Assert.That(server.LaunchFailedCalls.Count(c => c.AgentId == "rereg-race-1")).IsEqualTo(1);
+    }
+
+    /// <summary>The stale-Status race: the finalizer has set LaunchFailureVerdictReported (with
+    /// proper memory ordering) but a concurrent ReRegister still reads the agent's Status field as
+    /// "Running". The INNER re-check on the flag — not the outer Status filter — must suppress the
+    /// resend. Seeds that state directly so the window is exercised without a race.</summary>
+    [Test]
+    public async Task Reregistration_of_a_reported_verdict_agent_skips_its_status_resend() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = orch.SeedAgentForTest("rereg-reported-1", status: "Running");
+        agent.LaunchFailureVerdictReported = 1; // the finalizer already claimed the report
+
+        await orch.ReRegisterAgentsForTestAsync();
+
+        await Assert.That(server.StatusChangedCalls.Any(c => c.AgentId == "rereg-reported-1")).IsFalse();
+    }
+
+    /// <summary>The stop-gate TOCTOU: StopAgentCoreAsync snapshots the suppression signals once, then
+    /// (synchronously) reaches the Completed send. A verdict published in that window must still be
+    /// suppressed — which only a pre-send RE-CHECK, not the snapshot, can do. The hook publishes the
+    /// verdict in exactly that window.</summary>
+    [Test]
+    public async Task Stop_gate_rechecks_a_verdict_published_after_its_snapshot() {
+        var server = new CaptureServerConnection();
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var (runtime, process, fake) = BuildVerdictRuntime("stop-toctou-1");
+        await using var _ = fake;
+
+        var agent = SeedAcpAgent(orch, "stop-toctou-1", runtime, status: "Running");
+        process.SignalExited(0);
+
+        // No verdict yet — the stop gate's snapshot reads "no suppression". The hook then publishes an
+        // in-window verdict between that snapshot and the Completed send, so only a pre-send re-check
+        // can suppress the transition.
+        orch.StopGateAfterSnapshotHookForTest = () =>
+            runtime.TryStartReap("kiro_reviewer_mcp_surface_unexpected: violation", () => Task.CompletedTask);
+
+        await orch.HandleStopAgentForTest("stop-toctou-1");
+
+        await Assert.That(server.StatusChangedCalls.Any(
+            c => c.AgentId == "stop-toctou-1" && c.Status == "Completed")).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -2272,6 +2272,21 @@ public partial class AgentOrchestratorVendorTests {
         public int AgentRegisteredFailTimes { get; init; }
         public int AgentRegisteredCallCount { get; private set; }
 
+        /// <summary>Completed the instant AgentRegisteredAsync is entered — lets a test hold
+        /// re-registration inside that await and publish a verdict there (finding 1 refinement).</summary>
+        public TaskCompletionSource? AgentRegisteredEntered { get; init; }
+
+        /// <summary>When set, AgentRegisteredAsync awaits this before returning — holding the
+        /// re-registration open across the AgentRegistered await.</summary>
+        public TaskCompletionSource? AgentRegisteredGate { get; init; }
+
+        /// <summary>When set, every non-failure AgentStatusChanged send checks this runtime's verdict
+        /// AT SEND TIME (via the lock-synchronised ReadVerdict); if a launch-window verdict is already
+        /// published, <see cref="NonFailureStatusSentAfterVerdictPublished"/> latches true — the exact
+        /// "non-failure status after publication" invariant violation finding 1 closes.</summary>
+        public AcpHostedAgentRuntime? VerdictCaptureRuntime { get; set; }
+        public bool NonFailureStatusSentAfterVerdictPublished { get; private set; }
+
         /// <summary>Every (agentId, model) pair the orchestrator registered — proves the AgentInstance
         /// the server sees carries the model the process actually runs (the pinned explicit-reviewer
         /// LaunchModel, not the dispatched cmd.Model).</summary>
@@ -2281,7 +2296,7 @@ public partial class AgentOrchestratorVendorTests {
         /// initial registration and every reconnect re-registration report the same pair.</summary>
         public List<(string AgentId, string? Sandbox, string? Approval)> AgentRegisteredPostures { get; } = [];
 
-        public override Task AgentRegisteredAsync(
+        public override async Task AgentRegisteredAsync(
                 string agentId, string? prompt, string? model, string? effort, string? repoPath,
                 string? sandboxPolicy = null, string? approvalPolicy = null) {
             AgentRegisteredCallCount++;
@@ -2289,9 +2304,11 @@ public partial class AgentOrchestratorVendorTests {
             lock (AgentRegisteredCalls) AgentRegisteredCalls.Add((agentId, model));
             lock (AgentRegisteredPostures) AgentRegisteredPostures.Add((agentId, sandboxPolicy, approvalPolicy));
 
-            return AgentRegisteredCallCount <= AgentRegisteredFailTimes
-                ? Task.FromException(new InvalidOperationException("transient re-register failure"))
-                : Task.CompletedTask;
+            AgentRegisteredEntered?.TrySetResult();
+            if (AgentRegisteredGate is { } gate) await gate.Task.ConfigureAwait(false);
+
+            if (AgentRegisteredCallCount <= AgentRegisteredFailTimes)
+                throw new InvalidOperationException("transient re-register failure");
         }
 
         // ── Option B task 4: ACP bind/forward capture ────────────────────────────────────
@@ -2398,6 +2415,12 @@ public partial class AgentOrchestratorVendorTests {
         public List<(string AgentId, string Status)> StatusChangedCalls { get; } = [];
 
         public override Task AgentStatusChangedAsync(string agentId, string status, string? sessionId) {
+            // Capture BEFORE recording: was a launch-window verdict already published when this
+            // non-failure status was sent? (finding 1 — the invariant a check-to-send race breaks.)
+            if (status is "Completed" or "Running" or "Starting"
+                && VerdictCaptureRuntime?.ReadVerdict() is { ReapedInsideLaunchWindow: true })
+                NonFailureStatusSentAfterVerdictPublished = true;
+
             lock (StatusChangedCalls) StatusChangedCalls.Add((agentId, status));
 
             return Task.CompletedTask;

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -2218,6 +2218,11 @@ public partial class AgentOrchestratorVendorTests {
         internal override string? CurrentConnectionId => ConnectionIdForTest;
         public List<(string AgentId, string Reason)> LaunchFailedCalls { get; } = [];
 
+        /// <summary>When set, LaunchFailedAsync still RECORDS the call (so a test can assert the
+        /// send was attempted) but returns a faulted task — for the finalizer's verdict-report
+        /// fault-containment test (a report fault must never skip CleanupAgentAsync/unregister).</summary>
+        public Exception? LaunchFailedThrow { get; init; }
+
         /// <summary>When set, EndAgentSessionAsync blocks until this token is cancelled,
         /// simulating a session-end call stuck waiting for a SignalR reconnect.</summary>
         public CancellationTokenSource? EndSessionBlockUntil { get; init; }
@@ -2228,7 +2233,7 @@ public partial class AgentOrchestratorVendorTests {
         public override Task LaunchFailedAsync(string agentId, string reason) {
             LaunchFailedCalls.Add((agentId, reason));
 
-            return Task.CompletedTask;
+            return LaunchFailedThrow is { } ex ? Task.FromException(ex) : Task.CompletedTask;
         }
 
         /// <summary>Every <see cref="DaemonStatusReport"/> the orchestrator sent, in order — the

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -2223,6 +2223,16 @@ public partial class AgentOrchestratorVendorTests {
         /// fault-containment test (a report fault must never skip CleanupAgentAsync/unregister).</summary>
         public Exception? LaunchFailedThrow { get; init; }
 
+        /// <summary>Completed the instant LaunchFailedAsync is entered (after recording the call) —
+        /// lets a test prove the finalizer is genuinely INSIDE its verdict-report await, so a
+        /// concurrent status emitter (reconnect re-registration) can be driven in exactly that
+        /// window (finding 2).</summary>
+        public TaskCompletionSource? LaunchFailedEntered { get; init; }
+
+        /// <summary>When set, LaunchFailedAsync awaits this task before returning — holding the
+        /// finalizer's report open so a concurrent emission can race it deterministically.</summary>
+        public TaskCompletionSource? LaunchFailedGate { get; init; }
+
         /// <summary>When set, EndAgentSessionAsync blocks until this token is cancelled,
         /// simulating a session-end call stuck waiting for a SignalR reconnect.</summary>
         public CancellationTokenSource? EndSessionBlockUntil { get; init; }
@@ -2230,10 +2240,12 @@ public partial class AgentOrchestratorVendorTests {
         /// <summary>Reasons passed to EndAgentSessionAsync, in call order.</summary>
         public List<string> EndSessionReasons { get; } = [];
 
-        public override Task LaunchFailedAsync(string agentId, string reason) {
+        public override async Task LaunchFailedAsync(string agentId, string reason) {
             LaunchFailedCalls.Add((agentId, reason));
+            LaunchFailedEntered?.TrySetResult();
 
-            return LaunchFailedThrow is { } ex ? Task.FromException(ex) : Task.CompletedTask;
+            if (LaunchFailedGate is { } gate) await gate.Task.ConfigureAwait(false);
+            if (LaunchFailedThrow is { } ex) throw ex;
         }
 
         /// <summary>Every <see cref="DaemonStatusReport"/> the orchestrator sent, in order — the

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -2959,11 +2959,17 @@ public class AcpHostedAgentRuntimeFactoryTests {
         await fake.DisposeAsync();
     }
 
-    /// <summary>The launch-DEADLINE catch (~308–333) must consult the verdict identically to the
-    /// general catch-all — a deadline racing a reap must not bypass reclassification and surface the
-    /// generic <c>{vendor}_reviewer_launch_timeout</c> text instead.</summary>
+    /// <summary>Reap-during-handshake reclassification: a reap that lands while the handshake is in
+    /// flight must surface the coded verdict, never the generic <c>{vendor}_reviewer_launch_timeout</c>
+    /// text. It runs through the GENERAL handshake-failure catch — the reap faults the pending
+    /// <c>initialize</c> sub-second, so the launch-deadline catch is never reached (see the in-body
+    /// note) — and BOTH the general and launch-deadline catch arms funnel through the SAME
+    /// <c>ReclassifyIfReaped</c>, so the shared "verdict wins over the generic launch-timeout text"
+    /// property IS pinned here. The deadline-SPECIFIC catch arm cannot be exercised deterministically
+    /// WITH a published verdict without a TimeProvider seam on the launch deadline (deliberately absent)
+    /// — a documented, accepted coverage gap, NOT one disguised by this test's name.</summary>
     [Test]
-    public async Task Deadline_catch_racing_verdict_reclassifies() {
+    public async Task Reap_during_handshake_reclassifies_to_verdict_via_general_catch() {
         // POSIX-only — see ReapDuringInitialize_WithDisposalHook_ for the full reason: this launches the
         // OpenCode unattended reviewer, refused on Windows before a connection exists.
         Skip.When(OperatingSystem.IsWindows(),
@@ -2977,8 +2983,8 @@ public class AcpHostedAgentRuntimeFactoryTests {
         // shares: a published verdict is surfaced (never the generic `{vendor}_reviewer_launch_timeout`).
         // The deadline arm cannot be reached deterministically WITH a reap-published verdict without a
         // TimeProvider seam on the launch deadline (deliberately absent) — because a real verdict only
-        // exists once the reap has already cancelled `_cts` and faulted the handshake. Flagged to the
-        // coordinator.
+        // exists once the reap has already cancelled `_cts` and faulted the handshake. That is the
+        // accepted, documented coverage gap the test name and summary now state honestly.
         var fake = new FakeAcpAgent();
         fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -2996,7 +3002,7 @@ public class AcpHostedAgentRuntimeFactoryTests {
 
         var startTask = factory.StartAsync(ReviewContext(), cts.Token);
 
-        // initialize is provably received (synchronous under inline reads) — well before the deadline.
+        // initialize is provably received (recorded on the fake's read loop) — well before the deadline.
         await fake.InitializeReceived.WaitAsync(HangGuard);
 
         // Publish the verdict well before the launch deadline fires below.

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -2643,11 +2643,17 @@ public class AcpHostedAgentRuntimeFactoryTests {
     /// matrix cell exists to prove that, not to find a NEW divergent behavior.</summary>
     [Test]
     public async Task ReapDuringInitialize_WithDisposalHook_FactoryReclassifiesToVerdict_NoAuthHint() {
-        // inlineAgentReads: the connection writes `initialize` synchronously in StartAsync, so inline
-        // reads make the fake RECORD it synchronously — the reap below can never preempt it, on any
-        // runner (the windows ordering race). We then gate the reap on the deterministic
-        // InitializeReceived signal rather than a wall-clock poll.
-        var fake = new FakeAcpAgent(inlineAgentReads: true);
+        // POSIX-only. This launches the OpenCode unattended reviewer, which OpenCodeReviewerCapability
+        // refuses on Windows (UnsupportedPlatform — its containment is an owner-only empty config dir,
+        // impossible without 0700). RequireReviewerCapability therefore throws BEFORE _connectionSource
+        // runs, so no connection is created, `initialize` is never sent, and there is no handshake to
+        // reap — the InitializeReceived await below would simply time out. The reclassification
+        // behaviour under test is platform-independent managed logic, fully exercised on the POSIX
+        // (ubuntu/macOS) legs; the skip aligns the test's platform with the production path it drives.
+        Skip.When(OperatingSystem.IsWindows(),
+            "OpenCode unattended reviewer is POSIX-only; the review launch is refused pre-handshake on Windows. Behaviour is covered on the POSIX legs.");
+
+        var fake = new FakeAcpAgent();
         fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var factory = new AcpHostedAgentRuntimeFactory(
@@ -2866,9 +2872,13 @@ public class AcpHostedAgentRuntimeFactoryTests {
     /// regress the shape that ALREADY awaited the reap pre-fix.</summary>
     [Test]
     public async Task ReapLandsDuringDisposalAwait_WithDisposalHook_BlocksFactoryUntilReapCompletes() {
-        // inlineAgentReads: record `initialize` synchronously with the connection's write so the reap
-        // can never preempt it (windows ordering race); the reap is gated on InitializeReceived below.
-        var fake    = new FakeAcpAgent(inlineAgentReads: true);
+        // POSIX-only — see ReapDuringInitialize_WithDisposalHook_ for the full reason: this launches the
+        // OpenCode unattended reviewer, which is refused on Windows before a connection exists, so there
+        // is no handshake to reap. Behaviour is covered on the POSIX legs.
+        Skip.When(OperatingSystem.IsWindows(),
+            "OpenCode unattended reviewer is POSIX-only; the review launch is refused pre-handshake on Windows. Behaviour is covered on the POSIX legs.");
+
+        var fake    = new FakeAcpAgent();
         var process = new GatedAcpProcess();
         fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -2954,19 +2964,22 @@ public class AcpHostedAgentRuntimeFactoryTests {
     /// generic <c>{vendor}_reviewer_launch_timeout</c> text instead.</summary>
     [Test]
     public async Task Deadline_catch_racing_verdict_reclassifies() {
-        // inlineAgentReads: record `initialize` synchronously with the connection's write so the reap
-        // below can never preempt the handshake on any runner (the windows ordering race).
-        //
-        // HONEST NOTE on which catch arm this traverses: the reap's own `_cts.Cancel()` faults the
-        // pending `initialize` request, so StartAsync throws via the GENERAL handshake-failure catch
-        // (sub-second — the ~700ms runtime confirms it), NOT the launch-deadline catch, which the
-        // generous 12s budget is never allowed to reach. Both arms funnel through the SAME
-        // ReclassifyIfReaped, so this still pins the property the deadline arm shares: a published
-        // verdict is surfaced (never the generic `{vendor}_reviewer_launch_timeout`). The deadline arm
-        // cannot be reached deterministically WITH a reap-published verdict without a TimeProvider seam
-        // on the launch deadline (deliberately absent) — because a real verdict only exists once the
-        // reap has already cancelled `_cts` and faulted the handshake. Flagged to the coordinator.
-        var fake = new FakeAcpAgent(inlineAgentReads: true);
+        // POSIX-only — see ReapDuringInitialize_WithDisposalHook_ for the full reason: this launches the
+        // OpenCode unattended reviewer, refused on Windows before a connection exists.
+        Skip.When(OperatingSystem.IsWindows(),
+            "OpenCode unattended reviewer is POSIX-only; the review launch is refused pre-handshake on Windows. Behaviour is covered on the POSIX legs.");
+
+        // HONEST NOTE on which catch arm this traverses (on the POSIX legs where it runs): the reap's
+        // own `_cts.Cancel()` faults the pending `initialize` request, so StartAsync throws via the
+        // GENERAL handshake-failure catch (sub-second — the ~700ms runtime confirms it), NOT the
+        // launch-deadline catch, which the generous 12s budget is never allowed to reach. Both arms
+        // funnel through the SAME ReclassifyIfReaped, so this still pins the property the deadline arm
+        // shares: a published verdict is surfaced (never the generic `{vendor}_reviewer_launch_timeout`).
+        // The deadline arm cannot be reached deterministically WITH a reap-published verdict without a
+        // TimeProvider seam on the launch deadline (deliberately absent) — because a real verdict only
+        // exists once the reap has already cancelled `_cts` and faulted the handshake. Flagged to the
+        // coordinator.
+        var fake = new FakeAcpAgent();
         fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var factory = new AcpHostedAgentRuntimeFactory(

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -41,6 +41,86 @@ public class AcpHostedAgentRuntimeFactoryTests {
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
+    /// <summary>An <see cref="IAcpProcess"/> whose <see cref="TerminateAsync"/> blocks until the test
+    /// completes <see cref="ReleaseTerminate"/> — unlike <see cref="FakeAcpProcess"/>'s
+    /// instant-resolving TerminateAsync, this lets a test PROVE disposal genuinely awaits an in-flight
+    /// reap task (rather than merely being consistent with either "awaited" or "not awaited at all").
+    /// <see cref="TerminateEntered"/>'s completion is set synchronously, inside the SAME claim that
+    /// starts this task, strictly BEFORE <see cref="AcpHostedAgentRuntime.Verdict"/> is assigned a few
+    /// statements later in that same unbroken call stack — but because this TCS uses
+    /// <c>RunContinuationsAsynchronously</c>, a test awaiting it only resumes on a LATER scheduled
+    /// continuation, by which point that synchronous burst (Verdict included) has unconditionally
+    /// already finished. So by the time a test observes this signal, Verdict is guaranteed published,
+    /// and it can assert the factory's overall launch task is still pending with zero ambiguity about
+    /// ordering.</summary>
+    sealed class GatedAcpProcess : IAcpProcess {
+        readonly TaskCompletionSource _exited = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public readonly TaskCompletionSource ReleaseTerminate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public readonly TaskCompletionSource TerminateEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int  Pid       { get; init; } = 4343;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => _exited.Task;
+
+        public async Task TerminateAsync(TimeSpan? timeout = null) {
+            TerminateEntered.TrySetResult();
+            await ReleaseTerminate.Task.ConfigureAwait(false);
+            HasExited = true;
+            ExitCode  = 0;
+            _exited.TrySetResult();
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// An <see cref="IAcpProcess"/> whose <see cref="TerminateAsync"/> SYNCHRONOUSLY cancels a
+    /// caller-supplied token as its very first action, before returning a completed task.
+    ///
+    /// <para>Exists for one scenario: reclassification during model selection, where the ONLY way to
+    /// make the (by-design never-fatal) <c>session/set_config_option</c> RPC actually escape
+    /// <c>StartAsync</c> uncaught is to cancel the launch's own token — but that races the reap's OWN
+    /// <c>_cts.Cancel()</c>, which independently tears down the read loop and faults the SAME pending
+    /// RPC with a non-cancellation exception the model selector's catch swallows. A test-side
+    /// await-a-barrier-then-cancel sequence cannot close that race: the barrier's continuation is
+    /// scheduled (<c>RunContinuationsAsynchronously</c>), so resuming test code to fire the
+    /// cancellation is itself subject to threadpool delay — exactly the delay that let the read-loop
+    /// teardown win under load.</para>
+    ///
+    /// <para>This closes it structurally instead of by timing: <c>TryStartReap</c> calls its
+    /// <c>start</c> closure — which synchronously reaches <c>Process.TerminateAsync</c> — BEFORE
+    /// assigning <c>Verdict</c>. Canceling here, synchronously, only QUEUES the pending RPC's
+    /// cancellation continuation; that continuation cannot actually run until this synchronous call
+    /// stack unwinds back through <c>TryStartReap</c>, which assigns <c>Verdict</c> on the way out —
+    /// so by the time anything resumes <c>StartAsync</c>'s unwind, the verdict this test asserts on
+    /// is unconditionally already published. No scheduling assumption, no barrier wait.</para>
+    /// </summary>
+    sealed class CancelCallerTokenOnTerminateProcess(CancellationTokenSource cancelOnTerminate) : IAcpProcess {
+        // A GENUINELY pending exit signal (mirrors FakeAcpProcess) — NOT an already-completed task:
+        // WatchProcessExitAsync starts watching at runtime CONSTRUCTION, and an immediately-completed
+        // WaitForExitAsync (with HasExited still false) fed it an inconsistent "already exited" signal
+        // that derailed the handshake before it ever reached model selection.
+        readonly TaskCompletionSource _exited = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int  Pid       { get; init; } = 4444;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => _exited.Task;
+
+        public Task TerminateAsync(TimeSpan? timeout = null) {
+            cancelOnTerminate.Cancel();
+            HasExited = true;
+            ExitCode  = 0;
+            _exited.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
     /// <summary>
     /// Records whether <see cref="ServerConnection.RequestAcpInteractionAsync"/> was actually
     /// invoked BY THE RUNTIME THE FACTORY PRODUCED (not by the test calling it directly) — a real
@@ -2453,5 +2533,444 @@ public class AcpHostedAgentRuntimeFactoryTests {
         try { await fakeRun.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
         await started.Runtime.DisposeAsync();
         await fake.DisposeAsync();
+    }
+
+    // ── Launch-phase reclassification: a reap's coded verdict replaces the generic handshake/
+    //    timeout text, after disposal unconditionally awaits any claimed reap ──────────────────────
+    // Every reap here is triggered the same way: an unattended review-flow launch (Fail policy —
+    // Cursor/OpenCode both use it) reaps on ANY inbound server request, so a bare
+    // session/request_permission frame — written directly via FakeAcpAgent.WriteRawFrameAsync,
+    // bypassing the fake's own scripted dispatch loop entirely — publishes the deterministic verdict
+    // reason "unattended_interaction_forbidden:session/request_permission" without needing the frame's
+    // own params (sessionId/toolCall/options) to be well-formed. The read loop is live from
+    // StartAsync's very first line, before any handshake RPC is even sent, so this can land during
+    // any stage.
+
+    const string ReapVerdictReason = "unattended_interaction_forbidden:session/request_permission";
+
+    /// <summary>OpenCode is a GATED reviewer vendor (like Kiro/Gemini) — RequireReviewerCapability
+    /// refuses it before <c>_connectionSource</c> even runs unless the operator has opted in AND the
+    /// resolved build matches (or exceeds) what this daemon has affirmed. Mirrors the established
+    /// <c>GeminiEnabledConfig</c> pattern: a real, per-test-unique StateDir backs a filesystem
+    /// <see cref="ReviewerVersionStore"/>, and <paramref name="launchTimeoutSeconds"/> lets a caller
+    /// override the 120s default when a test needs the deadline to actually fire.</summary>
+    const string OpenCodeBuild = "1.0.0";
+
+    static DaemonConfig OpenCodeEnabledConfig(int? launchTimeoutSeconds = null) {
+        var config = new DaemonConfig {
+            OpenCodeUnattendedReviewerEnabled = true,
+            StateDir = Path.Combine(Path.GetTempPath(), "kcap-opencode-gate-" + Guid.NewGuid().ToString("N")),
+            Name     = "test-daemon"
+        };
+
+        if (launchTimeoutSeconds is { } seconds)
+            config.OpenCodeReviewerLaunchTimeoutSeconds = seconds;
+
+        AcpHostedAgentRuntimeFactory.VersionStoreFor(config, AcpVendorDescriptors.OpenCode.Vendor).Affirm(OpenCodeBuild);
+
+        return config;
+    }
+
+    static Task WriteReapTriggerFrameAsync(FakeAcpAgent fake) =>
+        fake.WriteRawFrameAsync(
+            FakeAcpAgent.BuildRequestPermissionFrame(id: 999, sessionId: "unused", toolCallJson: "{}", optionsJson: "[]"),
+            CancellationToken.None);
+
+    /// <summary>Per-stage coverage, stage 1 of 3: a reap during <c>initialize</c>. Also stands in for
+    /// race order (a) — reap fully resolved (claim, window snapshot, verdict publish, AND the fake
+    /// process's instant-resolving TerminateAsync) before StartAsync's own catch even runs, since
+    /// nothing here holds the reap's async portion open.</summary>
+    [Test]
+    public async Task ReapDuringInitialize_Cursor_FactoryReclassifiesToVerdict_NoAuthHint() {
+        var fake = new FakeAcpAgent();
+        fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            descriptor: AcpVendorDescriptors.Cursor,
+            config: new DaemonConfig(),
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, new FakeAcpProcess()));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var startTask = factory.StartAsync(ReviewContext(), cts.Token);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!fake.ReceivedCalls.Any(c => c.Method == "initialize") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "initialize")).IsTrue();
+
+        await WriteReapTriggerFrameAsync(fake);
+
+        // The reap's own process termination doesn't tear down THIS fake's pipes (FakeAcpProcess is a
+        // stub) — the crash is simulated explicitly, standing in for what a real child's death does
+        // to the transport (design spec's "the in-flight handshake RPC dies with the transport's
+        // 'read loop ended' exception").
+        fake.SimulateCrash();
+
+        var ex = await Assert.ThrowsAsync<AcpHostedAgentRuntimeFactory.AcpReviewerReapedException>(
+            () => startTask.WaitAsync(HangGuard));
+
+        await Assert.That(ex.Message).StartsWith(ReapVerdictReason);
+        await Assert.That(ex.Message).Contains("(transport:");
+        await Assert.That(ex.Message).Contains("read loop ended");
+        await Assert.That(ex.Message).DoesNotContain("auth/subscription");
+        await Assert.That(ex.InnerException).IsNotNull();
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch { /* torn down by the simulated crash */ }
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Per-stage coverage, stage 2 of 3: a reap during <c>session/new</c> — the SAME
+    /// hint-composing wrapper as initialize, so the reclassification path is identical; this pins
+    /// that the stage boundary itself doesn't matter.</summary>
+    [Test]
+    public async Task ReapDuringSessionNew_Cursor_FactoryReclassifiesToVerdict_NoAuthHint() {
+        var fake = new FakeAcpAgent();
+        fake.HoldSessionNewResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            descriptor: AcpVendorDescriptors.Cursor,
+            config: new DaemonConfig(),
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, new FakeAcpProcess()));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var startTask = factory.StartAsync(ReviewContext(), cts.Token);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!fake.ReceivedCalls.Any(c => c.Method == "session/new") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "session/new")).IsTrue();
+
+        await WriteReapTriggerFrameAsync(fake);
+        fake.SimulateCrash();
+
+        var ex = await Assert.ThrowsAsync<AcpHostedAgentRuntimeFactory.AcpReviewerReapedException>(
+            () => startTask.WaitAsync(HangGuard));
+
+        await Assert.That(ex.Message).StartsWith(ReapVerdictReason);
+        await Assert.That(ex.Message).Contains("(transport:");
+        await Assert.That(ex.Message).DoesNotContain("auth/subscription");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch { /* torn down by the simulated crash */ }
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Per-stage coverage, stage 3 of 3: a reap during model selection — the ONE stage
+    /// StartAsync's hint-composing wrapper never covered (it runs strictly after that try/catch), so
+    /// its raw exception is never an <see cref="AcpHostedAgentRuntime.AcpHandshakeFailedException"/>
+    /// and the factory falls to <c>Sanitize(ex.Message)</c> for the transport half.
+    ///
+    /// <para>Model selection's own RPC failures are BY DESIGN never fatal
+    /// (<c>ConfigOptionModelSelector.TrySelectAsync</c>'s <c>catch (Exception ex) when (ex is not
+    /// OperationCanceledException)</c> swallows a transport fault exactly like the one
+    /// <see cref="ReapDuringInitialize_Cursor_FactoryReclassifiesToVerdict_NoAuthHint"/> uses — so
+    /// simulating the crash here would let StartAsync recover and return normally, with nothing for
+    /// the factory to reclassify. Cancelling the caller's own token is the one thing that DOES escape
+    /// that catch (its cancellation contract), and — since Cursor carries no launch deadline of its
+    /// own — routes through the GENERAL catch-all rather than the deadline-specific one, proving
+    /// reclassification does not depend on which of the two catches observes the exception.</para>
+    ///
+    /// <para>Canceling the caller's token itself races the reap's OWN internal <c>_cts.Cancel()</c>,
+    /// which independently tears down the read loop and faults the SAME pending RPC with a
+    /// non-cancellation exception the selector's catch swallows — so a naive "await a signal, then
+    /// cancel" sequence is racy under load (the signal's own continuation is scheduled, handing the
+    /// read-loop teardown extra time). <see cref="CancelCallerTokenOnTerminateProcess"/> closes this
+    /// structurally: see its own remarks.</para>
+    /// </summary>
+    [Test]
+    public async Task ReapDuringModelSet_Cursor_FactoryReclassifiesToVerdict_NoAuthHint() {
+        var fake = new FakeAcpAgent();
+        fake.SetSessionNewResult(FakeAcpAgent.BuildSessionNewResult(
+            FakeAcpAgent.FixedSessionId,
+            currentModelId: "composer-2.5[fast=true]",
+            availableModels: [("claude-sonnet-4-5[thinking=true,context=200k]", "claude-sonnet-4-5")]));
+        fake.HoldSetConfigOptionResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var cts = new CancellationTokenSource();
+        var process = new CancelCallerTokenOnTerminateProcess(cts);
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            descriptor: AcpVendorDescriptors.Cursor,
+            config: new DaemonConfig(),
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, process));
+
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var ctx = ReviewContext() with { Model = "claude-sonnet-4-5" };
+        var startTask = factory.StartAsync(ctx, cts.Token);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!fake.ReceivedCalls.Any(c => c.Method == "session/set_config_option") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "session/set_config_option")).IsTrue();
+
+        // Triggers the reap; its OWN dispatch synchronously reaches CancelCallerTokenOnTerminateProcess
+        // .TerminateAsync, which cancels cts before TryStartReap assigns Verdict on the way back out —
+        // by the time anything resumes StartAsync's pending model-selection await, Verdict is already
+        // published. Cursor carries no launch deadline of its own, so this exercises the GENERAL
+        // catch-all (not the deadline-specific one), proving reclassification is stage-agnostic even
+        // for the one stage StartAsync's hint-composing wrapper never covered.
+        await WriteReapTriggerFrameAsync(fake);
+
+        var ex = await Assert.ThrowsAsync<AcpHostedAgentRuntimeFactory.AcpReviewerReapedException>(
+            () => startTask.WaitAsync(HangGuard));
+
+        await Assert.That(ex.Message).StartsWith(ReapVerdictReason);
+        await Assert.That(ex.Message).Contains("(transport:");
+        await Assert.That(ex.Message).DoesNotContain("auth/subscription");
+
+        fake.HoldSetConfigOptionResponse.TrySetResult();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Race order (b), no-hook (cursor) shape — the regression this whole task exists to
+    /// close: pre-fix, DisposeAsync only looked at TakeReap() when `_onDisposed` was non-null, so a
+    /// cursor-shaped runtime's disposal could return (and the factory reclassify against a possibly
+    /// still-forming Verdict — or, worse on a slower machine, an unclaimed one) WITHOUT ever waiting
+    /// for an in-flight reap. <see cref="GatedAcpProcess.TerminateEntered"/> proves the reap's async
+    /// portion has genuinely started (so its synchronous claim + Verdict publish are already done)
+    /// before this asserts the overall launch task is STILL PENDING — deterministic on the "started"
+    /// half, then a short bounded wait (matching this project's established
+    /// "give a task a chance to (not) complete, then assert IsCompleted" idiom — see e.g.
+    /// AcpHostedAgentRuntimeTests.ReadOutputAsync_stays_open_until_the_process_exits) to let a
+    /// regressed implementation demonstrate completing prematurely if it would.</summary>
+    [Test]
+    public async Task ReapLandsDuringDisposalAwait_CursorShape_NoHook_BlocksFactoryUntilReapCompletes() {
+        var fake    = new FakeAcpAgent();
+        var process = new GatedAcpProcess();
+        fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            // ReviewerLaunchTimeoutSeconds is null for Cursor (only Kiro/OpenCode carry one) => no
+            // onDisposed cleanup hook is wired for this launch.
+            descriptor: AcpVendorDescriptors.Cursor,
+            config: new DaemonConfig(),
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, process));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var startTask = factory.StartAsync(ReviewContext(), cts.Token);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!fake.ReceivedCalls.Any(c => c.Method == "initialize") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "initialize")).IsTrue();
+
+        await WriteReapTriggerFrameAsync(fake);
+
+        // Proves the reap's async portion (ReapUnexpectedInteractionAsync -> Process.TerminateAsync)
+        // has started — Verdict is already published by this point (it's set synchronously, inside
+        // the same claim that started this task).
+        await process.TerminateEntered.Task.WaitAsync(HangGuard);
+
+        fake.SimulateCrash();
+
+        // ReleaseTerminate is still unset, so the reap task cannot have completed — give a (possibly
+        // regressed) implementation a bounded window to complete anyway before asserting it hasn't.
+        await Task.WhenAny(startTask, Task.Delay(300));
+        await Assert.That(startTask.IsCompleted).IsFalse();
+
+        process.ReleaseTerminate.TrySetResult();
+
+        var ex = await Assert.ThrowsAsync<AcpHostedAgentRuntimeFactory.AcpReviewerReapedException>(
+            () => startTask.WaitAsync(HangGuard));
+
+        await Assert.That(ex.Message).StartsWith(ReapVerdictReason);
+        await Assert.That(ex.Message).DoesNotContain("auth/subscription");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch { /* torn down by the simulated crash */ }
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Race order (b), WITH a disposal hook (OpenCode — also Fail policy, so the SAME
+    /// trigger mechanism as the cursor-shape sibling test applies; only the vendor's reviewer-launch
+    /// timeout — hence `onDisposed` wiring — differs). Proves the fix's unconditional move doesn't
+    /// regress the shape that ALREADY awaited the reap pre-fix.</summary>
+    [Test]
+    public async Task ReapLandsDuringDisposalAwait_WithDisposalHook_BlocksFactoryUntilReapCompletes() {
+        var fake    = new FakeAcpAgent();
+        var process = new GatedAcpProcess();
+        fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            // OpenCodeReviewerLaunchTimeoutSeconds defaults to 120s (long enough never to fire here)
+            // => onDisposed IS wired for this launch (DeleteReviewerIsolatedDirectory). OpenCode is a
+            // GATED reviewer vendor (like Kiro/Gemini) — the enabled config carries a matching
+            // operator opt-in + version affirmation, or RequireReviewerCapability refuses the launch
+            // before _connectionSource ever runs.
+            descriptor: AcpVendorDescriptors.OpenCode,
+            config: OpenCodeEnabledConfig(),
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, process),
+            resolveVendorVersion: _ => OpenCodeBuild);
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var startTask = factory.StartAsync(ReviewContext(), cts.Token);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!fake.ReceivedCalls.Any(c => c.Method == "initialize") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "initialize")).IsTrue();
+
+        await WriteReapTriggerFrameAsync(fake);
+
+        await process.TerminateEntered.Task.WaitAsync(HangGuard);
+
+        fake.SimulateCrash();
+
+        await Task.WhenAny(startTask, Task.Delay(300));
+        await Assert.That(startTask.IsCompleted).IsFalse();
+
+        process.ReleaseTerminate.TrySetResult();
+
+        var ex = await Assert.ThrowsAsync<AcpHostedAgentRuntimeFactory.AcpReviewerReapedException>(
+            () => startTask.WaitAsync(HangGuard));
+
+        await Assert.That(ex.Message).StartsWith(ReapVerdictReason);
+        await Assert.That(ex.Message).DoesNotContain("auth/subscription");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch { /* torn down by the simulated crash */ }
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Mutation guard (design spec §3.2): with no reap ever claimed, there is no verdict to
+    /// reclassify against, so the composed message — auth hint included — must stay exactly what
+    /// StartAsync produced before AcpHandshakeFailedException/AcpReviewerReapedException existed.
+    /// Also pins the new exception's shape: TransportMessage holds the SANITIZED cause alone, with
+    /// no hint appended.</summary>
+    [Test]
+    public async Task No_verdict_keeps_message_byte_identical() {
+        var fake = new FakeAcpAgent();
+        fake.FailNextInitialize(-32000, "not authenticated");
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            descriptor: AcpVendorDescriptors.Cursor,
+            config: new DaemonConfig { CursorPath = "cursor-agent" },
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, new FakeAcpProcess()));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var ex = await Assert.ThrowsAsync<AcpHostedAgentRuntime.AcpHandshakeFailedException>(
+            () => factory.StartAsync(MakeContext("agent-1"), cts.Token).WaitAsync(HangGuard));
+
+        await Assert.That(ex.Message).IsEqualTo(
+            "ACP handshake (initialize/session-new) failed: not authenticated — if this is an "
+          + "auth/subscription issue, run `cursor-agent login` and verify a Team-tier subscription.");
+        await Assert.That(ex.TransportMessage).IsEqualTo("not authenticated");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>The launch-DEADLINE catch (~308–333) must consult the verdict identically to the
+    /// general catch-all — a deadline racing a reap must not bypass reclassification and surface the
+    /// generic <c>{vendor}_reviewer_launch_timeout</c> text instead.</summary>
+    [Test]
+    public async Task Deadline_catch_racing_verdict_reclassifies() {
+        var fake = new FakeAcpAgent();
+        fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            // OpenCode is a GATED reviewer vendor (like Kiro/Gemini) — see OpenCodeEnabledConfig.
+            descriptor: AcpVendorDescriptors.OpenCode,
+            // Real wall-clock budget — ReviewerLaunchDeadline's CancelAfter has no TimeProvider seam.
+            // Short but not razor-thin, so CI contention can't starve the reap-trigger write before it fires.
+            config: OpenCodeEnabledConfig(launchTimeoutSeconds: 2),
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, new FakeAcpProcess()),
+            resolveVendorVersion: _ => OpenCodeBuild);
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var startTask = factory.StartAsync(ReviewContext(), cts.Token);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!fake.ReceivedCalls.Any(c => c.Method == "initialize") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "initialize")).IsTrue();
+
+        // Publish the verdict well before the 2s launch deadline fires below.
+        await WriteReapTriggerFrameAsync(fake);
+
+        var ex = await Assert.ThrowsAsync<AcpHostedAgentRuntimeFactory.AcpReviewerReapedException>(
+            () => startTask.WaitAsync(HangGuard));
+
+        await Assert.That(ex.Message).StartsWith(ReapVerdictReason);
+        await Assert.That(ex.Message).DoesNotContain("opencode_reviewer_launch_timeout");
+        await Assert.That(ex.Message).DoesNotContain("auth/subscription");
+
+        fake.HoldInitializeResponse.TrySetResult();
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>
+    /// No production step between a successful spawn (_connectionSource returning) and
+    /// runtime.StartAsync is reachable-by-test to organically throw with any normal input today — so
+    /// this exercises the extracted disposal unit directly. Design spec §3.2's fix ("a
+    /// post-spawn/pre-protected-region construction failure currently leaks the child") is about
+    /// WHATEVER this launch already obtained getting torn down even when no runtime was ever built
+    /// to own it — exactly what <see cref="AcpHostedAgentRuntimeFactory.DisposeUnclaimedSpawnAsync"/>
+    /// does, and what the factory's widened try/catch now calls when `runtime` is still null.
+    /// </summary>
+    [Test]
+    public async Task Post_spawn_construction_failure_disposes_child() {
+        var fake       = new FakeAcpAgent();
+        var connection = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process    = new FakeAcpProcess();
+
+        await AcpHostedAgentRuntimeFactory.DisposeUnclaimedSpawnAsync(connection, process);
+
+        await Assert.That(process.HasExited).IsTrue();
+
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>§3.5's non-empty-reason fallback: Task 4's orchestrator mapping owns applying it, but
+    /// a pre-StartAsync factory failure — no runtime ever wired, so no verdict — is exactly the case
+    /// that formula exists to cover, and this pins the shared formula plus that the factory itself
+    /// propagates such a failure byte-identically (untouched by this task's reclassification).</summary>
+    [Test]
+    public async Task Whitespace_prespawn_exception_yields_typed_fallback() {
+        var factory = new AcpHostedAgentRuntimeFactory(
+            descriptor: AcpVendorDescriptors.Cursor,
+            config: new DaemonConfig { CursorPath = "cursor-agent" },
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => throw new InvalidOperationException("   "));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => factory.StartAsync(MakeContext("agent-1"), CancellationToken.None).WaitAsync(HangGuard));
+
+        await Assert.That(ex.Message.Trim()).IsEmpty();
+        await Assert.That(AcpHostedAgentRuntimeFactory.DescribeLaunchFailure(ex))
+            .IsEqualTo($"launch_failed:{nameof(InvalidOperationException)} — see daemon log");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -2643,7 +2643,11 @@ public class AcpHostedAgentRuntimeFactoryTests {
     /// matrix cell exists to prove that, not to find a NEW divergent behavior.</summary>
     [Test]
     public async Task ReapDuringInitialize_WithDisposalHook_FactoryReclassifiesToVerdict_NoAuthHint() {
-        var fake = new FakeAcpAgent();
+        // inlineAgentReads: the connection writes `initialize` synchronously in StartAsync, so inline
+        // reads make the fake RECORD it synchronously — the reap below can never preempt it, on any
+        // runner (the windows ordering race). We then gate the reap on the deterministic
+        // InitializeReceived signal rather than a wall-clock poll.
+        var fake = new FakeAcpAgent(inlineAgentReads: true);
         fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var factory = new AcpHostedAgentRuntimeFactory(
@@ -2661,10 +2665,9 @@ public class AcpHostedAgentRuntimeFactoryTests {
 
         var startTask = factory.StartAsync(ReviewContext(), cts.Token);
 
-        var deadline = DateTime.UtcNow + HangGuard;
-        while (!fake.ReceivedCalls.Any(c => c.Method == "initialize") && DateTime.UtcNow < deadline)
-            await Task.Delay(10);
-        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "initialize")).IsTrue();
+        // Reap DURING initialize, provably AFTER initialize is received (never a timer). A runtime that
+        // never sends initialize would hang this — the mutation this assertion still catches.
+        await fake.InitializeReceived.WaitAsync(HangGuard);
 
         await WriteReapTriggerFrameAsync(fake);
         fake.SimulateCrash();
@@ -2863,7 +2866,9 @@ public class AcpHostedAgentRuntimeFactoryTests {
     /// regress the shape that ALREADY awaited the reap pre-fix.</summary>
     [Test]
     public async Task ReapLandsDuringDisposalAwait_WithDisposalHook_BlocksFactoryUntilReapCompletes() {
-        var fake    = new FakeAcpAgent();
+        // inlineAgentReads: record `initialize` synchronously with the connection's write so the reap
+        // can never preempt it (windows ordering race); the reap is gated on InitializeReceived below.
+        var fake    = new FakeAcpAgent(inlineAgentReads: true);
         var process = new GatedAcpProcess();
         fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -2885,10 +2890,9 @@ public class AcpHostedAgentRuntimeFactoryTests {
 
         var startTask = factory.StartAsync(ReviewContext(), cts.Token);
 
-        var deadline = DateTime.UtcNow + HangGuard;
-        while (!fake.ReceivedCalls.Any(c => c.Method == "initialize") && DateTime.UtcNow < deadline)
-            await Task.Delay(10);
-        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "initialize")).IsTrue();
+        // Reap provably AFTER initialize is received (never a timer). A runtime that never sends
+        // initialize would hang this — the mutation this still catches.
+        await fake.InitializeReceived.WaitAsync(HangGuard);
 
         await WriteReapTriggerFrameAsync(fake);
 
@@ -2950,17 +2954,24 @@ public class AcpHostedAgentRuntimeFactoryTests {
     /// generic <c>{vendor}_reviewer_launch_timeout</c> text instead.</summary>
     [Test]
     public async Task Deadline_catch_racing_verdict_reclassifies() {
-        var fake = new FakeAcpAgent();
+        // inlineAgentReads: record `initialize` synchronously with the connection's write so the reap
+        // below can never preempt the handshake on any runner (the windows ordering race).
+        //
+        // HONEST NOTE on which catch arm this traverses: the reap's own `_cts.Cancel()` faults the
+        // pending `initialize` request, so StartAsync throws via the GENERAL handshake-failure catch
+        // (sub-second — the ~700ms runtime confirms it), NOT the launch-deadline catch, which the
+        // generous 12s budget is never allowed to reach. Both arms funnel through the SAME
+        // ReclassifyIfReaped, so this still pins the property the deadline arm shares: a published
+        // verdict is surfaced (never the generic `{vendor}_reviewer_launch_timeout`). The deadline arm
+        // cannot be reached deterministically WITH a reap-published verdict without a TimeProvider seam
+        // on the launch deadline (deliberately absent) — because a real verdict only exists once the
+        // reap has already cancelled `_cts` and faulted the handshake. Flagged to the coordinator.
+        var fake = new FakeAcpAgent(inlineAgentReads: true);
         fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var factory = new AcpHostedAgentRuntimeFactory(
             // OpenCode is a GATED reviewer vendor (like Kiro/Gemini) — see OpenCodeEnabledConfig.
             descriptor: AcpVendorDescriptors.OpenCode,
-            // Real wall-clock budget — ReviewerLaunchDeadline's CancelAfter has no TimeProvider seam.
-            // 12s (was 2s): must comfortably exceed the real handshake's spawn+initialize+reap-trigger
-            // latency on the slower windows CI runner under parallel load (a 2s deadline fired before
-            // "initialize" was even sent there), yet stay below HangGuard so startTask.WaitAsync(HangGuard)
-            // still observes the deadline-driven throw. The deadline catch is still the path under test.
             config: OpenCodeEnabledConfig(launchTimeoutSeconds: 12),
             loggerFactory: NullLoggerFactory.Instance,
             connection: new CaptureServerConnection(),
@@ -2972,10 +2983,8 @@ public class AcpHostedAgentRuntimeFactoryTests {
 
         var startTask = factory.StartAsync(ReviewContext(), cts.Token);
 
-        var deadline = DateTime.UtcNow + HangGuard;
-        while (!fake.ReceivedCalls.Any(c => c.Method == "initialize") && DateTime.UtcNow < deadline)
-            await Task.Delay(10);
-        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "initialize")).IsTrue();
+        // initialize is provably received (synchronous under inline reads) — well before the deadline.
+        await fake.InitializeReceived.WaitAsync(HangGuard);
 
         // Publish the verdict well before the launch deadline fires below.
         await WriteReapTriggerFrameAsync(fake);

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -3027,4 +3027,123 @@ public class AcpHostedAgentRuntimeFactoryTests {
         await Assert.That(AcpHostedAgentRuntimeFactory.DescribeLaunchFailure(ex))
             .IsEqualTo($"launch_failed:{nameof(InvalidOperationException)} — see daemon log");
     }
+
+    // ── Finding 3: a disposal fault must not bypass verdict reclassification ─────────────────────
+
+    /// <summary>An <see cref="IAcpProcess"/> that terminates instantly (so the reap completes) but
+    /// FAULTS on <see cref="DisposeAsync"/> — the connection/process disposal fault the runtime's own
+    /// DisposeAsync propagates. Pre-fix, that fault escapes the factory's launch-failure catch BEFORE
+    /// <c>ReclassifyIfReaped</c> runs, replacing the coded verdict with a teardown exception.</summary>
+    sealed class ThrowingDisposeAcpProcess : IAcpProcess {
+        readonly TaskCompletionSource _exited = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int  Pid       { get; init; } = 4545;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => _exited.Task;
+        public Task TerminateAsync(TimeSpan? timeout = null) { HasExited = true; ExitCode = 0; _exited.TrySetResult(); return Task.CompletedTask; }
+        public ValueTask DisposeAsync() => throw new InvalidOperationException("teardown-fault: process disposal");
+    }
+
+    /// <summary>A reap during <c>initialize</c> whose runtime disposal then FAULTS must still be
+    /// reclassified to the coded verdict — the disposal fault is contained and logged, never allowed
+    /// to become the launch failure's headline. Pre-fix, <c>await runtime.DisposeAsync()</c> throws
+    /// out of the catch before reclassification and the teardown exception surfaces instead.</summary>
+    [Test]
+    public async Task ReapDuringInitialize_ThrowingDisposal_StillReclassifiesToVerdict() {
+        var fake = new FakeAcpAgent();
+        fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            descriptor: AcpVendorDescriptors.Cursor,
+            config: new DaemonConfig(),
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, new ThrowingDisposeAcpProcess()));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var startTask = factory.StartAsync(ReviewContext(), cts.Token);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!fake.ReceivedCalls.Any(c => c.Method == "initialize") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "initialize")).IsTrue();
+
+        await WriteReapTriggerFrameAsync(fake);
+        fake.SimulateCrash();
+
+        var ex = await Assert.ThrowsAsync<AcpHostedAgentRuntimeFactory.AcpReviewerReapedException>(
+            () => startTask.WaitAsync(HangGuard));
+
+        await Assert.That(ex.Message).StartsWith(ReapVerdictReason);
+        await Assert.That(ex.Message).DoesNotContain("teardown-fault"); // never the disposal exception
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch { /* torn down by the simulated crash */ }
+        await fake.DisposeAsync();
+    }
+
+    // ── Finding 4: DisposeUnclaimedSpawnAsync must not leak or mask on a cleanup fault ───────────
+
+    /// <summary>A <see cref="Stream"/> whose disposal FAULTS — makes <c>AcpConnection.DisposeAsync</c>
+    /// throw, standing in for a throwing stream disposal.</summary>
+    sealed class ThrowOnDisposeStream : Stream {
+        public override bool CanRead  => false;
+        public override bool CanSeek  => false;
+        public override bool CanWrite => true;
+        public override long Length   => 0;
+        public override long Position { get => 0; set { } }
+        public override void Flush() { }
+        public override int  Read(byte[] buffer, int offset, int count) => 0;
+        public override long Seek(long offset, SeekOrigin origin) => 0;
+        public override void SetLength(long value) { }
+        public override void Write(byte[] buffer, int offset, int count) { }
+        protected override void Dispose(bool disposing) => throw new InvalidOperationException("stream-disposal-fault");
+        public override ValueTask DisposeAsync() => throw new InvalidOperationException("stream-disposal-fault");
+    }
+
+    /// <summary>Tracks Terminate/Dispose so a test can prove the process was disposed even when the
+    /// connection disposal above it faulted.</summary>
+    sealed class DisposeTrackingAcpProcess : IAcpProcess {
+        readonly TaskCompletionSource _exited = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int  Pid            { get; init; } = 4646;
+        public bool HasExited      { get; private set; }
+        public int? ExitCode       { get; private set; }
+        public int  TerminateCalls { get; private set; }
+        public int  DisposeCalls   { get; private set; }
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => _exited.Task;
+        public Task TerminateAsync(TimeSpan? timeout = null) { TerminateCalls++; HasExited = true; ExitCode = 0; _exited.TrySetResult(); return Task.CompletedTask; }
+        public ValueTask DisposeAsync() { DisposeCalls++; return ValueTask.CompletedTask; }
+    }
+
+    /// <summary>A throwing connection disposal must neither skip the process disposal below it nor
+    /// escape to mask the construction failure that brought us here (the "best-effort throughout"
+    /// contract). Pre-fix, <c>connection.DisposeAsync</c> is awaited with no guard, so its fault
+    /// propagates out — the process is left undisposed and the launch's real error is masked.</summary>
+    [Test]
+    public async Task DisposeUnclaimedSpawn_ConnectionDisposalFault_StillDisposesProcess_AndDoesNotThrow() {
+        var connection = new AcpConnection(new ThrowOnDisposeStream(), new MemoryStream(), NullLogger.Instance);
+        var process    = new DisposeTrackingAcpProcess();
+
+        // Must NOT throw — a cleanup fault cannot replace the launch's real error.
+        await AcpHostedAgentRuntimeFactory.DisposeUnclaimedSpawnAsync(connection, process);
+
+        await Assert.That(process.TerminateCalls).IsGreaterThan(0);
+        await Assert.That(process.DisposeCalls).IsGreaterThan(0); // ran despite the connection fault
+    }
+
+    // ── Finding 5: the §3.5 fallback format string has a single owner ────────────────────────────
+
+    /// <summary>The exception-backed (factory <c>DescribeLaunchFailure</c>) and reason-backed
+    /// (orchestrator <c>MapLaunchFailureReason</c>) fallback paths route through ONE formatter, so
+    /// they cannot drift to different <c>launch_failed:…</c> shapes.</summary>
+    [Test]
+    public async Task Launch_failure_fallback_format_has_a_single_owner() {
+        var fromFactory = AcpHostedAgentRuntimeFactory.DescribeLaunchFailure(new InvalidOperationException("   "));
+        var fromOrch    = AgentOrchestrator.MapLaunchFailureReason(null, nameof(InvalidOperationException));
+
+        await Assert.That(fromFactory).IsEqualTo(fromOrch);
+        await Assert.That(fromFactory).IsEqualTo($"launch_failed:{nameof(InvalidOperationException)} — see daemon log");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -2624,6 +2624,60 @@ public class AcpHostedAgentRuntimeFactoryTests {
         await fake.DisposeAsync();
     }
 
+    /// <summary>Race order (a), WITH a disposal hook — the fourth cell of the 2×2 matrix (race order
+    /// (a)/(b) × no-hook/with-hook) alongside
+    /// <see cref="ReapDuringInitialize_Cursor_FactoryReclassifiesToVerdict_NoAuthHint"/> (a, no-hook)
+    /// and both <c>ReapLandsDuringDisposalAwait_*</c> tests (b, no-hook / b, with-hook). Same recipe
+    /// as the no-hook sibling — OpenCode instead of Cursor for the hook, a plain (instant-resolving)
+    /// <see cref="FakeAcpProcess"/> so the reap's claim AND its async portion both settle before
+    /// <c>StartAsync</c>'s own catch even runs. In THIS order the reap is already fully resolved
+    /// before disposal starts, so the hook's presence changes nothing observable about
+    /// reclassification (disposal's exit-confirmation gate is scoped inside the
+    /// <c>_onDisposed is not null</c> block, downstream of the now-unconditional reap-await) — the
+    /// assertions are deliberately identical to the no-hook sibling's, which is itself the point: the
+    /// matrix cell exists to prove that, not to find a NEW divergent behavior.</summary>
+    [Test]
+    public async Task ReapDuringInitialize_WithDisposalHook_FactoryReclassifiesToVerdict_NoAuthHint() {
+        var fake = new FakeAcpAgent();
+        fake.HoldInitializeResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var factory = new AcpHostedAgentRuntimeFactory(
+            // OpenCode is a GATED reviewer vendor (like Kiro/Gemini) — see OpenCodeEnabledConfig. Its
+            // default 120s ReviewerLaunchTimeoutSeconds is what wires the onDisposed cleanup hook.
+            descriptor: AcpVendorDescriptors.OpenCode,
+            config: OpenCodeEnabledConfig(),
+            loggerFactory: NullLoggerFactory.Instance,
+            connection: new CaptureServerConnection(),
+            connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, new FakeAcpProcess()),
+            resolveVendorVersion: _ => OpenCodeBuild);
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        var startTask = factory.StartAsync(ReviewContext(), cts.Token);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!fake.ReceivedCalls.Any(c => c.Method == "initialize") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "initialize")).IsTrue();
+
+        await WriteReapTriggerFrameAsync(fake);
+        fake.SimulateCrash();
+
+        var ex = await Assert.ThrowsAsync<AcpHostedAgentRuntimeFactory.AcpReviewerReapedException>(
+            () => startTask.WaitAsync(HangGuard));
+
+        await Assert.That(ex.Message).StartsWith(ReapVerdictReason);
+        await Assert.That(ex.Message).Contains("(transport:");
+        await Assert.That(ex.Message).Contains("read loop ended");
+        await Assert.That(ex.Message).DoesNotContain("auth/subscription");
+        await Assert.That(ex.InnerException).IsNotNull();
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch { /* torn down by the simulated crash */ }
+        await fake.DisposeAsync();
+    }
+
     /// <summary>Per-stage coverage, stage 2 of 3: a reap during <c>session/new</c> — the SAME
     /// hint-composing wrapper as initialize, so the reclassification path is identical; this pins
     /// that the stage boundary itself doesn't matter.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -28,7 +28,12 @@ namespace Capacitor.Cli.Tests.Unit.Services;
 /// replaces.
 /// </summary>
 public class AcpHostedAgentRuntimeFactoryTests {
-    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+    // 20s (was 5s): several barrier tests poll a REAL handshake for its "initialize" send within this
+    // window; on the slower/differently-scheduled windows CI runner, under parallel load, that send
+    // was not recorded within 5s and three ACP reap tests failed on the same
+    // `ReceivedCalls.Any(c => c.Method == "initialize")` assertion (green on ubuntu). A longer bound
+    // only lengthens a genuinely-hung failure; a passing poll still exits the instant the call lands.
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(20);
 
     sealed class FakeAcpProcess : IAcpProcess {
         readonly TaskCompletionSource _exited = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2952,8 +2957,11 @@ public class AcpHostedAgentRuntimeFactoryTests {
             // OpenCode is a GATED reviewer vendor (like Kiro/Gemini) — see OpenCodeEnabledConfig.
             descriptor: AcpVendorDescriptors.OpenCode,
             // Real wall-clock budget — ReviewerLaunchDeadline's CancelAfter has no TimeProvider seam.
-            // Short but not razor-thin, so CI contention can't starve the reap-trigger write before it fires.
-            config: OpenCodeEnabledConfig(launchTimeoutSeconds: 2),
+            // 12s (was 2s): must comfortably exceed the real handshake's spawn+initialize+reap-trigger
+            // latency on the slower windows CI runner under parallel load (a 2s deadline fired before
+            // "initialize" was even sent there), yet stay below HangGuard so startTask.WaitAsync(HangGuard)
+            // still observes the deadline-driven throw. The deadline catch is still the path under test.
+            config: OpenCodeEnabledConfig(launchTimeoutSeconds: 12),
             loggerFactory: NullLoggerFactory.Instance,
             connection: new CaptureServerConnection(),
             connectionSource: _ => (fake.ClientWriteStream, fake.ClientReadStream, new FakeAcpProcess()),
@@ -2969,7 +2977,7 @@ public class AcpHostedAgentRuntimeFactoryTests {
             await Task.Delay(10);
         await Assert.That(fake.ReceivedCalls.Any(c => c.Method == "initialize")).IsTrue();
 
-        // Publish the verdict well before the 2s launch deadline fires below.
+        // Publish the verdict well before the launch deadline fires below.
         await WriteReapTriggerFrameAsync(fake);
 
         var ex = await Assert.ThrowsAsync<AcpHostedAgentRuntimeFactory.AcpReviewerReapedException>(


### PR DESCRIPTION
## Problem

When the daemon reaps a reviewer launch for a coded, known reason (a containment tripwire — e.g. `KiroMcpSurfaceMonitor`'s `kiro_reviewer_mcp_surface_unexpected: …`), the flow caller almost never sees it: the flow surface reports `participant_launch_failed: … unknown failure` or the generic `ACP handshake … failed — if this is an auth/subscription issue…` catch-all (AI-1818's documented "red herring"). During the 2026-08-08 vendor cert, all nine kiro reviewer launches were reaped this way and ~2 hours were spent falsifying auth theories the hint seeded. Flows are routinely driven from machines with no daemon-log access.

Fixes AI-1828. This is the **daemon (Part A)** half; the kcap-server ready-wait/assignment re-checks (§3.4/§3.6) land in a companion PR. Spec: `docs/superpowers/specs/2026-08-09-ai1828-launch-failure-reason-propagation-design.md`.

## This PR — carry the coded verdict end-to-end

- **`TerminationVerdict` fused to the reap claim** (`AcpHostedAgentRuntime`): the coded reason is published on a `Verdict` property only on a successful reap claim, with `ReapedInsideLaunchWindow` snapshotted from the first-turn marker **at claim time, before** the reap's own `_cts.Cancel()` settles that marker (otherwise self-contaminating). Winner-of-claim ≡ winner-of-verdict, under one lock.
- **Bridge reason-bearing callbacks** (`AcpInteractionBridge`): the reap callback now carries the coded reason — `unattended_frame_unadmittable: {why}` (frame) / `unattended_interaction_forbidden:{method}` (forbidden method) — forwarded verbatim into the claim.
- **Factory reclassification** (`AcpHostedAgentRuntimeFactory`): a reap during `StartAsync` is reclassified, after an **unconditional** tracked-reap disposal await (now covering cursor's no-hook runtime too), into `AcpReviewerReapedException` headed by the verdict; a typed `AcpHandshakeFailedException` carries the transport cause as a separate property so the auth-hint suffix is **structurally unreachable** from the reclassified message across all three handshake stages. Both the launch-failure and launch-deadline catches consult the verdict.
- **Finalizer verdict arm** (`AgentOrchestrator`): a launch-window reap of a *registered* agent reports `LaunchFailed(agentId, verdict.Reason)` as the finalizer's **first action** (before the exit wait), exactly once (structural dedupe vs the factory path), failure-contained, forcing terminal `Failed` and suppressing any later non-failure `AgentStatusChanged` — including a racing `StopAgentCoreAsync` from the heartbeat reap sweep.
- **Unicode-safe truncation** (`SanitizeForForward`, now shared by the runtime and factory): never splits a UTF-16 surrogate pair (reap reasons can embed agent-controlled JSON-RPC text).
- **§3.5 non-empty fallback**: `launch_failed:{exception type} — see daemon log` for a blank reason, wired into the general launch-failure catches.

Guarantees are deliberately conditional (spec §1) — the tests pin the residuals so they can't silently widen.

## Tests

~230 across the touched classes (`AcpHostedAgentRuntimeTests`, `AcpInteractionBridgeTests`, `AcpHostedAgentRuntimeFactoryTests`, `AgentOrchestratorVendorTests`), all green — including the load-bearing concurrency ones (window-snapshot-before-cancel; concurrent-loser-cannot-publish; the two race orders × two runtime shapes; report-before-exit-wait; exactly-once; faulted-report-doesn't-skip-cleanup; published-verdict-forces-Failed; post-window byte-identical; surrogate-boundary) and the byte-identical no-verdict handshake-message guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)