### PR TITLE
kcap feedback: promise email replies in the success line (verified live)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1890,11 +1890,11 @@ kcap feedback --feedback                               # send feedback; prompts 
 ```
 
 > `kcap feedback (--bug | --feedback) [-m|--message <text>]` files a report through the
-> server's support-intake pipeline (when the tenant has it configured). On success, it
-> prints the reporter email and promises that support replies arrive by email. Exactly one
-> of `--bug`/`--feedback` is required. `-m`/`--message` is required when stdin isn't a TTY
+> server's support-intake pipeline (when the tenant has it configured). Exactly one of
+> `--bug`/`--feedback` is required. `-m`/`--message` is required when stdin isn't a TTY
 > (scripts, CI); on an interactive terminal without it, the command prompts for a
-> multi-line message ended by an empty line.
+> multi-line message ended by an empty line. On success, it prints:
+> `✓ Sent to Kurrent support as {email} — replies will reach you by email.`
 
 > `kcap update` is the one-step upgrade for npm-global installs: it checks the
 > registry, runs `npm install -g @kurrent/kcap@<tag>`, then refreshes your

--- a/README.md
+++ b/README.md
@@ -1890,11 +1890,11 @@ kcap feedback --feedback                               # send feedback; prompts 
 ```
 
 > `kcap feedback (--bug | --feedback) [-m|--message <text>]` files a report through the
-> server's support-intake pipeline (when the tenant has it configured) and prints the
-> reporter email it was filed under on success. Exactly one of `--bug`/`--feedback` is
-> required. `-m`/`--message` is required when stdin isn't a TTY (scripts, CI); on an
-> interactive terminal without it, the command prompts for a multi-line message ended by
-> an empty line.
+> server's support-intake pipeline (when the tenant has it configured). On success, it
+> prints the reporter email and promises that support replies arrive by email. Exactly one
+> of `--bug`/`--feedback` is required. `-m`/`--message` is required when stdin isn't a TTY
+> (scripts, CI); on an interactive terminal without it, the command prompts for a
+> multi-line message ended by an empty line.
 
 > `kcap update` is the one-step upgrade for npm-global installs: it checks the
 > registry, runs `npm install -g @kurrent/kcap@<tag>`, then refreshes your

--- a/src/Capacitor.Cli/Commands/FeedbackCommand.cs
+++ b/src/Capacitor.Cli/Commands/FeedbackCommand.cs
@@ -19,9 +19,8 @@ namespace Capacitor.Cli.Commands;
 /// </summary>
 public static class FeedbackCommand {
     /// <summary>
-    /// The pinned success line (spec: no reply promise — a later revision may add one, but this
-    /// exact string is what ships first). Printed to stdout so <c>kcap feedback ... | ...</c> can
-    /// capture it; everything else in this command writes to stderr.
+    /// The pinned success line (post-spike variant: promises email replies). Printed to stdout so
+    /// <c>kcap feedback ... | ...</c> can capture it; everything else in this command writes to stderr.
     /// </summary>
     internal const string SuccessPrefix = "✓ Sent to Kurrent support as ";
 
@@ -119,7 +118,7 @@ public static class FeedbackCommand {
     static async Task<int> ReportResultAsync(HttpResponseMessage resp) {
         if (resp.StatusCode == HttpStatusCode.OK) {
             var success = await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.FeedbackSubmitResponse);
-            await Console.Out.WriteLineAsync($"{SuccessPrefix}{success?.ReporterEmail ?? ""}");
+            await Console.Out.WriteLineAsync($"{SuccessPrefix}{success?.ReporterEmail ?? ""} — replies will reach you by email.");
 
             return 0;
         }

--- a/test/Capacitor.Cli.Tests.Unit/FeedbackCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FeedbackCommandTests.cs
@@ -135,7 +135,7 @@ public class FeedbackCommandTests : IDisposable {
 
         await Assert.That(exitCode).IsEqualTo(0);
         await Assert.That(stderr).Contains("What's going on? (end with an empty line)");
-        await Assert.That(stdout.Trim()).IsEqualTo("✓ Sent to Kurrent support as someone@example.com");
+        await Assert.That(stdout.Trim()).IsEqualTo("✓ Sent to Kurrent support as someone@example.com — replies will reach you by email.");
 
         var hit = _server.LogEntries.Single(e => e.RequestMessage.Path == "/api/feedback");
         using var doc = JsonDocument.Parse(hit.RequestMessage.Body!);
@@ -235,8 +235,8 @@ public class FeedbackCommandTests : IDisposable {
             FeedbackCommand.HandleCore(client, _server.Urls[0], "bug", "hi"));
 
         await Assert.That(exitCode).IsEqualTo(0);
-        // Byte-exact: the pinned string, including the checkmark glyph, with no reply promise.
-        await Assert.That(stdout.Trim()).IsEqualTo("✓ Sent to Kurrent support as alice@example.com");
+        // Byte-exact: the pinned string, including the checkmark glyph, with the reply promise.
+        await Assert.That(stdout.Trim()).IsEqualTo("✓ Sent to Kurrent support as alice@example.com — replies will reach you by email.");
     }
 
     [Test, NotInParallel]

--- a/test/Capacitor.Cli.Tests.Unit/FeedbackCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FeedbackCommandTests.cs
@@ -135,7 +135,7 @@ public class FeedbackCommandTests : IDisposable {
 
         await Assert.That(exitCode).IsEqualTo(0);
         await Assert.That(stderr).Contains("What's going on? (end with an empty line)");
-        await Assert.That(stdout.Trim()).IsEqualTo("✓ Sent to Kurrent support as someone@example.com — replies will reach you by email.");
+        await Assert.That(stdout.TrimEnd('\r', '\n')).IsEqualTo("✓ Sent to Kurrent support as someone@example.com — replies will reach you by email.");
 
         var hit = _server.LogEntries.Single(e => e.RequestMessage.Path == "/api/feedback");
         using var doc = JsonDocument.Parse(hit.RequestMessage.Body!);
@@ -236,7 +236,7 @@ public class FeedbackCommandTests : IDisposable {
 
         await Assert.That(exitCode).IsEqualTo(0);
         // Byte-exact: the pinned string, including the checkmark glyph, with the reply promise.
-        await Assert.That(stdout.Trim()).IsEqualTo("✓ Sent to Kurrent support as alice@example.com — replies will reach you by email.");
+        await Assert.That(stdout.TrimEnd('\r', '\n')).IsEqualTo("✓ Sent to Kurrent support as alice@example.com — replies will reach you by email.");
     }
 
     [Test, NotInParallel]


### PR DESCRIPTION
Follow-up to #549. The reply-delivery spike is now verified live (2026-08-13): a support agent's reply from the Plain inbox was delivered by email to the reporter. That unlocks the second — and final — pinned success-string variant:

`✓ Sent to Kurrent support as {reporter_email} — replies will reach you by email.`

One-line copy change + the two byte-exact test pins updated (`FeedbackCommandTests` 19/19). Spike record: the AI-1820 Linear issue's spike-2 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)