### PR TITLE
[AI-1863] Cap the passive update notice + kcap status at the connected server's version

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ error, so you no longer have to run `kcap whoami` to work out why recording stop
 hooks print the same advice to stderr instead of an in-session notice, since not every agent
 surfaces hook output in its UI. `kcap status` prints its own
 **Version** line — the installed CLI version, with an inline `(update available: …)` annotation
-when a newer one is out — see [`kcap update`](#other-commands) for the full opt-out story.
+when a newer one is out (capped at your connected server's version, marked `(…, server version)` when
+your tenant trails npm) — see [`kcap update`](#other-commands) for the full opt-out story.
 
 Setup closes with a **Next steps** box. Each item opens with a question, because neither step is for
 everyone:

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -78,11 +78,18 @@ public static class HttpClientExtensions {
         HttpClient NewClient(DelegatingHandler? retry = null) {
             var primary = new HttpClientHandler { AllowAutoRedirect = allowAutoRedirect };
 
-            if (retry is null) return new(primary);
+            HttpMessageHandler inner = primary;
 
-            retry.InnerHandler = primary;
+            if (retry is not null) {
+                retry.InnerHandler = primary;
+                inner = retry;
+            }
 
-            return new(retry);
+            // Capture the server's own version (X-Kcap-Server-Version) from every response — outermost,
+            // so it observes the FINAL response after any 401-retry. No extra requests; best-effort.
+            var capture = new ServerVersionCaptureHandler(baseUrl) { InnerHandler = inner };
+
+            return new(capture);
         }
 
         var provider = await DiscoverProviderAsync(baseUrl, ct);
@@ -154,6 +161,11 @@ public static class HttpClientExtensions {
 
     /// <summary>Wire header naming the installed CLI's display version (see <see cref="CapacitorVersion.CurrentDisplay"/>).</summary>
     public const string CliVersionHeader = "X-Kcap-Cli-Version";
+
+    /// <summary>Response header carrying the connected server's own version, captured by
+    /// <see cref="ServerVersionCaptureHandler"/> so the passive update notice can cap its
+    /// recommendation at <c>min(npm latest, server version)</c>.</summary>
+    public const string ServerVersionHeader = "X-Kcap-Server-Version";
 
     /// <summary>
     /// Wire header sent ONLY to declare the active profile's update-check preference is off. Its
@@ -523,5 +535,28 @@ public static class HttpClientExtensions {
                 $"(per-attempt timeout {perAttemptTimeout.TotalSeconds:F0}s).",
                 inner
             );
+    }
+}
+
+/// <summary>
+/// Passively records the connected server's version from each response's
+/// <see cref="HttpClientExtensions.ServerVersionHeader"/> into <see cref="ServerVersionStore"/>, so
+/// the passive update notice and <c>kcap status</c> can cap their recommendation at the server's
+/// version. Installed as the OUTERMOST handler on every authenticated client (see the choke point's
+/// <c>NewClient</c>), so it observes the final response after any retry. Best-effort: it never alters
+/// the request/response and never lets a capture failure surface.
+/// </summary>
+internal sealed class ServerVersionCaptureHandler(string serverUrl) : DelegatingHandler {
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+        var response = await base.SendAsync(request, ct);
+
+        try {
+            if (response.Headers.TryGetValues(HttpClientExtensions.ServerVersionHeader, out var values))
+                ServerVersionStore.Set(serverUrl, values.FirstOrDefault());
+        } catch {
+            // Header capture must never affect the response the caller gets back.
+        }
+
+        return response;
     }
 }

--- a/src/Capacitor.Cli.Core/Resources/help-update.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-update.txt
@@ -27,6 +27,15 @@ Options:
 Beta releases correspond to server versions rolled out to internal
 tenants first. Most users should stay on the default stable channel.
 
+The passive "update available" hint and the kcap status version line are
+capped at the version of the server you're connected to: when your tenant's
+server trails npm (rollouts are manual and can lag by days), they recommend
+the server's version — shown with a "(server version)" marker and a pinned
+"npm install -g @kurrent/kcap@<version>" command — rather than steering you
+to a CLI newer than the server supports. `kcap update` itself is never
+capped; it always installs the latest on your channel. The cap applies on
+the stable channel only; beta deliberately rides ahead.
+
 update_check (kcap config set update_check false):
   Controls ALL kcap update nudging, not just the local stderr hint. With
   it off, kcap: skips the passive "update available" hint printed after

--- a/src/Capacitor.Cli.Core/ServerVersionStore.cs
+++ b/src/Capacitor.Cli.Core/ServerVersionStore.cs
@@ -77,13 +77,9 @@ public static class ServerVersionStore {
         }
     }
 
-    /// <summary>Normalizes a server URL to a stable cache key using the repo's own server identity
-    /// (<see cref="ServerIdentity.Canonicalize"/>): scheme and host are lower-cased and an implicit vs
-    /// explicit default port converges, but the path is preserved case-sensitively — a path-routed
-    /// deployment (<c>/TenantA</c> vs <c>/tenanta</c>) is a DISTINCT server, and flattening its case
-    /// would cap it against the wrong server. Falls back to a conservative trim (NOT lower-cased) for a
-    /// URL that isn't an admissible server base, so the store still yields a stable key without
-    /// conflating query/fragment-bearing spellings.</summary>
+    /// <summary>Stable cache key via the repo's own <see cref="ServerIdentity.Canonicalize"/> (path stays
+    /// case-sensitive — a path-routed tenant is a distinct server), falling back to a conservative trim for
+    /// a URL that isn't an admissible server base.</summary>
     internal static string Normalize(string serverUrl) =>
         ServerIdentity.Canonicalize(serverUrl) ?? serverUrl.Trim().TrimEnd('/');
 

--- a/src/Capacitor.Cli.Core/ServerVersionStore.cs
+++ b/src/Capacitor.Cli.Core/ServerVersionStore.cs
@@ -1,0 +1,88 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Core;
+
+/// <summary>
+/// Durable, per-server cache of the connected Kurrent Capacitor server's own version, learned
+/// passively from the <c>X-Kcap-Server-Version</c> response header (see
+/// <see cref="HttpClientExtensions"/>'s capture handler). The passive update notice and
+/// <c>kcap status</c> read it to cap the recommended CLI version at <c>min(npm latest, server
+/// version)</c> — a manually-rolled tenant can trail npm for days, and nudging a user to a CLI newer
+/// than the server they talk to only risks protocol mismatch.
+///
+/// <para>One flat file per normalized server URL (<c>server-version-{hash}.json</c> in the CLI config
+/// dir, honouring <c>KCAP_CONFIG_DIR</c> — the <see cref="MachineId"/> precedent), so a multi-profile
+/// user gets a per-server cap for free and two servers never race one map file. Best-effort
+/// throughout: a read or write failure never surfaces — an absent value just means "no cap", which is
+/// exactly today's behaviour. <see cref="Set"/> is deduped in-process so the per-response hot path
+/// touches disk at most once per distinct value per process.</para>
+/// </summary>
+public static class ServerVersionStore {
+    // Per-process memo of the last value written for each server, so a long-lived process (the daemon)
+    // making many requests doesn't rewrite the same file on every response.
+    static readonly ConcurrentDictionary<string, string> WrittenThisProcess = new();
+
+    /// <summary>
+    /// Records the server version observed for <paramref name="serverUrl"/>. No-op for a blank URL or
+    /// version, or when the same value was already written this process. Never throws.
+    /// </summary>
+    public static void Set(string? serverUrl, string? version) {
+        if (string.IsNullOrWhiteSpace(serverUrl) || string.IsNullOrWhiteSpace(version)) return;
+
+        var key = Normalize(serverUrl);
+
+        if (WrittenThisProcess.TryGetValue(key, out var prev) && prev == version) return;
+
+        try {
+            var obj = new JsonObject {
+                ["url"]     = key,
+                ["version"] = version,
+                ["seen_at"] = DateTimeOffset.UtcNow,
+            };
+
+            var path     = PathFor(key);
+            var tempPath = $"{path}.tmp";
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(tempPath, obj.ToJsonString());
+            File.Move(tempPath, path, overwrite: true);
+
+            WrittenThisProcess[key] = version;
+        } catch {
+            // Best-effort — a cache write must never break the request it rides on.
+        }
+    }
+
+    /// <summary>
+    /// The last-observed server version for <paramref name="serverUrl"/>, or null when none has been
+    /// seen (an old CLI, a never-connected server, or a server that doesn't send the header). Never
+    /// throws — a corrupt/unreadable file reads as null and re-populates on the next request.
+    /// </summary>
+    public static string? Get(string? serverUrl) {
+        if (string.IsNullOrWhiteSpace(serverUrl)) return null;
+
+        try {
+            var path = PathFor(Normalize(serverUrl));
+            if (!File.Exists(path)) return null;
+
+            var node    = JsonNode.Parse(File.ReadAllText(path));
+            var version = node?["version"]?.GetValue<string>();
+
+            return string.IsNullOrWhiteSpace(version) ? null : version;
+        } catch {
+            return null;
+        }
+    }
+
+    /// <summary>Normalizes a server URL to a stable cache key: trimmed, no trailing slash,
+    /// lower-cased (scheme+host+port only — these carry no case-sensitive path).</summary>
+    internal static string Normalize(string serverUrl) => serverUrl.Trim().TrimEnd('/').ToLowerInvariant();
+
+    static string PathFor(string normalizedUrl) {
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalizedUrl)))[..16].ToLowerInvariant();
+
+        return PathHelpers.ConfigPath($"server-version-{hash}.json");
+    }
+}

--- a/src/Capacitor.Cli.Core/ServerVersionStore.cs
+++ b/src/Capacitor.Cli.Core/ServerVersionStore.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json.Nodes;
+using Capacitor.Cli.Core.Auth;
 
 namespace Capacitor.Cli.Core;
 
@@ -76,9 +77,15 @@ public static class ServerVersionStore {
         }
     }
 
-    /// <summary>Normalizes a server URL to a stable cache key: trimmed, no trailing slash,
-    /// lower-cased (scheme+host+port only — these carry no case-sensitive path).</summary>
-    internal static string Normalize(string serverUrl) => serverUrl.Trim().TrimEnd('/').ToLowerInvariant();
+    /// <summary>Normalizes a server URL to a stable cache key using the repo's own server identity
+    /// (<see cref="ServerIdentity.Canonicalize"/>): scheme and host are lower-cased and an implicit vs
+    /// explicit default port converges, but the path is preserved case-sensitively — a path-routed
+    /// deployment (<c>/TenantA</c> vs <c>/tenanta</c>) is a DISTINCT server, and flattening its case
+    /// would cap it against the wrong server. Falls back to a conservative trim (NOT lower-cased) for a
+    /// URL that isn't an admissible server base, so the store still yields a stable key without
+    /// conflating query/fragment-bearing spellings.</summary>
+    internal static string Normalize(string serverUrl) =>
+        ServerIdentity.Canonicalize(serverUrl) ?? serverUrl.Trim().TrimEnd('/');
 
     static string PathFor(string normalizedUrl) {
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalizedUrl)))[..16].ToLowerInvariant();

--- a/src/Capacitor.Cli/Commands/StatusCommand.cs
+++ b/src/Capacitor.Cli/Commands/StatusCommand.cs
@@ -109,7 +109,7 @@ public static class StatusCommand {
         // check is performed at all (never force one the user turned off) — the line still
         // prints the bare version.
         if (args.Contains("--no-update-check")) {
-            await Console.Out.WriteLineAsync(FormatVersionLine(current, null));
+            await Console.Out.WriteLineAsync(FormatVersionLine(current, default));
 
             return;
         }
@@ -117,17 +117,20 @@ public static class StatusCommand {
         var profile = await AppConfig.GetActiveProfileAsync();
 
         if (profile?.UpdateCheck == false) {
-            await Console.Out.WriteLineAsync(FormatVersionLine(current, null));
+            await Console.Out.WriteLineAsync(FormatVersionLine(current, default));
 
             return;
         }
 
-        var channel = UpdateCommand.ResolveChannel(args, profile?.UpdateChannel);
-        var result  = await UpdateNotice.GetSharedCheckAsync(channel);
+        var channel  = UpdateCommand.ResolveChannel(args, profile?.UpdateChannel);
+        var result   = await UpdateNotice.GetSharedCheckAsync(channel);
 
-        await Console.Out.WriteLineAsync(FormatVersionLine(current, result));
+        // Cap the recommendation at the connected server's version (min(npm latest, server)).
+        var advisory = UpdateAdvisoryResolver.Resolve(result, channel);
 
-        if (result is { Newer: true, Latest: not null }) {
+        await Console.Out.WriteLineAsync(FormatVersionLine(current, advisory));
+
+        if (advisory.Newer) {
             // Surfaced inline already — the exit-time footer (UpdateNotice.FlushAsync) must not
             // print the same information a second time.
             UpdateNotice.MarkReported();
@@ -136,13 +139,16 @@ public static class StatusCommand {
 
     /// <summary>
     /// Pure formatting for the Version line: <c>kcap {current}</c>, with an inline
-    /// <c>(update available: {latest})</c> annotation appended only when
-    /// <paramref name="result"/> reports a newer version. Split out from
-    /// <see cref="WriteVersionLineAsync"/> so the exact text is unit-testable without any I/O.
+    /// <c>(update available: {target})</c> annotation appended only when <paramref name="advisory"/>
+    /// reports a newer version — and, when the target was capped at the server's version, a
+    /// <c>, server version</c> marker. Split out from <see cref="WriteVersionLineAsync"/> so the exact
+    /// text is unit-testable without any I/O.
     /// </summary>
-    internal static string FormatVersionLine(string current, UpdateCommand.UpdateCheckResult? result) =>
-        result is { Newer: true, Latest: not null }
-            ? $"kcap {current} (update available: {result.Latest})"
+    internal static string FormatVersionLine(string current, UpdateAdvisory advisory) =>
+        advisory is { Newer: true, Target: { } target }
+            ? advisory.ServerCapped
+                ? $"kcap {current} (update available: {target}, server version)"
+                : $"kcap {current} (update available: {target})"
             : $"kcap {current}";
 
     static async Task WriteAgentStatusAsync() {

--- a/src/Capacitor.Cli/UpdateAdvisory.cs
+++ b/src/Capacitor.Cli/UpdateAdvisory.cs
@@ -41,8 +41,11 @@ internal static class UpdateAdvisoryResolver {
             return new(current, latest, result.Newer, ServerCapped: false);
 
         // min(npm latest, server version): the server caps only when it is strictly older than npm latest.
+        // Strip any +buildmetadata from the server version before it becomes the user-facing / pinned-install
+        // target — MinVer stamps a commit SHA there, and `npm install @kurrent/kcap@0.11.15+sha` would not
+        // resolve (SemVer comparison ignores build metadata, so the cap decision is unchanged either way).
         var capped = PrereleaseSemver.IsNewer(latest, cachedServerVersion);
-        var target = capped ? cachedServerVersion : latest;
+        var target = capped ? CapacitorVersion.Display(cachedServerVersion) : latest;
 
         return new(current, target, PrereleaseSemver.IsNewer(target, current), ServerCapped: capped);
     }

--- a/src/Capacitor.Cli/UpdateAdvisory.cs
+++ b/src/Capacitor.Cli/UpdateAdvisory.cs
@@ -1,0 +1,61 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli;
+
+/// <summary>
+/// The effective "update available" advisory after capping the raw npm-latest target at the connected
+/// server's version. A manually-rolled tenant can trail npm for days, so recommending a CLI newer than
+/// the server it talks to only risks protocol mismatch; the passive update notice and <c>kcap status</c>
+/// render this instead of the raw npm result. <see cref="ServerCapped"/> drives the pinned-install copy.
+/// </summary>
+internal readonly record struct UpdateAdvisory(string? Current, string? Target, bool Newer, bool ServerCapped);
+
+internal static class UpdateAdvisoryResolver {
+    /// <summary>Resolves the server URL the same way the authenticated HTTP choke point does
+    /// (<c>HttpClientExtensions.CreateClientCoreImplAsync</c>), so the cached server version is read
+    /// under the same key it was captured with.</summary>
+    internal static string ResolvedServerUrl() =>
+        AppConfig.ResolvedServerUrl ?? Environment.GetEnvironmentVariable("KCAP_URL") ?? "http://localhost:5108";
+
+    /// <summary>Production entry: caps against the cached version for the current server.</summary>
+    internal static UpdateAdvisory Resolve(UpdateCommand.UpdateCheckResult? result, string channel) =>
+        Resolve(result, channel, ServerVersionStore.Get(ResolvedServerUrl()));
+
+    /// <summary>
+    /// Pure, testable core. The cap engages ONLY on the stable <c>latest</c> channel (a beta user
+    /// deliberately rides ahead of the server) AND when a cached server version is present and parses as
+    /// a stable release. Otherwise the raw npm result passes through unchanged — an old CLI, a
+    /// never-connected server, or the beta channel keeps today's behaviour (the cold-start doctrine).
+    /// When capping, the target is <c>min(npm latest, server version)</c> and "newer" is recomputed
+    /// against it, so a user already at/ahead of their server is never nagged.
+    /// </summary>
+    internal static UpdateAdvisory Resolve(UpdateCommand.UpdateCheckResult? result, string channel, string? cachedServerVersion) {
+        if (result is not { Latest: { } latest, Current: { } current })
+            return new(result?.Current, result?.Latest, result?.Newer ?? false, ServerCapped: false);
+
+        if (!string.Equals(channel, "latest", StringComparison.Ordinal)
+                || cachedServerVersion is null
+                || !IsStableRelease(cachedServerVersion))
+            return new(current, latest, result.Newer, ServerCapped: false);
+
+        // min(npm latest, server version): the server caps only when it is strictly older than npm latest.
+        var capped = PrereleaseSemver.IsNewer(latest, cachedServerVersion);
+        var target = capped ? cachedServerVersion : latest;
+
+        return new(current, target, PrereleaseSemver.IsNewer(target, current), ServerCapped: capped);
+    }
+
+    /// <summary>A "stable release" parses as a dotted numeric core (≥3 components) with no prerelease
+    /// suffix (build metadata is ignored). The server only ever sends stable versions in the header;
+    /// this is belt-and-braces against an old or malformed cached value.</summary>
+    internal static bool IsStableRelease(string version) {
+        var s    = version.Trim();
+        var plus = s.IndexOf('+');
+        if (plus >= 0) s = s[..plus];
+        if (s.Contains('-')) return false; // prerelease suffix
+
+        return Version.TryParse(s, out var v) && v.Build >= 0; // Build < 0 ⇒ fewer than 3 components
+    }
+}

--- a/src/Capacitor.Cli/UpdateNotice.cs
+++ b/src/Capacitor.Cli/UpdateNotice.cs
@@ -75,18 +75,31 @@ internal static class UpdateNotice {
             var profile = await AppConfig.GetActiveProfileAsync();
             if (profile?.UpdateCheck == false) return;
 
-            var channel = UpdateCommand.ResolveChannel(args, profile?.UpdateChannel);
-            var result  = await GetSharedCheckAsync(channel);
+            var channel  = UpdateCommand.ResolveChannel(args, profile?.UpdateChannel);
+            var result   = await GetSharedCheckAsync(channel);
+
+            // Cap the recommendation at the connected server's version (min(npm latest, server)) so we
+            // never steer a user to a CLI newer than the server they talk to. Uncapped ⇒ today's copy.
+            var advisory = UpdateAdvisoryResolver.Resolve(result, channel);
 
             // Re-check after the await: `kcap status` may have won the race and already reported
             // while this was in flight (both may share the same in-flight task via GetSharedCheckAsync).
-            if (_reported || result is not { Newer: true, Latest: not null, Current: not null }) return;
+            if (_reported || !advisory.Newer || advisory.Target is null || advisory.Current is null) return;
 
             _reported = true;
 
             await Console.Error.WriteLineAsync();
-            await Console.Error.WriteLineAsync($"Update available: {result.Current} {UpdateCommand.Arrow} {result.Latest}");
-            await Console.Error.WriteLineAsync("Run `kcap update` to update");
+
+            if (advisory.ServerCapped) {
+                // The server is behind npm latest; plain `kcap update` follows the dist-tag and would
+                // overshoot the cap, so recommend the pinned install of the server's version.
+                await Console.Error.WriteLineAsync(
+                    $"Update available: {advisory.Current} {UpdateCommand.Arrow} {advisory.Target} (server version)");
+                await Console.Error.WriteLineAsync($"Run: npm install -g @kurrent/kcap@{advisory.Target}");
+            } else {
+                await Console.Error.WriteLineAsync($"Update available: {advisory.Current} {UpdateCommand.Arrow} {advisory.Target}");
+                await Console.Error.WriteLineAsync("Run `kcap update` to update");
+            }
         } catch {
             // Best effort — an update notice must never break the command it's attached to.
         }

--- a/test/Capacitor.Cli.Tests.Unit/ServerVersionCaptureHandlerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ServerVersionCaptureHandlerTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The passive capture path: a response carrying <c>X-Kcap-Server-Version</c> lands in
+/// <see cref="ServerVersionStore"/>; one without it captures nothing. Drives the internal
+/// <c>ServerVersionCaptureHandler</c> over a stub inner handler (no network).
+/// </summary>
+public class ServerVersionCaptureHandlerTests {
+    sealed class StubHandler(HttpResponseMessage response) : HttpMessageHandler {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(response);
+    }
+
+    static async Task SendThrough(string serverUrl, HttpResponseMessage response) {
+        var capture = new ServerVersionCaptureHandler(serverUrl) { InnerHandler = new StubHandler(response) };
+        using var client = new HttpClient(capture);
+        using var _ = await client.GetAsync(serverUrl);
+    }
+
+    [Test]
+    public async Task Response_WithHeader_CapturesServerVersion() {
+        var url      = $"https://cap-{Guid.NewGuid():N}.example.com";
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+        response.Headers.Add(HttpClientExtensions.ServerVersionHeader, "0.11.15");
+
+        await SendThrough(url, response);
+
+        await Assert.That(ServerVersionStore.Get(url)).IsEqualTo("0.11.15");
+    }
+
+    [Test]
+    public async Task Response_WithoutHeader_CapturesNothing() {
+        var url      = $"https://cap-{Guid.NewGuid():N}.example.com";
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+        await SendThrough(url, response);
+
+        await Assert.That(ServerVersionStore.Get(url)).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/ServerVersionStoreTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ServerVersionStoreTests.cs
@@ -52,6 +52,26 @@ public class ServerVersionStoreTests {
     }
 
     [Test]
+    public async Task Set_DefaultPort_ConvergesWithImplicit() {
+        // https://host and https://host:443 are the same server — one cache entry, not two.
+        var host = $"cap-{Guid.NewGuid():N}.example.com";
+        ServerVersionStore.Set($"https://{host}", "0.11.15");
+
+        await Assert.That(ServerVersionStore.Get($"https://{host}:443")).IsEqualTo("0.11.15");
+    }
+
+    [Test]
+    public async Task Set_PathCase_IsSignificant() {
+        // Path-routed deployments are DISTINCT servers; path casing must not be flattened, or one tenant
+        // would be capped against another's server version.
+        var host = $"cap-{Guid.NewGuid():N}.example.com";
+        ServerVersionStore.Set($"https://{host}/TenantA", "0.11.15");
+
+        await Assert.That(ServerVersionStore.Get($"https://{host}/tenanta")).IsNull();
+        await Assert.That(ServerVersionStore.Get($"https://{host}/TenantA")).IsEqualTo("0.11.15");
+    }
+
+    [Test]
     public async Task Set_DistinctServers_AreIndependent() {
         var a = UniqueUrl("srv-a");
         var b = UniqueUrl("srv-b");

--- a/test/Capacitor.Cli.Tests.Unit/ServerVersionStoreTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ServerVersionStoreTests.cs
@@ -1,0 +1,73 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Round-trip + normalization coverage for <see cref="ServerVersionStore"/>, the durable per-server
+/// cache of the <c>X-Kcap-Server-Version</c> header. Writes into the assembly-wide shared config dir
+/// (set by the module initializer); every test uses a UNIQUE server URL so the per-URL hashed files
+/// never collide with a sibling test.
+/// </summary>
+public class ServerVersionStoreTests {
+    // A distinct URL per test/case so the hashed filename (and the in-process dedup) can't collide.
+    static string UniqueUrl(string tag) => $"https://{tag}-{Guid.NewGuid():N}.example.com";
+
+    [Test]
+    public async Task SetThenGet_RoundTrips() {
+        var url = UniqueUrl("roundtrip");
+        ServerVersionStore.Set(url, "0.11.15");
+
+        await Assert.That(ServerVersionStore.Get(url)).IsEqualTo("0.11.15");
+    }
+
+    [Test]
+    public async Task Get_UnknownServer_ReturnsNull() {
+        await Assert.That(ServerVersionStore.Get(UniqueUrl("unknown"))).IsNull();
+    }
+
+    [Test]
+    public async Task Get_BlankUrl_ReturnsNull() {
+        await Assert.That(ServerVersionStore.Get(null)).IsNull();
+        await Assert.That(ServerVersionStore.Get("   ")).IsNull();
+    }
+
+    [Test]
+    public async Task Set_NormalizesTrailingSlashAndCase() {
+        var host = $"cap-{Guid.NewGuid():N}.example.com";
+        ServerVersionStore.Set($"https://{host}/", "0.11.15");
+
+        // A different-cased, slash-free spelling of the same server resolves the same entry.
+        await Assert.That(ServerVersionStore.Get($"HTTPS://{host.ToUpperInvariant()}")).IsEqualTo("0.11.15");
+    }
+
+    [Test]
+    public async Task Set_BlankVersionOrUrl_IsNoOp() {
+        var url = UniqueUrl("blank");
+        ServerVersionStore.Set(url, "");
+        ServerVersionStore.Set(url, null);
+        ServerVersionStore.Set(null, "0.11.15");
+        ServerVersionStore.Set("  ", "0.11.15");
+
+        await Assert.That(ServerVersionStore.Get(url)).IsNull();
+    }
+
+    [Test]
+    public async Task Set_DistinctServers_AreIndependent() {
+        var a = UniqueUrl("srv-a");
+        var b = UniqueUrl("srv-b");
+        ServerVersionStore.Set(a, "0.11.15");
+        ServerVersionStore.Set(b, "0.12.0");
+
+        await Assert.That(ServerVersionStore.Get(a)).IsEqualTo("0.11.15");
+        await Assert.That(ServerVersionStore.Get(b)).IsEqualTo("0.12.0");
+    }
+
+    [Test]
+    public async Task Set_OverwritesWithNewerObservation() {
+        var url = UniqueUrl("overwrite");
+        ServerVersionStore.Set(url, "0.11.15");
+        ServerVersionStore.Set(url, "0.12.0"); // a later deploy bumped the server
+
+        await Assert.That(ServerVersionStore.Get(url)).IsEqualTo("0.12.0");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/StatusVersionLineFormattingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/StatusVersionLineFormattingTests.cs
@@ -12,32 +12,41 @@ namespace Capacitor.Cli.Tests.Unit;
 /// </summary>
 public class StatusVersionLineFormattingTests {
     [Test]
-    public async Task NullResult_PrintsBareVersion() {
-        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", null)).IsEqualTo("kcap 0.11.12");
+    public async Task NotAvailable_PrintsBareVersion() {
+        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", default)).IsEqualTo("kcap 0.11.12");
     }
 
     [Test]
     public async Task NotNewer_PrintsBareVersion_NoAnnotation() {
-        var result = new UpdateCommand.UpdateCheckResult(Current: "0.11.12", Latest: "0.11.12", Newer: false, FromCache: true);
+        var advisory = new UpdateAdvisory(Current: "0.11.12", Target: "0.11.12", Newer: false, ServerCapped: false);
 
-        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", result)).IsEqualTo("kcap 0.11.12");
+        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", advisory)).IsEqualTo("kcap 0.11.12");
     }
 
     [Test]
     public async Task Newer_AppendsInlineUpdateAvailableAnnotation() {
-        var result = new UpdateCommand.UpdateCheckResult(Current: "0.11.12", Latest: "0.11.14", Newer: true, FromCache: true);
+        var advisory = new UpdateAdvisory(Current: "0.11.12", Target: "0.11.14", Newer: true, ServerCapped: false);
 
-        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", result))
+        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", advisory))
             .IsEqualTo("kcap 0.11.12 (update available: 0.11.14)");
     }
 
-    // Newer:true with a null Latest is a shape the current UpdateCheckResult never actually
-    // produces together, but the formatter defends against it anyway rather than trusting the
-    // flag alone — same discipline as UpdateNotice.FlushAsync's own pattern match.
     [Test]
-    public async Task Newer_ButLatestNull_PrintsBareVersion() {
-        var result = new UpdateCommand.UpdateCheckResult(Current: "0.11.12", Latest: null, Newer: true, FromCache: true);
+    public async Task ServerCapped_AppendsServerVersionMarker() {
+        // npm is ahead of the server; the annotation names the capped (server) target and marks it.
+        var advisory = new UpdateAdvisory(Current: "0.11.12", Target: "0.11.15", Newer: true, ServerCapped: true);
 
-        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", result)).IsEqualTo("kcap 0.11.12");
+        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", advisory))
+            .IsEqualTo("kcap 0.11.12 (update available: 0.11.15, server version)");
+    }
+
+    // Newer:true with a null Target is a shape the resolver never actually produces together, but the
+    // formatter defends against it anyway rather than trusting the flag alone — same discipline as
+    // UpdateNotice.FlushAsync's own pattern match.
+    [Test]
+    public async Task Newer_ButTargetNull_PrintsBareVersion() {
+        var advisory = new UpdateAdvisory(Current: "0.11.12", Target: null, Newer: true, ServerCapped: false);
+
+        await Assert.That(StatusCommand.FormatVersionLine("0.11.12", advisory)).IsEqualTo("kcap 0.11.12");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/UpdateAdvisoryResolverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UpdateAdvisoryResolverTests.cs
@@ -1,0 +1,115 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// Truth table for <see cref="UpdateAdvisoryResolver.Resolve(UpdateCommand.UpdateCheckResult?, string, string?)"/>
+/// — the pure cap logic. The cap engages ONLY on the stable <c>latest</c> channel with a cached, stable
+/// server version present; otherwise the raw npm result passes through unchanged. When capping, the
+/// target is <c>min(npm latest, server version)</c> and "newer" is recomputed against it.
+/// </summary>
+public class UpdateAdvisoryResolverTests {
+    static UpdateCommand.UpdateCheckResult Result(string current, string? latest, bool newer) =>
+        new(current, latest, newer, FromCache: true);
+
+    // ── passthrough (no cap) ─────────────────────────────────────────────────────
+
+    [Test]
+    public async Task NoCachedServer_PassesThroughNpmLatest() {
+        var advisory = UpdateAdvisoryResolver.Resolve(Result("0.11.0", "0.12.0", newer: true), "latest", cachedServerVersion: null);
+
+        await Assert.That(advisory.Target).IsEqualTo("0.12.0");
+        await Assert.That(advisory.Newer).IsTrue();
+        await Assert.That(advisory.ServerCapped).IsFalse();
+    }
+
+    [Test]
+    public async Task BetaChannel_NotCapped_EvenWithACachedServer() {
+        // Beta users deliberately ride ahead of the server; the cap never applies off the latest channel.
+        var advisory = UpdateAdvisoryResolver.Resolve(Result("0.11.0", "0.12.0", newer: true), "beta", cachedServerVersion: "0.11.15");
+
+        await Assert.That(advisory.Target).IsEqualTo("0.12.0");
+        await Assert.That(advisory.ServerCapped).IsFalse();
+    }
+
+    [Test]
+    public async Task CachedServerIsPrerelease_NotCapped() {
+        // Belt-and-braces: the server only sends stable versions, but a malformed cached value must
+        // not become a cap.
+        var advisory = UpdateAdvisoryResolver.Resolve(Result("0.11.0", "0.12.0", newer: true), "latest", cachedServerVersion: "0.11.15-beta.1");
+
+        await Assert.That(advisory.Target).IsEqualTo("0.12.0");
+        await Assert.That(advisory.ServerCapped).IsFalse();
+    }
+
+    [Test]
+    public async Task ServerAtOrAheadOfNpm_NotCapped() {
+        // min(npm, server) = npm here — a server at/ahead of npm never withholds an installable release.
+        var advisory = UpdateAdvisoryResolver.Resolve(Result("0.11.0", "0.11.15", newer: true), "latest", cachedServerVersion: "0.12.0");
+
+        await Assert.That(advisory.Target).IsEqualTo("0.11.15");
+        await Assert.That(advisory.ServerCapped).IsFalse();
+    }
+
+    // ── capping ──────────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task NpmAheadOfServer_CapsAtServerVersion() {
+        var advisory = UpdateAdvisoryResolver.Resolve(Result("0.11.0", "0.12.0", newer: true), "latest", cachedServerVersion: "0.11.15");
+
+        await Assert.That(advisory.Target).IsEqualTo("0.11.15")
+            .Because("capped at the server version, never the withheld npm latest");
+        await Assert.That(advisory.Newer).IsTrue();
+        await Assert.That(advisory.ServerCapped).IsTrue();
+    }
+
+    [Test]
+    public async Task UserAtServerVersion_ButBehindNpm_NotNewer() {
+        // Already as current as the server supports ⇒ no nudge (never a downgrade recommendation).
+        var advisory = UpdateAdvisoryResolver.Resolve(Result("0.11.15", "0.12.0", newer: true), "latest", cachedServerVersion: "0.11.15");
+
+        await Assert.That(advisory.Target).IsEqualTo("0.11.15");
+        await Assert.That(advisory.Newer).IsFalse();
+        await Assert.That(advisory.ServerCapped).IsTrue();
+    }
+
+    [Test]
+    public async Task UserAheadOfServerTarget_NotNewer() {
+        var advisory = UpdateAdvisoryResolver.Resolve(Result("0.11.16", "0.12.0", newer: true), "latest", cachedServerVersion: "0.11.15");
+
+        await Assert.That(advisory.Newer).IsFalse()
+            .Because("a user between the server and npm is never told to downgrade");
+    }
+
+    // ── degenerate inputs ────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task NullResult_NotAvailable() {
+        var advisory = UpdateAdvisoryResolver.Resolve(null, "latest", cachedServerVersion: "0.11.15");
+
+        await Assert.That(advisory.Newer).IsFalse();
+        await Assert.That(advisory.Target).IsNull();
+        await Assert.That(advisory.ServerCapped).IsFalse();
+    }
+
+    [Test]
+    public async Task NullLatest_PassesThrough_NoCap() {
+        var advisory = UpdateAdvisoryResolver.Resolve(Result("0.11.0", latest: null, newer: false), "latest", cachedServerVersion: "0.11.15");
+
+        await Assert.That(advisory.Target).IsNull();
+        await Assert.That(advisory.ServerCapped).IsFalse();
+    }
+
+    // ── the stable-release gate ──────────────────────────────────────────────────
+
+    [Test]
+    [Arguments("0.11.15", true)]
+    [Arguments("0.11.15+sha.abc", true)]   // build metadata is ignored
+    [Arguments("0.11.15-beta.1", false)]   // prerelease
+    [Arguments("0.11", false)]             // fewer than three components
+    [Arguments("not-a-version", false)]
+    [Arguments("", false)]
+    public async Task IsStableRelease_Gate(string version, bool expected) {
+        await Assert.That(UpdateAdvisoryResolver.IsStableRelease(version)).IsEqualTo(expected);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/UpdateAdvisoryResolverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UpdateAdvisoryResolverTests.cs
@@ -64,6 +64,18 @@ public class UpdateAdvisoryResolverTests {
     }
 
     [Test]
+    public async Task CappedTarget_StripsServerBuildMetadata() {
+        // MinVer stamps a commit SHA as +buildmetadata; it must not leak into the "(server version)" copy
+        // or the pinned `npm install @kurrent/kcap@<target>` command (which would then fail to resolve).
+        var advisory = UpdateAdvisoryResolver.Resolve(Result("0.11.0", "0.12.0", newer: true), "latest", cachedServerVersion: "0.11.15+sha.abc");
+
+        await Assert.That(advisory.Target).IsEqualTo("0.11.15")
+            .Because("build metadata is stripped from the user-facing / pinned-install target");
+        await Assert.That(advisory.ServerCapped).IsTrue();
+        await Assert.That(advisory.Newer).IsTrue();
+    }
+
+    [Test]
     public async Task UserAtServerVersion_ButBehindNpm_NotNewer() {
         // Already as current as the server supports ⇒ no nudge (never a downgrade recommendation).
         var advisory = UpdateAdvisoryResolver.Resolve(Result("0.11.15", "0.12.0", newer: true), "latest", cachedServerVersion: "0.11.15");


### PR DESCRIPTION
## Context

The server half ([kcap-server #1404](https://github.com/kurrent-io/kcap-server/pull/1404), AI-1863) caps CLI-update recommendations at **`min(npm latest, server version)`** and emits an `X-Kcap-Server-Version` response header. This is the **client half**: the CLI now consumes that header so its own passive "update available" stderr notice and the `kcap status` version line never steer a user to a CLI newer than the server they talk to — manual tenant rollouts can trail npm by days, and a newer CLI risks protocol mismatch against the older server.

## What changed

- **`ServerVersionStore`** — a durable, per-normalized-server-URL cache of the server version (one flat file per server in the config dir; best-effort, with an in-process write-dedup so the per-response hot path touches disk at most once per distinct value).
- **`ServerVersionCaptureHandler`** — the outermost `DelegatingHandler` on every authenticated client (the `CreateClientCoreImplAsync` choke point, the same one that attaches the request-side observation headers), reading `X-Kcap-Server-Version` from each response into the store. No extra requests; best-effort, never alters the response.
- **`UpdateAdvisoryResolver`** — caps the npm-latest target at `min(npm, cached server version)`, **only** on the stable `latest` channel with a cached, stable server version present (beta deliberately rides ahead; an absent cache keeps today's behaviour — the cold-start doctrine). Recomputes "newer" against the capped target, so a user already at/ahead of their server is never nagged.
- **`UpdateNotice`** (passive exit-time stderr notice) and **`kcap status`** render the capped advisory: when capped, a pinned `npm install -g @kurrent/kcap@<target>` command and a `(server version)` marker (plain `kcap update` follows the dist-tag and would overshoot the cap). **`kcap update` and `--check` stay UNCAPPED** — they're explicit actions, not recommendations.

**Surface D (the in-agent `VersionNudgeEmitter`) needs no change**: the server *omits* the hook `version` field when the target is capped, so the emitter only ever receives an uncapped target (where plain `kcap update` is correct).

## Tests

29 unit tests, all green locally:
- `ServerVersionStoreTests` (round-trip, normalization, per-server independence, overwrite, no-op guards);
- `ServerVersionCaptureHandlerTests` (header present → captured; absent → nothing);
- `UpdateAdvisoryResolverTests` (the cap truth table — passthrough when uncapped/beta/prerelease/absent, cap at min, user-ahead-not-nagged, plus the stable-release gate);
- `StatusVersionLineFormattingTests` (bare / uncapped / capped-with-marker rendering).

README + `help-update.txt` updated in the same PR (house rule).

Completes the client half of [AI-1863](https://linear.app/kurrent/issue/AI-1863).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
