### PR TITLE
Fix two flaky ubuntu CI tests: revoked-token keep-alive artifact + StopsInFlight collector race

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -245,10 +245,16 @@ internal sealed partial class LocalPermissionBridge(
         var token = ExtractToken(reviewerBridgeUrlOrToken);
         if (token is null) return;
 
-        lock (_prefixLock) {
-            if (_reviewerTokens.TryRemove(token, out _))
-                _listener?.Prefixes.Remove($"http://127.0.0.1:{_port}/{token}/");
-        }
+        // Removing the token from the dictionary is the ONE authoritative revocation: HandleAsync
+        // re-validates every request against _reviewerTokens (a stray prefix "can't quietly admit
+        // anything"), so a dict miss is a deterministic 404. We deliberately do NOT remove the
+        // HttpListener prefix. On the managed (Linux/macOS) HttpListener, a request on a keep-alive
+        // connection to a just-removed prefix no longer routes to our handler and instead yields a
+        // transport-level artifact — a spurious empty-body 200 or a connection reset — rather than
+        // the clean 404 our code would return. Keeping the prefix registered means the request still
+        // reaches HandleAsync, where the dict miss produces the intended 404. The prefixes are freed
+        // when the listener closes; their count is bounded by the daemon's reviewer-launch count.
+        _reviewerTokens.TryRemove(token, out _);
     }
 
     /// <summary>Atomically publishes a completed immutable sidecar generation for a live reviewer.

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -30,6 +30,12 @@ internal sealed partial class LocalPermissionBridge(
     const int    MaxBindAttempts = 15;
     const string PathSuffix      = "/permission-request";
 
+    // Revoked reviewer prefixes are intentionally retained (see RevokeReviewerToken), so the
+    // listener's prefix set only grows over a daemon's lifetime, bounded by the reviewer-launch
+    // count. Warn once each time the count crosses a multiple of this step so runaway growth in a
+    // very long-lived daemon is diagnosable rather than silent.
+    const int    ReviewerPrefixHighWaterStep = 1024;
+
     /// <summary>Cap on a reviewer submission body. The poster is a sandboxed vendor child, so an
     /// unbounded read is a memory-exhaustion lever.</summary>
     internal const int MaxSubmitBodyBytes = 1024 * 1024;
@@ -234,6 +240,12 @@ internal sealed partial class LocalPermissionBridge(
             _listener.Prefixes.Add($"http://127.0.0.1:{_port}/{token}/");
             _reviewerTokens[token] = new ReviewerGrant(
                 [.. allowlistServers], reviewContext, activityClock, submitForwarder);
+
+            // Prefixes are never removed on revoke, so this count only rises — surface a warning at
+            // each high-water step so a leak is diagnosable (the count grows by one per launch).
+            var prefixCount = _listener.Prefixes.Count;
+            if (prefixCount % ReviewerPrefixHighWaterStep == 0)
+                LogReviewerPrefixHighWater(logger, prefixCount);
 
             return $"http://127.0.0.1:{_port}/{token}";
         }
@@ -728,4 +740,7 @@ internal sealed partial class LocalPermissionBridge(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Permission bridge shutdown failed; continuing teardown")]
     static partial void LogDisposeFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Local permission bridge has {PrefixCount} listener prefixes; revoked reviewer prefixes are retained until the daemon stops")]
+    static partial void LogReviewerPrefixHighWater(ILogger logger, int prefixCount);
 }

--- a/test/Capacitor.App.Tests.Unit/AgentActionServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AgentActionServiceTests.cs
@@ -32,7 +32,7 @@ public class AgentActionServiceTests {
         var ops = new ScriptedLocalControlOps();
         var notifier = new RecordingNotifier();
         var service = NewService(ops, notifier, new RecordingOpener());
-        var states = new List<IReadOnlySet<string>>();
+        var states = new StopStateRecorder();
         using var sub = service.StopsInFlight.Subscribe(states.Add);
 
         ops.QueueStop(new StopAgentResult(true, "stopped", null));
@@ -117,7 +117,7 @@ public class AgentActionServiceTests {
         var notifier = new RecordingNotifier();
         var cts = new CancellationTokenSource();
         var service = NewService(ops, notifier, new RecordingOpener(), shutdownToken: cts.Token);
-        var states = new List<IReadOnlySet<string>>();
+        var states = new StopStateRecorder();
         using var sub = service.StopsInFlight.Subscribe(states.Add);
 
         var gate = ops.ArmStop();
@@ -137,7 +137,7 @@ public class AgentActionServiceTests {
         var ops = new ScriptedLocalControlOps();
         var notifier = new RecordingNotifier();
         var service = NewService(ops, notifier, new RecordingOpener());
-        var states = new List<IReadOnlySet<string>>();
+        var states = new StopStateRecorder();
         using var sub = service.StopsInFlight.Subscribe(states.Add);
 
         ops.QueueStopUnmappedFailure(new InvalidOperationException("boom"));
@@ -159,7 +159,7 @@ public class AgentActionServiceTests {
         var ops = new ScriptedLocalControlOps();
         var notifier = new RecordingNotifier();
         var service = NewService(ops, notifier, new RecordingOpener());
-        var states = new List<IReadOnlySet<string>>();
+        var states = new StopStateRecorder();
         using var sub = service.StopsInFlight.Subscribe(states.Add);
 
         var gate = ops.ArmStop();
@@ -180,7 +180,7 @@ public class AgentActionServiceTests {
         var ops = new ScriptedLocalControlOps();
         var notifier = new RecordingNotifier();
         var service = NewService(ops, notifier, new RecordingOpener());
-        var states = new List<IReadOnlySet<string>>();
+        var states = new StopStateRecorder();
         using var sub = service.StopsInFlight.Subscribe(states.Add);
 
         var gateA = ops.ArmStop();
@@ -203,7 +203,7 @@ public class AgentActionServiceTests {
         var ops = new ScriptedLocalControlOps();
         var notifier = new RecordingNotifier();
         var service = NewService(ops, notifier, new RecordingOpener());
-        var states = new List<IReadOnlySet<string>>();
+        var states = new StopStateRecorder();
         using var sub = service.StopsInFlight.Subscribe(states.Add);
 
         await Assert.That(states.Count).IsEqualTo(1);
@@ -290,7 +290,7 @@ public class AgentActionServiceTests {
         var notifier = new RecordingNotifier();
         var confirmer = new RecordingConfirmer();
         var service = NewService(ops, notifier, new RecordingOpener(), confirmForceStop: confirmer.Confirm);
-        var states = new List<IReadOnlySet<string>>();
+        var states = new StopStateRecorder();
         using var sub = service.StopsInFlight.Subscribe(states.Add);
 
         confirmer.Queue(false);
@@ -346,7 +346,7 @@ public class AgentActionServiceTests {
         var notifier = new RecordingNotifier();
         var confirmer = new RecordingConfirmer();
         var service = NewService(ops, notifier, new RecordingOpener(), confirmForceStop: confirmer.Confirm);
-        var states = new List<IReadOnlySet<string>>();
+        var states = new StopStateRecorder();
         using var sub = service.StopsInFlight.Subscribe(states.Add);
 
         var gate = confirmer.Arm();
@@ -362,4 +362,18 @@ public class AgentActionServiceTests {
         await WaitUntilAsync(() => states[^1].Count == 0, what: "in-flight cleared");
         await Assert.That(ops.StopCalls).IsEqualTo(1); // exactly one call ever issued
     }
+}
+
+/// Thread-safe collector for StopsInFlight pushes. AgentActionService.RequestStop pushes
+/// synchronously on the test thread, while RunStopAsync's completion pushes on a threadpool
+/// thread — BehaviorSubject invokes subscribers on whichever thread calls OnNext. A plain
+/// List&lt;T&gt; written from both threads while the test thread polls Count/[^1] tears under a
+/// concurrent Add during an internal array resize and NREs on read. Every access takes one lock.
+sealed class StopStateRecorder {
+    readonly Lock _gate = new();
+    readonly List<IReadOnlySet<string>> _states = [];
+
+    public void Add(IReadOnlySet<string> state) { lock (_gate) _states.Add(state); }
+    public int Count { get { lock (_gate) return _states.Count; } }
+    public IReadOnlySet<string> this[Index index] { get { lock (_gate) return _states[index]; } }
 }

--- a/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalPermissionBridgeTests.cs
@@ -983,6 +983,31 @@ public class LocalPermissionBridgeTests {
         } finally { await bridge.DisposeAsync(); }
     }
 
+    // Regression: revocation must remove the grant from the dictionary ONLY, never the HttpListener
+    // prefix. On the managed (Linux/macOS) HttpListener, a request on a KEEP-ALIVE connection to a
+    // just-removed prefix no longer routes to HandleAsync and yields a transport artifact — a
+    // spurious empty-body 200 or a connection reset — instead of the intended 404. Reusing one
+    // client (so every request after the first rides a keep-alive connection) across many
+    // register→revoke→request cycles reproduces that ~4%-per-request artifact deterministically:
+    // with the prefix kept, every revoked request cleanly 404s from the dict miss.
+    [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
+    public async Task Revoked_token_requests_404_on_reused_keepalive_connection() {
+        var (bridge, _) = CreateBridge();
+        try {
+            await bridge.StartAsync(CancellationToken.None);
+            using var client = CreateClient();
+
+            for (var i = 0; i < 200; i++) {
+                var reviewerUrl = bridge.RegisterReviewerToken(["kcap-review"]);
+                bridge.RevokeReviewerToken(reviewerUrl);
+                using var r = await client.PostAsync(
+                    $"{reviewerUrl}/codex/permission-request",
+                    JsonContent.Create(new { session_id = "abc", tool_name = "submit_review_result" }));
+                await Assert.That((int)r.StatusCode).IsEqualTo(404);
+            }
+        } finally { await bridge.DisposeAsync(); }
+    }
+
     [Test, NotInParallel(nameof(LocalPermissionBridgeTests))]
     public async Task Concurrent_reviewer_tokens_are_independent() {
         var (bridge, server) = CreateBridge((_, _, _, _, _) => Task.FromResult(new PermissionDecision("deny", null, null)));


### PR DESCRIPTION
Fixes two independent, pre-existing intermittent failures on the ubuntu CI leg. Tracked in Linear as AI-1868.

## Flake 2 (production defect) — `LocalPermissionBridgeTests.Revoked_reviewer_token_returns_404`

`RevokeReviewerToken` removed the `HttpListener` **prefix** in addition to the dictionary grant. On the managed (Linux/macOS) `HttpListener`, a request on a reused **keep-alive** connection to a just-removed prefix no longer routes to `HandleAsync` and yields a transport-level artifact — a spurious **empty-body 200** or a **connection reset** — instead of the intended 404.

The issue's original hypothesis (a dict revocation race between two lookup sites) does not hold: both requests hit the same general handler, and a *live* codex token would auto-approve **both** tools (200/200), a revoked one → 404/404 — so the observed `r1=404 / r2=200` split can't come from the dict. Instrumentation confirmed every anomalous `r2=200` had an **empty body** and `ReviewerTokenCountForTest == 0`, i.e. the request was never admitted by our code.

**Fix:** remove the grant from `_reviewerTokens` only; do **not** remove the listener prefix. `HandleAsync` already re-validates every request against the dictionary, so a dict miss is a deterministic 404, and keeping the prefix ensures the revoked-token request still routes to our handler. Prefixes are freed when the listener closes; their count is bounded by the daemon's reviewer-launch count.

- Reproduced at ~4% per request over an 8000-iteration stress loop; **0** anomalies after the fix.
- Added regression test `Revoked_token_requests_404_on_reused_keepalive_connection` (200 register→revoke→request cycles over one reused keep-alive client).

## Flake 1 (test defect) — `AgentActionServiceTests.Second_request_same_id_while_inflight_is_noop` (and siblings)

The tests collected `StopsInFlight` pushes into a plain `List<T>`. `AgentActionService` pushes synchronously on the test thread (`RequestStop`) **and** on a threadpool thread (`RunStopAsync` completion) — `BehaviorSubject` invokes subscribers on whichever thread calls `OnNext` — while the test thread polls `Count`/`[^1]`. A concurrent `Add` during an internal array resize leaves a torn backing store → `NullReferenceException` on read (load-dependent, CI-only).

**Fix:** replaced the shared `List<T>` with a lock-guarded `StopStateRecorder` across all eight sibling tests in the file.

## Verification

- `LocalPermissionBridgeTests`: 61/61 green.
- `AgentActionServiceTests`: 19/19 green across 5 consecutive runs.