### PR TITLE
daemon: input delivery is activity — round-dispatch grace hardening

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentActivityClock.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentActivityClock.cs
@@ -80,6 +80,28 @@ internal sealed class AgentActivityClock(TimeProvider time) {
         }
     }
 
+    /// <summary>All four observables read under ONE lock acquisition, so they describe the same
+    /// instant. The individual properties above cannot give that: each takes and releases
+    /// <see cref="_gate"/> on its own, so a reader sampling several of them can interleave with an
+    /// <see cref="Advance"/> between any two and act on a mixture of before- and after-states. The
+    /// reviewer reaper depends on exactly that atomicity — it decides from the idle/age/turn fields and
+    /// fences its later claim on <see cref="ActivitySeq"/>, and a seq belonging to a different instant
+    /// than the idle it was selected on is precisely the stale evidence the fence exists to reject.
+    /// </summary>
+    public ActivitySnapshot Snapshot() {
+        lock (_gate) {
+            return new ActivitySnapshot(
+                _activitySeq, Elapsed(_lastAdvanceTimestamp), Elapsed(_spawnTimestamp), _turnInFlight);
+        }
+    }
+
+    // Caller must hold _gate. Same clamp the IdleForMs/AgeMs properties apply.
+    ulong Elapsed(long since) {
+        var elapsed = time.GetElapsedTime(since);
+
+        return elapsed <= TimeSpan.Zero ? 0UL : (ulong) elapsed.TotalMilliseconds;
+    }
+
     /// <summary>Records one unit of activity: bumps <see cref="ActivitySeq"/> and resets the idle
     /// window to zero from this instant. Called from all five sources (see the class doc).</summary>
     public void Advance() {
@@ -125,3 +147,9 @@ internal sealed class AgentActivityClock(TimeProvider time) {
         _lastAdvanceTimestamp = time.GetTimestamp();
     }
 }
+
+/// <summary>One <see cref="AgentActivityClock"/> reading — all four fields from the same instant.
+/// See <see cref="AgentActivityClock.Snapshot"/> for why sampling the properties separately is not
+/// equivalent.</summary>
+internal readonly record struct ActivitySnapshot(
+    ulong ActivitySeq, ulong IdleForMs, ulong AgeMs, bool TurnInFlight);

--- a/src/Capacitor.Cli.Daemon/Services/AgentActivityClock.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentActivityClock.cs
@@ -4,7 +4,8 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <summary>
 /// Monotonic per-agent activity clock (liveness-supervision spec §0/§1). One instance per launch — a
 /// relaunch gets a fresh one — fed by PTY output chunks, ACP transcript envelopes, ACP turn
-/// start/end, and <c>LocalPermissionBridge</c> reviewer tool-call hits.
+/// start/end, <c>LocalPermissionBridge</c> reviewer tool-call hits, and (round-dispatch grace) a
+/// successfully delivered <c>SendInput</c> — see <see cref="AgentOrchestrator.HandleSendInput"/>.
 ///
 /// <para>READS are lock-guarded, not just writes: the sources above run on independent threads (a PTY
 /// read loop, an ACP connection's read thread, an HTTP listener), and an unguarded property read can
@@ -80,7 +81,7 @@ internal sealed class AgentActivityClock(TimeProvider time) {
     }
 
     /// <summary>Records one unit of activity: bumps <see cref="ActivitySeq"/> and resets the idle
-    /// window to zero from this instant. Called from all four sources.</summary>
+    /// window to zero from this instant. Called from all five sources (see the class doc).</summary>
     public void Advance() {
         lock (_gate) AdvanceLocked();
     }

--- a/src/Capacitor.Cli.Daemon/Services/AgentActivityClock.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentActivityClock.cs
@@ -4,7 +4,8 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <summary>
 /// Monotonic per-agent activity clock (liveness-supervision spec §0/§1). One instance per launch — a
 /// relaunch gets a fresh one — fed by PTY output chunks, ACP transcript envelopes, ACP turn
-/// start/end, <c>LocalPermissionBridge</c> reviewer tool-call hits, and (round-dispatch grace) a
+/// start/end, Antigravity's and Pi's own <c>agentActivity</c>-flagged advances, two independent
+/// <c>LocalPermissionBridge</c> reviewer tool-call-hit sites, and (round-dispatch grace) a
 /// successfully delivered <c>SendInput</c> — see <see cref="AgentOrchestrator.HandleSendInput"/>.
 ///
 /// <para>READS are lock-guarded, not just writes: the sources above run on independent threads (a PTY
@@ -103,7 +104,7 @@ internal sealed class AgentActivityClock(TimeProvider time) {
     }
 
     /// <summary>Records one unit of activity: bumps <see cref="ActivitySeq"/> and resets the idle
-    /// window to zero from this instant. Called from all five sources (see the class doc).</summary>
+    /// window to zero from this instant. Called from all six sources (see the class doc).</summary>
     public void Advance() {
         lock (_gate) AdvanceLocked();
     }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -430,7 +430,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     const ushort HostedPtyCols = PtyDefaults.Cols;
     const ushort HostedPtyRows = PtyDefaults.Rows;
 
-    readonly PeriodicTimer _heartbeatTimer = new(TimeSpan.FromSeconds(30));
+    /// <summary>The per-agent heartbeat/reap sweep period. Named rather than inlined because
+    /// <see cref="ReapClaimGateWait"/> is sized against it — that relation is asserted by a test, so a
+    /// change here cannot silently weaken the one-claim-waiter-per-agent property.</summary>
+    internal static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(30);
+
+    readonly PeriodicTimer _heartbeatTimer = new(HeartbeatInterval);
 
     // heartbeat tightened from 60 s SendAsync to round-trip Ping.
     // tick halved (15 → 7 s) and deadline halved (10 → 5 s) so a
@@ -2582,7 +2587,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// hook (which writes SessionEnded plus the what's-done summary). 15s covers a typical
     /// session-end POST + watcher drain on a healthy connection.
     /// </summary>
-    static readonly TimeSpan GracefulExitWait = TimeSpan.FromSeconds(15);
+    /// <summary>Budget for the graceful phase of a stop — applied SEPARATELY to sending the stop and
+    /// to waiting for the exit it asks for, because sending it is itself unbounded work on some
+    /// runtimes (see <see cref="StopAgentCoreAsync"/>). Settable only so a test need not spend it for
+    /// real; production never changes it.</summary>
+    internal TimeSpan GracefulExitWait { get; set; } = TimeSpan.FromSeconds(15);
 
     /// <summary>Phase B2-b (sequenced-settlement design §4.2.2): the sequenced stop. Routes through the
     /// processor's serial lane (accepted exactly-in-order, executed once, terminal StopExecuted outcome →
@@ -2633,10 +2642,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     }
 
     /// <summary>How long a reap claim waits for the per-agent delivery section before giving up on it.
-    /// Sized UNDER the 30s heartbeat period on purpose: a delivery parked longer than this leaves at
-    /// most one claim waiter alive per agent, instead of accumulating one per tick for as long as the
+    /// Sized UNDER <see cref="HeartbeatInterval"/> on purpose: a delivery parked longer than this leaves
+    /// at most one claim waiter alive per agent, instead of accumulating one per tick for as long as the
     /// parked write lasts. Settable only so a test need not spend a real heartbeat proving the timeout
-    /// arms behave; production never changes it.</summary>
+    /// arms behave; production never changes it.
+    ///
+    /// <para>Note it is SHORTER than a delivery's own worst-case in-section time (the borrowed-snapshot
+    /// refresh is budgeted 30s), so the unfenced timeout arm fires against healthy deliveries too — by
+    /// design, and handled by <see cref="HandleSendInput"/>'s pre-write re-read of the claim latch
+    /// rather than by inflating this wait, which would only restore the deadlock it exists to
+    /// prevent.</para></summary>
     internal TimeSpan ReapClaimGateWait { get; set; } = TimeSpan.FromSeconds(20);
 
     /// <summary>Execute one selected reap: claim it under the per-agent fence, and stop the agent only
@@ -2699,8 +2714,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             //   claim waiter per agent is alive at a time, rather than one accumulating per tick.)
             //
             //   UNFENCED (absolute lifetime) — must not be deferrable by ANY amount of traffic, least
-            //   of all by a delivery that may never complete. It claims lock-free and proceeds: the
-            //   terminate it is about to run is precisely what releases the parked write.
+            //   of all by a delivery that may never complete. It claims lock-free and proceeds to the
+            //   terminate, which is what releases a parked write (SIGKILL closes the slave and the
+            //   write returns EIO). That reachability is NOT free: StopAgentCoreAsync's graceful "/exit"
+            //   send goes to the same fd and had to be bounded before terminate could be relied on —
+            //   see the bound there, which this arm depends on.
             if (candidate.FencedOnActivity) {
                 LogReapAborted(candidate.Id, candidate.Reason, "delivery_in_progress");
                 return false;
@@ -2765,11 +2783,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// proven (a relaunch under the same id must not be killed on its predecessor's age) and the claim
     /// is still single-flight, because both paths CAS the same latch.
     ///
-    /// <para>It races a delivery by construction. That is the intended outcome, not a tolerated one:
-    /// the delivery is parked in an uncancellable write to a child that is not reading, and terminating
-    /// that child is what ends it. The write then fails, so nothing advances the clock and nothing is
-    /// reported — the round fails and the server heals it, exactly as for a delivery that loses the
-    /// ordinary sectioned race.</para></summary>
+    /// <para>It races a delivery by construction, and the delivery it races is NOT necessarily a
+    /// wedged one. The section is legitimately held past this wait by healthy work — the borrowed-
+    /// snapshot refresh alone is budgeted 30s — so this claim can fire against an in-flight, entirely
+    /// well-behaved delivery. That is why <see cref="HandleSendInput"/> re-reads the latch immediately
+    /// before its write instead of only on entry: a healthy delivery must ABORT there rather than
+    /// complete into a condemned agent. The genuinely parked case resolves differently — the write is
+    /// released by the terminate this claim leads to (which is reachable only because
+    /// <see cref="StopAgentCoreAsync"/>'s graceful send is bounded), and fails.</para>
+    ///
+    /// <para>Either way nothing advances the clock and nothing is reported, so the round fails and the
+    /// server heals it on resubmit.</para></summary>
     bool TryClaimUnfencedReapWithoutSection(ReapCandidate candidate) {
         var agent = candidate.Agent;
 
@@ -2831,6 +2855,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         await StopAgentCoreAsync(agent);
     }
+
+    /// <summary>Test-only: awaited inside <see cref="HandleSendInput"/>'s section in the window between
+    /// its slow pre-write steps (the borrowed-snapshot refresh, attachment downloads) and its
+    /// pre-write re-read of the reap-claim latch — i.e. exactly where a reaper's un-sectioned claim
+    /// lands in production, since that refresh is budgeted LONGER than the claim's gate wait. A test
+    /// occupies that window to prove the delivery aborts there; null in production (one null check).
+    ///
+    /// <para>The seam exists because the window cannot otherwise be entered deterministically: parking
+    /// the refresh itself only proves the refresh's own failure path, which returns before this point.
+    /// Same shape and rationale as <see cref="StopGateAfterSnapshotHookForTest"/> below.</para></summary>
+    internal Func<Task>? SendInputBeforeWriteHookForTest;
 
     /// <summary>Test-only: invoked ONCE inside <see cref="StopAgentCoreAsync"/> immediately AFTER the
     /// suppress-Completed snapshot and BEFORE the Completed send, so a test can publish a verdict in
@@ -2914,9 +2949,30 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // in a single write makes Claude treat the carriage return as part of the
             // command buffer instead of a submit. HandleSendInput uses the same split
             // pattern; matching it here makes the graceful path actually fire.
+            // BOTH steps are bounded, and bounding the SEND is the load-bearing half. Asking for the
+            // graceful stop is not free work: for a PTY runtime it writes "/exit" to the same master fd
+            // a delivery writes to (an uncancellable write(2)), so against a child that has stopped
+            // draining its stdin it parks forever — and an unbounded await here would mean TerminateAsync
+            // below is never reached, i.e. the one action that ends the wedge (SIGKILL closes the slave,
+            // every parked write returns EIO) is unreachable precisely when it is needed. This is
+            // pre-existing — every stop, including a user's, could hang here — but the reviewer reaper
+            // now DEPENDS on reaching terminate, so the bound is no longer optional.
+            //
+            // No legitimate graceful path is truncated: PTY writes + a submit, ACP sends one
+            // session/cancel notify, Antigravity returns Task.CompletedTask, and Pi's own grace is 3s.
+            // A timeout here just falls through to the same terminate a graceful-exit timeout already
+            // falls through to.
+            var graceful = agent.Runtime.RequestGracefulStopAsync();
+
             try {
-                await agent.Runtime.RequestGracefulStopAsync();
+                await graceful.WaitAsync(GracefulExitWait);
                 await agent.Runtime.WaitForExitAsync(GracefulExitWait);
+            } catch (TimeoutException ex) {
+                // WaitAsync abandons the send rather than cancelling it (nothing CAN cancel it), so the
+                // abandoned task is observed separately — it completes on its own once the terminate
+                // below releases the write.
+                ObserveAbandonedGracefulStop(graceful, agentId);
+                LogGracefulExitFailed(ex, agentId);
             } catch (Exception ex) {
                 LogGracefulExitFailed(ex, agentId);
             }
@@ -2953,6 +3009,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return false;
         }
     }
+
+    /// <summary>Observes an abandoned graceful-stop send (see <see cref="StopAgentCoreAsync"/>) so its
+    /// eventual completion — or fault, once the terminate releases whatever it was parked on — is not
+    /// an unobserved task exception.</summary>
+    void ObserveAbandonedGracefulStop(Task graceful, string agentId) =>
+        _ = graceful.ContinueWith(
+            t => LogGracefulExitFailed(t.Exception!.GetBaseException(), agentId),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     /// <summary>
     /// Observes a background EndAgentSession retry that outlived the finalize budget so a
@@ -3049,6 +3115,24 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 if (paths.Count > 0) {
                     message = $"{text}\n\n[Attached files: {string.Join(", ", paths)}]";
                 }
+            }
+
+            // Re-checked HERE, immediately before the write, and NOT only at the top of the section.
+            // The steps between the two checks are slow by design — the borrowed-snapshot refresh alone
+            // is budgeted 30s (BorrowedSnapshotRefreshTimeout), plus any attachment downloads — which is
+            // LONGER than the reap claim's own gate wait, so a perfectly healthy borrowed delivery
+            // routinely leaves the section held past it. The absolute-lifetime claim then legitimately
+            // fires without the section (see TryClaimUnfencedReapWithoutSection) against an agent whose
+            // in-flight delivery is not parked at all, and without this second read that delivery would
+            // sail on to write the round, advance the clock and emit a delivered-input report for an
+            // agent already condemned — exactly the outcome the top-of-section refusal exists to
+            // prevent. The re-read is free and sound: the latch is monotonic 0→1 and read through
+            // Volatile.Read, so observing it true is never a false positive.
+            if (SendInputBeforeWriteHookForTest is { } beforeWrite) await beforeWrite();
+
+            if (agent.IsReapClaimed) {
+                LogSendInputReapClaimed(agentId);
+                return;
             }
 
             // PTY runtimes use bracketed paste; ACP runtimes send a structured prompt.

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1169,52 +1169,69 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         finally { Interlocked.Exchange(ref _quarantineSweepRunning, 0); }
     }
 
-    /// <summary>Round-dispatch grace: the per-daemon ordering section for status reports. Held from
-    /// snapshot construction THROUGH completion of the hub send, so captured content is monotone in
-    /// wire order (SignalR preserves per-connection send order).
+    /// <summary>Round-dispatch grace: the per-daemon ordering section for status-report build+send.
     ///
-    /// <para>This is load-bearing, not hygiene. The server folds every flow-participant report and
-    /// treats ANY activity-seq regression as permanent corruption — the fold latches "regressed" and
-    /// disables that agent's liveness supervision for good. Two concurrent emissions that captured
-    /// their snapshots independently can send seq N after seq N+1 (a report built before a delivery
-    /// advanced the clock, sent after the delivery-triggered one), tripping exactly that latch:
-    /// silently DISABLING supervision, the opposite failure direction from the one this work fixes.
-    /// Serializing snapshot+send removes the interleaving entirely.</para>
+    /// <para><b>Invariant.</b> Wire content must be non-decreasing in per-agent
+    /// <see cref="AgentActivityClock.ActivitySeq"/> — the server's flow-participant fold treats ANY
+    /// regression as permanent corruption (latches "regressed", disables that agent's liveness
+    /// supervision for good). <see cref="BuildStatusReport"/> runs inside this section, and the hub-send
+    /// is INVOKED inside it too, so invocation order — and with it SignalR's per-connection wire order
+    /// — is fixed by acquisition order regardless of how long any one send takes to finish (see
+    /// <see cref="SendDaemonStatusReportOnceAsync"/>'s bounded wait).</para>
     ///
-    /// <para>EVERY status-report emission site MUST route through
-    /// <see cref="SendDaemonStatusReportOnceAsync"/> and therefore through this gate — today the 60s
-    /// periodic loop, the server's on-request nudge, the launch-stage transition, and the delivered-
-    /// input report; and equally any future one (a correlated status-request/echo handler above all,
-    /// since a correlated reply is the exact variant whose content is captured under contention).
-    /// A site that calls <c>_server.DaemonStatusReportAsync</c> directly bypasses the ordering and
-    /// reintroduces the latch.</para>
+    /// <para><b>Rule.</b> EVERY status-report emission site MUST route through
+    /// <see cref="SendDaemonStatusReportOnceAsync"/>; a direct <c>_server.DaemonStatusReportAsync</c>
+    /// call bypasses the ordering and can regress the fold.</para>
     ///
-    /// <para><b>Lock ordering.</b> This gate is held across a whole hub send and takes
-    /// <see cref="AgentActivityClock"/>'s lock underneath it (via <see cref="BuildStatusReport"/>), so
-    /// the permitted edge is ordering → clock. It must NEVER be acquired while a per-agent
-    /// <see cref="AgentInstance.BorrowedSnapshotGate"/> is held: that would put an unbounded network
-    /// wait under a per-agent lock whose other holder can be parked in an uncancellable pty write.
-    /// The delivery-triggered emission therefore offloads (see <see cref="HandleSendInput"/>) rather
-    /// than awaiting this gate inside the section.</para>
+    /// <para><b>Lock order.</b> ordering → clock (via <see cref="BuildStatusReport"/>). MUST NEVER be
+    /// acquired while a per-agent <see cref="AgentInstance.BorrowedSnapshotGate"/> is held —
+    /// <see cref="HandleSendInput"/> offloads its emission for exactly this reason.</para>
     ///
-    /// <para>Deliberately never disposed: emissions are fire-and-forget, so a waiter parked here
-    /// during teardown would surface an <see cref="ObjectDisposedException"/> on a task nobody
-    /// observes. Same treatment as the per-agent <c>BorrowedSnapshotGate</c>.</para></summary>
+    /// <para>Never disposed: emissions are fire-and-forget, so a waiter parked here during teardown
+    /// must not fault on an <see cref="ObjectDisposedException"/> nobody observes.</para>
+    ///
+    /// See docs/superpowers/specs/2026-08-10-ai1842-round-dispatch-grace-design.md (kcap-server) for
+    /// rationale.</summary>
     readonly SemaphoreSlim _statusReportOrderingGate = new(1, 1);
 
-    /// <summary>Phase B (D2): build + send one status report, one-way, swallowing errors (an
-    /// old server has no handler; a transient send failure must not touch the agent loops).
-    /// Round-dispatch grace: the build+send pair runs under
-    /// <see cref="_statusReportOrderingGate"/> — see that field for why the ordering is load-bearing
-    /// and why every emission site has to come through here.</summary>
+    /// <summary>Bound on <see cref="SendDaemonStatusReportOnceAsync"/>'s in-gate wait for the hub send
+    /// to complete. A parked send (dead/degraded connection) must not hold every other emission behind
+    /// it forever; see that method for why releasing the WAIT here is safe. Settable so tests don't
+    /// wait the real 30s.</summary>
+    internal TimeSpan StatusReportSendTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>Phase B (D2): build + send one status report, one-way, swallowing errors (an old
+    /// server has no handler). Snapshot build AND the send's INVOCATION happen inside
+    /// <see cref="_statusReportOrderingGate"/> — see that field for the ordering invariant. The WAIT for
+    /// completion is bounded by <see cref="StatusReportSendTimeout"/> and released on timeout without
+    /// waiting further: invocation order, not completion order, is what the invariant needs, so
+    /// dropping the wait here is safe while dropping the invocation itself out from under the gate
+    /// would not be.</summary>
     internal async Task SendDaemonStatusReportOnceAsync() {
-        await _statusReportOrderingGate.WaitAsync();
+        try {
+            await _statusReportOrderingGate.WaitAsync(_shutdownCts.Token);
+        } catch (OperationCanceledException) {
+            return; // shutdown must not strand a waiter behind a gate nobody will release
+        }
+
         try {
             // BuildStatusReport() is evaluated INSIDE the section, not passed in from outside it —
             // a snapshot captured before acquisition is exactly the stale content the section exists
-            // to keep off the wire.
-            try { await _server.DaemonStatusReportAsync(BuildStatusReport()); }
-            catch (Exception ex) { _logger.LogDebug(ex, "DaemonStatusReport send failed — ignoring"); }
+            // to keep off the wire. The invocation itself is inside this try too (not just the await):
+            // a double that throws synchronously instead of returning a faulted Task must be swallowed
+            // the same as an awaited failure.
+            Task? send = null;
+            try {
+                send = _server.DaemonStatusReportAsync(BuildStatusReport());
+                await send.WaitAsync(StatusReportSendTimeout, _shutdownCts.Token);
+            } catch (TimeoutException) {
+                // The invocation already happened under the gate (see the gate's own doc), so wire
+                // FIFO on this single connection still holds even though we stop waiting here.
+                LogStatusReportSendTimedOut(StatusReportSendTimeout.TotalSeconds);
+                ObserveAbandonedStatusReportSend(send!);
+            } catch (Exception ex) {
+                _logger.LogDebug(ex, "DaemonStatusReport send failed — ignoring");
+            }
         } finally {
             _statusReportOrderingGate.Release();
         }
@@ -1235,6 +1252,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // already relies on.
         Processor?.RedeliverUnretiredProcessedAcks();
     }
+
+    /// <summary>Observes an abandoned status-report send (see
+    /// <see cref="SendDaemonStatusReportOnceAsync"/>) so its eventual completion — or fault, once it
+    /// finally lands or the connection reclaims it — is not an unobserved task exception.</summary>
+    void ObserveAbandonedStatusReportSend(Task send) =>
+        _ = send.ContinueWith(
+            t => LogStatusReportSendFailedInBackground(t.Exception!.GetBaseException()),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
     /// <summary>The out-of-cycle report fired on a launch-stage transition, wired in
     /// <see cref="CreateActivityClock"/>. Shares <see cref="SendDaemonStatusReportOnceAsync"/>'s
@@ -2661,10 +2688,27 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         try {
             if (!await TryClaimReapAsync(candidate)) return;
 
-            await HandleStopAgent(candidate.Id);
+            await StopClaimedReapAsync(candidate);
         } catch (Exception ex) {
             LogReapFailed(ex, candidate.Id, candidate.Reason);
         }
+    }
+
+    /// <summary>The stop half of a WON claim, split out from <see cref="ReapReviewerAsync"/> so the
+    /// re-check below is independently testable. <see cref="HandleStopAgent"/> re-resolves
+    /// <paramref name="candidate"/>'s id from <c>_agents</c> rather than taking the claimed instance
+    /// directly, so a relaunch that reused the id between the claim and this call would stop the FRESH
+    /// incarnation on the claimed one's evidence. Unreachable today — ids are unique per launch — but
+    /// this makes it structural rather than assumed: re-validate the map entry is still the claimed
+    /// instance immediately before handing off, and abort (same "agent_gone" cause as the claim's own
+    /// incarnation check) on mismatch instead of stopping whatever now answers to the id.</summary>
+    async Task StopClaimedReapAsync(ReapCandidate candidate) {
+        if (!_agents.TryGetValue(candidate.Id, out var current) || !ReferenceEquals(current, candidate.Agent)) {
+            LogReapAborted(candidate.Id, candidate.Reason, "agent_gone");
+            return;
+        }
+
+        await HandleStopAgent(candidate.Id);
     }
 
     /// <summary>The atomic reap claim (round-dispatch grace §3). Runs inside
@@ -3101,12 +3145,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         await agent.BorrowedSnapshotGate.WaitAsync(_shutdownCts.Token);
         try {
-            // The losing side of the reap claim (round-dispatch grace §3). The reaper won this agent's
-            // section before we entered it, so it is condemned: deliver nothing, advance nothing,
-            // announce nothing. Refusing here rather than writing into a runtime that is about to be
-            // terminated is what makes the round's dispatch fail promptly — the server heals it on
-            // resubmit, whereas a write accepted by a dying PTY would leave the round waiting out its
-            // whole bound on a corpse.
+            // Losing side of the reap claim (round-dispatch grace §3): a reap-claimed agent gets
+            // nothing — no write, no clock advance, no report. Failing the dispatch here (not writing
+            // into a dying runtime) is deliberate; the server heals it on resubmit.
             if (agent.IsReapClaimed) {
                 LogSendInputReapClaimed(agentId);
                 return;
@@ -3124,17 +3165,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 }
             }
 
-            // Re-checked HERE, immediately before the write, and NOT only at the top of the section.
-            // The steps between the two checks are slow by design — the borrowed-snapshot refresh alone
-            // is budgeted 30s (BorrowedSnapshotRefreshTimeout), plus any attachment downloads — which is
-            // LONGER than the reap claim's own gate wait, so a perfectly healthy borrowed delivery
-            // routinely leaves the section held past it. The absolute-lifetime claim then legitimately
-            // fires without the section (see TryClaimUnfencedReapWithoutSection) against an agent whose
-            // in-flight delivery is not parked at all, and without this second read that delivery would
-            // sail on to write the round, advance the clock and emit a delivered-input report for an
-            // agent already condemned — exactly the outcome the top-of-section refusal exists to
-            // prevent. The re-read is free and sound: the latch is monotonic 0→1 and read through
-            // Volatile.Read, so observing it true is never a false positive.
+            // Re-checked HERE, not only at the top of the section: the borrowed-snapshot refresh
+            // budget (30s, BorrowedSnapshotRefreshTimeout) plus any downloads routinely exceeds the
+            // reap claim's own gate wait (20s, ReapClaimGateWait), so an unfenced claim
+            // (TryClaimUnfencedReapWithoutSection) can land mid-section. The latch is monotonic 0→1
+            // via Volatile.Read, so this re-read can never false-positive.
             if (SendInputBeforeWriteHookForTest is { } beforeWrite) await beforeWrite();
 
             if (agent.IsReapClaimed) {
@@ -3148,49 +3183,23 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             else
                 await agent.Runtime.SendUserInputAsync(message);
 
-            // Round-dispatch grace: input delivery is itself an activity signal, not just an
-            // agent's own subsequent output — reused via the SAME AgentActivityClock.Advance() PTY
-            // output/ACP envelopes/turn transitions already call. A throw from either await above
-            // skips this line entirely, so a failed/cancelled delivery advances nothing.
-            //
-            // For the default (non-borrowed) ACP path, SendUserInputAsync's non-throwing return only
-            // means "enqueued" (AcpHostedAgentRuntime.EnqueueTurn(acknowledgeWrite: false)) — a full
-            // _pendingTurns queue silently drops the input without throwing. Advancing on that is a
-            // known, accepted residual: a false advance only DELAYS a reap/silence verdict for this
-            // agent, it can never manufacture one, so it is kill-delaying-only and deliberately not
-            // worth restructuring the ACP queue (an acknowledged write) to close.
+            // Input delivery counts as activity (AgentActivityClock.Advance(), shared with PTY
+            // output/ACP envelopes/turn transitions); a throw from either await above skips it. Known
+            // residual: a full ACP _pendingTurns queue drops input silently without throwing, so this
+            // can advance on a delivery that was actually dropped — kill-delaying only, accepted.
             agent.ActivityClock.Advance();
 
-            // ...and announce it immediately rather than letting the fresh attestation wait out the
-            // rest of the 60s report cadence — the server's dispatch-relative grace is what consumes
-            // it, and a report that lands after the grace has already elapsed is worthless. One
-            // report per successfully handled invocation: SendInputCommand carries no round/dispatch
-            // identity (agent + text + attachments), so "one per round" is not implementable and
-            // duplicates are tolerated by design — a duplicate is content-honest, and the server's
-            // freshness rule still requires the idle it attests to genuinely cover the bound.
+            // One report per successfully handled invocation (SendInputCommand carries no round
+            // identity, so a duplicate is tolerated and content-honest); fire-and-forget, contained,
+            // one-way. Captured strictly after Advance() above, so it can never carry a pre-delivery
+            // seq — monotonicity comes from _statusReportOrderingGate's acquisition order, never from
+            // the order these Task.Run calls happen to be scheduled in.
             //
-            // Fire-and-forget, matching the launch-stage transition hook: the send is contained and
-            // one-way (SendDaemonStatusReportOnceAsync swallows its own failures), so a report
-            // failure can never fail the delivery. The report snapshot is captured inside the
-            // ordering section, i.e. strictly after the Advance() above, so this report can never
-            // carry a pre-delivery seq.
-            //
-            // The offload is ALSO the lock-ordering invariant, not only a latency choice: awaiting the
-            // emission here would acquire _statusReportOrderingGate while this agent's
-            // BorrowedSnapshotGate is held, creating the one edge (per-agent → ordering) both gates'
-            // docs forbid — an unbounded hub send underneath a per-agent lock whose other holder can be
-            // parked in an uncancellable pty write. Reverting this to an awaited call reintroduces it.
-            //
-            // Task.Run, not a bare discard, because a discard is only asynchronous when it BLOCKS:
-            // SemaphoreSlim.WaitAsync completes synchronously on an uncontended gate — the common
-            // case — and the method would then run BuildStatusReport() inline, on the SignalR
-            // receive-loop thread that dispatched this command, while we still hold this agent's
-            // BorrowedSnapshotGate. That build is not cheap or purely in-memory: it reads the PID
-            // record store off disk (twice, via the blocked-candidate and startup-reap-completeness
-            // arms). Contended, it would be worse still — an inline await would park the receive loop
-            // and this agent's delivery behind another emission's whole hub send. Offloading costs
-            // nothing in ordering terms: content is made monotone by the gate, never by the order
-            // emissions are STARTED in.
+            // MUST offload rather than await here (lock order): _statusReportOrderingGate must never
+            // be acquired while this agent's BorrowedSnapshotGate is held (see the gate's own doc).
+            // Task.Run, not a bare discard — WaitAsync can complete synchronously on an uncontended
+            // gate, which would otherwise run BuildStatusReport() (disk I/O) inline on this receive
+            // loop while still holding BorrowedSnapshotGate.
             _ = Task.Run(() => SendDaemonStatusReportOnceAsync());
 
             LogSendInputDelivered(agentId, agent.Runtime.Vendor, message.Length);
@@ -4321,6 +4330,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     [LoggerMessage(Level = LogLevel.Warning, Message = "EndAgentSession for agent {AgentId} did not complete within {Seconds}s; proceeding with cleanup while the retry continues in the background (server reconciles on daemon disconnect)")]
     partial void LogEndSessionTimedOut(string agentId, double seconds);
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "DaemonStatusReport send did not complete within {Seconds}s; releasing the ordering gate (invocation already issued, so wire order still holds)")]
+    partial void LogStatusReportSendTimedOut(double seconds);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Abandoned DaemonStatusReport send faulted after the ordering gate was released — ignoring")]
+    partial void LogStatusReportSendFailedInBackground(Exception ex);
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Spawned what's-done generator for session {SessionId} (PID {Pid})")]
     partial void LogWhatsDoneSpawned(string sessionId, int pid);
 
@@ -4462,6 +4477,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// which side won the section without also driving a stop whose (slow, side-effecting) teardown is
     /// not what is under test.</summary>
     internal Task<bool> TryClaimReapForTest(ReapCandidate candidate) => TryClaimReapAsync(candidate);
+
+    /// <summary>Test-only: the post-claim stop ALONE, without a real claim ahead of it — lets a test
+    /// swap <c>_agents</c>' entry for <c>candidate</c>'s id between "claim won" and this call to prove
+    /// the incarnation re-check aborts rather than stopping a relaunch.</summary>
+    internal Task StopClaimedReapForTest(ReapCandidate candidate) => StopClaimedReapAsync(candidate);
 
     /// <summary>Test-only entry point to the private probe-borrow-source handler.</summary>
     internal Task<BorrowProbeResult> HandleProbeBorrowSourceForTest(string path) => HandleProbeBorrowSource(path);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2737,6 +2737,19 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             else
                 await agent.Runtime.SendUserInputAsync(message);
 
+            // Round-dispatch grace: input delivery is itself an activity signal, not just an
+            // agent's own subsequent output — reused via the SAME AgentActivityClock.Advance() PTY
+            // output/ACP envelopes/turn transitions already call. A throw from either await above
+            // skips this line entirely, so a failed/cancelled delivery advances nothing.
+            //
+            // For the default (non-borrowed) ACP path, SendUserInputAsync's non-throwing return only
+            // means "enqueued" (AcpHostedAgentRuntime.EnqueueTurn(acknowledgeWrite: false)) — a full
+            // _pendingTurns queue silently drops the input without throwing. Advancing on that is a
+            // known, accepted residual: a false advance only DELAYS a reap/silence verdict for this
+            // agent, it can never manufacture one, so it is kill-delaying-only and deliberately not
+            // worth restructuring the ACP queue (an acknowledged write) to close.
+            agent.ActivityClock.Advance();
+
             LogSendInputDelivered(agentId, agent.Runtime.Vendor, message.Length);
         } finally {
             agent.BorrowedSnapshotGate.Release();

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1127,6 +1127,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // status-report moment is also a re-sync moment. A validated AckProcessedPrefix stops the re-sends.
         // Runs OUTSIDE the ordering section above: it re-sends acks, not the report, so serializing it
         // would only extend the section's hold without ordering anything the server folds by seq.
+        //
+        // Round-dispatch grace added a FOURTH trigger — the delivered-input report — which therefore
+        // also re-drives this sweep at input rate rather than at the 60s cadence. Benign in both
+        // directions: the unretired set is normally empty (so this is a no-op), and a duplicate ack is
+        // explicitly tolerated by the server per D2″ — the same tolerance the on-request trigger
+        // already relies on.
         Processor?.RedeliverUnretiredProcessedAcks();
     }
 
@@ -2799,11 +2805,21 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             //
             // Fire-and-forget, matching the launch-stage transition hook: the send is contained and
             // one-way (SendDaemonStatusReportOnceAsync swallows its own failures), so a report
-            // failure can never fail the delivery — and awaiting it here would block THIS agent's
-            // delivery (we still hold BorrowedSnapshotGate) behind another emission's hub send.
-            // The report snapshot is captured inside the ordering section, i.e. strictly after the
-            // Advance() above, so this report can never carry a pre-delivery seq.
-            _ = SendDaemonStatusReportOnceAsync();
+            // failure can never fail the delivery. The report snapshot is captured inside the
+            // ordering section, i.e. strictly after the Advance() above, so this report can never
+            // carry a pre-delivery seq.
+            //
+            // Task.Run, not a bare discard, because a discard is only asynchronous when it BLOCKS:
+            // SemaphoreSlim.WaitAsync completes synchronously on an uncontended gate — the common
+            // case — and the method would then run BuildStatusReport() inline, on the SignalR
+            // receive-loop thread that dispatched this command, while we still hold this agent's
+            // BorrowedSnapshotGate. That build is not cheap or purely in-memory: it reads the PID
+            // record store off disk (twice, via the blocked-candidate and startup-reap-completeness
+            // arms). Contended, it would be worse still — an inline await would park the receive loop
+            // and this agent's delivery behind another emission's whole hub send. Offloading costs
+            // nothing in ordering terms: content is made monotone by the gate, never by the order
+            // emissions are STARTED in.
+            _ = Task.Run(() => SendDaemonStatusReportOnceAsync());
 
             LogSendInputDelivered(agentId, agent.Runtime.Vendor, message.Length);
         } finally {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1077,17 +1077,56 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         finally { Interlocked.Exchange(ref _quarantineSweepRunning, 0); }
     }
 
+    /// <summary>Round-dispatch grace: the per-daemon ordering section for status reports. Held from
+    /// snapshot construction THROUGH completion of the hub send, so captured content is monotone in
+    /// wire order (SignalR preserves per-connection send order).
+    ///
+    /// <para>This is load-bearing, not hygiene. The server folds every flow-participant report and
+    /// treats ANY activity-seq regression as permanent corruption — the fold latches "regressed" and
+    /// disables that agent's liveness supervision for good. Two concurrent emissions that captured
+    /// their snapshots independently can send seq N after seq N+1 (a report built before a delivery
+    /// advanced the clock, sent after the delivery-triggered one), tripping exactly that latch:
+    /// silently DISABLING supervision, the opposite failure direction from the one this work fixes.
+    /// Serializing snapshot+send removes the interleaving entirely.</para>
+    ///
+    /// <para>EVERY status-report emission site MUST route through
+    /// <see cref="SendDaemonStatusReportOnceAsync"/> and therefore through this gate — today the 60s
+    /// periodic loop, the server's on-request nudge, the launch-stage transition, and the delivered-
+    /// input report; and equally any future one (a correlated status-request/echo handler above all,
+    /// since a correlated reply is the exact variant whose content is captured under contention).
+    /// A site that calls <c>_server.DaemonStatusReportAsync</c> directly bypasses the ordering and
+    /// reintroduces the latch.</para>
+    ///
+    /// <para>Deliberately never disposed: emissions are fire-and-forget, so a waiter parked here
+    /// during teardown would surface an <see cref="ObjectDisposedException"/> on a task nobody
+    /// observes. Same treatment as the per-agent <c>BorrowedSnapshotGate</c>.</para></summary>
+    readonly SemaphoreSlim _statusReportOrderingGate = new(1, 1);
+
     /// <summary>Phase B (D2): build + send one status report, one-way, swallowing errors (an
-    /// old server has no handler; a transient send failure must not touch the agent loops).</summary>
+    /// old server has no handler; a transient send failure must not touch the agent loops).
+    /// Round-dispatch grace: the build+send pair runs under
+    /// <see cref="_statusReportOrderingGate"/> — see that field for why the ordering is load-bearing
+    /// and why every emission site has to come through here.</summary>
     internal async Task SendDaemonStatusReportOnceAsync() {
-        try { await _server.DaemonStatusReportAsync(BuildStatusReport()); }
-        catch (Exception ex) { _logger.LogDebug(ex, "DaemonStatusReport send failed — ignoring"); }
+        await _statusReportOrderingGate.WaitAsync();
+        try {
+            // BuildStatusReport() is evaluated INSIDE the section, not passed in from outside it —
+            // a snapshot captured before acquisition is exactly the stale content the section exists
+            // to keep off the wire.
+            try { await _server.DaemonStatusReportAsync(BuildStatusReport()); }
+            catch (Exception ex) { _logger.LogDebug(ex, "DaemonStatusReport send failed — ignoring"); }
+        } finally {
+            _statusReportOrderingGate.Release();
+        }
+
         // Settlement lost-ack redelivery (D1): after advertising the watermarks, re-deliver any UNRETIRED terminal acks — a lost
         // ack in a reconnect window is re-elicited here instead of waiting for the server to retransmit
         // the whole command (the server tolerates the duplicate per D2″). No-op when nothing is
         // unretired; sends are contained + one-way, so this can never fault the report path. This covers
         // the periodic tick, the server's on-request report, and the activity-triggered report — every
         // status-report moment is also a re-sync moment. A validated AckProcessedPrefix stops the re-sends.
+        // Runs OUTSIDE the ordering section above: it re-sends acks, not the report, so serializing it
+        // would only extend the section's hold without ordering anything the server folds by seq.
         Processor?.RedeliverUnretiredProcessedAcks();
     }
 
@@ -2749,6 +2788,22 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // agent, it can never manufacture one, so it is kill-delaying-only and deliberately not
             // worth restructuring the ACP queue (an acknowledged write) to close.
             agent.ActivityClock.Advance();
+
+            // ...and announce it immediately rather than letting the fresh attestation wait out the
+            // rest of the 60s report cadence — the server's dispatch-relative grace is what consumes
+            // it, and a report that lands after the grace has already elapsed is worthless. One
+            // report per successfully handled invocation: SendInputCommand carries no round/dispatch
+            // identity (agent + text + attachments), so "one per round" is not implementable and
+            // duplicates are tolerated by design — a duplicate is content-honest, and the server's
+            // freshness rule still requires the idle it attests to genuinely cover the bound.
+            //
+            // Fire-and-forget, matching the launch-stage transition hook: the send is contained and
+            // one-way (SendDaemonStatusReportOnceAsync swallows its own failures), so a report
+            // failure can never fail the delivery — and awaiting it here would block THIS agent's
+            // delivery (we still hold BorrowedSnapshotGate) behind another emission's hub send.
+            // The report snapshot is captured inside the ordering section, i.e. strictly after the
+            // Advance() above, so this report can never carry a pre-delivery seq.
+            _ = SendDaemonStatusReportOnceAsync();
 
             LogSendInputDelivered(agentId, agent.Runtime.Vendor, message.Length);
         } finally {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -162,7 +162,35 @@ internal record AgentInstance(
     /// <summary>Authorized live checkout mirrored into this owned worktree for a runtime that
     /// cannot safely execute in-place. Refreshed before each later review round.</summary>
     public string? BorrowedSnapshotSource { get; init; }
+
+    /// <summary>The per-agent critical section. Named for its original duty (serializing the borrowed-
+    /// checkout refresh against a concurrent send) but it has always wrapped the ENTIRE
+    /// <see cref="AgentOrchestrator.HandleSendInput"/> body for EVERY vendor, borrowed or not — so it
+    /// is simply "the delivery section", and that is its second, load-bearing purpose:
+    ///
+    /// <para><b>The delivery/reap fence (round-dispatch grace §3).</b> The reaper's
+    /// validate-and-claim (<see cref="AgentOrchestrator.TryClaimReapAsync"/>) runs inside this same
+    /// section, so a delivery's clock advance and a reap claim are mutually exclusive and exactly one
+    /// side wins: a delivery that completes first advances <see cref="AgentActivityClock.ActivitySeq"/>
+    /// past the generation captured at selection, and the claim aborts; a claim that lands first sets
+    /// <see cref="ReapClaimed"/>, and the next delivery refuses. Selection alone can never be the
+    /// decision — <see cref="AgentOrchestrator.FindReviewersToReap"/> reads a snapshot, and any recheck
+    /// outside this section leaves a recheck-to-stop window.</para>
+    ///
+    /// <para>Deliberately never disposed: a reap claim and a delivery can both be parked here while
+    /// teardown runs, and an <see cref="ObjectDisposedException"/> on either would surface on a task
+    /// nobody observes.</para></summary>
     public SemaphoreSlim BorrowedSnapshotGate { get; } = new(1, 1);
+
+    /// <summary>Set (once, inside <see cref="BorrowedSnapshotGate"/>) by the reaper that WON the claim
+    /// for this agent; read there by <see cref="AgentOrchestrator.HandleSendInput"/>, which refuses to
+    /// deliver to a condemned agent. Never reset: a claimed agent is on its way down, and
+    /// <see cref="AgentOrchestrator.StopAgentCoreAsync"/> flipping the status to "Completed" already
+    /// takes it out of the reap candidate set permanently, so the latch adds no new terminality — it
+    /// only makes the losing side of the race observable to the delivery path BEFORE the teardown has
+    /// physically closed the transport. The gate is the whole synchronization: no interlocked access
+    /// (or any access at all) outside it.</summary>
+    public bool ReapClaimed;
 
     /// <summary>Current PTY dimensions — the single source of truth for every dims send
     /// (registration, reconnect). Updated by every resize path (local clamp + web resize).
@@ -712,34 +740,68 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <para>Idle comes from <see cref="AgentActivityClock"/>, never <see cref="AgentInstance.LastOutputAt"/>
     /// (PTY-only, so it sits frozen at launch for every ACP vendor, degenerating "2h idle" into a hard
     /// 2h cap) and never a <see cref="DateTime"/> delta (a wall-clock jump would reap a healthy
-    /// reviewer).</para></summary>
-    internal IReadOnlyList<(string Id, string Reason)> FindReviewersToReap() {
-        var result = new List<(string, string)>();
+    /// reviewer).</para>
+    ///
+    /// <para>This is SELECTION, never the decision: the result is a snapshot, and the agent it names
+    /// can become active in the very next instant. Each candidate therefore carries the activity
+    /// generation it was selected against, which <see cref="TryClaimReapAsync"/> re-validates inside
+    /// the per-agent fence.</para></summary>
+    internal IReadOnlyList<ReapCandidate> FindReviewersToReap() {
+        var result = new List<ReapCandidate>();
 
         foreach (var a in _agents.Values) {
             if (a.Kind != LaunchKind.ReviewFlow || a.Status != "Running") continue;
 
             var clock = a.ActivityClock;
 
+            // Captured BEFORE the threshold reads below, and that order is load-bearing rather than
+            // stylistic. The clock's properties are four independent lock acquisitions, so a delivery
+            // can land between any two of them; taking the generation FIRST makes every interleaving
+            // safe. A delivery landing after this read leaves seq > generation, so the claim aborts; a
+            // delivery landing before it is necessarily reflected in the idle/wedge reads that follow
+            // (Advance() resets the idle window under the same lock), so the candidate is not selected
+            // at all. Reading the generation LAST would leave the one unsafe window: an agent selected
+            // on a stale idle read whose post-read delivery is then baked into the "unchanged"
+            // generation the claim compares against.
+            var generation = clock.ActivitySeq;
+
             if (_config.ReviewerMaxLifetime > TimeSpan.Zero && clock.AgeMs > (ulong) _config.ReviewerMaxLifetime.TotalMilliseconds) {
-                result.Add((a.Id, "reviewer_ttl_expired"));
+                // The absolute cap is deliberately NOT activity-fenced: it fires regardless of how
+                // active the reviewer is (that is what "absolute" means here), so a delivery racing it
+                // must not abort it.
+                result.Add(new ReapCandidate(a, "reviewer_ttl_expired", generation, FencedOnActivity: false));
                 continue;
             }
 
             if (clock.TurnInFlight) {
                 if (_config.ReviewerTurnWedgeCeiling > TimeSpan.Zero
                  && clock.IdleForMs > (ulong) _config.ReviewerTurnWedgeCeiling.TotalMilliseconds) {
-                    result.Add((a.Id, "turn_wedged"));
+                    result.Add(new ReapCandidate(a, "turn_wedged", generation, FencedOnActivity: true));
                 }
 
                 continue; // a held turn suppresses the plain idle rule outright
             }
 
             if (_config.ReviewerIdleTimeout > TimeSpan.Zero && clock.IdleForMs > (ulong) _config.ReviewerIdleTimeout.TotalMilliseconds)
-                result.Add((a.Id, "reviewer_idle_expired"));
+                result.Add(new ReapCandidate(a, "reviewer_idle_expired", generation, FencedOnActivity: true));
         }
 
         return result;
+    }
+
+    /// <summary>One reap target as SELECTED, plus the evidence <see cref="TryClaimReapAsync"/> revalidates
+    /// the selection against inside the per-agent fence.</summary>
+    /// <param name="Agent">The instance selected — carried, not just its id, so the claim can prove the
+    /// id still resolves to THIS incarnation rather than a relaunch that reused the name.</param>
+    /// <param name="Reason">Which rule fired; becomes <see cref="AgentInstance.PendingEndReason"/> on a
+    /// won claim, so server-side end attribution names the rule.</param>
+    /// <param name="ActivityGeneration"><see cref="AgentActivityClock.ActivitySeq"/> at selection.</param>
+    /// <param name="FencedOnActivity">Whether an activity advance since selection ABORTS this reap —
+    /// true for the idle and wedge rules (both are "nothing has happened" claims, which a delivery
+    /// falsifies), false for the absolute lifetime cap (which holds regardless of activity).</param>
+    internal readonly record struct ReapCandidate(
+            AgentInstance Agent, string Reason, ulong ActivityGeneration, bool FencedOnActivity) {
+        public string Id => Agent.Id;
     }
 
     /// <summary>Phase B (D2): the daemon's self-report snapshot — its authoritative
@@ -2542,6 +2604,94 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (outcome is SubmitOutcome.Refused) LogUnsequencedStopRefused(agentId);
     }
 
+    /// <summary>Execute one selected reap: claim it under the per-agent fence, and stop the agent only
+    /// if the claim was WON. Fire-and-forget from the heartbeat, so it contains its own faults —
+    /// <see cref="StopAgentCoreAsync"/> already swallows the stop's, leaving only the gate wait.</summary>
+    async Task ReapReviewerAsync(ReapCandidate candidate) {
+        try {
+            if (!await TryClaimReapAsync(candidate)) return;
+
+            await HandleStopAgent(candidate.Id);
+        } catch (Exception ex) {
+            LogReapFailed(ex, candidate.Id, candidate.Reason);
+        }
+    }
+
+    /// <summary>The atomic reap claim (round-dispatch grace §3). Runs inside
+    /// <see cref="AgentInstance.BorrowedSnapshotGate"/> — the same per-agent section every
+    /// <see cref="HandleSendInput"/> delivery holds across its clock advance — so the claim and a
+    /// delivery are mutually exclusive and exactly one of them wins.
+    ///
+    /// <para>Rechecking "immediately before" the stop would NOT do: selection is a snapshot, and any
+    /// recheck outside the section leaves a recheck-to-stop window in which a delivery lands and the
+    /// reviewer is torn down under an in-flight round anyway. Inside the section the two orders are
+    /// both terminal: a delivery that got here first has already advanced
+    /// <see cref="AgentActivityClock.ActivitySeq"/> past the captured generation and this returns false;
+    /// a claim that got here first sets <see cref="AgentInstance.ReapClaimed"/> and the delivery
+    /// refuses. A delivery that arrives after a won claim loses NORMALLY — nothing is delivered, so the
+    /// round's own dispatch fails and the server heals it on resubmit.</para>
+    ///
+    /// <para>Scope, stated honestly: this fences the IDLE and WEDGE rules only. The absolute
+    /// <see cref="DaemonConfig.ReviewerMaxLifetime"/> cap carries
+    /// <see cref="ReapCandidate.FencedOnActivity"/> false and reaps regardless of activity, unchanged —
+    /// it still takes the section (so membership/incarnation are revalidated and a claim is never
+    /// double-counted), it just never aborts on a generation advance.</para></summary>
+    async Task<bool> TryClaimReapAsync(ReapCandidate candidate) {
+        var agent = candidate.Agent;
+
+        try {
+            await agent.BorrowedSnapshotGate.WaitAsync(_shutdownCts.Token);
+        } catch (OperationCanceledException) {
+            return false; // daemon teardown supersedes the reap — it kills the registered children itself
+        }
+
+        try {
+            // Incarnation, not just membership: an id can be republished by a relaunch, and reaping the
+            // fresh incarnation on its predecessor's evidence is the same class of mistake as reaping on
+            // a stale generation.
+            if (!_agents.TryGetValue(candidate.Id, out var current) || !ReferenceEquals(current, agent)) {
+                LogReapAborted(candidate.Id, candidate.Reason, "agent_gone");
+                return false;
+            }
+
+            if (agent.ReapClaimed) return false; // an earlier sweep already claimed it; single-flight
+
+            // A stop from any other source (server, local socket) flips the status first; the reviewer
+            // is already on its way down and must not be stopped twice.
+            if (agent.Status != "Running") {
+                LogReapAborted(candidate.Id, candidate.Reason, "not_running");
+                return false;
+            }
+
+            // THE fence. The clock is monotonic, so any difference is an advance: something happened
+            // to this agent after it was selected, which falsifies the idle/wedge claim outright. The
+            // comparison is against the generation captured at selection — never a freshly re-derived
+            // idle/threshold check, which would just re-run the same snapshot decision one moment later
+            // and answer the same way.
+            var generation = agent.ActivityClock.ActivitySeq;
+
+            if (candidate.FencedOnActivity && generation != candidate.ActivityGeneration) {
+                LogReapAbortedOnActivity(candidate.Id, candidate.Reason, candidate.ActivityGeneration, generation);
+                return false;
+            }
+
+            agent.ReapClaimed      = true;
+            agent.PendingEndReason = candidate.Reason;
+
+            // Logged off the SAME clock the decision was made from — CreatedAt/LastOutputAt would
+            // misreport an ACP reviewer's idle time as frozen since launch.
+            _logger.LogInformation(
+                "Reaping review-flow reviewer {AgentId} ({Reason}); age {AgeHours:F1}h, idle {IdleHours:F1}h",
+                candidate.Id, candidate.Reason,
+                TimeSpan.FromMilliseconds(agent.ActivityClock.AgeMs).TotalHours,
+                TimeSpan.FromMilliseconds(agent.ActivityClock.IdleForMs).TotalHours);
+
+            return true;
+        } finally {
+            agent.BorrowedSnapshotGate.Release();
+        }
+    }
+
     /// <summary>The shared stop executor: graceful <c>/exit</c> then terminate (via
     /// <see cref="StopAgentCoreAsync"/>), or a PID-record fallback for an id this incarnation never
     /// registered. Reached from three kinds of caller: the un-sequenced <c>StopAgent</c> lane item, the
@@ -2764,6 +2914,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         await agent.BorrowedSnapshotGate.WaitAsync(_shutdownCts.Token);
         try {
+            // The losing side of the reap claim (round-dispatch grace §3). The reaper won this agent's
+            // section before we entered it, so it is condemned: deliver nothing, advance nothing,
+            // announce nothing. Refusing here rather than writing into a runtime that is about to be
+            // terminated is what makes the round's dispatch fail promptly — the server heals it on
+            // resubmit, whereas a write accepted by a dying PTY would leave the round waiting out its
+            // whole bound on a corpse.
+            if (agent.ReapClaimed) {
+                LogSendInputReapClaimed(agentId);
+                return;
+            }
+
             if (!await TryRefreshBorrowedSnapshotAsync(agent)) return;
 
             var message = text;
@@ -3523,19 +3684,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // recordless survivors. Fire-and-forget; single-flight; swallows its own faults.
             _ = ReapOrphansOnceAsync(ct);
 
-            foreach (var (id, reason) in FindReviewersToReap()) {
-                if (_agents.TryGetValue(id, out var reviewer)) {
-                    // Logged off the SAME clock the decision was made from — CreatedAt/LastOutputAt
-                    // would misreport an ACP reviewer's idle time as frozen since launch.
-                    _logger.LogInformation(
-                        "Reaping review-flow reviewer {AgentId} ({Reason}); age {AgeHours:F1}h, idle {IdleHours:F1}h",
-                        id, reason,
-                        TimeSpan.FromMilliseconds(reviewer.ActivityClock.AgeMs).TotalHours,
-                        TimeSpan.FromMilliseconds(reviewer.ActivityClock.IdleForMs).TotalHours);
-                    reviewer.PendingEndReason = reason;
-                    _ = HandleStopAgent(id);
-                }
-            }
+            // Selection is a snapshot; the DECISION is the claim each of these makes under the agent's
+            // own fence (TryClaimReapAsync), which re-validates incarnation and — for the idle/wedge
+            // rules — the activity generation this candidate was selected against. The end-reason stamp
+            // moved in there with it: an aborted reap must not leave "reviewer_idle_expired" on a live
+            // agent for whatever ends it later.
+            foreach (var candidate in FindReviewersToReap()) _ = ReapReviewerAsync(candidate);
 
             // PrivateLocal agents get no heartbeats and no stuck-Starting auto-stop (deny-all;
             // the local user is present and drives them directly).
@@ -3866,6 +4020,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     [LoggerMessage(Level = LogLevel.Warning, Message = "SendInput dropped: agent {AgentId} is private — server-origin input is ignored")]
     partial void LogSendInputPrivateAgent(string agentId);
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "SendInput dropped: agent {AgentId} was already claimed by the reviewer reaper and is being stopped — the round's dispatch fails here and the server heals it on resubmit")]
+    partial void LogSendInputReapClaimed(string agentId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Reap of review-flow reviewer {AgentId} ({Reason}) aborted at the claim: {Cause}")]
+    partial void LogReapAborted(string agentId, string reason, string cause);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Reap of review-flow reviewer {AgentId} ({Reason}) aborted at the claim: activity advanced from generation {SelectedGeneration} to {CurrentGeneration} since it was selected")]
+    partial void LogReapAbortedOnActivity(string agentId, string reason, ulong selectedGeneration, ulong currentGeneration);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Reaping review-flow reviewer {AgentId} ({Reason}) failed")]
+    partial void LogReapFailed(Exception ex, string agentId, string reason);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "SendSpecialKey '{Key}' dropped: agent {AgentId} not found on this daemon ({KnownAgents} agents registered)")]
     partial void LogSendSpecialKeyUnknownAgent(string agentId, string key, int knownAgents);
 
@@ -4067,6 +4233,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     /// <summary>Test-only entry point to the private send-input handler (bracketed-paste submit).</summary>
     internal Task HandleSendInputForTest(SendInputCommand cmd) => HandleSendInput(cmd);
+
+    /// <summary>Test-only: run ONE selected reap exactly as the heartbeat does (claim, then stop only
+    /// if the claim was won) — the seam for driving a candidate selected before some racing event.</summary>
+    internal Task ReapReviewerForTest(ReapCandidate candidate) => ReapReviewerAsync(candidate);
+
+    /// <summary>Test-only: the claim ALONE, without the teardown it gates. Lets a contention test pin
+    /// which side won the section without also driving a stop whose (slow, side-effecting) teardown is
+    /// not what is under test.</summary>
+    internal Task<bool> TryClaimReapForTest(ReapCandidate candidate) => TryClaimReapAsync(candidate);
 
     /// <summary>Test-only entry point to the private probe-borrow-source handler.</summary>
     internal Task<BorrowProbeResult> HandleProbeBorrowSourceForTest(string path) => HandleProbeBorrowSource(path);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -177,12 +177,17 @@ internal record AgentInstance(
     /// decision — <see cref="AgentOrchestrator.FindReviewersToReap"/> reads a snapshot, and any recheck
     /// outside this section leaves a recheck-to-stop window.</para>
     ///
-    /// <para><b>Waiting on this gate must always be BOUNDED.</b> It is held across a delivery, and a
-    /// delivery can block for an unbounded time on a healthy-looking transport — the PTY path ends in
-    /// <c>UnixPtyProcess.WriteAsync</c>, a raw <c>write(2)</c> on the pty master with no timeout and no
-    /// cancellation, which parks forever if the child stops draining its stdin. An unbounded waiter
-    /// here would therefore be waiting on the very process that only the waiter's own action (terminate)
-    /// can unblock. See <see cref="AgentOrchestrator.TryClaimReapAsync"/>.</para>
+    /// <para><b>A waiter whose own action is needed to unblock the holder must bound its wait.</b> It
+    /// is held across a delivery, and a delivery can block for an unbounded time on a healthy-looking
+    /// transport — the PTY path ends in <c>UnixPtyProcess.WriteAsync</c>, a raw <c>write(2)</c> on the
+    /// pty master with no timeout and no cancellation, which parks forever if the child stops draining
+    /// its stdin. The graceful-stop wait in <see cref="StopAgentCoreAsync"/> is exactly this case: it
+    /// is waiting on the very process that only its OWN next action (terminate) can unblock, so that
+    /// wait is bounded. The delivery's own ENTRY wait onto this gate (<see
+    /// cref="AgentOrchestrator.HandleSendInput"/>) is exempt from this rule — it is the holder class,
+    /// not the bounded class: it is unblocked by whatever the current holder is itself waiting on (the
+    /// child exiting, or a stop completing), never by an action the entry waiter must take. See <see
+    /// cref="AgentOrchestrator.TryClaimReapAsync"/>.</para>
     ///
     /// <para><b>Lock ordering.</b> This gate is OUTERMOST relative to
     /// <see cref="AgentActivityClock"/>'s internal lock (holders read the clock while holding it) and
@@ -2582,11 +2587,6 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         }
     }
 
-    /// <summary>
-    /// Initial wait after sending /exit to give claude a chance to flush its session-end
-    /// hook (which writes SessionEnded plus the what's-done summary). 15s covers a typical
-    /// session-end POST + watcher drain on a healthy connection.
-    /// </summary>
     /// <summary>Budget for the graceful phase of a stop — applied SEPARATELY to sending the stop and
     /// to waiting for the exit it asks for, because sending it is itself unbounded work on some
     /// runtimes (see <see cref="StopAgentCoreAsync"/>). Settable only so a test need not spend it for
@@ -2962,9 +2962,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // session/cancel notify, Antigravity returns Task.CompletedTask, and Pi's own grace is 3s.
             // A timeout here just falls through to the same terminate a graceful-exit timeout already
             // falls through to.
-            var graceful = agent.Runtime.RequestGracefulStopAsync();
+            //
+            // Inside the try, not before it: RequestGracefulStopAsync() itself (not just the await) can
+            // throw synchronously, and that throw must land in the catch below and fall through to
+            // terminate — not escape via the OUTER catch and skip terminate, which on the reap path
+            // leaves a permanent zombie (ReapClaimed latched, agent still Running, every future reap
+            // CAS-refused).
+            Task graceful = Task.CompletedTask;
 
             try {
+                graceful = agent.Runtime.RequestGracefulStopAsync();
                 await graceful.WaitAsync(GracefulExitWait);
                 await agent.Runtime.WaitForExitAsync(GracefulExitWait);
             } catch (TimeoutException ex) {
@@ -3131,7 +3138,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             if (SendInputBeforeWriteHookForTest is { } beforeWrite) await beforeWrite();
 
             if (agent.IsReapClaimed) {
-                LogSendInputReapClaimed(agentId);
+                LogSendInputReapClaimedLate(agentId);
                 return;
             }
 
@@ -4226,6 +4233,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "SendInput dropped: agent {AgentId} was already claimed by the reviewer reaper and is being stopped — the round's dispatch fails here and the server heals it on resubmit")]
     partial void LogSendInputReapClaimed(string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "SendInput dropped: agent {AgentId} was claimed by the reviewer reaper's unfenced absolute-lifetime path AFTER this delivery had already entered the section — the late re-read caught a healthy in-flight delivery racing a claim that landed mid-flight; the round's dispatch fails here and the server heals it on resubmit")]
+    partial void LogSendInputReapClaimedLate(string agentId);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Reap of review-flow reviewer {AgentId} ({Reason}) aborted at the claim: {Cause}")]
     partial void LogReapAborted(string agentId, string reason, string cause);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -177,20 +177,45 @@ internal record AgentInstance(
     /// decision — <see cref="AgentOrchestrator.FindReviewersToReap"/> reads a snapshot, and any recheck
     /// outside this section leaves a recheck-to-stop window.</para>
     ///
+    /// <para><b>Waiting on this gate must always be BOUNDED.</b> It is held across a delivery, and a
+    /// delivery can block for an unbounded time on a healthy-looking transport — the PTY path ends in
+    /// <c>UnixPtyProcess.WriteAsync</c>, a raw <c>write(2)</c> on the pty master with no timeout and no
+    /// cancellation, which parks forever if the child stops draining its stdin. An unbounded waiter
+    /// here would therefore be waiting on the very process that only the waiter's own action (terminate)
+    /// can unblock. See <see cref="AgentOrchestrator.TryClaimReapAsync"/>.</para>
+    ///
+    /// <para><b>Lock ordering.</b> This gate is OUTERMOST relative to
+    /// <see cref="AgentActivityClock"/>'s internal lock (holders read the clock while holding it) and
+    /// must NEVER be held across an acquisition of
+    /// <c>AgentOrchestrator._statusReportOrderingGate</c> — that gate is held across a whole hub send
+    /// and takes the clock itself, so a per-agent → ordering edge would put an unbounded network wait
+    /// underneath a per-agent lock, on top of the write(2) hazard above. The permitted edges are
+    /// per-agent → clock and ordering → clock, never per-agent → ordering.</para>
+    ///
     /// <para>Deliberately never disposed: a reap claim and a delivery can both be parked here while
     /// teardown runs, and an <see cref="ObjectDisposedException"/> on either would surface on a task
     /// nobody observes.</para></summary>
     public SemaphoreSlim BorrowedSnapshotGate { get; } = new(1, 1);
 
-    /// <summary>Set (once, inside <see cref="BorrowedSnapshotGate"/>) by the reaper that WON the claim
-    /// for this agent; read there by <see cref="AgentOrchestrator.HandleSendInput"/>, which refuses to
-    /// deliver to a condemned agent. Never reset: a claimed agent is on its way down, and
-    /// <see cref="AgentOrchestrator.StopAgentCoreAsync"/> flipping the status to "Completed" already
-    /// takes it out of the reap candidate set permanently, so the latch adds no new terminality — it
-    /// only makes the losing side of the race observable to the delivery path BEFORE the teardown has
-    /// physically closed the transport. The gate is the whole synchronization: no interlocked access
-    /// (or any access at all) outside it.</summary>
-    public bool ReapClaimed;
+    /// <summary>0/1 single-flight latch claimed by the reaper that WON this agent, via
+    /// <see cref="System.Threading.Interlocked.CompareExchange(ref int,int,int)"/> — the same shape as
+    /// <see cref="CleanupStarted"/>, and interlocked rather than gate-guarded ON PURPOSE: the absolute-
+    /// lifetime reap must be able to claim WITHOUT <see cref="BorrowedSnapshotGate"/> when a parked
+    /// delivery is holding it (see <see cref="AgentOrchestrator.TryClaimReapAsync"/>), so the two claim
+    /// paths cannot share a lock and must share a CAS instead.
+    ///
+    /// <para>Read via <see cref="IsReapClaimed"/> by <see cref="AgentOrchestrator.HandleSendInput"/>,
+    /// which refuses to deliver to a condemned agent. Never reset: a claimed agent is on its way down,
+    /// and <see cref="AgentOrchestrator.StopAgentCoreAsync"/> flipping the status to "Completed"
+    /// already takes it out of the reap candidate set permanently, so the latch adds no new
+    /// terminality — it only makes the losing side of the race observable to the delivery path BEFORE
+    /// teardown has physically closed the transport.</para></summary>
+    public int ReapClaimed;
+
+    /// <summary><see cref="ReapClaimed"/> as a bool, through a
+    /// <see cref="System.Threading.Volatile.Read(ref int)"/> — the un-gated absolute-lifetime claim
+    /// path writes it outside any lock, so a plain field read is not guaranteed to observe it.</summary>
+    public bool IsReapClaimed => Volatile.Read(ref ReapClaimed) != 0;
 
     /// <summary>Current PTY dimensions — the single source of truth for every dims send
     /// (registration, reconnect). Updated by every resize path (local clamp + web resize).
@@ -749,41 +774,36 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal IReadOnlyList<ReapCandidate> FindReviewersToReap() {
         var result = new List<ReapCandidate>();
 
+        // IsPrivate is excluded explicitly, matching the stuck-Starting sweep below rather than resting
+        // on the (true today, but unenforced) fact that a local `kcap agent start --private` can never
+        // carry LaunchKind.ReviewFlow. A private agent has no server-side row and no flow to heal, so
+        // a daemon-internal backstop must not act on one.
         foreach (var a in _agents.Values) {
-            if (a.Kind != LaunchKind.ReviewFlow || a.Status != "Running") continue;
+            if (a.Kind != LaunchKind.ReviewFlow || a.Status != "Running" || a.IsPrivate) continue;
 
-            var clock = a.ActivityClock;
-
-            // Captured BEFORE the threshold reads below, and that order is load-bearing rather than
-            // stylistic. The clock's properties are four independent lock acquisitions, so a delivery
-            // can land between any two of them; taking the generation FIRST makes every interleaving
-            // safe. A delivery landing after this read leaves seq > generation, so the claim aborts; a
-            // delivery landing before it is necessarily reflected in the idle/wedge reads that follow
-            // (Advance() resets the idle window under the same lock), so the candidate is not selected
-            // at all. Reading the generation LAST would leave the one unsafe window: an agent selected
-            // on a stale idle read whose post-read delivery is then baked into the "unchanged"
-            // generation the claim compares against.
-            var generation = clock.ActivitySeq;
+            // One snapshot, one lock acquisition: the seq the claim is later fenced on belongs to the
+            // same instant as the idle/age/turn fields the rule below decides from.
+            var clock = a.ActivityClock.Snapshot();
 
             if (_config.ReviewerMaxLifetime > TimeSpan.Zero && clock.AgeMs > (ulong) _config.ReviewerMaxLifetime.TotalMilliseconds) {
                 // The absolute cap is deliberately NOT activity-fenced: it fires regardless of how
                 // active the reviewer is (that is what "absolute" means here), so a delivery racing it
                 // must not abort it.
-                result.Add(new ReapCandidate(a, "reviewer_ttl_expired", generation, FencedOnActivity: false));
+                result.Add(new ReapCandidate(a, "reviewer_ttl_expired", clock.ActivitySeq, FencedOnActivity: false));
                 continue;
             }
 
             if (clock.TurnInFlight) {
                 if (_config.ReviewerTurnWedgeCeiling > TimeSpan.Zero
                  && clock.IdleForMs > (ulong) _config.ReviewerTurnWedgeCeiling.TotalMilliseconds) {
-                    result.Add(new ReapCandidate(a, "turn_wedged", generation, FencedOnActivity: true));
+                    result.Add(new ReapCandidate(a, "turn_wedged", clock.ActivitySeq, FencedOnActivity: true));
                 }
 
                 continue; // a held turn suppresses the plain idle rule outright
             }
 
             if (_config.ReviewerIdleTimeout > TimeSpan.Zero && clock.IdleForMs > (ulong) _config.ReviewerIdleTimeout.TotalMilliseconds)
-                result.Add(new ReapCandidate(a, "reviewer_idle_expired", generation, FencedOnActivity: true));
+                result.Add(new ReapCandidate(a, "reviewer_idle_expired", clock.ActivitySeq, FencedOnActivity: true));
         }
 
         return result;
@@ -1158,6 +1178,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// since a correlated reply is the exact variant whose content is captured under contention).
     /// A site that calls <c>_server.DaemonStatusReportAsync</c> directly bypasses the ordering and
     /// reintroduces the latch.</para>
+    ///
+    /// <para><b>Lock ordering.</b> This gate is held across a whole hub send and takes
+    /// <see cref="AgentActivityClock"/>'s lock underneath it (via <see cref="BuildStatusReport"/>), so
+    /// the permitted edge is ordering → clock. It must NEVER be acquired while a per-agent
+    /// <see cref="AgentInstance.BorrowedSnapshotGate"/> is held: that would put an unbounded network
+    /// wait under a per-agent lock whose other holder can be parked in an uncancellable pty write.
+    /// The delivery-triggered emission therefore offloads (see <see cref="HandleSendInput"/>) rather
+    /// than awaiting this gate inside the section.</para>
     ///
     /// <para>Deliberately never disposed: emissions are fire-and-forget, so a waiter parked here
     /// during teardown would surface an <see cref="ObjectDisposedException"/> on a task nobody
@@ -2604,6 +2632,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         if (outcome is SubmitOutcome.Refused) LogUnsequencedStopRefused(agentId);
     }
 
+    /// <summary>How long a reap claim waits for the per-agent delivery section before giving up on it.
+    /// Sized UNDER the 30s heartbeat period on purpose: a delivery parked longer than this leaves at
+    /// most one claim waiter alive per agent, instead of accumulating one per tick for as long as the
+    /// parked write lasts. Settable only so a test need not spend a real heartbeat proving the timeout
+    /// arms behave; production never changes it.</summary>
+    internal TimeSpan ReapClaimGateWait { get; set; } = TimeSpan.FromSeconds(20);
+
     /// <summary>Execute one selected reap: claim it under the per-agent fence, and stop the agent only
     /// if the claim was WON. Fire-and-forget from the heartbeat, so it contains its own faults —
     /// <see cref="StopAgentCoreAsync"/> already swallows the stop's, leaving only the gate wait.</summary>
@@ -2634,15 +2669,44 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <para>Scope, stated honestly: this fences the IDLE and WEDGE rules only. The absolute
     /// <see cref="DaemonConfig.ReviewerMaxLifetime"/> cap carries
     /// <see cref="ReapCandidate.FencedOnActivity"/> false and reaps regardless of activity, unchanged —
-    /// it still takes the section (so membership/incarnation are revalidated and a claim is never
-    /// double-counted), it just never aborts on a generation advance.</para></summary>
+    /// it takes the section when it can (so incarnation is revalidated the same way), but it is never
+    /// DEFERRABLE by it; see the timeout arm below.</para>
+    ///
+    /// <para><b>The gate wait is bounded, and that is a correctness requirement, not hygiene.</b> A
+    /// delivery holds the section across a raw <c>write(2)</c> to the pty master
+    /// (<c>UnixPtyProcess.WriteAsync</c>, no timeout, not cancellable), which parks indefinitely if the
+    /// child has stopped draining its stdin. An unbounded wait here is therefore a circular wait: the
+    /// reap that would SIGTERM/SIGKILL the child — the only thing that unblocks that write — would be
+    /// queued behind the write itself. Before this fence existed the reap was unconditional and broke
+    /// the cycle by construction; the two arms below restore that property deliberately.</para></summary>
     async Task<bool> TryClaimReapAsync(ReapCandidate candidate) {
         var agent = candidate.Agent;
+        bool entered;
 
         try {
-            await agent.BorrowedSnapshotGate.WaitAsync(_shutdownCts.Token);
+            entered = await agent.BorrowedSnapshotGate.WaitAsync(ReapClaimGateWait, _shutdownCts.Token);
         } catch (OperationCanceledException) {
             return false; // daemon teardown supersedes the reap — it kills the registered children itself
+        }
+
+        if (!entered) {
+            // The section is held by a delivery that is not finishing. The two rules answer this
+            // OPPOSITELY, and the asymmetry is the whole point:
+            //
+            //   FENCED (idle/wedge) — an in-progress delivery IS activity, so "nothing has happened"
+            //   is already false and there is nothing to reclaim. Give up; the next heartbeat re-selects
+            //   from a fresh snapshot. (The wait is sized under the heartbeat period so at most one
+            //   claim waiter per agent is alive at a time, rather than one accumulating per tick.)
+            //
+            //   UNFENCED (absolute lifetime) — must not be deferrable by ANY amount of traffic, least
+            //   of all by a delivery that may never complete. It claims lock-free and proceeds: the
+            //   terminate it is about to run is precisely what releases the parked write.
+            if (candidate.FencedOnActivity) {
+                LogReapAborted(candidate.Id, candidate.Reason, "delivery_in_progress");
+                return false;
+            }
+
+            return TryClaimUnfencedReapWithoutSection(candidate);
         }
 
         try {
@@ -2654,8 +2718,6 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 return false;
             }
 
-            if (agent.ReapClaimed) return false; // an earlier sweep already claimed it; single-flight
-
             // A stop from any other source (server, local socket) flips the status first; the reviewer
             // is already on its way down and must not be stopped twice.
             if (agent.Status != "Running") {
@@ -2663,33 +2725,85 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 return false;
             }
 
+            // One read for both the fence and the log below, so the age/idle an operator sees is the
+            // state the decision was actually made on rather than a re-sample taken after it.
+            var clock = agent.ActivityClock.Snapshot();
+
             // THE fence. The clock is monotonic, so any difference is an advance: something happened
             // to this agent after it was selected, which falsifies the idle/wedge claim outright. The
             // comparison is against the generation captured at selection — never a freshly re-derived
             // idle/threshold check, which would just re-run the same snapshot decision one moment later
             // and answer the same way.
-            var generation = agent.ActivityClock.ActivitySeq;
-
-            if (candidate.FencedOnActivity && generation != candidate.ActivityGeneration) {
-                LogReapAbortedOnActivity(candidate.Id, candidate.Reason, candidate.ActivityGeneration, generation);
+            if (candidate.FencedOnActivity && clock.ActivitySeq != candidate.ActivityGeneration) {
+                LogReapAbortedOnActivity(candidate.Id, candidate.Reason, candidate.ActivityGeneration, clock.ActivitySeq);
                 return false;
             }
 
-            agent.ReapClaimed      = true;
-            agent.PendingEndReason = candidate.Reason;
+            // Claimed LAST, after every validation: an aborted reap must leave the latch clear. The CAS
+            // (not a plain assignment) is what makes this single claim shared with the un-sectioned path
+            // above, which by definition cannot be holding this gate.
+            if (!TryLatchClaim(candidate)) return false;
 
             // Logged off the SAME clock the decision was made from — CreatedAt/LastOutputAt would
             // misreport an ACP reviewer's idle time as frozen since launch.
             _logger.LogInformation(
                 "Reaping review-flow reviewer {AgentId} ({Reason}); age {AgeHours:F1}h, idle {IdleHours:F1}h",
                 candidate.Id, candidate.Reason,
-                TimeSpan.FromMilliseconds(agent.ActivityClock.AgeMs).TotalHours,
-                TimeSpan.FromMilliseconds(agent.ActivityClock.IdleForMs).TotalHours);
+                TimeSpan.FromMilliseconds(clock.AgeMs).TotalHours,
+                TimeSpan.FromMilliseconds(clock.IdleForMs).TotalHours);
 
             return true;
         } finally {
             agent.BorrowedSnapshotGate.Release();
         }
+    }
+
+    /// <summary>The absolute-lifetime claim when <see cref="AgentInstance.BorrowedSnapshotGate"/> could
+    /// not be taken in time. Deliberately does everything the sectioned path does EXCEPT hold the
+    /// section and re-read the activity generation — this rule never aborts on activity, so the seq is
+    /// not evidence it needs, and the section is exactly what is unavailable. Incarnation is still
+    /// proven (a relaunch under the same id must not be killed on its predecessor's age) and the claim
+    /// is still single-flight, because both paths CAS the same latch.
+    ///
+    /// <para>It races a delivery by construction. That is the intended outcome, not a tolerated one:
+    /// the delivery is parked in an uncancellable write to a child that is not reading, and terminating
+    /// that child is what ends it. The write then fails, so nothing advances the clock and nothing is
+    /// reported — the round fails and the server heals it, exactly as for a delivery that loses the
+    /// ordinary sectioned race.</para></summary>
+    bool TryClaimUnfencedReapWithoutSection(ReapCandidate candidate) {
+        var agent = candidate.Agent;
+
+        if (!_agents.TryGetValue(candidate.Id, out var current) || !ReferenceEquals(current, agent)) {
+            LogReapAborted(candidate.Id, candidate.Reason, "agent_gone");
+            return false;
+        }
+
+        if (agent.Status != "Running") {
+            LogReapAborted(candidate.Id, candidate.Reason, "not_running");
+            return false;
+        }
+
+        if (!TryLatchClaim(candidate)) return false;
+
+        LogUnsectionedReapClaim(candidate.Id, candidate.Reason, ReapClaimGateWait.TotalSeconds);
+
+        return true;
+    }
+
+    /// <summary>The single-flight claim both paths share. 0→1 or nothing.</summary>
+    bool TryLatchClaim(ReapCandidate candidate) {
+        if (Interlocked.CompareExchange(ref candidate.Agent.ReapClaimed, 1, 0) != 0) {
+            // Debug, unlike its sibling aborts: losing this CAS is a benign internal collision (another
+            // sweep or the other claim path got there first and the agent IS being reaped), not an
+            // operational event — but it must not be silent either, or the one abort an operator cannot
+            // see is the one that fires when two paths disagree.
+            LogReapAlreadyClaimed(candidate.Id, candidate.Reason);
+            return false;
+        }
+
+        candidate.Agent.PendingEndReason = candidate.Reason;
+
+        return true;
     }
 
     /// <summary>The shared stop executor: graceful <c>/exit</c> then terminate (via
@@ -2920,7 +3034,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // terminated is what makes the round's dispatch fail promptly — the server heals it on
             // resubmit, whereas a write accepted by a dying PTY would leave the round waiting out its
             // whole bound on a corpse.
-            if (agent.ReapClaimed) {
+            if (agent.IsReapClaimed) {
                 LogSendInputReapClaimed(agentId);
                 return;
             }
@@ -2969,6 +3083,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // failure can never fail the delivery. The report snapshot is captured inside the
             // ordering section, i.e. strictly after the Advance() above, so this report can never
             // carry a pre-delivery seq.
+            //
+            // The offload is ALSO the lock-ordering invariant, not only a latency choice: awaiting the
+            // emission here would acquire _statusReportOrderingGate while this agent's
+            // BorrowedSnapshotGate is held, creating the one edge (per-agent → ordering) both gates'
+            // docs forbid — an unbounded hub send underneath a per-agent lock whose other holder can be
+            // parked in an uncancellable pty write. Reverting this to an awaited call reintroduces it.
             //
             // Task.Run, not a bare discard, because a discard is only asynchronous when it BLOCKS:
             // SemaphoreSlim.WaitAsync completes synchronously on an uncontended gate — the common
@@ -4028,6 +4148,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Reap of review-flow reviewer {AgentId} ({Reason}) aborted at the claim: activity advanced from generation {SelectedGeneration} to {CurrentGeneration} since it was selected")]
     partial void LogReapAbortedOnActivity(string agentId, string reason, ulong selectedGeneration, ulong currentGeneration);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Reap of review-flow reviewer {AgentId} ({Reason}) aborted at the claim: another claim got there first")]
+    partial void LogReapAlreadyClaimed(string agentId, string reason);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Reaping review-flow reviewer {AgentId} ({Reason}) without the per-agent delivery section: a delivery held it for more than {WaitSeconds:F0}s, and the absolute lifetime cap is not deferrable by an in-flight (possibly permanently parked) write")]
+    partial void LogUnsectionedReapClaim(string agentId, string reason, double waitSeconds);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Reaping review-flow reviewer {AgentId} ({Reason}) failed")]
     partial void LogReapFailed(Exception ex, string agentId, string reason);

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -241,7 +241,10 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         // mutation, so it invokes inline and returns a completed task.
         _hub.On<StopAgentV2>("StopAgentV2", cmd => SafeInvoke("StopAgentV2", () => OnStopAgentV2?.Invoke(cmd)));
         _hub.On<AckProcessedPrefix>("AckProcessedPrefix", ack => { OnAckProcessedPrefix?.Invoke(ack); return Task.CompletedTask; });
-        _hub.On("RequestStatusReport", () => SafeInvoke("RequestStatusReport", () => OnRequestStatusReport?.Invoke()));
+        // Offloaded via Task.Run, same as the delivery site's report in AgentOrchestrator.HandleSendInput:
+        // OnRequestStatusReport ends in the same gated SendDaemonStatusReportOnceAsync, and awaiting it
+        // inline here would park this receive loop behind another emission's whole hub send.
+        _hub.On("RequestStatusReport", () => { _ = Task.Run(() => SafeInvoke("RequestStatusReport", () => OnRequestStatusReport?.Invoke())); return Task.CompletedTask; });
 
         // Client-result invocations for per-phase eval dispatch.
         _hub.On<PrepareEvalCommand, PrepareResult>("PrepareEval",

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorFinalizerVerdictTests.cs
@@ -91,15 +91,20 @@ public partial class AgentOrchestratorVendorTests {
 
     /// <summary>Constructs an <see cref="AgentInstance"/> directly — <c>SeedAgentForTest</c> only
     /// builds PTY runtimes — wrapping the given ACP runtime, and registers it via
-    /// <c>RegisterAgentForTest</c> so it is reachable exactly like a real launch's registration.</summary>
+    /// <c>RegisterAgentForTest</c> so it is reachable exactly like a real launch's registration.
+    /// <paramref name="activityClock"/> mirrors <c>SeedAgentForTest</c>'s own optional clock override
+    /// — a test that needs a controllable (<see cref="Microsoft.Extensions.Time.Testing.FakeTimeProvider"/>-backed)
+    /// clock passes one; omitting it keeps every existing caller's real-time default.</summary>
     static AgentInstance SeedAcpAgent(
-            AgentOrchestrator orch, string agentId, IHostedAgentRuntime runtime, string status = "Running") {
+            AgentOrchestrator orch, string agentId, IHostedAgentRuntime runtime, string status = "Running",
+            AgentActivityClock? activityClock = null) {
         var agent = new AgentInstance(
             agentId, "review this", "default", null, "/repo", "cursor",
             runtime,
             new WorktreeInfo("/repo", "b", "/repo"),
             new CancellationTokenSource()) {
-            Status = status
+            Status = status,
+            ActivityClock = activityClock ?? new AgentActivityClock(TimeProvider.System)
         };
 
         orch.RegisterAgentForTest(agent);

--- a/test/Capacitor.Cli.Tests.Unit/AntigravityReviewerReapingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AntigravityReviewerReapingTests.cs
@@ -57,7 +57,7 @@ public partial class AgentOrchestratorVendorTests {
 
         // The REASON, not merely "it is in the list": at this elapsed time the TTL rule cannot fire,
         // so naming the idle rule pins that the plain idle path was reached at all.
-        await Assert.That(orch.FindReviewersToReap()).Contains(("agy-between-turns", "reviewer_idle_expired"));
+        await Assert.That(Verdicts(orch.FindReviewersToReap())).Contains(("agy-between-turns", "reviewer_idle_expired"));
     }
 
     /// <summary>
@@ -111,7 +111,7 @@ public partial class AgentOrchestratorVendorTests {
         var reap = orch.FindReviewersToReap();
 
         await Assert.That(reap.Select(r => r.Id)).DoesNotContain("agy-mid-turn");
-        await Assert.That(reap).Contains(("agy-settled", "reviewer_idle_expired"));
+        await Assert.That(Verdicts(reap)).Contains(("agy-settled", "reviewer_idle_expired"));
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerTtlTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/ReviewerTtlTests.cs
@@ -50,8 +50,8 @@ public partial class AgentOrchestratorVendorTests {
 
         var reap = orch.FindReviewersToReap();
 
-        await Assert.That(reap).Contains(("rev-old", "reviewer_ttl_expired"));
-        await Assert.That(reap).Contains(("rev-idle", "reviewer_idle_expired"));
+        await Assert.That(Verdicts(reap)).Contains(("rev-old", "reviewer_ttl_expired"));
+        await Assert.That(Verdicts(reap)).Contains(("rev-idle", "reviewer_idle_expired"));
         await Assert.That(reap.Select(r => r.Id)).DoesNotContain("interactive");
         await Assert.That(reap.Select(r => r.Id)).DoesNotContain("rev-fresh");
     }

--- a/test/Capacitor.Cli.Tests.Unit/DeliveryTriggeredStatusReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/DeliveryTriggeredStatusReportTests.cs
@@ -88,9 +88,17 @@ public partial class AgentOrchestratorVendorTests {
     /// <para>(ii) send-completion order equals snapshot-capture order — the report that captured
     /// seq 1 completes first, so the server never folds seq 1 after seq 2.</para>
     ///
-    /// Without the section this fails at BOTH: the delivery-triggered emission would capture seq 2 and
-    /// complete immediately past the parked seq-1 send, delivering the regression that permanently
-    /// latches the server's fold into <c>Regressed</c>.</summary>
+    /// <para>(iii) the snapshot is captured INSIDE the section, not before acquiring it. This is a
+    /// separate mutation from (i)/(ii) and it is genuinely unsound rather than untidy: two emissions
+    /// that build their reports outside the section can enqueue on the semaphore in the OPPOSITE order
+    /// to their capture order (<see cref="SemaphoreSlim"/> is only approximately FIFO), putting the
+    /// older content on the wire second. The probe below pins it by advancing the clock again while
+    /// the second emission is provably still parked on the gate — a capture taken before acquisition
+    /// cannot see that advance.</para>
+    ///
+    /// Without the section this fails at BOTH (i) and (ii): the delivery-triggered emission would
+    /// capture seq 2 and complete immediately past the parked seq-1 send, delivering the regression
+    /// that permanently latches the server's fold into <c>Regressed</c>.</summary>
     [Test]
     public async Task Report_content_is_monotone_in_send_completion_order() {
         var probe = new OrderingProbeServerConnection();
@@ -114,6 +122,14 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(probe.EnteredCount).IsEqualTo(1);
         await Assert.That(probe.CompletedInOrder.Count).IsEqualTo(0);
 
+        // (iii) the assertion above has just PROVEN the delivery-triggered emission is still parked on
+        // the gate, so this advance necessarily happens before it can capture. A snapshot taken inside
+        // the section therefore reads seq 3; one hoisted above the acquire froze at seq 2 back when the
+        // delivery fired. The 100ms settle above is what makes the mutant deterministic too — it gives
+        // a hoisted build ample time to have run before the clock moves.
+        agent.ActivityClock.Advance();
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(3UL);
+
         probe.ReleaseFirstSend();
         await slowPeriodic.WaitAsync(TimeSpan.FromSeconds(5));
         await PollUntilAsync(() => probe.CompletedInOrder.Count >= 2);
@@ -124,7 +140,7 @@ public partial class AgentOrchestratorVendorTests {
             .Select(r => r.LiveAgents.Single(a => a.Id == agent.Id).ActivitySeq)
             .ToList();
         await Assert.That(seqs[0]).IsEqualTo(1UL);
-        await Assert.That(seqs[1]).IsEqualTo(2UL);
+        await Assert.That(seqs[1]).IsEqualTo(3UL);
     }
 
     /// <summary>Contract pin for the "no correlation nonce" half of the design: the unsolicited

--- a/test/Capacitor.Cli.Tests.Unit/DeliveryTriggeredStatusReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/DeliveryTriggeredStatusReportTests.cs
@@ -143,6 +143,51 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(seqs[1]).IsEqualTo(3UL);
     }
 
+    /// <summary>Qodo (reliability): a stalled send must not hold <c>_statusReportOrderingGate</c> — and
+    /// every OTHER waiter behind it — forever. <see cref="AgentOrchestrator.StatusReportSendTimeout"/>
+    /// bounds the in-gate WAIT, not the send's invocation, so a parked first send times out, the gate
+    /// releases, and a second emission proceeds and reaches the wire — and the content-monotonicity
+    /// property from <see cref="Report_content_is_monotone_in_send_completion_order"/> still holds: the
+    /// abandoned send's INVOCATION already happened under the gate before the second one's, so it keeps
+    /// its place in wire (completion) order even though it finishes later.</summary>
+    [Test]
+    public async Task Timed_out_send_releases_the_gate_for_the_next_report() {
+        var probe = new OrderingProbeServerConnection();
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(probe, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.StatusReportSendTimeout = TimeSpan.FromMilliseconds(200);
+
+        var agent = orch.SeedAgentForTest("timeout-1", pty: new RecordingPtyProcess(), activityClock: clock);
+
+        // Parks inside the hub send, holding the gate past the (shortened) send timeout.
+        var stalled = orch.SendDaemonStatusReportOnceAsync();
+        await probe.FirstSendEntered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        clock.Advance(); // so the second emission's capture is distinguishable from the parked one's
+
+        // Bounded by the test's own 5s wait, not by StatusReportSendTimeout: if the gate stayed held
+        // for the never-releasing parked send, this would hang instead of completing.
+        await orch.SendDaemonStatusReportOnceAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        await PollUntilAsync(() => probe.CompletedInOrder.Count >= 1);
+        await Assert.That(probe.CompletedInOrder[0].LiveAgents.Single(a => a.Id == agent.Id).ActivitySeq)
+            .IsEqualTo(2UL); // the second emission's own capture, on the wire first
+
+        // The abandoned first send eventually completes once released — content-honest (still seq 1,
+        // captured before the release) even though it lands second.
+        probe.ReleaseFirstSend();
+        await stalled.WaitAsync(TimeSpan.FromSeconds(5));
+        await PollUntilAsync(() => probe.CompletedInOrder.Count >= 2);
+
+        var seqs = probe.CompletedInOrder
+            .Select(r => r.LiveAgents.Single(a => a.Id == agent.Id).ActivitySeq)
+            .ToList();
+        await Assert.That(seqs[0]).IsEqualTo(2UL);
+        await Assert.That(seqs[1]).IsEqualTo(1UL);
+    }
+
     /// <summary>Contract pin for the "no correlation nonce" half of the design: the unsolicited
     /// delivery-triggered report reuses the ONE report shape, and that shape carries no nonce/echo
     /// member at all — so it is structurally incapable of masquerading as the answer to a correlated

--- a/test/Capacitor.Cli.Tests.Unit/DeliveryTriggeredStatusReportTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/DeliveryTriggeredStatusReportTests.cs
@@ -1,0 +1,184 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Round-dispatch grace (server-side design doc
+/// docs/superpowers/specs/2026-08-10-ai1842-round-dispatch-grace-design.md in kcap-server), the two
+/// halves that sit on top of the delivered-input clock advance (see SendInputActivityClockTests.cs):
+///
+/// <para><b>(1) The immediate out-of-cycle report.</b> One <c>DaemonStatusReport</c> per successfully
+/// handled input invocation, so the server sees the fresh attestation at dispatch time instead of up
+/// to a full 60s report cadence later. The wire carries no round/dispatch identity
+/// (<see cref="SendInputCommand"/> is agent+text+attachments), so "per round" is not implementable
+/// and duplicates are tolerated by design. The report carries NO correlation nonce — it must never
+/// masquerade as an answer to a server-side correlated status request.</para>
+///
+/// <para><b>(2) The snapshot/send ordering section — load-bearing, not hygiene.</b> The server folds
+/// every flow-participant report and treats ANY activity-seq regression as permanent corruption: the
+/// fold latches <c>Regressed</c> and disables liveness supervision for that agent id forever. A report
+/// whose CONTENT was captured before a delivery advanced the clock but which is SENT after the
+/// delivery-triggered report would present seq N after seq N+1 and trip exactly that latch — silently
+/// disabling supervision, the opposite failure direction from the one this work exists to fix. So
+/// every emission captures its snapshot AND completes its hub send under one per-daemon ordering
+/// section, making captured content monotone in wire order (SignalR preserves per-connection send
+/// order).</para>
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Delivered_input_emits_exactly_one_report_carrying_the_advanced_seq_and_reset_idle() {
+        var server = new CaptureServerConnection();
+        var time   = new FakeTimeProvider();
+        var clock  = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var agent = orch.SeedAgentForTest("dispatch-report-1", pty: new RecordingPtyProcess(), activityClock: clock);
+
+        time.Advance(TimeSpan.FromSeconds(10));
+        await Assert.That(server.StatusReportCount).IsEqualTo(0); // nothing has emitted yet
+
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "hello", null));
+
+        await PollUntilAsync(() => server.StatusReportCount >= 1);
+        // Give a wrongly-duplicated emission a chance to land before pinning the count.
+        await Task.Delay(50);
+        await Assert.That(server.StatusReportCount).IsEqualTo(1);
+
+        // The whole point of emitting HERE rather than waiting for the next 60s tick: the report the
+        // server receives must already carry the post-delivery attestation. A snapshot captured before
+        // the advance would still read seq 1 / idle 10_000.
+        var entry = server.StatusReports[0].LiveAgents.Single(a => a.Id == agent.Id);
+        await Assert.That(entry.ActivitySeq).IsEqualTo(2UL);
+        await Assert.That(entry.IdleForMs).IsEqualTo(0UL);
+    }
+
+    /// <summary>The emission is gated on the SAME delivery success the clock advance is gated on: a
+    /// failed write advances nothing, so there is no new attestation to announce and announcing the
+    /// old one out of cycle would be pure noise (and, worse, a "the daemon is talking about this
+    /// agent" signal for an agent whose write just failed).</summary>
+    [Test]
+    public async Task Failed_delivery_emits_no_report() {
+        var server = new CaptureServerConnection();
+        var time   = new FakeTimeProvider();
+        var clock  = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var agent = orch.SeedAgentForTest("dispatch-report-fail", pty: new AlwaysThrowsPtyProcess(), activityClock: clock);
+
+        time.Advance(TimeSpan.FromSeconds(10));
+
+        await Assert.ThrowsAsync<IOException>(
+            async () => await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "hello", null)));
+
+        // The emission is fire-and-forget, so a wrongly-placed one would land shortly AFTER the throw
+        // propagates — wait before asserting absence rather than reading the count immediately.
+        await Task.Delay(100);
+        await Assert.That(server.StatusReportCount).IsEqualTo(0);
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(1UL);
+    }
+
+    /// <summary>The ordering section, proven at its two load-bearing properties:
+    ///
+    /// <para>(i) it is held THROUGH the hub send, not merely through task creation — while a parked
+    /// send holds it, a second emission cannot even reach the send (let alone capture a snapshot);</para>
+    ///
+    /// <para>(ii) send-completion order equals snapshot-capture order — the report that captured
+    /// seq 1 completes first, so the server never folds seq 1 after seq 2.</para>
+    ///
+    /// Without the section this fails at BOTH: the delivery-triggered emission would capture seq 2 and
+    /// complete immediately past the parked seq-1 send, delivering the regression that permanently
+    /// latches the server's fold into <c>Regressed</c>.</summary>
+    [Test]
+    public async Task Report_content_is_monotone_in_send_completion_order() {
+        var probe = new OrderingProbeServerConnection();
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(probe, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var agent = orch.SeedAgentForTest("ordering-1", pty: new RecordingPtyProcess(), activityClock: clock);
+
+        // The "slow periodic" emission: it captures the pre-delivery snapshot (seq 1) and then parks
+        // INSIDE the hub send, exactly the window where a send that ignored the section could overtake it.
+        var slowPeriodic = orch.SendDaemonStatusReportOnceAsync();
+        await probe.FirstSendEntered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // The delivery advances the clock to seq 2 and fires its own emission while that send is parked.
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "hello", null));
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(2UL);
+
+        // (i) held through the send: the parked call is still the ONLY one to have reached the wire.
+        await Task.Delay(100);
+        await Assert.That(probe.EnteredCount).IsEqualTo(1);
+        await Assert.That(probe.CompletedInOrder.Count).IsEqualTo(0);
+
+        probe.ReleaseFirstSend();
+        await slowPeriodic.WaitAsync(TimeSpan.FromSeconds(5));
+        await PollUntilAsync(() => probe.CompletedInOrder.Count >= 2);
+        await Assert.That(probe.CompletedInOrder.Count).IsEqualTo(2);
+
+        // (ii) completion (= wire) order carries non-decreasing content.
+        var seqs = probe.CompletedInOrder
+            .Select(r => r.LiveAgents.Single(a => a.Id == agent.Id).ActivitySeq)
+            .ToList();
+        await Assert.That(seqs[0]).IsEqualTo(1UL);
+        await Assert.That(seqs[1]).IsEqualTo(2UL);
+    }
+
+    /// <summary>Contract pin for the "no correlation nonce" half of the design: the unsolicited
+    /// delivery-triggered report reuses the ONE report shape, and that shape carries no nonce/echo
+    /// member at all — so it is structurally incapable of masquerading as the answer to a correlated
+    /// server-side status request. Should a correlated request/echo ever be added to this DTO, this
+    /// test fails and forces the unsolicited emission to be re-examined (it must leave the field
+    /// unset) rather than silently inheriting it.</summary>
+    [Test]
+    public async Task The_report_shape_carries_no_correlation_nonce() {
+        var reportMembers = typeof(DaemonStatusReport).GetProperties().Select(p => p.Name);
+        var agentMembers  = typeof(LiveAgentInfo).GetProperties().Select(p => p.Name);
+
+        foreach (var name in reportMembers.Concat(agentMembers)) {
+            await Assert.That(name.Contains("nonce", StringComparison.OrdinalIgnoreCase)).IsFalse();
+            await Assert.That(name.Contains("echo", StringComparison.OrdinalIgnoreCase)).IsFalse();
+        }
+    }
+
+    /// <summary><see cref="ServerConnection"/> double that can PARK its first
+    /// <see cref="ServerConnection.DaemonStatusReportAsync"/> call inside the send and records reports
+    /// in COMPLETION order (not entry order) — completion order is what "wire order" means for the
+    /// ordering section, and recording at entry would make a section-less implementation look correct.
+    /// </summary>
+    sealed class OrderingProbeServerConnection() : ServerConnection(
+        new() { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+        NullLoggerFactory.Instance,
+        NullLogger<ServerConnection>.Instance
+    ) {
+        readonly Lock                     _gate      = new();
+        readonly List<DaemonStatusReport> _completed = [];
+        readonly TaskCompletionSource     _entered   = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        readonly TaskCompletionSource     _release   = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int                               _enteredCount;
+
+        /// <summary>Completes the instant the first send is entered — the test drives its concurrent
+        /// emission from exactly that window rather than from a timing guess.</summary>
+        public Task FirstSendEntered => _entered.Task;
+
+        public int EnteredCount => Volatile.Read(ref _enteredCount);
+
+        public IReadOnlyList<DaemonStatusReport> CompletedInOrder {
+            get { lock (_gate) return [.. _completed]; }
+        }
+
+        public void ReleaseFirstSend() => _release.TrySetResult();
+
+        public override async Task DaemonStatusReportAsync(DaemonStatusReport report) {
+            if (Interlocked.Increment(ref _enteredCount) == 1) {
+                _entered.TrySetResult();
+                await _release.Task;
+            }
+
+            lock (_gate) _completed.Add(report);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ReviewerReapingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReviewerReapingTests.cs
@@ -483,6 +483,11 @@ public partial class AgentOrchestratorVendorTests {
     /// write, must therefore never queue behind it without a bound: before the fence existed the reap
     /// was unconditional and broke the cycle by construction.</para>
     ///
+    /// <para>This test controls only the CLAIM's half of that: its double lets the stop path's own
+    /// "/exit" write through, so it says nothing about whether the reap's terminate is reachable once
+    /// claimed. That second half is
+    /// <see cref="Parked_exit_write_does_not_stall_the_reaps_terminate"/>.</para>
+    ///
     /// <para>Both agents below have a delivery parked in exactly that state, and answer OPPOSITELY.
     /// The absolute lifetime cap claims without the section and completes the stop (a rule that a
     /// permanently parked write could defer is not absolute). The idle rule gives up and waits for the
@@ -558,13 +563,150 @@ public partial class AgentOrchestratorVendorTests {
         await idleDelivery.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
+    /// <summary>The other half of the deadlock, one step further down: reaching the claim is not enough
+    /// if the STOP then parks. <c>StopAgentCoreAsync</c> asks for a graceful "/exit" first, and for a
+    /// PTY that is a write to the SAME master fd the round was written to — so against a child that has
+    /// stopped draining stdin it parks exactly like the delivery did, and an unbounded await there means
+    /// <c>TerminateAsync</c> is never reached and the wedge is never broken.
+    ///
+    /// <para>Here EVERY write parks (<see cref="ParkingPtyProcess.ParkEveryWrite"/>), which is what a
+    /// non-draining child actually does — the earlier arms let "/exit" through and so could not see
+    /// this. The reap must still run to completion: claim without the section, time out the graceful
+    /// send, terminate.</para>
+    ///
+    /// <para>Mutation anchor: dropping the <c>WaitAsync(GracefulExitWait)</c> around
+    /// <c>RequestGracefulStopAsync()</c> hangs this test at the stop, while the other claim tests —
+    /// whose stop-path writes pass straight through — all still pass.</para></summary>
+    [Test]
+    public async Task Parked_exit_write_does_not_stall_the_reaps_terminate() {
+        var server = new CaptureServerConnection();
+        var time   = new FakeTimeProvider();
+        var clock  = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.ReapClaimGateWait = TimeSpan.FromMilliseconds(200);
+        orch.GracefulExitWait  = TimeSpan.FromMilliseconds(200); // the real 15s, shortened for the test
+
+        var pty = new ParkingPtyProcess { ParkEveryWrite = true };
+        var agent = orch.SeedAgentForTest("parked-exit", LaunchKind.ReviewFlow, status: "Running",
+            pty: pty, activityClock: clock);
+
+        time.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1));
+
+        var candidate = orch.FindReviewersToReap().Single(c => c.Id == "parked-exit");
+        await Assert.That(candidate.Reason).IsEqualTo("reviewer_ttl_expired");
+
+        var delivery = orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "round 7", null));
+        await pty.FirstWriteEntered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Claim (no section) → graceful "/exit" (parks, bounded) → terminate. Unbounded anywhere on
+        // that path and this never returns.
+        await orch.ReapReviewerForTest(candidate).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(agent.IsReapClaimed).IsTrue();
+        await Assert.That(pty.TerminateCount).IsGreaterThanOrEqualTo(1); // the wedge-breaking step ran
+        await Assert.That(server.StatusChangedCalls).Contains(("parked-exit", "Completed"));
+
+        pty.ReleaseFirstWrite();
+        await delivery.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>The un-sectioned claim does not only race WEDGED deliveries — and this is the case that
+    /// makes the pre-write re-read of the claim latch load-bearing rather than defensive.
+    ///
+    /// <para>A borrowed delivery legitimately spends up to <c>BorrowedSnapshotRefreshTimeout</c> (30s)
+    /// inside the section refreshing its snapshot, which is LONGER than the claim's gate wait. So the
+    /// absolute-lifetime claim fires against a perfectly healthy in-flight delivery with nothing parked
+    /// anywhere. Checking the latch only on entry to the section would let that delivery finish into an
+    /// agent already condemned: write the round, advance the activity clock, emit a delivered-input
+    /// report — precisely what the refusal exists to prevent, and worse than the wedged case because
+    /// nothing fails to make it visible.</para>
+    ///
+    /// <para>The window is entered through <c>SendInputBeforeWriteHookForTest</c> rather than by
+    /// parking the refresh itself. That is not a shortcut — an earlier revision of this test DID park
+    /// a borrowed refresh, and it passed with the re-read deleted: without a real borrowed checkout the
+    /// refresh's own authorisation fails on release, so <c>HandleSendInput</c> returned at the
+    /// refresh's error path and never reached the write it was supposed to be proving something about.
+    /// The seam enters the genuine window instead of a vacuous one.</para>
+    ///
+    /// <para>Mutation anchor: removing the pre-write re-read (keeping only the entry check) fails on
+    /// all three of the write, the seq and the report below.</para></summary>
+    [Test]
+    public async Task Healthy_in_section_delivery_refuses_after_a_claim_lands_mid_flight() {
+        var server = new CaptureServerConnection();
+        var time   = new FakeTimeProvider();
+        var clock  = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.ReapClaimGateWait = TimeSpan.FromMilliseconds(200);
+
+        var pty   = new RecordingPtyProcess();
+        var agent = orch.SeedAgentForTest("healthy-in-flight", LaunchKind.ReviewFlow, status: "Running",
+            pty: pty, activityClock: clock);
+
+        time.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1));
+
+        var candidate = orch.FindReviewersToReap().Single(c => c.Id == "healthy-in-flight");
+        await Assert.That(candidate.Reason).IsEqualTo("reviewer_ttl_expired");
+        await Assert.That(candidate.FencedOnActivity).IsFalse();
+
+        var seqBeforeDelivery = agent.ActivityClock.ActivitySeq;
+        var reportsBefore     = server.StatusReportCount;
+        var claimed           = false;
+
+        // Stand in for the slow pre-write work (a 30s-budgeted borrowed refresh): while the delivery
+        // holds the section here, the reaper's claim times out on the gate and — being unfenced —
+        // claims anyway. The delivery then resumes, inside a section the claim never took.
+        orch.SendInputBeforeWriteHookForTest = async () => {
+            orch.SendInputBeforeWriteHookForTest = null; // once
+            claimed = await orch.TryClaimReapForTest(candidate);
+        };
+
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "round 7", null))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(claimed).IsTrue();          // the claim really did land mid-delivery
+        await Assert.That(agent.IsReapClaimed).IsTrue();
+
+        await Assert.That(pty.Writes).IsEmpty();      // nothing written to the condemned agent
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(seqBeforeDelivery); // nothing advanced
+        await Task.Delay(100);                        // a wrongly-emitted report would land late
+        await Assert.That(server.StatusReportCount).IsEqualTo(reportsBefore);            // nothing announced
+    }
+
+    /// <summary>The sizing relation the claim wait's "at most one waiter per agent" property rests on,
+    /// asserted rather than left to a comment: a later change to either constant that inverts them
+    /// would silently let a parked delivery accumulate one abandoned claim waiter per heartbeat tick.
+    /// </summary>
+    [Test]
+    public async Task Reap_claim_gate_wait_stays_under_the_heartbeat_interval() {
+        await using var orch = BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        await Assert.That(orch.ReapClaimGateWait).IsLessThan(AgentOrchestrator.HeartbeatInterval);
+    }
+
     /// <summary>PTY double that PARKS inside its first write, holding whatever section its caller is in
     /// until the test releases it. Later writes (the submit CR, and anything the stop path sends) pass
-    /// straight through, so only the one window under test is controlled.</summary>
+    /// straight through by default, so only the one window under test is controlled.
+    ///
+    /// <para><see cref="ParkEveryWrite"/> models the harsher and more realistic wedge: a child that has
+    /// stopped draining its stdin parks EVERY write to the master fd, including the stop path's
+    /// "/exit". That is the state in which the graceful-stop send has to be bounded for the terminate
+    /// to be reachable at all.</para></summary>
     sealed class ParkingPtyProcess : IPtyProcess {
         readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
         readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
         int                           _writes;
+
+        /// <summary>When set, every write parks on the same release — not just the first. Models a
+        /// child that stopped reading its stdin entirely, so "/exit" parks exactly like the round did.
+        /// </summary>
+        public bool ParkEveryWrite { get; init; }
 
         /// <summary>Completes the instant the first write is entered — the test drives the racing reap
         /// from exactly that window rather than from a timing guess.</summary>
@@ -576,9 +718,20 @@ public partial class AgentOrchestratorVendorTests {
         public bool HasExited => false;
         public int? ExitCode  => null;
 
+        int _terminates;
+
+        /// <summary>How many times the stop path reached terminate — the step that, on a real pty,
+        /// SIGKILLs the child and so releases every parked write.</summary>
+        public int TerminateCount => Volatile.Read(ref _terminates);
+
         public ValueTask DisposeAsync() => default;
         public Task WaitForExitAsync(TimeSpan? _) => Task.CompletedTask;
-        public Task TerminateAsync(TimeSpan?   _) => Task.CompletedTask;
+
+        public Task TerminateAsync(TimeSpan? _) {
+            Interlocked.Increment(ref _terminates);
+
+            return Task.CompletedTask;
+        }
 
 #pragma warning disable CS1998
         public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken _ = default) {
@@ -587,7 +740,7 @@ public partial class AgentOrchestratorVendorTests {
 #pragma warning restore CS1998
 
         public async Task WriteAsync(string _) {
-            if (Interlocked.Increment(ref _writes) != 1) return;
+            if (Interlocked.Increment(ref _writes) != 1 && !ParkEveryWrite) return;
 
             _entered.TrySetResult();
             await _release.Task;

--- a/test/Capacitor.Cli.Tests.Unit/ReviewerReapingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReviewerReapingTests.cs
@@ -346,7 +346,7 @@ public partial class AgentOrchestratorVendorTests {
 
         await orch.ReapReviewerForTest(candidate);
 
-        await Assert.That(agent.ReapClaimed).IsFalse();
+        await Assert.That(agent.IsReapClaimed).IsFalse();
         await Assert.That(agent.Status).IsEqualTo("Running");
         // The end-reason stamp belongs to a WON claim: an aborted reap must not leave a reap reason on
         // a live agent for whatever ends it later to report.
@@ -405,7 +405,7 @@ public partial class AgentOrchestratorVendorTests {
 
         await Assert.That(delivered.ActivityClock.ActivitySeq)
             .IsEqualTo(deliveryCandidate.ActivityGeneration + 1); // the delivery landed
-        await Assert.That(delivered.ReapClaimed).IsFalse();       // ...so the reap lost
+        await Assert.That(delivered.IsReapClaimed).IsFalse();     // ...so the reap lost
         await Assert.That(delivered.Status).IsEqualTo("Running");
         await Assert.That(server.StatusChangedCalls).DoesNotContain(("race-delivery-wins", "Completed"));
 
@@ -428,7 +428,7 @@ public partial class AgentOrchestratorVendorTests {
 
         // The claim alone — the teardown it gates is not what this arm is about.
         await Assert.That(await orch.TryClaimReapForTest(reapCandidate)).IsTrue();
-        await Assert.That(condemned.ReapClaimed).IsTrue();
+        await Assert.That(condemned.IsReapClaimed).IsTrue();
 
         var seqAtClaim   = condemned.ActivityClock.ActivitySeq;
         var reportsAtClaim = server.StatusReportCount;
@@ -470,9 +470,92 @@ public partial class AgentOrchestratorVendorTests {
 
         await orch.ReapReviewerForTest(candidate);
 
-        await Assert.That(agent.ReapClaimed).IsTrue();
+        await Assert.That(agent.IsReapClaimed).IsTrue();
         await Assert.That(agent.PendingEndReason).IsEqualTo("reviewer_ttl_expired");
         await Assert.That(server.StatusChangedCalls).Contains(("ttl-reap", "Completed"));
+    }
+
+    /// <summary>The circular wait the fence would otherwise introduce, and the asymmetry that breaks it.
+    ///
+    /// <para>A delivery holds the per-agent section across <c>UnixPtyProcess.WriteAsync</c> — a raw
+    /// <c>write(2)</c> to the pty master with no timeout and no cancellation, which parks indefinitely
+    /// if the child stops draining its stdin. The reap that would terminate that child, releasing the
+    /// write, must therefore never queue behind it without a bound: before the fence existed the reap
+    /// was unconditional and broke the cycle by construction.</para>
+    ///
+    /// <para>Both agents below have a delivery parked in exactly that state, and answer OPPOSITELY.
+    /// The absolute lifetime cap claims without the section and completes the stop (a rule that a
+    /// permanently parked write could defer is not absolute). The idle rule gives up and waits for the
+    /// next heartbeat — an in-progress delivery IS activity, so there is nothing for it to reclaim.</para>
+    ///
+    /// <para>Mutation anchor: an unbounded <c>WaitAsync</c> in <c>TryClaimReapAsync</c> hangs the TTL
+    /// arm forever (the bound below fails it), while every other claim test still passes.</para></summary>
+    [Test]
+    public async Task Parked_delivery_does_not_defer_the_absolute_lifetime_reap() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        // Shortened only so the test need not spend a real 20s proving the timeout arms; production
+        // sizes this under the 30s heartbeat.
+        orch.ReapClaimGateWait = TimeSpan.FromMilliseconds(200);
+
+        // ── the absolute cap: claims anyway ─────────────────────────────────────────────────
+        var ttlTime  = new FakeTimeProvider();
+        var ttlClock = new AgentActivityClock(ttlTime);
+        var ttlPty   = new ParkingPtyProcess();
+
+        var expired = orch.SeedAgentForTest("parked-ttl", LaunchKind.ReviewFlow, status: "Running",
+            pty: ttlPty, activityClock: ttlClock);
+
+        ttlTime.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1));
+
+        var ttlCandidate = orch.FindReviewersToReap().Single(c => c.Id == "parked-ttl");
+        await Assert.That(ttlCandidate.Reason).IsEqualTo("reviewer_ttl_expired");
+        await Assert.That(ttlCandidate.FencedOnActivity).IsFalse();
+
+        var ttlDelivery = orch.HandleSendInputForTest(new SendInputCommand(expired.Id, "round 7", null));
+        await ttlPty.FirstWriteEntered.WaitAsync(TimeSpan.FromSeconds(5)); // parked, holding the section
+
+        // THE regression bound. With an unbounded gate wait this never returns: the write is only
+        // released by the terminate this very call is trying to reach.
+        await orch.ReapReviewerForTest(ttlCandidate).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(expired.IsReapClaimed).IsTrue();
+        await Assert.That(expired.PendingEndReason).IsEqualTo("reviewer_ttl_expired");
+        await Assert.That(server.StatusChangedCalls).Contains(("parked-ttl", "Completed"));
+
+        // ── the idle rule under an IDENTICALLY parked delivery: defers ──────────────────────
+        var idleTime  = new FakeTimeProvider();
+        var idleClock = new AgentActivityClock(idleTime);
+        var idlePty   = new ParkingPtyProcess();
+
+        var idle = orch.SeedAgentForTest("parked-idle", LaunchKind.ReviewFlow, status: "Running",
+            pty: idlePty, activityClock: idleClock);
+
+        idleTime.Advance(TimeSpan.FromHours(2) + TimeSpan.FromMinutes(1)); // past 2h idle, under the 6h cap
+
+        var idleCandidate = orch.FindReviewersToReap().Single(c => c.Id == "parked-idle");
+        await Assert.That(idleCandidate.Reason).IsEqualTo("reviewer_idle_expired");
+        await Assert.That(idleCandidate.FencedOnActivity).IsTrue();
+
+        var idleDelivery = orch.HandleSendInputForTest(new SendInputCommand(idle.Id, "round 2", null));
+        await idlePty.FirstWriteEntered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Bounded the same way — it gives up on the section rather than waiting on the parked write.
+        await orch.ReapReviewerForTest(idleCandidate).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(idle.IsReapClaimed).IsFalse();
+        await Assert.That(idle.Status).IsEqualTo("Running");
+        await Assert.That(idle.PendingEndReason).IsEqualTo("agent_exited");
+        await Assert.That(server.StatusChangedCalls).DoesNotContain(("parked-idle", "Completed"));
+
+        // Release both so the abandoned deliveries do not outlive the test.
+        ttlPty.ReleaseFirstWrite();
+        idlePty.ReleaseFirstWrite();
+        await ttlDelivery.WaitAsync(TimeSpan.FromSeconds(5));
+        await idleDelivery.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     /// <summary>PTY double that PARKS inside its first write, holding whatever section its caller is in

--- a/test/Capacitor.Cli.Tests.Unit/ReviewerReapingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReviewerReapingTests.cs
@@ -1,4 +1,6 @@
+using System.Runtime.CompilerServices;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Pty;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Time.Testing;
 
@@ -23,6 +25,14 @@ namespace Capacitor.Cli.Tests.Unit;
 /// same pattern as <c>ReviewerTtlTests.cs</c>/<c>OneExecutionDomainTests.cs</c>.
 /// </summary>
 public partial class AgentOrchestratorVendorTests {
+    /// <summary>(id, reason) projection of a selection. The decision-table tests below assert on the
+    /// RULE that fired; the rest of <see cref="AgentOrchestrator.ReapCandidate"/> is claim evidence
+    /// (the captured activity generation and whether the rule is activity-fenced), which the claim
+    /// tests at the bottom of this file pin instead.</summary>
+    static IEnumerable<(string Id, string Reason)> Verdicts(
+            IEnumerable<AgentOrchestrator.ReapCandidate> selection) =>
+        selection.Select(c => (c.Id, c.Reason));
+
     /// <summary>
     /// THE regression this fix exists for: a reviewer that has finished round 1 and is waiting while
     /// the driver spends half an hour addressing its findings emits nothing, so <c>IdleForMs</c>
@@ -78,8 +88,8 @@ public partial class AgentOrchestratorVendorTests {
 
         var reap = orch.FindReviewersToReap();
 
-        await Assert.That(reap).Contains(("bound-active-old", "reviewer_ttl_expired"));
-        await Assert.That(reap).Contains(("bound-idle-young", "reviewer_idle_expired"));
+        await Assert.That(Verdicts(reap)).Contains(("bound-active-old", "reviewer_ttl_expired"));
+        await Assert.That(Verdicts(reap)).Contains(("bound-idle-young", "reviewer_idle_expired"));
     }
 
     /// <summary>A held turn suppresses the plain idle rule outright — idle 5m with <c>TurnInFlight</c>
@@ -121,7 +131,7 @@ public partial class AgentOrchestratorVendorTests {
 
         var reap = orch.FindReviewersToReap();
 
-        await Assert.That(reap).Contains(("wedged", "turn_wedged"));
+        await Assert.That(Verdicts(reap)).Contains(("wedged", "turn_wedged"));
     }
 
     /// <summary>Positive control for the wedge rule: an envelope arriving mid-turn (a genuine seq
@@ -171,8 +181,8 @@ public partial class AgentOrchestratorVendorTests {
 
         var reap = orch.FindReviewersToReap();
 
-        await Assert.That(reap).Contains(("active-old", "reviewer_ttl_expired"));
-        await Assert.That(reap).Contains(("idle-young", "reviewer_idle_expired"));
+        await Assert.That(Verdicts(reap)).Contains(("active-old", "reviewer_ttl_expired"));
+        await Assert.That(Verdicts(reap)).Contains(("idle-young", "reviewer_idle_expired"));
     }
 
     /// <summary>
@@ -233,7 +243,7 @@ public partial class AgentOrchestratorVendorTests {
         var reap = orch.FindReviewersToReap();
 
         await Assert.That(reap.Select(r => r.Id)).DoesNotContain("interactive-extreme");
-        await Assert.That(reap).Contains(("reviewer-extreme", "reviewer_ttl_expired"));
+        await Assert.That(Verdicts(reap)).Contains(("reviewer-extreme", "reviewer_ttl_expired"));
     }
 
     /// <summary>End-to-end launch-path proof (as opposed to every test above, which injects the field
@@ -288,5 +298,221 @@ public partial class AgentOrchestratorVendorTests {
         orch.ClockUtc = () => DateTime.UtcNow.AddYears(10);
 
         await Assert.That(orch.FindReviewersToReap().Select(r => r.Id)).DoesNotContain("healthy");
+    }
+
+    // ── The atomic reap claim (round-dispatch grace §3) ──────────────────────────────────────
+    //
+    // Everything above judges SELECTION. These judge the CLAIM, which is the actual decision:
+    // FindReviewersToReap reads a snapshot and the teardown happens later, so a reviewer that
+    // receives a round in between must survive. The fence is the per-agent BorrowedSnapshotGate —
+    // already held across every vendor's whole delivery body — so the delivery's clock advance and
+    // the reaper's claim are mutually exclusive and exactly one side wins.
+    //
+    // Bounds are load-bearing in all three: idle past ReviewerIdleTimeout (2h) with age under
+    // ReviewerMaxLifetime (6h), i.e. the daemon's OWN backstops. The server's round bound is not a
+    // rule here at all (see the top of this file), so no test may lean on it.
+
+    /// <summary>The stale-selection case, in its natural order: the sweep selects an idle-expired
+    /// reviewer, THEN the driver's next round is delivered, THEN the pending reap runs. The reap must
+    /// abort — the "nothing has happened for 2h" claim it was selected on is now false.
+    ///
+    /// <para>Mutation anchor: dropping the generation re-validation from <c>TryClaimReapAsync</c>
+    /// fails exactly here (the reviewer is stopped seconds after being handed round 2), while every
+    /// selection test above still passes — selection is not what changed.</para></summary>
+    [Test]
+    public async Task Stale_reap_selection_aborts_after_delivery() {
+        var server = new CaptureServerConnection();
+        var time   = new FakeTimeProvider();
+        var clock  = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        // defaults: 6h lifetime / 2h idle / 60m wedge ceiling
+
+        var agent = orch.SeedAgentForTest("stale-reap", LaunchKind.ReviewFlow, status: "Running",
+            pty: new RecordingPtyProcess(), activityClock: clock);
+
+        time.Advance(TimeSpan.FromHours(2) + TimeSpan.FromMinutes(1)); // past 2h idle, far under 6h TTL
+
+        var candidate = orch.FindReviewersToReap().Single(c => c.Id == "stale-reap");
+        // WHICH rule selected it, not merely that it was selected: only an activity-fenced rule may
+        // abort, so a test that accidentally selected on the TTL would prove the opposite of the point.
+        await Assert.That(candidate.Reason).IsEqualTo("reviewer_idle_expired");
+        await Assert.That(candidate.FencedOnActivity).IsTrue();
+
+        // ...and now round 2 lands, between selection and teardown.
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "round 2", null));
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(candidate.ActivityGeneration + 1);
+
+        await orch.ReapReviewerForTest(candidate);
+
+        await Assert.That(agent.ReapClaimed).IsFalse();
+        await Assert.That(agent.Status).IsEqualTo("Running");
+        // The end-reason stamp belongs to a WON claim: an aborted reap must not leave a reap reason on
+        // a live agent for whatever ends it later to report.
+        await Assert.That(agent.PendingEndReason).IsEqualTo("agent_exited");
+        await Assert.That(server.StatusChangedCalls).DoesNotContain(("stale-reap", "Completed"));
+    }
+
+    /// <summary>Contention AT the claim boundary — both orders, on two agents whose situations are
+    /// otherwise identical, so neither outcome can come from anything but who reached the section
+    /// first.
+    ///
+    /// <para><b>Delivery first:</b> the delivery is parked mid-write while holding the section. The
+    /// reap cannot even begin to validate until the delivery releases it (asserted directly: the reap
+    /// task is still incomplete while the write is parked — that is the mutual exclusion), and by then
+    /// the clock has advanced, so it aborts.</para>
+    ///
+    /// <para><b>Reap first:</b> the claim wins the section, and the delivery that follows refuses —
+    /// nothing is written to the runtime, the clock does not advance, and no out-of-cycle report is
+    /// emitted for it. The round's dispatch fails there, which is the intended loss: the server heals
+    /// it on resubmit, whereas a delivery quietly "succeeding" into an agent already being torn down
+    /// would leave the round waiting on a corpse.</para></summary>
+    [Test]
+    public async Task Reap_claim_contention_has_exactly_one_winner() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        // ── delivery first ──────────────────────────────────────────────────────────────────
+        var deliveryTime  = new FakeTimeProvider();
+        var deliveryClock = new AgentActivityClock(deliveryTime);
+        var parking       = new ParkingPtyProcess();
+
+        var delivered = orch.SeedAgentForTest("race-delivery-wins", LaunchKind.ReviewFlow, status: "Running",
+            pty: parking, activityClock: deliveryClock);
+
+        deliveryTime.Advance(TimeSpan.FromHours(2) + TimeSpan.FromMinutes(1));
+
+        var deliveryCandidate = orch.FindReviewersToReap().Single(c => c.Id == "race-delivery-wins");
+        await Assert.That(deliveryCandidate.Reason).IsEqualTo("reviewer_idle_expired");
+
+        var delivery = orch.HandleSendInputForTest(new SendInputCommand(delivered.Id, "round 2", null));
+        await parking.FirstWriteEntered.WaitAsync(TimeSpan.FromSeconds(5)); // provably inside the section
+
+        var racingReap = orch.ReapReviewerForTest(deliveryCandidate);
+        await Task.Delay(100);
+
+        // Mutual exclusion, asserted as such: a reaper that did not enter the section would have
+        // validated and stopped this agent inside that window.
+        await Assert.That(racingReap.IsCompleted).IsFalse();
+        await Assert.That(delivered.Status).IsEqualTo("Running");
+
+        parking.ReleaseFirstWrite();
+        await delivery.WaitAsync(TimeSpan.FromSeconds(5));
+        await racingReap.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(delivered.ActivityClock.ActivitySeq)
+            .IsEqualTo(deliveryCandidate.ActivityGeneration + 1); // the delivery landed
+        await Assert.That(delivered.ReapClaimed).IsFalse();       // ...so the reap lost
+        await Assert.That(delivered.Status).IsEqualTo("Running");
+        await Assert.That(server.StatusChangedCalls).DoesNotContain(("race-delivery-wins", "Completed"));
+
+        // The winning delivery's own out-of-cycle report is fire-and-forget, so wait for it HERE —
+        // otherwise it lands mid-arm-2 and pollutes that arm's "no report was emitted" baseline.
+        await PollUntilAsync(() => server.StatusReportCount >= 1);
+
+        // ── reap first ──────────────────────────────────────────────────────────────────────
+        var reapTime  = new FakeTimeProvider();
+        var reapClock = new AgentActivityClock(reapTime);
+        var recording = new RecordingPtyProcess();
+
+        var condemned = orch.SeedAgentForTest("race-reap-wins", LaunchKind.ReviewFlow, status: "Running",
+            pty: recording, activityClock: reapClock);
+
+        reapTime.Advance(TimeSpan.FromHours(2) + TimeSpan.FromMinutes(1));
+
+        var reapCandidate = orch.FindReviewersToReap().Single(c => c.Id == "race-reap-wins");
+        await Assert.That(reapCandidate.Reason).IsEqualTo("reviewer_idle_expired");
+
+        // The claim alone — the teardown it gates is not what this arm is about.
+        await Assert.That(await orch.TryClaimReapForTest(reapCandidate)).IsTrue();
+        await Assert.That(condemned.ReapClaimed).IsTrue();
+
+        var seqAtClaim   = condemned.ActivityClock.ActivitySeq;
+        var reportsAtClaim = server.StatusReportCount;
+
+        await orch.HandleSendInputForTest(new SendInputCommand(condemned.Id, "too late", null));
+
+        await Assert.That(recording.Writes).IsEmpty();                          // nothing reached the runtime
+        await Assert.That(condemned.ActivityClock.ActivitySeq).IsEqualTo(seqAtClaim);
+        await Task.Delay(100); // the delivery report is fire-and-forget; give a wrong one time to land
+        await Assert.That(server.StatusReportCount).IsEqualTo(reportsAtClaim);
+    }
+
+    /// <summary>The fence is scoped to the "nothing has happened" rules. The 6h absolute cap is not one
+    /// of them: it reaps a reviewer that is demonstrably active — here one that took a round AFTER
+    /// selection, advancing the very generation the idle/wedge rules would have aborted on — because
+    /// "absolute" is exactly what it means. Without the scoping, the one rule that guarantees a leaked
+    /// daemon slot is eventually reclaimed becomes indefinitely deferrable by traffic.</summary>
+    [Test]
+    public async Task Max_lifetime_reaps_regardless_of_delivery() {
+        var server = new CaptureServerConnection();
+        var time   = new FakeTimeProvider();
+        var clock  = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var agent = orch.SeedAgentForTest("ttl-reap", LaunchKind.ReviewFlow, status: "Running",
+            pty: new RecordingPtyProcess(), activityClock: clock);
+
+        time.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1)); // past the 6h absolute cap
+
+        var candidate = orch.FindReviewersToReap().Single(c => c.Id == "ttl-reap");
+        await Assert.That(candidate.Reason).IsEqualTo("reviewer_ttl_expired");
+        await Assert.That(candidate.FencedOnActivity).IsFalse();
+
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "round 7", null));
+        await Assert.That(agent.ActivityClock.ActivitySeq)
+            .IsEqualTo(candidate.ActivityGeneration + 1); // the exact advance that aborts an idle reap
+
+        await orch.ReapReviewerForTest(candidate);
+
+        await Assert.That(agent.ReapClaimed).IsTrue();
+        await Assert.That(agent.PendingEndReason).IsEqualTo("reviewer_ttl_expired");
+        await Assert.That(server.StatusChangedCalls).Contains(("ttl-reap", "Completed"));
+    }
+
+    /// <summary>PTY double that PARKS inside its first write, holding whatever section its caller is in
+    /// until the test releases it. Later writes (the submit CR, and anything the stop path sends) pass
+    /// straight through, so only the one window under test is controlled.</summary>
+    sealed class ParkingPtyProcess : IPtyProcess {
+        readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int                           _writes;
+
+        /// <summary>Completes the instant the first write is entered — the test drives the racing reap
+        /// from exactly that window rather than from a timing guess.</summary>
+        public Task FirstWriteEntered => _entered.Task;
+
+        public void ReleaseFirstWrite() => _release.TrySetResult();
+
+        public int  Pid       => 5152;
+        public bool HasExited => false;
+        public int? ExitCode  => null;
+
+        public ValueTask DisposeAsync() => default;
+        public Task WaitForExitAsync(TimeSpan? _) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan?   _) => Task.CompletedTask;
+
+#pragma warning disable CS1998
+        public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken _ = default) {
+            yield break;
+        }
+#pragma warning restore CS1998
+
+        public async Task WriteAsync(string _) {
+            if (Interlocked.Increment(ref _writes) != 1) return;
+
+            _entered.TrySetResult();
+            await _release.Task;
+        }
+
+        public Task WriteAsync(byte[] _) => Task.CompletedTask;
+
+        public void Resize(ushort _, ushort __) { }
+        public void SendInterrupt() { }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ReviewerReapingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ReviewerReapingTests.cs
@@ -690,6 +690,43 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(orch.ReapClaimGateWait).IsLessThan(AgentOrchestrator.HeartbeatInterval);
     }
 
+    /// <summary>The TOCTOU between a WON claim and the stop it gates: <c>HandleStopAgent</c> re-resolves
+    /// the id from the live agent map rather than taking the claimed instance directly, so a relaunch
+    /// reusing the id between the claim and the stop would otherwise tear down the FRESH incarnation on
+    /// the claimed one's evidence. Unreachable today — ids are unique per launch — but
+    /// <c>StopClaimedReapAsync</c>'s incarnation re-check closes it structurally.
+    ///
+    /// <para>Drives the post-claim half directly via <c>StopClaimedReapForTest</c> rather than
+    /// re-running <c>ReapReviewerForTest</c> end to end: a second claim attempt on the same candidate
+    /// would already abort on the swapped map entry through the claim's OWN incarnation check (a
+    /// different guard, exercised elsewhere in this file) before ever reaching the one under test
+    /// here.</para></summary>
+    [Test]
+    public async Task Relaunch_between_claim_and_stop_aborts_the_reap() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var claimed = orch.SeedAgentForTest("reused-id", LaunchKind.ReviewFlow, status: "Running",
+            pty: new RecordingPtyProcess());
+        var candidate = new AgentOrchestrator.ReapCandidate(claimed, "reviewer_ttl_expired", 0, FencedOnActivity: false);
+
+        await Assert.That(await orch.TryClaimReapForTest(candidate)).IsTrue();
+        await Assert.That(claimed.IsReapClaimed).IsTrue();
+
+        // Stands in for a relaunch reusing the id after the claim won but before the stop runs — the
+        // exact window HandleStopAgent's by-id resolve cannot see.
+        var relaunched = orch.SeedAgentForTest("reused-id", LaunchKind.ReviewFlow, status: "Running",
+            pty: new RecordingPtyProcess());
+
+        await orch.StopClaimedReapForTest(candidate);
+
+        await Assert.That(claimed.Status).IsEqualTo("Running");
+        await Assert.That(relaunched.Status).IsEqualTo("Running");
+        await Assert.That(server.StatusChangedCalls).DoesNotContain(("reused-id", "Completed"));
+    }
+
     /// <summary>PTY double that PARKS inside its first write, holding whatever section its caller is in
     /// until the test releases it. Later writes (the submit CR, and anything the stop path sends) pass
     /// straight through by default, so only the one window under test is controlled.

--- a/test/Capacitor.Cli.Tests.Unit/SendInputActivityClockTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SendInputActivityClockTests.cs
@@ -1,0 +1,89 @@
+using System.Runtime.CompilerServices;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Pty;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Round-dispatch grace (server-side design doc
+/// docs/superpowers/specs/2026-08-10-ai1842-round-dispatch-grace-design.md in kcap-server):
+/// delivered <c>SendInput</c> must advance the same per-agent <see cref="AgentActivityClock"/> that
+/// PTY output, ACP envelopes, and turn transitions already advance (see
+/// <c>AgentActivityClockTests.PTY_output_chunk_advances_the_agents_activity_clock</c> for the
+/// output-side precedent). Before this, an agent that only ever RECEIVED input — never producing
+/// output before the next reap sweep — looked idle to the reaper even while a human/driver was
+/// actively working with it.
+///
+/// <see cref="AgentOrchestrator.HandleSendInput"/> calls <c>Advance()</c> only once delivery is
+/// KNOWN to have succeeded — the runtime write returned without throwing. A failed/cancelled
+/// delivery must leave the clock untouched: a false advance would mask a genuinely wedged/dead
+/// agent from the reaper, which is exactly the failure mode this whole clock exists to catch.
+/// </summary>
+public partial class AgentOrchestratorVendorTests {
+    [Test]
+    public async Task Delivered_input_advances_the_activity_seq_and_resets_the_idle_clock() {
+        var server = new CaptureServerConnection();
+        var time   = new FakeTimeProvider();
+        var clock  = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var agent = orch.SeedAgentForTest("send-input-ok", pty: new RecordingPtyProcess(), activityClock: clock);
+
+        time.Advance(TimeSpan.FromSeconds(10));
+        await Assert.That(agent.ActivityClock.IdleForMs).IsGreaterThanOrEqualTo(9_900UL);
+
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "hello", null));
+
+        // Spawn (1) + the delivered input (2) — nothing else in this test touches the clock.
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(2UL);
+        await Assert.That(agent.ActivityClock.IdleForMs).IsEqualTo(0UL);
+    }
+
+    [Test]
+    public async Task Failed_delivery_advances_nothing() {
+        var server = new CaptureServerConnection();
+        var time   = new FakeTimeProvider();
+        var clock  = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var agent = orch.SeedAgentForTest("send-input-fail", pty: new AlwaysThrowsPtyProcess(), activityClock: clock);
+
+        time.Advance(TimeSpan.FromSeconds(10));
+
+        await Assert.ThrowsAsync<IOException>(
+            async () => await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "hello", null)));
+
+        // The write failed before "delivered" — seq and idle are exactly where spawn left them.
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(1UL);
+        await Assert.That(agent.ActivityClock.IdleForMs).IsGreaterThanOrEqualTo(9_900UL);
+    }
+
+    /// <summary>PTY double whose every write throws — simulates a dead/closed PTY
+    /// (<see cref="IPtyProcess.WriteAsync(string)"/> is documented "unguarded and throws on a closed
+    /// pipe" — see <see cref="PtyHostedAgentRuntime.WriteSubmitCarriageReturnAsync"/>'s remarks), so
+    /// <see cref="AgentOrchestrator.HandleSendInput"/>'s delivery await never completes without an
+    /// exception and the activity-clock advance it gates on must not run.</summary>
+    sealed class AlwaysThrowsPtyProcess : IPtyProcess {
+        public int  Pid       => 5151;
+        public bool HasExited => false;
+        public int? ExitCode  => null;
+
+        public ValueTask DisposeAsync() => default;
+        public Task WaitForExitAsync(TimeSpan? _) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan?   _) => Task.CompletedTask;
+
+#pragma warning disable CS1998
+        public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken _ = default) {
+            yield break;
+        }
+#pragma warning restore CS1998
+
+        public Task WriteAsync(string _) => throw new IOException("simulated closed pty pipe");
+        public Task WriteAsync(byte[] _) => throw new IOException("simulated closed pty pipe");
+
+        public void Resize(ushort _, ushort __) { }
+        public void SendInterrupt() { }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SendInputActivityClockTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SendInputActivityClockTests.cs
@@ -41,6 +41,34 @@ public partial class AgentOrchestratorVendorTests {
         await Assert.That(agent.ActivityClock.IdleForMs).IsEqualTo(0UL);
     }
 
+    /// <summary>Pins the mechanism the design's residual note is about: ACP's default (non-borrowed)
+    /// <c>SendUserInputAsync</c> is fire-and-forget — its non-throwing return means "enqueued", not
+    /// "the agent read it" (<c>AcpHostedAgentRuntime.EnqueueTurn</c>'s full-queue branch drops
+    /// silently, no throw) — yet <see cref="AgentOrchestrator.HandleSendInput"/> still advances the
+    /// clock on it, by design (a false advance only delays a reap/silence verdict, never manufactures
+    /// one). Uses <see cref="FakeAcpRuntime"/> (an <see cref="IHostedAgentRuntime"/> test double
+    /// already in this partial class, from the ACP-forwarding tests) via <c>SeedAcpAgent</c> — its
+    /// <c>SendUserInputAsync</c> is itself a non-throwing no-op, matching the enqueue-accepted shape
+    /// this test pins, without needing the full duplex <c>AcpHostedAgentRuntime</c>/<c>FakeAcpAgent</c>
+    /// harness the finalizer-verdict tests use.</summary>
+    [Test]
+    public async Task Acp_enqueue_accepted_input_advances_the_activity_seq_and_resets_the_idle_clock() {
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+
+        await using var orch = BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var agent = SeedAcpAgent(orch, "send-input-acp-ok", new FakeAcpRuntime(), activityClock: clock);
+
+        time.Advance(TimeSpan.FromSeconds(10));
+        await Assert.That(agent.ActivityClock.IdleForMs).IsGreaterThanOrEqualTo(9_900UL);
+
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "hello", null));
+
+        // Spawn (1) + the enqueue-accepted delivery (2).
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(2UL);
+        await Assert.That(agent.ActivityClock.IdleForMs).IsEqualTo(0UL);
+    }
+
     [Test]
     public async Task Failed_delivery_advances_nothing() {
         var server = new CaptureServerConnection();


### PR DESCRIPTION
## Summary

This is the daemon (`kcap-cli`) half of [kurrent-io/kcap-server#1403](https://github.com/kurrent-io/kcap-server/pull/1403) — round-dispatch grace for the participant-inactivity rule. Design: [`docs/superpowers/specs/2026-08-10-ai1842-round-dispatch-grace-design.md`](https://github.com/kurrent-io/kcap-server/blob/alexeyzimarev/ai-1842-round-dispatch-grace/docs/superpowers/specs/2026-08-10-ai1842-round-dispatch-grace-design.md) (kcap-server, PR #1403).

The server side treats a stopped participant as reachable again once it can prove an in-flight round; this PR gives the daemon the two things that proof needs: input delivery is now activity (so a round that's actually being worked doesn't look idle), and a delivery-triggered status report so the server learns that fact promptly instead of waiting out the 60s cycle. It also closes the gap that made "input delivery is activity" unsafe on its own — a reviewer being idle-reaped while a round is mid-delivery.

## What changed

**1. Delivered input advances the per-agent activity clock — the sixth source.** `HandleSendInput` now calls `AgentActivityClock.Advance()` on the delivery success path, joining PTY output, ACP envelope emission and turn start/end, Antigravity's and Pi's own `agentActivity` events, and `LocalPermissionBridge`'s two reviewer tool-call-hit sites as clock sources. "Successfully handled" is decided per vendor mechanism: PTY and RPC throw on a genuine delivery failure, and Antigravity's exec-per-turn queue explicitly faults even its fire-and-forget branch — all three are clean. ACP's default (non-borrowed) path is not: `EnqueueTurn(acknowledgeWrite: false)` returns success on enqueue, not on the agent actually reading it, so a full `_pendingTurns` queue silently drops the input while still looking like a successful delivery. That residual is accepted and documented as **kill-delaying-only** — it can make a genuinely stuck reviewer look briefly alive to the clock, but it can never manufacture activity that isn't there for a healthy one, and it never suppresses a real timeout, only delays it by however long the delivery pipeline was already broken.

**2. A delivery-triggered, uncorrelated status report — and the ordering gate it needs.** Every delivered input now fires an out-of-cycle `DaemonStatusReport` (fire-and-forget, off the SignalR receive loop via `Task.Run`, matching the existing launch-stage-triggered report), so the server sees the advanced `ActivitySeq`/reset `IdleForMs` without waiting on the 60s periodic loop. This is only safe because of a new per-daemon `_statusReportOrderingGate` (`SemaphoreSlim(1,1)`), held from snapshot construction (`BuildStatusReport()`, evaluated *inside* the section) through completion of the hub send — never just through task creation. Without it, two concurrent emissions can enqueue on the semaphore in the opposite order from their content's causal order (`SemaphoreSlim` is only approximately FIFO), putting older content on the wire *after* newer content and permanently tripping the server's `Regressed` latch on wire-order content regression. All existing emission sites (periodic loop, legacy on-request nudge, launch-stage transition) already funnel through one method (`SendDaemonStatusReportOnceAsync`), so the gate covers them for free; the new delivery-triggered report is the second site added by this PR.

**3. The atomic reap claim — fencing the reviewer-idle-reap race against the delivery window.** Before this change, the heartbeat's `FindReviewersToReap` selection and the actual stop were separated only by an "does the agent still exist" check — no revalidation that the agent was still idle by the time the stop executed. Now:
- The reap claim runs inside the *same* per-agent gate `HandleSendInput` already holds across its whole delivery body (`BorrowedSnapshotGate`, extended rather than renamed — its doc now names both purposes) — so a delivery and a reap claim are mutually exclusive.
- The gate wait is **bounded** (`ReapClaimGateWait`, 20s, deliberately under the 30s heartbeat period) and falls back to a **lock-free CAS claim** for the unfenced rule (the absolute `ReviewerMaxLifetime` cap) on timeout — this closes a real circular-wait hazard: an unbounded wait would let a parked, non-draining PTY `write(2)` (no timeout, no cancellation) defer the reap that's supposed to end it, forever.
- **A permanently parked delivery defers idle/wedge reaps on every tick, by design** — an in-progress delivery IS activity, so `FindReviewersToReap`'s idle/wedge rules never select an agent whose delivery is still parked in the section, and reclaim shifts entirely to the unfenced absolute-lifetime cap (`ReviewerMaxLifetime`, ≤6h by default). With `ReviewerMaxLifetime=0` (that rule disabled) a permanently parked delivery defers reaping indefinitely — accepted, not fixed, by this PR.
- A **late in-section refusal re-read** (`if (agent.IsReapClaimed) return;`) sits immediately before the actual write, because the unfenced TTL claim's wait is deliberately *shorter* than a delivery's worst-case in-section time (borrowed-snapshot refresh can take up to 30s) — without the re-read, a perfectly healthy but slow delivery could complete into an agent already condemned by a claim that landed mid-flight, writing input and emitting an activity report for a stop that's already happening.
- The **graceful stop is now bounded** (`GracefulExitWait`, 15s) around the send half, not just the exit-wait half — this applies to **every** stop, reap or otherwise, not just this PR's new path. It closes a pre-existing (not new) hazard: a non-draining child parks the graceful `/exit` send on the same uncancellable `write(2)` a parked delivery would, making `TerminateAsync` — the step that actually ends the wedge — unreachable exactly when it's needed most. Per-runtime check before widening the bound: ACP sends one `session/cancel` notify, Antigravity's graceful stop returns `Task.CompletedTask` immediately, and Pi's own stop grace is 3s — 15s truncates no legitimate graceful path on any of the four vendors; only a wedged PTY's raw `write(2)` was ever at risk.

Selection now captures a `ReapCandidate` (agent instance, reason, activity generation, `FencedOnActivity`) with the generation read *before* the age/idle/turn reads — the ordering is load-bearing (reasoned and documented in code; not independently testable without a clock-internal seam). `FencedOnActivity` distinguishes the two rules explicitly rather than by string-matching the reason later: idle/wedge reaps abort on an activity advance, the 6h absolute-lifetime cap never does (by design — "absolute" means absolute) but still takes the section so incarnation/membership are revalidated.

Scope: idle/wedge reaping only. User- and server-commanded stops are untouched — `StopAgentCoreAsync`/`HandleStopAgent` are the same shared executor for every caller, unmodified except for the graceful-stop bound, which is deliberately global (see above).

## Test evidence

- **Full daemon unit-test suite** (`test/Capacitor.Cli.Tests.Unit`, 7066 tests): 6981 passed, 50 failed, 35 skipped (gated live-vendor certification tests). Every one of the 50 failures was individually investigated and traced to one of two causes, **neither caused by this branch**:
  - 44 failures across 6 test classes (`CodexConfigTomlTests`, `CodexConfigWriterTests`, `CodexLauncherTests`, `CodexProjectKeyTests`, `PluginCommandCodexInstallIntegrationTests`, `UninstallCommandTests`) reproduce **identically** (same names, same counts) on a byte-for-byte pristine `origin/main` checkout in an isolated worktree — a pre-existing, machine-local environment issue (Codex `config.toml` temp-path handling on this host), wholly unrelated to this diff, which touches no Codex/uninstall code.
  - 6 failures (`BorrowedReviewAuthBrokerTests` ×3, `GitProviderRouterTests` ×1, and 2 in the touched `AgentOrchestratorVendorTests` partial class — `PTY_output_chunk_advances_the_agents_activity_clock`, part of the documented closed set of ~5 PTY/consent-dialog tests, and `Shutdown_with_live_children_and_queued_stops_discards_the_queue_and_kills_every_child`, a real-child-process dispose test whose own file this branch never touches) are machine-load timing flakes: all pass cleanly and quickly (sub-second to ~1s) when re-run individually, including the shutdown test, which missed its 30s bound by ~1s under load (31.1s) and completed in 1.17s alone.
- **The reap-claim suite** (`ReviewerReapingTests.cs`): six claim tests plus a bound-relation pin, written across three TDD rounds — the initial three (stale-selection-aborts-after-delivery, contention-has-exactly-one-winner, max-lifetime-reaps-regardless-of-delivery), the bounded-wait round's parked-delivery-does-not-defer-the-absolute-lifetime-reap, and the graceful-stop round's parked-exit-write-does-not-stall-the-reap's-terminate and healthy-in-section-delivery-refuses-after-a-claim-lands-mid-flight — plus the reap-claim-gate-wait-stays-under-the-heartbeat-interval relation pin (not itself a claim test).
- **Mutation probes**, all run by hand (mutate → red → restore → green): the ordering-gate removal and release-before-send mutations on the status-report test; the capture-before-acquire mutation (content built outside the section) on the same test; the unbounded-wait reversion reproducing the circular-wait deadlock; the unbounded-graceful-send reversion reproducing the unreachable-terminate hang; and the reap-claimed-refusal removal on the delivery side of the contention test.
- `scripts/check-linear-ids.sh` — clean (exit 0) against the full branch diff.

## Known residuals

- **Claim-during-write is still a live window.** If a reap claim lands *during* an in-flight write (rather than before or after it), the delivery still advances the clock and emits a report once the write itself completes — the window is bounded by the write's own duration, not by the claim's timing. This is a smaller, inherent version of the race the late re-read (item 3 above) closes for the common case; closing it fully would need a second `IsReapClaimed` read positioned after the write but before `Advance()`, which was not built.
- **The correlated status-report handler (`RequestStatusReport2`/`EchoNonce`, AI-1787) remains unbuilt.** It did not exist in the daemon at this branch's base commit. `The_report_shape_carries_no_correlation_nonce` is a **deliberate tripwire test** — reflection over `DaemonStatusReport`/`LiveAgentInfo` asserting no `*nonce*`/`*echo*` member exists — so that whoever lands the correlated handler inherits a red test by design, forcing them to route it through the same ordering section rather than silently bypassing it.
- **The must-route-through-the-gate rule is documented, not enforced.** `SendDaemonStatusReportOnceAsync` is the one production call site of `ServerConnection.DaemonStatusReportAsync`, and the gate's field doc states that every future emission site must go through it — but nothing stops a future call site from invoking `DaemonStatusReportAsync` directly, compiling cleanly and silently reintroducing the server's `Regressed` latch. No architectural enforcement (visibility narrowing, a call-site-count test) was added; flagged as a candidate follow-up.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Do NOT merge.**

