### PR TITLE
Land the setup visibility cursor on the labelled default

### DIFF
--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -181,17 +181,21 @@ public static class SetupCommand {
 
             await Console.Out.WriteLineAsync($"  Default visibility: {defaultVisibility}");
         } else {
-            defaultVisibility = AnsiConsole.Prompt(
-                new SelectionPrompt<string>()
-                    .Title("Which of your sessions should be readable by other users in the same Kurrent Capacitor account by default?")
-                    .AddChoices(AppConfig.ValidVisibilities)
-                    .UseConverter(v => v switch {
-                        "private"    => "All private — only you can see your sessions",
-                        "project"    => "Project repos public to fellow project members, others private",
-                        "org_public" => "Org repos public, others private (default)",
-                        "public"     => "All public — others can see all your sessions",
-                        _            => v
-                    }));
+            var visibilityPrompt = new SelectionPrompt<string>()
+                .Title("Which of your sessions should be readable by other users in the same Kurrent Capacitor account by default?")
+                .AddChoices(AppConfig.ValidVisibilities)
+                .UseConverter(v => v switch {
+                    "private"    => "All private — only you can see your sessions",
+                    "project"    => "Project repos public to fellow project members, others private",
+                    "org_public" => "Org repos public, others private (default)",
+                    "public"     => "All public — others can see all your sessions",
+                    _            => v
+                });
+
+            // Start the cursor on the option we label "(default)" rather than the first choice.
+            visibilityPrompt.DefaultValue = "org_public";
+
+            defaultVisibility = AnsiConsole.Prompt(visibilityPrompt);
 
             await Console.Out.WriteLineAsync($"  Default visibility: {defaultVisibility}");
         }


### PR DESCRIPTION
## What

During `kcap setup`, Step 3/6 (Default session visibility) presents a selection list. The option labelled `(default)` — "Org repos public, others private" (`org_public`) — is also the value used by the non-interactive `--no-prompt` path.

The interactive `SelectionPrompt`, however, highlights its **first** choice (`private`, "All private"). So the cursor sat on "All private" even though the prompt advertises `org_public` as the default, and pressing Enter without moving picked a value that disagreed with the labelled default.

## Fix

Set the prompt's `DefaultValue` to `org_public` so the initial highlight matches the labelled and `--no-prompt` default. The choice ordering (private → project → org_public → public) is unchanged, and the actual default value is unchanged — only the initial cursor position is corrected, so no README/docs update is needed.

## Testing

- `dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj` — 0 errors.
- The interactive cursor position isn't unit-testable without an ANSI-console harness; existing `SetupCommandTests` exercise the `--no-prompt` path, whose default (`org_public`) is unchanged.

Closes #518
AI-1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)