### PR TITLE
Clear the shared AuthProviderCache store between tests

### DIFF
--- a/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheGlobalSetup.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheGlobalSetup.cs
@@ -9,6 +9,14 @@ namespace Capacitor.Cli.Tests.Unit;
 /// prior run (an OS-reused WireMock port would collide) and skip its own <c>/auth/config</c> stub,
 /// or pollute the real cache file. Pinning the store to a throwaway temp file per run keeps the
 /// cache a clean no-op for every test that doesn't explicitly exercise it.
+///
+/// <para>Pinning alone is not enough: the pinned file is <b>shared for the whole run</b>, so an
+/// entry one test writes for <c>http://localhost:{port}</c> survives into a later test whose
+/// WireMock server the OS handed the same freed port — which then reads that stale provider instead
+/// of its own stub. <see cref="ClearBetweenTests"/> deletes the file before every test so each
+/// starts from an empty store. Without it, <c>ReportVersionCommandTests.NotAuthenticated</c> read a
+/// <c>"None"</c> left by an earlier <c>StubDiscovery("None")</c> test and issued a request it
+/// asserts never happens — a deterministic CI failure that never reproduced locally.</para>
 /// </summary>
 public class AuthProviderCacheGlobalSetup {
     static readonly string StoreFile = Path.Combine(
@@ -18,6 +26,11 @@ public class AuthProviderCacheGlobalSetup {
 
     [Before(Assembly)]
     public static void PinStore() => AuthProviderCache.OverridePathForTesting = StoreFile;
+
+    [BeforeEvery(Test)]
+    public static void ClearBetweenTests() {
+        try { File.Delete(StoreFile); } catch { /* best effort */ }
+    }
 
     [After(Assembly)]
     public static void CleanupStore() {

--- a/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheGlobalSetup.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheGlobalSetup.cs
@@ -28,9 +28,11 @@ public class AuthProviderCacheGlobalSetup {
     public static void PinStore() => AuthProviderCache.OverridePathForTesting = StoreFile;
 
     [BeforeEvery(Test)]
-    public static void ClearBetweenTests() {
-        try { File.Delete(StoreFile); } catch { /* best effort */ }
-    }
+    public static void ClearBetweenTests() =>
+        // Not best-effort: a swallowed sharing violation (a handle outliving a prior test on Windows)
+        // would leave the stale entry in place and silently reintroduce the very leak this hook exists
+        // to prevent. Bounded-retry the transient case; throw with a named cause on a persistent one.
+        SharedConfigDirCleanup.ClearWithRetry("the auth-provider cache", () => File.Delete(StoreFile));
 
     [After(Assembly)]
     public static void CleanupStore() {

--- a/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheIsolationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheIsolationTests.cs
@@ -9,13 +9,19 @@ namespace Capacitor.Cli.Tests.Unit;
 /// that collision real. Each test asserts the store holds nothing for its key, then writes it;
 /// whichever of the two runs second fails when the reset is missing.
 ///
+/// <para>Unkeyed <c>[NotInParallel]</c> — not a named key — so the two tests run strictly alone: the
+/// pinned store is one shared file, <see cref="AuthProviderCache.Set"/> is an unlocked whole-file
+/// read-modify-write, and the per-test clear in <see cref="AuthProviderCacheGlobalSetup"/> fires for
+/// every test, so any concurrent test in a local parallel run could wipe or race this store and make
+/// the guard nondeterministic. (CI already serialises the whole suite.)</para>
+///
 /// <para>This is the isolated regression for the CI-only failure of
 /// <c>ReportVersionCommandTests.NotAuthenticated_MakesNoRequest_AndReturnsZero</c>: a stale
 /// <c>"None"</c> entry left by an earlier <c>StubDiscovery("None")</c> test was served to it, so
 /// discovery reported "no auth required" and the command issued the very request the test asserts
 /// never happens.</para>
 /// </summary>
-[NotInParallel(nameof(AuthProviderCacheIsolationTests))]
+[NotInParallel]
 public class AuthProviderCacheIsolationTests {
     const string Url = "http://authprovider-isolation.invalid";
 

--- a/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheIsolationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProviderCacheIsolationTests.cs
@@ -1,0 +1,32 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Guards the between-tests reset in <see cref="AuthProviderCacheGlobalSetup"/>. The provider cache
+/// is a single shared on-disk store for the whole run, so without a clear between tests one test can
+/// read an entry another test wrote under the same base URL — and an OS-reused WireMock port makes
+/// that collision real. Each test asserts the store holds nothing for its key, then writes it;
+/// whichever of the two runs second fails when the reset is missing.
+///
+/// <para>This is the isolated regression for the CI-only failure of
+/// <c>ReportVersionCommandTests.NotAuthenticated_MakesNoRequest_AndReturnsZero</c>: a stale
+/// <c>"None"</c> entry left by an earlier <c>StubDiscovery("None")</c> test was served to it, so
+/// discovery reported "no auth required" and the command issued the very request the test asserts
+/// never happens.</para>
+/// </summary>
+[NotInParallel(nameof(AuthProviderCacheIsolationTests))]
+public class AuthProviderCacheIsolationTests {
+    const string Url = "http://authprovider-isolation.invalid";
+
+    static async Task AssertStoreCleanThenPolluteAsync() {
+        await Assert.That(AuthProviderCache.TryGet(Url)).IsNull();
+        AuthProviderCache.Set(Url, "None");
+    }
+
+    [Test]
+    public Task StoreIsCleanAtTestStart_A() => AssertStoreCleanThenPolluteAsync();
+
+    [Test]
+    public Task StoreIsCleanAtTestStart_B() => AssertStoreCleanThenPolluteAsync();
+}

--- a/test/Capacitor.Cli.Tests.Unit/ReportVersionCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReportVersionCommandTests.cs
@@ -29,16 +29,22 @@ namespace Capacitor.Cli.Tests.Unit;
 public class ReportVersionCommandTests : IDisposable {
     const string ProbePath = WhoamiCommand.ProbePath;
 
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+
     readonly WireMockServer _server = WireMockServer.Start();
 
     [Before(Test)]
     public void Cleanup() {
-        AppConfig.ResetResolvedStateForTesting();
         HttpClientExtensions.ResetProviderCacheForTesting();
         Environment.SetEnvironmentVariable("KCAP_URL", null);
 
-        var cfg = AppConfig.GetConfigPath();
-        if (File.Exists(cfg)) File.Delete(cfg);
+        // Clears the tokens dir, legacy tokens file, config.json and resolved profile state. The
+        // token store is the second leak the not-authenticated case is sensitive to: a VALID token
+        // left under the DEFAULT profile by another test — bound to a localhost port the OS reuses
+        // for this test's WireMock server — resolves Ok and issues the request the test asserts
+        // never happens. (The provider-cache half is cleared globally by AuthProviderCacheGlobalSetup.)
+        SharedConfigDirCleanup.ClearTokenAndProfileState(LegacyPath, TokensDir);
     }
 
     public void Dispose() {
@@ -143,6 +149,24 @@ public class ReportVersionCommandTests : IDisposable {
         await Assert.That(result).IsEqualTo(0);
         await Assert.That(_server.LogEntries.Any(e => e.RequestMessage.Path == ProbePath)).IsFalse();
     }
+
+    // Regression for the token-store half of the leak: Cleanup must clear the tokens directory so a
+    // token another test wrote there cannot survive into the next one. Both tests assert the marker
+    // is absent at start, then write it; whichever runs second fails if Cleanup stops clearing the
+    // store. Order-independent, so it does not depend on the runner's test ordering.
+    static string LeakMarker => Path.Combine(TokensDir, "report-version-leak-guard.json");
+
+    async Task AssertTokenStoreClearedThenSeedAsync() {
+        await Assert.That(File.Exists(LeakMarker)).IsFalse();
+        Directory.CreateDirectory(TokensDir);
+        await File.WriteAllTextAsync(LeakMarker, "{}");
+    }
+
+    [Test]
+    public Task Cleanup_clears_the_token_store_between_tests_A() => AssertTokenStoreClearedThenSeedAsync();
+
+    [Test]
+    public Task Cleanup_clears_the_token_store_between_tests_B() => AssertTokenStoreClearedThenSeedAsync();
 
     // ── Server-side failures: fail-open, never throws ──────────────────────────────────────────
 


### PR DESCRIPTION
## What

Makes `ReportVersionCommandTests.NotAuthenticated_MakesNoRequest_AndReturnsZero` reliable on CI. It failed on the Linux/Windows runners while passing locally, because it was sensitive to **two** cross-test leaks, both triggered by the OS reusing WireMock ephemeral ports across sequential tests.

## Leak 1 — provider cache (disk)

`AuthProviderCacheGlobalSetup` pins the on-disk provider cache to one file for the whole run but never cleared it between tests. A `"None"` provider written by an earlier `StubDiscovery("None")` test was served to a later test that reused the same `localhost:{port}` → `DiscoverProviderAsync` returned `"None"` → `NoAuthRequired` → a request was made.

**Fix:** clear the store before every test (`[BeforeEvery(Test)]`, via `SharedConfigDirCleanup.ClearWithRetry` so a Windows sharing violation surfaces instead of silently leaving the file). Regression: `AuthProviderCacheIsolationTests`.

## Leak 2 — token store (disk)

`ReportVersionCommandTests.Cleanup` reset resolved state and deleted `config.json`, but never cleared the token store. With config gone the active profile resolves to `default`, so a VALID token left under the `default` profile by another test — bound to a reused port — resolved `Ok` → a request was made. Confirmed with a reproduction (seeding `tokens/default.json` bound to the server URL makes `HandleAsync` request).

**Fix:** clear the tokens dir, legacy tokens file, config.json and resolved profile state in `Cleanup` via `SharedConfigDirCleanup.ClearTokenAndProfileState` (the helper the other token-sensitive classes already use). Regression: two order-independent tests that fail if `Cleanup` stops clearing the store.

Test-infra only — no production code changes.

Closes #520
AI-1853