### PR TITLE
[AI-1899] Parse retain_fact object shape + carry applies_to_* on the judge-fact wire

### DIFF
--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -25,7 +25,7 @@ public static class EvalService {
     // per-question prompt already instructs the judge to emit explicit
     // nulls, so this matches existing expectations.
     const string VerdictJsonSchema = """
-        {"type":"object","properties":{"category":{"type":"string"},"question_id":{"type":"string"},"score":{"type":"integer","minimum":1,"maximum":5},"verdict":{"type":"string","enum":["pass","warn","fail"]},"finding":{"type":"string"},"evidence":{"type":["string","null"]},"recommendation":{"type":["string","null"]},"retain_fact":{"type":["string","null"]}},"required":["category","question_id","score","verdict","finding","evidence","recommendation","retain_fact"],"additionalProperties":false}
+        {"type":"object","properties":{"category":{"type":"string"},"question_id":{"type":"string"},"score":{"type":"integer","minimum":1,"maximum":5},"verdict":{"type":"string","enum":["pass","warn","fail"]},"finding":{"type":"string"},"evidence":{"type":["string","null"]},"recommendation":{"type":["string","null"]},"retain_fact":{"type":["string","object","null"],"properties":{"fact":{"type":"string"},"applies_to_vendors":{"type":"array","items":{"type":"string"}},"applies_to_session_kinds":{"type":"array","items":{"type":"string"}}}}},"required":["category","question_id","score","verdict","finding","evidence","recommendation","retain_fact"],"additionalProperties":false}
         """;
 
     // maxItems mirrors the prompt's documented caps: at most three
@@ -566,8 +566,9 @@ public static class EvalService {
         // If the judge emitted a retain_fact, persist it for future evals.
         if (ExtractRetainFact(result.Result) is { } retainedFact) {
             if (await PostJudgeFactAsync(httpClient, baseUrl, ctx.EncodedSessionId, question.Category,
-                    retainedFact, ctx.EvalRunId, observer, ct)) {
-                observer.OnFactRetained(question.Category, retainedFact);
+                    retainedFact.Fact, ctx.EvalRunId, retainedFact.AppliesToVendors, retainedFact.AppliesToSessionKinds,
+                    observer, ct)) {
+                observer.OnFactRetained(question.Category, retainedFact.Fact);
             }
         }
 
@@ -1005,14 +1006,20 @@ public static class EvalService {
         return list;
     }
 
+    /// <summary>A retained fact plus the judge's optional applicability declaration. Both axes are
+    /// null when undeclared (= applies everywhere).</summary>
+    public readonly record struct RetainedFact(string Fact, string[]? AppliesToVendors, string[]? AppliesToSessionKinds);
+
     /// <summary>
-    /// Extracts the optional <c>retain_fact</c> string from a raw judge
-    /// response. Returns null when absent, explicitly null, empty, or when
-    /// the response isn't parseable JSON. Independent of
-    /// <see cref="ParseVerdict"/> so the retained-fact plumbing doesn't
-    /// depend on verdict parsing succeeding.
+    /// Extracts the optional <c>retain_fact</c> from a raw judge response. Accepts BOTH shapes:
+    /// the plain string (back-compat) and the object
+    /// <c>{"fact": "...", "applies_to_vendors": [...], "applies_to_session_kinds": [...]}</c>.
+    /// Returns null when absent, explicitly null, empty-fact, or not parseable JSON. A malformed
+    /// object (missing/empty fact) yields null (no fact) rather than throwing; a malformed axis
+    /// (not an array of strings) is dropped to null for that axis, keeping the fact. Independent of
+    /// <see cref="ParseVerdict"/> so the retained-fact plumbing doesn't depend on verdict parsing.
     /// </summary>
-    public static string? ExtractRetainFact(string rawResponse) {
+    public static RetainedFact? ExtractRetainFact(string rawResponse) {
         var json = StripCodeFences(rawResponse.Trim());
 
         try {
@@ -1021,19 +1028,44 @@ public static class EvalService {
                 return null;
             }
 
-            if (prop.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined) {
-                return null;
-            }
+            switch (prop.ValueKind) {
+                case JsonValueKind.String: {
+                    var text = prop.GetString()?.Trim();
+                    return string.IsNullOrEmpty(text) ? null : new RetainedFact(text, null, null);
+                }
+                case JsonValueKind.Object: {
+                    var fact = prop.TryGetProperty("fact", out var f) && f.ValueKind == JsonValueKind.String
+                        ? f.GetString()?.Trim()
+                        : null;
+                    if (string.IsNullOrEmpty(fact)) return null; // object without a usable fact — skip.
 
-            if (prop.ValueKind != JsonValueKind.String) {
-                return null;
+                    return new RetainedFact(
+                        fact,
+                        ReadStringArrayOrNull(prop, "applies_to_vendors"),
+                        ReadStringArrayOrNull(prop, "applies_to_session_kinds"));
+                }
+                default:
+                    return null; // null / number / bool / array — no fact.
             }
-
-            var text = prop.GetString()?.Trim();
-            return string.IsNullOrEmpty(text) ? null : text;
         } catch (JsonException) {
             return null;
         }
+    }
+
+    /// <summary>Reads a JSON array of non-empty strings from <paramref name="prop"/>, or null when
+    /// the field is absent, not an array, or empty. A non-string element drops the WHOLE axis to
+    /// null (fail-open: the server also whole-axis-discards a malformed declaration).</summary>
+    static string[]? ReadStringArrayOrNull(JsonElement prop, string name) {
+        if (!prop.TryGetProperty(name, out var arr) || arr.ValueKind != JsonValueKind.Array) return null;
+
+        var list = new List<string>();
+        foreach (var item in arr.EnumerateArray()) {
+            if (item.ValueKind != JsonValueKind.String) return null; // malformed axis → drop it entirely.
+            var v = item.GetString();
+            if (!string.IsNullOrWhiteSpace(v)) list.Add(v);
+        }
+
+        return list.Count == 0 ? null : list.ToArray();
     }
 
     static string StripCodeFences(string text) {
@@ -1274,13 +1306,17 @@ public static class EvalService {
             string            category,
             string            fact,
             string            evalRunId,
+            string[]?         appliesToVendors,
+            string[]?         appliesToSessionKinds,
             IEvalObserver     observer,
             CancellationToken ct
         ) {
         var payload = new JudgeFactPayload {
-            Category        = category,
-            Fact            = fact,
-            SourceEvalRunId = evalRunId
+            Category              = category,
+            Fact                  = fact,
+            SourceEvalRunId       = evalRunId,
+            AppliesToVendors      = appliesToVendors,
+            AppliesToSessionKinds = appliesToSessionKinds
         };
 
         var       payloadJson = JsonSerializer.Serialize(payload, CapacitorJsonContext.Default.JudgeFactPayload);

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -1027,32 +1027,27 @@ public static class EvalService {
             // Guard before TryGetProperty: it throws InvalidOperationException on a non-object root
             // (a bare string/array/number/bool is valid JSON but not an object), which the
             // JsonException catch below would NOT swallow — the contract is malformed → null, never throw.
-            if (doc.RootElement.ValueKind != JsonValueKind.Object) {
+            if (!doc.RootElement.IsObject) {
                 return null;
             }
             if (!doc.RootElement.TryGetProperty("retain_fact", out var prop)) {
                 return null;
             }
 
-            switch (prop.ValueKind) {
-                case JsonValueKind.String: {
-                    var text = prop.GetString()?.Trim();
-                    return string.IsNullOrEmpty(text) ? null : new RetainedFact(text, null, null);
-                }
-                case JsonValueKind.Object: {
-                    var fact = prop.TryGetProperty("fact", out var f) && f.ValueKind == JsonValueKind.String
-                        ? f.GetString()?.Trim()
-                        : null;
-                    if (string.IsNullOrEmpty(fact)) return null; // object without a usable fact — skip.
-
-                    return new RetainedFact(
-                        fact,
-                        ReadStringArrayOrNull(prop, "applies_to_vendors"),
-                        ReadStringArrayOrNull(prop, "applies_to_session_kinds"));
-                }
-                default:
-                    return null; // null / number / bool / array — no fact.
+            if (prop.IsString) {
+                var text = prop.GetString()?.Trim();
+                return string.IsNullOrEmpty(text) ? null : new RetainedFact(text, null, null);
             }
+            if (prop.IsObject) {
+                var fact = prop.Str("fact")?.Trim();
+                if (string.IsNullOrEmpty(fact)) return null; // object without a usable fact — skip.
+
+                return new RetainedFact(
+                    fact,
+                    ReadStringArrayOrNull(prop, "applies_to_vendors"),
+                    ReadStringArrayOrNull(prop, "applies_to_session_kinds"));
+            }
+            return null; // null / number / bool / array — no fact.
         } catch (JsonException) {
             return null;
         }
@@ -1066,12 +1061,12 @@ public static class EvalService {
     /// the field is absent, not an array, or empty. A non-string element drops the WHOLE axis to
     /// null (fail-open: the server also whole-axis-discards a malformed declaration).</summary>
     static string[]? ReadStringArrayOrNull(JsonElement prop, string name) {
-        if (!prop.TryGetProperty(name, out var arr) || arr.ValueKind != JsonValueKind.Array) return null;
+        if (prop.Arr(name) is not { } arr) return null;
 
         var list = new List<string>();
         foreach (var item in arr.EnumerateArray()) {
-            if (item.ValueKind != JsonValueKind.String) return null; // malformed axis → drop it entirely.
-            var v = item.GetString()?.Trim();                        // trim so "codex " matches the server's exact filter
+            if (!item.IsString) return null;          // malformed axis → drop it entirely.
+            var v = item.GetString()?.Trim();         // trim so "codex " matches the server's exact filter
             if (!string.IsNullOrEmpty(v) && list.Count < MaxApplicabilityItems) list.Add(v);
         }
 

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -25,7 +25,7 @@ public static class EvalService {
     // per-question prompt already instructs the judge to emit explicit
     // nulls, so this matches existing expectations.
     const string VerdictJsonSchema = """
-        {"type":"object","properties":{"category":{"type":"string"},"question_id":{"type":"string"},"score":{"type":"integer","minimum":1,"maximum":5},"verdict":{"type":"string","enum":["pass","warn","fail"]},"finding":{"type":"string"},"evidence":{"type":["string","null"]},"recommendation":{"type":["string","null"]},"retain_fact":{"type":["string","object","null"],"properties":{"fact":{"type":"string"},"applies_to_vendors":{"type":"array","items":{"type":"string"},"maxItems":16},"applies_to_session_kinds":{"type":"array","items":{"type":"string"},"maxItems":16}},"required":["fact"]}},"required":["category","question_id","score","verdict","finding","evidence","recommendation","retain_fact"],"additionalProperties":false}
+        {"type":"object","properties":{"category":{"type":"string"},"question_id":{"type":"string"},"score":{"type":"integer","minimum":1,"maximum":5},"verdict":{"type":"string","enum":["pass","warn","fail"]},"finding":{"type":"string"},"evidence":{"type":["string","null"]},"recommendation":{"type":["string","null"]},"retain_fact":{"type":["string","object","null"],"properties":{"fact":{"type":"string"},"applies_to_vendors":{"type":"array","items":{"type":"string"},"maxItems":16},"applies_to_session_kinds":{"type":"array","items":{"type":"string"},"maxItems":16}},"required":["fact"],"additionalProperties":false}},"required":["category","question_id","score","verdict","finding","evidence","recommendation","retain_fact"],"additionalProperties":false}
         """;
 
     // maxItems mirrors the prompt's documented caps: at most three
@@ -1024,6 +1024,12 @@ public static class EvalService {
 
         try {
             using var doc = JsonDocument.Parse(json);
+            // Guard before TryGetProperty: it throws InvalidOperationException on a non-object root
+            // (a bare string/array/number/bool is valid JSON but not an object), which the
+            // JsonException catch below would NOT swallow — the contract is malformed → null, never throw.
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) {
+                return null;
+            }
             if (!doc.RootElement.TryGetProperty("retain_fact", out var prop)) {
                 return null;
             }
@@ -1052,13 +1058,13 @@ public static class EvalService {
         }
     }
 
-    /// <summary>Reads a JSON array of non-empty strings from <paramref name="prop"/>, or null when
-    /// the field is absent, not an array, or empty. A non-string element drops the WHOLE axis to
-    /// null (fail-open: the server also whole-axis-discards a malformed declaration).</summary>
     // Mirrors the schema's maxItems — a defensive cap so a hallucinating judge can't bloat the
     // outgoing payload with an unbounded applicability list.
     const int MaxApplicabilityItems = 16;
 
+    /// <summary>Reads a JSON array of non-empty strings from <paramref name="prop"/>, or null when
+    /// the field is absent, not an array, or empty. A non-string element drops the WHOLE axis to
+    /// null (fail-open: the server also whole-axis-discards a malformed declaration).</summary>
     static string[]? ReadStringArrayOrNull(JsonElement prop, string name) {
         if (!prop.TryGetProperty(name, out var arr) || arr.ValueKind != JsonValueKind.Array) return null;
 

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -25,7 +25,7 @@ public static class EvalService {
     // per-question prompt already instructs the judge to emit explicit
     // nulls, so this matches existing expectations.
     const string VerdictJsonSchema = """
-        {"type":"object","properties":{"category":{"type":"string"},"question_id":{"type":"string"},"score":{"type":"integer","minimum":1,"maximum":5},"verdict":{"type":"string","enum":["pass","warn","fail"]},"finding":{"type":"string"},"evidence":{"type":["string","null"]},"recommendation":{"type":["string","null"]},"retain_fact":{"type":["string","object","null"],"properties":{"fact":{"type":"string"},"applies_to_vendors":{"type":"array","items":{"type":"string"}},"applies_to_session_kinds":{"type":"array","items":{"type":"string"}}}}},"required":["category","question_id","score","verdict","finding","evidence","recommendation","retain_fact"],"additionalProperties":false}
+        {"type":"object","properties":{"category":{"type":"string"},"question_id":{"type":"string"},"score":{"type":"integer","minimum":1,"maximum":5},"verdict":{"type":"string","enum":["pass","warn","fail"]},"finding":{"type":"string"},"evidence":{"type":["string","null"]},"recommendation":{"type":["string","null"]},"retain_fact":{"type":["string","object","null"],"properties":{"fact":{"type":"string"},"applies_to_vendors":{"type":"array","items":{"type":"string"},"maxItems":16},"applies_to_session_kinds":{"type":"array","items":{"type":"string"},"maxItems":16}},"required":["fact"]}},"required":["category","question_id","score","verdict","finding","evidence","recommendation","retain_fact"],"additionalProperties":false}
         """;
 
     // maxItems mirrors the prompt's documented caps: at most three
@@ -1055,14 +1055,18 @@ public static class EvalService {
     /// <summary>Reads a JSON array of non-empty strings from <paramref name="prop"/>, or null when
     /// the field is absent, not an array, or empty. A non-string element drops the WHOLE axis to
     /// null (fail-open: the server also whole-axis-discards a malformed declaration).</summary>
+    // Mirrors the schema's maxItems — a defensive cap so a hallucinating judge can't bloat the
+    // outgoing payload with an unbounded applicability list.
+    const int MaxApplicabilityItems = 16;
+
     static string[]? ReadStringArrayOrNull(JsonElement prop, string name) {
         if (!prop.TryGetProperty(name, out var arr) || arr.ValueKind != JsonValueKind.Array) return null;
 
         var list = new List<string>();
         foreach (var item in arr.EnumerateArray()) {
             if (item.ValueKind != JsonValueKind.String) return null; // malformed axis → drop it entirely.
-            var v = item.GetString();
-            if (!string.IsNullOrWhiteSpace(v)) list.Add(v);
+            var v = item.GetString()?.Trim();                        // trim so "codex " matches the server's exact filter
+            if (!string.IsNullOrEmpty(v) && list.Count < MaxApplicabilityItems) list.Add(v);
         }
 
         return list.Count == 0 ? null : list.ToArray();

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -507,6 +507,16 @@ record JudgeFactPayload {
 
     [JsonPropertyName("source_eval_run_id")]
     public required string SourceEvalRunId { get; init; }
+
+    // Optional judge-declared applicability (where the fact is specific to). Omitted from the wire
+    // when null so older servers ignore them; a non-empty array restricts, absent = applies everywhere.
+    [JsonPropertyName("applies_to_vendors")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string[]? AppliesToVendors { get; init; }
+
+    [JsonPropertyName("applies_to_session_kinds")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string[]? AppliesToSessionKinds { get; init; }
 }
 
 public record JudgeFact {

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
@@ -571,6 +571,16 @@ public class EvalServiceTests {
         await Assert.That(EvalService.ExtractRetainFact("not json")).IsNull();
     }
 
+    [Test]
+    [Arguments("\"just a bare string\"")]
+    [Arguments("[1,2,3]")]
+    [Arguments("42")]
+    [Arguments("true")]
+    public async Task ExtractRetainFact_valid_json_non_object_root_is_null_not_throw(string response) {
+        // TryGetProperty throws on a non-object root; the parser must guard and return null, not throw.
+        await Assert.That(EvalService.ExtractRetainFact(response)).IsNull();
+    }
+
     // ── ParseRetrospective / BuildRetrospectivePrompt ──────────────────────
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
@@ -506,6 +506,21 @@ public class EvalServiceTests {
     }
 
     [Test]
+    public async Task ExtractRetainFact_trims_applicability_values() {
+        const string response = """{"retain_fact":{"fact":"F","applies_to_vendors":["  codex  "]}}""";
+        var rf = EvalService.ExtractRetainFact(response);
+        await Assert.That(rf!.Value.AppliesToVendors).IsEquivalentTo(["codex"]); // trimmed to match server filter
+    }
+
+    [Test]
+    public async Task ExtractRetainFact_caps_oversized_applicability_array() {
+        var many = string.Join(",", Enumerable.Range(0, 40).Select(i => "\"v" + i + "\""));
+        var response = "{\"retain_fact\":{\"fact\":\"F\",\"applies_to_vendors\":[" + many + "]}}";
+        var rf = EvalService.ExtractRetainFact(response);
+        await Assert.That(rf!.Value.AppliesToVendors!.Length).IsEqualTo(16); // capped
+    }
+
+    [Test]
     public async Task ExtractRetainFact_returns_null_when_field_absent() {
         const string response = """
                                 {"score":5,"verdict":"pass","finding":"."}

--- a/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/EvalServiceTests.cs
@@ -439,7 +439,7 @@ public class EvalServiceTests {
                                 {"score":4,"verdict":"pass","finding":".","retain_fact":"User skips tests for small fixes."}
                                 """;
 
-        await Assert.That(EvalService.ExtractRetainFact(response)).IsEqualTo("User skips tests for small fixes.");
+        await Assert.That(EvalService.ExtractRetainFact(response)?.Fact).IsEqualTo("User skips tests for small fixes.");
     }
 
     [Test]
@@ -450,7 +450,59 @@ public class EvalServiceTests {
                                 ```
                                 """;
 
-        await Assert.That(EvalService.ExtractRetainFact(response)).IsEqualTo("Agent writes tests first.");
+        await Assert.That(EvalService.ExtractRetainFact(response)?.Fact).IsEqualTo("Agent writes tests first.");
+    }
+
+    [Test]
+    public async Task ExtractRetainFact_string_shape_has_no_applicability() {
+        const string response = """{"retain_fact":"A plain string fact."}""";
+        var rf = EvalService.ExtractRetainFact(response);
+        await Assert.That(rf?.Fact).IsEqualTo("A plain string fact.");
+        await Assert.That(rf!.Value.AppliesToVendors).IsNull();
+        await Assert.That(rf!.Value.AppliesToSessionKinds).IsNull();
+    }
+
+    [Test]
+    public async Task ExtractRetainFact_object_shape_reads_fact_and_both_axes() {
+        const string response = """
+                                {"retain_fact":{"fact":"Codex apply_patch rejects fuzzy hunks.","applies_to_vendors":["codex"],"applies_to_session_kinds":["flow_participant"]}}
+                                """;
+        var rf = EvalService.ExtractRetainFact(response);
+        await Assert.That(rf?.Fact).IsEqualTo("Codex apply_patch rejects fuzzy hunks.");
+        await Assert.That(rf!.Value.AppliesToVendors).IsEquivalentTo(["codex"]);
+        await Assert.That(rf!.Value.AppliesToSessionKinds).IsEquivalentTo(["flow_participant"]);
+    }
+
+    [Test]
+    public async Task ExtractRetainFact_object_shape_one_axis_only() {
+        const string response = """{"retain_fact":{"fact":"F","applies_to_vendors":["claude","codex"]}}""";
+        var rf = EvalService.ExtractRetainFact(response);
+        await Assert.That(rf?.Fact).IsEqualTo("F");
+        await Assert.That(rf!.Value.AppliesToVendors).IsEquivalentTo(["claude", "codex"]);
+        await Assert.That(rf!.Value.AppliesToSessionKinds).IsNull(); // omitted axis = null
+    }
+
+    [Test]
+    public async Task ExtractRetainFact_object_empty_array_axis_becomes_null() {
+        const string response = """{"retain_fact":{"fact":"F","applies_to_vendors":[]}}""";
+        var rf = EvalService.ExtractRetainFact(response);
+        await Assert.That(rf?.Fact).IsEqualTo("F");
+        await Assert.That(rf!.Value.AppliesToVendors).IsNull(); // empty = no restriction
+    }
+
+    [Test]
+    public async Task ExtractRetainFact_object_malformed_axis_drops_that_axis_keeps_fact() {
+        const string response = """{"retain_fact":{"fact":"F","applies_to_vendors":[1,2],"applies_to_session_kinds":["interactive"]}}""";
+        var rf = EvalService.ExtractRetainFact(response);
+        await Assert.That(rf?.Fact).IsEqualTo("F");
+        await Assert.That(rf!.Value.AppliesToVendors).IsNull(); // non-string element → whole axis dropped
+        await Assert.That(rf!.Value.AppliesToSessionKinds).IsEquivalentTo(["interactive"]); // other axis survives
+    }
+
+    [Test]
+    public async Task ExtractRetainFact_object_without_fact_is_null() {
+        const string response = """{"retain_fact":{"applies_to_vendors":["codex"]}}""";
+        await Assert.That(EvalService.ExtractRetainFact(response)).IsNull();
     }
 
     [Test]


### PR DESCRIPTION
## AI-1899 (kcap-cli) — parse the widened retain_fact contract

The daemon eval runner's judge may now return `retain_fact` as either the plain string (unchanged) or an object `{"fact": "...", "applies_to_vendors": [...], "applies_to_session_kinds": [...]}` declaring which vendors / session kinds a fact is specific to. This is the kcap-cli half; the kcap-server prompt widening + payload-tolerance ship first.

### Changes
- `EvalService.ExtractRetainFact` returns a `RetainedFact` struct (fact + optional `AppliesToVendors`/`AppliesToSessionKinds`), parsing **both** shapes:
  - string → fact only (no applicability);
  - object → `fact` (required; missing/empty ⇒ no fact, never throws) + each axis read as an array of non-empty strings, or **null** when absent/empty/malformed (a non-string element drops the whole axis, keeping the fact and the other axis — matching the server's whole-axis-discard).
- Verdict JSON schema widened: `retain_fact` is now `string | object | null`.
- `JudgeFactPayload` carries the two optional arrays (omitted from the wire when null, so older servers ignore them).

### Rollout safety
Server-first: an older server tolerates the extra JSON fields, and an older CLI already degrades an object-shaped `retain_fact` to no fact (its parse returns null for non-string), so no combination breaks.

### Tests
`EvalServiceTests` ExtractRetainFact suite: 14 cases (string shape has no applicability; object both-axes / one-axis / empty-array-axis→null / malformed-axis-drops-that-axis / object-without-fact→null; plus the existing null/empty/fence/malformed cases).
