### PR TITLE
Back-fill in-flight Codex tool calls for session watchers too

### DIFF
--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -1158,16 +1158,11 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// Codex's counterpart to <see cref="BackfillClaudePendingToolCallsAsync"/>, rebuilding what a
-    /// watcher resuming at the server watermark can never re-read. Both roles need the pending
-    /// call set: a <c>function_call</c> that opened before the cursor produces no rollout line
-    /// until its output lands, so without this a session watcher reads <c>toolInFlight</c> false
-    /// and idle-ends a session whose tool is still running. A CHILD additionally folds turn state,
-    /// or a watcher dying between the <c>task_complete</c> ack and the grace-delayed stop POST
-    /// leaves the card spinning until the parent-end teardown; a session watcher never reads it.
-    /// Bounded and cursor-stopped like the Claude backfill — the drain folds the rest.
-    /// Best-effort: an unreadable rollout just leaves fresh-start state, with the idle timeout and
-    /// the parent-end teardown as backstops.
+    /// Codex's counterpart to <see cref="BackfillClaudePendingToolCallsAsync"/>, same window and
+    /// fail-soft properties. Both roles need the pending set — a <c>function_call</c> that opened
+    /// before the cursor writes nothing until its output lands, so a session watcher would read
+    /// <c>toolInFlight</c> false and idle-end a live session. Turn state is child-only: nothing
+    /// else re-delivers the acknowledged <c>task_complete</c> that arms the live stop.
     /// </summary>
     internal static async Task BackfillCodexWatcherStateAsync(
             WatchState state, string transcriptPath, bool isChildWatcher, int upToLine, CancellationToken ct) {

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -464,16 +464,10 @@ static partial class WatchCommand {
 
         // Idle grace between a Codex collab child's task_complete and its live
         // subagent-stop POST (codex child watchers only — see the loop's stop check). The
-        // agent type is read lazily from the child rollout's own header, once. The seed
-        // rebuilds turn/pending state from the acknowledged prefix, which a restarted
-        // watcher's watermark-resumed drain would otherwise never re-deliver.
+        // agent type is read lazily from the child rollout's own header, once.
         var     codexSubagentStopGrace   = CodexSubagentTurnTracker.ResolveStopGrace(Environment.GetEnvironmentVariable("KCAP_CODEX_SUBAGENT_IDLE_MINUTES"));
         string? codexChildAgentType      = null;
         var     codexStopNextAttemptAt   = DateTimeOffset.MinValue;
-
-        if (vendor == "codex" && agentId is not null) {
-            SeedCodexSubagentTurnState(state, transcriptPath);
-        }
 
         if (skipTitle) {
             state.TitleGenerated = true;
@@ -643,11 +637,19 @@ static partial class WatchCommand {
             cts.Cancel();
         }
 
-        // Resumed past a tool that opened before the cursor: rebuild the in-flight set so the idle
-        // ceiling doesn't mistake a running subagent for an idle one. Only reachable on a resume.
-        if (TracksClaudeToolCalls(vendor, isSessionWatcher: agentId is null) && state.LinesProcessed > 0) {
-            await BackfillClaudePendingToolCallsAsync(
-                state.PendingClaudeToolCalls, transcriptPath, state.LinesProcessed, cts.Token);
+        // Resumed past a tool that opened before the cursor: rebuild the in-flight set so idle-end
+        // doesn't mistake a running agent for an idle one. Only reachable on a resume — at line 0
+        // the drain delivers the whole file and folds it itself.
+        if (state.LinesProcessed > 0) {
+            if (TracksClaudeToolCalls(vendor, isSessionWatcher: agentId is null)) {
+                await BackfillClaudePendingToolCallsAsync(
+                    state.PendingClaudeToolCalls, transcriptPath, state.LinesProcessed, cts.Token);
+            }
+
+            if (TracksCodexToolCalls(vendor)) {
+                await BackfillCodexWatcherStateAsync(
+                    state, transcriptPath, isChildWatcher: agentId is not null, state.LinesProcessed, cts.Token);
+            }
         }
 
         // Gemini fires no subagent hooks, so the parent watcher discovers nested subagent
@@ -1156,30 +1158,39 @@ static partial class WatchCommand {
     }
 
     /// <summary>
-    /// Startup restart-recovery for a Codex collab CHILD watcher's live-stop state:
-    /// a restarted watcher resumes from the server watermark
-    /// (<c>WatcherConnect</c>), so the drain never re-delivers already-acknowledged lines —
-    /// including the <c>task_complete</c> that should drive the live stop. Without this
-    /// seed, a child watcher dying between that ack and the grace-delayed stop POST left
-    /// the card spinning until the parent-end teardown. Folds the rollout's full on-disk
-    /// prefix through both the turn tracker and the pending-call set; the first drain
-    /// re-observing the unacknowledged suffix is harmless — both folds converge on the
-    /// same last-state. Best-effort: an unreadable rollout just leaves fresh-start state
-    /// (the pre-seed behavior), with the parent-end teardown as backstop.
+    /// Codex's counterpart to <see cref="BackfillClaudePendingToolCallsAsync"/>, rebuilding what a
+    /// watcher resuming at the server watermark can never re-read. Both roles need the pending
+    /// call set: a <c>function_call</c> that opened before the cursor produces no rollout line
+    /// until its output lands, so without this a session watcher reads <c>toolInFlight</c> false
+    /// and idle-ends a session whose tool is still running. A CHILD additionally folds turn state,
+    /// or a watcher dying between the <c>task_complete</c> ack and the grace-delayed stop POST
+    /// leaves the card spinning until the parent-end teardown; a session watcher never reads it.
+    /// Bounded and cursor-stopped like the Claude backfill — the drain folds the rest.
+    /// Best-effort: an unreadable rollout just leaves fresh-start state, with the idle timeout and
+    /// the parent-end teardown as backstops.
     /// </summary>
-    internal static void SeedCodexSubagentTurnState(WatchState state, string transcriptPath) {
-        try {
-            using var fs     = new FileStream(transcriptPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            using var reader = new StreamReader(fs);
+    internal static async Task BackfillCodexWatcherStateAsync(
+            WatchState state, string transcriptPath, bool isChildWatcher, int upToLine, CancellationToken ct) {
+        if (ct.IsCancellationRequested) return;
 
-            while (reader.ReadLine() is { } line) {
-                if (string.IsNullOrWhiteSpace(line)) continue;
+        var firstParsedLine = Math.Max(0, upToLine - ToolBackfillWindowLines);
+
+        try {
+            await using var stream = new FileStream(transcriptPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var       reader = new StreamReader(stream);
+
+            for (var lineNumber = 0; lineNumber < upToLine; lineNumber++) {
+                if (await reader.ReadLineAsync(ct) is not { } line) break;
+                if (lineNumber < firstParsedLine) continue;
 
                 UpdateCodexPendingToolCalls(state.PendingCodexToolCalls, line);
-                state.CodexSubagentTurn.Observe(line);
+
+                if (isChildWatcher) state.CodexSubagentTurn.Observe(line);
             }
-        } catch {
-            // Missing/locked rollout — seed is best-effort, see doc comment.
+        } catch (OperationCanceledException) {
+            // Shutdown racing startup — expected, and not worth a log line.
+        } catch (Exception ex) {
+            Log($"Codex watcher-state backfill skipped: {ex.Message}");
         }
     }
 
@@ -1449,19 +1460,20 @@ static partial class WatchCommand {
         vendor == "claude" && !isSessionWatcher;
 
     /// <summary>
-    /// How far back from the resume cursor <see cref="BackfillClaudePendingToolCallsAsync"/> parses.
-    /// An unfinished tool sits at the tail by construction — nothing is appended between its
-    /// <c>tool_use</c> and the matching <c>tool_result</c> — so older lines are settled and parsing
-    /// them only costs startup latency. Bounding also stops a stale unmatched <c>tool_use</c> from
-    /// an interrupted turn stranding an id and suppressing the ceiling forever.
+    /// How far back from the resume cursor the tool-call backfills parse. An unfinished tool sits
+    /// at the tail by construction — nothing is appended between the call and its result — so older
+    /// lines are settled and parsing them only costs startup latency. Bounding also stops a stale
+    /// unmatched call from an interrupted turn stranding an id and suppressing idle-end forever.
+    /// Shared by the Claude and Codex backfills: same rationale, and nothing about the number is
+    /// vendor-specific.
     /// </summary>
-    internal const int ClaudeToolBackfillWindowLines = 512;
+    internal const int ToolBackfillWindowLines = 512;
 
     /// <summary>
     /// Rebuilds the in-flight set from the transcript lines before a resume cursor. A watcher that
     /// reconnects mid-tool starts draining at the server's line position and never sees the
     /// <c>tool_use</c> that opened before it, so the set would come up empty and the ceiling would
-    /// treat a live subagent as idle. Parses only the last <see cref="ClaudeToolBackfillWindowLines"/>
+    /// treat a live subagent as idle. Parses only the last <see cref="ToolBackfillWindowLines"/>
     /// lines before <paramref name="upToLine"/>; everything from the cursor on arrives through the
     /// normal drain. Opened <c>FileShare.ReadWrite</c>: the agent is still writing this file.
     /// Failure is a no-op, never fatal — losing the backstop beats failing a watcher's startup.
@@ -1470,7 +1482,7 @@ static partial class WatchCommand {
             HashSet<string> pending, string transcriptPath, int upToLine, CancellationToken ct) {
         if (ct.IsCancellationRequested) return;
 
-        var firstParsedLine = Math.Max(0, upToLine - ClaudeToolBackfillWindowLines);
+        var firstParsedLine = Math.Max(0, upToLine - ToolBackfillWindowLines);
 
         try {
             await using var stream = new FileStream(transcriptPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
@@ -1912,7 +1924,7 @@ static partial class WatchCommand {
             // (task_complete vs renewed activity) so the polling loop can post a live
             // subagent-stop once the child is done + idle. Raw lines here too, in the other
             // direction: a redacted response_item reads as no activity, so a re-engaged child
-            // would be reported stopped while working. Matches SeedCodexSubagentTurnState.
+            // would be reported stopped while working. Matches BackfillCodexWatcherStateAsync.
             if (vendor == "codex" && agentId is not null) {
                 foreach (var line in drainRead.Lines) {
                     state.CodexSubagentTurn.Observe(line);

--- a/test/Capacitor.Cli.Tests.Unit/CodexSubagentTurnTrackerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexSubagentTurnTrackerTests.cs
@@ -120,11 +120,11 @@ public class CodexSubagentTurnTrackerTests {
         await Assert.That(Eligible(tracker)).IsTrue();
     }
 
-    // ── SeedCodexSubagentTurnState (restart recovery) ─────────────────────
-    // A restarted child watcher resumes from the server watermark, so the drain never
-    // re-delivers already-acknowledged lines — including the task_complete that should
-    // drive the live stop. The seed rebuilds tracker + pending-call state from the
-    // rollout's full on-disk prefix at startup.
+    // ── BackfillCodexWatcherStateAsync (resume recovery) ──────────────────
+    // Every Codex watcher resumes from the server watermark, so the drain never re-delivers
+    // already-acknowledged lines — for a child, the task_complete that should drive the live
+    // stop; for either role, a function_call whose output has not landed yet. The backfill
+    // rebuilds both from the window of rollout lines just before that cursor.
 
     const string FunctionCall =
         """{"timestamp":"2026-08-11T08:55:00.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"call_seed1","arguments":"{}"}}""";
@@ -132,14 +132,15 @@ public class CodexSubagentTurnTrackerTests {
     const string FunctionCallOutput =
         """{"timestamp":"2026-08-11T08:55:05.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_seed1","output":"ok"}}""";
 
-    static WatchState SeededFrom(params string[] lines) {
+    static async Task<WatchState> BackfilledFrom(bool isChildWatcher, int? upToLine, params string[] lines) {
         var tmp = Directory.CreateTempSubdirectory("kcap-cstt").FullName;
         try {
             var path = Path.Combine(tmp, "rollout-2026-08-11T10-54-19-child.jsonl");
-            File.WriteAllLines(path, lines);
+            await File.WriteAllLinesAsync(path, lines);
 
             var state = new WatchState();
-            WatchCommand.SeedCodexSubagentTurnState(state, path);
+            await WatchCommand.BackfillCodexWatcherStateAsync(
+                state, path, isChildWatcher, upToLine ?? lines.Length, CancellationToken.None);
 
             return state;
         } finally {
@@ -148,8 +149,8 @@ public class CodexSubagentTurnTrackerTests {
     }
 
     [Test]
-    public async Task Seed_FileEndingWithTaskComplete_RearmsTheStop() {
-        var state = SeededFrom(FunctionCall, FunctionCallOutput, TaskComplete);
+    public async Task Backfill_FileEndingWithTaskComplete_RearmsTheChildStop() {
+        var state = await BackfilledFrom(isChildWatcher: true, upToLine: null, FunctionCall, FunctionCallOutput, TaskComplete);
 
         await Assert.That(state.CodexSubagentTurn.TurnCompleted).IsTrue();
         await Assert.That(state.PendingCodexToolCalls).IsEmpty();
@@ -157,22 +158,102 @@ public class CodexSubagentTurnTrackerTests {
     }
 
     [Test]
-    public async Task Seed_FileEndingMidTurn_StaysDisarmed() {
+    public async Task Backfill_FileEndingMidTurn_StaysDisarmed() {
         // A completed earlier turn followed by a live tool call: not completed, call pending.
-        var state = SeededFrom(TaskComplete, UserMessage, FunctionCall);
+        var state = await BackfilledFrom(isChildWatcher: true, upToLine: null, TaskComplete, UserMessage, FunctionCall);
 
         await Assert.That(state.CodexSubagentTurn.TurnCompleted).IsFalse();
         await Assert.That(state.PendingCodexToolCalls).Contains("call_seed1");
         await Assert.That(Eligible(state.CodexSubagentTurn, pending: state.PendingCodexToolCalls.Count)).IsFalse();
     }
 
+    // The gap this fixes: a session watcher (no agent id) that reconnects while a tool is
+    // still running came up with an empty pending set, so ShouldEndOnIdle read toolInFlight
+    // false and could end a live session with reason idle_timeout.
     [Test]
-    public async Task Seed_MissingFile_IsANoOp() {
+    public async Task Backfill_RecoversACallLeftOpenBeforeTheCursor_ForASessionWatcher() {
+        var state = await BackfilledFrom(isChildWatcher: false, upToLine: null, FunctionCall, TokenCount);
+
+        await Assert.That(state.PendingCodexToolCalls).Contains("call_seed1");
+    }
+
+    // The decision the backfill exists to protect, wired the way RunWatch wires it: without the
+    // recovered call_id the set is empty, toolInFlight reads false, and a session whose tool is
+    // still running is ended with reason idle_timeout.
+    [Test]
+    public async Task Backfill_KeepsASessionWithARunningTool_OffTheIdleEnd() {
+        var state = await BackfilledFrom(isChildWatcher: false, upToLine: null, FunctionCall, TokenCount);
+
+        var idle = WatchCommand.ShouldEndOnIdle(
+            "codex", isSessionWatcher: true, thresholdReached: true,
+            lastActivityAt: T0, now: T0 + TimeSpan.FromHours(3),
+            idleTimeout: WatchCommand.DefaultCodexIdleTimeout,
+            toolInFlight: state.PendingCodexToolCalls.Count > 0);
+
+        await Assert.That(idle).IsFalse();
+    }
+
+    // Turn state only drives the child's live subagent-stop; a session watcher never reads it,
+    // so folding it there would be state kept for nobody.
+    [Test]
+    public async Task Backfill_DoesNotFoldTurnState_ForASessionWatcher() {
+        var state = await BackfilledFrom(isChildWatcher: false, upToLine: null, TaskComplete);
+
+        await Assert.That(state.CodexSubagentTurn.TurnCompleted).IsFalse();
+    }
+
+    // Only the prefix is the watcher's blind spot; the cursor onwards arrives through the
+    // normal drain, which folds it there.
+    [Test]
+    public async Task Backfill_StopsAtTheCursor() {
+        var state = await BackfilledFrom(isChildWatcher: true, upToLine: 1, FunctionCall, FunctionCallOutput, TaskComplete);
+
+        await Assert.That(state.PendingCodexToolCalls).Contains("call_seed1");
+        await Assert.That(state.CodexSubagentTurn.TurnCompleted).IsFalse();
+    }
+
+    // Bounded like the Claude backfill: an in-flight call sits at the tail by construction —
+    // nothing is written between a function_call and its output — so anything further back is
+    // settled, and a window keeps startup work off the length of the rollout.
+    [Test]
+    public async Task Backfill_IgnoresACallOlderThanTheScanWindow() {
+        var lines = new List<string> { FunctionCall };  // never resolved, then buried
+        lines.AddRange(Enumerable.Repeat(TokenCount, WatchCommand.ToolBackfillWindowLines + 10));
+
+        var state = await BackfilledFrom(isChildWatcher: true, upToLine: null, [.. lines]);
+
+        await Assert.That(state.PendingCodexToolCalls).IsEmpty();
+    }
+
+    [Test]
+    public async Task Backfill_MissingFile_IsANoOp() {
         var state = new WatchState();
-        WatchCommand.SeedCodexSubagentTurnState(state, "/nonexistent/rollout.jsonl");
+
+        await WatchCommand.BackfillCodexWatcherStateAsync(
+            state, "/nonexistent/rollout.jsonl", isChildWatcher: true, upToLine: 5, CancellationToken.None);
 
         await Assert.That(state.CodexSubagentTurn.TurnCompleted).IsFalse();
         await Assert.That(state.PendingCodexToolCalls).IsEmpty();
+    }
+
+    [Test]
+    public async Task Backfill_ReturnsSilentlyWhenAlreadyCancelled() {
+        var tmp = Directory.CreateTempSubdirectory("kcap-cstt").FullName;
+        try {
+            var path = Path.Combine(tmp, "rollout.jsonl");
+            await File.WriteAllLinesAsync(path, [FunctionCall]);
+
+            var       state     = new WatchState();
+            using var cancelled = new CancellationTokenSource();
+            await cancelled.CancelAsync();
+
+            await WatchCommand.BackfillCodexWatcherStateAsync(
+                state, path, isChildWatcher: true, upToLine: 1, cancelled.Token);
+
+            await Assert.That(state.PendingCodexToolCalls).IsEmpty();
+        } finally {
+            Directory.Delete(tmp, recursive: true);
+        }
     }
 
     // ── ResolveStopGrace ──────────────────────────────────────────────────

--- a/test/Capacitor.Cli.Tests.Unit/CodexSubagentTurnTrackerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CodexSubagentTurnTrackerTests.cs
@@ -121,10 +121,8 @@ public class CodexSubagentTurnTrackerTests {
     }
 
     // ── BackfillCodexWatcherStateAsync (resume recovery) ──────────────────
-    // Every Codex watcher resumes from the server watermark, so the drain never re-delivers
-    // already-acknowledged lines — for a child, the task_complete that should drive the live
-    // stop; for either role, a function_call whose output has not landed yet. The backfill
-    // rebuilds both from the window of rollout lines just before that cursor.
+    // A watcher resuming at the server watermark never sees the acknowledged prefix again, so
+    // the backfill rebuilds from it what the drain can no longer deliver.
 
     const string FunctionCall =
         """{"timestamp":"2026-08-11T08:55:00.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"call_seed1","arguments":"{}"}}""";
@@ -167,9 +165,7 @@ public class CodexSubagentTurnTrackerTests {
         await Assert.That(Eligible(state.CodexSubagentTurn, pending: state.PendingCodexToolCalls.Count)).IsFalse();
     }
 
-    // The gap this fixes: a session watcher (no agent id) that reconnects while a tool is
-    // still running came up with an empty pending set, so ShouldEndOnIdle read toolInFlight
-    // false and could end a live session with reason idle_timeout.
+    // The gap this fixes (#532): a session watcher resuming mid-tool came up with an empty set.
     [Test]
     public async Task Backfill_RecoversACallLeftOpenBeforeTheCursor_ForASessionWatcher() {
         var state = await BackfilledFrom(isChildWatcher: false, upToLine: null, FunctionCall, TokenCount);
@@ -177,9 +173,7 @@ public class CodexSubagentTurnTrackerTests {
         await Assert.That(state.PendingCodexToolCalls).Contains("call_seed1");
     }
 
-    // The decision the backfill exists to protect, wired the way RunWatch wires it: without the
-    // recovered call_id the set is empty, toolInFlight reads false, and a session whose tool is
-    // still running is ended with reason idle_timeout.
+    // The decision itself, wired the way RunWatch wires it — an empty set idle-ends a live session.
     [Test]
     public async Task Backfill_KeepsASessionWithARunningTool_OffTheIdleEnd() {
         var state = await BackfilledFrom(isChildWatcher: false, upToLine: null, FunctionCall, TokenCount);
@@ -193,8 +187,7 @@ public class CodexSubagentTurnTrackerTests {
         await Assert.That(idle).IsFalse();
     }
 
-    // Turn state only drives the child's live subagent-stop; a session watcher never reads it,
-    // so folding it there would be state kept for nobody.
+    // Turn state only drives the child's live subagent-stop.
     [Test]
     public async Task Backfill_DoesNotFoldTurnState_ForASessionWatcher() {
         var state = await BackfilledFrom(isChildWatcher: false, upToLine: null, TaskComplete);
@@ -202,8 +195,7 @@ public class CodexSubagentTurnTrackerTests {
         await Assert.That(state.CodexSubagentTurn.TurnCompleted).IsFalse();
     }
 
-    // Only the prefix is the watcher's blind spot; the cursor onwards arrives through the
-    // normal drain, which folds it there.
+    // Only the prefix is the blind spot; the cursor onwards arrives through the drain.
     [Test]
     public async Task Backfill_StopsAtTheCursor() {
         var state = await BackfilledFrom(isChildWatcher: true, upToLine: 1, FunctionCall, FunctionCallOutput, TaskComplete);
@@ -212,9 +204,7 @@ public class CodexSubagentTurnTrackerTests {
         await Assert.That(state.CodexSubagentTurn.TurnCompleted).IsFalse();
     }
 
-    // Bounded like the Claude backfill: an in-flight call sits at the tail by construction —
-    // nothing is written between a function_call and its output — so anything further back is
-    // settled, and a window keeps startup work off the length of the rollout.
+    // An in-flight call sits at the tail by construction, so anything older is settled.
     [Test]
     public async Task Backfill_IgnoresACallOlderThanTheScanWindow() {
         var lines = new List<string> { FunctionCall };  // never resolved, then buried

--- a/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
@@ -1001,7 +1001,7 @@ public class ClaudeToolTrackingSourceTests {
         var lines = new List<string> { ToolUse };  // never resolved, then buried by later activity
         lines.AddRange(Enumerable.Repeat(
             """{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"later"}]}}""",
-            WatchCommand.ClaudeToolBackfillWindowLines + 10));
+            WatchCommand.ToolBackfillWindowLines + 10));
 
         await File.WriteAllLinesAsync(path, lines);
 


### PR DESCRIPTION
Closes #532 — AI-1872.

## The gap

Every Codex watcher resumes at the server's acknowledged watermark (`WatcherConnect`), so the drain
only ever returns lines at or past it. A `function_call` that opened *before* that cursor is never
re-observed — and only collab **child** watchers rebuilt it:

```csharp
if (vendor == "codex" && agentId is not null) {   // the old gate
    SeedCodexSubagentTurnState(state, transcriptPath);
}
```

A session watcher therefore came up with an empty `PendingCodexToolCalls`, read `toolInFlight`
false, and could POST `session-end` (`reason: idle_timeout`) on a session whose tool was still
running — precisely the case that set exists to suppress, since a long-running tool writes no
rollout line between its call and its output. The README already promised the correct behaviour
("no new rollout lines **and no Codex tool call in flight**"), so this makes the code match the
docs rather than changing them.

Same blind spot #517 fixed on the Claude side, arriving from the other role.

## The fix

`SeedCodexSubagentTurnState` → `BackfillCodexWatcherStateAsync`, mirroring
`BackfillClaudePendingToolCallsAsync`: same window, cursor stop, `FileShare.ReadWrite`, fail-soft.
Runs for both roles after `WatcherConnect`; turn state stays child-only, since a session watcher
never reads it. Gated through `TracksCodexToolCalls` rather than an inline role check — replacing
an inline condition with a tested predicate is what caught the analogous gap in #529.

Gating on `LinesProcessed > 0` is not a behaviour change for children: at line 0 the drain delivers
the whole file and folds it itself, which is what the seed was duplicating.

## On the bounding claim in the issue — I overstated it

The issue argued the unbounded seed could strand a `call_id` from an interrupted turn, pinning
`toolInFlight` true forever. I checked before building for it, and the data does not support that:

| | |
|---|---|
| rollouts scanned | 470 (`~/.codex/sessions`) |
| ever stranding a `call_id` — at EOF **or** at a `task_complete` boundary | **0** |
| containing `turn_aborted` | 50, none of them stranding |

Codex writes the `function_call_output` even for aborted turns. So the bound is cheap insurance on
a shape we have no evidence of, not a fix for an observed failure — worth stating plainly rather
than letting the issue's framing stand.

The same data says the bound costs nothing in the other direction, which is the reason to keep it
rather than drop it: at most **2** lines separate a rollout's last state-bearing line from EOF
(median rollout 265 lines, max 1767), against a 512-line window. So a child's `task_complete` can't
realistically fall outside it, and startup work stops scaling with rollout length.

`ClaudeToolBackfillWindowLines` → `ToolBackfillWindowLines`: one number, one rationale, now two
vendors.

## Verification

- `CodexSubagentTurnTrackerTests` 24/24, `WatchCommandTests` 77/77,
  `ClaudeToolTrackingSourceTests` 7/7, `CodexToolTrackingSourceTests` 6/6
- RED verified by reverting the method to pre-fix semantics (child-only, unbounded): the three
  tests that encode the bug fail —
  `Backfill_RecoversACallLeftOpenBeforeTheCursor_ForASessionWatcher`,
  `Backfill_KeepsASessionWithARunningTool_OffTheIdleEnd` (the decision itself, wired the way
  `RunWatch` wires it), `Backfill_IgnoresACallOlderThanTheScanWindow`
- AOT publish clean, no IL2026/IL3050
- No README change: no CLI surface, flag, or env var moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
