### PR TITLE
Add kcap feedback: file bugs and product feedback to Kurrent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ At a glance — each links to its section below:
 | [`kcap update`](#other-commands) | Upgrade the CLI and refresh agent plugins |
 | [`kcap uninstall`](#uninstalling) | Remove kcap from this machine |
 | [`kcap status` / `whoami` / `login` / `logout`](#other-commands) | Health, identity, and auth |
+| [`kcap feedback`](#other-commands) | Report a bug or send feedback to Kurrent support |
 
 ### Initial setup
 
@@ -1871,7 +1872,16 @@ kcap update         # upgrade the CLI and refresh agent plugins (npm-global inst
 kcap update --beta  # switch to the beta channel and update to the latest beta
 kcap update --stable # switch back to the stable channel (the default)
 kcap logout         # delete stored tokens
+kcap feedback --bug -m "the daemon crashed on stop"   # file a bug report
+kcap feedback --feedback                               # send feedback; prompts for the message on a TTY
 ```
+
+> `kcap feedback (--bug | --feedback) [-m|--message <text>]` files a report through the
+> server's support-intake pipeline (when the tenant has it configured) and prints the
+> reporter email it was filed under on success. Exactly one of `--bug`/`--feedback` is
+> required. `-m`/`--message` is required when stdin isn't a TTY (scripts, CI); on an
+> interactive terminal without it, the command prompts for a multi-line message ended by
+> an empty line.
 
 > `kcap update` is the one-step upgrade for npm-global installs: it checks the
 > registry, runs `npm install -g @kurrent/kcap@<tag>`, then refreshes your

--- a/src/Capacitor.Cli.Core/Commands/FeedbackSubmission.cs
+++ b/src/Capacitor.Cli.Core/Commands/FeedbackSubmission.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.Commands;
+
+/// <summary>Request body for the tenant's <c>POST /api/feedback</c> — see the server's
+/// <c>FeedbackRequestDto</c>. <see cref="ClientRequestId"/> is a fresh <see cref="Guid"/> per
+/// invocation: it is the idempotency key the server's <c>FeedbackIdempotencyStore</c> dedupes a
+/// retried request on, so a transport-level retry of the SAME submission must reuse it — which is
+/// why it is minted once by the caller and threaded through, never regenerated per attempt.</summary>
+public sealed record FeedbackSubmitRequest(
+        [property: JsonPropertyName("category")]           string                 Category,
+        [property: JsonPropertyName("message")]             string                 Message,
+        [property: JsonPropertyName("client_request_id")]   Guid                   ClientRequestId,
+        [property: JsonPropertyName("context")]             FeedbackSubmitContext  Context
+    );
+
+/// <summary>Client-supplied context carried alongside a feedback submission. <see cref="Source"/>
+/// is always <c>"cli"</c> for this caller — it is how the server (and any future dashboard) tells a
+/// CLI-filed report apart from one filed through the web widget.</summary>
+public sealed record FeedbackSubmitContext(
+        [property: JsonPropertyName("source")]         string  Source,
+        [property: JsonPropertyName("client_version")] string? ClientVersion,
+        [property: JsonPropertyName("os")]              string? Os
+    );
+
+/// <summary>The server's 200 response — the reporter's email, resolved server-side from their
+/// persisted profile (never trusted from the client).</summary>
+public sealed record FeedbackSubmitResponse {
+    [JsonPropertyName("reporter_email")] public string ReporterEmail { get; init; } = "";
+}

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1091,6 +1091,9 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(Capacitor.Cli.Core.Commands.RegisterMachineRequest))]
 [JsonSerializable(typeof(Capacitor.Cli.Core.Commands.RegisterMachineResponse))]
 [JsonSerializable(typeof(Capacitor.Cli.Core.Commands.MachineSummary[]))]
+[JsonSerializable(typeof(Capacitor.Cli.Core.Commands.FeedbackSubmitRequest))]
+[JsonSerializable(typeof(Capacitor.Cli.Core.Commands.FeedbackSubmitContext))]
+[JsonSerializable(typeof(Capacitor.Cli.Core.Commands.FeedbackSubmitResponse))]
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     UseStringEnumConverter = true

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -60,6 +60,7 @@ Session:
   disable                          Stop recording and delete session data
   hide                             Hide session (owner-only visibility)
   review <pr>                      Launch Claude with PR review context
+  feedback (--bug|--feedback) [-m <text>]  Report a bug or send feedback to Kurrent support
 
 Curation:
   curate apply [--dry-run] [--yes]   Write promoted guidelines into CLAUDE.md / AGENTS.md

--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -60,7 +60,6 @@ Session:
   disable                          Stop recording and delete session data
   hide                             Hide session (owner-only visibility)
   review <pr>                      Launch Claude with PR review context
-  feedback (--bug|--feedback) [-m <text>]  Report a bug or send feedback to Kurrent support
 
 Curation:
   curate apply [--dry-run] [--yes]   Write promoted guidelines into CLAUDE.md / AGENTS.md
@@ -80,6 +79,7 @@ Plugin:
 
 Maintenance:
   update                           Check for and install updates
+  feedback (--bug|--feedback) [-m <text>]  Report a bug or send feedback to Kurrent support
   cleanup                          Kill all orphaned watcher processes
   uninstall [--project] [--yes]    Remove kcap config + all agent integrations
   --version                        Show version

--- a/src/Capacitor.Cli.Core/Telemetry/CommandEvents.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/CommandEvents.cs
@@ -42,7 +42,7 @@ public static partial class CommandEvents {
         "ignore", "remap", "repos", "projects", "project", "update", "review", "mcp",
         "curate", "cleanup", "uninstall", "disable", "hide", "import", "watch",
         "copilot-finalize", "set-title", "hook", "cursor", "cursor-verify-appendonly",
-        "generate-whats-done", "permission-request",
+        "generate-whats-done", "permission-request", "feedback",
     };
 
     // Verbs whose args[1] is a known literal rather than user data. Verbs absent from this

--- a/src/Capacitor.Cli.Core/Telemetry/CommandEvents.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/CommandEvents.cs
@@ -59,6 +59,20 @@ public static partial class CommandEvents {
 
     const int MaxFlags = 12;
 
+    // Flags whose NEXT argv token is a VALUE, never a candidate flag name — skipped outright by
+    // Flags() below, even when that value happens to itself look like a flag (e.g. a --message
+    // value that starts with "--"). Without this, `kcap feedback --bug -m --looks-like-a-flag`
+    // would report the message text "--looks-like-a-flag" as a captured flag name, leaking
+    // free-form user prose into telemetry.
+    //
+    // Seeded with just -m/--message: the one value-taking flag across the CLI whose value is
+    // ever free-form text a person types, rather than a fixed-vocabulary token (--model,
+    // --visibility, …) or something already excluded by shape (a URL, a path, a session id).
+    // Extend this set if another free-text value flag is ever added.
+    static readonly HashSet<string> ValueFlags = new(StringComparer.Ordinal) {
+        "-m", "--message",
+    };
+
     public static bool IsReportable(string command) => !Denylisted.Contains(command);
 
     /// <summary>
@@ -84,14 +98,33 @@ public static partial class CommandEvents {
     /// ceiling is a GUID token (38 chars: `--` + 36 UUID). Headroom prevents breakage from
     /// minor flag additions; relaxing re-admits GUIDs; tightening silently drops real flags.
     /// </summary>
-    public static string[] Flags(string[] args) =>
-        args.Where(a => a.StartsWith("--", StringComparison.Ordinal))
-            .Select(a => a.Split('=', 2)[0])
+    public static string[] Flags(string[] args) {
+        var candidates = new List<string>();
+
+        for (var i = 0; i < args.Length; i++) {
+            var token = args[i];
+
+            if (token.StartsWith("--", StringComparison.Ordinal)) {
+                candidates.Add(token.Split('=', 2)[0]);
+            }
+
+            // The token bound to a value-taking flag is DATA, not a candidate flag name — skip
+            // it outright so it never reaches the shape/dedup pipeline below, whatever it looks
+            // like. This is a plain array skip, not a lookahead into an already-consumed token:
+            // the loop's own `i++` advances past `token` as usual, and this second `i++` advances
+            // past the value bound to it.
+            if (ValueFlags.Contains(token)) {
+                i++;
+            }
+        }
+
+        return candidates
             .Where(a => FlagShape().IsMatch(a))
             .Distinct(StringComparer.Ordinal)
             .Order(StringComparer.Ordinal)
             .Take(MaxFlags)
             .ToArray();
+    }
 
     [GeneratedRegex(@"^--[a-z][a-z0-9-]{0,34}$")]
     private static partial Regex FlagShape();

--- a/src/Capacitor.Cli/Commands/FeedbackCommand.cs
+++ b/src/Capacitor.Cli/Commands/FeedbackCommand.cs
@@ -1,0 +1,218 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Commands;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// <c>kcap feedback (--bug | --feedback) [-m|--message &lt;text&gt;]</c> — files a bug report or
+/// sends feedback to Kurrent support through the tenant's <c>POST /api/feedback</c> (Task 10),
+/// which resolves the reporter's email server-side and forwards to the auth proxy's Plain sink.
+///
+/// <para>Follows <see cref="ValidatePlanCommand"/>'s <c>Handle</c>/<c>HandleCore</c> split: <c>Handle</c>
+/// owns argument parsing, the interactive prompt, and building the authenticated client;
+/// <c>HandleCore</c> takes an already-built <see cref="HttpClient"/> so tests can drive it against a
+/// fake server without touching the token store.</para>
+/// </summary>
+public static class FeedbackCommand {
+    /// <summary>
+    /// The pinned success line (spec: no reply promise — a later revision may add one, but this
+    /// exact string is what ships first). Printed to stdout so <c>kcap feedback ... | ...</c> can
+    /// capture it; everything else in this command writes to stderr.
+    /// </summary>
+    internal const string SuccessPrefix = "✓ Sent to Kurrent support as ";
+
+    const string BugFlag      = "--bug";
+    const string FeedbackFlag = "--feedback";
+
+    const string InteractivePrompt = "What's going on? (end with an empty line)";
+
+    public static Task<int> HandleAsync(string baseUrl, string[] args) =>
+        HandleAsync(baseUrl, args, Console.IsInputRedirected, Console.ReadLine);
+
+    /// <summary>
+    /// Test-friendly entry point: <paramref name="stdinIsRedirected"/> and <paramref name="readLine"/>
+    /// stand in for <see cref="Console.IsInputRedirected"/>/<see cref="Console.ReadLine"/> so the
+    /// TTY-vs-piped branch and the interactive prompt's line collection are exercised without a real
+    /// terminal or process stdin.
+    /// </summary>
+    internal static async Task<int> HandleAsync(
+            string baseUrl, string[] args, bool stdinIsRedirected, Func<string?> readLine) {
+        var isBug      = args.Contains(BugFlag);
+        var isFeedback = args.Contains(FeedbackFlag);
+
+        // Exactly one of --bug/--feedback: neither and both are the same usage error, naming both
+        // flags so the fix is obvious either way.
+        if (isBug == isFeedback) {
+            await Console.Error.WriteLineAsync("Usage: kcap feedback (--bug | --feedback) [-m|--message <text>]");
+            await Console.Error.WriteLineAsync("  Pass exactly one of --bug or --feedback.");
+
+            return 1;
+        }
+
+        var category   = isBug ? "bug" : "feedback";
+        var rawMessage = GetMessageArg(args);
+
+        if (rawMessage is null) {
+            // stdin is not a TTY (piped/redirected): there is no one to prompt, so -m is mandatory.
+            if (stdinIsRedirected) {
+                await Console.Error.WriteLineAsync("A message is required.");
+
+                return 1;
+            }
+
+            await Console.Error.WriteLineAsync(InteractivePrompt);
+            rawMessage = ReadInteractiveMessage(readLine);
+        }
+
+        var message = rawMessage.Trim();
+
+        if (message.Length == 0) {
+            await Console.Error.WriteLineAsync("A message is required.");
+
+            return 1;
+        }
+
+        using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync();
+
+        return await HandleCore(httpClient, baseUrl, category, message);
+    }
+
+    /// <summary>
+    /// Test-friendly core: caller owns the <see cref="HttpClient"/> (mirrors
+    /// <see cref="ValidatePlanCommand.HandleCore"/>'s seam). <paramref name="category"/> is already
+    /// "bug"/"feedback" and <paramref name="message"/> is already trimmed and non-empty.
+    /// </summary>
+    internal static async Task<int> HandleCore(HttpClient httpClient, string baseUrl, string category, string message) {
+        var request = new FeedbackSubmitRequest(
+            Category:        category,
+            Message:         message,
+            ClientRequestId: Guid.NewGuid(),
+            Context: new FeedbackSubmitContext(
+                Source:        "cli",
+                ClientVersion: CapacitorVersion.CurrentDisplay(),
+                Os:            RuntimeInformation.OSDescription
+            )
+        );
+
+        HttpResponseMessage resp;
+
+        try {
+            using var content = JsonContent.Create(request, CapacitorJsonContext.Default.FeedbackSubmitRequest);
+            resp = await httpClient.PostWithRetryAsync($"{baseUrl}/api/feedback", content);
+        } catch (HttpRequestException ex) {
+            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+
+            return 1;
+        }
+
+        if (await HttpClientExtensions.HandleUnauthorizedAsync(resp)) {
+            return 1;
+        }
+
+        return await ReportResultAsync(resp);
+    }
+
+    static async Task<int> ReportResultAsync(HttpResponseMessage resp) {
+        if (resp.StatusCode == HttpStatusCode.OK) {
+            var success = await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.FeedbackSubmitResponse);
+            await Console.Out.WriteLineAsync($"{SuccessPrefix}{success?.ReporterEmail ?? ""}");
+
+            return 0;
+        }
+
+        var body      = await resp.Content.ReadAsStringAsync();
+        var errorCode = TryGetField(body, "error");
+
+        switch (resp.StatusCode) {
+            // A bare 404/405 (no JSON body — see the server's SupportEndpoints doc: a POST to an
+            // unmapped route 405s via ASP.NET's own routing layer, a GET 404s via the Blazor
+            // fallback route) means the whole feature is off on this server. A CODED 404
+            // (`feedback_not_configured`) means the route exists but the sink isn't configured —
+            // same user-facing advice as the coded 503, so both land on the same message below.
+            case HttpStatusCode.NotFound or HttpStatusCode.MethodNotAllowed when errorCode is null:
+                await Console.Error.WriteLineAsync("This server doesn't have support intake enabled.");
+
+                return 1;
+
+            case HttpStatusCode.NotFound or HttpStatusCode.ServiceUnavailable:
+                await Console.Error.WriteLineAsync("Support intake isn't configured on this server — ask your admin.");
+
+                return 1;
+
+            case HttpStatusCode.Conflict:
+                await Console.Error.WriteLineAsync(
+                    "Your account has no email on file — sign in to the web app once, then retry.");
+
+                return 1;
+
+            case HttpStatusCode.TooManyRequests:
+                await Console.Error.WriteLineAsync("You've sent several reports recently — try again in a few minutes.");
+
+                return 1;
+
+            case HttpStatusCode.BadGateway:
+                var suffix = resp.Headers.RetryAfter?.Delta is { } delta
+                    ? $" in {(int)Math.Ceiling(delta.TotalSeconds)}s."
+                    : ".";
+                await Console.Error.WriteLineAsync($"Couldn't reach Kurrent support (temporary) — try again{suffix}");
+
+                return 1;
+
+            case HttpStatusCode.BadRequest:
+                await Console.Error.WriteLineAsync(TryGetField(body, "message") ?? "The feedback request was invalid.");
+
+                return 1;
+
+            default:
+                await Console.Error.WriteLineAsync($"HTTP {(int)resp.StatusCode}");
+
+                return 1;
+        }
+    }
+
+    /// <summary>Reads a named string field from a possibly-empty, possibly-non-JSON body. Absence
+    /// (empty body, malformed JSON, or a missing/wrong-typed field) all read as <c>null</c> — the
+    /// same defensive contract <see cref="JsonElementExtensions"/> uses everywhere else.</summary>
+    static string? TryGetField(string body, string field) {
+        if (string.IsNullOrEmpty(body)) return null;
+
+        try {
+            using var doc = JsonDocument.Parse(body);
+
+            return doc.RootElement.Str(field);
+        } catch (JsonException) {
+            return null;
+        }
+    }
+
+    static string? GetMessageArg(string[] args) {
+        for (var i = 0; i < args.Length - 1; i++) {
+            if (args[i] is "-m" or "--message") return args[i + 1];
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Collects lines from <paramref name="readLine"/> until an empty line (or end of input,
+    /// e.g. Ctrl+D) and joins them with newlines. Pure and injectable so tests can drive the
+    /// multi-line collection without a real TTY.
+    /// </summary>
+    internal static string ReadInteractiveMessage(Func<string?> readLine) {
+        var lines = new List<string>();
+
+        while (true) {
+            var line = readLine();
+
+            if (string.IsNullOrEmpty(line)) break;
+
+            lines.Add(line);
+        }
+
+        return string.Join('\n', lines);
+    }
+}

--- a/src/Capacitor.Cli/InteractiveLifetime.cs
+++ b/src/Capacitor.Cli/InteractiveLifetime.cs
@@ -47,9 +47,13 @@ static class InteractiveLifetime {
     /// need the safety net. Kept as an explicit allow-list so non-interactive
     /// commands (hooks, mcp servers) and commands that manage their own
     /// lifetime (<c>watch</c>, <c>daemon</c>) are never affected.
+    ///
+    /// <c>feedback</c> joins this list for the same reason <c>import</c> does: on a real TTY with
+    /// no <c>-m</c> flag it blocks on a plain <see cref="Console.ReadLine"/> loop, which has the
+    /// same "no timeout, no signal awareness" gap as a Spectre prompt.
     /// </summary>
     public static bool IsInteractiveCommand(string command) => command is
-        "setup" or "login" or "profile" or "use" or "import" or "uninstall";
+        "setup" or "login" or "profile" or "use" or "import" or "uninstall" or "feedback";
 
     /// <summary>
     /// Installs the interrupt handlers and the parent-liveness watchdog. Best

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -237,6 +237,8 @@ switch (command) {
 
         return await ValidatePlanCommand.Handle(baseUrl!, vpSessionId);
     }
+    case "feedback":
+        return await FeedbackCommand.HandleAsync(baseUrl!, args);
     case "eval": {
         // --list-questions is a standalone sub-action; short-circuit.
         if (args.Contains("--list-questions")) {

--- a/test/Capacitor.Cli.Tests.Integration/FeedbackVerbDispatchTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/FeedbackVerbDispatchTests.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// `kcap feedback` must reach <see cref="Capacitor.Cli.Commands.FeedbackCommand"/>. Pinned through
+/// the real binary for the same reason <c>AgentVerbDispatchTests</c> is: the dispatch lives in
+/// Program.cs's top-level flow, where a guard added ahead of the switch can shadow a whole verb
+/// without failing a single unit test that only calls <c>FeedbackCommand</c> directly.
+///
+/// Asserts a string only <c>FeedbackCommand</c> emits (its usage line naming both category flags)
+/// rather than merely "not Unknown command" — a bare "not the tombstone" check would pass for any
+/// other pre-dispatch guard that exits non-zero with unrelated text.
+/// </summary>
+public class FeedbackVerbDispatchTests {
+    [Test]
+    public async Task Bare_feedback_reaches_the_handlers_usage_error() {
+        var (stdout, stderr, exitCode) = await RunCli("feedback");
+        var output = stdout + stderr;
+
+        await Assert.That(output).Contains("kcap feedback (--bug | --feedback)");
+        await Assert.That(output).Contains("Pass exactly one of --bug or --feedback.");
+        await Assert.That(output).DoesNotContain("Unknown command");
+        await Assert.That(exitCode).IsNotEqualTo(0);
+    }
+
+    static async Task<(string Stdout, string Stderr, int ExitCode)> RunCli(
+            string argLine, bool clearServerUrl = false) {
+        var binary = GetCliBinaryPath();
+
+        if (!File.Exists(binary)) {
+            throw new FileNotFoundException(
+                $"kcap binary not found at {binary}. Build it first: " +
+                "dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj",
+                binary
+            );
+        }
+
+        var psi = new ProcessStartInfo(binary, argLine + " --no-update-check") {
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+            CreateNoWindow         = true
+        };
+
+        // Isolate from the developer's own profile so this assertion doesn't depend on whether
+        // this machine happens to have a server configured. Unreachable-but-present is enough:
+        // FeedbackCommand's usage error fires before any server call is attempted.
+        psi.Environment["KCAP_URL"] = clearServerUrl ? "" : "http://127.0.0.1:1";
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start kcap process");
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return (await stdoutTask, await stderrTask, process.ExitCode);
+    }
+
+    static string GetCliBinaryPath() {
+        var asmDir      = Path.GetDirectoryName(typeof(FeedbackVerbDispatchTests).Assembly.Location)!;
+        var binDir      = Path.GetDirectoryName(asmDir)!;
+        var config      = Path.GetFileName(binDir);
+        var testBin     = Path.GetDirectoryName(binDir)!;
+        var testProjDir = Path.GetDirectoryName(testBin)!;
+        var testRoot    = Path.GetDirectoryName(testProjDir)!;
+        var repoRoot    = Path.GetDirectoryName(testRoot)!;
+        var binaryName  = OperatingSystem.IsWindows() ? "kcap.exe" : "kcap";
+        return Path.Combine(repoRoot, "src", "Capacitor.Cli", "bin", config, "net10.0", binaryName);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/FeedbackCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FeedbackCommandTests.cs
@@ -1,0 +1,396 @@
+using System.Text.Json;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// <c>kcap feedback (--bug | --feedback) [-m|--message &lt;text&gt;]</c> — files a bug/feedback
+/// report through the tenant's <c>POST /api/feedback</c> (server contract: Task 10's
+/// <c>SupportEndpoints</c>/<c>FeedbackService</c>).
+///
+/// <para>Flag-validation and message-resolution tests drive
+/// <see cref="FeedbackCommand.HandleAsync(string, string[], bool, Func{string?})"/> directly with an
+/// injected TTY flag and line reader — no real stdin needed. Body-shape and response-mapping tests
+/// drive <see cref="FeedbackCommand.HandleCore"/> with a plain unauthenticated <see cref="HttpClient"/>
+/// against a WireMock stub, mirroring <c>ValidatePlanCommandTests</c>'s <c>HandleCore</c> seam — no
+/// token store or <c>/auth/config</c> discovery needed since <c>HandleCore</c> never touches auth.</para>
+///
+/// <para>The one test that walks the interactive-prompt path all the way through
+/// (<see cref="Interactive_prompt_collects_lines_until_empty_and_posts_the_joined_message"/>) DOES go
+/// through <see cref="FeedbackCommand.HandleAsync(string, string[], bool, Func{string?})"/>'s
+/// authenticated-client path, so it stubs <c>/auth/config</c> as <c>"None"</c> (no token needed) and
+/// shares <see cref="ReportVersionCommandTests"/>'s <c>TokenStoreProfileTests</c> serialization key —
+/// same reasoning as that class's doc comment: these tests touch the process-wide
+/// <see cref="AppConfig.ResolvedProfile"/> static and the shared config dir other classes in this
+/// assembly also read and write, plus the process-wide <see cref="Console.Out"/>/<see cref="Console.Error"/>.</para>
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class FeedbackCommandTests : IDisposable {
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+
+    readonly WireMockServer _server = WireMockServer.Start();
+
+    [Before(Test)]
+    public void Cleanup() {
+        HttpClientExtensions.ResetProviderCacheForTesting();
+        Environment.SetEnvironmentVariable("KCAP_URL", null);
+        SharedConfigDirCleanup.ClearTokenAndProfileState(LegacyPath, TokensDir);
+    }
+
+    public void Dispose() {
+        _server.Stop();
+        AppConfig.ResetResolvedStateForTesting();
+        HttpClientExtensions.ResetProviderCacheForTesting();
+    }
+
+    void StubNoAuthDiscovery() =>
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"provider":"None"}"""));
+
+    static async Task<(int ExitCode, string Stdout, string Stderr)> RunAsync(Func<Task<int>> action) {
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+        var stdout      = new StringWriter { NewLine = "\n" };
+        var stderr      = new StringWriter { NewLine = "\n" };
+        int exitCode;
+
+        try {
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            exitCode = await action();
+        } finally {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
+
+        return (exitCode, stdout.ToString(), stderr.ToString());
+    }
+
+    // ── flag validation ────────────────────────────────────────────────────────────────────────
+
+    [Test, NotInParallel]
+    public async Task Neither_bug_nor_feedback_is_a_usage_error_naming_both_flags() {
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleAsync("http://unused.invalid", ["feedback", "-m", "hi"], true, () => null));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr).Contains("--bug");
+        await Assert.That(stderr).Contains("--feedback");
+    }
+
+    [Test, NotInParallel]
+    public async Task Both_bug_and_feedback_is_a_usage_error_naming_both_flags() {
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleAsync(
+                "http://unused.invalid", ["feedback", "--bug", "--feedback", "-m", "hi"], true, () => null));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr).Contains("--bug");
+        await Assert.That(stderr).Contains("--feedback");
+    }
+
+    // ── message resolution ─────────────────────────────────────────────────────────────────────
+
+    [Test, NotInParallel]
+    public async Task Message_required_when_stdin_is_not_a_tty_and_dash_m_is_omitted() {
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleAsync(
+                "http://unused.invalid", ["feedback", "--bug"], stdinIsRedirected: true, readLine: () => null));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("A message is required.");
+    }
+
+    [Test, NotInParallel]
+    public async Task Whitespace_only_message_is_rejected_after_trim() {
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleAsync(
+                "http://unused.invalid", ["feedback", "--bug", "-m", "   "], stdinIsRedirected: true, readLine: () => null));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("A message is required.");
+    }
+
+    [Test, NotInParallel]
+    public async Task Interactive_prompt_collects_lines_until_empty_and_posts_the_joined_message() {
+        StubNoAuthDiscovery();
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"reporter_email":"someone@example.com"}"""));
+
+        var lines = new Queue<string?>(["first line", "second line", ""]);
+
+        var (exitCode, stdout, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleAsync(
+                _server.Urls[0], ["feedback", "--feedback"], stdinIsRedirected: false, readLine: () => lines.Dequeue()));
+
+        await Assert.That(exitCode).IsEqualTo(0);
+        await Assert.That(stderr).Contains("What's going on? (end with an empty line)");
+        await Assert.That(stdout.Trim()).IsEqualTo("✓ Sent to Kurrent support as someone@example.com");
+
+        var hit = _server.LogEntries.Single(e => e.RequestMessage.Path == "/api/feedback");
+        using var doc = JsonDocument.Parse(hit.RequestMessage.Body!);
+        await Assert.That(doc.RootElement.GetProperty("message").GetString()).IsEqualTo("first line\nsecond line");
+        await Assert.That(doc.RootElement.GetProperty("category").GetString()).IsEqualTo("feedback");
+    }
+
+    [Test, NotInParallel]
+    public async Task Dash_dash_message_is_accepted_as_an_alias_for_dash_m() {
+        StubNoAuthDiscovery();
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"reporter_email":"someone@example.com"}"""));
+
+        var (exitCode, _, _) = await RunAsync(() =>
+            FeedbackCommand.HandleAsync(
+                _server.Urls[0], ["feedback", "--bug", "--message", "via long flag"], true, () => null));
+
+        await Assert.That(exitCode).IsEqualTo(0);
+
+        var hit = _server.LogEntries.Single(e => e.RequestMessage.Path == "/api/feedback");
+        using var doc = JsonDocument.Parse(hit.RequestMessage.Body!);
+        await Assert.That(doc.RootElement.GetProperty("message").GetString()).IsEqualTo("via long flag");
+        await Assert.That(doc.RootElement.GetProperty("category").GetString()).IsEqualTo("bug");
+    }
+
+    // ── body shape (via HandleCore — no auth path involved) ───────────────────────────────────
+
+    [Test, NotInParallel]
+    public async Task Body_carries_snake_case_keys_a_fresh_client_request_id_guid_and_cli_context() {
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"reporter_email":"someone@example.com"}"""));
+
+        using var client = new HttpClient();
+        var exitCode = await FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "the daemon crashed");
+
+        await Assert.That(exitCode).IsEqualTo(0);
+
+        var hit = _server.LogEntries.Single(e => e.RequestMessage.Path == "/api/feedback");
+        using var doc = JsonDocument.Parse(hit.RequestMessage.Body!);
+        var root = doc.RootElement;
+
+        await Assert.That(root.GetProperty("category").GetString()).IsEqualTo("bug");
+        await Assert.That(root.GetProperty("message").GetString()).IsEqualTo("the daemon crashed");
+
+        // client_request_id must be present, snake_case, and a real (non-empty, parseable) GUID —
+        // it is the server's idempotency key, so a malformed or absent value would break dedup.
+        var rawId = root.GetProperty("client_request_id").GetString();
+        await Assert.That(Guid.TryParse(rawId, out var parsed)).IsTrue();
+        await Assert.That(parsed).IsNotEqualTo(Guid.Empty);
+
+        var context = root.GetProperty("context");
+        await Assert.That(context.GetProperty("source").GetString()).IsEqualTo("cli");
+        await Assert.That(context.GetProperty("client_version").GetString()).IsEqualTo(CapacitorVersion.CurrentDisplay());
+        await Assert.That(string.IsNullOrEmpty(context.GetProperty("os").GetString())).IsFalse();
+
+        // No camelCase leakage — the server binds snake_case only (Task 10's global JSON policy).
+        await Assert.That(root.TryGetProperty("clientRequestId", out _)).IsFalse();
+    }
+
+    [Test, NotInParallel]
+    public async Task Two_submissions_mint_two_distinct_client_request_ids() {
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"reporter_email":"someone@example.com"}"""));
+
+        using var client = new HttpClient();
+        await FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "first");
+        await FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "second");
+
+        var hits = _server.LogEntries.Where(e => e.RequestMessage.Path == "/api/feedback").ToList();
+        await Assert.That(hits.Count).IsEqualTo(2);
+
+        var ids = hits.Select(h => {
+            using var doc = JsonDocument.Parse(h.RequestMessage.Body!);
+            return doc.RootElement.GetProperty("client_request_id").GetString();
+        }).ToList();
+
+        await Assert.That(ids[0]).IsNotEqualTo(ids[1]);
+    }
+
+    // ── response mapping (via HandleCore) ─────────────────────────────────────────────────────
+
+    [Test, NotInParallel]
+    public async Task Ok_prints_the_pinned_success_line_with_the_reporter_email() {
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"reporter_email":"alice@example.com"}"""));
+
+        using var client = new HttpClient();
+        var (exitCode, stdout, _) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsEqualTo(0);
+        // Byte-exact: the pinned string, including the checkmark glyph, with no reply promise.
+        await Assert.That(stdout.Trim()).IsEqualTo("✓ Sent to Kurrent support as alice@example.com");
+    }
+
+    [Test, NotInParallel]
+    public async Task Bare_404_with_no_body_reports_support_intake_not_enabled() {
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(404));
+
+        using var client = new HttpClient();
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("This server doesn't have support intake enabled.");
+    }
+
+    [Test, NotInParallel]
+    public async Task Bare_405_with_no_body_reports_support_intake_not_enabled() {
+        // The real flag-off shape (see FeedbackCommand's doc comment): ASP.NET's routing layer
+        // itself answers 405 for a POST to an unmapped route, carrying no JSON body at all.
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(405));
+
+        using var client = new HttpClient();
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("This server doesn't have support intake enabled.");
+    }
+
+    [Test, NotInParallel]
+    public async Task Coded_404_feedback_not_configured_reports_ask_your_admin() {
+        // Same status code as the bare case above, but WITH a JSON error body — the route exists
+        // (Features:Feedback is on) and the sink itself isn't configured. Must NOT be confused with
+        // the bare 404 "feature is off" message.
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(404)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"error":"feedback_not_configured","message":"Feedback submission is not configured for this server."}"""));
+
+        using var client = new HttpClient();
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("Support intake isn't configured on this server — ask your admin.");
+    }
+
+    [Test, NotInParallel]
+    public async Task Coded_503_feedback_misconfigured_reports_ask_your_admin() {
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(503)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"error":"feedback_misconfigured","message":"Feedback submission is currently misconfigured on this server."}"""));
+
+        using var client = new HttpClient();
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("Support intake isn't configured on this server — ask your admin.");
+    }
+
+    [Test, NotInParallel]
+    public async Task Conflict_feedback_no_email_reports_sign_in_to_the_web_app() {
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(409)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"error":"feedback_no_email","message":"We don't have an email address on file for your account."}"""));
+
+        using var client = new HttpClient();
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo(
+            "Your account has no email on file — sign in to the web app once, then retry.");
+    }
+
+    [Test, NotInParallel]
+    public async Task TooManyRequests_reports_try_again_in_a_few_minutes() {
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(429)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"error":"feedback_rate_limited","message":"Too many feedback submissions — please try again later."}"""));
+
+        using var client = new HttpClient();
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("You've sent several reports recently — try again in a few minutes.");
+    }
+
+    [Test, NotInParallel]
+    public async Task BadGateway_with_retry_after_reports_the_seconds() {
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(502)
+                .WithHeader("Retry-After", "30")
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"error":"feedback_sink_error","message":"Feedback submission is temporarily unavailable — please try again shortly."}"""));
+
+        using var client = new HttpClient();
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("Couldn't reach Kurrent support (temporary) — try again in 30s.");
+    }
+
+    [Test, NotInParallel]
+    public async Task BadGateway_without_retry_after_reports_the_bare_sentence() {
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(502)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"error":"feedback_sink_error","message":"Feedback submission is temporarily unavailable — please try again shortly."}"""));
+
+        using var client = new HttpClient();
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("Couldn't reach Kurrent support (temporary) — try again.");
+    }
+
+    [Test, NotInParallel]
+    public async Task BadRequest_echoes_the_servers_message_field_verbatim() {
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(400)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"error":"feedback_invalid","message":"a custom validation message from the server"}"""));
+
+        using var client = new HttpClient();
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("a custom validation message from the server");
+    }
+
+    [Test, NotInParallel]
+    public async Task Unauthorized_prints_the_servers_message_and_reuses_the_standard_handler() {
+        // Mirrors HttpClientExtensions.HandleUnauthorizedAsync's own contract (used unchanged by
+        // every other command) — this command must not invent its own 401 handling.
+        _server.Given(Request.Create().WithPath("/api/feedback").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(401)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"message":"Your session has expired. Run 'kcap login' to re-authenticate."}"""));
+
+        using var client = new HttpClient();
+        var (exitCode, _, stderr) = await RunAsync(() =>
+            FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
+
+        await Assert.That(exitCode).IsNotEqualTo(0);
+        await Assert.That(stderr.Trim()).IsEqualTo("Your session has expired. Run 'kcap login' to re-authenticate.");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Telemetry/CommandEventsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Telemetry/CommandEventsTests.cs
@@ -91,6 +91,59 @@ public class CommandEventsTests {
         await Assert.That(flags.Length).IsEqualTo(0);
     }
 
+    // Regression: a --message/-m value is free-form user prose, and a message that happens to
+    // start with "--" (e.g. someone pasting a real flag name as part of their bug report) must
+    // never be captured as if it were a flag name in its own right — that would leak the message
+    // text itself into telemetry, defeating the whole point of never capturing message content.
+    [Test]
+    public async Task Message_value_that_looks_like_a_flag_is_never_captured_short_form() {
+        var flags = CommandEvents.Flags(["feedback", "--bug", "-m", "--looks-like-a-flag"]);
+
+        await Assert.That(flags).Contains("--bug");
+        await Assert.That(flags).DoesNotContain("--looks-like-a-flag");
+        // "-m" itself was never captured before this fix either — short flags don't match
+        // FlagShape's "--" prefix requirement — so this isn't a NEW gap introduced by the fix.
+        await Assert.That(flags).DoesNotContain("-m");
+    }
+
+    [Test]
+    public async Task Message_value_that_looks_like_a_flag_is_never_captured_long_form() {
+        var flags = CommandEvents.Flags(["feedback", "--bug", "--message", "--looks-like-a-flag"]);
+
+        // The flag NAME --message is still legitimate metadata and must still be reported —
+        // only the value bound to it is data.
+        await Assert.That(flags).Contains("--bug");
+        await Assert.That(flags).Contains("--message");
+        await Assert.That(flags).DoesNotContain("--looks-like-a-flag");
+        await Assert.That(flags.Length).IsEqualTo(2);
+    }
+
+    // A --message value that does NOT look like a flag must obviously still be excluded (it never
+    // starts with "--", so it was already excluded before this fix) — pinned here so a future
+    // change to the skip mechanism can't accidentally start treating it as a flag some other way.
+    [Test]
+    public async Task Ordinary_message_value_is_still_excluded() {
+        var flags = CommandEvents.Flags(["feedback", "--feedback", "--message", "the app crashed on startup"]);
+
+        await Assert.That(flags).Contains("--feedback");
+        await Assert.That(flags).Contains("--message");
+        await Assert.That(flags.Length).IsEqualTo(2);
+    }
+
+    // Other verbs' flag extraction must be byte-for-byte unchanged by the value-flag skip —
+    // none of their flags are in CommandEvents' ValueFlags set, so this is the same assertion
+    // Flags_are_collected_sorted_and_deduplicated and Flag_values_are_stripped_and_never_reported
+    // already make; repeated here explicitly as the regression check for this fix.
+    [Test]
+    public async Task Unrelated_verbs_flag_extraction_is_unchanged() {
+        var setupFlags = CommandEvents.Flags(["setup", "--no-prompt", "--skip-codex-hooks", "--no-prompt"]);
+        await Assert.That(setupFlags).IsEquivalentTo(["--no-prompt", "--skip-codex-hooks"]);
+
+        var serverUrlFlags = CommandEvents.Flags(
+            ["setup", "--server-url=https://internal.corp.example", "--server-url", "https://internal.corp.example"]);
+        await Assert.That(serverUrlFlags).IsEquivalentTo(["--server-url"]);
+    }
+
     // Shape rule: the pattern cannot express a path, URL, GUID, or email.
     [Test]
     [Arguments("--Bad-Upper")]


### PR DESCRIPTION
CLI half of the kcap support-intake feature (server PRs: kurrent-io/kcap-server#1429/#1430/#1432 — spec `docs/superpowers/specs/2026-08-12-ai1820-plain-support-intake-design.md` there; Linear AI-1820).

`kcap feedback (--bug | --feedback) [-m <text>]` posts to the tenant server's `POST /api/feedback` (bearer-authed) with a fresh `client_request_id` GUID (server-side idempotency key) and a `context {source: "cli", client_version, os}` block; on a TTY without `-m` it prompts for a multi-line message.

Response mapping: 200 prints the pinned success line `✓ Sent to Kurrent support as {reporter_email}` (attribution email is server-resolved from the persisted profile — deliberately no reply promise yet; a reply-delivery spike gates that suffix). Bare 404/405 (feature flag off — no JSON error body) → "support intake not enabled"; coded 404/503 → "not configured, ask your admin"; 409 → "no email on file"; 429 → local rate-limit message; 502 ± `Retry-After` → transient retry hint; 400 → server's message; 401 → the standard not-logged-in handling. Non-zero exit on every failure.

AOT-safe (source-generated `CapacitorJsonContext` types), telemetry-safe (verb only — message text never captured), interactive-lifetime allow-listed for the TTY prompt.

**Tests:** `FeedbackCommandTests` 19/19 (flag validation, body shape incl. GUID freshness, every response mapping, byte-exact pinned success string) + a dispatch-level integration test (the `AgentVerbDispatchTests` pattern — guards against pre-switch verb shadowing); full integration suite 220/220.

Note: the kcap-server `src/cli` submodule pin bump to ship this is Alexey's, per house rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)