### PR TITLE
Daemon: stand down cleanly on ACP bind rejection; self-terminalize forwarder

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1072,6 +1072,7 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(AcpEventEnvelope))]
 [JsonSerializable(typeof(AcpEventEnvelope[]))]
 [JsonSerializable(typeof(AcpBatchAck))]
+[JsonSerializable(typeof(AcpBindOutcome))]
 [JsonSerializable(typeof(TranscriptBatchAck))]
 // The AcpSessionStarted hub method's optional metadata argument. Registered as its own root type
 // (not just nested inside another JsonSerializable graph) because SignalR's JsonHubProtocol
@@ -1291,8 +1292,23 @@ public readonly record struct AcpEventEnvelope(
 /// (resend from <see cref="ExpectedNextSeq"/> on a gap; a terminal-drop ack
 /// has <see cref="AcceptedSeq"/> below the daemon's max-sent seq AND a null
 /// <see cref="ExpectedNextSeq"/>).
+/// <para>
+/// <see cref="Rejected"/> is set on a stale-binding rejection (missing agent, foreign
+/// connection, or unbound/terminal session). The server returns the canonical rejection ack
+/// <c>(-1, -1, null, true)</c> instead of throwing; the forwarder terminalizes on it. An old daemon
+/// (no <see cref="Rejected"/> field) still stops because <see cref="AcceptedSeq"/> == -1 is below any
+/// real max-sent seq, which trips the terminal-drop path above.
+/// </para>
 /// </summary>
-public readonly record struct AcpBatchAck(long AcceptedSeq, long PersistedSeq, long? ExpectedNextSeq = null);
+public readonly record struct AcpBatchAck(long AcceptedSeq, long PersistedSeq, long? ExpectedNextSeq = null, bool Rejected = false);
+
+/// <summary>
+/// outcome of the server's <c>AcpSessionStarted</c> hub method — a field-for-field mirror of
+/// the server-side <c>Capacitor.Server.Core.Acp.AcpBindOutcome</c>. <see cref="Bound"/> is <c>0</c> so
+/// an OLD server's void return decodes to it (legacy success). <see cref="Rejected"/> means the server
+/// declined a stale/foreign/conflicting binding; the daemon stands down without a retry storm.
+/// </summary>
+public enum AcpBindOutcome { Bound = 0, Rejected = 1 }
 
 /// <summary>
 /// Ack returned from the server's <c>SendTranscriptBatchAcked</c> hub method (D3).

--- a/src/Capacitor.Cli.Daemon/Services/AcpTranscriptForwarder.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpTranscriptForwarder.cs
@@ -178,6 +178,19 @@ internal sealed class AcpTranscriptForwarder {
 
                 var ack = await SendWithRetryAsync(batch, ct).ConfigureAwait(false);
 
+                // the server explicitly rejected this binding (stale/foreign/unbound). Stop
+                // BEFORE interpreting the gap/cursor fields — the rejection ack deliberately carries a
+                // -1 AcceptedSeq that would otherwise read as a terminal-drop anyway, but checking the
+                // flag first keeps the intent explicit. An old server never sets this; that path still
+                // stops via the AcceptedSeq < _highestSent terminal-drop below.
+                if (ack.Rejected) {
+                    LogRejectedBinding();
+                    _unacked.Clear();
+                    IsTerminal = true;
+
+                    return;
+                }
+
                 if (ack.ExpectedNextSeq is { } expectedNextSeq) {
                     // A legitimate gap resolves on the first resend (the server wanted an earlier seq,
                     // then catches up — a NEW ExpectedNextSeq each round = progress). But the server's
@@ -279,6 +292,10 @@ internal sealed class AcpTranscriptForwarder {
         _logger.LogWarning(
             "ACP transcript forwarder: terminal-drop ack (AcceptedSeq={AcceptedSeq} < highest-sent={HighestSent}) — the server-side binding is terminal; stopping.",
             acceptedSeq, highestSent);
+
+    void LogRejectedBinding() =>
+        _logger.LogInformation(
+            "ACP transcript forwarder: server returned a rejection ack (stale/foreign/unbound binding) — stopping.");
 
     void LogSendFailed(Exception ex, long firstSeq, long lastSeq, TimeSpan delay) =>
         _logger.LogDebug(

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1048,13 +1048,37 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// <see cref="UnregisterAcpBinding"/> removes it so a LATER reconnect doesn't replay it either.
     /// </summary>
     internal async Task ReBindAcpSessionsAsync() {
+        // belt-and-braces: never replay a binding whose agent the daemon no longer hosts as
+        // live. _acpBindings is maintained independently of the live-agent set, so a stale entry to a
+        // gone agent is exactly the binding the server now rejects. GetLiveAgentIds is the same source
+        // the reconnect survivor set uses; when it isn't wired (tests) we skip the pre-filter.
+        var live = GetLiveAgentIds is { } getLive ? new HashSet<string>(getLive(), StringComparer.Ordinal) : null;
+
         foreach (var (agentId, bind) in _acpBindings) {
-            var rebound = false;
+            if (live is not null && !live.Contains(agentId)) {
+                LogAcpRebindSkippedNotLive(agentId, bind.AcpSessionId);
+                UnregisterAcpBinding(agentId);
+
+                continue;
+            }
+
+            var settled = false; // the invoke returned an OUTCOME (Bound or Rejected): stop, don't give up
 
             for (var attempt = 1; attempt <= AcpRebindMaxAttempts; attempt++) {
                 try {
-                    await InvokeAcpSessionStartedRawAsync(agentId, bind.Vendor, bind.AcpSessionId, bind.Cwd, bind.Model, bind.Metadata, _ct);
-                    rebound = true;
+                    var outcome = await InvokeAcpSessionStartedRawAsync(agentId, bind.Vendor, bind.AcpSessionId, bind.Cwd, bind.Model, bind.Metadata, _ct);
+
+                    // a Rejected outcome is a terminal stand-down, not a transient failure —
+                    // the server declined a stale/foreign/conflicting binding. Drop the binding (so a
+                    // later reconnect doesn't replay it) and move on WITHOUT retrying; the agent's
+                    // forwarder terminalizes independently on the matching AcpSessionEvents rejection
+                    // ack. An old server (void return) decodes as Bound, preserving today's behaviour.
+                    if (outcome == AcpBindOutcome.Rejected) {
+                        LogAcpRebindRejected(agentId, bind.AcpSessionId);
+                        UnregisterAcpBinding(agentId);
+                    }
+
+                    settled = true;
 
                     break;
                 } catch (Exception ex) {
@@ -1070,7 +1094,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 }
             }
 
-            if (!rebound) {
+            if (!settled) {
                 LogAcpRebindGivingUp(agentId, bind.AcpSessionId, AcpRebindMaxAttempts);
                 UnregisterAcpBinding(agentId);
             }
@@ -1086,7 +1110,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// class's own <see cref="ReBindAcpSessionsAsync"/> reconnect path) may invoke the underlying hub
     /// method again freely — a redundant re-bind is harmless even if the two race.
     /// </summary>
-    public virtual Task AcpSessionStartedAsync(
+    public virtual async Task AcpSessionStartedAsync(
             string                               agentId,
             string                               vendor,
             string                               acpSessionId,
@@ -1094,13 +1118,22 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             string?                              model,
             IReadOnlyDictionary<string, string>? metadata,
             CancellationToken                    ct = default
-        ) => ConnectionRetry.InvokeWithConnectionRetryAsync(
+        ) {
+        var outcome = await ConnectionRetry.InvokeWithConnectionRetryAsync(
             () => InvokeAcpSessionStartedRawAsync(agentId, vendor, acpSessionId, cwd, model, metadata, ct),
             () => IsReady,
             AcpRetryPollInterval,
             attempt => LogAcpSessionStartedRetry(agentId, attempt),
             ct
-        );
+        ).ConfigureAwait(false);
+
+        // an INITIAL bind that the server declines (stale/foreign/conflict) must NOT register
+        // a binding or start a forwarder. Surface it as a local exception (never a HubException) so the
+        // launch path's existing "bind threw ⇒ don't register" catch handles it unchanged. Reason-
+        // agnostic: any Rejected origin maps here. An old server's void return decodes to Bound.
+        if (outcome == AcpBindOutcome.Rejected)
+            throw new AcpBindRejectedException(agentId, acpSessionId);
+    }
 
     /// <summary>
     /// Forwards a batch of ACP transcript envelopes to the server's <c>AcpSessionEvents</c> hub
@@ -1130,7 +1163,11 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// <see cref="ReBindAcpSessionsAsync"/> (ungated, see its remarks) share one call site, and so
     /// unit tests can capture/verify the exact payload without a live hub connection.
     /// </summary>
-    internal virtual Task InvokeAcpSessionStartedRawAsync(
+    /// returns the server's <see cref="AcpBindOutcome"/>. An OLD server whose hub method is
+    /// still <c>void</c> completes with no result, which <c>InvokeAsync&lt;AcpBindOutcome&gt;</c> decodes
+    /// to <c>default</c> == <see cref="AcpBindOutcome.Bound"/> — legacy success, preserving today's
+    /// behaviour against an un-upgraded server.
+    internal virtual Task<AcpBindOutcome> InvokeAcpSessionStartedRawAsync(
             string                               agentId,
             string                               vendor,
             string                               acpSessionId,
@@ -1138,7 +1175,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             string?                              model,
             IReadOnlyDictionary<string, string>? metadata,
             CancellationToken                    ct
-        ) => _hub.InvokeAsync("AcpSessionStarted", agentId, vendor, acpSessionId, cwd, model, metadata, cancellationToken: ct);
+        ) => _hub.InvokeAsync<AcpBindOutcome>("AcpSessionStarted", agentId, vendor, acpSessionId, cwd, model, metadata, cancellationToken: ct);
 
     /// <summary>
     /// The actual <c>AcpSessionEvents</c> hub invocation, isolated into its own <c>virtual</c> method
@@ -1384,6 +1421,12 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     [LoggerMessage(Level = LogLevel.Warning, Message = "Reconnect re-bind of ACP session {AcpSessionId} for agent {AgentId} failed after {MaxAttempts} attempts — unregistering the binding so it isn't replayed forever")]
     partial void LogAcpRebindGivingUp(string agentId, string acpSessionId, int maxAttempts);
 
+    [LoggerMessage(Level = LogLevel.Information, Message = "Reconnect re-bind of ACP session {AcpSessionId} for agent {AgentId} was rejected by the server (stale/foreign/conflicting binding) — standing down and unregistering the binding")]
+    partial void LogAcpRebindRejected(string agentId, string acpSessionId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Skipping reconnect re-bind of ACP session {AcpSessionId} for agent {AgentId} — the agent is no longer hosted as live; unregistering the stale binding")]
+    partial void LogAcpRebindSkippedNotLive(string agentId, string acpSessionId);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to post agent run event, retrying in {Delay}s")]
     partial void LogEventPostFailed(Exception ex, double delay);
 
@@ -1449,3 +1492,17 @@ internal sealed record AcpBindInfo(
     string?                              Model,
     IReadOnlyDictionary<string, string>? Metadata = null
 );
+
+/// <summary>
+/// thrown by <see cref="ServerConnection.AcpSessionStartedAsync"/> when the server declines
+/// an INITIAL bind (a stale/foreign/conflicting binding, surfaced as <see cref="AcpBindOutcome.Rejected"/>).
+/// A LOCAL exception, never a <c>HubException</c>, so the launch path's existing "bind threw ⇒ do not
+/// register a binding / do not start a forwarder" catch handles it unchanged. The reconnect path
+/// (<see cref="ServerConnection.ReBindAcpSessionsAsync"/>) reads the outcome directly and never throws
+/// this.
+/// </summary>
+internal sealed class AcpBindRejectedException(string agentId, string acpSessionId)
+    : Exception($"Server rejected the ACP bind for agent {agentId} (session {acpSessionId})") {
+    public string AgentId      { get; } = agentId;
+    public string AcpSessionId { get; } = acpSessionId;
+}

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpServerConnectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpServerConnectionTests.cs
@@ -48,7 +48,11 @@ public class AcpServerConnectionTests {
         /// and transient-failure-then-recover cases. Absent/zero entries always succeed.</summary>
         public Dictionary<string, int> FailSessionStartedRemaining { get; } = [];
 
-        internal override Task InvokeAcpSessionStartedRawAsync(
+        /// <summary>agent ids whose raw AcpSessionStarted invoke should return
+        /// <see cref="AcpBindOutcome.Rejected"/> (a server stand-down, NOT a thrown transport failure).</summary>
+        public HashSet<string> RejectSessionStarted { get; } = [];
+
+        internal override Task<AcpBindOutcome> InvokeAcpSessionStartedRawAsync(
                 string agentId, string vendor, string acpSessionId, string? cwd, string? model,
                 IReadOnlyDictionary<string, string>? metadata, CancellationToken ct
             ) {
@@ -58,10 +62,10 @@ public class AcpServerConnectionTests {
             if (FailSessionStartedRemaining.TryGetValue(agentId, out var remaining) && remaining > 0) {
                 FailSessionStartedRemaining[agentId] = remaining - 1;
 
-                return Task.FromException(new InvalidOperationException($"simulated AcpSessionStarted failure for {agentId}"));
+                return Task.FromException<AcpBindOutcome>(new InvalidOperationException($"simulated AcpSessionStarted failure for {agentId}"));
             }
 
-            return Task.CompletedTask;
+            return Task.FromResult(RejectSessionStarted.Contains(agentId) ? AcpBindOutcome.Rejected : AcpBindOutcome.Bound);
         }
 
         internal override Task<AcpBatchAck> InvokeAcpSessionEventsRawAsync(
@@ -256,6 +260,85 @@ public class AcpServerConnectionTests {
 
         await Assert.That(conn.SessionStartedCalls.Count(c => c.AgentId == "agentB")).IsEqualTo(1);
         await Assert.That(conn.SessionStartedCalls.Count(c => c.AgentId == "agentA")).IsEqualTo(ServerConnection.AcpRebindMaxAttempts);
+    }
+
+    // ── reconnect re-bind stand-down on a server Rejected outcome ────────────────────────
+
+    /// <summary>
+    /// a <see cref="AcpBindOutcome.Rejected"/> outcome is a terminal stand-down, NOT a
+    /// transient failure — the server declined a stale/foreign/conflicting binding. It must be
+    /// invoked exactly ONCE (no 3× retry storm) and the binding unregistered so a later reconnect
+    /// never replays it.
+    /// </summary>
+    [Test]
+    public async Task ReBindAcpSessionsAsync_stands_down_without_retrying_on_a_Rejected_outcome() {
+        var conn = new TestServerConnection();
+        conn.AcpRebindRetryDelay = TimeSpan.FromMilliseconds(5);
+
+        conn.RegisterAcpBinding("agentA", new AcpBindInfo("cursor", "sess-a", "/wt-a", null));
+        conn.RejectSessionStarted.Add("agentA");
+
+        await conn.ReBindAcpSessionsAsync().WaitAsync(HangGuard);
+
+        // Exactly one attempt — no retry storm.
+        await Assert.That(conn.SessionStartedCalls.Count(c => c.AgentId == "agentA")).IsEqualTo(1);
+
+        // Unregistered: a later reconnect replays nothing for agentA.
+        var callsBefore = conn.SessionStartedCalls.Count;
+        await conn.ReBindAcpSessionsAsync().WaitAsync(HangGuard);
+        await Assert.That(conn.SessionStartedCalls.Count).IsEqualTo(callsBefore);
+    }
+
+    /// <summary>
+    /// belt-and-braces: a binding whose agent is no longer hosted as live (per
+    /// <see cref="ServerConnection.GetLiveAgentIds"/>) is not replayed at all — it is skipped and
+    /// unregistered, so the server is never asked to bind a gone agent.
+    /// </summary>
+    [Test]
+    public async Task ReBindAcpSessionsAsync_skips_and_unregisters_a_binding_whose_agent_is_not_live() {
+        var conn = new TestServerConnection { GetLiveAgentIds = () => ["agentLive"] };
+
+        conn.RegisterAcpBinding("agentGone", new AcpBindInfo("cursor", "sess-gone", "/wt", null));
+        conn.RegisterAcpBinding("agentLive", new AcpBindInfo("cursor", "sess-live", "/wt", null));
+
+        await conn.ReBindAcpSessionsAsync().WaitAsync(HangGuard);
+
+        // The gone agent was never re-bound; the live one was.
+        await Assert.That(conn.SessionStartedCalls.Count(c => c.AgentId == "agentGone")).IsEqualTo(0);
+        await Assert.That(conn.SessionStartedCalls.Count(c => c.AgentId == "agentLive")).IsEqualTo(1);
+
+        // agentGone's stale binding was unregistered — a later reconnect (even without the live gate)
+        // never replays it.
+        conn.GetLiveAgentIds = null;
+        var callsBefore = conn.SessionStartedCalls.Count;
+        await conn.ReBindAcpSessionsAsync().WaitAsync(HangGuard);
+        await Assert.That(conn.SessionStartedCalls.Count(c => c.AgentId == "agentGone")).IsEqualTo(0);
+        await Assert.That(conn.SessionStartedCalls.Count).IsEqualTo(callsBefore + 1); // only agentLive replayed
+    }
+
+    /// <summary>
+    /// an INITIAL bind that the server declines surfaces as a local
+    /// <c>AcpBindRejectedException</c> (never a <c>HubException</c>), so the launch path's existing
+    /// "bind threw ⇒ don't register / don't start a forwarder" catch handles it unchanged.
+    /// </summary>
+    [Test]
+    public async Task AcpSessionStartedAsync_throws_AcpBindRejectedException_on_a_Rejected_initial_bind() {
+        var conn = new TestServerConnection { Ready = true };
+        conn.RejectSessionStarted.Add("agent1");
+
+        await Assert.That(async () => await conn.AcpSessionStartedAsync("agent1", "cursor", "sess-1", "/wt", "model-x", null))
+            .Throws<AcpBindRejectedException>();
+    }
+
+    /// <summary>
+    /// mixed-version invariant: <see cref="AcpBindOutcome.Bound"/> must be the zero value, so
+    /// an OLD server whose hub method still returns void decodes to <c>default</c> == Bound (legacy
+    /// success) on a new daemon.
+    /// </summary>
+    [Test]
+    public async Task AcpBindOutcome_default_is_Bound() {
+        await Assert.That(default(AcpBindOutcome)).IsEqualTo(AcpBindOutcome.Bound);
+        await Assert.That((int)AcpBindOutcome.Bound).IsEqualTo(0);
     }
 
     // ── Reconnect re-bind ordering (design spec §2.3) ────────────────────────────────────────────

--- a/test/Capacitor.Cli.Tests.Unit/Acp/AcpTranscriptForwarderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Acp/AcpTranscriptForwarderTests.cs
@@ -163,6 +163,64 @@ public class AcpTranscriptForwarderTests {
         await Assert.That(callCount).IsEqualTo(2); // never retried/resent once terminal
     }
 
+    // ── server rejection ack terminalizes the forwarder ────────────────────
+
+    /// <summary>
+    /// the server returns the canonical rejection ack for a stale/foreign/unbound binding.
+    /// The forwarder must stop on the very first such ack — via the explicit <see cref="AcpBatchAck.Rejected"/>
+    /// flag — without retrying.
+    /// </summary>
+    [Test]
+    public async Task Rejected_ack_stops_the_loop_on_the_first_ack() {
+        var channel = NewChannel();
+        channel.Writer.TryWrite(NewTextEnvelope("a")); // seq 1 (never completed — a still-looping forwarder would hang)
+
+        var callCount = 0;
+
+        Task<AcpBatchAck> Send(AcpEventEnvelope[] batch, CancellationToken _) {
+            callCount++;
+
+            return Task.FromResult(new AcpBatchAck(-1, -1, ExpectedNextSeq: null, Rejected: true));
+        }
+
+        var forwarder = NewForwarder(Send, channel.Reader);
+
+        await forwarder.RunAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(forwarder.IsTerminal).IsTrue();
+        await Assert.That(forwarder.UnackedCount).IsEqualTo(0);
+        await Assert.That(callCount).IsEqualTo(1); // stopped immediately, no retry
+    }
+
+    /// <summary>
+    /// old-daemon compatibility: even an un-upgraded forwarder shape (one that ignores the new
+    /// <see cref="AcpBatchAck.Rejected"/> flag) stops on the canonical rejection ack, because
+    /// <see cref="AcpBatchAck.AcceptedSeq"/> == -1 is below any real highest-sent seq and trips the
+    /// existing terminal-drop path.
+    /// </summary>
+    [Test]
+    public async Task Rejection_ack_minus_one_stops_via_terminal_drop_even_ignoring_the_Rejected_flag() {
+        var channel = NewChannel();
+        channel.Writer.TryWrite(NewTextEnvelope("a")); // seq 1
+
+        var callCount = 0;
+
+        Task<AcpBatchAck> Send(AcpEventEnvelope[] batch, CancellationToken _) {
+            callCount++;
+
+            // Rejected deliberately left at its default false — proves the AcceptedSeq == -1 sentinel
+            // alone drives the terminal-drop stop path.
+            return Task.FromResult(new AcpBatchAck(-1, -1));
+        }
+
+        var forwarder = NewForwarder(Send, channel.Reader);
+
+        await forwarder.RunAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(forwarder.IsTerminal).IsTrue();
+        await Assert.That(callCount).IsEqualTo(1);
+    }
+
     // ── Hot-loop guard: stalled gap → terminal ─────────────────────────────────────
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AgentOrchestratorVendorTests.cs
@@ -2353,7 +2353,7 @@ public partial class AgentOrchestratorVendorTests {
         /// <paramref name="ct"/> so the test controls exactly when the "late bind" resolves.</summary>
         public TaskCompletionSource? PendingAcpBindGate { get; set; }
 
-        internal override async Task InvokeAcpSessionStartedRawAsync(
+        internal override async Task<AcpBindOutcome> InvokeAcpSessionStartedRawAsync(
                 string agentId, string vendor, string acpSessionId, string? cwd, string? model,
                 IReadOnlyDictionary<string, string>? metadata, CancellationToken ct
             ) {
@@ -2366,6 +2366,8 @@ public partial class AgentOrchestratorVendorTests {
                 PendingAcpBindGate = null;
                 await gate.Task;
             }
+
+            return AcpBindOutcome.Bound;
         }
 
         internal override async Task<AcpBatchAck> InvokeAcpSessionEventsRawAsync(


### PR DESCRIPTION
Companion daemon half of the kcap-server ACP reconnect fix (Linear **AI-1966**, Sentry **KCAP-SERVER-8P**; kcap-server PR: kurrent-io/kcap-server#1457).

## Context

On a daemon SignalR reconnect, an ACP (Cursor-family) agent that is server-`Failed` but daemon-`Running` loses its ownership match. The server used to `throw` on the replayed `AcpSessionStarted` (logged at Error → Sentry), and a stale binding then made the daemon's transcript forwarder retry `AcpSessionEvents` forever.

The server side now returns a **coded `AcpBindOutcome`** for `AcpSessionStarted` and a **canonical rejection ack** `AcpBatchAck(-1, -1, null, Rejected: true)` for `AcpSessionEvents` instead of throwing. This PR makes the daemon consume those signals.

## Changes

- **`Models.cs`**: `AcpBatchAck` gains an additive `bool Rejected = false`; new `AcpBindOutcome { Bound = 0, Rejected = 1 }` + `JsonSerializable` roots. `Bound = 0` so an **old server's** void return decodes to `Bound` (legacy success) — mixed-version safe.
- **`ServerConnection`**:
  - `InvokeAcpSessionStartedRawAsync` now returns `Task<AcpBindOutcome>`.
  - `AcpSessionStartedAsync` (initial launch bind) maps a `Rejected` outcome to a **local** `AcpBindRejectedException` (never a `HubException`), preserving the launch path's existing "bind threw ⇒ don't register / don't start a forwarder" contract unchanged.
  - `ReBindAcpSessionsAsync` (reconnect) reads the outcome: `Rejected` ⇒ `UnregisterAcpBinding` + stand down with **no 3× retry storm**; a transport error still retries as before. It also **pre-filters** bindings whose agent is no longer live (`GetLiveAgentIds`), dropping the stale entry rather than replaying it.
- **`AcpTranscriptForwarder`**: stops on a `Rejected` ack (checked before the gap/cursor logic). An un-upgraded forwarder shape still stops via the existing `AcceptedSeq == -1` terminal-drop path, so a new server heals an old daemon too.

## Testing

- Forwarder terminalizes on a `Rejected` ack **and** on the `-1` old-shaped ack (compat).
- `ReBindAcpSessionsAsync` stands down exactly once on `Rejected` (no retry), and skips + unregisters a non-live agent.
- Initial-bind `Rejected` throws `AcpBindRejectedException`.
- `AcpBindOutcome` default is `Bound` (mixed-version invariant).
- AOT publish clean (no IL2026/IL3050).

Requires a submodule pin bump in kcap-server after merge (server ships first; both mixed-version directions are safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)