### PR TITLE
Onboarding substrate: harden evidence containment and gated-start rechecks

### DIFF
--- a/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
+++ b/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
@@ -54,10 +54,9 @@ public static class ConfigMutator {
         try {
             json = File.ReadAllText(path);
         } catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
-            // DirectoryNotFoundException is ambiguous between "the parent chain genuinely doesn't
-            // exist yet" and "a path segment exists but blocks the walk" (a file, or a dangling
-            // symlink) — walk up to the first ancestor that exists at all and check its type.
-            if (ex is DirectoryNotFoundException && FirstExistingAncestorIsFile(path)) {
+            // A link at the exact path (dangling included), or a file/link ancestor, is
+            // structural evidence — unreadable, not absence.
+            if (PathEvidence.PathBlockedByFileOrLink(path)) {
                 config = FreshDefault();
                 return false;
             }
@@ -94,29 +93,6 @@ public static class ConfigMutator {
     }
 
     static ProfileConfig FreshDefault() => new() { Profiles = new() { ["default"] = new() } };
-
-    /// Walks up from <paramref name="path"/>'s parent chain to the first ancestor that exists —
-    /// as a directory, a file, or a dangling symlink — and reports whether it blocks the walk
-    /// structurally (file or dangling link) rather than being a genuine, simply never-created
-    /// directory level.
-    static bool FirstExistingAncestorIsFile(string path) {
-        var current = Path.GetDirectoryName(path);
-        while (!string.IsNullOrEmpty(current)) {
-            if (File.Exists(current)) return true;
-            if (Directory.Exists(current)) return false;
-            if (IsLink(current)) return true; // reached only when dangling — Exists above catches a live link
-            current = Path.GetDirectoryName(current);
-        }
-        return false;
-    }
-
-    /// <summary>Whether <paramref name="path"/> is itself a symlink, regardless of whether its
-    /// target exists — File.Exists/Directory.Exists both FOLLOW links, so a dangling one reads as
-    /// pure absence and the walk above would otherwise skip straight past it.</summary>
-    static bool IsLink(string path) {
-        try { return File.ResolveLinkTarget(path, returnFinalTarget: false) is not null; }
-        catch { return false; }
-    }
 
     static void Publish(string path, ProfileConfig config) {
         var tmp = path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];

--- a/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
+++ b/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Capacitor.Cli.Core; // JsonElement IsObject extension
 
 namespace Capacitor.Cli.Core.Config;
 
@@ -44,23 +45,32 @@ public static class ConfigMutator {
     /// silently treat it the same as absence (e.g. a gated identity check) use this instead of
     /// <see cref="LoadPure"/>.
     public static bool TryLoadPure(string path, out ProfileConfig config) {
-        // A directory sitting at the config path is NOT absence — File.Exists alone would say
-        // false and this would silently fall through to "nothing configured yet" for what is
-        // actually an unreadable/misconfigured location.
-        if (Directory.Exists(path)) {
-            config = new() { Profiles = new() { ["default"] = new() } };
-            return false;
-        }
-
-        if (!File.Exists(path)) {
-            config = new() { Profiles = new() { ["default"] = new() } };
-            return true;
-        }
-
+        // Attempt the read directly rather than probing Directory.Exists/File.Exists first: BOTH
+        // return false on a permission-denied path (or an unreadable ancestor directory), which
+        // would silently degrade "inaccessible" into "absent, defaults are fine" — exactly wrong
+        // for a caller (the start gate) that must fail closed on unreadable evidence rather than
+        // proceed as though nothing were configured.
         string json;
         try {
             json = File.ReadAllText(path);
-        } catch (Exception ex) when (ex is IOException or UnauthorizedAccessException) {
+        } catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
+            // FileNotFoundException is unambiguous (the file itself is absent). A
+            // DirectoryNotFoundException, though, is ambiguous on this runtime between "the parent
+            // chain truly does not exist yet" (genuine absence) and "a path segment exists but is a
+            // FILE, not a directory" (a structural misconfiguration that must not be read as
+            // absence). Disambiguate explicitly rather than trust the exception type alone.
+            var parent = Path.GetDirectoryName(path);
+            if (ex is DirectoryNotFoundException && parent is not null && File.Exists(parent)) {
+                config = new() { Profiles = new() { ["default"] = new() } };
+                return false;
+            }
+
+            config = new() { Profiles = new() { ["default"] = new() } };
+            return true;
+        } catch {
+            // A directory sitting at the config path (UnauthorizedAccessException on read), a
+            // permission error, or any other I/O failure — unreadable EVIDENCE, never silently
+            // folded into absence.
             config = new() { Profiles = new() { ["default"] = new() } };
             return false;
         }
@@ -71,7 +81,7 @@ public static class ConfigMutator {
         // contract.
         try {
             using var doc = JsonDocument.Parse(json);
-            if (doc.RootElement.ValueKind != JsonValueKind.Object) throw new JsonException("config root is not a JSON object");
+            if (!doc.RootElement.IsObject) throw new JsonException("config root is not a JSON object");
         } catch (JsonException) {
             config = new() { Profiles = new() { ["default"] = new() } };
             return false;

--- a/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
+++ b/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
@@ -58,9 +58,11 @@ public static class ConfigMutator {
             // DirectoryNotFoundException, though, is ambiguous on this runtime between "the parent
             // chain truly does not exist yet" (genuine absence) and "a path segment exists but is a
             // FILE, not a directory" (a structural misconfiguration that must not be read as
-            // absence). Disambiguate explicitly rather than trust the exception type alone.
-            var parent = Path.GetDirectoryName(path);
-            if (ex is DirectoryNotFoundException && parent is not null && File.Exists(parent)) {
+            // absence). The immediate parent alone isn't enough to tell them apart — a path like
+            // `somefile/child/config.json` needs two levels of walking before it reaches the file
+            // that's actually blocking it — so walk up to the FIRST ancestor that exists at all and
+            // check ITS type.
+            if (ex is DirectoryNotFoundException && FirstExistingAncestorIsFile(path)) {
                 config = new() { Profiles = new() { ["default"] = new() } };
                 return false;
             }
@@ -94,6 +96,21 @@ public static class ConfigMutator {
             config = new() { Profiles = new() { ["default"] = new() } };
             return false;
         }
+    }
+
+    /// Walks up from <paramref name="path"/>'s parent chain to the first ancestor that actually
+    /// exists on disk, and reports whether that ancestor is a FILE — a path segment blocking the
+    /// walk structurally — rather than a directory, where every missing level above is simply
+    /// never-created and therefore genuine absence. Handles any depth of missing directories, not
+    /// just the immediate parent.
+    static bool FirstExistingAncestorIsFile(string path) {
+        var current = Path.GetDirectoryName(path);
+        while (!string.IsNullOrEmpty(current)) {
+            if (File.Exists(current)) return true;
+            if (Directory.Exists(current)) return false;
+            current = Path.GetDirectoryName(current);
+        }
+        return false;
     }
 
     static void Publish(string path, ProfileConfig config) {

--- a/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
+++ b/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
@@ -98,6 +98,18 @@ public static class ConfigMutator {
         var tmp = path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
         File.WriteAllBytes(tmp,
             JsonSerializer.SerializeToUtf8Bytes(config, ProfileConfigJsonContextIndented.Default.ProfileConfig));
-        File.Move(tmp, path, overwrite: true);
+        // Windows denies replace-into-place while any reader holds the destination without
+        // FILE_SHARE_DELETE; readers are short-lived, so retry briefly before surfacing.
+        for (var attempt = 0; ; attempt++) {
+            try {
+                File.Move(tmp, path, overwrite: true);
+                return;
+            } catch (Exception e) when (e is UnauthorizedAccessException or IOException && attempt < 49) {
+                Thread.Sleep(20);
+            } catch {
+                try { File.Delete(tmp); } catch { /* best effort */ }
+                throw;
+            }
+        }
     }
 }

--- a/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
+++ b/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
@@ -54,26 +54,21 @@ public static class ConfigMutator {
         try {
             json = File.ReadAllText(path);
         } catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
-            // FileNotFoundException is unambiguous (the file itself is absent). A
-            // DirectoryNotFoundException, though, is ambiguous on this runtime between "the parent
-            // chain truly does not exist yet" (genuine absence) and "a path segment exists but is a
-            // FILE, not a directory" (a structural misconfiguration that must not be read as
-            // absence). The immediate parent alone isn't enough to tell them apart — a path like
-            // `somefile/child/config.json` needs two levels of walking before it reaches the file
-            // that's actually blocking it — so walk up to the FIRST ancestor that exists at all and
-            // check ITS type.
+            // DirectoryNotFoundException is ambiguous between "the parent chain genuinely doesn't
+            // exist yet" and "a path segment exists but blocks the walk" (a file, or a dangling
+            // symlink) — walk up to the first ancestor that exists at all and check its type.
             if (ex is DirectoryNotFoundException && FirstExistingAncestorIsFile(path)) {
-                config = new() { Profiles = new() { ["default"] = new() } };
+                config = FreshDefault();
                 return false;
             }
 
-            config = new() { Profiles = new() { ["default"] = new() } };
+            config = FreshDefault();
             return true;
         } catch {
             // A directory sitting at the config path (UnauthorizedAccessException on read), a
             // permission error, or any other I/O failure — unreadable EVIDENCE, never silently
             // folded into absence.
-            config = new() { Profiles = new() { ["default"] = new() } };
+            config = FreshDefault();
             return false;
         }
 
@@ -85,7 +80,7 @@ public static class ConfigMutator {
             using var doc = JsonDocument.Parse(json);
             if (!doc.RootElement.IsObject) throw new JsonException("config root is not a JSON object");
         } catch (JsonException) {
-            config = new() { Profiles = new() { ["default"] = new() } };
+            config = FreshDefault();
             return false;
         }
 
@@ -93,24 +88,34 @@ public static class ConfigMutator {
             config = ConfigMigration.MigrateIfNeeded(json).Config;
             return true;
         } catch (JsonException) {
-            config = new() { Profiles = new() { ["default"] = new() } };
+            config = FreshDefault();
             return false;
         }
     }
 
-    /// Walks up from <paramref name="path"/>'s parent chain to the first ancestor that actually
-    /// exists on disk, and reports whether that ancestor is a FILE — a path segment blocking the
-    /// walk structurally — rather than a directory, where every missing level above is simply
-    /// never-created and therefore genuine absence. Handles any depth of missing directories, not
-    /// just the immediate parent.
+    static ProfileConfig FreshDefault() => new() { Profiles = new() { ["default"] = new() } };
+
+    /// Walks up from <paramref name="path"/>'s parent chain to the first ancestor that exists —
+    /// as a directory, a file, or a dangling symlink — and reports whether it blocks the walk
+    /// structurally (file or dangling link) rather than being a genuine, simply never-created
+    /// directory level.
     static bool FirstExistingAncestorIsFile(string path) {
         var current = Path.GetDirectoryName(path);
         while (!string.IsNullOrEmpty(current)) {
             if (File.Exists(current)) return true;
             if (Directory.Exists(current)) return false;
+            if (IsLink(current)) return true; // reached only when dangling — Exists above catches a live link
             current = Path.GetDirectoryName(current);
         }
         return false;
+    }
+
+    /// <summary>Whether <paramref name="path"/> is itself a symlink, regardless of whether its
+    /// target exists — File.Exists/Directory.Exists both FOLLOW links, so a dangling one reads as
+    /// pure absence and the walk above would otherwise skip straight past it.</summary>
+    static bool IsLink(string path) {
+        try { return File.ResolveLinkTarget(path, returnFinalTarget: false) is not null; }
+        catch { return false; }
     }
 
     static void Publish(string path, ProfileConfig config) {

--- a/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
+++ b/src/Capacitor.Cli.Core/Config/ConfigMutator.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Capacitor.Cli.Core; // JsonElement IsObject extension
 
 namespace Capacitor.Cli.Core.Config;
 

--- a/src/Capacitor.Cli.Core/PathEvidence.cs
+++ b/src/Capacitor.Cli.Core/PathEvidence.cs
@@ -1,0 +1,24 @@
+namespace Capacitor.Cli.Core;
+
+/// Structural path-evidence probe shared by not-found-classification callers.
+public static class PathEvidence {
+    /// True when a not-found read failure at <paramref name="path"/> is explained by a link at the
+    /// exact path, or a file/link ancestor, rather than a chain of directories never created.
+    public static bool PathBlockedByFileOrLink(string path) {
+        if (IsLink(path)) return true;
+
+        var current = Path.GetDirectoryName(path);
+        while (!string.IsNullOrEmpty(current)) {
+            if (File.Exists(current)) return true;
+            if (Directory.Exists(current)) return false;
+            if (IsLink(current)) return true;
+            current = Path.GetDirectoryName(current);
+        }
+        return false;
+    }
+
+    static bool IsLink(string path) {
+        try { return File.ResolveLinkTarget(path, returnFinalTarget: false) is not null; }
+        catch { return false; }
+    }
+}

--- a/src/Capacitor.Cli.Core/Setup/AgentDetection.cs
+++ b/src/Capacitor.Cli.Core/Setup/AgentDetection.cs
@@ -114,24 +114,18 @@ public static class AgentDetection {
     public static bool BinaryOnPath(string binaryName, AgentDetectionInputs i) =>
         BinaryOnPath(binaryName, i, IsExecutable);
 
-    /// <summary>Counting/stubbing seam for <see cref="BinaryOnPath(string, AgentDetectionInputs)"/>:
-    /// lets a test observe exactly which candidate paths get probed, so PATH-entry dedup is pinned
-    /// by call count rather than only by the boolean result.</summary>
+    /// <summary>Stubbing seam for <see cref="BinaryOnPath(string, AgentDetectionInputs)"/>; separator/
+    /// extensions/comparer are all derived from <paramref name="i"/>'s platform, never the host's.</summary>
     internal static bool BinaryOnPath(string binaryName, AgentDetectionInputs i, Func<string, bool, bool> isExecutable) {
         if (string.IsNullOrEmpty(i.PathEnv)) return false;
 
-        // Both derived from the injected platform, never the host-global Path.PathSeparator/
-        // OS-comparer: a test simulating Windows behavior on a non-Windows host (or vice versa)
-        // must get what that platform actually uses. Windows PATH entries are case-insensitive
-        // identity (two case-variant dirs are the SAME entry, probed once); Unix PATH entries are
-        // case-sensitive (case-variant dirs are genuinely distinct, each probed).
         var separator  = i.IsWindows ? ';' : ':';
         var paths      = i.PathEnv.Split(separator);
         var extensions = i.IsWindows ? WindowsExtensions(i.PathExt) : [""];
         var comparer   = i.IsWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
         return paths.Where(dir => !string.IsNullOrEmpty(dir))
-            .Distinct(comparer) // a dir repeated in PATH (by platform identity) is probed once, not once per occurrence
+            .Distinct(comparer)
             .Any(dir => extensions.Select(ext => Path.Combine(dir, binaryName + ext)).Any(path => isExecutable(path, i.IsWindows)));
     }
 

--- a/src/Capacitor.Cli.Core/Setup/AgentDetection.cs
+++ b/src/Capacitor.Cli.Core/Setup/AgentDetection.cs
@@ -111,19 +111,28 @@ public static class AgentDetection {
     /// null/empty PATH. On Unix, requires at least one of the user/group/other execute bits; on
     /// Windows, walks PATHEXT (defaulting to .EXE/.CMD/.BAT) and accepts any file that exists.
     /// </summary>
-    public static bool BinaryOnPath(string binaryName, AgentDetectionInputs i) {
+    public static bool BinaryOnPath(string binaryName, AgentDetectionInputs i) =>
+        BinaryOnPath(binaryName, i, IsExecutable);
+
+    /// <summary>Counting/stubbing seam for <see cref="BinaryOnPath(string, AgentDetectionInputs)"/>:
+    /// lets a test observe exactly which candidate paths get probed, so PATH-entry dedup is pinned
+    /// by call count rather than only by the boolean result.</summary>
+    internal static bool BinaryOnPath(string binaryName, AgentDetectionInputs i, Func<string, bool, bool> isExecutable) {
         if (string.IsNullOrEmpty(i.PathEnv)) return false;
 
-        // Derived from the injected platform, never the host-global Path.PathSeparator: a test
-        // simulating Windows PATHEXT/separator behavior on a non-Windows host (or vice versa) must
-        // get the SEPARATOR that platform actually uses, not whatever the test runner's own OS is.
+        // Both derived from the injected platform, never the host-global Path.PathSeparator/
+        // OS-comparer: a test simulating Windows behavior on a non-Windows host (or vice versa)
+        // must get what that platform actually uses. Windows PATH entries are case-insensitive
+        // identity (two case-variant dirs are the SAME entry, probed once); Unix PATH entries are
+        // case-sensitive (case-variant dirs are genuinely distinct, each probed).
         var separator  = i.IsWindows ? ';' : ':';
         var paths      = i.PathEnv.Split(separator);
         var extensions = i.IsWindows ? WindowsExtensions(i.PathExt) : [""];
+        var comparer   = i.IsWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
         return paths.Where(dir => !string.IsNullOrEmpty(dir))
-            .Distinct(StringComparer.Ordinal) // a dir repeated in PATH is probed once, not once per occurrence
-            .Any(dir => extensions.Select(ext => Path.Combine(dir, binaryName + ext)).Any(path => IsExecutable(path, i.IsWindows)));
+            .Distinct(comparer) // a dir repeated in PATH (by platform identity) is probed once, not once per occurrence
+            .Any(dir => extensions.Select(ext => Path.Combine(dir, binaryName + ext)).Any(path => isExecutable(path, i.IsWindows)));
     }
 
     /// <summary>Convenience overload for CLI call sites that only need a single-binary current-

--- a/src/Capacitor.Cli.Core/Setup/AgentDetection.cs
+++ b/src/Capacitor.Cli.Core/Setup/AgentDetection.cs
@@ -122,6 +122,7 @@ public static class AgentDetection {
         var extensions = i.IsWindows ? WindowsExtensions(i.PathExt) : [""];
 
         return paths.Where(dir => !string.IsNullOrEmpty(dir))
+            .Distinct(StringComparer.Ordinal) // a dir repeated in PATH is probed once, not once per occurrence
             .Any(dir => extensions.Select(ext => Path.Combine(dir, binaryName + ext)).Any(path => IsExecutable(path, i.IsWindows)));
     }
 

--- a/src/Capacitor.Cli.Core/Setup/AgentDetection.cs
+++ b/src/Capacitor.Cli.Core/Setup/AgentDetection.cs
@@ -114,7 +114,11 @@ public static class AgentDetection {
     public static bool BinaryOnPath(string binaryName, AgentDetectionInputs i) {
         if (string.IsNullOrEmpty(i.PathEnv)) return false;
 
-        var paths      = i.PathEnv.Split(Path.PathSeparator);
+        // Derived from the injected platform, never the host-global Path.PathSeparator: a test
+        // simulating Windows PATHEXT/separator behavior on a non-Windows host (or vice versa) must
+        // get the SEPARATOR that platform actually uses, not whatever the test runner's own OS is.
+        var separator  = i.IsWindows ? ';' : ':';
+        var paths      = i.PathEnv.Split(separator);
         var extensions = i.IsWindows ? WindowsExtensions(i.PathExt) : [""];
 
         return paths.Where(dir => !string.IsNullOrEmpty(dir))

--- a/src/Capacitor.Cli/Services/IServiceManager.cs
+++ b/src/Capacitor.Cli/Services/IServiceManager.cs
@@ -73,11 +73,9 @@ interface IVerifyServiceManager {
     void         WriteAndBootstrap(ServiceSpec spec, TimeSpan timeout);
     bool         Uninstall(string serviceId, TimeSpan timeout, out string? error);
     bool         Start(string serviceId, TimeSpan timeout, out string? error);
-    /// <summary>Bootstrap-only start for the gated start path: activate the ALREADY-WRITTEN unit
-    /// without the generic <see cref="Start"/>'s Loaded→kickstart branch. If the label turns out
-    /// Loaded (a foreign writer raced the gate's own confirmed-absent check), this must fail rather
-    /// than kickstart it — kickstarting an unverified loaded definition is exactly what the gate
-    /// exists to prevent.</summary>
+    /// <summary>Bootstrap-only start for the gated path: activates the already-written unit, but
+    /// fails — never kickstarts — when the label reads Loaded, closing the race with the gate's own
+    /// confirmed-absent check.</summary>
     bool         StartBootstrapOnly(string serviceId, TimeSpan timeout, out string? error);
     bool         Stop(string serviceId, TimeSpan timeout, out string? error);
 }

--- a/src/Capacitor.Cli/Services/LaunchdServiceManager.cs
+++ b/src/Capacitor.Cli/Services/LaunchdServiceManager.cs
@@ -58,8 +58,10 @@ sealed partial class LaunchdServiceManager(
     public ServiceQuery Query(string serviceId, TimeSpan t)     => QueryCore(serviceId, t);
 
     ServiceQuery QueryCore(string serviceId, TimeSpan? timeout) {
-        var path        = LaunchdUnit.PlistPath(serviceId);
-        var unitPresent = File.Exists(path);
+        var path = LaunchdUnit.PlistPath(serviceId);
+        // File.Exists alone reads a DIRECTORY at the path (or an inaccessible ancestor) as
+        // absent — open directly so presence and unreadable-but-present are never conflated.
+        var unitPresent = LaunchdUnit.TryReadPlist(path, out _) != LaunchdUnit.PlistRead.Absent;
         var bin         = unitPresent ? ReadBinaryPathSafe(path) : null;
         var (code, stdout, stderr, timedOut) = RunCtl(timeout, LaunchdUnit.PrintArgs(Uid(), serviceId));
         // A killed-on-timeout print told us nothing about the label — never let its kill exit code

--- a/src/Capacitor.Cli/Services/LaunchdServiceManager.cs
+++ b/src/Capacitor.Cli/Services/LaunchdServiceManager.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace Capacitor.Cli.Services;
@@ -48,7 +49,7 @@ sealed partial class LaunchdServiceManager(
     public ServiceStatus Status(string serviceId) {
         var path = LaunchdUnit.PlistPath(serviceId);
         if (!File.Exists(path)) return new ServiceStatus(ServiceState.NotInstalled, null);
-        var bin = LaunchdUnit.BinaryFromPlist(File.ReadAllText(path)); // ProgramArguments[0], not the Label
+        var bin = ReadBinaryPathSafe(path); // ProgramArguments[0], not the Label
         var (code, stdout, _) = _runProcess("launchctl", LaunchdUnit.PrintArgs(Uid(), serviceId));
         return new ServiceStatus(LaunchdUnit.StatusFromPrint(code, stdout), bin);
     }
@@ -59,13 +60,24 @@ sealed partial class LaunchdServiceManager(
     ServiceQuery QueryCore(string serviceId, TimeSpan? timeout) {
         var path        = LaunchdUnit.PlistPath(serviceId);
         var unitPresent = File.Exists(path);
-        var bin         = unitPresent ? LaunchdUnit.BinaryFromPlist(File.ReadAllText(path)) : null;
+        var bin         = unitPresent ? ReadBinaryPathSafe(path) : null;
         var (code, stdout, stderr, timedOut) = RunCtl(timeout, LaunchdUnit.PrintArgs(Uid(), serviceId));
         // A killed-on-timeout print told us nothing about the label — never let its kill exit code
         // masquerade as a real classification; report Unknown so nothing destructive follows.
         var probe = timedOut ? LabelProbe.Unknown : LaunchdUnit.ClassifyPrint(code, stdout, stderr);
         var state = probe == LabelProbe.Loaded ? LaunchdUnit.StatusFromPrint(code, stdout) : ServiceState.NotInstalled;
         return new ServiceQuery(probe, unitPresent, state, bin, probe == LabelProbe.Loaded ? LaunchdUnit.PidFromPrint(stdout) : null);
+    }
+
+    /// <summary>Total plist-evidence read: <c>File.ReadAllText</c> + <see cref="LaunchdUnit.BinaryFromPlist"/>
+    /// together, contained so that ANY failure — an I/O error, malformed XML, a duplicate
+    /// <c>ProgramArguments</c> key — yields null rather than escaping. <see cref="Query(string)"/>
+    /// and <see cref="Status"/> are total, never-throwing probes; the gate's own contained Phase-A
+    /// parse (<c>ServiceVerify</c>'s <c>_readPlist</c> path) remains the sole authority for coded
+    /// evidence classification (malformed → <c>evidence_unreadable</c>).</summary>
+    static string? ReadBinaryPathSafe(string path) {
+        try { return LaunchdUnit.BinaryFromPlist(File.ReadAllText(path)); }
+        catch { return null; }
     }
 
     public void Install(ServiceSpec spec, bool startNow) {
@@ -163,14 +175,13 @@ sealed partial class LaunchdServiceManager(
         return true;
     }
 
-    /// <summary>
-    /// The gated start path's bootstrap-only verb (verify-only, no legacy no-timeout overload):
-    /// re-probes the label immediately before acting, and ONLY bootstraps when it reads Absent —
-    /// unlike <see cref="StartCore"/>, a Loaded probe here is a FAILURE, never a kickstart. This is
-    /// the re-check that closes the race between the gate's own confirmed-absent wait and this call:
-    /// a foreign writer that loaded the label in that window must not get silently kickstarted.
-    /// </summary>
+    /// <summary>launchd implementation of <see cref="IVerifyServiceManager.StartBootstrapOnly"/>:
+    /// re-probes the label immediately before acting. Both launchctl calls share ONE deadline —
+    /// the probe gets the full <paramref name="timeout"/>, and the bootstrap gets only what's left
+    /// of it — rather than each getting the full budget (which would let the pair invade up to 2x
+    /// the caller's forward remainder, including its separately reserved rollback budget).</summary>
     public bool StartBootstrapOnly(string serviceId, TimeSpan timeout, out string? error) {
+        var sw = Stopwatch.StartNew();
         var (probeExit, probeOut, probeErr, probeTimedOut) = RunCtl(timeout, LaunchdUnit.PrintArgs(Uid(), serviceId));
         var probe = probeTimedOut ? LabelProbe.Unknown : LaunchdUnit.ClassifyPrint(probeExit, probeOut, probeErr);
 
@@ -179,7 +190,13 @@ sealed partial class LaunchdServiceManager(
             return false;
         }
 
-        var (bootstrapExit, _, bootstrapErr, bootstrapTimedOut) = RunCtl(timeout, LaunchdUnit.BootstrapArgs(Uid(), LaunchdUnit.PlistPath(serviceId)));
+        var remaining = timeout - sw.Elapsed;
+        if (remaining <= TimeSpan.Zero) {
+            error = "launchctl bootstrap timed out and was terminated";
+            return false;
+        }
+
+        var (bootstrapExit, _, bootstrapErr, bootstrapTimedOut) = RunCtl(remaining, LaunchdUnit.BootstrapArgs(Uid(), LaunchdUnit.PlistPath(serviceId)));
         if (bootstrapTimedOut) { error = "launchctl bootstrap timed out and was terminated"; return false; }
         if (bootstrapExit != 0) {
             error = $"launchctl bootstrap failed (exit {bootstrapExit}): {bootstrapErr.Trim()}";

--- a/src/Capacitor.Cli/Services/LaunchdUnit.cs
+++ b/src/Capacitor.Cli/Services/LaunchdUnit.cs
@@ -87,37 +87,25 @@ static class LaunchdUnit {
             : null;
     }
 
-    /// <summary>Outcome of <see cref="TryReadPlist"/> — kept distinct from a bare null so a
-    /// caller can never conflate genuine absence with present-but-unreadable evidence.</summary>
+    /// <summary>Distinguishes genuine absence from present-but-unreadable evidence.</summary>
     internal enum PlistRead { Absent, Ok, Unreadable }
 
-    /// <summary>Total, discriminated plist read: opens the file directly rather than probing
-    /// <c>File.Exists</c> first, because <c>File.Exists</c> reads a DIRECTORY at the path as
-    /// absent (it only follows through to files) — a caller gating on that flag alone would
-    /// misclassify a directory-at-path as genuine absence. Only the two not-found exceptions are
-    /// <see cref="PlistRead.Absent"/>; anything else (permission denial, a directory opened as a
-    /// file, any other I/O failure) is <see cref="PlistRead.Unreadable"/>.</summary>
+    /// <summary>Discriminated read: a not-found blocked by structural evidence (a link at the exact
+    /// path, or a file/link ancestor) is <see cref="PlistRead.Unreadable"/>, never <see cref="PlistRead.Absent"/>.</summary>
     internal static PlistRead TryReadPlist(string path, out string? content) {
         try {
             content = File.ReadAllText(path);
             return PlistRead.Ok;
         } catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
             content = null;
-            return PlistRead.Absent;
+            return PathEvidence.PathBlockedByFileOrLink(path) ? PlistRead.Unreadable : PlistRead.Absent;
         } catch {
             content = null;
             return PlistRead.Unreadable;
         }
     }
 
-    /// <summary>Strict key/value walk shared by <see cref="TopLevelValue"/> and
-    /// <see cref="EnvFromPlist"/>'s inner walk: yields each (key, value) pair in
-    /// <paramref name="dict"/>'s direct children. A <c>&lt;key&gt;</c> immediately following
-    /// another <c>&lt;key&gt;</c>, a value with no preceding key, or a dangling trailing
-    /// <c>&lt;key&gt;</c> all throw <see cref="InvalidDataException"/> — this file is never
-    /// hand-edited, so any of those shapes can only mean a foreign/corrupt writer. Callers own
-    /// duplicate-key and value-type validation, since the two levels enforce those differently.
-    /// </summary>
+    /// <summary>Strict key/value walk: throws on any malformed key/value alternation.</summary>
     static IEnumerable<(string Key, XElement Value)> KeyedElements(XElement dict, string context) {
         string? pendingKey = null;
         foreach (var el in dict.Elements()) {

--- a/src/Capacitor.Cli/Services/LaunchdUnit.cs
+++ b/src/Capacitor.Cli/Services/LaunchdUnit.cs
@@ -88,15 +88,15 @@ static class LaunchdUnit {
     }
 
     /// <summary>
-    /// Walks <paramref name="dict"/>'s OWN top-level elements (never recursing into a nested
-    /// container) pairing each <c>&lt;key&gt;</c> with the single element that immediately follows
-    /// it, and returns the element paired with <paramref name="key"/> — or null when that key never
-    /// appears. A decoy container planted anywhere else under a DIFFERENT key must never be
-    /// returned — only the element PAIRED WITH this exact key is. This file is never hand-edited,
-    /// so a key repeated at this level can only mean a foreign/corrupt writer: throws
-    /// <see cref="InvalidDataException"/> rather than silently picking one, so every caller's
-    /// "unreadable evidence" containment sees it. Callers validate the returned element's own KIND
-    /// (array, dict, ...) themselves — this helper only resolves identity, never a value type.
+    /// Pairs each top-level <c>&lt;key&gt;</c> in <paramref name="dict"/> with the single element
+    /// that immediately follows it (never recursing into a nested container), and returns the
+    /// element paired with <paramref name="key"/>, or null when that key never appears. Requires
+    /// strict key/value alternation: a <c>&lt;key&gt;</c> immediately following another
+    /// <c>&lt;key&gt;</c>, a value with no preceding key, a dangling trailing <c>&lt;key&gt;</c>,
+    /// or a duplicate <paramref name="key"/> all throw <see cref="InvalidDataException"/> rather
+    /// than guessing — this file is never hand-edited, so any of those shapes can only mean a
+    /// foreign/corrupt writer. Callers validate the returned element's own kind (array, dict, ...)
+    /// themselves — this helper only resolves identity, never a value type.
     /// </summary>
     static XElement? TopLevelValue(XElement dict, string key) {
         XElement? result = null;
@@ -104,7 +104,15 @@ static class LaunchdUnit {
         string? pendingKey = null;
 
         foreach (var el in dict.Elements()) {
-            if (el.Name == "key") { pendingKey = el.Value; continue; }
+            if (el.Name == "key") {
+                if (pendingKey is not null)
+                    throw new InvalidDataException($"consecutive <key> nodes ('{pendingKey}', '{el.Value}') in plist");
+                pendingKey = el.Value;
+                continue;
+            }
+
+            if (pendingKey is null)
+                throw new InvalidDataException("value with no preceding key in plist");
 
             if (pendingKey == key) {
                 if (found) throw new InvalidDataException($"duplicate {key} key in plist");
@@ -114,6 +122,9 @@ static class LaunchdUnit {
 
             pendingKey = null;
         }
+
+        if (pendingKey is not null)
+            throw new InvalidDataException($"dangling <key>{pendingKey}</key> with no value in plist");
 
         return result;
     }
@@ -134,17 +145,15 @@ static class LaunchdUnit {
     /// <summary>
     /// The environment baked into a plist — the dict paired with the top-level
     /// <c>&lt;key&gt;EnvironmentVariables&lt;/key&gt;</c> (see <see cref="TopLevelValue"/>), then a
-    /// STRICT walk of that dict's own key/value pairs: used by <c>daemon service status --json</c>
+    /// strict walk of that dict's own key/value pairs: used by <c>daemon service status --json</c>
     /// to surface the baked profile/server/consent evidence as UX-only fields, and by the start
     /// gate to read identity/digest evidence. Returns empty only when the
-    /// <c>EnvironmentVariables</c> block is genuinely absent — every other malformed shape throws
-    /// <see cref="InvalidDataException"/> rather than silently degrading, because this file is
+    /// <c>EnvironmentVariables</c> block is genuinely absent; every other malformed shape — a
+    /// non-<c>dict</c> pairing, a non-<c>string</c> value, consecutive or dangling
+    /// <c>&lt;key&gt;</c> nodes, a value with no preceding key, or a duplicate key — throws
+    /// <see cref="InvalidDataException"/> rather than degrading silently, because this file is
     /// never hand-edited and a gate caller reading identity evidence out of this map must see
-    /// ambiguous evidence as unreadable, never guess: the paired value is not a <c>dict</c>; a
-    /// <c>&lt;key&gt;</c> is followed by another <c>&lt;key&gt;</c> instead of a value (would
-    /// silently overwrite the pending key and dodge duplicate detection); a value element is not a
-    /// <c>&lt;string&gt;</c> (silently skipped previously); a value with no preceding key; a
-    /// dangling trailing <c>&lt;key&gt;</c>; or a duplicate key (silent last-win previously).
+    /// ambiguous evidence as unreadable, never guessed.
     /// </summary>
     public static IReadOnlyDictionary<string, string> EnvFromPlist(string plistXml) {
         var result = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/src/Capacitor.Cli/Services/LaunchdUnit.cs
+++ b/src/Capacitor.Cli/Services/LaunchdUnit.cs
@@ -87,45 +87,69 @@ static class LaunchdUnit {
             : null;
     }
 
-    /// <summary>
-    /// Pairs each top-level <c>&lt;key&gt;</c> in <paramref name="dict"/> with the single element
-    /// that immediately follows it (never recursing into a nested container), and returns the
-    /// element paired with <paramref name="key"/>, or null when that key never appears. Requires
-    /// strict key/value alternation: a <c>&lt;key&gt;</c> immediately following another
-    /// <c>&lt;key&gt;</c>, a value with no preceding key, a dangling trailing <c>&lt;key&gt;</c>,
-    /// or a duplicate <paramref name="key"/> all throw <see cref="InvalidDataException"/> rather
-    /// than guessing — this file is never hand-edited, so any of those shapes can only mean a
-    /// foreign/corrupt writer. Callers validate the returned element's own kind (array, dict, ...)
-    /// themselves — this helper only resolves identity, never a value type.
-    /// </summary>
-    static XElement? TopLevelValue(XElement dict, string key) {
-        XElement? result = null;
-        var found = false;
-        string? pendingKey = null;
+    /// <summary>Outcome of <see cref="TryReadPlist"/> — kept distinct from a bare null so a
+    /// caller can never conflate genuine absence with present-but-unreadable evidence.</summary>
+    internal enum PlistRead { Absent, Ok, Unreadable }
 
+    /// <summary>Total, discriminated plist read: opens the file directly rather than probing
+    /// <c>File.Exists</c> first, because <c>File.Exists</c> reads a DIRECTORY at the path as
+    /// absent (it only follows through to files) — a caller gating on that flag alone would
+    /// misclassify a directory-at-path as genuine absence. Only the two not-found exceptions are
+    /// <see cref="PlistRead.Absent"/>; anything else (permission denial, a directory opened as a
+    /// file, any other I/O failure) is <see cref="PlistRead.Unreadable"/>.</summary>
+    internal static PlistRead TryReadPlist(string path, out string? content) {
+        try {
+            content = File.ReadAllText(path);
+            return PlistRead.Ok;
+        } catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
+            content = null;
+            return PlistRead.Absent;
+        } catch {
+            content = null;
+            return PlistRead.Unreadable;
+        }
+    }
+
+    /// <summary>Strict key/value walk shared by <see cref="TopLevelValue"/> and
+    /// <see cref="EnvFromPlist"/>'s inner walk: yields each (key, value) pair in
+    /// <paramref name="dict"/>'s direct children. A <c>&lt;key&gt;</c> immediately following
+    /// another <c>&lt;key&gt;</c>, a value with no preceding key, or a dangling trailing
+    /// <c>&lt;key&gt;</c> all throw <see cref="InvalidDataException"/> — this file is never
+    /// hand-edited, so any of those shapes can only mean a foreign/corrupt writer. Callers own
+    /// duplicate-key and value-type validation, since the two levels enforce those differently.
+    /// </summary>
+    static IEnumerable<(string Key, XElement Value)> KeyedElements(XElement dict, string context) {
+        string? pendingKey = null;
         foreach (var el in dict.Elements()) {
             if (el.Name == "key") {
                 if (pendingKey is not null)
-                    throw new InvalidDataException($"consecutive <key> nodes ('{pendingKey}', '{el.Value}') in plist");
+                    throw new InvalidDataException($"{context}consecutive <key> nodes ('{pendingKey}', '{el.Value}') in plist");
                 pendingKey = el.Value;
                 continue;
             }
 
             if (pendingKey is null)
-                throw new InvalidDataException("value with no preceding key in plist");
+                throw new InvalidDataException($"{context}value with no preceding key in plist");
 
-            if (pendingKey == key) {
-                if (found) throw new InvalidDataException($"duplicate {key} key in plist");
-                found  = true;
-                result = el;
-            }
-
+            yield return (pendingKey, el);
             pendingKey = null;
         }
 
         if (pendingKey is not null)
-            throw new InvalidDataException($"dangling <key>{pendingKey}</key> with no value in plist");
+            throw new InvalidDataException($"{context}dangling <key>{pendingKey}</key> with no value in plist");
+    }
 
+    /// <summary>The element paired with the top-level <c>&lt;key&gt;</c> named
+    /// <paramref name="key"/>, or null when that key never appears; a duplicate throws.</summary>
+    static XElement? TopLevelValue(XElement dict, string key) {
+        XElement? result = null;
+        var found = false;
+        foreach (var (k, value) in KeyedElements(dict, "")) {
+            if (k != key) continue;
+            if (found) throw new InvalidDataException($"duplicate {key} key in plist");
+            found  = true;
+            result = value;
+        }
         return result;
     }
 
@@ -144,16 +168,11 @@ static class LaunchdUnit {
 
     /// <summary>
     /// The environment baked into a plist — the dict paired with the top-level
-    /// <c>&lt;key&gt;EnvironmentVariables&lt;/key&gt;</c> (see <see cref="TopLevelValue"/>), then a
-    /// strict walk of that dict's own key/value pairs: used by <c>daemon service status --json</c>
-    /// to surface the baked profile/server/consent evidence as UX-only fields, and by the start
-    /// gate to read identity/digest evidence. Returns empty only when the
-    /// <c>EnvironmentVariables</c> block is genuinely absent; every other malformed shape — a
-    /// non-<c>dict</c> pairing, a non-<c>string</c> value, consecutive or dangling
-    /// <c>&lt;key&gt;</c> nodes, a value with no preceding key, or a duplicate key — throws
-    /// <see cref="InvalidDataException"/> rather than degrading silently, because this file is
-    /// never hand-edited and a gate caller reading identity evidence out of this map must see
-    /// ambiguous evidence as unreadable, never guessed.
+    /// <c>EnvironmentVariables</c> key, walked strictly (see <see cref="KeyedElements"/>). Empty
+    /// only when the block is genuinely absent; any other malformed shape throws
+    /// <see cref="InvalidDataException"/> rather than degrading silently — this file is never
+    /// hand-edited, so a gate caller reading identity evidence here must see ambiguous evidence
+    /// as unreadable, never guessed.
     /// </summary>
     public static IReadOnlyDictionary<string, string> EnvFromPlist(string plistXml) {
         var result = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -166,30 +185,12 @@ static class LaunchdUnit {
         if (envDict.Name != "dict")
             throw new InvalidDataException("EnvironmentVariables is not a dict in plist");
 
-        string? pendingKey = null;
-        foreach (var kv in envDict.Elements()) {
-            if (kv.Name == "key") {
-                if (pendingKey is not null)
-                    throw new InvalidDataException(
-                        $"EnvironmentVariables has consecutive <key> nodes ('{pendingKey}', '{kv.Value}') in plist");
-                pendingKey = kv.Value;
-                continue;
-            }
-
-            if (pendingKey is null)
-                throw new InvalidDataException("EnvironmentVariables has a value with no preceding key in plist");
-
-            if (kv.Name != "string")
-                throw new InvalidDataException($"EnvironmentVariables key '{pendingKey}' is paired with a non-string value in plist");
-
-            if (!result.TryAdd(pendingKey, kv.Value))
-                throw new InvalidDataException($"duplicate EnvironmentVariables key '{pendingKey}' in plist");
-
-            pendingKey = null;
+        foreach (var (key, value) in KeyedElements(envDict, "EnvironmentVariables has ")) {
+            if (value.Name != "string")
+                throw new InvalidDataException($"EnvironmentVariables key '{key}' is paired with a non-string value in plist");
+            if (!result.TryAdd(key, value.Value))
+                throw new InvalidDataException($"duplicate EnvironmentVariables key '{key}' in plist");
         }
-
-        if (pendingKey is not null)
-            throw new InvalidDataException($"EnvironmentVariables ends on a dangling <key>{pendingKey}</key> with no value in plist");
 
         return result;
     }

--- a/src/Capacitor.Cli/Services/LaunchdUnit.cs
+++ b/src/Capacitor.Cli/Services/LaunchdUnit.cs
@@ -88,30 +88,28 @@ static class LaunchdUnit {
     }
 
     /// <summary>
-    /// The daemon binary baked into a plist — the first <c>&lt;string&gt;</c> of the
-    /// <c>&lt;array&gt;</c> PAIRED WITH the top-level <c>&lt;key&gt;ProgramArguments&lt;/key&gt;</c>,
-    /// never just "the document's first <c>&lt;array&gt;</c>" — a decoy array planted anywhere
-    /// earlier in the document must not be read as the binary launchd will actually execute. Used
-    /// by <c>daemon doctor</c> to detect a moved binary. A DUPLICATE top-level
-    /// <c>ProgramArguments</c> key throws <see cref="InvalidDataException"/> rather than silently
-    /// picking one — this file is never hand-edited, so two occurrences means a foreign/corrupt
-    /// writer, and callers that gate on this value must see that as unreadable evidence, not a guess.
+    /// Walks <paramref name="dict"/>'s OWN top-level elements (never recursing into a nested
+    /// container) pairing each <c>&lt;key&gt;</c> with the single element that immediately follows
+    /// it, and returns the element paired with <paramref name="key"/> — or null when that key never
+    /// appears. A decoy container planted anywhere else under a DIFFERENT key must never be
+    /// returned — only the element PAIRED WITH this exact key is. This file is never hand-edited,
+    /// so a key repeated at this level can only mean a foreign/corrupt writer: throws
+    /// <see cref="InvalidDataException"/> rather than silently picking one, so every caller's
+    /// "unreadable evidence" containment sees it. Callers validate the returned element's own KIND
+    /// (array, dict, ...) themselves — this helper only resolves identity, never a value type.
     /// </summary>
-    public static string? BinaryFromPlist(string plistXml) {
-        var topDict = XDocument.Parse(plistXml).Root?.Element("dict");
-        if (topDict is null) return null;
-
-        string? result = null;
+    static XElement? TopLevelValue(XElement dict, string key) {
+        XElement? result = null;
         var found = false;
         string? pendingKey = null;
 
-        foreach (var el in topDict.Elements()) {
+        foreach (var el in dict.Elements()) {
             if (el.Name == "key") { pendingKey = el.Value; continue; }
 
-            if (pendingKey == "ProgramArguments") {
-                if (found) throw new InvalidDataException("duplicate ProgramArguments key in plist");
+            if (pendingKey == key) {
+                if (found) throw new InvalidDataException($"duplicate {key} key in plist");
                 found  = true;
-                result = el.Name == "array" ? el.Elements("string").FirstOrDefault()?.Value : null;
+                result = el;
             }
 
             pendingKey = null;
@@ -121,47 +119,68 @@ static class LaunchdUnit {
     }
 
     /// <summary>
-    /// The environment baked into a plist — the dict PAIRED WITH the top-level
-    /// <c>&lt;key&gt;EnvironmentVariables&lt;/key&gt;</c>, walking the top-level dict's own key/value
-    /// pairs rather than searching the whole document. Returns empty rather than throwing when the
-    /// block is absent or empty; used by <c>daemon service status --json</c> to surface the baked
-    /// profile/server/consent evidence as UX-only fields. A DUPLICATE top-level
-    /// <c>EnvironmentVariables</c> key, or a duplicate KEY within the one block, both throw
-    /// <see cref="InvalidDataException"/> rather than silently last-win — this file is never
-    /// hand-edited, so any of those means a foreign/corrupt writer, and the gate callers that read
-    /// identity evidence out of this map must see that as unreadable, not silently pick whichever
-    /// value happened to land last.
+    /// The daemon binary baked into a plist — the first <c>&lt;string&gt;</c> of the
+    /// <c>&lt;array&gt;</c> paired with the top-level <c>&lt;key&gt;ProgramArguments&lt;/key&gt;</c>
+    /// (see <see cref="TopLevelValue"/>). Used by <c>daemon doctor</c> to detect a moved binary.
+    /// </summary>
+    public static string? BinaryFromPlist(string plistXml) {
+        var topDict = XDocument.Parse(plistXml).Root?.Element("dict");
+        if (topDict is null) return null;
+
+        var programArguments = TopLevelValue(topDict, "ProgramArguments");
+        return programArguments?.Name == "array" ? programArguments.Elements("string").FirstOrDefault()?.Value : null;
+    }
+
+    /// <summary>
+    /// The environment baked into a plist — the dict paired with the top-level
+    /// <c>&lt;key&gt;EnvironmentVariables&lt;/key&gt;</c> (see <see cref="TopLevelValue"/>), then a
+    /// STRICT walk of that dict's own key/value pairs: used by <c>daemon service status --json</c>
+    /// to surface the baked profile/server/consent evidence as UX-only fields, and by the start
+    /// gate to read identity/digest evidence. Returns empty only when the
+    /// <c>EnvironmentVariables</c> block is genuinely absent — every other malformed shape throws
+    /// <see cref="InvalidDataException"/> rather than silently degrading, because this file is
+    /// never hand-edited and a gate caller reading identity evidence out of this map must see
+    /// ambiguous evidence as unreadable, never guess: the paired value is not a <c>dict</c>; a
+    /// <c>&lt;key&gt;</c> is followed by another <c>&lt;key&gt;</c> instead of a value (would
+    /// silently overwrite the pending key and dodge duplicate detection); a value element is not a
+    /// <c>&lt;string&gt;</c> (silently skipped previously); a value with no preceding key; a
+    /// dangling trailing <c>&lt;key&gt;</c>; or a duplicate key (silent last-win previously).
     /// </summary>
     public static IReadOnlyDictionary<string, string> EnvFromPlist(string plistXml) {
         var result = new Dictionary<string, string>(StringComparer.Ordinal);
         var topDict = XDocument.Parse(plistXml).Root?.Element("dict");
         if (topDict is null) return result;
 
-        var found = false;
+        var envDict = TopLevelValue(topDict, "EnvironmentVariables");
+        if (envDict is null) return result; // genuinely absent — a legitimate "no baked env" shape
+
+        if (envDict.Name != "dict")
+            throw new InvalidDataException("EnvironmentVariables is not a dict in plist");
+
         string? pendingKey = null;
-
-        foreach (var el in topDict.Elements()) {
-            if (el.Name == "key") { pendingKey = el.Value; continue; }
-
-            if (pendingKey == "EnvironmentVariables") {
-                if (found) throw new InvalidDataException("duplicate EnvironmentVariables key in plist");
-                found = true;
-
-                if (el.Name == "dict") {
-                    string? key = null;
-                    foreach (var kv in el.Elements()) {
-                        if (kv.Name == "key") key = kv.Value;
-                        else if (kv.Name == "string" && key is not null) {
-                            if (!result.TryAdd(key, kv.Value))
-                                throw new InvalidDataException($"duplicate EnvironmentVariables key '{key}' in plist");
-                            key = null;
-                        }
-                    }
-                }
+        foreach (var kv in envDict.Elements()) {
+            if (kv.Name == "key") {
+                if (pendingKey is not null)
+                    throw new InvalidDataException(
+                        $"EnvironmentVariables has consecutive <key> nodes ('{pendingKey}', '{kv.Value}') in plist");
+                pendingKey = kv.Value;
+                continue;
             }
+
+            if (pendingKey is null)
+                throw new InvalidDataException("EnvironmentVariables has a value with no preceding key in plist");
+
+            if (kv.Name != "string")
+                throw new InvalidDataException($"EnvironmentVariables key '{pendingKey}' is paired with a non-string value in plist");
+
+            if (!result.TryAdd(pendingKey, kv.Value))
+                throw new InvalidDataException($"duplicate EnvironmentVariables key '{pendingKey}' in plist");
 
             pendingKey = null;
         }
+
+        if (pendingKey is not null)
+            throw new InvalidDataException($"EnvironmentVariables ends on a dangling <key>{pendingKey}</key> with no value in plist");
 
         return result;
     }

--- a/src/Capacitor.Cli/Services/ServiceVerify.cs
+++ b/src/Capacitor.Cli/Services/ServiceVerify.cs
@@ -141,13 +141,6 @@ sealed class ServiceVerify(
     /// <see cref="_readPlist"/> returns null for both.</summary>
     readonly Func<string, bool> _plistExists = plistExists ?? File.Exists;
 
-    /// <summary>Phase A's own discriminated read (see <see cref="LaunchdUnit.PlistRead"/>): the
-    /// real default opens the file directly rather than composing <see cref="_readPlist"/> with
-    /// <see cref="_plistExists"/> — both are File.Exists-based and read a directory-at-path (or an
-    /// inaccessible ancestor) as absent, which would otherwise let Phase A evaluate an empty env
-    /// and reach the takeover-safe DirectiveMissing instead of EvidenceUnreadable. Tests that stub
-    /// the older readPlist/plistExists pair get an equivalent discriminator synthesized from
-    /// those, so none of that existing seam shape needs to change.</summary>
     readonly Func<string, (LaunchdUnit.PlistRead Status, string? Content)> _phaseAPlistRead =
         readPlist is null && plistExists is null
             ? (path => { var status = LaunchdUnit.TryReadPlist(path, out var content); return (status, content); })
@@ -227,11 +220,6 @@ sealed class ServiceVerify(
             var (readStatus, content) = _phaseAPlistRead(plistPath);
             phaseAPlistContent = content;
 
-            // Unreadable is coded directly from the discriminated read — never inferred from a
-            // null content plus a separate presence check, which is exactly what let a
-            // directory-at-path evade classification. A malformed/truncated-but-present plist
-            // (the foreign-writer race Phase B also defends against) must not let the parse below
-            // escape as an uncoded exit 1, so it lands here too.
             StartGateReason? reason;
             if (readStatus == LaunchdUnit.PlistRead.Unreadable) {
                 reason = StartGateReason.EvidenceUnreadable;

--- a/src/Capacitor.Cli/Services/ServiceVerify.cs
+++ b/src/Capacitor.Cli/Services/ServiceVerify.cs
@@ -141,6 +141,23 @@ sealed class ServiceVerify(
     /// <see cref="_readPlist"/> returns null for both.</summary>
     readonly Func<string, bool> _plistExists = plistExists ?? File.Exists;
 
+    /// <summary>Phase A's own discriminated read (see <see cref="LaunchdUnit.PlistRead"/>): the
+    /// real default opens the file directly rather than composing <see cref="_readPlist"/> with
+    /// <see cref="_plistExists"/> — both are File.Exists-based and read a directory-at-path (or an
+    /// inaccessible ancestor) as absent, which would otherwise let Phase A evaluate an empty env
+    /// and reach the takeover-safe DirectiveMissing instead of EvidenceUnreadable. Tests that stub
+    /// the older readPlist/plistExists pair get an equivalent discriminator synthesized from
+    /// those, so none of that existing seam shape needs to change.</summary>
+    readonly Func<string, (LaunchdUnit.PlistRead Status, string? Content)> _phaseAPlistRead =
+        readPlist is null && plistExists is null
+            ? (path => { var status = LaunchdUnit.TryReadPlist(path, out var content); return (status, content); })
+            : (path => {
+                var content = readPlist?.Invoke(path);
+                if (content is not null) return (LaunchdUnit.PlistRead.Ok, content);
+                var exists = plistExists?.Invoke(path) ?? false;
+                return (exists ? LaunchdUnit.PlistRead.Unreadable : LaunchdUnit.PlistRead.Absent, null);
+            });
+
     /// <summary>The gated start seam: when non-null AND <c>gateEnv(ConsentSeedVar)</c> is
     /// PRESENT — any value, including empty, under the exact-value contract —
     /// <see cref="StartVerifiedAsync"/> runs the pre-mutation gate (Phase A) and the
@@ -207,24 +224,21 @@ sealed class ServiceVerify(
 
         if (gated) {
             var plistPath = LaunchdUnit.PlistPath(serviceId);
-            phaseAPlistContent = _readPlist(plistPath);
+            var (readStatus, content) = _phaseAPlistRead(plistPath);
+            phaseAPlistContent = content;
 
-            // A malformed/truncated plist (exactly the foreign-writer race Phase B defends
-            // against, caught here instead) must not let XDocument.Parse's XmlException escape
-            // this method — that would abort to a generic, uncoded exit 1 instead of the gate's
-            // own contract. Unreadable evidence is EvidenceUnreadable, same as every other
-            // evidence read this gate performs.
+            // Unreadable is coded directly from the discriminated read — never inferred from a
+            // null content plus a separate presence check, which is exactly what let a
+            // directory-at-path evade classification. A malformed/truncated-but-present plist
+            // (the foreign-writer race Phase B also defends against) must not let the parse below
+            // escape as an uncoded exit 1, so it lands here too.
             StartGateReason? reason;
-            if (phaseAPlistContent is null && (pre.UnitPresent || _plistExists(plistPath))) {
-                // A null read is ambiguous by itself — genuinely absent AND present-but-unreadable
-                // both read null through _readPlist. A unit the fresh query (or the dedicated
-                // existence seam) says IS present must never fall through to the empty-env path
-                // below, which would misclassify it as the takeover-safe DirectiveMissing.
+            if (readStatus == LaunchdUnit.PlistRead.Unreadable) {
                 reason = StartGateReason.EvidenceUnreadable;
             } else {
                 try {
-                    var unitEnv = phaseAPlistContent is not null ? LaunchdUnit.EnvFromPlist(phaseAPlistContent) : new Dictionary<string, string>();
-                    var unitBinaryPath = phaseAPlistContent is not null ? LaunchdUnit.BinaryFromPlist(phaseAPlistContent) : null;
+                    var unitEnv = content is not null ? LaunchdUnit.EnvFromPlist(content) : new Dictionary<string, string>();
+                    var unitBinaryPath = content is not null ? LaunchdUnit.BinaryFromPlist(content) : null;
                     reason = EvaluateStartGate(unitEnv, unitBinaryPath, UnitIdentity.ResolveDaemonBinary(), _gateEnv!, _digestMatches);
                     unitEnv.TryGetValue(ExpectVar, out unitExpectation);
                 } catch {
@@ -375,14 +389,10 @@ sealed class ServiceVerify(
         return AttributeReadinessTimeout(serviceId, rollbackExit, gated, attributionEnabled, unitExpectation, observedJobPids);
     }
 
-    /// <summary>
-    /// The gated start path's shared TOCTOU-recheck shape, used by both Phase B's pre-bootstrap
-    /// recheck and the post-readiness recheck: re-read the plist, parse its baked binary path and
-    /// re-check the digest (both contained — an unreadable/malformed re-read IS drift, never an
-    /// escaping exception), then compare the freshly re-read content against Phase A's own
-    /// captured <paramref name="phaseAPlistContent"/>. False means drift; the caller still owns
-    /// its own stage-specific marker phase and rollback call.
-    /// </summary>
+    /// <summary>Re-reads the plist and re-checks the digest (both contained — never an escaping
+    /// exception), comparing against Phase A's captured <paramref name="phaseAPlistContent"/>;
+    /// false means drift. Shared by Phase B's pre-bootstrap and post-readiness rechecks — callers
+    /// own their own marker phase and rollback call.</summary>
     bool RecheckPlistUnchanged(string serviceId, string? phaseAPlistContent) {
         var content = _readPlist(LaunchdUnit.PlistPath(serviceId));
         bool digestGood;

--- a/src/Capacitor.Cli/Services/ServiceVerify.cs
+++ b/src/Capacitor.Cli/Services/ServiceVerify.cs
@@ -215,13 +215,21 @@ sealed class ServiceVerify(
             // own contract. Unreadable evidence is EvidenceUnreadable, same as every other
             // evidence read this gate performs.
             StartGateReason? reason;
-            try {
-                var unitEnv = phaseAPlistContent is not null ? LaunchdUnit.EnvFromPlist(phaseAPlistContent) : new Dictionary<string, string>();
-                var unitBinaryPath = phaseAPlistContent is not null ? LaunchdUnit.BinaryFromPlist(phaseAPlistContent) : null;
-                reason = EvaluateStartGate(unitEnv, unitBinaryPath, UnitIdentity.ResolveDaemonBinary(), _gateEnv!, _digestMatches);
-                unitEnv.TryGetValue(ExpectVar, out unitExpectation);
-            } catch {
+            if (phaseAPlistContent is null && (pre.UnitPresent || _plistExists(plistPath))) {
+                // A null read is ambiguous by itself — genuinely absent AND present-but-unreadable
+                // both read null through _readPlist. A unit the fresh query (or the dedicated
+                // existence seam) says IS present must never fall through to the empty-env path
+                // below, which would misclassify it as the takeover-safe DirectiveMissing.
                 reason = StartGateReason.EvidenceUnreadable;
+            } else {
+                try {
+                    var unitEnv = phaseAPlistContent is not null ? LaunchdUnit.EnvFromPlist(phaseAPlistContent) : new Dictionary<string, string>();
+                    var unitBinaryPath = phaseAPlistContent is not null ? LaunchdUnit.BinaryFromPlist(phaseAPlistContent) : null;
+                    reason = EvaluateStartGate(unitEnv, unitBinaryPath, UnitIdentity.ResolveDaemonBinary(), _gateEnv!, _digestMatches);
+                    unitEnv.TryGetValue(ExpectVar, out unitExpectation);
+                } catch {
+                    reason = StartGateReason.EvidenceUnreadable;
+                }
             }
 
             if (reason is { } r) {
@@ -267,24 +275,13 @@ sealed class ServiceVerify(
                 }
             }
 
-            var plistPath      = LaunchdUnit.PlistPath(serviceId);
-            var recheckContent = _readPlist(plistPath);
-
             // Same XmlException hazard as Phase A's parse, but here escaping is worse: it would
             // abort AFTER the marker write and boot-out, past the point Rollback runs, leaving the
             // service stopped with a stuck marker instead of the guaranteed unloaded-plist-retained
             // outcome. A recheck that can't be parsed/validated is exactly what drift means — the
             // content changed (to something unreadable) or can no longer be confirmed unchanged —
             // so route it into the same drift branch rather than letting it throw.
-            bool digestStillGood;
-            try {
-                var recheckBinary = recheckContent is not null ? LaunchdUnit.BinaryFromPlist(recheckContent) : null;
-                digestStillGood = recheckBinary is not null && _digestMatches(recheckBinary);
-            } catch {
-                digestStillGood = false;
-            }
-
-            if (recheckContent != phaseAPlistContent || !digestStillGood) {
+            if (!RecheckPlistUnchanged(serviceId, phaseAPlistContent)) {
                 ServiceTxnMarker.Write(serviceId,
                     new TxnMarker(1, "start", "gate-drift", DescribeQuery(pre), "unloaded-plist-retained", null));
                 return await Rollback(serviceId, VerifyExit.StartGateDrift, VerifyExit.StartGateDriftToken);
@@ -354,21 +351,10 @@ sealed class ServiceVerify(
                     // bytes AFTER that, but before this commit, must not ride readiness into a
                     // silent commit. Re-read the plist (contained) and compare against Phase A's own
                     // captured content, and re-check the digest one more time.
-                    if (gated) {
-                        var postPlistContent = _readPlist(LaunchdUnit.PlistPath(serviceId));
-                        bool postDigestGood;
-                        try {
-                            var postBinary = postPlistContent is not null ? LaunchdUnit.BinaryFromPlist(postPlistContent) : null;
-                            postDigestGood = postBinary is not null && _digestMatches(postBinary);
-                        } catch {
-                            postDigestGood = false;
-                        }
-
-                        if (postPlistContent != phaseAPlistContent || !postDigestGood) {
-                            ServiceTxnMarker.Write(serviceId,
-                                new TxnMarker(1, "start", "gate-post-readiness-drift", DescribeQuery(pre), "unloaded-plist-retained", null));
-                            return await Rollback(serviceId, VerifyExit.StartGateDrift, VerifyExit.StartGateDriftToken);
-                        }
+                    if (gated && !RecheckPlistUnchanged(serviceId, phaseAPlistContent)) {
+                        ServiceTxnMarker.Write(serviceId,
+                            new TxnMarker(1, "start", "gate-post-readiness-drift", DescribeQuery(pre), "unloaded-plist-retained", null));
+                        return await Rollback(serviceId, VerifyExit.StartGateDrift, VerifyExit.StartGateDriftToken);
                     }
 
                     ServiceTxnMarker.Write(serviceId,
@@ -387,6 +373,27 @@ sealed class ServiceVerify(
         var rollbackExit = await Rollback(serviceId);
 
         return AttributeReadinessTimeout(serviceId, rollbackExit, gated, attributionEnabled, unitExpectation, observedJobPids);
+    }
+
+    /// <summary>
+    /// The gated start path's shared TOCTOU-recheck shape, used by both Phase B's pre-bootstrap
+    /// recheck and the post-readiness recheck: re-read the plist, parse its baked binary path and
+    /// re-check the digest (both contained — an unreadable/malformed re-read IS drift, never an
+    /// escaping exception), then compare the freshly re-read content against Phase A's own
+    /// captured <paramref name="phaseAPlistContent"/>. False means drift; the caller still owns
+    /// its own stage-specific marker phase and rollback call.
+    /// </summary>
+    bool RecheckPlistUnchanged(string serviceId, string? phaseAPlistContent) {
+        var content = _readPlist(LaunchdUnit.PlistPath(serviceId));
+        bool digestGood;
+        try {
+            var binary = content is not null ? LaunchdUnit.BinaryFromPlist(content) : null;
+            digestGood = binary is not null && _digestMatches(binary);
+        } catch {
+            digestGood = false;
+        }
+
+        return content == phaseAPlistContent && digestGood;
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Services/ServiceVerify.cs
+++ b/src/Capacitor.Cli/Services/ServiceVerify.cs
@@ -131,17 +131,17 @@ sealed class ServiceVerify(
     /// tests; the command wires the real resolution.</summary>
     readonly Func<bool> _profileViable = profileViable ?? (() => true);
 
-    /// <summary>Install-only seam for the on-disk plist read (final recheck + rollback's foreign-file
-    /// guard). Real launchd needs HOME to compute the path, so tests inject this directly.</summary>
+    /// <summary>Install-only seam for the on-disk plist read (Phase B's pre/post-readiness recheck
+    /// and install's final on-disk fingerprint recheck). Real launchd needs HOME to compute the
+    /// path, so tests inject this directly.</summary>
     readonly Func<string, string?> _readPlist = readPlist ?? (path => {
         try { return File.Exists(path) ? File.ReadAllText(path) : null; } catch { return null; }
     });
 
-    /// <summary>Entry-recovery-only seam: distinguishes "absent" from "present but unreadable" when
-    /// <see cref="_readPlist"/> returns null for both.</summary>
-    readonly Func<string, bool> _plistExists = plistExists ?? File.Exists;
-
-    readonly Func<string, (LaunchdUnit.PlistRead Status, string? Content)> _phaseAPlistRead =
+    /// <summary>Discriminated read shared by Phase A, marker recovery, and install rollback: unlike
+    /// <see cref="_readPlist"/> composed with a separate exists check, a structural obstruction (a
+    /// directory, a dangling symlink) can never be misread as confirmed absence.</summary>
+    readonly Func<string, (LaunchdUnit.PlistRead Status, string? Content)> _discriminatedPlistRead =
         readPlist is null && plistExists is null
             ? (path => { var status = LaunchdUnit.TryReadPlist(path, out var content); return (status, content); })
             : (path => {
@@ -217,11 +217,13 @@ sealed class ServiceVerify(
 
         if (gated) {
             var plistPath = LaunchdUnit.PlistPath(serviceId);
-            var (readStatus, content) = _phaseAPlistRead(plistPath);
+            var (readStatus, content) = _discriminatedPlistRead(plistPath);
             phaseAPlistContent = content;
 
             StartGateReason? reason;
-            if (readStatus == LaunchdUnit.PlistRead.Unreadable) {
+            // A fresh query that saw the unit but a read that didn't is contradictory evidence, not
+            // genuine absence — only agreement on absence may pass through to directive_missing.
+            if (readStatus == LaunchdUnit.PlistRead.Unreadable || (readStatus == LaunchdUnit.PlistRead.Absent && pre.UnitPresent)) {
                 reason = StartGateReason.EvidenceUnreadable;
             } else {
                 try {
@@ -860,19 +862,18 @@ sealed class ServiceVerify(
             return null;
         }
 
-        var onDisk = _readPlist(onDiskPath);
-        if (onDisk is null) {
-            if (_plistExists(onDiskPath)) {
-                // Present but unreadable is NOT absent — the file exists and was never fingerprint-
-                // compared, so never guess it's our own gone residue.
-                Say(VerifyExit.RestoreVerificationToken);
-                return VerifyExit.RestoreVerification;
-            }
+        var (status, onDisk) = _discriminatedPlistRead(onDiskPath);
+        if (status == LaunchdUnit.PlistRead.Unreadable) {
+            // Present but unreadable is NOT absent — never guess it's our own gone residue.
+            Say(VerifyExit.RestoreVerificationToken);
+            return VerifyExit.RestoreVerification;
+        }
+        if (status == LaunchdUnit.PlistRead.Absent) {
             ServiceTxnMarker.Delete(serviceId); // confirmed absent — residue already gone
             return null;
         }
 
-        if (ServiceTxnMarker.Fingerprint(onDisk) != leftover.PlistFingerprint) {
+        if (ServiceTxnMarker.Fingerprint(onDisk!) != leftover.PlistFingerprint) {
             // A foreign writer touched the file after the death — surface, never pave.
             Say(VerifyExit.RestoreVerificationToken);
             return VerifyExit.RestoreVerification;
@@ -1037,18 +1038,14 @@ sealed class ServiceVerify(
     /// is label-absent AND file-gone (unlike start, which retains the plist), bounded by the reserve. A
     /// foreign plist (fingerprint mismatch) is never touched — checked before the uninstall.</summary>
     async Task<int> InstallRollback(string serviceId, string plistPath, string fingerprint, int reasonExit, string reasonToken) {
-        // Never uninstall what we can't verify is ours. A null read is either genuine absence OR a
-        // present-but-unreadable file (a lock-unaware writer replaced ours between bootstrap and
-        // rollback): only the confirmed-absent case (read null AND the file does not exist) may be
-        // cleared. Present-but-unreadable, and readable-but-foreign, both surface untouched — the
-        // same fail-closed rule RecoverLeftoverMarker applies at entry.
-        var onDisk = _readPlist(plistPath);
-        if (onDisk is null) {
-            if (_plistExists(plistPath)) {
-                Say(VerifyExit.RestoreVerificationToken);
-                return VerifyExit.RestoreVerification;
-            }
-        } else if (ServiceTxnMarker.Fingerprint(onDisk) != fingerprint) {
+        // Never uninstall what we can't verify is ours — unreadable-but-present and readable-but-
+        // foreign both surface untouched, the same fail-closed rule RecoverLeftoverMarker applies.
+        var (status, onDisk) = _discriminatedPlistRead(plistPath);
+        if (status == LaunchdUnit.PlistRead.Unreadable) {
+            Say(VerifyExit.RestoreVerificationToken);
+            return VerifyExit.RestoreVerification;
+        }
+        if (status == LaunchdUnit.PlistRead.Ok && ServiceTxnMarker.Fingerprint(onDisk!) != fingerprint) {
             Say(VerifyExit.RestoreVerificationToken);
             return VerifyExit.RestoreVerification;
         }

--- a/src/Capacitor.Cli/Services/ServiceVerify.cs
+++ b/src/Capacitor.Cli/Services/ServiceVerify.cs
@@ -302,14 +302,9 @@ sealed class ServiceVerify(
             if (!attributionEnabled) Say("boot-refusal marker could not be cleared; coded attribution disabled");
         }
 
-        // The gated path uses the bootstrap-only seam instead of the generic Start: StartCore's own
-        // Loaded-probe branch would silently KICKSTART a stale definition if a foreign writer
-        // re-loaded the label in the window between the confirmed-absent wait above and this call —
-        // exactly the race this gate exists to close. A bootstrap-only failure (including "the label
-        // turned out Loaded") is therefore fatal here, not a soft warning: the label state is no
-        // longer what Phase B proved, so roll back via the coded bootout-unknown exit instead of
-        // bootstrapping onto unverified ground. The ungated path keeps the soft-warning Start(),
-        // whose readiness poll — not the call's own return value — is the source of truth.
+        // Bootstrap-only (see IVerifyServiceManager.StartBootstrapOnly): any failure — including a
+        // Loaded probe — rolls back via BootoutUnknown rather than falling through to the ungated
+        // Start() below, whose own readiness poll is normally the source of truth.
         if (gated) {
             if (!manager.StartBootstrapOnly(serviceId, Remaining(deadline), out var bootstrapOnlyError)) {
                 Say($"start: {bootstrapOnlyError}");
@@ -353,6 +348,29 @@ sealed class ServiceVerify(
                 var (confirmed, confirmedPid) = await IsReadyAsync(serviceId, deadline, requirePid: pid);
                 if (confirmedPid is not null) observedJobPids.Add(confirmedPid.Value);
                 if (confirmed) {
+                    // Post-readiness recheck (spec §3, mirrors install/replace's own final recheck):
+                    // Phase B's pre-bootstrap recheck only bounds the recheck→exec race up to the
+                    // moment bootstrap started — a foreign writer swapping the plist or the binary
+                    // bytes AFTER that, but before this commit, must not ride readiness into a
+                    // silent commit. Re-read the plist (contained) and compare against Phase A's own
+                    // captured content, and re-check the digest one more time.
+                    if (gated) {
+                        var postPlistContent = _readPlist(LaunchdUnit.PlistPath(serviceId));
+                        bool postDigestGood;
+                        try {
+                            var postBinary = postPlistContent is not null ? LaunchdUnit.BinaryFromPlist(postPlistContent) : null;
+                            postDigestGood = postBinary is not null && _digestMatches(postBinary);
+                        } catch {
+                            postDigestGood = false;
+                        }
+
+                        if (postPlistContent != phaseAPlistContent || !postDigestGood) {
+                            ServiceTxnMarker.Write(serviceId,
+                                new TxnMarker(1, "start", "gate-post-readiness-drift", DescribeQuery(pre), "unloaded-plist-retained", null));
+                            return await Rollback(serviceId, VerifyExit.StartGateDrift, VerifyExit.StartGateDriftToken);
+                        }
+                    }
+
                     ServiceTxnMarker.Write(serviceId,
                         new TxnMarker(1, "start", "committed", DescribeQuery(pre), "unloaded-plist-retained", null));
                     onCommitted?.Invoke();

--- a/test/Capacitor.Cli.Tests.Unit/Config/ConfigMutatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Config/ConfigMutatorTests.cs
@@ -202,6 +202,23 @@ public class ConfigMutatorTests {
         await Assert.That(config.Profiles.ContainsKey("default")).IsTrue(); // still a usable default out param
     }
 
+    /// <summary>A dangling symlink AT the exact config path (not an ancestor) raises
+    /// <see cref="FileNotFoundException"/>, not <see cref="DirectoryNotFoundException"/> — must still
+    /// classify as unreadable, never the takeover-safe "nothing configured yet".</summary>
+    [Test]
+    public async Task TryLoadPure_dangling_symlink_at_exact_path_is_failure_not_absence() {
+        Skip.When(OperatingSystem.IsWindows(), "symlink creation needs elevated privilege on Windows CI");
+
+        var root = Directory.CreateTempSubdirectory("kcap-trypure-").FullName;
+        var path = Path.Combine(root, "config.json");
+        File.CreateSymbolicLink(path, Path.Combine(root, "never-created-target"));
+
+        var ok = ConfigMutator.TryLoadPure(path, out var config);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(config.Profiles.ContainsKey("default")).IsTrue(); // still a usable default out param
+    }
+
     /// <summary>A genuinely never-created parent chain must still read as absence — disambiguating
     /// a blocked ancestor must not turn every missing directory level into a false failure.</summary>
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Config/ConfigMutatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Config/ConfigMutatorTests.cs
@@ -154,6 +154,39 @@ public class ConfigMutatorTests {
         await Assert.That(config.Profiles.ContainsKey("default")).IsTrue();
     }
 
+    /// <summary>Round-3 review finding #4: <c>Directory.Exists</c>/<c>File.Exists</c> both return
+    /// false on a permission-denied path, which would silently degrade "inaccessible" into
+    /// "absent, defaults are fine". The simplest deterministic way to force a non-not-found I/O
+    /// failure (without relying on platform-specific permission bits) is to make the config path's
+    /// PARENT a plain file rather than a directory — opening through it fails structurally, not
+    /// because anything is missing.</summary>
+    [Test]
+    public async Task TryLoadPure_parent_replaced_by_a_file_is_failure_not_absence() {
+        var root = Directory.CreateTempSubdirectory("kcap-trypure-").FullName;
+        var parentAsFile = Path.Combine(root, "not-a-directory");
+        await File.WriteAllTextAsync(parentAsFile, "i am a file, not a directory");
+        var path = Path.Combine(parentAsFile, "config.json");
+
+        var ok = ConfigMutator.TryLoadPure(path, out var config);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(config.Profiles.ContainsKey("default")).IsTrue(); // still a usable default out param
+    }
+
+    /// <summary>Positive control for the fix above: a path whose parent chain genuinely does not
+    /// exist yet (nothing has ever been created there) must still read as absence, not failure —
+    /// the disambiguation must not turn every missing ancestor directory into a false failure.</summary>
+    [Test]
+    public async Task TryLoadPure_missing_parent_directory_is_still_absence() {
+        var root = Directory.CreateTempSubdirectory("kcap-trypure-").FullName;
+        var path = Path.Combine(root, "never-created", "config.json");
+
+        var ok = ConfigMutator.TryLoadPure(path, out var config);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(config.Profiles.ContainsKey("default")).IsTrue();
+    }
+
     [Test]
     public async Task TryLoadPure_valid_file_is_success() {
         var path = Path.Combine(Directory.CreateTempSubdirectory("kcap-trypure-").FullName, "config.json");

--- a/test/Capacitor.Cli.Tests.Unit/Config/ConfigMutatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Config/ConfigMutatorTests.cs
@@ -65,6 +65,26 @@ public class ConfigMutatorTests {
     }
 
     [Test]
+    public async Task Mutate_survives_a_transient_reader_holding_the_destination() {
+        await ConfigMutator.MutateAsync(c => c with { MachineId = "before" });
+
+        // Share-read only (no FILE_SHARE_DELETE): on Windows this blocks the replace-into-place
+        // until released, exercising Publish's retry; on Unix rename is unaffected.
+        var reader = new FileStream(ConfigPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        try {
+            var mutate = ConfigMutator.MutateAsync(c => c with { MachineId = "after" });
+            await Task.Delay(100);
+            reader.Dispose();
+            await mutate;
+        } finally {
+            reader.Dispose();
+        }
+
+        var final = await AppConfig.LoadProfileConfig();
+        await Assert.That(final.MachineId).IsEqualTo("after");
+    }
+
+    [Test]
     public async Task Legacy_v1_config_is_migrated_in_memory_and_persisted_through_the_mutation() {
         // minimal v1 flat config (no "version"/"profiles" — ConfigMigration's v1 shape)
         Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);

--- a/test/Capacitor.Cli.Tests.Unit/Config/ConfigMutatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Config/ConfigMutatorTests.cs
@@ -154,12 +154,8 @@ public class ConfigMutatorTests {
         await Assert.That(config.Profiles.ContainsKey("default")).IsTrue();
     }
 
-    /// <summary><c>Directory.Exists</c>/<c>File.Exists</c> both return false on a
-    /// permission-denied path, which would silently degrade "inaccessible" into "absent, defaults
-    /// are fine". The simplest deterministic way to force a non-not-found I/O failure (without
-    /// relying on platform-specific permission bits) is to make the config path's PARENT a plain
-    /// file rather than a directory — opening through it fails structurally, not because anything
-    /// is missing.</summary>
+    /// <summary>A non-not-found I/O failure, forced deterministically: the config path's PARENT
+    /// is a plain file rather than a directory, so opening through it fails structurally.</summary>
     [Test]
     public async Task TryLoadPure_parent_replaced_by_a_file_is_failure_not_absence() {
         var root = Directory.CreateTempSubdirectory("kcap-trypure-").FullName;
@@ -173,9 +169,8 @@ public class ConfigMutatorTests {
         await Assert.That(config.Profiles.ContainsKey("default")).IsTrue(); // still a usable default out param
     }
 
-    /// <summary>The immediate parent alone isn't enough to disambiguate: a path nested TWO levels
-    /// under a planted file (<c>file/child/config.json</c>) needs the ancestor walk to climb past
-    /// the never-created <c>child</c> directory to reach the file actually blocking it.</summary>
+    /// <summary>The immediate parent alone isn't enough: a path nested TWO levels under a
+    /// planted file needs the ancestor walk to climb past the never-created child directory.</summary>
     [Test]
     public async Task TryLoadPure_grandparent_replaced_by_a_file_is_failure_not_absence() {
         var root = Directory.CreateTempSubdirectory("kcap-trypure-").FullName;
@@ -189,10 +184,26 @@ public class ConfigMutatorTests {
         await Assert.That(config.Profiles.ContainsKey("default")).IsTrue(); // still a usable default out param
     }
 
-    /// <summary>A path whose parent chain genuinely does not exist yet (nothing has ever been
-    /// created there) must still read as absence, not failure — disambiguating a blocked ancestor
-    /// from a missing one must not turn every missing directory level into a false
-    /// failure.</summary>
+    /// <summary>A dangling symlink segment (<c>File.Exists</c>/<c>Directory.Exists</c> both read
+    /// it as absent, since they follow to the missing target) must not let the ancestor walk skip
+    /// past it to a real directory further up.</summary>
+    [Test]
+    public async Task TryLoadPure_dangling_symlink_ancestor_is_failure_not_absence() {
+        Skip.When(OperatingSystem.IsWindows(), "symlink creation needs elevated privilege on Windows CI");
+
+        var root = Directory.CreateTempSubdirectory("kcap-trypure-").FullName;
+        var link = Path.Combine(root, "danglink");
+        Directory.CreateSymbolicLink(link, Path.Combine(root, "never-created-target"));
+        var path = Path.Combine(link, "config.json");
+
+        var ok = ConfigMutator.TryLoadPure(path, out var config);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(config.Profiles.ContainsKey("default")).IsTrue(); // still a usable default out param
+    }
+
+    /// <summary>A genuinely never-created parent chain must still read as absence — disambiguating
+    /// a blocked ancestor must not turn every missing directory level into a false failure.</summary>
     [Test]
     public async Task TryLoadPure_missing_parent_directory_is_still_absence() {
         var root = Directory.CreateTempSubdirectory("kcap-trypure-").FullName;

--- a/test/Capacitor.Cli.Tests.Unit/Config/ConfigMutatorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Config/ConfigMutatorTests.cs
@@ -154,12 +154,12 @@ public class ConfigMutatorTests {
         await Assert.That(config.Profiles.ContainsKey("default")).IsTrue();
     }
 
-    /// <summary>Round-3 review finding #4: <c>Directory.Exists</c>/<c>File.Exists</c> both return
-    /// false on a permission-denied path, which would silently degrade "inaccessible" into
-    /// "absent, defaults are fine". The simplest deterministic way to force a non-not-found I/O
-    /// failure (without relying on platform-specific permission bits) is to make the config path's
-    /// PARENT a plain file rather than a directory — opening through it fails structurally, not
-    /// because anything is missing.</summary>
+    /// <summary><c>Directory.Exists</c>/<c>File.Exists</c> both return false on a
+    /// permission-denied path, which would silently degrade "inaccessible" into "absent, defaults
+    /// are fine". The simplest deterministic way to force a non-not-found I/O failure (without
+    /// relying on platform-specific permission bits) is to make the config path's PARENT a plain
+    /// file rather than a directory — opening through it fails structurally, not because anything
+    /// is missing.</summary>
     [Test]
     public async Task TryLoadPure_parent_replaced_by_a_file_is_failure_not_absence() {
         var root = Directory.CreateTempSubdirectory("kcap-trypure-").FullName;
@@ -173,9 +173,26 @@ public class ConfigMutatorTests {
         await Assert.That(config.Profiles.ContainsKey("default")).IsTrue(); // still a usable default out param
     }
 
-    /// <summary>Positive control for the fix above: a path whose parent chain genuinely does not
-    /// exist yet (nothing has ever been created there) must still read as absence, not failure —
-    /// the disambiguation must not turn every missing ancestor directory into a false failure.</summary>
+    /// <summary>The immediate parent alone isn't enough to disambiguate: a path nested TWO levels
+    /// under a planted file (<c>file/child/config.json</c>) needs the ancestor walk to climb past
+    /// the never-created <c>child</c> directory to reach the file actually blocking it.</summary>
+    [Test]
+    public async Task TryLoadPure_grandparent_replaced_by_a_file_is_failure_not_absence() {
+        var root = Directory.CreateTempSubdirectory("kcap-trypure-").FullName;
+        var grandparentAsFile = Path.Combine(root, "not-a-directory");
+        await File.WriteAllTextAsync(grandparentAsFile, "i am a file, not a directory");
+        var path = Path.Combine(grandparentAsFile, "child", "config.json");
+
+        var ok = ConfigMutator.TryLoadPure(path, out var config);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(config.Profiles.ContainsKey("default")).IsTrue(); // still a usable default out param
+    }
+
+    /// <summary>A path whose parent chain genuinely does not exist yet (nothing has ever been
+    /// created there) must still read as absence, not failure — disambiguating a blocked ancestor
+    /// from a missing one must not turn every missing directory level into a false
+    /// failure.</summary>
     [Test]
     public async Task TryLoadPure_missing_parent_directory_is_still_absence() {
         var root = Directory.CreateTempSubdirectory("kcap-trypure-").FullName;

--- a/test/Capacitor.Cli.Tests.Unit/Services/LaunchdStartStopTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/LaunchdStartStopTests.cs
@@ -212,7 +212,7 @@ public partial class LaunchdStartStopTests {
         });
     }
 
-    // ── Query containment (round-3 review finding #1): round-2's throwing leaf parsers must never
+    // ── Query containment: a malformed on-disk plist (duplicate key, truncated XML) must never
     // escape Query as an uncoded failure — Query is a total, never-throwing probe. See
     // ServiceVerifyStartGateProductionPathTests for the same shape carried through the gate. ──
 
@@ -269,7 +269,7 @@ public partial class LaunchdStartStopTests {
         });
     }
 
-    // ── StartBootstrapOnly budget discipline (round-3 review finding #5) ──
+    // ── StartBootstrapOnly budget discipline ──
 
     [Test]
     public async Task StartBootstrapOnly_shares_one_deadline_across_probe_and_bootstrap_not_two_full_budgets() {

--- a/test/Capacitor.Cli.Tests.Unit/Services/LaunchdStartStopTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/LaunchdStartStopTests.cs
@@ -212,6 +212,111 @@ public partial class LaunchdStartStopTests {
         });
     }
 
+    // ── Query containment (round-3 review finding #1): round-2's throwing leaf parsers must never
+    // escape Query as an uncoded failure — Query is a total, never-throwing probe. See
+    // ServiceVerifyStartGateProductionPathTests for the same shape carried through the gate. ──
+
+    [Test]
+    public async Task Query_does_not_throw_on_a_duplicate_ProgramArguments_key_plist_and_reports_null_binary_path() {
+        Skip.When(OperatingSystem.IsWindows(), "Uid() P/Invokes libc's getuid, POSIX-only");
+
+        await WithHome(async path => {
+            const string duplicateKeyPlist = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                <plist version="1.0">
+                <dict>
+                  <key>Label</key><string>io.kurrent.kcap.daemon.test</string>
+                  <key>ProgramArguments</key><array>
+                    <string>/bin/kcap-daemon</string>
+                  </array>
+                  <key>ProgramArguments</key><array>
+                    <string>/bin/evil-daemon</string>
+                  </array>
+                </dict>
+                </plist>
+                """;
+            File.WriteAllText(path, duplicateKeyPlist);
+
+            var mgr = new LaunchdServiceManager(runProcess: (_, args) =>
+                args[0] == "print"
+                    ? (113, "", "Could not find service \"io.kurrent.kcap.daemon.test\" in domain for user gui: 501")
+                    : (0, "", ""));
+
+            var query = mgr.Query("test");
+
+            await Assert.That(query.BinaryPath).IsNull();
+            await Assert.That(query.UnitPresent).IsTrue();
+            await Assert.That(query.Probe).IsEqualTo(LabelProbe.Absent);
+        });
+    }
+
+    [Test]
+    public async Task Status_does_not_throw_on_a_malformed_plist_and_reports_null_binary_path() {
+        Skip.When(OperatingSystem.IsWindows(), "Uid() P/Invokes libc's getuid, POSIX-only");
+
+        await WithHome(async path => {
+            File.WriteAllText(path, "<plist version=\"1.0\"><dict><key>Truncated");
+
+            var mgr = new LaunchdServiceManager(runProcess: (_, args) =>
+                args[0] == "print"
+                    ? (113, "", "Could not find service \"io.kurrent.kcap.daemon.test\" in domain for user gui: 501")
+                    : (0, "", ""));
+
+            var status = mgr.Status("test");
+
+            await Assert.That(status.BinaryPath).IsNull();
+        });
+    }
+
+    // ── StartBootstrapOnly budget discipline (round-3 review finding #5) ──
+
+    [Test]
+    public async Task StartBootstrapOnly_shares_one_deadline_across_probe_and_bootstrap_not_two_full_budgets() {
+        Skip.When(OperatingSystem.IsWindows(), "Uid() P/Invokes libc's getuid, POSIX-only");
+
+        await WithHome(async _ => {
+            var timeouts = new List<TimeSpan>();
+            var mgr = new LaunchdServiceManager(runBounded: (_, args, timeout) => {
+                timeouts.Add(timeout);
+                if (args[0] == "print") {
+                    Thread.Sleep(50); // consume a real, measurable slice of the shared budget
+                    return (113, "", "Could not find service \"io.kurrent.kcap.daemon.test\" in domain for user gui: 501", false);
+                }
+                return (0, "", "", false);
+            });
+
+            var ok = mgr.StartBootstrapOnly("test", TimeSpan.FromSeconds(5), out var error);
+
+            await Assert.That(ok).IsTrue();
+            await Assert.That(error).IsNull();
+            await Assert.That(timeouts.Count).IsEqualTo(2);
+            // The probe gets the full budget; the bootstrap call must get only what's LEFT of it —
+            // never another full 5s, which would let the pair invade up to 2x the caller's forward
+            // remainder (including the separately reserved rollback budget).
+            await Assert.That(timeouts[0]).IsEqualTo(TimeSpan.FromSeconds(5));
+            await Assert.That(timeouts[1]).IsLessThan(TimeSpan.FromSeconds(5));
+        });
+    }
+
+    [Test]
+    public async Task StartBootstrapOnly_reports_timeout_when_the_probe_alone_exhausts_the_budget() {
+        Skip.When(OperatingSystem.IsWindows(), "Uid() P/Invokes libc's getuid, POSIX-only");
+
+        await WithHome(async _ => {
+            var mgr = new LaunchdServiceManager(runBounded: (_, args, timeout) =>
+                args[0] == "print"
+                    ? (113, "", "Could not find service \"io.kurrent.kcap.daemon.test\" in domain for user gui: 501", true) // timed out
+                    : (0, "", "", false));
+
+            var ok = mgr.StartBootstrapOnly("test", TimeSpan.FromSeconds(5), out var error);
+
+            // A timed-out print reports Unknown, not Absent — bootstrap must never run.
+            await Assert.That(ok).IsFalse();
+            await Assert.That(error).IsNotNull();
+        });
+    }
+
     [Test]
     public async Task Start_probe_unknown_fails_without_issuing_bootstrap_or_kickstart() {
         Skip.When(OperatingSystem.IsWindows(), "Uid() P/Invokes libc's getuid, POSIX-only");

--- a/test/Capacitor.Cli.Tests.Unit/Services/LaunchdUnitTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/LaunchdUnitTests.cs
@@ -169,9 +169,8 @@ public class LaunchdUnitTests {
         await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
     }
 
-    // ── EnvFromPlist: the three malformed keyed-structure shapes finding #3 of the round-3 review
-    // requires to throw rather than silently degrade (empty map / skipped pair / dodged duplicate
-    // detection). ──
+    // ── EnvFromPlist: malformed keyed-structure shapes that must throw rather than silently
+    // degrade (empty map / skipped pair / dodged duplicate detection). ──
 
     [Test]
     public async Task EnvFromPlist_throws_when_EnvironmentVariables_is_paired_with_a_non_dict() {
@@ -190,9 +189,8 @@ public class LaunchdUnitTests {
             </dict>
             </plist>
             """;
-        // Previously silently returned an empty map (the `el.Name == "dict"` guard skipped the
-        // whole block without complaint) — a non-dict pairing is ambiguous/malformed evidence, not
-        // "no env vars", so it must throw.
+        // A non-dict pairing is ambiguous/malformed evidence, not "no env vars" — it must throw
+        // rather than silently return an empty map.
         await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
     }
 
@@ -213,8 +211,8 @@ public class LaunchdUnitTests {
             </dict>
             </plist>
             """;
-        // Previously silently skipped the pair (the `kv.Name == "string"` guard just fell through)
-        // — a relevant key paired with the wrong value type is malformed evidence, not absence.
+        // A relevant key paired with the wrong value type is malformed evidence, not absence — it
+        // must throw rather than silently skip the pair.
         await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
     }
 
@@ -236,10 +234,82 @@ public class LaunchdUnitTests {
             </dict>
             </plist>
             """;
-        // Previously the second <key> silently overwrote the pending key, dropping
-        // KCAP_CONSENT_SEED_DEFAULT entirely without complaint and dodging duplicate-key detection
-        // for whatever the dropped key would otherwise have collided with.
+        // The second <key> must not silently overwrite the pending key — that would drop
+        // KCAP_CONSENT_SEED_DEFAULT entirely and dodge duplicate-key detection for whatever key it
+        // collided with.
         await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
+    }
+
+    // ── TopLevelValue (the shared root-dict walk BinaryFromPlist/EnvFromPlist both use to find
+    // their own top-level key): the same strict key/value alternation as EnvFromPlist's inner walk
+    // above, at the OUTER level. ──
+
+    [Test]
+    public async Task EnvFromPlist_throws_on_two_consecutive_identical_top_level_keys_followed_by_one_value() {
+        const string xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+              <key>Label</key><string>io.kurrent.kcap.daemon.dup</string>
+              <key>ProgramArguments</key><array>
+                <string>/bin/kcap-daemon</string>
+              </array>
+              <key>EnvironmentVariables</key>
+              <key>EnvironmentVariables</key><dict>
+                <key>KCAP_CONSENT_SEED_DEFAULT</key><string>prompt</string>
+              </dict>
+            </dict>
+            </plist>
+            """;
+        // Two consecutive top-level <key> nodes naming the SAME key, followed by only one value,
+        // must still throw — pairing the lone value with whichever key happened to land last would
+        // let this shape masquerade as a single declaration and evade duplicate-key detection.
+        await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
+    }
+
+    [Test]
+    public async Task EnvFromPlist_throws_when_the_EnvironmentVariables_key_is_immediately_followed_by_another_key() {
+        const string xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+              <key>Label</key><string>io.kurrent.kcap.daemon.dup</string>
+              <key>ProgramArguments</key><array>
+                <string>/bin/kcap-daemon</string>
+              </array>
+              <key>EnvironmentVariables</key>
+              <key>Decoy</key><dict>
+                <key>KCAP_CONSENT_SEED_DEFAULT</key><string>prompt</string>
+              </dict>
+            </dict>
+            </plist>
+            """;
+        // The real EnvironmentVariables key is immediately followed by a DIFFERENT key before any
+        // value — pairing the dict with that LATER key instead would make EnvironmentVariables
+        // read as absent (an empty map), the takeover-safe outcome a gate caller must never see
+        // for a plist this malformed.
+        await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
+    }
+
+    [Test]
+    public async Task BinaryFromPlist_throws_on_a_top_level_value_with_no_preceding_key() {
+        const string xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+              <string>orphan value with no preceding key</string>
+              <key>ProgramArguments</key><array>
+                <string>/bin/kcap-daemon</string>
+              </array>
+            </dict>
+            </plist>
+            """;
+        // A top-level value with no preceding <key> at all must throw rather than be silently
+        // ignored (no key can ever match it, so the old walk just skipped it without complaint).
+        await Assert.That(() => LaunchdUnit.BinaryFromPlist(xml)).Throws<InvalidDataException>();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Services/LaunchdUnitTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/LaunchdUnitTests.cs
@@ -240,9 +240,8 @@ public class LaunchdUnitTests {
         await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
     }
 
-    // ── TopLevelValue (the shared root-dict walk BinaryFromPlist/EnvFromPlist both use to find
-    // their own top-level key): the same strict key/value alternation as EnvFromPlist's inner walk
-    // above, at the OUTER level. ──
+    // ── TopLevelValue: the same strict key/value alternation as EnvFromPlist's inner walk above,
+    // enforced at the OUTER (top-level dict) level. ──
 
     [Test]
     public async Task EnvFromPlist_throws_on_two_consecutive_identical_top_level_keys_followed_by_one_value() {
@@ -262,9 +261,8 @@ public class LaunchdUnitTests {
             </dict>
             </plist>
             """;
-        // Two consecutive top-level <key> nodes naming the SAME key, followed by only one value,
-        // must still throw — pairing the lone value with whichever key happened to land last would
-        // let this shape masquerade as a single declaration and evade duplicate-key detection.
+        // Must still throw — pairing the lone value with whichever key landed last would evade
+        // duplicate-key detection.
         await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
     }
 
@@ -286,10 +284,8 @@ public class LaunchdUnitTests {
             </dict>
             </plist>
             """;
-        // The real EnvironmentVariables key is immediately followed by a DIFFERENT key before any
-        // value — pairing the dict with that LATER key instead would make EnvironmentVariables
-        // read as absent (an empty map), the takeover-safe outcome a gate caller must never see
-        // for a plist this malformed.
+        // Pairing the dict with the LATER key instead would make EnvironmentVariables read as
+        // absent — the takeover-safe outcome a gate caller must never see for a malformed plist.
         await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
     }
 
@@ -307,8 +303,6 @@ public class LaunchdUnitTests {
             </dict>
             </plist>
             """;
-        // A top-level value with no preceding <key> at all must throw rather than be silently
-        // ignored (no key can ever match it, so the old walk just skipped it without complaint).
         await Assert.That(() => LaunchdUnit.BinaryFromPlist(xml)).Throws<InvalidDataException>();
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Services/LaunchdUnitTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/LaunchdUnitTests.cs
@@ -169,6 +169,79 @@ public class LaunchdUnitTests {
         await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
     }
 
+    // ── EnvFromPlist: the three malformed keyed-structure shapes finding #3 of the round-3 review
+    // requires to throw rather than silently degrade (empty map / skipped pair / dodged duplicate
+    // detection). ──
+
+    [Test]
+    public async Task EnvFromPlist_throws_when_EnvironmentVariables_is_paired_with_a_non_dict() {
+        const string xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+              <key>Label</key><string>io.kurrent.kcap.daemon.bad</string>
+              <key>ProgramArguments</key><array>
+                <string>/bin/kcap-daemon</string>
+              </array>
+              <key>EnvironmentVariables</key><array>
+                <string>not a dict at all</string>
+              </array>
+            </dict>
+            </plist>
+            """;
+        // Previously silently returned an empty map (the `el.Name == "dict"` guard skipped the
+        // whole block without complaint) — a non-dict pairing is ambiguous/malformed evidence, not
+        // "no env vars", so it must throw.
+        await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
+    }
+
+    [Test]
+    public async Task EnvFromPlist_throws_when_a_key_is_paired_with_a_non_string_value() {
+        const string xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+              <key>Label</key><string>io.kurrent.kcap.daemon.bad</string>
+              <key>ProgramArguments</key><array>
+                <string>/bin/kcap-daemon</string>
+              </array>
+              <key>EnvironmentVariables</key><dict>
+                <key>KCAP_CONSENT_SEED_DEFAULT</key><integer>1</integer>
+              </dict>
+            </dict>
+            </plist>
+            """;
+        // Previously silently skipped the pair (the `kv.Name == "string"` guard just fell through)
+        // — a relevant key paired with the wrong value type is malformed evidence, not absence.
+        await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
+    }
+
+    [Test]
+    public async Task EnvFromPlist_throws_on_consecutive_key_nodes_rather_than_silently_overwriting() {
+        const string xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+              <key>Label</key><string>io.kurrent.kcap.daemon.bad</string>
+              <key>ProgramArguments</key><array>
+                <string>/bin/kcap-daemon</string>
+              </array>
+              <key>EnvironmentVariables</key><dict>
+                <key>KCAP_CONSENT_SEED_DEFAULT</key>
+                <key>KCAP_PROFILE</key><string>work</string>
+              </dict>
+            </dict>
+            </plist>
+            """;
+        // Previously the second <key> silently overwrote the pending key, dropping
+        // KCAP_CONSENT_SEED_DEFAULT entirely without complaint and dodging duplicate-key detection
+        // for whatever the dropped key would otherwise have collided with.
+        await Assert.That(() => LaunchdUnit.EnvFromPlist(xml)).Throws<InvalidDataException>();
+    }
+
     [Test]
     public async Task StatusFromPrint_maps_exit_and_state() {
         await Assert.That(LaunchdUnit.StatusFromPrint(exitCode: 1, stdout: "")).IsEqualTo(ServiceState.NotInstalled);

--- a/test/Capacitor.Cli.Tests.Unit/Services/LaunchdUnitTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/LaunchdUnitTests.cs
@@ -306,6 +306,18 @@ public class LaunchdUnitTests {
         await Assert.That(() => LaunchdUnit.BinaryFromPlist(xml)).Throws<InvalidDataException>();
     }
 
+    /// <summary>A genuinely never-created parent chain must still classify as Absent — link/file
+    /// evidence detection must not turn every missing directory level into Unreadable.</summary>
+    [Test]
+    public async Task TryReadPlist_missing_parent_directories_is_still_absent() {
+        var path = Path.Combine(Directory.CreateTempSubdirectory("kcap-plist-").FullName, "never-created", "sub", "x.plist");
+
+        var status = LaunchdUnit.TryReadPlist(path, out var content);
+
+        await Assert.That(status).IsEqualTo(LaunchdUnit.PlistRead.Absent);
+        await Assert.That(content).IsNull();
+    }
+
     [Test]
     public async Task StatusFromPrint_maps_exit_and_state() {
         await Assert.That(LaunchdUnit.StatusFromPrint(exitCode: 1, stdout: "")).IsEqualTo(ServiceState.NotInstalled);

--- a/test/Capacitor.Cli.Tests.Unit/Services/ProdPathFixture.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ProdPathFixture.cs
@@ -3,10 +3,7 @@ using Capacitor.Cli.Services;
 
 namespace Capacitor.Cli.Tests.Unit.Services;
 
-/// <summary>HOME/lock-dir isolation and a stubbed launchd manager (every <c>launchctl print</c>
-/// reports the unit not found) shared by the real-<see cref="LaunchdServiceManager"/> production-path
-/// suites — each test arranges only its own on-disk plist evidence before touching
-/// <see cref="Manager"/> or <see cref="PlistPath"/>.</summary>
+/// <summary>Shared HOME/lock-dir isolation for the production-path suites.</summary>
 sealed class ProdPathFixture : IDisposable {
     readonly string _id;
     readonly string? _originalHome;
@@ -47,5 +44,6 @@ sealed class ProdPathFixture : IDisposable {
         DaemonLockPaths.OverrideDirectoryForTesting(null);
         Environment.SetEnvironmentVariable("HOME", _originalHome);
         try { Directory.Delete(_home, recursive: true); } catch { /* best effort */ }
+        try { Directory.Delete(_lockDir, recursive: true); } catch { /* best effort */ }
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/ProdPathFixture.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ProdPathFixture.cs
@@ -1,0 +1,51 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>HOME/lock-dir isolation and a stubbed launchd manager (every <c>launchctl print</c>
+/// reports the unit not found) shared by the real-<see cref="LaunchdServiceManager"/> production-path
+/// suites — each test arranges only its own on-disk plist evidence before touching
+/// <see cref="Manager"/> or <see cref="PlistPath"/>.</summary>
+sealed class ProdPathFixture : IDisposable {
+    readonly string _id;
+    readonly string? _originalHome;
+    readonly string _home;
+    readonly string _lockDir;
+
+    public string PlistPath => LaunchdUnit.PlistPath(_id);
+    public string DaemonPath { get; }
+
+    public LaunchdServiceManager Manager { get; }
+
+    public ProdPathFixture(string id) {
+        _id = id;
+        _originalHome = Environment.GetEnvironmentVariable("HOME");
+        _home = Directory.CreateTempSubdirectory($"kcap-{id}-home-").FullName;
+        Environment.SetEnvironmentVariable("HOME", _home);
+
+        _lockDir = Directory.CreateTempSubdirectory($"kcap-{id}-lock-").FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(_lockDir);
+
+        DaemonPath = Path.Combine(_lockDir, "kcap-daemon");
+        File.WriteAllText(DaemonPath, "");
+
+        Manager = new(
+            runProcess: (_, args) => PrintNotFound(args),
+            runBounded: (_, args, _) => {
+                var (code, stdout, stderr) = PrintNotFound(args);
+                return (code, stdout, stderr, false);
+            });
+    }
+
+    (int ExitCode, string StdOut, string StdErr) PrintNotFound(string[] args) =>
+        args[0] == "print"
+            ? (113, "", $"Could not find service \"{LaunchdUnit.Label(_id)}\" in domain for user gui: 501")
+            : (0, "", "");
+
+    public void Dispose() {
+        DaemonLockPaths.OverrideDirectoryForTesting(null);
+        Environment.SetEnvironmentVariable("HOME", _originalHome);
+        try { Directory.Delete(_home, recursive: true); } catch { /* best effort */ }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyInstallProductionPathTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyInstallProductionPathTests.cs
@@ -3,68 +3,23 @@ using Capacitor.Cli.Services;
 
 namespace Capacitor.Cli.Tests.Unit.Services;
 
-/// <summary>Proves entry-time marker recovery's discriminated plist read never treats a structural
-/// obstruction (a directory sitting at the plist path) as confirmed-absent residue — end to end
-/// through the REAL <see cref="LaunchdServiceManager"/>, mirroring
-/// <see cref="ServiceVerifyStartGateProductionPathTests"/>'s coverage of the same contract for
-/// <c>StartVerifiedAsync</c>'s Phase A.</summary>
+// Real-manager counterpart to ServiceVerifyStartGateProductionPathTests, covering the same
+// discriminated-read contract for InstallVerifiedAsync's marker recovery.
 [NotInParallel(["HomeEnvVarMutation", nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting"])]
 public class ServiceVerifyInstallProductionPathTests {
     const string Id = "prodpath-install";
-
-    sealed class ProdPathFixture : IDisposable {
-        readonly string? _originalHome;
-        readonly string _home;
-        readonly string _lockDir;
-
-        public string PlistPath  => LaunchdUnit.PlistPath(Id);
-        public string DaemonPath { get; }
-
-        public LaunchdServiceManager Manager { get; } = new(
-            runProcess: (_, args) => PrintNotFound(args),
-            runBounded: (_, args, _) => {
-                var (code, stdout, stderr) = PrintNotFound(args);
-                return (code, stdout, stderr, false);
-            });
-
-        public ProdPathFixture() {
-            _originalHome = Environment.GetEnvironmentVariable("HOME");
-            _home = Directory.CreateTempSubdirectory("kcap-prodpath-install-home-").FullName;
-            Environment.SetEnvironmentVariable("HOME", _home);
-
-            _lockDir = Directory.CreateTempSubdirectory("kcap-prodpath-install-lock-").FullName;
-            DaemonLockPaths.OverrideDirectoryForTesting(_lockDir);
-
-            DaemonPath = Path.Combine(_lockDir, "kcap-daemon");
-            File.WriteAllText(DaemonPath, "");
-        }
-
-        static (int ExitCode, string StdOut, string StdErr) PrintNotFound(string[] args) =>
-            args[0] == "print"
-                ? (113, "", $"Could not find service \"{LaunchdUnit.Label(Id)}\" in domain for user gui: 501")
-                : (0, "", "");
-
-        public void Dispose() {
-            DaemonLockPaths.OverrideDirectoryForTesting(null);
-            Environment.SetEnvironmentVariable("HOME", _originalHome);
-            try { Directory.Delete(_home, recursive: true); } catch { /* best effort */ }
-        }
-    }
 
     static ServiceSpec Spec(string daemonPath) =>
         new(Id, daemonPath, Path.Combine(Path.GetTempPath(), "prodpath-install-daemon.log"),
             new Dictionary<string, string>(), []);
 
-    /// <summary>A DIRECTORY at the plist path is present by every real signal but unreadable as
-    /// content — <c>File.Exists</c> reads a directory as ABSENT, so a leftover-marker recovery that
-    /// composed <c>_readPlist</c>/<c>_plistExists</c> separately would misclassify it as its own
-    /// gone residue and delete the marker. Must surface RestoreVerification with the marker
-    /// retained instead.</summary>
+    // File.Exists reads a directory as absent, so recovery must classify via the discriminated
+    // read, not existence, or it would delete the marker instead of retaining it.
     [Test, NotInParallel]
     public async Task Leftover_marker_with_a_directory_at_the_plist_path_is_restore_verification_marker_retained() {
         Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
 
-        using var fx = new ProdPathFixture();
+        using var fx = new ProdPathFixture(Id);
         Directory.CreateDirectory(LaunchdUnit.AgentsDir());
         Directory.CreateDirectory(fx.PlistPath); // a DIRECTORY sits at the plist path, not a file
 

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyInstallProductionPathTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyInstallProductionPathTests.cs
@@ -1,0 +1,85 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>Proves entry-time marker recovery's discriminated plist read never treats a structural
+/// obstruction (a directory sitting at the plist path) as confirmed-absent residue — end to end
+/// through the REAL <see cref="LaunchdServiceManager"/>, mirroring
+/// <see cref="ServiceVerifyStartGateProductionPathTests"/>'s coverage of the same contract for
+/// <c>StartVerifiedAsync</c>'s Phase A.</summary>
+[NotInParallel(["HomeEnvVarMutation", nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting"])]
+public class ServiceVerifyInstallProductionPathTests {
+    const string Id = "prodpath-install";
+
+    sealed class ProdPathFixture : IDisposable {
+        readonly string? _originalHome;
+        readonly string _home;
+        readonly string _lockDir;
+
+        public string PlistPath  => LaunchdUnit.PlistPath(Id);
+        public string DaemonPath { get; }
+
+        public LaunchdServiceManager Manager { get; } = new(
+            runProcess: (_, args) => PrintNotFound(args),
+            runBounded: (_, args, _) => {
+                var (code, stdout, stderr) = PrintNotFound(args);
+                return (code, stdout, stderr, false);
+            });
+
+        public ProdPathFixture() {
+            _originalHome = Environment.GetEnvironmentVariable("HOME");
+            _home = Directory.CreateTempSubdirectory("kcap-prodpath-install-home-").FullName;
+            Environment.SetEnvironmentVariable("HOME", _home);
+
+            _lockDir = Directory.CreateTempSubdirectory("kcap-prodpath-install-lock-").FullName;
+            DaemonLockPaths.OverrideDirectoryForTesting(_lockDir);
+
+            DaemonPath = Path.Combine(_lockDir, "kcap-daemon");
+            File.WriteAllText(DaemonPath, "");
+        }
+
+        static (int ExitCode, string StdOut, string StdErr) PrintNotFound(string[] args) =>
+            args[0] == "print"
+                ? (113, "", $"Could not find service \"{LaunchdUnit.Label(Id)}\" in domain for user gui: 501")
+                : (0, "", "");
+
+        public void Dispose() {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            Environment.SetEnvironmentVariable("HOME", _originalHome);
+            try { Directory.Delete(_home, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    static ServiceSpec Spec(string daemonPath) =>
+        new(Id, daemonPath, Path.Combine(Path.GetTempPath(), "prodpath-install-daemon.log"),
+            new Dictionary<string, string>(), []);
+
+    /// <summary>A DIRECTORY at the plist path is present by every real signal but unreadable as
+    /// content — <c>File.Exists</c> reads a directory as ABSENT, so a leftover-marker recovery that
+    /// composed <c>_readPlist</c>/<c>_plistExists</c> separately would misclassify it as its own
+    /// gone residue and delete the marker. Must surface RestoreVerification with the marker
+    /// retained instead.</summary>
+    [Test, NotInParallel]
+    public async Task Leftover_marker_with_a_directory_at_the_plist_path_is_restore_verification_marker_retained() {
+        Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
+
+        using var fx = new ProdPathFixture();
+        Directory.CreateDirectory(LaunchdUnit.AgentsDir());
+        Directory.CreateDirectory(fx.PlistPath); // a DIRECTORY sits at the plist path, not a file
+
+        // The fingerprint value is irrelevant — recovery must never reach the fingerprint compare
+        // once the read is classified Unreadable.
+        ServiceTxnMarker.Write(Id, new TxnMarker(1, "install", "written", "stale", "no-unit", "irrelevant-fingerprint"));
+
+        Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
+            Task.FromResult(new HelloProbeResult(false, null, null, null));
+
+        var sut = new ServiceVerify(fx.Manager, _ => 4242, Hello, TimeProvider.System);
+
+        var exit = await sut.InstallVerifiedAsync(Spec(fx.DaemonPath), replace: false, expectedVersion: null);
+
+        await Assert.That(exit).IsEqualTo(VerifyExit.RestoreVerification);
+        await Assert.That(ServiceTxnMarker.Exists(Id)).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
@@ -33,58 +33,82 @@ public class ServiceVerifyStartGateProductionPathTests {
         </plist>
         """;
 
-    static (int ExitCode, string StdOut, string StdErr) PrintNotFound(string[] args) =>
-        args[0] == "print"
-            ? (113, "", "Could not find service \"io.kurrent.kcap.daemon.prodpath\" in domain for user gui: 501")
-            : (0, "", "");
+    /// <summary>HOME/lock-dir isolation, the stubbed launchctl manager/hello pair, and stderr
+    /// capture shared by every test in this file — each test arranges only its own on-disk evidence
+    /// shape (a malformed plist, stripped permissions, a directory, a dangling symlink, ...) before
+    /// calling <see cref="RunStartVerifiedAsync"/>.</summary>
+    sealed class ProdPathFixture : IDisposable {
+        readonly string? _originalHome;
+        readonly string _home;
+        readonly TextWriter _originalErr = Console.Error;
+
+        public string PlistPath => LaunchdUnit.PlistPath(Id);
+
+        public LaunchdServiceManager Manager { get; } = new(
+            runProcess: (_, args) => PrintNotFound(args),
+            runBounded: (_, args, _) => {
+                var (code, stdout, stderr) = PrintNotFound(args);
+                return (code, stdout, stderr, false);
+            });
+
+        public ProdPathFixture() {
+            _originalHome = Environment.GetEnvironmentVariable("HOME");
+            _home = Directory.CreateTempSubdirectory("kcap-prodpath-home-").FullName;
+            Environment.SetEnvironmentVariable("HOME", _home);
+
+            var lockDir = Directory.CreateTempSubdirectory("kcap-prodpath-lock-").FullName;
+            DaemonLockPaths.OverrideDirectoryForTesting(lockDir);
+        }
+
+        static (int ExitCode, string StdOut, string StdErr) PrintNotFound(string[] args) =>
+            args[0] == "print"
+                ? (113, "", $"Could not find service \"{LaunchdUnit.Label(Id)}\" in domain for user gui: 501")
+                : (0, "", "");
+
+        static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
+            Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
+
+        public async Task<(int Exit, string[] StdErrLines)> RunStartVerifiedAsync() {
+            var sut = new ServiceVerify(Manager, _ => 4242, Hello, TimeProvider.System,
+                gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
+
+            var capturedErr = new StringWriter();
+            Console.SetError(capturedErr);
+            int exit;
+            try {
+                exit = await sut.StartVerifiedAsync(Id);
+            } finally {
+                Console.SetError(_originalErr);
+            }
+
+            return (exit, capturedErr.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        public void Dispose() {
+            Console.SetError(_originalErr);
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            Environment.SetEnvironmentVariable("HOME", _originalHome);
+            try { Directory.Delete(_home, recursive: true); } catch { /* best effort */ }
+        }
+    }
 
     [Test]
     public async Task Malformed_unit_on_disk_is_contained_through_the_real_manager_and_reaches_exit_28() {
         Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
 
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        var home = Directory.CreateTempSubdirectory("kcap-prodpath-home-").FullName;
-        Environment.SetEnvironmentVariable("HOME", home);
+        using var fx = new ProdPathFixture();
+        Directory.CreateDirectory(LaunchdUnit.AgentsDir());
+        File.WriteAllText(fx.PlistPath, DuplicateKeyPlist);
 
-        var lockDir = Directory.CreateTempSubdirectory("kcap-prodpath-lock-").FullName;
-        DaemonLockPaths.OverrideDirectoryForTesting(lockDir);
+        // The `service status --json` style call: Query must NOT throw on this exact malformed
+        // unit — only report unreadable binary evidence.
+        var query = fx.Manager.Query(Id);
+        await Assert.That(query.BinaryPath).IsNull();
+        await Assert.That(query.UnitPresent).IsTrue();
 
-        try {
-            Directory.CreateDirectory(LaunchdUnit.AgentsDir());
-            File.WriteAllText(LaunchdUnit.PlistPath(Id), DuplicateKeyPlist);
+        var (exit, _) = await fx.RunStartVerifiedAsync();
 
-            // Both launchctl seams stubbed (Query is called with and without a timeout across this
-            // test) so no real launchctl process is ever invoked — this test proves the FILE-parsing
-            // containment, not launchd interaction.
-            var manager = new LaunchdServiceManager(
-                runProcess: (_, args) => PrintNotFound(args),
-                runBounded: (_, args, _) => {
-                    var (code, stdout, stderr) = PrintNotFound(args);
-                    return (code, stdout, stderr, false);
-                });
-
-            // The `service status --json` style call: Query must NOT throw on this exact malformed
-            // unit — only report unreadable binary evidence.
-            var query = manager.Query(Id);
-            await Assert.That(query.BinaryPath).IsNull();
-            await Assert.That(query.UnitPresent).IsTrue();
-
-            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
-                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
-
-            // Default readPlist (real File.ReadAllText) and the real manager — the gate's own
-            // contained Phase-A parse is the sole authority for coded evidence classification.
-            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
-                gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
-
-            var exit = await sut.StartVerifiedAsync(Id);
-
-            await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
-        } finally {
-            DaemonLockPaths.OverrideDirectoryForTesting(null);
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-            try { Directory.Delete(home, recursive: true); } catch { /* best effort */ }
-        }
+        await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
     }
 
     /// <summary>A unit that IS present but whose plist cannot be read must classify as
@@ -95,53 +119,23 @@ public class ServiceVerifyStartGateProductionPathTests {
     public async Task Present_but_unreadable_unit_is_evidence_unreadable_not_directive_missing() {
         Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution and Unix file modes are POSIX-only");
 
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        var home = Directory.CreateTempSubdirectory("kcap-prodpath-home-").FullName;
-        Environment.SetEnvironmentVariable("HOME", home);
-
-        var lockDir = Directory.CreateTempSubdirectory("kcap-prodpath-lock-").FullName;
-        DaemonLockPaths.OverrideDirectoryForTesting(lockDir);
-
-        var originalErr = Console.Error;
-        var capturedErr = new StringWriter();
+        using var fx = new ProdPathFixture();
+        Directory.CreateDirectory(LaunchdUnit.AgentsDir());
+        File.WriteAllText(fx.PlistPath, DuplicateKeyPlist); // content is irrelevant — the read never succeeds
+        File.SetUnixFileMode(fx.PlistPath, UnixFileMode.None);
 
         try {
-            Directory.CreateDirectory(LaunchdUnit.AgentsDir());
-            var plistPath = LaunchdUnit.PlistPath(Id);
-            File.WriteAllText(plistPath, DuplicateKeyPlist); // content is irrelevant — the read never succeeds
-            File.SetUnixFileMode(plistPath, UnixFileMode.None);
-
-            var manager = new LaunchdServiceManager(
-                runProcess: (_, args) => PrintNotFound(args),
-                runBounded: (_, args, _) => {
-                    var (code, stdout, stderr) = PrintNotFound(args);
-                    return (code, stdout, stderr, false);
-                });
-
             // The unit-level presence signal Query reports must stay true — File.Exists sees the
             // file regardless of its permission bits.
-            var query = manager.Query(Id);
+            var query = fx.Manager.Query(Id);
             await Assert.That(query.UnitPresent).IsTrue();
 
-            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
-                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
-
-            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
-                gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
-
-            Console.SetError(capturedErr);
-            var exit = await sut.StartVerifiedAsync(Id);
-            Console.SetError(originalErr);
+            var (exit, lines) = await fx.RunStartVerifiedAsync();
 
             await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
-            var lines = capturedErr.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
             await Assert.That(lines).Contains("start_gate_reason=evidence_unreadable");
         } finally {
-            Console.SetError(originalErr);
-            try { File.SetUnixFileMode(LaunchdUnit.PlistPath(Id), UnixFileMode.UserRead | UnixFileMode.UserWrite); } catch { /* best effort */ }
-            DaemonLockPaths.OverrideDirectoryForTesting(null);
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-            try { Directory.Delete(home, recursive: true); } catch { /* best effort */ }
+            try { File.SetUnixFileMode(fx.PlistPath, UnixFileMode.UserRead | UnixFileMode.UserWrite); } catch { /* best effort */ }
         }
     }
 
@@ -153,50 +147,55 @@ public class ServiceVerifyStartGateProductionPathTests {
     public async Task Directory_at_plist_path_is_evidence_unreadable_not_directive_missing() {
         Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
 
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        var home = Directory.CreateTempSubdirectory("kcap-prodpath-home-").FullName;
-        Environment.SetEnvironmentVariable("HOME", home);
+        using var fx = new ProdPathFixture();
+        Directory.CreateDirectory(LaunchdUnit.AgentsDir());
+        Directory.CreateDirectory(fx.PlistPath); // a DIRECTORY sits at the plist path, not a file
 
-        var lockDir = Directory.CreateTempSubdirectory("kcap-prodpath-lock-").FullName;
-        DaemonLockPaths.OverrideDirectoryForTesting(lockDir);
+        // The unit-level presence signal Query reports must stay true even though
+        // File.Exists itself would say otherwise for a directory.
+        var query = fx.Manager.Query(Id);
+        await Assert.That(query.UnitPresent).IsTrue();
 
-        var originalErr = Console.Error;
-        var capturedErr = new StringWriter();
+        var (exit, lines) = await fx.RunStartVerifiedAsync();
 
-        try {
-            Directory.CreateDirectory(LaunchdUnit.AgentsDir());
-            Directory.CreateDirectory(LaunchdUnit.PlistPath(Id)); // a DIRECTORY sits at the plist path, not a file
+        await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
+        await Assert.That(lines).Contains("start_gate_reason=evidence_unreadable");
+    }
 
-            var manager = new LaunchdServiceManager(
-                runProcess: (_, args) => PrintNotFound(args),
-                runBounded: (_, args, _) => {
-                    var (code, stdout, stderr) = PrintNotFound(args);
-                    return (code, stdout, stderr, false);
-                });
+    /// <summary>A dangling symlink AT the plist path — <c>File.Exists</c> reads it as absent (it
+    /// follows through to the missing target), but the open raises <see cref="FileNotFoundException"/>
+    /// with structural link evidence right at the path. Must classify <c>evidence_unreadable</c>,
+    /// never <c>directive_missing</c>.</summary>
+    [Test, NotInParallel]
+    public async Task Dangling_symlink_at_plist_path_is_evidence_unreadable_not_directive_missing() {
+        Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
 
-            // The unit-level presence signal Query reports must stay true even though
-            // File.Exists itself would say otherwise for a directory.
-            var query = manager.Query(Id);
-            await Assert.That(query.UnitPresent).IsTrue();
+        using var fx = new ProdPathFixture();
+        Directory.CreateDirectory(LaunchdUnit.AgentsDir());
+        File.CreateSymbolicLink(fx.PlistPath, Path.Combine(LaunchdUnit.AgentsDir(), "never-created-target"));
 
-            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
-                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
+        var (exit, lines) = await fx.RunStartVerifiedAsync();
 
-            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
-                gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
+        await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
+        await Assert.That(lines).Contains("start_gate_reason=evidence_unreadable");
+    }
 
-            Console.SetError(capturedErr);
-            var exit = await sut.StartVerifiedAsync(Id);
-            Console.SetError(originalErr);
+    /// <summary>A dangling symlink standing in for an ANCESTOR directory of the plist path (here,
+    /// <c>~/Library</c> itself) raises <see cref="DirectoryNotFoundException"/> rather than
+    /// <see cref="FileNotFoundException"/> — must still classify <c>evidence_unreadable</c>, never
+    /// <c>directive_missing</c>.</summary>
+    [Test, NotInParallel]
+    public async Task Dangling_symlink_ancestor_of_plist_path_is_evidence_unreadable_not_directive_missing() {
+        Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
 
-            await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
-            var lines = capturedErr.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-            await Assert.That(lines).Contains("start_gate_reason=evidence_unreadable");
-        } finally {
-            Console.SetError(originalErr);
-            DaemonLockPaths.OverrideDirectoryForTesting(null);
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-            try { Directory.Delete(home, recursive: true); } catch { /* best effort */ }
-        }
+        using var fx = new ProdPathFixture();
+        var home = PathHelpers.HomeDirectory;
+        var library = Path.Combine(home, "Library");
+        File.CreateSymbolicLink(library, Path.Combine(home, "never-created-target"));
+
+        var (exit, lines) = await fx.RunStartVerifiedAsync();
+
+        await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
+        await Assert.That(lines).Contains("start_gate_reason=evidence_unreadable");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
@@ -4,14 +4,13 @@ using Capacitor.Cli.Services;
 namespace Capacitor.Cli.Tests.Unit.Services;
 
 /// <summary>
-/// Finding #1 of the PR #554 round-3 review: <c>LaunchdServiceManager.QueryCore</c> used to parse
-/// the plist's binary evidence directly, so round-2's own throwing leaf parsers (malformed XML, a
-/// duplicate <c>ProgramArguments</c> key) escaped <c>manager.Query</c> as UNCODED failures — both
-/// before the start gate's own <c>gated</c> determination, and post-mutation. <see
-/// cref="ServiceVerifyStartTests"/> already pins the leaf-parser-throws contract and the gate's OWN
-/// contained Phase-A re-parse (via a stubbed <c>readPlist</c> seam on a Fake manager); this class
-/// proves the fix end to end through the REAL <see cref="LaunchdServiceManager"/> — the exact
-/// combination the finding calls out as "not just the leaf parser test".
+/// <c>LaunchdServiceManager.Query</c> must never let a malformed on-disk unit (truncated XML, a
+/// duplicate <c>ProgramArguments</c> key, a present-but-unreadable file) escape as an uncoded
+/// failure — both before the start gate's own <c>gated</c> determination, and post-mutation. <see
+/// cref="ServiceVerifyStartTests"/> pins the leaf-parser-throws contract and the gate's own
+/// contained Phase-A re-parse via a stubbed <c>readPlist</c> seam on a Fake manager; this class
+/// proves the same containment end to end through the REAL <see cref="LaunchdServiceManager"/> and
+/// its default, unstubbed plist read.
 /// </summary>
 [NotInParallel(["HomeEnvVarMutation", nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting"])]
 public class ServiceVerifyStartGateProductionPathTests {
@@ -87,6 +86,67 @@ public class ServiceVerifyStartGateProductionPathTests {
 
             await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
         } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            Environment.SetEnvironmentVariable("HOME", originalHome);
+            try { Directory.Delete(home, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>A unit that IS present but whose plist cannot be read must classify as
+    /// <c>evidence_unreadable</c>, never the takeover-safe <c>directive_missing</c> a genuinely
+    /// absent unit gets — the two are indistinguishable from <c>_readPlist</c>'s null return alone,
+    /// so the gate must consult presence separately. Driven through the real, unstubbed
+    /// <c>File.ReadAllText</c>-backed <c>_readPlist</c>: a real plist file with its read
+    /// permission stripped is present (<c>File.Exists</c> ignores permission bits) but throws on
+    /// read.</summary>
+    [Test, NotInParallel]
+    public async Task Present_but_unreadable_unit_is_evidence_unreadable_not_directive_missing() {
+        Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution and Unix file modes are POSIX-only");
+
+        var originalHome = Environment.GetEnvironmentVariable("HOME");
+        var home = Directory.CreateTempSubdirectory("kcap-prodpath-home-").FullName;
+        Environment.SetEnvironmentVariable("HOME", home);
+
+        var lockDir = Directory.CreateTempSubdirectory("kcap-prodpath-lock-").FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(lockDir);
+
+        var originalErr = Console.Error;
+        var capturedErr = new StringWriter();
+
+        try {
+            Directory.CreateDirectory(LaunchdUnit.AgentsDir());
+            var plistPath = LaunchdUnit.PlistPath(Id);
+            File.WriteAllText(plistPath, DuplicateKeyPlist); // content is irrelevant — the read never succeeds
+            File.SetUnixFileMode(plistPath, UnixFileMode.None);
+
+            var manager = new LaunchdServiceManager(
+                runProcess: (_, args) => PrintNotFound(args),
+                runBounded: (_, args, _) => {
+                    var (code, stdout, stderr) = PrintNotFound(args);
+                    return (code, stdout, stderr, false);
+                });
+
+            // The unit-level presence signal Query reports must stay true — File.Exists sees the
+            // file regardless of its permission bits.
+            var query = manager.Query(Id);
+            await Assert.That(query.UnitPresent).IsTrue();
+
+            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
+                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
+
+            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
+                gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
+
+            Console.SetError(capturedErr);
+            var exit = await sut.StartVerifiedAsync(Id);
+            Console.SetError(originalErr);
+
+            await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
+            var lines = capturedErr.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            await Assert.That(lines).Contains("start_gate_reason=evidence_unreadable");
+        } finally {
+            Console.SetError(originalErr);
+            try { File.SetUnixFileMode(LaunchdUnit.PlistPath(Id), UnixFileMode.UserRead | UnixFileMode.UserWrite); } catch { /* best effort */ }
             DaemonLockPaths.OverrideDirectoryForTesting(null);
             Environment.SetEnvironmentVariable("HOME", originalHome);
             try { Directory.Delete(home, recursive: true); } catch { /* best effort */ }

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
@@ -3,15 +3,10 @@ using Capacitor.Cli.Services;
 
 namespace Capacitor.Cli.Tests.Unit.Services;
 
-/// <summary>
-/// <c>LaunchdServiceManager.Query</c> must never let a malformed on-disk unit (truncated XML, a
-/// duplicate <c>ProgramArguments</c> key, a present-but-unreadable file) escape as an uncoded
-/// failure — both before the start gate's own <c>gated</c> determination, and post-mutation. <see
-/// cref="ServiceVerifyStartTests"/> pins the leaf-parser-throws contract and the gate's own
-/// contained Phase-A re-parse via a stubbed <c>readPlist</c> seam on a Fake manager; this class
-/// proves the same containment end to end through the REAL <see cref="LaunchdServiceManager"/> and
-/// its default, unstubbed plist read.
-/// </summary>
+/// <summary>Proves <see cref="LaunchdServiceManager"/>'s default, unstubbed plist read never lets
+/// a malformed or unreadable on-disk unit escape the start gate as an uncoded failure — end to end
+/// through the REAL manager, complementing <see cref="ServiceVerifyStartTests"/>'s stubbed-seam
+/// coverage of the same contract.</summary>
 [NotInParallel(["HomeEnvVarMutation", nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting"])]
 public class ServiceVerifyStartGateProductionPathTests {
     const string Id = "prodpath";
@@ -94,11 +89,8 @@ public class ServiceVerifyStartGateProductionPathTests {
 
     /// <summary>A unit that IS present but whose plist cannot be read must classify as
     /// <c>evidence_unreadable</c>, never the takeover-safe <c>directive_missing</c> a genuinely
-    /// absent unit gets — the two are indistinguishable from <c>_readPlist</c>'s null return alone,
-    /// so the gate must consult presence separately. Driven through the real, unstubbed
-    /// <c>File.ReadAllText</c>-backed <c>_readPlist</c>: a real plist file with its read
-    /// permission stripped is present (<c>File.Exists</c> ignores permission bits) but throws on
-    /// read.</summary>
+    /// absent unit gets. Here: a real plist file with its read permission stripped —
+    /// <c>File.Exists</c> still reports it present, but the open throws.</summary>
     [Test, NotInParallel]
     public async Task Present_but_unreadable_unit_is_evidence_unreadable_not_directive_missing() {
         Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution and Unix file modes are POSIX-only");
@@ -147,6 +139,61 @@ public class ServiceVerifyStartGateProductionPathTests {
         } finally {
             Console.SetError(originalErr);
             try { File.SetUnixFileMode(LaunchdUnit.PlistPath(Id), UnixFileMode.UserRead | UnixFileMode.UserWrite); } catch { /* best effort */ }
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            Environment.SetEnvironmentVariable("HOME", originalHome);
+            try { Directory.Delete(home, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>A DIRECTORY at the plist path is present by every real signal but unreadable as
+    /// content. <c>File.Exists</c> (which the presence check used to compose on) reads a
+    /// directory as ABSENT — it only follows through to files — so this must still classify
+    /// <c>evidence_unreadable</c>, never the takeover-safe <c>directive_missing</c>.</summary>
+    [Test, NotInParallel]
+    public async Task Directory_at_plist_path_is_evidence_unreadable_not_directive_missing() {
+        Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
+
+        var originalHome = Environment.GetEnvironmentVariable("HOME");
+        var home = Directory.CreateTempSubdirectory("kcap-prodpath-home-").FullName;
+        Environment.SetEnvironmentVariable("HOME", home);
+
+        var lockDir = Directory.CreateTempSubdirectory("kcap-prodpath-lock-").FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(lockDir);
+
+        var originalErr = Console.Error;
+        var capturedErr = new StringWriter();
+
+        try {
+            Directory.CreateDirectory(LaunchdUnit.AgentsDir());
+            Directory.CreateDirectory(LaunchdUnit.PlistPath(Id)); // a DIRECTORY sits at the plist path, not a file
+
+            var manager = new LaunchdServiceManager(
+                runProcess: (_, args) => PrintNotFound(args),
+                runBounded: (_, args, _) => {
+                    var (code, stdout, stderr) = PrintNotFound(args);
+                    return (code, stdout, stderr, false);
+                });
+
+            // The unit-level presence signal Query reports must stay true even though
+            // File.Exists itself would say otherwise for a directory.
+            var query = manager.Query(Id);
+            await Assert.That(query.UnitPresent).IsTrue();
+
+            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
+                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
+
+            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
+                gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
+
+            Console.SetError(capturedErr);
+            var exit = await sut.StartVerifiedAsync(Id);
+            Console.SetError(originalErr);
+
+            await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
+            var lines = capturedErr.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            await Assert.That(lines).Contains("start_gate_reason=evidence_unreadable");
+        } finally {
+            Console.SetError(originalErr);
             DaemonLockPaths.OverrideDirectoryForTesting(null);
             Environment.SetEnvironmentVariable("HOME", originalHome);
             try { Directory.Delete(home, recursive: true); } catch { /* best effort */ }

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
@@ -33,11 +33,6 @@ public class ServiceVerifyStartGateProductionPathTests {
         </plist>
         """;
 
-    /// <summary>Adds the stderr capture and gated <see cref="RunStartVerifiedAsync"/> helper this
-    /// file's tests need on top of the shared <see cref="ProdPathFixture"/> (HOME/lock-dir isolation
-    /// and the stubbed launchctl manager) — each test arranges only its own on-disk evidence shape
-    /// (a malformed plist, stripped permissions, a directory, a dangling symlink, ...) before
-    /// calling it.</summary>
     sealed class Fixture : IDisposable {
         readonly ProdPathFixture _core = new(Id);
         readonly TextWriter _originalErr = Console.Error;

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
@@ -33,37 +33,17 @@ public class ServiceVerifyStartGateProductionPathTests {
         </plist>
         """;
 
-    /// <summary>HOME/lock-dir isolation, the stubbed launchctl manager/hello pair, and stderr
-    /// capture shared by every test in this file — each test arranges only its own on-disk evidence
-    /// shape (a malformed plist, stripped permissions, a directory, a dangling symlink, ...) before
-    /// calling <see cref="RunStartVerifiedAsync"/>.</summary>
-    sealed class ProdPathFixture : IDisposable {
-        readonly string? _originalHome;
-        readonly string _home;
+    /// <summary>Adds the stderr capture and gated <see cref="RunStartVerifiedAsync"/> helper this
+    /// file's tests need on top of the shared <see cref="ProdPathFixture"/> (HOME/lock-dir isolation
+    /// and the stubbed launchctl manager) — each test arranges only its own on-disk evidence shape
+    /// (a malformed plist, stripped permissions, a directory, a dangling symlink, ...) before
+    /// calling it.</summary>
+    sealed class Fixture : IDisposable {
+        readonly ProdPathFixture _core = new(Id);
         readonly TextWriter _originalErr = Console.Error;
 
-        public string PlistPath => LaunchdUnit.PlistPath(Id);
-
-        public LaunchdServiceManager Manager { get; } = new(
-            runProcess: (_, args) => PrintNotFound(args),
-            runBounded: (_, args, _) => {
-                var (code, stdout, stderr) = PrintNotFound(args);
-                return (code, stdout, stderr, false);
-            });
-
-        public ProdPathFixture() {
-            _originalHome = Environment.GetEnvironmentVariable("HOME");
-            _home = Directory.CreateTempSubdirectory("kcap-prodpath-home-").FullName;
-            Environment.SetEnvironmentVariable("HOME", _home);
-
-            var lockDir = Directory.CreateTempSubdirectory("kcap-prodpath-lock-").FullName;
-            DaemonLockPaths.OverrideDirectoryForTesting(lockDir);
-        }
-
-        static (int ExitCode, string StdOut, string StdErr) PrintNotFound(string[] args) =>
-            args[0] == "print"
-                ? (113, "", $"Could not find service \"{LaunchdUnit.Label(Id)}\" in domain for user gui: 501")
-                : (0, "", "");
+        public string PlistPath => _core.PlistPath;
+        public LaunchdServiceManager Manager => _core.Manager;
 
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
@@ -86,9 +66,7 @@ public class ServiceVerifyStartGateProductionPathTests {
 
         public void Dispose() {
             Console.SetError(_originalErr);
-            DaemonLockPaths.OverrideDirectoryForTesting(null);
-            Environment.SetEnvironmentVariable("HOME", _originalHome);
-            try { Directory.Delete(_home, recursive: true); } catch { /* best effort */ }
+            _core.Dispose();
         }
     }
 
@@ -96,7 +74,7 @@ public class ServiceVerifyStartGateProductionPathTests {
     public async Task Malformed_unit_on_disk_is_contained_through_the_real_manager_and_reaches_exit_28() {
         Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
 
-        using var fx = new ProdPathFixture();
+        using var fx = new Fixture();
         Directory.CreateDirectory(LaunchdUnit.AgentsDir());
         File.WriteAllText(fx.PlistPath, DuplicateKeyPlist);
 
@@ -119,7 +97,7 @@ public class ServiceVerifyStartGateProductionPathTests {
     public async Task Present_but_unreadable_unit_is_evidence_unreadable_not_directive_missing() {
         Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution and Unix file modes are POSIX-only");
 
-        using var fx = new ProdPathFixture();
+        using var fx = new Fixture();
         Directory.CreateDirectory(LaunchdUnit.AgentsDir());
         File.WriteAllText(fx.PlistPath, DuplicateKeyPlist); // content is irrelevant — the read never succeeds
         File.SetUnixFileMode(fx.PlistPath, UnixFileMode.None);
@@ -147,7 +125,7 @@ public class ServiceVerifyStartGateProductionPathTests {
     public async Task Directory_at_plist_path_is_evidence_unreadable_not_directive_missing() {
         Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
 
-        using var fx = new ProdPathFixture();
+        using var fx = new Fixture();
         Directory.CreateDirectory(LaunchdUnit.AgentsDir());
         Directory.CreateDirectory(fx.PlistPath); // a DIRECTORY sits at the plist path, not a file
 
@@ -170,7 +148,7 @@ public class ServiceVerifyStartGateProductionPathTests {
     public async Task Dangling_symlink_at_plist_path_is_evidence_unreadable_not_directive_missing() {
         Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
 
-        using var fx = new ProdPathFixture();
+        using var fx = new Fixture();
         Directory.CreateDirectory(LaunchdUnit.AgentsDir());
         File.CreateSymbolicLink(fx.PlistPath, Path.Combine(LaunchdUnit.AgentsDir(), "never-created-target"));
 
@@ -188,7 +166,7 @@ public class ServiceVerifyStartGateProductionPathTests {
     public async Task Dangling_symlink_ancestor_of_plist_path_is_evidence_unreadable_not_directive_missing() {
         Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
 
-        using var fx = new ProdPathFixture();
+        using var fx = new Fixture();
         var home = PathHelpers.HomeDirectory;
         var library = Path.Combine(home, "Library");
         File.CreateSymbolicLink(library, Path.Combine(home, "never-created-target"));

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartGateProductionPathTests.cs
@@ -1,0 +1,95 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Services;
+
+namespace Capacitor.Cli.Tests.Unit.Services;
+
+/// <summary>
+/// Finding #1 of the PR #554 round-3 review: <c>LaunchdServiceManager.QueryCore</c> used to parse
+/// the plist's binary evidence directly, so round-2's own throwing leaf parsers (malformed XML, a
+/// duplicate <c>ProgramArguments</c> key) escaped <c>manager.Query</c> as UNCODED failures — both
+/// before the start gate's own <c>gated</c> determination, and post-mutation. <see
+/// cref="ServiceVerifyStartTests"/> already pins the leaf-parser-throws contract and the gate's OWN
+/// contained Phase-A re-parse (via a stubbed <c>readPlist</c> seam on a Fake manager); this class
+/// proves the fix end to end through the REAL <see cref="LaunchdServiceManager"/> — the exact
+/// combination the finding calls out as "not just the leaf parser test".
+/// </summary>
+[NotInParallel(["HomeEnvVarMutation", nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting"])]
+public class ServiceVerifyStartGateProductionPathTests {
+    const string Id = "prodpath";
+
+    // A duplicate top-level ProgramArguments key — never written by LaunchdUnit.Plist itself, so
+    // this can only be a foreign/corrupt writer — with the gate's own consent directive baked so
+    // Phase A actually has evidence to re-parse.
+    const string DuplicateKeyPlist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key><string>io.kurrent.kcap.daemon.prodpath</string>
+          <key>ProgramArguments</key><array>
+            <string>/bin/kcap-daemon</string>
+          </array>
+          <key>ProgramArguments</key><array>
+            <string>/bin/evil-daemon</string>
+          </array>
+          <key>EnvironmentVariables</key><dict>
+            <key>KCAP_CONSENT_SEED_DEFAULT</key><string>prompt</string>
+          </dict>
+        </dict>
+        </plist>
+        """;
+
+    static (int ExitCode, string StdOut, string StdErr) PrintNotFound(string[] args) =>
+        args[0] == "print"
+            ? (113, "", "Could not find service \"io.kurrent.kcap.daemon.prodpath\" in domain for user gui: 501")
+            : (0, "", "");
+
+    [Test]
+    public async Task Malformed_unit_on_disk_is_contained_through_the_real_manager_and_reaches_exit_28() {
+        Skip.When(OperatingSystem.IsWindows(), "launchd/HOME-based plist resolution is POSIX-only");
+
+        var originalHome = Environment.GetEnvironmentVariable("HOME");
+        var home = Directory.CreateTempSubdirectory("kcap-prodpath-home-").FullName;
+        Environment.SetEnvironmentVariable("HOME", home);
+
+        var lockDir = Directory.CreateTempSubdirectory("kcap-prodpath-lock-").FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(lockDir);
+
+        try {
+            Directory.CreateDirectory(LaunchdUnit.AgentsDir());
+            File.WriteAllText(LaunchdUnit.PlistPath(Id), DuplicateKeyPlist);
+
+            // Both launchctl seams stubbed (Query is called with and without a timeout across this
+            // test) so no real launchctl process is ever invoked — this test proves the FILE-parsing
+            // containment, not launchd interaction.
+            var manager = new LaunchdServiceManager(
+                runProcess: (_, args) => PrintNotFound(args),
+                runBounded: (_, args, _) => {
+                    var (code, stdout, stderr) = PrintNotFound(args);
+                    return (code, stdout, stderr, false);
+                });
+
+            // The `service status --json` style call: Query must NOT throw on this exact malformed
+            // unit — only report unreadable binary evidence.
+            var query = manager.Query(Id);
+            await Assert.That(query.BinaryPath).IsNull();
+            await Assert.That(query.UnitPresent).IsTrue();
+
+            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
+                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
+
+            // Default readPlist (real File.ReadAllText) and the real manager — the gate's own
+            // contained Phase-A parse is the sole authority for coded evidence classification.
+            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
+                gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
+
+            var exit = await sut.StartVerifiedAsync(Id);
+
+            await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            Environment.SetEnvironmentVariable("HOME", originalHome);
+            try { Directory.Delete(home, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
@@ -710,6 +710,110 @@ public class ServiceVerifyStartTests {
         } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); }
     }
 
+    /// <summary>Round-3 review finding #2: after the second (confirming) successful readiness
+    /// probe, the gated path must re-read the plist and re-check the digest ONE more time before
+    /// committing — the same post-readiness recheck install/replace already has — because the
+    /// recheck→exec race Phase B closes only covers the window up to bootstrap, not the window
+    /// between bootstrap and the transaction actually observing readiness. Forced-order regression:
+    /// the readPlist seam returns Phase A's content through Phase B's own recheck AND both
+    /// readiness probes, then a foreign writer's altered content on the FIRST read taken after
+    /// readiness is confirmed — proving the recheck fires post-readiness, not merely pre-bootstrap.</summary>
+    [Test]
+    public async Task Post_readiness_recheck_detects_plist_drift_after_confirmed_ready_and_rolls_back_to_29() {
+        var dir = Directory.CreateTempSubdirectory().FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        try {
+            var manager = new FakeServiceManager();
+
+            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
+                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
+
+            var reads = 0;
+            string? ReadPlist(string _) {
+                reads++;
+                // Phase A (read 1) and Phase B's own pre-bootstrap recheck (read 2) both see the
+                // same passing content — readiness is then genuinely, twice confirmed. A foreign
+                // writer swaps the plist only AFTER that, so the post-readiness recheck (read 3)
+                // must be what catches it.
+                return reads <= 2
+                    ? MinimalPlist("/bin/kcap-daemon", "prompt", GatedServerUrl)
+                    : MinimalPlist("/bin/kcap-daemon-moved", "prompt", GatedServerUrl);
+            }
+
+            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
+                readPlist: ReadPlist,
+                gateEnv: GatedEnvWithIdentity(),
+                digestMatches: _ => true);
+
+            var exit = await sut.StartVerifiedAsync(Id);
+
+            await Assert.That(exit).IsEqualTo(VerifyExit.StartGateDrift);
+            // Bootstrap DID run — this is a post-mutation catch, unlike the Phase A/B drift tests
+            // above, which never start at all.
+            await Assert.That(manager.StartCalls).IsEqualTo(1);
+            await Assert.That(ServiceTxnMarker.Exists(Id)).IsFalse();
+            await Assert.That(reads).IsGreaterThanOrEqualTo(3);
+        } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); }
+    }
+
+    /// <summary>The post-readiness recheck also re-verifies the digest, independent of plist
+    /// content drift — a swapped binary at the SAME baked path must still roll back to 29.</summary>
+    [Test]
+    public async Task Post_readiness_recheck_detects_digest_drift_after_confirmed_ready_and_rolls_back_to_29() {
+        var dir = Directory.CreateTempSubdirectory().FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        try {
+            var manager = new FakeServiceManager();
+
+            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
+                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
+
+            var digestChecks = 0;
+            bool DigestMatches(string _) {
+                digestChecks++;
+                // Passes for Phase A and Phase B's pre-bootstrap recheck; fails from the third
+                // check onward — the post-readiness recheck.
+                return digestChecks <= 2;
+            }
+
+            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
+                readPlist: _ => MinimalPlist("/bin/kcap-daemon", "prompt", GatedServerUrl),
+                gateEnv: GatedEnvWithIdentity(),
+                digestMatches: DigestMatches);
+
+            var exit = await sut.StartVerifiedAsync(Id);
+
+            await Assert.That(exit).IsEqualTo(VerifyExit.StartGateDrift);
+            await Assert.That(manager.StartCalls).IsEqualTo(1);
+            await Assert.That(ServiceTxnMarker.Exists(Id)).IsFalse();
+        } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); }
+    }
+
+    /// <summary>Negative control for finding #2: the UNGATED path (no consent-seed directive
+    /// carried by the invoker) must never run the post-readiness recheck — start behavior for a
+    /// bare terminal invocation is unchanged.</summary>
+    [Test]
+    public async Task Ungated_start_never_runs_the_post_readiness_recheck() {
+        var dir = Directory.CreateTempSubdirectory().FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        try {
+            var manager = new FakeServiceManager();
+            var readPlistCalls = 0;
+
+            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
+                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
+
+            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
+                readPlist: _ => { readPlistCalls++; return MinimalPlist("/bin/kcap-daemon", "prompt", GatedServerUrl); });
+            // no gateEnv — ungated
+
+            var exit = await sut.StartVerifiedAsync(Id);
+
+            await Assert.That(exit).IsEqualTo(VerifyExit.Ok);
+            await Assert.That(readPlistCalls).IsEqualTo(0);
+        } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); }
+    }
+
     [Test]
     public async Task Bootstrap_only_never_kickstarts_a_label_that_turned_loaded_just_before_it() {
         var dir = Directory.CreateTempSubdirectory().FullName;

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
@@ -19,9 +19,7 @@ public class ServiceVerifyStartTests {
         public string? StopError;
 
         /// <summary>Reported as <see cref="ServiceQuery.UnitPresent"/> on every <see cref="Query"/>
-        /// call. Defaults true (a plist on disk is the common case every other test scripts around);
-        /// a test simulating a genuinely absent unit sets this false so Phase A's presence check
-        /// sees absence, not just a stubbed null <c>readPlist</c>.</summary>
+        /// call. Defaults true; a genuinely-absent-unit test sets this false.</summary>
         public bool UnitPresent = true;
 
         /// <summary>When set, <see cref="StopError"/> is reported on only the FIRST <see cref="Stop"/>
@@ -463,8 +461,8 @@ public class ServiceVerifyStartTests {
         var originalErr = Console.Error;
         var capturedErr = new StringWriter();
         try {
-            // Genuinely absent unit: UnitPresent false (not just a stubbed null readPlist) so
-            // Phase A's presence check agrees the unit truly isn't there, not merely unreadable.
+            // Genuinely absent unit: readPlist returns null and plistExists is left at its
+            // (unstubbed) default false, so Phase A's discriminator reads Absent, not Unreadable.
             var manager = new FakeServiceManager { UnitPresent = false };
 
             Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
@@ -730,14 +728,9 @@ public class ServiceVerifyStartTests {
         } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); }
     }
 
-    /// <summary>After the second (confirming) successful readiness probe, the gated path must
-    /// re-read the plist and re-check the digest ONE more time before committing — the same
-    /// post-readiness recheck install/replace already has — because the recheck→exec race Phase B
-    /// closes only covers the window up to bootstrap, not the window between bootstrap and the
-    /// transaction actually observing readiness. Forced-order regression: the readPlist seam
-    /// returns Phase A's content through Phase B's own recheck AND both readiness probes, then a
-    /// foreign writer's altered content on the FIRST read taken after readiness is confirmed —
-    /// proving the recheck fires post-readiness, not merely pre-bootstrap.</summary>
+    /// <summary>The gated path re-checks the plist/digest once more after readiness is confirmed,
+    /// not just pre-bootstrap: content only drifts on the FIRST read taken after both readiness
+    /// probes already saw matching content.</summary>
     [Test]
     public async Task Post_readiness_recheck_detects_plist_drift_after_confirmed_ready_and_rolls_back_to_29() {
         var dir = Directory.CreateTempSubdirectory().FullName;

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
@@ -454,58 +454,19 @@ public class ServiceVerifyStartTests {
         _                           => null,
     };
 
+    // Contradictory evidence (query saw the unit; the read didn't) must classify
+    // evidence_unreadable, never directive_missing — that's reserved for genuine agreed-absence.
     [Test, NotInParallel]
-    public async Task Pre_mutation_gate_failure_returns_28_and_touches_nothing() {
+    [Arguments(false, "directive_missing")]   // query and read agree the unit is absent
+    [Arguments(true, "evidence_unreadable")]  // query saw the unit but the read reports absent
+    public async Task Phase_a_absence_evidence_disambiguates_directive_missing_from_evidence_unreadable(
+        bool unitPresent, string expectedReason) {
         var dir = Directory.CreateTempSubdirectory().FullName;
         DaemonLockPaths.OverrideDirectoryForTesting(dir);
         var originalErr = Console.Error;
         var capturedErr = new StringWriter();
         try {
-            // Genuinely absent unit: readPlist returns null and plistExists is left at its
-            // (unstubbed) default false, so Phase A's discriminator reads Absent, not Unreadable.
-            var manager = new FakeServiceManager { UnitPresent = false };
-
-            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
-                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
-
-            // The unit bakes nothing (readPlist "sees" no unit) while this invocation carries the
-            // consent-seed directive — Phase A's DirectiveMissing case — so the gate must fire
-            // before the fresh query's under-lock work does anything else.
-            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
-                readPlist: _ => null,
-                gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
-
-            Console.SetError(capturedErr);
-            var exit = await sut.StartVerifiedAsync(Id);
-            Console.SetError(originalErr);
-
-            await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
-            var lines = capturedErr.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-            // Genuine absence is DirectiveMissing, never EvidenceUnreadable — that reason is
-            // reserved for a unit that IS present but couldn't be read (see
-            // ServiceVerifyStartGateProductionPathTests).
-            await Assert.That(lines).Contains("start_gate_reason=directive_missing");
-            await Assert.That(manager.Calls.Count).IsEqualTo(1);
-            await Assert.That(manager.Calls.All(c => c == "query")).IsTrue();
-            await Assert.That(ServiceTxnMarker.Exists(Id)).IsFalse();
-        } finally {
-            Console.SetError(originalErr);
-            DaemonLockPaths.OverrideDirectoryForTesting(null);
-        }
-    }
-
-    /// <summary>The forced-order race the sibling test above does NOT cover: the fresh query
-    /// observed the unit present, but the plist read seam reports genuine absence (a lock-unaware
-    /// writer deleted it in the window between the two). Contradictory evidence must never fall
-    /// through to the agreeing-absence case's takeover-safe directive_missing.</summary>
-    [Test, NotInParallel]
-    public async Task Query_sees_the_unit_but_the_read_does_not_is_evidence_unreadable_not_directive_missing() {
-        var dir = Directory.CreateTempSubdirectory().FullName;
-        DaemonLockPaths.OverrideDirectoryForTesting(dir);
-        var originalErr = Console.Error;
-        var capturedErr = new StringWriter();
-        try {
-            var manager = new FakeServiceManager { UnitPresent = true };
+            var manager = new FakeServiceManager { UnitPresent = unitPresent };
 
             Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
                 Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
@@ -521,7 +482,7 @@ public class ServiceVerifyStartTests {
 
             await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
             var lines = capturedErr.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-            await Assert.That(lines).Contains("start_gate_reason=evidence_unreadable");
+            await Assert.That(lines).Contains($"start_gate_reason={expectedReason}");
             await Assert.That(manager.Calls.Count).IsEqualTo(1);
             await Assert.That(manager.Calls.All(c => c == "query")).IsTrue();
             await Assert.That(ServiceTxnMarker.Exists(Id)).IsFalse();

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
@@ -494,6 +494,43 @@ public class ServiceVerifyStartTests {
         }
     }
 
+    /// <summary>The forced-order race the sibling test above does NOT cover: the fresh query
+    /// observed the unit present, but the plist read seam reports genuine absence (a lock-unaware
+    /// writer deleted it in the window between the two). Contradictory evidence must never fall
+    /// through to the agreeing-absence case's takeover-safe directive_missing.</summary>
+    [Test, NotInParallel]
+    public async Task Query_sees_the_unit_but_the_read_does_not_is_evidence_unreadable_not_directive_missing() {
+        var dir = Directory.CreateTempSubdirectory().FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        var originalErr = Console.Error;
+        var capturedErr = new StringWriter();
+        try {
+            var manager = new FakeServiceManager { UnitPresent = true };
+
+            Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
+                Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
+
+            var sut = new ServiceVerify(manager, _ => 4242, Hello, TimeProvider.System,
+                readPlist: _ => null,
+                plistExists: _ => false,
+                gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
+
+            Console.SetError(capturedErr);
+            var exit = await sut.StartVerifiedAsync(Id);
+            Console.SetError(originalErr);
+
+            await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
+            var lines = capturedErr.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            await Assert.That(lines).Contains("start_gate_reason=evidence_unreadable");
+            await Assert.That(manager.Calls.Count).IsEqualTo(1);
+            await Assert.That(manager.Calls.All(c => c == "query")).IsTrue();
+            await Assert.That(ServiceTxnMarker.Exists(Id)).IsFalse();
+        } finally {
+            Console.SetError(originalErr);
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+        }
+    }
+
     [Test]
     public async Task Plist_drift_between_phase_a_and_phase_b_rolls_back_to_29_without_ever_starting() {
         var dir = Directory.CreateTempSubdirectory().FullName;

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
@@ -18,6 +18,12 @@ public class ServiceVerifyStartTests {
         public int? RunningPid = 4242;
         public string? StopError;
 
+        /// <summary>Reported as <see cref="ServiceQuery.UnitPresent"/> on every <see cref="Query"/>
+        /// call. Defaults true (a plist on disk is the common case every other test scripts around);
+        /// a test simulating a genuinely absent unit sets this false so Phase A's presence check
+        /// sees absence, not just a stubbed null <c>readPlist</c>.</summary>
+        public bool UnitPresent = true;
+
         /// <summary>When set, <see cref="StopError"/> is reported on only the FIRST <see cref="Stop"/>
         /// call and cleared thereafter — for scripting a bootout that fails once (e.g. a foreign
         /// writer momentarily holding the label) but succeeds on Rollback's own re-attempt.</summary>
@@ -54,15 +60,15 @@ public class ServiceVerifyStartTests {
             if (Started && HangQueryClock is not null) HangQueryClock.Advance(timeout);
             if (Stopped) {
                 if (ProbeUnknownAfterStop)
-                    return new ServiceQuery(LabelProbe.Unknown, true, ServiceState.Installed, "/bin/kcap-daemon", null);
+                    return new ServiceQuery(LabelProbe.Unknown, UnitPresent, ServiceState.Installed, "/bin/kcap-daemon", null);
                 if (RemainsLoadedUntilSecondStop && StopCalls < 2)
-                    return new ServiceQuery(LabelProbe.Loaded, true, ServiceState.Running, "/bin/kcap-daemon", RunningPid);
+                    return new ServiceQuery(LabelProbe.Loaded, UnitPresent, ServiceState.Running, "/bin/kcap-daemon", RunningPid);
                 if (!RemainsLoadedAfterStop)
-                    return new ServiceQuery(LabelProbe.Absent, true, ServiceState.Installed, "/bin/kcap-daemon", null);
+                    return new ServiceQuery(LabelProbe.Absent, UnitPresent, ServiceState.Installed, "/bin/kcap-daemon", null);
             }
             if (Started)
-                return new ServiceQuery(LabelProbe.Loaded, true, ServiceState.Running, "/bin/kcap-daemon", RunningPid);
-            return new ServiceQuery(LabelProbe.Absent, true, ServiceState.Installed, "/bin/kcap-daemon", null);
+                return new ServiceQuery(LabelProbe.Loaded, UnitPresent, ServiceState.Running, "/bin/kcap-daemon", RunningPid);
+            return new ServiceQuery(LabelProbe.Absent, UnitPresent, ServiceState.Installed, "/bin/kcap-daemon", null);
         }
 
         public void WriteAndBootstrap(ServiceSpec spec, TimeSpan timeout) { }
@@ -450,12 +456,16 @@ public class ServiceVerifyStartTests {
         _                           => null,
     };
 
-    [Test]
+    [Test, NotInParallel]
     public async Task Pre_mutation_gate_failure_returns_28_and_touches_nothing() {
         var dir = Directory.CreateTempSubdirectory().FullName;
         DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        var originalErr = Console.Error;
+        var capturedErr = new StringWriter();
         try {
-            var manager = new FakeServiceManager();
+            // Genuinely absent unit: UnitPresent false (not just a stubbed null readPlist) so
+            // Phase A's presence check agrees the unit truly isn't there, not merely unreadable.
+            var manager = new FakeServiceManager { UnitPresent = false };
 
             Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
                 Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
@@ -467,13 +477,23 @@ public class ServiceVerifyStartTests {
                 readPlist: _ => null,
                 gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
 
+            Console.SetError(capturedErr);
             var exit = await sut.StartVerifiedAsync(Id);
+            Console.SetError(originalErr);
 
             await Assert.That(exit).IsEqualTo(VerifyExit.StartGate);
+            var lines = capturedErr.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+            // Genuine absence is DirectiveMissing, never EvidenceUnreadable — that reason is
+            // reserved for a unit that IS present but couldn't be read (see
+            // ServiceVerifyStartGateProductionPathTests).
+            await Assert.That(lines).Contains("start_gate_reason=directive_missing");
             await Assert.That(manager.Calls.Count).IsEqualTo(1);
             await Assert.That(manager.Calls.All(c => c == "query")).IsTrue();
             await Assert.That(ServiceTxnMarker.Exists(Id)).IsFalse();
-        } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); }
+        } finally {
+            Console.SetError(originalErr);
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+        }
     }
 
     [Test]
@@ -710,14 +730,14 @@ public class ServiceVerifyStartTests {
         } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); }
     }
 
-    /// <summary>Round-3 review finding #2: after the second (confirming) successful readiness
-    /// probe, the gated path must re-read the plist and re-check the digest ONE more time before
-    /// committing — the same post-readiness recheck install/replace already has — because the
-    /// recheck→exec race Phase B closes only covers the window up to bootstrap, not the window
-    /// between bootstrap and the transaction actually observing readiness. Forced-order regression:
-    /// the readPlist seam returns Phase A's content through Phase B's own recheck AND both
-    /// readiness probes, then a foreign writer's altered content on the FIRST read taken after
-    /// readiness is confirmed — proving the recheck fires post-readiness, not merely pre-bootstrap.</summary>
+    /// <summary>After the second (confirming) successful readiness probe, the gated path must
+    /// re-read the plist and re-check the digest ONE more time before committing — the same
+    /// post-readiness recheck install/replace already has — because the recheck→exec race Phase B
+    /// closes only covers the window up to bootstrap, not the window between bootstrap and the
+    /// transaction actually observing readiness. Forced-order regression: the readPlist seam
+    /// returns Phase A's content through Phase B's own recheck AND both readiness probes, then a
+    /// foreign writer's altered content on the FIRST read taken after readiness is confirmed —
+    /// proving the recheck fires post-readiness, not merely pre-bootstrap.</summary>
     [Test]
     public async Task Post_readiness_recheck_detects_plist_drift_after_confirmed_ready_and_rolls_back_to_29() {
         var dir = Directory.CreateTempSubdirectory().FullName;
@@ -789,9 +809,9 @@ public class ServiceVerifyStartTests {
         } finally { DaemonLockPaths.OverrideDirectoryForTesting(null); }
     }
 
-    /// <summary>Negative control for finding #2: the UNGATED path (no consent-seed directive
-    /// carried by the invoker) must never run the post-readiness recheck — start behavior for a
-    /// bare terminal invocation is unchanged.</summary>
+    /// <summary>The UNGATED path (no consent-seed directive carried by the invoker) must never run
+    /// the post-readiness recheck — start behavior for a bare terminal invocation is
+    /// unchanged.</summary>
     [Test]
     public async Task Ungated_start_never_runs_the_post_readiness_recheck() {
         var dir = Directory.CreateTempSubdirectory().FullName;

--- a/test/Capacitor.Cli.Tests.Unit/Setup/AgentDetectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Setup/AgentDetectionTests.cs
@@ -119,6 +119,21 @@ public class AgentDetectionTests {
     }
 
     [Test]
+    public async Task BinaryOnPath_dedupes_a_repeated_PATH_entry() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var dir    = Directory.CreateTempSubdirectory("kcap-detect-dedupe-").FullName;
+        var claude = Path.Combine(dir, "claude");
+        await File.WriteAllTextAsync(claude, "#!/bin/sh\n");
+        File.SetUnixFileMode(claude, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+        // The same directory repeated three times must still be found (and probed only once per
+        // Distinct dir, not once per occurrence).
+        var pathEnv = $"{dir}{Path.PathSeparator}{dir}{Path.PathSeparator}{dir}";
+        await Assert.That(AgentDetection.BinaryOnPath("claude", Inputs(pathEnv: pathEnv))).IsTrue();
+    }
+
+    [Test]
     public async Task BinaryOnPath_skips_empty_path_entries_without_throwing() {
         if (OperatingSystem.IsWindows()) return;
 
@@ -216,7 +231,7 @@ public class AgentDetectionTests {
     }
 
     // ── BinaryOnPath separator is derived from the injected platform, never the host-global
-    // Path.PathSeparator (round-3 review finding #6) — pin both directions purely. ──
+    // Path.PathSeparator — pin both directions purely. ──
 
     [Test]
     public async Task BinaryOnPath_windows_input_splits_on_semicolon_regardless_of_host_platform() {

--- a/test/Capacitor.Cli.Tests.Unit/Setup/AgentDetectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Setup/AgentDetectionTests.cs
@@ -192,33 +192,14 @@ public class AgentDetectionTests {
         await Assert.That(inputs.IsWindows).IsEqualTo(OperatingSystem.IsWindows());
     }
 
-    // ── BinaryOnPath(string): the single-arg convenience overload (FromEnvironment() + the pure
-    // walk), against the REAL process environment — what call sites moved off AgentDetector to. ──
+    // ── BinaryOnPath(string): the single-arg convenience overload is documented as nothing more
+    // than FromEnvironment() + the pure walk (see AgentDetection.cs) — FromEnvironment_reads_the_
+    // real_process_PATH above already smoke-tests that wiring. The edge cases below (empty/null
+    // PATH, exec-bit requirement) are therefore driven through the pure 2-arg overload with
+    // injected inputs — never mutating real process PATH — so nothing here needs NotInParallel. ──
 
-    [Test, NotInParallel("PATH_env_mutation")]
-    public async Task BinaryOnPath_single_arg_returns_false_when_path_env_is_empty() {
-        var original = Environment.GetEnvironmentVariable("PATH");
-        Environment.SetEnvironmentVariable("PATH", "");
-        try {
-            await Assert.That(AgentDetection.BinaryOnPath("anything-at-all")).IsFalse();
-        } finally {
-            Environment.SetEnvironmentVariable("PATH", original);
-        }
-    }
-
-    [Test, NotInParallel("PATH_env_mutation")]
-    public async Task BinaryOnPath_single_arg_returns_false_when_path_env_is_null() {
-        var original = Environment.GetEnvironmentVariable("PATH");
-        Environment.SetEnvironmentVariable("PATH", null);
-        try {
-            await Assert.That(AgentDetection.BinaryOnPath("anything-at-all")).IsFalse();
-        } finally {
-            Environment.SetEnvironmentVariable("PATH", original);
-        }
-    }
-
-    [Test, NotInParallel("PATH_env_mutation")]
-    public async Task BinaryOnPath_single_arg_unix_requires_any_execute_bit() {
+    [Test]
+    public async Task BinaryOnPath_pure_unix_requires_any_execute_bit() {
         if (OperatingSystem.IsWindows()) return; // Unix-only
 
         var tmp     = Directory.CreateTempSubdirectory("kcap-agentprobe-").FullName;
@@ -230,13 +211,39 @@ public class AgentDetectionTests {
         File.SetUnixFileMode(exec,    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);   // 0700
         File.SetUnixFileMode(nonExec, UnixFileMode.UserRead | UnixFileMode.UserWrite);                              // 0600
 
-        var original = Environment.GetEnvironmentVariable("PATH");
-        Environment.SetEnvironmentVariable("PATH", tmp);
-        try {
-            await Assert.That(AgentDetection.BinaryOnPath("agentprobe-exec")).IsTrue();
-            await Assert.That(AgentDetection.BinaryOnPath("agentprobe-nonexec")).IsFalse();
-        } finally {
-            Environment.SetEnvironmentVariable("PATH", original);
-        }
+        await Assert.That(AgentDetection.BinaryOnPath("agentprobe-exec", Inputs(pathEnv: tmp))).IsTrue();
+        await Assert.That(AgentDetection.BinaryOnPath("agentprobe-nonexec", Inputs(pathEnv: tmp))).IsFalse();
+    }
+
+    // ── BinaryOnPath separator is derived from the injected platform, never the host-global
+    // Path.PathSeparator (round-3 review finding #6) — pin both directions purely. ──
+
+    [Test]
+    public async Task BinaryOnPath_windows_input_splits_on_semicolon_regardless_of_host_platform() {
+        var dir = Directory.CreateTempSubdirectory("kcap-detect-winsep-").FullName;
+        await File.WriteAllTextAsync(Path.Combine(dir, "claude.CMD"), "@echo off\n");
+
+        var otherDir = Directory.CreateTempSubdirectory("kcap-detect-winsep2-").FullName;
+        var winInputs = new AgentDetectionInputs(
+            PathEnv: $"{otherDir};{dir}", PathExt: ".EXE;.CMD", IsWindows: true, Home: "/nonexistent");
+
+        // A colon-joined PATH would be read as ONE bogus entry under a semicolon split and never
+        // find claude.CMD in `dir` — this only passes if the separator is genuinely ';' here.
+        await Assert.That(AgentDetection.BinaryOnPath("claude", winInputs)).IsTrue();
+    }
+
+    [Test]
+    public async Task BinaryOnPath_unix_input_splits_on_colon() {
+        if (OperatingSystem.IsWindows()) return; // exec-bit semantics only make sense on Unix
+
+        var dir = Directory.CreateTempSubdirectory("kcap-detect-unixsep-").FullName;
+        var claude = Path.Combine(dir, "claude");
+        await File.WriteAllTextAsync(claude, "#!/bin/sh\n");
+        File.SetUnixFileMode(claude, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+        var otherDir = Directory.CreateTempSubdirectory("kcap-detect-unixsep2-").FullName;
+        var r = AgentDetection.Detect(Inputs(pathEnv: $"{otherDir}:{dir}", home: "/nonexistent"));
+
+        await Assert.That(r.Claude.BinaryFound).IsTrue();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Setup/AgentDetectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Setup/AgentDetectionTests.cs
@@ -134,6 +134,53 @@ public class AgentDetectionTests {
     }
 
     [Test]
+    public async Task BinaryOnPath_windows_dedupes_case_variant_directories() {
+        var probed = new List<string>();
+        bool CountingProbe(string path, bool isWindows) { probed.Add(path); return false; }
+
+        var winInputs = new AgentDetectionInputs(
+            PathEnv: @"C:\Tools;c:\tools;C:\TOOLS", PathExt: ".EXE", IsWindows: true, Home: "/nonexistent");
+
+        AgentDetection.BinaryOnPath("claude", winInputs, CountingProbe);
+
+        // Three case-variant spellings of the same directory collapse to ONE probed candidate
+        // (one extension × one deduped dir) under Windows' case-insensitive PATH identity.
+        await Assert.That(probed.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task BinaryOnPath_unix_dedupes_same_case_duplicate_directories() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var probed = new List<string>();
+        bool CountingProbe(string path, bool isWindows) { probed.Add(path); return false; }
+
+        var inputs = new AgentDetectionInputs(
+            PathEnv: "/usr/bin:/usr/bin:/usr/bin", PathExt: null, IsWindows: false, Home: "/nonexistent");
+
+        AgentDetection.BinaryOnPath("claude", inputs, CountingProbe);
+
+        await Assert.That(probed.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task BinaryOnPath_unix_probes_case_variant_directories_separately() {
+        if (OperatingSystem.IsWindows()) return;
+
+        var probed = new List<string>();
+        bool CountingProbe(string path, bool isWindows) { probed.Add(path); return false; }
+
+        var inputs = new AgentDetectionInputs(
+            PathEnv: "/usr/bin:/USR/BIN", PathExt: null, IsWindows: false, Home: "/nonexistent");
+
+        AgentDetection.BinaryOnPath("claude", inputs, CountingProbe);
+
+        // Unix PATH identity is case-sensitive — these are two genuinely distinct directories,
+        // each probed once, unlike Windows' case-insensitive dedup above.
+        await Assert.That(probed.Count).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task BinaryOnPath_skips_empty_path_entries_without_throwing() {
         if (OperatingSystem.IsWindows()) return;
 


### PR DESCRIPTION
Part of #553. AI-1655. Follow-up to #554, which merged mid-review — this carries the code-review flow's round-3 findings.

- **Query is total again**: the hardened (throwing) plist parsers no longer escape `manager.Query` as uncoded failures — state/PID probing is separated from fallible evidence reads (`BinaryPath` null on any parse failure), while the gate's own contained Phase-A parse remains the coded authority (`evidence_unreadable`), now pinned through the production path, not just the leaf parser.
- **Gated start gains the post-readiness recheck** the spec requires (plist + digest re-verified after readiness, exit-29 marker-backed rollback on drift) — closing the recheck→exec bound the install/replace paths already had.
- **`EnvFromPlist` rejects malformed keyed structures** (non-dict `EnvironmentVariables`, non-string values, broken key/value alternation) as unreadable evidence instead of silently returning empty/partial maps; the keyed top-level traversal is centralized in one shared helper.
- **`TryLoadPure` distinguishes inaccessible from absent** (direct open; not-found stays absent-with-defaults, permission/IO failures fail closed to the attention path).
- **`StartBootstrapOnly` honors one deadline** across both launchctl calls instead of double-spending the forward budget into the rollback reserve.
- **`AgentDetection`** derives the PATH separator from the injected platform, and its tests no longer mutate process env.
- Comment trims + `JsonElementExtensions` conformance.

All targeted suites green; full build clean; both AOT publishes warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)