### PR TITLE
Fix telemetry lane-overlap, leftover-token, and consent timer-race CI flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,20 +53,22 @@ jobs:
           node npm/kcap/bin/refresh.test.js
 
       - name: Run unit tests
-        # --maximum-parallel-tests 1 serializes the entire unit suite.
-        # The codebase has many tests that mutate process-global state
-        # (Environment.SetEnvironmentVariable on HOME/PATH/KCAP_*,
-        # Console.SetOut/SetError) and rely on [NotInParallel(group)] to
-        # serialize among themselves. Cross-group parallel execution still
-        # races the shared process state intermittently on the slower
-        # Linux CI runner, producing a different flake every run. Until
-        # the affected tests are refactored to inject paths/streams
-        # rather than mutate Environment/Console, run serially. Local dev
+        # --maximum-parallel-tests 1 does NOT serialize the entire suite.
+        # It caps TUnit's parallel bucket (unattributed tests) at one, but
+        # keyed [NotInParallel("key")] tests are scheduled by the
+        # constraint-key scheduler, which starts every test whose keys are
+        # free WITHOUT consulting this cap — classes with disjoint key
+        # sets still run concurrently under this flag (verified against
+        # TUnit 1.18.37's TestScheduler/ConstraintKeyScheduler). So any
+        # test touching process-global state (Environment/Console,
+        # CliTelemetry/TelemetryState statics, the shared KCAP_CONFIG_DIR)
+        # must hold the SAME NotInParallel key as every other toucher of
+        # that state; this flag only quiets the unkeyed bucket. Local dev
         # runs stay parallel (the flag lives only in CI).
         run: dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --maximum-parallel-tests 1
 
       - name: Run app tests
-        # Same serial discipline as the unit suite: the app tests share process-global
+        # Same flag, same caveat as the unit suite: the app tests share process-global
         # Avalonia/Rx state behind [NotInParallel("AvaloniaSession")].
         run: dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --maximum-parallel-tests 1
 

--- a/test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs
@@ -498,11 +498,9 @@ sealed class TimerCountingTimeProvider(FakeTimeProvider inner) : TimeProvider {
     public override long TimestampFrequency      => inner.TimestampFrequency;
 
     public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period) {
-        // Register with the fake FIRST: the count is the harness's "armed" signal, and a count
-        // that rises before the inner registration completes lets RetryAsync advance the clock
-        // while the timer does not exist yet — the delay then gets scheduled one second into a
-        // future nothing ever advances to, and the wait for the resubscribe times out. That
-        // window is preemption-sized, which is exactly what a loaded CI runner provides.
+        // Register with the fake FIRST: the count is the harness's "armed" signal, and if it
+        // rose before the inner registration completed, RetryAsync could advance the clock
+        // while the timer did not exist yet — scheduling it into a future nothing advances to.
         var timer = inner.CreateTimer(callback, state, dueTime, period);
         Interlocked.Increment(ref _timersCreated);
         return timer;

--- a/test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentServiceTests.cs
@@ -498,8 +498,14 @@ sealed class TimerCountingTimeProvider(FakeTimeProvider inner) : TimeProvider {
     public override long TimestampFrequency      => inner.TimestampFrequency;
 
     public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period) {
+        // Register with the fake FIRST: the count is the harness's "armed" signal, and a count
+        // that rises before the inner registration completes lets RetryAsync advance the clock
+        // while the timer does not exist yet — the delay then gets scheduled one second into a
+        // future nothing ever advances to, and the wait for the resubscribe times out. That
+        // window is preemption-sized, which is exactly what a loaded CI runner provides.
+        var timer = inner.CreateTimer(callback, state, dueTime, period);
         Interlocked.Increment(ref _timersCreated);
-        return inner.CreateTimer(callback, state, dueTime, period);
+        return timer;
     }
 }
 

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
@@ -811,23 +811,14 @@ public class McpFlowsServerTests {
 
     static void CleanupDefaultToken() {
         // Loud, not best-effort: a silently-leaked "default" token makes any later test that
-        // resolves the default profile authenticate for real (ReportVersionCommandTests'
-        // NotAuthenticated_* proved a probe was NOT made — a leftover token here fires it).
-        // Retry the transient Windows sharing violation on a just-written file, then throw
-        // naming the leak instead of leaving a poisoned token store behind.
-        for (var attempt = 1; ; attempt++) {
-            try {
-                TokenStore.Delete("default");
-                break;
-            } catch (Exception e) when (e is IOException or UnauthorizedAccessException) {
-                if (attempt >= 5)
-                    throw new InvalidOperationException(
-                        "Could not delete the seeded 'default' profile token; leaving it behind poisons later auth-sensitive tests.", e);
-                Thread.Sleep(40);
-            }
+        // resolves the default profile authenticate for real. ClearWithRetry throws a named
+        // cause after its bounded retry; the config cleanup still runs either way.
+        try {
+            SharedConfigDirCleanup.ClearWithRetry("the seeded default-profile token", () => TokenStore.Delete("default"));
+        } finally {
+            var cfg = Capacitor.Cli.Core.Config.AppConfig.GetConfigPath();
+            try { if (File.Exists(cfg)) File.Delete(cfg); } catch { /* best effort */ }
         }
-        var cfg = Capacitor.Cli.Core.Config.AppConfig.GetConfigPath();
-        try { if (File.Exists(cfg)) File.Delete(cfg); } catch { /* best effort */ }
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/McpFlowsServerTests.cs
@@ -810,7 +810,22 @@ public class McpFlowsServerTests {
     }
 
     static void CleanupDefaultToken() {
-        try { TokenStore.Delete("default"); } catch { /* best effort */ }
+        // Loud, not best-effort: a silently-leaked "default" token makes any later test that
+        // resolves the default profile authenticate for real (ReportVersionCommandTests'
+        // NotAuthenticated_* proved a probe was NOT made — a leftover token here fires it).
+        // Retry the transient Windows sharing violation on a just-written file, then throw
+        // naming the leak instead of leaving a poisoned token store behind.
+        for (var attempt = 1; ; attempt++) {
+            try {
+                TokenStore.Delete("default");
+                break;
+            } catch (Exception e) when (e is IOException or UnauthorizedAccessException) {
+                if (attempt >= 5)
+                    throw new InvalidOperationException(
+                        "Could not delete the seeded 'default' profile token; leaving it behind poisons later auth-sensitive tests.", e);
+                Thread.Sleep(40);
+            }
+        }
         var cfg = Capacitor.Cli.Core.Config.AppConfig.GetConfigPath();
         try { if (File.Exists(cfg)) File.Delete(cfg); } catch { /* best effort */ }
     }

--- a/test/Capacitor.Cli.Tests.Unit/SharedConfigDirCleanup.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SharedConfigDirCleanup.cs
@@ -8,10 +8,12 @@ namespace Capacitor.Cli.Tests.Unit;
 /// <c>tokens/</c>, and any of them can be the one whose hook runs while a handle is still open —
 /// which is why the retry belongs here rather than in whichever class is currently failing.
 ///
-/// <para>Two facts worth knowing before changing this. A <c>NotInParallel</c> key cannot help: CI
-/// runs this suite with <c>--maximum-parallel-tests 1</c>, so there is no concurrency to serialise,
-/// and a lock at hook time therefore means a handle OUTLIVED its owning test (an undisposed stream,
-/// or an unreaped child process). And it is Windows-only because Windows refuses to delete a file
+/// <para>Two facts worth knowing before changing this. The config-dir classes all share one
+/// <c>NotInParallel</c> key, so they never run concurrently — the key, not CI's
+/// <c>--maximum-parallel-tests 1</c>, is what guarantees that (keyed tests with disjoint keys
+/// still overlap under the flag; see ci.yml) — and a lock at hook time therefore means a handle
+/// OUTLIVED its owning test (an undisposed stream, or an unreaped child process). And it is
+/// Windows-only because Windows refuses to delete a file
 /// with an open handle while Unix unlinks regardless — hence also intermittent, since whether the
 /// holder has released is timing rather than ordering.</para>
 /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/Telemetry/ConfigSetTelemetryCompositionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Telemetry/ConfigSetTelemetryCompositionTests.cs
@@ -31,22 +31,26 @@ namespace Capacitor.Cli.Tests.Unit.Telemetry;
 /// rewrites <c>config.json</c> underneath this test.
 ///
 /// Deliberately does NOT set <see cref="TelemetryState.PathOverride"/> or
-/// <see cref="TelemetryDeviceId.PathOverride"/>. Those statics have their own dedicated lock keys
-/// (<c>nameof(TelemetryState) + "." + nameof(TelemetryState.PathOverride)</c> and the
-/// <c>TelemetryDeviceId</c> equivalent, see <c>TelemetryStateTests</c>/<c>TelemetryDeviceIdTests</c>),
-/// shared by every class that mutates them (<c>TelemetryStateTests</c>, <c>TelemetryDeviceIdTests</c>,
-/// <c>SetupFunnelTests</c>, <c>CliTelemetryTests</c>, <c>McpTelemetryTests</c>,
-/// <c>ConfigTelemetryKeyTests</c>). This class locks under <c>TokenStoreProfileTests</c> instead,
-/// for the config dir it genuinely shares — setting either override too would race those telemetry
-/// classes under local (non-CI) parallelism, a gap CI's <c>--maximum-parallel-tests 1</c> would
-/// never expose. It doesn't need to: left unset, telemetry state and the device id both fall back
-/// to their own defaults (<c>PathHelpers.ConfigPath("telemetry.json")</c> and
-/// <c>PathHelpers.ConfigPath("telemetry-device.json")</c>), which already resolve inside the same
-/// <c>KCAP_CONFIG_DIR</c> the module initializer pinned. Both files are cleaned up in
-/// <c>[After(Test)]</c> so neither can leak into a later test that reads persisted telemetry state
-/// without an override.
+/// <see cref="TelemetryDeviceId.PathOverride"/> — the point of this class is the DEFAULT path
+/// resolution under the pinned <c>KCAP_CONFIG_DIR</c>. It must still HOLD both telemetry lock keys
+/// (alongside <c>TokenStoreProfileTests</c> for the config dir it shares), because the production
+/// path it drives — <c>TryApplyTelemetry("telemetry", "off")</c> →
+/// <see cref="TelemetryState.SetEnabled"/> → <see cref="TelemetryDeviceId.Delete"/> plus
+/// <see cref="CliTelemetry.DiscardAndDisable"/> — dereferences whatever those statics point at the
+/// instant it runs. TUnit schedules [NotInParallel] tests with disjoint key sets CONCURRENTLY, and
+/// its constraint-key scheduler does not consult <c>--maximum-parallel-tests</c>, so CI's serial
+/// flag never prevented the overlap: without these keys, this class's side effects landed inside
+/// concurrently-running telemetry tests — deleting the device-id file a test had just created
+/// under its own <c>PathOverride</c> (the #524 timestamp flake) and clearing the live
+/// <c>CliTelemetry.TestSink</c> mid-test (the empty-sink funnel flakes). Both files are cleaned up
+/// in <c>[After(Test)]</c> so neither can leak into a later test that reads persisted telemetry
+/// state without an override.
 /// </summary>
-[NotInParallel(nameof(TokenStoreProfileTests))]
+[NotInParallel([
+    nameof(TokenStoreProfileTests),
+    nameof(TelemetryState) + "." + nameof(TelemetryState.PathOverride),
+    nameof(TelemetryDeviceId) + "." + nameof(TelemetryDeviceId.PathOverride),
+])]
 public class ConfigSetTelemetryCompositionTests {
     static string ConfigPath    => AppConfig.GetConfigPath();
     static string TelemetryPath => PathHelpers.ConfigPath("telemetry.json");


### PR DESCRIPTION
Fixes three independent CI flake mechanisms. All fixes are root-cause fixes in test/CI infrastructure — no production code changes, no wait-budget inflation.

## 1. `--maximum-parallel-tests 1` never serialized the keyed phase (empty-sink funnel failures + device-id timestamp flake)

TUnit's `TestScheduler` applies the global cap only to the *parallel bucket*; keyed `[NotInParallel("key")]` tests go through `ConstraintKeyScheduler.ExecuteTestsWithConstraintsAsync`, which starts every test whose keys are free **without consulting the cap** (verified against TUnit 1.18.37 source). Tests with disjoint key sets therefore run concurrently even on CI.

`ConfigSetTelemetryCompositionTests` held only the `TokenStoreProfileTests` key while driving the real `config set telemetry off` path:

- `TelemetryState.SetEnabled(false)` → `TelemetryDeviceId.Delete()` dereferences whatever `TelemetryDeviceId.PathOverride` points at *the instant it runs* — mid-flight, that's the concurrently-running telemetry-keyed test's private file. That is the `Second_get_or_create_does_not_rewrite_file_when_id_exists` failure (#524): the sidecar really was deleted and re-created (with a fresh GUID), not an mtime-resolution artifact.
- `CliTelemetry.DiscardAndDisable()` clears the live `TestSink` and flips `Enabled` — the `SetupFunnelTests` "collection has 0 items but expected 2" / "Expected 12 but found 0" failures, where `AssertEnabled` passes at test start and the emit sites provably execute (the failing run's own stderr shows the zero-tenant dead-end message) yet the sink ends empty.

Fix: the class now holds the two telemetry lock keys alongside the config-dir key, and its class doc explains why (the old doc's "left unset, both fall back to their own defaults" reasoning missed that the production path dereferences the *live* overrides). Evidence: a TRX timing run on the unfixed code showed a `ConfigSetTelemetryCompositionTests` test overlapping a telemetry-keyed test on the very first attempt; post-fix runs show zero cross-lane overlaps (guaranteed by the shared key, not luck).

The ci.yml comment claiming the flag "serializes the entire unit suite" is corrected so nobody trusts it to prevent this class of race again.

## 2. Silent best-effort cleanup of the seeded `default`-profile token

#521 (already on main) fixed the `NotAuthenticated_MakesNoRequest_AndReturnsZero` victim side: the stale provider-cache entry on a reused WireMock port plus per-test token/profile clearing. This PR hardens the one remaining *seeder*: `McpFlowsServerTests.CleanupDefaultToken` swallowed every delete failure, so one transient Windows sharing violation leaves a VALID `default`-profile token that makes any later default-profile-resolving test authenticate for real. The cleanup now retries transient sharing violations and then throws naming the leak, instead of silently leaving the poison behind.

## 3. Consent harness timer counter rose before the timer existed (`Timed out waiting for: the resubscribe`, #523)

`TimerCountingTimeProvider.CreateTimer` incremented its counter **before** calling `inner.CreateTimer`. `ConsentHarness.RetryAsync` uses that counter as the "retry delay is armed" signal before advancing the fake clock — so a preemption between the increment and FakeTimeProvider's internal registration let the test thread `Advance(1s)` while the timer didn't exist yet. The delay then got scheduled one second into a future nothing ever advances to, and the wait for the resubscribe timed out after 5s. Preemption-sized window ⇒ rare, loaded-Windows-runner-biased, passes on rerun — exactly the observed shape. `ConsentService` has exactly one timer consumer of the injected `TimeProvider` (the retry delay), so no other mechanism was in play.

Fix: register with the fake first, increment after.

## Verification

- Telemetry namespace (152 tests): pre-fix TRX run demonstrated the cross-lane overlap; 3 post-fix TRX rounds green with zero overlaps; 30-loop soak green.
- `McpFlowsServerTests` 52/52, `ReportVersionCommandTests` (main's #521 version) 12/12, `AuthProviderCacheIsolationTests` 2/2, `ConsentServiceTests` 25/25 (×5 pre-rebase).
- `scripts/check-linear-ids.sh` clean.

Closes #523
Closes #524
Fixes AI-1859
Fixes AI-1860
Fixes AI-1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)
