### PR TITLE
Feed the Codex watcher state trackers raw lines, not redacted ones

### DIFF
--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -1884,7 +1884,12 @@ static partial class WatchCommand {
             // but runs unconditionally so it is not gated on the title phase or
             // threshold). Non-Codex lines have a different top-level shape (no
             // response_item), so this is a cheap no-op for them.
-            foreach (var line in newLines) {
+            //
+            // Raw drainRead.Lines, not the redacted newLines: an oversized function_call_output
+            // (a build log) redacts to a placeholder with no call_id, which would strand the id
+            // and pin toolInFlight true forever — and for Codex the idle timeout is the ONLY
+            // per-conversation session-end path, so the session would stay Active for good.
+            foreach (var line in drainRead.Lines) {
                 UpdateCodexPendingToolCalls(state.PendingCodexToolCalls, line);
             }
 
@@ -1903,8 +1908,12 @@ static partial class WatchCommand {
             // (task_complete vs renewed activity) so the polling loop can post a live
             // subagent-stop once the child is done + idle. Gated, unlike the
             // pending-call tracking above, because only codex child watchers ever consult it.
+            // Raw lines for the same reason, and here in the other direction: a redacted
+            // response_item is not recognised as renewed activity, so a child that re-engaged
+            // would still look finished and be reported stopped while working. Matches what
+            // SeedCodexSubagentTurnState already does when it folds this state from disk.
             if (vendor == "codex" && agentId is not null) {
-                foreach (var line in newLines) {
+                foreach (var line in drainRead.Lines) {
                     state.CodexSubagentTurn.Observe(line);
                 }
             }

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -1390,6 +1390,14 @@ static partial class WatchCommand {
     /// All other lines and malformed JSON are silently ignored so this is safe to
     /// call unconditionally for every line of any vendor transcript.
     /// </summary>
+    /// <summary>
+    /// Which watchers feed <see cref="UpdateCodexPendingToolCalls"/>. It reads RAW drain lines,
+    /// which are unbounded, so — unlike when it read the 64 KiB-bounded redacted list — running it
+    /// for every vendor would make an unrelated watcher parse a multi-megabyte line it can never
+    /// match. Not gated on watcher role: a collab child needs it for ShouldPostSubagentStop.
+    /// </summary>
+    internal static bool TracksCodexToolCalls(string vendor) => vendor == "codex";
+
     internal static void UpdateCodexPendingToolCalls(HashSet<string> pending, string line) {
         try {
             using var doc  = JsonDocument.Parse(line);
@@ -1880,17 +1888,13 @@ static partial class WatchCommand {
                 state.AccumulatedDisconnected = TimeSpan.Zero;
             }
 
-            // Track Codex tool calls in flight across all new lines (Codex-only,
-            // but runs unconditionally so it is not gated on the title phase or
-            // threshold). Non-Codex lines have a different top-level shape (no
-            // response_item), so this is a cheap no-op for them.
-            //
-            // Raw drainRead.Lines, not the redacted newLines: an oversized function_call_output
-            // (a build log) redacts to a placeholder with no call_id, which would strand the id
-            // and pin toolInFlight true forever — and for Codex the idle timeout is the ONLY
-            // per-conversation session-end path, so the session would stay Active for good.
-            foreach (var line in drainRead.Lines) {
-                UpdateCodexPendingToolCalls(state.PendingCodexToolCalls, line);
+            // Codex tool calls in flight, from RAW drainRead.Lines: an oversized
+            // function_call_output redacts to a placeholder with no call_id, stranding it and
+            // pinning toolInFlight true forever (#528). Never gated on title phase or threshold.
+            if (TracksCodexToolCalls(vendor)) {
+                foreach (var line in drainRead.Lines) {
+                    UpdateCodexPendingToolCalls(state.PendingCodexToolCalls, line);
+                }
             }
 
             // Claude subagent idle-ceiling guard. Reads drainRead.Lines, NOT the redacted newLines:
@@ -1906,12 +1910,9 @@ static partial class WatchCommand {
 
             // A Codex collab CHILD watcher additionally folds its own rollout's turn state
             // (task_complete vs renewed activity) so the polling loop can post a live
-            // subagent-stop once the child is done + idle. Gated, unlike the
-            // pending-call tracking above, because only codex child watchers ever consult it.
-            // Raw lines for the same reason, and here in the other direction: a redacted
-            // response_item is not recognised as renewed activity, so a child that re-engaged
-            // would still look finished and be reported stopped while working. Matches what
-            // SeedCodexSubagentTurnState already does when it folds this state from disk.
+            // subagent-stop once the child is done + idle. Raw lines here too, in the other
+            // direction: a redacted response_item reads as no activity, so a re-engaged child
+            // would be reported stopped while working. Matches SeedCodexSubagentTurnState.
             if (vendor == "codex" && agentId is not null) {
                 foreach (var line in drainRead.Lines) {
                     state.CodexSubagentTurn.Observe(line);

--- a/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
@@ -847,6 +847,62 @@ public class UpdateClaudePendingToolCallsTests {
     }
 }
 
+/// <summary>
+/// The Codex counterpart of <see cref="ClaudeToolTrackingSourceTests"/>: both watcher state trackers
+/// must be fed the drain's RAW lines. RedactLine swaps anything over the size limit for a placeholder
+/// with no <c>call_id</c> and a <c>type</c> neither tracker recognises, and an oversized
+/// <c>function_call_output</c> — a build log, a big file read — is routine. See issue #528.
+/// </summary>
+public class CodexToolTrackingSourceTests {
+    const string FunctionCall =
+        """{"type":"response_item","payload":{"type":"function_call","call_id":"call_big","name":"shell","arguments":"{}"}}""";
+
+    static string OversizedFunctionCallOutput() =>
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call_output\",\"call_id\":\"call_big\",\"output\":\""
+      + new string('x', SecretRedactor.MaxRedactableLineChars + 1024)
+      + "\"}}";
+
+    /// <summary>
+    /// Worse for Codex than the Claude equivalent was: the idle timeout is the ONLY per-conversation
+    /// session-end path (the desktop app's shared app-server never exits), so a stranded call_id
+    /// pins toolInFlight true and leaves the session Active in the read model forever.
+    /// </summary>
+    [Test]
+    public async Task RedactedLines_StrandTheCallId_ButRawLinesClearIt() {
+        var viaRedacted = new HashSet<string>(StringComparer.Ordinal);
+        WatchCommand.UpdateCodexPendingToolCalls(viaRedacted, SecretRedactor.RedactLine(FunctionCall));
+        WatchCommand.UpdateCodexPendingToolCalls(viaRedacted, SecretRedactor.RedactLine(OversizedFunctionCallOutput()));
+
+        await Assert.That(viaRedacted.Contains("call_big")).IsTrue();
+
+        var viaRaw = new HashSet<string>(StringComparer.Ordinal);
+        WatchCommand.UpdateCodexPendingToolCalls(viaRaw, FunctionCall);
+        WatchCommand.UpdateCodexPendingToolCalls(viaRaw, OversizedFunctionCallOutput());
+
+        await Assert.That(viaRaw.Count).IsEqualTo(0);
+    }
+
+    /// <summary>
+    /// The other direction on the same placeholder: Observe treats any response_item as the turn
+    /// re-opening, so an oversized one is not recognised and a child that re-engaged after
+    /// task_complete still looks finished — a premature live subagent-stop.
+    /// </summary>
+    [Test]
+    public async Task RedactedResponseItem_FailsToReopenTheTurn_ButTheRawOneDoes() {
+        var viaRedacted = new CodexSubagentTurnTracker();
+        viaRedacted.Observe("""{"type":"event_msg","payload":{"type":"task_complete"}}""");
+        viaRedacted.Observe(SecretRedactor.RedactLine(OversizedFunctionCallOutput()));
+
+        await Assert.That(viaRedacted.TurnCompleted).IsTrue();
+
+        var viaRaw = new CodexSubagentTurnTracker();
+        viaRaw.Observe("""{"type":"event_msg","payload":{"type":"task_complete"}}""");
+        viaRaw.Observe(OversizedFunctionCallOutput());
+
+        await Assert.That(viaRaw.TurnCompleted).IsFalse();
+    }
+}
+
 public class ClaudeToolTrackingSourceTests {
     const string ToolUse =
         """{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_big","name":"Bash","input":{"command":"build"}}]}}""";

--- a/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
@@ -847,13 +847,20 @@ public class UpdateClaudePendingToolCallsTests {
     }
 }
 
-/// <summary>
-/// The Codex counterpart of <see cref="ClaudeToolTrackingSourceTests"/>: both watcher state trackers
-/// must be fed the drain's RAW lines. RedactLine swaps anything over the size limit for a placeholder
-/// with no <c>call_id</c> and a <c>type</c> neither tracker recognises, and an oversized
-/// <c>function_call_output</c> — a build log, a big file read — is routine. See issue #528.
-/// </summary>
+// Codex counterpart of ClaudeToolTrackingSourceTests: both trackers must read the drain's RAW
+// lines, because RedactLine's oversize placeholder carries no call_id and no recognised type (#528).
 public class CodexToolTrackingSourceTests {
+    // The tracker reads RAW lines, which are unbounded — so unlike when it read the 64 KiB-bounded
+    // redacted list, it must not run for vendors whose transcripts it can never match. Both roles
+    // for codex: a collab child needs it too, for ShouldPostSubagentStop.
+    [Test]
+    [Arguments("codex",  true)]
+    [Arguments("claude", false)]
+    [Arguments("cursor", false)]
+    [Arguments("gemini", false)]
+    public async Task TracksCodexToolCalls_only_for_codex(string vendor, bool expected) =>
+        await Assert.That(WatchCommand.TracksCodexToolCalls(vendor)).IsEqualTo(expected);
+
     const string FunctionCall =
         """{"type":"response_item","payload":{"type":"function_call","call_id":"call_big","name":"shell","arguments":"{}"}}""";
 
@@ -862,11 +869,8 @@ public class CodexToolTrackingSourceTests {
       + new string('x', SecretRedactor.MaxRedactableLineChars + 1024)
       + "\"}}";
 
-    /// <summary>
-    /// Worse for Codex than the Claude equivalent was: the idle timeout is the ONLY per-conversation
-    /// session-end path (the desktop app's shared app-server never exits), so a stranded call_id
-    /// pins toolInFlight true and leaves the session Active in the read model forever.
-    /// </summary>
+    // A stranded call_id pins toolInFlight true, and for Codex the idle timeout is the only
+    // per-conversation session-end path — so the session stays Active forever.
     [Test]
     public async Task RedactedLines_StrandTheCallId_ButRawLinesClearIt() {
         var viaRedacted = new HashSet<string>(StringComparer.Ordinal);
@@ -882,11 +886,8 @@ public class CodexToolTrackingSourceTests {
         await Assert.That(viaRaw.Count).IsEqualTo(0);
     }
 
-    /// <summary>
-    /// The other direction on the same placeholder: Observe treats any response_item as the turn
-    /// re-opening, so an oversized one is not recognised and a child that re-engaged after
-    /// task_complete still looks finished — a premature live subagent-stop.
-    /// </summary>
+    // Other direction on the same placeholder: an unrecognised response_item leaves a re-engaged
+    // child looking finished, so it is reported stopped while still working.
     [Test]
     public async Task RedactedResponseItem_FailsToReopenTheTurn_ButTheRawOneDoes() {
         var viaRedacted = new CodexSubagentTurnTracker();


### PR DESCRIPTION
Closes #528 (AI-1844 follow-up — the Codex counterpart of #517).

## The bug

Two watcher state trackers read the **redacted** line list. `SecretRedactor.RedactLine` replaces any
line over 64 KiB with a placeholder carrying no `call_id` and a `type` neither tracker recognises,
and an oversized `function_call_output` — a build log, a large file read, a verbose test run — is
routine rather than exceptional.

```csharp
var newLines = drainRead.Lines.Select(SecretRedactor.RedactLine).ToList();   // for SENDING
...
foreach (var line in newLines) UpdateCodexPendingToolCalls(...);             // for DECIDING
```

`SeedCodexSubagentTurnState` (`WatchCommand.cs:1170`) already folds both trackers from the rollout
**raw on disk**. Only the live drain path was inconsistent — the seed had it right.

## Why it matters more for Codex than it did for Claude

**1. Sessions stuck `Active` forever.** The stranded `call_id` keeps `PendingCodexToolCalls`
non-empty for the watcher's life, pinning `toolInFlight` true so `ShouldEndOnIdle` can never fire.
For Codex that isn't a degraded backstop — the desktop app's shared `codex app-server` never exits
per conversation, so the idle timeout is the *only* per-conversation session-end path. The session
stays `Active` in the read model indefinitely and the watcher never exits.

**2. #526's live subagent-stop never posts.** `ShouldPostSubagentStop` requires no tool call in
flight, so the same stranded `call_id` blocks it permanently — reinstating the exact symptom #526
fixed (a finished child's chat card spinning for the parent's whole lifetime).

**3. Premature subagent-stop.** `Observe` treats any `response_item` as the turn re-opening. An
oversized one isn't recognised, so a child that re-engaged after `task_complete` can be reported
stopped while still working.

(1) and (2) are silent and permanent; (3) is a race.

## The fix

Both trackers read `drainRead.Lines`. Neither emits anything — they read `call_id` and `type` only —
so no unredacted content leaves the process and redaction still governs everything sent to the
server. Identical to the Claude fix at `WatchCommand.cs:1896-1899`.

## Testing

`CodexToolTrackingSourceTests` mirrors `ClaudeToolTrackingSourceTests`, covering both directions:
the `call_id` **is** stranded when the redacted line is used and cleared when the raw one is, and a
redacted `response_item` fails to re-open the turn while the raw one re-opens it. Payloads are sized
off `SecretRedactor.MaxRedactableLineChars` rather than hard-coded, per the review of #517.

Being straight about coverage: these tests pin the *invariant*, and they passed the moment they were
written. The defect is at a call site inside `RunWatch`'s local `DrainNewLines`, which closes over
loop state and isn't reachable from a unit test — the same limitation as #517. What the tests
guarantee is that if `RedactLine`'s placeholder or either tracker changes shape, the reason these
call sites must use raw lines is asserted rather than assumed.

- `CodexToolTrackingSourceTests` 2/2, `CodexSubagentTurnTrackerTests` 18/18,
  `UpdateCodexPendingToolCallsTests` 6/6, `ClaudeToolTrackingSourceTests` 7/7, `WatchCommandTests` 77/77.
- AOT publish clean, no IL3050/IL2026.
- Full unit suite 72 failures vs the 56-77 band this repo's daemon cluster produces on a loaded dev
  machine; integration 3 vs 2 on main, overlapping names (`SchemePresent_ProbeHitsAuthConfig` fails
  on both). No failures in the affected area on either.

## Not fixed here

`UpdateCodexPendingToolCalls` has no equivalent of #517's resume backfill for the **session** watcher,
so a watcher reconnecting mid-tool starts with an empty pending set and could idle-end a live Codex
session after `KCAP_CODEX_IDLE_MINUTES`. Pre-existing and independent of the redaction bug —
`SeedCodexSubagentTurnState` covers only the collab-child path. Left out to keep this reviewable;
noted in #528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
