### PR TITLE
Stop Codex collab child watchers leaking after the parent session ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1470,8 +1470,9 @@ long build or test run cannot be cut short. Like Cursor's ceiling, this exit pos
 #550): they relied on the parent session watcher's teardown, which finalized their server-side
 records but never stopped the local processes — so each collab subagent leaked one watcher process
 that reconnected to the server indefinitely. The parent session watcher now stops every child
-watcher it spawned as part of its own exit (each child gets a SIGTERM and runs its final drain),
-and as a backstop for a hard-killed parent, a Codex subagent watcher self-reaps after
+watcher it spawned as part of its own exit (SIGTERM-first on macOS/Linux so each child runs its
+final drain; on Windows the stop is forceful and any undelivered tail is recovered by the
+spool/import paths), and as a backstop for a hard-killed parent, a Codex subagent watcher self-reaps after
 `KCAP_CODEX_SUBAGENT_REAP_MINUTES` of rollout silence. A reaped subagent that the parent later
 re-engages is respawned by the parent's rollout scan as soon as its rollout grows again, resuming
 from the server's frontier so no content is lost. Like the Claude ceiling, the reap exit posts no

--- a/README.md
+++ b/README.md
@@ -1452,6 +1452,7 @@ verbatim, exactly like every other agent, with no Cursor/ACP-specific redaction.
 |----------------------|---------|-------------|
 | `KCAP_CODEX_IDLE_MINUTES` | `60` | How long a Codex rollout file may be idle (no new rollout lines and no Codex tool call in flight) before the `kcap watch` background watcher ends the session (`reason: idle_timeout`). Increase for very long thinking/compute turns; decrease for faster cleanup of abandoned sessions. Invalid or non-positive values fall back to the 60-minute default. |
 | `KCAP_CODEX_SUBAGENT_IDLE_MINUTES` | `5` | Idle grace between a Codex collab subagent finishing its turn (its rollout's `task_complete`, no tool call in flight) and the child watcher marking it completed on the server, so the subagent's chat card stops showing "in progress" while the parent session keeps running. The grace absorbs quick same-round re-engagements by the parent; `0` marks completion immediately at turn end. The completion is one-shot — a subagent the parent re-engages after the grace keeps streaming into its transcript but stays marked completed. Invalid or negative values fall back to the 5-minute default. |
+| `KCAP_CODEX_SUBAGENT_REAP_MINUTES` | `360` | How long a Codex collab **subagent** watcher may go idle before it reaps itself (see below). Applies only to subagent watchers — the parent session watcher's idle behavior is tuned by `KCAP_CODEX_IDLE_MINUTES`. Deliberately generous (6h): this is a leak backstop, not an end-of-conversation signal. A subagent with a tool call still in flight is never reaped. Invalid or non-positive values fall back to 360 minutes. |
 | `KCAP_PARENT_DEAD_CEILING_MINUTES` | `360` | Staged recovery ceiling for a watcher whose parent coding-agent PID was already dead at startup (a resolution glitch) and can't be re-resolved. The watcher first periodically re-resolves and re-arms the parent-exit watchdog; only if that keeps failing AND the transcript makes no progress for this long does it post `session-end` (`reason: parent_dead_ceiling`). Deliberately far above the idle timeout so a user parked at a Kiro/OpenCode prompt is never ended prematurely. Invalid or non-positive values fall back to 360 minutes (6h). |
 | `KCAP_CURSOR_IDLE_CEILING_MINUTES` | `60` | How long a Cursor session's transcript watcher may go idle before it exits (AI-1382). Unlike Codex/Antigravity, this exit does NOT itself POST `session-end` — Cursor's end-of-session synthesis stays owned by the `sessionEnd` hook or, as a backstop, a server-side lease-gated sweep; the next hook for that session reactivates a fresh watcher. Invalid or non-positive values fall back to the 60-minute default. |
 | `KCAP_CLAUDE_SUBAGENT_IDLE_MINUTES` | `360` | How long a Claude **subagent** watcher may go idle before it reaps itself (see below). Applies only to subagent watchers — a Claude *session* watcher has no idle ceiling and is unaffected. Deliberately generous (6h): this is a leak backstop, not an end-of-conversation signal. Invalid or non-positive values fall back to 360 minutes. |
@@ -1464,6 +1465,17 @@ life of the session (issue #514). Subagent watchers now also self-reap after
 (a `tool_use` with no matching `tool_result`) is never reaped no matter how long it is quiet, so a
 long build or test run cannot be cut short. Like Cursor's ceiling, this exit posts no
 `session-end` — a subagent watcher never owned that.
+
+**Codex subagent watcher reaping.** Codex collab subagent watchers had no exit path at all (issue
+#550): they relied on the parent session watcher's teardown, which finalized their server-side
+records but never stopped the local processes — so each collab subagent leaked one watcher process
+that reconnected to the server indefinitely. The parent session watcher now stops every child
+watcher it spawned as part of its own exit (each child gets a SIGTERM and runs its final drain),
+and as a backstop for a hard-killed parent, a Codex subagent watcher self-reaps after
+`KCAP_CODEX_SUBAGENT_REAP_MINUTES` of rollout silence. A reaped subagent that the parent later
+re-engages is respawned by the parent's rollout scan as soon as its rollout grows again, resuming
+from the server's frontier so no content is lost. Like the Claude ceiling, the reap exit posts no
+`session-end`.
 
 ### Hosted Pi agents
 

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -663,6 +663,16 @@ static partial class WatchCommand {
         // deliberately never cached so it is retried (see CodexSubagentDiscovery).
         var codexRuledOutRollouts = new HashSet<string>(StringComparer.Ordinal);
 
+        // Codex-only: last mtime ChildRolloutAdvanced fired for, per child rollout — backs the
+        // re-ensure gate that respawns a reaped child watcher when its subagent re-engages.
+        var codexRolloutMtimes = new Dictionary<string, DateTime>(StringComparer.Ordinal);
+
+        // Watcher keys of every child watcher this session watcher spawned (#550). The parent is
+        // the only thing that knows they exist, so it must also stop them on its own exit —
+        // children have no parent-pid watchdog (this process's ancestry has no coding agent) and
+        // the server's StopWatcher only reaches the session watcher's connection.
+        var spawnedChildWatcherKeys = new HashSet<string>(StringComparer.Ordinal);
+
         try {
             while (!cts.Token.IsCancellationRequested) {
                 // Task 9: touch every iteration — including no-content drains and
@@ -714,11 +724,13 @@ static partial class WatchCommand {
                 // spawn-time signal — drained this tick (nesting only, subagents are
                 // captured standalone already).
                 if (agentId is null && vendor == "gemini") {
-                    await ScanGeminiSubagents(baseUrl, sessionId, transcriptPath, seenSubagents, cts.Token);
+                    await ScanGeminiSubagents(baseUrl, sessionId, transcriptPath, seenSubagents, spawnedChildWatcherKeys, cts.Token);
                 } else if (agentId is null && vendor == "opencode") {
-                    await ScanOpenCodeSubagents(baseUrl, sessionId, transcriptPath, seenSubagents, cts.Token);
+                    await ScanOpenCodeSubagents(baseUrl, sessionId, transcriptPath, seenSubagents, spawnedChildWatcherKeys, cts.Token);
                 } else if (agentId is null && vendor == "codex") {
-                    await ScanCodexSubagents(baseUrl, sessionId, transcriptPath, seenSubagents, codexRuledOutRollouts, cts.Token);
+                    await ScanCodexSubagents(
+                        baseUrl, sessionId, transcriptPath, seenSubagents, codexRuledOutRollouts,
+                        codexRolloutMtimes, spawnedChildWatcherKeys, cts.Token);
                 } else if (agentId is null && vendor == "antigravity") {
                     await ScanAntigravitySubagentLinks(baseUrl, sessionId, drained, state.PostedSubagentLinks, cts.Token);
                 }
@@ -860,6 +872,16 @@ static partial class WatchCommand {
             Log($"Failed to signal drain complete: {ex.Message}");
         }
 
+        // #550: stop the child watchers this session watcher spawned — the parent is the only
+        // process that knows they exist, so its teardown is their stop signal on every exit path
+        // (StopWatcher, parent-exit, idle timeout, signals). SIGTERM lets each child run its own
+        // final drain before the parent posts session-end below. A parent killed hard (SIGKILL)
+        // skips this, which is exactly the orphan case the codex-child reap ceiling backstops.
+        if (spawnedChildWatcherKeys.Count > 0) {
+            Log($"Stopping {spawnedChildWatcherKeys.Count} spawned child watcher(s)");
+            await WatcherManager.KillWatchers(spawnedChildWatcherKeys);
+        }
+
         Log($"Done. {state.LinesProcessed} total lines processed.");
 
         await hubConnection.DisposeAsync();
@@ -905,11 +927,12 @@ static partial class WatchCommand {
     /// deterministic server-side lifecycle ids make re-registration safe.
     /// </summary>
     static async Task ScanGeminiSubagents(
-            string          baseUrl,
-            string          sessionId,
-            string          transcriptPath,
-            HashSet<string> seen,
-            CancellationToken ct
+            string              baseUrl,
+            string              sessionId,
+            string              transcriptPath,
+            HashSet<string>     seen,
+            ICollection<string> spawnedChildKeys,
+            CancellationToken   ct
         ) {
         IReadOnlyList<string> subFiles;
         try {
@@ -943,6 +966,7 @@ static partial class WatchCommand {
             await WatcherManager.EnsureWatcherRunning(
                 baseUrl, key: $"{sessionId}-{agentId}", transcriptPath: subFile,
                 agentId: agentId, sessionIdOverride: sessionId, vendor: "gemini");
+            spawnedChildKeys.Add($"{sessionId}-{agentId}");
 
             Log($"Gemini subagent {agentId} ({agentType}) registered + child watcher spawned");
         }
@@ -975,11 +999,12 @@ static partial class WatchCommand {
     /// ids make re-registration safe.
     /// </summary>
     static async Task ScanOpenCodeSubagents(
-            string            baseUrl,
-            string            sessionId,
-            string            transcriptPath,
-            HashSet<string>   seen,
-            CancellationToken ct
+            string              baseUrl,
+            string              sessionId,
+            string              transcriptPath,
+            HashSet<string>     seen,
+            ICollection<string> spawnedChildKeys,
+            CancellationToken   ct
         ) {
         IReadOnlyList<string> subFiles;
         try {
@@ -1008,6 +1033,7 @@ static partial class WatchCommand {
             await WatcherManager.EnsureWatcherRunning(
                 baseUrl, key: $"{sessionId}-{agentId}", transcriptPath: subFile,
                 agentId: agentId, sessionIdOverride: sessionId, vendor: "opencode");
+            spawnedChildKeys.Add($"{sessionId}-{agentId}");
 
             Log($"OpenCode subagent {agentId} ({agentType}) registered + child watcher spawned");
         }
@@ -1041,13 +1067,30 @@ static partial class WatchCommand {
     /// the parent's in-band <c>sub_agent_activity</c> events) so a restarted parent watcher
     /// still recovers already-spawned children.
     /// </summary>
+    /// <summary>
+    /// #550 companion to the codex-child reap ceiling: decides whether a child rollout needs its
+    /// watcher (re-)ensured. Fires on first sight and thereafter only when the rollout's mtime
+    /// advances — so a ceiling-reaped child stays reaped while its rollout is quiet, but is
+    /// re-spawned the moment its subagent re-engages (the fresh watcher resumes from the server
+    /// frontier, so nothing is lost). Records the mtime it fired for. Pure so it's unit-testable.
+    /// </summary>
+    internal static bool ChildRolloutAdvanced(Dictionary<string, DateTime> lastMtimes, string filePath, DateTime currentMtime) {
+        if (lastMtimes.TryGetValue(filePath, out var prev) && prev == currentMtime) return false;
+
+        lastMtimes[filePath] = currentMtime;
+
+        return true;
+    }
+
     static async Task ScanCodexSubagents(
-            string            baseUrl,
-            string            sessionId,
-            string            transcriptPath,
-            HashSet<string>   seen,
-            HashSet<string>   ruledOut,
-            CancellationToken ct
+            string                       baseUrl,
+            string                       sessionId,
+            string                       transcriptPath,
+            HashSet<string>              seen,
+            HashSet<string>              ruledOut,
+            Dictionary<string, DateTime> rolloutMtimes,
+            ICollection<string>          spawnedChildKeys,
+            CancellationToken            ct
         ) {
         List<CodexSubagentDiscovery.SubagentRollout> subs;
         try {
@@ -1058,14 +1101,23 @@ static partial class WatchCommand {
 
         foreach (var sub in subs) {
             if (ct.IsCancellationRequested) return;
-            if (!seen.Add(sub.FilePath)) continue; // already registered + spawned
+
+            // Evaluate BOTH gates before branching — ChildRolloutAdvanced must record the mtime
+            // even on first sight, or the first re-scan tick would re-fire for an unchanged file.
+            var advanced = ChildRolloutAdvanced(rolloutMtimes, sub.FilePath, File.GetLastWriteTimeUtc(sub.FilePath));
+            var isNew    = seen.Add(sub.FilePath);
+
+            // Already registered and the rollout hasn't grown: whatever watcher state exists is
+            // the intended one (alive and streaming, or reaped-idle) — don't respawn a reaped
+            // child for a rollout that is over.
+            if (!isNew && !advanced) continue;
 
             var childAgentId = sub.ChildDashlessId;
             var agentType    = CodexSubagentDiscovery.AgentTypeFrom(sub.AgentPath, sub.AgentNickname);
 
             // Fail-closed: register the subagent (→ SubagentStarted) before its child watcher
             // streams content. On POST failure, drop from `seen` so the next tick retries.
-            if (!await PostCodexSubagentStartAsync(baseUrl, sessionId, childAgentId, agentType, sub.FilePath, ct)) {
+            if (isNew && !await PostCodexSubagentStartAsync(baseUrl, sessionId, childAgentId, agentType, sub.FilePath, ct)) {
                 seen.Remove(sub.FilePath);
                 continue;
             }
@@ -1073,8 +1125,9 @@ static partial class WatchCommand {
             await WatcherManager.EnsureWatcherRunning(
                 baseUrl, key: $"{sessionId}-{childAgentId}", transcriptPath: sub.FilePath,
                 agentId: childAgentId, sessionIdOverride: sessionId, vendor: "codex");
+            spawnedChildKeys.Add($"{sessionId}-{childAgentId}");
 
-            Log($"Codex subagent {childAgentId} ({agentType}) registered + child watcher spawned");
+            if (isNew) Log($"Codex subagent {childAgentId} ({agentType}) registered + child watcher spawned");
         }
     }
 
@@ -1267,6 +1320,28 @@ static partial class WatchCommand {
             : DefaultClaudeSubagentIdleCeiling;
 
     /// <summary>
+    /// Reap ceiling for a Codex collab CHILD watcher (#550). Codex children are spawned by the
+    /// parent session watcher, whose own ancestry contains no codex process — so the parent-exit
+    /// watchdog never arms — and the server's StopWatcher goes only to the session watcher's
+    /// connection. Without a ceiling a child that outlives its parent's teardown has NO exit
+    /// path at all. Same "leak backstop, not end-of-conversation detector" sizing rationale as
+    /// <see cref="DefaultClaudeSubagentIdleCeiling"/>: a child posts no session-end, so reaping
+    /// late costs nothing while reaping a LIVE subagent drops the rest of its transcript.
+    /// </summary>
+    internal static readonly TimeSpan DefaultCodexSubagentReapCeiling = TimeSpan.FromHours(6);
+
+    /// <summary>
+    /// Resolves the Codex subagent reap ceiling from KCAP_CODEX_SUBAGENT_REAP_MINUTES — its own
+    /// knob because KCAP_CODEX_SUBAGENT_IDLE_MINUTES already tunes the subagent-stop grace.
+    /// Falls back to <see cref="DefaultCodexSubagentReapCeiling"/> for unset/blank/non-numeric/
+    /// non-positive values. Pure so the parsing is unit-testable.
+    /// </summary>
+    internal static TimeSpan ResolveCodexSubagentReapCeiling(string? envValue) =>
+        int.TryParse(envValue, out var minutes) && minutes > 0
+            ? TimeSpan.FromMinutes(minutes)
+            : DefaultCodexSubagentReapCeiling;
+
+    /// <summary>
     /// The idle window <see cref="RunWatch"/> measures against, per vendor and watcher role — each
     /// vendor on its OWN knob. <paramref name="env"/> is injected to keep the mapping testable.
     /// The role argument exists for Claude, whose CHILD watchers get the subagent backstop rather
@@ -1277,6 +1352,7 @@ static partial class WatchCommand {
             "antigravity"                     => ResolveCodexIdleTimeout(env("KCAP_ANTIGRAVITY_IDLE_MINUTES")),
             "cursor"                          => ResolveCursorIdleCeiling(env("KCAP_CURSOR_IDLE_CEILING_MINUTES")),
             "claude" when !isSessionWatcher   => ResolveClaudeSubagentIdleCeiling(env("KCAP_CLAUDE_SUBAGENT_IDLE_MINUTES")),
+            "codex" when !isSessionWatcher    => ResolveCodexSubagentReapCeiling(env("KCAP_CODEX_SUBAGENT_REAP_MINUTES")),
             _                                 => ResolveCodexIdleTimeout(env("KCAP_CODEX_IDLE_MINUTES")),
         };
 
@@ -1312,21 +1388,26 @@ static partial class WatchCommand {
             TimeSpan       disconnectedSinceActivity = default
         ) {
         // Which vendors may idle-exit, and in which role:
-        //   codex/antigravity — session only. Codex collab CHILD watchers (ScanCodexSubagents) are
-        //                       deliberately excluded: the parent's session-end teardown finalizes
-        //                       them with subagent-stop, so an idle self-exit would end nothing
-        //                       server-side. Antigravity spawns no child watchers at all.
+        //   codex             — both. Session: the 60-min idle window is the fallback session-end
+        //                       signal (no per-conversation parent-exit hook). CHILD (collab
+        //                       subagent, ScanCodexSubagents): the reap ceiling is a leak
+        //                       backstop (#550) — a child has no parent-pid watchdog (its spawner
+        //                       is the session watcher, whose ancestry has no codex process) and
+        //                       the server's StopWatcher goes only to the session watcher, so
+        //                       without the ceiling a child that outlives the parent's teardown
+        //                       never exits. Its server-side record is finalized by its own live
+        //                       subagent-stop POST or the parent-end teardown, never this exit.
+        //   antigravity       — session only; it spawns no child watchers at all.
         //   cursor            — both; no shell hook fires a reliable parent-exit signal either.
-        //   claude            — CHILD only, and for the opposite reason to Codex: nothing else
-        //                       finalizes it (a missed SubagentStop leaks it for the life of the
-        //                       parent). Its SESSION watcher has a working watchdog AND a
-        //                       sessionEnd hook, so a ceiling there could end a live session out
-        //                       from under a thinking user.
+        //   claude            — CHILD only: nothing else finalizes it (a missed SubagentStop
+        //                       leaks it for the life of the parent). Its SESSION watcher has a
+        //                       working watchdog AND a sessionEnd hook, so a ceiling there could
+        //                       end a live session out from under a thinking user.
         var eligible = vendor switch {
-            "codex" or "antigravity" => isSessionWatcher,
-            "cursor"                 => true,
-            "claude"                 => !isSessionWatcher,
-            _                        => false,
+            "codex" or "cursor" => true,
+            "antigravity"       => isSessionWatcher,
+            "claude"            => !isSessionWatcher,
+            _                   => false,
         };
 
         if (!eligible) return false;

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -667,10 +667,8 @@ static partial class WatchCommand {
         // re-ensure gate that respawns a reaped child watcher when its subagent re-engages.
         var codexRolloutMtimes = new Dictionary<string, DateTime>(StringComparer.Ordinal);
 
-        // Watcher keys of every child watcher this session watcher spawned (#550). The parent is
-        // the only thing that knows they exist, so it must also stop them on its own exit —
-        // children have no parent-pid watchdog (this process's ancestry has no coding agent) and
-        // the server's StopWatcher only reaches the session watcher's connection.
+        // Every child watcher key this session watcher spawned (#550) — the parent is the only
+        // process that knows they exist, so its teardown must stop them.
         var spawnedChildWatcherKeys = new HashSet<string>(StringComparer.Ordinal);
 
         try {
@@ -872,11 +870,9 @@ static partial class WatchCommand {
             Log($"Failed to signal drain complete: {ex.Message}");
         }
 
-        // #550: stop the child watchers this session watcher spawned — the parent is the only
-        // process that knows they exist, so its teardown is their stop signal on every exit path
-        // (StopWatcher, parent-exit, idle timeout, signals). SIGTERM lets each child run its own
-        // final drain before the parent posts session-end below. A parent killed hard (SIGKILL)
-        // skips this, which is exactly the orphan case the codex-child reap ceiling backstops.
+        // #550: stop spawned child watchers on every parent exit path — SIGTERM-first, so each
+        // runs its final drain before the session-end POST below. A SIGKILLed parent skips this;
+        // that orphan case is what the codex-child reap ceiling backstops.
         if (spawnedChildWatcherKeys.Count > 0) {
             Log($"Stopping {spawnedChildWatcherKeys.Count} spawned child watcher(s)");
             await WatcherManager.KillWatchers(spawnedChildWatcherKeys);
@@ -912,6 +908,11 @@ static partial class WatchCommand {
         if (endReason is not null && agentId is null && state.ThresholdReached && !cursorSuppressesEndPost) {
             await PostSessionEndOnParentExitAsync(baseUrl, sessionId, transcriptPath, cwd, vendor, state.Repository, endReason);
         }
+
+        // Graceful exit: retire this incarnation's pid file so no later teardown/cleanup can act
+        // on a recycled pid (KillWatcher's token guard is the crash-exit backstop).
+        WatcherManager.RemoveOwnPidFile(
+            agentId is null ? sessionId : $"{sessionId}-{agentId}", Environment.ProcessId);
 
         await logWriter.DisposeAsync();
 
@@ -1068,11 +1069,10 @@ static partial class WatchCommand {
     /// still recovers already-spawned children.
     /// </summary>
     /// <summary>
-    /// #550 companion to the codex-child reap ceiling: decides whether a child rollout needs its
-    /// watcher (re-)ensured. Fires on first sight and thereafter only when the rollout's mtime
-    /// advances — so a ceiling-reaped child stays reaped while its rollout is quiet, but is
-    /// re-spawned the moment its subagent re-engages (the fresh watcher resumes from the server
-    /// frontier, so nothing is lost). Records the mtime it fired for. Pure so it's unit-testable.
+    /// #550 companion to the codex-child reap ceiling: fires on first sight of a rollout and
+    /// thereafter only when its mtime advances, recording the mtime it fired for — so a reaped
+    /// child stays reaped while its rollout is quiet but is re-ensured the moment its subagent
+    /// re-engages (the fresh watcher resumes from the server frontier). Pure for testability.
     /// </summary>
     internal static bool ChildRolloutAdvanced(Dictionary<string, DateTime> lastMtimes, string filePath, DateTime currentMtime) {
         if (lastMtimes.TryGetValue(filePath, out var prev) && prev == currentMtime) return false;
@@ -1102,14 +1102,12 @@ static partial class WatchCommand {
         foreach (var sub in subs) {
             if (ct.IsCancellationRequested) return;
 
-            // Evaluate BOTH gates before branching — ChildRolloutAdvanced must record the mtime
-            // even on first sight, or the first re-scan tick would re-fire for an unchanged file.
+            // Both gates evaluate before branching so first sight also records the mtime. An
+            // already-seen rollout that hasn't grown keeps its watcher state as-is — alive and
+            // streaming, or reaped-idle — rather than respawning a reaped child for a finished rollout.
             var advanced = ChildRolloutAdvanced(rolloutMtimes, sub.FilePath, File.GetLastWriteTimeUtc(sub.FilePath));
             var isNew    = seen.Add(sub.FilePath);
 
-            // Already registered and the rollout hasn't grown: whatever watcher state exists is
-            // the intended one (alive and streaming, or reaped-idle) — don't respawn a reaped
-            // child for a rollout that is over.
             if (!isNew && !advanced) continue;
 
             var childAgentId = sub.ChildDashlessId;
@@ -1320,13 +1318,11 @@ static partial class WatchCommand {
             : DefaultClaudeSubagentIdleCeiling;
 
     /// <summary>
-    /// Reap ceiling for a Codex collab CHILD watcher (#550). Codex children are spawned by the
-    /// parent session watcher, whose own ancestry contains no codex process — so the parent-exit
-    /// watchdog never arms — and the server's StopWatcher goes only to the session watcher's
-    /// connection. Without a ceiling a child that outlives its parent's teardown has NO exit
-    /// path at all. Same "leak backstop, not end-of-conversation detector" sizing rationale as
-    /// <see cref="DefaultClaudeSubagentIdleCeiling"/>: a child posts no session-end, so reaping
-    /// late costs nothing while reaping a LIVE subagent drops the rest of its transcript.
+    /// Reap ceiling for a Codex collab CHILD watcher (#550), the backstop for a child orphaned by
+    /// a hard-killed parent (no parent-pid watchdog, and StopWatcher only reaches the session
+    /// watcher). Same sizing rationale as <see cref="DefaultClaudeSubagentIdleCeiling"/>: a leak
+    /// backstop, not an end-of-conversation detector — reaping late costs nothing, reaping a LIVE
+    /// subagent drops the rest of its transcript.
     /// </summary>
     internal static readonly TimeSpan DefaultCodexSubagentReapCeiling = TimeSpan.FromHours(6);
 
@@ -1388,14 +1384,12 @@ static partial class WatchCommand {
             TimeSpan       disconnectedSinceActivity = default
         ) {
         // Which vendors may idle-exit, and in which role:
-        //   codex             — both. Session: the 60-min idle window is the fallback session-end
-        //                       signal (no per-conversation parent-exit hook). CHILD (collab
-        //                       subagent, ScanCodexSubagents): the reap ceiling is a leak
-        //                       backstop (#550) — a child has no parent-pid watchdog (its spawner
-        //                       is the session watcher, whose ancestry has no codex process) and
-        //                       the server's StopWatcher goes only to the session watcher, so
-        //                       without the ceiling a child that outlives the parent's teardown
-        //                       never exits. Its server-side record is finalized by its own live
+        //   codex             — both. Session: the idle window is the fallback session-end signal
+        //                       (no per-conversation parent-exit hook). CHILD: the reap ceiling
+        //                       is a leak backstop (#550) — no parent-pid watchdog, and the
+        //                       server's StopWatcher only reaches the session watcher, so a child
+        //                       that outlives the parent's teardown would otherwise never exit.
+        //                       Server-side finalization stays with the child's own live
         //                       subagent-stop POST or the parent-end teardown, never this exit.
         //   antigravity       — session only; it spawns no child watchers at all.
         //   cursor            — both; no shell hook fires a reliable parent-exit signal either.

--- a/src/Capacitor.Cli/WatcherManager.cs
+++ b/src/Capacitor.Cli/WatcherManager.cs
@@ -284,6 +284,17 @@ static class WatcherManager {
         }
     }
 
+    /// <summary>
+    /// Kills every watcher in <paramref name="keys"/> concurrently (#550): a session watcher
+    /// stops the child watchers it spawned on its own way out — children have no parent-pid
+    /// watchdog (their spawner's ancestry contains no coding agent) and the server's StopWatcher
+    /// only reaches the session watcher's connection, so the parent's teardown is the only thing
+    /// that knows they exist. <see cref="KillWatcher"/>'s SIGTERM gives each child its final
+    /// drain, and its per-child 5s force-kill bound keeps a wedged child from stalling the
+    /// parent's own exit.
+    /// </summary>
+    public static Task KillWatchers(IEnumerable<string> keys) => Task.WhenAll(keys.Select(KillWatcher));
+
     /// <summary>PID-only liveness: the process exists, irrespective of whether it's wedged.</summary>
     static bool PidAlive(string key) {
         var pidFile = GetPidFilePath(key);

--- a/src/Capacitor.Cli/WatcherManager.cs
+++ b/src/Capacitor.Cli/WatcherManager.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Commands;
@@ -7,7 +8,7 @@ using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli;
 
-static class WatcherManager {
+static partial class WatcherManager {
     internal static string GetWatcherDir() {
         var overrideDir = Environment.GetEnvironmentVariable("KCAP_WATCHER_DIR");
 
@@ -162,7 +163,11 @@ static class WatcherManager {
             process.StandardOutput.Close();
             process.StandardError.Close();
 
-            await File.WriteAllTextAsync(GetPidFilePath(key), process.Id.ToString());
+            // Line 2 is this incarnation's start-identity token (daemon pid-file layout) so
+            // KillWatcher can tell the spawned watcher apart from a later recycle of its pid.
+            var token = ProcessStartToken.ForPid(process.Id);
+            await File.WriteAllTextAsync(
+                GetPidFilePath(key), token is null ? process.Id.ToString() : $"{process.Id}\n{token}");
 
             // Task 9: record this instance's start time so a later staleness probe
             // knows whether it's still within the startup grace window — written here (not
@@ -238,10 +243,24 @@ static class WatcherManager {
         }
 
         try {
-            var pidText = (await File.ReadAllTextAsync(pidFile)).Trim();
+            // Line 1 is the pid; line 2 (when present) is the incarnation's ProcessStartToken
+            // written by SpawnWatcher — the same layout as the daemon pid file.
+            var lines = await File.ReadAllLinesAsync(pidFile);
 
-            if (!int.TryParse(pidText, out var pid)) {
+            if (lines.Length == 0 || !int.TryParse(lines[0].Trim(), out var pid)) {
                 File.Delete(pidFile);
+
+                return false;
+            }
+
+            // "Ambiguity never kills" (ProcessStartToken): a conclusive token mismatch means the
+            // watcher died and the OS recycled its pid onto an unrelated process — sweep the
+            // stale file, never signal. A missing/uncomparable token (legacy file, process gone)
+            // falls through to the kill attempt, exactly as before tokens existed.
+            var token = lines.Length > 1 ? lines[1].Trim() : "";
+
+            if (token.Length > 0 && ProcessStartToken.Matches(pid, token) == false) {
+                await Console.Error.WriteLineAsync($"Watcher {key} (PID {pid}) was recycled by another process; sweeping stale pid file");
 
                 return false;
             }
@@ -249,8 +268,12 @@ static class WatcherManager {
             try {
                 var process = Process.GetProcessById(pid);
 
-                // Send SIGTERM
-                process.Kill(entireProcessTree: false);
+                // SIGTERM-first on Unix so the watcher runs its shutdown path (final drain +
+                // undelivered-tail spool) — Process.Kill is SIGKILL there. Windows has no
+                // SIGTERM; the stop is hard and recovery is left to the spool/import paths.
+                if (!TrySignalTerm(pid)) {
+                    process.Kill(entireProcessTree: false);
+                }
 
                 // Wait up to 5 seconds for graceful exit
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -285,15 +308,45 @@ static class WatcherManager {
     }
 
     /// <summary>
-    /// Kills every watcher in <paramref name="keys"/> concurrently (#550): a session watcher
-    /// stops the child watchers it spawned on its own way out — children have no parent-pid
-    /// watchdog (their spawner's ancestry contains no coding agent) and the server's StopWatcher
-    /// only reaches the session watcher's connection, so the parent's teardown is the only thing
-    /// that knows they exist. <see cref="KillWatcher"/>'s SIGTERM gives each child its final
-    /// drain, and its per-child 5s force-kill bound keeps a wedged child from stalling the
-    /// parent's own exit.
+    /// Stops every watcher in <paramref name="keys"/> concurrently (#550, a session watcher's
+    /// teardown of its spawned children). <see cref="KillWatcher"/>'s SIGTERM-first gives each
+    /// child its final drain; its 5s force-kill bound keeps a wedged child from stalling the caller.
     /// </summary>
     public static Task KillWatchers(IEnumerable<string> keys) => Task.WhenAll(keys.Select(KillWatcher));
+
+    /// <summary>
+    /// Retires this watcher's own pid file (+ heartbeat markers) on graceful exit, but only while
+    /// it still names this incarnation — a successor that already overwrote the file is left
+    /// alone. Keeps a later teardown/cleanup from ever acting on this watcher's recycled pid.
+    /// </summary>
+    public static void RemoveOwnPidFile(string key, int ownPid) {
+        try {
+            var lines = File.ReadAllLines(GetPidFilePath(key));
+
+            if (lines.Length == 0 || !int.TryParse(lines[0].Trim(), out var filePid) || filePid != ownPid) return;
+
+            File.Delete(GetPidFilePath(key));
+            DeleteHeartbeatFiles(key);
+        } catch {
+            /* best-effort — a missing/unreadable file means there is nothing to retire */
+        }
+    }
+
+    const int Sigterm = 15;
+
+    [LibraryImport("libc", EntryPoint = "kill", SetLastError = true)]
+    private static partial int sys_kill(int pid, int sig);
+
+    /// <summary>SIGTERM on Unix; false on Windows or when the signal can't be delivered.</summary>
+    static bool TrySignalTerm(int pid) {
+        if (OperatingSystem.IsWindows()) return false;
+
+        try {
+            return sys_kill(pid, Sigterm) == 0;
+        } catch {
+            return false;
+        }
+    }
 
     /// <summary>PID-only liveness: the process exists, irrespective of whether it's wedged.</summary>
     static bool PidAlive(string key) {
@@ -304,9 +357,9 @@ static class WatcherManager {
         }
 
         try {
-            var pidText = File.ReadAllText(pidFile).Trim();
+            var lines = File.ReadAllLines(pidFile);
 
-            if (!int.TryParse(pidText, out var pid)) {
+            if (lines.Length == 0 || !int.TryParse(lines[0].Trim(), out var pid)) {
                 return false;
             }
 

--- a/test/Capacitor.Cli.Tests.Integration/PermissionRequestWatcherSelfHealTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/PermissionRequestWatcherSelfHealTests.cs
@@ -56,8 +56,8 @@ public class PermissionRequestWatcherSelfHealTests {
             await PermissionRequestCommand.TryEnsureWatcher("http://localhost:0", sessionId, node);
 
             await Assert.That(File.Exists(pidFile)).IsTrue();
-            var pidText = await File.ReadAllTextAsync(pidFile);
-            await Assert.That(int.TryParse(pidText.Trim(), out _)).IsTrue();
+            var lines = await File.ReadAllLinesAsync(pidFile);
+            await Assert.That(int.TryParse(lines[0].Trim(), out _)).IsTrue();
         } finally {
             await Cli.WatcherManager.KillWatcher(sessionId);
             File.Delete(transcriptPath);

--- a/test/Capacitor.Cli.Tests.Integration/WatcherLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/WatcherLifecycleTests.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using Capacitor.Cli.Core;
+
 namespace Capacitor.Cli.Tests.Integration;
 
 [NotInParallel]
@@ -29,8 +32,9 @@ public class WatcherLifecycleTests {
 
     static async Task AssertPidFileValid(string pidFile) {
         await Assert.That(File.Exists(pidFile)).IsTrue();
-        var pidText = await File.ReadAllTextAsync(pidFile);
-        await Assert.That(int.TryParse(pidText.Trim(), out _)).IsTrue();
+        var lines = await File.ReadAllLinesAsync(pidFile);
+        await Assert.That(lines.Length).IsGreaterThanOrEqualTo(1);
+        await Assert.That(int.TryParse(lines[0].Trim(), out _)).IsTrue();
     }
 
     [Test]
@@ -60,6 +64,103 @@ public class WatcherLifecycleTests {
         } finally {
             File.Delete(transcriptPath);
         }
+    }
+
+    // The pid file must identify the watcher INCARNATION, not just the pid — a recycled pid must
+    // never be killable through a stale file. Line 2 carries the spawn-time ProcessStartToken,
+    // mirroring the daemon pid file.
+    [Test]
+    public async Task SpawnWatcher_records_the_process_start_token_beside_the_pid() {
+        var (key, transcriptPath, pidFile) = SetUpWatcher();
+
+        try {
+            await Cli.WatcherManager.SpawnWatcher("http://localhost:0", key, transcriptPath, agentId: null);
+
+            var lines = await File.ReadAllLinesAsync(pidFile);
+            await Assert.That(lines.Length).IsGreaterThanOrEqualTo(2);
+
+            var pid = int.Parse(lines[0].Trim());
+            await Assert.That(lines[1].Trim()).IsEqualTo(ProcessStartToken.ForPid(pid));
+
+            await Cli.WatcherManager.KillWatcher(key);
+        } finally {
+            File.Delete(transcriptPath);
+        }
+    }
+
+    // Process.Kill is SIGKILL on Unix, so before this fix a "killed" watcher never ran its
+    // SIGTERM shutdown path (final drain + undelivered-tail spool). Exit code 42 from the trap
+    // proves the process saw SIGTERM and exited on its own terms.
+    [Test]
+    public async Task KillWatcher_sigterms_first_so_the_watcher_can_run_its_drain() {
+        if (OperatingSystem.IsWindows()) return; // no SIGTERM semantics on Windows
+
+        var (key, transcriptPath, pidFile) = SetUpWatcher();
+        var readyMarker = Path.Combine(TempDir, $"{key}.trap-ready");
+        var psi = new ProcessStartInfo("/bin/bash") { UseShellExecute = false };
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add($"trap 'exit 42' TERM; echo ready > '{readyMarker}'; while true; do sleep 0.2; done");
+        using var trapped = Process.Start(psi)!;
+
+        try {
+            // Signalling before the trap is installed would hit bash's default disposition (143).
+            var readyDeadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5);
+            while (!File.Exists(readyMarker) && DateTimeOffset.UtcNow < readyDeadline) await Task.Delay(20);
+            await Assert.That(File.Exists(readyMarker)).IsTrue();
+
+            await File.WriteAllTextAsync(pidFile, $"{trapped.Id}\n{ProcessStartToken.ForPid(trapped.Id)}");
+
+            var wasRunning = await Cli.WatcherManager.KillWatcher(key);
+
+            await Assert.That(wasRunning).IsTrue();
+            await trapped.WaitForExitAsync(new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token);
+            await Assert.That(trapped.ExitCode).IsEqualTo(42);
+        } finally {
+            try { if (!trapped.HasExited) trapped.Kill(); } catch { /* best effort */ }
+            File.Delete(transcriptPath);
+        }
+    }
+
+    // "Ambiguity never kills": a pid file whose token conclusively belongs to a different process
+    // incarnation (the watcher died, the OS recycled its pid) must be swept without signalling
+    // the unrelated process now holding that pid.
+    [Test]
+    public async Task KillWatcher_spares_a_recycled_pid_and_sweeps_the_stale_file() {
+        if (OperatingSystem.IsWindows()) return; // sacrificial sleeper is unix-only
+
+        var (key, transcriptPath, pidFile) = SetUpWatcher();
+        using var bystander = Process.Start(new ProcessStartInfo("/bin/sleep", "30") { UseShellExecute = false })!;
+
+        try {
+            // Same token scheme, provably different incarnation: the current test process's token.
+            await File.WriteAllTextAsync(pidFile, $"{bystander.Id}\n{ProcessStartToken.ForCurrent()}");
+
+            var wasRunning = await Cli.WatcherManager.KillWatcher(key);
+
+            await Assert.That(wasRunning).IsFalse();
+            await Assert.That(bystander.HasExited).IsFalse();
+            await Assert.That(File.Exists(pidFile)).IsFalse();
+        } finally {
+            try { if (!bystander.HasExited) bystander.Kill(); } catch { /* best effort */ }
+            File.Delete(transcriptPath);
+        }
+    }
+
+    // A watcher retires its own pid file on graceful exit (self-reap, StopWatcher, parent-exit) —
+    // but only its own: a successor incarnation's file must be left alone.
+    [Test]
+    public async Task RemoveOwnPidFile_removes_only_this_incarnations_file() {
+        var (ownKey, _, ownPidFile)             = SetUpWatcher();
+        var (successorKey, _, successorPidFile) = SetUpWatcher();
+
+        await File.WriteAllTextAsync(ownPidFile, $"{Environment.ProcessId}\ntk:1");
+        await File.WriteAllTextAsync(successorPidFile, $"{Environment.ProcessId + 1}\ntk:2");
+
+        Cli.WatcherManager.RemoveOwnPidFile(ownKey, Environment.ProcessId);
+        Cli.WatcherManager.RemoveOwnPidFile(successorKey, Environment.ProcessId);
+
+        await Assert.That(File.Exists(ownPidFile)).IsFalse();
+        await Assert.That(File.Exists(successorPidFile)).IsTrue();
     }
 
     // #550: a session watcher must stop the child watchers it spawned on its own way out — they

--- a/test/Capacitor.Cli.Tests.Integration/WatcherLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/WatcherLifecycleTests.cs
@@ -61,4 +61,31 @@ public class WatcherLifecycleTests {
             File.Delete(transcriptPath);
         }
     }
+
+    // #550: a session watcher must stop the child watchers it spawned on its own way out — they
+    // have no parent-pid watchdog and the server's StopWatcher only reaches the session watcher's
+    // connection, so the parent's teardown is the only thing that knows they exist. One live and
+    // one already-dead child in the same batch: both pid files must be gone afterwards (the dead
+    // entry is swept, never an error that aborts the batch).
+    [Test]
+    public async Task KillWatchers_stops_every_tracked_child_and_clears_their_pid_files() {
+        var (liveKey, liveTranscript, livePidFile) = SetUpWatcher();
+        var (deadKey, deadTranscript, deadPidFile) = SetUpWatcher();
+
+        try {
+            await Cli.WatcherManager.SpawnWatcher("http://localhost:0", liveKey, liveTranscript, agentId: null);
+            await AssertPidFileValid(livePidFile);
+
+            // A pid that cannot belong to a live process — exercises the already-exited sweep arm.
+            await File.WriteAllTextAsync(deadPidFile, "99999999");
+
+            await Cli.WatcherManager.KillWatchers([liveKey, deadKey]);
+
+            await Assert.That(File.Exists(livePidFile)).IsFalse();
+            await Assert.That(File.Exists(deadPidFile)).IsFalse();
+        } finally {
+            File.Delete(liveTranscript);
+            File.Delete(deadTranscript);
+        }
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchCommandTests.cs
@@ -350,16 +350,6 @@ public class WatchCommandTests {
     }
 
     [Test]
-    public async Task ShouldEndOnIdle_false_for_subagent_watcher() {
-        var should = WatchCommand.ShouldEndOnIdle(
-            vendor: "codex", isSessionWatcher: false, thresholdReached: true,
-            lastActivityAt: IdleNow - TimeSpan.FromMinutes(61), now: IdleNow, idleTimeout: IdleWindow,
-            toolInFlight: false);
-
-        await Assert.That(should).IsFalse();
-    }
-
-    [Test]
     public async Task ShouldEndOnIdle_false_below_threshold() {
         var should = WatchCommand.ShouldEndOnIdle(
             vendor: "codex", isSessionWatcher: true, thresholdReached: false,
@@ -430,18 +420,16 @@ public class WatchCommandTests {
             lastActivityAt: now.AddMinutes(-5), now: now, idleTimeout: TimeSpan.FromMinutes(60))).IsFalse();
     }
 
-    // Regression guard: the child-watcher exemption from the threshold gate is Cursor-specific —
-    // a non-session (subagent) watcher for every other idle-ceiling vendor (codex/antigravity)
-    // must stay ineligible, exactly as before this fix.
+    // Regression guard: Antigravity spawns no child watchers at all, so a non-session watcher
+    // carrying that vendor is a misconfiguration — it must stay ineligible rather than reap
+    // anything. (Codex children joined the ceiling in the #550 fix; Claude/Cursor were already in.)
     [Test]
-    [Arguments("codex")]
-    [Arguments("antigravity")]
-    public async Task NonCursor_child_watcher_stays_ineligible_for_the_idle_ceiling(string vendor) {
+    public async Task Antigravity_child_watcher_stays_ineligible_for_the_idle_ceiling() {
         var now  = DateTimeOffset.UtcNow;
         var idle = now.AddMinutes(-61);
 
         await Assert.That(WatchCommand.ShouldEndOnIdle(
-            vendor: vendor, isSessionWatcher: false, thresholdReached: true,
+            vendor: "antigravity", isSessionWatcher: false, thresholdReached: true,
             lastActivityAt: idle, now: now, idleTimeout: TimeSpan.FromMinutes(60))).IsFalse();
     }
 
@@ -543,6 +531,7 @@ public class WatchCommandTests {
     // Codex knob, and vice versa.
     [Test]
     [Arguments("codex",       true,  "KCAP_CODEX_IDLE_MINUTES",           "15", 15)]
+    [Arguments("codex",       false, "KCAP_CODEX_SUBAGENT_REAP_MINUTES",  "45", 45)]
     [Arguments("antigravity", true,  "KCAP_ANTIGRAVITY_IDLE_MINUTES",     "20", 20)]
     [Arguments("cursor",      true,  "KCAP_CURSOR_IDLE_CEILING_MINUTES",  "25", 25)]
     [Arguments("claude",      false, "KCAP_CLAUDE_SUBAGENT_IDLE_MINUTES", "30", 30)]
@@ -565,6 +554,92 @@ public class WatchCommandTests {
         var result = WatchCommand.ResolveClaudeSubagentIdleCeiling(env);
 
         await Assert.That(result).IsEqualTo(TimeSpan.FromMinutes(expectedMinutes));
+    }
+
+    // A Codex collab CHILD watcher had NO exit path at all (#550): excluded from the idle
+    // ceiling on the assumption the parent's session-end teardown finalizes it (that teardown is
+    // server-side records only), spawned without --parent-pid (the spawning parent session
+    // watcher's ancestry has no codex process to resolve), and never sent StopWatcher. Observed:
+    // 16 children from one session still alive two days after the parent exited. Children join
+    // the ceiling as a leak backstop; like Claude's, they never buffer, so the threshold gate
+    // cannot apply.
+    [Test]
+    public async Task Codex_child_watcher_is_idle_ceiling_eligible_without_threshold_reached() {
+        var now = DateTimeOffset.UtcNow;
+
+        await Assert.That(WatchCommand.ShouldEndOnIdle(
+            vendor: "codex", isSessionWatcher: false, thresholdReached: false,
+            lastActivityAt: now - (TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1)), now: now,
+            idleTimeout: TimeSpan.FromHours(6))).IsTrue();
+
+        // Not yet idle — still false.
+        await Assert.That(WatchCommand.ShouldEndOnIdle(
+            vendor: "codex", isSessionWatcher: false, thresholdReached: false,
+            lastActivityAt: now.AddMinutes(-5), now: now, idleTimeout: TimeSpan.FromHours(6))).IsFalse();
+    }
+
+    // Same safety property as the Claude child ceiling: a subagent running a long tool call
+    // writes nothing to its rollout between the call and its output record, so rollout silence
+    // alone must never reap it.
+    [Test]
+    public async Task Codex_child_watcher_never_idle_exits_while_a_tool_is_in_flight() {
+        var now = DateTimeOffset.UtcNow;
+
+        await Assert.That(WatchCommand.ShouldEndOnIdle(
+            vendor: "codex", isSessionWatcher: false, thresholdReached: false,
+            lastActivityAt: now.AddHours(-12), now: now, idleTimeout: TimeSpan.FromHours(6),
+            toolInFlight: true)).IsFalse();
+    }
+
+    // The ceiling only reaps anything if RunWatch hands a Codex CHILD watcher the reap ceiling
+    // rather than the 60-minute session window — reaping a quiet-but-live subagent at 60 minutes
+    // would drop the rest of its transcript.
+    [Test]
+    public async Task ResolveIdleWindow_gives_codex_child_watchers_the_reap_ceiling() {
+        var window = WatchCommand.ResolveIdleWindow("codex", isSessionWatcher: false, _ => null);
+
+        await Assert.That(window).IsEqualTo(WatchCommand.DefaultCodexSubagentReapCeiling);
+    }
+
+    // KCAP_CODEX_SUBAGENT_IDLE_MINUTES is already taken by the subagent-stop grace, so the reap
+    // ceiling gets its own knob.
+    [Test]
+    [Arguments(null, 360)]    // unset → default 6h
+    [Arguments("abc", 360)]   // non-numeric → default
+    [Arguments("0", 360)]     // non-positive → default
+    [Arguments("45", 45)]     // valid override
+    public async Task ResolveCodexSubagentReapCeiling_parses_env_with_default(string? env, int expectedMinutes) {
+        var result = WatchCommand.ResolveCodexSubagentReapCeiling(env);
+
+        await Assert.That(result).IsEqualTo(TimeSpan.FromMinutes(expectedMinutes));
+    }
+
+    // #550 companion: with children joining the reap ceiling, ScanCodexSubagents' first-sight-only
+    // gate became a content-loss hazard — a ceiling-reaped child whose subagent re-engages would
+    // grow its rollout with nobody watching for the rest of the parent's life. The scan therefore
+    // re-ensures the child watcher whenever the rollout's mtime advances; this pure gate decides
+    // when, recording the mtime it fired for so an unchanged rollout stays quiet.
+    [Test]
+    public async Task ChildRolloutAdvanced_fires_on_first_sight_and_then_only_on_mtime_change() {
+        var mtimes = new Dictionary<string, DateTime>(StringComparer.Ordinal);
+        var t0     = new DateTime(2026, 8, 13, 12, 0, 0, DateTimeKind.Utc);
+
+        await Assert.That(WatchCommand.ChildRolloutAdvanced(mtimes, "/a.jsonl", t0)).IsTrue();
+        await Assert.That(WatchCommand.ChildRolloutAdvanced(mtimes, "/a.jsonl", t0)).IsFalse();
+        await Assert.That(WatchCommand.ChildRolloutAdvanced(mtimes, "/a.jsonl", t0.AddSeconds(1))).IsTrue();
+        await Assert.That(WatchCommand.ChildRolloutAdvanced(mtimes, "/a.jsonl", t0.AddSeconds(1))).IsFalse();
+    }
+
+    // Distinct rollouts are tracked independently — one child's growth must not re-ensure another.
+    [Test]
+    public async Task ChildRolloutAdvanced_tracks_each_rollout_independently() {
+        var mtimes = new Dictionary<string, DateTime>(StringComparer.Ordinal);
+        var t0     = new DateTime(2026, 8, 13, 12, 0, 0, DateTimeKind.Utc);
+
+        await Assert.That(WatchCommand.ChildRolloutAdvanced(mtimes, "/a.jsonl", t0)).IsTrue();
+        await Assert.That(WatchCommand.ChildRolloutAdvanced(mtimes, "/b.jsonl", t0)).IsTrue();
+        await Assert.That(WatchCommand.ChildRolloutAdvanced(mtimes, "/a.jsonl", t0.AddSeconds(5))).IsTrue();
+        await Assert.That(WatchCommand.ChildRolloutAdvanced(mtimes, "/b.jsonl", t0)).IsFalse();
     }
 
     // ResolveCursorIdleClock: the idle clock is the LATER of transcript


### PR DESCRIPTION
Closes #550 (AI-1928)

## Problem

A Codex collab child watcher had **no exit path at all** — observed as 16 `kcap watch … --vendor codex` processes from a single session still running two days after the parent session ended, each stuck in an infinite reconnect-and-resend loop against the server:

1. `ShouldEndOnIdle` deliberately excluded codex children, assuming "the parent's session-end teardown finalizes them" — but that teardown finalizes server-side records only, never the local processes.
2. The parent-exit watchdog never arms: children are spawned by the parent *session watcher*, whose ancestry contains no `codex` process for `GetCodingAgentPid` to resolve, so every child starts with "No parent pid supplied; parent-exit watchdog disabled".
3. `KillWatcher` was never called from `WatchCommand`, and the server's `StopWatcher` signal only reaches the session watcher's connection.

## Fix (three layers)

- **Parent teardown stops its children.** The session watcher tracks every child watcher key it spawns (codex, and the same-shaped gemini/opencode scans) and stops them on its own way out via the new `WatcherManager.KillWatchers` — SIGTERM first, so each child runs its final drain before the parent posts session-end; the existing per-child 5s force-kill bound keeps a wedged child from stalling the parent's exit.
- **Reap ceiling as backstop.** Codex child watchers join the idle ceiling for the hard-killed-parent orphan case: 6h default on the new `KCAP_CODEX_SUBAGENT_REAP_MINUTES` knob (`KCAP_CODEX_SUBAGENT_IDLE_MINUTES` is already the subagent-stop grace), and never while a tool call is in flight — mirroring the Claude subagent ceiling from #517. The original "an idle self-exit would end nothing server-side" rationale went stale with #526: children post their own live subagent-stop, and once exited the watcher is GONE, which is exactly the state the server sweep can finalize.
- **Re-engagement stays safe.** `ScanCodexSubagents` re-ensures a child watcher whenever its rollout's mtime advances instead of gating on first sight only, so a reaped child whose subagent re-engages is respawned and resumes from the server frontier. Without this, the ceiling would turn re-engagement into silent content loss for the rest of the parent's life.

## Testing

- Unit: codex-child ceiling eligibility/window/knob routing + `ChildRolloutAdvanced` gate (TDD, watched red first); the codex regression guard that pinned the old ineligible behavior is superseded and updated.
- Integration: `KillWatchers_stops_every_tracked_child_and_clears_their_pid_files` — one live and one already-dead child in a batch, both swept.
- Full unit suite: only the known rotating local timing flakes (daemon/PTY areas, disjoint from this diff). AOT publish: no IL3050/IL2026 warnings.

README documents the new knob and reaping behavior in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)