### PR TITLE
[AI-1775] Codex PTY turn-start diagnostic: watch the rollout after a follow-up round

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -42,11 +42,13 @@ internal record AgentInstance(
     /// (never a directory scan). Null until detection resolves it, and for non-Codex agents.</summary>
     public string? CodexRolloutPath { get; set; }
 
-    /// <summary>Codex turn diagnostic: single-flight guard for the post-send rollout-growth probe.
-    /// Each follow-up round cancels the prior round's probe and installs its own, so a later round's
-    /// growth is never attributed to an earlier round's input. A plain field so
-    /// <see cref="System.Threading.Interlocked.Exchange{T}(ref T, T)"/> can swap it atomically.</summary>
-    public CancellationTokenSource? CodexTurnProbeCts;
+    /// <summary>Codex turn diagnostic: monotonic per-agent round generation for the post-send
+    /// rollout-growth probe. Bumped (under the send gate, BEFORE each round's input is delivered) so
+    /// a later round instantly invalidates any earlier round's probe — a probe emits a verdict only
+    /// while its captured generation is still the latest, so a later round's growth can never be
+    /// attributed to an earlier round even during the earlier probe's own poll. A plain field for
+    /// <see cref="System.Threading.Interlocked.Increment(ref long)"/>.</summary>
+    public long CodexTurnProbeGen;
 
     /// <summary>This agent's monotonic activity clock. One instance per launch — a relaunch gets a
     /// fresh one, never inheriting the predecessor's idle window. Defaults to a real-time instance so
@@ -2728,11 +2730,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         LogSendInputReceived(agentId, agent.Runtime.Vendor, text.Length, attachmentIds?.Length ?? 0);
 
-        // Codex turn diagnostic: whether to run the post-send rollout probe, and the rollout's
-        // length sampled just BEFORE delivery. Declared out here so the baseline survives the
-        // try/finally to reach ArmCodexTurnProbe below.
+        // Codex turn diagnostic: whether to run the post-send rollout probe, plus this round's
+        // generation and the rollout length sampled just BEFORE delivery. Declared out here so both
+        // survive the try/finally to reach ArmCodexTurnProbe below.
         var   isCodex       = string.Equals(agent.Runtime.Vendor, "codex", StringComparison.OrdinalIgnoreCase);
         long? codexBaseline = null;
+        long  codexGen      = 0;
 
         await agent.BorrowedSnapshotGate.WaitAsync(_shutdownCts.Token);
         try {
@@ -2748,11 +2751,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 }
             }
 
-            // Codex turn diagnostic: sample the rollout length BEFORE delivery, from the path the
-            // session detector already cached (a single stat, never a scan). Capturing it AFTER the
-            // send would fold a fast Codex append into the baseline and mis-report "no turn". A null
-            // here (path not resolved yet, or the stat failed) is handled in ArmCodexTurnProbe.
-            if (isCodex && agent.CodexRolloutPath is { } rolloutPath) codexBaseline = TryFileLength(rolloutPath);
+            // Codex turn diagnostic: BEFORE delivering this round's input — and while the send gate
+            // is held, so it is ordered per agent — bump the round generation and sample the rollout
+            // length from the cached path. Bumping first instantly invalidates any prior round's
+            // still-running probe (it emits a verdict only while its generation is the latest), so a
+            // fast Codex append caused by THIS input can never be credited to the previous round.
+            // Sampling the length after the bump but before the send keeps the baseline honest (the
+            // append lands strictly after it). A null here (path not cached yet, or the stat failed)
+            // is handled in ArmCodexTurnProbe.
+            if (isCodex) {
+                codexGen = Interlocked.Increment(ref agent.CodexTurnProbeGen);
+                if (agent.CodexRolloutPath is { } rolloutPath) codexBaseline = TryFileLength(rolloutPath);
+            }
 
             // PTY runtimes use bracketed paste; ACP runtimes send a structured prompt.
             if (agent.BorrowedSnapshotSource is not null)
@@ -2768,53 +2778,41 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // Codex turn diagnostic: arm the post-send rollout-growth probe. Only reached on the
         // successful-delivery path (the guards and the borrowed-snapshot failure above all return
         // before here).
-        if (isCodex) ArmCodexTurnProbe(agent, codexBaseline);
+        if (isCodex) ArmCodexTurnProbe(agent, codexBaseline, codexGen);
     }
 
     /// <summary>
-    /// Codex turn diagnostic: start a bounded, single-flight, off-handler probe that watches the
-    /// reviewer's rollout for growth past <paramref name="baseline"/> (the length captured just
-    /// before this round's input was delivered) and logs whether a turn began — the only clean
-    /// turn-start signal a PTY runtime gives the daemon (see <see cref="CodexTurnObserver"/>).
+    /// Codex turn diagnostic: schedule a bounded, off-handler probe that watches the reviewer's
+    /// rollout for growth past <paramref name="baseline"/> (the length captured just before this
+    /// round's input was delivered) and logs whether a turn began — the only clean turn-start signal
+    /// a PTY runtime gives the daemon (see <see cref="CodexTurnObserver"/>).
     ///
-    /// <para>A null <paramref name="baseline"/> means the rollout path was not cached yet, or its
-    /// pre-delivery stat failed — logged and skipped (never a false "no turn"). The probe is
-    /// single-flight per agent: arming cancels the prior round's probe, so a later round's growth is
-    /// never attributed to an earlier round's input. It runs on a pooled thread (never the command
-    /// loop) and is bounded by the agent's stop, daemon shutdown, and the observe timeout.</para>
+    /// <para>Single-flight is by GENERATION, established in <see cref="HandleSendInput"/> before
+    /// delivery: <paramref name="gen"/> is this round's generation, and the probe emits a verdict
+    /// only while it is still the agent's latest — so a later round's growth is never credited to an
+    /// earlier round even during that earlier probe's own poll. This method itself does no I/O and
+    /// touches no disposable of the (already torn-down?) agent: it only schedules onto the pool, so
+    /// it cannot throw a teardown fault back onto the just-completed send. A null
+    /// <paramref name="baseline"/> (path not cached yet, or the pre-delivery stat failed) is logged
+    /// and skipped — never a false "no turn"; the generation was still bumped, so any prior probe is
+    /// already invalidated.</para>
     /// </summary>
-    void ArmCodexTurnProbe(AgentInstance agent, long? baseline) {
-        try {
-            var rolloutPath = agent.CodexRolloutPath;
-            var canObserve  = rolloutPath is not null && baseline is not null;
-
-            // Supersede any prior round's probe FIRST — always, even when this round cannot be
-            // observed — so a predecessor can neither keep running nor log a verdict for this round's
-            // growth. Installing null when we cannot observe still cancels the predecessor and makes
-            // its ownership check fail.
-            var newCts = canObserve
-                ? CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token)
-                : null;
-            var prev = Interlocked.Exchange(ref agent.CodexTurnProbeCts, newCts);
-            if (prev is not null) {
-                try { prev.Cancel(); } catch (ObjectDisposedException) { /* the prior probe already finished + disposed it */ }
-            }
-
-            if (!canObserve) {
-                LogCodexTurnRolloutUnresolved(agent.Id);
-                return;
-            }
-
-            _ = Task.Run(() => ObserveCodexTurnAsync(agent, rolloutPath!, baseline!.Value, newCts!));
-        } catch (Exception ex) {
-            // Arming is best-effort and runs AFTER the input was already delivered — a fault here
-            // (e.g. ReadCts disposed by concurrent teardown) must NEVER surface as a send failure.
-            LogCodexTurnObserveFailed(ex, agent.Id);
+    void ArmCodexTurnProbe(AgentInstance agent, long? baseline, long gen) {
+        if (agent.CodexRolloutPath is not { } rolloutPath || baseline is not { } b) {
+            LogCodexTurnRolloutUnresolved(agent.Id);
+            return;
         }
+
+        _ = Task.Run(() => ObserveCodexTurnAsync(agent, rolloutPath, b, gen));
     }
 
-    async Task ObserveCodexTurnAsync(AgentInstance agent, string rolloutPath, long baseline, CancellationTokenSource cts) {
+    async Task ObserveCodexTurnAsync(AgentInstance agent, string rolloutPath, long baseline, long gen) {
         try {
+            // The linked token is created HERE (on the pool), not on the send handler, so a
+            // concurrent teardown that has disposed ReadCts faults this best-effort probe rather
+            // than the send. Bounded by the agent's stop, daemon shutdown, and the observe timeout.
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
+
             long CurrentLength() {
                 try { return new FileInfo(rolloutPath).Length; } catch { return -1; } // <0 ⇒ momentarily unreadable
             }
@@ -2824,11 +2822,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             var outcome = await CodexTurnObserver.ObserveGrowthAsync(
                 CurrentLength, baseline, CodexTurnObserveTimeout, CodexTurnObserveInterval, TimeProvider.System, cts.Token);
 
-            // Single-flight: only the CURRENT probe may emit a verdict. If a newer round installed
-            // its own CTS while we were observing, our growth may belong to THAT round — drop
-            // silently (the newer probe reports). Cancellation alone can't guarantee this: we may
-            // have already computed `outcome` before the new round cancelled us.
-            if (!ReferenceEquals(Volatile.Read(ref agent.CodexTurnProbeCts), cts)) return;
+            // Single-flight: only the LATEST round's probe may emit a verdict. The generation was
+            // bumped (under the send gate) before this round's input was delivered, so if a newer
+            // round has since bumped it, the growth we saw belongs to THAT round — drop silently and
+            // let the newer probe report. A superseded probe is not actively cancelled; it simply
+            // stops here (and its ~2-minute timer self-expires), which costs nothing but a timer.
+            if (Volatile.Read(ref agent.CodexTurnProbeGen) != gen) return;
 
             switch (outcome) {
                 case CodexTurnObserver.Outcome.TurnObserved:
@@ -2842,15 +2841,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     // evidence the reviewer ignored the input. Do not emit the strong "no turn" line.
                     LogCodexTurnRolloutUnavailable(agent.Id);
                     break;
-                // Cancelled: superseded by a newer round, the agent stopped, or daemon shutdown — no verdict.
+                // Cancelled: the agent stopped or the daemon is shutting down — no verdict to report.
             }
         } catch (Exception ex) {
             LogCodexTurnObserveFailed(ex, agent.Id);
-        } finally {
-            // Release our slot only if it is still ours (a newer round may already have replaced it),
-            // then dispose the CTS we own.
-            Interlocked.CompareExchange(ref agent.CodexTurnProbeCts, null, cts);
-            cts.Dispose();
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2819,15 +2819,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             var start = DateTime.UtcNow;
 
+            // Single-flight: this round's generation was bumped (under the send gate) BEFORE its
+            // input was delivered, so a newer round instantly makes this one stale. The predicate
+            // is checked inside the poll loop, so a superseded probe STOPS within one interval
+            // (returns Superseded) rather than polling to the timeout — bounding how many probes a
+            // rapid retry burst can keep alive. The generation stays the sole verdict authority.
             var outcome = await CodexTurnObserver.ObserveGrowthAsync(
-                CurrentLength, baseline, CodexTurnObserveTimeout, CodexTurnObserveInterval, TimeProvider.System, cts.Token);
-
-            // Single-flight: only the LATEST round's probe may emit a verdict. The generation was
-            // bumped (under the send gate) before this round's input was delivered, so if a newer
-            // round has since bumped it, the growth we saw belongs to THAT round — drop silently and
-            // let the newer probe report. A superseded probe is not actively cancelled; it simply
-            // stops here (and its ~2-minute timer self-expires), which costs nothing but a timer.
-            if (Volatile.Read(ref agent.CodexTurnProbeGen) != gen) return;
+                CurrentLength, baseline, CodexTurnObserveTimeout, CodexTurnObserveInterval, TimeProvider.System, cts.Token,
+                isCurrent: () => Volatile.Read(ref agent.CodexTurnProbeGen) == gen);
 
             switch (outcome) {
                 case CodexTurnObserver.Outcome.TurnObserved:
@@ -2841,6 +2840,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     // evidence the reviewer ignored the input. Do not emit the strong "no turn" line.
                     LogCodexTurnRolloutUnavailable(agent.Id);
                     break;
+                // Superseded: a newer round took over — it reports; no verdict here.
                 // Cancelled: the agent stopped or the daemon is shutting down — no verdict to report.
             }
         } catch (Exception ex) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -37,6 +37,17 @@ internal record AgentInstance(
     public bool                 HasReceivedOutput { get; set; }
     public TerminalOutputBuffer OutputBuffer      { get; } = new();
 
+    /// <summary>Codex turn diagnostic: the reviewer's own rollout JSONL path, resolved ONCE by the
+    /// session-id detector and cached so the send path can sample its length with a single stat
+    /// (never a directory scan). Null until detection resolves it, and for non-Codex agents.</summary>
+    public string? CodexRolloutPath { get; set; }
+
+    /// <summary>Codex turn diagnostic: single-flight guard for the post-send rollout-growth probe.
+    /// Each follow-up round cancels the prior round's probe and installs its own, so a later round's
+    /// growth is never attributed to an earlier round's input. A plain field so
+    /// <see cref="System.Threading.Interlocked.Exchange{T}(ref T, T)"/> can swap it atomically.</summary>
+    public CancellationTokenSource? CodexTurnProbeCts;
+
     /// <summary>This agent's monotonic activity clock. One instance per launch — a relaunch gets a
     /// fresh one, never inheriting the predecessor's idle window. Defaults to a real-time instance so
     /// existing test constructions keep compiling; a production launch builds it explicitly, before
@@ -2717,6 +2728,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         LogSendInputReceived(agentId, agent.Runtime.Vendor, text.Length, attachmentIds?.Length ?? 0);
 
+        // Codex turn diagnostic: whether to run the post-send rollout probe, and the rollout's
+        // length sampled just BEFORE delivery. Declared out here so the baseline survives the
+        // try/finally to reach ArmCodexTurnProbe below.
+        var   isCodex       = string.Equals(agent.Runtime.Vendor, "codex", StringComparison.OrdinalIgnoreCase);
+        long? codexBaseline = null;
+
         await agent.BorrowedSnapshotGate.WaitAsync(_shutdownCts.Token);
         try {
             if (!await TryRefreshBorrowedSnapshotAsync(agent)) return;
@@ -2731,6 +2748,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 }
             }
 
+            // Codex turn diagnostic: sample the rollout length BEFORE delivery, from the path the
+            // session detector already cached (a single stat, never a scan). Capturing it AFTER the
+            // send would fold a fast Codex append into the baseline and mis-report "no turn". A null
+            // here (path not resolved yet, or the stat failed) is handled in ArmCodexTurnProbe.
+            if (isCodex && agent.CodexRolloutPath is { } rolloutPath) codexBaseline = TryFileLength(rolloutPath);
+
             // PTY runtimes use bracketed paste; ACP runtimes send a structured prompt.
             if (agent.BorrowedSnapshotSource is not null)
                 await agent.Runtime.SendUserInputAndWaitForWriteAsync(message);
@@ -2742,44 +2765,46 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             agent.BorrowedSnapshotGate.Release();
         }
 
-        // Codex turn-start diagnostic: a PTY Codex runtime exposes no turn-start signal to the daemon, so on a
-        // follow-up round the log otherwise stops at "delivered" and cannot tell a slow-but-working
-        // reviewer from one that received the input and never began a turn. Watch Codex's rollout
-        // for growth after delivery and log the verdict. Fire-and-forget, bounded, best-effort —
-        // never affects delivery. Only reached on the successful-delivery path (the guards and the
-        // borrowed-snapshot failure above all return before here).
-        if (string.Equals(agent.Runtime.Vendor, "codex", StringComparison.OrdinalIgnoreCase))
-            _ = ObserveCodexTurnAfterSendAsync(agent);
+        // Codex turn diagnostic: arm the post-send rollout-growth probe. Only reached on the
+        // successful-delivery path (the guards and the borrowed-snapshot failure above all return
+        // before here).
+        if (isCodex) ArmCodexTurnProbe(agent, codexBaseline);
     }
 
     /// <summary>
-    /// Codex turn-start diagnostic: after input is delivered to a hosted Codex reviewer, watch its rollout
-    /// JSONL for growth (the only clean turn-start signal a PTY runtime gives the daemon — see
-    /// <see cref="CodexTurnObserver"/>) and log whether a turn began. Fully best-effort: an
-    /// unresolvable rollout, a read fault, or the agent stopping is logged (or silently dropped for
-    /// cancellation) and never disturbs the send path.
+    /// Codex turn diagnostic: start a bounded, single-flight, off-handler probe that watches the
+    /// reviewer's rollout for growth past <paramref name="baseline"/> (the length captured just
+    /// before this round's input was delivered) and logs whether a turn began — the only clean
+    /// turn-start signal a PTY runtime gives the daemon (see <see cref="CodexTurnObserver"/>).
+    ///
+    /// <para>A null <paramref name="baseline"/> means the rollout path was not cached yet, or its
+    /// pre-delivery stat failed — logged and skipped (never a false "no turn"). The probe is
+    /// single-flight per agent: arming cancels the prior round's probe, so a later round's growth is
+    /// never attributed to an earlier round's input. It runs on a pooled thread (never the command
+    /// loop) and is bounded by the agent's stop, daemon shutdown, and the observe timeout.</para>
     /// </summary>
-    async Task ObserveCodexTurnAfterSendAsync(AgentInstance agent) {
+    void ArmCodexTurnProbe(AgentInstance agent, long? baseline) {
+        if (agent.CodexRolloutPath is not { } rolloutPath || baseline is not { } b) {
+            LogCodexTurnRolloutUnresolved(agent.Id);
+            return;
+        }
+
+        var cts  = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
+        var prev = Interlocked.Exchange(ref agent.CodexTurnProbeCts, cts);
+        if (prev is not null) {
+            try { prev.Cancel(); } catch (ObjectDisposedException) { /* the prior probe already finished + disposed it */ }
+        }
+
+        _ = Task.Run(() => ObserveCodexTurnAsync(agent, rolloutPath, b, cts));
+    }
+
+    async Task ObserveCodexTurnAsync(AgentInstance agent, string rolloutPath, long baseline, CancellationTokenSource cts) {
         try {
-            // Same cwd + spawn-time disambiguation the session-id detector uses, so we watch the
-            // reviewer's OWN rollout, not a concurrent Codex session under the shared tree.
-            if (CodexSessionRolloutLocator.TryLocatePath(CodexPaths.Sessions, agent.Worktree.Path, agent.CreatedAt) is not { } rolloutPath) {
-                LogCodexTurnRolloutUnresolved(agent.Id);
-                return;
-            }
-
             long CurrentLength() {
-                try { return new FileInfo(rolloutPath).Length; } catch { return -1; }
+                try { return new FileInfo(rolloutPath).Length; } catch { return -1; } // <0 ⇒ momentarily unreadable
             }
 
-            var baseline = CurrentLength();
-            if (baseline < 0) {
-                LogCodexTurnRolloutUnresolved(agent.Id);
-                return;
-            }
-
-            using var cts   = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
-            var       start = DateTime.UtcNow;
+            var start = DateTime.UtcNow;
 
             var outcome = await CodexTurnObserver.ObserveGrowthAsync(
                 CurrentLength, baseline, CodexTurnObserveTimeout, CodexTurnObserveInterval, TimeProvider.System, cts.Token);
@@ -2791,11 +2816,25 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 case CodexTurnObserver.Outcome.NotObserved:
                     LogCodexTurnNotObserved(agent.Id, CodexTurnObserveTimeout.TotalSeconds);
                     break;
-                // Cancelled: the agent stopped or the daemon is shutting down — no verdict to report.
+                case CodexTurnObserver.Outcome.Unavailable:
+                    // The rollout became unreadable and never showed growth — a measurement gap, NOT
+                    // evidence the reviewer ignored the input. Do not emit the strong "no turn" line.
+                    LogCodexTurnRolloutUnavailable(agent.Id);
+                    break;
+                // Cancelled: superseded by a newer round, the agent stopped, or daemon shutdown — no verdict.
             }
         } catch (Exception ex) {
             LogCodexTurnObserveFailed(ex, agent.Id);
+        } finally {
+            // Release our slot only if it is still ours (a newer round may already have replaced it),
+            // then dispose the CTS we own.
+            Interlocked.CompareExchange(ref agent.CodexTurnProbeCts, null, cts);
+            cts.Dispose();
         }
+    }
+
+    static long? TryFileLength(string path) {
+        try { return new FileInfo(path).Length; } catch { return null; }
     }
 
     static readonly TimeSpan BorrowedSnapshotRefreshTimeout = TimeSpan.FromSeconds(30);
@@ -3426,8 +3465,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         Func<ISet<string>, string?>? locate = vendor.ToLowerInvariant() switch {
             "claude" => ruledOut => SessionTranscriptLocator.TryLocate(
                 ClaudePaths.ProjectDir(agent.Worktree.Path), agent.Worktree.Path, spawnedAtUtc, ruledOut),
-            "codex" => ruledOut => CodexSessionRolloutLocator.TryLocate(
-                CodexPaths.Sessions, agent.Worktree.Path, spawnedAtUtc, ruledOut),
+            // Codex turn diagnostic: resolve id AND path together and cache the path on the agent,
+            // so the send-path probe needs only a single stat later — no directory scan on the
+            // daemon command loop. The path is stable for a session's lifetime.
+            "codex" => ruledOut => {
+                if (CodexSessionRolloutLocator.TryLocateWinner(
+                        CodexPaths.Sessions, agent.Worktree.Path, spawnedAtUtc, ruledOut) is not { } winner)
+                    return null;
+                agent.CodexRolloutPath = winner.Path;
+                return winner.SessionId;
+            },
             _ => null,
         };
 
@@ -3853,6 +3900,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Codex turn observer: could not resolve a rollout for agent {AgentId} — skipping turn-start diagnostic for this round")]
     partial void LogCodexTurnRolloutUnresolved(string agentId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Codex turn observer: rollout for agent {AgentId} became unreadable during observation — no turn verdict for this round (measurement gap, not evidence of no turn)")]
+    partial void LogCodexTurnRolloutUnavailable(string agentId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Codex turn observer faulted for agent {AgentId} (diagnostic only — delivery unaffected)")]
     partial void LogCodexTurnObserveFailed(Exception ex, string agentId);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2784,18 +2784,33 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// loop) and is bounded by the agent's stop, daemon shutdown, and the observe timeout.</para>
     /// </summary>
     void ArmCodexTurnProbe(AgentInstance agent, long? baseline) {
-        if (agent.CodexRolloutPath is not { } rolloutPath || baseline is not { } b) {
-            LogCodexTurnRolloutUnresolved(agent.Id);
-            return;
-        }
+        try {
+            var rolloutPath = agent.CodexRolloutPath;
+            var canObserve  = rolloutPath is not null && baseline is not null;
 
-        var cts  = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
-        var prev = Interlocked.Exchange(ref agent.CodexTurnProbeCts, cts);
-        if (prev is not null) {
-            try { prev.Cancel(); } catch (ObjectDisposedException) { /* the prior probe already finished + disposed it */ }
-        }
+            // Supersede any prior round's probe FIRST — always, even when this round cannot be
+            // observed — so a predecessor can neither keep running nor log a verdict for this round's
+            // growth. Installing null when we cannot observe still cancels the predecessor and makes
+            // its ownership check fail.
+            var newCts = canObserve
+                ? CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token)
+                : null;
+            var prev = Interlocked.Exchange(ref agent.CodexTurnProbeCts, newCts);
+            if (prev is not null) {
+                try { prev.Cancel(); } catch (ObjectDisposedException) { /* the prior probe already finished + disposed it */ }
+            }
 
-        _ = Task.Run(() => ObserveCodexTurnAsync(agent, rolloutPath, b, cts));
+            if (!canObserve) {
+                LogCodexTurnRolloutUnresolved(agent.Id);
+                return;
+            }
+
+            _ = Task.Run(() => ObserveCodexTurnAsync(agent, rolloutPath!, baseline!.Value, newCts!));
+        } catch (Exception ex) {
+            // Arming is best-effort and runs AFTER the input was already delivered — a fault here
+            // (e.g. ReadCts disposed by concurrent teardown) must NEVER surface as a send failure.
+            LogCodexTurnObserveFailed(ex, agent.Id);
+        }
     }
 
     async Task ObserveCodexTurnAsync(AgentInstance agent, string rolloutPath, long baseline, CancellationTokenSource cts) {
@@ -2808,6 +2823,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             var outcome = await CodexTurnObserver.ObserveGrowthAsync(
                 CurrentLength, baseline, CodexTurnObserveTimeout, CodexTurnObserveInterval, TimeProvider.System, cts.Token);
+
+            // Single-flight: only the CURRENT probe may emit a verdict. If a newer round installed
+            // its own CTS while we were observing, our growth may belong to THAT round — drop
+            // silently (the newer probe reports). Cancellation alone can't guarantee this: we may
+            // have already computed `outcome` before the new round cancelled us.
+            if (!ReferenceEquals(Volatile.Read(ref agent.CodexTurnProbeCts), cts)) return;
 
             switch (outcome) {
                 case CodexTurnObserver.Outcome.TurnObserved:

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2741,6 +2741,61 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         } finally {
             agent.BorrowedSnapshotGate.Release();
         }
+
+        // Codex turn-start diagnostic: a PTY Codex runtime exposes no turn-start signal to the daemon, so on a
+        // follow-up round the log otherwise stops at "delivered" and cannot tell a slow-but-working
+        // reviewer from one that received the input and never began a turn. Watch Codex's rollout
+        // for growth after delivery and log the verdict. Fire-and-forget, bounded, best-effort —
+        // never affects delivery. Only reached on the successful-delivery path (the guards and the
+        // borrowed-snapshot failure above all return before here).
+        if (string.Equals(agent.Runtime.Vendor, "codex", StringComparison.OrdinalIgnoreCase))
+            _ = ObserveCodexTurnAfterSendAsync(agent);
+    }
+
+    /// <summary>
+    /// Codex turn-start diagnostic: after input is delivered to a hosted Codex reviewer, watch its rollout
+    /// JSONL for growth (the only clean turn-start signal a PTY runtime gives the daemon — see
+    /// <see cref="CodexTurnObserver"/>) and log whether a turn began. Fully best-effort: an
+    /// unresolvable rollout, a read fault, or the agent stopping is logged (or silently dropped for
+    /// cancellation) and never disturbs the send path.
+    /// </summary>
+    async Task ObserveCodexTurnAfterSendAsync(AgentInstance agent) {
+        try {
+            // Same cwd + spawn-time disambiguation the session-id detector uses, so we watch the
+            // reviewer's OWN rollout, not a concurrent Codex session under the shared tree.
+            if (CodexSessionRolloutLocator.TryLocatePath(CodexPaths.Sessions, agent.Worktree.Path, agent.CreatedAt) is not { } rolloutPath) {
+                LogCodexTurnRolloutUnresolved(agent.Id);
+                return;
+            }
+
+            long CurrentLength() {
+                try { return new FileInfo(rolloutPath).Length; } catch { return -1; }
+            }
+
+            var baseline = CurrentLength();
+            if (baseline < 0) {
+                LogCodexTurnRolloutUnresolved(agent.Id);
+                return;
+            }
+
+            using var cts   = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
+            var       start = DateTime.UtcNow;
+
+            var outcome = await CodexTurnObserver.ObserveGrowthAsync(
+                CurrentLength, baseline, CodexTurnObserveTimeout, CodexTurnObserveInterval, TimeProvider.System, cts.Token);
+
+            switch (outcome) {
+                case CodexTurnObserver.Outcome.TurnObserved:
+                    LogCodexTurnStarted(agent.Id, (long)(DateTime.UtcNow - start).TotalMilliseconds);
+                    break;
+                case CodexTurnObserver.Outcome.NotObserved:
+                    LogCodexTurnNotObserved(agent.Id, CodexTurnObserveTimeout.TotalSeconds);
+                    break;
+                // Cancelled: the agent stopped or the daemon is shutting down — no verdict to report.
+            }
+        } catch (Exception ex) {
+            LogCodexTurnObserveFailed(ex, agent.Id);
+        }
     }
 
     static readonly TimeSpan BorrowedSnapshotRefreshTimeout = TimeSpan.FromSeconds(30);
@@ -3340,6 +3395,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     static readonly TimeSpan SessionIdPollInterval = TimeSpan.FromSeconds(2);
     static readonly TimeSpan SessionIdPollTimeout  = TimeSpan.FromMinutes(3);
 
+    // Codex turn-start diagnostic: how long, and how often, to watch a hosted Codex reviewer's rollout for growth
+    // after a round's input is delivered, so the daemon log can say whether Codex began a turn.
+    // A working reviewer appends response items within seconds of starting; 2 minutes of silence
+    // is the "received input, produced no turn" signature, not a slow-but-working reviewer.
+    static readonly TimeSpan CodexTurnObserveInterval = TimeSpan.FromSeconds(2);
+    static readonly TimeSpan CodexTurnObserveTimeout  = TimeSpan.FromMinutes(2);
+
     /// <summary>
     /// Vendor-dispatched, best-effort background fallback that discovers a spawned agent's
     /// session id from the transcript/rollout its harness writes and reports it to the server,
@@ -3781,6 +3843,19 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "SendInput dropped: agent {AgentId} is private — server-origin input is ignored")]
     partial void LogSendInputPrivateAgent(string agentId);
+
+    // Codex (PTY) turn-start diagnostic — after SendInput is delivered, did Codex act?
+    [LoggerMessage(Level = LogLevel.Information, Message = "Codex turn started for agent {AgentId} after input ({ElapsedMs}ms after delivery)")]
+    partial void LogCodexTurnStarted(string agentId, long elapsedMs);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Codex produced NO turn for agent {AgentId} within {Seconds}s of input delivery — the reviewer received the prompt but did not act on it")]
+    partial void LogCodexTurnNotObserved(string agentId, double seconds);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Codex turn observer: could not resolve a rollout for agent {AgentId} — skipping turn-start diagnostic for this round")]
+    partial void LogCodexTurnRolloutUnresolved(string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Codex turn observer faulted for agent {AgentId} (diagnostic only — delivery unaffected)")]
+    partial void LogCodexTurnObserveFailed(Exception ex, string agentId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "SendSpecialKey '{Key}' dropped: agent {AgentId} not found on this daemon ({KnownAgents} agents registered)")]
     partial void LogSendSpecialKeyUnknownAgent(string agentId, string key, int knownAgents);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2817,13 +2817,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 try { return new FileInfo(rolloutPath).Length; } catch { return -1; } // <0 ⇒ momentarily unreadable
             }
 
-            var start = DateTime.UtcNow;
+            // Monotonic elapsed measurement (same clock domain the observer uses) — DateTime.UtcNow
+            // could skew or go negative if the wall clock shifts mid-observation.
+            var startTs = TimeProvider.System.GetTimestamp();
 
-            // Single-flight: this round's generation was bumped (under the send gate) BEFORE its
-            // input was delivered, so a newer round instantly makes this one stale. The predicate
-            // is checked inside the poll loop, so a superseded probe STOPS within one interval
-            // (returns Superseded) rather than polling to the timeout — bounding how many probes a
-            // rapid retry burst can keep alive. The generation stays the sole verdict authority.
+            // Single-flight: this round's generation was bumped (under the send gate) before its
+            // input was delivered, so a newer round instantly makes this one stale. The predicate is
+            // checked inside the poll loop, so a superseded probe stops within one interval instead
+            // of polling to the timeout; the generation stays the sole verdict authority.
             var outcome = await CodexTurnObserver.ObserveGrowthAsync(
                 CurrentLength, baseline, CodexTurnObserveTimeout, CodexTurnObserveInterval, TimeProvider.System, cts.Token,
                 isCurrent: () => Volatile.Read(ref agent.CodexTurnProbeGen) == gen);
@@ -2837,7 +2838,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             switch (outcome) {
                 case CodexTurnObserver.Outcome.TurnObserved:
-                    LogCodexTurnStarted(agent.Id, (long)(DateTime.UtcNow - start).TotalMilliseconds);
+                    LogCodexTurnStarted(agent.Id, (long)TimeProvider.System.GetElapsedTime(startTs).TotalMilliseconds);
                     break;
                 case CodexTurnObserver.Outcome.NotObserved:
                     LogCodexTurnNotObserved(agent.Id, CodexTurnObserveTimeout.TotalSeconds);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2828,6 +2828,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 CurrentLength, baseline, CodexTurnObserveTimeout, CodexTurnObserveInterval, TimeProvider.System, cts.Token,
                 isCurrent: () => Volatile.Read(ref agent.CodexTurnProbeGen) == gen);
 
+            // Verdict authority: the in-loop predicate stops a superseded probe promptly, but it is
+            // checked BEFORE each length stat — so a newer round could bump the generation AND grow
+            // the rollout between that check and the read, yielding a TurnObserved that belongs to
+            // the newer round. Re-check the generation HERE, immediately before logging, so a stale
+            // round never emits a verdict (leaving only the sub-microsecond check-to-log window).
+            if (Volatile.Read(ref agent.CodexTurnProbeGen) != gen) return;
+
             switch (outcome) {
                 case CodexTurnObserver.Outcome.TurnObserved:
                     LogCodexTurnStarted(agent.Id, (long)(DateTime.UtcNow - start).TotalMilliseconds);

--- a/src/Capacitor.Cli.Daemon/Services/CodexSessionRolloutLocator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexSessionRolloutLocator.cs
@@ -24,7 +24,8 @@ namespace Capacitor.Cli.Daemon.Services;
 /// birth time (<c>SetCreationTime</c> is a no-op) and does not reliably expose it, so the
 /// filesystem creation time is unusable there for distinguishing rollouts — the filename stamp is
 /// Codex's own session-start time, stable and cross-platform. The decision logic is pure and
-/// unit-tested without a filesystem; only <see cref="TryLocate"/> touches disk.
+/// unit-tested without a filesystem; only the <see cref="TryLocate"/>/<see cref="TryLocatePath"/>
+/// scan touches disk.
 /// </summary>
 internal static class CodexSessionRolloutLocator {
     /// <summary>How many non-blank rollout lines to inspect for a <c>payload.cwd</c> before
@@ -61,10 +62,26 @@ internal static class CodexSessionRolloutLocator {
     /// <em>definitive</em> non-matches are added (a foreign cwd, or a name that isn't a rollout);
     /// a rollout with no cwd yet is left out so the reviewer's own file is always re-checked.
     /// </param>
-    public static string? TryLocate(string sessionsRoot, string cwd, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) {
+    public static string? TryLocate(string sessionsRoot, string cwd, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) =>
+        TryLocateWinner(sessionsRoot, cwd, spawnedAtUtc, ruledOut)?.SessionId;
+
+    /// <summary>
+    /// Like <see cref="TryLocate"/> but returns the matching rollout's <b>file path</b> rather than
+    /// its session id — for a caller that must read the rollout itself (watching it for
+    /// post-input growth as a Codex turn-start signal). Same disambiguation, same best-effort
+    /// contract: null when no candidate matches yet.
+    /// </summary>
+    public static string? TryLocatePath(string sessionsRoot, string cwd, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) =>
+        TryLocateWinner(sessionsRoot, cwd, spawnedAtUtc, ruledOut)?.Path;
+
+    /// <summary>Shared scan for <see cref="TryLocate"/>/<see cref="TryLocatePath"/>: returns the
+    /// winning rollout's normalized session id AND its file path together, so the two public
+    /// entry points can never disagree on which file won.</summary>
+    static (string SessionId, string Path)? TryLocateWinner(string sessionsRoot, string cwd, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) {
         if (!Directory.Exists(sessionsRoot)) return null;
 
         string?   bestId       = null;
+        string?   bestFile     = null;
         DateTime? bestCreation = null;
 
         foreach (var file in EnumerateRecentRolloutFiles(sessionsRoot, spawnedAtUtc)) {
@@ -94,6 +111,7 @@ internal static class CodexSessionRolloutLocator {
                         if (bestCreation is null || IsCloserToSpawn(creation, bestCreation.Value, spawnedAtUtc)) {
                             bestCreation = creation;
                             bestId       = sessionId;
+                            bestFile     = file;
                         }
 
                         break;
@@ -108,7 +126,7 @@ internal static class CodexSessionRolloutLocator {
             }
         }
 
-        return bestId;
+        return bestId is not null && bestFile is not null ? (bestId, bestFile) : null;
     }
 
     /// <summary>True when <paramref name="candidate"/> is a better spawn-time match than

--- a/src/Capacitor.Cli.Daemon/Services/CodexSessionRolloutLocator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexSessionRolloutLocator.cs
@@ -24,8 +24,8 @@ namespace Capacitor.Cli.Daemon.Services;
 /// birth time (<c>SetCreationTime</c> is a no-op) and does not reliably expose it, so the
 /// filesystem creation time is unusable there for distinguishing rollouts — the filename stamp is
 /// Codex's own session-start time, stable and cross-platform. The decision logic is pure and
-/// unit-tested without a filesystem; only the <see cref="TryLocate"/>/<see cref="TryLocatePath"/>
-/// scan touches disk.
+/// unit-tested without a filesystem; only the <see cref="TryLocateWinner"/> scan (behind
+/// <see cref="TryLocate"/>) touches disk.
 /// </summary>
 internal static class CodexSessionRolloutLocator {
     /// <summary>How many non-blank rollout lines to inspect for a <c>payload.cwd</c> before
@@ -65,19 +65,12 @@ internal static class CodexSessionRolloutLocator {
     public static string? TryLocate(string sessionsRoot, string cwd, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) =>
         TryLocateWinner(sessionsRoot, cwd, spawnedAtUtc, ruledOut)?.SessionId;
 
-    /// <summary>
-    /// Like <see cref="TryLocate"/> but returns the matching rollout's <b>file path</b> rather than
-    /// its session id — for a caller that must read the rollout itself (watching it for
-    /// post-input growth as a Codex turn-start signal). Same disambiguation, same best-effort
-    /// contract: null when no candidate matches yet.
-    /// </summary>
-    public static string? TryLocatePath(string sessionsRoot, string cwd, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) =>
-        TryLocateWinner(sessionsRoot, cwd, spawnedAtUtc, ruledOut)?.Path;
-
-    /// <summary>Shared scan for <see cref="TryLocate"/>/<see cref="TryLocatePath"/>: returns the
-    /// winning rollout's normalized session id AND its file path together, so the two public
-    /// entry points can never disagree on which file won.</summary>
-    static (string SessionId, string Path)? TryLocateWinner(string sessionsRoot, string cwd, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) {
+    /// <summary>Like <see cref="TryLocate"/> but returns the winning rollout's normalized session id
+    /// AND its file path together — for a caller that must also read the rollout itself (the daemon
+    /// caches the path to watch it for post-input growth as a Codex turn-start signal). Returning
+    /// both from one scan means the id and the path can never disagree on which file won. Same
+    /// disambiguation, same best-effort contract: null when no candidate matches yet.</summary>
+    internal static (string SessionId, string Path)? TryLocateWinner(string sessionsRoot, string cwd, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) {
         if (!Directory.Exists(sessionsRoot)) return null;
 
         string?   bestId       = null;

--- a/src/Capacitor.Cli.Daemon/Services/CodexTurnObserver.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexTurnObserver.cs
@@ -1,20 +1,12 @@
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Codex turn-start diagnostic. After a follow-up round's input is delivered to a hosted <b>Codex</b> reviewer, the
-/// daemon log stops at <c>"SendInput delivered"</c> — it cannot say whether Codex then began a turn
-/// or silently ignored the input, which is the entire open question when a round-2 review times out.
-///
-/// <para>Unlike an ACP runtime (explicit turn boundaries, logged by <c>LogTurnStarted</c>/
-/// <c>LogTurnEnded</c> in <c>AcpHostedAgentRuntime</c>), a PTY Codex runtime exposes no turn signal
-/// to the daemon: the read loop advances the activity clock on <em>every</em> PTY output chunk,
-/// including TUI redraws, so "there was output" is not a turn gate. Codex's own rollout JSONL
-/// (<c>~/.codex/sessions/**.jsonl</c>) is the one clean signal — it grows only when Codex commits
-/// response items. This observer watches that file's length for growth after input, turning a
-/// round-2 timeout into a one-log-line diagnosis instead of a forensic session.</para>
-///
-/// <para>Pure and unit-testable: the growth source and the clock are injected; only the caller
-/// (<c>AgentOrchestrator</c>) touches the filesystem.</para>
+/// Codex turn-start diagnostic: after a follow-up round's input is delivered, did Codex begin a turn
+/// or ignore it? A PTY Codex runtime gives the daemon no turn signal (PTY output advances the
+/// activity clock on every TUI redraw, so "there was output" is not a turn gate), but its rollout
+/// JSONL grows only when Codex commits response items. This observer watches that file's length for
+/// growth after input. Pure/testable: the growth source and clock are injected; only the caller
+/// touches the filesystem.
 /// </summary>
 internal static class CodexTurnObserver {
     internal enum Outcome {

--- a/src/Capacitor.Cli.Daemon/Services/CodexTurnObserver.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexTurnObserver.cs
@@ -1,0 +1,60 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Codex turn-start diagnostic. After a follow-up round's input is delivered to a hosted <b>Codex</b> reviewer, the
+/// daemon log stops at <c>"SendInput delivered"</c> — it cannot say whether Codex then began a turn
+/// or silently ignored the input, which is the entire open question when a round-2 review times out.
+///
+/// <para>Unlike an ACP runtime (explicit turn boundaries, logged by <c>LogTurnStarted</c>/
+/// <c>LogTurnEnded</c> in <c>AcpHostedAgentRuntime</c>), a PTY Codex runtime exposes no turn signal
+/// to the daemon: the read loop advances the activity clock on <em>every</em> PTY output chunk,
+/// including TUI redraws, so "there was output" is not a turn gate. Codex's own rollout JSONL
+/// (<c>~/.codex/sessions/**.jsonl</c>) is the one clean signal — it grows only when Codex commits
+/// response items. This observer watches that file's length for growth after input, turning a
+/// round-2 timeout into a one-log-line diagnosis instead of a forensic session.</para>
+///
+/// <para>Pure and unit-testable: the growth source and the clock are injected; only the caller
+/// (<c>AgentOrchestrator</c>) touches the filesystem.</para>
+/// </summary>
+internal static class CodexTurnObserver {
+    internal enum Outcome {
+        /// <summary>The rollout grew past its post-input baseline — Codex began a turn.</summary>
+        TurnObserved,
+        /// <summary>The timeout elapsed with no growth — Codex received the input but produced no
+        /// turn (the "input delivered, no turn" failure signature).</summary>
+        NotObserved,
+        /// <summary>The agent stopped or the daemon began shutting down before a verdict.</summary>
+        Cancelled,
+    }
+
+    /// <summary>
+    /// Polls <paramref name="currentLength"/> until it exceeds <paramref name="baseline"/> (⇒
+    /// <see cref="Outcome.TurnObserved"/>), <paramref name="timeout"/> elapses (⇒
+    /// <see cref="Outcome.NotObserved"/>), or <paramref name="ct"/> fires (⇒
+    /// <see cref="Outcome.Cancelled"/>). The length is checked once up front (a fast turn may land
+    /// before the first poll) and once more after the loop exits on the deadline, so a turn landing
+    /// in the final interval is still credited rather than lost to an off-by-one.
+    /// </summary>
+    public static async Task<Outcome> ObserveGrowthAsync(
+        Func<long>        currentLength,
+        long              baseline,
+        TimeSpan          timeout,
+        TimeSpan          pollInterval,
+        TimeProvider      time,
+        CancellationToken ct) {
+        var start = time.GetTimestamp();
+
+        try {
+            while (time.GetElapsedTime(start) < timeout) {
+                if (currentLength() > baseline) return Outcome.TurnObserved;
+                await Task.Delay(pollInterval, time, ct);
+            }
+
+            // Final check: a turn that landed during the last delay must not be missed just
+            // because the loop condition fired first.
+            return currentLength() > baseline ? Outcome.TurnObserved : Outcome.NotObserved;
+        } catch (OperationCanceledException) {
+            return Outcome.Cancelled;
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/CodexTurnObserver.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexTurnObserver.cs
@@ -27,6 +27,10 @@ internal static class CodexTurnObserver {
         /// sustained stat failure) and no growth was ever seen — a measurement gap, NOT evidence
         /// that the reviewer ignored the input. The caller must not report this as "no turn".</summary>
         Unavailable,
+        /// <summary>A newer round superseded this probe (the injected <c>isCurrent</c> predicate went
+        /// false) before a verdict — the newer probe reports. Returned promptly so a superseded probe
+        /// stops polling within one interval instead of running to the timeout.</summary>
+        Superseded,
         /// <summary>The agent stopped or the daemon began shutting down before a verdict.</summary>
         Cancelled,
     }
@@ -47,24 +51,33 @@ internal static class CodexTurnObserver {
     /// <see cref="Outcome.Unavailable"/> — distinguishing a genuine measurement failure from a real
     /// "no turn".</para>
     /// </summary>
+    /// <param name="isCurrent">Optional single-flight predicate. Checked at the top of every poll
+    /// (and once more at the deadline) BEFORE the length stat; the first time it returns false the
+    /// probe stops with <see cref="Outcome.Superseded"/>. This is what makes a superseded probe stop
+    /// polling within one interval rather than running to <paramref name="timeout"/> — the caller
+    /// keeps the actual verdict authority (a generation), so this only manages the probe's lifetime.
+    /// Null (the default) disables it.</param>
     public static async Task<Outcome> ObserveGrowthAsync(
         Func<long>        currentLength,
         long              baseline,
         TimeSpan          timeout,
         TimeSpan          pollInterval,
         TimeProvider      time,
-        CancellationToken ct) {
+        CancellationToken ct,
+        Func<bool>?       isCurrent = null) {
         var start = time.GetTimestamp();
 
         try {
             while (time.GetElapsedTime(start) < timeout) {
-                if (currentLength() > baseline) return Outcome.TurnObserved;
+                if (isCurrent is not null && !isCurrent()) return Outcome.Superseded;
+                if (currentLength() > baseline)            return Outcome.TurnObserved;
                 await Task.Delay(pollInterval, time, ct);
             }
 
             // Final check: a turn that landed during the last delay must not be missed just because
             // the loop condition fired first. A negative reading here is a genuine measurement gap,
             // not a "no turn" verdict.
+            if (isCurrent is not null && !isCurrent()) return Outcome.Superseded;
             var finalLength = currentLength();
             if (finalLength < 0)        return Outcome.Unavailable;
             return finalLength > baseline ? Outcome.TurnObserved : Outcome.NotObserved;

--- a/src/Capacitor.Cli.Daemon/Services/CodexTurnObserver.cs
+++ b/src/Capacitor.Cli.Daemon/Services/CodexTurnObserver.cs
@@ -23,6 +23,10 @@ internal static class CodexTurnObserver {
         /// <summary>The timeout elapsed with no growth — Codex received the input but produced no
         /// turn (the "input delivered, no turn" failure signature).</summary>
         NotObserved,
+        /// <summary>The length was still unreadable at the deadline (a deleted/moved rollout or a
+        /// sustained stat failure) and no growth was ever seen — a measurement gap, NOT evidence
+        /// that the reviewer ignored the input. The caller must not report this as "no turn".</summary>
+        Unavailable,
         /// <summary>The agent stopped or the daemon began shutting down before a verdict.</summary>
         Cancelled,
     }
@@ -30,10 +34,18 @@ internal static class CodexTurnObserver {
     /// <summary>
     /// Polls <paramref name="currentLength"/> until it exceeds <paramref name="baseline"/> (⇒
     /// <see cref="Outcome.TurnObserved"/>), <paramref name="timeout"/> elapses (⇒
-    /// <see cref="Outcome.NotObserved"/>), or <paramref name="ct"/> fires (⇒
-    /// <see cref="Outcome.Cancelled"/>). The length is checked once up front (a fast turn may land
-    /// before the first poll) and once more after the loop exits on the deadline, so a turn landing
-    /// in the final interval is still credited rather than lost to an off-by-one.
+    /// <see cref="Outcome.NotObserved"/>, or <see cref="Outcome.Unavailable"/> when the final read
+    /// signalled unavailability), or <paramref name="ct"/> fires (⇒ <see cref="Outcome.Cancelled"/>).
+    /// The length is checked once up front (a fast turn may land before the first poll) and once more
+    /// after the loop exits on the deadline, so a turn landing in the final interval is still credited
+    /// rather than lost to an off-by-one.
+    ///
+    /// <para><paramref name="currentLength"/> returns a <b>negative</b> value to signal the length is
+    /// momentarily unreadable. During polling that is simply "not grown yet" (a real growth always
+    /// resolves to a value &gt; baseline first, so a transient read failure can never mask a turn we
+    /// already saw); only a negative value at the final deadline check yields
+    /// <see cref="Outcome.Unavailable"/> — distinguishing a genuine measurement failure from a real
+    /// "no turn".</para>
     /// </summary>
     public static async Task<Outcome> ObserveGrowthAsync(
         Func<long>        currentLength,
@@ -50,9 +62,12 @@ internal static class CodexTurnObserver {
                 await Task.Delay(pollInterval, time, ct);
             }
 
-            // Final check: a turn that landed during the last delay must not be missed just
-            // because the loop condition fired first.
-            return currentLength() > baseline ? Outcome.TurnObserved : Outcome.NotObserved;
+            // Final check: a turn that landed during the last delay must not be missed just because
+            // the loop condition fired first. A negative reading here is a genuine measurement gap,
+            // not a "no turn" verdict.
+            var finalLength = currentLength();
+            if (finalLength < 0)        return Outcome.Unavailable;
+            return finalLength > baseline ? Outcome.TurnObserved : Outcome.NotObserved;
         } catch (OperationCanceledException) {
             return Outcome.Cancelled;
         }

--- a/test/Capacitor.Cli.Tests.Unit/CodexSessionRolloutLocatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexSessionRolloutLocatorTests.cs
@@ -120,6 +120,40 @@ public class CodexSessionRolloutLocatorTests {
         }
     }
 
+    // TryLocatePath returns the winning rollout's FILE PATH (for growth-watching), and
+    // must agree with TryLocate on which file won.
+    [Test]
+    public async Task TryLocatePath_returns_the_matching_rollout_file() {
+        var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
+        try {
+            var spawn = DateTime.UtcNow;
+            var uuid  = "019f0022-1702-7a02-a630-edbfb043add4";
+            var wt    = Path.Combine(root, "worktree");
+            var file  = WriteRollout(root, uuid, wt, creationUtc: spawn);
+
+            var path = CodexSessionRolloutLocator.TryLocatePath(root, wt, spawn.AddSeconds(-1));
+
+            await Assert.That(path).IsEqualTo(file);
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task TryLocatePath_returns_null_when_no_rollout_matches() {
+        var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
+        try {
+            var spawn = DateTime.UtcNow;
+            WriteRollout(root, "019f0022-1702-7a02-a630-edbfb043add4", "/some/other/cwd", creationUtc: spawn);
+
+            var path = CodexSessionRolloutLocator.TryLocatePath(root, Path.Combine(root, "worktree"), spawn.AddSeconds(-1));
+
+            await Assert.That(path).IsNull();
+        } finally {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     [Test]
     public async Task TryLocate_ignores_a_foreign_cwd_rollout() {
         var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;

--- a/test/Capacitor.Cli.Tests.Unit/CodexSessionRolloutLocatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexSessionRolloutLocatorTests.cs
@@ -120,10 +120,10 @@ public class CodexSessionRolloutLocatorTests {
         }
     }
 
-    // TryLocatePath returns the winning rollout's FILE PATH (for growth-watching), and
-    // must agree with TryLocate on which file won.
+    // TryLocateWinner returns the winning rollout's session id AND file path together (the daemon
+    // caches the path for growth-watching); id and path must agree on which file won.
     [Test]
-    public async Task TryLocatePath_returns_the_matching_rollout_file() {
+    public async Task TryLocateWinner_returns_matching_id_and_file_path() {
         var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
         try {
             var spawn = DateTime.UtcNow;
@@ -131,24 +131,25 @@ public class CodexSessionRolloutLocatorTests {
             var wt    = Path.Combine(root, "worktree");
             var file  = WriteRollout(root, uuid, wt, creationUtc: spawn);
 
-            var path = CodexSessionRolloutLocator.TryLocatePath(root, wt, spawn.AddSeconds(-1));
+            var winner = CodexSessionRolloutLocator.TryLocateWinner(root, wt, spawn.AddSeconds(-1));
 
-            await Assert.That(path).IsEqualTo(file);
+            await Assert.That(winner?.Path).IsEqualTo(file);
+            await Assert.That(winner?.SessionId).IsEqualTo(uuid.Replace("-", ""));
         } finally {
             Directory.Delete(root, recursive: true);
         }
     }
 
     [Test]
-    public async Task TryLocatePath_returns_null_when_no_rollout_matches() {
+    public async Task TryLocateWinner_returns_null_when_no_rollout_matches() {
         var root = Directory.CreateTempSubdirectory("kcap-codexrollout-").FullName;
         try {
             var spawn = DateTime.UtcNow;
             WriteRollout(root, "019f0022-1702-7a02-a630-edbfb043add4", "/some/other/cwd", creationUtc: spawn);
 
-            var path = CodexSessionRolloutLocator.TryLocatePath(root, Path.Combine(root, "worktree"), spawn.AddSeconds(-1));
+            var winner = CodexSessionRolloutLocator.TryLocateWinner(root, Path.Combine(root, "worktree"), spawn.AddSeconds(-1));
 
-            await Assert.That(path).IsNull();
+            await Assert.That(winner).IsNull();
         } finally {
             Directory.Delete(root, recursive: true);
         }

--- a/test/Capacitor.Cli.Tests.Unit/CodexTurnObserverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexTurnObserverTests.cs
@@ -75,6 +75,24 @@ public class CodexTurnObserverTests {
     }
 
     [Test]
+    public async Task Superseded_probe_stops_promptly_without_a_verdict() {
+        var  time    = new FakeTimeProvider();
+        long len     = 10;   // never grows on its own
+        var  current = true; // becomes false to simulate a newer round superseding this probe
+
+        var task = CodexTurnObserver.ObserveGrowthAsync(
+            () => len, baseline: 10, Timeout, Poll, time, CancellationToken.None, isCurrent: () => current);
+
+        // A newer round supersedes us AND its growth lands on the shared file — but this stale probe
+        // must NOT claim it; it must stop with Superseded at its next poll.
+        current = false;
+        len     = 999;
+        time.Advance(Poll);
+
+        await Assert.That(await task).IsEqualTo(CodexTurnObserver.Outcome.Superseded);
+    }
+
+    [Test]
     public async Task Cancellation_is_reported() {
         var       time = new FakeTimeProvider();
         using var cts  = new CancellationTokenSource();

--- a/test/Capacitor.Cli.Tests.Unit/CodexTurnObserverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexTurnObserverTests.cs
@@ -1,0 +1,62 @@
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Codex turn-start diagnostic: tests the pure growth-observation core that turns a hosted Codex reviewer's rollout
+/// into a turn-start signal. Growth ⇒ the reviewer began a turn; silence to the deadline ⇒ it
+/// received the input but produced no turn; cancellation ⇒ the agent stopped. The length source
+/// and clock are injected, so no filesystem or wall-clock is involved.
+/// </summary>
+public class CodexTurnObserverTests {
+    static readonly TimeSpan Timeout = TimeSpan.FromMinutes(2);
+    static readonly TimeSpan Poll    = TimeSpan.FromSeconds(2);
+
+    [Test]
+    public async Task Growth_before_first_poll_is_observed_immediately() {
+        // A fast reviewer that has already appended by the first check needs no polling at all.
+        var outcome = await CodexTurnObserver.ObserveGrowthAsync(
+            currentLength: () => 100, baseline: 10, Timeout, Poll, new FakeTimeProvider(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(CodexTurnObserver.Outcome.TurnObserved);
+    }
+
+    [Test]
+    public async Task Growth_during_polling_is_observed() {
+        var  time = new FakeTimeProvider();
+        long len  = 10; // starts at the baseline — the first check must NOT credit a turn
+
+        var task = CodexTurnObserver.ObserveGrowthAsync(() => len, baseline: 10, Timeout, Poll, time, CancellationToken.None);
+
+        // The synchronous first check (len==baseline) already ran and armed the poll delay; now the
+        // rollout grows and the clock advances past one interval, so the next check credits the turn.
+        len = 42;
+        time.Advance(Poll);
+
+        await Assert.That(await task).IsEqualTo(CodexTurnObserver.Outcome.TurnObserved);
+    }
+
+    [Test]
+    public async Task No_growth_until_timeout_is_not_observed() {
+        var time = new FakeTimeProvider();
+
+        var task = CodexTurnObserver.ObserveGrowthAsync(() => 10, baseline: 10, Timeout, Poll, time, CancellationToken.None);
+
+        time.Advance(Timeout + Poll); // push past the deadline with the length unchanged
+
+        await Assert.That(await task).IsEqualTo(CodexTurnObserver.Outcome.NotObserved);
+    }
+
+    [Test]
+    public async Task Cancellation_is_reported() {
+        var       time = new FakeTimeProvider();
+        using var cts  = new CancellationTokenSource();
+
+        var task = CodexTurnObserver.ObserveGrowthAsync(() => 10, baseline: 10, Timeout, Poll, time, cts.Token);
+
+        await cts.CancelAsync();
+
+        await Assert.That(await task).IsEqualTo(CodexTurnObserver.Outcome.Cancelled);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/CodexTurnObserverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexTurnObserverTests.cs
@@ -49,6 +49,32 @@ public class CodexTurnObserverTests {
     }
 
     [Test]
+    public async Task Unreadable_length_at_deadline_is_unavailable_not_no_turn() {
+        var time = new FakeTimeProvider();
+
+        // The length source signals "unreadable" (negative) the whole time — a deleted/moved
+        // rollout or sustained stat failure. This must NOT be reported as "no turn".
+        var task = CodexTurnObserver.ObserveGrowthAsync(() => -1, baseline: 10, Timeout, Poll, time, CancellationToken.None);
+
+        time.Advance(Timeout + Poll);
+
+        await Assert.That(await task).IsEqualTo(CodexTurnObserver.Outcome.Unavailable);
+    }
+
+    [Test]
+    public async Task Transient_unreadable_then_growth_is_still_observed() {
+        var  time = new FakeTimeProvider();
+        long len  = -1; // momentarily unreadable at the first check — must not terminate the probe
+
+        var task = CodexTurnObserver.ObserveGrowthAsync(() => len, baseline: 10, Timeout, Poll, time, CancellationToken.None);
+
+        len = 42; // the file becomes readable and has grown
+        time.Advance(Poll);
+
+        await Assert.That(await task).IsEqualTo(CodexTurnObserver.Outcome.TurnObserved);
+    }
+
+    [Test]
     public async Task Cancellation_is_reported() {
         var       time = new FakeTimeProvider();
         using var cts  = new CancellationTokenSource();

--- a/test/Capacitor.Cli.Tests.Unit/CodexTurnObserverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexTurnObserverTests.cs
@@ -3,12 +3,9 @@ using Microsoft.Extensions.Time.Testing;
 
 namespace Capacitor.Cli.Tests.Unit;
 
-/// <summary>
-/// Codex turn-start diagnostic: tests the pure growth-observation core that turns a hosted Codex reviewer's rollout
-/// into a turn-start signal. Growth ⇒ the reviewer began a turn; silence to the deadline ⇒ it
-/// received the input but produced no turn; cancellation ⇒ the agent stopped. The length source
-/// and clock are injected, so no filesystem or wall-clock is involved.
-/// </summary>
+/// <summary>Tests the pure growth-observation core (<see cref="CodexTurnObserver"/>): growth ⇒ turn
+/// started; silence to the deadline ⇒ no turn; unreadable ⇒ measurement gap; superseded/cancelled ⇒
+/// no verdict. Length source and clock are injected — no filesystem or wall-clock.</summary>
 public class CodexTurnObserverTests {
     static readonly TimeSpan Timeout = TimeSpan.FromMinutes(2);
     static readonly TimeSpan Poll    = TimeSpan.FromSeconds(2);


### PR DESCRIPTION
Closes the diagnostic gap AI-1775 identified for **Codex** reviewers, discovered while reproducing that issue.

## Why

kcap-cli #478 added ACP turn start/end logging so a round-2 review timeout is a one-log-line diagnosis. But **Codex hosts on the PTY runtime, not ACP** — `PtyHostedAgentRuntime` is a thin writer with no turn concept, and the daemon reads a Codex rollout only once (for session-id detection) and never tails it. So for the one vendor AI-1775 is about, the log still stops at `SendInput delivered` and cannot distinguish a slow-but-working reviewer from one that received the input and never began a turn. Empirically `grep -c "ACP turn" ~/.config/kcap/daemon-*.log` = 0 — the #478 line never fires for Codex.

(The reproduction itself, on kcap 0.11.17, showed the *original* symptom no longer occurs post-AI-1750 — round-2 input reliably produced a turn — so this is about making a *future* recurrence diagnosable, as the issue asked.)

## What

Codex's rollout JSONL is the one clean turn signal: it grows only when Codex commits response items, whereas PTY output advances the activity clock on every TUI redraw and so is not a turn gate. After input is delivered to a Codex reviewer, watch that file for growth and log the verdict:

- `Codex turn started for agent … (Nms after delivery)` — the reviewer acted.
- `Codex produced NO turn for agent … within 120s of input delivery — the reviewer received the prompt but did not act on it` — the AI-1775 failure signature.

## How

- **`CodexSessionRolloutLocator`** — expose the winning rollout's **file path** (`TryLocatePath`) via a shared `TryLocateWinner` core, so the id and path can never disagree on which file won. `TryLocate` behaviour is byte-for-byte unchanged.
- **`CodexTurnObserver`** — a pure, injected-clock growth-observation core (`TurnObserved` / `NotObserved` / `Cancelled`), unit-tested with `FakeTimeProvider`, no filesystem or wall-clock.
- **`AgentOrchestrator`** — a bounded (2 min, 2 s poll), fire-and-forget, best-effort probe armed **only** on `codex` and **only** on the successful-delivery path (guards and borrowed-snapshot failures return before it). It uses the same cwd + spawn-time disambiguation as session-id detection, so it watches the reviewer's own rollout, not a concurrent Codex session under the shared tree. It never affects delivery: an unresolvable rollout, a read fault, or the agent stopping is logged (or silently dropped for cancellation).

Fires on follow-up rounds only (round 1's prompt is delivered at launch, not via `SendInput`) — exactly the AI-1775 scenario.

## Backwards compatibility

Daemon-only, no wire/protocol/server change. No new capability, no coded error, nothing gated. AOT-safe (LoggerMessage source-gen, no reflection). Other vendors are untouched.

## Verification

- `CodexTurnObserverTests` (4) — immediate growth, growth-during-polling, no-growth-to-timeout, cancellation (FakeTimeProvider).
- `CodexSessionRolloutLocatorTests` — `TryLocatePath` returns the matching file / null on no match (2 new), plus the 18 existing locator tests still green.
- Daemon + test project build clean. Linear-ID guard (`scripts/check-linear-ids.sh`) passes.

The pre-existing `CodexLauncherTests` failures on this machine are an environment baseline (they need `~/.codex/config.toml` written by the config writer) and are unrelated to this change, which touches neither `CodexLauncher` nor `CodexConfigWriter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
