### PR TITLE
Set FD_CLOEXEC on the forkpty master descriptor

### DIFF
--- a/src/Capacitor.Cli.Daemon/Native/pty_shim.c
+++ b/src/Capacitor.Cli.Daemon/Native/pty_shim.c
@@ -670,16 +670,21 @@ int pty_spawn(const pty_exec_plan *plan, char *const envp[], const char *cwd,
     }
 
     // ── PARENT ──
-    // forkpty returns the master bare — unlike the error pipe above, it carries no CLOEXEC
-    // flag. Set it now, before anything else in the parent runs, so a child forked
-    // concurrently on another daemon thread cannot inherit a live read/write descriptor onto
-    // THIS PTY agent's terminal (crossing an isolation boundary the daemon draws deliberately).
-    // Best-effort, deliberately NOT fail-closed like the error-pipe CLOEXEC above: that flag's
-    // absence is a correctness hazard (a stray write-end copy defers the exec-success EOF),
-    // whereas a leaked master is only a bounded resource + isolation cost, never a wrong result
-    // — and on a just-returned valid fd this fcntl cannot realistically fail (EBADF/EINVAL are
-    // both unreachable), so tearing down an otherwise-healthy agent for it would be strictly
-    // worse than the leak it guards against.
+    // forkpty returns the master bare — unlike the error pipe above, it carries no CLOEXEC flag,
+    // so without this every child the daemon execs later inherits a live read/write descriptor
+    // onto THIS PTY agent's terminal, crossing an isolation boundary the daemon draws
+    // deliberately. Set it as the first parent statement — the earliest a caller can, since
+    // forkpty has no O_CLOEXEC-style atomic variant. That fully closes inheritance by any LATER
+    // exec, but only NARROWS (cannot eliminate) the race against a child forked concurrently on
+    // another daemon thread, whose fork can begin before forkpty even returns here; a hard
+    // guarantee against concurrent spawns would require serializing all process creation across
+    // the forkpty+F_SETFD pair, out of scope for this fix.
+    // Best-effort, deliberately NOT fail-closed like the error-pipe CLOEXEC above, whose absence
+    // is a genuine correctness hazard (a stray write-end copy defers the exec-success EOF). A
+    // leaked master is a real isolation/resource cost but never a wrong result, and on a
+    // just-returned valid fd this fcntl cannot realistically fail (EBADF/EINVAL both unreachable),
+    // so tearing down an otherwise-healthy agent for it would be strictly worse than the residual
+    // leak it guards against.
     fcntl(master_fd, F_SETFD, FD_CLOEXEC);
     close(errpipe[1]);
 

--- a/src/Capacitor.Cli.Daemon/Native/pty_shim.c
+++ b/src/Capacitor.Cli.Daemon/Native/pty_shim.c
@@ -670,6 +670,17 @@ int pty_spawn(const pty_exec_plan *plan, char *const envp[], const char *cwd,
     }
 
     // ── PARENT ──
+    // forkpty returns the master bare — unlike the error pipe above, it carries no CLOEXEC
+    // flag. Set it now, before anything else in the parent runs, so a child forked
+    // concurrently on another daemon thread cannot inherit a live read/write descriptor onto
+    // THIS PTY agent's terminal (crossing an isolation boundary the daemon draws deliberately).
+    // Best-effort, deliberately NOT fail-closed like the error-pipe CLOEXEC above: that flag's
+    // absence is a correctness hazard (a stray write-end copy defers the exec-success EOF),
+    // whereas a leaked master is only a bounded resource + isolation cost, never a wrong result
+    // — and on a just-returned valid fd this fcntl cannot realistically fail (EBADF/EINVAL are
+    // both unreachable), so tearing down an otherwise-healthy agent for it would be strictly
+    // worse than the leak it guards against.
+    fcntl(master_fd, F_SETFD, FD_CLOEXEC);
     close(errpipe[1]);
 
     // CAPTURE-BINDING RULE: identity is captured HERE, immediately after forkpty returns,

--- a/src/Capacitor.Cli.Daemon/Native/pty_shim.c
+++ b/src/Capacitor.Cli.Daemon/Native/pty_shim.c
@@ -670,21 +670,14 @@ int pty_spawn(const pty_exec_plan *plan, char *const envp[], const char *cwd,
     }
 
     // ── PARENT ──
-    // forkpty returns the master bare — unlike the error pipe above, it carries no CLOEXEC flag,
-    // so without this every child the daemon execs later inherits a live read/write descriptor
-    // onto THIS PTY agent's terminal, crossing an isolation boundary the daemon draws
-    // deliberately. Set it as the first parent statement — the earliest a caller can, since
-    // forkpty has no O_CLOEXEC-style atomic variant. That fully closes inheritance by any LATER
-    // exec, but only NARROWS (cannot eliminate) the race against a child forked concurrently on
-    // another daemon thread, whose fork can begin before forkpty even returns here; a hard
-    // guarantee against concurrent spawns would require serializing all process creation across
-    // the forkpty+F_SETFD pair, out of scope for this fix.
-    // Best-effort, deliberately NOT fail-closed like the error-pipe CLOEXEC above, whose absence
-    // is a genuine correctness hazard (a stray write-end copy defers the exec-success EOF). A
-    // leaked master is a real isolation/resource cost but never a wrong result, and on a
-    // just-returned valid fd this fcntl cannot realistically fail (EBADF/EINVAL both unreachable),
-    // so tearing down an otherwise-healthy agent for it would be strictly worse than the residual
-    // leak it guards against.
+    // forkpty returns the master with no CLOEXEC flag, so a child the daemon execs later would
+    // inherit a live descriptor onto THIS agent's terminal (an isolation boundary). Doing this
+    // as the first parent statement is the earliest possible — forkpty has no atomic O_CLOEXEC
+    // variant — so it fully closes later-exec inheritance but only NARROWS the race against a
+    // concurrent fork on another thread (fully closing that means serializing process creation,
+    // out of scope here). Best-effort, unlike the fail-closed error-pipe CLOEXEC above: a leaked
+    // master is an isolation/resource cost, never a wrong result, and F_SETFD on a just-returned
+    // valid fd cannot realistically fail — so failing the spawn over it would be worse.
     fcntl(master_fd, F_SETFD, FD_CLOEXEC);
     close(errpipe[1]);
 

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/PtySpawnTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/PtySpawnTests.cs
@@ -143,6 +143,37 @@ public class PtySpawnTests {
         } finally { Free(plan); }
     }
 
+    [Test]
+    public async Task Successful_spawn_marks_the_pty_master_fd_close_on_exec() {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+
+        // Regression (spec §3.0a): forkpty returns the master bare, so without an explicit
+        // FD_CLOEXEC on it every child the daemon spawns afterwards inherits a live read/write
+        // descriptor onto this PTY agent's terminal — crossing an isolation boundary the daemon
+        // draws deliberately. The master must therefore be close-on-exec, exactly as the error
+        // pipe already is.
+        var plan = Preflight("/bin/sleep", ["sleep", "5"]);
+        try {
+            var rc = Spawn(plan, out var result);
+            try {
+                await Assert.That(rc).IsEqualTo(0);
+                await Assert.That(result.MasterFd).IsGreaterThanOrEqualTo(0);
+                var flags = fcntl(result.MasterFd, F_GETFD, 0);
+                await Assert.That(flags).IsGreaterThanOrEqualTo(0); // fcntl itself succeeded
+                await Assert.That(flags & FD_CLOEXEC).IsEqualTo(FD_CLOEXEC);
+            } finally {
+                UnixPtyInterop.close(result.MasterFd);
+                UnixPtyInterop.kill(result.Pid, UnixPtyInterop.SIGKILL);
+                UnixPtyInterop.waitpid(result.Pid, out _, 0);
+            }
+        } finally { Free(plan); }
+    }
+
+    const int F_GETFD    = 1;
+    const int FD_CLOEXEC = 1;
+    [System.Runtime.InteropServices.DllImport("libc", SetLastError = true)]
+    static extern int fcntl(int fd, int cmd, int arg);
+
     // See PtyShimNativeTests for why these NULL-termination helpers exist: argv/envp cross
     // into the shim as a bare `char* const[]` with no length prefix (mirrors execve), so the
     // native walk to the NULL sentinel reads out of bounds unless every array handed across

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/PtySpawnTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/PtySpawnTests.cs
@@ -155,9 +155,15 @@ public class PtySpawnTests {
         var plan = Preflight("/bin/sleep", ["sleep", "5"]);
         try {
             var rc = Spawn(plan, out var result);
+            // Assert a genuine successful spawn BEFORE the cleanup block: on a failure path
+            // pty_spawn leaves result zero-filled (Pid 0, MasterFd -1), and running cleanup on
+            // those sentinels would be actively harmful — kill(0, SIGKILL) signals the whole
+            // process group (the test host) and close(0) closes stdin. So only enter the
+            // fd-owning try once we hold a real child + fd.
+            await Assert.That(rc).IsEqualTo(0);
+            await Assert.That(result.Pid).IsGreaterThan(0);
+            await Assert.That(result.MasterFd).IsGreaterThanOrEqualTo(0);
             try {
-                await Assert.That(rc).IsEqualTo(0);
-                await Assert.That(result.MasterFd).IsGreaterThanOrEqualTo(0);
                 var flags = fcntl(result.MasterFd, F_GETFD, 0);
                 await Assert.That(flags).IsGreaterThanOrEqualTo(0); // fcntl itself succeeded
                 await Assert.That(flags & FD_CLOEXEC).IsEqualTo(FD_CLOEXEC);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/PtySpawnTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/PtySpawnTests.cs
@@ -156,10 +156,10 @@ public class PtySpawnTests {
         try {
             var rc = Spawn(plan, out var result);
             // Assert a genuine successful spawn BEFORE the cleanup block: on a failure path
-            // pty_spawn leaves result zero-filled (Pid 0, MasterFd -1), and running cleanup on
-            // those sentinels would be actively harmful — kill(0, SIGKILL) signals the whole
-            // process group (the test host) and close(0) closes stdin. So only enter the
-            // fd-owning try once we hold a real child + fd.
+            // pty_spawn leaves result zero-filled (Pid 0) with MasterFd -1. close(-1) is a
+            // harmless no-op, but kill(0, SIGKILL) is actively harmful — it signals the whole
+            // process group (the test host). So only enter the fd-owning try once we hold a
+            // real child + fd.
             await Assert.That(rc).IsEqualTo(0);
             await Assert.That(result.Pid).IsGreaterThan(0);
             await Assert.That(result.MasterFd).IsGreaterThanOrEqualTo(0);

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/PtySpawnTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/PtySpawnTests.cs
@@ -155,22 +155,22 @@ public class PtySpawnTests {
         var plan = Preflight("/bin/sleep", ["sleep", "5"]);
         try {
             var rc = Spawn(plan, out var result);
-            // Assert a genuine successful spawn BEFORE the cleanup block: on a failure path
-            // pty_spawn leaves result zero-filled (Pid 0) with MasterFd -1. close(-1) is a
-            // harmless no-op, but kill(0, SIGKILL) is actively harmful — it signals the whole
-            // process group (the test host). So only enter the fd-owning try once we hold a
-            // real child + fd.
-            await Assert.That(rc).IsEqualTo(0);
-            await Assert.That(result.Pid).IsGreaterThan(0);
-            await Assert.That(result.MasterFd).IsGreaterThanOrEqualTo(0);
             try {
+                await Assert.That(rc).IsEqualTo(0);
+                await Assert.That(result.MasterFd).IsGreaterThanOrEqualTo(0);
                 var flags = fcntl(result.MasterFd, F_GETFD, 0);
                 await Assert.That(flags).IsGreaterThanOrEqualTo(0); // fcntl itself succeeded
                 await Assert.That(flags & FD_CLOEXEC).IsEqualTo(FD_CLOEXEC);
             } finally {
-                UnixPtyInterop.close(result.MasterFd);
-                UnixPtyInterop.kill(result.Pid, UnixPtyInterop.SIGKILL);
-                UnixPtyInterop.waitpid(result.Pid, out _, 0);
+                // Cleanup is GUARDED, not gated: it always runs after Spawn returns, so a child
+                // created before a failing assertion is still reaped — but each op is conditioned
+                // on a valid sentinel, since pty_spawn zero-fills result on failure (Pid 0,
+                // MasterFd -1) and kill(0, SIGKILL) would signal the whole process group.
+                if (result.MasterFd >= 0) UnixPtyInterop.close(result.MasterFd);
+                if (result.Pid > 0) {
+                    UnixPtyInterop.kill(result.Pid, UnixPtyInterop.SIGKILL);
+                    UnixPtyInterop.waitpid(result.Pid, out _, 0);
+                }
             }
         } finally { Free(plan); }
     }


### PR DESCRIPTION
## Problem

`pty_shim.c` sets `FD_CLOEXEC` on the error pipe but returns the `forkpty` master **bare**. Every child the daemon spawns while a PTY agent is live therefore inherits a live read/write descriptor onto that agent's terminal.

Two bounded costs:

1. An extra fd + a retained pty device per (live PTY agent × concurrently-spawned child), for that child's lifetime.
2. The sharper one: a spawned child's process tree holds a live read/write descriptor on **another hosted agent's terminal** — a capability crossing the isolation boundary the daemon otherwise draws deliberately (isolated per-launch `HOME`, no widened reviewer permissions).

Measured (macOS arm64): a child spawned exactly as the daemon's turn processes are, while a PTY agent was live, saw the master fd (28) and slave fd (29) in its fd table; `lsof` confirmed fd 28 → `/dev/ptmx`.

## Fix

One `fcntl(master_fd, F_SETFD, FD_CLOEXEC)` in the parent, immediately after `forkpty`. Best-effort, deliberately **not** fail-closed like the error-pipe CLOEXEC: that flag's absence is a correctness hazard (a stray write-end copy defers the exec-success EOF), whereas a leaked master is only a bounded resource/isolation cost, never a wrong result — and on a just-returned valid fd this `fcntl` cannot realistically fail (`EBADF`/`EINVAL` unreachable), so tearing down an otherwise-healthy agent for it would be strictly worse than the leak it guards.

`ProcessHelpers.PreventInheritedHandles` can't be reused: it lives in `Capacitor.Cli` (unreferenced by the daemon) and only marks descriptors positively identified as **pipes**, whereas a pty master is a character device.

## Test

Adds `PtySpawnTests.Successful_spawn_marks_the_pty_master_fd_close_on_exec`, which spawns a real child and asserts the returned master is `FD_CLOEXEC`. Verified red before the fix (`flags & FD_CLOEXEC == 0`), green after. All sibling native/spawn test classes stay green.

## Refs

Closes #485
Linear: AI-1795

🤖 Generated with [Claude Code](https://claude.com/claude-code)