### PR TITLE
[AI-1941] Fix daemon doctor --clean never removing lock-only stale entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ kcap daemon restart --name laptop              # restart now if idle; refuses wh
 kcap daemon restart --name laptop --when-idle  # queue the restart for the next idle moment
 kcap daemon restart --name laptop --force      # restart now even if busy (tears down running agents)
 kcap daemon doctor                  # diagnose lock-file state for every daemon name
-kcap daemon doctor --clean          # also remove stale lock/pid files (held entries are never touched)
+kcap daemon doctor --clean          # also remove a stale entry's pid/marker files, dropping it from the list (held entries are never touched; the inert lock file is left in place)
 ```
 
 `agent` was this group's name before it was renamed to `daemon`, and it now belongs to a different group — [`kcap agent`](#local-agents-kcap-agent) runs coding agents. The two still share `start` and `stop`, so check which one you mean: `kcap daemon start` starts the daemon, `kcap agent start <vendor>` starts a coding agent. Daemon-only verbs typed against the wrong group (`kcap agent status`, `restart`, `logs`, `doctor`, `service`) answer with a pointer back here.

--- a/src/Capacitor.Cli.Core/DaemonLockPaths.cs
+++ b/src/Capacitor.Cli.Core/DaemonLockPaths.cs
@@ -117,20 +117,27 @@ public static partial class DaemonLockPaths {
     public static void EnsureDirectory() => System.IO.Directory.CreateDirectory(Directory);
 
     /// <summary>
-    /// Returns the daemon names visible on disk — the union of names
-    /// derived from <c>*.lock</c>, <c>*.pid</c>, <c>*.restart-pending</c>, and
-    /// <c>*.version</c> files. Used by <c>daemon doctor</c> to classify held vs
-    /// stale entries; covers orphan PID files that have no matching lock (e.g. a
-    /// legacy daemon whose migration ran for the PID file but not the start
-    /// lock, or a stop that removed the lock but left the PID behind) and
-    /// marker-only leftovers (a crash between queueing a restart and applying it,
-    /// or a version marker left after an unclean exit).
+    /// Returns the daemon names visible on disk — the union of names derived from the
+    /// STATE markers <c>*.pid</c>, <c>*.restart-pending</c>, and <c>*.version</c>. Used
+    /// by <c>daemon doctor</c> to classify held vs stale entries; covers orphan PID
+    /// files (e.g. a stop that removed the lock but left the PID behind) and marker-only
+    /// leftovers (a crash between queueing a restart and applying it, or a version
+    /// marker left after an unclean exit).
+    ///
+    /// <para>A lone <c>*.lock</c> is deliberately NOT a name source. The lock file is a
+    /// per-inode <c>flock</c> mutex, not a liveness marker: its mere presence never means
+    /// a daemon exists (a live daemon also writes <c>.pid</c> inside the flock during
+    /// startup, so it is always covered by the PID lane), and it cannot be safely deleted
+    /// — unlinking a held/free <c>flock</c> file lets a later <c>daemon start</c> create a
+    /// fresh inode at the same path and hold a SECOND independent flock, so <c>doctor
+    /// --clean</c> deliberately leaves it. If a lone lock counted as a name, a cleaned
+    /// entry (markers removed, inert lock left) would be re-listed forever — the exact bug
+    /// this exclusion fixes. Once its markers are gone the name simply stops appearing;
+    /// the inert lock lingers harmlessly and is reused by the next start of that name.</para>
     /// </summary>
     public static IReadOnlyList<string> EnumerateNames() {
         if (!System.IO.Directory.Exists(Directory)) return [];
 
-        var fromLocks = System.IO.Directory.EnumerateFiles(Directory, "*.lock")
-            .Select(Path.GetFileNameWithoutExtension);
         var fromPids  = System.IO.Directory.EnumerateFiles(Directory, "*.pid")
             .Select(Path.GetFileNameWithoutExtension);
         var fromMarkers = System.IO.Directory.EnumerateFiles(Directory, "*.restart-pending")
@@ -139,7 +146,7 @@ public static partial class DaemonLockPaths {
             .Select(Path.GetFileNameWithoutExtension);
 
         return [
-            .. fromLocks.Concat(fromPids).Concat(fromMarkers).Concat(fromVersions)
+            .. fromPids.Concat(fromMarkers).Concat(fromVersions)
                 .Where(n => !string.IsNullOrEmpty(n))
                 .Select(n => n!)
                 .Distinct()

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonDoctorCleanTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonDoctorCleanTests.cs
@@ -1,0 +1,81 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Tests.Unit.Daemon;
+
+/// <summary>
+/// Regression cover for the bug where <c>kcap daemon doctor --clean</c> could never
+/// remove a confirmed-stale entry whose leftover included the <c>.lock</c> file.
+///
+/// <para>The lock is a per-inode <c>flock</c> mutex that cannot be safely deleted, so
+/// <c>--clean</c> leaves it and only removes the state markers. The listing must
+/// therefore key on the markers, not the lock: once the markers are gone the entry
+/// disappears from <see cref="DaemonLockPaths.EnumerateNames"/> even though the inert
+/// lock file remains on disk. Previously the lock alone kept the name in the listing,
+/// so the entry was re-surfaced on every run.</para>
+/// </summary>
+[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+public class DaemonDoctorCleanTests {
+    static string NewDir() {
+        var dir = Path.Combine(Path.GetTempPath(), "kcap-doctor-clean-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        return dir;
+    }
+
+    [Test]
+    public async Task RemovingMarkers_DropsEntryFromEnumeration_EvenWhenLockLingers() {
+        var dir = NewDir();
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+
+        try {
+            const string name = "ai1409";
+
+            // A confirmed-stale entry with the full leftover set: markers + the inert lock
+            // + a dead control socket.
+            File.WriteAllText(DaemonLockPaths.LockPath(name),           "deadbeef");
+            File.WriteAllText(DaemonLockPaths.PidPath(name),            "12345");
+            File.WriteAllText(DaemonLockPaths.VersionPath(name),        "0.11.7");
+            File.WriteAllText(DaemonLockPaths.RestartPendingPath(name), "");
+            File.WriteAllText(LocalSocketPaths.Socket(name),           "");
+
+            await Assert.That(DaemonLockPaths.EnumerateNames()).Contains(name);
+
+            // What `doctor --clean` does for a confirmed-stale entry: delete the state
+            // markers under the held flock, but LEAVE the lock file (it cannot be safely
+            // unlinked — doing so would break the per-inode flock mutex).
+            File.Delete(DaemonLockPaths.PidPath(name));
+            File.Delete(DaemonLockPaths.VersionPath(name));
+            File.Delete(DaemonLockPaths.RestartPendingPath(name));
+
+            // The entry is gone from the listing even though the lock file is still there.
+            await Assert.That(DaemonLockPaths.EnumerateNames()).DoesNotContain(name);
+            await Assert.That(File.Exists(DaemonLockPaths.LockPath(name))).IsTrue();
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Test]
+    public async Task BareLockLeftover_IsNeverListed() {
+        var dir = NewDir();
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+
+        try {
+            const string name = "agy-cert";
+
+            // The exact shape a user hit: a lock (+ dead socket + start lock) with no
+            // state markers. It must not appear at all — there is nothing `--clean` can
+            // safely remove, and listing it would be a phantom stale entry forever.
+            File.WriteAllText(DaemonLockPaths.LockPath(name),      "deadbeef");
+            File.WriteAllText(DaemonLockPaths.StartLockPath(name), "");
+            File.WriteAllText(LocalSocketPaths.Socket(name),      "");
+
+            await Assert.That(DaemonLockPaths.EnumerateNames()).DoesNotContain(name);
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonDoctorCleanTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonDoctorCleanTests.cs
@@ -4,15 +4,10 @@ using Capacitor.Cli.Core.LocalIpc;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// Regression cover for the bug where <c>kcap daemon doctor --clean</c> could never
-/// remove a confirmed-stale entry whose leftover included the <c>.lock</c> file.
-///
-/// <para>The lock is a per-inode <c>flock</c> mutex that cannot be safely deleted, so
-/// <c>--clean</c> leaves it and only removes the state markers. The listing must
-/// therefore key on the markers, not the lock: once the markers are gone the entry
-/// disappears from <see cref="DaemonLockPaths.EnumerateNames"/> even though the inert
-/// lock file remains on disk. Previously the lock alone kept the name in the listing,
-/// so the entry was re-surfaced on every run.</para>
+/// A cleaned stale entry must drop out of <see cref="DaemonLockPaths.EnumerateNames"/>.
+/// The lock file is a flock mutex that <c>--clean</c> cannot safely delete, so the listing
+/// keys on the state markers: once they are gone the name disappears even though the inert
+/// lock lingers. Previously a lone lock kept re-surfacing the entry on every run.
 /// </summary>
 [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
 public class DaemonDoctorCleanTests {

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockEnumerationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockEnumerationTests.cs
@@ -3,23 +3,27 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// <see cref="DaemonLockPaths.EnumerateNames"/> must
-/// union <c>*.lock</c> and <c>*.pid</c> filenames, not just <c>*.lock</c>.
-/// An orphan PID file (no matching lock, e.g. a daemon that stopped via
-/// the path before the per-name layout existed) needs to be visible
-/// to <c>kcap daemon doctor --clean</c>; previously it was invisible.
+/// <see cref="DaemonLockPaths.EnumerateNames"/> derives names from the STATE markers
+/// (<c>*.pid</c>/<c>*.restart-pending</c>/<c>*.version</c>) and deliberately NOT from a
+/// lone <c>*.lock</c>. An orphan PID file (no matching lock, e.g. a daemon that stopped
+/// via the path before the per-name layout existed) must still be visible to
+/// <c>kcap daemon doctor --clean</c>; a bare lock — the inert flock file left behind
+/// after a clean, which cannot be safely deleted — must NOT be, or the entry would be
+/// re-listed forever.
 /// </summary>
 [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
 public class DaemonLockEnumerationTests {
     [Test]
-    public async Task EnumerateNames_UnionsLockAndPidFiles() {
+    public async Task EnumerateNames_DerivesFromMarkers_NotFromBareLock() {
         var dir = Path.Combine(Path.GetTempPath(), "kcap-enum-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         DaemonLockPaths.OverrideDirectoryForTesting(dir);
 
         try {
-            // alpha has both lock and pid (held daemon).
-            // beta has only a lock (e.g. doctor just cleaned the pid).
+            // alpha has both lock and pid (a live/recently-live daemon — always writes .pid).
+            // beta has ONLY a lock (doctor already cleaned its markers): an inert leftover
+            //   that must NOT be listed — the lock file cannot be safely deleted, so listing
+            //   it would re-surface the entry on every run (the bug this exclusion fixes).
             // gamma has only a pid (orphan from before migration).
             File.WriteAllText(Path.Combine(dir, "alpha.lock"), "instance-1");
             File.WriteAllText(Path.Combine(dir, "alpha.pid"),  "12345");
@@ -28,10 +32,10 @@ public class DaemonLockEnumerationTests {
 
             var names = DaemonLockPaths.EnumerateNames();
 
-            await Assert.That(names).Count().IsEqualTo(3);
+            await Assert.That(names).Count().IsEqualTo(2);
             await Assert.That(names).Contains("alpha");
-            await Assert.That(names).Contains("beta");
             await Assert.That(names).Contains("gamma");
+            await Assert.That(names).DoesNotContain("beta");
         } finally {
             DaemonLockPaths.OverrideDirectoryForTesting(null);
             try { Directory.Delete(dir, recursive: true); } catch { /* best-effort */ }
@@ -39,14 +43,14 @@ public class DaemonLockEnumerationTests {
     }
 
     [Test]
-    public async Task EnumerateNames_DeduplicatesNamesAppearingInBoth() {
+    public async Task EnumerateNames_DeduplicatesNamesAppearingInMultipleMarkers() {
         var dir = Path.Combine(Path.GetTempPath(), "kcap-enum-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         DaemonLockPaths.OverrideDirectoryForTesting(dir);
 
         try {
-            File.WriteAllText(Path.Combine(dir, "alpha.lock"), "instance-1");
-            File.WriteAllText(Path.Combine(dir, "alpha.pid"),  "12345");
+            File.WriteAllText(Path.Combine(dir, "alpha.pid"),     "12345");
+            File.WriteAllText(Path.Combine(dir, "alpha.version"), "0.11.7");
 
             var names = DaemonLockPaths.EnumerateNames();
 

--- a/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockEnumerationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Daemon/DaemonLockEnumerationTests.cs
@@ -3,13 +3,10 @@ using Capacitor.Cli.Core;
 namespace Capacitor.Cli.Tests.Unit.Daemon;
 
 /// <summary>
-/// <see cref="DaemonLockPaths.EnumerateNames"/> derives names from the STATE markers
-/// (<c>*.pid</c>/<c>*.restart-pending</c>/<c>*.version</c>) and deliberately NOT from a
-/// lone <c>*.lock</c>. An orphan PID file (no matching lock, e.g. a daemon that stopped
-/// via the path before the per-name layout existed) must still be visible to
-/// <c>kcap daemon doctor --clean</c>; a bare lock — the inert flock file left behind
-/// after a clean, which cannot be safely deleted — must NOT be, or the entry would be
-/// re-listed forever.
+/// <see cref="DaemonLockPaths.EnumerateNames"/> derives names from the state markers
+/// (<c>*.pid</c>/<c>*.restart-pending</c>/<c>*.version</c>), not from a lone <c>*.lock</c>:
+/// an orphan PID must stay visible to <c>doctor --clean</c>, while an inert leftover lock
+/// (which cannot be safely deleted) must not, or the entry would be re-listed forever.
 /// </summary>
 [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
 public class DaemonLockEnumerationTests {


### PR DESCRIPTION
## Problem

`kcap daemon doctor --clean` reports N stale entries, claims to clean them, but the next `kcap daemon doctor` shows the exact same entries — forever. A user hit this with 9 stale daemon entries that `--clean` could never remove.

## Root cause

`doctor`'s listing is driven by `DaemonLockPaths.EnumerateNames()`, which unioned `*.lock` into the name set. For a confirmed-stale entry whose only leftover was the `.lock` file, `--clean` deletes the state markers but **deliberately leaves the `.lock`** — and it must: the lock file is a per-inode `flock` mutex, not a liveness marker. Unlinking it is genuinely unsafe (a later `daemon start` recreates a fresh inode at the same path and holds a *second* independent flock; supervised launchd/systemd daemons take no serialising start-lock, so there's no safe window to delete it). Because the `.lock` stayed and enumeration keyed on it, the name was re-listed on every run.

## Fix

Derive names only from the **state markers** — `*.pid` / `*.restart-pending` / `*.version` — never from a lone `*.lock`. A live daemon always writes `.pid` inside the flock during startup, so nothing real is hidden; a bare lock is an inert leftover and simply stops being listed. Once a stale entry's markers are cleaned it disappears from the listing even though the inert lock lingers (reused by the next start of that name).

This is a **single conceptual change** with no concurrency surface: `DaemonCommands` / the lock-deletion behaviour is untouched. It also makes the user's existing bare-lock leftovers vanish on upgrade with zero file deletion, on every platform.

### Why not just delete the lock in `--clean`?

That was the first attempt; it's unsound. `.NET` maps only `FileShare.None` to `flock(LOCK_EX)` (any shared mode is `LOCK_SH`), and unlinking a flock file breaks the per-inode mutex — reintroducing exactly the double-daemon race the original code avoided by never deleting it. A codex review flagged this; the enumeration change sidesteps it entirely.

## Tests

- `DaemonLockEnumerationTests` — a bare `.lock` is **not** a name source; markers are; dedup across markers holds.
- `DaemonDoctorCleanTests` — removing a stale entry's markers drops it from `EnumerateNames` while the lock file lingers; a bare-lock leftover (the exact user shape) is never listed.

All green locally (31 daemon lock/enumeration/marker tests, 0 failures).

Fixes AI-1941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)