### PR TITLE
Fix two CLI telemetry signals that could not report what they claimed

### DIFF
--- a/docs/superpowers/specs/2026-08-08-cli-telemetry-signup-funnel-design.md
+++ b/docs/superpowers/specs/2026-08-08-cli-telemetry-signup-funnel-design.md
@@ -155,7 +155,15 @@ analytics id outright without touching authentication.
 ## Event catalog
 
 Every CLI event carries `source: "cli"` (mirroring the server's `source: "server"`), `cli_version`,
-`os`, `arch`, `is_ci`, `is_headless`, `$ip: null`, and `$geoip_disable: true`.
+`build_channel`, `os`, `arch`, `is_ci`, `is_headless`, `$ip: null`, and `$geoip_disable: true`.
+
+`build_channel` is `release` / `prerelease` / `unknown`, derived from `cli_version`. It exists
+because `is_ci` does not cover the largest source of non-human devices in practice: local dev loops
+and Aspire-spawned dev daemons run prerelease builds against throwaway `KCAP_CONFIG_DIR`s, so each
+run mints a fresh device id while reporting `is_ci = false`. In the first day of live data these
+outnumbered real released-build devices roughly 4:1 (107 vs 26). The version string alone could
+express this, but only via a `cli_version NOT LIKE '%alpha%'` match that every future insight has to
+remember; a first-class property makes excluding them a normal filter.
 
 **No CLI event may reuse a server event name.** The server already emits `cli_setup_completed`
 (`PosthogEventMapper.cs:39`); a second producer of that name would double-count across two different
@@ -221,6 +229,14 @@ Flushed eagerly, in order:
 | `cli_setup_workspace_provisioned` | poll resolves live | |
 | `cli_setup_workspace_failed` | poll fails | `reason`: `slug_taken`, `reserved`, `poll_timeout`, `unauthorized` |
 | `cli_setup_succeeded` | setup finishes | `agents_configured` (count, not vendor names) |
+
+`has_existing_profile` means "a profile with a server URL is already persisted", via
+`AppConfig.HasConfiguredProfile`. It deliberately does NOT ask `LoadProfileConfig().Profiles.Count > 0`:
+that method synthesizes a `default` entry whenever config.json is missing, so the count test is true
+on a machine that has never run kcap and the property was hardcoded-true by construction. It shipped
+that way and reported `true` for every run in the first day of live data (14/14), which is the
+failure mode to watch for — a property whose value is structurally constant reads as a fact rather
+than as a broken measure.
 
 The drop-off measure is `cli_setup_tenant_none` minus `cli_setup_workspace_provisioned`, split by the
 last step reached — with `cli_setup_workspace_redirected` excluded from that split. It is not

--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -269,6 +269,16 @@ public static class AppConfig {
         ResolvedProfile   = null;
     }
 
+    /// <summary>
+    /// Whether any profile has actually been configured — NOT whether <see cref="LoadProfileConfig"/>
+    /// returned one. That method synthesizes a `default` entry whenever config.json is missing or
+    /// unreadable, so `Profiles.Count > 0` is true on a machine that has never run kcap and cannot
+    /// distinguish a first-time setup from a re-run. A server URL is what setup actually persists,
+    /// so it is what "configured" means here.
+    /// </summary>
+    public static bool HasConfiguredProfile(ProfileConfig config) =>
+        config.Profiles.Values.Any(p => !string.IsNullOrWhiteSpace(p.ServerUrl));
+
     public static async Task<ProfileConfig> LoadProfileConfig(CancellationToken ct = default) {
         if (!File.Exists(ConfigPath))
             return new() { Profiles = new() { ["default"] = new() } };

--- a/src/Capacitor.Cli.Core/Telemetry/CliTelemetry.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/CliTelemetry.cs
@@ -54,16 +54,19 @@ public static class CliTelemetry {
             // this rare fallback case.
             _deviceId = TelemetryDeviceId.GetOrCreate() ?? Guid.NewGuid().ToString("N");
 
+            var version = Version();
+
             _orgGroup = PostHogPayload.OrgGroup(serverUrl);
             _shared   = new JsonObject {
-                ["source"]      = "cli",
-                ["cli_version"] = Version(),
-                ["os"]          = OS(),
-                ["arch"]        = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
-                ["is_ci"]       = IsCi(),
-                ["is_headless"] = Auth.HeadlessEnvironment.IsHeadless(),
-                ["has_server"]  = serverUrl is not null,
-                ["logged_in"]   = loggedIn,
+                ["source"]        = "cli",
+                ["cli_version"]   = version,
+                ["build_channel"] = TelemetryEnvironment.BuildChannel(version),
+                ["os"]            = OS(),
+                ["arch"]          = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
+                ["is_ci"]         = TelemetryEnvironment.IsCi(),
+                ["is_headless"]   = Auth.HeadlessEnvironment.IsHeadless(),
+                ["has_server"]    = serverUrl is not null,
+                ["logged_in"]     = loggedIn,
             };
 
             if (TestSink is null)
@@ -198,10 +201,4 @@ public static class CliTelemetry {
         : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)   ? "macos"
         : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux"
         : "other";
-
-    // CI machines are ephemeral and mint a fresh device id per run, so they are tagged rather
-    // than dropped — funnel insights filter is_ci = false.
-    static bool IsCi() =>
-        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI"))
-     || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
 }

--- a/src/Capacitor.Cli.Core/Telemetry/TelemetryEnvironment.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/TelemetryEnvironment.cs
@@ -1,0 +1,74 @@
+namespace Capacitor.Cli.Core.Telemetry;
+
+/// <summary>
+/// Facts about the machine and build a run is happening on, as pure functions over an injected
+/// environment — the same seam <see cref="TelemetrySettings"/> uses, so the provider table is
+/// testable without mutating the real process environment.
+/// </summary>
+public static class TelemetryEnvironment {
+    // Presence-based providers. Jenkins, TeamCity and Azure Pipelines are the load-bearing
+    // entries: none of them exports the generic `CI`, so a run on any of them used to be
+    // indistinguishable from a human at a terminal.
+    static readonly string[] ProviderVariables = [
+        "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE", "CIRCLECI", "TRAVIS",
+        "JENKINS_URL", "TEAMCITY_VERSION", "TF_BUILD", "APPVEYOR",
+        "BITBUCKET_BUILD_NUMBER", "CODEBUILD_BUILD_ID", "DRONE", "WOODPECKER_CI",
+        "SEMAPHORE", "HEROKU_TEST_RUN_ID", "NETLIFY", "VERCEL",
+    ];
+
+    /// <summary>
+    /// CI machines are ephemeral and mint a fresh device id per run, so they are tagged rather
+    /// than dropped — funnel insights filter is_ci = false.
+    /// </summary>
+    public static bool IsCi(IReadOnlyDictionary<string, string?> env) {
+        // The generic flag is the one tools deliberately set to "false" to opt OUT, so its value
+        // is meaningful. Provider variables below are presence-based instead: nothing sets
+        // GITHUB_ACTIONS=false to mean "not GitHub Actions".
+        if (env.TryGetValue("CI", out var ci) && !string.IsNullOrWhiteSpace(ci) && !IsNegative(ci))
+            return true;
+
+        foreach (var name in ProviderVariables)
+            if (env.TryGetValue(name, out var raw) && !string.IsNullOrWhiteSpace(raw))
+                return true;
+
+        return false;
+    }
+
+    /// <summary>Live resolution against the real environment.</summary>
+    public static bool IsCi() => IsCi(ReadEnv());
+
+    /// <summary>
+    /// "release" | "prerelease" | "unknown". Exists so insights can exclude dev-loop noise with a
+    /// property filter rather than a `cli_version NOT LIKE '%alpha%'` string match that every
+    /// future query has to remember to include. Local dev and Aspire-spawned dev daemons run
+    /// prerelease builds against throwaway KCAP_CONFIG_DIRs, minting a device id per run, and
+    /// they are not tagged is_ci — the version is the only thing that separates them from users.
+    /// </summary>
+    public static string BuildChannel(string? version) {
+        if (string.IsNullOrWhiteSpace(version)) return "unknown";
+
+        var s = version.Trim();
+        if (string.Equals(s, "unknown", StringComparison.Ordinal)) return "unknown";
+
+        // Build metadata may itself contain a hyphen (`+feature-branch.1`), so it has to go
+        // before the prerelease test — otherwise a release build reads as a prerelease.
+        var plus = s.IndexOf('+');
+        if (plus >= 0) s = s[..plus];
+
+        return s.Contains('-') ? "prerelease" : "release";
+    }
+
+    static IReadOnlyDictionary<string, string?> ReadEnv() {
+        var env = new Dictionary<string, string?>(ProviderVariables.Length + 1) {
+            ["CI"] = Environment.GetEnvironmentVariable("CI"),
+        };
+
+        foreach (var name in ProviderVariables)
+            env[name] = Environment.GetEnvironmentVariable(name);
+
+        return env;
+    }
+
+    static bool IsNegative(string raw) =>
+        raw.Trim().ToLowerInvariant() is "false" or "0" or "no" or "off";
+}

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -60,7 +60,7 @@ public static class SetupCommand {
         var legacyProjectScope = legacyPluginScope == "project";
 
         SetupFunnel.Started(
-            hasExistingProfile: (await AppConfig.LoadProfileConfig()).Profiles.Count > 0,
+            hasExistingProfile: AppConfig.HasConfiguredProfile(await AppConfig.LoadProfileConfig()),
             serverUrlProvided:  serverUrlArg is not null,
             noPrompt:           noPrompt);
 

--- a/test/Capacitor.Cli.Tests.Unit/AppConfigHasConfiguredProfileTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AppConfigHasConfiguredProfileTests.cs
@@ -1,0 +1,58 @@
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+// The setup funnel's `has_existing_profile` reported true on every run ever recorded, including
+// on machines that had never run kcap. LoadProfileConfig synthesizes a `default` entry when
+// config.json does not exist, so the `Profiles.Count > 0` test the funnel used could not be false
+// by construction — the property carried no information at all.
+//
+// These pin the distinction the funnel actually needs: a profile someone configured, not one the
+// loader invented to keep its return type non-empty.
+public class AppConfigHasConfiguredProfileTests {
+    [Test]
+    public async Task Synthesized_default_profile_is_not_a_configured_profile() {
+        // Byte-for-byte what LoadProfileConfig returns when config.json does not exist.
+        var fresh = new ProfileConfig { Profiles = new() { ["default"] = new() } };
+
+        await Assert.That(AppConfig.HasConfiguredProfile(fresh)).IsFalse();
+    }
+
+    [Test]
+    public async Task Profile_with_a_server_url_is_a_configured_profile() {
+        var configured = new ProfileConfig {
+            Profiles = new() { ["default"] = new() { ServerUrl = "https://acme.kcap.ai" } },
+        };
+
+        await Assert.That(AppConfig.HasConfiguredProfile(configured)).IsTrue();
+    }
+
+    [Test]
+    public async Task Blank_server_url_does_not_count_as_configured() {
+        var blank = new ProfileConfig {
+            Profiles = new() { ["default"] = new() { ServerUrl = "   " } },
+        };
+
+        await Assert.That(AppConfig.HasConfiguredProfile(blank)).IsFalse();
+    }
+
+    [Test]
+    public async Task A_configured_profile_counts_even_when_it_is_not_the_active_one() {
+        // "Has this person set kcap up before?" is a question about any profile, not the active
+        // one — re-running setup after `kcap use` pointed elsewhere is still a re-run.
+        var config = new ProfileConfig {
+            ActiveProfile = "default",
+            Profiles = new() {
+                ["default"] = new(),
+                ["work"]    = new() { ServerUrl = "https://acme.kcap.ai" },
+            },
+        };
+
+        await Assert.That(AppConfig.HasConfiguredProfile(config)).IsTrue();
+    }
+
+    [Test]
+    public async Task No_profiles_at_all_is_not_configured() {
+        await Assert.That(AppConfig.HasConfiguredProfile(new ProfileConfig())).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Telemetry/McpTelemetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Telemetry/McpTelemetryTests.cs
@@ -74,7 +74,8 @@ public class McpTelemetryTests {
         // merges in (see CliTelemetry.Initialize's `_shared` object) — nothing else may appear.
         var allowed = new HashSet<string> {
             "server", "tool", "ok", "duration_ms",
-            "source", "cli_version", "os", "arch", "is_ci", "is_headless", "has_server", "logged_in"
+            "source", "cli_version", "build_channel", "os", "arch", "is_ci", "is_headless",
+            "has_server", "logged_in"
         };
 
         var keys = sink.Single().Properties.Select(p => p.Key).ToArray();

--- a/test/Capacitor.Cli.Tests.Unit/Telemetry/TelemetryEnvironmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Telemetry/TelemetryEnvironmentTests.cs
@@ -1,0 +1,84 @@
+using Capacitor.Cli.Core.Telemetry;
+
+namespace Capacitor.Cli.Tests.Unit.Telemetry;
+
+// Pure over an injected environment, so these run without touching the real process env and
+// without [NotInParallel] — the same seam TelemetrySettings uses for the opt-out precedence table.
+public class TelemetryEnvironmentTests {
+    static Dictionary<string, string?> Env(string key, string? value) => new() { [key] = value };
+
+    // Every provider below is one whose runners the CLI can plausibly execute on. Jenkins,
+    // TeamCity and Azure Pipelines are the load-bearing entries: none of them sets the generic
+    // `CI` variable, so before this list they were counted as human machines.
+    [Test]
+    [Arguments("CI")]
+    [Arguments("GITHUB_ACTIONS")]
+    [Arguments("GITLAB_CI")]
+    [Arguments("BUILDKITE")]
+    [Arguments("CIRCLECI")]
+    [Arguments("TRAVIS")]
+    [Arguments("JENKINS_URL")]
+    [Arguments("TEAMCITY_VERSION")]
+    [Arguments("TF_BUILD")]
+    [Arguments("APPVEYOR")]
+    [Arguments("BITBUCKET_BUILD_NUMBER")]
+    [Arguments("CODEBUILD_BUILD_ID")]
+    [Arguments("DRONE")]
+    [Arguments("WOODPECKER_CI")]
+    [Arguments("SEMAPHORE")]
+    [Arguments("HEROKU_TEST_RUN_ID")]
+    [Arguments("NETLIFY")]
+    [Arguments("VERCEL")]
+    public async Task Known_provider_variable_marks_the_run_as_ci(string variable) =>
+        await Assert.That(TelemetryEnvironment.IsCi(Env(variable, "1"))).IsTrue();
+
+    [Test]
+    public async Task Empty_environment_is_not_ci() =>
+        await Assert.That(TelemetryEnvironment.IsCi(new Dictionary<string, string?>())).IsFalse();
+
+    // Tools that export `CI=false` to opt OUT are common enough (and the value is meaningful
+    // rather than incidental) that presence alone must not decide it. A blanket
+    // "non-empty means CI" reading would tag exactly the machines trying to say the opposite.
+    [Test]
+    [Arguments("false")]
+    [Arguments("False")]
+    [Arguments("0")]
+    public async Task Explicitly_negative_ci_flag_is_not_ci(string value) =>
+        await Assert.That(TelemetryEnvironment.IsCi(Env("CI", value))).IsFalse();
+
+    [Test]
+    public async Task Blank_provider_variable_is_not_ci() =>
+        await Assert.That(TelemetryEnvironment.IsCi(Env("GITHUB_ACTIONS", "  "))).IsFalse();
+
+    // A provider-specific variable is presence-based, unlike the generic `CI`: GitHub sets
+    // GITHUB_ACTIONS=true and nothing sets it to "false" to mean "not GitHub Actions".
+    [Test]
+    public async Task Provider_variable_set_to_false_is_still_ci() =>
+        await Assert.That(TelemetryEnvironment.IsCi(Env("GITHUB_ACTIONS", "false"))).IsTrue();
+
+    // `build_channel` exists so insights can exclude dev-loop noise with a property filter
+    // instead of a `cli_version NOT LIKE '%alpha%'` string match every future query must remember.
+    [Test]
+    [Arguments("0.11.17+8d933b0fb1de7ada3316880867a17f0b3d23bd8a", "release")]
+    [Arguments("0.11.17", "release")]
+    [Arguments("0.11.17-alpha.0.6+cceb5ef9b3299645c4e59f7fd7685ec649702421", "prerelease")]
+    [Arguments("0.11.14-alpha.0.48", "prerelease")]
+    [Arguments("0.7.0-beta.1", "prerelease")]
+    public async Task Build_channel_splits_release_from_prerelease(string version, string expected) =>
+        await Assert.That(TelemetryEnvironment.BuildChannel(version)).IsEqualTo(expected);
+
+    // Version() falls back to the literal "unknown" when the assembly attribute is missing; a
+    // hyphen-free unparseable string must not be silently reported as a release build.
+    [Test]
+    [Arguments("unknown")]
+    [Arguments("")]
+    [Arguments(null)]
+    public async Task Unresolvable_version_reports_an_unknown_channel(string? version) =>
+        await Assert.That(TelemetryEnvironment.BuildChannel(version)).IsEqualTo("unknown");
+
+    // Build metadata may itself contain a hyphen; splitting on the first '-' without dropping
+    // '+…' first would misread a release build as a prerelease.
+    [Test]
+    public async Task Hyphen_inside_build_metadata_does_not_imply_prerelease() =>
+        await Assert.That(TelemetryEnvironment.BuildChannel("0.11.17+feature-branch.1")).IsEqualTo("release");
+}


### PR DESCRIPTION
Closes #530. Linear auto-imports the GitHub issue, so the imported AI-* issue links back to this PR.

Follow-up to #501 (CLI telemetry and the signup-funnel measurement gap), from reading the first day of live data.

## Problem

Two setup-funnel properties cannot report what they claim.

**`has_existing_profile` is `true` by construction.** `SetupCommand` asked `LoadProfileConfig().Profiles.Count > 0`, but that method synthesizes a `default` entry whenever `config.json` is missing (`AppConfig.cs:273-274`), so the count is >= 1 on a machine that has never run kcap. It reported `true` for **14/14** recorded runs. The funnel therefore cannot separate first-time onboarding from a re-run — the split it exists to measure.

**`is_ci` misses most CI providers.** Detection checked only `CI` and `GITHUB_ACTIONS`; Jenkins, TeamCity and Azure Pipelines export none of those and were counted as human machines. The inverse was broken too — `!string.IsNullOrEmpty(...)` treats the common opt-out `CI=false` as CI, tagging exactly the machines asking not to be.

## Fix

`AppConfig.HasConfiguredProfile(ProfileConfig)` defines "configured" as *a profile carrying a server URL* — what setup actually persists — and `SetupCommand` calls it instead of the count test.

New `TelemetryEnvironment` covers 17 CI providers plus the generic flag, presence-based per provider but value-aware for `CI` (so `CI=false` opts out). It is pure over an injected environment, the same seam `TelemetrySettings` uses, so the provider table is testable without mutating the process env.

## Also: `build_channel`

`is_ci` does not cover the largest source of non-human devices in practice. Local dev loops and Aspire-spawned dev daemons run prerelease builds against throwaway `KCAP_CONFIG_DIR`s, minting a device id per run while legitimately reporting `is_ci=false` — they outnumbered real released-build devices **107 to 26** in the first day. Every event now carries `build_channel` (`release` / `prerelease` / `unknown`), so excluding them is a normal property filter rather than a `cli_version NOT LIKE '%alpha%'` string match every future insight has to remember.

`McpTelemetryTests`' property allowlist gains `build_channel` — that guard doing its job is precisely why a new shared property has to be a deliberate decision.

## Tests

TDD throughout: tests written first, watched fail for the right reason, then implemented.

- `AppConfigHasConfiguredProfileTests` (5): the synthesized-`default` case that caused the bug, blank/whitespace server URL, a configured non-active profile, no profiles at all.
- `TelemetryEnvironmentTests` (18 + 8): one case per provider variable, `CI=false`/`False`/`0` opting out, blank values, provider var set to `"false"` still counting, and `build_channel` including the trap where build metadata itself contains a hyphen (`0.11.17+feature-branch.1` is a release).

Full unit suite: **57 pre-existing failures on both this branch and a clean `origin/main` baseline** (stashed and re-ran to confirm) — the known-flaky PTY/timer/Codex-TOML classes. The one test this change broke, `No_argument_data_is_carried`, is the property allowlist and is fixed here. Two timing-sensitive tests differed run-to-run; both pass in isolation and touch neither telemetry nor config.

AOT publish clean — no IL2026/IL3050.

Verified against the real AOT binary:

| Scenario | Before | After |
|---|---|---|
| Fresh config dir | `has_existing_profile: true` | `false` |
| Profile with server URL | `true` | `true` |
| `TEAMCITY_VERSION=2024.1` | `is_ci: false` | `true` |
| `CI=false` | `is_ci: true` | `false` |

## Notes

No README change: no CLI surface changed, and `build_channel` is derived from the already-sent `cli_version`, so the privacy statement is unaffected. The event catalog in `docs/superpowers/specs/2026-08-08-cli-telemetry-signup-funnel-design.md` is updated with both corrections.

Existing `has_existing_profile` data (v0.11.16 through v0.11.18) should be treated as unusable rather than as evidence that everyone re-runs setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)