### PR TITLE
[AI-1283] Report the new CLI version to the server after kcap update

### DIFF
--- a/npm/kcap/bin/kcap.js
+++ b/npm/kcap/bin/kcap.js
@@ -372,6 +372,20 @@ function runUpdate(binaryPath, updArgs) {
   require("./refresh").runRefreshes(fs.realpathSync(__filename));
   console.log("kcap updated.");
 
+  // Tell the server about the new version right away, so its "CLI out of
+  // date" banner/notification clear immediately instead of lingering until
+  // whatever the user runs next happens to hit the server. `binaryPath` now
+  // points at the freshly-installed NEW binary (overwritten in place above,
+  // or laid down at the same path after Windows's rename-aside). Best-effort
+  // and silent: this must never fail or slow down `kcap update` — the server
+  // observes the new version from the next incidental request anyway if this
+  // doesn't run or doesn't complete.
+  try {
+    execFileSync(binaryPath, ["report-version", "--no-update-check"], { stdio: "ignore", timeout: 8000 });
+  } catch {
+    // fire-and-forget: the server will observe on the next request anyway
+  }
+
   // A running daemon keeps executing the old image until restarted. On
   // macOS/Linux it self-detects the new binary and restarts when idle; on
   // Windows self-detection is off (the running image was moved, not replaced),

--- a/npm/kcap/bin/kcap.js
+++ b/npm/kcap/bin/kcap.js
@@ -372,14 +372,8 @@ function runUpdate(binaryPath, updArgs) {
   require("./refresh").runRefreshes(fs.realpathSync(__filename));
   console.log("kcap updated.");
 
-  // Tell the server about the new version right away, so its "CLI out of
-  // date" banner/notification clear immediately instead of lingering until
-  // whatever the user runs next happens to hit the server. `binaryPath` now
-  // points at the freshly-installed NEW binary (overwritten in place above,
-  // or laid down at the same path after Windows's rename-aside). Best-effort
-  // and silent: this must never fail or slow down `kcap update` — the server
-  // observes the new version from the next incidental request anyway if this
-  // doesn't run or doesn't complete.
+  // Tell the server about the new version now, so the "CLI out of date"
+  // banner clears immediately instead of waiting for the next request.
   try {
     execFileSync(binaryPath, ["report-version", "--no-update-check"], { stdio: "ignore", timeout: 8000 });
   } catch {

--- a/npm/kcap/bin/kcap.test.js
+++ b/npm/kcap/bin/kcap.test.js
@@ -108,16 +108,7 @@ assert.strictEqual(describeRole("kcap.exe watch"), "kcap process");
   }
 }
 
-// runUpdate's post-refresh version report to the server: `execFileSync` is destructured from
-// `child_process` at module load (`const { execFileSync, spawnSync } = require("child_process")`),
-// so there is no seam to intercept it short of restructuring the module or adding a mocking
-// dependency this package doesn't otherwise carry (no proxyquire/sinon/jest here — see
-// kcap.test.js's existing style, plain node:assert only). Actually running `runUpdate` would mean
-// actually running `npm install -g` — unacceptable in a unit test. So this asserts the SOURCE
-// shape instead: the call exists, is scoped to the exact command this fix depends on, is guarded
-// by its own try/catch (a throw here must never fail `kcap update`), and sits after the refresh
-// step succeeds and before runUpdate's own process.exit(0) — matching the design: report the new
-// version only once the update itself is done, and never let that report block or fail the exit.
+// Source-shape guard for runUpdate's report-version call: execFileSync has no mock seam (module-load-destructured), so this checks presence/ordering/try-catch by text instead of exact literals.
 {
   const src = fs.readFileSync(path.join(__dirname, "kcap.js"), "utf8");
 
@@ -127,22 +118,21 @@ assert.strictEqual(describeRole("kcap.exe watch"), "kcap process");
   const runUpdateBody = src.slice(updateStart, updateEnd >= 0 ? updateEnd : undefined);
 
   const refreshIdx = runUpdateBody.indexOf("runRefreshes(");
-  const reportIdx  = runUpdateBody.indexOf('execFileSync(binaryPath, ["report-version", "--no-update-check"]');
+  const reportIdx  = runUpdateBody.indexOf("report-version");
   const exitIdx    = runUpdateBody.lastIndexOf("process.exit(0)");
 
   assert(refreshIdx >= 0, "expected runUpdate to call runRefreshes(...)");
-  assert(reportIdx >= 0, "expected runUpdate to spawn the new binary's report-version, --no-update-check");
+  assert(reportIdx >= 0, "expected runUpdate to spawn report-version");
   assert(exitIdx >= 0, "expected runUpdate to still exit 0 on its success path");
   assert(refreshIdx < reportIdx, "report-version must be spawned AFTER the refresh step");
   assert(reportIdx < exitIdx, "report-version must be spawned BEFORE runUpdate's process.exit(0)");
 
-  // The report-version call must be inside its own try/catch (the closest preceding `try {`
-  // ahead of any intervening `catch` — i.e. no catch closes it before the call itself appears).
-  const precedingSlice  = runUpdateBody.slice(0, reportIdx);
+  // Guarded by its own try/catch: the nearest preceding `try {` must be closer than any `} catch`.
+  const precedingSlice = runUpdateBody.slice(0, reportIdx);
   const lastTryIdx      = precedingSlice.lastIndexOf("try {");
   const lastCatchIdx    = precedingSlice.lastIndexOf("} catch");
   assert(lastTryIdx >= 0 && lastTryIdx > lastCatchIdx,
-    "report-version must be guarded by its own try/catch — a throw here must never fail `kcap update`");
+    "report-version must be guarded by its own try/catch");
 }
 
 console.log("ok");

--- a/npm/kcap/bin/kcap.test.js
+++ b/npm/kcap/bin/kcap.test.js
@@ -108,4 +108,41 @@ assert.strictEqual(describeRole("kcap.exe watch"), "kcap process");
   }
 }
 
+// runUpdate's post-refresh version report to the server: `execFileSync` is destructured from
+// `child_process` at module load (`const { execFileSync, spawnSync } = require("child_process")`),
+// so there is no seam to intercept it short of restructuring the module or adding a mocking
+// dependency this package doesn't otherwise carry (no proxyquire/sinon/jest here — see
+// kcap.test.js's existing style, plain node:assert only). Actually running `runUpdate` would mean
+// actually running `npm install -g` — unacceptable in a unit test. So this asserts the SOURCE
+// shape instead: the call exists, is scoped to the exact command this fix depends on, is guarded
+// by its own try/catch (a throw here must never fail `kcap update`), and sits after the refresh
+// step succeeds and before runUpdate's own process.exit(0) — matching the design: report the new
+// version only once the update itself is done, and never let that report block or fail the exit.
+{
+  const src = fs.readFileSync(path.join(__dirname, "kcap.js"), "utf8");
+
+  const updateStart = src.indexOf("function runUpdate(");
+  assert(updateStart >= 0, "expected a runUpdate function in kcap.js");
+  const updateEnd = src.indexOf("\nfunction ", updateStart + 1);
+  const runUpdateBody = src.slice(updateStart, updateEnd >= 0 ? updateEnd : undefined);
+
+  const refreshIdx = runUpdateBody.indexOf("runRefreshes(");
+  const reportIdx  = runUpdateBody.indexOf('execFileSync(binaryPath, ["report-version", "--no-update-check"]');
+  const exitIdx    = runUpdateBody.lastIndexOf("process.exit(0)");
+
+  assert(refreshIdx >= 0, "expected runUpdate to call runRefreshes(...)");
+  assert(reportIdx >= 0, "expected runUpdate to spawn the new binary's report-version, --no-update-check");
+  assert(exitIdx >= 0, "expected runUpdate to still exit 0 on its success path");
+  assert(refreshIdx < reportIdx, "report-version must be spawned AFTER the refresh step");
+  assert(reportIdx < exitIdx, "report-version must be spawned BEFORE runUpdate's process.exit(0)");
+
+  // The report-version call must be inside its own try/catch (the closest preceding `try {`
+  // ahead of any intervening `catch` — i.e. no catch closes it before the call itself appears).
+  const precedingSlice  = runUpdateBody.slice(0, reportIdx);
+  const lastTryIdx      = precedingSlice.lastIndexOf("try {");
+  const lastCatchIdx    = precedingSlice.lastIndexOf("} catch");
+  assert(lastTryIdx >= 0 && lastTryIdx > lastCatchIdx,
+    "report-version must be guarded by its own try/catch — a throw here must never fail `kcap update`");
+}
+
 console.log("ok");

--- a/src/Capacitor.Cli/Commands/ReportVersionCommand.cs
+++ b/src/Capacitor.Cli/Commands/ReportVersionCommand.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Hidden, tooling-internal command: <c>npm/kcap/bin/kcap.js</c>'s <c>runUpdate</c> spawns the
+/// freshly-installed binary with this one argument right after <c>npm install</c> succeeds.
+///
+/// <para>The problem it closes: the server only learns a CLI's version from the
+/// <see cref="HttpClientExtensions.CliVersionHeader"/> header, attached at
+/// <see cref="HttpClientExtensions.CreateClientCoreAsync"/>'s single choke point to every
+/// authenticated request. `kcap update` itself is handled entirely by the npm wrapper — the OLD
+/// binary never makes another server call after installing the new one — so without this command
+/// the server keeps believing the OLD version until whatever the user runs next happens to hit
+/// the server, and the "CLI out of date" banner/notification linger in the meantime. Running the
+/// NEW binary once, right here, closes that gap immediately.</para>
+///
+/// <para>Fail-open by construction: never throws, never prints on the happy path, always returns
+/// 0. It reuses <see cref="SetupCommand"/>'s <c>/api/users/me/cli-setup</c> POST shape as an
+/// explicit "report my version" call, but — unlike that best-effort ping — goes through
+/// <see cref="HttpClientExtensions.CreateClientWithAuthStatusAsync"/> so the version header is
+/// actually attached; a bare <see cref="HttpClient"/> would carry no header and defeat the whole
+/// point. When the caller isn't authenticated (offline, never logged in, wrong server) it makes
+/// no request at all — there is nothing useful to observe from an anonymous or foreign token, and
+/// attempting one would just be a doomed round-trip on every update.</para>
+/// </summary>
+public static class ReportVersionCommand {
+    static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(5);
+
+    public static async Task<int> HandleAsync(string? baseUrl) {
+        try {
+            var (client, status) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl);
+
+            using (client) {
+                if (status != AuthStatus.Ok) return 0;
+
+                var version = CapacitorVersion.CurrentDisplay();
+                var payload = new JsonObject { ["cliVersion"] = version };
+
+                using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+
+                var url = AppConfig.NormalizeUrl(baseUrl ?? AppConfig.ResolvedServerUrl ?? "http://localhost:5108")
+                        + "/api/users/me/cli-setup";
+
+                using var _ = await client.PostOnceAsync(url, content, RequestTimeout);
+            }
+        } catch {
+            // Fail-open: this command's sole purpose is a best-effort side-effect that the
+            // server will otherwise learn on the next incidental request anyway. Nothing here
+            // may ever surface as a non-zero exit or console output.
+        }
+
+        return 0;
+    }
+}

--- a/src/Capacitor.Cli/Commands/ReportVersionCommand.cs
+++ b/src/Capacitor.Cli/Commands/ReportVersionCommand.cs
@@ -1,5 +1,3 @@
-using System.Text;
-using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
@@ -19,14 +17,26 @@ namespace Capacitor.Cli.Commands;
 /// the server, and the "CLI out of date" banner/notification linger in the meantime. Running the
 /// NEW binary once, right here, closes that gap immediately.</para>
 ///
+/// <para>The server's version observer (<c>CliVersionObserverMiddleware</c>) is
+/// ENDPOINT-AGNOSTIC — it reads the header off any authenticated request, so the request itself
+/// only needs to (a) require auth, so <c>GetUserId()</c> resolves, and (b) have no side effects,
+/// since this command runs on every update whether or not the user ever intended to trigger
+/// anything. That rules out <see cref="SetupCommand"/>'s <c>/api/users/me/cli-setup</c> POST — its
+/// handler fires a one-time "setup completed" event the first time a user's <c>CliSetupAt</c> is
+/// null, which would falsely mark onboarding complete for a user who logged in but never ran
+/// `kcap setup`. Instead this reuses <see cref="WhoamiCommand.ProbePath"/>, the same read-only
+/// identity GET `kcap whoami` uses to ask "do you accept this token?" — authenticated, and
+/// provably free of writes.</para>
+///
 /// <para>Fail-open by construction: never throws, never prints on the happy path, always returns
-/// 0. It reuses <see cref="SetupCommand"/>'s <c>/api/users/me/cli-setup</c> POST shape as an
-/// explicit "report my version" call, but — unlike that best-effort ping — goes through
-/// <see cref="HttpClientExtensions.CreateClientWithAuthStatusAsync"/> so the version header is
-/// actually attached; a bare <see cref="HttpClient"/> would carry no header and defeat the whole
-/// point. When the caller isn't authenticated (offline, never logged in, wrong server) it makes
-/// no request at all — there is nothing useful to observe from an anonymous or foreign token, and
-/// attempting one would just be a doomed round-trip on every update.</para>
+/// 0. Goes through <see cref="HttpClientExtensions.CreateClientWithAuthStatusAsync"/> so the
+/// version header is actually attached; a bare <see cref="HttpClient"/> would carry no header and
+/// defeat the whole point. Proceeds on <see cref="AuthStatus.Ok"/> (a real bearer token) and on
+/// <see cref="AuthStatus.NoAuthRequired"/> (an <c>Auth:Provider=None</c> tenant, where the request
+/// still authenticates via a synthetic principal and the middleware still observes it) — anything
+/// else (offline, never logged in, expired, wrong server) makes no request at all, since there is
+/// nothing useful to observe from an anonymous or foreign token and attempting one would just be a
+/// doomed round-trip on every update.</para>
 /// </summary>
 public static class ReportVersionCommand {
     static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(5);
@@ -36,17 +46,12 @@ public static class ReportVersionCommand {
             var (client, status) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl);
 
             using (client) {
-                if (status != AuthStatus.Ok) return 0;
-
-                var version = CapacitorVersion.CurrentDisplay();
-                var payload = new JsonObject { ["cliVersion"] = version };
-
-                using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+                if (status is not (AuthStatus.Ok or AuthStatus.NoAuthRequired)) return 0;
 
                 var url = AppConfig.NormalizeUrl(baseUrl ?? AppConfig.ResolvedServerUrl ?? "http://localhost:5108")
-                        + "/api/users/me/cli-setup";
+                        + WhoamiCommand.ProbePath;
 
-                using var _ = await client.PostOnceAsync(url, content, RequestTimeout);
+                using var _ = await client.GetOnceAsync(url, RequestTimeout);
             }
         } catch {
             // Fail-open: this command's sole purpose is a best-effort side-effect that the

--- a/src/Capacitor.Cli/Commands/ReportVersionCommand.cs
+++ b/src/Capacitor.Cli/Commands/ReportVersionCommand.cs
@@ -5,58 +5,40 @@ using Capacitor.Cli.Core.Config;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Hidden, tooling-internal command: <c>npm/kcap/bin/kcap.js</c>'s <c>runUpdate</c> spawns the
-/// freshly-installed binary with this one argument right after <c>npm install</c> succeeds.
-///
-/// <para>The problem it closes: the server only learns a CLI's version from the
-/// <see cref="HttpClientExtensions.CliVersionHeader"/> header, attached at
-/// <see cref="HttpClientExtensions.CreateClientCoreAsync"/>'s single choke point to every
-/// authenticated request. `kcap update` itself is handled entirely by the npm wrapper — the OLD
-/// binary never makes another server call after installing the new one — so without this command
-/// the server keeps believing the OLD version until whatever the user runs next happens to hit
-/// the server, and the "CLI out of date" banner/notification linger in the meantime. Running the
-/// NEW binary once, right here, closes that gap immediately.</para>
-///
-/// <para>The server's version observer (<c>CliVersionObserverMiddleware</c>) is
-/// ENDPOINT-AGNOSTIC — it reads the header off any authenticated request, so the request itself
-/// only needs to (a) require auth, so <c>GetUserId()</c> resolves, and (b) have no side effects,
-/// since this command runs on every update whether or not the user ever intended to trigger
-/// anything. That rules out <see cref="SetupCommand"/>'s <c>/api/users/me/cli-setup</c> POST — its
-/// handler fires a one-time "setup completed" event the first time a user's <c>CliSetupAt</c> is
-/// null, which would falsely mark onboarding complete for a user who logged in but never ran
-/// `kcap setup`. Instead this reuses <see cref="WhoamiCommand.ProbePath"/>, the same read-only
-/// identity GET `kcap whoami` uses to ask "do you accept this token?" — authenticated, and
-/// provably free of writes.</para>
-///
-/// <para>Fail-open by construction: never throws, never prints on the happy path, always returns
-/// 0. Goes through <see cref="HttpClientExtensions.CreateClientWithAuthStatusAsync"/> so the
-/// version header is actually attached; a bare <see cref="HttpClient"/> would carry no header and
-/// defeat the whole point. Proceeds on <see cref="AuthStatus.Ok"/> (a real bearer token) and on
-/// <see cref="AuthStatus.NoAuthRequired"/> (an <c>Auth:Provider=None</c> tenant, where the request
-/// still authenticates via a synthetic principal and the middleware still observes it) — anything
-/// else (offline, never logged in, expired, wrong server) makes no request at all, since there is
-/// nothing useful to observe from an anonymous or foreign token and attempting one would just be a
-/// doomed round-trip on every update.</para>
+/// Hidden command spawned by the npm wrapper right after <c>kcap update</c> installs a new
+/// binary: makes one authenticated GET against <see cref="WhoamiCommand.ProbePath"/> (read-only,
+/// no side effects — unlike <see cref="SetupCommand"/>'s cli-setup POST) so the server's
+/// endpoint-agnostic version-observer middleware sees the new <see cref="HttpClientExtensions.CliVersionHeader"/>
+/// immediately. Fail-open: never throws, never prints, always returns 0, bounded to
+/// <see cref="Budget"/> total (discovery + request).
 /// </summary>
 public static class ReportVersionCommand {
-    static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(5);
+    static readonly TimeSpan Budget = TimeSpan.FromSeconds(5);
 
     public static async Task<int> HandleAsync(string? baseUrl) {
         try {
-            var (client, status) = await HttpClientExtensions.CreateClientWithAuthStatusAsync(baseUrl);
+            using var cts = new CancellationTokenSource(Budget);
+
+            // One resolved URL for both auth and the request — CreateClientWithAuthStatusAsync's
+            // own fallback also consults KCAP_URL, so recomputing it differently here would
+            // authenticate against one host and probe another.
+            var effectiveBaseUrl = baseUrl
+                ?? AppConfig.ResolvedServerUrl
+                ?? Environment.GetEnvironmentVariable("KCAP_URL")
+                ?? "http://localhost:5108";
+
+            var (client, status) =
+                await HttpClientExtensions.CreateClientWithAuthStatusAsync(effectiveBaseUrl, cts.Token);
 
             using (client) {
                 if (status is not (AuthStatus.Ok or AuthStatus.NoAuthRequired)) return 0;
 
-                var url = AppConfig.NormalizeUrl(baseUrl ?? AppConfig.ResolvedServerUrl ?? "http://localhost:5108")
-                        + WhoamiCommand.ProbePath;
+                var url = AppConfig.NormalizeUrl(effectiveBaseUrl) + WhoamiCommand.ProbePath;
 
-                using var _ = await client.GetOnceAsync(url, RequestTimeout);
+                using var _ = await client.GetOnceAsync(url, Budget, cts.Token);
             }
         } catch {
-            // Fail-open: this command's sole purpose is a best-effort side-effect that the
-            // server will otherwise learn on the next incidental request anyway. Nothing here
-            // may ever surface as a non-zero exit or console output.
+            // Fail-open — see class doc.
         }
 
         return 0;

--- a/src/Capacitor.Cli/CrashReporter.cs
+++ b/src/Capacitor.Cli/CrashReporter.cs
@@ -21,7 +21,7 @@ internal static class CrashReporter {
     // directly by UpdateNotice.IsHumanFacing — the same population never gets the
     // exit-time update notice either, since nobody reads their stderr.
     internal static readonly HashSet<string> FailOpenCommands = new(StringComparer.Ordinal) {
-        "hook", "generate-whats-done", "set-title", "copilot-finalize",
+        "hook", "generate-whats-done", "set-title", "copilot-finalize", "report-version",
     };
 
     /// <summary>True for agent-spawned commands that must fail open (exit 0) on a crash.</summary>

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -140,7 +140,10 @@ if (args.Skip(1).Any(a => a is "--help" or "-h")) {
 }
 
 // Commands that don't need a server URL
-string[] offlineCommands = ["--help", "-h", "help", "--version", "-v", "logout", "cleanup", "config", "daemon", "setup", "status", "update", "plugin", "profile", "use", "repos", "login", "ignore", "remap", "uninstall", "cursor-verify-appendonly", "agent"];
+// report-version: a no-server host must still hit ReportVersionCommand.HandleAsync's own
+// fail-open logic and return 0 silently, per its doc comment — never the generic
+// "No server configured" exit 1 this gate would otherwise produce.
+string[] offlineCommands = ["--help", "-h", "help", "--version", "-v", "logout", "cleanup", "config", "daemon", "setup", "status", "update", "plugin", "profile", "use", "repos", "login", "ignore", "remap", "uninstall", "cursor-verify-appendonly", "agent", "report-version"];
 
 if (baseUrl is null && !offlineCommands.Contains(command)) {
     Console.Error.WriteLine("No server configured. Run `kcap setup` or set KCAP_URL.");

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -731,6 +731,13 @@ switch (command) {
 
         return 0;
     }
+    // Hidden, tooling-internal: spawned once by the npm wrapper's `runUpdate` right after
+    // `npm install` lands the new binary, so the server observes the new version immediately
+    // instead of waiting for whatever the user runs next. Not in PrintUsage — like
+    // generate-whats-done/set-title/copilot-finalize, nobody types this by hand. See
+    // ReportVersionCommand for why it never surfaces an error.
+    case "report-version":
+        return await ReportVersionCommand.HandleAsync(baseUrl);
     case "hook": {
         // Task 12: global, session-agnostic drain pass run early in EVERY non-Codex hook
         // invocation — centralizes the per-vendor AgentHookPoster.DrainSpoolsAsync calls Tasks 4-6

--- a/src/Capacitor.Cli/UpdateNotice.cs
+++ b/src/Capacitor.Cli/UpdateNotice.cs
@@ -20,7 +20,8 @@ internal static class UpdateNotice {
     /// <summary>
     /// The suppression predicate. False (suppressed) for:
     /// <see cref="CrashReporter.FailOpenCommands"/> (<c>hook</c>, <c>generate-whats-done</c>,
-    /// <c>set-title</c>, <c>copilot-finalize</c> — agent-spawned, nobody reads their stderr);
+    /// <c>set-title</c>, <c>copilot-finalize</c>, <c>report-version</c> — agent/tooling-spawned,
+    /// nobody reads their stderr);
     /// <c>mcp</c> (a stdio JSON-RPC server — stderr is not a terminal) and <c>watch</c> (a
     /// long-lived background process); the entire <c>daemon</c> command family (there is no
     /// separate <c>run</c> subcommand — the foreground shape is plain <c>kcap daemon start</c>

--- a/test/Capacitor.Cli.Tests.Unit/ReportVersionCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReportVersionCommandTests.cs
@@ -1,0 +1,161 @@
+using System.Diagnostics;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The hidden <c>kcap report-version</c> command, invoked by the npm wrapper right after
+/// `kcap update` installs a new binary. Its whole purpose is to make ONE authenticated request
+/// through <see cref="HttpClientExtensions.CreateClientWithAuthStatusAsync"/> — the single choke
+/// point that attaches <see cref="HttpClientExtensions.CliVersionHeader"/> — so the server's
+/// version observer sees the new version immediately instead of waiting for the next incidental
+/// request. It must never surface an error: not-authenticated makes no request at all, and a
+/// server fault or a slow server still returns 0 within its own request budget.
+///
+/// <para><c>[NotInParallel(nameof(TokenStoreProfileTests))]</c>: shares
+/// <c>ObservationHeaderTests</c>'s serialization key — these tests touch the process-wide
+/// <see cref="AppConfig.ResolvedProfile"/> static and the shared <c>KCAP_CONFIG_DIR</c>
+/// config.json that other classes in this assembly also read and write.</para>
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class ReportVersionCommandTests : IDisposable {
+    const string ReportPath = "/api/users/me/cli-setup";
+
+    readonly WireMockServer _server = WireMockServer.Start();
+
+    [Before(Test)]
+    public void Cleanup() {
+        AppConfig.ResetResolvedStateForTesting();
+        HttpClientExtensions.ResetProviderCacheForTesting();
+
+        var cfg = AppConfig.GetConfigPath();
+        if (File.Exists(cfg)) File.Delete(cfg);
+    }
+
+    public void Dispose() {
+        _server.Stop();
+        AppConfig.ResetResolvedStateForTesting();
+        HttpClientExtensions.ResetProviderCacheForTesting();
+    }
+
+    void StubDiscovery(string provider) =>
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{"provider":"{{provider}}"}"""));
+
+    async Task SeedValidTokenAsync(string profileName) {
+        AppConfig.SetResolvedState(_server.Urls[0], profileName, new Profile());
+        await TokenStore.SaveAsync(profileName, new StoredTokens {
+            AccessToken    = "tok-" + profileName,
+            ExpiresAt      = DateTimeOffset.UtcNow.AddHours(1),
+            GitHubUsername = "alice",
+            Provider       = AuthProvider.GitHubApp,
+            ServerUrl      = _server.Urls[0],
+        });
+    }
+
+    // ── Authenticated: exactly one request, carrying the version header ───────────────────────
+
+    [Test]
+    public async Task Authenticated_MakesOneRequestCarryingTheVersionHeader() {
+        StubDiscovery("github_app");
+        _server.Given(Request.Create().WithPath(ReportPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        await SeedValidTokenAsync("report-version-ok");
+
+        var result = await ReportVersionCommand.HandleAsync(_server.Urls[0]);
+
+        await Assert.That(result).IsEqualTo(0);
+
+        var requests = _server.LogEntries.Where(e => e.RequestMessage.Path == ReportPath).ToList();
+        await Assert.That(requests.Count).IsEqualTo(1);
+        await Assert.That(requests[0].RequestMessage.Headers![HttpClientExtensions.CliVersionHeader].Single())
+            .IsEqualTo(CapacitorVersion.CurrentDisplay());
+    }
+
+    // ── Not authenticated: no request at all, still returns 0 ─────────────────────────────────
+
+    [Test]
+    public async Task NotAuthenticated_MakesNoRequest_AndReturnsZero() {
+        StubDiscovery("github_app");
+        _server.Given(Request.Create().WithPath(ReportPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        // No token stored, no resolved profile — AuthStatus resolves to NotAuthenticated.
+        var result = await ReportVersionCommand.HandleAsync(_server.Urls[0]);
+
+        await Assert.That(result).IsEqualTo(0);
+        await Assert.That(_server.LogEntries.Any(e => e.RequestMessage.Path == ReportPath)).IsFalse();
+    }
+
+    [Test]
+    public async Task ExpiredToken_MakesNoRequest_AndReturnsZero() {
+        StubDiscovery("github_app");
+        _server.Given(Request.Create().WithPath(ReportPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        const string profileName = "report-version-expired";
+        AppConfig.SetResolvedState(_server.Urls[0], profileName, new Profile());
+        await TokenStore.SaveAsync(profileName, new StoredTokens {
+            AccessToken    = "tok-expired",
+            ExpiresAt      = DateTimeOffset.UtcNow.AddHours(-1),
+            GitHubUsername = "alice",
+            Provider       = AuthProvider.GitHubApp,
+            ServerUrl      = _server.Urls[0],
+        });
+
+        var result = await ReportVersionCommand.HandleAsync(_server.Urls[0]);
+
+        await Assert.That(result).IsEqualTo(0);
+        await Assert.That(_server.LogEntries.Any(e => e.RequestMessage.Path == ReportPath)).IsFalse();
+    }
+
+    // ── Server-side failures: fail-open, never throws ──────────────────────────────────────────
+
+    [Test]
+    public async Task ServerErrorResponse_StillReturnsZero() {
+        StubDiscovery("github_app");
+        _server.Given(Request.Create().WithPath(ReportPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(500));
+
+        await SeedValidTokenAsync("report-version-500");
+
+        var result = await ReportVersionCommand.HandleAsync(_server.Urls[0]);
+
+        await Assert.That(result).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SlowServer_StillReturnsZero_WithinItsOwnBudget() {
+        StubDiscovery("github_app");
+        _server.Given(Request.Create().WithPath(ReportPath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithDelay(TimeSpan.FromSeconds(10)));
+
+        await SeedValidTokenAsync("report-version-slow");
+
+        var sw     = Stopwatch.StartNew();
+        var result = await ReportVersionCommand.HandleAsync(_server.Urls[0]);
+        sw.Stop();
+
+        await Assert.That(result).IsEqualTo(0);
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(8));
+    }
+
+    [Test]
+    public async Task UnreachableServer_StillReturnsZero() {
+        // No discovery stub, no listener at all on this port — DiscoverProviderAsync's own
+        // catch falls back to local tokens, finds none, resolves NotAuthenticated; even if it
+        // somehow resolved Ok, the command's own try/catch must still swallow the failure.
+        var result = await ReportVersionCommand.HandleAsync("http://127.0.0.1:1");
+
+        await Assert.That(result).IsEqualTo(0);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ReportVersionCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReportVersionCommandTests.cs
@@ -35,6 +35,7 @@ public class ReportVersionCommandTests : IDisposable {
     public void Cleanup() {
         AppConfig.ResetResolvedStateForTesting();
         HttpClientExtensions.ResetProviderCacheForTesting();
+        Environment.SetEnvironmentVariable("KCAP_URL", null);
 
         var cfg = AppConfig.GetConfigPath();
         if (File.Exists(cfg)) File.Delete(cfg);
@@ -165,6 +166,51 @@ public class ReportVersionCommandTests : IDisposable {
             .RespondWith(Response.Create().WithStatusCode(200).WithDelay(TimeSpan.FromSeconds(10)));
 
         await SeedValidTokenAsync("report-version-slow");
+
+        var sw     = Stopwatch.StartNew();
+        var result = await ReportVersionCommand.HandleAsync(_server.Urls[0]);
+        sw.Stop();
+
+        await Assert.That(result).IsEqualTo(0);
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(8));
+    }
+
+    /// <summary>
+    /// Regression for the wrong-host bug: <c>CreateClientWithAuthStatusAsync</c>'s own baseUrl
+    /// fallback also consults <c>KCAP_URL</c>, so the probe URL must be built from that SAME
+    /// resolved value — not recomputed without it — or the client authenticates against one host
+    /// while the GET (carrying the bearer token) goes to another.
+    /// </summary>
+    [Test]
+    public async Task NoBaseUrl_FallsBackToKcapUrlEnvVar_NotLocalhost() {
+        StubDiscovery("None");
+        _server.Given(Request.Create().WithPath(ProbePath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var previous = Environment.GetEnvironmentVariable("KCAP_URL");
+        Environment.SetEnvironmentVariable("KCAP_URL", _server.Urls[0]);
+        try {
+            var result = await ReportVersionCommand.HandleAsync(null);
+
+            await Assert.That(result).IsEqualTo(0);
+
+            var requests = _server.LogEntries.Where(e => e.RequestMessage.Path == ProbePath).ToList();
+            await Assert.That(requests.Count).IsEqualTo(1);
+        } finally {
+            Environment.SetEnvironmentVariable("KCAP_URL", previous);
+        }
+    }
+
+    /// <summary>Discovery itself has no deadline; the command's own budget must still bound it.</summary>
+    [Test]
+    public async Task SlowDiscovery_StillReturnsZero_WithinBudget() {
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"provider":"github_app"}""")
+                .WithDelay(TimeSpan.FromSeconds(10)));
+
+        await SeedValidTokenAsync("report-version-slow-discovery");
 
         var sw     = Stopwatch.StartNew();
         var result = await ReportVersionCommand.HandleAsync(_server.Urls[0]);

--- a/test/Capacitor.Cli.Tests.Unit/ReportVersionCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReportVersionCommandTests.cs
@@ -11,12 +11,14 @@ namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
 /// The hidden <c>kcap report-version</c> command, invoked by the npm wrapper right after
-/// `kcap update` installs a new binary. Its whole purpose is to make ONE authenticated request
-/// through <see cref="HttpClientExtensions.CreateClientWithAuthStatusAsync"/> — the single choke
-/// point that attaches <see cref="HttpClientExtensions.CliVersionHeader"/> — so the server's
-/// version observer sees the new version immediately instead of waiting for the next incidental
-/// request. It must never surface an error: not-authenticated makes no request at all, and a
-/// server fault or a slow server still returns 0 within its own request budget.
+/// `kcap update` installs a new binary. Its whole purpose is to make ONE authenticated,
+/// side-effect-free GET through <see cref="HttpClientExtensions.CreateClientWithAuthStatusAsync"/>
+/// — the single choke point that attaches <see cref="HttpClientExtensions.CliVersionHeader"/> — so
+/// the server's version observer sees the new version immediately instead of waiting for the next
+/// incidental request. It reuses <see cref="WhoamiCommand.ProbePath"/> (the same read-only
+/// identity GET <c>kcap whoami</c> uses) rather than any write-side-effecting endpoint. It must
+/// never surface an error: not-authenticated makes no request at all, and a server fault, a slow
+/// server, or no server configured at all still returns 0.
 ///
 /// <para><c>[NotInParallel(nameof(TokenStoreProfileTests))]</c>: shares
 /// <c>ObservationHeaderTests</c>'s serialization key — these tests touch the process-wide
@@ -25,7 +27,7 @@ namespace Capacitor.Cli.Tests.Unit;
 /// </summary>
 [NotInParallel(nameof(TokenStoreProfileTests))]
 public class ReportVersionCommandTests : IDisposable {
-    const string ReportPath = "/api/users/me/cli-setup";
+    const string ProbePath = WhoamiCommand.ProbePath;
 
     readonly WireMockServer _server = WireMockServer.Start();
 
@@ -61,12 +63,12 @@ public class ReportVersionCommandTests : IDisposable {
         });
     }
 
-    // ── Authenticated: exactly one request, carrying the version header ───────────────────────
+    // ── Authenticated: exactly one GET, carrying the version header, no write side effect ──────
 
     [Test]
-    public async Task Authenticated_MakesOneRequestCarryingTheVersionHeader() {
+    public async Task Authenticated_MakesOneGetCarryingTheVersionHeader() {
         StubDiscovery("github_app");
-        _server.Given(Request.Create().WithPath(ReportPath).UsingPost())
+        _server.Given(Request.Create().WithPath(ProbePath).UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200));
 
         await SeedValidTokenAsync("report-version-ok");
@@ -75,7 +77,30 @@ public class ReportVersionCommandTests : IDisposable {
 
         await Assert.That(result).IsEqualTo(0);
 
-        var requests = _server.LogEntries.Where(e => e.RequestMessage.Path == ReportPath).ToList();
+        var requests = _server.LogEntries.Where(e => e.RequestMessage.Path == ProbePath).ToList();
+        await Assert.That(requests.Count).IsEqualTo(1);
+        await Assert.That(requests[0].RequestMessage.Method).IsEqualTo("GET");
+        await Assert.That(requests[0].RequestMessage.Headers![HttpClientExtensions.CliVersionHeader].Single())
+            .IsEqualTo(CapacitorVersion.CurrentDisplay());
+    }
+
+    /// <summary>
+    /// An <c>Auth:Provider=None</c> tenant: no bearer token exists (there is nothing to log
+    /// into), but the request still authenticates via the server's synthetic principal, so the
+    /// middleware still observes it — <see cref="AuthStatus.NoAuthRequired"/> must proceed exactly
+    /// like <see cref="AuthStatus.Ok"/>, not be treated as "not authenticated".
+    /// </summary>
+    [Test]
+    public async Task NoAuthTenant_MakesOneGetCarryingTheVersionHeader() {
+        StubDiscovery("None");
+        _server.Given(Request.Create().WithPath(ProbePath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        var result = await ReportVersionCommand.HandleAsync(_server.Urls[0]);
+
+        await Assert.That(result).IsEqualTo(0);
+
+        var requests = _server.LogEntries.Where(e => e.RequestMessage.Path == ProbePath).ToList();
         await Assert.That(requests.Count).IsEqualTo(1);
         await Assert.That(requests[0].RequestMessage.Headers![HttpClientExtensions.CliVersionHeader].Single())
             .IsEqualTo(CapacitorVersion.CurrentDisplay());
@@ -86,20 +111,20 @@ public class ReportVersionCommandTests : IDisposable {
     [Test]
     public async Task NotAuthenticated_MakesNoRequest_AndReturnsZero() {
         StubDiscovery("github_app");
-        _server.Given(Request.Create().WithPath(ReportPath).UsingPost())
+        _server.Given(Request.Create().WithPath(ProbePath).UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200));
 
         // No token stored, no resolved profile — AuthStatus resolves to NotAuthenticated.
         var result = await ReportVersionCommand.HandleAsync(_server.Urls[0]);
 
         await Assert.That(result).IsEqualTo(0);
-        await Assert.That(_server.LogEntries.Any(e => e.RequestMessage.Path == ReportPath)).IsFalse();
+        await Assert.That(_server.LogEntries.Any(e => e.RequestMessage.Path == ProbePath)).IsFalse();
     }
 
     [Test]
     public async Task ExpiredToken_MakesNoRequest_AndReturnsZero() {
         StubDiscovery("github_app");
-        _server.Given(Request.Create().WithPath(ReportPath).UsingPost())
+        _server.Given(Request.Create().WithPath(ProbePath).UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200));
 
         const string profileName = "report-version-expired";
@@ -115,7 +140,7 @@ public class ReportVersionCommandTests : IDisposable {
         var result = await ReportVersionCommand.HandleAsync(_server.Urls[0]);
 
         await Assert.That(result).IsEqualTo(0);
-        await Assert.That(_server.LogEntries.Any(e => e.RequestMessage.Path == ReportPath)).IsFalse();
+        await Assert.That(_server.LogEntries.Any(e => e.RequestMessage.Path == ProbePath)).IsFalse();
     }
 
     // ── Server-side failures: fail-open, never throws ──────────────────────────────────────────
@@ -123,7 +148,7 @@ public class ReportVersionCommandTests : IDisposable {
     [Test]
     public async Task ServerErrorResponse_StillReturnsZero() {
         StubDiscovery("github_app");
-        _server.Given(Request.Create().WithPath(ReportPath).UsingPost())
+        _server.Given(Request.Create().WithPath(ProbePath).UsingGet())
             .RespondWith(Response.Create().WithStatusCode(500));
 
         await SeedValidTokenAsync("report-version-500");
@@ -136,7 +161,7 @@ public class ReportVersionCommandTests : IDisposable {
     [Test]
     public async Task SlowServer_StillReturnsZero_WithinItsOwnBudget() {
         StubDiscovery("github_app");
-        _server.Given(Request.Create().WithPath(ReportPath).UsingPost())
+        _server.Given(Request.Create().WithPath(ProbePath).UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithDelay(TimeSpan.FromSeconds(10)));
 
         await SeedValidTokenAsync("report-version-slow");
@@ -155,6 +180,22 @@ public class ReportVersionCommandTests : IDisposable {
         // catch falls back to local tokens, finds none, resolves NotAuthenticated; even if it
         // somehow resolved Ok, the command's own try/catch must still swallow the failure.
         var result = await ReportVersionCommand.HandleAsync("http://127.0.0.1:1");
+
+        await Assert.That(result).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// Mirrors <c>Program.cs</c>'s dispatch: <c>report-version</c> is in <c>offlineCommands</c>,
+    /// so a host with no server configured at all reaches this command with a null
+    /// <c>baseUrl</c> — it must still hit this command's own fail-open logic and return 0 silently
+    /// rather than the generic "No server configured" exit 1 the pre-dispatch gate would
+    /// otherwise produce for any command not on that list.
+    /// </summary>
+    [Test]
+    public async Task NoServerConfigured_MakesNoRequest_AndReturnsZero() {
+        // No AppConfig.SetResolvedState, no KCAP_URL: CreateClientWithAuthStatusAsync falls back
+        // to its hardcoded "http://localhost:5108" default, which nothing is listening on here.
+        var result = await ReportVersionCommand.HandleAsync(null);
 
         await Assert.That(result).IsEqualTo(0);
     }


### PR DESCRIPTION
Part of AI-1283 — companion to kcap-server#1389. Together they fix a reported bug: after `kcap update`, the "your kcap CLI is out of date" web banner/notification linger.

## Gap this closes
The server only learns your installed CLI version from an authenticated CLI→server request carrying `X-Kcap-Cli-Version`. **`kcap update` itself makes no such request** (it only talks to the npm registry), so the server didn't re-observe the new version until your next incidental hook/`status`/daemon call — leaving the out-of-date surfaces stale in the meantime.

## Fix
- New hidden `report-version` command: makes ONE quiet, fail-open **authenticated GET to a side-effect-free probe** (`/api/me/notification-prefs`, the same read `whoami` uses) via the header-carrying client, so the server's observer middleware records the new version from the `X-Kcap-Cli-Version` header. Never prints on the happy path, always returns 0, bounded ~5s. Skips silently when not authenticated; proceeds on both `Ok` and `NoAuthRequired` tenants; listed in `offlineCommands` so a no-server host still returns 0.
- The npm wrapper (`bin/kcap.js runUpdate`) invokes the **new** binary's `report-version` after a successful install/refresh and before exit, best-effort (`stdio: "ignore"`, timeout, try/catch) — it can never change the update's exit code.

Deliberately a side-effect-free GET, **not** the `/api/users/me/cli-setup` POST: that endpoint fires a one-time onboarding event, which would falsely mark a login-but-never-`setup` user as "Registered" (caught in review).

## Notes
- No Linear IDs in any `.cs` (repo lint).
- Tests: `ReportVersionCommandTests` 8/8 (header-on-GET, not-authed→no-request, no-auth-tenant, no-server, error/timeout all return 0), observation-header + update-notice suites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
