### PR TITLE
[AI-1914] Register kcap-workitems on every harness

### DIFF
--- a/kcap/.codex-mcp.json
+++ b/kcap/.codex-mcp.json
@@ -19,6 +19,10 @@
     "kcap-analytics": {
       "command": "kcap",
       "args": ["mcp", "analytics"]
+    },
+    "kcap-workitems": {
+      "command": "kcap",
+      "args": ["mcp", "workitems"]
     }
   }
 }

--- a/src/Capacitor.Cli.Core/Mcp/HarnessMcpProjections.cs
+++ b/src/Capacitor.Cli.Core/Mcp/HarnessMcpProjections.cs
@@ -41,8 +41,8 @@ public sealed record HarnessMcpProjection(
 /// <c>kcap/.mcp.json</c> rather than anything generated. Pi is absent because it registers no MCP
 /// config at all — it emits a bridge that discovers tools at runtime.</para></summary>
 public static class HarnessMcpProjections {
-    // Every non-Claude JSON harness receives the same subset: kcap-workitems is Claude-Code-plugin
-    // only (its session-id default rides the Claude hook env).
+    // Every non-Claude JSON harness receives the same subset — the full set,
+    // kcap-workitems included (see KcapMcpServers.ForCursor).
     public static readonly HarnessMcpProjection Cursor      = new("cursor",      KcapMcpServers.ForCursor, McpConfigShape.Standard);
     public static readonly HarnessMcpProjection Copilot     = new("copilot",     KcapMcpServers.ForCursor, McpConfigShape.Copilot);
     public static readonly HarnessMcpProjection Gemini      = new("gemini",      KcapMcpServers.ForCursor, McpConfigShape.Gemini);

--- a/src/Capacitor.Cli.Core/Mcp/KcapMcpServers.cs
+++ b/src/Capacitor.Cli.Core/Mcp/KcapMcpServers.cs
@@ -28,14 +28,15 @@ public static class KcapMcpServers {
             "Query the org's AI coding-agent analytics (sessions, tools, tokens, cost, commits, PRs, evals) with read-only SQL. Repo-aware: defaults to the current repo; pass scope 'global' for org-wide.", ReadOnly: true),
     ];
 
-    /// <summary>Codex receives flows so any driver can explicitly route a reserved review alias
-    /// to any certified reviewer vendor. Flows remains non-read-only and is never auto-approved.
-    /// Workitems remains Claude-plugin-only.</summary>
-    public static IReadOnlyList<KcapMcpServer> ForCodex =>
-        All.Where(s => s.Name != "kcap-workitems").ToArray();
+    /// <summary>Codex receives the full set. Kept as a named per-harness seam so a future
+    /// divergence has a home, but today it is the whole `All` list — `kcap-workitems` is now
+    /// registered everywhere (its session id resolves from an explicit arg / `KCAP_SESSION_ID` /
+    /// `CODEX_THREAD_ID`, and its breakdown/relation tools need no session id at all). Flows remains
+    /// non-read-only and is never auto-approved.</summary>
+    public static IReadOnlyList<KcapMcpServer> ForCodex => All;
 
     /// <summary>The shared set for every non-Claude JSON harness (Cursor, Copilot, OpenCode,
-    /// Kiro, Gemini, Antigravity) — omits only `kcap-workitems` (Claude Code plugin only).</summary>
-    public static IReadOnlyList<KcapMcpServer> ForCursor =>
-        All.Where(s => s.Name != "kcap-workitems").ToArray();
+    /// Kiro, Gemini, Antigravity). The full `All` list — `kcap-workitems` included.
+    /// Kept as a named seam (mirrors <see cref="ForCodex"/>) for a future per-harness divergence.</summary>
+    public static IReadOnlyList<KcapMcpServer> ForCursor => All;
 }

--- a/src/Capacitor.Cli.Core/Pi/PiMcpExtensionInstaller.cs
+++ b/src/Capacitor.Cli.Core/Pi/PiMcpExtensionInstaller.cs
@@ -26,7 +26,7 @@ public static class PiMcpExtensionInstaller {
 
         import { spawn } from "node:child_process";
 
-        const KCAP_MCP_SERVERS = ["review", "sessions", "flows", "memory", "analytics"];
+        const KCAP_MCP_SERVERS = ["review", "sessions", "flows", "memory", "analytics", "workitems"];
         const HANDSHAKE_TIMEOUT_MS = 10000;
         // Generous — above the flows server's own round timeouts; only a backstop against a
         // stalled-but-not-exited server. A timeout surfaces as a tool failure (execute throws).

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -339,8 +339,7 @@ public static class SetupCommand {
             EnableCodexNetworkAccess: () => CodexConfigToml.EnableNetworkAccess(codexAllowDomains),
             RegisterCodexMcp:         () => CodexConfigToml.RegisterKcapMcpServers(),
             // every non-Claude JSON harness registers the ForCursor subset — the full set,
-            // kcap-workitems included (session id resolves from an explicit arg /
-            // KCAP_SESSION_ID / CODEX_THREAD_ID; breakdown/relation tools need no session id).
+            // kcap-workitems included (see KcapMcpServers.ForCursor).
             RegisterCursorMcp:        () => HarnessMcpProjections.Cursor.Register(CursorPaths.UserMcpJson()),
             RegisterCopilotMcp:       () => HarnessMcpProjections.Copilot.Register(CopilotPaths.McpConfigJson()),
             InstallCopilotInstructions: () => AgentInstructionsWriter.Write(

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -338,8 +338,9 @@ public static class SetupCommand {
             InstallAntigravityHooks:  PluginCommand.InstallAntigravityHooks,
             EnableCodexNetworkAccess: () => CodexConfigToml.EnableNetworkAccess(codexAllowDomains),
             RegisterCodexMcp:         () => CodexConfigToml.RegisterKcapMcpServers(),
-            // every non-Claude JSON harness registers the ForCursor subset — kcap-workitems
-            // is a Claude Code plugin-only tool (its session-id default rides the Claude hook env).
+            // every non-Claude JSON harness registers the ForCursor subset — the full set,
+            // kcap-workitems included (session id resolves from an explicit arg /
+            // KCAP_SESSION_ID / CODEX_THREAD_ID; breakdown/relation tools need no session id).
             RegisterCursorMcp:        () => HarnessMcpProjections.Cursor.Register(CursorPaths.UserMcpJson()),
             RegisterCopilotMcp:       () => HarnessMcpProjections.Copilot.Register(CopilotPaths.McpConfigJson()),
             InstallCopilotInstructions: () => AgentInstructionsWriter.Write(

--- a/test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryReviewFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/KcapMcpRegistryReviewFlowTests.cs
@@ -43,6 +43,16 @@ public class KcapMcpRegistryReviewFlowTests {
     }
 
     [Test]
+    public async Task Resolve_rejects_write_server_kcap_workitems() {
+        // kcap-workitems is registered on every harness, but it is a writer: it must never be
+        // auto-approved for an unattended review-flow reviewer (only kcap-review/kcap-sessions are).
+        var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(["kcap-workitems"], out _, out var rejected);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(rejected).IsEqualTo("kcap-workitems");
+    }
+
+    [Test]
     public async Task Resolve_rejects_unknown_server() {
         var ok = KcapMcpRegistry.TryResolveReviewFlowAllowlist(["not-a-server"], out _, out var rejected);
 

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/KcapMcpServersTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/KcapMcpServersTests.cs
@@ -10,15 +10,17 @@ public class KcapMcpServersTests {
     }
 
     [Test]
-    public async Task ForCodex_excludes_only_workitems() {
+    public async Task ForCodex_is_the_full_set_including_workitems() {
+        // kcap-workitems is now registered on every harness, so the Codex subset is All.
         var names = KcapMcpServers.ForCodex.Select(s => s.Name).ToArray();
-        await Assert.That(names).IsEquivalentTo(new[] { "kcap-review", "kcap-sessions", "kcap-flows", "kcap-memory", "kcap-analytics" });
+        await Assert.That(names).IsEquivalentTo(new[] { "kcap-review", "kcap-sessions", "kcap-flows", "kcap-memory", "kcap-workitems", "kcap-analytics" });
     }
 
     [Test]
-    public async Task ForCursor_excludes_only_workitems() {
+    public async Task ForCursor_is_the_full_set_including_workitems() {
+        // every non-Claude JSON harness now receives kcap-workitems too.
         var names = KcapMcpServers.ForCursor.Select(s => s.Name).ToArray();
-        await Assert.That(names).IsEquivalentTo(new[] { "kcap-review", "kcap-sessions", "kcap-flows", "kcap-memory", "kcap-analytics" });
+        await Assert.That(names).IsEquivalentTo(new[] { "kcap-review", "kcap-sessions", "kcap-flows", "kcap-memory", "kcap-workitems", "kcap-analytics" });
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Mcp/McpCanonicalContractTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Mcp/McpCanonicalContractTests.cs
@@ -55,9 +55,10 @@ public class McpCanonicalContractTests {
     }
 
     [Test]
-    public async Task Codex_subset_excludes_workitems() {
+    public async Task Codex_subset_includes_workitems() {
+        // kcap-workitems is now registered for Codex (and every harness).
         var names = KcapMcpServers.ForCodex.Select(s => s.Name).ToArray();
-        await Assert.That(names).DoesNotContain("kcap-workitems");
+        await Assert.That(names).Contains("kcap-workitems");
     }
 
     [Test]
@@ -67,9 +68,10 @@ public class McpCanonicalContractTests {
     }
 
     [Test]
-    public async Task Cursor_subset_excludes_workitems_but_keeps_flows_and_memory() {
+    public async Task Cursor_subset_includes_workitems_flows_and_memory() {
+        // kcap-workitems now rides the same writer path as every other non-Claude harness.
         var names = KcapMcpServers.ForCursor.Select(s => s.Name).ToArray();
-        await Assert.That(names).DoesNotContain("kcap-workitems");
+        await Assert.That(names).Contains("kcap-workitems");
         await Assert.That(names).Contains("kcap-flows");
         await Assert.That(names).Contains("kcap-memory");
     }

--- a/test/Capacitor.Cli.Tests.Unit/PiMcpExtensionInstallerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PiMcpExtensionInstallerTests.cs
@@ -35,8 +35,8 @@ public class PiMcpExtensionInstallerTests {
         // Async factory (pi awaits it before session_start → tools ready turn 1).
         await Assert.That(content).Contains("export default async function");
         // Bridges every kcap server Pi ships, including analytics (the guided tour's menu
-        // query needs query_analytics — kcap-workitems stays Claude-plugin-only).
-        await Assert.That(content).Contains("[\"review\", \"sessions\", \"flows\", \"memory\", \"analytics\"]");
+        // query needs query_analytics) and workitems (registered on every harness).
+        await Assert.That(content).Contains("[\"review\", \"sessions\", \"flows\", \"memory\", \"analytics\", \"workitems\"]");
         // MCP handshake incl. the mandatory notifications/initialized.
         await Assert.That(content).Contains("initialize");
         await Assert.That(content).Contains("notifications/initialized");

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandCursorTests.cs
@@ -70,8 +70,8 @@ public class PluginCommandCursorTests {
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-sessions");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-flows");
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-memory");
-        // kcap-workitems is Claude Code plugin only — not auto-registered for Cursor.
-        await Assert.That(servers.Select(kv => kv.Key)).DoesNotContain("kcap-workitems");
+        // kcap-workitems is now registered for Cursor (and every harness).
+        await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-workitems");
         // kcap-analytics rides the same CWD-resolved writer path as kcap-sessions.
         await Assert.That(servers.Select(kv => kv.Key)).Contains("kcap-analytics");
         await Assert.That(servers["my-tool"]).IsNotNull(); // user server preserved

--- a/test/Capacitor.Cli.Tests.Unit/PluginCommandGeminiTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PluginCommandGeminiTests.cs
@@ -49,6 +49,8 @@ public class PluginCommandGeminiTests {
         await Assert.That(servers["kcap-analytics"]!["trust"]!.GetValue<bool>()).IsTrue();
         await Assert.That(servers["kcap-flows"]!["trust"]).IsNull();
         await Assert.That(servers["kcap-memory"]!["trust"]).IsNull();
+        // kcap-workitems is registered for Gemini but writes, so it is never auto-trusted.
+        await Assert.That(servers["kcap-workitems"]!["trust"]).IsNull();
         await Assert.That(servers["my-tool"]).IsNotNull();  // user server preserved
         await Assert.That(root["hooks"]).IsNotNull();       // hooks block preserved
         await Assert.That(root["theme"]!.GetValue<string>()).IsEqualTo("dark");  // unrelated setting preserved


### PR DESCRIPTION
## What

`kcap-workitems` was registered only for Claude Code. Every other harness (Codex, Cursor, Copilot, Gemini, Kiro, OpenCode, Antigravity, Pi) received a 5-server subset that stripped it — so those agents could not `declare_work_item`, nor declare the breakdown / `blocks`/`blocked_by` dependency topology (AI-1683/AI-1718).

The "Claude-only" rationale was stale: `McpWorkItemsServer.ResolveSessionId` resolves an explicit `session_id` arg (wins), else `KCAP_SESSION_ID`, else `CODEX_THREAD_ID`, else throws a clear error; the breakdown/relation tools need no session id at all.

## Changes

- `KcapMcpServers.ForCodex` / `ForCursor` now return the full `All` set (kept as named per-harness seams for future divergence).
- Add `kcap-workitems` to the bundled `kcap/.codex-mcp.json`.
- Add `"workitems"` to the Pi MCP-bridge extension's `KCAP_MCP_SERVERS` (Pi's `analytics` gap was already closed on main; `workitems` was the only remaining one).
- Refresh the stale "Claude-only" comments in `HarnessMcpProjections` and `SetupCommand`.

## Invariants preserved (and tested)

- **Never auto-trusted** — `kcap-workitems` is not `ReadOnly`, so it keeps prompting everywhere. Asserted against Gemini's per-server trust (`kcap-workitems` trust is null).
- **Unattended-reviewer safe** — it stays out of `KcapMcpRegistry.ReviewFlowAutoApprovableServers` (`{review, sessions}`); a reviewer allowlist naming `kcap-workitems` fails the launch. New test in `KcapMcpRegistryReviewFlowTests`.
- No server/protocol change.

## Tests

Inverted the subset-exclusion assertions in `KcapMcpServersTests` and `McpCanonicalContractTests`; added `kcap-workitems` to the Cursor/Gemini/Pi expectations; added the trust + unattended-reviewer-rejection assertions above. Touched test classes pass locally (52 green); the only local reds are the pre-existing macOS-only Codex-config-temp-symlink baseline, which passes on Linux CI.

Spec + codex spec-review (clean, 5 rounds) recorded on the Linear issue.

Ships in the same release as AI-1915 (the SessionStart work-items nudge).

Fixes AI-1914
