### PR TITLE
Onboarding app substrate: mutation lane, consent-flip claims, gate (Plan B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,22 @@ subscriber-arrival waiter in the broker (one shared `TaskCompletionSource` per z
 period) lets concurrent waiters converge with arrival winning ties. Cancellation (the launch's own
 shutdown token) aborts the wait and the launch together — no consent decision is ever fabricated.
 
+**AI-1655 Plan B** (spec: `docs/superpowers/specs/2026-08-12-ai1655-onboarding-wizard-design.md` §4/§6)
+is the desktop app's mutation-safety substrate. Every daemon mutation the app performs routes through
+ONE app-lifetime `DaemonMutationLane` (`Capacitor.App/Services/Mutation/`): per-action CLI pinning
+(validated login-shell resolver, strict `0.12.0-beta.1` floor probe per mutation), an action-scoped
+`KcapCli` executor overlaying `KCAP_CONSENT_SEED_DEFAULT`/`KCAP_EXPECT_SERVER_URL`/
+`KCAP_APP_SPAWN_NO_TELEMETRY`/`KCAP_BOOT_ATTEMPT`, instance-bound evidence classification (one
+shared predicate; misclassification-toward-success is the cardinal sin), boot-refusal-marker
+attribution by attempt id, and a leased FIFO outcome channel whose single consumer owns ALL
+actionable presentation (waiter results are state-only; requeue-exactly-once, second abandonment =
+logged consume). `ConsentFlipClaims` (durable, `ConfigFileLock`-mutated, two-lock conditional clear,
+quarantine-aside) + `ConsentFlipCoordinator` (factory guard → `ConsentRulesPutV2`) cover
+pre-existing daemons. `OnboardingGate` (provider-aware, mirrors `TokenStore`'s real refresh rules,
+shared URL validator with `App.ValidProfileName`) drives the decision-2 startup carve-out:
+gate-incomplete machines build the graph with lifecycle auto-actions permanently closed and the
+shim auto-offer suppressed (item stays visible). Wizard UI + the Core auth façade are Plan C.
+
 The receive pump no longer awaits launch/stop EXECUTION for either command format: arrival order is
 preserved by routing sequenced AND un-sequenced server-origin launch/stop traffic through the ONE
 existing serial lane (`RunLaneAsync`). Un-sequenced commands commit via a typed, no-ack entry point

--- a/docs/superpowers/plans/2026-08-14-ai1655-plan-b-app-lane-claims-gate.md
+++ b/docs/superpowers/plans/2026-08-14-ai1655-plan-b-app-lane-claims-gate.md
@@ -457,7 +457,7 @@ thread `Connected.Identity` into the published `AttachStatus`.
 ```csharp
 public sealed class DaemonMutationLane : IAsyncDisposable {
     public DaemonMutationLane(
-        IProcessRunner runner, ILoginShellProbe shellProbe, OutcomeChannel channel,
+        ILoginShellProbe shellProbe, OutcomeChannel channel,
         Func<string?> cliOverride,                       // () => CliResolver override result (absolute or null)
         Func<MutationRequest, string?, IKcapCli> executorFactory,  // (request, pinnedPath) => action-scoped KcapCli
         Func<MutationRequest, IDaemonObservation> oneShotFactory,

--- a/docs/superpowers/plans/2026-08-14-ai1655-plan-b-app-lane-claims-gate.md
+++ b/docs/superpowers/plans/2026-08-14-ai1655-plan-b-app-lane-claims-gate.md
@@ -1,0 +1,838 @@
+# AI-1655 Plan B — App mutation lane, consent-flip claims, onboarding gate
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the app-side safety substrate of the onboarding wizard — the `DaemonMutationLane`
+singleton (probe → mutation → reconciliation), the `ConsentFlipClaims` store +
+`ConsentFlipCoordinator`, the `OnboardingGate`, and the decision-2 startup carve-out — wired into
+the existing lifecycle controller and main-window Start, WITHOUT the wizard UI (Plan C).
+
+**Architecture:** Everything lands in `src/Capacitor.App/` except three Core additions (the
+`auth_provider` profile stamp, `ILocalControlOps.PutConsentPolicyV2Async`, and an additive
+`Identity` on the app-visible attach status). The lane is one deep module composed from small,
+separately-tested pieces built first: version-floor predicate, validated path resolver, process-only
+kill mode, outcome algebra + reason-line parsing, boot-refusal marker reader, leased outcome
+channel, observation adapters. Plan A's CLI/daemon substrate (gates 28/29, exit 43, boot-refusal
+markers, `ConsentRulesPutV2`/`consent/3`, `pid`/`instance_id` DTOs, `LocalControlProbe`,
+`ConfigMutator`) is consumed, never modified.
+
+**Tech stack:** .NET 10, Avalonia (app), Rx/DynamicData (existing app patterns), TUnit on MTP,
+`Microsoft.Extensions.TimeProvider.Testing`.
+
+**Governing spec:** `docs/superpowers/specs/2026-08-12-ai1655-onboarding-wizard-design.md` —
+sections §4 (components), §6 (consent), §6a (service lane), decisions 1/2/4/7/10, §10 (testing).
+Where this plan and the spec disagree, the spec governs; stop and flag it.
+
+## Global Constraints
+
+- The compatibility floor is the literal `0.12.0-beta.1` — never `0.12.0`.
+- Fail-closed doctrine: missing/malformed/ambiguous evidence → attention/repair outcomes, never
+  `Succeeded`, never a destructive recovery. Unknown/future reason tokens → fail-closed attention.
+- Reason-line rule: machine-readable stderr lines are parsed by prefix; exactly ONE matching line
+  is required — zero, duplicate, or conflicting matching lines fail closed. Unrelated stderr never
+  affects routing.
+- `ConfigFileLock` is a thread-affine named Mutex: no `await` while held; async callers wrap the
+  whole critical section in `Task.Run`. Global lock order is config → claims, both held across any
+  compare-and-delete.
+- Attribution never uses wall-clock comparison; detached-start attribution is by `attempt_id`
+  equality, service-verb attribution is verified-pre-clear + observed-job-PID correlation (the CLI
+  transaction does this; the app consumes only the `refusal_reason=` line).
+- App-managed daemon spawns carry `KCAP_CONSENT_SEED_DEFAULT=prompt`, `KCAP_EXPECT_SERVER_URL`,
+  `KCAP_PROFILE`, and `KCAP_APP_SPAWN_NO_TELEMETRY=1`; no bare-`"kcap"` fallback on any mutation
+  path.
+- Repo rules: no Linear IDs in code comments; concise comments (one short invariant line max);
+  `JsonElementExtensions` for JSON kind checks; `new JsonArray(...)` constructor; `Path.Combine`
+  in path assertions (Windows CI leg); TUnit filter syntax `--treenode-filter "/*/*/ClassName/*"`;
+  run local suites with `TMPDIR=/private/tmp`; real-socket tests take
+  `[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]` + a Windows guard.
+- After any Core/CLI/daemon-touching task: `dotnet publish -c Release` for BOTH
+  `src/Capacitor.Cli/Capacitor.Cli.csproj` and `src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj`
+  must show zero `IL[23]0xx` warnings. The app is not AOT-published; it must still build clean.
+- No README changes in this plan (zero user-visible CLI surface changes).
+
+## Existing seams this plan consumes (verified against `origin/main` @ 2732f9fbd)
+
+- `KcapCli(IProcessRunner runner, string? cliPath, string daemonName, string profileName, Func<CancellationToken,Task<string?>>? terminalPathAsync)`
+  with `VersionAsync`, `ServiceStatusAsync`, `ServiceStartVerifiedAsync`,
+  `ServiceInstallVerifiedAsync(bool replace, ct)`, `DetachedStartAsync`; null `CliPath` degrades to
+  synthetic `ProcessResult(127, "", "kcap CLI not found", false)`.
+- `RunOptions(IReadOnlyDictionary<string,string>? EnvOverlay, TimeSpan? Timeout, CancelMode CancelMode)`;
+  `ProcessResult(int ExitCode, string Stdout, string Stderr, bool TimedOut)`; runner impl is
+  `DaemonClientService.ProcessRunner` (internal nested); internal timeout kill is currently ALWAYS
+  `Process.Kill(entireProcessTree: true)`.
+- `DaemonClientService` publishes `IObservable<AttachStatus> Status` (BehaviorSubject),
+  `Snapshots`, `Agents`; `AttachStatus(AttachState State, string? Reason, IReadOnlyList<string>? Capabilities, string? DaemonVersion = null)`;
+  `LocalControlEvent.Connected(Capabilities, FirstSnapshot, ConnectedIdentity? Identity)` — the
+  service currently DISCARDS `Identity`.
+- `LocalControlProbe.ProbeAsync(string daemonName, TimeSpan timeout, ct)` →
+  `ProbeResult(bool Reachable, HelloReplyDto? Hello, DaemonStatusDto? Snapshot, bool IdentityConsistent)`.
+- `FrameType.ConsentRulesPutV2 = 19`; `ConsentPolicyPutV2Dto(string ExpectedName, string ExpectedServerUrl, ConsentPolicyDto Policy)`;
+  `ConsentAckDto(bool Ok, string? Error, bool? RuleSaved)`; daemon answers `identity_mismatch` as a
+  coded `Error` string; capability `consent/3`. `ILocalControlOps` has NO v2-put method yet.
+- `ConfigFileLock.Acquire(string configPath, TimeSpan? timeout = null)` (10s default, SHA-256-of-path
+  mutex name); `ConfigMutator.MutateAsync/Mutate/LoadPure/TryLoadPure`;
+  `AppConfig.ResolveActiveProfile(string[])`, `AppConfig.ResolvedProfile`,
+  `AppConfig.GetConfigPath()`; `DaemonNameResolver.Resolve(args, profileDaemonName)`;
+  `ServerIdentity.Canonicalize/SameServer/Matches`; `PathHelpers.ConfigPath(name)`.
+- `TokenStore.LoadForProfileAsync(profile, ct)` (raw, refresh-free) → `StoredTokens?` with
+  `AccessToken`, `RefreshToken`, `ExpiresAt`, `Provider` (`AuthProvider.GitHubApp|WorkOS|None`
+  consts), `ClientId`, `ServerUrl`, `IsExpired`.
+- `PrereleaseSemver.Compare(string? a, string? b)` (full SemVer2 precedence; unparseable sorts
+  lowest). NOTE: it ACCEPTS invalid SemVer (leading-zero cores, illegal identifiers) — the strict
+  parse in Task 1 must reject those BEFORE comparing.
+- `LoginShellProbe : ILoginShellProbe` with `TerminalPathAsync(ct)` and
+  `KcapOnPathAsync(ct, forceRefresh)`; per-instance task-caching; "cacheable" = both shell attempts
+  ran to completion.
+- CLI-side `BootRefusalReader` (`src/Capacitor.Cli/Services/BootRefusalReader.cs`) — the
+  duplication precedent for the app-side reader in Task 6. Marker path:
+  `Path.Combine(DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(daemonName), "boot-refusal.json")`.
+  Record members on disk: `schema, daemon name, token, expectation, resolved, pid, instance_id,
+  attempt_id, timestamp`.
+- `DaemonLifecycleController` (39K) — decision matrix + `_gate` SemaphoreSlim serialization +
+  `PhaseClosed` + `_armClaimed` once-per-run arm; `ShimOfferCoordinator` gates on `PhaseClosed`.
+- `AppStateStore` / `AppState(bool ShimOffered, bool ShimDenied, IReadOnlyList<string>? DeclinedTakeoverPairs)`;
+  in-process `SemaphoreSlim` only (UX-grade by contract).
+- App tests live flat in `test/Capacitor.App.Tests.Unit/`; `FakeProcessRunner` per-file pattern
+  (capture fields + injectable behavior); `ScriptedLocalControlOps` shared fake for
+  `ILocalControlOps`; `AppStateStoreTests` is the file-store test template.
+- Verify exit codes / tokens (CLI): 28 `verify_start_gate` + `start_gate_reason=` enum
+  `directive_missing|directive_invalid|identity_mismatch|foreign_binary|package_inconsistent|evidence_unreadable`;
+  29 `verify_start_gate_drift`; readiness timeout token `verify_readiness_timeout` with optional
+  `refusal_reason=` line; detached `daemon start` exit 43 + `daemon_start_reason=package_inconsistent`;
+  boot-refusal reason tokens `server_expectation_mismatch|consent_seed_unwritable|consent_seed_invalid`.
+
+## File structure (created/modified by this plan)
+
+```
+src/Capacitor.App/Services/KcapCliCompatibility.cs                     (new, Task 1)
+src/Capacitor.App/Services/LoginShellProbe.cs                          (modify, Task 2)
+src/Capacitor.App/Services/IProcessRunner.cs                           (modify, Task 3)
+src/Capacitor.App/Services/DaemonClientService.cs                      (modify, Tasks 3, 8, 10)
+src/Capacitor.App/Services/KcapCli.cs                                  (modify, Task 4)
+src/Capacitor.App/Services/Mutation/MutationModel.cs                   (new, Task 5)
+src/Capacitor.App/Services/Mutation/ReasonLine.cs                      (new, Task 5)
+src/Capacitor.App/Services/Mutation/BootRefusalMarker.cs               (new, Task 6)
+src/Capacitor.App/Services/Mutation/OutcomeChannel.cs                  (new, Task 7)
+src/Capacitor.App/Services/Mutation/DaemonObservation.cs               (new, Task 8)
+src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs              (new, Tasks 9a/9b)
+src/Capacitor.App/Services/DaemonLifecycleController.cs                (modify, Task 10)
+src/Capacitor.App/Services/AttachStatus.cs                             (modify, Task 8)
+src/Capacitor.App/Services/Onboarding/ConsentFlipClaims.cs             (new, Task 11)
+src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs                     (modify, Task 12)
+src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs        (new, Task 13)
+src/Capacitor.Cli.Core/Config/ProfileConfig.cs                         (modify, Task 14)
+src/Capacitor.App/Services/Onboarding/OnboardingGate.cs                (new, Task 14)
+src/Capacitor.App/App.axaml.cs                                         (modify, Tasks 10, 15)
+src/Capacitor.App/Services/AppStateStore.cs                            (modify, Task 13)
+test/Capacitor.App.Tests.Unit/…                                        (one test file per new type)
+test/Capacitor.Cli.Tests.Unit/…                                        (Tasks 12, 14 Core tests)
+```
+
+---
+
+### Task 1: `KcapCliCompatibility` — strict floor predicate
+
+**Files:**
+- Create: `src/Capacitor.App/Services/KcapCliCompatibility.cs`
+- Test: `test/Capacitor.App.Tests.Unit/KcapCliCompatibilityTests.cs`
+
+**Interfaces:**
+- Produces: `public static class KcapCliCompatibility { public const string Floor = "0.12.0-beta.1"; public static bool Satisfies(string? version); public static bool StrictParse(string version); }`
+- Consumes: `Capacitor.Cli.Core.PrereleaseSemver.Compare`.
+
+**Contract:** `Satisfies` = non-null AND `StrictParse(version)` AND
+`PrereleaseSemver.Compare(version, Floor) >= 0`. `StrictParse` implements the SemVer 2.0.0 grammar
+strictly: `MAJOR.MINOR.PATCH` numeric identifiers with NO leading zeros (`0` itself is fine),
+optional `-prerelease` whose dot-separated identifiers are each either strictly-numeric with no
+leading zeros or alphanumeric-with-hyphen (nonempty), optional `+build` (any nonempty
+dot-separated `[0-9A-Za-z-]+` identifiers, ignored for comparison but still validated). No
+regex-free requirement — a `[GeneratedRegex]` is fine (the app is not AOT-published, but prefer
+manual parsing anyway for symmetry with Core style).
+
+- [ ] **Step 1: Failing tests.** Matrix (each row `[Arguments]`): `"0.12.0-beta.1"` → true;
+  `"0.12.0-beta.2"` → true; `"0.12.0"` → true; `"0.12.1-beta.1"` → true; `"0.13.0"` → true;
+  `"0.11.9"` → false; `"0.12.0-beta.0"` → false; `"0.12.0-alpha.9"` → false (alpha < beta);
+  `"01.2.3"` → false (strict parse); `"0.12.0-beta.01"` → false (leading-zero prerelease
+  numeric); `"0.12.0-"` → false; `"0.12"` → false; `""`/null/`"unknown"`/`"v0.12.0"` → false;
+  `"0.12.0+build.5"` → true (build ignored); `"0.12.0-beta.1+x"` → true.
+- [ ] **Step 2: Run, verify failure** (type absent).
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run, verify pass.** `TMPDIR=/private/tmp dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/KcapCliCompatibilityTests/*"`
+- [ ] **Step 5: Commit** `feat(app): strict CLI compatibility floor 0.12.0-beta.1`
+
+### Task 2: `ILoginShellProbe.KcapPathAsync` — validated path-returning resolver
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/LoginShellProbe.cs`
+- Test: `test/Capacitor.App.Tests.Unit/LoginShellProbeTests.cs` (extend)
+
+**Interfaces:**
+- Produces: `Task<string?> KcapPathAsync(CancellationToken ct, bool forceRefresh = false)` on
+  `ILoginShellProbe` + impl.
+- Consumes: the existing probe script machinery (`-lic`/`-lc` attempts, sentinel parsing, caching).
+
+**Contract:** Same probe transport as `KcapOnPathAsync` but the script runs `command -v kcap` and
+returns raw output. Validation before returning: trim to first line; must be an absolute rooted
+path (`Path.IsPathRooted` AND `Path.IsPathFullyQualified`) to an EXISTING regular file
+(`File.Exists`; a directory fails). Alias output (`alias kcap=…`), function definitions
+(multi-line), relative paths, and bare words → null. Null = no pin (callers fail closed).
+Caching mirrors `KcapOnPathAsync` exactly: its own independent cache field, same "cacheable only if
+both shell attempts completed" rule, `forceRefresh` bypass-and-repopulate. Symlinks are NOT
+resolved here — invocation-time resolution is deliberate.
+
+- [ ] **Step 1: Failing tests** using the existing fake-runner pattern in `LoginShellProbeTests`:
+  absolute existing file → returned verbatim; absolute path with spaces → returned;
+  relative `bin/kcap` → null; bare `kcap` → null; `alias kcap='/usr/local/bin/kcap'` → null;
+  multi-line function definition → null; absolute path to a MISSING file → null; absolute path to
+  a directory → null; cache: second call runs no new process; `forceRefresh: true` re-runs;
+  process-start failure not cached.
+- [ ] **Step 2: Run, verify failure.**
+- [ ] **Step 3: Implement** (share the script-run/parse plumbing with `KcapOnPathAsync` via a
+  private helper; do not duplicate the shell-attempt loop).
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** `feat(app): validated path-returning kcap resolver on the login-shell probe`
+
+### Task 3: Process-only timeout kill mode on the runner
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/IProcessRunner.cs`, `src/Capacitor.App/Services/DaemonClientService.cs` (nested `ProcessRunner`)
+- Test: `test/Capacitor.App.Tests.Unit/ProcessRunnerTests.cs` (extend)
+
+**Interfaces:**
+- Produces: `public enum TimeoutKillScope { Tree, ProcessOnly }` and an additive `RunOptions`
+  member `TimeoutKillScope TimeoutKill = TimeoutKillScope.Tree` (record default preserves every
+  existing call site).
+- Consumes: nothing new.
+
+**Contract:** Only the INTERNAL-timeout kill path changes: on deadline expiry,
+`TimeoutKillScope.Tree` → today's `Kill(entireProcessTree: true)`; `ProcessOnly` →
+`Kill(entireProcessTree: false)`. `CancelMode` (caller-token) semantics are untouched —
+`KillTree` cancellation still kills the tree regardless of `TimeoutKill` (cancel is the caller
+saying "tear it down"; the timeout is the lane sparing the detached daemon).
+
+- [ ] **Step 1: Failing test (real processes, POSIX-guarded
+  `Skip.When(OperatingSystem.IsWindows(), …)`):** run `/bin/sh -c 'echo child-started; sleep 30 & echo $!; wait'`
+  variant that prints the grandchild PID, with `Timeout = 500ms, TimeoutKill = ProcessOnly`;
+  assert `TimedOut == true` and the printed grandchild PID is STILL ALIVE (`kill -0` via
+  `Process.GetProcessById` not throwing), then clean it up (`kill`). Sibling test with
+  `TimeoutKill = Tree` asserts the grandchild is dead. A third test pins that `CancelMode.KillTree`
+  cancellation kills the tree even with `TimeoutKill = ProcessOnly`.
+- [ ] **Step 2: Run, verify failure** (member absent).
+- [ ] **Step 3: Implement** (one-line scope selection at the existing `KillAndAwaitAsync` call).
+- [ ] **Step 4: Run, verify pass** (`ProcessRunnerTests` suite).
+- [ ] **Step 5: Commit** `feat(app): process-only timeout kill scope on the runner`
+
+### Task 4: `KcapCli` becomes the action-scoped executor
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/KcapCli.cs` (+ `IKcapCli`)
+- Test: `test/Capacitor.App.Tests.Unit/KcapCliTests.cs` (extend)
+
+**Interfaces:**
+- Produces: constructor gains `string? canonicalServer = null` (nullable — long-lived non-mutating
+  instances pass null); `DetachedStartAsync(CancellationToken ct)` gains an overload
+  `DetachedStartAsync(string bootAttemptId, CancellationToken ct)`; a new
+  `public const string`s block for the overlay variable names.
+- Consumes: Task 3's `TimeoutKillScope`.
+
+**Contract (env overlays, per spawn kind):**
+- EVERY spawn (version/status/mutations/detached): `KCAP_PROFILE` (existing) +
+  `KCAP_APP_SPAWN_NO_TELEMETRY=1` (new — Plan A's `Program.cs` consumes-and-removes it).
+- Daemon-mutating spawns (`ServiceInstallVerifiedAsync`, `ServiceStartVerifiedAsync`,
+  `DetachedStartAsync`): additionally `KCAP_CONSENT_SEED_DEFAULT=prompt` and — when
+  `canonicalServer` is non-null — `KCAP_EXPECT_SERVER_URL=<canonicalServer>`. A null
+  `canonicalServer` on a mutation call throws `InvalidOperationException` (mutations are
+  action-scoped; the lane always binds a server — constructing a mutating call without one is a
+  programming error, not a runtime state).
+- `DetachedStartAsync(bootAttemptId, ct)`: additionally `KCAP_BOOT_ATTEMPT=<bootAttemptId>`, a
+  bounded `Timeout` (`DetachedStartTimeout = TimeSpan.FromSeconds(75)` — above the CLI's own
+  60s mutation budget), and `TimeoutKill = TimeoutKillScope.ProcessOnly`. The parameterless
+  overload delegates with a fresh `Guid.NewGuid().ToString("N")` (kept for the graph's
+  non-lane callers until Task 10 removes them).
+- `VersionAsync` args gain `--no-update-check` if not already present.
+
+- [ ] **Step 1: Failing tests** (FakeProcessRunner captures `SeenOptions`): every existing call
+  asserts `KCAP_APP_SPAWN_NO_TELEMETRY=1`; mutation calls assert seed + expectation overlays;
+  status/version calls assert seed/expectation ABSENT; detached start asserts `KCAP_BOOT_ATTEMPT`
+  present, `Timeout == 75s`, `TimeoutKill == ProcessOnly`, `CancelMode == AbandonWait`; mutation
+  with null server throws; user env (`KCAP_TELEMETRY`) never touched (overlay contains only the
+  documented keys).
+- [ ] **Step 2: Run, verify failure.**
+- [ ] **Step 3: Implement.** Update existing constructions (`App.axaml.cs`
+  `BuildLifecycleController`, `DaemonClientService.CreateDefaultAsync` if it constructs one) to
+  pass `canonicalServer: AppConfig.ResolvedProfile?.ServerUrl` canonicalized via
+  `ServerIdentity.Canonicalize` — they may currently be non-mutating-only; pass the value anyway
+  so Task 10's rewiring doesn't have to revisit signatures.
+- [ ] **Step 4: Run full `KcapCliTests` + build the app project.**
+- [ ] **Step 5: Commit** `feat(app): action-scoped env overlays and bounded detached start on KcapCli`
+
+### Task 5: Outcome algebra + reason-line parsing
+
+**Files:**
+- Create: `src/Capacitor.App/Services/Mutation/MutationModel.cs`, `src/Capacitor.App/Services/Mutation/ReasonLine.cs`
+- Test: `test/Capacitor.App.Tests.Unit/MutationModelTests.cs`, `test/Capacitor.App.Tests.Unit/ReasonLineTests.cs`
+
+**Interfaces (produced, exact):**
+```csharp
+public enum MutationVerb { Install, Replace, StartVerified, DetachedStart }
+
+public sealed record MutationRequest(
+    MutationVerb Verb, string Profile, string CanonicalServer, string DaemonName);
+
+public enum RecoverySurface { Takeover, Reinstall, Attention, Storage, None }
+
+public abstract record MutationOutcome {
+    public sealed record Succeeded : MutationOutcome;
+    public sealed record SucceededAfterTimeout : MutationOutcome;
+    public sealed record AttentionSkew(string Detail) : MutationOutcome;
+    public sealed record AttentionRepair(string Detail) : MutationOutcome;
+    public sealed record UnconfirmedNoAttach : MutationOutcome;
+    public sealed record Refused(string Reason, RecoverySurface Surface) : MutationOutcome;
+    public sealed record Failed(int ExitCode, string? Reason, RecoverySurface Surface) : MutationOutcome;
+}
+
+public sealed record OutcomeEnvelope(MutationRequest Request, MutationOutcome Outcome);
+
+public static class ReasonRouting {
+    public static RecoverySurface ForStartGate(string token);     // 28/29 start_gate_reason=
+    public static RecoverySurface ForDaemonStart(string token);   // 43 daemon_start_reason=
+    public static RecoverySurface ForBootRefusal(string token);   // refusal_reason= / marker token
+}
+
+public static class ReasonLine {
+    // Exactly one line beginning with `prefix` (after trimming \r): its token.
+    // Zero matching lines, two+ matching lines, or two lines with different tokens → null.
+    public static string? TrySingle(string stderr, string prefix);
+}
+```
+
+**Routing tables (pinned by spec §3/§4):**
+- `ForStartGate`: `directive_missing|directive_invalid|identity_mismatch|foreign_binary` →
+  `Takeover`; `package_inconsistent` → `Reinstall`; `evidence_unreadable` and ANY unknown →
+  `Attention`.
+- `ForDaemonStart`: `package_inconsistent` → `Reinstall`; unknown → `Attention`.
+- `ForBootRefusal`: `server_expectation_mismatch` → `Takeover`; `consent_seed_unwritable` →
+  `Storage`; `consent_seed_invalid` → `Takeover`; unknown → `Attention`.
+
+- [ ] **Step 1: Failing tests.** `ReasonLine`: single match → token; zero → null; duplicate same
+  token → null; two different tokens → null; matching line surrounded by unrelated stderr → token;
+  prefix appearing mid-line (not line start) → not a match; `\r\n` input handled. `ReasonRouting`:
+  every pinned token row + one unknown per table → `Attention`.
+- [ ] **Step 2: Run, verify failure.**
+- [ ] **Step 3: Implement** (pure; no I/O).
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** `feat(app): mutation outcome algebra and machine-readable reason routing`
+
+### Task 6: App-side boot-refusal marker reader
+
+**Files:**
+- Create: `src/Capacitor.App/Services/Mutation/BootRefusalMarker.cs`
+- Test: `test/Capacitor.App.Tests.Unit/BootRefusalMarkerTests.cs`
+
+**Interfaces:**
+- Produces:
+```csharp
+public sealed record BootRefusalEvidence(
+    string DaemonName, string Token, string? Expectation, string? Resolved,
+    int Pid, string? InstanceId, string? AttemptId);
+public static class BootRefusalMarker {
+    public static string MarkerPath(string daemonName);   // DaemonLockPaths.Directory/Sanitize(name)/boot-refusal.json
+    public static BootRefusalEvidence? TryRead(string daemonName);   // absent/corrupt → null, left in place
+    public static BootRefusalEvidence? TryAttribute(string daemonName, string attemptId); // read + AttemptId equality + identity fields non-empty; on match: consume (best-effort delete) and return; else null, marker untouched
+}
+```
+- Consumes: `DaemonLockPaths.Directory`/`Sanitize` (Core). Mirror the CLI's
+  `BootRefusalReader` duplication precedent (same on-disk member names; source-generated JSON ctx;
+  the app never quarantines or clears a foreign marker — `TryAttribute` deletes ONLY on an
+  attributed match, because the lane is that marker's single consumer for detached starts).
+
+- [ ] **Step 1: Failing tests** (temp dir via `DaemonLockPaths.OverrideDirectoryForTesting`, the
+  `[NotInParallel]` key from Global Constraints): valid marker + matching attempt → returned AND
+  file deleted; valid marker + different attempt → null AND file retained; marker with null
+  `attempt_id` → never attributed; corrupt JSON → null, file retained; absent → null; daemon-name
+  mismatch inside the record (foreign evidence) → not attributed.
+- [ ] **Step 2–4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): boot-refusal marker reader with attempt-scoped attribution`
+
+### Task 7: Leased single-consumer outcome channel
+
+**Files:**
+- Create: `src/Capacitor.App/Services/Mutation/OutcomeChannel.cs`
+- Test: `test/Capacitor.App.Tests.Unit/OutcomeChannelTests.cs`
+
+**Interfaces (produced, exact):**
+```csharp
+public sealed class OutcomeLease {
+    public OutcomeEnvelope Envelope { get; }
+    public void Ack();          // presentation reached the user — envelope permanently consumed
+    public void CancelLease();  // consumer tore down before presentation — requeue exactly once
+}
+public sealed class OutcomeChannel {
+    public void Enqueue(OutcomeEnvelope envelope);                       // producer side (lane)
+    public IAsyncEnumerable<OutcomeLease> ConsumeAsync(CancellationToken ct); // ONE active consumer
+    public void TransferConsumer();  // atomically completes the current consumer's enumeration;
+                                     // the next ConsumeAsync call owns everything undelivered
+}
+```
+
+**Contract:** FIFO. An envelope is LEASED at dequeue, not removed: `Ack` consumes;
+`CancelLease` requeues at the FRONT exactly once (a second cancel of the same envelope after its
+requeue-redelivery does NOT requeue again — track a per-envelope requeued flag); an envelope whose
+lease is neither acked nor cancelled when the consumer's enumeration ends (ct fired or
+`TransferConsumer`) is treated as lease-cancelled (requeue-once rule applies). Exactly one active
+consumer: a second concurrent `ConsumeAsync` throws `InvalidOperationException`. Enqueue racing
+`TransferConsumer` delivers to exactly one consumer (lock the handoff). No envelope is ever
+dropped or duplicated: N enqueues → exactly N acks across all consumers, regardless of transfers.
+
+- [ ] **Step 1: Failing tests:** two enqueued outcomes, waiterless → both surface in FIFO order
+  exactly once; late enqueue after a consumer drained empty → wakes the live consumer; enqueue
+  racing `TransferConsumer` (barrier via TaskCompletionSource ordering, not sleeps) → delivered to
+  exactly one; dequeue-then-`CancelLease` → redelivered to the NEXT consumer exactly once;
+  cancel-after-redelivery-ack → consumed, not duplicated; consumer ct cancellation with an
+  unacked lease → requeued; second concurrent consumer throws; ack-after-transfer of an
+  already-presented envelope → consumed, never requeued (the visible-dialog disposition).
+- [ ] **Step 2–4: red → implement → green.** Implementation hint: a `Channel`-free custom queue
+  (`LinkedList<Entry>` + `SemaphoreSlim`/TCS wakeup + one lock) is simpler to make
+  transfer-atomic than `System.Threading.Channels`.
+- [ ] **Step 5: Commit** `feat(app): leased FIFO outcome channel with atomic consumer transfer`
+
+### Task 8: Observation adapters + identity on `AttachStatus`
+
+**Files:**
+- Create: `src/Capacitor.App/Services/Mutation/DaemonObservation.cs`
+- Modify: `src/Capacitor.App/Services/AttachStatus.cs`, `src/Capacitor.App/Services/DaemonClientService.cs`
+- Test: `test/Capacitor.App.Tests.Unit/DaemonObservationTests.cs`, extend `DaemonClientServiceTests`
+
+**Interfaces (produced, exact):**
+```csharp
+// AttachStatus gains an additive member (default null — every existing construction compiles):
+public sealed record AttachStatus(AttachState State, string? Reason,
+    IReadOnlyList<string>? Capabilities, string? DaemonVersion = null,
+    ConnectedIdentity? Identity = null);
+
+public sealed record ObservedEvidence(
+    bool Reachable, IReadOnlyList<string>? Capabilities, string? DaemonVersion,
+    string? ServerUrl, string? DaemonName, int? Pid, string? InstanceId,
+    bool IdentityConsistent);   // hello↔snapshot pid+instance agreement, BOTH sides present
+
+public interface IDaemonObservation {
+    Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct);
+}
+public sealed class OneShotObservation(TimeSpan timeout) : IDaemonObservation;      // LocalControlProbe
+public sealed class LiveGraphObservation(IDaemonClientService client) : IDaemonObservation;
+```
+
+**Contract:** `OneShotObservation` calls `LocalControlProbe.ProbeAsync(request.DaemonName, …)` and
+maps: unreachable → `ObservedEvidence(false, …)`; reachable → capabilities/version from hello,
+server + name from `Snapshot.Daemon`, pid/instance from hello, `IdentityConsistent` from the
+probe's own correlation. `LiveGraphObservation` first checks FULL identity: the client's pinned
+`DaemonName == request.DaemonName` AND the current snapshot's server matches
+`request.CanonicalServer` (`ServerIdentity.Matches`) — on ANY mismatch it returns null
+(caller falls back to a one-shot; the graph's client cannot observe an arbitrary target). On match
+it reads the CURRENT `AttachStatus` (must be `Connected` — else evidence is
+`Reachable=false`) + latest snapshot, and `IdentityConsistent` requires `Identity` non-null with
+pid+instance matching the snapshot's `Daemon.Pid`/`InstanceId`. In `DaemonClientService.Apply`,
+thread `Connected.Identity` into the published `AttachStatus`.
+
+- [ ] **Step 1: Failing tests.** DaemonClientService: a `Connected` event with identity → `Status`
+  emission carries it. OneShot (scripted probe results via an injectable
+  `Func<string, TimeSpan, CancellationToken, Task<ProbeResult>>` seam on the adapter): reachable
+  consistent / reachable inconsistent / unreachable / pre-slice daemon (null pid+instance →
+  `IdentityConsistent == false`). LiveGraph (fake `IDaemonClientService` — extract the needed
+  members; the fake publishes controlled `AttachStatus`/snapshots): name mismatch → null; server
+  mismatch → null; connected with matching identity → consistent evidence; connected with
+  hello↔snapshot pid mismatch → `IdentityConsistent == false`; non-Connected → unreachable.
+- [ ] **Step 2–4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): daemon observation adapters with instance-bound evidence`
+
+### Task 9a: `DaemonMutationLane` — skeleton (serialization, coalescing, probe, executor binding)
+
+**Files:**
+- Create: `src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs`
+- Test: `test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs`
+
+**Interfaces (produced, exact):**
+```csharp
+public sealed class DaemonMutationLane : IAsyncDisposable {
+    public DaemonMutationLane(
+        IProcessRunner runner, ILoginShellProbe shellProbe, OutcomeChannel channel,
+        Func<string?> cliOverride,                       // () => CliResolver override result (absolute or null)
+        Func<MutationRequest, string?, IKcapCli> executorFactory,  // (request, pinnedPath) => action-scoped KcapCli
+        Func<MutationRequest, IDaemonObservation> oneShotFactory,
+        TimeProvider time);
+    public void SetLiveAdapter(IDaemonObservation? live);   // atomic slot swap at graph build/teardown
+    public Task<MutationOutcome> RunAsync(MutationRequest request, CancellationToken waiterCt);
+    public Task QuiescedAsync(CancellationToken ct);
+    public ValueTask DisposeAsync();
+}
+```
+
+**Contract (this task delivers the mechanics; classification is Task 9b):**
+- ONE owned action at a time. An arriving request equal to the IN-FLIGHT request (record equality)
+  coalesces: it awaits the same owned task. A DIFFERENT request queues (FIFO) and, when admitted,
+  performs its OWN fresh probe. Waiter cancellation detaches THAT waiter only (`WaitAsync(ct)`
+  pattern) — the owned action always runs to its terminal state under the lane's lifetime token.
+- Owned action sequence: (1) **pin**: `cliOverride()` if non-null else
+  `await shellProbe.KcapPathAsync(ct, forceRefresh: false)`; null pin →
+  `Refused("cli_not_found", Attention)`, no spawn. (2) **floor probe**: build the action executor
+  ONCE via `executorFactory(request, pinnedPath)`; `VersionAsync` through it;
+  `!KcapCliCompatibility.Satisfies(version)` → `Refused("cli_below_floor", Attention)`, no
+  mutation. (3) **observation pin**: choose the observation strategy ONCE at action start — the
+  live adapter slot if set AND `ObserveAsync` would target the matching identity (delegate the
+  decision: try live, null → one-shot), pinned for the action's lifetime. (4) **mutation** through
+  the SAME executor (verb-dispatched: `ServiceInstallVerifiedAsync(replace:…)`,
+  `ServiceStartVerifiedAsync`, `DetachedStartAsync(attemptId, ct)` with a fresh
+  `Guid` attempt id). (5) hand `ProcessResult` + context to the Task 9b classifier. (6) enqueue
+  actionable outcomes on `channel` (all except `Succeeded`/`SucceededAfterTimeout`, which are
+  waiter-state-only; waiterless success is logged); resolve all waiters with the outcome;
+  quiesce; admit next.
+- `QuiescedAsync` completes when no action is owned and the queue is empty.
+
+- [ ] **Step 1: Failing tests** (fake runner scripted per verb; fake shell probe; recording
+  executor factory): identical concurrent requests → ONE probe, ONE mutation, both waiters get
+  the outcome; different queued request → second fresh probe after admission (probe count == 2,
+  strictly after the first action's terminal state); waiter A cancels → B still completes, action
+  uncancelled; ALL waiters cancel → action still reaches terminal state and its actionable
+  outcome lands in the channel; null pin → `Refused(cli_not_found)`, zero runner invocations of
+  the mutation verb; below-floor version → `Refused(cli_below_floor)`, no mutation call; probe
+  in-flight blocks the mutation until resolved (TCS-gated fake); executor factory called exactly
+  once per owned action with the pinned path (identical filename for version + mutation —
+  asserted via the factory's recording); `QuiescedAsync` completes only after terminal state;
+  CLI replaced between two actions (cliOverride returns pathA then pathB) → second action pins
+  pathB (fresh pin per action).
+- [ ] **Step 2–4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): daemon mutation lane skeleton — serialization, coalescing, per-action pinning`
+
+### Task 9b: `DaemonMutationLane` — classification & reconciliation
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs`
+- Test: extend `DaemonMutationLaneTests.cs`
+
+**Contract (the classifier, per verb):**
+- **Service verbs (Install/Replace/StartVerified):** exit 0 → post-result observation;
+  `Succeeded` requires successful process result AND observed identity match
+  (`ServerIdentity.Matches(evidence.ServerUrl, request.CanonicalServer)` and
+  `evidence.DaemonName == request.DaemonName`) AND `IdentityConsistent` AND ownership — the
+  executor's `ServiceStatusAsync` reports `job_pid == daemon_pid`, both non-null (add
+  `JobPid`/`DaemonPid`/`TxnActive`/`TxnMarkerStale` to the app's `ServiceSnapshot` if absent —
+  additive parse of the existing `service status --json` fields). ANY missing/inconsistent leg →
+  `AttentionSkew`, never `Succeeded`. Exit 28 → `ReasonLine.TrySingle(stderr, "start_gate_reason=")`;
+  token → `Failed(28, token, ReasonRouting.ForStartGate(token))`; null (zero/dup/conflict) →
+  `Failed(28, null, Attention)`. Exit 29 → `Failed(29, token?, Attention)` (never auto-retry).
+  Readiness-timeout exits carrying a `refusal_reason=` line →
+  `Refused(token, ReasonRouting.ForBootRefusal(token))`; without the line → `UnconfirmedNoAttach`.
+  Other nonzero → `Failed(code, null, Attention)`.
+- **DetachedStart:** exit 0 → bounded post-spawn observation window (poll the pinned observation,
+  `DetachedConfirmWindow = 10s`, injectable via `TimeProvider`): full evidence (reachable,
+  identity match, `IdentityConsistent`) → `Succeeded`; a boot-refusal marker attributed via
+  `BootRefusalMarker.TryAttribute(request.DaemonName, attemptId)` →
+  `Refused(token, ForBootRefusal(token))`; window expiry with neither → `UnconfirmedNoAttach`.
+  Exit 43 → `ReasonLine.TrySingle(stderr, "daemon_start_reason=")` →
+  `Failed(43, token, ForDaemonStart(token))` / null → `Failed(43, null, Attention)`.
+  `ProcessResult.TimedOut == true` (the lane's own bounded wrapper timeout, process-only kill) →
+  the SAME full-evidence observation: complete → `SucceededAfterTimeout`; marker attributed →
+  `Refused`; else → `UnconfirmedNoAttach`.
+- **Legacy/skew evidence:** observed `Capabilities` missing `"consent/3"`, or a pre-slice
+  status/hello without pid+instance, or version below floor at observation time → `AttentionSkew`.
+  Stale `txn_marker` / orphan-unit signals from `ServiceStatusAsync` → `AttentionRepair`.
+- All evidence contributing to ONE classification must carry the SAME `InstanceId` (evidence is
+  captured as one `ObservedEvidence` — the adapter already enforces hello↔snapshot; the ownership
+  read's `daemon_pid` must equal `evidence.Pid` or the classification degrades to `AttentionSkew`).
+
+- [ ] **Step 1: Failing tests** (scripted runner + scripted observation): the §10 lane matrix
+  subset — mutation failure beside an already-Connected daemon → NOT `Succeeded`; wrong-server
+  Connected → `AttentionSkew`; manual/non-owning Connected (job≠daemon pid) → not `Succeeded`;
+  unreachable, no owner → `UnconfirmedNoAttach`; missing `consent/3` → `AttentionSkew`;
+  pre-slice daemon (null pid/instance) → `AttentionSkew`, never `Succeeded`; pid-vs-daemon_pid
+  cross-check failure → `AttentionSkew`; exit 28 with each routed token → `Failed(28,…)` with
+  the pinned surface; 28 with zero AND with duplicate conflicting lines → `Failed(28, null,
+  Attention)`; exit 29 → attention, and the test asserts no second mutation is attempted;
+  exit 43 routed/unknown; readiness timeout with `refusal_reason=server_expectation_mismatch` →
+  `Refused` with `Takeover`; detached exit-0 + attributed marker → `Refused` (marker consumed —
+  file gone); detached exit-0 + FOREIGN marker (different attempt id) → `UnconfirmedNoAttach`,
+  marker retained; detached wrapper `TimedOut` + full evidence → `SucceededAfterTimeout` (runner
+  result shape asserted: the existing non-nullable `ProcessResult` with `TimedOut == true`);
+  `TimedOut` + incomplete evidence → `UnconfirmedNoAttach`; success is waiter-state-only (channel
+  stays empty); every actionable outcome enqueued exactly once with its `MutationRequest`.
+- [ ] **Step 2–4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): mutation lane outcome classification and detached reconciliation`
+
+### Task 10: Route the three mutation surfaces through the lane
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/DaemonLifecycleController.cs`,
+  `src/Capacitor.App/Services/DaemonClientService.cs`, `src/Capacitor.App/App.axaml.cs`,
+  `src/Capacitor.App/ViewModels/MainWindowViewModel.cs` (whatever calls `StartDaemonAsync`)
+- Test: extend `DaemonLifecycleControllerTests` + `DaemonClientServiceTests`
+
+**Contract:**
+- `App.StartAsync` constructs ONE `DaemonMutationLane` FIRST (before any graph object) and
+  disposes it last; the composition root drains `channel.ConsumeAsync` into the existing
+  attention/status surfaces (`ILifecycleSurface`) routed by `RecoverySurface` (Takeover → the
+  existing takeover-dialog path with its disclosures; Reinstall → reinstall guidance message;
+  Attention/Storage → attention state; a `Refused`/`Failed` detail message always names the coded
+  token). This root consumer starts immediately — in Plan B there is no wizard consumer yet, so
+  no `TransferConsumer` call sites land here (the API is exercised in tests; Plan C adds the
+  wizard handoff).
+- `DaemonLifecycleController`: every mutating branch (auto-install, auto-start, `StartActionAsync`,
+  takeover/replace) builds a `MutationRequest` from its pinned identity and awaits
+  `lane.RunAsync` instead of calling `IKcapCli` mutation methods directly. Its OWN `_gate`
+  continues to serialize decision-making; the lane serializes execution. Its result handling maps
+  outcome cases onto the existing surface semantics — but per the channel contract, `RunAsync`
+  results update controller STATE only (retry availability, `PhaseClosed`); actionable
+  presentation flows through the channel consumer, so delete/bypass the controller's direct
+  attention-raising for lane-executed mutations (single-presentation rule). `QuiescedAsync`
+  awaits the lane too.
+- `DaemonClientService.StartDaemonAsync` (main-window Start/Retry): delegate to
+  `lane.RunAsync(new MutationRequest(DetachedStart, …))` via an injected
+  `Func<CancellationToken, Task<MutationOutcome>>` — the service no longer spawns
+  `daemon start -d` itself and loses the bare-`"kcap"` fallback; with no resolvable CLI the
+  outcome is `Refused("cli_not_found")` surfaced as the honest message. Keep `RestartLoopAsync`
+  kick on success outcomes (incl. `SucceededAfterTimeout`).
+- The lane's live adapter: `SetLiveAdapter(new LiveGraphObservation(service))` right after the
+  graph's `DaemonClientService` is constructed; `SetLiveAdapter(null)` at teardown.
+
+- [ ] **Step 1: Failing tests:** controller auto-start routes through a fake lane (recording
+  `MutationRequest`s — verb `StartVerified`, identity = pinned profile/server/name); main-window
+  Start produces verb `DetachedStart` through the lane and NO direct runner spawn from
+  `DaemonClientService` (fake runner records zero `daemon start` invocations); a lane
+  `AttentionSkew` outcome does NOT raise the controller's direct attention surface (channel-only);
+  `Refused(cli_not_found)` surfaces the honest not-found message; success still kicks
+  `RestartLoopAsync`.
+- [ ] **Step 2–4: red → implement → green.** Run the FULL app unit suite — this task touches the
+  controller's existing matrix tests; adapt their fakes to the lane seam without weakening any
+  existing assertion (each preserved assertion moves to the lane-request boundary).
+- [ ] **Step 5: Commit** `feat(app): route lifecycle and main-window mutations through the mutation lane`
+
+### Task 11: `ConsentFlipClaims` store
+
+**Files:**
+- Create: `src/Capacitor.App/Services/Onboarding/ConsentFlipClaims.cs`
+- Test: `test/Capacitor.App.Tests.Unit/ConsentFlipClaimsTests.cs`
+
+**Interfaces (produced, exact):**
+```csharp
+public sealed record ConsentFlipClaim(string Profile, string CanonicalServer);  // key = both, canonicalized
+
+public sealed class ConsentFlipClaims(string path) {   // {config}/consent-flip-claims.json
+    public static ConsentFlipClaims Default();          // PathHelpers.ConfigPath("consent-flip-claims.json")
+    public IReadOnlyList<ConsentFlipClaim> Pending();               // read-only snapshot (lock, read, release)
+    public bool Arm(ConsentFlipClaim claim);                        // upsert + durable flush; false = write failed
+    public bool TryConsume(ConsentFlipClaim claim, Func<(string Profile, string Server, string DaemonName)> reResolveUnderConfigLock, string expectedDaemonName);
+    public QuarantineState? Quarantine();                           // non-null once a corrupt file was set aside
+    public sealed record QuarantineState(string PreservedPath);
+}
+```
+
+**Contract:**
+- File shape: `{"version":1,"claims":[{"profile":"…","server":"…"}]}` — source-generated ctx.
+- EVERY mutation runs under `ConfigFileLock.Acquire(path)` (the claims file's own lock) as a
+  synchronous critical section (callers `Task.Run` if async). `Arm`: read-fresh → upsert by key →
+  unique temp write → flush file (`FileStream.Flush(flushToDisk: true)`) → rename → best-effort
+  directory flush. Returns false on any failure (caller blocks the commit — decision 7).
+- `TryConsume` is the two-lock conditional clear (spec §6): acquire the CONFIG lock
+  (`ConfigFileLock.Acquire(AppConfig.GetConfigPath())`) FIRST, call `reResolveUnderConfigLock()`
+  (re-reads config under that lock), and only if the re-resolved `{Profile, Server}` equals the
+  claim's key AND the resolved daemon name equals `expectedDaemonName` — still holding config —
+  acquire the claims lock and remove the key (same durable publication as `Arm`). Any mismatch or
+  pre-rename failure → claim retained, return false. Post-rename durability failures → still
+  consumed (return true) — a crash-resurrected key is safe (idempotent re-apply). Fixed lock
+  order config → claims; no await anywhere inside.
+- Corruption on ANY read: rename the file aside to `consent-flip-claims.quarantined-<n>.json`
+  (first free `n`), start a FRESH empty store, record `QuarantineState`. Arming never rejects due
+  to old corruption.
+
+- [ ] **Step 1: Failing tests** (temp config dir per test; real `ConfigFileLock`): arm → durable
+  file with the key; arm twice same key → one entry; two distinct identities → two keys, no
+  clobber (concurrent arms via `Task.Run` race, both present after); consume with matching
+  re-resolve → key removed; re-resolve returns a DIFFERENT daemon name → retained + false;
+  re-resolve different server → retained; corrupt file → quarantined aside (original preserved
+  with content intact), fresh store arms fine, `Quarantine()` non-null; write-failure injection
+  (make the directory read-only, POSIX-guarded) → `Arm` false; a rename injected between capture
+  and consume (simulated by mutating what `reResolveUnderConfigLock` returns) → retained.
+- [ ] **Step 2–4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): durable consent-flip claim store with two-lock conditional clear`
+
+### Task 12: `ILocalControlOps.PutConsentPolicyV2Async` (Core)
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs` (+ the `ILocalControlOps` interface)
+- Test: `test/Capacitor.Cli.Tests.Unit/LocalIpc/LocalControlOpsV2PutTests.cs` (real-socket, Unix-guarded)
+- Modify: `test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs` (add the scripted member)
+
+**Interfaces:**
+- Produces: `Task<ConsentAckDto> PutConsentPolicyV2Async(ConsentPolicyPutV2Dto put, CancellationToken ct)`
+  — sends `FrameType.ConsentRulesPutV2` on a fresh connection (same connect/one-frame/read-ack
+  pattern as the existing `PutConsentPolicyAsync`), returns the ack verbatim. Transport failures
+  throw (callers map to "retry later"); a decoded ack with `Ok == false` returns normally.
+
+- [ ] **Step 1: Failing tests** against the real daemon-side handler (the existing real-socket
+  harness pattern used by Plan A's `HandleRulesPutV2Async` tests — reuse its server fixture):
+  identity match → applied (follow-up `GetConsentPolicyAsync` sees it) + `Ok == true`; name
+  mismatch → `Ok == false, Error == "identity_mismatch"`, policy unchanged; server mismatch →
+  same. Scripted fake: `QueuePutV2(...)`/capture list mirroring the existing per-verb pattern.
+- [ ] **Step 2–4: red → implement → green.** AOT publish both binaries — zero IL warnings.
+- [ ] **Step 5: Commit** `feat(core): identity-conditional consent rules put (v2) on local control ops`
+
+### Task 13: `ConsentFlipCoordinator` + quarantine ack in app-state
+
+**Files:**
+- Create: `src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs`
+- Modify: `src/Capacitor.App/Services/AppStateStore.cs` (`AppState` gains
+  `bool ConsentQuarantineAcked = false`)
+- Test: `test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs`
+
+**Interfaces:**
+```csharp
+public sealed class ConsentFlipCoordinator(
+    IDaemonClientService client, ILocalControlOps ops, ConsentFlipClaims claims,
+    Func<(string Profile, string Server, string DaemonName)> resolveIdentityUnderConfigLock,
+    ILifecycleSurface surface, IAppStateStore appState, CancellationToken lifetime) {
+    public void Start();   // subscribes client.Status
+}
+```
+
+**Contract (spec §6, coordinator path):** On each transition to `Connected` with
+`Capabilities` containing `"consent/3"`: snapshot `claims.Pending()`; for a claim whose
+`{Profile, CanonicalServer}` matches the CURRENT resolved identity (resolved via the injected
+resolver — one plain read, NOT yet under lock): (1) resolve target daemon name from current
+config; (2) `GetConsentPolicyAsync` → FACTORY GUARD: proceed only if default is `allow` with zero
+rules (any other policy → claim left pending and inert — NOT consumed); (3)
+`PutConsentPolicyV2Async(new(name, claim.CanonicalServer, promptPolicy))`; ack `Ok == false` (any
+error, incl. `identity_mismatch`) → claim retained, stop; (4) on success,
+`claims.TryConsume(claim, resolveIdentityUnderConfigLock, name)` — the two-lock conditional
+clear; a false return leaves it pending for the next graph. Missing `consent/3` → no put, claim
+pending. All of this single-flight (one pass per Connected transition; a `SemaphoreSlim(1,1)`
+like `ConsentService`). Quarantine surfacing: on `Start()`, if `claims.Quarantine()` is non-null
+and `AppState.ConsentQuarantineAcked` is false → surface ONE attention state naming the preserved
+path + the recovery guidance ("pre-existing daemons may need `kcap daemon consent set-default
+prompt`, or re-run onboarding"); acknowledging persists the flag.
+
+- [ ] **Step 1: Failing tests** (fake client Status subject + `ScriptedLocalControlOps` +
+  scripted resolver): Connected+capability+matching claim+factory-allow-zero-rules → get, v2 put
+  with `{resolved name, claim server}`, consume called; policy with rules → NO put, claim
+  pending; default `prompt` → no put; missing capability → nothing; `identity_mismatch` ack →
+  claim retained; put success + resolver now returns a renamed daemon at consume time → claim
+  retained (the §10 rename-injection rows: after resolve / after get / after put); non-matching
+  `{profile, server}` claim → inert; quarantine surfaced once, ack persisted → not re-surfaced
+  on restart (fresh coordinator + acked state).
+- [ ] **Step 2–4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): consent-flip coordinator with factory guard and conditional clear`
+
+### Task 14: `auth_provider` stamp (Core) + `OnboardingGate`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Config/ProfileConfig.cs` — `Profile` gains
+  `[JsonPropertyName("auth_provider")] public AuthProviderStamp? AuthProvider { get; init; }`
+  with `public sealed record AuthProviderStamp([property: JsonPropertyName("provider")] string Provider, [property: JsonPropertyName("server_url")] string ServerUrl)`
+  (additive, serialization ctx updated; nothing WRITES it in Plan B — the wizard's commit boundary
+  writes it in Plan C).
+- Create: `src/Capacitor.App/Services/Onboarding/OnboardingGate.cs`
+- Modify: `src/Capacitor.App/App.axaml.cs` — `ValidProfileName`'s URL validity check delegates to
+  the same validator the gate uses.
+- Test: `test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs`, `test/Capacitor.Cli.Tests.Unit/Config/ProfileAuthProviderStampTests.cs`
+
+**Interfaces:**
+```csharp
+public abstract record GateResult {
+    public sealed record Complete : GateResult;
+    public sealed record Incomplete(GateReason Reason) : GateResult;
+}
+public enum GateReason { NoProfile, InvalidServerUrl, NoToken, TokenUnusableBinding, TokenUnusableExpired }
+public static class OnboardingGate {
+    public static bool ValidServerUrl(string? url);   // the ONE shared validator: canonical http(s) via ServerIdentity
+    public static Task<GateResult> EvaluateAsync(CancellationToken ct);
+}
+```
+
+**Contract (decision 1 — local, side-effect-free, no refresh):** resolve profile
+(`AppConfig.ResolveActiveProfile([])`); no resolvable profile → `NoProfile`. Profile's
+`server_url` must canonicalize to an absolute `http`/`https` origin (`ValidServerUrl` — rejects
+`file://`, bare words; built on `ServerIdentity.TryCanonicalizeForStamping` restricted to
+http/https) → else `InvalidServerUrl`. Provider stamp: if `profile.AuthProvider` is
+`{Provider: "none"}` AND `ServerIdentity.SameServer(stamp.ServerUrl, profile.ServerUrl)` →
+`Complete` (no token needed); a stale stamp (server differs) is ignored (token required). Token:
+`TokenStore.LoadForProfileAsync(profileName, ct)` (raw, refresh-free); null/unreadable/corrupt →
+`NoToken`; token present but its `ServerUrl` binding fails `SameServer` against the profile →
+`TokenUnusableBinding`; unexpired → `Complete`; expired → refresh-capable ⇒ `Complete` where
+GitHubApp is ALWAYS refresh-capable and WorkOS requires BOTH `RefreshToken` and `ClientId`, else
+`TokenUnusableExpired`. Legacy unbound token (null `ServerUrl` stamp): treat as usable binding
+(pre-upgrade tokens carry no stamp — matches `TokenStore`'s own leniency) — pin this with a test
+either way after reading `TokenStore.SameServer` usage; if `TokenStore` treats unbound as
+usable-for-any, the gate must agree (decision 1: "matching TokenStore's real refresh rules").
+
+- [ ] **Step 1: Failing tests** — the full §10 gate matrix: no profile / invalid URL incl.
+  `file://` (via the SHARED validator — one test asserts `App.ValidProfileName` and the gate
+  reject the same `file://` input) / no token file / WorkOS expired with both refresh fields
+  (Complete) / WorkOS expired missing `ClientId` (TokenUnusableExpired) / GitHubApp expired
+  (Complete) / wrong-server token (TokenUnusableBinding) / legacy unbound token (pinned per
+  `TokenStore` semantics) / corrupt token file (NoToken) / stamp `none` matching server
+  (Complete, no token file at all) / stale `none` stamp after `server_url` change (NoToken) /
+  legacy profile without stamp (token required). Core test: `auth_provider` round-trips through
+  serialization and is absent-by-default (old configs load with null).
+- [ ] **Step 2–4: red → implement → green.** AOT publish both CLI binaries (Core changed).
+- [ ] **Step 5: Commit** `feat: onboarding gate with provider-aware token usability and shared URL validator`
+
+### Task 15: Startup carve-out wiring (gate-aware graph, no wizard yet)
+
+**Files:**
+- Modify: `src/Capacitor.App/App.axaml.cs`, `src/Capacitor.App/Services/DaemonLifecycleController.cs`
+  (constructor gains `bool autoActionsPermanentlyClosed = false`),
+  `src/Capacitor.App/Services/ShimOfferCoordinator.cs` (suppression flag or simply not started)
+- Test: `test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs` (headless where needed)
+
+**Contract (decision 2's carve-out, WITHOUT wizard-first windowing — that lands in Plan C):**
+`App.StartAsync` evaluates `OnboardingGate.EvaluateAsync()` FIRST. `Complete` → today's startup
+exactly. `Incomplete` → the graph is still built (Plan C replaces this arm with wizard-first),
+but: the lifecycle controller is constructed with `autoActionsPermanentlyClosed: true` — its
+startup auto-action branches (auto-install/auto-start/silent repair) never fire, `PhaseClosed`
+still completes on the first terminal attach, user-clicked `StartActionAsync` still works — and
+the `ShimOfferCoordinator` auto-offer is not started (tray manual shim item keeps working). The
+`DaemonMutationLane` is constructed before the gate evaluation either way (app-lifetime
+singleton). Mark the `Incomplete` arm with a comment: `// Plan C replaces this arm with wizard-first startup (spec decision 2).`
+
+- [ ] **Step 1: Failing tests:** gate-incomplete → controller constructed with auto-actions
+  closed (no mutation request reaches the lane on a fresh-machine fixture: valid URL + no token,
+  attach unreachable) AND shim auto-offer never starts; gate-complete → auto-actions armed as
+  today (existing startup-matrix tests keep passing); user-clicked Start still routes a
+  `DetachedStart` request through the lane in the carve-out mode. Assert ZERO service mutations
+  for: valid URL + no token; invalid/non-HTTP URL (the two §10 carve-out rows applicable without
+  a wizard).
+- [ ] **Step 2–4: red → implement → green.** Run the FULL app suite + both AOT publishes + the
+  full CLI/daemon unit + integration suites (`TMPDIR=/private/tmp`).
+- [ ] **Step 5: Commit** `feat(app): gate-aware startup carve-out — auto-actions closed on incomplete setup`
+
+### Task 16: Project docs + final verification sweep
+
+**Files:**
+- Modify: `CLAUDE.md` (the "What this project does" section gains a short Plan-B paragraph:
+  app-side `DaemonMutationLane` singleton, `ConsentFlipClaims`/`ConsentFlipCoordinator`,
+  `OnboardingGate` + carve-out, pointing at the spec)
+- No README change (no user-visible CLI surface changed).
+
+- [ ] **Step 1:** Write the CLAUDE.md paragraph (match the existing sections' density; ≤ 12 lines).
+- [ ] **Step 2:** Full verification: app unit suite, CLI unit suite, integration suite, both AOT
+  publishes (zero IL warnings), `dotnet build Capacitor.slnx` clean (IDE0005 is error-enforced).
+- [ ] **Step 3: Commit** `docs: record plan-B app substrate in CLAUDE.md`
+
+---
+
+## Explicitly deferred to Plan C (do NOT build here)
+
+Wizard UI (`OnboardingWindow`, step ViewModels), `WizardAuthService`, the Core auth façade (§5)
+and `setup`/`login` re-plumb, `KcapCli.PluginInstallAsync` + streaming import (§7), the
+`auth_provider` stamp WRITE path, wizard-first startup windowing + wizard-close graph handoff
+(`TransferConsumer` call sites), claim ARMING from the commit boundary (Plan B arms only in
+tests), `AgentDetection` app feed. The §10 rows covering those flows land with Plan C.
+
+## Self-review notes
+
+- Task ordering is dependency-clean: 1–8 are leaves; 9a needs 1,2,4,5,7,8; 9b needs 6; 10 needs
+  9b; 13 needs 11,12; 15 needs 10,14; 16 last.
+- Interfaces named in later tasks are defined in earlier ones (checked: `MutationRequest`/
+  `MutationOutcome`/`OutcomeChannel`/`ObservedEvidence`/`KcapCliCompatibility.Satisfies`/
+  `KcapPathAsync`/`TimeoutKillScope`/`BootRefusalMarker.TryAttribute`).
+- Every task carries its own red → green cycle and commit; no placeholders remain.

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -473,7 +473,7 @@ public partial class App : Application {
             Func<CancellationToken, Task<string?>> terminalPathAsync, Func<string?> cliVersion, CancellationToken ct,
             HashSet<(MutationRequest Request, string Token)>? declinedTakeoverPairs = null) {
         if (envelope.Outcome is MutationOutcome.UnconfirmedNoAttach) {
-            surface.Attention($"{VerbDisplay(envelope.Request.Verb)} started, not yet confirmed — check status.");
+            surface.Attention($"The daemon {VerbDisplay(envelope.Request.Verb)} is not yet confirmed — check status.");
             return;
         }
 

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -136,7 +136,7 @@ public partial class App : Application {
             // spec subscribe-before-pump: the controller's attach subscription must be live
             // BEFORE service.Start() begins pumping, or the startup phase could miss the very
             // first terminal outcome it hinges on (DaemonLifecycleController.Start's own comment).
-            var (lifecycle, shimOffer, lifecycleSurface) =
+            var (lifecycle, shimOffer, lifecycleSurface, lifecycleProbe) =
                 BuildLifecycleController(service, lifecycleStatus.OnNext, lifecycleAttention.OnNext, lane.RunAsync);
             lifecycle.Start();
             _lifecycle = lifecycle;
@@ -148,8 +148,11 @@ public partial class App : Application {
 
             // The composition-root outcome consumer: shares lifecycle's own ILifecycleSurface, so
             // a lane-executed mutation's dialog reuses its serialized gate rather than a competing
-            // one. Starts immediately — Plan C adds the wizard TransferConsumer handoff.
-            _ = ConsumeMutationOutcomesAsync(channel, lifecycleSurface, _shutdown.Token);
+            // one; also shares its probe (disclosure) and CliVersion (dialog text) and the lane
+            // itself (a Takeover accept re-mutates through it). Starts immediately — Plan C adds
+            // the wizard TransferConsumer handoff.
+            _ = ConsumeMutationOutcomesAsync(
+                channel, lifecycleSurface, lane.RunAsync, lifecycleProbe.TerminalPathAsync, () => lifecycle.CliVersion, _shutdown.Token);
 
             service.Start();
             _service = service;
@@ -359,16 +362,17 @@ public partial class App : Application {
     // spec composition: wires the daemon-service CLI facade (decision 1: everything through the
     // CLI), the login-shell PATH probe, and the persisted decline-memory store. A broken
     // KCAP_APP_CLI_PATH override (CliResolver.ResolvePath returning null) is treated as "no CLI"
-    // here — unlike CreateDefaultAsync's own lenient `daemon start -d` fallback above, the
-    // lifecycle features must never silently point at the wrong binary.
+    // here — the lifecycle features must never silently point at the wrong binary.
     //
     // Task 24: also builds ShimOfferCoordinator here (not a separate method) — it shares
     // cliPath/probe/store/surface with the lifecycle controller rather than re-resolving them.
     // Task 10: `runMutation` (the lane's RunAsync) and the resolved canonical server are threaded
     // through so the controller's own mutating branches route execution through the ONE lane
     // instead of calling IKcapCli mutation methods directly; `cli` below is kept for read-only
-    // VersionAsync/ServiceStatusAsync only.
-    (DaemonLifecycleController Lifecycle, ShimOfferCoordinator ShimOffer, ILifecycleSurface Surface) BuildLifecycleController(
+    // VersionAsync/ServiceStatusAsync only. `Probe` is returned too so the composition-root
+    // outcome consumer can compute a takeover dialog's PathDegraded disclosure from the SAME
+    // probe instance the controller's own preconditions use.
+    (DaemonLifecycleController Lifecycle, ShimOfferCoordinator ShimOffer, ILifecycleSurface Surface, ILoginShellProbe Probe) BuildLifecycleController(
             DaemonClientService service, Action<string> setLifecycleStatus, Action<string> setLifecycleAttention,
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
         var cliPath = CliResolver.ResolvePath(Environment.GetEnvironmentVariable, File.Exists);
@@ -394,7 +398,7 @@ public partial class App : Application {
         var shimOffer = new ShimOfferCoordinator(
             lifecycle.PhaseClosed, probe, new PathShimInstaller(runner, probe), store, surface, shimTarget, _shutdown.Token);
 
-        return (lifecycle, shimOffer, surface);
+        return (lifecycle, shimOffer, surface, probe);
     }
 
     static string? ValidProfileName(ResolvedProfile? profile) =>
@@ -402,55 +406,88 @@ public partial class App : Application {
             ? profile.ProfileName
             : null;
 
-    // Task 10: the lane's cliOverride seam. CliResolver.ResolvePath's own bare-"kcap"
-    // fallback (no KCAP_APP_CLI_PATH override set) pins nothing — it's PATH resolution deferred to
-    // spawn time — so it is remapped to null here, letting the lane's own shell-probe path answer
-    // instead. An override that IS set still passes through verbatim, including a broken one
-    // (fileExists=false), which ResolvePath already reports as null — fail closed, never a silent
-    // fallback to PATH.
+    // The lane's cliOverride seam. Unlike CreateDefaultAsync's shared CliResolver.ResolvePath
+    // (whose no-override answer is the bare string "kcap", a PATH-resolution-at-spawn-time
+    // sentinel), the lane needs an unambiguous absolute pin or nothing — string-comparing
+    // ResolvePath's return against "kcap" could, in principle, misfire on a real override whose
+    // resolved value is also exactly "kcap" (round-1 review M-4). Reads KCAP_APP_CLI_PATH
+    // directly instead: set + exists → an absolute pin (Path.GetFullPath); set + missing → null
+    // (fail closed, never a silent PATH fallback); truly absent → null (the lane's own
+    // shell-probe path answers instead).
     static string? ResolveCliOverride() =>
-        MapBareKcapToNull(CliResolver.ResolvePath(Environment.GetEnvironmentVariable, File.Exists));
+        ResolveCliOverrideCore(Environment.GetEnvironmentVariable("KCAP_APP_CLI_PATH"), File.Exists, Path.GetFullPath);
 
-    // Split out of ResolveCliOverride so a test can drive the remapping without touching the real
-    // environment (CliResolverTests already covers ResolvePath's own override/no-override/broken
-    // cases exhaustively).
-    internal static string? MapBareKcapToNull(string? resolved) => resolved == "kcap" ? null : resolved;
+    // Split out so a test can drive it without touching the real environment.
+    internal static string? ResolveCliOverrideCore(string? overrideEnv, Func<string, bool> fileExists, Func<string, string> getFullPath) {
+        if (string.IsNullOrEmpty(overrideEnv)) return null;
+        return fileExists(overrideEnv) ? getFullPath(overrideEnv) : null;
+    }
 
     // Drains every non-success outcome the lane enqueues and presents it through the SAME
-    // ILifecycleSurface the controller uses for its own dialogs (single-presentation rule).
-    static async Task ConsumeMutationOutcomesAsync(OutcomeChannel channel, ILifecycleSurface surface, CancellationToken ct) {
+    // ILifecycleSurface the controller uses for its own dialogs (single-presentation rule). A
+    // presentation failure for ONE envelope is caught and logged INSIDE the loop (round-1 review
+    // I-1) so it can never brick every presentation after it — only a shutdown cancellation ends
+    // the loop.
+    internal static async Task ConsumeMutationOutcomesAsync(
+            OutcomeChannel channel, ILifecycleSurface surface,
+            Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
+            Func<CancellationToken, Task<string?>> terminalPathAsync, Func<string?> cliVersion, CancellationToken ct) {
         try {
             await foreach (var lease in channel.ConsumeAsync(ct)) {
                 try {
-                    await PresentOutcomeAsync(surface, lease.Envelope, ct).ConfigureAwait(false);
+                    await PresentOutcomeAsync(surface, lease.Envelope, runMutation, terminalPathAsync, cliVersion, ct).ConfigureAwait(false);
+                } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                    throw; // shutdown — let the outer catch end the whole loop, not just this envelope
+                } catch (Exception ex) {
+                    Console.Error.WriteLine($"kcap app failed to present a mutation outcome: {ex}");
                 } finally {
-                    lease.Ack(); // presented (or a presentation failure was logged below) — never redelivered
+                    lease.Ack(); // presented, logged-and-skipped, or shutting down — never redelivered
                 }
             }
         } catch (OperationCanceledException) {
             // shutdown — draining stops; anything still queued is simply not presented
-        } catch (Exception ex) {
-            Console.Error.WriteLine($"kcap app outcome-channel consumer failed unexpectedly: {ex}");
         }
     }
 
-    // Takeover reuses the controller's own gated ConfirmAsync dialog; Reinstall/Attention/Storage
-    // are a status/attention line naming the coded token; UnconfirmedNoAttach and any success case
-    // are non-actionable here (the caller already surfaced local state) and are skipped.
-    internal static async Task PresentOutcomeAsync(ILifecycleSurface surface, OutcomeEnvelope envelope, CancellationToken ct) {
-        var (recoverySurface, token) = ClassifyForPresentation(envelope.Outcome);
-        if (recoverySurface == RecoverySurface.None) return;
+    // Takeover reuses the controller's own gated ConfirmAsync dialog — accept re-mutates via
+    // Replace at the ENVELOPE's own identity (never freshly resolved: a takeover targets the
+    // identity that failed) and is state-only (any follow-up actionable outcome re-arrives on its
+    // own envelope — that loop is the design); decline is the ONE exception to "never
+    // surface.Status for Takeover" — one line naming the token, nothing else (round-1 review C-1).
+    // Reinstall/Attention/Storage are an attention line naming the coded token (round-1 review
+    // C-2: Reinstall moved off the status slot — the controller's own guard-refusal status line is
+    // now the ONLY status-slot writer for a mutation outcome). UnconfirmedNoAttach is actionable
+    // (round-1 review I-3) — one attention line naming the verb; any success case never reaches
+    // here at all (the lane's Deliver only enqueues non-success outcomes).
+    internal static async Task PresentOutcomeAsync(
+            ILifecycleSurface surface, OutcomeEnvelope envelope,
+            Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
+            Func<CancellationToken, Task<string?>> terminalPathAsync, Func<string?> cliVersion, CancellationToken ct) {
+        if (envelope.Outcome is MutationOutcome.UnconfirmedNoAttach) {
+            surface.Attention($"{envelope.Request.Verb} started, not yet confirmed — check status.");
+            return;
+        }
 
-        var named = token ?? "unspecified";
+        var (recoverySurface, token) = ClassifyForPresentation(envelope.Outcome);
+        if (recoverySurface == RecoverySurface.None) return; // success cases only — never enqueued anyway
+
+        // Refused/Failed always resolve a non-null token (Failed falls back to the exit-code
+        // token) and AttentionSkew/AttentionRepair's own detail is never null either — every
+        // branch below that reaches this point has a real token to name.
+        var named = token!;
         switch (recoverySurface) {
             case RecoverySurface.Takeover:
-                surface.Status($"kcap needs to replace the daemon service to continue ({named}).");
-                await surface.ConfirmAsync(
-                        new LifecyclePrompt(LifecyclePrompt.KindTakeover, null, null, false, DaemonLifecycleController.TakeoverDisclosure), ct)
-                    .ConfigureAwait(false);
+                var pathDegraded = await terminalPathAsync(ct).ConfigureAwait(false) is null;
+                var prompt = new LifecyclePrompt(
+                    LifecyclePrompt.KindTakeover, null, cliVersion(), pathDegraded, DaemonLifecycleController.TakeoverDisclosure);
+                var accepted = await surface.ConfirmAsync(prompt, ct).ConfigureAwait(false);
+                if (accepted)
+                    _ = await runMutation(envelope.Request with { Verb = MutationVerb.Replace }, ct).ConfigureAwait(false);
+                else
+                    surface.Status($"kcap needs to replace the daemon service to continue ({named}) — declined.");
                 break;
             case RecoverySurface.Reinstall:
-                surface.Status($"kcap needs to be reinstalled to continue ({named}).");
+                surface.Attention($"kcap needs to be reinstalled to continue ({named}).");
                 break;
             case RecoverySurface.Attention:
             case RecoverySurface.Storage:
@@ -459,12 +496,16 @@ public partial class App : Application {
         }
     }
 
+    // Succeeded/SucceededAfterTimeout are the only cases still landing on the None catch-all —
+    // they're never enqueued onto the channel at all, so this is unreachable in production;
+    // UnconfirmedNoAttach is handled by PresentOutcomeAsync BEFORE this classification runs
+    // (round-1 review I-3 — it is actionable, not skipped).
     internal static (RecoverySurface Surface, string? Token) ClassifyForPresentation(MutationOutcome outcome) => outcome switch {
         MutationOutcome.Refused(var reason, var surface)                => (surface, reason),
         MutationOutcome.Failed(var exitCode, var reason, var surface)   => (surface, reason ?? VerifyExitCodes.Token(exitCode)),
         MutationOutcome.AttentionSkew(var detail)                       => (RecoverySurface.Attention, detail),
         MutationOutcome.AttentionRepair(var detail)                     => (RecoverySurface.Attention, detail),
-        _ => (RecoverySurface.None, null), // UnconfirmedNoAttach, and any success case (never enqueued anyway)
+        _ => (RecoverySurface.None, null),
     };
 
     Task<bool> ConfirmLifecyclePromptAsync(LifecyclePrompt prompt, CancellationToken ct) =>

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -265,10 +265,9 @@ public partial class App : Application {
                 Console.Error.WriteLine($"kcap app failed to dispose the daemon lifecycle controller during startup-failure cleanup: {disposeEx}");
             }
         }
-        // Unset BEFORE disposing service: a mutation still draining out of the lane (its own
-        // disposal is last, below) must never dial into a service whose Status/Snapshots Subjects
-        // are about to be disposed — PinObservationAsync falls back to the one-shot adapter once
-        // this is null.
+        // Unset BEFORE disposing service: an action starting after this pins a plain one-shot;
+        // an in-flight action keeps its pinned composite, whose live leg reading a disposed
+        // subject lands in DeliverFaulted rather than hanging.
         lane?.SetLiveAdapter(null);
         if (service is not null) {
             shutdown.Cancel();

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -46,6 +46,8 @@ public partial class App : Application {
     // await chain against BuildLifecycleController's cliPath/probe/store/surface and _shutdown.Token,
     // so cancelling _shutdown (every teardown path below already does) is what stops it.
     ShimOfferCoordinator? _shimOffer;
+    // No disposal needed — its Status subscription dies with _service's own subject disposal below.
+    ConsentFlipCoordinator? _consentFlip;
     // Assigned by StartAsync's success path only; every one is still null on a startup failure
     // (and cleared again by the catch, which disposes whatever had been built). Teardown —
     // shutdown and startup-failure alike — disposes them in reverse creation order, tray icon
@@ -113,6 +115,10 @@ public partial class App : Application {
                 TimeProvider.System);
             _lane = lane;
 
+            // Plan C replaces this arm with wizard-first startup (spec decision 2).
+            var gate = await OnboardingGate.EvaluateAsync(_shutdown.Token);
+            var autoActionsPermanentlyClosed = AutoActionsPermanentlyClosed(gate);
+
             var service = await DaemonClientService.CreateDefaultAsync(lane.RunAsync);
             // The live adapter answers a mutation's own confirmation with zero extra socket cost
             // whenever the request targets THIS service's daemon/server — LiveGraphObservation
@@ -137,15 +143,19 @@ public partial class App : Application {
             // spec subscribe-before-pump: the controller's attach subscription must be live
             // BEFORE service.Start() begins pumping, or the startup phase could miss the very
             // first terminal outcome it hinges on (DaemonLifecycleController.Start's own comment).
-            var (lifecycle, shimOffer, lifecycleSurface, lifecycleProbe) =
-                BuildLifecycleController(service, lifecycleStatus.OnNext, lifecycleAttention.OnNext, lane.RunAsync);
+            var (lifecycle, shimOffer, consentFlip, lifecycleSurface, lifecycleProbe) = BuildLifecycleController(
+                service, ops, autoActionsPermanentlyClosed, lifecycleStatus.OnNext, lifecycleAttention.OnNext, lane.RunAsync);
             lifecycle.Start();
             _lifecycle = lifecycle;
             // Task 24: unlike lifecycle's Start(), subscribe-before-run doesn't matter here —
             // Offerable is a BehaviorSubject, so TrayViewModel (built further below) still sees
             // the current value the moment it subscribes.
-            shimOffer.Start();
+            // Incomplete: the once-ever auto-offer never runs; the tray's manual install command stays wired.
+            if (!autoActionsPermanentlyClosed) shimOffer.Start();
             _shimOffer = shimOffer;
+
+            consentFlip.Start();
+            _consentFlip = consentFlip;
 
             // The composition-root outcome consumer: shares lifecycle's own ILifecycleSurface, so
             // a lane-executed mutation's dialog reuses its serialized gate rather than a competing
@@ -221,6 +231,7 @@ public partial class App : Application {
             _lifecycle = null;
             _lane = null;
             _shimOffer = null; // no disposal of its own (see field comment) — just drop the reference
+            _consentFlip = null; // same — no disposal of its own
             _tray = null;
             _trayVm = null;
             _promptCoordinator = null;
@@ -373,8 +384,11 @@ public partial class App : Application {
     // VersionAsync/ServiceStatusAsync only. `Probe` is returned too so the composition-root
     // outcome consumer can compute a takeover dialog's PathDegraded disclosure from the SAME
     // probe instance the controller's own preconditions use.
-    (DaemonLifecycleController Lifecycle, ShimOfferCoordinator ShimOffer, ILifecycleSurface Surface, ILoginShellProbe Probe) BuildLifecycleController(
-            DaemonClientService service, Action<string> setLifecycleStatus, Action<string> setLifecycleAttention,
+    // `ops` (already built by StartAsync) is shared with the ConsentFlipCoordinator built here too.
+    (DaemonLifecycleController Lifecycle, ShimOfferCoordinator ShimOffer, ConsentFlipCoordinator ConsentFlip,
+            ILifecycleSurface Surface, ILoginShellProbe Probe) BuildLifecycleController(
+            DaemonClientService service, ILocalControlOps ops, bool autoActionsPermanentlyClosed,
+            Action<string> setLifecycleStatus, Action<string> setLifecycleAttention,
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
         var cliPath = CliResolver.ResolvePath(Environment.GetEnvironmentVariable, File.Exists);
         var runner  = new DaemonClientService.ProcessRunner();
@@ -390,7 +404,7 @@ public partial class App : Application {
 
         var lifecycle = new DaemonLifecycleController(
             service, cli, probe, store, surface, () => Task.FromResult(ValidProfileName(profile)), TimeProvider.System,
-            canonicalServer, runMutation);
+            canonicalServer, runMutation, autoActionsPermanentlyClosed);
 
         // The shim links to the RESOLVED ABSOLUTE path only — CliResolver's bare "kcap" fallback
         // (no override set, or the not-yet-landed bundle-relative arm) means there is
@@ -399,7 +413,21 @@ public partial class App : Application {
         var shimOffer = new ShimOfferCoordinator(
             lifecycle.PhaseClosed, probe, new PathShimInstaller(runner, probe), store, surface, shimTarget, _shutdown.Token);
 
-        return (lifecycle, shimOffer, surface, probe);
+        // The delegate below and ConsentFlipClaims.Default() both resolve AppConfig.GetConfigPath().
+        var consentFlip = new ConsentFlipCoordinator(
+            service, ops, ConsentFlipClaims.Default(), ResolveConsentFlipIdentity, surface, store, _shutdown.Token);
+
+        return (lifecycle, shimOffer, consentFlip, surface, probe);
+    }
+
+    // Pure LoadPure read only — TryConsume already holds this same config lock when this delegate runs.
+    internal static (string Profile, string Server, string DaemonName) ResolveConsentFlipIdentity() {
+        var config      = ConfigMutator.LoadPure(AppConfig.GetConfigPath());
+        var profileName = config.ActiveProfile;
+        var profile     = config.Profiles.GetValueOrDefault(profileName);
+        var server      = ServerIdentity.Canonicalize(profile?.ServerUrl) ?? profile?.ServerUrl ?? "";
+        var daemonName  = DaemonNameResolver.Resolve([], profile?.Daemon?.Name);
+        return (profileName, server, daemonName);
     }
 
     // Delegates to the ONE shared validator: must agree with OnboardingGate on what counts as a
@@ -409,6 +437,9 @@ public partial class App : Application {
         OnboardingGate.ValidServerUrl(profile?.ServerUrl)
             ? profile!.ProfileName
             : null;
+
+    // Decision 2's carve-out switch: Incomplete is the only gate outcome that closes auto-actions.
+    internal static bool AutoActionsPermanentlyClosed(GateResult gate) => gate is GateResult.Incomplete;
 
     // The lane's cliOverride seam. Unlike CreateDefaultAsync's shared CliResolver.ResolvePath
     // (whose no-override answer is the bare string "kcap", a PATH-resolution-at-spawn-time

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.App.Services.Mutation;
+using Capacitor.App.Services.Onboarding;
 using Capacitor.App.ViewModels;
 using Capacitor.App.Views;
 using Capacitor.Cli.Core;
@@ -401,9 +402,12 @@ public partial class App : Application {
         return (lifecycle, shimOffer, surface, probe);
     }
 
-    static string? ValidProfileName(ResolvedProfile? profile) =>
-        !string.IsNullOrWhiteSpace(profile?.ServerUrl) && Uri.TryCreate(profile.ServerUrl, UriKind.Absolute, out _)
-            ? profile.ProfileName
+    // Delegates to the ONE shared validator: must agree with OnboardingGate on what counts as a
+    // valid server_url (e.g. both reject file://), or a gate-incomplete machine could still pass
+    // this precondition into the normal daemon graph.
+    internal static string? ValidProfileName(ResolvedProfile? profile) =>
+        OnboardingGate.ValidServerUrl(profile?.ServerUrl)
+            ? profile!.ProfileName
             : null;
 
     // The lane's cliOverride seam. Unlike CreateDefaultAsync's shared CliResolver.ResolvePath

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -29,13 +29,11 @@ public partial class App : Application {
     // lane's 10s DetachedConfirmWindow.
     static readonly TimeSpan OneShotProbeTimeout = TimeSpan.FromSeconds(2);
 
-    // Linked to the app's shutdown sequence below; the token StartDaemonCommand's WAIT is
-    // built against (Task 4 carry-note: never CancellationToken.None — an unbounded wait would
-    // survive app exit).
+    // Linked to the app's shutdown sequence below; the token StartDaemonCommand's WAIT is built
+    // against — never CancellationToken.None, or an unbounded wait would survive app exit.
     readonly CancellationTokenSource _shutdown = new();
-    // Task 10: constructed FIRST (before any other graph object) in StartAsync and
-    // disposed LAST — every daemon mutation in the app runs through it, so nothing that might
-    // still call RunAsync can outlive it.
+    // Constructed FIRST (before any other graph object) in StartAsync and disposed LAST — every
+    // daemon mutation in the app runs through it, so nothing that might still call RunAsync can outlive it.
     DaemonMutationLane? _lane;
     DaemonClientService? _service; // concrete type: IAsyncDisposable is not on the interface
     // spec: subscribed and Start()'d BEFORE _service.Start() begins pumping (subscribe-before-
@@ -99,10 +97,7 @@ public partial class App : Application {
     // surface (stderr is invisible for a GUI-launched WinExe) — it must fail loudly instead.
     async Task StartAsync(IClassicDesktopStyleApplicationLifetime desktop) {
         try {
-            // Task 10: the lane is constructed FIRST, before any other graph object —
-            // every daemon mutation in the app, from here on, routes through this one instance.
-            // Its own dependencies (a process runner + login-shell probe) need neither a resolved
-            // profile nor a live service, so nothing below is reordered to make this possible.
+            // The lane is constructed FIRST, before any other graph object, since every daemon mutation routes through this one instance and its own dependencies need neither a resolved profile nor a live service.
             var laneRunner = new DaemonClientService.ProcessRunner();
             var laneProbe  = new LoginShellProbe(laneRunner, Environment.GetEnvironmentVariable);
             var channel    = new OutcomeChannel();
@@ -121,13 +116,7 @@ public partial class App : Application {
             // itself falls back to null (one-shot) for any other target.
             lane.SetLiveAdapter(new LiveGraphObservation(service));
 
-            // Shares CreateDefaultAsync's own AppConfig.ResolveActiveProfile resolution (Codex P1
-            // review): a second, independent self-resolving gate call could observe a different
-            // active profile than the graph above if it changed concurrently between the two
-            // resolves — evaluating Complete for profile A while the graph builds for
-            // unauthenticated profile B with auto-actions open. EvaluateResolvedAsync skips its
-            // own resolution and reads the SAME AppConfig.ResolvedProfile CreateDefaultAsync just
-            // set, so the verdict and the graph identity can never diverge.
+            // Shares CreateDefaultAsync's own AppConfig.ResolveActiveProfile resolution: EvaluateResolvedAsync reads the SAME AppConfig.ResolvedProfile rather than re-resolving, so the gate verdict and the graph identity can never diverge on a profile that changes concurrently between the two.
             var resolvedProfile = AppConfig.ResolvedProfile;
             var gate = await EvaluateGateSafelyAsync(
                 ct => OnboardingGate.EvaluateResolvedAsync(resolvedProfile?.ProfileName, resolvedProfile?.Profile, ct),
@@ -157,11 +146,7 @@ public partial class App : Application {
                 service, ops, autoActionsPermanentlyClosed, lifecycleStatus.OnNext, lifecycleAttention.OnNext, lane.RunAsync);
             lifecycle.Start();
             _lifecycle = lifecycle;
-            // Task 24: unlike lifecycle's Start(), subscribe-before-run doesn't matter here —
-            // Offerable is a BehaviorSubject, so TrayViewModel (built further below) still sees
-            // the current value the moment it subscribes.
-            // Always started: the item and manual install must keep working in Incomplete mode too
-            // — BuildLifecycleController's autoOfferSuppressed is what skips only the dialog.
+            // Unlike lifecycle's Start(), subscribe-before-run doesn't matter here (Offerable is a BehaviorSubject, replayed to TrayViewModel whenever it subscribes); always started so the item and manual install keep working in Incomplete mode too — BuildLifecycleController's autoOfferSuppressed skips only the dialog.
             shimOffer.Start();
             _shimOffer = shimOffer;
 
@@ -290,8 +275,7 @@ public partial class App : Application {
                 Console.Error.WriteLine($"kcap app failed to dispose the daemon client service during startup-failure cleanup: {disposeEx}");
             }
         }
-        // The lane goes LAST (Task 10): both lifecycle and service can still be calling
-        // its RunAsync until their own disposal above completes.
+        // The lane goes LAST: both lifecycle and service can still be calling its RunAsync until their own disposal above completes.
         if (lane is not null) {
             try {
                 await lane.DisposeAsync();
@@ -386,15 +370,7 @@ public partial class App : Application {
     // KCAP_APP_CLI_PATH override (CliResolver.ResolvePath returning null) is treated as "no CLI"
     // here — the lifecycle features must never silently point at the wrong binary.
     //
-    // Task 24: also builds ShimOfferCoordinator here (not a separate method) — it shares
-    // cliPath/probe/store/surface with the lifecycle controller rather than re-resolving them.
-    // Task 10: `runMutation` (the lane's RunAsync) and the resolved canonical server are threaded
-    // through so the controller's own mutating branches route execution through the ONE lane
-    // instead of calling IKcapCli mutation methods directly; `cli` below is kept for read-only
-    // VersionAsync/ServiceStatusAsync only. `Probe` is returned too so the composition-root
-    // outcome consumer can compute a takeover dialog's PathDegraded disclosure from the SAME
-    // probe instance the controller's own preconditions use.
-    // `ops` (already built by StartAsync) is shared with the ConsentFlipCoordinator built here too.
+    // Also builds ShimOfferCoordinator here (not a separate method), sharing cliPath/probe/store/surface with the lifecycle controller rather than re-resolving them; threads `runMutation` (the lane's RunAsync) and the resolved canonical server so the controller's mutating branches route through the ONE lane (`cli` stays read-only VersionAsync/ServiceStatusAsync); returns `Probe` so the outcome consumer computes a takeover dialog's PathDegraded from the SAME instance; shares `ops` (already built by StartAsync) with the ConsentFlipCoordinator built here too.
     (DaemonLifecycleController Lifecycle, ShimOfferCoordinator ShimOffer, ConsentFlipCoordinator ConsentFlip,
             ILifecycleSurface Surface, ILoginShellProbe Probe) BuildLifecycleController(
             DaemonClientService service, ILocalControlOps ops, bool autoActionsPermanentlyClosed,
@@ -420,8 +396,7 @@ public partial class App : Application {
         // (no override set, or the not-yet-landed bundle-relative arm) means there is
         // nothing to link, so the offer and the menu item both stay off for the whole run.
         var shimTarget = cliPath is not null && Path.IsPathRooted(cliPath) ? cliPath : null;
-        // autoOfferSuppressed (round-1 review): Start() always runs now — Offerable/manual install
-        // must keep working in Incomplete mode — only the once-ever auto-offer dialog is skipped.
+        // autoOfferSuppressed: Start() always runs — Offerable/manual install must keep working in Incomplete mode; only the once-ever auto-offer dialog is skipped.
         var shimOffer = new ShimOfferCoordinator(
             lifecycle.PhaseClosed, probe, new PathShimInstaller(runner, probe), store, surface, shimTarget,
             _shutdown.Token, autoActionsPermanentlyClosed);
@@ -456,8 +431,7 @@ public partial class App : Application {
     // Decision 2's carve-out switch: Incomplete is the only gate outcome that closes auto-actions.
     internal static bool AutoActionsPermanentlyClosed(GateResult gate) => gate is GateResult.Incomplete;
 
-    // Round-1 review (adjudicated): a gate-evaluation exception must never brick startup — degrades
-    // to Incomplete (fail-safe: the app still launches, with auto-actions closed) instead of throwing.
+    // A gate-evaluation exception must never brick startup — degrades to Incomplete (fail-safe: the app still launches, with auto-actions closed) instead of throwing.
     internal static async Task<GateResult> EvaluateGateSafelyAsync(
             Func<CancellationToken, Task<GateResult>> evaluate, CancellationToken ct) {
         try {
@@ -470,14 +444,7 @@ public partial class App : Application {
         }
     }
 
-    // The lane's cliOverride seam. Unlike CreateDefaultAsync's shared CliResolver.ResolvePath
-    // (whose no-override answer is the bare string "kcap", a PATH-resolution-at-spawn-time
-    // sentinel), the lane needs an unambiguous absolute pin or nothing — string-comparing
-    // ResolvePath's return against "kcap" could, in principle, misfire on a real override whose
-    // resolved value is also exactly "kcap" (round-1 review M-4). Reads KCAP_APP_CLI_PATH
-    // directly instead: set + exists → an absolute pin (Path.GetFullPath); set + missing → null
-    // (fail closed, never a silent PATH fallback); truly absent → null (the lane's own
-    // shell-probe path answers instead).
+    // The lane's cliOverride seam reads KCAP_APP_CLI_PATH directly rather than sharing CreateDefaultAsync's CliResolver.ResolvePath (whose no-override answer is the bare string "kcap" — indistinguishable by string-compare from a real override of that same value): set + exists → an absolute pin (Path.GetFullPath); set + missing → null (fail closed, never a silent PATH fallback); truly absent → null (the lane's own shell-probe path answers instead).
     static string? ResolveCliOverride() =>
         ResolveCliOverrideCore(Environment.GetEnvironmentVariable("KCAP_APP_CLI_PATH"), File.Exists, Path.GetFullPath);
 
@@ -488,12 +455,14 @@ public partial class App : Application {
     }
 
     // Drains every non-success outcome the lane enqueues and presents it through the SAME
-    // ILifecycleSurface the controller uses for its own dialogs (single-presentation rule). A
-    // presentation failure for ONE envelope is caught and logged INSIDE the loop (round-1 review
-    // I-1) so it can never brick every presentation after it — only a shutdown cancellation ends
-    // the loop. Owns the per-run Takeover decline memory (round-2 review R2-2): one HashSet per
-    // call ("per run"), never persisted — the controller's own persisted DeclinedTakeoverPairs is
-    // a separate concern entirely.
+    // ILifecycleSurface the controller uses for its own dialogs, tracking whether the UI boundary
+    // was actually reached: a presentation failure BEFORE it (e.g. terminalPathAsync throwing
+    // ahead of the takeover dialog) requeues the envelope once for the next consumer, while a
+    // fault AFTER it (e.g. the accepted takeover's own re-mutation throwing) still acks — the
+    // outcome was genuinely shown. A shutdown OperationCanceledException keeps its prior
+    // disposition (acked; draining stops right after, so nothing could redeliver it anyway). Owns
+    // the per-run (never persisted) Takeover decline memory — separate from the controller's own
+    // persisted DeclinedTakeoverPairs.
     internal static async Task ConsumeMutationOutcomesAsync(
             OutcomeChannel channel, ILifecycleSurface surface,
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
@@ -501,16 +470,19 @@ public partial class App : Application {
         var declinedTakeoverPairs = new HashSet<(MutationRequest Request, string Token)>();
         try {
             await foreach (var lease in channel.ConsumeAsync(ct)) {
+                var presented = false;
                 try {
                     await PresentOutcomeAsync(
-                            surface, lease.Envelope, runMutation, terminalPathAsync, cliVersion, ct, declinedTakeoverPairs)
+                            surface, lease.Envelope, runMutation, terminalPathAsync, cliVersion, ct, declinedTakeoverPairs,
+                            () => presented = true)
                         .ConfigureAwait(false);
+                    lease.Ack(); // ran to completion — whether or not anything needed showing
                 } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
-                    throw; // shutdown — let the outer catch end the whole loop, not just this envelope
+                    lease.Ack(); // shutdown: same disposition as before this envelope-boundary fix
+                    throw; // let the outer catch end the whole loop, not just this envelope
                 } catch (Exception ex) {
                     Console.Error.WriteLine($"kcap app failed to present a mutation outcome: {ex}");
-                } finally {
-                    lease.Ack(); // presented, logged-and-skipped, or shutting down — never redelivered
+                    if (presented) lease.Ack(); else lease.CancelLease(); // requeue-once only for a pre-presentation failure
                 }
             }
         } catch (OperationCanceledException) {
@@ -518,26 +490,25 @@ public partial class App : Application {
         }
     }
 
-    // Takeover reuses the controller's own gated ConfirmAsync dialog — accept re-mutates via
-    // Replace at the ENVELOPE's own identity (never freshly resolved: a takeover targets the
-    // identity that failed) and is state-only (any follow-up actionable outcome re-arrives on its
-    // own envelope — that loop is the design); decline is the ONE exception to "never
-    // surface.Status for Takeover" — one line naming the token, nothing else (round-1 review C-1).
-    // Reinstall/Attention/Storage are an attention line naming the coded token (round-1 review
-    // C-2: Reinstall moved off the status slot — the controller's own guard-refusal status line is
-    // now the ONLY status-slot writer for a mutation outcome). UnconfirmedNoAttach is actionable
-    // (round-1 review I-3) — one attention line naming the verb; any success case never reaches
-    // here at all (the lane's Deliver only enqueues non-success outcomes).
-    // `declinedTakeoverPairs` defaults to a fresh (empty) set so every existing direct call site
-    // keeps working unchanged — only ConsumeMutationOutcomesAsync's loop threads one shared
-    // instance across the whole run.
+    // Presents one classified outcome exactly once: Takeover reuses the controller's own gated
+    // ConfirmAsync dialog, whose accept re-mutates via Replace at the ENVELOPE's own identity
+    // (never freshly resolved — a takeover targets the identity that failed) and is state-only,
+    // and whose decline is the ONE exception to "never surface.Status for Takeover" (one line
+    // naming the token); Reinstall/Attention/Storage/UnconfirmedNoAttach each write a single
+    // attention line naming the token or verb; success cases never reach here (the lane's Deliver
+    // only enqueues non-success outcomes). `markPresented` fires once the UI boundary is reached
+    // (right after the surface call/dialog that constitutes presentation) so the caller can tell a
+    // pre-presentation failure from a post-presentation one. `declinedTakeoverPairs` defaults to a
+    // fresh (empty) set so every existing direct call site keeps working unchanged — only
+    // ConsumeMutationOutcomesAsync's loop threads one shared instance across the whole run.
     internal static async Task PresentOutcomeAsync(
             ILifecycleSurface surface, OutcomeEnvelope envelope,
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
             Func<CancellationToken, Task<string?>> terminalPathAsync, Func<string?> cliVersion, CancellationToken ct,
-            HashSet<(MutationRequest Request, string Token)>? declinedTakeoverPairs = null) {
+            HashSet<(MutationRequest Request, string Token)>? declinedTakeoverPairs = null, Action? markPresented = null) {
         if (envelope.Outcome is MutationOutcome.UnconfirmedNoAttach) {
             surface.Attention($"The daemon {VerbDisplay(envelope.Request.Verb)} is not yet confirmed — check status.");
+            markPresented?.Invoke();
             return;
         }
 
@@ -553,10 +524,9 @@ public partial class App : Application {
                 var declined = declinedTakeoverPairs ?? [];
                 var pairKey = (envelope.Request, named);
                 if (declined.Contains(pairKey)) {
-                    // round-2 review R2-2: a persistent failure the user already declined once
-                    // this run is downgraded to a one-line attention presentation — still
-                    // exactly-once per envelope, just never a re-dialog for the SAME pair.
+                    // A persistent failure the user already declined once this run downgrades to a one-line attention presentation — still exactly-once per envelope, just never a re-dialog for the SAME pair.
                     surface.Attention($"kcap needs to replace the daemon service to continue ({named}).");
+                    markPresented?.Invoke();
                     break;
                 }
 
@@ -564,13 +534,9 @@ public partial class App : Application {
                 var prompt = new LifecyclePrompt(
                     LifecyclePrompt.KindTakeover, null, cliVersion(), pathDegraded, DaemonLifecycleController.TakeoverDisclosure);
                 var accepted = await surface.ConfirmAsync(prompt, ct).ConfigureAwait(false);
+                markPresented?.Invoke(); // the dialog was shown and answered — everything after this is post-presentation
                 if (accepted) {
-                    // round-2 review R2-1 (adjudicated, deferred to Plan C): no app-side evidence
-                    // revalidation before re-mutating — a stale Accept can only fail coded (28/29,
-                    // under the CLI's own per-label transaction lock, the designed guard for
-                    // exactly this staleness) and re-arrives as a fresh channel outcome; richer
-                    // accept-time UX (incl. any advisory revalidation) is the wizard consumer's to
-                    // own.
+                    // No app-side evidence revalidation before re-mutating on accept — a stale Accept can only fail coded (28/29, under the CLI's own per-label transaction lock) and re-arrives as a fresh channel outcome; richer accept-time UX is the wizard consumer's to own.
                     _ = await runMutation(envelope.Request with { Verb = MutationVerb.Replace }, ct).ConfigureAwait(false);
                 } else {
                     declined.Add(pairKey); // Accept never records here — an accepting user wants the retry loop
@@ -580,16 +546,17 @@ public partial class App : Application {
             }
             case RecoverySurface.Reinstall:
                 surface.Attention($"kcap needs to be reinstalled to continue ({named}).");
+                markPresented?.Invoke();
                 break;
             case RecoverySurface.Attention:
             case RecoverySurface.Storage:
                 surface.Attention($"A daemon mutation needs attention ({named}).");
+                markPresented?.Invoke();
                 break;
         }
     }
 
-    // round-2 review R2-3: a small display map instead of MutationVerb.ToString() for
-    // user-facing copy.
+    // A small display map instead of MutationVerb.ToString() for user-facing copy.
     static string VerbDisplay(MutationVerb verb) => verb switch {
         MutationVerb.Install       => "install",
         MutationVerb.Replace       => "replace",
@@ -598,15 +565,23 @@ public partial class App : Application {
         _                          => verb.ToString(),
     };
 
-    // Succeeded/SucceededAfterTimeout are the only cases still landing on the None catch-all —
-    // they're never enqueued onto the channel at all, so this is unreachable in production;
-    // UnconfirmedNoAttach is handled by PresentOutcomeAsync BEFORE this classification runs
-    // (round-1 review I-3 — it is actionable, not skipped).
+    // spec §10: the closed set of AttentionSkew detail tokens that mean "connected but below the
+    // floor this app requires" — read verbatim off DaemonMutationLane.EvidenceFailureLeg, never
+    // guessed — route to the same caller-routed Takeover presentation as a coded Failed/Refused
+    // (dialog + per-run decline memory, accept issues Replace); every other AttentionSkew detail
+    // (wrong-server, ownership mismatch, unreachable-with-owner, unknown) stays non-destructive
+    // Attention. AttentionRepair is always Attention. Succeeded/SucceededAfterTimeout are the only
+    // cases landing on the None catch-all — unreachable in production, since the lane's Deliver
+    // never enqueues a success outcome; UnconfirmedNoAttach is handled by PresentOutcomeAsync
+    // before this classification runs (it is actionable, not skipped).
+    static readonly HashSet<string> TakeoverRoutedSkewTokens = ["missing_capability_consent_3", "daemon_below_floor", "pre_slice_evidence"];
+
     internal static (RecoverySurface Surface, string? Token) ClassifyForPresentation(MutationOutcome outcome) => outcome switch {
-        MutationOutcome.Refused(var reason, var surface)                => (surface, reason),
-        MutationOutcome.Failed(var exitCode, var reason, var surface)   => (surface, reason ?? VerifyExitCodes.Token(exitCode)),
-        MutationOutcome.AttentionSkew(var detail)                       => (RecoverySurface.Attention, detail),
-        MutationOutcome.AttentionRepair(var detail)                     => (RecoverySurface.Attention, detail),
+        MutationOutcome.Refused(var reason, var surface)              => (surface, reason),
+        MutationOutcome.Failed(var exitCode, var reason, var surface) => (surface, reason ?? VerifyExitCodes.Token(exitCode)),
+        MutationOutcome.AttentionSkew(var detail) =>
+            (TakeoverRoutedSkewTokens.Contains(detail) ? RecoverySurface.Takeover : RecoverySurface.Attention, detail),
+        MutationOutcome.AttentionRepair(var detail) => (RecoverySurface.Attention, detail),
         _ => (RecoverySurface.None, null),
     };
 
@@ -778,11 +753,7 @@ public partial class App : Application {
     }
 
     async Task DisposeAndShutdownAsync() {
-        // spec §3.6: mutations are never abandoned — give a lifecycle-controller-triggered
-        // mutation (startup matrix, skew, txn-requery; none of these carry _shutdown.Token) OR a
-        // main-window-triggered one (Task 10: the lane's own in-flight RunAsync, not gated by
-        // _lifecycle's gate at all) a bounded chance to finish naturally, WHILE the UI is still
-        // up, before anything below starts tearing it down.
+        // spec §3.6: mutations are never abandoned — give a lifecycle-controller-triggered mutation (startup matrix, skew, txn-requery; none of these carry _shutdown.Token) or a main-window-triggered one (the lane's own in-flight RunAsync, ungated by _lifecycle) a bounded chance to finish naturally, while the UI is still up, before anything below starts tearing it down.
         if (_lifecycle is not null || _lane is not null)
             await AwaitQuiescedAsync(() => QuiesceLifecycleAndLaneAsync(_lifecycle, _lane), QuiesceShutdownCap).ConfigureAwait(false);
 
@@ -800,12 +771,7 @@ public partial class App : Application {
         }
     }
 
-    // The dependent (_lifecycle, subscribed to _service's streams) goes first — same rule as
-    // BuildLifecycleController's construction-order comment, in reverse. A throw disposing it must
-    // never skip _service's own disposal, so it gets its own guard rather than sharing the outer
-    // DisposeAndConfirmShutdownAsync's single try/catch. The lane (Task 10) goes LAST, after
-    // BOTH: it is the substrate everything else's mutations run through, so it must outlive every
-    // caller that might still be awaiting a RunAsync call as its OWN disposal above proceeds.
+    // The dependent (_lifecycle, subscribed to _service's streams) goes first, reversing BuildLifecycleController's construction order, with its own guard so a throw disposing it never skips _service's disposal; the lane goes LAST, after both, since it's the substrate every mutation runs through and must outlive any caller still awaiting a RunAsync call as its own disposal proceeds.
     async ValueTask DisposeLifecycleAndServiceAsync() {
         if (_lifecycle is not null) {
             try {
@@ -828,13 +794,7 @@ public partial class App : Application {
         }
     }
 
-    // Task 10: composes the controller's own QuiescedAsync (which only covers mutations
-    // it itself triggered, still serialized by its `_gate`) with the lane's (which also covers the
-    // main-window Start/Retry path — DaemonClientService.StartDaemonAsync calls the lane directly,
-    // never through the controller's gate at all). CancellationToken.None on the lane call: the
-    // bound is the race against Task.Delay(cap) in AwaitQuiescedAsync above, exactly like the
-    // controller's own parameterless QuiescedAsync — an already-cancelled token here would resolve
-    // instantly and defeat the wait entirely.
+    // Composes the controller's own QuiescedAsync (mutations it triggered, serialized by its `_gate`) with the lane's (which also covers main-window Start/Retry, since DaemonClientService.StartDaemonAsync calls the lane directly, never through the controller's gate); CancellationToken.None on the lane call because the bound is the race against Task.Delay(cap) in AwaitQuiescedAsync above — an already-cancelled token here would resolve instantly and defeat the wait.
     internal static async Task QuiesceLifecycleAndLaneAsync(DaemonLifecycleController? lifecycle, DaemonMutationLane? lane) {
         var waits = new List<Task>(2);
         if (lifecycle is not null) waits.Add(lifecycle.QuiescedAsync());

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -97,7 +97,7 @@ public partial class App : Application {
     // surface (stderr is invisible for a GUI-launched WinExe) — it must fail loudly instead.
     async Task StartAsync(IClassicDesktopStyleApplicationLifetime desktop) {
         try {
-            // The lane is constructed FIRST, before any other graph object, since every daemon mutation routes through this one instance and its own dependencies need neither a resolved profile nor a live service.
+            // The lane is constructed first — every daemon mutation routes through this one instance, and its dependencies need neither a resolved profile nor a live service.
             var laneRunner = new DaemonClientService.ProcessRunner();
             var laneProbe  = new LoginShellProbe(laneRunner, Environment.GetEnvironmentVariable);
             var channel    = new OutcomeChannel();
@@ -111,12 +111,12 @@ public partial class App : Application {
             _lane = lane;
 
             var service = await DaemonClientService.CreateDefaultAsync(lane.RunAsync);
-            // The live adapter answers a mutation's own confirmation with zero extra socket cost
+            // The live adapter answers a mutation's own confirmation without a fresh socket dial
             // whenever the request targets THIS service's daemon/server — LiveGraphObservation
-            // itself falls back to null (one-shot) for any other target.
-            lane.SetLiveAdapter(new LiveGraphObservation(service));
+            // itself falls back to null (one-shot) for any other target, or a stale/timed-out one.
+            lane.SetLiveAdapter(new LiveGraphObservation(service, TimeProvider.System));
 
-            // Shares CreateDefaultAsync's own AppConfig.ResolveActiveProfile resolution: EvaluateResolvedAsync reads the SAME AppConfig.ResolvedProfile rather than re-resolving, so the gate verdict and the graph identity can never diverge on a profile that changes concurrently between the two.
+            // Reads the SAME AppConfig.ResolvedProfile CreateDefaultAsync already resolved — the gate verdict and the graph identity can never diverge on a concurrently-changing profile.
             var resolvedProfile = AppConfig.ResolvedProfile;
             var gate = await EvaluateGateSafelyAsync(
                 ct => OnboardingGate.EvaluateResolvedAsync(resolvedProfile?.ProfileName, resolvedProfile?.Profile, ct),
@@ -146,7 +146,7 @@ public partial class App : Application {
                 service, ops, autoActionsPermanentlyClosed, lifecycleStatus.OnNext, lifecycleAttention.OnNext, lane.RunAsync);
             lifecycle.Start();
             _lifecycle = lifecycle;
-            // Unlike lifecycle's Start(), subscribe-before-run doesn't matter here (Offerable is a BehaviorSubject, replayed to TrayViewModel whenever it subscribes); always started so the item and manual install keep working in Incomplete mode too — BuildLifecycleController's autoOfferSuppressed skips only the dialog.
+            // Subscribe-before-run doesn't matter here (Offerable replays); always started so manual install keeps working in Incomplete mode — autoOfferSuppressed skips only the dialog.
             shimOffer.Start();
             _shimOffer = shimOffer;
 
@@ -365,12 +365,7 @@ public partial class App : Application {
         return window;
     }
 
-    // spec composition: wires the daemon-service CLI facade (decision 1: everything through the
-    // CLI), the login-shell PATH probe, and the persisted decline-memory store. A broken
-    // KCAP_APP_CLI_PATH override (CliResolver.ResolvePath returning null) is treated as "no CLI"
-    // here — the lifecycle features must never silently point at the wrong binary.
-    //
-    // Also builds ShimOfferCoordinator here (not a separate method), sharing cliPath/probe/store/surface with the lifecycle controller rather than re-resolving them; threads `runMutation` (the lane's RunAsync) and the resolved canonical server so the controller's mutating branches route through the ONE lane (`cli` stays read-only VersionAsync/ServiceStatusAsync); returns `Probe` so the outcome consumer computes a takeover dialog's PathDegraded from the SAME instance; shares `ops` (already built by StartAsync) with the ConsentFlipCoordinator built here too.
+    // Wires the CLI facade, PATH probe, and decline-memory store (a broken override is "no CLI"); also builds the shim/consent-flip coordinators, sharing rather than re-resolving them.
     (DaemonLifecycleController Lifecycle, ShimOfferCoordinator ShimOffer, ConsentFlipCoordinator ConsentFlip,
             ILifecycleSurface Surface, ILoginShellProbe Probe) BuildLifecycleController(
             DaemonClientService service, ILocalControlOps ops, bool autoActionsPermanentlyClosed,
@@ -444,7 +439,7 @@ public partial class App : Application {
         }
     }
 
-    // The lane's cliOverride seam reads KCAP_APP_CLI_PATH directly rather than sharing CreateDefaultAsync's CliResolver.ResolvePath (whose no-override answer is the bare string "kcap" — indistinguishable by string-compare from a real override of that same value): set + exists → an absolute pin (Path.GetFullPath); set + missing → null (fail closed, never a silent PATH fallback); truly absent → null (the lane's own shell-probe path answers instead).
+    // Reads KCAP_APP_CLI_PATH directly, not CliResolver.ResolvePath (its no-override "kcap" answer is indistinguishable from a real override): set+exists → absolute pin; set+missing or absent → null.
     static string? ResolveCliOverride() =>
         ResolveCliOverrideCore(Environment.GetEnvironmentVariable("KCAP_APP_CLI_PATH"), File.Exists, Path.GetFullPath);
 
@@ -454,15 +449,7 @@ public partial class App : Application {
         return fileExists(overrideEnv) ? getFullPath(overrideEnv) : null;
     }
 
-    // Drains every non-success outcome the lane enqueues and presents it through the SAME
-    // ILifecycleSurface the controller uses for its own dialogs, tracking whether the UI boundary
-    // was actually reached: a presentation failure BEFORE it (e.g. terminalPathAsync throwing
-    // ahead of the takeover dialog) requeues the envelope once for the next consumer, while a
-    // fault AFTER it (e.g. the accepted takeover's own re-mutation throwing) still acks — the
-    // outcome was genuinely shown. A shutdown OperationCanceledException keeps its prior
-    // disposition (acked; draining stops right after, so nothing could redeliver it anyway). Owns
-    // the per-run (never persisted) Takeover decline memory — separate from the controller's own
-    // persisted DeclinedTakeoverPairs.
+    // Drains every non-success outcome: pre-presentation failures/cancellations requeue once, post-presentation ones still ack. Owns the per-run (never persisted) Takeover decline memory.
     internal static async Task ConsumeMutationOutcomesAsync(
             OutcomeChannel channel, ILifecycleSurface surface,
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
@@ -478,7 +465,7 @@ public partial class App : Application {
                         .ConfigureAwait(false);
                     lease.Ack(); // ran to completion — whether or not anything needed showing
                 } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
-                    lease.Ack(); // shutdown: same disposition as before this envelope-boundary fix
+                    if (presented) lease.Ack(); else lease.CancelLease(); // requeue-once only for a pre-presentation cancellation
                     throw; // let the outer catch end the whole loop, not just this envelope
                 } catch (Exception ex) {
                     Console.Error.WriteLine($"kcap app failed to present a mutation outcome: {ex}");
@@ -490,17 +477,7 @@ public partial class App : Application {
         }
     }
 
-    // Presents one classified outcome exactly once: Takeover reuses the controller's own gated
-    // ConfirmAsync dialog, whose accept re-mutates via Replace at the ENVELOPE's own identity
-    // (never freshly resolved — a takeover targets the identity that failed) and is state-only,
-    // and whose decline is the ONE exception to "never surface.Status for Takeover" (one line
-    // naming the token); Reinstall/Attention/Storage/UnconfirmedNoAttach each write a single
-    // attention line naming the token or verb; success cases never reach here (the lane's Deliver
-    // only enqueues non-success outcomes). `markPresented` fires once the UI boundary is reached
-    // (right after the surface call/dialog that constitutes presentation) so the caller can tell a
-    // pre-presentation failure from a post-presentation one. `declinedTakeoverPairs` defaults to a
-    // fresh (empty) set so every existing direct call site keeps working unchanged — only
-    // ConsumeMutationOutcomesAsync's loop threads one shared instance across the whole run.
+    // Presents one classified outcome exactly once (success never reaches here). `markPresented` marks the UI boundary reached; `declinedTakeoverPairs` defaults fresh per caller.
     internal static async Task PresentOutcomeAsync(
             ILifecycleSurface surface, OutcomeEnvelope envelope,
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
@@ -524,7 +501,7 @@ public partial class App : Application {
                 var declined = declinedTakeoverPairs ?? [];
                 var pairKey = (envelope.Request, named);
                 if (declined.Contains(pairKey)) {
-                    // A persistent failure the user already declined once this run downgrades to a one-line attention presentation — still exactly-once per envelope, just never a re-dialog for the SAME pair.
+                    // A pair already declined this run downgrades to a one-line attention presentation — still exactly-once, just never a re-dialog for the SAME pair.
                     surface.Attention($"kcap needs to replace the daemon service to continue ({named}).");
                     markPresented?.Invoke();
                     break;
@@ -533,10 +510,11 @@ public partial class App : Application {
                 var pathDegraded = await terminalPathAsync(ct).ConfigureAwait(false) is null;
                 var prompt = new LifecyclePrompt(
                     LifecyclePrompt.KindTakeover, null, cliVersion(), pathDegraded, DaemonLifecycleController.TakeoverDisclosure);
-                var accepted = await surface.ConfirmAsync(prompt, ct).ConfigureAwait(false);
+                var accepted = await surface.TryConfirmAsync(prompt, ct).ConfigureAwait(false);
+                if (accepted is null) { ct.ThrowIfCancellationRequested(); throw new OperationCanceledException(ct); } // cancelled before the dialog ever ran — never presented
                 markPresented?.Invoke(); // the dialog was shown and answered — everything after this is post-presentation
-                if (accepted) {
-                    // No app-side evidence revalidation before re-mutating on accept — a stale Accept can only fail coded (28/29, under the CLI's own per-label transaction lock) and re-arrives as a fresh channel outcome; richer accept-time UX is the wizard consumer's to own.
+                if (accepted.Value) {
+                    // No app-side evidence revalidation on accept: a stale Accept only fails coded (28/29, under the CLI's transaction lock) and re-arrives as a fresh outcome.
                     _ = await runMutation(envelope.Request with { Verb = MutationVerb.Replace }, ct).ConfigureAwait(false);
                 } else {
                     declined.Add(pairKey); // Accept never records here — an accepting user wants the retry loop
@@ -753,7 +731,7 @@ public partial class App : Application {
     }
 
     async Task DisposeAndShutdownAsync() {
-        // spec §3.6: mutations are never abandoned — give a lifecycle-controller-triggered mutation (startup matrix, skew, txn-requery; none of these carry _shutdown.Token) or a main-window-triggered one (the lane's own in-flight RunAsync, ungated by _lifecycle) a bounded chance to finish naturally, while the UI is still up, before anything below starts tearing it down.
+        // spec §3.6: mutations are never abandoned — give an in-flight lifecycle or lane mutation a bounded chance to finish naturally, while the UI is still up, before tearing anything down.
         if (_lifecycle is not null || _lane is not null)
             await AwaitQuiescedAsync(() => QuiesceLifecycleAndLaneAsync(_lifecycle, _lane), QuiesceShutdownCap).ConfigureAwait(false);
 
@@ -771,7 +749,7 @@ public partial class App : Application {
         }
     }
 
-    // The dependent (_lifecycle, subscribed to _service's streams) goes first, reversing BuildLifecycleController's construction order, with its own guard so a throw disposing it never skips _service's disposal; the lane goes LAST, after both, since it's the substrate every mutation runs through and must outlive any caller still awaiting a RunAsync call as its own disposal proceeds.
+    // _lifecycle goes first (guarded, so a throw never skips _service's disposal); the lane goes LAST — its substrate must outlive any caller still awaiting RunAsync.
     async ValueTask DisposeLifecycleAndServiceAsync() {
         if (_lifecycle is not null) {
             try {
@@ -794,7 +772,7 @@ public partial class App : Application {
         }
     }
 
-    // Composes the controller's own QuiescedAsync (mutations it triggered, serialized by its `_gate`) with the lane's (which also covers main-window Start/Retry, since DaemonClientService.StartDaemonAsync calls the lane directly, never through the controller's gate); CancellationToken.None on the lane call because the bound is the race against Task.Delay(cap) in AwaitQuiescedAsync above — an already-cancelled token here would resolve instantly and defeat the wait.
+    // Composes the controller's QuiescedAsync with the lane's (covers main-window Start/Retry too); CancellationToken.None — the bound is AwaitQuiescedAsync's own race against Task.Delay(cap).
     internal static async Task QuiesceLifecycleAndLaneAsync(DaemonLifecycleController? lifecycle, DaemonMutationLane? lane) {
         var waits = new List<Task>(2);
         if (lifecycle is not null) waits.Add(lifecycle.QuiescedAsync());

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -115,8 +115,8 @@ public partial class App : Application {
                 TimeProvider.System);
             _lane = lane;
 
-            // Plan C replaces this arm with wizard-first startup (spec decision 2).
-            var gate = await OnboardingGate.EvaluateAsync(_shutdown.Token);
+            var gate = await EvaluateGateSafelyAsync(OnboardingGate.EvaluateAsync, _shutdown.Token);
+            // Plan C replaces the Incomplete outcome below with wizard-first startup (spec decision 2).
             var autoActionsPermanentlyClosed = AutoActionsPermanentlyClosed(gate);
 
             var service = await DaemonClientService.CreateDefaultAsync(lane.RunAsync);
@@ -150,8 +150,9 @@ public partial class App : Application {
             // Task 24: unlike lifecycle's Start(), subscribe-before-run doesn't matter here —
             // Offerable is a BehaviorSubject, so TrayViewModel (built further below) still sees
             // the current value the moment it subscribes.
-            // Incomplete: the once-ever auto-offer never runs; the tray's manual install command stays wired.
-            if (!autoActionsPermanentlyClosed) shimOffer.Start();
+            // Always started: the item and manual install must keep working in Incomplete mode too
+            // — BuildLifecycleController's autoOfferSuppressed is what skips only the dialog.
+            shimOffer.Start();
             _shimOffer = shimOffer;
 
             consentFlip.Start();
@@ -410,8 +411,11 @@ public partial class App : Application {
         // (no override set, or the not-yet-landed bundle-relative arm) means there is
         // nothing to link, so the offer and the menu item both stay off for the whole run.
         var shimTarget = cliPath is not null && Path.IsPathRooted(cliPath) ? cliPath : null;
+        // autoOfferSuppressed (round-1 review): Start() always runs now — Offerable/manual install
+        // must keep working in Incomplete mode — only the once-ever auto-offer dialog is skipped.
         var shimOffer = new ShimOfferCoordinator(
-            lifecycle.PhaseClosed, probe, new PathShimInstaller(runner, probe), store, surface, shimTarget, _shutdown.Token);
+            lifecycle.PhaseClosed, probe, new PathShimInstaller(runner, probe), store, surface, shimTarget,
+            _shutdown.Token, autoActionsPermanentlyClosed);
 
         // The delegate below and ConsentFlipClaims.Default() both resolve AppConfig.GetConfigPath().
         var consentFlip = new ConsentFlipCoordinator(
@@ -421,6 +425,8 @@ public partial class App : Application {
     }
 
     // Pure LoadPure read only — TryConsume already holds this same config lock when this delegate runs.
+    // Deliberately literal ActiveProfile (no KCAP_PROFILE layering) — a divergence there is fail-safe
+    // via the daemon's own identity-conditional ack (task-13-report).
     internal static (string Profile, string Server, string DaemonName) ResolveConsentFlipIdentity() {
         var config      = ConfigMutator.LoadPure(AppConfig.GetConfigPath());
         var profileName = config.ActiveProfile;
@@ -440,6 +446,20 @@ public partial class App : Application {
 
     // Decision 2's carve-out switch: Incomplete is the only gate outcome that closes auto-actions.
     internal static bool AutoActionsPermanentlyClosed(GateResult gate) => gate is GateResult.Incomplete;
+
+    // Round-1 review (adjudicated): a gate-evaluation exception must never brick startup — degrades
+    // to Incomplete (fail-safe: the app still launches, with auto-actions closed) instead of throwing.
+    internal static async Task<GateResult> EvaluateGateSafelyAsync(
+            Func<CancellationToken, Task<GateResult>> evaluate, CancellationToken ct) {
+        try {
+            return await evaluate(ct).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            throw; // shutdown mid-evaluation — not a gate failure, let the caller's own catch handle it
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: onboarding gate evaluation failed unexpectedly — degrading to Incomplete: {ex.Message}");
+            return new GateResult.Incomplete(GateReason.EvaluationFailed);
+        }
+    }
 
     // The lane's cliOverride seam. Unlike CreateDefaultAsync's shared CliResolver.ResolvePath
     // (whose no-override answer is the bare string "kcap", a PATH-resolution-at-spawn-time

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
 using Capacitor.App.ViewModels;
 using Capacitor.App.Views;
 using Capacitor.Cli.Core;
@@ -22,10 +23,19 @@ public partial class App : Application {
     // has no other shutdown-token wiring, so an uncapped wait could hang shutdown forever.
     static readonly TimeSpan QuiesceShutdownCap = TimeSpan.FromSeconds(60);
 
+    // One socket dial's bound inside DaemonMutationLane's own confirmation polling (its
+    // DetachedPollInterval is 1s) — short enough that a handful of polls still fit inside the
+    // lane's 10s DetachedConfirmWindow.
+    static readonly TimeSpan OneShotProbeTimeout = TimeSpan.FromSeconds(2);
+
     // Linked to the app's shutdown sequence below; the token StartDaemonCommand's WAIT is
     // built against (Task 4 carry-note: never CancellationToken.None — an unbounded wait would
     // survive app exit).
     readonly CancellationTokenSource _shutdown = new();
+    // Task 10: constructed FIRST (before any other graph object) in StartAsync and
+    // disposed LAST — every daemon mutation in the app runs through it, so nothing that might
+    // still call RunAsync can outlive it.
+    DaemonMutationLane? _lane;
     DaemonClientService? _service; // concrete type: IAsyncDisposable is not on the interface
     // spec: subscribed and Start()'d BEFORE _service.Start() begins pumping (subscribe-before-
     // pump — DaemonLifecycleController.Start's own doc comment). Disposed before _service in every
@@ -86,7 +96,27 @@ public partial class App : Application {
     // surface (stderr is invisible for a GUI-launched WinExe) — it must fail loudly instead.
     async Task StartAsync(IClassicDesktopStyleApplicationLifetime desktop) {
         try {
-            var service = await DaemonClientService.CreateDefaultAsync();
+            // Task 10: the lane is constructed FIRST, before any other graph object —
+            // every daemon mutation in the app, from here on, routes through this one instance.
+            // Its own dependencies (a process runner + login-shell probe) need neither a resolved
+            // profile nor a live service, so nothing below is reordered to make this possible.
+            var laneRunner = new DaemonClientService.ProcessRunner();
+            var laneProbe  = new LoginShellProbe(laneRunner, Environment.GetEnvironmentVariable);
+            var channel    = new OutcomeChannel();
+            var lane = new DaemonMutationLane(
+                laneProbe, channel, ResolveCliOverride,
+                (request, pinnedPath) => new KcapCli(
+                    laneRunner, pinnedPath, request.DaemonName, request.Profile, laneProbe.TerminalPathAsync,
+                    canonicalServer: request.CanonicalServer),
+                _ => new OneShotObservation(OneShotProbeTimeout),
+                TimeProvider.System);
+            _lane = lane;
+
+            var service = await DaemonClientService.CreateDefaultAsync(lane.RunAsync);
+            // The live adapter answers a mutation's own confirmation with zero extra socket cost
+            // whenever the request targets THIS service's daemon/server — LiveGraphObservation
+            // itself falls back to null (one-shot) for any other target.
+            lane.SetLiveAdapter(new LiveGraphObservation(service));
 
             // One LocalControlOps and one AppNotifier for the whole app: the tray menu and the
             // window rows share a single stop/open-in-web code path (spec §7) and a single
@@ -106,7 +136,8 @@ public partial class App : Application {
             // spec subscribe-before-pump: the controller's attach subscription must be live
             // BEFORE service.Start() begins pumping, or the startup phase could miss the very
             // first terminal outcome it hinges on (DaemonLifecycleController.Start's own comment).
-            var (lifecycle, shimOffer) = BuildLifecycleController(service, lifecycleStatus.OnNext, lifecycleAttention.OnNext);
+            var (lifecycle, shimOffer, lifecycleSurface) =
+                BuildLifecycleController(service, lifecycleStatus.OnNext, lifecycleAttention.OnNext, lane.RunAsync);
             lifecycle.Start();
             _lifecycle = lifecycle;
             // Task 24: unlike lifecycle's Start(), subscribe-before-run doesn't matter here —
@@ -114,6 +145,11 @@ public partial class App : Application {
             // the current value the moment it subscribes.
             shimOffer.Start();
             _shimOffer = shimOffer;
+
+            // The composition-root outcome consumer: shares lifecycle's own ILifecycleSurface, so
+            // a lane-executed mutation's dialog reuses its serialized gate rather than a competing
+            // one. Starts immediately — Plan C adds the wizard TransferConsumer handoff.
+            _ = ConsumeMutationOutcomesAsync(channel, lifecycleSurface, _shutdown.Token);
 
             service.Start();
             _service = service;
@@ -174,11 +210,12 @@ public partial class App : Application {
             if (_coordinator is not null) _coordinator.QuitInProgress = true;
             Console.Error.WriteLine($"kcap app failed to start: {ex}");
             await HandleStartupFailureAsync(
-                desktop, ex, _service, _shutdown, [_tray, _trayVm, _promptCoordinator, _consent, _activity, _pause], _lifecycle);
+                desktop, ex, _service, _shutdown, [_tray, _trayVm, _promptCoordinator, _consent, _activity, _pause], _lifecycle, _lane);
             // all already disposed above — never let a later OnShutdownRequested (e.g. Cmd+Q
             // while the error window is up) dispose any of them a second time
             _service = null;
             _lifecycle = null;
+            _lane = null;
             _shimOffer = null; // no disposal of its own (see field comment) — just drop the reference
             _tray = null;
             _trayVm = null;
@@ -200,7 +237,7 @@ public partial class App : Application {
     internal static async Task HandleStartupFailureAsync(
             IClassicDesktopStyleApplicationLifetime desktop, Exception ex, DaemonClientService? service,
             CancellationTokenSource shutdown, IReadOnlyList<IDisposable?> uiDisposables,
-            DaemonLifecycleController? lifecycle = null) {
+            DaemonLifecycleController? lifecycle = null, DaemonMutationLane? lane = null) {
         // The dependent goes first (it subscribes to service's streams) — same ordering rule as
         // the normal shutdown path below. Its own DisposeAsync cancels its independent lifetime
         // token and waits out any mutation it started; that wait is unbounded here on purpose — a
@@ -212,6 +249,11 @@ public partial class App : Application {
                 Console.Error.WriteLine($"kcap app failed to dispose the daemon lifecycle controller during startup-failure cleanup: {disposeEx}");
             }
         }
+        // Unset BEFORE disposing service: a mutation still draining out of the lane (its own
+        // disposal is last, below) must never dial into a service whose Status/Snapshots Subjects
+        // are about to be disposed — PinObservationAsync falls back to the one-shot adapter once
+        // this is null.
+        lane?.SetLiveAdapter(null);
         if (service is not null) {
             shutdown.Cancel();
             try {
@@ -221,6 +263,15 @@ public partial class App : Application {
                 // below) must never be masked by a secondary dispose failure — append it to the
                 // same Console.Error channel instead of letting it propagate.
                 Console.Error.WriteLine($"kcap app failed to dispose the daemon client service during startup-failure cleanup: {disposeEx}");
+            }
+        }
+        // The lane goes LAST (Task 10): both lifecycle and service can still be calling
+        // its RunAsync until their own disposal above completes.
+        if (lane is not null) {
+            try {
+                await lane.DisposeAsync();
+            } catch (Exception disposeEx) {
+                Console.Error.WriteLine($"kcap app failed to dispose the daemon mutation lane during startup-failure cleanup: {disposeEx}");
             }
         }
         // Same rule, same reason, for whatever the success path had already built when it threw
@@ -313,22 +364,28 @@ public partial class App : Application {
     //
     // Task 24: also builds ShimOfferCoordinator here (not a separate method) — it shares
     // cliPath/probe/store/surface with the lifecycle controller rather than re-resolving them.
-    (DaemonLifecycleController Lifecycle, ShimOfferCoordinator ShimOffer) BuildLifecycleController(
-            DaemonClientService service, Action<string> setLifecycleStatus, Action<string> setLifecycleAttention) {
+    // Task 10: `runMutation` (the lane's RunAsync) and the resolved canonical server are threaded
+    // through so the controller's own mutating branches route execution through the ONE lane
+    // instead of calling IKcapCli mutation methods directly; `cli` below is kept for read-only
+    // VersionAsync/ServiceStatusAsync only.
+    (DaemonLifecycleController Lifecycle, ShimOfferCoordinator ShimOffer, ILifecycleSurface Surface) BuildLifecycleController(
+            DaemonClientService service, Action<string> setLifecycleStatus, Action<string> setLifecycleAttention,
+            Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
         var cliPath = CliResolver.ResolvePath(Environment.GetEnvironmentVariable, File.Exists);
         var runner  = new DaemonClientService.ProcessRunner();
         var profile = AppConfig.ResolvedProfile; // already resolved by CreateDefaultAsync above
         var probe   = new LoginShellProbe(runner, Environment.GetEnvironmentVariable);
+        var canonicalServer = ServerIdentity.Canonicalize(profile?.ServerUrl);
         // Shared with the probe above (not re-resolved) — decision 7's PATH overlay on `install`
         // must reflect the SAME probe outcome that the controller's preconditions/PathDegraded see.
-        // canonicalServer: passed ahead of Task 10's per-action KcapCli so that rewiring needs no signature change here.
         var cli     = new KcapCli(runner, cliPath, service.DaemonName, profile?.ProfileName ?? "default", probe.TerminalPathAsync,
-            canonicalServer: ServerIdentity.Canonicalize(profile?.ServerUrl));
+            canonicalServer: canonicalServer);
         var store   = new AppStateStore(PathHelpers.ConfigPath("app-state.json"));
         var surface = new LifecycleSurface(setLifecycleStatus, setLifecycleAttention, ConfirmLifecyclePromptAsync);
 
         var lifecycle = new DaemonLifecycleController(
-            service, cli, probe, store, surface, () => Task.FromResult(ValidProfileName(profile)), TimeProvider.System);
+            service, cli, probe, store, surface, () => Task.FromResult(ValidProfileName(profile)), TimeProvider.System,
+            canonicalServer, runMutation);
 
         // The shim links to the RESOLVED ABSOLUTE path only — CliResolver's bare "kcap" fallback
         // (no override set, or the not-yet-landed bundle-relative arm) means there is
@@ -337,13 +394,78 @@ public partial class App : Application {
         var shimOffer = new ShimOfferCoordinator(
             lifecycle.PhaseClosed, probe, new PathShimInstaller(runner, probe), store, surface, shimTarget, _shutdown.Token);
 
-        return (lifecycle, shimOffer);
+        return (lifecycle, shimOffer, surface);
     }
 
     static string? ValidProfileName(ResolvedProfile? profile) =>
         !string.IsNullOrWhiteSpace(profile?.ServerUrl) && Uri.TryCreate(profile.ServerUrl, UriKind.Absolute, out _)
             ? profile.ProfileName
             : null;
+
+    // Task 10: the lane's cliOverride seam. CliResolver.ResolvePath's own bare-"kcap"
+    // fallback (no KCAP_APP_CLI_PATH override set) pins nothing — it's PATH resolution deferred to
+    // spawn time — so it is remapped to null here, letting the lane's own shell-probe path answer
+    // instead. An override that IS set still passes through verbatim, including a broken one
+    // (fileExists=false), which ResolvePath already reports as null — fail closed, never a silent
+    // fallback to PATH.
+    static string? ResolveCliOverride() =>
+        MapBareKcapToNull(CliResolver.ResolvePath(Environment.GetEnvironmentVariable, File.Exists));
+
+    // Split out of ResolveCliOverride so a test can drive the remapping without touching the real
+    // environment (CliResolverTests already covers ResolvePath's own override/no-override/broken
+    // cases exhaustively).
+    internal static string? MapBareKcapToNull(string? resolved) => resolved == "kcap" ? null : resolved;
+
+    // Drains every non-success outcome the lane enqueues and presents it through the SAME
+    // ILifecycleSurface the controller uses for its own dialogs (single-presentation rule).
+    static async Task ConsumeMutationOutcomesAsync(OutcomeChannel channel, ILifecycleSurface surface, CancellationToken ct) {
+        try {
+            await foreach (var lease in channel.ConsumeAsync(ct)) {
+                try {
+                    await PresentOutcomeAsync(surface, lease.Envelope, ct).ConfigureAwait(false);
+                } finally {
+                    lease.Ack(); // presented (or a presentation failure was logged below) — never redelivered
+                }
+            }
+        } catch (OperationCanceledException) {
+            // shutdown — draining stops; anything still queued is simply not presented
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap app outcome-channel consumer failed unexpectedly: {ex}");
+        }
+    }
+
+    // Takeover reuses the controller's own gated ConfirmAsync dialog; Reinstall/Attention/Storage
+    // are a status/attention line naming the coded token; UnconfirmedNoAttach and any success case
+    // are non-actionable here (the caller already surfaced local state) and are skipped.
+    internal static async Task PresentOutcomeAsync(ILifecycleSurface surface, OutcomeEnvelope envelope, CancellationToken ct) {
+        var (recoverySurface, token) = ClassifyForPresentation(envelope.Outcome);
+        if (recoverySurface == RecoverySurface.None) return;
+
+        var named = token ?? "unspecified";
+        switch (recoverySurface) {
+            case RecoverySurface.Takeover:
+                surface.Status($"kcap needs to replace the daemon service to continue ({named}).");
+                await surface.ConfirmAsync(
+                        new LifecyclePrompt(LifecyclePrompt.KindTakeover, null, null, false, DaemonLifecycleController.TakeoverDisclosure), ct)
+                    .ConfigureAwait(false);
+                break;
+            case RecoverySurface.Reinstall:
+                surface.Status($"kcap needs to be reinstalled to continue ({named}).");
+                break;
+            case RecoverySurface.Attention:
+            case RecoverySurface.Storage:
+                surface.Attention($"A daemon mutation needs attention ({named}).");
+                break;
+        }
+    }
+
+    internal static (RecoverySurface Surface, string? Token) ClassifyForPresentation(MutationOutcome outcome) => outcome switch {
+        MutationOutcome.Refused(var reason, var surface)                => (surface, reason),
+        MutationOutcome.Failed(var exitCode, var reason, var surface)   => (surface, reason ?? VerifyExitCodes.Token(exitCode)),
+        MutationOutcome.AttentionSkew(var detail)                       => (RecoverySurface.Attention, detail),
+        MutationOutcome.AttentionRepair(var detail)                     => (RecoverySurface.Attention, detail),
+        _ => (RecoverySurface.None, null), // UnconfirmedNoAttach, and any success case (never enqueued anyway)
+    };
 
     Task<bool> ConfirmLifecyclePromptAsync(LifecyclePrompt prompt, CancellationToken ct) =>
         Dispatcher.UIThread.InvokeAsync(() => ShowLifecyclePromptDialogAsync(prompt, ct));
@@ -514,10 +636,12 @@ public partial class App : Application {
 
     async Task DisposeAndShutdownAsync() {
         // spec §3.6: mutations are never abandoned — give a lifecycle-controller-triggered
-        // mutation (startup matrix, skew, txn-requery; none of these carry _shutdown.Token) a
-        // bounded chance to finish naturally, WHILE the UI is still up, before anything below
-        // starts tearing it down.
-        if (_lifecycle is not null) await AwaitQuiescedAsync(_lifecycle.QuiescedAsync, QuiesceShutdownCap).ConfigureAwait(false);
+        // mutation (startup matrix, skew, txn-requery; none of these carry _shutdown.Token) OR a
+        // main-window-triggered one (Task 10: the lane's own in-flight RunAsync, not gated by
+        // _lifecycle's gate at all) a bounded chance to finish naturally, WHILE the UI is still
+        // up, before anything below starts tearing it down.
+        if (_lifecycle is not null || _lane is not null)
+            await AwaitQuiescedAsync(() => QuiesceLifecycleAndLaneAsync(_lifecycle, _lane), QuiesceShutdownCap).ConfigureAwait(false);
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
             // Prompt coordinator BEFORE the consent service (spec §5): the window and its
@@ -536,7 +660,9 @@ public partial class App : Application {
     // The dependent (_lifecycle, subscribed to _service's streams) goes first — same rule as
     // BuildLifecycleController's construction-order comment, in reverse. A throw disposing it must
     // never skip _service's own disposal, so it gets its own guard rather than sharing the outer
-    // DisposeAndConfirmShutdownAsync's single try/catch.
+    // DisposeAndConfirmShutdownAsync's single try/catch. The lane (Task 10) goes LAST, after
+    // BOTH: it is the substrate everything else's mutations run through, so it must outlive every
+    // caller that might still be awaiting a RunAsync call as its OWN disposal above proceeds.
     async ValueTask DisposeLifecycleAndServiceAsync() {
         if (_lifecycle is not null) {
             try {
@@ -545,7 +671,32 @@ public partial class App : Application {
                 Console.Error.WriteLine($"kcap app failed to dispose the daemon lifecycle controller during shutdown: {ex}");
             }
         }
+        // Unset BEFORE disposing the service — same reason as HandleStartupFailureAsync's own
+        // ordering comment: a mutation still draining out of the lane must never dial into a
+        // service whose Status/Snapshots Subjects are about to be disposed.
+        _lane?.SetLiveAdapter(null);
         if (_service is not null) await _service.DisposeAsync().ConfigureAwait(false);
+        if (_lane is not null) {
+            try {
+                await _lane.DisposeAsync().ConfigureAwait(false);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"kcap app failed to dispose the daemon mutation lane during shutdown: {ex}");
+            }
+        }
+    }
+
+    // Task 10: composes the controller's own QuiescedAsync (which only covers mutations
+    // it itself triggered, still serialized by its `_gate`) with the lane's (which also covers the
+    // main-window Start/Retry path — DaemonClientService.StartDaemonAsync calls the lane directly,
+    // never through the controller's gate at all). CancellationToken.None on the lane call: the
+    // bound is the race against Task.Delay(cap) in AwaitQuiescedAsync above, exactly like the
+    // controller's own parameterless QuiescedAsync — an already-cancelled token here would resolve
+    // instantly and defeat the wait entirely.
+    internal static async Task QuiesceLifecycleAndLaneAsync(DaemonLifecycleController? lifecycle, DaemonMutationLane? lane) {
+        var waits = new List<Task>(2);
+        if (lifecycle is not null) waits.Add(lifecycle.QuiescedAsync());
+        if (lane is not null) waits.Add(lane.QuiescedAsync(CancellationToken.None));
+        if (waits.Count > 0) await Task.WhenAll(waits).ConfigureAwait(false);
     }
 
     // §3.6's cap: QuiescedAsync itself is unbounded (it just waits for the gate), so this is what

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -427,15 +427,20 @@ public partial class App : Application {
     // ILifecycleSurface the controller uses for its own dialogs (single-presentation rule). A
     // presentation failure for ONE envelope is caught and logged INSIDE the loop (round-1 review
     // I-1) so it can never brick every presentation after it — only a shutdown cancellation ends
-    // the loop.
+    // the loop. Owns the per-run Takeover decline memory (round-2 review R2-2): one HashSet per
+    // call ("per run"), never persisted — the controller's own persisted DeclinedTakeoverPairs is
+    // a separate concern entirely.
     internal static async Task ConsumeMutationOutcomesAsync(
             OutcomeChannel channel, ILifecycleSurface surface,
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
             Func<CancellationToken, Task<string?>> terminalPathAsync, Func<string?> cliVersion, CancellationToken ct) {
+        var declinedTakeoverPairs = new HashSet<(MutationRequest Request, string Token)>();
         try {
             await foreach (var lease in channel.ConsumeAsync(ct)) {
                 try {
-                    await PresentOutcomeAsync(surface, lease.Envelope, runMutation, terminalPathAsync, cliVersion, ct).ConfigureAwait(false);
+                    await PresentOutcomeAsync(
+                            surface, lease.Envelope, runMutation, terminalPathAsync, cliVersion, ct, declinedTakeoverPairs)
+                        .ConfigureAwait(false);
                 } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
                     throw; // shutdown — let the outer catch end the whole loop, not just this envelope
                 } catch (Exception ex) {
@@ -459,12 +464,16 @@ public partial class App : Application {
     // now the ONLY status-slot writer for a mutation outcome). UnconfirmedNoAttach is actionable
     // (round-1 review I-3) — one attention line naming the verb; any success case never reaches
     // here at all (the lane's Deliver only enqueues non-success outcomes).
+    // `declinedTakeoverPairs` defaults to a fresh (empty) set so every existing direct call site
+    // keeps working unchanged — only ConsumeMutationOutcomesAsync's loop threads one shared
+    // instance across the whole run.
     internal static async Task PresentOutcomeAsync(
             ILifecycleSurface surface, OutcomeEnvelope envelope,
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
-            Func<CancellationToken, Task<string?>> terminalPathAsync, Func<string?> cliVersion, CancellationToken ct) {
+            Func<CancellationToken, Task<string?>> terminalPathAsync, Func<string?> cliVersion, CancellationToken ct,
+            HashSet<(MutationRequest Request, string Token)>? declinedTakeoverPairs = null) {
         if (envelope.Outcome is MutationOutcome.UnconfirmedNoAttach) {
-            surface.Attention($"{envelope.Request.Verb} started, not yet confirmed — check status.");
+            surface.Attention($"{VerbDisplay(envelope.Request.Verb)} started, not yet confirmed — check status.");
             return;
         }
 
@@ -476,16 +485,35 @@ public partial class App : Application {
         // branch below that reaches this point has a real token to name.
         var named = token!;
         switch (recoverySurface) {
-            case RecoverySurface.Takeover:
+            case RecoverySurface.Takeover: {
+                var declined = declinedTakeoverPairs ?? [];
+                var pairKey = (envelope.Request, named);
+                if (declined.Contains(pairKey)) {
+                    // round-2 review R2-2: a persistent failure the user already declined once
+                    // this run is downgraded to a one-line attention presentation — still
+                    // exactly-once per envelope, just never a re-dialog for the SAME pair.
+                    surface.Attention($"kcap needs to replace the daemon service to continue ({named}).");
+                    break;
+                }
+
                 var pathDegraded = await terminalPathAsync(ct).ConfigureAwait(false) is null;
                 var prompt = new LifecyclePrompt(
                     LifecyclePrompt.KindTakeover, null, cliVersion(), pathDegraded, DaemonLifecycleController.TakeoverDisclosure);
                 var accepted = await surface.ConfirmAsync(prompt, ct).ConfigureAwait(false);
-                if (accepted)
+                if (accepted) {
+                    // round-2 review R2-1 (adjudicated, deferred to Plan C): no app-side evidence
+                    // revalidation before re-mutating — a stale Accept can only fail coded (28/29,
+                    // under the CLI's own per-label transaction lock, the designed guard for
+                    // exactly this staleness) and re-arrives as a fresh channel outcome; richer
+                    // accept-time UX (incl. any advisory revalidation) is the wizard consumer's to
+                    // own.
                     _ = await runMutation(envelope.Request with { Verb = MutationVerb.Replace }, ct).ConfigureAwait(false);
-                else
+                } else {
+                    declined.Add(pairKey); // Accept never records here — an accepting user wants the retry loop
                     surface.Status($"kcap needs to replace the daemon service to continue ({named}) — declined.");
+                }
                 break;
+            }
             case RecoverySurface.Reinstall:
                 surface.Attention($"kcap needs to be reinstalled to continue ({named}).");
                 break;
@@ -495,6 +523,16 @@ public partial class App : Application {
                 break;
         }
     }
+
+    // round-2 review R2-3: a small display map instead of MutationVerb.ToString() for
+    // user-facing copy.
+    static string VerbDisplay(MutationVerb verb) => verb switch {
+        MutationVerb.Install       => "install",
+        MutationVerb.Replace       => "replace",
+        MutationVerb.StartVerified => "verified start",
+        MutationVerb.DetachedStart => "daemon start",
+        _                          => verb.ToString(),
+    };
 
     // Succeeded/SucceededAfterTimeout are the only cases still landing on the None catch-all —
     // they're never enqueued onto the channel at all, so this is unreachable in production;

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -115,15 +115,25 @@ public partial class App : Application {
                 TimeProvider.System);
             _lane = lane;
 
-            var gate = await EvaluateGateSafelyAsync(OnboardingGate.EvaluateAsync, _shutdown.Token);
-            // Plan C replaces the Incomplete outcome below with wizard-first startup (spec decision 2).
-            var autoActionsPermanentlyClosed = AutoActionsPermanentlyClosed(gate);
-
             var service = await DaemonClientService.CreateDefaultAsync(lane.RunAsync);
             // The live adapter answers a mutation's own confirmation with zero extra socket cost
             // whenever the request targets THIS service's daemon/server — LiveGraphObservation
             // itself falls back to null (one-shot) for any other target.
             lane.SetLiveAdapter(new LiveGraphObservation(service));
+
+            // Shares CreateDefaultAsync's own AppConfig.ResolveActiveProfile resolution (Codex P1
+            // review): a second, independent self-resolving gate call could observe a different
+            // active profile than the graph above if it changed concurrently between the two
+            // resolves — evaluating Complete for profile A while the graph builds for
+            // unauthenticated profile B with auto-actions open. EvaluateResolvedAsync skips its
+            // own resolution and reads the SAME AppConfig.ResolvedProfile CreateDefaultAsync just
+            // set, so the verdict and the graph identity can never diverge.
+            var resolvedProfile = AppConfig.ResolvedProfile;
+            var gate = await EvaluateGateSafelyAsync(
+                ct => OnboardingGate.EvaluateResolvedAsync(resolvedProfile?.ProfileName, resolvedProfile?.Profile, ct),
+                _shutdown.Token);
+            // Plan C replaces the Incomplete outcome below with wizard-first startup (spec decision 2).
+            var autoActionsPermanentlyClosed = AutoActionsPermanentlyClosed(gate);
 
             // One LocalControlOps and one AppNotifier for the whole app: the tray menu and the
             // window rows share a single stop/open-in-web code path (spec §7) and a single

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -111,10 +111,6 @@ public partial class App : Application {
             _lane = lane;
 
             var service = await DaemonClientService.CreateDefaultAsync(lane.RunAsync);
-            // The live adapter answers a mutation's own confirmation without a fresh socket dial
-            // whenever the request targets THIS service's daemon/server — LiveGraphObservation
-            // itself falls back to null (one-shot) for any other target, or a stale/timed-out one.
-            lane.SetLiveAdapter(new LiveGraphObservation(service, TimeProvider.System));
 
             // Reads the SAME AppConfig.ResolvedProfile CreateDefaultAsync already resolved — the gate verdict and the graph identity can never diverge on a concurrently-changing profile.
             var resolvedProfile = AppConfig.ResolvedProfile;
@@ -153,11 +149,7 @@ public partial class App : Application {
             consentFlip.Start();
             _consentFlip = consentFlip;
 
-            // The composition-root outcome consumer: shares lifecycle's own ILifecycleSurface, so
-            // a lane-executed mutation's dialog reuses its serialized gate rather than a competing
-            // one; also shares its probe (disclosure) and CliVersion (dialog text) and the lane
-            // itself (a Takeover accept re-mutates through it). Starts immediately — Plan C adds
-            // the wizard TransferConsumer handoff.
+            // Composition-root outcome consumer: shares lifecycle's own surface/probe/CliVersion and the lane itself, so a Takeover accept re-mutates through the same gate.
             _ = ConsumeMutationOutcomesAsync(
                 channel, lifecycleSurface, lane.RunAsync, lifecycleProbe.TerminalPathAsync, () => lifecycle.CliVersion, _shutdown.Token);
 
@@ -260,10 +252,6 @@ public partial class App : Application {
                 Console.Error.WriteLine($"kcap app failed to dispose the daemon lifecycle controller during startup-failure cleanup: {disposeEx}");
             }
         }
-        // Unset BEFORE disposing service: an action starting after this pins a plain one-shot;
-        // an in-flight action keeps its pinned composite, whose live leg reading a disposed
-        // subject lands in DeliverFaulted rather than hanging.
-        lane?.SetLiveAdapter(null);
         if (service is not null) {
             shutdown.Cancel();
             try {
@@ -543,15 +531,7 @@ public partial class App : Application {
         _                          => verb.ToString(),
     };
 
-    // spec §10: the closed set of AttentionSkew detail tokens that mean "connected but below the
-    // floor this app requires" — read verbatim off DaemonMutationLane.EvidenceFailureLeg, never
-    // guessed — route to the same caller-routed Takeover presentation as a coded Failed/Refused
-    // (dialog + per-run decline memory, accept issues Replace); every other AttentionSkew detail
-    // (wrong-server, ownership mismatch, unreachable-with-owner, unknown) stays non-destructive
-    // Attention. AttentionRepair is always Attention. Succeeded/SucceededAfterTimeout are the only
-    // cases landing on the None catch-all — unreachable in production, since the lane's Deliver
-    // never enqueues a success outcome; UnconfirmedNoAttach is handled by PresentOutcomeAsync
-    // before this classification runs (it is actionable, not skipped).
+    // spec §10 invariant: only these AttentionSkew tokens route to Takeover; every other AttentionSkew/AttentionRepair stays Attention.
     static readonly HashSet<string> TakeoverRoutedSkewTokens = ["missing_capability_consent_3", "daemon_below_floor", "pre_slice_evidence"];
 
     internal static (RecoverySurface Surface, string? Token) ClassifyForPresentation(MutationOutcome outcome) => outcome switch {
@@ -758,10 +738,6 @@ public partial class App : Application {
                 Console.Error.WriteLine($"kcap app failed to dispose the daemon lifecycle controller during shutdown: {ex}");
             }
         }
-        // Unset BEFORE disposing the service — same reason as HandleStartupFailureAsync's own
-        // ordering comment: a mutation still draining out of the lane must never dial into a
-        // service whose Status/Snapshots Subjects are about to be disposed.
-        _lane?.SetLiveAdapter(null);
         if (_service is not null) await _service.DisposeAsync().ConfigureAwait(false);
         if (_lane is not null) {
             try {

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -10,6 +10,7 @@ using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
 using Capacitor.App.Views;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.LocalIpc;
 
@@ -320,7 +321,9 @@ public partial class App : Application {
         var probe   = new LoginShellProbe(runner, Environment.GetEnvironmentVariable);
         // Shared with the probe above (not re-resolved) — decision 7's PATH overlay on `install`
         // must reflect the SAME probe outcome that the controller's preconditions/PathDegraded see.
-        var cli     = new KcapCli(runner, cliPath, service.DaemonName, profile?.ProfileName ?? "default", probe.TerminalPathAsync);
+        // canonicalServer: passed ahead of Task 10's per-action KcapCli so that rewiring needs no signature change here.
+        var cli     = new KcapCli(runner, cliPath, service.DaemonName, profile?.ProfileName ?? "default", probe.TerminalPathAsync,
+            canonicalServer: ServerIdentity.Canonicalize(profile?.ServerUrl));
         var store   = new AppStateStore(PathHelpers.ConfigPath("app-state.json"));
         var surface = new LifecycleSurface(setLifecycleStatus, setLifecycleAttention, ConfirmLifecyclePromptAsync);
 

--- a/src/Capacitor.App/Capacitor.App.csproj
+++ b/src/Capacitor.App/Capacitor.App.csproj
@@ -5,6 +5,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <!-- ConsentFlipClaims' directory-fsync barrier uses LibraryImport, which requires this. -->
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <!-- This is an unbundled `dotnet run` executable, so macOS shows the binary name (not an
              app-bundle display name) on dock hover — give it a human-friendly one. RootNamespace
              stays Capacitor.App: only the output/assembly identity changes here. -->

--- a/src/Capacitor.App/Services/AppStateStore.cs
+++ b/src/Capacitor.App/Services/AppStateStore.cs
@@ -9,7 +9,8 @@ namespace Capacitor.App.Services;
 public sealed record AppState(
     bool ShimOffered = false,
     bool ShimDenied = false,
-    IReadOnlyList<string>? DeclinedTakeoverPairs = null);
+    IReadOnlyList<string>? DeclinedTakeoverPairs = null,
+    bool ConsentQuarantineAcked = false);
 
 public interface IAppStateStore {
     Task<AppState> LoadAsync();

--- a/src/Capacitor.App/Services/AttachStatus.cs
+++ b/src/Capacitor.App/Services/AttachStatus.cs
@@ -1,3 +1,5 @@
+using Capacitor.Cli.Core.LocalIpc;
+
 namespace Capacitor.App.Services;
 
 /// App-side attach state, projected from Capacitor.Cli.Core.LocalIpc.LocalControlEvent.
@@ -7,9 +9,11 @@ public enum AttachState { Connecting, Connected, Unreachable }
 /// state/reason observables that can tear are forbidden. Capabilities are null on every
 /// non-connected state — never retained from a previous incarnation. DaemonVersion carries the
 /// hello reply's version on Unreachable (spec decision 6); it is null on Connecting/Connected —
-/// Connected's version arrives via snapshots, not attach status.
+/// Connected's version arrives via snapshots, not attach status. Identity carries Connected's
+/// hello-derived ConnectedIdentity; null on every non-Connected state.
 public sealed record AttachStatus(
-    AttachState State, string? Reason, IReadOnlyList<string>? Capabilities, string? DaemonVersion = null);
+    AttachState State, string? Reason, IReadOnlyList<string>? Capabilities, string? DaemonVersion = null,
+    ConnectedIdentity? Identity = null);
 
 /// Outcome of a `kcap daemon start -d --name <name>` spawn attempt.
 public sealed record StartDaemonResult(bool Ok, string? Message);

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -32,17 +32,13 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
     public DaemonClientService(
             string daemonName,
             Func<CancellationToken, IAsyncEnumerable<LocalControlEvent>> runClient,
-            Func<CancellationToken, Task<MutationOutcome>> startDaemon,
-            string? profileName = null) {
+            Func<CancellationToken, Task<MutationOutcome>> startDaemon) {
         DaemonName   = daemonName;
         _runClient   = runClient;
         _startDaemon = startDaemon;
-        ProfileName  = profileName;
     }
 
     public string DaemonName { get; }
-
-    public string? ProfileName { get; }
 
     public IObservable<AttachStatus> Status => _status.AsObservable();
 
@@ -158,8 +154,7 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
 
         return new DaemonClientService(
             name, ct => new LocalControlClient(name).RunAsync(ct),
-            BuildStartDaemon(name, () => AppConfig.ResolvedProfile, runMutation),
-            AppConfig.ResolvedProfile?.ProfileName);
+            BuildStartDaemon(name, () => AppConfig.ResolvedProfile, runMutation));
     }
 
     /// The main-window Start/Retry delegate: builds a DetachedStart MutationRequest at the

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -172,7 +172,7 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
 
     /// Production IProcessRunner: wraps System.Diagnostics.Process with stdout/stderr capture, an
     /// env overlay, an internal timeout, and a per-call cancel mode. `RunOptions.Timeout` is an
-    /// internal deadline distinct from `ct`: on expiry the tree is killed and awaited, and the
+    /// internal deadline distinct from `ct`: on expiry the process (or tree, per `RunOptions.TimeoutKill`) is killed and awaited, and the
     /// result comes back with TimedOut=true rather than throwing. `ct` cancellation behaves per
     /// `RunOptions.CancelMode`: AbandonWait abandons the WAIT only (a detached `daemon start -d`
     /// keeps running) and still throws OperationCanceledException; KillTree kills the tree and

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -58,10 +58,10 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
             case LocalControlEvent.Connecting:
                 _status.OnNext(new(AttachState.Connecting, null, null));
                 break;
-            case LocalControlEvent.Connected(var caps, var first, _):
+            case LocalControlEvent.Connected(var caps, var first, var identity):
                 _snapshots.OnNext(first);
                 Agents.EditDiff(first.Agents, EqualityComparer<AgentStatusDto>.Default);
-                _status.OnNext(new(AttachState.Connected, null, caps));
+                _status.OnNext(new(AttachState.Connected, null, caps, null, identity));
                 break;
             case LocalControlEvent.Status(var snap):
                 _snapshots.OnNext(snap);

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -218,7 +218,7 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
                 }
 
                 // Only the internal timeout could have fired the linked token.
-                await KillAndAwaitAsync(process).ConfigureAwait(false);
+                await KillAndAwaitAsync(process, options.TimeoutKill == TimeoutKillScope.Tree).ConfigureAwait(false);
                 await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
                 return new ProcessResult(process.ExitCode, stdoutTask.Result, stderrTask.Result, TimedOut: true);
             }
@@ -227,8 +227,8 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
             return new ProcessResult(process.ExitCode, stdoutTask.Result, stderrTask.Result, TimedOut: false);
         }
 
-        static async Task KillAndAwaitAsync(Process process) {
-            try { process.Kill(entireProcessTree: true); }
+        static async Task KillAndAwaitAsync(Process process, bool entireProcessTree = true) {
+            try { process.Kill(entireProcessTree); }
             catch (InvalidOperationException) { /* already exited */ }
             await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
         }

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -32,13 +32,17 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
     public DaemonClientService(
             string daemonName,
             Func<CancellationToken, IAsyncEnumerable<LocalControlEvent>> runClient,
-            Func<CancellationToken, Task<MutationOutcome>> startDaemon) {
+            Func<CancellationToken, Task<MutationOutcome>> startDaemon,
+            string? profileName = null) {
         DaemonName   = daemonName;
         _runClient   = runClient;
         _startDaemon = startDaemon;
+        ProfileName  = profileName;
     }
 
     public string DaemonName { get; }
+
+    public string? ProfileName { get; }
 
     public IObservable<AttachStatus> Status => _status.AsObservable();
 
@@ -145,8 +149,8 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
 
     /// Resolves the daemon name ONCE via the same chain DaemonCommands.ResolveName uses, so the
     /// watched daemon and the started daemon can never diverge (spec §5). `runMutation` is the
-    /// app-lifetime DaemonMutationLane's RunAsync (Task 10), injected by the composition
-    /// root so this factory never spawns a process of its own.
+    /// app-lifetime DaemonMutationLane's RunAsync, injected by the composition root so this
+    /// factory never spawns a process of its own.
     public static async Task<DaemonClientService> CreateDefaultAsync(
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
         await AppConfig.ResolveActiveProfile([]);
@@ -154,7 +158,8 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
 
         return new DaemonClientService(
             name, ct => new LocalControlClient(name).RunAsync(ct),
-            BuildStartDaemon(name, () => AppConfig.ResolvedProfile, runMutation));
+            BuildStartDaemon(name, () => AppConfig.ResolvedProfile, runMutation),
+            AppConfig.ResolvedProfile?.ProfileName);
     }
 
     /// The main-window Start/Retry delegate: builds a DetachedStart MutationRequest at the

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -120,11 +120,13 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
     /// StartDaemonResult the UI already understands — ct abandons the WAIT only (a detached start
     /// already spawned keeps running, never reported as a failure); the lane's own RunAsync
     /// rethrows OperationCanceledException the same way, so it just propagates here unmodified.
+    /// The reattach kick fires UNCONDITIONALLY, not just on Succeeded/SucceededAfterTimeout: any
+    /// mutation attempt may have restarted the daemon even when it did not end in success, and
+    /// kicking reattach is idempotent — the attach doesn't sit out a backoff either way.
     public async Task<StartDaemonResult> StartDaemonAsync(CancellationToken ct) {
         var outcome = await _startDaemon(ct).ConfigureAwait(false);
 
-        if (outcome is MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout)
-            _ = RestartLoopAsync(); // immediate kick — the attach doesn't sit out a backoff
+        _ = RestartLoopAsync();
 
         return ToResult(outcome);
     }

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using Capacitor.App.Services.Mutation;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.LocalIpc;
@@ -9,12 +10,14 @@ using DynamicData;
 namespace Capacitor.App.Services;
 
 /// Rx/DynamicData adapter over LocalControlClient.RunAsync: owns the single live attach
-/// enumeration, publishes the atomic AttachStatus + Snapshots streams and the keyed Agents
-/// cache, and spawns `kcap daemon start` on request. See app-shell design spec §5.
+/// enumeration, publishes the atomic AttachStatus + Snapshots streams, and delegates
+/// `daemon start -d` to the injected mutation-lane runner on request. See app-shell design spec §5.
 public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable {
     readonly Func<CancellationToken, IAsyncEnumerable<LocalControlEvent>> _runClient;
-    readonly IProcessRunner _processRunner;
-    readonly string _cliPath;
+    // The lane's RunAsync, pre-bound to a DetachedStart request for THIS daemon (or an honest
+    // Refused("no_server_configured") when no canonical server can be bound) — this service no
+    // longer spawns `daemon start -d` itself and carries no bare-"kcap" fallback of its own.
+    readonly Func<CancellationToken, Task<MutationOutcome>> _startDaemon;
 
     readonly BehaviorSubject<AttachStatus> _status = new(new(AttachState.Connecting, null, null));
     readonly ReplaySubject<DaemonStatusDto> _snapshots = new(1);
@@ -29,12 +32,10 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
     public DaemonClientService(
             string daemonName,
             Func<CancellationToken, IAsyncEnumerable<LocalControlEvent>> runClient,
-            IProcessRunner processRunner,
-            string cliPath) {
-        DaemonName    = daemonName;
-        _runClient    = runClient;
-        _processRunner = processRunner;
-        _cliPath      = cliPath;
+            Func<CancellationToken, Task<MutationOutcome>> startDaemon) {
+        DaemonName   = daemonName;
+        _runClient   = runClient;
+        _startDaemon = startDaemon;
     }
 
     public string DaemonName { get; }
@@ -115,41 +116,60 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
         catch { /* contained — see PumpAsync */ }
     }
 
+    /// Delegates to the injected lane runner and maps its MutationOutcome onto the honest
+    /// StartDaemonResult the UI already understands — ct abandons the WAIT only (a detached start
+    /// already spawned keeps running, never reported as a failure); the lane's own RunAsync
+    /// rethrows OperationCanceledException the same way, so it just propagates here unmodified.
     public async Task<StartDaemonResult> StartDaemonAsync(CancellationToken ct) {
-        try {
-            var result = await _processRunner
-                .RunAsync(_cliPath, ["daemon", "start", "-d", "--name", DaemonName], new RunOptions(), ct)
-                .ConfigureAwait(false);
+        var outcome = await _startDaemon(ct).ConfigureAwait(false);
 
-            if (result.ExitCode == 0) {
-                _ = RestartLoopAsync(); // immediate kick — the attach doesn't sit out a backoff
-                return new(true, null);
-            }
+        if (outcome is MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout)
+            _ = RestartLoopAsync(); // immediate kick — the attach doesn't sit out a backoff
 
-            return new(false, string.IsNullOrWhiteSpace(result.Stderr)
-                ? $"kcap daemon start exited with code {result.ExitCode}"
-                : result.Stderr.Trim());
-        } catch (OperationCanceledException) {
-            throw; // ct abandons the WAIT, not the started daemon — never reported as a failure
-        } catch (Exception ex) {
-            return new(false, ex.Message);
-        }
+        return ToResult(outcome);
     }
 
+    static StartDaemonResult ToResult(MutationOutcome outcome) => outcome switch {
+        MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout => new(true, null),
+        MutationOutcome.Refused("cli_not_found", _)                       => new(false, "kcap CLI not found"),
+        MutationOutcome.Refused(var reason, _)                            => new(false, reason),
+        MutationOutcome.Failed(var exitCode, var reason, _) =>
+            new(false, reason ?? $"kcap daemon start exited with code {exitCode}"),
+        MutationOutcome.AttentionSkew(var detail)   => new(false, detail),
+        MutationOutcome.AttentionRepair(var detail) => new(false, detail),
+        MutationOutcome.UnconfirmedNoAttach         => new(false, "daemon start not yet confirmed — check status"),
+        _                                            => new(false, outcome.GetType().Name),
+    };
+
     /// Resolves the daemon name ONCE via the same chain DaemonCommands.ResolveName uses, so the
-    /// watched daemon and the started daemon can never diverge (spec §5).
-    public static async Task<DaemonClientService> CreateDefaultAsync() {
+    /// watched daemon and the started daemon can never diverge (spec §5). `runMutation` is the
+    /// app-lifetime DaemonMutationLane's RunAsync (Task 10), injected by the composition
+    /// root so this factory never spawns a process of its own.
+    public static async Task<DaemonClientService> CreateDefaultAsync(
+            Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
         await AppConfig.ResolveActiveProfile([]);
         var name = DaemonNameResolver.Resolve([], AppConfig.ResolvedProfile?.Profile?.Daemon?.Name);
 
-        // Lenient by design: unlike the lifecycle features (Task 19+), which treat a broken
-        // KCAP_APP_CLI_PATH override as "no CLI" (CliResolver.ResolvePath returning null), this
-        // ad hoc `daemon start -d` path keeps its long-standing fallback so existing behavior is
-        // unchanged here.
-        var cliPath = CliResolver.ResolvePath(Environment.GetEnvironmentVariable, File.Exists) ?? "kcap";
-
-        return new DaemonClientService(name, ct => new LocalControlClient(name).RunAsync(ct), new ProcessRunner(), cliPath);
+        return new DaemonClientService(
+            name, ct => new LocalControlClient(name).RunAsync(ct),
+            BuildStartDaemon(name, () => AppConfig.ResolvedProfile, runMutation));
     }
+
+    /// The main-window Start/Retry delegate: builds a DetachedStart MutationRequest at the
+    /// CURRENTLY resolved profile/server (re-read on every call, never captured once — a profile
+    /// resolved after this service was constructed must still be honored) and hands it to
+    /// `runMutation`; a caller that cannot bind a canonical server never reaches it (binding
+    /// ruling 1). Extracted from CreateDefaultAsync — whose own AppConfig.ResolveActiveProfile
+    /// call touches real config I/O — so this request-building logic stays unit-testable on its own.
+    internal static Func<CancellationToken, Task<MutationOutcome>> BuildStartDaemon(
+            string daemonName, Func<ResolvedProfile?> resolveProfile,
+            Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) =>
+        ct => {
+            var profile = resolveProfile();
+            var refusal = MutationRequestFactory.TryBuild(
+                MutationVerb.DetachedStart, profile?.ProfileName, profile?.ServerUrl, daemonName, out var request);
+            return refusal is not null ? Task.FromResult(refusal) : runMutation(request!, ct);
+        };
 
     public async ValueTask DisposeAsync() {
         _lifetime.Cancel();

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -65,6 +65,8 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     // directly — this controller's own _gate still serializes DECIDING, the lane serializes
     // EXECUTION.
     readonly Func<MutationRequest, CancellationToken, Task<MutationOutcome>> _runMutation;
+    // When true, RunStartupBranchAsync never admits; PhaseClosed still resolves, StartActionAsync unaffected.
+    readonly bool _autoActionsPermanentlyClosed;
 
     readonly SemaphoreSlim _gate = new(1, 1);
     readonly CancellationTokenSource _lifetime = new();
@@ -84,16 +86,18 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     public DaemonLifecycleController(
             IDaemonClientService client, IKcapCli cli, ILoginShellProbe probe, IAppStateStore store,
             ILifecycleSurface surface, Func<Task<string?>> resolveProfileName, TimeProvider time,
-            string? canonicalServer, Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
-        _client             = client;
-        _cli                = cli;
-        _probe              = probe;
-        _store              = store;
-        _surface            = surface;
-        _resolveProfileName = resolveProfileName;
-        _time               = time;
-        _canonicalServer    = canonicalServer;
-        _runMutation        = runMutation;
+            string? canonicalServer, Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
+            bool autoActionsPermanentlyClosed = false) {
+        _client                        = client;
+        _cli                           = cli;
+        _probe                         = probe;
+        _store                         = store;
+        _surface                       = surface;
+        _resolveProfileName            = resolveProfileName;
+        _time                          = time;
+        _canonicalServer               = canonicalServer;
+        _runMutation                   = runMutation;
+        _autoActionsPermanentlyClosed  = autoActionsPermanentlyClosed;
     }
 
     /// Completes permanently on the first terminal attach outcome (Connected /
@@ -172,7 +176,11 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
                 _ = RunSkewCheckAsync(status.DaemonVersion); // every incompatible event, same reason as above
                 break;
             case AttachState.Unreachable:
-                if (isFirstTerminalOutcome) _ = RunStartupBranchAsync((status.State, status.Reason));
+                // Closed: PhaseClosed still resolves here — only the startup matrix itself never admits.
+                if (isFirstTerminalOutcome) {
+                    if (_autoActionsPermanentlyClosed) ClosePhase();
+                    else _ = RunStartupBranchAsync((status.State, status.Reason));
+                }
                 break;
         }
     }

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -18,7 +18,7 @@ internal static class VerifyExitCodes {
     public const int RestoreVerification = 27;
     public const int StartGate           = 28;
     public const int StartGateDrift      = 29;
-    public const int DigestGate          = 43;
+    public const int DigestGate          = 43; // not a VerifyExit code (DaemonCommands' own digest gate) — deliberately absent from Token()'s map below
 
     public static string Token(int exitCode) => exitCode switch {
         Contended           => "verify_contended",

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -1,3 +1,4 @@
+using Capacitor.App.Services.Mutation;
 using Capacitor.Cli.Core.LocalIpc;
 
 namespace Capacitor.App.Services;
@@ -46,7 +47,6 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     internal const string TakeoverDisclosure =
         "This replaces the existing daemon service and re-captures its settings; a failed replacement leaves it uninstalled rather than restored.";
 
-    internal static readonly TimeSpan ConfirmWindow         = TimeSpan.FromSeconds(15);
     internal static readonly TimeSpan TxnActiveRequeryDelay = TimeSpan.FromSeconds(2);
 
     readonly IDaemonClientService _client;
@@ -56,6 +56,15 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     readonly ILifecycleSurface _surface;
     readonly Func<Task<string?>> _resolveProfileName;
     readonly TimeProvider _time;
+    // Fixed for the controller's lifetime, same as KcapCli's own canonicalServer (both resolved
+    // once from the same AppConfig.ResolvedProfile at composition time) — the mutation-request
+    // guard (MutationRequestFactory) reads this at every lane call, never re-resolving it.
+    readonly string? _canonicalServer;
+    // The lane's RunAsync, injected so every mutating branch below routes execution through the
+    // ONE app-lifetime lane (Task 10) instead of calling IKcapCli mutation methods
+    // directly — this controller's own _gate still serializes DECIDING, the lane serializes
+    // EXECUTION.
+    readonly Func<MutationRequest, CancellationToken, Task<MutationOutcome>> _runMutation;
 
     readonly SemaphoreSlim _gate = new(1, 1);
     readonly CancellationTokenSource _lifetime = new();
@@ -68,15 +77,14 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     bool _disposed;
     int _generation;
     (AttachState State, string? Reason) _lastObserved = (AttachState.Connecting, null);
-    TaskCompletionSource<bool>? _confirmWaiter;
-    int _confirmSinceGen;
     string? _latestSnapshotVersion;
     bool _skewDialogShownThisRun;
     Task _versionCached = Task.CompletedTask;
 
     public DaemonLifecycleController(
             IDaemonClientService client, IKcapCli cli, ILoginShellProbe probe, IAppStateStore store,
-            ILifecycleSurface surface, Func<Task<string?>> resolveProfileName, TimeProvider time) {
+            ILifecycleSurface surface, Func<Task<string?>> resolveProfileName, TimeProvider time,
+            string? canonicalServer, Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
         _client             = client;
         _cli                = cli;
         _probe              = probe;
@@ -84,6 +92,8 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         _surface            = surface;
         _resolveProfileName = resolveProfileName;
         _time               = time;
+        _canonicalServer    = canonicalServer;
+        _runMutation        = runMutation;
     }
 
     /// Completes permanently on the first terminal attach outcome (Connected /
@@ -125,31 +135,23 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         }
     }
 
-    // Every AttachStatus transition bumps the generation, records the last-observed outcome, and
-    // may signal an armed confirm waiter — this ALWAYS happens, regardless of the once-per-run
-    // arm below. Only a TERMINAL outcome (never Connecting) can claim that arm, and only the
-    // FIRST one ever does — but the switch itself still runs for every later event: the arm gates
-    // startup AUTO-ACTION eligibility only, never event admission, so a later daemon_incompatible
-    // still reaches its skew/takeover case below unconditionally.
+    // Every AttachStatus transition bumps the generation and records the last-observed outcome —
+    // this ALWAYS happens, regardless of the once-per-run arm below. Only a TERMINAL outcome
+    // (never Connecting) can claim that arm, and only the FIRST one ever does — but the switch
+    // itself still runs for every later event: the arm gates startup AUTO-ACTION eligibility
+    // only, never event admission, so a later daemon_incompatible still reaches its
+    // skew/takeover case below unconditionally.
     void OnAttachStatus(AttachStatus status) {
-        TaskCompletionSource<bool>? toSignal = null;
         bool isFirstTerminalOutcome;
 
         lock (_lock) {
             _generation++;
-            var gen = _generation;
             _lastObserved = (status.State, status.Reason);
-
-            if (status.State == AttachState.Connected && _confirmWaiter is not null && gen > _confirmSinceGen) {
-                toSignal       = _confirmWaiter;
-                _confirmWaiter = null;
-            }
 
             isFirstTerminalOutcome = status.State != AttachState.Connecting && !_armClaimed;
             if (isFirstTerminalOutcome) _armClaimed = true;
         }
 
-        toSignal?.TrySetResult(true);
         if (status.State == AttachState.Connecting) return;
 
         switch (status.State) {
@@ -190,21 +192,6 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     bool IsCurrentlyAttached() { lock (_lock) return _lastObserved.State == AttachState.Connected; }
 
     string? LatestSnapshotVersion() { lock (_lock) return _latestSnapshotVersion; }
-
-    TaskCompletionSource<bool> ArmConfirmWaiter() {
-        lock (_lock) {
-            _confirmSinceGen = _generation;
-            var waiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _confirmWaiter = waiter;
-            return waiter;
-        }
-    }
-
-    void DisarmConfirmWaiter(TaskCompletionSource<bool> waiter) {
-        lock (_lock) {
-            if (ReferenceEquals(_confirmWaiter, waiter)) _confirmWaiter = null;
-        }
-    }
 
     async Task<bool> TryAcquireGateAsync(CancellationToken ct) {
         try {
@@ -342,7 +329,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
                 AttentionCoexistence(snap.DaemonPid.Value);
                 return;
             }
-            await RunVerifiedMutationAsync(_cli.ServiceStartVerifiedAsync, ct).ConfigureAwait(false);
+            await RunLaneMutationAsync(MutationVerb.StartVerified, ct).ConfigureAwait(false);
             return;
         }
 
@@ -352,7 +339,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
                 AttentionCoexistence(snap.DaemonPid.Value);
                 return;
             }
-            await RunVerifiedMutationAsync(_cli.ServiceStartVerifiedAsync, ct).ConfigureAwait(false);
+            await RunLaneMutationAsync(MutationVerb.StartVerified, ct).ConfigureAwait(false);
             return;
         }
 
@@ -366,7 +353,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         // this name is the install --verify transaction's own job to detect and safely roll back
         // from (post-install ownership + hello verification, spec §3.4; E2E item 2) — not a
         // pre-flight guess by the app.
-        await RunVerifiedMutationAsync(c => _cli.ServiceInstallVerifiedAsync(replace: false, c), ct).ConfigureAwait(false);
+        await RunLaneMutationAsync(MutationVerb.Install, ct).ConfigureAwait(false);
     }
 
     void AttentionCoexistence(int daemonPid) =>
@@ -391,52 +378,32 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         return null;
     }
 
-    /// One CLI mutation call, confirmed by a FRESH Connected (spec §4.2) observed strictly after
-    /// this call began — the confirm waiter is armed BEFORE `mutate` runs so a Connected racing
-    /// the CLI call still counts. No rollback call exists anywhere in IKcapCli: the CLI
-    /// transaction itself already rolled back internally on a coded failure. Returns whether the
-    /// CLI call itself exited Ok (a coded failure is fully surfaced already; callers that offered
-    /// this mutation via a dialog use the return value to decide whether the user got a
-    /// resolution or needs to be able to re-offer).
-    async Task<bool> RunVerifiedMutationAsync(Func<CancellationToken, Task<ProcessResult>> mutate, CancellationToken ct) {
-        var waiter = ArmConfirmWaiter();
-        try {
-            var result = await mutate(ct).ConfigureAwait(false);
+    /// Routes execution through the lane at this action's pinned identity; per the single-
+    /// presentation rule, updates only caller STATE (reattach kick, a coded-failure status line) —
+    /// actionable presentation is the channel consumer's job alone, never `_surface.Attention`
+    /// here. Returns whether the mutation itself succeeded.
+    async Task<bool> RunLaneMutationAsync(MutationVerb verb, CancellationToken ct) {
+        var profileName = await _resolveProfileName().ConfigureAwait(false);
+        var refusal = MutationRequestFactory.TryBuild(verb, profileName, _canonicalServer, _client.DaemonName, out var request);
+        var outcome = refusal ?? await _runMutation(request!, ct).ConfigureAwait(false);
 
-            // §3.6: a forced kill after the CLI transaction's own bound is exceeded (pathological)
-            // — the killed tree's exit code is not a verify outcome and must never be read as one.
-            // Re-query fresh evidence and surface Attention; never auto-mutate off a kill the app
-            // itself had to force.
-            if (result.TimedOut) {
-                await SurfaceTimeoutAttentionAsync(ct).ConfigureAwait(false);
-                return false;
-            }
-
-            _ = _client.RestartLoopAsync(); // kick reattach after any attempted action, success or coded failure
-
-            if (result.ExitCode == VerifyExitCodes.Ok) {
-                using var confirmDeadline = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                var delay = Task.Delay(ConfirmWindow, _time, confirmDeadline.Token);
-                var won = await Task.WhenAny(waiter.Task, delay).ConfigureAwait(false);
-                if (won == waiter.Task)
-                    confirmDeadline.Cancel(); // fresh Connected already arrived — release the timer early
-                else if (!ct.IsCancellationRequested)
-                    _surface.Status("daemon started, app not yet attached — retrying");
+        switch (outcome) {
+            case MutationOutcome.Succeeded:
+            case MutationOutcome.SucceededAfterTimeout:
+                _ = _client.RestartLoopAsync(); // kick reattach after a lane-confirmed mutation
                 return true;
-            }
-
-            _surface.Status($"{VerifyExitCodes.Token(result.ExitCode)}: {result.Stderr.Trim()}");
-            return false;
-        } finally {
-            DisarmConfirmWaiter(waiter);
+            case MutationOutcome.Failed(var exitCode, var reason, _):
+                _surface.Status(reason is null ? VerifyExitCodes.Token(exitCode) : $"{VerifyExitCodes.Token(exitCode)}: {reason}");
+                return false;
+            case MutationOutcome.Refused(var reason, _):
+                _surface.Status($"kcap: {reason}");
+                return false;
+            default:
+                // AttentionSkew/AttentionRepair/UnconfirmedNoAttach: the lane already enqueued
+                // these onto the outcome channel (Deliver enqueues every non-success outcome) —
+                // no local surface call, or the composition-root consumer's presentation doubles up.
+                return false;
         }
-    }
-
-    async Task SurfaceTimeoutAttentionAsync(CancellationToken ct) {
-        var snap = await _cli.ServiceStatusAsync(ct).ConfigureAwait(false);
-        _surface.Attention(snap is null
-            ? "The daemon service operation timed out and its outcome could not be re-checked — check state."
-            : $"The daemon service operation timed out — check state (txn_marker={snap.TxnMarker}, txn_active={snap.TxnActive}).");
     }
 
     /// §4.3: runs on every Connected (paired with the latest known snapshot version) and every
@@ -487,8 +454,9 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
             lock (_lock) _skewDialogShownThisRun = true;
 
             // The retract runs BEFORE the mutation (acceptance itself invalidates the decline
-            // claim), not after: RunVerifiedMutationAsync doesn't catch around the CLI call, so an
-            // install that throws (shutdown mid-spawn, a process/IO fault) would skip a
+            // claim), not after: RunLaneMutationAsync doesn't catch around the lane call, so an
+            // install that throws (shutdown mid-spawn, a process/IO fault, or a lane-lifetime
+            // cancellation) would skip a
             // post-mutation retract entirely and leave an accepted pair mislabeled "declined" on
             // disk. "Declined" must mean the user declined, full stop.
             var (outcome, succeeded) = await ConfirmAndTakeoverAsync(
@@ -520,7 +488,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
 
     /// The ONE accept path every unit rewrite in this controller goes through — skew's takeover
     /// (§4.3) and Start's repair affordance (§4.4) both funnel here, so a future kind can never
-    /// grow a second `ServiceInstallVerifiedAsync(replace: true)` call site. `onAcceptedNotStale`,
+    /// grow a second `MutationVerb.Replace` call site. `onAcceptedNotStale`,
     /// when given, runs after acceptance is confirmed fresh but BEFORE the mutation itself (skew's
     /// decline-claim retract — see its own comment above).
     ///
@@ -553,8 +521,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
 
         if (onAcceptedNotStale is not null) await onAcceptedNotStale().ConfigureAwait(false);
 
-        var succeeded = await RunVerifiedMutationAsync(c => _cli.ServiceInstallVerifiedAsync(replace: true, c), ct)
-            .ConfigureAwait(false);
+        var succeeded = await RunLaneMutationAsync(MutationVerb.Replace, ct).ConfigureAwait(false);
         return (ConfirmOutcome.Attempted, succeeded);
     }
 
@@ -707,7 +674,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
 
                 if (state == ServiceState.Installed) {
                     if (snap.UnitPresent && snap.DaemonPid is null)
-                        await RunVerifiedMutationAsync(_cli.ServiceStartVerifiedAsync, lct).ConfigureAwait(false);
+                        await RunLaneMutationAsync(MutationVerb.StartVerified, lct).ConfigureAwait(false);
                     else
                         await OfferRepairAsync(snap, lct).ConfigureAwait(false); // orphan label or coexistence
                     return;
@@ -716,13 +683,13 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
                 // state == ServiceState.NotInstalled: no loaded label.
                 if (snap.UnitPresent) {
                     if (snap.DaemonPid is null)
-                        await RunVerifiedMutationAsync(_cli.ServiceStartVerifiedAsync, lct).ConfigureAwait(false); // bootstrap the stopped unit
+                        await RunLaneMutationAsync(MutationVerb.StartVerified, lct).ConfigureAwait(false); // bootstrap the stopped unit
                     else
                         await OfferRepairAsync(snap, lct).ConfigureAwait(false); // a manual daemon owns the name
                     return;
                 }
 
-                await _cli.DetachedStartAsync(lct).ConfigureAwait(false); // nothing at all — today's detached start, no unit to rewrite
+                await RunLaneMutationAsync(MutationVerb.DetachedStart, lct).ConfigureAwait(false); // nothing at all — no unit to rewrite
             } finally {
                 _gate.Release();
             }

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -3,9 +3,10 @@ using Capacitor.Cli.Core.LocalIpc;
 namespace Capacitor.App.Services;
 
 /// Mirrors Capacitor.Cli.Services.VerifyExit (source of truth:
-/// src/Capacitor.Cli/Services/ServiceVerify.cs). The app never references the CLI project, so
-/// the coded exits are duplicated here deliberately.
-static class VerifyExitCodes {
+/// src/Capacitor.Cli/Services/ServiceVerify.cs) plus DaemonCommands' detached-start digest gate. The
+/// app never references the CLI project, so the coded exits are duplicated here deliberately — the
+/// one shared home for every coded daemon-mutation exit, reused by DaemonMutationLane's classifier.
+internal static class VerifyExitCodes {
     public const int Ok                  = 0;
     public const int Contended           = 20;
     public const int Viability           = 21;
@@ -15,6 +16,9 @@ static class VerifyExitCodes {
     public const int HelloValidation     = 25;
     public const int RollbackBudget      = 26;
     public const int RestoreVerification = 27;
+    public const int StartGate           = 28;
+    public const int StartGateDrift      = 29;
+    public const int DigestGate          = 43;
 
     public static string Token(int exitCode) => exitCode switch {
         Contended           => "verify_contended",
@@ -25,6 +29,8 @@ static class VerifyExitCodes {
         HelloValidation     => "verify_hello_validation",
         RollbackBudget      => "verify_rollback_budget",
         RestoreVerification => "verify_restore_verification",
+        StartGate           => "verify_start_gate",
+        StartGateDrift      => "verify_start_gate_drift",
         _                   => $"verify_unknown_{exitCode}",
     };
 }

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -378,32 +378,29 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         return null;
     }
 
-    /// Routes execution through the lane at this action's pinned identity; per the single-
-    /// presentation rule, updates only caller STATE (reattach kick, a coded-failure status line) —
-    /// actionable presentation is the channel consumer's job alone, never `_surface.Attention`
-    /// here. Returns whether the mutation itself succeeded.
+    /// Routes execution through the lane at this action's pinned identity. Two DISTINCT surfaces
+    /// (round-1 review C-2): a guard refusal (`MutationRequestFactory` rejecting BEFORE the lane
+    /// is ever touched) never reaches the outcome channel, so the controller is its sole
+    /// presenter — one `_surface.Status` line. Everything that DOES reach the lane is a different
+    /// story: on success this only kicks the reattach (caller state); on any other outcome, the
+    /// lane already enqueued it onto the channel (Deliver enqueues every non-success outcome), so
+    /// this makes NO surface call at all — a second call here would double-present. Returns
+    /// whether the mutation itself succeeded.
     async Task<bool> RunLaneMutationAsync(MutationVerb verb, CancellationToken ct) {
         var profileName = await _resolveProfileName().ConfigureAwait(false);
         var refusal = MutationRequestFactory.TryBuild(verb, profileName, _canonicalServer, _client.DaemonName, out var request);
-        var outcome = refusal ?? await _runMutation(request!, ct).ConfigureAwait(false);
-
-        switch (outcome) {
-            case MutationOutcome.Succeeded:
-            case MutationOutcome.SucceededAfterTimeout:
-                _ = _client.RestartLoopAsync(); // kick reattach after a lane-confirmed mutation
-                return true;
-            case MutationOutcome.Failed(var exitCode, var reason, _):
-                _surface.Status(reason is null ? VerifyExitCodes.Token(exitCode) : $"{VerifyExitCodes.Token(exitCode)}: {reason}");
-                return false;
-            case MutationOutcome.Refused(var reason, _):
-                _surface.Status($"kcap: {reason}");
-                return false;
-            default:
-                // AttentionSkew/AttentionRepair/UnconfirmedNoAttach: the lane already enqueued
-                // these onto the outcome channel (Deliver enqueues every non-success outcome) —
-                // no local surface call, or the composition-root consumer's presentation doubles up.
-                return false;
+        if (refusal is MutationOutcome.Refused(var guardReason, _)) {
+            _surface.Status($"kcap: {guardReason}");
+            return false;
         }
+
+        var outcome = await _runMutation(request!, ct).ConfigureAwait(false);
+        if (outcome is MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout) {
+            _ = _client.RestartLoopAsync(); // kick reattach after a lane-confirmed mutation
+            return true;
+        }
+
+        return false;
     }
 
     /// §4.3: runs on every Connected (paired with the latest known snapshot version) and every
@@ -456,9 +453,8 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
             // The retract runs BEFORE the mutation (acceptance itself invalidates the decline
             // claim), not after: RunLaneMutationAsync doesn't catch around the lane call, so an
             // install that throws (shutdown mid-spawn, a process/IO fault, or a lane-lifetime
-            // cancellation) would skip a
-            // post-mutation retract entirely and leave an accepted pair mislabeled "declined" on
-            // disk. "Declined" must mean the user declined, full stop.
+            // cancellation) would skip a post-mutation retract entirely and leave an accepted pair
+            // mislabeled "declined" on disk. "Declined" must mean the user declined, full stop.
             var (outcome, succeeded) = await ConfirmAndTakeoverAsync(
                 prompt, revalidate: fresh => ClassifyTakeover(fresh) == kind,
                 onAcceptedNotStale: () => RetractDeclineAsync(pairKey), _lifetime.Token).ConfigureAwait(false);

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -61,7 +61,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     // once from the same AppConfig.ResolvedProfile at composition time) — the mutation-request
     // guard (MutationRequestFactory) reads this at every lane call, never re-resolving it.
     readonly string? _canonicalServer;
-    // The lane's RunAsync, injected so every mutating branch below routes execution through the ONE app-lifetime lane instead of calling IKcapCli mutation methods directly — this controller's own _gate still serializes DECIDING, the lane serializes EXECUTION.
+    // The lane's RunAsync — every mutating branch routes through it instead of IKcapCli directly; this controller's own _gate serializes DECIDING, the lane serializes EXECUTION.
     readonly Func<MutationRequest, CancellationToken, Task<MutationOutcome>> _runMutation;
     // When true, RunStartupBranchAsync never admits; PhaseClosed still resolves, StartActionAsync unaffected.
     readonly bool _autoActionsPermanentlyClosed;
@@ -384,7 +384,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         return null;
     }
 
-    /// Routes execution through the lane at this action's pinned identity. Two DISTINCT surfaces: a guard refusal (`MutationRequestFactory` rejecting BEFORE the lane is ever touched) never reaches the outcome channel, so the controller is its sole presenter (one `_surface.Status` line, no lane call, no restart); everything that DOES reach the lane fires the reattach kick UNCONDITIONALLY after every `_runMutation` call regardless of outcome (idempotent, since a mutation attempt may have restarted the daemon even without Succeeded/SucceededAfterTimeout) and makes NO surface call of its own, since the lane already enqueued any non-success outcome onto the channel and a second call here would double-present. Returns whether the mutation itself succeeded.
+    /// Routes execution through the lane. A guard refusal is presented here directly; anything reaching the lane fires an idempotent reattach kick and makes no surface call of its own.
     async Task<bool> RunLaneMutationAsync(MutationVerb verb, CancellationToken ct) {
         var profileName = await _resolveProfileName().ConfigureAwait(false);
         var refusal = MutationRequestFactory.TryBuild(verb, profileName, _canonicalServer, _client.DaemonName, out var request);

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -19,7 +19,7 @@ internal static class VerifyExitCodes {
     public const int RestoreVerification = 27;
     public const int StartGate           = 28;
     public const int StartGateDrift      = 29;
-    public const int DigestGate          = 43; // not a VerifyExit code (DaemonCommands' own digest gate) — deliberately absent from Token()'s map below
+    public const int DigestGate          = 43; // not a VerifyExit code (DaemonCommands' own digest gate) — mapped in Token() below like every other coded exit
 
     public static string Token(int exitCode) => exitCode switch {
         Contended           => "verify_contended",
@@ -32,6 +32,7 @@ internal static class VerifyExitCodes {
         RestoreVerification => "verify_restore_verification",
         StartGate           => "verify_start_gate",
         StartGateDrift      => "verify_start_gate_drift",
+        DigestGate          => "daemon_start_gate",
         _                   => $"verify_unknown_{exitCode}",
     };
 }
@@ -389,11 +390,14 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     /// Routes execution through the lane at this action's pinned identity. Two DISTINCT surfaces
     /// (round-1 review C-2): a guard refusal (`MutationRequestFactory` rejecting BEFORE the lane
     /// is ever touched) never reaches the outcome channel, so the controller is its sole
-    /// presenter — one `_surface.Status` line. Everything that DOES reach the lane is a different
-    /// story: on success this only kicks the reattach (caller state); on any other outcome, the
-    /// lane already enqueued it onto the channel (Deliver enqueues every non-success outcome), so
-    /// this makes NO surface call at all — a second call here would double-present. Returns
-    /// whether the mutation itself succeeded.
+    /// presenter — one `_surface.Status` line, and no lane call ever happened for the daemon to
+    /// have restarted. Everything that DOES reach the lane is a different story: the reattach kick
+    /// fires UNCONDITIONALLY after every `_runMutation` call, regardless of outcome — a mutation
+    /// attempt (takeover Replace, StartVerified, DetachedStart) may have restarted the daemon even
+    /// when it did not end in Succeeded/SucceededAfterTimeout, and kicking reattach is idempotent.
+    /// On any non-success outcome, the lane already enqueued it onto the channel (Deliver enqueues
+    /// every non-success outcome), so this makes NO surface call of its own — a second call here
+    /// would double-present. Returns whether the mutation itself succeeded.
     async Task<bool> RunLaneMutationAsync(MutationVerb verb, CancellationToken ct) {
         var profileName = await _resolveProfileName().ConfigureAwait(false);
         var refusal = MutationRequestFactory.TryBuild(verb, profileName, _canonicalServer, _client.DaemonName, out var request);
@@ -403,12 +407,8 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         }
 
         var outcome = await _runMutation(request!, ct).ConfigureAwait(false);
-        if (outcome is MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout) {
-            _ = _client.RestartLoopAsync(); // kick reattach after a lane-confirmed mutation
-            return true;
-        }
-
-        return false;
+        _ = _client.RestartLoopAsync(); // any mutation attempt may have restarted the daemon; kicking reattach is idempotent
+        return outcome is MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout;
     }
 
     /// §4.3: runs on every Connected (paired with the latest known snapshot version) and every

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -61,10 +61,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     // once from the same AppConfig.ResolvedProfile at composition time) — the mutation-request
     // guard (MutationRequestFactory) reads this at every lane call, never re-resolving it.
     readonly string? _canonicalServer;
-    // The lane's RunAsync, injected so every mutating branch below routes execution through the
-    // ONE app-lifetime lane (Task 10) instead of calling IKcapCli mutation methods
-    // directly — this controller's own _gate still serializes DECIDING, the lane serializes
-    // EXECUTION.
+    // The lane's RunAsync, injected so every mutating branch below routes execution through the ONE app-lifetime lane instead of calling IKcapCli mutation methods directly — this controller's own _gate still serializes DECIDING, the lane serializes EXECUTION.
     readonly Func<MutationRequest, CancellationToken, Task<MutationOutcome>> _runMutation;
     // When true, RunStartupBranchAsync never admits; PhaseClosed still resolves, StartActionAsync unaffected.
     readonly bool _autoActionsPermanentlyClosed;
@@ -387,17 +384,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         return null;
     }
 
-    /// Routes execution through the lane at this action's pinned identity. Two DISTINCT surfaces
-    /// (round-1 review C-2): a guard refusal (`MutationRequestFactory` rejecting BEFORE the lane
-    /// is ever touched) never reaches the outcome channel, so the controller is its sole
-    /// presenter — one `_surface.Status` line, and no lane call ever happened for the daemon to
-    /// have restarted. Everything that DOES reach the lane is a different story: the reattach kick
-    /// fires UNCONDITIONALLY after every `_runMutation` call, regardless of outcome — a mutation
-    /// attempt (takeover Replace, StartVerified, DetachedStart) may have restarted the daemon even
-    /// when it did not end in Succeeded/SucceededAfterTimeout, and kicking reattach is idempotent.
-    /// On any non-success outcome, the lane already enqueued it onto the channel (Deliver enqueues
-    /// every non-success outcome), so this makes NO surface call of its own — a second call here
-    /// would double-present. Returns whether the mutation itself succeeded.
+    /// Routes execution through the lane at this action's pinned identity. Two DISTINCT surfaces: a guard refusal (`MutationRequestFactory` rejecting BEFORE the lane is ever touched) never reaches the outcome channel, so the controller is its sole presenter (one `_surface.Status` line, no lane call, no restart); everything that DOES reach the lane fires the reattach kick UNCONDITIONALLY after every `_runMutation` call regardless of outcome (idempotent, since a mutation attempt may have restarted the daemon even without Succeeded/SucceededAfterTimeout) and makes NO surface call of its own, since the lane already enqueued any non-success outcome onto the channel and a second call here would double-present. Returns whether the mutation itself succeeded.
     async Task<bool> RunLaneMutationAsync(MutationVerb verb, CancellationToken ct) {
         var profileName = await _resolveProfileName().ConfigureAwait(false);
         var refusal = MutationRequestFactory.TryBuild(verb, profileName, _canonicalServer, _client.DaemonName, out var request);

--- a/src/Capacitor.App/Services/IDaemonClientService.cs
+++ b/src/Capacitor.App/Services/IDaemonClientService.cs
@@ -24,9 +24,4 @@ public interface IDaemonClientService {
     Task<StartDaemonResult> StartDaemonAsync(CancellationToken ct);
 
     string DaemonName { get; }
-
-    /// The profile CreateDefaultAsync resolved this client against, or null when none resolved —
-    /// spec §4's live-adapter identity gate (daemon name AND profile/server) needs this to tell a
-    /// same-named daemon under a DIFFERENT profile from the one this client actually attaches to.
-    string? ProfileName { get; }
 }

--- a/src/Capacitor.App/Services/IDaemonClientService.cs
+++ b/src/Capacitor.App/Services/IDaemonClientService.cs
@@ -24,4 +24,9 @@ public interface IDaemonClientService {
     Task<StartDaemonResult> StartDaemonAsync(CancellationToken ct);
 
     string DaemonName { get; }
+
+    /// The profile CreateDefaultAsync resolved this client against, or null when none resolved —
+    /// spec §4's live-adapter identity gate (daemon name AND profile/server) needs this to tell a
+    /// same-named daemon under a DIFFERENT profile from the one this client actually attaches to.
+    string? ProfileName { get; }
 }

--- a/src/Capacitor.App/Services/ILifecycleSurface.cs
+++ b/src/Capacitor.App/Services/ILifecycleSurface.cs
@@ -8,6 +8,9 @@ public interface ILifecycleSurface {
 
     Task<bool> ConfirmAsync(LifecyclePrompt prompt, CancellationToken ct);
 
+    /// Like ConfirmAsync, but null distinguishes "ct won before the dialog factory ran" from a genuinely shown-and-declined dialog (false).
+    Task<bool?> TryConfirmAsync(LifecyclePrompt prompt, CancellationToken ct);
+
     /// Repair-affordance surfaces (spec §4.4) — never a silent mutation.
     void Attention(string message);
 }

--- a/src/Capacitor.App/Services/IProcessRunner.cs
+++ b/src/Capacitor.App/Services/IProcessRunner.cs
@@ -7,12 +7,19 @@ public enum CancelMode {
     KillTree,
 }
 
+/// Scope of the kill on internal Timeout expiry only — CancelMode's KillTree always kills the tree.
+public enum TimeoutKillScope {
+    Tree,
+    ProcessOnly,
+}
+
 public sealed record ProcessResult(int ExitCode, string Stdout, string Stderr, bool TimedOut);
 
 public sealed record RunOptions(
     IReadOnlyDictionary<string, string>? EnvOverlay = null, // adds/overrides; rest of env untouched
     TimeSpan? Timeout = null,                                // internal deadline: kills the tree + awaits on expiry
-    CancelMode CancelMode = CancelMode.AbandonWait);
+    CancelMode CancelMode = CancelMode.AbandonWait,
+    TimeoutKillScope TimeoutKill = TimeoutKillScope.Tree);
 
 /// Seam over process spawning so StartDaemonAsync is testable without touching a real CLI
 /// binary. The production implementation wraps System.Diagnostics.Process.

--- a/src/Capacitor.App/Services/IProcessRunner.cs
+++ b/src/Capacitor.App/Services/IProcessRunner.cs
@@ -17,7 +17,7 @@ public sealed record ProcessResult(int ExitCode, string Stdout, string Stderr, b
 
 public sealed record RunOptions(
     IReadOnlyDictionary<string, string>? EnvOverlay = null, // adds/overrides; rest of env untouched
-    TimeSpan? Timeout = null,                                // internal deadline: kills the tree + awaits on expiry
+    TimeSpan? Timeout = null,                                // internal deadline: kills per TimeoutKill scope + awaits on expiry
     CancelMode CancelMode = CancelMode.AbandonWait,
     TimeoutKillScope TimeoutKill = TimeoutKillScope.Tree);
 

--- a/src/Capacitor.App/Services/KcapCli.cs
+++ b/src/Capacitor.App/Services/KcapCli.cs
@@ -44,10 +44,8 @@ public interface IKcapCli {
 
     Task<ProcessResult> ServiceInstallVerifiedAsync(bool replace, CancellationToken ct);
 
-    /// `daemon start -d --name <name>`, bounded + ProcessOnly-kill; delegates with a fresh boot-attempt id.
-    Task<ProcessResult> DetachedStartAsync(CancellationToken ct);
-
-    /// Same call, stamped with a boot-attempt id for the daemon's own boot-carrier correlation.
+    /// `daemon start -d --name <name>`, bounded + ProcessOnly-kill, stamped with a boot-attempt id
+    /// for the daemon's own boot-carrier correlation — the lane always mints a fresh one per action.
     Task<ProcessResult> DetachedStartAsync(string bootAttemptId, CancellationToken ct);
 }
 
@@ -144,9 +142,6 @@ public sealed class KcapCli : IKcapCli {
         var env = await EnvWithTerminalPathAsync(mutation, ct).ConfigureAwait(false);
         return await Run(cliPath, args.ToArray(), new RunOptions(EnvOverlay: env, Timeout: MutationTimeout), ct).ConfigureAwait(false);
     }
-
-    public Task<ProcessResult> DetachedStartAsync(CancellationToken ct) =>
-        DetachedStartAsync(Guid.NewGuid().ToString("N"), ct);
 
     public Task<ProcessResult> DetachedStartAsync(string bootAttemptId, CancellationToken ct) {
         var env = MutationEnv(); // throws before any spawn if the instance carries no server

--- a/src/Capacitor.App/Services/KcapCli.cs
+++ b/src/Capacitor.App/Services/KcapCli.cs
@@ -44,9 +44,11 @@ public interface IKcapCli {
 
     Task<ProcessResult> ServiceInstallVerifiedAsync(bool replace, CancellationToken ct);
 
-    /// `daemon start -d --name <name>`; AbandonWait, uncapped — a detached daemon must outlive an
-    /// abandoned wait.
+    /// `daemon start -d --name <name>`, bounded + ProcessOnly-kill; delegates with a fresh boot-attempt id.
     Task<ProcessResult> DetachedStartAsync(CancellationToken ct);
+
+    /// Same call, stamped with a boot-attempt id for the daemon's own boot-carrier correlation.
+    Task<ProcessResult> DetachedStartAsync(string bootAttemptId, CancellationToken ct);
 }
 
 public sealed class KcapCli : IKcapCli {
@@ -60,22 +62,33 @@ public sealed class KcapCli : IKcapCli {
     // Same tier as VersionTimeout — also a read-only query — so a hung `launchctl print` can
     // never block the §3.2 per-mutation gate forever once the lifecycle controller polls this.
     static readonly TimeSpan StatusTimeout = TimeSpan.FromSeconds(10);
+    // Above MutationTimeout's 60s — bounds the wrapper without killing a still-forking detach (ProcessOnly).
+    static readonly TimeSpan DetachedStartTimeout = TimeSpan.FromSeconds(75);
+
+    // Overlay variable names every app-initiated spawn carries — the lane and KcapCliTests reference these.
+    public const string SpawnNoTelemetryVar   = "KCAP_APP_SPAWN_NO_TELEMETRY";
+    public const string ConsentSeedDefaultVar = "KCAP_CONSENT_SEED_DEFAULT";
+    public const string ExpectServerUrlVar    = "KCAP_EXPECT_SERVER_URL";
+    public const string BootAttemptVar        = "KCAP_BOOT_ATTEMPT";
 
     readonly IProcessRunner _runner;
     readonly string _daemonName;
     readonly string _profileName;
+    // Bound once at construction (one KcapCli per owned action); null is fine until a mutation runs.
+    readonly string? _canonicalServer;
     // Lazy, not a static ctor value: the terminal PATH is only known once the async probe has run,
     // and the probe itself caches — so resolving it per install call is cheap and always current.
     readonly Func<CancellationToken, Task<string?>>? _terminalPathAsync;
 
     public KcapCli(
             IProcessRunner runner, string? cliPath, string daemonName, string profileName,
-            Func<CancellationToken, Task<string?>>? terminalPathAsync) {
+            Func<CancellationToken, Task<string?>>? terminalPathAsync, string? canonicalServer = null) {
         _runner            = runner;
         CliPath            = cliPath;
         _daemonName        = daemonName;
         _profileName       = profileName;
         _terminalPathAsync = terminalPathAsync;
+        _canonicalServer   = canonicalServer;
     }
 
     public string? CliPath { get; }
@@ -110,30 +123,43 @@ public sealed class KcapCli : IKcapCli {
         }
     }
 
-    public Task<ProcessResult> ServiceStartVerifiedAsync(CancellationToken ct) =>
-        CliPath is not { } cliPath
+    public Task<ProcessResult> ServiceStartVerifiedAsync(CancellationToken ct) {
+        var env = MutationEnv(); // throws before any spawn if the instance carries no server
+        return CliPath is not { } cliPath
             ? NoCliResult()
             : Run(cliPath, ["daemon", "service", "start", "--name", _daemonName, "--verify"],
-                new RunOptions(EnvOverlay: Env(), Timeout: MutationTimeout), ct);
+                new RunOptions(EnvOverlay: env, Timeout: MutationTimeout), ct);
+    }
 
     // The interface's `replace` is the only per-call knob; the profile is pinned once at
     // construction (spec decision 7) and reused verbatim for both the `--profile` flag and the
     // KCAP_PROFILE overlay below, so the two can never disagree.
     public async Task<ProcessResult> ServiceInstallVerifiedAsync(bool replace, CancellationToken ct) {
+        var mutation = MutationEnv(); // throws before any spawn if the instance carries no server
         if (CliPath is not { } cliPath) return await NoCliResult().ConfigureAwait(false);
 
         List<string> args = ["daemon", "service", "install", "--name", _daemonName, "--profile", _profileName, "--verify"];
         if (replace) args.Add("--replace");
 
-        var env = await EnvWithTerminalPathAsync(ct).ConfigureAwait(false);
+        var env = await EnvWithTerminalPathAsync(mutation, ct).ConfigureAwait(false);
         return await Run(cliPath, args.ToArray(), new RunOptions(EnvOverlay: env, Timeout: MutationTimeout), ct).ConfigureAwait(false);
     }
 
     public Task<ProcessResult> DetachedStartAsync(CancellationToken ct) =>
-        CliPath is not { } cliPath
+        DetachedStartAsync(Guid.NewGuid().ToString("N"), ct);
+
+    public Task<ProcessResult> DetachedStartAsync(string bootAttemptId, CancellationToken ct) {
+        var env = MutationEnv(); // throws before any spawn if the instance carries no server
+        env[BootAttemptVar] = bootAttemptId;
+
+        return CliPath is not { } cliPath
             ? NoCliResult()
             : Run(cliPath, ["daemon", "start", "-d", "--name", _daemonName],
-                new RunOptions(EnvOverlay: Env(), CancelMode: CancelMode.AbandonWait), ct);
+                new RunOptions(
+                    EnvOverlay: env, Timeout: DetachedStartTimeout,
+                    CancelMode: CancelMode.AbandonWait, TimeoutKill: TimeoutKillScope.ProcessOnly),
+                ct);
+    }
 
     // Deterministic exit 127 ("command not found") rather than throwing on a null CliPath — a
     // broken KCAP_APP_CLI_PATH must degrade the same way every other no-CLI case does, not crash
@@ -143,8 +169,22 @@ public sealed class KcapCli : IKcapCli {
     Task<ProcessResult> Run(string cliPath, string[] args, RunOptions options, CancellationToken ct) =>
         _runner.RunAsync(cliPath, args, options, ct);
 
-    // Every child carries the pinned profile.
-    Dictionary<string, string> Env() => new() { ["KCAP_PROFILE"] = _profileName };
+    // Every child carries the pinned profile and the app-spawn telemetry-suppression marker.
+    Dictionary<string, string> Env() => new() {
+        ["KCAP_PROFILE"]      = _profileName,
+        [SpawnNoTelemetryVar] = "1",
+    };
+
+    // Null canonicalServer here is a construction bug (mutations are action-scoped) — fail loudly, don't spawn.
+    Dictionary<string, string> MutationEnv() {
+        if (_canonicalServer is not { } server)
+            throw new InvalidOperationException("KcapCli: mutation spawn requires a non-null canonicalServer.");
+
+        var env = Env();
+        env[ConsentSeedDefaultVar] = "prompt";
+        env[ExpectServerUrlVar]    = server;
+        return env;
+    }
 
     // PATH overlaid ONLY here (spec decision 7): install is the sole unit-writing mutation, so it's
     // the only call that needs the terminal's PATH baked into the launchd unit. Start-verify
@@ -152,8 +192,7 @@ public sealed class KcapCli : IKcapCli {
     // Resolved lazily against the mutation's own token, never a detached one; an unknown probe
     // result (null) leaves PATH out rather than overlaying a value that isn't actually the user's —
     // ServiceEnvironment.Capture then honestly bakes whatever the app itself inherited.
-    async Task<Dictionary<string, string>> EnvWithTerminalPathAsync(CancellationToken ct) {
-        var env = Env();
+    async Task<Dictionary<string, string>> EnvWithTerminalPathAsync(Dictionary<string, string> env, CancellationToken ct) {
         var terminalPath = _terminalPathAsync is null ? null : await _terminalPathAsync(ct).ConfigureAwait(false);
         if (terminalPath is not null) env["PATH"] = terminalPath;
 

--- a/src/Capacitor.App/Services/KcapCliCompatibility.cs
+++ b/src/Capacitor.App/Services/KcapCliCompatibility.cs
@@ -1,0 +1,93 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.App.Services;
+
+/// <summary>
+/// Strict floor predicate for the daemon-side kcap CLI version. Unlike
+/// <see cref="PrereleaseSemver"/>'s tolerant Compare (which treats unparseable input as lowest),
+/// StrictParse rejects malformed SemVer outright so a garbled version string never silently reads
+/// as "too old" instead of "unknown".
+/// </summary>
+public static class KcapCliCompatibility {
+    public const string Floor = "0.12.0-beta.1";
+
+    public static bool Satisfies(string? version) =>
+        version is not null &&
+        StrictParse(version) &&
+        PrereleaseSemver.Compare(version, Floor) >= 0;
+
+    public static bool StrictParse(string version) {
+        var core = version;
+
+        var plusIndex = core.IndexOf('+');
+        if (plusIndex >= 0) {
+            var build = core[(plusIndex + 1)..];
+            core = core[..plusIndex];
+            if (!IsValidBuild(build)) return false;
+        }
+
+        var dashIndex = core.IndexOf('-');
+        if (dashIndex >= 0) {
+            var prerelease = core[(dashIndex + 1)..];
+            core = core[..dashIndex];
+            if (!IsValidPrerelease(prerelease)) return false;
+        }
+
+        return IsValidCore(core);
+    }
+
+    static bool IsValidCore(string core) {
+        var parts = core.Split('.');
+        if (parts.Length != 3) return false;
+        foreach (var part in parts) {
+            if (!IsNumericIdentifierNoLeadingZero(part)) return false;
+        }
+        return true;
+    }
+
+    static bool IsValidPrerelease(string prerelease) {
+        if (prerelease.Length == 0) return false;
+        var identifiers = prerelease.Split('.');
+        foreach (var id in identifiers) {
+            if (id.Length == 0) return false;
+            // Each identifier is either strictly numeric (no leading zero) or alphanumeric-with-hyphen.
+            if (IsAllDigits(id)) {
+                if (!IsNumericIdentifierNoLeadingZero(id)) return false;
+            } else if (!IsAlphanumericWithHyphen(id)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Build identifiers, unlike prerelease ones, allow leading zeros (SemVer §10).
+    static bool IsValidBuild(string value) {
+        if (value.Length == 0) return false;
+        var identifiers = value.Split('.');
+        foreach (var id in identifiers) {
+            if (!IsAlphanumericWithHyphen(id)) return false;
+        }
+        return true;
+    }
+
+    static bool IsNumericIdentifierNoLeadingZero(string value) {
+        if (!IsAllDigits(value)) return false;
+        return value.Length == 1 || value[0] != '0';
+    }
+
+    static bool IsAllDigits(string value) {
+        if (value.Length == 0) return false;
+        foreach (var c in value) {
+            if (c is < '0' or > '9') return false;
+        }
+        return true;
+    }
+
+    static bool IsAlphanumericWithHyphen(string value) {
+        if (value.Length == 0) return false;
+        foreach (var c in value) {
+            if (c is not ((>= '0' and <= '9') or (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or '-')) return false;
+        }
+        return true;
+    }
+}

--- a/src/Capacitor.App/Services/LifecycleSurface.cs
+++ b/src/Capacitor.App/Services/LifecycleSurface.cs
@@ -16,15 +16,14 @@ public sealed class LifecycleSurface(
     public void Status(string message) => setStatus(message);
     public void Attention(string message) => setAttention(message);
 
-    public async Task<bool> ConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) {
+    public async Task<bool> ConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) =>
+        await TryConfirmAsync(prompt, ct).ConfigureAwait(false) ?? false;
+
+    public async Task<bool?> TryConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) {
         try {
             await _gate.WaitAsync(ct).ConfigureAwait(false);
         } catch (OperationCanceledException) {
-            // Never got to show a dialog — the shutdown-quiesce contract (Task 21's
-            // WireDialogCancellation, carried forward) still needs `false` from every ConfirmAsync
-            // outcome, not a thrown exception, so a caller awaiting the gate itself degrades the
-            // same way a caller whose already-open dialog got cancelled does.
-            return false;
+            return null; // never got to show a dialog — distinct from a shown-and-declined one (ConfirmAsync degrades this to false)
         }
 
         try {

--- a/src/Capacitor.App/Services/LoginShellProbe.cs
+++ b/src/Capacitor.App/Services/LoginShellProbe.cs
@@ -15,6 +15,14 @@ public interface ILoginShellProbe {
     /// changed the filesystem (e.g. a fresh symlink install) needs a real re-probe, not the
     /// pre-change cached answer.
     Task<bool?> KcapOnPathAsync(CancellationToken ct, bool forceRefresh = false);
+
+    /// Validated `command -v kcap` output, or null (fail closed) when it isn't an absolute,
+    /// fully-qualified path to an existing regular file — an alias, a function definition, a
+    /// relative path, or a bare word all resolve to null, never a fabricated pin. Symlinks are not
+    /// resolved; that is left to invocation time. Cached independently of the other two probes,
+    /// with the same retry-on-process-start-failure and <paramref name="forceRefresh"/> rules as
+    /// KcapOnPathAsync.
+    Task<string?> KcapPathAsync(CancellationToken ct, bool forceRefresh = false);
 }
 
 public sealed class LoginShellProbe(IProcessRunner runner, Func<string, string?> getEnv) : ILoginShellProbe {
@@ -26,6 +34,7 @@ public sealed class LoginShellProbe(IProcessRunner runner, Func<string, string?>
     // actually asked, so TerminalPathAsync/KcapOnPathAsync must not memoize it.
     Task<(string? Value, bool Cacheable)>? _terminalPath;
     Task<(bool? Value, bool Cacheable)>? _kcapOnPath;
+    Task<(string? Value, bool Cacheable)>? _kcapPath;
 
     public async Task<string?> TerminalPathAsync(CancellationToken ct) {
         var task = _terminalPath ??= RunScript($"printf '{Sentinel}%s{Sentinel}' \"$PATH\"");
@@ -53,6 +62,33 @@ public sealed class LoginShellProbe(IProcessRunner runner, Func<string, string?>
             _ => null,
         };
         return (value, cacheable);
+    }
+
+    public async Task<string?> KcapPathAsync(CancellationToken ct, bool forceRefresh = false) {
+        if (forceRefresh) _kcapPath = null; // discard any cached answer — repopulated below
+        var task = _kcapPath ??= ProbeKcapPath();
+        var (value, cacheable) = await task.WaitAsync(ct).ConfigureAwait(false);
+        if (!cacheable) _kcapPath = null;
+        return value;
+    }
+
+    async Task<(string? Value, bool Cacheable)> ProbeKcapPath() {
+        // $(...) captures `command -v kcap` raw (alias line, function body, path, or nothing on
+        // a nonzero exit) without letting its own exit code flip the enclosing script's — the
+        // trailing printf always exits 0, so "not found" is a determined (cacheable) outcome.
+        var (raw, cacheable) = await RunScript($"out=$(command -v kcap 2>/dev/null); printf '{Sentinel}%s{Sentinel}' \"$out\"")
+            .ConfigureAwait(false);
+        return (ValidateKcapPath(raw), cacheable);
+    }
+
+    // Fail closed: only an absolute, fully-qualified path to an existing regular file is a pin —
+    // aliases, function definitions, relative paths, and bare words all resolve to null. Symlinks
+    // are deliberately left unresolved here.
+    static string? ValidateKcapPath(string? raw) {
+        if (raw is null) return null;
+        var firstLine = raw.Split('\n', 2)[0].TrimEnd('\r');
+        if (!Path.IsPathRooted(firstLine) || !Path.IsPathFullyQualified(firstLine)) return null;
+        return File.Exists(firstLine) ? firstLine : null;
     }
 
     // One primitive for both questions: -lic (login + interactive) first, -lc (login only) on a

--- a/src/Capacitor.App/Services/Mutation/BootRefusalMarker.cs
+++ b/src/Capacitor.App/Services/Mutation/BootRefusalMarker.cs
@@ -1,16 +1,19 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
 
 namespace Capacitor.App.Services.Mutation;
 
 /// App-side duplicated view of the daemon's boot-refusal.json marker; same duplication precedent as Capacitor.Cli.Services.BootRefusalReader (the app never references the daemon assembly).
 public sealed record BootRefusalEvidence(
-    string DaemonName, string Token, string? Expectation, string? Resolved,
+    int Schema, string DaemonName, string Token, string? Expectation, string? Resolved,
     int Pid, string? InstanceId, string? AttemptId);
 
 /// For DETACHED starts, the mutation lane is this marker's single consumer — attribution requires the lane's own attempt GUID, never a foreign one.
 public static partial class BootRefusalMarker {
+    const int CurrentSchema = 1;
+
     public static string MarkerPath(string daemonName) =>
         Path.Combine(DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(daemonName), "boot-refusal.json");
 
@@ -30,10 +33,24 @@ public static partial class BootRefusalMarker {
         }
     }
 
-    /// Attributes only when AttemptId matches attemptId and DaemonName matches daemonName; any mismatch returns null and leaves the marker untouched.
-    public static BootRefusalEvidence? TryAttribute(string daemonName, string attemptId) {
+    /// Attributes only against a VERIFIABLE identity, not just a timestamp: schema, a non-null
+    /// AttemptId equal to <paramref name="attemptId"/>, DaemonName equal to <paramref
+    /// name="daemonName"/>, a non-empty Token/InstanceId, a positive Pid, and the marker's own
+    /// Expectation matching <paramref name="requestCanonicalServer"/> (every app detached start
+    /// bakes the expectation, so an attributable marker always carries one) must ALL hold. Any
+    /// single failure returns null and leaves the marker untouched — a marker failing identity
+    /// validation against the request is not attributed, and the caller degrades to its generic
+    /// outcome.
+    public static BootRefusalEvidence? TryAttribute(string daemonName, string attemptId, string? requestCanonicalServer) {
         var evidence = TryRead(daemonName);
-        if (evidence is null || evidence.AttemptId != attemptId || evidence.DaemonName != daemonName) return null;
+        if (evidence is null) return null;
+        if (evidence.Schema != CurrentSchema) return null;
+        if (evidence.AttemptId is null || evidence.AttemptId != attemptId) return null;
+        if (evidence.DaemonName != daemonName) return null;
+        if (string.IsNullOrEmpty(evidence.Token)) return null;
+        if (evidence.Pid <= 0) return null;
+        if (string.IsNullOrEmpty(evidence.InstanceId)) return null;
+        if (!ServerIdentity.Matches(evidence.Expectation, requestCanonicalServer)) return null;
 
         try { File.Delete(MarkerPath(daemonName)); } catch { /* best-effort consume, already attributed */ }
         return evidence;

--- a/src/Capacitor.App/Services/Mutation/BootRefusalMarker.cs
+++ b/src/Capacitor.App/Services/Mutation/BootRefusalMarker.cs
@@ -15,13 +15,17 @@ public static partial class BootRefusalMarker {
         Path.Combine(DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(daemonName), "boot-refusal.json");
 
     /// Absent or corrupt → null, left in place — the app has no ownership authority over a marker the daemon writes.
+    /// Reads via a share-all FileStream (never File.ReadAllText) — the daemon owns this file and may
+    /// concurrently rename/rewrite it; a write-denying open would stall that on Windows.
     public static BootRefusalEvidence? TryRead(string daemonName) {
         var path = MarkerPath(daemonName);
-        if (!File.Exists(path)) return null;
 
         try {
-            return JsonSerializer.Deserialize(File.ReadAllText(path), BootRefusalJsonCtx.Default.BootRefusalEvidence);
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+            return JsonSerializer.Deserialize(reader.ReadToEnd(), BootRefusalJsonCtx.Default.BootRefusalEvidence);
         } catch {
+            // Missing (FileNotFoundException) or corrupt — both answer null, left in place.
             return null;
         }
     }

--- a/src/Capacitor.App/Services/Mutation/BootRefusalMarker.cs
+++ b/src/Capacitor.App/Services/Mutation/BootRefusalMarker.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.App.Services.Mutation;
+
+/// App-side duplicated view of the daemon's boot-refusal.json marker; same duplication precedent as Capacitor.Cli.Services.BootRefusalReader (the app never references the daemon assembly).
+public sealed record BootRefusalEvidence(
+    string DaemonName, string Token, string? Expectation, string? Resolved,
+    int Pid, string? InstanceId, string? AttemptId);
+
+/// For DETACHED starts, the mutation lane is this marker's single consumer — attribution requires the lane's own attempt GUID, never a foreign one.
+public static partial class BootRefusalMarker {
+    public static string MarkerPath(string daemonName) =>
+        Path.Combine(DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(daemonName), "boot-refusal.json");
+
+    /// Absent or corrupt → null, left in place — the app has no ownership authority over a marker the daemon writes.
+    public static BootRefusalEvidence? TryRead(string daemonName) {
+        var path = MarkerPath(daemonName);
+        if (!File.Exists(path)) return null;
+
+        try {
+            return JsonSerializer.Deserialize(File.ReadAllText(path), BootRefusalJsonCtx.Default.BootRefusalEvidence);
+        } catch {
+            return null;
+        }
+    }
+
+    /// Attributes only when AttemptId matches attemptId and DaemonName matches daemonName; any mismatch returns null and leaves the marker untouched.
+    public static BootRefusalEvidence? TryAttribute(string daemonName, string attemptId) {
+        var evidence = TryRead(daemonName);
+        if (evidence is null || evidence.AttemptId != attemptId || evidence.DaemonName != daemonName) return null;
+
+        try { File.Delete(MarkerPath(daemonName)); } catch { /* best-effort consume, already attributed */ }
+        return evidence;
+    }
+
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+    [JsonSerializable(typeof(BootRefusalEvidence))]
+    partial class BootRefusalJsonCtx : JsonSerializerContext;
+}

--- a/src/Capacitor.App/Services/Mutation/BootRefusalMarker.cs
+++ b/src/Capacitor.App/Services/Mutation/BootRefusalMarker.cs
@@ -33,14 +33,7 @@ public static partial class BootRefusalMarker {
         }
     }
 
-    /// Attributes only against a VERIFIABLE identity, not just a timestamp: schema, a non-null
-    /// AttemptId equal to <paramref name="attemptId"/>, DaemonName equal to <paramref
-    /// name="daemonName"/>, a non-empty Token/InstanceId, a positive Pid, and the marker's own
-    /// Expectation matching <paramref name="requestCanonicalServer"/> (every app detached start
-    /// bakes the expectation, so an attributable marker always carries one) must ALL hold. Any
-    /// single failure returns null and leaves the marker untouched — a marker failing identity
-    /// validation against the request is not attributed, and the caller degrades to its generic
-    /// outcome.
+    /// Attributes only against a verifiable identity (schema, attemptId, daemonName, Token/InstanceId, Pid, Expectation) — any mismatch returns null, marker untouched.
     public static BootRefusalEvidence? TryAttribute(string daemonName, string attemptId, string? requestCanonicalServer) {
         var evidence = TryRead(daemonName);
         if (evidence is null) return null;

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -217,8 +217,7 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     async Task<MutationOutcome> ExecuteActionAsync(MutationRequest request, CancellationToken ct) {
         ct.ThrowIfCancellationRequested(); // a disposed lane's cancelled token must stop admission before any spawn
 
-        // Pinned before the first await (spec pin-once rule): evidence is always a fresh socket
-        // dial — a live-graph replay can never prove it postdates the mutation.
+        // Pinned before the first await (spec pin-once rule): evidence is always a fresh socket dial, never a live-graph replay.
         var observation = _oneShotFactory(request);
 
         var pinnedPath = _cliOverride() ?? await _shellProbe.KcapPathAsync(ct, forceRefresh: false).ConfigureAwait(false);
@@ -322,6 +321,15 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
 
         if (ownership.DaemonPid != evidence!.Pid) // evidenceLeg == null guarantees evidence is non-null and fully valid here
             return new MutationOutcome.AttentionSkew("instance_pid_mismatch"); // same-instance rule
+
+        // ABA guard (round-4 P1): the ServiceStatusAsync read above can straddle a process swap that
+        // reuses pid P, so a pid-only cross-check alone can't tell instance A from a replacement B.
+        // A second fresh dial — required to reproduce the SAME InstanceId+Pid as the first — is the
+        // only proof one continuous process held pid P for the whole window; a per-boot instance id
+        // cannot survive a process swap. Only this (the would-be-Succeeded) path pays for it.
+        var confirm = await observation.ObserveAsync(request, ct).ConfigureAwait(false);
+        if (confirm?.Pid != evidence.Pid || confirm?.InstanceId != evidence.InstanceId)
+            return new MutationOutcome.AttentionSkew("instance_changed_during_classification");
 
         return new MutationOutcome.Succeeded();
     }

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -1,8 +1,9 @@
 using System.Diagnostics;
+using Capacitor.Cli.Core.Auth;
 
 namespace Capacitor.App.Services.Mutation;
 
-/// The per-verb classification seam Task 9b implements; kept separate so the lane's control flow never has to change to swap it.
+/// The per-verb classification seam the lane's control flow delegates into — kept separate so control flow never has to change when classification rules change.
 internal delegate Task<MutationOutcome> MutationClassifier(
     MutationRequest request, ProcessResult result, IKcapCli executor, IDaemonObservation observation,
     string? attemptId, CancellationToken ct);
@@ -10,6 +11,22 @@ internal delegate Task<MutationOutcome> MutationClassifier(
 /// The app-lifetime singleton every daemon mutation runs through: one owned action at a time,
 /// identical concurrent requests coalesce, a different request queues FIFO for its own fresh probe.
 public sealed class DaemonMutationLane : IAsyncDisposable {
+    // Named so DeliverFaulted's outcome is self-explanatory instead of a bare magic number.
+    internal const int UnexpectedExitCode = -1;
+
+    // Duplicated exit-code family from Capacitor.Cli.Services.VerifyExit / DaemonCommands' digest
+    // gate — same duplication precedent as VerifyExitCodes in DaemonLifecycleController.cs.
+    internal const int ReadinessTimeoutExit = 24;
+    internal const int StartGateExit        = 28;
+    internal const int StartGateDriftExit   = 29;
+    internal const int DigestGateExit       = 43;
+
+    // The capability a positive service-verb success requires the observed daemon to advertise.
+    const string ConsentCapability = "consent/3";
+
+    internal static readonly TimeSpan DetachedConfirmWindow = TimeSpan.FromSeconds(10);
+    internal static readonly TimeSpan DetachedPollInterval  = TimeSpan.FromSeconds(1);
+
     readonly ILoginShellProbe _shellProbe;
     readonly OutcomeChannel _channel;
     readonly Func<string?> _cliOverride;
@@ -17,6 +34,9 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     readonly Func<MutationRequest, IDaemonObservation> _oneShotFactory;
     readonly TimeProvider _time;
     readonly CancellationTokenSource _lifetime = new();
+    // Captured once, before any dispose: _lifetime.Token throws ObjectDisposedException once the
+    // source itself is disposed, but a token value obtained earlier stays safely readable/storable.
+    readonly CancellationToken _lifetimeToken;
 
     readonly object _gate = new();
     ActionSlot? _owned;
@@ -27,8 +47,8 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     // Atomic slot: an owned action reads this ONCE at start and never again for its own lifetime.
     volatile IDaemonObservation? _liveAdapter;
 
-    // Injectable seam: 9a wires the placeholder below, Task 9b swaps in the real classifier.
-    internal MutationClassifier Classify { get; set; } = ClassifyPlaceholder;
+    // Injectable seam: defaults to the real per-verb classifier below; tests override to pin/observe without running full classification.
+    internal MutationClassifier Classify { get; set; }
 
     public DaemonMutationLane(
             ILoginShellProbe shellProbe, OutcomeChannel channel,
@@ -40,6 +60,8 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         _executorFactory = executorFactory;
         _oneShotFactory  = oneShotFactory;
         _time            = time;
+        _lifetimeToken   = _lifetime.Token;
+        Classify         = ClassifyOutcomeAsync;
     }
 
     public void SetLiveAdapter(IDaemonObservation? live) => _liveAdapter = live;
@@ -95,6 +117,13 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         ActionSlot slot;
         ActionSlot? toStart = null;
         lock (_gate) {
+            if (_disposed) {
+                // A disposed lane never spawns: resolve cancelled immediately, nothing owned/queued, nothing enqueued.
+                var refused = new ActionSlot(request) { WaiterCount = 1 };
+                refused.Completion.TrySetCanceled(_lifetimeToken);
+                return refused;
+            }
+
             var existing = _owned is { } owned && owned.Request == request ? owned : _queue.Find(s => s.Request == request);
             if (existing is not null) {
                 existing.WaiterCount++;
@@ -182,10 +211,10 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         if (waiterless) LogWaiterlessCancellation(slot.Request);
     }
 
-    // An unexpected exception during a mutation attempt is actionable evidence, not a fabricated exception surfaced to waiters.
+    // An unexpected exception during a mutation attempt is actionable evidence, not a fabricated exception surfaced to waiters — the exception itself stays in the log line only.
     void DeliverFaulted(ActionSlot slot, Exception ex) {
         LogUnexpectedFault(slot.Request, ex);
-        var outcome = new MutationOutcome.Failed(-1, ex.GetType().Name, RecoverySurface.Attention);
+        var outcome = new MutationOutcome.Failed(UnexpectedExitCode, "internal_error", RecoverySurface.Attention);
         _channel.Enqueue(new OutcomeEnvelope(slot.Request, outcome));
         slot.Completion.TrySetResult(outcome);
     }
@@ -231,13 +260,135 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         return _oneShotFactory(request);
     }
 
-    // Task 9b replaces this placeholder classification.
-    static Task<MutationOutcome> ClassifyPlaceholder(
+    // --- classification (spec §3/§4) ---
+
+    Task<MutationOutcome> ClassifyOutcomeAsync(
             MutationRequest request, ProcessResult result, IKcapCli executor, IDaemonObservation observation,
             string? attemptId, CancellationToken ct) =>
-        Task.FromResult<MutationOutcome>(result.ExitCode == 0
-            ? new MutationOutcome.Succeeded()
-            : new MutationOutcome.Failed(result.ExitCode, null, RecoverySurface.Attention));
+        request.Verb == MutationVerb.DetachedStart
+            ? ClassifyDetachedStartAsync(request, result, observation, attemptId!, ct)
+            : ClassifyServiceVerbAsync(request, result, executor, observation, ct);
+
+    // Install/Replace/StartVerified: the CLI's own ServiceVerify transaction engine already
+    // performed its readiness poll — exit code alone routes every non-success case.
+    static async Task<MutationOutcome> ClassifyServiceVerbAsync(
+            MutationRequest request, ProcessResult result, IKcapCli executor, IDaemonObservation observation, CancellationToken ct) {
+        if (result.ExitCode == 0) return await ClassifyServiceSuccessAsync(request, executor, observation, ct).ConfigureAwait(false);
+
+        if (result.ExitCode == StartGateExit) {
+            var token = ReasonLine.TrySingle(result.Stderr, "start_gate_reason=");
+            return token is null
+                ? new MutationOutcome.Failed(StartGateExit, null, RecoverySurface.Attention)
+                : new MutationOutcome.Failed(StartGateExit, token, ReasonRouting.ForStartGate(token));
+        }
+
+        if (result.ExitCode == StartGateDriftExit) {
+            // Drift is never auto-retried — always Attention, regardless of whether a reason line happens to be present.
+            var token = ReasonLine.TrySingle(result.Stderr, "start_gate_reason=");
+            return new MutationOutcome.Failed(StartGateDriftExit, token, RecoverySurface.Attention);
+        }
+
+        if (result.ExitCode == ReadinessTimeoutExit) {
+            var token = ReasonLine.TrySingle(result.Stderr, "refusal_reason=");
+            return token is null
+                ? new MutationOutcome.UnconfirmedNoAttach()
+                : new MutationOutcome.Refused(token, ReasonRouting.ForBootRefusal(token));
+        }
+
+        return new MutationOutcome.Failed(result.ExitCode, null, RecoverySurface.Attention);
+    }
+
+    // Positive evidence only (spec §6): every leg below must independently hold for Succeeded — any
+    // gap degrades to AttentionSkew/AttentionRepair/UnconfirmedNoAttach, never a guessed success.
+    static async Task<MutationOutcome> ClassifyServiceSuccessAsync(
+            MutationRequest request, IKcapCli executor, IDaemonObservation observation, CancellationToken ct) {
+        var evidence  = await observation.ObserveAsync(request, ct).ConfigureAwait(false);
+        var ownership = await executor.ServiceStatusAsync(ct).ConfigureAwait(false);
+
+        if (evidence is not { Reachable: true })
+            // No independent evidence either way vs. a recorded owner with nothing to show for it are different signals.
+            return ownership?.DaemonPid is null
+                ? new MutationOutcome.UnconfirmedNoAttach()
+                : new MutationOutcome.AttentionSkew("unreachable_with_recorded_owner");
+
+        if (!ServerIdentity.Matches(evidence.ServerUrl, request.CanonicalServer) || evidence.DaemonName != request.DaemonName)
+            return new MutationOutcome.AttentionSkew("server_or_name_mismatch");
+
+        if (evidence.Pid is null || evidence.InstanceId is null)
+            return new MutationOutcome.AttentionSkew("pre_slice_evidence");
+
+        if (!evidence.IdentityConsistent)
+            return new MutationOutcome.AttentionSkew("identity_inconsistent");
+
+        if (evidence.Capabilities is null || !evidence.Capabilities.Contains(ConsentCapability))
+            return new MutationOutcome.AttentionSkew("missing_capability_consent_3");
+
+        if (!KcapCliCompatibility.Satisfies(evidence.DaemonVersion))
+            return new MutationOutcome.AttentionSkew("daemon_below_floor");
+
+        if (ownership is null)
+            return new MutationOutcome.AttentionSkew("ownership_unknown");
+
+        if (ownership.TxnMarker && !ownership.TxnActive)
+            return new MutationOutcome.AttentionRepair("stale_txn_marker");
+
+        if (ownership.JobPid is null || ownership.DaemonPid is null || ownership.JobPid != ownership.DaemonPid)
+            return new MutationOutcome.AttentionSkew("ownership_mismatch");
+
+        if (ownership.DaemonPid != evidence.Pid) // same-instance rule: the ownership read must describe THIS observed daemon
+            return new MutationOutcome.AttentionSkew("instance_pid_mismatch");
+
+        return new MutationOutcome.Succeeded();
+    }
+
+    // DetachedStart has no CLI-side verify engine — the lane itself confirms via a bounded post-spawn observation window.
+    async Task<MutationOutcome> ClassifyDetachedStartAsync(
+            MutationRequest request, ProcessResult result, IDaemonObservation observation, string attemptId, CancellationToken ct) {
+        // A forced process-only kill after the wrapper's own bound makes the exit code meaningless — only evidence counts.
+        if (result.TimedOut)
+            return await AwaitDetachedConfirmationAsync(
+                request, observation, attemptId, static () => new MutationOutcome.SucceededAfterTimeout(), ct).ConfigureAwait(false);
+
+        if (result.ExitCode == 0)
+            return await AwaitDetachedConfirmationAsync(
+                request, observation, attemptId, static () => new MutationOutcome.Succeeded(), ct).ConfigureAwait(false);
+
+        if (result.ExitCode == DigestGateExit) {
+            var token = ReasonLine.TrySingle(result.Stderr, "daemon_start_reason=");
+            return token is null
+                ? new MutationOutcome.Failed(DigestGateExit, null, RecoverySurface.Attention)
+                : new MutationOutcome.Failed(DigestGateExit, token, ReasonRouting.ForDaemonStart(token));
+        }
+
+        return new MutationOutcome.Failed(result.ExitCode, null, RecoverySurface.Attention);
+    }
+
+    // Polls the pinned observation for up to DetachedConfirmWindow: full evidence wins via
+    // onFullEvidence, an attributed boot-refusal marker wins Refused, and window expiry with
+    // neither is UnconfirmedNoAttach. Entirely TimeProvider-driven so tests never wait for real time.
+    async Task<MutationOutcome> AwaitDetachedConfirmationAsync(
+            MutationRequest request, IDaemonObservation observation, string attemptId,
+            Func<MutationOutcome> onFullEvidence, CancellationToken ct) {
+        var deadline = _time.GetUtcNow() + DetachedConfirmWindow;
+        while (true) {
+            var evidence = await observation.ObserveAsync(request, ct).ConfigureAwait(false);
+            if (IsFullEvidence(evidence, request)) return onFullEvidence();
+
+            if (BootRefusalMarker.TryAttribute(request.DaemonName, attemptId) is { } refusal)
+                return new MutationOutcome.Refused(refusal.Token, ReasonRouting.ForBootRefusal(refusal.Token));
+
+            var remaining = deadline - _time.GetUtcNow();
+            if (remaining <= TimeSpan.Zero) return new MutationOutcome.UnconfirmedNoAttach();
+
+            var wait = remaining < DetachedPollInterval ? remaining : DetachedPollInterval;
+            await Task.Delay(wait, _time, ct).ConfigureAwait(false);
+        }
+    }
+
+    static bool IsFullEvidence(ObservedEvidence? evidence, MutationRequest request) =>
+        evidence is { Reachable: true, IdentityConsistent: true }
+        && ServerIdentity.Matches(evidence.ServerUrl, request.CanonicalServer)
+        && evidence.DaemonName == request.DaemonName;
 
     static void LogWaiterlessSuccess(MutationRequest request, MutationOutcome outcome) =>
         Console.Error.WriteLine(

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -227,7 +227,7 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         var version = await executor.VersionAsync(ct).ConfigureAwait(false);
         if (!KcapCliCompatibility.Satisfies(version)) return new MutationOutcome.Refused("cli_below_floor", RecoverySurface.Attention);
 
-        var observation = await PinObservationAsync(request, ct).ConfigureAwait(false);
+        var observation = PinObservation(request);
 
         var attemptId = request.Verb == MutationVerb.DetachedStart ? Guid.NewGuid().ToString("N") : null;
 
@@ -249,11 +249,26 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
             _ => throw new ArgumentOutOfRangeException(nameof(request), request.Verb, "unknown MutationVerb"),
         };
 
-    // Live adapter usable only when it can actually target this request's identity; unset or a mismatch falls back to one-shot.
-    async Task<IDaemonObservation> PinObservationAsync(MutationRequest request, CancellationToken ct) {
+    // Live adapter usable only when it can actually target this request's identity; unset falls
+    // back to a plain one-shot probe. When set, the pin is a COMPOSITE that tries live on every
+    // ObserveAsync call and falls through to a FRESH one-shot whenever live's result is null or
+    // not Reachable — e.g. a mutation (takeover Replace, StartVerified, DetachedStart) that
+    // restarted the daemon tears down the app's own attach mid-action, and the live adapter would
+    // otherwise keep replaying that stale "unreachable" snapshot for the rest of classification.
+    // Exactly one observation result feeds a given classification attempt, never a live/one-shot
+    // blend. Pinned ONCE at action start (spec pin-once rule): the live reference and
+    // oneShotFactory this wrapper closes over never change even if SetLiveAdapter is called again
+    // while this action is still in flight.
+    IDaemonObservation PinObservation(MutationRequest request) {
         var live = _liveAdapter;
-        if (live is not null && await live.ObserveAsync(request, ct).ConfigureAwait(false) is not null) return live;
-        return _oneShotFactory(request);
+        return live is null ? _oneShotFactory(request) : new CompositeObservation(live, _oneShotFactory);
+    }
+
+    sealed class CompositeObservation(IDaemonObservation live, Func<MutationRequest, IDaemonObservation> oneShotFactory) : IDaemonObservation {
+        public async Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
+            var evidence = await live.ObserveAsync(request, ct).ConfigureAwait(false);
+            return evidence is { Reachable: true } ? evidence : await oneShotFactory(request).ObserveAsync(request, ct).ConfigureAwait(false);
+        }
     }
 
     // --- classification (spec §3/§4) ---

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -222,6 +222,10 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     async Task<MutationOutcome> ExecuteActionAsync(MutationRequest request, CancellationToken ct) {
         ct.ThrowIfCancellationRequested(); // a disposed lane's cancelled token must stop admission before any spawn
 
+        // Pinned before the first await (spec pin-once rule): a concurrent SetLiveAdapter swap
+        // during the CLI/version probes below must never change an already-started action's observer.
+        var observation = PinObservation(request);
+
         var pinnedPath = _cliOverride() ?? await _shellProbe.KcapPathAsync(ct, forceRefresh: false).ConfigureAwait(false);
         // A cached negative must not refuse forever: one forced re-probe lets a CLI installed after
         // the cache went negative recover on the very next action, instead of requiring an app restart.
@@ -231,8 +235,6 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         var executor = _executorFactory(request, pinnedPath); // built ONCE; the same instance runs the probe and the mutation
         var version = await executor.VersionAsync(ct).ConfigureAwait(false);
         if (!KcapCliCompatibility.Satisfies(version)) return new MutationOutcome.Refused("cli_below_floor", RecoverySurface.Attention);
-
-        var observation = PinObservation(request);
 
         var attemptId = request.Verb == MutationVerb.DetachedStart ? Guid.NewGuid().ToString("N") : null;
 
@@ -254,17 +256,9 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
             _ => throw new ArgumentOutOfRangeException(nameof(request), request.Verb, "unknown MutationVerb"),
         };
 
-    // Live adapter usable only when it can actually target this request's identity; unset falls
-    // back to a plain one-shot probe. When set, the pin is a COMPOSITE that tries live on every
-    // ObserveAsync call and falls through to a FRESH one-shot whenever live's result is null or
-    // not Reachable — e.g. a mutation (takeover Replace, StartVerified, DetachedStart) that
-    // restarted the daemon tears down the app's own attach mid-action, and the live adapter would
-    // otherwise keep replaying that stale "unreachable" snapshot for the rest of classification.
-    // Exactly one observation result feeds a given classification attempt, never a live/one-shot
-    // blend. Pinned ONCE at action start (spec pin-once rule): the live reference and
-    // oneShotFactory this wrapper closes over never change even if SetLiveAdapter is called again
-    // while this action is still in flight.
+    // Pinned ONCE at action start (before the caller's first await), so a later SetLiveAdapter call never changes an in-flight action's observer; DetachedStart always pins the one-shot factory, never the live adapter, because a one-shot dials fresh sockets per poll (post-mutation evidence by construction) while the live adapter would synchronously replay possibly pre-mutation status with no fresh-ownership cross-check to catch it. For every other verb an unset live adapter falls back to a plain one-shot probe, and a set one is wrapped in a COMPOSITE that tries live first and falls through to a FRESH one-shot whenever live's result is null or not Reachable (e.g. a mutation that restarted the daemon and tore down the app's own attach) — exactly one observation result feeds a given classification attempt, never a live/one-shot blend.
     IDaemonObservation PinObservation(MutationRequest request) {
+        if (request.Verb == MutationVerb.DetachedStart) return _oneShotFactory(request);
         var live = _liveAdapter;
         return live is null ? _oneShotFactory(request) : new CompositeObservation(live, _oneShotFactory);
     }
@@ -385,17 +379,7 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         return new MutationOutcome.Failed(result.ExitCode, null, RecoverySurface.Attention);
     }
 
-    // Polls the pinned observation for up to DetachedConfirmWindow: full evidence at ANY poll wins
-    // immediately via onFullEvidence; an attributed boot-refusal marker wins Refused. A non-full,
-    // non-unreachable leg (e.g. the two-dial probe's transient mid-boot shape — hello answered,
-    // snapshot not yet subscribed — reads as a server/name mismatch) does NOT fail fast: it is only
-    // ever a snapshot of ONE poll, so the loop keeps polling through it, remembering the LAST
-    // observed leg. Only at window expiry does that last leg decide the outcome: "unreachable" (or
-    // no evidence ever observed) → UnconfirmedNoAttach; any other leg, still true at expiry →
-    // AttentionSkew(leg). Entirely TimeProvider-driven so tests never wait for real time.
-    // `attemptId` is null only via direct test injection through the Classify seam — a real
-    // DetachedStart action always carries one; a null one must never attribute a marker, since a
-    // null-attempt marker belongs to a service-verb refusal, not this action.
+    // Polls the pinned observation (marker checked first each iteration, so an attributed boot-refusal always wins Refused) for up to DetachedConfirmWindow: full evidence at any poll resolves immediately via onFullEvidence, a non-full non-unreachable leg is remembered and polled through rather than failing fast (only a single-poll snapshot), and only at window expiry does the last leg decide — "unreachable"/never-observed → UnconfirmedNoAttach, anything else → AttentionSkew(leg); entirely TimeProvider-driven. `attemptId` is null only via direct test injection through the Classify seam (a real DetachedStart action always carries one) and must never attribute a marker, since a null-attempt marker belongs to a service-verb refusal, not this action.
     async Task<MutationOutcome> AwaitDetachedConfirmationAsync(
             MutationRequest request, IDaemonObservation observation, string? attemptId,
             Func<MutationOutcome> onFullEvidence, CancellationToken ct) {
@@ -406,7 +390,7 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
             // can never produce a false Refused, while evidence-first could let a pre-existing
             // same-name daemon (or, here, a transient mid-boot evidence shape) mask a real refusal —
             // checked fresh every iteration, so a refusal arriving mid-window is caught on the next poll.
-            if (attemptId is not null && BootRefusalMarker.TryAttribute(request.DaemonName, attemptId) is { } refusal)
+            if (attemptId is not null && BootRefusalMarker.TryAttribute(request.DaemonName, attemptId, request.CanonicalServer) is { } refusal)
                 return new MutationOutcome.Refused(refusal.Token, ReasonRouting.ForBootRefusal(refusal.Token));
 
             var evidence = await observation.ObserveAsync(request, ct).ConfigureAwait(false);

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -1,0 +1,211 @@
+namespace Capacitor.App.Services.Mutation;
+
+/// The per-verb classification seam Task 9b implements; kept separate so the lane's control flow never has to change to swap it.
+internal delegate Task<MutationOutcome> MutationClassifier(
+    MutationRequest request, ProcessResult result, IKcapCli executor, IDaemonObservation observation,
+    string? attemptId, CancellationToken ct);
+
+/// The app-lifetime singleton every daemon mutation runs through: one owned action at a time,
+/// identical concurrent requests coalesce, a different request queues FIFO for its own fresh probe.
+public sealed class DaemonMutationLane : IAsyncDisposable {
+    readonly IProcessRunner _runner;
+    readonly ILoginShellProbe _shellProbe;
+    readonly OutcomeChannel _channel;
+    readonly Func<string?> _cliOverride;
+    readonly Func<MutationRequest, string?, IKcapCli> _executorFactory;
+    readonly Func<MutationRequest, IDaemonObservation> _oneShotFactory;
+    readonly TimeProvider _time;
+    readonly CancellationTokenSource _lifetime = new();
+
+    readonly object _gate = new();
+    ActionSlot? _owned;
+    readonly List<ActionSlot> _queue = [];
+    TaskCompletionSource _quiescent = CompletedSignal();
+
+    // Atomic slot: an owned action reads this ONCE at start and never again for its own lifetime.
+    volatile IDaemonObservation? _liveAdapter;
+
+    // Injectable seam: 9a wires the placeholder below, Task 9b swaps in the real classifier.
+    internal MutationClassifier Classify { get; set; } = ClassifyPlaceholder;
+
+    public DaemonMutationLane(
+            IProcessRunner runner, ILoginShellProbe shellProbe, OutcomeChannel channel,
+            Func<string?> cliOverride, Func<MutationRequest, string?, IKcapCli> executorFactory,
+            Func<MutationRequest, IDaemonObservation> oneShotFactory, TimeProvider time) {
+        _runner          = runner;
+        _shellProbe      = shellProbe;
+        _channel         = channel;
+        _cliOverride     = cliOverride;
+        _executorFactory = executorFactory;
+        _oneShotFactory  = oneShotFactory;
+        _time            = time;
+    }
+
+    public void SetLiveAdapter(IDaemonObservation? live) => _liveAdapter = live;
+
+    public async Task<MutationOutcome> RunAsync(MutationRequest request, CancellationToken waiterCt) {
+        var slot = AttachOrCreate(request);
+        try {
+            return await slot.Completion.Task.WaitAsync(waiterCt).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (waiterCt.IsCancellationRequested) {
+            DetachWaiter(slot); // this waiter only — the owned action keeps running under the lane's own token
+            throw;
+        }
+    }
+
+    public async Task QuiescedAsync(CancellationToken ct) {
+        while (true) {
+            Task wait;
+            lock (_gate) {
+                if (_owned is null && _queue.Count == 0) return;
+                wait = _quiescent.Task;
+            }
+            await wait.WaitAsync(ct).ConfigureAwait(false);
+        }
+    }
+
+    public async ValueTask DisposeAsync() {
+        Task<MutationOutcome>? owned;
+        lock (_gate) { owned = _owned?.Completion.Task; }
+
+        _lifetime.Cancel();
+
+        if (owned is not null) {
+            try { await owned.ConfigureAwait(false); } catch { /* terminal disposition already lives on the slot's own TCS */ }
+        }
+        _lifetime.Dispose();
+    }
+
+    // --- admission / coalescing ---
+
+    ActionSlot AttachOrCreate(MutationRequest request) {
+        ActionSlot slot;
+        ActionSlot? toStart = null;
+        lock (_gate) {
+            var existing = _owned is { } owned && owned.Request == request ? owned : _queue.Find(s => s.Request == request);
+            if (existing is not null) {
+                existing.WaiterCount++;
+                return existing;
+            }
+
+            slot = new ActionSlot(request) { WaiterCount = 1 };
+            if (_owned is null) {
+                _owned = slot;
+                if (_quiescent.Task.IsCompleted) _quiescent = NewSignal(); // idle -> busy
+                toStart = slot;
+            } else {
+                _queue.Add(slot);
+            }
+        }
+        if (toStart is not null) StartAction(toStart);
+        return slot;
+    }
+
+    void DetachWaiter(ActionSlot slot) {
+        lock (_gate) { slot.WaiterCount--; }
+    }
+
+    void StartAction(ActionSlot slot) => _ = RunOwnedAsync(slot);
+
+    async Task RunOwnedAsync(ActionSlot slot) {
+        try {
+            var outcome = await ExecuteActionAsync(slot.Request, _lifetime.Token).ConfigureAwait(false);
+            Deliver(slot, outcome);
+        } catch (OperationCanceledException oce) {
+            slot.Completion.TrySetCanceled(oce.CancellationToken);
+        } catch (Exception ex) {
+            slot.Completion.TrySetException(ex);
+        } finally {
+            FinishAndAdmitNext(slot);
+        }
+    }
+
+    void FinishAndAdmitNext(ActionSlot finished) {
+        ActionSlot? next = null;
+        lock (_gate) {
+            if (ReferenceEquals(_owned, finished)) _owned = null;
+            if (_queue.Count > 0) {
+                next = _queue[0];
+                _queue.RemoveAt(0);
+                _owned = next;
+            } else {
+                _quiescent.TrySetResult(); // busy -> idle
+            }
+        }
+        if (next is not null) StartAction(next);
+    }
+
+    void Deliver(ActionSlot slot, MutationOutcome outcome) {
+        var isSuccess = outcome is MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout;
+        if (!isSuccess) {
+            _channel.Enqueue(new OutcomeEnvelope(slot.Request, outcome));
+        } else {
+            bool waiterless;
+            lock (_gate) { waiterless = slot.WaiterCount <= 0; }
+            if (waiterless) LogWaiterlessSuccess(slot.Request, outcome);
+        }
+        slot.Completion.TrySetResult(outcome);
+    }
+
+    // --- the owned action itself ---
+
+    async Task<MutationOutcome> ExecuteActionAsync(MutationRequest request, CancellationToken ct) {
+        var pinnedPath = _cliOverride() ?? await _shellProbe.KcapPathAsync(ct, forceRefresh: false).ConfigureAwait(false);
+        if (pinnedPath is null) return new MutationOutcome.Refused("cli_not_found", RecoverySurface.Attention);
+
+        var executor = _executorFactory(request, pinnedPath); // built ONCE; the same instance runs the probe and the mutation
+        var version = await executor.VersionAsync(ct).ConfigureAwait(false);
+        if (!KcapCliCompatibility.Satisfies(version)) return new MutationOutcome.Refused("cli_below_floor", RecoverySurface.Attention);
+
+        var observation = await PinObservationAsync(request, ct).ConfigureAwait(false);
+
+        var attemptId = request.Verb == MutationVerb.DetachedStart ? Guid.NewGuid().ToString("N") : null;
+        var result = await Dispatch(executor, request, attemptId, ct).ConfigureAwait(false);
+
+        return await Classify(request, result, executor, observation, attemptId, ct).ConfigureAwait(false);
+    }
+
+    static Task<ProcessResult> Dispatch(IKcapCli executor, MutationRequest request, string? attemptId, CancellationToken ct) =>
+        request.Verb switch {
+            MutationVerb.Install       => executor.ServiceInstallVerifiedAsync(replace: false, ct),
+            MutationVerb.Replace       => executor.ServiceInstallVerifiedAsync(replace: true, ct),
+            MutationVerb.StartVerified => executor.ServiceStartVerifiedAsync(ct),
+            MutationVerb.DetachedStart => executor.DetachedStartAsync(attemptId!, ct),
+            // Fail closed, never permissive: an unnamed enum value must halt, not silently pick a verb.
+            _ => throw new ArgumentOutOfRangeException(nameof(request), request.Verb, "unknown MutationVerb"),
+        };
+
+    // Live adapter usable only when it can actually target this request's identity; unset or a mismatch falls back to one-shot.
+    async Task<IDaemonObservation> PinObservationAsync(MutationRequest request, CancellationToken ct) {
+        var live = _liveAdapter;
+        if (live is not null && await live.ObserveAsync(request, ct).ConfigureAwait(false) is not null) return live;
+        return _oneShotFactory(request);
+    }
+
+    // Task 9b replaces this placeholder classification.
+    static Task<MutationOutcome> ClassifyPlaceholder(
+            MutationRequest request, ProcessResult result, IKcapCli executor, IDaemonObservation observation,
+            string? attemptId, CancellationToken ct) =>
+        Task.FromResult<MutationOutcome>(result.ExitCode == 0
+            ? new MutationOutcome.Succeeded()
+            : new MutationOutcome.Failed(result.ExitCode, null, RecoverySurface.Attention));
+
+    static void LogWaiterlessSuccess(MutationRequest request, MutationOutcome outcome) =>
+        Console.Error.WriteLine(
+            $"DaemonMutationLane: waiterless {outcome.GetType().Name} verb={request.Verb} profile={request.Profile} " +
+            $"server={request.CanonicalServer} daemon={request.DaemonName}");
+
+    static TaskCompletionSource CompletedSignal() {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        tcs.SetResult();
+        return tcs;
+    }
+
+    static TaskCompletionSource NewSignal() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    sealed class ActionSlot(MutationRequest request) {
+        public MutationRequest Request { get; } = request;
+        public TaskCompletionSource<MutationOutcome> Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int WaiterCount;
+    }
+}

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -256,7 +256,7 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
             _ => throw new ArgumentOutOfRangeException(nameof(request), request.Verb, "unknown MutationVerb"),
         };
 
-    // Pinned ONCE at action start (before the caller's first await), so a later SetLiveAdapter call never changes an in-flight action's observer; DetachedStart always pins the one-shot factory, never the live adapter, because a one-shot dials fresh sockets per poll (post-mutation evidence by construction) while the live adapter would synchronously replay possibly pre-mutation status with no fresh-ownership cross-check to catch it. For every other verb an unset live adapter falls back to a plain one-shot probe, and a set one is wrapped in a COMPOSITE that tries live first and falls through to a FRESH one-shot whenever live's result is null or not Reachable (e.g. a mutation that restarted the daemon and tore down the app's own attach) — exactly one observation result feeds a given classification attempt, never a live/one-shot blend.
+    // Pinned once before the first await, immune to a later SetLiveAdapter swap; DetachedStart always pins one-shot, other verbs composite a set live adapter with a one-shot fallback.
     IDaemonObservation PinObservation(MutationRequest request) {
         if (request.Verb == MutationVerb.DetachedStart) return _oneShotFactory(request);
         var live = _liveAdapter;
@@ -379,7 +379,7 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         return new MutationOutcome.Failed(result.ExitCode, null, RecoverySurface.Attention);
     }
 
-    // Polls the pinned observation (marker checked first each iteration, so an attributed boot-refusal always wins Refused) for up to DetachedConfirmWindow: full evidence at any poll resolves immediately via onFullEvidence, a non-full non-unreachable leg is remembered and polled through rather than failing fast (only a single-poll snapshot), and only at window expiry does the last leg decide — "unreachable"/never-observed → UnconfirmedNoAttach, anything else → AttentionSkew(leg); entirely TimeProvider-driven. `attemptId` is null only via direct test injection through the Classify seam (a real DetachedStart action always carries one) and must never attribute a marker, since a null-attempt marker belongs to a service-verb refusal, not this action.
+    // Polls up to DetachedConfirmWindow (marker checked first): full evidence resolves immediately, else the last leg decides at expiry. `attemptId` null is test-only and never attributes a marker.
     async Task<MutationOutcome> AwaitDetachedConfirmationAsync(
             MutationRequest request, IDaemonObservation observation, string? attemptId,
             Func<MutationOutcome> onFullEvidence, CancellationToken ct) {

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Capacitor.App.Services.Mutation;
 
 /// The per-verb classification seam Task 9b implements; kept separate so the lane's control flow never has to change to swap it.
@@ -8,7 +10,6 @@ internal delegate Task<MutationOutcome> MutationClassifier(
 /// The app-lifetime singleton every daemon mutation runs through: one owned action at a time,
 /// identical concurrent requests coalesce, a different request queues FIFO for its own fresh probe.
 public sealed class DaemonMutationLane : IAsyncDisposable {
-    readonly IProcessRunner _runner;
     readonly ILoginShellProbe _shellProbe;
     readonly OutcomeChannel _channel;
     readonly Func<string?> _cliOverride;
@@ -21,6 +22,7 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     ActionSlot? _owned;
     readonly List<ActionSlot> _queue = [];
     TaskCompletionSource _quiescent = CompletedSignal();
+    bool _disposed;
 
     // Atomic slot: an owned action reads this ONCE at start and never again for its own lifetime.
     volatile IDaemonObservation? _liveAdapter;
@@ -29,10 +31,9 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     internal MutationClassifier Classify { get; set; } = ClassifyPlaceholder;
 
     public DaemonMutationLane(
-            IProcessRunner runner, ILoginShellProbe shellProbe, OutcomeChannel channel,
+            ILoginShellProbe shellProbe, OutcomeChannel channel,
             Func<string?> cliOverride, Func<MutationRequest, string?, IKcapCli> executorFactory,
             Func<MutationRequest, IDaemonObservation> oneShotFactory, TimeProvider time) {
-        _runner          = runner;
         _shellProbe      = shellProbe;
         _channel         = channel;
         _cliOverride     = cliOverride;
@@ -65,15 +66,27 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     }
 
     public async ValueTask DisposeAsync() {
-        Task<MutationOutcome>? owned;
-        lock (_gate) { owned = _owned?.Completion.Task; }
+        Task<MutationOutcome>? ownedTask;
+        lock (_gate) {
+            if (_disposed) return; // idempotent: a second call must not re-cancel/re-dispose the lifetime token
+            _disposed = true;
+
+            ownedTask = _owned?.Completion.Task;
+
+            // Cancel every queued waiter up front: shutdown is not an actionable outcome (nothing
+            // enqueued to the channel), and draining now means the owned action's own finish has
+            // nothing left to admit once it completes.
+            foreach (var queued in _queue) queued.Completion.TrySetCanceled(_lifetime.Token);
+            _queue.Clear();
+        }
 
         _lifetime.Cancel();
 
-        if (owned is not null) {
-            try { await owned.ConfigureAwait(false); } catch { /* terminal disposition already lives on the slot's own TCS */ }
+        if (ownedTask is not null) {
+            try { await ownedTask.ConfigureAwait(false); } catch { /* terminal disposition already lives on the slot's own TCS */ }
         }
-        _lifetime.Dispose();
+
+        _lifetime.Dispose(); // only after the drain + owned-action await — no other path can still touch the token
     }
 
     // --- admission / coalescing ---
@@ -108,22 +121,35 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     void StartAction(ActionSlot slot) => _ = RunOwnedAsync(slot);
 
     async Task RunOwnedAsync(ActionSlot slot) {
+        MutationOutcome? outcome = null;
+        OperationCanceledException? cancelled = null;
+        Exception? fault = null;
         try {
-            var outcome = await ExecuteActionAsync(slot.Request, _lifetime.Token).ConfigureAwait(false);
-            Deliver(slot, outcome);
+            outcome = await ExecuteActionAsync(slot.Request, _lifetime.Token).ConfigureAwait(false);
         } catch (OperationCanceledException oce) {
-            slot.Completion.TrySetCanceled(oce.CancellationToken);
+            cancelled = oce;
         } catch (Exception ex) {
-            slot.Completion.TrySetException(ex);
-        } finally {
-            FinishAndAdmitNext(slot);
+            fault = ex;
         }
+
+        // Detach BEFORE resolving the outcome below: closes the window where a fresh RunAsync for
+        // the SAME request could coalesce onto a slot whose result is already decided.
+        var next = DetachAndAdmitNext(slot);
+
+        if (outcome is not null) Deliver(slot, outcome);
+        else if (cancelled is not null) DeliverCancelled(slot, cancelled);
+        else DeliverFaulted(slot, fault!);
+
+        // Recursive by construction when actions settle synchronously (fakes, or an already-exited
+        // real child) — bounded by queue depth, which stays small in practice; real I/O never does this.
+        if (next is not null) StartAction(next);
     }
 
-    void FinishAndAdmitNext(ActionSlot finished) {
+    ActionSlot? DetachAndAdmitNext(ActionSlot finished) {
         ActionSlot? next = null;
         lock (_gate) {
-            if (ReferenceEquals(_owned, finished)) _owned = null;
+            Debug.Assert(ReferenceEquals(_owned, finished), "DetachAndAdmitNext: the finishing action must still be the owned slot.");
+            _owned = null;
             if (_queue.Count > 0) {
                 next = _queue[0];
                 _queue.RemoveAt(0);
@@ -132,24 +158,43 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
                 _quiescent.TrySetResult(); // busy -> idle
             }
         }
-        if (next is not null) StartAction(next);
+        return next;
     }
 
     void Deliver(ActionSlot slot, MutationOutcome outcome) {
         var isSuccess = outcome is MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout;
         if (!isSuccess) {
             _channel.Enqueue(new OutcomeEnvelope(slot.Request, outcome));
-        } else {
-            bool waiterless;
-            lock (_gate) { waiterless = slot.WaiterCount <= 0; }
-            if (waiterless) LogWaiterlessSuccess(slot.Request, outcome);
+            slot.Completion.TrySetResult(outcome);
+            return;
         }
+        slot.Completion.TrySetResult(outcome); // resolve waiters FIRST, then decide waiterless — narrows the detach race
+        bool waiterless;
+        lock (_gate) { waiterless = slot.WaiterCount <= 0; }
+        if (waiterless) LogWaiterlessSuccess(slot.Request, outcome);
+    }
+
+    // Lane-lifetime cancellation (Dispose) is not an actionable outcome: never enqueued, only logged when nobody is left to observe it directly.
+    void DeliverCancelled(ActionSlot slot, OperationCanceledException oce) {
+        slot.Completion.TrySetCanceled(oce.CancellationToken);
+        bool waiterless;
+        lock (_gate) { waiterless = slot.WaiterCount <= 0; }
+        if (waiterless) LogWaiterlessCancellation(slot.Request);
+    }
+
+    // An unexpected exception during a mutation attempt is actionable evidence, not a fabricated exception surfaced to waiters.
+    void DeliverFaulted(ActionSlot slot, Exception ex) {
+        LogUnexpectedFault(slot.Request, ex);
+        var outcome = new MutationOutcome.Failed(-1, ex.GetType().Name, RecoverySurface.Attention);
+        _channel.Enqueue(new OutcomeEnvelope(slot.Request, outcome));
         slot.Completion.TrySetResult(outcome);
     }
 
     // --- the owned action itself ---
 
     async Task<MutationOutcome> ExecuteActionAsync(MutationRequest request, CancellationToken ct) {
+        ct.ThrowIfCancellationRequested(); // a disposed lane's cancelled token must stop admission before any spawn
+
         var pinnedPath = _cliOverride() ?? await _shellProbe.KcapPathAsync(ct, forceRefresh: false).ConfigureAwait(false);
         if (pinnedPath is null) return new MutationOutcome.Refused("cli_not_found", RecoverySurface.Attention);
 
@@ -160,6 +205,10 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         var observation = await PinObservationAsync(request, ct).ConfigureAwait(false);
 
         var attemptId = request.Verb == MutationVerb.DetachedStart ? Guid.NewGuid().ToString("N") : null;
+
+        // The runner starts the child before consulting ct, and an already-exited child's own wait
+        // can return normally under a cancelled token — this is the last gate before a real spawn.
+        ct.ThrowIfCancellationRequested();
         var result = await Dispatch(executor, request, attemptId, ct).ConfigureAwait(false);
 
         return await Classify(request, result, executor, observation, attemptId, ct).ConfigureAwait(false);
@@ -194,6 +243,16 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         Console.Error.WriteLine(
             $"DaemonMutationLane: waiterless {outcome.GetType().Name} verb={request.Verb} profile={request.Profile} " +
             $"server={request.CanonicalServer} daemon={request.DaemonName}");
+
+    static void LogWaiterlessCancellation(MutationRequest request) =>
+        Console.Error.WriteLine(
+            $"DaemonMutationLane: waiterless cancellation (lane lifetime cancel — no envelope) verb={request.Verb} " +
+            $"profile={request.Profile} server={request.CanonicalServer} daemon={request.DaemonName}");
+
+    static void LogUnexpectedFault(MutationRequest request, Exception ex) =>
+        Console.Error.WriteLine(
+            $"DaemonMutationLane: unexpected {ex.GetType().Name} during a mutation attempt verb={request.Verb} " +
+            $"profile={request.Profile} server={request.CanonicalServer} daemon={request.DaemonName}: {ex.Message}");
 
     static TaskCompletionSource CompletedSignal() {
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -40,9 +40,6 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     TaskCompletionSource _quiescent = CompletedSignal();
     bool _disposed;
 
-    // Atomic slot: an owned action reads this ONCE at start and never again for its own lifetime.
-    volatile IDaemonObservation? _liveAdapter;
-
     // Injectable seam: defaults to the real per-verb classifier below; tests override to pin/observe without running full classification.
     internal MutationClassifier Classify { get; set; }
 
@@ -59,8 +56,6 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         _lifetimeToken   = _lifetime.Token;
         Classify         = ClassifyOutcomeAsync;
     }
-
-    public void SetLiveAdapter(IDaemonObservation? live) => _liveAdapter = live;
 
     public async Task<MutationOutcome> RunAsync(MutationRequest request, CancellationToken waiterCt) {
         var slot = AttachOrCreate(request);
@@ -222,9 +217,9 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     async Task<MutationOutcome> ExecuteActionAsync(MutationRequest request, CancellationToken ct) {
         ct.ThrowIfCancellationRequested(); // a disposed lane's cancelled token must stop admission before any spawn
 
-        // Pinned before the first await (spec pin-once rule): a concurrent SetLiveAdapter swap
-        // during the CLI/version probes below must never change an already-started action's observer.
-        var observation = PinObservation(request);
+        // Pinned before the first await (spec pin-once rule): evidence is always a fresh socket
+        // dial — a live-graph replay can never prove it postdates the mutation.
+        var observation = _oneShotFactory(request);
 
         var pinnedPath = _cliOverride() ?? await _shellProbe.KcapPathAsync(ct, forceRefresh: false).ConfigureAwait(false);
         // A cached negative must not refuse forever: one forced re-probe lets a CLI installed after
@@ -255,20 +250,6 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
             // Fail closed, never permissive: an unnamed enum value must halt, not silently pick a verb.
             _ => throw new ArgumentOutOfRangeException(nameof(request), request.Verb, "unknown MutationVerb"),
         };
-
-    // Pinned once before the first await, immune to a later SetLiveAdapter swap; DetachedStart always pins one-shot, other verbs composite a set live adapter with a one-shot fallback.
-    IDaemonObservation PinObservation(MutationRequest request) {
-        if (request.Verb == MutationVerb.DetachedStart) return _oneShotFactory(request);
-        var live = _liveAdapter;
-        return live is null ? _oneShotFactory(request) : new CompositeObservation(live, _oneShotFactory);
-    }
-
-    sealed class CompositeObservation(IDaemonObservation live, Func<MutationRequest, IDaemonObservation> oneShotFactory) : IDaemonObservation {
-        public async Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
-            var evidence = await live.ObserveAsync(request, ct).ConfigureAwait(false);
-            return evidence is { Reachable: true } ? evidence : await oneShotFactory(request).ObserveAsync(request, ct).ConfigureAwait(false);
-        }
-    }
 
     // --- classification (spec §3/§4) ---
 

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -93,8 +93,10 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
 
             // Cancel every queued waiter up front: shutdown is not an actionable outcome (nothing
             // enqueued to the channel), and draining now means the owned action's own finish has
-            // nothing left to admit once it completes.
-            foreach (var queued in _queue) queued.Completion.TrySetCanceled(_lifetime.Token);
+            // nothing left to admit once it completes. Parameterless TrySetCanceled — _lifetime.Cancel()
+            // hasn't run yet at this point, so claiming _lifetime.Token here would let a waiter observe
+            // a cancelled task whose token isn't actually cancelled yet.
+            foreach (var queued in _queue) queued.Completion.TrySetCanceled();
             _queue.Clear();
         }
 
@@ -221,6 +223,9 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         ct.ThrowIfCancellationRequested(); // a disposed lane's cancelled token must stop admission before any spawn
 
         var pinnedPath = _cliOverride() ?? await _shellProbe.KcapPathAsync(ct, forceRefresh: false).ConfigureAwait(false);
+        // A cached negative must not refuse forever: one forced re-probe lets a CLI installed after
+        // the cache went negative recover on the very next action, instead of requiring an app restart.
+        pinnedPath ??= await _shellProbe.KcapPathAsync(ct, forceRefresh: true).ConfigureAwait(false);
         if (pinnedPath is null) return new MutationOutcome.Refused("cli_not_found", RecoverySurface.Attention);
 
         var executor = _executorFactory(request, pinnedPath); // built ONCE; the same instance runs the probe and the mutation

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -322,13 +322,13 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         if (ownership.DaemonPid != evidence!.Pid) // evidenceLeg == null guarantees evidence is non-null and fully valid here
             return new MutationOutcome.AttentionSkew("instance_pid_mismatch"); // same-instance rule
 
-        // ABA guard (round-4 P1): the ServiceStatusAsync read above can straddle a process swap that
-        // reuses pid P, so a pid-only cross-check alone can't tell instance A from a replacement B.
-        // A second fresh dial — required to reproduce the SAME InstanceId+Pid as the first — is the
-        // only proof one continuous process held pid P for the whole window; a per-boot instance id
-        // cannot survive a process swap. Only this (the would-be-Succeeded) path pays for it.
+        // Invariant: Succeeded requires a second fresh dial that independently passes full evidence validation AND matches the first's Pid+InstanceId.
         var confirm = await observation.ObserveAsync(request, ct).ConfigureAwait(false);
-        if (confirm?.Pid != evidence.Pid || confirm?.InstanceId != evidence.InstanceId)
+        var confirmLeg = EvidenceFailureLeg(confirm, request);
+        if (confirmLeg is not null)
+            return new MutationOutcome.AttentionSkew(confirmLeg);
+
+        if (confirm!.Pid != evidence.Pid || confirm.InstanceId != evidence.InstanceId)
             return new MutationOutcome.AttentionSkew("instance_changed_during_classification");
 
         return new MutationOutcome.Succeeded();

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -14,15 +14,11 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
     // Named so DeliverFaulted's outcome is self-explanatory instead of a bare magic number.
     internal const int UnexpectedExitCode = -1;
 
-    // Duplicated exit-code family from Capacitor.Cli.Services.VerifyExit / DaemonCommands' digest
-    // gate — same duplication precedent as VerifyExitCodes in DaemonLifecycleController.cs.
-    internal const int ReadinessTimeoutExit = 24;
-    internal const int StartGateExit        = 28;
-    internal const int StartGateDriftExit   = 29;
-    internal const int DigestGateExit       = 43;
-
-    // The capability a positive service-verb success requires the observed daemon to advertise.
+    // The capability a positive service-verb/DetachedStart success requires the observed daemon to advertise.
     const string ConsentCapability = "consent/3";
+
+    // The one EvidenceFailureLeg sentinel that means "not yet confirmable" rather than "a definite problem".
+    const string UnreachableLeg = "unreachable";
 
     internal static readonly TimeSpan DetachedConfirmWindow = TimeSpan.FromSeconds(10);
     internal static readonly TimeSpan DetachedPollInterval  = TimeSpan.FromSeconds(1);
@@ -266,29 +262,33 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
             MutationRequest request, ProcessResult result, IKcapCli executor, IDaemonObservation observation,
             string? attemptId, CancellationToken ct) =>
         request.Verb == MutationVerb.DetachedStart
-            ? ClassifyDetachedStartAsync(request, result, observation, attemptId!, ct)
+            ? ClassifyDetachedStartAsync(request, result, observation, attemptId, ct)
             : ClassifyServiceVerbAsync(request, result, executor, observation, ct);
 
     // Install/Replace/StartVerified: the CLI's own ServiceVerify transaction engine already
     // performed its readiness poll — exit code alone routes every non-success case.
     static async Task<MutationOutcome> ClassifyServiceVerbAsync(
             MutationRequest request, ProcessResult result, IKcapCli executor, IDaemonObservation observation, CancellationToken ct) {
+        // A forced kill's exit code is not a verify outcome (the transaction may have already
+        // committed) — never read as a success OR a coded failure; SucceededAfterTimeout is detached-only.
+        if (result.TimedOut) return new MutationOutcome.UnconfirmedNoAttach();
+
         if (result.ExitCode == 0) return await ClassifyServiceSuccessAsync(request, executor, observation, ct).ConfigureAwait(false);
 
-        if (result.ExitCode == StartGateExit) {
+        if (result.ExitCode == VerifyExitCodes.StartGate) {
             var token = ReasonLine.TrySingle(result.Stderr, "start_gate_reason=");
             return token is null
-                ? new MutationOutcome.Failed(StartGateExit, null, RecoverySurface.Attention)
-                : new MutationOutcome.Failed(StartGateExit, token, ReasonRouting.ForStartGate(token));
+                ? new MutationOutcome.Failed(VerifyExitCodes.StartGate, null, RecoverySurface.Attention)
+                : new MutationOutcome.Failed(VerifyExitCodes.StartGate, token, ReasonRouting.ForStartGate(token));
         }
 
-        if (result.ExitCode == StartGateDriftExit) {
+        if (result.ExitCode == VerifyExitCodes.StartGateDrift) {
             // Drift is never auto-retried — always Attention, regardless of whether a reason line happens to be present.
             var token = ReasonLine.TrySingle(result.Stderr, "start_gate_reason=");
-            return new MutationOutcome.Failed(StartGateDriftExit, token, RecoverySurface.Attention);
+            return new MutationOutcome.Failed(VerifyExitCodes.StartGateDrift, token, RecoverySurface.Attention);
         }
 
-        if (result.ExitCode == ReadinessTimeoutExit) {
+        if (result.ExitCode == VerifyExitCodes.ReadinessTimeout) {
             var token = ReasonLine.TrySingle(result.Stderr, "refusal_reason=");
             return token is null
                 ? new MutationOutcome.UnconfirmedNoAttach()
@@ -305,45 +305,47 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         var evidence  = await observation.ObserveAsync(request, ct).ConfigureAwait(false);
         var ownership = await executor.ServiceStatusAsync(ct).ConfigureAwait(false);
 
-        if (evidence is not { Reachable: true })
+        // Ownership-derived repair/skew signals are evaluated regardless of evidence reachability —
+        // a stale marker or an orphaned unit is worth flagging even when the daemon can't be reached.
+        if (ownership is not null && OwnershipRepairLeg(ownership) is { } repairLeg)
+            return new MutationOutcome.AttentionRepair(repairLeg);
+
+        var evidenceLeg = EvidenceFailureLeg(evidence, request);
+        if (evidenceLeg == UnreachableLeg)
             // No independent evidence either way vs. a recorded owner with nothing to show for it are different signals.
             return ownership?.DaemonPid is null
                 ? new MutationOutcome.UnconfirmedNoAttach()
                 : new MutationOutcome.AttentionSkew("unreachable_with_recorded_owner");
-
-        if (!ServerIdentity.Matches(evidence.ServerUrl, request.CanonicalServer) || evidence.DaemonName != request.DaemonName)
-            return new MutationOutcome.AttentionSkew("server_or_name_mismatch");
-
-        if (evidence.Pid is null || evidence.InstanceId is null)
-            return new MutationOutcome.AttentionSkew("pre_slice_evidence");
-
-        if (!evidence.IdentityConsistent)
-            return new MutationOutcome.AttentionSkew("identity_inconsistent");
-
-        if (evidence.Capabilities is null || !evidence.Capabilities.Contains(ConsentCapability))
-            return new MutationOutcome.AttentionSkew("missing_capability_consent_3");
-
-        if (!KcapCliCompatibility.Satisfies(evidence.DaemonVersion))
-            return new MutationOutcome.AttentionSkew("daemon_below_floor");
+        if (evidenceLeg is not null)
+            return new MutationOutcome.AttentionSkew(evidenceLeg);
 
         if (ownership is null)
             return new MutationOutcome.AttentionSkew("ownership_unknown");
 
-        if (ownership.TxnMarker && !ownership.TxnActive)
-            return new MutationOutcome.AttentionRepair("stale_txn_marker");
-
         if (ownership.JobPid is null || ownership.DaemonPid is null || ownership.JobPid != ownership.DaemonPid)
             return new MutationOutcome.AttentionSkew("ownership_mismatch");
 
-        if (ownership.DaemonPid != evidence.Pid) // same-instance rule: the ownership read must describe THIS observed daemon
-            return new MutationOutcome.AttentionSkew("instance_pid_mismatch");
+        if (ownership.DaemonPid != evidence!.Pid) // evidenceLeg == null guarantees evidence is non-null and fully valid here
+            return new MutationOutcome.AttentionSkew("instance_pid_mismatch"); // same-instance rule
 
         return new MutationOutcome.Succeeded();
     }
 
+    // Mirrors DaemonLifecycleController.Reconcile's two orphan-unit predicates plus the stale-marker
+    // check — pure signals from ONE ServiceStatusAsync read, independent of any evidence.
+    static string? OwnershipRepairLeg(ServiceSnapshot ownership) {
+        if (ownership.TxnMarker && !ownership.TxnActive) return "stale_txn_marker";
+
+        var state = ServiceStateClassifier.Parse(ownership.State);
+        if (state == ServiceState.Running && ownership.DaemonPid is null) return "running_without_daemon_pid";
+        if (ownership.UnitPresent && state == ServiceState.NotInstalled && ownership.DaemonPid is not null) return "daemon_running_outside_service";
+
+        return null;
+    }
+
     // DetachedStart has no CLI-side verify engine — the lane itself confirms via a bounded post-spawn observation window.
     async Task<MutationOutcome> ClassifyDetachedStartAsync(
-            MutationRequest request, ProcessResult result, IDaemonObservation observation, string attemptId, CancellationToken ct) {
+            MutationRequest request, ProcessResult result, IDaemonObservation observation, string? attemptId, CancellationToken ct) {
         // A forced process-only kill after the wrapper's own bound makes the exit code meaningless — only evidence counts.
         if (result.TimedOut)
             return await AwaitDetachedConfirmationAsync(
@@ -353,29 +355,38 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
             return await AwaitDetachedConfirmationAsync(
                 request, observation, attemptId, static () => new MutationOutcome.Succeeded(), ct).ConfigureAwait(false);
 
-        if (result.ExitCode == DigestGateExit) {
+        if (result.ExitCode == VerifyExitCodes.DigestGate) {
             var token = ReasonLine.TrySingle(result.Stderr, "daemon_start_reason=");
             return token is null
-                ? new MutationOutcome.Failed(DigestGateExit, null, RecoverySurface.Attention)
-                : new MutationOutcome.Failed(DigestGateExit, token, ReasonRouting.ForDaemonStart(token));
+                ? new MutationOutcome.Failed(VerifyExitCodes.DigestGate, null, RecoverySurface.Attention)
+                : new MutationOutcome.Failed(VerifyExitCodes.DigestGate, token, ReasonRouting.ForDaemonStart(token));
         }
 
         return new MutationOutcome.Failed(result.ExitCode, null, RecoverySurface.Attention);
     }
 
     // Polls the pinned observation for up to DetachedConfirmWindow: full evidence wins via
-    // onFullEvidence, an attributed boot-refusal marker wins Refused, and window expiry with
-    // neither is UnconfirmedNoAttach. Entirely TimeProvider-driven so tests never wait for real time.
+    // onFullEvidence; an attributed boot-refusal marker wins Refused; window expiry with neither is
+    // UnconfirmedNoAttach; any OTHER (non-unreachable) evidence defect is an immediate, definite
+    // AttentionSkew — never worth waiting out. Entirely TimeProvider-driven so tests never wait for
+    // real time. `attemptId` is null only via direct test injection through the Classify seam — a
+    // real DetachedStart action always carries one; a null one must never attribute a marker,
+    // since a null-attempt marker belongs to a service-verb refusal, not this action.
     async Task<MutationOutcome> AwaitDetachedConfirmationAsync(
-            MutationRequest request, IDaemonObservation observation, string attemptId,
+            MutationRequest request, IDaemonObservation observation, string? attemptId,
             Func<MutationOutcome> onFullEvidence, CancellationToken ct) {
         var deadline = _time.GetUtcNow() + DetachedConfirmWindow;
         while (true) {
-            var evidence = await observation.ObserveAsync(request, ct).ConfigureAwait(false);
-            if (IsFullEvidence(evidence, request)) return onFullEvidence();
-
-            if (BootRefusalMarker.TryAttribute(request.DaemonName, attemptId) is { } refusal)
+            // Marker-first: a refusing daemon never attaches, so checking the marker before evidence
+            // can never produce a false Refused, while evidence-first could let a pre-existing
+            // same-name daemon mask a real refusal.
+            if (attemptId is not null && BootRefusalMarker.TryAttribute(request.DaemonName, attemptId) is { } refusal)
                 return new MutationOutcome.Refused(refusal.Token, ReasonRouting.ForBootRefusal(refusal.Token));
+
+            var evidence = await observation.ObserveAsync(request, ct).ConfigureAwait(false);
+            var leg = EvidenceFailureLeg(evidence, request);
+            if (leg is null) return onFullEvidence();
+            if (leg != UnreachableLeg) return new MutationOutcome.AttentionSkew(leg);
 
             var remaining = deadline - _time.GetUtcNow();
             if (remaining <= TimeSpan.Zero) return new MutationOutcome.UnconfirmedNoAttach();
@@ -385,10 +396,26 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         }
     }
 
-    static bool IsFullEvidence(ObservedEvidence? evidence, MutationRequest request) =>
-        evidence is { Reachable: true, IdentityConsistent: true }
-        && ServerIdentity.Matches(evidence.ServerUrl, request.CanonicalServer)
-        && evidence.DaemonName == request.DaemonName;
+    // The ONE evidence check both service-verb success and DetachedStart confirmation rely on —
+    // returns the name of the first failing leg, or null once evidence is fully positive. Structural:
+    // pid/instance presence is checked directly, never inferred from the observation's own
+    // IdentityConsistent flag (which a broken/legacy adapter could report true without backing it).
+    static string? EvidenceFailureLeg(ObservedEvidence? evidence, MutationRequest request) {
+        if (evidence is not { Reachable: true }) return UnreachableLeg;
+
+        if (!ServerIdentity.Matches(evidence.ServerUrl, request.CanonicalServer) || evidence.DaemonName != request.DaemonName)
+            return "server_or_name_mismatch";
+
+        if (evidence.Pid is null || evidence.InstanceId is null) return "pre_slice_evidence";
+
+        if (!evidence.IdentityConsistent) return "identity_inconsistent";
+
+        if (evidence.Capabilities is null || !evidence.Capabilities.Contains(ConsentCapability)) return "missing_capability_consent_3";
+
+        if (!KcapCliCompatibility.Satisfies(evidence.DaemonVersion)) return "daemon_below_floor";
+
+        return null;
+    }
 
     static void LogWaiterlessSuccess(MutationRequest request, MutationOutcome outcome) =>
         Console.Error.WriteLine(

--- a/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonMutationLane.cs
@@ -365,31 +365,40 @@ public sealed class DaemonMutationLane : IAsyncDisposable {
         return new MutationOutcome.Failed(result.ExitCode, null, RecoverySurface.Attention);
     }
 
-    // Polls the pinned observation for up to DetachedConfirmWindow: full evidence wins via
-    // onFullEvidence; an attributed boot-refusal marker wins Refused; window expiry with neither is
-    // UnconfirmedNoAttach; any OTHER (non-unreachable) evidence defect is an immediate, definite
-    // AttentionSkew — never worth waiting out. Entirely TimeProvider-driven so tests never wait for
-    // real time. `attemptId` is null only via direct test injection through the Classify seam — a
-    // real DetachedStart action always carries one; a null one must never attribute a marker,
-    // since a null-attempt marker belongs to a service-verb refusal, not this action.
+    // Polls the pinned observation for up to DetachedConfirmWindow: full evidence at ANY poll wins
+    // immediately via onFullEvidence; an attributed boot-refusal marker wins Refused. A non-full,
+    // non-unreachable leg (e.g. the two-dial probe's transient mid-boot shape — hello answered,
+    // snapshot not yet subscribed — reads as a server/name mismatch) does NOT fail fast: it is only
+    // ever a snapshot of ONE poll, so the loop keeps polling through it, remembering the LAST
+    // observed leg. Only at window expiry does that last leg decide the outcome: "unreachable" (or
+    // no evidence ever observed) → UnconfirmedNoAttach; any other leg, still true at expiry →
+    // AttentionSkew(leg). Entirely TimeProvider-driven so tests never wait for real time.
+    // `attemptId` is null only via direct test injection through the Classify seam — a real
+    // DetachedStart action always carries one; a null one must never attribute a marker, since a
+    // null-attempt marker belongs to a service-verb refusal, not this action.
     async Task<MutationOutcome> AwaitDetachedConfirmationAsync(
             MutationRequest request, IDaemonObservation observation, string? attemptId,
             Func<MutationOutcome> onFullEvidence, CancellationToken ct) {
         var deadline = _time.GetUtcNow() + DetachedConfirmWindow;
+        var lastLeg = UnreachableLeg;
         while (true) {
             // Marker-first: a refusing daemon never attaches, so checking the marker before evidence
             // can never produce a false Refused, while evidence-first could let a pre-existing
-            // same-name daemon mask a real refusal.
+            // same-name daemon (or, here, a transient mid-boot evidence shape) mask a real refusal —
+            // checked fresh every iteration, so a refusal arriving mid-window is caught on the next poll.
             if (attemptId is not null && BootRefusalMarker.TryAttribute(request.DaemonName, attemptId) is { } refusal)
                 return new MutationOutcome.Refused(refusal.Token, ReasonRouting.ForBootRefusal(refusal.Token));
 
             var evidence = await observation.ObserveAsync(request, ct).ConfigureAwait(false);
             var leg = EvidenceFailureLeg(evidence, request);
             if (leg is null) return onFullEvidence();
-            if (leg != UnreachableLeg) return new MutationOutcome.AttentionSkew(leg);
+            lastLeg = leg;
 
             var remaining = deadline - _time.GetUtcNow();
-            if (remaining <= TimeSpan.Zero) return new MutationOutcome.UnconfirmedNoAttach();
+            if (remaining <= TimeSpan.Zero)
+                return lastLeg == UnreachableLeg
+                    ? new MutationOutcome.UnconfirmedNoAttach()
+                    : new MutationOutcome.AttentionSkew(lastLeg);
 
             var wait = remaining < DetachedPollInterval ? remaining : DetachedPollInterval;
             await Task.Delay(wait, _time, ct).ConfigureAwait(false);

--- a/src/Capacitor.App/Services/Mutation/DaemonObservation.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonObservation.cs
@@ -1,0 +1,76 @@
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.Services.Mutation;
+
+/// Evidence about one daemon; IdentityConsistent is fail-closed — pid+instance must be present and agree on BOTH correlated sides.
+public sealed record ObservedEvidence(
+    bool Reachable, IReadOnlyList<string>? Capabilities, string? DaemonVersion,
+    string? ServerUrl, string? DaemonName, int? Pid, string? InstanceId,
+    bool IdentityConsistent);
+
+/// One evidence source for the mutation lane; null means "cannot observe this target", never Reachable=false.
+public interface IDaemonObservation {
+    Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct);
+}
+
+/// Bounded diagnostic dial via LocalControlProbe — correct for any target, at the cost of a fresh socket round trip per call.
+public sealed class OneShotObservation(TimeSpan timeout) : IDaemonObservation {
+    // Test seam: production always resolves to LocalControlProbe.ProbeAsync itself.
+    internal Func<string, TimeSpan, CancellationToken, Task<ProbeResult>> Probe { get; init; } = LocalControlProbe.ProbeAsync;
+
+    public async Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
+        var result = await Probe(request.DaemonName, timeout, ct).ConfigureAwait(false);
+
+        if (!result.Reachable) return new ObservedEvidence(false, null, null, null, null, null, null, false);
+
+        return new ObservedEvidence(
+            Reachable: true,
+            Capabilities: result.Hello?.Capabilities,
+            DaemonVersion: result.Hello?.DaemonVersion,
+            ServerUrl: result.Snapshot?.Daemon.ServerUrl,
+            DaemonName: result.Snapshot?.Daemon.Name,
+            Pid: result.Hello?.Pid,
+            InstanceId: result.Hello?.InstanceId,
+            IdentityConsistent: result.IdentityConsistent);
+    }
+}
+
+/// Zero-cost evidence from the already-live attach stream — valid ONLY for the client's own pinned daemon on the request's own server.
+public sealed class LiveGraphObservation(IDaemonClientService client) : IDaemonObservation {
+    public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
+        // Identity gate first: a client bound to a different daemon name can never stand in for
+        // the requested one, regardless of what its own attach state currently shows.
+        if (client.DaemonName != request.DaemonName) return Task.FromResult<ObservedEvidence?>(null);
+
+        // Bounded immediate take — Status/Snapshots replay their latest value synchronously on
+        // subscribe (same seed-capture pattern as TrayViewModel), so this never waits.
+        AttachStatus? status = null;
+        using (client.Status.Subscribe(s => status = s)) { }
+        DaemonStatusDto? snapshot = null;
+        using (client.Snapshots.Subscribe(s => snapshot = s)) { }
+
+        if (status is null) return Task.FromResult<ObservedEvidence?>(null); // defensive: Status always replays
+
+        if (!ServerIdentity.Matches(snapshot?.Daemon.ServerUrl, request.CanonicalServer))
+            return Task.FromResult<ObservedEvidence?>(null);
+
+        if (status.State != AttachState.Connected)
+            return Task.FromResult<ObservedEvidence?>(new ObservedEvidence(false, null, null, null, null, null, null, false));
+
+        var daemon = snapshot?.Daemon;
+        var identityConsistent = status.Identity is { Pid: { } idPid, InstanceId: { } idInstance }
+            && daemon is { Pid: { } snapPid, InstanceId: { } snapInstance }
+            && idPid == snapPid && idInstance == snapInstance;
+
+        return Task.FromResult<ObservedEvidence?>(new ObservedEvidence(
+            Reachable: true,
+            Capabilities: status.Capabilities,
+            DaemonVersion: status.Identity?.DaemonVersion,
+            ServerUrl: daemon?.ServerUrl,
+            DaemonName: daemon?.Name,
+            Pid: status.Identity?.Pid,
+            InstanceId: status.Identity?.InstanceId,
+            IdentityConsistent: identityConsistent));
+    }
+}

--- a/src/Capacitor.App/Services/Mutation/DaemonObservation.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonObservation.cs
@@ -36,43 +36,58 @@ public sealed class OneShotObservation(TimeSpan timeout) : IDaemonObservation {
     }
 }
 
-/// Zero-cost evidence from the already-live attach stream — valid ONLY for the client's own pinned daemon on the request's own server.
-public sealed class LiveGraphObservation(IDaemonClientService client) : IDaemonObservation {
-    public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
+/// A generation barrier: discards whatever Status/Snapshots replay on subscribe, waits for the next post-subscription emission of each; a timeout degrades to null.
+public sealed class LiveGraphObservation(IDaemonClientService client, TimeProvider time) : IDaemonObservation {
+    internal static readonly TimeSpan FreshEmissionTimeout = TimeSpan.FromSeconds(2);
+
+    public async Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
         // Identity gate first: a client bound to a different daemon name, or a different profile,
         // can never stand in for the requested one (spec §4: "the client's daemon name + its
         // profile/server" must match), regardless of what its own attach state currently shows.
-        if (client.DaemonName != request.DaemonName) return Task.FromResult<ObservedEvidence?>(null);
-        if (client.ProfileName != request.Profile) return Task.FromResult<ObservedEvidence?>(null);
+        if (client.DaemonName != request.DaemonName) return null;
+        if (client.ProfileName != request.Profile) return null;
 
-        // Bounded immediate take — Status/Snapshots replay their latest value synchronously on
-        // subscribe (same seed-capture pattern as TrayViewModel), so this never waits.
-        AttachStatus? status = null;
-        using (client.Status.Subscribe(s => status = s)) { }
-        DaemonStatusDto? snapshot = null;
-        using (client.Snapshots.Subscribe(s => snapshot = s)) { }
+        var statusTcs = new TaskCompletionSource<AttachStatus>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var duringStatusReplay = true;
+        using var statusSub = client.Status.Subscribe(s => { if (!duringStatusReplay) statusTcs.TrySetResult(s); });
+        duringStatusReplay = false;
 
-        if (status is null) return Task.FromResult<ObservedEvidence?>(null); // defensive: Status always replays
+        var snapshotTcs = new TaskCompletionSource<DaemonStatusDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var duringSnapshotReplay = true;
+        using var snapshotSub = client.Snapshots.Subscribe(s => { if (!duringSnapshotReplay) snapshotTcs.TrySetResult(s); });
+        duringSnapshotReplay = false;
 
-        if (!ServerIdentity.Matches(snapshot?.Daemon.ServerUrl, request.CanonicalServer))
-            return Task.FromResult<ObservedEvidence?>(null);
+        using var timeoutCts = new CancellationTokenSource();
+        try {
+            var timeoutTask = Task.Delay(FreshEmissionTimeout, time, timeoutCts.Token);
+            var freshPair = Task.WhenAll(statusTcs.Task, snapshotTcs.Task);
+            var winner = await Task.WhenAny(freshPair, timeoutTask).WaitAsync(ct).ConfigureAwait(false);
+            if (winner == timeoutTask) return null; // no fresh post-subscription emission within the bound
+        } finally {
+            timeoutCts.Cancel();
+        }
+
+        var status   = statusTcs.Task.Result;
+        var snapshot = snapshotTcs.Task.Result;
+
+        if (!ServerIdentity.Matches(snapshot.Daemon.ServerUrl, request.CanonicalServer)) return null;
 
         if (status.State != AttachState.Connected)
-            return Task.FromResult<ObservedEvidence?>(new ObservedEvidence(false, null, null, null, null, null, null, false));
+            return new ObservedEvidence(false, null, null, null, null, null, null, false);
 
-        var daemon = snapshot?.Daemon;
+        var daemon = snapshot.Daemon;
         var identityConsistent = status.Identity is { Pid: { } idPid, InstanceId: { } idInstance }
             && daemon is { Pid: { } snapPid, InstanceId: { } snapInstance }
             && idPid == snapPid && idInstance == snapInstance;
 
-        return Task.FromResult<ObservedEvidence?>(new ObservedEvidence(
+        return new ObservedEvidence(
             Reachable: true,
             Capabilities: status.Capabilities,
             DaemonVersion: status.Identity?.DaemonVersion,
-            ServerUrl: daemon?.ServerUrl,
-            DaemonName: daemon?.Name,
+            ServerUrl: daemon.ServerUrl,
+            DaemonName: daemon.Name,
             Pid: status.Identity?.Pid,
             InstanceId: status.Identity?.InstanceId,
-            IdentityConsistent: identityConsistent));
+            IdentityConsistent: identityConsistent);
     }
 }

--- a/src/Capacitor.App/Services/Mutation/DaemonObservation.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonObservation.cs
@@ -1,4 +1,3 @@
-using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.LocalIpc;
 
 namespace Capacitor.App.Services.Mutation;
@@ -33,61 +32,5 @@ public sealed class OneShotObservation(TimeSpan timeout) : IDaemonObservation {
             Pid: result.Hello?.Pid,
             InstanceId: result.Hello?.InstanceId,
             IdentityConsistent: result.IdentityConsistent);
-    }
-}
-
-/// A generation barrier: discards whatever Status/Snapshots replay on subscribe, waits for the next post-subscription emission of each; a timeout degrades to null.
-public sealed class LiveGraphObservation(IDaemonClientService client, TimeProvider time) : IDaemonObservation {
-    internal static readonly TimeSpan FreshEmissionTimeout = TimeSpan.FromSeconds(2);
-
-    public async Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
-        // Identity gate first: a client bound to a different daemon name, or a different profile,
-        // can never stand in for the requested one (spec §4: "the client's daemon name + its
-        // profile/server" must match), regardless of what its own attach state currently shows.
-        if (client.DaemonName != request.DaemonName) return null;
-        if (client.ProfileName != request.Profile) return null;
-
-        var statusTcs = new TaskCompletionSource<AttachStatus>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var duringStatusReplay = true;
-        using var statusSub = client.Status.Subscribe(s => { if (!duringStatusReplay) statusTcs.TrySetResult(s); });
-        duringStatusReplay = false;
-
-        var snapshotTcs = new TaskCompletionSource<DaemonStatusDto>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var duringSnapshotReplay = true;
-        using var snapshotSub = client.Snapshots.Subscribe(s => { if (!duringSnapshotReplay) snapshotTcs.TrySetResult(s); });
-        duringSnapshotReplay = false;
-
-        using var timeoutCts = new CancellationTokenSource();
-        try {
-            var timeoutTask = Task.Delay(FreshEmissionTimeout, time, timeoutCts.Token);
-            var freshPair = Task.WhenAll(statusTcs.Task, snapshotTcs.Task);
-            var winner = await Task.WhenAny(freshPair, timeoutTask).WaitAsync(ct).ConfigureAwait(false);
-            if (winner == timeoutTask) return null; // no fresh post-subscription emission within the bound
-        } finally {
-            timeoutCts.Cancel();
-        }
-
-        var status   = statusTcs.Task.Result;
-        var snapshot = snapshotTcs.Task.Result;
-
-        if (!ServerIdentity.Matches(snapshot.Daemon.ServerUrl, request.CanonicalServer)) return null;
-
-        if (status.State != AttachState.Connected)
-            return new ObservedEvidence(false, null, null, null, null, null, null, false);
-
-        var daemon = snapshot.Daemon;
-        var identityConsistent = status.Identity is { Pid: { } idPid, InstanceId: { } idInstance }
-            && daemon is { Pid: { } snapPid, InstanceId: { } snapInstance }
-            && idPid == snapPid && idInstance == snapInstance;
-
-        return new ObservedEvidence(
-            Reachable: true,
-            Capabilities: status.Capabilities,
-            DaemonVersion: status.Identity?.DaemonVersion,
-            ServerUrl: daemon.ServerUrl,
-            DaemonName: daemon.Name,
-            Pid: status.Identity?.Pid,
-            InstanceId: status.Identity?.InstanceId,
-            IdentityConsistent: identityConsistent);
     }
 }

--- a/src/Capacitor.App/Services/Mutation/DaemonObservation.cs
+++ b/src/Capacitor.App/Services/Mutation/DaemonObservation.cs
@@ -39,9 +39,11 @@ public sealed class OneShotObservation(TimeSpan timeout) : IDaemonObservation {
 /// Zero-cost evidence from the already-live attach stream — valid ONLY for the client's own pinned daemon on the request's own server.
 public sealed class LiveGraphObservation(IDaemonClientService client) : IDaemonObservation {
     public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
-        // Identity gate first: a client bound to a different daemon name can never stand in for
-        // the requested one, regardless of what its own attach state currently shows.
+        // Identity gate first: a client bound to a different daemon name, or a different profile,
+        // can never stand in for the requested one (spec §4: "the client's daemon name + its
+        // profile/server" must match), regardless of what its own attach state currently shows.
         if (client.DaemonName != request.DaemonName) return Task.FromResult<ObservedEvidence?>(null);
+        if (client.ProfileName != request.Profile) return Task.FromResult<ObservedEvidence?>(null);
 
         // Bounded immediate take — Status/Snapshots replay their latest value synchronously on
         // subscribe (same seed-capture pattern as TrayViewModel), so this never waits.

--- a/src/Capacitor.App/Services/Mutation/MutationModel.cs
+++ b/src/Capacitor.App/Services/Mutation/MutationModel.cs
@@ -1,0 +1,41 @@
+namespace Capacitor.App.Services.Mutation;
+
+public enum MutationVerb { Install, Replace, StartVerified, DetachedStart }
+
+public sealed record MutationRequest(
+    MutationVerb Verb, string Profile, string CanonicalServer, string DaemonName);
+
+public enum RecoverySurface { Takeover, Reinstall, Attention, Storage, None }
+
+/// One classified result of a daemon-mutation attempt (spec §3/§4); the mutation lane maps every raw outcome onto exactly one case.
+public abstract record MutationOutcome {
+    public sealed record Succeeded : MutationOutcome;
+    public sealed record SucceededAfterTimeout : MutationOutcome;
+    public sealed record AttentionSkew(string Detail) : MutationOutcome;
+    public sealed record AttentionRepair(string Detail) : MutationOutcome;
+    public sealed record UnconfirmedNoAttach : MutationOutcome;
+    public sealed record Refused(string Reason, RecoverySurface Surface) : MutationOutcome;
+    public sealed record Failed(int ExitCode, string? Reason, RecoverySurface Surface) : MutationOutcome;
+}
+
+public sealed record OutcomeEnvelope(MutationRequest Request, MutationOutcome Outcome);
+
+/// Maps a machine-readable reason token to a recovery surface (spec §3/§4 pinned tables); unknown tokens fail closed to Attention.
+public static class ReasonRouting {
+    public static RecoverySurface ForStartGate(string token) => token switch {
+        "directive_missing" or "directive_invalid" or "identity_mismatch" or "foreign_binary" => RecoverySurface.Takeover,
+        "package_inconsistent" => RecoverySurface.Reinstall,
+        _ => RecoverySurface.Attention,
+    };
+
+    public static RecoverySurface ForDaemonStart(string token) => token switch {
+        "package_inconsistent" => RecoverySurface.Reinstall,
+        _ => RecoverySurface.Attention,
+    };
+
+    public static RecoverySurface ForBootRefusal(string token) => token switch {
+        "server_expectation_mismatch" or "consent_seed_invalid" => RecoverySurface.Takeover,
+        "consent_seed_unwritable" => RecoverySurface.Storage,
+        _ => RecoverySurface.Attention,
+    };
+}

--- a/src/Capacitor.App/Services/Mutation/MutationRequestFactory.cs
+++ b/src/Capacitor.App/Services/Mutation/MutationRequestFactory.cs
@@ -1,0 +1,22 @@
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.App.Services.Mutation;
+
+/// The one place a MutationRequest is built from resolved profile/server identity: a caller that
+/// cannot bind a canonical server never reaches the executor — it fails closed to Refused before
+/// any MutationRequest exists. Canonicalization is idempotent, so callers may pass either a raw
+/// configured URL or an already-canonical one.
+public static class MutationRequestFactory {
+    /// Non-null return means refused (no request built); null return means `request` is usable.
+    public static MutationOutcome? TryBuild(
+            MutationVerb verb, string? profileName, string? serverUrl, string daemonName, out MutationRequest? request) {
+        var canonical = ServerIdentity.Canonicalize(serverUrl);
+        if (string.IsNullOrWhiteSpace(profileName) || canonical is null) {
+            request = null;
+            return new MutationOutcome.Refused("no_server_configured", RecoverySurface.Attention);
+        }
+
+        request = new MutationRequest(verb, profileName, canonical, daemonName);
+        return null;
+    }
+}

--- a/src/Capacitor.App/Services/Mutation/OutcomeChannel.cs
+++ b/src/Capacitor.App/Services/Mutation/OutcomeChannel.cs
@@ -1,0 +1,133 @@
+using System.Runtime.CompilerServices;
+
+namespace Capacitor.App.Services.Mutation;
+
+/// One outstanding delivery of an envelope: Ack consumes it permanently, CancelLease requeues it at the front at most once per envelope.
+public sealed class OutcomeLease {
+    readonly OutcomeChannel _owner;
+    readonly OutcomeChannel.Entry _entry;
+    readonly long _token;
+
+    internal OutcomeLease(OutcomeChannel owner, OutcomeChannel.Entry entry, long token) {
+        _owner = owner;
+        _entry = entry;
+        _token = token;
+    }
+
+    public OutcomeEnvelope Envelope => _entry.Envelope;
+
+    public void Ack() => _owner.Resolve(_entry, _token, requeue: false);
+    public void CancelLease() => _owner.Resolve(_entry, _token, requeue: true);
+}
+
+/// Leased FIFO with exactly one active consumer; TransferConsumer hands off atomically without disturbing an already-yielded, unresolved lease.
+public sealed class OutcomeChannel {
+    internal sealed class Entry(OutcomeEnvelope envelope) {
+        public readonly OutcomeEnvelope Envelope = envelope;
+        public bool Requeued;
+        public long ActiveLeaseToken; // 0 = not currently leased (queued or terminally resolved)
+    }
+
+    sealed class Session {
+        public bool Transferred;
+    }
+
+    readonly object _gate = new();
+    readonly LinkedList<Entry> _queue = new();
+    TaskCompletionSource _wakeup = NewWakeup();
+    Session? _current;
+    long _leaseTokenCounter;
+
+    static TaskCompletionSource NewWakeup() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public void Enqueue(OutcomeEnvelope envelope) {
+        lock (_gate) {
+            _queue.AddLast(new Entry(envelope));
+            Wake();
+        }
+    }
+
+    public IAsyncEnumerable<OutcomeLease> ConsumeAsync(CancellationToken ct) {
+        Session session;
+        lock (_gate) {
+            if (_current is not null) throw new InvalidOperationException("OutcomeChannel already has an active consumer.");
+            session = new Session();
+            _current = session;
+        }
+        return ConsumeCoreAsync(session, ct);
+    }
+
+    /// Only still-queued envelopes move to the next ConsumeAsync; a lease already yielded to this consumer stays outstanding.
+    public void TransferConsumer() {
+        lock (_gate) {
+            if (_current is null) return;
+            _current.Transferred = true;
+            _current = null;
+            Wake();
+        }
+    }
+
+    async IAsyncEnumerable<OutcomeLease> ConsumeCoreAsync(Session session, [EnumeratorCancellation] CancellationToken ct) {
+        var mine = new List<(Entry Entry, long Token)>();
+        try {
+            while (true) {
+                Entry? entry = null;
+                var wait = Task.CompletedTask;
+                bool superseded;
+                lock (_gate) {
+                    superseded = !ReferenceEquals(_current, session);
+                    if (!superseded) {
+                        if (_queue.Count > 0) {
+                            entry = _queue.First!.Value;
+                            _queue.RemoveFirst();
+                            entry.ActiveLeaseToken = ++_leaseTokenCounter;
+                            mine.Add((entry, entry.ActiveLeaseToken));
+                        } else {
+                            wait = _wakeup.Task;
+                        }
+                    }
+                }
+                if (superseded) yield break; // TransferConsumer: graceful end, no exception
+                if (entry is not null) {
+                    yield return new OutcomeLease(this, entry, entry.ActiveLeaseToken);
+                    continue;
+                }
+                await wait.WaitAsync(ct); // ct firing here propagates as OperationCanceledException
+            }
+        } finally {
+            lock (_gate) {
+                if (ReferenceEquals(_current, session)) _current = null;
+                if (!session.Transferred) {
+                    // ct/teardown: everything this session still holds unresolved gets its one requeue.
+                    for (var i = mine.Count - 1; i >= 0; i--) {
+                        var (entry, token) = mine[i];
+                        if (entry.ActiveLeaseToken != token) continue; // already resolved directly
+                        entry.ActiveLeaseToken = 0;
+                        if (!entry.Requeued) {
+                            entry.Requeued = true;
+                            _queue.AddFirst(entry);
+                        }
+                    }
+                }
+                Wake();
+            }
+        }
+    }
+
+    internal void Resolve(Entry entry, long token, bool requeue) {
+        lock (_gate) {
+            if (entry.ActiveLeaseToken != token) return; // stale: this lease was already resolved
+            entry.ActiveLeaseToken = 0;
+            if (requeue && !entry.Requeued) {
+                entry.Requeued = true;
+                _queue.AddFirst(entry);
+                Wake();
+            }
+        }
+    }
+
+    void Wake() { // caller must hold _gate
+        _wakeup.TrySetResult();
+        _wakeup = NewWakeup();
+    }
+}

--- a/src/Capacitor.App/Services/Mutation/OutcomeChannel.cs
+++ b/src/Capacitor.App/Services/Mutation/OutcomeChannel.cs
@@ -28,9 +28,10 @@ public sealed class OutcomeChannel {
         public long ActiveLeaseToken; // 0 = not currently leased (queued or terminally resolved)
     }
 
-    sealed class Session {
-        public bool Transferred;
-    }
+    // Reference-identity token for "which ConsumeAsync enumeration currently owns dequeuing" — no
+    // state of its own; TransferConsumer just clears _current so the owning enumeration's next
+    // gate check sees `superseded` and winds down.
+    sealed class Session;
 
     readonly object _gate = new();
     readonly LinkedList<Entry> _queue = new();
@@ -58,11 +59,12 @@ public sealed class OutcomeChannel {
         return ConsumeCoreAsync(session, ct);
     }
 
-    /// Only still-queued envelopes move to the next ConsumeAsync; a lease already yielded to this consumer stays outstanding.
+    /// Only still-queued envelopes move to the next ConsumeAsync; a lease already yielded to this
+    /// consumer stays outstanding and ackable until the old enumeration itself ends, at which
+    /// point any envelope still unresolved gets its one requeue (never silently dropped).
     public void TransferConsumer() {
         lock (_gate) {
             if (_current is null) return;
-            _current.Transferred = true;
             _current = null;
             Wake();
         }
@@ -98,18 +100,20 @@ public sealed class OutcomeChannel {
         } finally {
             lock (_gate) {
                 if (ReferenceEquals(_current, session)) _current = null;
-                if (!session.Transferred) {
-                    // ct/teardown: everything this session still holds unresolved gets its one requeue.
-                    for (var i = mine.Count - 1; i >= 0; i--) {
-                        var (entry, token) = mine[i];
-                        if (entry.ActiveLeaseToken != token) continue; // already resolved directly
-                        entry.ActiveLeaseToken = 0;
-                        if (!entry.Requeued) {
-                            entry.Requeued = true;
-                            _queue.AddFirst(entry);
-                        } else {
-                            LogSecondAbandonment(entry.Envelope); // already used its one requeue: consumed-with-log, never silent
-                        }
+                // Runs unconditionally, transferred-away or not: a lease already resolved (Ack/CancelLease
+                // called while still yielded) has a stale token here and is skipped; anything still
+                // unresolved when THIS enumeration ends — ct/teardown, or a transferred session whose old
+                // enumerator ends without ever being acked — gets its one requeue, so a
+                // dequeued-but-never-presented envelope is never silently lost across a transfer.
+                for (var i = mine.Count - 1; i >= 0; i--) {
+                    var (entry, token) = mine[i];
+                    if (entry.ActiveLeaseToken != token) continue; // already resolved directly
+                    entry.ActiveLeaseToken = 0;
+                    if (!entry.Requeued) {
+                        entry.Requeued = true;
+                        _queue.AddFirst(entry);
+                    } else {
+                        LogSecondAbandonment(entry.Envelope); // already used its one requeue: consumed-with-log, never silent
                     }
                 }
                 Wake();

--- a/src/Capacitor.App/Services/Mutation/OutcomeChannel.cs
+++ b/src/Capacitor.App/Services/Mutation/OutcomeChannel.cs
@@ -47,6 +47,7 @@ public sealed class OutcomeChannel {
         }
     }
 
+    /// An un-enumerated result still holds the exclusivity slot until it is enumerated (and ends) or its ct is cancelled.
     public IAsyncEnumerable<OutcomeLease> ConsumeAsync(CancellationToken ct) {
         Session session;
         lock (_gate) {
@@ -106,6 +107,8 @@ public sealed class OutcomeChannel {
                         if (!entry.Requeued) {
                             entry.Requeued = true;
                             _queue.AddFirst(entry);
+                        } else {
+                            LogSecondAbandonment(entry.Envelope); // already used its one requeue: consumed-with-log, never silent
                         }
                     }
                 }
@@ -118,12 +121,23 @@ public sealed class OutcomeChannel {
         lock (_gate) {
             if (entry.ActiveLeaseToken != token) return; // stale: this lease was already resolved
             entry.ActiveLeaseToken = 0;
-            if (requeue && !entry.Requeued) {
+            if (!requeue) return; // Ack: consumed, done
+            if (!entry.Requeued) {
                 entry.Requeued = true;
                 _queue.AddFirst(entry);
                 Wake();
+            } else {
+                LogSecondAbandonment(entry.Envelope); // already used its one requeue: consumed-with-log, never silent
             }
         }
+    }
+
+    // requeue-exactly-once is exhausted here by design; log so a second abandonment is never a silent drop.
+    static void LogSecondAbandonment(OutcomeEnvelope envelope) {
+        var r = envelope.Request;
+        Console.Error.WriteLine(
+            $"OutcomeChannel: envelope consumed after second abandonment (requeue-exactly-once exhausted) " +
+            $"verb={r.Verb} profile={r.Profile} server={r.CanonicalServer} daemon={r.DaemonName} outcome={envelope.Outcome.GetType().Name}");
     }
 
     void Wake() { // caller must hold _gate

--- a/src/Capacitor.App/Services/Mutation/ReasonLine.cs
+++ b/src/Capacitor.App/Services/Mutation/ReasonLine.cs
@@ -1,0 +1,18 @@
+namespace Capacitor.App.Services.Mutation;
+
+/// Extracts a single machine-readable reason token from daemon/CLI stderr.
+public static class ReasonLine {
+    // Exactly one line starting with `prefix` (after trimming \r) with a non-empty token wins;
+    // zero matches, 2+ matches, or a matching line with an empty token all fail closed to null.
+    public static string? TrySingle(string stderr, string prefix) {
+        string? token = null;
+        var matchCount = 0;
+        foreach (var rawLine in stderr.Split('\n')) {
+            var line = rawLine.TrimEnd('\r');
+            if (!line.StartsWith(prefix, StringComparison.Ordinal)) continue;
+            matchCount++;
+            token = line[prefix.Length..].Trim();
+        }
+        return matchCount == 1 && !string.IsNullOrEmpty(token) ? token : null;
+    }
+}

--- a/src/Capacitor.App/Services/Mutation/ReasonLine.cs
+++ b/src/Capacitor.App/Services/Mutation/ReasonLine.cs
@@ -2,8 +2,7 @@ namespace Capacitor.App.Services.Mutation;
 
 /// Extracts a single machine-readable reason token from daemon/CLI stderr.
 public static class ReasonLine {
-    // Exactly one line starting with `prefix` (after trimming \r) with a non-empty token wins;
-    // zero matches, 2+ matches, or a matching line with an empty token all fail closed to null.
+    // Exactly one matching line with a non-empty token wins; anything else fails closed to null.
     public static string? TrySingle(string stderr, string prefix) {
         string? token = null;
         var matchCount = 0;

--- a/src/Capacitor.App/Services/Onboarding/ConsentFlipClaims.cs
+++ b/src/Capacitor.App/Services/Onboarding/ConsentFlipClaims.cs
@@ -69,7 +69,8 @@ public sealed partial class ConsentFlipClaims(string path, string? configPath = 
             parsed = JsonSerializer.Deserialize(File.ReadAllText(path), ConsentFlipClaimsJsonCtx.Default.ClaimsFile);
         } catch { /* fall through to quarantine */ }
 
-        if (parsed?.Claims is not null) return parsed;
+        // Version gate: a future-version file must never be applied under v1 semantics/rewritten as v1.
+        if (parsed is { Version: 1, Claims: not null }) return parsed;
 
         try { _quarantine = new QuarantineState(QuarantineLocked()); }
         catch { /* quarantining itself failing must not wedge the read */ }

--- a/src/Capacitor.App/Services/Onboarding/ConsentFlipClaims.cs
+++ b/src/Capacitor.App/Services/Onboarding/ConsentFlipClaims.cs
@@ -43,6 +43,7 @@ public sealed partial class ConsentFlipClaims(string path, string? configPath = 
             ConsentFlipClaim claim,
             Func<(string Profile, string Server, string DaemonName)> reResolveUnderConfigLock,
             string expectedDaemonName) {
+        claim = claim with { CanonicalServer = ServerIdentity.Canonicalize(claim.CanonicalServer) ?? claim.CanonicalServer };
         using var configLock = ConfigFileLock.Acquire(_configPath);
         var resolved = reResolveUnderConfigLock();
         if (resolved.Profile != claim.Profile || resolved.Server != claim.CanonicalServer || resolved.DaemonName != expectedDaemonName)

--- a/src/Capacitor.App/Services/Onboarding/ConsentFlipClaims.cs
+++ b/src/Capacitor.App/Services/Onboarding/ConsentFlipClaims.cs
@@ -1,0 +1,156 @@
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.App.Services.Onboarding;
+
+/// Key = {Profile, CanonicalServer}; both are assumed already-canonicalized by the caller.
+public sealed record ConsentFlipClaim(string Profile, string CanonicalServer);
+
+/// Durable decision-7 claim store; every mutation is a synchronous ConfigFileLock critical section (no await while held).
+public sealed partial class ConsentFlipClaims(string path, string? configPath = null) {
+    // configPath is a test seam for TryConsume's config lock; production default is AppConfig.GetConfigPath().
+    readonly string _configPath = configPath ?? AppConfig.GetConfigPath();
+    volatile QuarantineState? _quarantine;
+
+    public static ConsentFlipClaims Default() => new(PathHelpers.ConfigPath("consent-flip-claims.json"));
+
+    public IReadOnlyList<ConsentFlipClaim> Pending() {
+        using var _ = ConfigFileLock.Acquire(path);
+        return ReadFreshLocked().Claims.Select(c => new ConsentFlipClaim(c.Profile, c.Server)).ToList();
+    }
+
+    /// Upsert by key + durable flush. False (any pre-durability failure) blocks the sign-in commit (decision 7).
+    public bool Arm(ConsentFlipClaim claim) {
+        using var _ = ConfigFileLock.Acquire(path);
+        var file = ReadFreshLocked();
+        var claims = file.Claims
+            .Where(c => c.Profile != claim.Profile || c.Server != claim.CanonicalServer)
+            .Append(new ClaimEntry(claim.Profile, claim.CanonicalServer))
+            .ToList();
+        return Publish(new ClaimsFile(1, claims));
+    }
+
+    /// Two-lock conditional clear (spec §6): config lock → re-resolve → claims lock, fixed order, no await inside.
+    public bool TryConsume(
+            ConsentFlipClaim claim,
+            Func<(string Profile, string Server, string DaemonName)> reResolveUnderConfigLock,
+            string expectedDaemonName) {
+        using var configLock = ConfigFileLock.Acquire(_configPath);
+        var resolved = reResolveUnderConfigLock();
+        if (resolved.Profile != claim.Profile || resolved.Server != claim.CanonicalServer || resolved.DaemonName != expectedDaemonName)
+            return false;
+
+        using var claimsLock = ConfigFileLock.Acquire(path);
+        var file = ReadFreshLocked();
+        var remaining = file.Claims.Where(c => c.Profile != claim.Profile || c.Server != claim.CanonicalServer).ToList();
+        if (remaining.Count == file.Claims.Count) return true; // already gone — idempotent re-apply, nothing to publish
+
+        // Publish's rename is the commit point — a post-rename durability failure still returns true (idempotent re-apply).
+        return Publish(new ClaimsFile(1, remaining));
+    }
+
+    public QuarantineState? Quarantine() => _quarantine;
+
+    // Corruption on any read quarantines the file aside and returns a fresh state (caller holds the lock).
+    ClaimsFile ReadFreshLocked() {
+        if (!File.Exists(path)) return new ClaimsFile(1, []);
+
+        ClaimsFile? parsed = null;
+        try {
+            parsed = JsonSerializer.Deserialize(File.ReadAllText(path), ConsentFlipClaimsJsonCtx.Default.ClaimsFile);
+        } catch { /* fall through to quarantine */ }
+
+        if (parsed?.Claims is not null) return parsed;
+
+        try { _quarantine = new QuarantineState(QuarantineLocked()); }
+        catch { /* quarantining itself failing must not wedge the read */ }
+        return new ClaimsFile(1, []);
+    }
+
+    string QuarantineLocked() {
+        for (var n = 0; ; n++) {
+            var candidate = QuarantinePath(n);
+            if (File.Exists(candidate)) continue;
+            File.Move(path, candidate);
+            return candidate;
+        }
+    }
+
+    string QuarantinePath(int n) {
+        var dir  = Path.GetDirectoryName(path) is { Length: > 0 } d ? d : ".";
+        var stem = Path.GetFileNameWithoutExtension(path);
+        var ext  = Path.GetExtension(path);
+        return Path.Combine(dir, $"{stem}.quarantined-{n}{ext}");
+    }
+
+    // Temp write + fsync-before-rename + Windows retry; post-rename fsync is best-effort (never turns a commit into false).
+    bool Publish(ClaimsFile file) {
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+        var tmp = path + ".tmp-" + Guid.NewGuid().ToString("N")[..8];
+        try {
+            using var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None);
+            fs.Write(JsonSerializer.SerializeToUtf8Bytes(file, ConsentFlipClaimsJsonCtx.Default.ClaimsFile));
+            fs.Flush(flushToDisk: true);
+        } catch {
+            try { File.Delete(tmp); } catch { /* best-effort cleanup */ }
+            return false;
+        }
+
+        for (var attempt = 0; ; attempt++) {
+            try {
+                File.Move(tmp, path, overwrite: true);
+                break;
+            } catch (Exception e) when (e is UnauthorizedAccessException or IOException && attempt < 49) {
+                Thread.Sleep(20);
+            } catch {
+                try { File.Delete(tmp); } catch { /* best-effort */ }
+                return false;
+            }
+        }
+
+        try {
+            using var handle = File.OpenHandle(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite);
+            RandomAccess.FlushToDisk(handle);
+        } catch { /* best-effort past the commit point */ }
+        FlushDirectory(!string.IsNullOrEmpty(dir) ? dir : ".");
+
+        return true;
+    }
+
+    // ── directory-durability barrier (same libc pattern as Capacitor.Cli's ServiceTxnMarker) ──
+
+    [LibraryImport("libc", EntryPoint = "open", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int open(string path, int flags);
+    [LibraryImport("libc", EntryPoint = "fsync")]
+    private static partial int fsync(int fd);
+    [LibraryImport("libc", EntryPoint = "close")]
+    private static partial int close(int fd);
+
+    static void FlushDirectory(string dir) {
+        if (OperatingSystem.IsWindows()) return; // no portable directory fsync on Windows
+
+        var fd = -1;
+        try {
+            fd = open(dir, 0 /* O_RDONLY */);
+            if (fd >= 0) fsync(fd);
+        } catch { /* durability hardening only — never break a claim write */
+        } finally {
+            if (fd >= 0) close(fd);
+        }
+    }
+
+    public sealed record QuarantineState(string PreservedPath);
+
+    // JSON DTO — public record's CanonicalServer maps to the "server" wire field.
+    private sealed record ClaimsFile(int Version, List<ClaimEntry> Claims);
+    private sealed record ClaimEntry(string Profile, string Server);
+
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+    [JsonSerializable(typeof(ClaimsFile))]
+    partial class ConsentFlipClaimsJsonCtx : JsonSerializerContext;
+}

--- a/src/Capacitor.App/Services/Onboarding/ConsentFlipClaims.cs
+++ b/src/Capacitor.App/Services/Onboarding/ConsentFlipClaims.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.App.Services.Onboarding;
@@ -23,7 +24,11 @@ public sealed partial class ConsentFlipClaims(string path, string? configPath = 
     }
 
     /// Upsert by key + durable flush. False (any pre-durability failure) blocks the sign-in commit (decision 7).
+    /// Defensively canonicalizes CanonicalServer at entry (idempotent for an already-canonical
+    /// caller) — a raw/uncanonical URL armed here would otherwise never match TryConsume's
+    /// canonical-identity re-resolve, stranding the claim as permanently pending.
     public bool Arm(ConsentFlipClaim claim) {
+        claim = claim with { CanonicalServer = ServerIdentity.Canonicalize(claim.CanonicalServer) ?? claim.CanonicalServer };
         using var _ = ConfigFileLock.Acquire(path);
         var file = ReadFreshLocked();
         var claims = file.Claims

--- a/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
+++ b/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
@@ -1,0 +1,120 @@
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.Services.Onboarding;
+
+/// spec §6 coordinator path: applies a pending decision-7 claim to a PRE-EXISTING daemon on every
+/// transition to Connected — the sibling of ShimOfferCoordinator, but re-triggered every time
+/// rather than once-ever, since a claim or a daemon restart can both arrive later.
+public sealed class ConsentFlipCoordinator(
+        IDaemonClientService client, ILocalControlOps ops, ConsentFlipClaims claims,
+        Func<(string Profile, string Server, string DaemonName)> resolveIdentityUnderConfigLock,
+        ILifecycleSurface surface, IAppStateStore appState, CancellationToken lifetime) {
+    internal const string ConsentV3Capability = "consent/3";
+
+    readonly SemaphoreSlim _gate = new(1, 1);
+
+    /// Test seam: counts settled RunAsync passes so tests can await one deterministically.
+    internal int PassCount;
+
+    /// Subscribes client.Status for the app lifetime; also fires the once-only quarantine surface.
+    public void Start() {
+        client.Status.Subscribe(OnStatus);
+        _ = SurfaceQuarantineOnceAsync();
+    }
+
+    void OnStatus(AttachStatus status) {
+        if (status.State != AttachState.Connected) return;
+        if (status.Capabilities is not { } caps || !caps.Contains(ConsentV3Capability)) return; // no put — claim stays pending
+        _ = RunAsync();
+    }
+
+    // Single-flight per transition (ConsentService's lane discipline): overlapping Connected
+    // transitions serialize onto this semaphore instead of running concurrent passes.
+    async Task RunAsync() {
+        try {
+            await _gate.WaitAsync(lifetime).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            return;
+        }
+        try {
+            await ApplyAsync().ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            // shutdown mid-pass
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: consent-flip coordinator pass failed unexpectedly: {ex.Message}");
+        } finally {
+            _gate.Release();
+            Interlocked.Increment(ref PassCount);
+        }
+    }
+
+    // Both this coordinator's own match AND TryConsume's later re-resolve (called through this
+    // same wrapper) must observe identical canonicalization — the store never re-canonicalizes.
+    (string Profile, string Server, string DaemonName) ResolveCanonical() {
+        var (profile, server, daemonName) = resolveIdentityUnderConfigLock();
+        return (profile, ServerIdentity.Canonicalize(server) ?? server, daemonName);
+    }
+
+    async Task ApplyAsync() {
+        var pending = await Task.Run(claims.Pending, lifetime).ConfigureAwait(false);
+        if (pending.Count == 0) return;
+
+        var identity = ResolveCanonical(); // one plain read — TryConsume re-resolves under lock at clear time
+        var claim = pending.FirstOrDefault(c => c.Profile == identity.Profile && c.CanonicalServer == identity.Server);
+        if (claim is null) return; // no claim for the currently resolved identity
+
+        ConsentPolicyDto policy;
+        try {
+            policy = await ops.GetConsentPolicyAsync(lifetime).ConfigureAwait(false);
+        } catch (LocalControlOpsException) {
+            return; // claim stays pending, retried on the next Connected transition
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            Console.Error.WriteLine($"kcap: consent-flip coordinator get failed unexpectedly: {ex.Message}");
+            return;
+        }
+
+        if (policy.Default != "allow" || policy.Rules.Count != 0) return; // factory guard: only a factory-looking policy flips
+
+        var put = new ConsentPolicyPutV2Dto(identity.DaemonName, claim.CanonicalServer, policy with { Default = "prompt" });
+
+        ConsentAckDto ack;
+        try {
+            ack = await ops.PutConsentPolicyV2Async(put, lifetime).ConfigureAwait(false);
+        } catch (LocalControlOpsException) {
+            return; // claim retained
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            Console.Error.WriteLine($"kcap: consent-flip coordinator put failed unexpectedly: {ex.Message}");
+            return;
+        }
+
+        if (!ack.Ok) return; // identity_mismatch or any other rejection — claim retained, nothing consumed
+
+        // Two-lock conditional clear; a false return leaves the claim pending for the next graph.
+        await Task.Run(() => claims.TryConsume(claim, ResolveCanonical, identity.DaemonName), lifetime).ConfigureAwait(false);
+    }
+
+    async Task SurfaceQuarantineOnceAsync() {
+        try {
+            // A read is what discovers corruption (ConsentFlipClaims quarantines lazily, on any
+            // read) — force one here so surfacing never depends on some other path having run first.
+            await Task.Run(claims.Pending, lifetime).ConfigureAwait(false);
+            if (claims.Quarantine() is not { } quarantine) return;
+            var state = await appState.LoadAsync().ConfigureAwait(false);
+            if (state.ConsentQuarantineAcked) return;
+
+            surface.Attention(
+                $"A corrupted consent-flip claims file was found and preserved at {quarantine.PreservedPath}. " +
+                "Pre-existing daemons may need `kcap daemon consent set-default prompt`, or re-run onboarding.");
+        } catch (OperationCanceledException) {
+            // shutdown before the surface could complete
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: consent quarantine surfacing failed unexpectedly: {ex.Message}");
+        }
+    }
+
+    /// Persists the ack so a later launch never re-surfaces this quarantine (invoking this from a
+    /// UI affordance is Plan C — only the method and its persistence are in scope here).
+    public Task<bool> AckQuarantineAsync() =>
+        appState.UpdateAsync(s => s.ConsentQuarantineAcked ? s : s with { ConsentQuarantineAcked = true });
+}

--- a/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
+++ b/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
@@ -75,29 +75,24 @@ public sealed class ConsentFlipCoordinator(
         }
 
         var isFactory = policy.Default == "allow" && policy.Rules.Count == 0; // factory guard: only a factory-looking policy flips
-        // Resurrected claim: a crash between a successful put and TryConsume can leave the claim
-        // pending while the daemon's policy is ALREADY "prompt" — the factory guard alone would
-        // then retain it forever, and a LATER deliberate operator allow+zero-rules could be
-        // re-flipped by the stale claim. Recognize the already-applied state and clear idempotently
-        // instead: no put needed, the policy already matches what the flip would have set.
+        // Resurrected claim: still routes through the identity-conditional put below (unchanged, a no-op) — Get's answer alone proves nothing about which daemon instance answered.
         var alreadyApplied = policy.Default == "prompt";
         if (!isFactory && !alreadyApplied) return; // deny, or allow-with-rules: not factory-looking, retain
 
-        if (isFactory) {
-            var put = new ConsentPolicyPutV2Dto(identity.DaemonName, claim.CanonicalServer, policy with { Default = "prompt" });
+        var putPolicy = isFactory ? policy with { Default = "prompt" } : policy;
+        var put = new ConsentPolicyPutV2Dto(identity.DaemonName, claim.CanonicalServer, putPolicy);
 
-            ConsentAckDto ack;
-            try {
-                ack = await ops.PutConsentPolicyV2Async(put, lifetime).ConfigureAwait(false);
-            } catch (LocalControlOpsException) {
-                return; // claim retained
-            } catch (Exception ex) when (ex is not OperationCanceledException) {
-                Console.Error.WriteLine($"kcap: consent-flip coordinator put failed unexpectedly: {ex.Message}");
-                return;
-            }
-
-            if (!ack.Ok) return; // identity_mismatch or any other rejection — claim retained, nothing consumed
+        ConsentAckDto ack;
+        try {
+            ack = await ops.PutConsentPolicyV2Async(put, lifetime).ConfigureAwait(false);
+        } catch (LocalControlOpsException) {
+            return; // claim retained
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            Console.Error.WriteLine($"kcap: consent-flip coordinator put failed unexpectedly: {ex.Message}");
+            return;
         }
+
+        if (!ack.Ok) return; // identity_mismatch or any other rejection — claim retained, nothing consumed
 
         // Two-lock conditional clear; a false return leaves the claim pending for the next graph.
         await Task.Run(() => claims.TryConsume(claim, ResolveCanonical, identity.DaemonName), lifetime).ConfigureAwait(false);

--- a/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
+++ b/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
@@ -74,21 +74,30 @@ public sealed class ConsentFlipCoordinator(
             return;
         }
 
-        if (policy.Default != "allow" || policy.Rules.Count != 0) return; // factory guard: only a factory-looking policy flips
+        var isFactory = policy.Default == "allow" && policy.Rules.Count == 0; // factory guard: only a factory-looking policy flips
+        // Resurrected claim: a crash between a successful put and TryConsume can leave the claim
+        // pending while the daemon's policy is ALREADY "prompt" — the factory guard alone would
+        // then retain it forever, and a LATER deliberate operator allow+zero-rules could be
+        // re-flipped by the stale claim. Recognize the already-applied state and clear idempotently
+        // instead: no put needed, the policy already matches what the flip would have set.
+        var alreadyApplied = policy.Default == "prompt";
+        if (!isFactory && !alreadyApplied) return; // deny, or allow-with-rules: not factory-looking, retain
 
-        var put = new ConsentPolicyPutV2Dto(identity.DaemonName, claim.CanonicalServer, policy with { Default = "prompt" });
+        if (isFactory) {
+            var put = new ConsentPolicyPutV2Dto(identity.DaemonName, claim.CanonicalServer, policy with { Default = "prompt" });
 
-        ConsentAckDto ack;
-        try {
-            ack = await ops.PutConsentPolicyV2Async(put, lifetime).ConfigureAwait(false);
-        } catch (LocalControlOpsException) {
-            return; // claim retained
-        } catch (Exception ex) when (ex is not OperationCanceledException) {
-            Console.Error.WriteLine($"kcap: consent-flip coordinator put failed unexpectedly: {ex.Message}");
-            return;
+            ConsentAckDto ack;
+            try {
+                ack = await ops.PutConsentPolicyV2Async(put, lifetime).ConfigureAwait(false);
+            } catch (LocalControlOpsException) {
+                return; // claim retained
+            } catch (Exception ex) when (ex is not OperationCanceledException) {
+                Console.Error.WriteLine($"kcap: consent-flip coordinator put failed unexpectedly: {ex.Message}");
+                return;
+            }
+
+            if (!ack.Ok) return; // identity_mismatch or any other rejection — claim retained, nothing consumed
         }
-
-        if (!ack.Ok) return; // identity_mismatch or any other rejection — claim retained, nothing consumed
 
         // Two-lock conditional clear; a false return leaves the claim pending for the next graph.
         await Task.Run(() => claims.TryConsume(claim, ResolveCanonical, identity.DaemonName), lifetime).ConfigureAwait(false);

--- a/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
+++ b/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
@@ -8,8 +8,7 @@ public abstract record GateResult {
     public sealed record Incomplete(GateReason Reason) : GateResult;
 }
 
-// EvaluationFailed: never returned by EvaluateAsync itself — App.EvaluateGateSafelyAsync's fail-safe
-// degrade for an unexpected exception (round-1 review, adjudicated).
+// EvaluationFailed is never returned by EvaluateAsync itself — it's App.EvaluateGateSafelyAsync's fail-safe degrade for an unexpected exception.
 public enum GateReason { NoProfile, InvalidServerUrl, NoToken, TokenUnusableBinding, TokenUnusableExpired, EvaluationFailed }
 
 /// <summary>

--- a/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
+++ b/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
@@ -45,7 +45,12 @@ public static class OnboardingGate {
 
         var stamp = profile.AuthProvider;
 
-        if (stamp is { Provider: "none" } && ServerIdentity.SameServer(stamp.ServerUrl, profile.ServerUrl)) {
+        // Case-insensitive: the stamp writer emits the AuthProvider.None constant verbatim
+        // ("None"), not a lowercased literal — an ordinal-exact "none" compare would silently
+        // never satisfy the gate for a real stamp.
+        if (stamp is not null
+                && string.Equals(stamp.Provider, AuthProvider.None, StringComparison.OrdinalIgnoreCase)
+                && ServerIdentity.SameServer(stamp.ServerUrl, profile.ServerUrl)) {
             return new GateResult.Complete();
         }
 

--- a/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
+++ b/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
@@ -34,8 +34,15 @@ public static class OnboardingGate {
         // Daemon-style resolution — no repo/git discovery, matching decision 1's "local" scope.
         await AppConfig.ResolveActiveProfile([]);
         var resolved = AppConfig.ResolvedProfile;
+        return await EvaluateResolvedAsync(resolved?.ProfileName, resolved?.Profile, ct);
+    }
 
-        if (resolved is not { Profile: { } profile, ProfileName: { Length: > 0 } profileName }) {
+    /// Shares a resolution the CALLER already performed (App.StartAsync: DaemonClientService.
+    /// CreateDefaultAsync's own AppConfig.ResolveActiveProfile) instead of resolving a second
+    /// time — two independent resolves racing a concurrent active-profile change could otherwise
+    /// evaluate the gate against a different profile than the one the daemon graph builds for.
+    public static async Task<GateResult> EvaluateResolvedAsync(string? profileName, Profile? profile, CancellationToken ct) {
+        if (profile is null || string.IsNullOrEmpty(profileName)) {
             return new GateResult.Incomplete(GateReason.NoProfile);
         }
 

--- a/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
+++ b/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
@@ -11,9 +11,12 @@ public abstract record GateResult {
 public enum GateReason { NoProfile, InvalidServerUrl, NoToken, TokenUnusableBinding, TokenUnusableExpired }
 
 /// <summary>
-/// Decision-1 first-run trigger: local, side-effect-free, no refresh. Whether the wizard opens
-/// is the exact inverse of "does TokenStore already consider this profile authenticated" — so
-/// every branch here mirrors a specific TokenStore rule rather than inventing its own.
+/// Decision-1 first-run trigger: local, side-effect-free except the shared resolution path's own
+/// v1→v2 migration write on legacy configs (kept intentionally shared with the normal daemon
+/// graph — decision 2 — rather than a purity-motivated divergent read that could resolve a
+/// different profile than the graph builds), no refresh. Whether the wizard opens is the exact
+/// inverse of "does TokenStore already consider this profile authenticated" — so every branch
+/// here mirrors a specific TokenStore rule rather than inventing its own.
 /// </summary>
 public static class OnboardingGate {
     /// <summary>

--- a/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
+++ b/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
@@ -8,7 +8,9 @@ public abstract record GateResult {
     public sealed record Incomplete(GateReason Reason) : GateResult;
 }
 
-public enum GateReason { NoProfile, InvalidServerUrl, NoToken, TokenUnusableBinding, TokenUnusableExpired }
+// EvaluationFailed: never returned by EvaluateAsync itself — App.EvaluateGateSafelyAsync's fail-safe
+// degrade for an unexpected exception (round-1 review, adjudicated).
+public enum GateReason { NoProfile, InvalidServerUrl, NoToken, TokenUnusableBinding, TokenUnusableExpired, EvaluationFailed }
 
 /// <summary>
 /// Decision-1 first-run trigger: local, side-effect-free except the shared resolution path's own

--- a/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
+++ b/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
@@ -1,0 +1,78 @@
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.App.Services.Onboarding;
+
+public abstract record GateResult {
+    public sealed record Complete : GateResult;
+    public sealed record Incomplete(GateReason Reason) : GateResult;
+}
+
+public enum GateReason { NoProfile, InvalidServerUrl, NoToken, TokenUnusableBinding, TokenUnusableExpired }
+
+/// <summary>
+/// Decision-1 first-run trigger: local, side-effect-free, no refresh. Whether the wizard opens
+/// is the exact inverse of "does TokenStore already consider this profile authenticated" — so
+/// every branch here mirrors a specific TokenStore rule rather than inventing its own.
+/// </summary>
+public static class OnboardingGate {
+    /// <summary>
+    /// The ONE shared validator for "is this usable as a server identity" — also used by
+    /// <c>App.ValidProfileName</c> so the gate and the lifecycle-controller precondition can
+    /// never disagree on what counts as a valid <c>server_url</c> (e.g. both reject
+    /// <c>file://</c>). Delegates to <see cref="ServerIdentity.Canonicalize"/>, which restricts
+    /// to absolute http/https origins with no userinfo/query/fragment.
+    /// </summary>
+    public static bool ValidServerUrl(string? url) => ServerIdentity.Canonicalize(url) is not null;
+
+    public static async Task<GateResult> EvaluateAsync(CancellationToken ct) {
+        // Daemon-style resolution — no repo/git discovery, matching decision 1's "local" scope.
+        await AppConfig.ResolveActiveProfile([]);
+        var resolved = AppConfig.ResolvedProfile;
+
+        if (resolved is not { Profile: { } profile, ProfileName: { Length: > 0 } profileName }) {
+            return new GateResult.Incomplete(GateReason.NoProfile);
+        }
+
+        if (!ValidServerUrl(profile.ServerUrl)) {
+            return new GateResult.Incomplete(GateReason.InvalidServerUrl);
+        }
+
+        var stamp = profile.AuthProvider;
+
+        if (stamp is { Provider: "none" } && ServerIdentity.SameServer(stamp.ServerUrl, profile.ServerUrl)) {
+            return new GateResult.Complete();
+        }
+
+        // Raw, refresh-free read — a stale/expiring token must not be rotated just to answer
+        // "is the wizard needed", which would spend a rotating WorkOS refresh token for nothing.
+        var tokens = await TokenStore.LoadForProfileAsync(profileName, ct);
+
+        if (tokens is null) {
+            return new GateResult.Incomplete(GateReason.NoToken);
+        }
+
+        if (!BoundToProfile(tokens, profile.ServerUrl)) {
+            return new GateResult.Incomplete(GateReason.TokenUnusableBinding);
+        }
+
+        if (!tokens.IsExpired) {
+            return new GateResult.Complete();
+        }
+
+        return RefreshCapable(tokens)
+            ? new GateResult.Complete()
+            : new GateResult.Incomplete(GateReason.TokenUnusableExpired);
+    }
+
+    // Mirrors TokenStore.BoundToTarget exactly: a legacy (pre-upgrade) token carries no
+    // ServerUrl stamp, so there is nothing to contradict — treated as usable for any server.
+    static bool BoundToProfile(StoredTokens tokens, string? serverUrl) =>
+        tokens.ServerUrl is null || ServerIdentity.SameServer(tokens.ServerUrl, serverUrl);
+
+    // Mirrors GetValidTokensForProfileAsync's refresh gating: GitHubApp always refreshes via the
+    // server's /auth/refresh; WorkOS needs its own rotating RefreshToken plus ClientId.
+    static bool RefreshCapable(StoredTokens tokens) =>
+        tokens.Provider is AuthProvider.GitHubApp
+     || tokens is { Provider: AuthProvider.WorkOS, RefreshToken: not null, ClientId: not null };
+}

--- a/src/Capacitor.App/Services/ShimOfferCoordinator.cs
+++ b/src/Capacitor.App/Services/ShimOfferCoordinator.cs
@@ -25,6 +25,9 @@ public sealed class ShimOfferCoordinator {
     readonly string? _target;
     readonly CancellationToken _lifetime;
     readonly string _destination;
+    // Task 15 round-1 review: true only for a gate-Incomplete startup — Offerable/manual install
+    // still work, only the once-ever auto-offer DIALOG is skipped.
+    readonly bool _autoOfferSuppressed;
 
     readonly BehaviorSubject<bool> _offerable = new(false);
 
@@ -35,8 +38,8 @@ public sealed class ShimOfferCoordinator {
     /// </param>
     public ShimOfferCoordinator(
             Task phaseClosed, ILoginShellProbe probe, PathShimInstaller installer, IAppStateStore store,
-            ILifecycleSurface surface, string? target, CancellationToken lifetime)
-        : this(phaseClosed, probe, installer, store, surface, target, lifetime, PathShimInstaller.Destination) { }
+            ILifecycleSurface surface, string? target, CancellationToken lifetime, bool autoOfferSuppressed = false)
+        : this(phaseClosed, probe, installer, store, surface, target, lifetime, PathShimInstaller.Destination, autoOfferSuppressed) { }
 
     // Test seam mirroring PathShimInstaller.InstallAsync's own internal destination-override
     // overload: lets tests drive real Preflight/InstallAsync taxonomy against a temp path instead
@@ -44,8 +47,9 @@ public sealed class ShimOfferCoordinator {
     // above, which pins `destination` to PathShimInstaller.Destination.
     internal ShimOfferCoordinator(
             Task phaseClosed, ILoginShellProbe probe, PathShimInstaller installer, IAppStateStore store,
-            ILifecycleSurface surface, string? target, CancellationToken lifetime, string destination)
-        : this(phaseClosed, probe, installer, store, surface, target, lifetime, destination, OperatingSystem.IsMacOS) { }
+            ILifecycleSurface surface, string? target, CancellationToken lifetime, string destination,
+            bool autoOfferSuppressed = false)
+        : this(phaseClosed, probe, installer, store, surface, target, lifetime, destination, OperatingSystem.IsMacOS, autoOfferSuppressed) { }
 
     // spec §3.3: macOS-only, no-op elsewhere. `isMacOs` is a test seam (off-macOS can't otherwise
     // be exercised from macOS CI); production always resolves to the real OS check. Nulling
@@ -54,15 +58,16 @@ public sealed class ShimOfferCoordinator {
     internal ShimOfferCoordinator(
             Task phaseClosed, ILoginShellProbe probe, PathShimInstaller installer, IAppStateStore store,
             ILifecycleSurface surface, string? target, CancellationToken lifetime, string destination,
-            Func<bool> isMacOs) {
-        _phaseClosed = phaseClosed;
-        _probe       = probe;
-        _installer   = installer;
-        _store       = store;
-        _surface     = surface;
-        _target      = isMacOs() ? target : null;
-        _lifetime    = lifetime;
-        _destination = destination;
+            Func<bool> isMacOs, bool autoOfferSuppressed = false) {
+        _phaseClosed          = phaseClosed;
+        _probe                = probe;
+        _installer            = installer;
+        _store                = store;
+        _surface              = surface;
+        _target               = isMacOs() ? target : null;
+        _lifetime             = lifetime;
+        _destination          = destination;
+        _autoOfferSuppressed  = autoOfferSuppressed;
     }
 
     /// True while the tray's "Install command-line tool…" item should show: applicable (an
@@ -88,6 +93,8 @@ public sealed class ShimOfferCoordinator {
             if (onPath != false) return; // true (already on PATH) or unknown → never auto-offer, item stays hidden
 
             _offerable.OnNext(true); // applicable-but-absent — the menu item is live from here on
+
+            if (_autoOfferSuppressed) return; // item + manual install still work; only the dialog never fires
 
             var state = await _store.LoadAsync().ConfigureAwait(false);
             if (state.ShimOffered || state.ShimDenied) return; // already resolved on a prior run

--- a/src/Capacitor.App/Services/ShimOfferCoordinator.cs
+++ b/src/Capacitor.App/Services/ShimOfferCoordinator.cs
@@ -25,8 +25,7 @@ public sealed class ShimOfferCoordinator {
     readonly string? _target;
     readonly CancellationToken _lifetime;
     readonly string _destination;
-    // Task 15 round-1 review: true only for a gate-Incomplete startup — Offerable/manual install
-    // still work, only the once-ever auto-offer DIALOG is skipped.
+    // True only for a gate-Incomplete startup — Offerable/manual install still work, only the once-ever auto-offer DIALOG is skipped.
     readonly bool _autoOfferSuppressed;
 
     readonly BehaviorSubject<bool> _offerable = new(false);

--- a/src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj
+++ b/src/Capacitor.Cli.Core/Capacitor.Cli.Core.csproj
@@ -15,6 +15,7 @@
         <InternalsVisibleTo Include="kcap-daemon" />
         <InternalsVisibleTo Include="Capacitor.Cli.Tests.Unit" />
         <InternalsVisibleTo Include="Capacitor.Cli.Tests.Integration" />
+        <InternalsVisibleTo Include="Capacitor.App.Tests.Unit" />
         <!-- Used when referenced as a submodule from the server repo -->
         <InternalsVisibleTo Include="Capacitor.Server.TestHelpers" />
         <InternalsVisibleTo Include="Capacitor.Server.Tests" />

--- a/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
@@ -108,12 +108,26 @@ public record Profile {
     [JsonPropertyName("flows")]
     public FlowsSettings? Flows { get; init; }
 
+    /// <summary>
+    /// Provider + canonical server identity learned at the last successful sign-in (Plan C's
+    /// commit boundary). Additive and READ-only in Plan B — nothing writes it yet; only
+    /// <c>OnboardingGate</c> reads it, and only when the stamped server still matches.
+    /// </summary>
+    [JsonPropertyName("auth_provider")]
+    public AuthProviderStamp? AuthProvider { get; init; }
+
     /// <summary>The saved reviewer-vendor preference, with null/blank/whitespace defensively
     /// read as "no preference" — a blank treated as set would consume the single preference
     /// retry with an effectively vendor-less request and re-fail identically.</summary>
     public string? EffectiveReviewerVendorPreference() =>
         string.IsNullOrWhiteSpace(Flows?.ReviewerVendor) ? null : Flows!.ReviewerVendor!.Trim();
 }
+
+/// <summary>Provider + the canonical server identity it was learned for — a stamp for a
+/// DIFFERENT server (after a <c>server_url</c> change) must never be trusted as current.</summary>
+public sealed record AuthProviderStamp(
+    [property: JsonPropertyName("provider")]   string Provider,
+    [property: JsonPropertyName("server_url")] string ServerUrl);
 
 public record FlowsSettings {
     [JsonPropertyName("reviewer_vendor")]

--- a/src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs
@@ -18,6 +18,7 @@ public interface ILocalControlOps {
     Task<StopAgentResult>  StopAgentAsync(string agentId, bool force, CancellationToken ct);
     Task<ConsentPolicyDto> GetConsentPolicyAsync(CancellationToken ct);
     Task<ConsentAckDto>    PutConsentPolicyAsync(ConsentPolicyDto policy, CancellationToken ct);
+    Task<ConsentAckDto>    PutConsentPolicyV2Async(ConsentPolicyPutV2Dto put, CancellationToken ct);
     Task<ConsentAckDto>    ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct);
 }
 
@@ -80,6 +81,21 @@ public sealed class LocalControlOps(string daemonName, TimeProvider? time = null
                 throw new LocalControlOpsException(DaemonRejected, reply.Text);
             default:
                 throw new LocalControlOpsException(UnexpectedReply, $"unexpected daemon response to consent rules put ({reply.Type})");
+        }
+    }
+
+    public async Task<ConsentAckDto> PutConsentPolicyV2Async(ConsentPolicyPutV2Dto put, CancellationToken ct) {
+        var json = JsonSerializer.Serialize(put, ConsentIpcJsonContext.Default.ConsentPolicyPutV2Dto);
+        var reply = await ExchangeAsync(LocalFrame.ConsentJson(FrameType.ConsentRulesPutV2, json), ConsentReplyTimeout, ct);
+        switch (reply.Type) {
+            case FrameType.ConsentAck:
+                var ack = DeserializeOrThrow(reply.Text, ConsentIpcJsonContext.Default.ConsentAckDto, "malformed consent ack reply");
+                if (ack is null) throw new LocalControlOpsException(UnexpectedReply, "malformed consent ack reply");
+                return ack; // Ok=false (e.g. identity_mismatch) returned as-is — not an exception
+            case FrameType.Error:
+                throw new LocalControlOpsException(DaemonRejected, reply.Text);
+            default:
+                throw new LocalControlOpsException(UnexpectedReply, $"unexpected daemon response to consent rules put v2 ({reply.Type})");
         }
     }
 

--- a/src/Capacitor.Cli/Services/BootRefusalReader.cs
+++ b/src/Capacitor.Cli/Services/BootRefusalReader.cs
@@ -27,14 +27,18 @@ public static partial class BootRefusalReader {
         Path.Combine(DaemonLockPaths.Directory, DaemonLockPaths.Sanitize(daemonName), "boot-refusal.json");
 
     /// <summary>Absent or corrupt → null. Unlike the daemon's own reader, a corrupt marker is LEFT IN
-    /// PLACE — the CLI has no ownership authority to quarantine/rename a file the daemon writes.</summary>
+    /// PLACE — the CLI has no ownership authority to quarantine/rename a file the daemon writes.
+    /// Reads via a share-all FileStream (never File.ReadAllText) — the daemon owns this file and may
+    /// concurrently rename/rewrite it; a write-denying open would stall that on Windows.</summary>
     public static BootRefusalEvidence? TryRead(string daemonName) {
         var path = MarkerPath(daemonName);
-        if (!File.Exists(path)) return null;
 
         try {
-            return JsonSerializer.Deserialize(File.ReadAllText(path), BootRefusalJsonCtx.Default.BootRefusalEvidence);
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+            return JsonSerializer.Deserialize(reader.ReadToEnd(), BootRefusalJsonCtx.Default.BootRefusalEvidence);
         } catch {
+            // Missing (FileNotFoundException) or corrupt — both answer null, left in place.
             return null;
         }
     }

--- a/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
@@ -1,0 +1,192 @@
+using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
+using AppUnderTest = Capacitor.App.App;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Task 10: the composition-root helpers wiring the mutation lane into App.axaml.cs — the
+/// outcome-channel presentation routing, the cliOverride null-remap, and the shutdown
+/// quiesce composition. Plain TUnit, no Avalonia session needed (these are pure/async functions
+/// over interfaces and fakes — FakeLifecycleSurface/FakeKcapCli/FakeLoginShellProbe are shared
+/// from DaemonLifecycleControllerTests.cs, same namespace).
+public class AppMutationLaneWiringTests {
+    // ---- ResolveCliOverride's testable core ----
+
+    [Test]
+    public async Task MapBareKcapToNull_maps_the_unset_fallback_to_null() {
+        await Assert.That(AppUnderTest.MapBareKcapToNull("kcap")).IsNull();
+    }
+
+    [Test]
+    public async Task MapBareKcapToNull_passes_a_real_override_through_verbatim() {
+        await Assert.That(AppUnderTest.MapBareKcapToNull("/opt/kcap/kcap")).IsEqualTo("/opt/kcap/kcap");
+    }
+
+    [Test]
+    public async Task MapBareKcapToNull_passes_a_broken_override_null_through() {
+        // CliResolver.ResolvePath already reports a broken override as null — must stay null, not "kcap".
+        await Assert.That(AppUnderTest.MapBareKcapToNull(null)).IsNull();
+    }
+
+    // ---- PresentOutcomeAsync / ClassifyForPresentation ----
+
+    static OutcomeEnvelope Envelope(MutationOutcome outcome) =>
+        new(new MutationRequest(MutationVerb.StartVerified, "default", "https://kcap.example.com:443", "daemon-a"), outcome);
+
+    [Test]
+    public async Task Takeover_surface_shows_the_dialog_and_names_the_token() {
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(true) };
+        var envelope = Envelope(new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover));
+
+        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+
+        await Assert.That(surface.Prompts.Count).IsEqualTo(1);
+        await Assert.That(surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindTakeover);
+        await Assert.That(surface.Prompts[0].Disclosure).IsEqualTo(DaemonLifecycleController.TakeoverDisclosure);
+        await Assert.That(surface.StatusMessages.Count).IsEqualTo(1);
+        await Assert.That(surface.StatusMessages[0]).Contains("foreign_binary");
+        await Assert.That(surface.AttentionMessages).IsEmpty();
+    }
+
+    [Test]
+    public async Task Reinstall_surface_is_a_status_line_naming_the_token_no_dialog() {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.Failed(28, "package_inconsistent", RecoverySurface.Reinstall));
+
+        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+
+        await Assert.That(surface.Prompts).IsEmpty();
+        await Assert.That(surface.StatusMessages.Count).IsEqualTo(1);
+        await Assert.That(surface.StatusMessages[0]).Contains("package_inconsistent");
+        await Assert.That(surface.AttentionMessages).IsEmpty();
+    }
+
+    [Test]
+    public async Task Attention_surface_names_the_token() {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.Failed(1, "internal_error", RecoverySurface.Attention));
+
+        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+
+        await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
+        await Assert.That(surface.AttentionMessages[0]).Contains("internal_error");
+        await Assert.That(surface.Prompts).IsEmpty();
+        await Assert.That(surface.StatusMessages).IsEmpty();
+    }
+
+    [Test]
+    public async Task Storage_surface_also_reads_as_attention_and_names_the_token() {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.Refused("consent_seed_unwritable", RecoverySurface.Storage));
+
+        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+
+        await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
+        await Assert.That(surface.AttentionMessages[0]).Contains("consent_seed_unwritable");
+    }
+
+    [Test]
+    public async Task AttentionSkew_always_reads_as_attention_naming_its_own_detail() {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.AttentionSkew("ownership_mismatch"));
+
+        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+
+        await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
+        await Assert.That(surface.AttentionMessages[0]).Contains("ownership_mismatch");
+    }
+
+    [Test]
+    public async Task AttentionRepair_always_reads_as_attention_naming_its_own_detail() {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.AttentionRepair("stale_txn_marker"));
+
+        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+
+        await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
+        await Assert.That(surface.AttentionMessages[0]).Contains("stale_txn_marker");
+    }
+
+    [Test]
+    public async Task UnconfirmedNoAttach_is_never_presented() {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.UnconfirmedNoAttach());
+
+        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+
+        await Assert.That(surface.Prompts).IsEmpty();
+        await Assert.That(surface.StatusMessages).IsEmpty();
+        await Assert.That(surface.AttentionMessages).IsEmpty();
+    }
+
+    [Test]
+    public async Task Failed_with_no_reason_token_falls_back_to_the_exit_code_token() {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.Failed(24, null, RecoverySurface.Attention));
+
+        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+
+        await Assert.That(surface.AttentionMessages[0]).Contains("verify_readiness_timeout");
+    }
+
+    // ---- ClassifyForPresentation (the pure routing table, standalone) ----
+
+    [Test]
+    public async Task ClassifyForPresentation_reads_Refused_and_Failed_off_their_own_surface_field() {
+        var (surface1, token1) = AppUnderTest.ClassifyForPresentation(new MutationOutcome.Refused("no_server_configured", RecoverySurface.Attention));
+        await Assert.That(surface1).IsEqualTo(RecoverySurface.Attention);
+        await Assert.That(token1).IsEqualTo("no_server_configured");
+
+        var (surface2, token2) = AppUnderTest.ClassifyForPresentation(new MutationOutcome.Failed(28, "identity_mismatch", RecoverySurface.Takeover));
+        await Assert.That(surface2).IsEqualTo(RecoverySurface.Takeover);
+        await Assert.That(token2).IsEqualTo("identity_mismatch");
+    }
+
+    [Test]
+    public async Task ClassifyForPresentation_success_cases_are_None() {
+        var (surface1, _) = AppUnderTest.ClassifyForPresentation(new MutationOutcome.Succeeded());
+        await Assert.That(surface1).IsEqualTo(RecoverySurface.None);
+
+        var (surface2, _) = AppUnderTest.ClassifyForPresentation(new MutationOutcome.SucceededAfterTimeout());
+        await Assert.That(surface2).IsEqualTo(RecoverySurface.None);
+    }
+
+    // ---- QuiesceLifecycleAndLaneAsync (shutdown composition) ----
+
+    [Test]
+    public async Task QuiesceLifecycleAndLaneAsync_with_nothing_live_completes_immediately() {
+        await AppUnderTest.QuiesceLifecycleAndLaneAsync(null, null).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    sealed class NeverObservation : IDaemonObservation {
+        public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) =>
+            Task.FromResult<ObservedEvidence?>(null);
+    }
+
+    // Proves the shutdown composition actually covers the lane's OWN in-flight work — not just
+    // the controller's gate — since DaemonClientService.StartDaemonAsync calls the lane directly,
+    // never through the controller at all (the reason this composition exists, ruling 6).
+    [Test]
+    public async Task QuiesceLifecycleAndLaneAsync_waits_for_an_in_flight_lane_mutation() {
+        var gate = new TaskCompletionSource<string?>();
+        var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
+        await using var lane = new DaemonMutationLane(
+            new FakeLoginShellProbe { KcapPathBehavior = _ => Task.FromResult<string?>(null) },
+            new OutcomeChannel(),
+            () => "/opt/kcap/bin/kcap",
+            (_, _) => cli,
+            _ => new NeverObservation(),
+            TimeProvider.System);
+
+        var request = new MutationRequest(MutationVerb.StartVerified, "default", "https://kcap.example.com:443", "daemon-a");
+        var runTask = lane.RunAsync(request, CancellationToken.None);
+
+        var quiesced = AppUnderTest.QuiesceLifecycleAndLaneAsync(null, lane);
+        await Task.Delay(50);
+        await Assert.That(quiesced.IsCompleted).IsFalse();
+
+        gate.SetResult("9.9.9");
+        await quiesced.WaitAsync(TimeSpan.FromSeconds(5));
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
@@ -45,8 +45,13 @@ public class AppMutationLaneWiringTests {
 
     [Test]
     public async Task ResolveCliOverrideCore_existing_override_is_absolute_pinned() {
-        var result = AppUnderTest.ResolveCliOverrideCore("./bin/kcap", _ => true, p => $"/abs/{p}");
-        await Assert.That(result).IsEqualTo("/abs/./bin/kcap");
+        // Path.GetTempPath() is a real absolute root on every platform (a Windows leg exercises
+        // this with its own drive/backslash form) — Path.Combine, not a hardcoded Unix literal,
+        // builds both the fake getFullPath's answer and the expectation.
+        var absRoot = Path.Combine(Path.GetTempPath(), "abs-root");
+        var overrideEnv = Path.Combine(".", "bin", "kcap");
+        var result = AppUnderTest.ResolveCliOverrideCore(overrideEnv, _ => true, p => Path.Combine(absRoot, p));
+        await Assert.That(result).IsEqualTo(Path.Combine(absRoot, overrideEnv));
     }
 
     [Test]
@@ -59,8 +64,9 @@ public class AppMutationLaneWiringTests {
     // silently treated as "no override set" via a string-compare ambiguity.
     [Test]
     public async Task ResolveCliOverrideCore_override_literally_named_kcap_is_not_confused_with_the_old_sentinel() {
-        var result = AppUnderTest.ResolveCliOverrideCore("kcap", _ => true, p => $"/abs/{p}");
-        await Assert.That(result).IsEqualTo("/abs/kcap");
+        var absRoot = Path.Combine(Path.GetTempPath(), "abs-root");
+        var result = AppUnderTest.ResolveCliOverrideCore("kcap", _ => true, p => Path.Combine(absRoot, p));
+        await Assert.That(result).IsEqualTo(Path.Combine(absRoot, "kcap"));
     }
 
     // ---- PresentOutcomeAsync: Takeover (round-1 review C-1 / C-2) ----
@@ -262,6 +268,77 @@ public class AppMutationLaneWiringTests {
         await Assert.That(surface2).IsEqualTo(RecoverySurface.None);
     }
 
+    // P2-5 / spec §10: the closed set of AttentionSkew tokens meaning "connected but below the
+    // floor this app requires" — read verbatim off DaemonMutationLane.EvidenceFailureLeg — routes
+    // to Takeover; every other AttentionSkew detail stays non-destructive Attention.
+    [Test]
+    [Arguments("missing_capability_consent_3")]
+    [Arguments("daemon_below_floor")]
+    [Arguments("pre_slice_evidence")]
+    public async Task ClassifyForPresentation_routes_the_closed_set_of_AttentionSkew_tokens_to_Takeover(string token) {
+        var (surface, detail) = AppUnderTest.ClassifyForPresentation(new MutationOutcome.AttentionSkew(token));
+        await Assert.That(surface).IsEqualTo(RecoverySurface.Takeover);
+        await Assert.That(detail).IsEqualTo(token);
+    }
+
+    [Test]
+    [Arguments("server_or_name_mismatch")]
+    [Arguments("identity_inconsistent")]
+    [Arguments("unreachable_with_recorded_owner")]
+    [Arguments("ownership_unknown")]
+    [Arguments("ownership_mismatch")]
+    [Arguments("instance_pid_mismatch")]
+    [Arguments("some_unknown_future_token")]
+    public async Task ClassifyForPresentation_routes_every_other_AttentionSkew_token_to_Attention(string token) {
+        var (surface, detail) = AppUnderTest.ClassifyForPresentation(new MutationOutcome.AttentionSkew(token));
+        await Assert.That(surface).IsEqualTo(RecoverySurface.Attention);
+        await Assert.That(detail).IsEqualTo(token);
+    }
+
+    // ---- PresentOutcomeAsync: AttentionSkew routed to Takeover (P2-5) ----
+
+    [Test]
+    [Arguments("missing_capability_consent_3")]
+    [Arguments("daemon_below_floor")]
+    [Arguments("pre_slice_evidence")]
+    public async Task AttentionSkew_known_token_prompts_takeover_and_accept_issues_Replace_at_envelope_identity(string token) {
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(true) };
+        var envelope = Envelope(new MutationOutcome.AttentionSkew(token));
+        var seen = new List<MutationRequest>();
+        Task<MutationOutcome> RunMutation(MutationRequest r, CancellationToken ct) {
+            seen.Add(r);
+            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        }
+
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, RunMutation, FixedTerminalPath("/usr/bin"), () => "1.2.3", CancellationToken.None);
+
+        await Assert.That(surface.Prompts.Count).IsEqualTo(1);
+        await Assert.That(surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindTakeover);
+        await Assert.That(seen.Count).IsEqualTo(1);
+        await Assert.That(seen[0].Verb).IsEqualTo(MutationVerb.Replace);
+        await Assert.That(seen[0].Profile).IsEqualTo(envelope.Request.Profile);
+        await Assert.That(seen[0].CanonicalServer).IsEqualTo(envelope.Request.CanonicalServer);
+        await Assert.That(seen[0].DaemonName).IsEqualTo(envelope.Request.DaemonName);
+    }
+
+    [Test]
+    [Arguments("server_or_name_mismatch")]
+    [Arguments("ownership_mismatch")]
+    [Arguments("unreachable_with_recorded_owner")]
+    [Arguments("some_unknown_future_token")]
+    public async Task AttentionSkew_other_token_is_attention_only_no_dialog(string token) {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.AttentionSkew(token));
+
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
+
+        await Assert.That(surface.Prompts).IsEmpty();
+        await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
+        await Assert.That(surface.AttentionMessages[0]).Contains(token);
+    }
+
     // ---- ConsumeMutationOutcomesAsync (round-1 review I-1) ----
 
     /// Throws on its FIRST Attention call only, then behaves normally — simulates a presentation
@@ -276,8 +353,11 @@ public class AppMutationLaneWiringTests {
         public Task<bool> ConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) => inner.ConfirmAsync(prompt, ct);
     }
 
+    // P1-2: a presentation failure BEFORE the UI boundary (surface.Attention throwing) must requeue
+    // the envelope for a re-presentation, never Ack-and-drop it — the loop itself survives either
+    // way (never faulted/canceled), but the outcome itself is no longer silently skipped.
     [Test]
-    public async Task ConsumeMutationOutcomesAsync_a_presentation_failure_does_not_kill_the_consumer() {
+    public async Task ConsumeMutationOutcomesAsync_a_presentation_failure_requeues_and_re_presents_then_acks() {
         var inner = new FakeLifecycleSurface();
         var surface = new ThrowOnceOnAttentionSurface(inner);
         var channel = new OutcomeChannel();
@@ -287,14 +367,50 @@ public class AppMutationLaneWiringTests {
             channel, surface, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, cts.Token);
 
         channel.Enqueue(new OutcomeEnvelope(Req(), new MutationOutcome.Failed(1, "boom1", RecoverySurface.Attention)));
-        channel.Enqueue(new OutcomeEnvelope(Req(), new MutationOutcome.Failed(2, "boom2", RecoverySurface.Attention)));
 
-        await WaitUntilAsync(() => inner.AttentionMessages.Count == 1, what: "the second envelope's presentation");
-        await Assert.That(inner.AttentionMessages[0]).Contains("boom2"); // first envelope's presentation threw and was skipped, not fatal
+        // The first attempt throws (pre-presentation) and is requeued at the front, not skipped —
+        // the retry succeeds (ThrowOnceOnAttentionSurface only throws once) and is what actually
+        // reaches the surface.
+        await WaitUntilAsync(() => inner.AttentionMessages.Count == 1, what: "the requeued retry's presentation");
+        await Assert.That(inner.AttentionMessages[0]).Contains("boom1");
+
+        // Channel remains functional afterward: a fresh envelope still presents normally.
+        channel.Enqueue(new OutcomeEnvelope(Req(), new MutationOutcome.Failed(2, "boom2", RecoverySurface.Attention)));
+        await WaitUntilAsync(() => inner.AttentionMessages.Count == 2, what: "the next envelope's presentation");
+        await Assert.That(inner.AttentionMessages[1]).Contains("boom2");
 
         cts.Cancel();
         // The loop's own outer catch swallows shutdown's OperationCanceledException by design
-        // (draining just stops) — the task completes normally, never faulted/canceled.
+        // (draining just stops) — the task completes normally, never faulted/canceled: the loop
+        // survives a presentation failure.
+        await consumerTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // P1-2: the takeover dialog IS the presentation boundary — once ConfirmAsync returns (shown
+    // and answered), a fault in the accept's OWN re-mutation must still Ack, never requeue the
+    // envelope for a second dialog.
+    [Test]
+    public async Task ConsumeMutationOutcomesAsync_a_fault_after_the_takeover_dialog_still_acks_not_requeues() {
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(true) }; // accept
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+        var runMutationCalls = 0;
+        Task<MutationOutcome> ThrowingRunMutation(MutationRequest r, CancellationToken ct) {
+            runMutationCalls++;
+            throw new InvalidOperationException("boom-after-accept");
+        }
+
+        var consumerTask = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, surface, ThrowingRunMutation, FixedTerminalPath("/usr/bin"), () => "1.2.3", cts.Token);
+
+        channel.Enqueue(Envelope(new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover)));
+
+        await WaitUntilAsync(() => runMutationCalls == 1, what: "the accept's re-mutation attempt");
+        await Task.Delay(100); // give a wrongly-requeued re-dialog every chance to fire before asserting it didn't
+        await Assert.That(runMutationCalls).IsEqualTo(1);
+        await Assert.That(surface.Prompts.Count).IsEqualTo(1); // never re-dialogued
+
+        cts.Cancel();
         await consumerTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 

--- a/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
@@ -351,6 +351,7 @@ public class AppMutationLaneWiringTests {
             inner.Attention(message);
         }
         public Task<bool> ConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) => inner.ConfirmAsync(prompt, ct);
+        public Task<bool?> TryConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) => inner.TryConfirmAsync(prompt, ct);
     }
 
     // P1-2: a presentation failure BEFORE the UI boundary (surface.Attention throwing) must requeue
@@ -384,6 +385,37 @@ public class AppMutationLaneWiringTests {
         // (draining just stops) — the task completes normally, never faulted/canceled: the loop
         // survives a presentation failure.
         await consumerTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // P1-2: a ct already cancelled BEFORE the takeover dialog is ever shown (TryConfirmAsync
+    // returns null) must requeue the envelope — never Ack it, never record decline memory for a
+    // dialog the user never saw. A fresh consumer over the same channel still gets to present it.
+    [Test]
+    public async Task ConsumeMutationOutcomesAsync_cancellation_before_the_takeover_dialog_requeues_and_records_no_decline() {
+        var surface = new FakeLifecycleSurface();
+        var channel = new OutcomeChannel();
+        using var cancelledCts = new CancellationTokenSource();
+
+        channel.Enqueue(Envelope(new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover)));
+        cancelledCts.Cancel(); // cancelled before the consumer ever starts draining this envelope
+
+        await AppUnderTest.ConsumeMutationOutcomesAsync(
+                channel, surface, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, cancelledCts.Token)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(surface.Prompts).IsEmpty(); // the dialog was never shown
+        await Assert.That(surface.StatusMessages).IsEmpty(); // no decline line — never declined, just never shown
+
+        var acceptingSurface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(true) };
+        using var liveCts = new CancellationTokenSource();
+        Task<MutationOutcome> AcceptMutation(MutationRequest r, CancellationToken ct) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        var secondConsumer = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, acceptingSurface, AcceptMutation, FixedTerminalPath("/usr/bin"), () => null, liveCts.Token);
+
+        await WaitUntilAsync(() => acceptingSurface.Prompts.Count == 1, what: "the requeued envelope's real presentation");
+
+        liveCts.Cancel();
+        await secondConsumer.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     // P1-2: the takeover dialog IS the presentation boundary — once ConfirmAsync returns (shown

--- a/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
@@ -5,60 +5,132 @@ using AppUnderTest = Capacitor.App.App;
 namespace Capacitor.App.Tests.Unit;
 
 /// Task 10: the composition-root helpers wiring the mutation lane into App.axaml.cs — the
-/// outcome-channel presentation routing, the cliOverride null-remap, and the shutdown
-/// quiesce composition. Plain TUnit, no Avalonia session needed (these are pure/async functions
-/// over interfaces and fakes — FakeLifecycleSurface/FakeKcapCli/FakeLoginShellProbe are shared
-/// from DaemonLifecycleControllerTests.cs, same namespace).
+/// outcome-channel presentation routing, the cliOverride absolute-pin resolution, and the
+/// shutdown quiesce composition. Plain TUnit, no Avalonia session needed (these are pure/async
+/// functions over interfaces and fakes — FakeLifecycleSurface/FakeKcapCli/FakeLoginShellProbe are
+/// shared from DaemonLifecycleControllerTests.cs, same namespace).
 public class AppMutationLaneWiringTests {
-    // ---- ResolveCliOverride's testable core ----
+    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    static MutationRequest Req(MutationVerb verb = MutationVerb.StartVerified) =>
+        new(verb, "default", "https://kcap.example.com:443", "daemon-a");
+
+    static OutcomeEnvelope Envelope(MutationOutcome outcome, MutationVerb verb = MutationVerb.StartVerified) =>
+        new(Req(verb), outcome);
+
+    // A tripwire for "must not be called" assertions — round-1 review C-1's Decline case, and
+    // every non-Takeover branch, must never re-mutate.
+    static Task<MutationOutcome> NeverRunMutation(MutationRequest request, CancellationToken ct) =>
+        throw new InvalidOperationException("runMutation must not be called");
+
+    static Func<CancellationToken, Task<string?>> FixedTerminalPath(string? path) => _ => Task.FromResult(path);
+
+    // ---- ResolveCliOverrideCore (round-1 review M-4) ----
 
     [Test]
-    public async Task MapBareKcapToNull_maps_the_unset_fallback_to_null() {
-        await Assert.That(AppUnderTest.MapBareKcapToNull("kcap")).IsNull();
+    public async Task ResolveCliOverrideCore_no_override_is_null() {
+        await Assert.That(AppUnderTest.ResolveCliOverrideCore(null, _ => true, p => p)).IsNull();
     }
 
     [Test]
-    public async Task MapBareKcapToNull_passes_a_real_override_through_verbatim() {
-        await Assert.That(AppUnderTest.MapBareKcapToNull("/opt/kcap/kcap")).IsEqualTo("/opt/kcap/kcap");
+    public async Task ResolveCliOverrideCore_empty_override_is_null() {
+        await Assert.That(AppUnderTest.ResolveCliOverrideCore("", _ => true, p => p)).IsNull();
     }
 
     [Test]
-    public async Task MapBareKcapToNull_passes_a_broken_override_null_through() {
-        // CliResolver.ResolvePath already reports a broken override as null — must stay null, not "kcap".
-        await Assert.That(AppUnderTest.MapBareKcapToNull(null)).IsNull();
+    public async Task ResolveCliOverrideCore_existing_override_is_absolute_pinned() {
+        var result = AppUnderTest.ResolveCliOverrideCore("./bin/kcap", _ => true, p => $"/abs/{p}");
+        await Assert.That(result).IsEqualTo("/abs/./bin/kcap");
     }
 
-    // ---- PresentOutcomeAsync / ClassifyForPresentation ----
+    [Test]
+    public async Task ResolveCliOverrideCore_broken_override_is_null_fail_closed() {
+        await Assert.That(AppUnderTest.ResolveCliOverrideCore("/opt/kcap/kcap", _ => false, p => p)).IsNull();
+    }
 
-    static OutcomeEnvelope Envelope(MutationOutcome outcome) =>
-        new(new MutationRequest(MutationVerb.StartVerified, "default", "https://kcap.example.com:443", "daemon-a"), outcome);
+    // The whole point of M-4: a real override whose value happens to equal the OLD no-override
+    // sentinel string ("kcap") must still resolve as a real, absolute-pinned override — not be
+    // silently treated as "no override set" via a string-compare ambiguity.
+    [Test]
+    public async Task ResolveCliOverrideCore_override_literally_named_kcap_is_not_confused_with_the_old_sentinel() {
+        var result = AppUnderTest.ResolveCliOverrideCore("kcap", _ => true, p => $"/abs/{p}");
+        await Assert.That(result).IsEqualTo("/abs/kcap");
+    }
+
+    // ---- PresentOutcomeAsync: Takeover (round-1 review C-1 / C-2) ----
 
     [Test]
-    public async Task Takeover_surface_shows_the_dialog_and_names_the_token() {
+    public async Task Takeover_accept_issues_exactly_one_Replace_request_at_the_envelopes_own_identity() {
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(true) };
+        var envelope = Envelope(new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover));
+        var seen = new List<MutationRequest>();
+        Task<MutationOutcome> RunMutation(MutationRequest r, CancellationToken ct) {
+            seen.Add(r);
+            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        }
+
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, RunMutation, FixedTerminalPath("/usr/bin:/bin"), () => "1.2.3", CancellationToken.None);
+
+        await Assert.That(seen.Count).IsEqualTo(1);
+        await Assert.That(seen[0].Verb).IsEqualTo(MutationVerb.Replace);
+        await Assert.That(seen[0].Profile).IsEqualTo(envelope.Request.Profile);
+        await Assert.That(seen[0].CanonicalServer).IsEqualTo(envelope.Request.CanonicalServer);
+        await Assert.That(seen[0].DaemonName).IsEqualTo(envelope.Request.DaemonName);
+        await Assert.That(surface.Prompts.Count).IsEqualTo(1);
+        await Assert.That(surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindTakeover);
+        await Assert.That(surface.Prompts[0].CliVersion).IsEqualTo("1.2.3");
+        await Assert.That(surface.Prompts[0].PathDegraded).IsFalse();
+        await Assert.That(surface.Prompts[0].Disclosure).IsEqualTo(DaemonLifecycleController.TakeoverDisclosure);
+        await Assert.That(surface.StatusMessages).IsEmpty(); // accept never writes Status — the dialog IS the presentation
+    }
+
+    [Test]
+    public async Task Takeover_accept_discloses_PathDegraded_true_and_null_CliVersion_when_unavailable() {
         var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(true) };
         var envelope = Envelope(new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover));
 
-        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded()),
+            FixedTerminalPath(null), () => null, CancellationToken.None);
 
-        await Assert.That(surface.Prompts.Count).IsEqualTo(1);
-        await Assert.That(surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindTakeover);
-        await Assert.That(surface.Prompts[0].Disclosure).IsEqualTo(DaemonLifecycleController.TakeoverDisclosure);
+        await Assert.That(surface.Prompts[0].PathDegraded).IsTrue();
+        await Assert.That(surface.Prompts[0].CliVersion).IsNull();
+    }
+
+    [Test]
+    public async Task Takeover_decline_issues_no_request_and_exactly_one_status_line_naming_the_token() {
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(false) };
+        var envelope = Envelope(new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover));
+
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => "1.2.3", CancellationToken.None);
+
         await Assert.That(surface.StatusMessages.Count).IsEqualTo(1);
         await Assert.That(surface.StatusMessages[0]).Contains("foreign_binary");
         await Assert.That(surface.AttentionMessages).IsEmpty();
     }
 
+    // ---- PresentOutcomeAsync: Reinstall/Attention/Storage (round-1 review C-2b) ----
+
     [Test]
-    public async Task Reinstall_surface_is_a_status_line_naming_the_token_no_dialog() {
+    public async Task Reinstall_surface_is_an_attention_line_naming_the_token_no_dialog_no_status() {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.Failed(28, "package_inconsistent", RecoverySurface.Reinstall));
 
-        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.Prompts).IsEmpty();
-        await Assert.That(surface.StatusMessages.Count).IsEqualTo(1);
-        await Assert.That(surface.StatusMessages[0]).Contains("package_inconsistent");
-        await Assert.That(surface.AttentionMessages).IsEmpty();
+        await Assert.That(surface.StatusMessages).IsEmpty(); // moved OFF the status slot per C-2
+        await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
+        await Assert.That(surface.AttentionMessages[0]).Contains("package_inconsistent");
     }
 
     [Test]
@@ -66,7 +138,8 @@ public class AppMutationLaneWiringTests {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.Failed(1, "internal_error", RecoverySurface.Attention));
 
-        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
         await Assert.That(surface.AttentionMessages[0]).Contains("internal_error");
@@ -79,7 +152,8 @@ public class AppMutationLaneWiringTests {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.Refused("consent_seed_unwritable", RecoverySurface.Storage));
 
-        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
         await Assert.That(surface.AttentionMessages[0]).Contains("consent_seed_unwritable");
@@ -90,7 +164,8 @@ public class AppMutationLaneWiringTests {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.AttentionSkew("ownership_mismatch"));
 
-        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
         await Assert.That(surface.AttentionMessages[0]).Contains("ownership_mismatch");
@@ -101,22 +176,27 @@ public class AppMutationLaneWiringTests {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.AttentionRepair("stale_txn_marker"));
 
-        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
         await Assert.That(surface.AttentionMessages[0]).Contains("stale_txn_marker");
     }
 
+    // round-1 review I-3: UnconfirmedNoAttach IS actionable — one attention presentation naming
+    // the verb (Succeeded/SucceededAfterTimeout still never reach the channel at all).
     [Test]
-    public async Task UnconfirmedNoAttach_is_never_presented() {
+    public async Task UnconfirmedNoAttach_is_presented_once_naming_the_verb() {
         var surface = new FakeLifecycleSurface();
-        var envelope = Envelope(new MutationOutcome.UnconfirmedNoAttach());
+        var envelope = Envelope(new MutationOutcome.UnconfirmedNoAttach(), MutationVerb.DetachedStart);
 
-        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
+        await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
+        await Assert.That(surface.AttentionMessages[0]).Contains("DetachedStart");
         await Assert.That(surface.Prompts).IsEmpty();
         await Assert.That(surface.StatusMessages).IsEmpty();
-        await Assert.That(surface.AttentionMessages).IsEmpty();
     }
 
     [Test]
@@ -124,7 +204,8 @@ public class AppMutationLaneWiringTests {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.Failed(24, null, RecoverySurface.Attention));
 
-        await AppUnderTest.PresentOutcomeAsync(surface, envelope, CancellationToken.None);
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.AttentionMessages[0]).Contains("verify_readiness_timeout");
     }
@@ -149,6 +230,42 @@ public class AppMutationLaneWiringTests {
 
         var (surface2, _) = AppUnderTest.ClassifyForPresentation(new MutationOutcome.SucceededAfterTimeout());
         await Assert.That(surface2).IsEqualTo(RecoverySurface.None);
+    }
+
+    // ---- ConsumeMutationOutcomesAsync (round-1 review I-1) ----
+
+    /// Throws on its FIRST Attention call only, then behaves normally — simulates a presentation
+    /// failure for exactly one envelope.
+    sealed class ThrowOnceOnAttentionSurface(ILifecycleSurface inner) : ILifecycleSurface {
+        bool _thrown;
+        public void Status(string message) => inner.Status(message);
+        public void Attention(string message) {
+            if (!_thrown) { _thrown = true; throw new InvalidOperationException("boom"); }
+            inner.Attention(message);
+        }
+        public Task<bool> ConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) => inner.ConfirmAsync(prompt, ct);
+    }
+
+    [Test]
+    public async Task ConsumeMutationOutcomesAsync_a_presentation_failure_does_not_kill_the_consumer() {
+        var inner = new FakeLifecycleSurface();
+        var surface = new ThrowOnceOnAttentionSurface(inner);
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+
+        var consumerTask = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, surface, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, cts.Token);
+
+        channel.Enqueue(new OutcomeEnvelope(Req(), new MutationOutcome.Failed(1, "boom1", RecoverySurface.Attention)));
+        channel.Enqueue(new OutcomeEnvelope(Req(), new MutationOutcome.Failed(2, "boom2", RecoverySurface.Attention)));
+
+        await WaitUntilAsync(() => inner.AttentionMessages.Count == 1, what: "the second envelope's presentation");
+        await Assert.That(inner.AttentionMessages[0]).Contains("boom2"); // first envelope's presentation threw and was skipped, not fatal
+
+        cts.Cancel();
+        // The loop's own outer catch swallows shutdown's OperationCanceledException by design
+        // (draining just stops) — the task completes normally, never faulted/canceled.
+        await consumerTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     // ---- QuiesceLifecycleAndLaneAsync (shutdown composition) ----
@@ -188,5 +305,57 @@ public class AppMutationLaneWiringTests {
         gate.SetResult("9.9.9");
         await quiesced.WaitAsync(TimeSpan.FromSeconds(5));
         await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // ---- round-1 review I-2: composed real-lane + real-consumer wiring ----
+
+    // This is the test that would have caught C-2's double presentation: a REAL DaemonMutationLane
+    // and a REAL ConsumeMutationOutcomesAsync loop, driving a REAL DaemonLifecycleController's
+    // startup matrix through a fake executor whose install exits with a Takeover-routed coded
+    // failure. Asserts exactly ONE presentation (the takeover dialog, declined -> its one status
+    // line) and that the controller itself made zero direct Attention calls and wrote no OTHER
+    // status line.
+    [Test]
+    public async Task Composed_real_lane_and_consumer_present_exactly_once_and_controller_makes_no_surface_call() {
+        var channel = new OutcomeChannel();
+        var client = new FakeDaemonClientService();
+        var cli = new FakeKcapCli {
+            StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(
+                new ServiceSnapshot("default", false, "not_installed", null, "/opt/kcap/kcapd", null, null, false, false)),
+            InstallVerifiedBehavior = (_, _) => Task.FromResult(new ProcessResult(28, "", "start_gate_reason=foreign_binary", false)),
+        };
+        var probe = new FakeLoginShellProbe();
+        var tempDir = Directory.CreateTempSubdirectory("kcap-composed-").FullName;
+        var store = new AppStateStore(Path.Combine(tempDir, "app-state.json"));
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(false) }; // decline
+
+        try {
+            await using var lane = new DaemonMutationLane(
+                probe, channel, () => "/opt/kcap/bin/kcap",
+                (_, _) => cli,
+                _ => new NeverObservation(),
+                TimeProvider.System);
+
+            await using var controller = new DaemonLifecycleController(
+                client, cli, probe, store, surface, () => Task.FromResult<string?>("default"), TimeProvider.System,
+                "https://kcap.example.com:443", lane.RunAsync);
+
+            using var consumerCts = new CancellationTokenSource();
+            var consumerTask = AppUnderTest.ConsumeMutationOutcomesAsync(
+                channel, surface, lane.RunAsync, probe.TerminalPathAsync, () => controller.CliVersion, consumerCts.Token);
+
+            controller.Start();
+            client.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+
+            await WaitUntilAsync(() => surface.Prompts.Count == 1, what: "the takeover dialog");
+            await Assert.That(surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindTakeover);
+            await Assert.That(surface.StatusMessages.Count).IsEqualTo(1); // the decline's one status line — not doubled
+            await Assert.That(surface.AttentionMessages).IsEmpty(); // the controller made ZERO direct surface calls
+
+            consumerCts.Cancel();
+            await consumerTask.WaitAsync(TimeSpan.FromSeconds(5)); // swallowed by design — completes normally
+        } finally {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort test cleanup */ }
+        }
     }
 }

--- a/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
@@ -184,7 +184,8 @@ public class AppMutationLaneWiringTests {
     }
 
     // round-1 review I-3: UnconfirmedNoAttach IS actionable — one attention presentation naming
-    // the verb (Succeeded/SucceededAfterTimeout still never reach the channel at all).
+    // the verb (Succeeded/SucceededAfterTimeout still never reach the channel at all). round-2
+    // review R2-3: the verb is rendered through a small display map, not MutationVerb.ToString().
     [Test]
     public async Task UnconfirmedNoAttach_is_presented_once_naming_the_verb() {
         var surface = new FakeLifecycleSurface();
@@ -194,9 +195,24 @@ public class AppMutationLaneWiringTests {
             surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
-        await Assert.That(surface.AttentionMessages[0]).Contains("DetachedStart");
+        await Assert.That(surface.AttentionMessages[0]).Contains("daemon start");
         await Assert.That(surface.Prompts).IsEmpty();
         await Assert.That(surface.StatusMessages).IsEmpty();
+    }
+
+    [Test]
+    [Arguments(MutationVerb.Install, "install")]
+    [Arguments(MutationVerb.Replace, "replace")]
+    [Arguments(MutationVerb.StartVerified, "verified start")]
+    [Arguments(MutationVerb.DetachedStart, "daemon start")]
+    public async Task UnconfirmedNoAttach_names_every_verb_via_the_display_map(MutationVerb verb, string expectedDisplay) {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.UnconfirmedNoAttach(), verb);
+
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
+
+        await Assert.That(surface.AttentionMessages[0]).Contains(expectedDisplay);
     }
 
     [Test]
@@ -265,6 +281,97 @@ public class AppMutationLaneWiringTests {
         cts.Cancel();
         // The loop's own outer catch swallows shutdown's OperationCanceledException by design
         // (draining just stops) — the task completes normally, never faulted/canceled.
+        await consumerTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // ---- ConsumeMutationOutcomesAsync: per-run Takeover decline memory (round-2 review R2-2) ----
+
+    [Test]
+    public async Task Decline_then_same_pair_rearrival_is_downgraded_to_one_attention_line_not_a_second_prompt() {
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(false) };
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+
+        var consumerTask = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, surface, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, cts.Token);
+
+        var envelope = Envelope(new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover));
+        channel.Enqueue(envelope);
+        await WaitUntilAsync(() => surface.Prompts.Count == 1, what: "the first takeover dialog");
+        await WaitUntilAsync(() => surface.StatusMessages.Count == 1, what: "the decline status line");
+
+        channel.Enqueue(envelope); // the SAME (request, token) pair re-arrives
+        await WaitUntilAsync(() => surface.AttentionMessages.Count == 1, what: "the downgraded attention presentation");
+        await Assert.That(surface.Prompts.Count).IsEqualTo(1); // no second dialog
+        await Assert.That(surface.AttentionMessages[0]).Contains("foreign_binary");
+
+        cts.Cancel();
+        await consumerTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Decline_then_a_different_reason_token_still_prompts() {
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(false) };
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+
+        var consumerTask = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, surface, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, cts.Token);
+
+        channel.Enqueue(Envelope(new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover)));
+        await WaitUntilAsync(() => surface.Prompts.Count == 1, what: "the first takeover dialog");
+
+        channel.Enqueue(Envelope(new MutationOutcome.Failed(28, "identity_mismatch", RecoverySurface.Takeover))); // a different token
+        await WaitUntilAsync(() => surface.Prompts.Count == 2, what: "a fresh dialog for a different token");
+
+        cts.Cancel();
+        await consumerTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Decline_then_a_different_request_identity_still_prompts() {
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(false) };
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+
+        var consumerTask = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, surface, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, cts.Token);
+
+        channel.Enqueue(new OutcomeEnvelope(Req(), new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover)));
+        await WaitUntilAsync(() => surface.Prompts.Count == 1, what: "the first takeover dialog");
+
+        // Same token, a DIFFERENT daemon identity — must still prompt.
+        var otherIdentity = new MutationRequest(MutationVerb.StartVerified, "default", "https://kcap.example.com:443", "daemon-b");
+        channel.Enqueue(new OutcomeEnvelope(otherIdentity, new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover)));
+        await WaitUntilAsync(() => surface.Prompts.Count == 2, what: "a fresh dialog for a different identity");
+
+        cts.Cancel();
+        await consumerTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Accept_does_not_record_decline_memory_same_pair_rearrival_still_prompts() {
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(true) };
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+        var runCount = 0;
+        Task<MutationOutcome> RunMutation(MutationRequest r, CancellationToken ct) {
+            runCount++;
+            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        }
+
+        var consumerTask = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, surface, RunMutation, FixedTerminalPath("/usr/bin"), () => null, cts.Token);
+
+        var envelope = Envelope(new MutationOutcome.Failed(28, "foreign_binary", RecoverySurface.Takeover));
+        channel.Enqueue(envelope);
+        await WaitUntilAsync(() => surface.Prompts.Count == 1, what: "the first takeover dialog");
+        await WaitUntilAsync(() => runCount == 1, what: "the accept re-mutation");
+
+        channel.Enqueue(envelope); // SAME pair — accept never records memory, so this still prompts
+        await WaitUntilAsync(() => surface.Prompts.Count == 2, what: "a fresh dialog since accept never records memory");
+
+        cts.Cancel();
         await consumerTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
@@ -349,7 +456,7 @@ public class AppMutationLaneWiringTests {
 
             await WaitUntilAsync(() => surface.Prompts.Count == 1, what: "the takeover dialog");
             await Assert.That(surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindTakeover);
-            await Assert.That(surface.StatusMessages.Count).IsEqualTo(1); // the decline's one status line — not doubled
+            await WaitUntilAsync(() => surface.StatusMessages.Count == 1, what: "the decline's one status line");
             await Assert.That(surface.AttentionMessages).IsEmpty(); // the controller made ZERO direct surface calls
 
             consumerCts.Cancel();
@@ -357,5 +464,50 @@ public class AppMutationLaneWiringTests {
         } finally {
             try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort test cleanup */ }
         }
+    }
+
+    // round-2 review R2-4: the accept-variant composed test — a REAL DaemonMutationLane, a REAL
+    // OutcomeChannel, and a REAL ConsumeMutationOutcomesAsync loop; no controller needed (the test
+    // drives the FIRST lane.RunAsync call itself, exactly as DaemonLifecycleController or
+    // DaemonClientService would). The executor's install exits 28/foreign_binary; the surface
+    // fake accepts the takeover dialog; the executor's SUBSEQUENT replace call exits 0 ("returns
+    // success" at the process level). Asserts the second lane request is genuinely Replace at the
+    // SAME identity and that accepting never shows a second dialog (covers accept-through-the-
+    // real-lane, including its own re-entry into RunAsync).
+    [Test]
+    public async Task Composed_accept_re_enters_the_real_lane_as_replace_with_no_second_prompt() {
+        var channel = new OutcomeChannel();
+        var cli = new FakeKcapCli {
+            StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(
+                new ServiceSnapshot("default", false, "not_installed", null, "/opt/kcap/kcapd", null, null, false, false)),
+            InstallVerifiedBehavior = (replace, _) => Task.FromResult(replace
+                ? new ProcessResult(0, "", "", false)
+                : new ProcessResult(28, "", "start_gate_reason=foreign_binary", false)),
+        };
+        var probe = new FakeLoginShellProbe();
+        var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(true) }; // accept
+
+        await using var lane = new DaemonMutationLane(
+            probe, channel, () => "/opt/kcap/bin/kcap",
+            (_, _) => cli,
+            _ => new NeverObservation(),
+            TimeProvider.System);
+
+        using var consumerCts = new CancellationTokenSource();
+        var consumerTask = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, surface, lane.RunAsync, probe.TerminalPathAsync, () => "1.2.3", consumerCts.Token);
+
+        var initialRequest = new MutationRequest(MutationVerb.Install, "default", "https://kcap.example.com:443", "daemon-a");
+        var firstOutcome = await lane.RunAsync(initialRequest, CancellationToken.None);
+        await Assert.That(firstOutcome).IsTypeOf<MutationOutcome.Failed>();
+
+        await WaitUntilAsync(() => surface.Prompts.Count == 1, what: "the takeover dialog");
+        await WaitUntilAsync(() => cli.InstallVerifiedCallCount == 2, what: "the accept's replace call through the SAME real lane");
+        await Assert.That(cli.LastInstallReplace).IsTrue();
+        await Assert.That(surface.Prompts.Count).IsEqualTo(1); // no second dialog
+        await Assert.That(surface.StatusMessages).IsEmpty(); // accept never writes Status
+
+        consumerCts.Cancel();
+        await consumerTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 }

--- a/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
@@ -226,6 +226,20 @@ public class AppMutationLaneWiringTests {
         await Assert.That(surface.AttentionMessages[0]).Contains("verify_readiness_timeout");
     }
 
+    // M2: DigestGate (43) is DaemonCommands' own gate, not a ServiceVerify exit code, but it still
+    // needs a real presentable token when the CLI emits no reason line — falling back to
+    // "verify_unknown_43" would surface a meaningless code to the user.
+    [Test]
+    public async Task Failed_digest_gate_with_no_reason_token_falls_back_to_the_daemon_start_gate_token() {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.Failed(VerifyExitCodes.DigestGate, null, RecoverySurface.Attention));
+
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
+
+        await Assert.That(surface.AttentionMessages[0]).Contains("daemon_start_gate");
+    }
+
     // ---- ClassifyForPresentation (the pure routing table, standalone) ----
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs
@@ -51,6 +51,7 @@ public class AppStartupCarveOutTests {
     [Arguments(GateReason.NoToken)]
     [Arguments(GateReason.TokenUnusableBinding)]
     [Arguments(GateReason.TokenUnusableExpired)]
+    [Arguments(GateReason.EvaluationFailed)]
     public async Task Incomplete_gate_closes_auto_actions_for_every_reason(GateReason reason) {
         await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(new GateResult.Incomplete(reason))).IsTrue();
     }

--- a/test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using AppUnderTest = Capacitor.App.App;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Task 15 decision-2 carve-out: App.StartAsync evaluates OnboardingGate.EvaluateAsync() FIRST and
+/// derives whether the lifecycle graph's auto-actions stay open (Complete) or close permanently
+/// (Incomplete). StartAsync itself needs a real daemon/profile — not a unit-test seam, same reason
+/// AppStartupTests drives extracted statics instead (see that file's own header comment) — so this
+/// exercises the two pure seams App exposes for the carve-out: AutoActionsPermanentlyClosed (the
+/// gate→flag switch) and ResolveConsentFlipIdentity (the ConsentFlipCoordinator identity delegate,
+/// MUST-WIRE 1). DaemonLifecycleControllerTests covers the controller-level ctor param behavior
+/// (fake lane, no gate involved) — this file is the App-level wiring half only.
+///
+/// [NotInParallel]: shares OnboardingGateTests' one real config.json under the assembly-wide
+/// KCAP_CONFIG_DIR (see OnboardingGateGlobalSetup) — same isolation rule, same shared resource.
+[NotInParallel(nameof(OnboardingGateTests))]
+public class AppStartupCarveOutTests {
+    const string ProfileName = "acme";
+    const string ServerUrl = "https://acme.example";
+
+    static string ConfigPath => AppConfig.GetConfigPath();
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+
+    [Before(Test)]
+    public void Cleanup() {
+        if (File.Exists(ConfigPath)) File.Delete(ConfigPath);
+        if (Directory.Exists(TokensDir)) Directory.Delete(TokensDir, recursive: true);
+        AppConfig.ResetResolvedStateForTesting();
+
+        // Same unauthenticated-path test-isolation rule OnboardingGateTests follows: a stray
+        // KCAP_URL/KCAP_PROFILE from the developer's shell must not redirect config resolution.
+        Environment.SetEnvironmentVariable("KCAP_URL", null);
+        Environment.SetEnvironmentVariable("KCAP_PROFILE", null);
+    }
+
+    // ---- AutoActionsPermanentlyClosed: the pure gate→flag switch ----
+
+    [Test]
+    public async Task Complete_gate_keeps_auto_actions_open() {
+        await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(new GateResult.Complete())).IsFalse();
+    }
+
+    [Test]
+    [Arguments(GateReason.NoProfile)]
+    [Arguments(GateReason.InvalidServerUrl)]
+    [Arguments(GateReason.NoToken)]
+    [Arguments(GateReason.TokenUnusableBinding)]
+    [Arguments(GateReason.TokenUnusableExpired)]
+    public async Task Incomplete_gate_closes_auto_actions_for_every_reason(GateReason reason) {
+        await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(new GateResult.Incomplete(reason))).IsTrue();
+    }
+
+    // ---- End-to-end against a REAL OnboardingGate.EvaluateAsync() — the brief's two §10 rows ----
+    // that apply without a wizard: valid URL + no token, and an invalid/non-HTTP URL.
+
+    [Test]
+    public async Task ValidUrl_noToken_fixture_closes_auto_actions() {
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = ServerUrl }));
+
+        var gate = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await Assert.That(gate).IsTypeOf<GateResult.Incomplete>();
+        await Assert.That(((GateResult.Incomplete)gate).Reason).IsEqualTo(GateReason.NoToken);
+        await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(gate)).IsTrue();
+    }
+
+    [Test]
+    public async Task InvalidNonHttpUrl_fixture_closes_auto_actions() {
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = "file:///tmp/x" }));
+
+        var gate = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await Assert.That(gate).IsTypeOf<GateResult.Incomplete>();
+        await Assert.That(((GateResult.Incomplete)gate).Reason).IsEqualTo(GateReason.InvalidServerUrl);
+        await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(gate)).IsTrue();
+    }
+
+    // Symmetric control: a genuinely Complete fixture must NOT close auto-actions.
+    [Test]
+    public async Task Complete_fixture_keeps_auto_actions_open() {
+        var profile = new Profile { ServerUrl = ServerUrl, AuthProvider = new AuthProviderStamp("none", ServerUrl) };
+        WriteConfig(SingleProfileConfig(profile));
+
+        var gate = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await Assert.That(gate).IsTypeOf<GateResult.Complete>();
+        await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(gate)).IsFalse();
+    }
+
+    // ---- ResolveConsentFlipIdentity: MUST-WIRE 1's ConsentFlipCoordinator identity delegate ----
+
+    [Test]
+    public async Task ResolveConsentFlipIdentity_resolves_active_profile_server_and_daemon_name() {
+        var profile = new Profile { ServerUrl = ServerUrl, Daemon = new DaemonSettings { Name = "acme-daemon" } };
+        WriteConfig(SingleProfileConfig(profile));
+
+        var (resolvedProfile, server, daemonName) = AppUnderTest.ResolveConsentFlipIdentity();
+
+        await Assert.That(resolvedProfile).IsEqualTo(ProfileName);
+        await Assert.That(server).IsEqualTo(ServerIdentity.Canonicalize(ServerUrl));
+        await Assert.That(daemonName).IsEqualTo("acme-daemon");
+    }
+
+    // Mirrors ConsentFlipCoordinatorTests' own unparseable-server fallback: Canonicalize(...) is null here.
+    [Test]
+    public async Task ResolveConsentFlipIdentity_falls_back_to_the_raw_server_when_unparseable() {
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = "not a url" }));
+
+        var (_, server, _) = AppUnderTest.ResolveConsentFlipIdentity();
+
+        await Assert.That(server).IsEqualTo("not a url");
+    }
+
+    // No config.json at all: ConfigMutator.LoadPure degrades to a fresh default rather than throwing.
+    [Test]
+    public async Task ResolveConsentFlipIdentity_no_config_file_yields_the_default_profile_with_no_server() {
+        var (resolvedProfile, server, daemonName) = AppUnderTest.ResolveConsentFlipIdentity();
+
+        await Assert.That(resolvedProfile).IsEqualTo("default");
+        await Assert.That(server).IsEqualTo("");
+        await Assert.That(daemonName).IsNotEmpty(); // DaemonNameResolver's OS-username/machine/"daemon" fallback chain
+    }
+
+    static ProfileConfig SingleProfileConfig(Profile profile) =>
+        new() { ActiveProfile = ProfileName, Profiles = new() { [ProfileName] = profile } };
+
+    static void WriteConfig(ProfileConfig config) =>
+        File.WriteAllText(ConfigPath, JsonSerializer.Serialize(config, ProfileConfigJsonContext.Default.ProfileConfig));
+}

--- a/test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs
@@ -126,6 +126,48 @@ public class AppStartupCarveOutTests {
         await Assert.That(daemonName).IsNotEmpty(); // DaemonNameResolver's OS-username/machine/"daemon" fallback chain
     }
 
+    // ---- EvaluateGateSafelyAsync: round-1 review — a gate exception must not brick startup ----
+
+    [Test]
+    public async Task EvaluateGateSafelyAsync_passes_a_successful_result_through_unchanged() {
+        var complete = new GateResult.Complete();
+
+        var result = await AppUnderTest.EvaluateGateSafelyAsync(_ => Task.FromResult<GateResult>(complete), CancellationToken.None);
+
+        await Assert.That(result).IsSameReferenceAs(complete);
+    }
+
+    [Test]
+    public async Task EvaluateGateSafelyAsync_degrades_an_unexpected_exception_to_incomplete() {
+        var result = await AppUnderTest.EvaluateGateSafelyAsync(
+            _ => throw new InvalidOperationException("boom"), CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<GateResult.Incomplete>();
+        await Assert.That(((GateResult.Incomplete)result).Reason).IsEqualTo(GateReason.EvaluationFailed);
+    }
+
+    // A cancellation matching the caller's OWN token is shutdown, not a gate failure — it must
+    // propagate rather than be swallowed into a fabricated Incomplete result.
+    [Test]
+    public async Task EvaluateGateSafelyAsync_rethrows_a_cancellation_matching_the_callers_token() {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            AppUnderTest.EvaluateGateSafelyAsync(_ => throw new OperationCanceledException(), cts.Token));
+    }
+
+    // An OperationCanceledException NOT tied to the caller's token (ct never cancelled) is just
+    // another unexpected exception — it degrades exactly like InvalidOperationException above.
+    [Test]
+    public async Task EvaluateGateSafelyAsync_degrades_an_unrelated_cancellation_to_incomplete() {
+        var result = await AppUnderTest.EvaluateGateSafelyAsync(
+            _ => throw new OperationCanceledException("unrelated"), CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<GateResult.Incomplete>();
+        await Assert.That(((GateResult.Incomplete)result).Reason).IsEqualTo(GateReason.EvaluationFailed);
+    }
+
     static ProfileConfig SingleProfileConfig(Profile profile) =>
         new() { ActiveProfile = ProfileName, Profiles = new() { [ProfileName] = profile } };
 

--- a/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
 using Capacitor.App.ViewModels;
 using Capacitor.App.Views;
 using Capacitor.Cli.Core.LocalIpc;
@@ -190,11 +191,6 @@ public class AppStartupTests {
         await Assert.That(result).IsTrue();
     }
 
-    sealed class NullProcessRunner : IProcessRunner {
-        public Task<ProcessResult> RunAsync(string fileName, string[] args, RunOptions options, CancellationToken ct) =>
-            Task.FromResult(new ProcessResult(0, "", "", false));
-    }
-
     /// Minimal stand-in for LocalControlClient.RunAsync: yields Connecting once, then sits
     /// forever until its ct is cancelled (RestartLoopAsync/DisposeAsync's normal teardown path)
     /// — enough to prove a DaemonClientService actually has a LIVE loop to dispose.
@@ -233,7 +229,7 @@ public class AppStartupTests {
     [NotInParallel("AvaloniaSession")]
     public async Task HandleStartupFailureAsync_disposes_the_live_service_before_showing_the_error_window() {
         var runClient = new ForeverRunClient();
-        var service = new DaemonClientService("daemon-a", runClient.Run, new NullProcessRunner(), "kcap");
+        var service = new DaemonClientService("daemon-a", runClient.Run, _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Refused("cli_not_found", RecoverySurface.Attention)));
         service.Start();
         await WaitUntilAsync(() => runClient.LiveEnumerations >= 1);
 
@@ -257,6 +253,37 @@ public class AppStartupTests {
         await service.DisposeAsync();
     }
 
+    sealed class NeverObservation : IDaemonObservation {
+        public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) => Task.FromResult<ObservedEvidence?>(null);
+    }
+
+    /// Task 10: the lane is disposed too during startup-failure cleanup (last, after
+    /// lifecycle/service — see HandleStartupFailureAsync's own ordering comment) — a disposed
+    /// lane cancels every subsequent RunAsync immediately, the observable proof this step ran.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task HandleStartupFailureAsync_disposes_the_lane() {
+        var lane = new DaemonMutationLane(
+            new FakeLoginShellProbe(), new OutcomeChannel(), () => null,
+            (_, pinnedPath) => new FakeKcapCli { CliPath = pinnedPath },
+            _ => new NeverObservation(), TimeProvider.System);
+
+        var (modeAfterShow, mainWindowAssigned) = await AvaloniaSession.DispatchAsync(async () => {
+            var (desktop, fake) = FakeClassicDesktopLifetime.Create();
+            await AppUnderTest.HandleStartupFailureAsync(
+                desktop, new InvalidOperationException("boom"), service: null, new CancellationTokenSource(), [],
+                lifecycle: null, lane: lane);
+            Dispatcher.UIThread.RunJobs();
+            return (fake.ShutdownMode, fake.MainWindow is not null);
+        });
+
+        await Assert.That(modeAfterShow).IsEqualTo(ShutdownMode.OnExplicitShutdown);
+        await Assert.That(mainWindowAssigned).IsTrue();
+
+        var request = new MutationRequest(MutationVerb.StartVerified, "default", "https://kcap.example.com:443", "daemon-a");
+        await Assert.ThrowsAsync<OperationCanceledException>(() => lane.RunAsync(request, CancellationToken.None));
+    }
+
     /// Regression coverage for a P2 bug found in re-review: TryShutdown() in the DEFERRED
     /// shutdown path (OnShutdownRequested -> DisposeAndShutdownAsync — e.g. Cmd+Q while the
     /// startup-error window is still up) used to be called with no exit code, defaulting to 0 —
@@ -269,7 +296,7 @@ public class AppStartupTests {
     [Test]
     public async Task DisposeAndConfirmShutdownAsync_disposes_then_confirms_then_carries_the_exit_code() {
         var runClient = new ForeverRunClient();
-        var service = new DaemonClientService("daemon-a", runClient.Run, new NullProcessRunner(), "kcap");
+        var service = new DaemonClientService("daemon-a", runClient.Run, _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Refused("cli_not_found", RecoverySurface.Attention)));
         service.Start();
         await WaitUntilAsync(() => runClient.LiveEnumerations >= 1);
 
@@ -294,7 +321,7 @@ public class AppStartupTests {
     [Test]
     public async Task DisposeAndConfirmShutdownAsync_normal_shutdown_carries_exit_code_zero() {
         var runClient = new ForeverRunClient();
-        var service = new DaemonClientService("daemon-a", runClient.Run, new NullProcessRunner(), "kcap");
+        var service = new DaemonClientService("daemon-a", runClient.Run, _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Refused("cli_not_found", RecoverySurface.Attention)));
         service.Start();
         await WaitUntilAsync(() => runClient.LiveEnumerations >= 1);
 

--- a/test/Capacitor.App.Tests.Unit/BootRefusalMarkerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/BootRefusalMarkerTests.cs
@@ -1,0 +1,116 @@
+using Capacitor.App.Services.Mutation;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Attempt-scoped attribution matrix (task-6 brief Step 1) for the app's lane-owned boot-refusal reader.
+[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+public class BootRefusalMarkerTests {
+    const string DaemonName = "boot-refusal-app-test";
+
+    static string Json(string daemonName, string? attemptId) => $$"""
+        {"daemon_name":"{{daemonName}}","token":"server_expectation_mismatch","expectation":"https://s","resolved":"https://t","pid":4242,"instance_id":"inst-1","attempt_id":{{(attemptId is null ? "null" : $"\"{attemptId}\"")}}}
+        """;
+
+    static async Task Run(Func<string, Task> body) {
+        var dir = Directory.CreateTempSubdirectory("boot-refusal-app-").FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        try {
+            await body(dir);
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+        }
+    }
+
+    static void PlantMarker(string content) {
+        var path = BootRefusalMarker.MarkerPath(DaemonName);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+    }
+
+    [Test]
+    public async Task Matching_attempt_is_attributed_and_consumes_the_marker() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, "att-1"));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1");
+
+            await Assert.That(evidence).IsNotNull();
+            await Assert.That(evidence!.AttemptId).IsEqualTo("att-1");
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsFalse();
+        });
+    }
+
+    [Test]
+    public async Task Different_attempt_is_not_attributed_and_marker_is_retained() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, "att-1"));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-2");
+
+            await Assert.That(evidence).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task Null_attempt_id_is_never_attributed() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, null));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1");
+
+            await Assert.That(evidence).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task Corrupt_json_reads_null_and_is_left_in_place() {
+        await Run(async _ => {
+            PlantMarker("{not json");
+
+            await Assert.That(BootRefusalMarker.TryRead(DaemonName)).IsNull();
+            await Assert.That(BootRefusalMarker.TryAttribute(DaemonName, "att-1")).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task Absent_marker_reads_null() {
+        await Run(async _ => {
+            await Assert.That(BootRefusalMarker.TryRead(DaemonName)).IsNull();
+            await Assert.That(BootRefusalMarker.TryAttribute(DaemonName, "att-1")).IsNull();
+        });
+    }
+
+    [Test]
+    public async Task Foreign_daemon_name_inside_the_record_is_never_attributed() {
+        await Run(async _ => {
+            PlantMarker(Json("some-other-daemon", "att-1"));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1");
+
+            await Assert.That(evidence).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task Valid_marker_round_trips_via_TryRead() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, "att-1"));
+
+            var evidence = BootRefusalMarker.TryRead(DaemonName);
+
+            await Assert.That(evidence).IsNotNull();
+            await Assert.That(evidence!.DaemonName).IsEqualTo(DaemonName);
+            await Assert.That(evidence.Token).IsEqualTo("server_expectation_mismatch");
+            await Assert.That(evidence.Expectation).IsEqualTo("https://s");
+            await Assert.That(evidence.Resolved).IsEqualTo("https://t");
+            await Assert.That(evidence.Pid).IsEqualTo(4242);
+            await Assert.That(evidence.InstanceId).IsEqualTo("inst-1");
+            await Assert.That(evidence.AttemptId).IsEqualTo("att-1");
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/BootRefusalMarkerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/BootRefusalMarkerTests.cs
@@ -3,13 +3,19 @@ using Capacitor.Cli.Core;
 
 namespace Capacitor.App.Tests.Unit;
 
-/// Attempt-scoped attribution matrix (task-6 brief Step 1) for the app's lane-owned boot-refusal reader.
+/// Attempt-scoped attribution matrix for the app's lane-owned boot-refusal reader — every
+/// attribution requires a VERIFIABLE identity (schema, attempt/daemon-name/token/pid/instance-id,
+/// and the marker's own Expectation matching the request's canonical server), cross-checked
+/// against the daemon writer's shape (src/Capacitor.Cli.Daemon/Services/BootRefusal.cs).
 [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
 public class BootRefusalMarkerTests {
     const string DaemonName = "boot-refusal-app-test";
+    const string Expectation = "https://s";
 
-    static string Json(string daemonName, string? attemptId) => $$"""
-        {"daemon_name":"{{daemonName}}","token":"server_expectation_mismatch","expectation":"https://s","resolved":"https://t","pid":4242,"instance_id":"inst-1","attempt_id":{{(attemptId is null ? "null" : $"\"{attemptId}\"")}}}
+    static string Json(
+            string daemonName, string? attemptId, int schema = 1, string? expectation = Expectation,
+            string token = "server_expectation_mismatch", int pid = 4242, string? instanceId = "inst-1") => $$"""
+        {"schema":{{schema}},"daemon_name":"{{daemonName}}","token":"{{token}}","expectation":{{(expectation is null ? "null" : $"\"{expectation}\"")}},"resolved":"https://t","pid":{{pid}},"instance_id":{{(instanceId is null ? "null" : $"\"{instanceId}\"")}},"attempt_id":{{(attemptId is null ? "null" : $"\"{attemptId}\"")}}}
         """;
 
     static async Task Run(Func<string, Task> body) {
@@ -29,11 +35,11 @@ public class BootRefusalMarkerTests {
     }
 
     [Test]
-    public async Task Matching_attempt_is_attributed_and_consumes_the_marker() {
+    public async Task Matching_attempt_and_identity_is_attributed_and_consumes_the_marker() {
         await Run(async _ => {
             PlantMarker(Json(DaemonName, "att-1"));
 
-            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1");
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation);
 
             await Assert.That(evidence).IsNotNull();
             await Assert.That(evidence!.AttemptId).IsEqualTo("att-1");
@@ -46,7 +52,7 @@ public class BootRefusalMarkerTests {
         await Run(async _ => {
             PlantMarker(Json(DaemonName, "att-1"));
 
-            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-2");
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-2", Expectation);
 
             await Assert.That(evidence).IsNull();
             await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
@@ -58,7 +64,7 @@ public class BootRefusalMarkerTests {
         await Run(async _ => {
             PlantMarker(Json(DaemonName, null));
 
-            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1");
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation);
 
             await Assert.That(evidence).IsNull();
             await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
@@ -71,7 +77,7 @@ public class BootRefusalMarkerTests {
             PlantMarker("{not json");
 
             await Assert.That(BootRefusalMarker.TryRead(DaemonName)).IsNull();
-            await Assert.That(BootRefusalMarker.TryAttribute(DaemonName, "att-1")).IsNull();
+            await Assert.That(BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation)).IsNull();
             await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
         });
     }
@@ -80,7 +86,7 @@ public class BootRefusalMarkerTests {
     public async Task Absent_marker_reads_null() {
         await Run(async _ => {
             await Assert.That(BootRefusalMarker.TryRead(DaemonName)).IsNull();
-            await Assert.That(BootRefusalMarker.TryAttribute(DaemonName, "att-1")).IsNull();
+            await Assert.That(BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation)).IsNull();
         });
     }
 
@@ -89,7 +95,93 @@ public class BootRefusalMarkerTests {
         await Run(async _ => {
             PlantMarker(Json("some-other-daemon", "att-1"));
 
-            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1");
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation);
+
+            await Assert.That(evidence).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    // ---- P2-4: identity-validation rejection arms, each retaining the marker ----
+
+    [Test]
+    public async Task Wrong_schema_is_never_attributed() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, "att-1", schema: 2));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation);
+
+            await Assert.That(evidence).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task Empty_token_is_never_attributed() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, "att-1", token: ""));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation);
+
+            await Assert.That(evidence).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task NonPositive_pid_is_never_attributed() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, "att-1", pid: 0));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation);
+
+            await Assert.That(evidence).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task Empty_instance_id_is_never_attributed() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, "att-1", instanceId: ""));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation);
+
+            await Assert.That(evidence).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task Null_instance_id_is_never_attributed() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, "att-1", instanceId: null));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation);
+
+            await Assert.That(evidence).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task Expectation_mismatch_against_the_requests_canonical_server_is_never_attributed() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, "att-1", expectation: "https://other"));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation);
+
+            await Assert.That(evidence).IsNull();
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
+        });
+    }
+
+    [Test]
+    public async Task Null_expectation_against_a_real_request_canonical_server_is_never_attributed() {
+        await Run(async _ => {
+            PlantMarker(Json(DaemonName, "att-1", expectation: null));
+
+            var evidence = BootRefusalMarker.TryAttribute(DaemonName, "att-1", Expectation);
 
             await Assert.That(evidence).IsNull();
             await Assert.That(File.Exists(BootRefusalMarker.MarkerPath(DaemonName))).IsTrue();
@@ -104,9 +196,10 @@ public class BootRefusalMarkerTests {
             var evidence = BootRefusalMarker.TryRead(DaemonName);
 
             await Assert.That(evidence).IsNotNull();
-            await Assert.That(evidence!.DaemonName).IsEqualTo(DaemonName);
+            await Assert.That(evidence!.Schema).IsEqualTo(1);
+            await Assert.That(evidence.DaemonName).IsEqualTo(DaemonName);
             await Assert.That(evidence.Token).IsEqualTo("server_expectation_mismatch");
-            await Assert.That(evidence.Expectation).IsEqualTo("https://s");
+            await Assert.That(evidence.Expectation).IsEqualTo(Expectation);
             await Assert.That(evidence.Resolved).IsEqualTo("https://t");
             await Assert.That(evidence.Pid).IsEqualTo(4242);
             await Assert.That(evidence.InstanceId).IsEqualTo("inst-1");

--- a/test/Capacitor.App.Tests.Unit/ConsentFlipClaimsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentFlipClaimsTests.cs
@@ -1,0 +1,193 @@
+using Capacitor.App.Services.Onboarding;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ConsentFlipClaimsTests {
+    static (string ClaimsPath, string ConfigPath) TempPaths() {
+        var dir = Directory.CreateTempSubdirectory("kcap-flipclaims-").FullName;
+        return (Path.Combine(dir, "consent-flip-claims.json"), Path.Combine(dir, "config.json"));
+    }
+
+    static readonly ConsentFlipClaim Claim = new("default", "https://example.test");
+
+    [Test]
+    public async Task Arm_writes_a_durable_file_with_the_key() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+
+        await Assert.That(store.Arm(Claim)).IsTrue();
+        await Assert.That(File.Exists(claimsPath)).IsTrue();
+
+        var reloaded = new ConsentFlipClaims(claimsPath, configPath);
+        await Assert.That(reloaded.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Arm_twice_same_key_yields_one_entry() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+
+        await Assert.That(store.Arm(Claim)).IsTrue();
+        await Assert.That(store.Arm(Claim)).IsTrue();
+
+        await Assert.That(store.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Two_distinct_identities_arm_concurrently_without_clobbering() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+        var a = new ConsentFlipClaim("default", "https://a.example.test");
+        var b = new ConsentFlipClaim("work", "https://b.example.test");
+
+        var results = await Task.WhenAll(Task.Run(() => store.Arm(a)), Task.Run(() => store.Arm(b)));
+
+        await Assert.That(results.All(r => r)).IsTrue();
+        await Assert.That(store.Pending()).IsEquivalentTo([a, b]);
+    }
+
+    [Test]
+    public async Task Consume_with_matching_re_resolve_removes_the_key() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+        store.Arm(Claim);
+
+        var consumed = store.TryConsume(Claim, () => (Claim.Profile, Claim.CanonicalServer, "kcap-daemon"), "kcap-daemon");
+
+        await Assert.That(consumed).IsTrue();
+        await Assert.That(store.Pending()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Consume_with_different_resolved_daemon_name_retains_the_claim() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+        store.Arm(Claim);
+
+        var consumed = store.TryConsume(Claim, () => (Claim.Profile, Claim.CanonicalServer, "other-daemon"), "kcap-daemon");
+
+        await Assert.That(consumed).IsFalse();
+        await Assert.That(store.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Consume_with_different_resolved_server_retains_the_claim() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+        store.Arm(Claim);
+
+        var consumed = store.TryConsume(Claim, () => (Claim.Profile, "https://different.test", "kcap-daemon"), "kcap-daemon");
+
+        await Assert.That(consumed).IsFalse();
+        await Assert.That(store.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Consume_with_different_resolved_profile_retains_the_claim() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+        store.Arm(Claim);
+
+        var consumed = store.TryConsume(Claim, () => ("other-profile", Claim.CanonicalServer, "kcap-daemon"), "kcap-daemon");
+
+        await Assert.That(consumed).IsFalse();
+        await Assert.That(store.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    // Simulates a `kcap config set daemon.name` landing between claim capture and TryConsume: the re-resolve answers with the renamed daemon.
+    [Test]
+    public async Task Rename_injected_between_capture_and_consume_retains_the_claim() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+        store.Arm(Claim);
+
+        var capturedDaemonName = "original-daemon";
+        var liveDaemonNameAfterRename = "renamed-daemon";
+
+        var consumed = store.TryConsume(
+            Claim, () => (Claim.Profile, Claim.CanonicalServer, liveDaemonNameAfterRename), capturedDaemonName);
+
+        await Assert.That(consumed).IsFalse();
+        await Assert.That(store.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Consuming_an_already_absent_claim_is_idempotently_true() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+
+        var consumed = store.TryConsume(Claim, () => (Claim.Profile, Claim.CanonicalServer, "kcap-daemon"), "kcap-daemon");
+
+        await Assert.That(consumed).IsTrue();
+        await Assert.That(store.Pending()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Missing_file_yields_no_pending_claims() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+
+        await Assert.That(store.Pending()).IsEmpty();
+        await Assert.That(store.Quarantine()).IsNull();
+    }
+
+    [Test]
+    public async Task Corrupt_file_is_quarantined_aside_with_content_intact_and_fresh_store_arms_fine() {
+        var (claimsPath, configPath) = TempPaths();
+        File.WriteAllText(claimsPath, "{not json");
+
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+        var pending = store.Pending();
+
+        await Assert.That(pending).IsEmpty();
+        var quarantine = store.Quarantine();
+        await Assert.That(quarantine).IsNotNull();
+        await Assert.That(File.Exists(quarantine!.PreservedPath)).IsTrue();
+        await Assert.That(File.ReadAllText(quarantine.PreservedPath)).IsEqualTo("{not json");
+        await Assert.That(File.Exists(claimsPath)).IsFalse();
+
+        await Assert.That(store.Arm(Claim)).IsTrue();
+        await Assert.That(store.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Second_corruption_after_quarantine_uses_the_next_free_index() {
+        var (claimsPath, configPath) = TempPaths();
+        var dir = Path.GetDirectoryName(claimsPath)!;
+        File.WriteAllText(Path.Combine(dir, "consent-flip-claims.quarantined-0.json"), "pre-existing");
+        File.WriteAllText(claimsPath, "{not json");
+
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+        store.Pending();
+
+        var quarantine = store.Quarantine();
+        await Assert.That(quarantine).IsNotNull();
+        await Assert.That(quarantine!.PreservedPath).IsEqualTo(Path.Combine(dir, "consent-flip-claims.quarantined-1.json"));
+        await Assert.That(File.ReadAllText(Path.Combine(dir, "consent-flip-claims.quarantined-0.json"))).IsEqualTo("pre-existing");
+    }
+
+    [Test]
+    public async Task Write_failure_when_directory_is_read_only_returns_false() {
+        Skip.When(OperatingSystem.IsWindows(), "chmod-based read-only directory is POSIX-only.");
+
+        var dir = Directory.CreateTempSubdirectory("kcap-flipclaims-ro-").FullName;
+        var claimsPath = Path.Combine(dir, "consent-flip-claims.json");
+        var configPath = Path.Combine(dir, "config.json");
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+
+        File.SetUnixFileMode(dir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        try {
+            var ok = store.Arm(Claim);
+            await Assert.That(ok).IsFalse();
+        } finally {
+            File.SetUnixFileMode(dir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    [Test]
+    public async Task Default_constructs_without_touching_the_filesystem() {
+        // Construction only — Default() targets the real user config dir, so arming it would be non-hermetic.
+        var store = ConsentFlipClaims.Default();
+        await Assert.That(store).IsNotNull();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ConsentFlipClaimsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentFlipClaimsTests.cs
@@ -208,6 +208,25 @@ public class ConsentFlipClaimsTests {
         }
     }
 
+    // Codex P2: a future-version file (even with a valid-looking claims array) must be quarantined,
+    // never applied under v1 semantics or rewritten as v1.
+    [Test]
+    public async Task Future_version_file_is_quarantined_even_with_valid_looking_claims() {
+        var (claimsPath, configPath) = TempPaths();
+        var futureVersion = """{"version":2,"claims":[{"profile":"default","server":"https://example.test:443"}]}""";
+        File.WriteAllText(claimsPath, futureVersion);
+
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+        var pending = store.Pending();
+
+        await Assert.That(pending).IsEmpty();
+        var quarantine = store.Quarantine();
+        await Assert.That(quarantine).IsNotNull();
+        await Assert.That(File.Exists(quarantine!.PreservedPath)).IsTrue();
+        await Assert.That(File.ReadAllText(quarantine.PreservedPath)).IsEqualTo(futureVersion);
+        await Assert.That(File.Exists(claimsPath)).IsFalse();
+    }
+
     [Test]
     public async Task Default_constructs_without_touching_the_filesystem() {
         // Construction only — Default() targets the real user config dir, so arming it would be non-hermetic.

--- a/test/Capacitor.App.Tests.Unit/ConsentFlipClaimsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentFlipClaimsTests.cs
@@ -8,7 +8,11 @@ public class ConsentFlipClaimsTests {
         return (Path.Combine(dir, "consent-flip-claims.json"), Path.Combine(dir, "config.json"));
     }
 
-    static readonly ConsentFlipClaim Claim = new("default", "https://example.test");
+    // Already canonical (explicit :443) — M1's defensive Arm canonicalization is idempotent for
+    // an already-canonical caller, so round-tripping this value must not change it. The
+    // deliberately-uncanonical case is covered by Arm_canonicalizes_a_raw_uncanonical_server_url_
+    // so_consuming_with_the_canonical_identity_works below.
+    static readonly ConsentFlipClaim Claim = new("default", "https://example.test:443");
 
     [Test]
     public async Task Arm_writes_a_durable_file_with_the_key() {
@@ -33,12 +37,32 @@ public class ConsentFlipClaimsTests {
         await Assert.That(store.Pending()).IsEquivalentTo([Claim]);
     }
 
+    // M1 (final review): Arm defensively canonicalizes CanonicalServer at entry — a raw/uncanonical
+    // URL armed here must still be found by a later TryConsume that re-resolves to the canonical
+    // identity, or the claim would be stuck pending forever (the stuck-pending bug class this
+    // guards against).
+    [Test]
+    public async Task Arm_canonicalizes_a_raw_uncanonical_server_url_so_consuming_with_the_canonical_identity_works() {
+        var (claimsPath, configPath) = TempPaths();
+        var store = new ConsentFlipClaims(claimsPath, configPath);
+        var raw = new ConsentFlipClaim("default", "HTTPS://Example.TEST:443/");
+        var canonical = new ConsentFlipClaim("default", "https://example.test:443");
+
+        await Assert.That(store.Arm(raw)).IsTrue();
+        await Assert.That(store.Pending()).IsEquivalentTo([canonical]);
+
+        var consumed = store.TryConsume(canonical, () => (canonical.Profile, canonical.CanonicalServer, "kcap-daemon"), "kcap-daemon");
+
+        await Assert.That(consumed).IsTrue();
+        await Assert.That(store.Pending()).IsEmpty();
+    }
+
     [Test]
     public async Task Two_distinct_identities_arm_concurrently_without_clobbering() {
         var (claimsPath, configPath) = TempPaths();
         var store = new ConsentFlipClaims(claimsPath, configPath);
-        var a = new ConsentFlipClaim("default", "https://a.example.test");
-        var b = new ConsentFlipClaim("work", "https://b.example.test");
+        var a = new ConsentFlipClaim("default", "https://a.example.test:443");
+        var b = new ConsentFlipClaim("work", "https://b.example.test:443");
 
         var results = await Task.WhenAll(Task.Run(() => store.Arm(a)), Task.Run(() => store.Arm(b)));
 

--- a/test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs
@@ -119,11 +119,29 @@ public class ConsentFlipCoordinatorTests {
         await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
     }
 
+    // P2-6: a resurrected claim (crash between a successful put and TryConsume) finds the policy
+    // ALREADY "prompt" on a later pass — no put needed, but the claim must still be consumed
+    // idempotently rather than retained forever (which would let a later deliberate operator
+    // allow+zero-rules be re-flipped by the stale claim).
     [Test]
-    public async Task Default_prompt_skips_the_put_and_leaves_the_claim_pending() {
+    public async Task Default_prompt_skips_the_put_and_consumes_the_resurrected_claim() {
         using var h = new Harness();
         h.Claims.Arm(Claim);
         h.Ops.QueueGet(new ConsentPolicyDto("prompt", 30, []));
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Claims.Pending().Count == 0, what: "the resurrected claim to be consumed");
+
+        await Assert.That(h.Ops.PutV2Calls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Default_deny_skips_the_put_and_leaves_the_claim_pending() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Ops.QueueGet(new ConsentPolicyDto("deny", 30, []));
 
         h.Coordinator.Start();
         h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));

--- a/test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs
@@ -168,6 +168,75 @@ public class ConsentFlipCoordinatorTests {
         await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
     }
 
+    // ---- Get/PutV2 throwing (the two-catch shape) ----
+
+    [Test]
+    public async Task Get_throwing_a_mapped_exception_retains_the_claim_and_skips_put() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Ops.QueueGetFailure("daemon_unreachable");
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Ops.GetCalls == 1, what: "the get to run");
+        await WaitUntilAsync(() => h.Coordinator.PassCount >= 1, what: "the pass to settle");
+
+        await Assert.That(h.Ops.PutV2Calls).IsEqualTo(0);
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Get_throwing_an_unmapped_exception_retains_the_claim_and_skips_put() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Ops.QueueGetUnmappedFailure(new InvalidOperationException("boom"));
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Ops.GetCalls == 1, what: "the get to run");
+        await WaitUntilAsync(() => h.Coordinator.PassCount >= 1, what: "the pass to settle");
+
+        await Assert.That(h.Ops.PutV2Calls).IsEqualTo(0);
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Put_throwing_retains_the_claim_without_consuming() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Ops.QueueGet(new ConsentPolicyDto("allow", 30, [])); // factory-looking — the put IS attempted
+        h.Ops.QueuePutV2Failure("daemon_unreachable");
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Ops.PutV2Calls == 1, what: "the put to run");
+        await WaitUntilAsync(() => h.Coordinator.PassCount >= 1, what: "the pass to settle");
+
+        // TryConsume never ran — the real store still holds the key (not merely "false was returned").
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    // ---- ResolveCanonical `?? server` fallback ----
+
+    // An unparseable resolved server can never equal a properly canonicalized claim key, so this
+    // degrades exactly like any other non-matching identity — inert, not a crash.
+    [Test]
+    public async Task Unparseable_resolved_server_falls_back_to_the_raw_value_and_stays_inert() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Resolver.Server = "not a url"; // ServerIdentity.Canonicalize returns null for this
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await Task.Delay(150); // give a wrongly-firing get every chance to appear
+        await Assert.That(h.Ops.GetCalls).IsEqualTo(0);
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
     // ---- §10 rename-injection rows: a rename landing at each point of the sequence must retain ----
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs
@@ -119,22 +119,50 @@ public class ConsentFlipCoordinatorTests {
         await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
     }
 
-    // P2-6: a resurrected claim (crash between a successful put and TryConsume) finds the policy
-    // ALREADY "prompt" on a later pass — no put needed, but the claim must still be consumed
-    // idempotently rather than retained forever (which would let a later deliberate operator
-    // allow+zero-rules be re-flipped by the stale claim).
+    // P2-6/P1-1: a resurrected claim (crash between a successful put and TryConsume) finds the
+    // policy ALREADY "prompt" on a later pass — the identity-conditional put still runs (of the
+    // UNCHANGED prompt policy, a daemon-side no-op) as the only live proof that the daemon
+    // answering Get is genuinely the one named by the currently-resolved identity; only its Ok ack
+    // consumes the claim, idempotently, rather than retaining it forever (which would let a later
+    // deliberate operator allow+zero-rules be re-flipped by the stale claim).
     [Test]
-    public async Task Default_prompt_skips_the_put_and_consumes_the_resurrected_claim() {
+    public async Task Default_prompt_sends_the_idempotent_put_and_consumes_the_resurrected_claim() {
         using var h = new Harness();
         h.Claims.Arm(Claim);
         h.Ops.QueueGet(new ConsentPolicyDto("prompt", 30, []));
+        h.Ops.QueuePutV2(true, null);
 
         h.Coordinator.Start();
         h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
 
         await WaitUntilAsync(() => h.Claims.Pending().Count == 0, what: "the resurrected claim to be consumed");
 
-        await Assert.That(h.Ops.PutV2Calls).IsEqualTo(0);
+        await Assert.That(h.Ops.PutV2Calls).IsEqualTo(1);
+        var put = h.Ops.PutV2Payloads[0];
+        await Assert.That(put.ExpectedName).IsEqualTo("kcap-daemon");
+        await Assert.That(put.ExpectedServerUrl).IsEqualTo(CanonicalServer);
+        await Assert.That(put.Policy.Default).IsEqualTo("prompt"); // unchanged — prompt-over-prompt
+        await Assert.That(put.Policy.PromptTimeoutSeconds).IsEqualTo(30);
+    }
+
+    // The rename hazard P1-1 closes: a pinned client answering Get for a daemon the config has
+    // since renamed away from must not have its "already prompt" reading trusted — the identity
+    // check now lives in the put itself, so an identity_mismatch ack retains the claim exactly
+    // like the factory-flip arm's own ack failure.
+    [Test]
+    public async Task Default_prompt_identity_mismatch_ack_retains_the_claim() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Ops.QueueGet(new ConsentPolicyDto("prompt", 30, []));
+        h.Ops.QueuePutV2(false, "identity_mismatch");
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Ops.PutV2Calls == 1, what: "the put to run");
+        await WaitUntilAsync(() => h.Coordinator.PassCount >= 1, what: "the pass to settle");
+
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs
@@ -1,0 +1,291 @@
+using Capacitor.App.Services;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// spec §6 coordinator path: capability gate → get → factory guard → identity-conditional v2 put
+/// → two-lock conditional clear, against a real `ConsentFlipClaims` on temp paths (so the actual
+/// TryConsume re-resolve/compare logic is exercised, not a mock of it) plus a scripted
+/// `ILocalControlOps` and a scripted resolver.
+public class ConsentFlipCoordinatorTests {
+    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    static readonly string CanonicalServer = ServerIdentity.Canonicalize("https://example.test")!;
+    static readonly ConsentFlipClaim Claim = new("default", CanonicalServer);
+
+    static AttachStatus Connected(params string[] capabilities) =>
+        new(AttachState.Connected, null, capabilities);
+
+    /// Deliberately returns the server in a non-canonical form by default (no explicit port) —
+    /// the happy-path test therefore also proves the coordinator canonicalizes before matching.
+    sealed class ScriptedResolver {
+        public string Profile = "default";
+        public string Server = "https://example.test";
+        public string DaemonName = "kcap-daemon";
+        public int Calls;
+
+        /// Invoked AFTER the return value for this call has been captured, so a hook mutating
+        /// these fields only affects calls that happen afterwards, never the call in progress.
+        public Action<int>? OnCall;
+
+        public (string Profile, string Server, string DaemonName) Resolve() {
+            var n = Interlocked.Increment(ref Calls);
+            var result = (Profile, Server, DaemonName);
+            OnCall?.Invoke(n);
+            return result;
+        }
+    }
+
+    sealed class FakeAppStateStore : IAppStateStore {
+        public AppState State = new();
+
+        public Task<AppState> LoadAsync() => Task.FromResult(State);
+
+        public Task<bool> UpdateAsync(Func<AppState, AppState> mutate) {
+            State = mutate(State);
+            return Task.FromResult(true);
+        }
+    }
+
+    sealed class Harness : IDisposable {
+        public readonly FakeDaemonClientService Client = new();
+        public readonly ScriptedLocalControlOps Ops = new();
+        public readonly FakeLifecycleSurface Surface = new();
+        public readonly FakeAppStateStore Store = new();
+        public readonly ScriptedResolver Resolver = new();
+        public readonly string TempDir = Directory.CreateTempSubdirectory("kcap-flipcoord-").FullName;
+        public readonly ConsentFlipClaims Claims;
+        public readonly ConsentFlipCoordinator Coordinator;
+
+        public Harness() {
+            Claims = new ConsentFlipClaims(
+                Path.Combine(TempDir, "consent-flip-claims.json"), Path.Combine(TempDir, "config.json"));
+            Coordinator = new ConsentFlipCoordinator(
+                Client, Ops, Claims, Resolver.Resolve, Surface, Store, CancellationToken.None);
+        }
+
+        public void Dispose() {
+            try { Directory.Delete(TempDir, recursive: true); } catch { /* best-effort test cleanup */ }
+        }
+    }
+
+    // ---- happy path ----
+
+    [Test]
+    public async Task Connected_with_capability_and_factory_policy_gets_puts_and_consumes() {
+        using var h = new Harness();
+        await Assert.That(h.Claims.Arm(Claim)).IsTrue();
+        h.Ops.QueueGet(new ConsentPolicyDto("allow", 30, []));
+        h.Ops.QueuePutV2(true, null);
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Claims.Pending().Count == 0, what: "the claim to be consumed");
+
+        await Assert.That(h.Ops.GetCalls).IsEqualTo(1);
+        await Assert.That(h.Ops.PutV2Calls).IsEqualTo(1);
+        var put = h.Ops.PutV2Payloads[0];
+        await Assert.That(put.ExpectedName).IsEqualTo("kcap-daemon");
+        await Assert.That(put.ExpectedServerUrl).IsEqualTo(CanonicalServer);
+        await Assert.That(put.Policy.Default).IsEqualTo("prompt");
+        await Assert.That(put.Policy.PromptTimeoutSeconds).IsEqualTo(30);
+        await Assert.That(put.Policy.Rules).IsEmpty();
+    }
+
+    // ---- factory guard ----
+
+    [Test]
+    public async Task Policy_with_rules_skips_the_put_and_leaves_the_claim_pending() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Ops.QueueGet(new ConsentPolicyDto("allow", 30, [new ConsentRuleDto("allow", "someone", null, null, null)]));
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Ops.GetCalls == 1, what: "the get to run");
+        await WaitUntilAsync(() => h.Coordinator.PassCount >= 1, what: "the pass to settle");
+
+        await Assert.That(h.Ops.PutV2Calls).IsEqualTo(0);
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Default_prompt_skips_the_put_and_leaves_the_claim_pending() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Ops.QueueGet(new ConsentPolicyDto("prompt", 30, []));
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Ops.GetCalls == 1, what: "the get to run");
+        await WaitUntilAsync(() => h.Coordinator.PassCount >= 1, what: "the pass to settle");
+
+        await Assert.That(h.Ops.PutV2Calls).IsEqualTo(0);
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    // ---- capability gate ----
+
+    [Test]
+    public async Task Missing_consent3_capability_does_nothing() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected("consent/2"));
+
+        await Task.Delay(150); // give a wrongly-firing get every chance to appear
+        await Assert.That(h.Ops.GetCalls).IsEqualTo(0);
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    // ---- ack failure ----
+
+    [Test]
+    public async Task IdentityMismatch_ack_retains_the_claim() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Ops.QueueGet(new ConsentPolicyDto("allow", 30, []));
+        h.Ops.QueuePutV2(false, "identity_mismatch");
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Ops.PutV2Calls == 1, what: "the put to run");
+        await WaitUntilAsync(() => h.Coordinator.PassCount >= 1, what: "the pass to settle");
+
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    // ---- §10 rename-injection rows: a rename landing at each point of the sequence must retain ----
+
+    [Test]
+    public async Task Rename_landing_right_after_the_initial_resolve_retains_the_claim() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Resolver.OnCall = n => { if (n == 1) h.Resolver.DaemonName = "renamed-daemon"; };
+        h.Ops.QueueGet(new ConsentPolicyDto("allow", 30, []));
+        h.Ops.QueuePutV2(true, null);
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Coordinator.PassCount >= 1, what: "the pass to settle");
+
+        // The put itself still used the ORIGINALLY resolved name (captured once, before the rename) —
+        // only the later conditional-clear re-resolve observes the rename and retains the claim.
+        await Assert.That(h.Ops.PutV2Calls).IsEqualTo(1);
+        await Assert.That(h.Ops.PutV2Payloads[0].ExpectedName).IsEqualTo("kcap-daemon");
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Rename_landing_after_get_before_put_retains_the_claim() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        var getTcs = h.Ops.ArmGet();
+        h.Ops.QueuePutV2(true, null);
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Ops.GetCalls == 1, what: "the get to be issued");
+        h.Resolver.DaemonName = "renamed-daemon"; // lands while the get round-trip is outstanding
+        getTcs.SetResult(new ConsentPolicyDto("allow", 30, []));
+
+        await WaitUntilAsync(() => h.Coordinator.PassCount >= 1, what: "the pass to settle");
+
+        await Assert.That(h.Ops.PutV2Calls).IsEqualTo(1);
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    [Test]
+    public async Task Rename_landing_after_put_before_consume_retains_the_claim() {
+        using var h = new Harness();
+        h.Claims.Arm(Claim);
+        h.Ops.QueueGet(new ConsentPolicyDto("allow", 30, []));
+        var putTcs = h.Ops.ArmPutV2();
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await WaitUntilAsync(() => h.Ops.PutV2Calls == 1, what: "the put to be issued");
+        h.Resolver.DaemonName = "renamed-daemon"; // lands while the put round-trip is outstanding
+        putTcs.SetResult(new ConsentAckDto(true, null, null));
+
+        await WaitUntilAsync(() => h.Coordinator.PassCount >= 1, what: "the pass to settle");
+
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([Claim]);
+    }
+
+    // ---- non-matching claim ----
+
+    [Test]
+    public async Task NonMatching_claim_is_inert() {
+        using var h = new Harness();
+        var other = new ConsentFlipClaim("other-profile", ServerIdentity.Canonicalize("https://other.test")!);
+        h.Claims.Arm(other);
+
+        h.Coordinator.Start();
+        h.Client.StatusSubject.OnNext(Connected(ConsentFlipCoordinator.ConsentV3Capability));
+
+        await Task.Delay(150); // give a wrongly-firing get every chance to appear
+        await Assert.That(h.Ops.GetCalls).IsEqualTo(0);
+        await Assert.That(h.Claims.Pending()).IsEquivalentTo([other]);
+    }
+
+    // ---- quarantine surfacing + ack ----
+
+    [Test]
+    public async Task Quarantine_surfaces_once_as_attention_naming_the_preserved_path() {
+        using var h = new Harness();
+        File.WriteAllText(Path.Combine(h.TempDir, "consent-flip-claims.json"), "{not json");
+
+        h.Coordinator.Start(); // Start()'s own read discovers the corruption — no pre-read needed
+
+        await WaitUntilAsync(() => h.Surface.AttentionMessages.Count == 1, what: "the quarantine attention line");
+        await Assert.That(h.Claims.Quarantine()).IsNotNull();
+        await Assert.That(h.Surface.AttentionMessages[0]).Contains(h.Claims.Quarantine()!.PreservedPath);
+        await Assert.That(h.Surface.AttentionMessages[0]).Contains("kcap daemon consent set-default prompt");
+
+        await Task.Delay(150); // give a duplicate surfacing every chance to appear
+        await Assert.That(h.Surface.AttentionMessages.Count).IsEqualTo(1);
+    }
+
+    // ConsentFlipClaims.Quarantine() is in-memory/per-instance and its evidence (the corrupt file)
+    // is consumed by the first read that discovers it — an actual process restart can never
+    // rediscover the SAME corruption. The behavior under test here is therefore the ack GATE
+    // itself: a fresh coordinator over the SAME long-lived claims store + the now-persisted
+    // AppState must not re-surface, which is exactly what a real relaunch (fresh coordinator,
+    // durable AppState, in-memory ConsentFlipClaims singleton) would observe.
+    [Test]
+    public async Task Acked_quarantine_is_not_re_surfaced_by_a_fresh_coordinator() {
+        using var h = new Harness();
+        File.WriteAllText(Path.Combine(h.TempDir, "consent-flip-claims.json"), "{not json");
+
+        h.Coordinator.Start();
+        await WaitUntilAsync(() => h.Surface.AttentionMessages.Count == 1, what: "the first surfacing");
+
+        await Assert.That(await h.Coordinator.AckQuarantineAsync()).IsTrue();
+        await Assert.That(h.Store.State.ConsentQuarantineAcked).IsTrue();
+
+        var freshSurface = new FakeLifecycleSurface();
+        var freshCoordinator = new ConsentFlipCoordinator(
+            h.Client, h.Ops, h.Claims, h.Resolver.Resolve, freshSurface, h.Store, CancellationToken.None);
+        freshCoordinator.Start();
+
+        await Task.Delay(150); // give a wrongly-firing re-surfacing every chance to appear
+        await Assert.That(freshSurface.AttentionMessages).IsEmpty();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
@@ -97,6 +97,19 @@ public class DaemonClientServiceTests {
             () => svc.Agents.Keys.OrderBy(k => k, StringComparer.Ordinal).SequenceEqual(expectedSortedIds, StringComparer.Ordinal),
             what: $"Agents cache to equal [{string.Join(", ", expectedSortedIds)}]");
 
+    // P1-3(b): ProfileName is exposed verbatim (or null, when unresolved) so LiveGraphObservation's
+    // identity gate can compare against a request's Profile — additive, so the 3-arg constructor
+    // callers above/below keep compiling unchanged.
+    [Test]
+    public async Task ProfileName_defaults_to_null_and_is_exposed_verbatim_when_provided() {
+        var script = new Script();
+        await using var noProfile = new DaemonClientService("daemon-a", script.Run, NoOpStart());
+        await Assert.That(noProfile.ProfileName).IsNull();
+
+        await using var withProfile = new DaemonClientService("daemon-a", script.Run, NoOpStart(), profileName: "work");
+        await Assert.That(withProfile.ProfileName).IsEqualTo("work");
+    }
+
     [Test]
     public async Task Initial_status_replays_connecting() {
         var script = new Script();

--- a/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
@@ -97,19 +97,6 @@ public class DaemonClientServiceTests {
             () => svc.Agents.Keys.OrderBy(k => k, StringComparer.Ordinal).SequenceEqual(expectedSortedIds, StringComparer.Ordinal),
             what: $"Agents cache to equal [{string.Join(", ", expectedSortedIds)}]");
 
-    // P1-3(b): ProfileName is exposed verbatim (or null, when unresolved) so LiveGraphObservation's
-    // identity gate can compare against a request's Profile — additive, so the 3-arg constructor
-    // callers above/below keep compiling unchanged.
-    [Test]
-    public async Task ProfileName_defaults_to_null_and_is_exposed_verbatim_when_provided() {
-        var script = new Script();
-        await using var noProfile = new DaemonClientService("daemon-a", script.Run, NoOpStart());
-        await Assert.That(noProfile.ProfileName).IsNull();
-
-        await using var withProfile = new DaemonClientService("daemon-a", script.Run, NoOpStart(), profileName: "work");
-        await Assert.That(withProfile.ProfileName).IsEqualTo("work");
-    }
-
     [Test]
     public async Task Initial_status_replays_connecting() {
         var script = new Script();

--- a/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
@@ -399,6 +399,27 @@ public class DaemonClientServiceTests {
         await WaitUntilAsync(() => script.StartCount > startCountBefore, TimeSpan.FromSeconds(2), what: "restart kick after SucceededAfterTimeout");
     }
 
+    // Blocker 1 (final review): the reattach kick must fire even when the mutation attempt did NOT
+    // succeed — a mutation that restarts the daemon (takeover Replace, StartVerified,
+    // DetachedStart) may have torn down the app's own attach regardless of its own outcome, and
+    // kicking reattach is idempotent.
+    [Test]
+    public async Task StartDaemon_non_success_outcome_still_kicks_restart() {
+        var script = new Script();
+        var fakeStart = new FakeStartDaemon {
+            Behavior = _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Failed(43, "daemon_start_gate", RecoverySurface.Attention)),
+        };
+        await using var svc = new DaemonClientService("daemon-a", script.Run, fakeStart.InvokeAsync);
+        svc.Start();
+        await WaitUntilAsync(() => script.LiveEnumerations >= 1, what: "enumeration to start");
+        var startCountBefore = script.StartCount;
+
+        var result = await svc.StartDaemonAsync(CancellationToken.None);
+
+        await Assert.That(result.Ok).IsFalse();
+        await WaitUntilAsync(() => script.StartCount > startCountBefore, TimeSpan.FromSeconds(2), what: "restart kick after a non-success outcome");
+    }
+
     // Refused("cli_not_found") is the one outcome that must surface the OLD honest "not found"
     // wording verbatim, not the raw coded token — StartDaemonResult.Message is user-facing text.
     [Test]

--- a/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
@@ -133,6 +133,25 @@ public class DaemonClientServiceTests {
         await Assert.That(seen[3]).IsEqualTo(new AttachStatus(AttachState.Connecting, null, null));
     }
 
+    [Test] // Connected's hello-derived identity threads verbatim into AttachStatus
+    public async Task Connected_identity_threads_into_attach_status() {
+        var script = new Script();
+        await using var svc = new DaemonClientService("daemon-a", script.Run, new FakeProcessRunner(), "kcap");
+        svc.Start();
+
+        var seen = new List<AttachStatus>();
+        using var sub = svc.Status.Subscribe(seen.Add);
+        await WaitUntilAsync(() => seen.Count >= 1, what: "initial Connecting status");
+
+        var caps = new List<string> { "status/1" };
+        var snap = Snap("daemon-a", "a1");
+        var identity = new ConnectedIdentity(4242, "inst-xyz", "daemon-a", "1.2.3");
+        script.Feed(new LocalControlEvent.Connected(caps, snap, identity));
+        await WaitUntilAsync(() => seen.Count >= 2, what: "Connected status after Connected event");
+
+        await Assert.That(seen[1]).IsEqualTo(new AttachStatus(AttachState.Connected, null, caps, null, identity));
+    }
+
     [Test] // spec decision 6: hello DaemonVersion propagates Unreachable → AttachStatus
     public async Task Unreachable_daemon_version_propagates_into_attach_status() {
         var script = new Script();

--- a/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
@@ -1,6 +1,8 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.LocalIpc;
 using TUnit.Assertions.Enums;
 
@@ -47,19 +49,26 @@ public class DaemonClientServiceTests {
         }
     }
 
-    sealed class FakeProcessRunner : IProcessRunner {
-        public string? SeenFileName;
-        public string[]? SeenArgs;
-        public RunOptions? SeenOptions;
-        public Func<CancellationToken, Task<ProcessResult>>? Behavior;
+    /// Scripted stand-in for the lane's RunAsync as injected via DaemonClientService's ctor
+    /// (Task 10: the service no longer owns a process runner at all — every
+    /// StartDaemonAsync call goes through exactly this seam).
+    sealed class FakeStartDaemon {
+        public int CallCount;
+        public CancellationToken? SeenCt;
+        public Func<CancellationToken, Task<MutationOutcome>> Behavior =
+            _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
 
-        public Task<ProcessResult> RunAsync(string fileName, string[] args, RunOptions options, CancellationToken ct) {
-            SeenFileName = fileName;
-            SeenArgs     = args;
-            SeenOptions  = options;
-            return (Behavior ?? (_ => Task.FromResult(new ProcessResult(0, "", "", false))))(ct);
+        public Task<MutationOutcome> InvokeAsync(CancellationToken ct) {
+            CallCount++;
+            SeenCt = ct;
+            return Behavior(ct);
         }
     }
+
+    // Filler for tests that never call StartDaemonAsync at all — a benign default that would
+    // fail loudly (wrong outcome type surfacing) rather than silently if it ever were.
+    static Func<CancellationToken, Task<MutationOutcome>> NoOpStart() =>
+        _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
 
     static DaemonStatusDto Snap(string daemon, params string[] ids) {
         var agents = ids.Select(id => new AgentStatusDto(
@@ -91,7 +100,7 @@ public class DaemonClientServiceTests {
     [Test]
     public async Task Initial_status_replays_connecting() {
         var script = new Script();
-        await using var svc = new DaemonClientService("daemon-a", script.Run, new FakeProcessRunner(), "kcap");
+        await using var svc = new DaemonClientService("daemon-a", script.Run, NoOpStart());
         svc.Start();
         await Task.Delay(20); // let the loop actually start before subscribing "late"
 
@@ -105,7 +114,7 @@ public class DaemonClientServiceTests {
     [Test]
     public async Task Event_mapping_is_complete_and_atomic() {
         var script = new Script();
-        await using var svc = new DaemonClientService("daemon-a", script.Run, new FakeProcessRunner(), "kcap");
+        await using var svc = new DaemonClientService("daemon-a", script.Run, NoOpStart());
         svc.Start();
 
         var seen = new List<AttachStatus>();
@@ -136,7 +145,7 @@ public class DaemonClientServiceTests {
     [Test] // Connected's hello-derived identity threads verbatim into AttachStatus
     public async Task Connected_identity_threads_into_attach_status() {
         var script = new Script();
-        await using var svc = new DaemonClientService("daemon-a", script.Run, new FakeProcessRunner(), "kcap");
+        await using var svc = new DaemonClientService("daemon-a", script.Run, NoOpStart());
         svc.Start();
 
         var seen = new List<AttachStatus>();
@@ -155,7 +164,7 @@ public class DaemonClientServiceTests {
     [Test] // spec decision 6: hello DaemonVersion propagates Unreachable → AttachStatus
     public async Task Unreachable_daemon_version_propagates_into_attach_status() {
         var script = new Script();
-        await using var svc = new DaemonClientService("daemon-a", script.Run, new FakeProcessRunner(), "kcap");
+        await using var svc = new DaemonClientService("daemon-a", script.Run, NoOpStart());
         svc.Start();
 
         var seen = new List<AttachStatus>();
@@ -171,7 +180,7 @@ public class DaemonClientServiceTests {
     [Test]
     public async Task No_stale_reconnect() {
         var script = new Script();
-        await using var svc = new DaemonClientService("daemon-a", script.Run, new FakeProcessRunner(), "kcap");
+        await using var svc = new DaemonClientService("daemon-a", script.Run, NoOpStart());
         svc.Start();
 
         // Captures (status, latest Snapshots value, current Agents keys) all read SYNCHRONOUSLY
@@ -247,7 +256,7 @@ public class DaemonClientServiceTests {
         // Not `await using` — DisposeAsync is called explicitly below as the assertion under
         // test, so a second implicit call at scope exit is avoided rather than relied upon to
         // be idempotent.
-        var svc = new DaemonClientService("daemon-a", FaultingThenNormalRun, new FakeProcessRunner(), "kcap");
+        var svc = new DaemonClientService("daemon-a", FaultingThenNormalRun, NoOpStart());
         svc.Start();
 
         // Let the faulting first enumeration run to completion (fault contained, no crash).
@@ -274,7 +283,7 @@ public class DaemonClientServiceTests {
     [Test]
     public async Task Snapshots_is_empty_until_first_and_cache_diffs() {
         var script = new Script();
-        await using var svc = new DaemonClientService("daemon-a", script.Run, new FakeProcessRunner(), "kcap");
+        await using var svc = new DaemonClientService("daemon-a", script.Run, NoOpStart());
         svc.Start();
 
         var snapshots = new List<DaemonStatusDto>();
@@ -303,7 +312,7 @@ public class DaemonClientServiceTests {
     [Test]
     public async Task Cache_retained_on_disconnect() {
         var script = new Script();
-        await using var svc = new DaemonClientService("daemon-a", script.Run, new FakeProcessRunner(), "kcap");
+        await using var svc = new DaemonClientService("daemon-a", script.Run, NoOpStart());
         svc.Start();
 
         var statuses = new List<AttachStatus>();
@@ -328,7 +337,7 @@ public class DaemonClientServiceTests {
     [Test]
     public async Task RestartLoop_is_single_flight() {
         var script = new Script();
-        await using var svc = new DaemonClientService("daemon-a", script.Run, new FakeProcessRunner(), "kcap");
+        await using var svc = new DaemonClientService("daemon-a", script.Run, NoOpStart());
         svc.Start();
         await WaitUntilAsync(() => script.LiveEnumerations >= 1, what: "first enumeration to start");
 
@@ -348,10 +357,10 @@ public class DaemonClientServiceTests {
     }
 
     [Test]
-    public async Task StartDaemon_success_argv_and_restart_kick() {
+    public async Task StartDaemon_success_kicks_restart_no_direct_spawn() {
         var script = new Script();
-        var runner = new FakeProcessRunner { Behavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
-        await using var svc = new DaemonClientService("daemon-a", script.Run, runner, "/opt/kcap");
+        var fakeStart = new FakeStartDaemon { Behavior = _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded()) };
+        await using var svc = new DaemonClientService("daemon-a", script.Run, fakeStart.InvokeAsync);
         svc.Start();
         await WaitUntilAsync(() => script.LiveEnumerations >= 1, what: "enumeration to start");
         var startCountBefore = script.StartCount;
@@ -360,54 +369,133 @@ public class DaemonClientServiceTests {
 
         await Assert.That(result.Ok).IsTrue();
         await Assert.That(result.Message).IsNull();
-        await Assert.That(runner.SeenFileName).IsEqualTo("/opt/kcap");
-        await Assert.That(runner.SeenArgs)
-            .IsEquivalentTo(["daemon", "start", "-d", "--name", "daemon-a"], CollectionOrdering.Matching);
+        // Task 10: the service owns no process runner at all any more — the ONLY way it
+        // can start a daemon is through the injected delegate, exercised exactly once here.
+        await Assert.That(fakeStart.CallCount).IsEqualTo(1);
 
-        // Exit 0 immediately kicks RestartLoopAsync — a NEW enumeration begins without a
-        // manual restart call and without waiting for backoff (StartCount strictly increases,
-        // not just LiveEnumerations dipping and recovering, which would be racy to observe).
+        // A Succeeded outcome immediately kicks RestartLoopAsync — a NEW enumeration begins
+        // without a manual restart call and without waiting for backoff (StartCount strictly
+        // increases, not just LiveEnumerations dipping and recovering, which would be racy).
         await WaitUntilAsync(() => script.StartCount > startCountBefore, TimeSpan.FromSeconds(2), what: "restart kick after successful start");
         await WaitUntilAsync(() => script.LiveEnumerations == 1, what: "single live enumeration after restart kick");
         await Assert.That(script.PeakLiveEnumerations).IsLessThanOrEqualTo(1);
+    }
+
+    // Keep RestartLoopAsync kick on success outcomes INCLUDING SucceededAfterTimeout — the same
+    // rule as the plain Succeeded case above, pinned separately since the two are classified
+    // differently by the lane.
+    [Test]
+    public async Task StartDaemon_succeeded_after_timeout_also_kicks_restart() {
+        var script = new Script();
+        var fakeStart = new FakeStartDaemon { Behavior = _ => Task.FromResult<MutationOutcome>(new MutationOutcome.SucceededAfterTimeout()) };
+        await using var svc = new DaemonClientService("daemon-a", script.Run, fakeStart.InvokeAsync);
+        svc.Start();
+        await WaitUntilAsync(() => script.LiveEnumerations >= 1, what: "enumeration to start");
+        var startCountBefore = script.StartCount;
+
+        var result = await svc.StartDaemonAsync(CancellationToken.None);
+
+        await Assert.That(result.Ok).IsTrue();
+        await WaitUntilAsync(() => script.StartCount > startCountBefore, TimeSpan.FromSeconds(2), what: "restart kick after SucceededAfterTimeout");
+    }
+
+    // Refused("cli_not_found") is the one outcome that must surface the OLD honest "not found"
+    // wording verbatim, not the raw coded token — StartDaemonResult.Message is user-facing text.
+    [Test]
+    public async Task StartDaemon_refused_cli_not_found_surfaces_the_honest_message() {
+        var script = new Script();
+        var fakeStart = new FakeStartDaemon {
+            Behavior = _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Refused("cli_not_found", RecoverySurface.Attention))
+        };
+        await using var svc = new DaemonClientService("daemon-a", script.Run, fakeStart.InvokeAsync);
+
+        var result = await svc.StartDaemonAsync(CancellationToken.None);
+
+        await Assert.That(result.Ok).IsFalse();
+        await Assert.That(result.Message).IsEqualTo("kcap CLI not found");
     }
 
     [Test]
     public async Task StartDaemon_failures_produce_messages() {
         var script = new Script();
 
-        var throwingRunner = new FakeProcessRunner {
-            Behavior = _ => throw new InvalidOperationException("spawn failed")
+        var refused = new FakeStartDaemon {
+            Behavior = _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Refused("no_server_configured", RecoverySurface.Attention))
         };
-        await using (var svc1 = new DaemonClientService("daemon-a", script.Run, throwingRunner, "kcap")) {
+        await using (var svc1 = new DaemonClientService("daemon-a", script.Run, refused.InvokeAsync)) {
             var r1 = await svc1.StartDaemonAsync(CancellationToken.None);
             await Assert.That(r1.Ok).IsFalse();
-            await Assert.That(string.IsNullOrWhiteSpace(r1.Message)).IsFalse();
+            await Assert.That(r1.Message).IsEqualTo("no_server_configured");
         }
 
-        var nonZeroWithStderr = new FakeProcessRunner {
-            Behavior = _ => Task.FromResult(new ProcessResult(1, "", "boom: could not bind socket", false))
+        var failedWithReason = new FakeStartDaemon {
+            Behavior = _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Failed(43, "package_inconsistent", RecoverySurface.Reinstall))
         };
-        await using (var svc2 = new DaemonClientService("daemon-b", script.Run, nonZeroWithStderr, "kcap")) {
+        await using (var svc2 = new DaemonClientService("daemon-b", script.Run, failedWithReason.InvokeAsync)) {
             var r2 = await svc2.StartDaemonAsync(CancellationToken.None);
             await Assert.That(r2.Ok).IsFalse();
-            await Assert.That(string.IsNullOrWhiteSpace(r2.Message)).IsFalse();
+            await Assert.That(r2.Message).IsEqualTo("package_inconsistent");
         }
 
-        var nonZeroEmptyStderr = new FakeProcessRunner {
-            Behavior = _ => Task.FromResult(new ProcessResult(1, "", "", false))
+        var failedNoReason = new FakeStartDaemon {
+            Behavior = _ => Task.FromResult<MutationOutcome>(new MutationOutcome.Failed(1, null, RecoverySurface.Attention))
         };
-        await using (var svc3 = new DaemonClientService("daemon-c", script.Run, nonZeroEmptyStderr, "kcap")) {
+        await using (var svc3 = new DaemonClientService("daemon-c", script.Run, failedNoReason.InvokeAsync)) {
             var r3 = await svc3.StartDaemonAsync(CancellationToken.None);
             await Assert.That(r3.Ok).IsFalse();
-            await Assert.That(string.IsNullOrWhiteSpace(r3.Message)).IsFalse();
+            await Assert.That(r3.Message).IsEqualTo("kcap daemon start exited with code 1");
         }
+    }
+
+    // Task 10: DaemonClientService.BuildStartDaemon is the extracted request-building seam
+    // CreateDefaultAsync wires to the real AppConfig.ResolvedProfile — this drives it directly
+    // against a scripted profile resolver, proving the main-window Start path produces a
+    // DetachedStart MutationRequest through the lane rather than any direct process spawn.
+    [Test]
+    public async Task BuildStartDaemon_produces_a_detached_start_request_at_the_resolved_identity() {
+        MutationRequest? seen = null;
+        Task<MutationOutcome> RunMutation(MutationRequest request, CancellationToken ct) {
+            seen = request;
+            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        }
+
+        var profile = new ResolvedProfile("https://kcap.example.com", "default", null, null);
+        var start = DaemonClientService.BuildStartDaemon("daemon-a", () => profile, RunMutation);
+
+        var outcome = await start(CancellationToken.None);
+
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.Succeeded>();
+        await Assert.That(seen).IsNotNull();
+        await Assert.That(seen!.Verb).IsEqualTo(MutationVerb.DetachedStart);
+        await Assert.That(seen.Profile).IsEqualTo("default");
+        await Assert.That(seen.CanonicalServer).IsEqualTo("https://kcap.example.com:443");
+        await Assert.That(seen.DaemonName).IsEqualTo("daemon-a");
+    }
+
+    // Binding ruling 1: a fresh/broken machine (no resolvable canonical server) must refuse
+    // WITHOUT ever calling runMutation — the guard lives at the request-building boundary, not
+    // inside the lane.
+    [Test]
+    public async Task BuildStartDaemon_no_server_configured_refuses_without_calling_runMutation() {
+        var runMutationCalls = 0;
+        Task<MutationOutcome> RunMutation(MutationRequest request, CancellationToken ct) {
+            runMutationCalls++;
+            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        }
+
+        var start = DaemonClientService.BuildStartDaemon("daemon-a", () => null, RunMutation);
+
+        var outcome = await start(CancellationToken.None);
+
+        await Assert.That(runMutationCalls).IsEqualTo(0);
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.Refused>();
+        await Assert.That(((MutationOutcome.Refused)outcome).Reason).IsEqualTo("no_server_configured");
     }
 
     [Test]
     public async Task Dispose_ends_the_loop_and_disposes_subjects() {
         var script = new Script();
-        var svc = new DaemonClientService("daemon-a", script.Run, new FakeProcessRunner(), "kcap");
+        var svc = new DaemonClientService("daemon-a", script.Run, NoOpStart());
         svc.Start();
         await WaitUntilAsync(() => script.LiveEnumerations >= 1, what: "enumeration to start");
 
@@ -439,7 +527,10 @@ public class DaemonClientServiceTests {
         var startCts = new CancellationTokenSource();
         var runnerEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var runner = new FakeProcessRunner {
+        // Mirrors DaemonMutationLane.RunAsync's real contract: a waiter's own ct abandons ITS
+        // wait (rethrown as OperationCanceledException carrying that same ct) without touching
+        // whatever the owned action is doing — this fake reproduces exactly that shape.
+        var fakeStart = new FakeStartDaemon {
             Behavior = async ct => {
                 runnerEntered.TrySetResult();
                 var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -449,7 +540,7 @@ public class DaemonClientServiceTests {
             }
         };
 
-        var svc = new DaemonClientService("daemon-a", script.Run, runner, "kcap");
+        var svc = new DaemonClientService("daemon-a", script.Run, fakeStart.InvokeAsync);
         svc.Start();
         await WaitUntilAsync(() => script.LiveEnumerations >= 1, what: "enumeration to start");
 

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -195,6 +195,53 @@ public class DaemonLifecycleControllerTests {
         await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
+    // ---- Task 15 decision-2 carve-out: autoActionsPermanentlyClosed ----
+
+    [Test]
+    public async Task AutoActionsClosed_terminal_unreachable_admits_no_startup_matrix_but_still_closes_the_phase() {
+        await using var h = new Harness(autoActionsPermanentlyClosed: true);
+        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap()); // would otherwise auto-install
+        h.Start();
+
+        h.PushUnreachable();
+
+        await h.Controller.PhaseClosed; // must complete even though the matrix never runs
+        await Task.Delay(50); // give a wrongly-firing query/mutation every chance to appear
+        await Assert.That(h.Cli.StatusCallCount).IsEqualTo(0); // RunStartupBranchAsync never admitted
+        await Assert.That(h.Lane.Requests).IsEmpty();
+        await Assert.That(h.Surface.StatusMessages).IsEmpty();
+        await Assert.That(h.Surface.AttentionMessages).IsEmpty();
+    }
+
+    // Closed mode adds no separate arm — a second unreachable stays just as inert as the open-graph one.
+    [Test]
+    public async Task AutoActionsClosed_second_unreachable_stays_inert() {
+        await using var h = new Harness(autoActionsPermanentlyClosed: true);
+        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap());
+        h.Start();
+
+        h.PushUnreachable();
+        await h.Controller.PhaseClosed;
+        h.PushUnreachable();
+        await Task.Delay(50);
+
+        await Assert.That(h.Cli.StatusCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
+    }
+
+    // StartActionAsync is a different code path from RunStartupBranchAsync — closing the latter must not touch it.
+    [Test]
+    public async Task AutoActionsClosed_user_clicked_StartAction_still_routes_through_the_lane() {
+        await using var h = new Harness(autoActionsPermanentlyClosed: true);
+        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap()); // nothing at all — DetachedStart row
+        h.Start();
+
+        await h.Controller.StartActionAsync(CancellationToken.None);
+
+        await Assert.That(h.Lane.Requests.Count).IsEqualTo(1);
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.DetachedStart);
+    }
+
     // ---- txn_active defers the startup matrix (spec §6: wait and re-query, never mutate into a held flock) ----
 
     [Test]
@@ -1280,13 +1327,13 @@ public class DaemonLifecycleControllerTests {
 
         public string? ProfileName = "default";
 
-        public Harness(string? canonicalServer = "https://kcap.example.com:443") {
+        public Harness(string? canonicalServer = "https://kcap.example.com:443", bool autoActionsPermanentlyClosed = false) {
             CanonicalServer = canonicalServer;
             Time  = new TimerCountingTimeProvider(Clock);
             Store = new AppStateStore(Path.Combine(TempDir, "app-state.json"));
             Controller = new DaemonLifecycleController(
                 Client, Cli, Probe, Store, Surface, () => Task.FromResult<string?>(ProfileName), Time,
-                CanonicalServer, Lane.RunAsync);
+                CanonicalServer, Lane.RunAsync, autoActionsPermanentlyClosed);
         }
 
         public void Start() => Controller.Start();

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -1,4 +1,5 @@
 using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Capacitor.App.Tests.Unit;
@@ -7,8 +8,12 @@ namespace Capacitor.App.Tests.Unit;
 /// clock-dependent wait goes through FakeTimeProvider (never Task.Delay-based ordering);
 /// settling between an event push and its effect is driven by WaitUntilAsync polling on the
 /// fakes' call counters (PauseControllerTests/ConsentServiceTests idiom).
+///
+/// Task 10: every mutating branch now routes through a fake lane (FakeMutationLane)
+/// instead of calling IKcapCli's mutation methods directly — FakeKcapCli's
+/// StartVerified/InstallVerified/DetachedStart call counts are kept as a belt-and-braces
+/// regression guard (they must stay 0 everywhere) alongside the new Lane.Requests assertions.
 public class DaemonLifecycleControllerTests {
-    static readonly TimeSpan ConfirmWindow         = DaemonLifecycleController.ConfirmWindow;
     static readonly TimeSpan TxnActiveRequeryDelay = DaemonLifecycleController.TxnActiveRequeryDelay;
 
     static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
@@ -25,9 +30,6 @@ public class DaemonLifecycleControllerTests {
             bool txnActive = false) =>
         new("default", unitPresent, state, binaryPath, installBinaryPath, jobPid, daemonPid, txnMarker, txnActive);
 
-    static ProcessResult Ok(string stdout = "") => new(0, stdout, "", false);
-    static ProcessResult Failed(int exitCode, string stderr) => new(exitCode, "", stderr, false);
-
     // ---- startup matrix rows (§4.2) ----
 
     [Test]
@@ -40,8 +42,7 @@ public class DaemonLifecycleControllerTests {
 
         await WaitUntilAsync(() => h.Cli.StatusCallCount == 1, what: "the matrix status query");
         await h.Controller.PhaseClosed;
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
         await Assert.That(h.Surface.AttentionMessages).IsEmpty();
     }
 
@@ -53,9 +54,12 @@ public class DaemonLifecycleControllerTests {
 
         h.PushUnreachable();
 
-        await WaitUntilAsync(() => h.Cli.StartVerifiedCallCount == 1, what: "service start --verify");
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane's service start --verify request");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.StartVerified);
         await Assert.That(h.Surface.AttentionMessages).IsEmpty();
+        // Never IKcapCli directly — the lane is the ONLY caller of these now.
+        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
     }
 
     [Test]
@@ -68,8 +72,7 @@ public class DaemonLifecycleControllerTests {
 
         await WaitUntilAsync(() => h.Surface.AttentionMessages.Count == 1, what: "the coexistence attention");
         await h.Controller.PhaseClosed;
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
@@ -82,8 +85,7 @@ public class DaemonLifecycleControllerTests {
 
         await WaitUntilAsync(() => h.Surface.AttentionMessages.Count == 1, what: "the orphan-label attention");
         await h.Controller.PhaseClosed;
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
@@ -94,8 +96,8 @@ public class DaemonLifecycleControllerTests {
 
         h.PushUnreachable();
 
-        await WaitUntilAsync(() => h.Cli.StartVerifiedCallCount == 1, what: "service start --verify (bootstrap)");
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane's service start --verify request (bootstrap)");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.StartVerified);
         await Assert.That(h.Surface.AttentionMessages).IsEmpty();
     }
 
@@ -108,8 +110,7 @@ public class DaemonLifecycleControllerTests {
         h.PushUnreachable();
 
         await WaitUntilAsync(() => h.Surface.AttentionMessages.Count == 1, what: "the coexistence attention");
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
@@ -120,9 +121,8 @@ public class DaemonLifecycleControllerTests {
 
         h.PushUnreachable();
 
-        await WaitUntilAsync(() => h.Cli.InstallVerifiedCallCount == 1, what: "service install --verify");
-        await Assert.That(h.Cli.LastInstallReplace).IsNotNull().And.IsEqualTo(false);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane's service install --verify request");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.Install); // never Replace on the silent-install row
         await Assert.That(h.Surface.AttentionMessages).IsEmpty();
     }
 
@@ -137,8 +137,7 @@ public class DaemonLifecycleControllerTests {
         h.PushUnreachable();
 
         await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the honest unrecognized-state line");
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
         await Assert.That(h.Surface.AttentionMessages).IsEmpty();
     }
 
@@ -152,8 +151,7 @@ public class DaemonLifecycleControllerTests {
         h.PushUnreachable();
 
         await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the honest no-profile line");
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
@@ -169,8 +167,7 @@ public class DaemonLifecycleControllerTests {
         await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the honest PATH-unknown line");
         await h.Controller.PhaseClosed;
         await Assert.That(beforePhaseClosed).IsFalse();
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
@@ -182,8 +179,8 @@ public class DaemonLifecycleControllerTests {
 
         h.PushUnreachable();
 
-        await WaitUntilAsync(() => h.Cli.StartVerifiedCallCount == 1, what: "service start --verify despite unknown PATH");
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane request despite unknown PATH");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.StartVerified);
     }
 
     [Test]
@@ -195,8 +192,7 @@ public class DaemonLifecycleControllerTests {
         h.PushUnreachable();
 
         await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the honest no-install-binary line");
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     // ---- txn_active defers the startup matrix (spec §6: wait and re-query, never mutate into a held flock) ----
@@ -213,13 +209,14 @@ public class DaemonLifecycleControllerTests {
 
         h.PushUnreachable();
         await WaitUntilAsync(() => h.Cli.StatusCallCount == 1, what: "the initial matrix query");
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0); // deferred — not mutated into the held flock
+        await Assert.That(h.Lane.Requests).IsEmpty(); // deferred — not mutated into the held flock
 
         await WaitUntilAsync(() => h.Time.TimersCreated >= 1, what: "the txn-active requery timer to be armed");
         h.Clock.Advance(TxnActiveRequeryDelay);
 
         await WaitUntilAsync(() => h.Cli.StatusCallCount == 2, what: "the one bounded requery");
-        await WaitUntilAsync(() => h.Cli.InstallVerifiedCallCount == 1, what: "the matrix proceeding once the flock cleared");
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the matrix proceeding once the flock cleared");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.Install);
     }
 
     [Test]
@@ -235,8 +232,7 @@ public class DaemonLifecycleControllerTests {
 
         await WaitUntilAsync(() => h.Cli.StatusCallCount == 2, what: "the one bounded requery");
         await h.Controller.PhaseClosed;
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     // ---- a racing (meaningfully different) event forces one re-evaluation instead of silence ----
@@ -284,8 +280,7 @@ public class DaemonLifecycleControllerTests {
         await Task.Delay(50); // a negative: give a would-be matrix run every chance to fire
 
         await Assert.That(h.Cli.StatusCallCount).IsEqualTo(1);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
@@ -303,8 +298,7 @@ public class DaemonLifecycleControllerTests {
         await Task.Delay(50);
 
         await Assert.That(h.Cli.StatusCallCount).IsEqualTo(1);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     // ---- once-per-run arm ----
@@ -374,47 +368,127 @@ public class DaemonLifecycleControllerTests {
         await Assert.That(h.Cli.StatusCallCount).IsEqualTo(2);
     }
 
-    // ---- UX confirmation ----
+    // ---- Task 10: routing through the lane ----
 
     [Test]
-    public async Task Successful_mutation_with_fresh_connected_within_window_no_status_message() {
+    public async Task Auto_start_routes_through_the_lane_with_the_pinned_identity() {
         await using var h = new Harness();
+        h.Client.DaemonName = "daemon-xyz";
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        var release = new TaskCompletionSource<ProcessResult>();
-        h.Cli.StartVerifiedBehavior = _ => release.Task;
         h.Start();
 
         h.PushUnreachable();
-        await WaitUntilAsync(() => h.Cli.StartVerifiedCallCount == 1, what: "the start-verify call to begin");
 
-        // A Connected racing the still-in-flight CLI call must still count as "after the
-        // mutation began" — the confirm waiter is armed before `mutate` runs.
-        h.PushConnected();
-        release.SetResult(Ok());
-
-        await WaitUntilAsync(() => h.Client.RestartCount >= 1, what: "the post-mutation reattach kick");
-        await h.Controller.PhaseClosed;
-        await Task.Delay(50); // give a wrongly-firing retry message every chance to appear
-        await Assert.That(h.Surface.StatusMessages).IsEmpty();
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane StartVerified request");
+        var request = h.Lane.Requests[0];
+        await Assert.That(request.Verb).IsEqualTo(MutationVerb.StartVerified);
+        await Assert.That(request.Profile).IsEqualTo("default");
+        await Assert.That(request.CanonicalServer).IsEqualTo(h.CanonicalServer);
+        await Assert.That(request.DaemonName).IsEqualTo("daemon-xyz");
+        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0); // never IKcapCli directly
     }
 
     [Test]
-    public async Task Successful_mutation_without_fresh_connected_times_out_to_retrying_status() {
-        await using var h = new Harness();
+    public async Task No_canonical_server_refuses_without_ever_calling_the_lane() {
+        await using var h = new Harness(canonicalServer: null);
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Cli.StartVerifiedBehavior = _ => Task.FromResult(Ok());
         h.Start();
 
         h.PushUnreachable();
-        await WaitUntilAsync(() => h.Cli.StartVerifiedCallCount == 1, what: "the start-verify call");
-        await WaitUntilAsync(() => h.Time.TimersCreated >= 1, what: "the confirm-window timer to be armed");
-        h.Clock.Advance(ConfirmWindow);
 
-        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the retrying status line");
-        await Assert.That(h.Surface.StatusMessages[0]).Contains("retrying");
-        // No rollback call exists on IKcapCli at all — assert no other call happened.
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.DetachedStartCallCount).IsEqualTo(0);
+        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the no-server status line");
+        await Assert.That(h.Lane.Requests).IsEmpty(); // the guard runs BEFORE the lane is ever touched
+        await Assert.That(h.Surface.StatusMessages[0]).Contains("no_server_configured");
+    }
+
+    // Single-presentation rule: an outcome the lane already routes to the outcome channel
+    // (AttentionSkew, here) must never ALSO be raised directly by the controller.
+    [Test]
+    public async Task AttentionSkew_outcome_does_not_raise_the_controllers_direct_attention_surface() {
+        await using var h = new Harness();
+        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
+        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.AttentionSkew("ownership_mismatch"));
+        h.Start();
+
+        h.PushUnreachable();
+
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane request");
+        await h.Controller.PhaseClosed;
+        await Task.Delay(50); // give a wrongly-firing Attention/Status every chance to appear
+        await Assert.That(h.Surface.AttentionMessages).IsEmpty();
+        await Assert.That(h.Surface.StatusMessages).IsEmpty();
+        await Assert.That(h.Client.RestartCount).IsEqualTo(0); // not a success outcome — no reattach kick
+    }
+
+    // An UnconfirmedNoAttach outcome (the lane's TimedOut classification, spec §3.6) supersedes
+    // the controller's former confirm-window/timeout handling entirely — no local surface call at
+    // all, channel-only, same as every other non-success outcome.
+    [Test]
+    public async Task UnconfirmedNoAttach_outcome_produces_no_controller_surface_call_or_reattach_kick() {
+        await using var h = new Harness();
+        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
+        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.UnconfirmedNoAttach());
+        h.Start();
+
+        h.PushUnreachable();
+
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane request");
+        await h.Controller.PhaseClosed;
+        await Task.Delay(50);
+        await Assert.That(h.Surface.StatusMessages).IsEmpty();
+        await Assert.That(h.Surface.AttentionMessages).IsEmpty();
+        await Assert.That(h.Client.RestartCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Refused_outcome_surfaces_the_honest_reason_as_status_text_only() {
+        await using var h = new Harness();
+        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
+        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Refused("cli_below_floor", RecoverySurface.Attention));
+        h.Start();
+
+        h.PushUnreachable();
+
+        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the refusal status line");
+        await Assert.That(h.Surface.StatusMessages[0]).Contains("cli_below_floor");
+        await Assert.That(h.Surface.AttentionMessages).IsEmpty(); // channel-only, never a direct Attention
+    }
+
+    // ---- UX confirmation ----
+
+    [Test]
+    public async Task Successful_mutation_kicks_restart_no_status_message() {
+        await using var h = new Harness();
+        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
+        var release = new TaskCompletionSource<MutationOutcome>();
+        h.Lane.Behavior = (_, _) => release.Task;
+        h.Start();
+
+        h.PushUnreachable();
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane request to begin");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.StartVerified);
+
+        release.SetResult(new MutationOutcome.Succeeded());
+
+        await WaitUntilAsync(() => h.Client.RestartCount >= 1, what: "the post-mutation reattach kick");
+        await h.Controller.PhaseClosed;
+        await Task.Delay(50); // give a wrongly-firing message every chance to appear
+        await Assert.That(h.Surface.StatusMessages).IsEmpty();
+        await Assert.That(h.Surface.AttentionMessages).IsEmpty();
+    }
+
+    [Test]
+    public async Task SucceededAfterTimeout_also_kicks_restart_no_status_message() {
+        await using var h = new Harness();
+        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
+        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.SucceededAfterTimeout());
+        h.Start();
+
+        h.PushUnreachable();
+
+        await WaitUntilAsync(() => h.Client.RestartCount >= 1, what: "the post-mutation reattach kick");
+        await h.Controller.PhaseClosed;
+        await Assert.That(h.Surface.StatusMessages).IsEmpty();
     }
 
     // ---- coded failure ----
@@ -423,75 +497,33 @@ public class DaemonLifecycleControllerTests {
     public async Task Coded_failure_surfaces_the_verify_token_once() {
         await using var h = new Harness();
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Cli.StartVerifiedBehavior = _ => Task.FromResult(Failed(24, "verify_readiness_timeout: gave up waiting"));
+        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Failed(24, "gave_up_waiting", RecoverySurface.Attention));
         h.Start();
 
         h.PushUnreachable();
 
         await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the coded-failure status line");
-        await Assert.That(h.Surface.StatusMessages[0]).Contains("verify_readiness_timeout");
+        await Assert.That(h.Surface.StatusMessages[0]).Contains("verify_readiness_timeout"); // VerifyExitCodes.Token(24)
+        await Assert.That(h.Surface.StatusMessages[0]).Contains("gave_up_waiting");
+        await Assert.That(h.Surface.AttentionMessages).IsEmpty(); // single-presentation: never also an Attention
 
         h.PushUnreachable(); // once-per-run: no retry
         await Task.Delay(50);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(1);
+        await Assert.That(h.Lane.Requests.Count).IsEqualTo(1);
         await Assert.That(h.Surface.StatusMessages.Count).IsEqualTo(1);
     }
 
-    // ---- Finding 8: forced-kill timeout is never read as a verify outcome (spec §3.6) ----
-
     [Test]
-    public async Task TimedOut_mutation_reQueries_status_and_raises_attention_not_a_status_line() {
-        await using var h = new Harness();
-        var statusCalls = 0;
-        h.Cli.StatusBehavior = _ => {
-            statusCalls++;
-            // First call is the matrix's own classification query (Row5: nothing installed →
-            // install). Second is RunVerifiedMutationAsync's post-timeout re-query.
-            return Task.FromResult<ServiceSnapshot?>(statusCalls == 1 ? Snap() : Snap(txnMarker: true, txnActive: true));
-        };
-        // ExitCode 0 here is deliberate: a killed tree's exit code must never be trusted as Ok.
-        h.Cli.InstallVerifiedBehavior = (_, _) => Task.FromResult(new ProcessResult(0, "", "killed", true));
-        h.Start();
-
-        h.PushUnreachable();
-
-        await WaitUntilAsync(() => h.Cli.InstallVerifiedCallCount == 1, what: "the install attempt");
-        await WaitUntilAsync(() => h.Surface.AttentionMessages.Count == 1, what: "the timeout attention");
-        await Assert.That(h.Surface.AttentionMessages[0]).Contains("txn_marker=True");
-        await Assert.That(h.Surface.AttentionMessages[0]).Contains("txn_active=True");
-        await Assert.That(h.Surface.StatusMessages).IsEmpty(); // never a plain exit-code Status line
-        await Assert.That(statusCalls).IsEqualTo(2);
-    }
-
-    [Test]
-    public async Task TimedOut_mutation_never_kicks_reattach_or_waits_for_confirmation() {
+    public async Task Coded_failure_with_no_reason_token_still_surfaces_the_exit_code_token() {
         await using var h = new Harness();
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Cli.StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(0, "", "killed", true));
+        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Failed(21, null, RecoverySurface.Attention));
         h.Start();
 
         h.PushUnreachable();
 
-        await WaitUntilAsync(() => h.Surface.AttentionMessages.Count == 1, what: "the timeout attention");
-        await h.Controller.PhaseClosed;
-        await Assert.That(h.Client.RestartCount).IsEqualTo(0);
-    }
-
-    [Test]
-    public async Task TimedOut_mutation_status_reQuery_failure_still_raises_attention() {
-        await using var h = new Harness();
-        var statusCalls = 0;
-        h.Cli.StatusBehavior = _ => {
-            statusCalls++;
-            return Task.FromResult<ServiceSnapshot?>(statusCalls == 1 ? Snap() : null);
-        };
-        h.Cli.InstallVerifiedBehavior = (_, _) => Task.FromResult(new ProcessResult(1, "", "killed", true));
-        h.Start();
-
-        h.PushUnreachable();
-
-        await WaitUntilAsync(() => h.Surface.AttentionMessages.Count == 1, what: "the timeout attention despite an unreadable re-query");
-        await Assert.That(h.Surface.StatusMessages).IsEmpty();
+        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the coded-failure status line");
+        await Assert.That(h.Surface.StatusMessages[0]).Contains("verify_viability"); // VerifyExitCodes.Token(21)
     }
 
     // ---- version caching ----
@@ -512,21 +544,18 @@ public class DaemonLifecycleControllerTests {
     public async Task QuiescedAsync_waits_for_an_in_flight_mutation() {
         await using var h = new Harness();
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        var release = new TaskCompletionSource<ProcessResult>();
-        h.Cli.StartVerifiedBehavior = _ => release.Task;
+        var release = new TaskCompletionSource<MutationOutcome>();
+        h.Lane.Behavior = (_, _) => release.Task;
         h.Start();
 
         h.PushUnreachable();
-        await WaitUntilAsync(() => h.Cli.StartVerifiedCallCount == 1, what: "the in-flight mutation");
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the in-flight mutation");
 
         var quiesced = h.Controller.QuiescedAsync();
         await Task.Delay(50);
         await Assert.That(quiesced.IsCompleted).IsFalse();
 
-        // A coded failure skips the confirm-wait entirely (no fake-clock advance needed here —
-        // that phase is covered by the UX-confirmation tests above) so the gate releases as soon
-        // as the CLI child itself finishes.
-        release.SetResult(Failed(24, "verify_readiness_timeout"));
+        release.SetResult(new MutationOutcome.Failed(24, "verify_readiness_timeout", RecoverySurface.Attention));
         await quiesced;
     }
 
@@ -552,8 +581,7 @@ public class DaemonLifecycleControllerTests {
         await h.Controller.StartActionAsync(CancellationToken.None);
 
         await Assert.That(h.Client.RestartCount).IsEqualTo(1);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
@@ -564,27 +592,27 @@ public class DaemonLifecycleControllerTests {
 
         await h.Controller.StartActionAsync(CancellationToken.None);
 
-        await Assert.That(h.Cli.DetachedStartCallCount).IsEqualTo(1);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests.Count).IsEqualTo(1);
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.DetachedStart);
+        // Task 10: DetachedStart from Start now shares the SAME success handling as every other
+        // verb (a strict improvement — it used to be a bare, result-discarding CLI call).
+        await Assert.That(h.Client.RestartCount).IsEqualTo(1);
     }
 
     [Test]
     public async Task StartAction_loaded_plist_present_pid_null_starts_verified() {
         await using var h = new Harness();
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        var release = new TaskCompletionSource<ProcessResult>();
-        h.Cli.StartVerifiedBehavior = _ => release.Task;
+        var release = new TaskCompletionSource<MutationOutcome>();
+        h.Lane.Behavior = (_, _) => release.Task;
         h.Start();
 
         var startTask = h.Controller.StartActionAsync(CancellationToken.None);
-        await WaitUntilAsync(() => h.Cli.StartVerifiedCallCount == 1, what: "service start --verify");
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane StartVerified request");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.StartVerified);
         await Assert.That(h.Surface.Prompts).IsEmpty();
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
 
-        // A coded failure skips the confirm-wait entirely (the UX-confirmation tests above already
-        // cover that phase) so this call — and the test — can complete without a clock advance.
-        release.SetResult(Failed(21, "verify_viability"));
+        release.SetResult(new MutationOutcome.Failed(21, "verify_viability", RecoverySurface.Attention));
         await startTask;
     }
 
@@ -598,7 +626,7 @@ public class DaemonLifecycleControllerTests {
 
         await Assert.That(h.Surface.Prompts.Count).IsEqualTo(1);
         await Assert.That(h.Surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindRepair);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
@@ -611,23 +639,23 @@ public class DaemonLifecycleControllerTests {
 
         await Assert.That(h.Surface.Prompts.Count).IsEqualTo(1);
         await Assert.That(h.Surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindRepair);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
     public async Task StartAction_no_label_plist_present_pid_null_starts_verified_bootstrap() {
         await using var h = new Harness();
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "not_installed"));
-        var release = new TaskCompletionSource<ProcessResult>();
-        h.Cli.StartVerifiedBehavior = _ => release.Task;
+        var release = new TaskCompletionSource<MutationOutcome>();
+        h.Lane.Behavior = (_, _) => release.Task;
         h.Start();
 
         var startTask = h.Controller.StartActionAsync(CancellationToken.None);
-        await WaitUntilAsync(() => h.Cli.StartVerifiedCallCount == 1, what: "service start --verify (bootstrap)");
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane StartVerified request (bootstrap)");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.StartVerified);
         await Assert.That(h.Surface.Prompts).IsEmpty();
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
 
-        release.SetResult(Failed(21, "verify_viability"));
+        release.SetResult(new MutationOutcome.Failed(21, "verify_viability", RecoverySurface.Attention));
         await startTask;
     }
 
@@ -641,26 +669,23 @@ public class DaemonLifecycleControllerTests {
 
         await Assert.That(h.Surface.Prompts.Count).IsEqualTo(1);
         await Assert.That(h.Surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindRepair);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.DetachedStartCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
-    public async Task StartAction_repair_accept_calls_install_verified_replace_true_same_helper_as_takeover() {
+    public async Task StartAction_repair_accept_calls_replace_same_helper_as_takeover() {
         await using var h = new Harness();
         h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed", daemonPid: 555));
-        var release = new TaskCompletionSource<ProcessResult>();
-        h.Cli.InstallVerifiedBehavior = (_, _) => release.Task;
+        var release = new TaskCompletionSource<MutationOutcome>();
+        h.Lane.Behavior = (_, _) => release.Task;
         h.Start();
 
         var startTask = h.Controller.StartActionAsync(CancellationToken.None);
-        await WaitUntilAsync(() => h.Cli.InstallVerifiedCallCount == 1, what: "the repair install");
-        await Assert.That(h.Cli.LastInstallReplace).IsNotNull().And.IsEqualTo(true);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.DetachedStartCallCount).IsEqualTo(0);
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the repair request");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.Replace);
 
-        release.SetResult(Failed(21, "verify_viability"));
+        release.SetResult(new MutationOutcome.Failed(21, "verify_viability", RecoverySurface.Attention));
         await startTask;
     }
 
@@ -673,7 +698,7 @@ public class DaemonLifecycleControllerTests {
 
         await h.Controller.StartActionAsync(CancellationToken.None);
 
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
     }
 
     [Test]
@@ -685,9 +710,7 @@ public class DaemonLifecycleControllerTests {
         await h.Controller.StartActionAsync(CancellationToken.None);
 
         await Assert.That(h.Surface.StatusMessages.Count).IsEqualTo(1);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.DetachedStartCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
         await Assert.That(h.Client.RestartCount).IsEqualTo(0);
     }
 
@@ -701,9 +724,7 @@ public class DaemonLifecycleControllerTests {
         await h.Controller.StartActionAsync(CancellationToken.None);
 
         await Assert.That(h.Surface.StatusMessages.Count).IsEqualTo(1);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.DetachedStartCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
         await Assert.That(h.Client.RestartCount).IsEqualTo(0);
     }
 
@@ -725,13 +746,13 @@ public class DaemonLifecycleControllerTests {
     [Test]
     public async Task StartAction_racing_auto_install_awaits_the_gate_then_reQueries_fresh_evidence() {
         await using var h = new Harness();
-        var install = new TaskCompletionSource<ProcessResult>();
+        var install = new TaskCompletionSource<MutationOutcome>();
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap()); // nothing at all — the install row
-        h.Cli.InstallVerifiedBehavior = (_, _) => install.Task;
+        h.Lane.Behavior = (_, _) => install.Task;
         h.Start();
 
         h.PushUnreachable(); // claims the arm, starts the startup matrix, blocks on the install call
-        await WaitUntilAsync(() => h.Cli.InstallVerifiedCallCount == 1, what: "the startup install to begin (holding the gate)");
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the startup install to begin (holding the gate)");
         var statusCallsBeforeStart = h.Cli.StatusCallCount;
 
         var startTask = h.Controller.StartActionAsync(CancellationToken.None);
@@ -739,10 +760,7 @@ public class DaemonLifecycleControllerTests {
         await Assert.That(startTask.IsCompleted).IsFalse();
         await Assert.That(h.Cli.StatusCallCount).IsEqualTo(statusCallsBeforeStart); // no re-query yet — still blocked
 
-        // A coded failure skips RunVerifiedMutationAsync's confirm-wait entirely (no fake-clock
-        // advance needed — that phase is covered by the UX-confirmation tests), so the gate
-        // releases as soon as this CLI child finishes.
-        install.SetResult(Failed(21, "verify_viability"));
+        install.SetResult(new MutationOutcome.Failed(21, "verify_viability", RecoverySurface.Attention));
         await startTask;
 
         await Assert.That(h.Cli.StatusCallCount).IsGreaterThan(statusCallsBeforeStart); // a fresh query after the gate cleared
@@ -752,18 +770,18 @@ public class DaemonLifecycleControllerTests {
     public async Task QuiescedAsync_waits_for_a_startAction_mutation() {
         await using var h = new Harness();
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        var release = new TaskCompletionSource<ProcessResult>();
-        h.Cli.StartVerifiedBehavior = _ => release.Task;
+        var release = new TaskCompletionSource<MutationOutcome>();
+        h.Lane.Behavior = (_, _) => release.Task;
         h.Start();
 
         var startTask = h.Controller.StartActionAsync(CancellationToken.None);
-        await WaitUntilAsync(() => h.Cli.StartVerifiedCallCount == 1, what: "the Start-triggered mutation");
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the Start-triggered mutation");
 
         var quiesced = h.Controller.QuiescedAsync();
         await Task.Delay(50);
         await Assert.That(quiesced.IsCompleted).IsFalse();
 
-        release.SetResult(Failed(24, "verify_readiness_timeout"));
+        release.SetResult(new MutationOutcome.Failed(24, "verify_readiness_timeout", RecoverySurface.Attention));
         await quiesced;
         await startTask;
     }
@@ -852,7 +870,7 @@ public class DaemonLifecycleControllerTests {
     public async Task Skew_daemon_unreachable_never_prompts() {
         await using var h = new Harness();
         // state:"running" is a no-mutation matrix row (Row1) — a mutating row would block this
-        // test's PhaseClosed wait on the fake-clock confirm window, which nothing here advances.
+        // test's PhaseClosed wait on the lane, which nothing here resolves.
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(state: "running", jobPid: 1, daemonPid: 1));
         h.Start();
         await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
@@ -896,20 +914,18 @@ public class DaemonLifecycleControllerTests {
     }
 
     [Test]
-    public async Task Skew_accept_calls_install_verified_replace_true_and_nothing_else() {
+    public async Task Skew_accept_calls_replace_and_nothing_else() {
         await using var h = new Harness();
         h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Cli.InstallVerifiedBehavior = (_, _) => Task.FromResult(Ok());
+        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
         h.Start();
         await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
 
         h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
 
-        await WaitUntilAsync(() => h.Cli.InstallVerifiedCallCount == 1, what: "the takeover install");
-        await Assert.That(h.Cli.LastInstallReplace).IsNotNull().And.IsEqualTo(true);
-        await Assert.That(h.Cli.StartVerifiedCallCount).IsEqualTo(0);
-        await Assert.That(h.Cli.DetachedStartCallCount).IsEqualTo(0);
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.Replace);
     }
 
     [Test]
@@ -931,7 +947,8 @@ public class DaemonLifecycleControllerTests {
         var client2  = new FakeDaemonClientService();
         var cli2     = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed")) };
         await using var controller2 = new DaemonLifecycleController(
-            client2, cli2, new FakeLoginShellProbe(), h.Store, surface2, () => Task.FromResult<string?>("default"), h.Time);
+            client2, cli2, new FakeLoginShellProbe(), h.Store, surface2, () => Task.FromResult<string?>("default"), h.Time,
+            h.CanonicalServer, new FakeMutationLane().RunAsync);
         controller2.Start();
         await WaitUntilAsync(() => cli2.VersionCallCount == 1, what: "controller2's version cache");
 
@@ -960,7 +977,7 @@ public class DaemonLifecycleControllerTests {
         confirmTcs.SetResult(true); // the user accepts what is now a stale offer
 
         await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the stale-consent abort status");
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
 
         // A stale accept was never a real decline — the claim-before-show pair is retracted...
         var afterAbort = await h.Store.LoadAsync();
@@ -1006,7 +1023,7 @@ public class DaemonLifecycleControllerTests {
         confirmTcs.SetResult(true); // accept — generation is unchanged
 
         await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the reclassification abort status");
-        await Assert.That(h.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+        await Assert.That(h.Lane.Requests).IsEmpty();
 
         // Never a real decline — the claim is retracted and the run flag cleared, same as the
         // generation-based stale-consent path.
@@ -1020,9 +1037,9 @@ public class DaemonLifecycleControllerTests {
     }
 
     // Unchanged evidence between show and accept proceeds — the counterpart to the reclassification
-    // abort above. Distinct from Skew_accept_calls_install_verified_replace_true_and_nothing_else:
-    // this one asserts the revalidation query itself ran (a StatusCallCount delta of 2) rather than
-    // just the eventual install call.
+    // abort above. Distinct from Skew_accept_calls_replace_and_nothing_else: this one asserts the
+    // revalidation query itself ran (a StatusCallCount delta of 2) rather than just the eventual
+    // lane request.
     [Test]
     public async Task Skew_accept_with_unchanged_status_revalidates_then_proceeds() {
         await using var h = new Harness();
@@ -1031,7 +1048,7 @@ public class DaemonLifecycleControllerTests {
         var noMutationRow = Snap(state: "running", jobPid: 1, daemonPid: 1);
         var next = noMutationRow;
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(next);
-        h.Cli.InstallVerifiedBehavior = (_, _) => Task.FromResult(Ok());
+        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
         h.Start();
         await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
 
@@ -1045,10 +1062,9 @@ public class DaemonLifecycleControllerTests {
         next = installedSnap;
         h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
 
-        await WaitUntilAsync(() => h.Cli.InstallVerifiedCallCount == 1, what: "the takeover install");
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request");
+        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.Replace);
         await Assert.That(h.Cli.StatusCallCount - statusCallsBeforeSkew).IsEqualTo(2); // the dialog query + the in-gate revalidation
-
-        h.PushConnected(); // let the mutation's confirm-wait resolve so disposal doesn't wait on it
     }
 
     [Test]
@@ -1056,12 +1072,12 @@ public class DaemonLifecycleControllerTests {
         await using var h = new Harness();
         h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Cli.InstallVerifiedBehavior = (_, _) => Task.FromResult(Failed(21, "verify_viability: nope"));
+        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Failed(21, "verify_viability_nope", RecoverySurface.Attention));
         h.Start();
         await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
 
         h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Cli.InstallVerifiedCallCount == 1, what: "the takeover install attempt");
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request attempt");
         await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the coded-failure status line");
 
         var afterFailure = await h.Store.LoadAsync();
@@ -1099,20 +1115,16 @@ public class DaemonLifecycleControllerTests {
         await using var h = new Harness();
         h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Cli.InstallVerifiedBehavior = (_, _) => Task.FromResult(Ok());
+        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
         h.Start();
         await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
 
         h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Cli.InstallVerifiedCallCount == 1, what: "the takeover install");
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request");
 
         await WaitUntilAsync(
             () => !(h.Store.LoadAsync().GetAwaiter().GetResult().DeclinedTakeoverPairs ?? []).Contains("0.9|1.0.0"),
             what: "the claim retracted on acceptance");
-
-        // Let the mutation actually resolve (it awaits a fresh Connected or the never-advanced
-        // fake-clock confirm window otherwise) so disposal doesn't wait on it.
-        h.PushConnected();
     }
 
     [Test]
@@ -1120,15 +1132,15 @@ public class DaemonLifecycleControllerTests {
         await using var h = new Harness();
         h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        // Simulates a shutdown mid-spawn or a process/IO fault — RunVerifiedMutationAsync does
-        // not catch around the CLI call, so this propagates out of RunSkewCheckAsync's mutation
-        // step entirely.
-        h.Cli.InstallVerifiedBehavior = (_, _) => Task.FromException<ProcessResult>(new OperationCanceledException("shutdown mid-install"));
+        // Simulates a shutdown mid-spawn or a lane-lifetime cancellation — RunLaneMutationAsync
+        // does not catch around the lane call, so this propagates out of RunSkewCheckAsync's
+        // mutation step entirely.
+        h.Lane.Behavior = (_, _) => Task.FromException<MutationOutcome>(new OperationCanceledException("shutdown mid-install"));
         h.Start();
         await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
 
         h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Cli.InstallVerifiedCallCount == 1, what: "the takeover install attempt");
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request attempt");
 
         await WaitUntilAsync(
             () => !(h.Store.LoadAsync().GetAwaiter().GetResult().DeclinedTakeoverPairs ?? []).Contains("0.9|1.0.0"),
@@ -1140,7 +1152,8 @@ public class DaemonLifecycleControllerTests {
         var client2  = new FakeDaemonClientService();
         var cli2     = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed")) };
         await using var controller2 = new DaemonLifecycleController(
-            client2, cli2, new FakeLoginShellProbe(), h.Store, surface2, () => Task.FromResult<string?>("default"), h.Time);
+            client2, cli2, new FakeLoginShellProbe(), h.Store, surface2, () => Task.FromResult<string?>("default"), h.Time,
+            h.CanonicalServer, new FakeMutationLane().RunAsync);
         controller2.Start();
         await WaitUntilAsync(() => cli2.VersionCallCount == 1, what: "controller2's version cache");
 
@@ -1235,6 +1248,22 @@ public class DaemonLifecycleControllerTests {
 
     // ---- harness ----
 
+    /// Records every MutationRequest the controller hands to `_runMutation` and lets a test
+    /// script an outcome per request (blanket Behavior, TCS-friendly) — the fake lane seam Task
+    /// 10's controller tests drive instead of a raw IKcapCli mutation call. Defaults to an
+    /// immediate Succeeded so tests that don't care about the mutation's own outcome (most of the
+    /// "no mutation happens" tests never even call this) aren't forced to script one.
+    sealed class FakeMutationLane {
+        public readonly List<MutationRequest> Requests = [];
+        public Func<MutationRequest, CancellationToken, Task<MutationOutcome>> Behavior =
+            (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+
+        public Task<MutationOutcome> RunAsync(MutationRequest request, CancellationToken ct) {
+            Requests.Add(request);
+            return Behavior(request, ct);
+        }
+    }
+
     sealed class Harness : IAsyncDisposable {
         public readonly FakeDaemonClientService Client = new();
         public readonly FakeKcapCli Cli = new();
@@ -1244,15 +1273,19 @@ public class DaemonLifecycleControllerTests {
         public readonly TimerCountingTimeProvider Time;
         public readonly string TempDir = Directory.CreateTempSubdirectory("kcap-lifecycle-").FullName;
         public readonly AppStateStore Store;
+        public readonly FakeMutationLane Lane = new();
         public readonly DaemonLifecycleController Controller;
+        public readonly string? CanonicalServer;
 
         public string? ProfileName = "default";
 
-        public Harness() {
+        public Harness(string? canonicalServer = "https://kcap.example.com:443") {
+            CanonicalServer = canonicalServer;
             Time  = new TimerCountingTimeProvider(Clock);
             Store = new AppStateStore(Path.Combine(TempDir, "app-state.json"));
             Controller = new DaemonLifecycleController(
-                Client, Cli, Probe, Store, Surface, () => Task.FromResult<string?>(ProfileName), Time);
+                Client, Cli, Probe, Store, Surface, () => Task.FromResult<string?>(ProfileName), Time,
+                CanonicalServer, Lane.RunAsync);
         }
 
         public void Start() => Controller.Start();
@@ -1277,7 +1310,10 @@ public class DaemonLifecycleControllerTests {
 
 /// Scripted IKcapCli — every member is a settable behavior func plus a call counter, so tests
 /// can drive both immediate results and TaskCompletionSource-controlled hangs (the once-per-run
-/// arm test) without touching a real process.
+/// arm test) without touching a real process. Task 10: StartVerified/InstallVerified/
+/// DetachedStart are no longer called by the controller AT ALL (routed through the lane instead)
+/// — their counters stay wired up purely as a regression tripwire (every controller test asserts
+/// they remain 0).
 sealed class FakeKcapCli : IKcapCli {
     public string? CliPath { get; set; } = "/opt/kcap/bin/kcap";
 

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -1433,5 +1433,10 @@ sealed class FakeLoginShellProbe : ILoginShellProbe {
     }
 
     public Func<CancellationToken, Task<string?>> KcapPathBehavior = _ => Task.FromResult<string?>(null);
-    public Task<string?> KcapPathAsync(CancellationToken ct, bool forceRefresh = false) => KcapPathBehavior(ct);
+    public Func<CancellationToken, Task<string?>>? KcapPathFreshBehavior;
+    public readonly List<bool> KcapPathForceRefreshCalls = [];
+    public Task<string?> KcapPathAsync(CancellationToken ct, bool forceRefresh = false) {
+        KcapPathForceRefreshCalls.Add(forceRefresh);
+        return forceRefresh ? (KcapPathFreshBehavior ?? KcapPathBehavior)(ct) : KcapPathBehavior(ct);
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -440,8 +440,13 @@ public class DaemonLifecycleControllerTests {
         await Assert.That(h.Client.RestartCount).IsEqualTo(0);
     }
 
+    // Round-1 review C-2: a Refused outcome that reached the LANE (as opposed to the guard
+    // refusing before ever touching it — see No_canonical_server_refuses_without_ever_calling_the_lane
+    // above) was already enqueued onto the outcome channel by the lane's own Deliver — the
+    // controller must make NO surface call of its own, or the composition-root consumer's
+    // presentation doubles up.
     [Test]
-    public async Task Refused_outcome_surfaces_the_honest_reason_as_status_text_only() {
+    public async Task Refused_outcome_from_the_lane_produces_no_controller_surface_call() {
         await using var h = new Harness();
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
         h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Refused("cli_below_floor", RecoverySurface.Attention));
@@ -449,9 +454,11 @@ public class DaemonLifecycleControllerTests {
 
         h.PushUnreachable();
 
-        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the refusal status line");
-        await Assert.That(h.Surface.StatusMessages[0]).Contains("cli_below_floor");
-        await Assert.That(h.Surface.AttentionMessages).IsEmpty(); // channel-only, never a direct Attention
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane request");
+        await h.Controller.PhaseClosed;
+        await Task.Delay(50); // give a wrongly-firing Status/Attention every chance to appear
+        await Assert.That(h.Surface.StatusMessages).IsEmpty();
+        await Assert.That(h.Surface.AttentionMessages).IsEmpty();
     }
 
     // ---- UX confirmation ----
@@ -493,8 +500,12 @@ public class DaemonLifecycleControllerTests {
 
     // ---- coded failure ----
 
+    // Round-1 review C-2: a Failed outcome from the lane is presented ONLY by the composition-root
+    // consumer now (see AppMutationLaneWiringTests.PresentOutcomeAsync's Attention/Reinstall/
+    // Takeover coverage for the actual message content) — the controller itself makes no surface
+    // call, but the once-per-run arm still holds (no retry on a second daemon_unreachable).
     [Test]
-    public async Task Coded_failure_surfaces_the_verify_token_once() {
+    public async Task Failed_outcome_from_the_lane_produces_no_controller_surface_call_but_counts_the_run_once() {
         await using var h = new Harness();
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
         h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Failed(24, "gave_up_waiting", RecoverySurface.Attention));
@@ -502,28 +513,15 @@ public class DaemonLifecycleControllerTests {
 
         h.PushUnreachable();
 
-        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the coded-failure status line");
-        await Assert.That(h.Surface.StatusMessages[0]).Contains("verify_readiness_timeout"); // VerifyExitCodes.Token(24)
-        await Assert.That(h.Surface.StatusMessages[0]).Contains("gave_up_waiting");
-        await Assert.That(h.Surface.AttentionMessages).IsEmpty(); // single-presentation: never also an Attention
+        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the lane request");
+        await h.Controller.PhaseClosed;
+        await Task.Delay(50); // give a wrongly-firing Status/Attention every chance to appear
+        await Assert.That(h.Surface.StatusMessages).IsEmpty();
+        await Assert.That(h.Surface.AttentionMessages).IsEmpty();
 
         h.PushUnreachable(); // once-per-run: no retry
         await Task.Delay(50);
         await Assert.That(h.Lane.Requests.Count).IsEqualTo(1);
-        await Assert.That(h.Surface.StatusMessages.Count).IsEqualTo(1);
-    }
-
-    [Test]
-    public async Task Coded_failure_with_no_reason_token_still_surfaces_the_exit_code_token() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Failed(21, null, RecoverySurface.Attention));
-        h.Start();
-
-        h.PushUnreachable();
-
-        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the coded-failure status line");
-        await Assert.That(h.Surface.StatusMessages[0]).Contains("verify_viability"); // VerifyExitCodes.Token(21)
     }
 
     // ---- version caching ----
@@ -1077,11 +1075,14 @@ public class DaemonLifecycleControllerTests {
         await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
 
         h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
+        // Lane.Behavior resolves immediately (Task.FromResult), and the retract is fully awaited
+        // BEFORE the mutation call (see the comment on the retract-before-mutation ordering
+        // above) — by the time the lane records the request, the retract has already landed.
         await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request attempt");
-        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the coded-failure status line");
 
         var afterFailure = await h.Store.LoadAsync();
         await Assert.That((afterFailure.DeclinedTakeoverPairs ?? []).Contains("0.9|1.0.0")).IsFalse();
+        await Assert.That(h.Surface.StatusMessages).IsEmpty(); // channel-only now (round-1 review C-2)
 
         // The run flag cleared too — a fresh trigger (a different pair, since this run's CLI
         // version hasn't changed) still gets an offer.

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -1318,6 +1318,13 @@ sealed class FakeKcapCli : IKcapCli {
         DetachedStartCallCount++;
         return DetachedStartBehavior(ct);
     }
+
+    public string? LastBootAttemptId;
+    public Task<ProcessResult> DetachedStartAsync(string bootAttemptId, CancellationToken ct) {
+        DetachedStartCallCount++;
+        LastBootAttemptId = bootAttemptId;
+        return DetachedStartBehavior(ct);
+    }
 }
 
 /// Scripted ILoginShellProbe — the controller only ever calls TerminalPathAsync (the install

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -206,7 +206,6 @@ public class DaemonLifecycleControllerTests {
         h.PushUnreachable();
 
         await h.Controller.PhaseClosed; // must complete even though the matrix never runs
-        await Task.Delay(50); // give a wrongly-firing query/mutation every chance to appear
         await Assert.That(h.Cli.StatusCallCount).IsEqualTo(0); // RunStartupBranchAsync never admitted
         await Assert.That(h.Lane.Requests).IsEmpty();
         await Assert.That(h.Surface.StatusMessages).IsEmpty();
@@ -223,7 +222,6 @@ public class DaemonLifecycleControllerTests {
         h.PushUnreachable();
         await h.Controller.PhaseClosed;
         h.PushUnreachable();
-        await Task.Delay(50);
 
         await Assert.That(h.Cli.StatusCallCount).IsEqualTo(0);
         await Assert.That(h.Lane.Requests).IsEmpty();

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -462,14 +462,16 @@ public class DaemonLifecycleControllerTests {
         await Task.Delay(50); // give a wrongly-firing Attention/Status every chance to appear
         await Assert.That(h.Surface.AttentionMessages).IsEmpty();
         await Assert.That(h.Surface.StatusMessages).IsEmpty();
-        await Assert.That(h.Client.RestartCount).IsEqualTo(0); // not a success outcome — no reattach kick
+        // Blocker 1: the reattach kick is unconditional after any lane mutation call — a mutation
+        // attempt may have restarted the daemon even though this outcome isn't itself a success.
+        await Assert.That(h.Client.RestartCount).IsEqualTo(1);
     }
 
     // An UnconfirmedNoAttach outcome (the lane's TimedOut classification, spec §3.6) supersedes
     // the controller's former confirm-window/timeout handling entirely — no local surface call at
     // all, channel-only, same as every other non-success outcome.
     [Test]
-    public async Task UnconfirmedNoAttach_outcome_produces_no_controller_surface_call_or_reattach_kick() {
+    public async Task UnconfirmedNoAttach_outcome_produces_no_controller_surface_call_but_still_kicks_reattach() {
         await using var h = new Harness();
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
         h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.UnconfirmedNoAttach());
@@ -482,7 +484,9 @@ public class DaemonLifecycleControllerTests {
         await Task.Delay(50);
         await Assert.That(h.Surface.StatusMessages).IsEmpty();
         await Assert.That(h.Surface.AttentionMessages).IsEmpty();
-        await Assert.That(h.Client.RestartCount).IsEqualTo(0);
+        // Blocker 1: any lane mutation attempt may have restarted the daemon, so the kick is
+        // unconditional — not gated on this outcome being a success.
+        await Assert.That(h.Client.RestartCount).IsEqualTo(1);
     }
 
     // Round-1 review C-2: a Refused outcome that reached the LANE (as opposed to the guard
@@ -563,10 +567,14 @@ public class DaemonLifecycleControllerTests {
         await Task.Delay(50); // give a wrongly-firing Status/Attention every chance to appear
         await Assert.That(h.Surface.StatusMessages).IsEmpty();
         await Assert.That(h.Surface.AttentionMessages).IsEmpty();
+        // Blocker 1: a Failed outcome may still mean the daemon got restarted mid-mutation — the
+        // kick is unconditional, not gated on Succeeded/SucceededAfterTimeout.
+        await Assert.That(h.Client.RestartCount).IsEqualTo(1);
 
         h.PushUnreachable(); // once-per-run: no retry
         await Task.Delay(50);
         await Assert.That(h.Lane.Requests.Count).IsEqualTo(1);
+        await Assert.That(h.Client.RestartCount).IsEqualTo(1); // no second lane call — no second kick
     }
 
     // ---- version caching ----
@@ -1396,10 +1404,6 @@ sealed class FakeKcapCli : IKcapCli {
 
     public int DetachedStartCallCount;
     public Func<CancellationToken, Task<ProcessResult>> DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false));
-    public Task<ProcessResult> DetachedStartAsync(CancellationToken ct) {
-        DetachedStartCallCount++;
-        return DetachedStartBehavior(ct);
-    }
 
     public string? LastBootAttemptId;
     public Task<ProcessResult> DetachedStartAsync(string bootAttemptId, CancellationToken ct) {

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -1338,4 +1338,7 @@ sealed class FakeLoginShellProbe : ILoginShellProbe {
         }
         return KcapOnPathBehavior(ct);
     }
+
+    public Func<CancellationToken, Task<string?>> KcapPathBehavior = _ => Task.FromResult<string?>(null);
+    public Task<string?> KcapPathAsync(CancellationToken ct, bool forceRefresh = false) => KcapPathBehavior(ct);
 }

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -1138,18 +1138,23 @@ public class DaemonMutationLaneTests {
         await lane.DisposeAsync();
     }
 
-    // ---- CRITICAL 1 (round 1): DetachedStart shares the SAME evidence predicate as the service-verb
-    // ladder — a legacy/below-floor/pid-less daemon must never read as Succeeded just because it's
-    // reachable and identity-consistent. Regression tests for the three reviewer-executed counterexamples. ----
+    // ---- CRITICAL 1 (round 1) / IMPORTANT (round 2): DetachedStart shares the SAME evidence
+    // predicate as the service-verb ladder — a legacy/below-floor/pid-less daemon must never read
+    // as Succeeded just because it's reachable and identity-consistent. Round 2: the loop no longer
+    // fails fast on the first bad poll (a transient mid-boot shape must not misfire) — it polls
+    // through and only decides at window expiry, so these are now persistent-leg-through-expiry
+    // tests, driven by FakeTimeProvider rather than resolving on the first poll. ----
 
     [Test]
-    public async Task DetachedStart_exit_zero_with_missing_consent_capability_yields_AttentionSkew_not_Succeeded() {
+    public async Task DetachedStart_persistent_missing_consent_capability_through_expiry_yields_AttentionSkew() {
+        var time = new FakeTimeProvider();
         var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
         var noCapabilities = MatchingEvidence() with { Capabilities = [] };
-        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(noCapabilities) });
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(noCapabilities) }, time: time);
 
-        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
 
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("missing_capability_consent_3"));
 
@@ -1157,13 +1162,15 @@ public class DaemonMutationLaneTests {
     }
 
     [Test]
-    public async Task DetachedStart_exit_zero_with_below_floor_daemon_version_yields_AttentionSkew_not_Succeeded() {
+    public async Task DetachedStart_persistent_below_floor_daemon_version_through_expiry_yields_AttentionSkew() {
+        var time = new FakeTimeProvider();
         var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
         var oldVersion = MatchingEvidence() with { DaemonVersion = "0.1.0" };
-        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(oldVersion) });
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(oldVersion) }, time: time);
 
-        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
 
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("daemon_below_floor"));
 
@@ -1171,19 +1178,85 @@ public class DaemonMutationLaneTests {
     }
 
     [Test]
-    public async Task DetachedStart_exit_zero_with_preslice_evidence_yields_AttentionSkew_not_Succeeded() {
+    public async Task DetachedStart_persistent_preslice_evidence_through_expiry_yields_AttentionSkew() {
         // IdentityConsistent is deliberately (wrongly) true here — the structural pid/instance check
         // must fire regardless of what the observation's own IdentityConsistent flag claims.
+        var time = new FakeTimeProvider();
         var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
         var preslice = new ObservedEvidence(true, ["consent/3"], "1.0.0", "https://cap.example.test", "daemon-a", null, null, true);
-        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(preslice) });
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(preslice) }, time: time);
 
-        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
 
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("pre_slice_evidence"));
 
         await lane.DisposeAsync();
+    }
+
+    // ---- IMPORTANT (round 2): a transient, non-full, non-unreachable evidence shape (the two-dial
+    // probe's genuine mid-boot reading — hello answered, snapshot not yet subscribed) must be
+    // polled THROUGH, never fail-fast — whether it eventually resolves to full evidence or is caught
+    // by a marker arriving mid-window. ----
+
+    static ObservedEvidence MidBootEvidence() =>
+        // Hello answered (capabilities/version/pid/instance present) but the snapshot dial isn't up
+        // yet — ServerUrl/DaemonName/IdentityConsistent all read as "no snapshot", exactly what
+        // OneShotObservation produces when LocalControlProbe's two dials answer out of step.
+        new(true, ["consent/3"], "1.0.0", null, null, 111, "inst-1", false);
+
+    [Test]
+    public async Task DetachedStart_transient_mid_boot_shape_then_full_evidence_is_Succeeded() {
+        var time = new FakeTimeProvider();
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var pollCount = 0;
+        var observation = new ScriptedObservation {
+            Behavior = (_, _) => {
+                pollCount++;
+                return Task.FromResult<ObservedEvidence?>(pollCount <= 2 ? MidBootEvidence() : MatchingEvidence());
+            },
+        };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation, time: time);
+
+        var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(pollCount).IsGreaterThanOrEqualTo(3);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test, NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task DetachedStart_transient_mid_boot_shape_with_a_marker_arriving_after_the_first_poll_is_Refused() {
+        var dir = Directory.CreateTempSubdirectory("dml-marker-").FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        var time = new FakeTimeProvider();
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var pollCount = 0;
+        var observation = new ScriptedObservation {
+            Behavior = (_, _) => {
+                pollCount++;
+                if (pollCount == 2) PlantMarker("daemon-a", MarkerJson("daemon-a", cli.LastBootAttemptId!)); // planted as a side effect of the 2nd observe call
+                return Task.FromResult<ObservedEvidence?>(MidBootEvidence());
+            },
+        };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation, time: time);
+        try {
+            var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+            var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
+
+            await Assert.That(outcome).IsEqualTo(new MutationOutcome.Refused("server_expectation_mismatch", RecoverySurface.Takeover));
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath("daemon-a"))).IsFalse(); // consumed
+            await Assert.That(pollCount).IsEqualTo(2); // caught by the NEXT iteration's marker-first check — no 3rd observe call
+
+            await lane.DisposeAsync();
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+        }
     }
 
     // ---- TEST GAP (round 1): the loop actually re-observes, not just waits out a single check ----

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -34,8 +34,8 @@ public class DaemonMutationLaneTests {
             string state = "running", bool unitPresent = true) =>
         new("daemon-a", unitPresent, state, "/opt/kcap/kcapd", "/opt/kcap/kcapd", jobPid, daemonPid, txnMarker, txnActive);
 
-    static string MarkerJson(string daemonName, string attemptId) => $$"""
-        {"daemon_name":"{{daemonName}}","token":"server_expectation_mismatch","expectation":"https://s","resolved":"https://t","pid":4242,"instance_id":"inst-1","attempt_id":"{{attemptId}}"}
+    static string MarkerJson(string daemonName, string? attemptId) => $$"""
+        {"daemon_name":"{{daemonName}}","token":"server_expectation_mismatch","expectation":"https://s","resolved":"https://t","pid":4242,"instance_id":"inst-1","attempt_id":{{(attemptId is null ? "null" : $"\"{attemptId}\"")}}}
         """;
 
     static void PlantMarker(string daemonName, string content) {
@@ -847,6 +847,69 @@ public class DaemonMutationLaneTests {
         var envelope = await NextEnvelopeAsync(channel);
         await Assert.That(envelope.Request).IsEqualTo(request);
         await Assert.That(envelope.Outcome).IsEqualTo(outcome);
+        await AssertChannelEmptyAsync(channel); // exactly once, not merely at-least-once
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Service_verb_TimedOut_never_enters_the_success_ladder_regardless_of_exit_code() {
+        // A forced kill's exit code is not a verify outcome — the transaction may have already
+        // committed. Full matching evidence must NOT read as Succeeded here; SucceededAfterTimeout
+        // is detached-only.
+        var cli = new FakeKcapCli {
+            StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", true)),
+            StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()),
+        };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
+
+        await lane.DisposeAsync();
+    }
+
+    // ---- IMPORTANT 2 (round 1): ownership repair/skew signals evaluated regardless of evidence reachability ----
+
+    [Test]
+    public async Task Stale_txn_marker_with_unreachable_evidence_yields_AttentionRepair_not_UnconfirmedNoAttach() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership(txnMarker: true, txnActive: false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory); // default evidence stays unreachable
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionRepair("stale_txn_marker"));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Running_service_without_a_daemon_pid_yields_AttentionRepair() {
+        // Mirrors DaemonLifecycleController.Reconcile's `state == ServiceState.Running && snap.DaemonPid is null` leg.
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership(jobPid: 111, daemonPid: null, state: "running")) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionRepair("running_without_daemon_pid"));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Daemon_running_outside_an_uninstalled_service_yields_AttentionRepair() {
+        // Mirrors DaemonLifecycleController.Reconcile's `snap.UnitPresent && state == ServiceState.NotInstalled && snap.DaemonPid is not null` leg.
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership(jobPid: null, daemonPid: 999, state: "not_installed", unitPresent: true)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory); // evidence unreachable by default — ownership repair wins regardless
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionRepair("daemon_running_outside_service"));
 
         await lane.DisposeAsync();
     }
@@ -909,6 +972,19 @@ public class DaemonMutationLaneTests {
     }
 
     [Test]
+    public async Task Exit28_with_the_known_but_unrouted_evidence_unreadable_token_fails_closed_to_Attention() {
+        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(28, "", "start_gate_reason=evidence_unreadable\n", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(28, "evidence_unreadable", RecoverySurface.Attention));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
     public async Task Exit29_is_Attention_and_the_lane_never_retries_the_mutation() {
         var cli = new FakeKcapCli { StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(29, "", "", false)) };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
@@ -918,6 +994,19 @@ public class DaemonMutationLaneTests {
 
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(29, null, RecoverySurface.Attention));
         await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(1);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Exit29_with_a_reason_line_present_still_fails_with_Attention_and_carries_the_token() {
+        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(29, "", "start_gate_reason=identity_mismatch\n", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(29, "identity_mismatch", RecoverySurface.Attention));
 
         await lane.DisposeAsync();
     }
@@ -1049,10 +1138,185 @@ public class DaemonMutationLaneTests {
         await lane.DisposeAsync();
     }
 
+    // ---- CRITICAL 1 (round 1): DetachedStart shares the SAME evidence predicate as the service-verb
+    // ladder — a legacy/below-floor/pid-less daemon must never read as Succeeded just because it's
+    // reachable and identity-consistent. Regression tests for the three reviewer-executed counterexamples. ----
+
+    [Test]
+    public async Task DetachedStart_exit_zero_with_missing_consent_capability_yields_AttentionSkew_not_Succeeded() {
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var noCapabilities = MatchingEvidence() with { Capabilities = [] };
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(noCapabilities) });
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("missing_capability_consent_3"));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task DetachedStart_exit_zero_with_below_floor_daemon_version_yields_AttentionSkew_not_Succeeded() {
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var oldVersion = MatchingEvidence() with { DaemonVersion = "0.1.0" };
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(oldVersion) });
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("daemon_below_floor"));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task DetachedStart_exit_zero_with_preslice_evidence_yields_AttentionSkew_not_Succeeded() {
+        // IdentityConsistent is deliberately (wrongly) true here — the structural pid/instance check
+        // must fire regardless of what the observation's own IdentityConsistent flag claims.
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var preslice = new ObservedEvidence(true, ["consent/3"], "1.0.0", "https://cap.example.test", "daemon-a", null, null, true);
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(preslice) });
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("pre_slice_evidence"));
+
+        await lane.DisposeAsync();
+    }
+
+    // ---- TEST GAP (round 1): the loop actually re-observes, not just waits out a single check ----
+
+    [Test]
+    public async Task DetachedStart_evidence_appearing_on_the_third_poll_is_Succeeded() {
+        var time = new FakeTimeProvider();
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var pollCount = 0;
+        var observation = new ScriptedObservation {
+            Behavior = (_, _) => {
+                pollCount++;
+                return Task.FromResult<ObservedEvidence?>(pollCount >= 3 ? MatchingEvidence() : null);
+            },
+        };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation, time: time);
+
+        var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(pollCount).IsGreaterThanOrEqualTo(3);
+
+        await lane.DisposeAsync();
+    }
+
+    // ---- MINOR 7 (round 1): window boundary, asserted against the real DetachedConfirmWindow const ----
+
+    [Test]
+    public async Task DetachedStart_evidence_arriving_just_inside_the_confirm_window_is_Succeeded() {
+        var time = new FakeTimeProvider();
+        var start = time.GetUtcNow();
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var observation = new ScriptedObservation {
+            Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(
+                time.GetUtcNow() - start >= DaemonMutationLane.DetachedConfirmWindow - TimeSpan.FromSeconds(1)
+                    ? MatchingEvidence()
+                    : null),
+        };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation, time: time);
+
+        var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task DetachedStart_evidence_arriving_just_past_the_confirm_window_is_UnconfirmedNoAttach() {
+        var time = new FakeTimeProvider();
+        var start = time.GetUtcNow();
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var observation = new ScriptedObservation {
+            // Never observed within the window (the loop stops polling once the deadline passes), so
+            // this proves expiry is enforced against the real const rather than a hardcoded 10s.
+            Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(
+                time.GetUtcNow() - start > DaemonMutationLane.DetachedConfirmWindow ? MatchingEvidence() : null),
+        };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation, time: time);
+
+        var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
+
+        await lane.DisposeAsync();
+    }
+
+    // ---- MINOR 6 (round 1): a null attemptId (only reachable via direct Classify-seam injection —
+    // a real DetachedStart action never produces one) must never attribute a marker, even a
+    // matching null-attempt one (which belongs to a service-verb refusal, not this action). ----
+
+    [Test, NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task DetachedStart_classifier_with_a_null_attemptId_never_attributes_even_a_null_attempt_marker() {
+        var dir = Directory.CreateTempSubdirectory("dml-marker-").FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        var time = new FakeTimeProvider();
+        try {
+            PlantMarker("daemon-a", MarkerJson("daemon-a", null)); // a null-attempt marker — belongs to a service verb, never this detached attempt
+            var lane = MakeLane(new RecordingExecutorFactory(), time: time);
+            var executor = new FakeKcapCli();
+            var observation = new ScriptedObservation(); // never full evidence
+
+            var task = lane.Classify(
+                Req(verb: MutationVerb.DetachedStart), new ProcessResult(0, "", "", false), executor, observation, null, CancellationToken.None);
+            var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
+
+            await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath("daemon-a"))).IsTrue(); // untouched — TryAttribute never called
+
+            await lane.DisposeAsync();
+        } finally {
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+        }
+    }
+
     // ==== Task 9b: DetachedStart boot-refusal marker attribution (real filesystem — BootRefusalMarkerTests pattern) ====
 
     [Test, NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
     public async Task DetachedStart_exit_zero_with_an_attributed_marker_is_Refused_and_consumes_the_marker() {
+        var dir = Directory.CreateTempSubdirectory("dml-marker-").FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        var time = new FakeTimeProvider(); // MINOR 8: no 10s wall-clock worst case if attribution ever regresses
+        var cli = new FakeKcapCli();
+        cli.DetachedStartBehavior = _ => {
+            PlantMarker("daemon-a", MarkerJson("daemon-a", cli.LastBootAttemptId!));
+            return Task.FromResult(new ProcessResult(0, "", "", false));
+        };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory, time: time); // default observation never shows full evidence
+        try {
+            var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+            var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
+
+            await Assert.That(outcome).IsEqualTo(new MutationOutcome.Refused("server_expectation_mismatch", RecoverySurface.Takeover));
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath("daemon-a"))).IsFalse();
+        } finally {
+            await lane.DisposeAsync();
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+        }
+    }
+
+    // ---- IMPORTANT 3 (round 1): marker checked BEFORE evidence each iteration — a refusing daemon
+    // never attaches, so marker-first can never produce a false Refused, while evidence-first could
+    // let a pre-existing same-name daemon's evidence mask a real refusal. ----
+
+    [Test, NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task DetachedStart_marker_and_full_evidence_both_present_from_the_start_marker_wins() {
         var dir = Directory.CreateTempSubdirectory("dml-marker-").FullName;
         DaemonLockPaths.OverrideDirectoryForTesting(dir);
         var cli = new FakeKcapCli();
@@ -1061,14 +1325,17 @@ public class DaemonMutationLaneTests {
             return Task.FromResult(new ProcessResult(0, "", "", false));
         };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory); // default observation never shows full evidence
+        // Full, matching evidence from t=0 — if evidence were checked first this would resolve Succeeded.
+        var observation = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
         try {
             var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
 
             await Assert.That(outcome).IsEqualTo(new MutationOutcome.Refused("server_expectation_mismatch", RecoverySurface.Takeover));
-            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath("daemon-a"))).IsFalse();
-        } finally {
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath("daemon-a"))).IsFalse(); // consumed
+
             await lane.DisposeAsync();
+        } finally {
             DaemonLockPaths.OverrideDirectoryForTesting(null);
         }
     }

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -809,8 +809,7 @@ public class DaemonMutationLaneTests {
     public async Task Full_matching_evidence_and_ownership_on_exit_zero_is_Succeeded() {
         var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        // Two independently-built evidence instances that agree on Pid+InstanceId — the sandwich's
-        // second dial is scripted explicitly rather than relying on a re-evaluated Behavior lambda.
+        // Two independently-built evidence instances that agree on Pid+InstanceId, scripted explicitly rather than via a re-evaluated Behavior lambda.
         var observation = new ScriptedObservation { Sequence = new([MatchingEvidence(), MatchingEvidence()]) };
         var lane = MakeLane(factory, oneShotFactory: _ => observation);
 
@@ -838,9 +837,7 @@ public class DaemonMutationLaneTests {
         await lane.DisposeAsync();
     }
 
-    // ---- round-4 P1: ABA guard — the ServiceStatusAsync ownership read can straddle a process swap
-    // that reuses pid P, so the sandwich requires a SECOND fresh dial to reproduce the first's own
-    // InstanceId+Pid before Succeeded is ever returned. ----
+    // ---- ABA guard: Succeeded needs a second fresh dial that both matches and independently validates. ----
 
     [Test]
     public async Task Sandwich_second_observation_different_instance_same_pid_yields_AttentionSkew_never_Succeeded() {
@@ -859,6 +856,40 @@ public class DaemonMutationLaneTests {
         await lane.DisposeAsync();
     }
 
+    // A second dial reproducing the first's own pid+instance but with IdentityConsistent false (a hello/status socket split) must still fail, not pass a naive pid+instance-only cross-check.
+    [Test]
+    public async Task Sandwich_second_observation_matching_pid_instance_but_identity_inconsistent_yields_AttentionSkew_never_Succeeded() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var first = MatchingEvidence();
+        var second = first with { IdentityConsistent = false };
+        var observation = new ScriptedObservation { Sequence = new([first, second]) };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("identity_inconsistent"));
+        await Assert.That(observation.CallCount).IsEqualTo(2);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Sandwich_second_observation_missing_capability_yields_AttentionSkew() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var first = MatchingEvidence();
+        var second = first with { Capabilities = [] };
+        var observation = new ScriptedObservation { Sequence = new([first, second]) };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("missing_capability_consent_3"));
+
+        await lane.DisposeAsync();
+    }
+
     [Test]
     public async Task Sandwich_second_observation_unreachable_fails_closed_to_AttentionSkew() {
         var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
@@ -869,7 +900,7 @@ public class DaemonMutationLaneTests {
 
         var outcome = await lane.RunAsync(Req(), CancellationToken.None);
 
-        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("instance_changed_during_classification"));
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("unreachable"));
 
         await lane.DisposeAsync();
     }
@@ -883,7 +914,7 @@ public class DaemonMutationLaneTests {
 
         var outcome = await lane.RunAsync(Req(), CancellationToken.None);
 
-        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("instance_changed_during_classification"));
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("unreachable"));
 
         await lane.DisposeAsync();
     }

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -245,6 +245,45 @@ public class DaemonMutationLaneTests {
         await lane.DisposeAsync();
     }
 
+    // Qodo: a cached negative must not refuse forever — installing a compatible CLI must let the
+    // very next action recover without an app restart, so a null cached probe gets exactly one
+    // forced re-probe before the lane gives up.
+    [Test]
+    public async Task Cached_negative_probe_recovers_via_one_forced_refresh_before_refusing() {
+        var cli = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var probe = new FakeLoginShellProbe {
+            KcapPathBehavior = _ => Task.FromResult<string?>(null), // cached negative
+            KcapPathFreshBehavior = _ => Task.FromResult<string?>("/opt/kcap/bin/kcap"), // just installed
+        };
+        var lane = MakeLane(factory, cliOverride: () => null, shellProbe: probe, classify: CannedSucceeded);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(factory.Calls.Count).IsEqualTo(1);
+        await Assert.That(factory.Calls[0].PinnedPath).IsEqualTo("/opt/kcap/bin/kcap");
+        await Assert.That(probe.KcapPathForceRefreshCalls).IsEquivalentTo([false, true]);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Still_null_after_the_forced_refresh_still_refuses_cli_not_found() {
+        var factory = new RecordingExecutorFactory();
+        var channel = new OutcomeChannel();
+        var probe = new FakeLoginShellProbe { KcapPathBehavior = _ => Task.FromResult<string?>(null) }; // both cached and refreshed answer null
+        var lane = MakeLane(factory, channel: channel, cliOverride: () => null, shellProbe: probe);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Refused("cli_not_found", RecoverySurface.Attention));
+        await Assert.That(factory.Calls.Count).IsEqualTo(0);
+        await Assert.That(probe.KcapPathForceRefreshCalls).IsEquivalentTo([false, true]);
+
+        await lane.DisposeAsync();
+    }
+
     [Test]
     public async Task Below_floor_version_refuses_without_a_mutation_call() {
         var cli = new FakeKcapCli { VersionBehavior = _ => Task.FromResult<string?>("0.1.0") };
@@ -600,6 +639,34 @@ public class DaemonMutationLaneTests {
 
         await Assert.That(factory.Calls.Count).IsEqualTo(1); // B's executor factory never invoked — no successor started
         await Assert.That(cliA.StartVerifiedCallCount).IsEqualTo(0); // A never actually dispatched either
+
+        await lane.DisposeAsync(); // idempotent
+    }
+
+    // Qodo Low: the drain cancels queued waiters BEFORE _lifetime.Cancel() runs (a reviewed
+    // ordering — the drain-under-_gate-first structure stays), so it must not claim the lifetime
+    // token's identity on a task that's cancelled ahead of that token actually being cancelled.
+    [Test]
+    public async Task Dispose_drain_cancellation_does_not_claim_the_lifetime_tokens_identity() {
+        var requestA = Req(daemonName: "daemon-a");
+        var requestB = Req(daemonName: "daemon-b");
+        var gateA = new TaskCompletionSource<string?>();
+        var cliA = new FakeKcapCli { VersionBehavior = _ => gateA.Task };
+        var cliB = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (req, _) => req.DaemonName == "daemon-a" ? cliA : cliB };
+        var lane = MakeLane(factory);
+
+        var tA = lane.RunAsync(requestA, CancellationToken.None);
+        var tB = lane.RunAsync(requestB, CancellationToken.None); // queues behind A
+
+        var disposeTask = lane.DisposeAsync().AsTask(); // drains B's queued slot synchronously, before _lifetime.Cancel()
+
+        var ex = await Assert.ThrowsAsync<OperationCanceledException>(() => tB);
+        await Assert.That(ex.CancellationToken).IsEqualTo(CancellationToken.None);
+
+        gateA.SetResult("9.9.9");
+        await Assert.ThrowsAsync<OperationCanceledException>(() => tA);
+        await disposeTask.WaitAsync(Bounded);
 
         await lane.DisposeAsync(); // idempotent
     }

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -446,24 +446,31 @@ public class DaemonMutationLaneTests {
 
     // ---- T2: SetLiveAdapter coverage ----
 
+    // Blocker 1 (final review): the pinned strategy is now a COMPOSITE that tries live first and
+    // falls through to a fresh one-shot only when live's own result is null/not-Reachable — so
+    // `observation` handed to Classify is never the raw live reference any more. These tests drive
+    // the composite through a REAL ObserveAsync call (rather than just capturing the reference) to
+    // prove the try-live-then-fall-through behavior at the classification-attempt level.
     [Test]
     public async Task Live_adapter_with_matching_evidence_is_pinned_and_the_oneshot_factory_is_never_called() {
         var cli = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var live = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) };
+        var expectedEvidence = MatchingEvidence(); // captured once — Capabilities is a reference type, so two separately-built instances are never record-equal
+        var live = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(expectedEvidence) };
         var oneShotCalls = 0;
-        IDaemonObservation? seen = null;
+        ObservedEvidence? observed = null;
         var lane = MakeLane(factory, oneShotFactory: _ => { oneShotCalls++; return new ScriptedObservation(); });
-        lane.Classify = (request, result, executor, observation, attemptId, ct) => {
-            seen = observation;
-            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        lane.Classify = async (request, result, executor, observation, attemptId, ct) => {
+            observed = await observation.ObserveAsync(request, ct);
+            return new MutationOutcome.Succeeded();
         };
         lane.SetLiveAdapter(live);
 
         await lane.RunAsync(Req(), CancellationToken.None);
 
         await Assert.That(oneShotCalls).IsEqualTo(0);
-        await Assert.That(seen).IsSameReferenceAs(live);
+        await Assert.That(live.CallCount).IsEqualTo(1);
+        await Assert.That(observed).IsEqualTo(expectedEvidence);
 
         await lane.DisposeAsync();
     }
@@ -473,19 +480,23 @@ public class DaemonMutationLaneTests {
         var cli = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
         var live = new ScriptedObservation(); // default behavior returns null — cannot target this request
+        var oneShotEvidence = MatchingEvidence(pid: 999, instanceId: "inst-oneshot");
         var oneShotCalls = 0;
-        IDaemonObservation? seen = null;
-        var lane = MakeLane(factory, oneShotFactory: _ => { oneShotCalls++; return new ScriptedObservation(); });
-        lane.Classify = (request, result, executor, observation, attemptId, ct) => {
-            seen = observation;
-            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        ObservedEvidence? observed = null;
+        var lane = MakeLane(factory, oneShotFactory: _ => {
+            oneShotCalls++;
+            return new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(oneShotEvidence) };
+        });
+        lane.Classify = async (request, result, executor, observation, attemptId, ct) => {
+            observed = await observation.ObserveAsync(request, ct);
+            return new MutationOutcome.Succeeded();
         };
         lane.SetLiveAdapter(live);
 
         await lane.RunAsync(Req(), CancellationToken.None);
 
         await Assert.That(oneShotCalls).IsEqualTo(1);
-        await Assert.That(seen).IsNotSameReferenceAs(live);
+        await Assert.That(observed).IsEqualTo(oneShotEvidence);
 
         await lane.DisposeAsync();
     }
@@ -495,13 +506,14 @@ public class DaemonMutationLaneTests {
         var gate = new TaskCompletionSource<ProcessResult>();
         var cli = new FakeKcapCli { StartVerifiedBehavior = _ => gate.Task }; // gate AFTER the pin step, not before it
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var originalLive = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) };
+        var expectedEvidence = MatchingEvidence(); // captured once — Capabilities is a reference type, so two separately-built instances are never record-equal
+        var originalLive = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(expectedEvidence) };
         var otherLive = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence(222, "inst-2")) };
-        IDaemonObservation? seen = null;
+        ObservedEvidence? observed = null;
         var lane = MakeLane(factory);
-        lane.Classify = (request, result, executor, observation, attemptId, ct) => {
-            seen = observation;
-            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        lane.Classify = async (request, result, executor, observation, attemptId, ct) => {
+            observed = await observation.ObserveAsync(request, ct);
+            return new MutationOutcome.Succeeded();
         };
         lane.SetLiveAdapter(originalLive);
 
@@ -512,8 +524,51 @@ public class DaemonMutationLaneTests {
         gate.SetResult(new ProcessResult(0, "", "", false));
         await t;
 
-        await Assert.That(seen).IsSameReferenceAs(originalLive);
-        await Assert.That(seen).IsNotSameReferenceAs(otherLive);
+        await Assert.That(observed).IsEqualTo(expectedEvidence);
+        await Assert.That(originalLive.CallCount).IsEqualTo(1);
+        await Assert.That(otherLive.CallCount).IsEqualTo(0);
+
+        await lane.DisposeAsync();
+    }
+
+    // Blocker 1 (final review) — the reviewer's pinned scenario: a mutation that restarts the
+    // daemon (takeover Replace, StartVerified, DetachedStart) tears down the app's own attach, so
+    // the live adapter replays a stale Reachable=false snapshot. The composite must not let that
+    // stale snapshot stand as the classification's evidence — it falls through to a fresh one-shot
+    // in the SAME classification attempt, and full evidence there still yields Succeeded.
+    [Test]
+    public async Task Live_adapter_unreachable_falls_back_to_a_fresh_oneshot_and_a_full_evidence_result_still_succeeds() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var live = new ScriptedObservation {
+            Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(new ObservedEvidence(false, null, null, null, null, null, null, false)),
+        };
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) });
+        lane.SetLiveAdapter(live);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+
+        await lane.DisposeAsync();
+    }
+
+    // Companion to the above: when the fallback one-shot ALSO comes back unreachable (a genuinely
+    // gone daemon, not just a stale app-side attach snapshot), the honest outcome is unchanged —
+    // the composite adds a fallback leg, it never manufactures evidence.
+    [Test]
+    public async Task Live_adapter_unreachable_and_oneshot_unreachable_yields_the_unchanged_honest_outcome() {
+        var cli = new FakeKcapCli(); // default: exit 0, StatusBehavior returns null (no recorded owner)
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var live = new ScriptedObservation {
+            Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(new ObservedEvidence(false, null, null, null, null, null, null, false)),
+        };
+        var lane = MakeLane(factory); // default oneShotFactory's ScriptedObservation returns null evidence
+        lane.SetLiveAdapter(live);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
 
         await lane.DisposeAsync();
     }

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -1,6 +1,7 @@
 using Capacitor.App.Services;
 using Capacitor.App.Services.Mutation;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Capacitor.App.Tests.Unit;
@@ -642,6 +643,35 @@ public class DaemonMutationLaneTests {
         var outcome = await lane.RunAsync(Req(), CancellationToken.None);
 
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
+
+        await lane.DisposeAsync();
+    }
+
+    // P2-3: a REAL LiveGraphObservation over a client whose Status/Snapshots hold only replayed
+    // (pre-mutation) values never completes a fresh pair — the generation barrier times out
+    // (FakeTimeProvider-driven) and the composite falls through to the one-shot factory, proving
+    // the fix at the level that actually matters: the lane never trusts stale live evidence.
+    [Test]
+    public async Task Real_live_graph_observation_with_no_fresh_emission_falls_back_to_the_oneshot_factory() {
+        var client = new FakeDaemonClientService { DaemonName = "daemon-a", ProfileName = "default" };
+        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "https://cap.example.test", pid: 111, instanceId: "inst-1"));
+        client.StatusSubject.OnNext(new AttachStatus(
+            AttachState.Connected, null, ["consent/3"], null, new ConnectedIdentity(111, "inst-1", "daemon-a", "1.0.0")));
+        var time = new FakeTimeProvider();
+        var live = new LiveGraphObservation(client, time);
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var oneShotCalls = 0;
+        var lane = MakeLane(factory, oneShotFactory: _ => {
+            oneShotCalls++;
+            return new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) };
+        });
+        lane.SetLiveAdapter(live);
+
+        var outcome = await Drive(lane.RunAsync(Req(), CancellationToken.None), time, LiveGraphObservation.FreshEmissionTimeout);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(oneShotCalls).IsEqualTo(1);
 
         await lane.DisposeAsync();
     }

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -17,9 +17,12 @@ public class DaemonMutationLaneTests {
 
     sealed class ScriptedObservation : IDaemonObservation {
         public Func<MutationRequest, CancellationToken, Task<ObservedEvidence?>> Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(null);
+        // Per-call sequencing: when set, each call dequeues the next scripted result; Behavior is the fallback once exhausted or when unset.
+        public Queue<ObservedEvidence?>? Sequence;
         public int CallCount;
         public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
             CallCount++;
+            if (Sequence is { Count: > 0 } seq) return Task.FromResult(seq.Dequeue());
             return Behavior(request, ct);
         }
     }
@@ -387,9 +390,7 @@ public class DaemonMutationLaneTests {
         await lane.DisposeAsync();
     }
 
-    // P1 (round 3): the live-observation path is gone — classification evidence is always a fresh
-    // one-shot probe. This pins the ONLY remaining source: the factory runs exactly once per
-    // action, with the action's own request identity, and its result is what Classify sees.
+    // The one-shot factory is invoked exactly once per action, with the action's own request identity, and its result is what Classify sees.
     [Test]
     public async Task Observation_is_pinned_once_via_the_oneshot_factory_with_the_requests_identity() {
         var cli = new FakeKcapCli();
@@ -808,11 +809,15 @@ public class DaemonMutationLaneTests {
     public async Task Full_matching_evidence_and_ownership_on_exit_zero_is_Succeeded() {
         var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) });
+        // Two independently-built evidence instances that agree on Pid+InstanceId — the sandwich's
+        // second dial is scripted explicitly rather than relying on a re-evaluated Behavior lambda.
+        var observation = new ScriptedObservation { Sequence = new([MatchingEvidence(), MatchingEvidence()]) };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
 
         var outcome = await lane.RunAsync(Req(), CancellationToken.None);
 
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(observation.CallCount).IsEqualTo(2);
 
         await lane.DisposeAsync();
     }
@@ -822,14 +827,80 @@ public class DaemonMutationLaneTests {
         var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
         var channel = new OutcomeChannel();
-        var lane = MakeLane(
-            factory, channel: channel,
-            oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) });
+        var observation = new ScriptedObservation { Sequence = new([MatchingEvidence(), MatchingEvidence()]) };
+        var lane = MakeLane(factory, channel: channel, oneShotFactory: _ => observation);
 
         var outcome = await lane.RunAsync(Req(), CancellationToken.None);
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
 
         await AssertChannelEmptyAsync(channel);
+
+        await lane.DisposeAsync();
+    }
+
+    // ---- round-4 P1: ABA guard — the ServiceStatusAsync ownership read can straddle a process swap
+    // that reuses pid P, so the sandwich requires a SECOND fresh dial to reproduce the first's own
+    // InstanceId+Pid before Succeeded is ever returned. ----
+
+    [Test]
+    public async Task Sandwich_second_observation_different_instance_same_pid_yields_AttentionSkew_never_Succeeded() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership(jobPid: 111, daemonPid: 111)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var first = MatchingEvidence(pid: 111, instanceId: "inst-1");
+        var second = MatchingEvidence(pid: 111, instanceId: "inst-2"); // same pid — a process swap that reused pid 111
+        var observation = new ScriptedObservation { Sequence = new([first, second]) };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("instance_changed_during_classification"));
+        await Assert.That(observation.CallCount).IsEqualTo(2);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Sandwich_second_observation_unreachable_fails_closed_to_AttentionSkew() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var unreachable = new ObservedEvidence(false, null, null, null, null, null, null, false);
+        var observation = new ScriptedObservation { Sequence = new([MatchingEvidence(), unreachable]) };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("instance_changed_during_classification"));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Sandwich_second_observation_null_fails_closed_to_AttentionSkew() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var observation = new ScriptedObservation { Sequence = new([MatchingEvidence(), null]) };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.AttentionSkew("instance_changed_during_classification"));
+
+        await lane.DisposeAsync();
+    }
+
+    // Failure paths (AttentionSkew resolved from the FIRST observation) never pay for a second dial.
+    [Test]
+    public async Task Sandwich_second_dial_never_runs_when_the_first_observation_already_fails() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var wrongServer = MatchingEvidence() with { ServerUrl = "https://wrong.example.test" };
+        var observation = new ScriptedObservation { Sequence = new([wrongServer]) }; // only ONE scripted result — CallCount below proves a 2nd call never happens
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.AttentionSkew>();
+        await Assert.That(observation.CallCount).IsEqualTo(1);
 
         await lane.DisposeAsync();
     }

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -34,8 +34,10 @@ public class DaemonMutationLaneTests {
             string state = "running", bool unitPresent = true) =>
         new("daemon-a", unitPresent, state, "/opt/kcap/kcapd", "/opt/kcap/kcapd", jobPid, daemonPid, txnMarker, txnActive);
 
+    // expectation matches Req()'s own default canonical server — P2-4's TryAttribute now requires
+    // ServerIdentity.Matches(Expectation, request.CanonicalServer) on top of schema/attempt/etc.
     static string MarkerJson(string daemonName, string? attemptId) => $$"""
-        {"daemon_name":"{{daemonName}}","token":"server_expectation_mismatch","expectation":"https://s","resolved":"https://t","pid":4242,"instance_id":"inst-1","attempt_id":{{(attemptId is null ? "null" : $"\"{attemptId}\"")}}}
+        {"schema":1,"daemon_name":"{{daemonName}}","token":"server_expectation_mismatch","expectation":"https://cap.example.test","resolved":"https://t","pid":4242,"instance_id":"inst-1","attempt_id":{{(attemptId is null ? "null" : $"\"{attemptId}\"")}}}
         """;
 
     static void PlantMarker(string daemonName, string content) {
@@ -250,11 +252,12 @@ public class DaemonMutationLaneTests {
     // forced re-probe before the lane gives up.
     [Test]
     public async Task Cached_negative_probe_recovers_via_one_forced_refresh_before_refusing() {
+        var justInstalledPath = Path.Combine(Path.GetTempPath(), "opt-kcap", "bin", "kcap"); // Path.Combine, not a Unix literal, for the Windows CI leg
         var cli = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
         var probe = new FakeLoginShellProbe {
             KcapPathBehavior = _ => Task.FromResult<string?>(null), // cached negative
-            KcapPathFreshBehavior = _ => Task.FromResult<string?>("/opt/kcap/bin/kcap"), // just installed
+            KcapPathFreshBehavior = _ => Task.FromResult<string?>(justInstalledPath), // just installed
         };
         var lane = MakeLane(factory, cliOverride: () => null, shellProbe: probe, classify: CannedSucceeded);
 
@@ -262,7 +265,7 @@ public class DaemonMutationLaneTests {
 
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
         await Assert.That(factory.Calls.Count).IsEqualTo(1);
-        await Assert.That(factory.Calls[0].PinnedPath).IsEqualTo("/opt/kcap/bin/kcap");
+        await Assert.That(factory.Calls[0].PinnedPath).IsEqualTo(justInstalledPath);
         await Assert.That(probe.KcapPathForceRefreshCalls).IsEquivalentTo([false, true]);
 
         await lane.DisposeAsync();
@@ -326,15 +329,16 @@ public class DaemonMutationLaneTests {
 
     [Test]
     public async Task Executor_factory_runs_once_per_action_and_the_same_pinned_path_serves_probe_and_mutation() {
+        var customPath = Path.Combine(Path.GetTempPath(), "custom", "kcap"); // Path.Combine, not a Unix literal, for the Windows CI leg
         var cli = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory, cliOverride: () => "/custom/kcap", classify: CannedSucceeded);
+        var lane = MakeLane(factory, cliOverride: () => customPath, classify: CannedSucceeded);
 
         var outcome = await lane.RunAsync(Req(), CancellationToken.None);
 
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
         await Assert.That(factory.Calls.Count).IsEqualTo(1);
-        await Assert.That(factory.Calls[0].PinnedPath).IsEqualTo("/custom/kcap");
+        await Assert.That(factory.Calls[0].PinnedPath).IsEqualTo(customPath);
         await Assert.That(cli.VersionCallCount).IsEqualTo(1);
         await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(1); // same FakeKcapCli instance served both calls
 
@@ -540,10 +544,14 @@ public class DaemonMutationLaneTests {
         await lane.DisposeAsync();
     }
 
+    // P1-3(a): the pin now happens BEFORE the first await in ExecuteActionAsync (ahead of the CLI
+    // path resolution and the version probe) — gate the VERSION probe itself (not the mutation
+    // dispatch, which now runs strictly after the pin regardless) so a swap landing here proves the
+    // pin genuinely precedes it, not merely something further downstream.
     [Test]
     public async Task Observation_strategy_pinned_at_action_start_survives_a_mid_action_SetLiveAdapter_swap() {
-        var gate = new TaskCompletionSource<ProcessResult>();
-        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => gate.Task }; // gate AFTER the pin step, not before it
+        var gate = new TaskCompletionSource<string?>();
+        var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task }; // gate the VERSION probe — after the pin, before dispatch
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
         var expectedEvidence = MatchingEvidence(); // captured once — Capabilities is a reference type, so two separately-built instances are never record-equal
         var originalLive = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(expectedEvidence) };
@@ -557,15 +565,41 @@ public class DaemonMutationLaneTests {
         lane.SetLiveAdapter(originalLive);
 
         var t = lane.RunAsync(Req(), CancellationToken.None);
-        // By now the pin step has already run (only the mutation is gated) — a swap here must not change it.
+        // By now the pin step has already run (only the version probe is gated) — a swap here must not change it.
         lane.SetLiveAdapter(otherLive);
 
-        gate.SetResult(new ProcessResult(0, "", "", false));
+        gate.SetResult("9.9.9");
         await t;
 
         await Assert.That(observed).IsEqualTo(expectedEvidence);
         await Assert.That(originalLive.CallCount).IsEqualTo(1);
         await Assert.That(otherLive.CallCount).IsEqualTo(0);
+
+        await lane.DisposeAsync();
+    }
+
+    // P1-3(c): DetachedStart never trusts the live adapter — even a matching, currently-set one —
+    // because it synchronously replays possibly PRE-mutation status with no fresh-ownership
+    // cross-check to catch it (unlike the service verbs' ServiceStatusAsync daemon_pid ==
+    // evidence.Pid correlation); only a fresh one-shot dial is post-mutation evidence by construction.
+    [Test]
+    public async Task DetachedStart_always_pins_the_oneshot_observation_even_with_a_matching_live_adapter_set() {
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var expectedEvidence = MatchingEvidence();
+        var live = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(expectedEvidence) };
+        var oneShotCalls = 0;
+        var lane = MakeLane(factory, oneShotFactory: _ => {
+            oneShotCalls++;
+            return new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(expectedEvidence) };
+        });
+        lane.SetLiveAdapter(live); // a live adapter IS set and WOULD match this request's identity
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(oneShotCalls).IsEqualTo(1); // the one-shot factory was used
+        await Assert.That(live.CallCount).IsEqualTo(0); // the live adapter was never even consulted
 
         await lane.DisposeAsync();
     }

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -1,0 +1,313 @@
+using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Deterministic TUnit tests: every ordering assertion is driven by TaskCompletionSource gates on
+/// FakeKcapCli (shared from DaemonLifecycleControllerTests.cs, same namespace), never Task.Delay.
+public class DaemonMutationLaneTests {
+    static readonly TimeSpan Bounded = TimeSpan.FromSeconds(5);
+
+    static MutationRequest Req(
+            MutationVerb verb = MutationVerb.StartVerified, string profile = "default",
+            string server = "https://cap.example.test", string daemonName = "daemon-a") =>
+        new(verb, profile, server, daemonName);
+
+    // The lane must route every mutation through the executor factory's IKcapCli, never the raw runner, in 9a.
+    sealed class UnusedProcessRunner : IProcessRunner {
+        public Task<ProcessResult> RunAsync(string fileName, string[] args, RunOptions options, CancellationToken ct) =>
+            throw new InvalidOperationException("DaemonMutationLane must not call IProcessRunner directly.");
+    }
+
+    sealed class FakeObservation : IDaemonObservation {
+        public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) => Task.FromResult<ObservedEvidence?>(null);
+    }
+
+    sealed class RecordingExecutorFactory {
+        public readonly List<(MutationRequest Request, string? PinnedPath)> Calls = [];
+        public Func<MutationRequest, string?, IKcapCli> Behavior = (_, path) => new FakeKcapCli { CliPath = path };
+        public IKcapCli Invoke(MutationRequest request, string? pinnedPath) {
+            Calls.Add((request, pinnedPath));
+            return Behavior(request, pinnedPath);
+        }
+    }
+
+    static DaemonMutationLane MakeLane(
+            RecordingExecutorFactory factory, OutcomeChannel? channel = null,
+            Func<string?>? cliOverride = null, ILoginShellProbe? shellProbe = null) =>
+        new(
+            new UnusedProcessRunner(),
+            shellProbe ?? new FakeLoginShellProbe { KcapPathBehavior = _ => Task.FromResult<string?>(null) },
+            channel ?? new OutcomeChannel(),
+            cliOverride ?? (() => "/opt/kcap/bin/kcap"),
+            factory.Invoke,
+            _ => new FakeObservation(),
+            TimeProvider.System);
+
+    static async Task<OutcomeEnvelope> NextEnvelopeAsync(OutcomeChannel channel) {
+        using var cts = new CancellationTokenSource();
+        var enumerator = channel.ConsumeAsync(cts.Token).GetAsyncEnumerator();
+        try {
+            var got = await enumerator.MoveNextAsync().AsTask().WaitAsync(Bounded);
+            if (!got) throw new InvalidOperationException("channel ended without an envelope");
+            var envelope = enumerator.Current.Envelope;
+            enumerator.Current.Ack();
+            return envelope;
+        } finally {
+            await enumerator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Identical_concurrent_requests_coalesce_into_one_probe_and_one_mutation() {
+        var request = Req();
+        var gate = new TaskCompletionSource<string?>();
+        var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var t1 = lane.RunAsync(request, CancellationToken.None);
+        var t2 = lane.RunAsync(request, CancellationToken.None);
+
+        // Second call arrived while the first was still in flight — it must coalesce, not probe again.
+        await Assert.That(factory.Calls.Count).IsEqualTo(1);
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(0);
+
+        gate.SetResult("9.9.9");
+        var outcome1 = await t1;
+        var outcome2 = await t2;
+
+        await Assert.That(outcome1).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(outcome2).IsEqualTo(outcome1);
+        await Assert.That(factory.Calls.Count).IsEqualTo(1);
+        await Assert.That(cli.VersionCallCount).IsEqualTo(1);
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(1);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Different_queued_request_gets_its_own_fresh_probe_only_after_the_first_admits_it() {
+        var requestA = Req(daemonName: "daemon-a");
+        var requestB = Req(daemonName: "daemon-b");
+        var gateA = new TaskCompletionSource<string?>();
+        var cliA = new FakeKcapCli { VersionBehavior = _ => gateA.Task };
+        var cliB = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (req, _) => req.DaemonName == "daemon-a" ? cliA : cliB };
+        var lane = MakeLane(factory);
+
+        var t1 = lane.RunAsync(requestA, CancellationToken.None);
+        var t2 = lane.RunAsync(requestB, CancellationToken.None);
+
+        // B is a DIFFERENT request: it queues, and must not probe while A is still in flight.
+        await Assert.That(factory.Calls.Count).IsEqualTo(1);
+        await Assert.That(cliB.VersionCallCount).IsEqualTo(0);
+
+        gateA.SetResult("9.9.9");
+        var outcome1 = await t1;
+        var outcome2 = await t2;
+
+        await Assert.That(outcome1).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(outcome2).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(factory.Calls.Count).IsEqualTo(2);
+        await Assert.That(factory.Calls[0].Request).IsEqualTo(requestA);
+        await Assert.That(factory.Calls[1].Request).IsEqualTo(requestB);
+        await Assert.That(cliB.VersionCallCount).IsEqualTo(1);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Waiter_cancellation_detaches_only_that_waiter_the_action_still_completes_for_others() {
+        var request = Req();
+        var gate = new TaskCompletionSource<string?>();
+        var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        using var ctsA = new CancellationTokenSource();
+        var tA = lane.RunAsync(request, ctsA.Token);
+        var tB = lane.RunAsync(request, CancellationToken.None);
+
+        await ctsA.CancelAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => tA);
+
+        gate.SetResult("9.9.9");
+        var outcomeB = await tB;
+
+        await Assert.That(outcomeB).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(cli.VersionCallCount).IsEqualTo(1);
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(1); // uncancelled: exactly one mutation attempt
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task All_waiters_cancelled_action_still_reaches_a_terminal_state_and_the_outcome_reaches_the_channel() {
+        var request = Req();
+        var gate = new TaskCompletionSource<string?>();
+        var cli = new FakeKcapCli {
+            VersionBehavior = _ => gate.Task,
+            StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(3, "", "boom", false)),
+        };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var channel = new OutcomeChannel();
+        var lane = MakeLane(factory, channel: channel);
+
+        using var ctsA = new CancellationTokenSource();
+        using var ctsB = new CancellationTokenSource();
+        var tA = lane.RunAsync(request, ctsA.Token);
+        var tB = lane.RunAsync(request, ctsB.Token);
+
+        await ctsA.CancelAsync();
+        await ctsB.CancelAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => tA);
+        await Assert.ThrowsAsync<OperationCanceledException>(() => tB);
+
+        gate.SetResult("9.9.9"); // no waiters left — the action still must run to completion
+
+        var envelope = await NextEnvelopeAsync(channel);
+        await Assert.That(envelope.Request).IsEqualTo(request);
+        await Assert.That(envelope.Outcome).IsEqualTo(new MutationOutcome.Failed(3, null, RecoverySurface.Attention));
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(1);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Null_pin_refuses_without_ever_building_an_executor() {
+        var factory = new RecordingExecutorFactory();
+        var lane = MakeLane(
+            factory, cliOverride: () => null,
+            shellProbe: new FakeLoginShellProbe { KcapPathBehavior = _ => Task.FromResult<string?>(null) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Refused("cli_not_found", RecoverySurface.Attention));
+        await Assert.That(factory.Calls.Count).IsEqualTo(0);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Below_floor_version_refuses_without_a_mutation_call() {
+        var cli = new FakeKcapCli { VersionBehavior = _ => Task.FromResult<string?>("0.1.0") };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Refused("cli_below_floor", RecoverySurface.Attention));
+        await Assert.That(cli.VersionCallCount).IsEqualTo(1);
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(0);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Probe_in_flight_blocks_the_mutation_until_it_resolves() {
+        var gate = new TaskCompletionSource<string?>();
+        var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var t = lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(0);
+
+        gate.SetResult("9.9.9");
+        var outcome = await t;
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(1);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Executor_factory_runs_once_per_action_and_the_same_pinned_path_serves_probe_and_mutation() {
+        var cli = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory, cliOverride: () => "/custom/kcap");
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(factory.Calls.Count).IsEqualTo(1);
+        await Assert.That(factory.Calls[0].PinnedPath).IsEqualTo("/custom/kcap");
+        await Assert.That(cli.VersionCallCount).IsEqualTo(1);
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(1); // same FakeKcapCli instance served both calls
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task QuiescedAsync_completes_only_after_the_owned_action_reaches_a_terminal_state() {
+        var gate = new TaskCompletionSource<string?>();
+        var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var t = lane.RunAsync(Req(), CancellationToken.None);
+        var quiesced = lane.QuiescedAsync(CancellationToken.None);
+
+        await Assert.That(quiesced.IsCompleted).IsFalse();
+
+        gate.SetResult("9.9.9");
+        await t;
+
+        await quiesced.WaitAsync(Bounded);
+        await Assert.That(quiesced.IsCompleted).IsTrue();
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Cli_override_is_read_fresh_per_action_not_cached_from_a_prior_action() {
+        var paths = new Queue<string?>(["path-a", "path-b"]);
+        var cliA = new FakeKcapCli();
+        var cliB = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory();
+        factory.Behavior = (req, _) => req.DaemonName == "daemon-a" ? cliA : cliB;
+        var lane = MakeLane(factory, cliOverride: paths.Dequeue);
+
+        var outcome1 = await lane.RunAsync(Req(daemonName: "daemon-a"), CancellationToken.None);
+        var outcome2 = await lane.RunAsync(Req(daemonName: "daemon-b"), CancellationToken.None);
+
+        await Assert.That(outcome1).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(outcome2).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(factory.Calls.Count).IsEqualTo(2);
+        await Assert.That(factory.Calls[0].PinnedPath).IsEqualTo("path-a");
+        await Assert.That(factory.Calls[1].PinnedPath).IsEqualTo("path-b");
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Observation_strategy_is_pinned_once_and_falls_back_to_the_oneshot_factory_when_no_live_adapter_is_set() {
+        var cli = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var oneShotCalls = 0;
+        IDaemonObservation? seen = null;
+        var lane = new DaemonMutationLane(
+            new UnusedProcessRunner(),
+            new FakeLoginShellProbe { KcapPathBehavior = _ => Task.FromResult<string?>(null) },
+            new OutcomeChannel(),
+            () => "/opt/kcap/bin/kcap",
+            factory.Invoke,
+            _ => { oneShotCalls++; return new FakeObservation(); },
+            TimeProvider.System) {
+            Classify = (request, result, executor, observation, attemptId, ct) => {
+                seen = observation;
+                return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+            },
+        };
+
+        await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(oneShotCalls).IsEqualTo(1);
+        await Assert.That(seen).IsTypeOf<FakeObservation>();
+
+        await lane.DisposeAsync();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -1,5 +1,7 @@
 using Capacitor.App.Services;
 using Capacitor.App.Services.Mutation;
+using Capacitor.Cli.Core;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -22,8 +24,39 @@ public class DaemonMutationLaneTests {
         }
     }
 
-    static ObservedEvidence MatchingEvidence(int pid = 111, string instanceId = "inst-1") =>
-        new(true, [], "1.0.0", "https://cap.example.test", "daemon-a", pid, instanceId, true);
+    static ObservedEvidence MatchingEvidence(
+            int pid = 111, string instanceId = "inst-1", string server = "https://cap.example.test",
+            string daemonName = "daemon-a", IReadOnlyList<string>? capabilities = null, string? version = "1.0.0") =>
+        new(true, capabilities ?? ["consent/3"], version, server, daemonName, pid, instanceId, true);
+
+    static ServiceSnapshot Ownership(
+            int? jobPid = 111, int? daemonPid = 111, bool txnMarker = false, bool txnActive = false,
+            string state = "running", bool unitPresent = true) =>
+        new("daemon-a", unitPresent, state, "/opt/kcap/kcapd", "/opt/kcap/kcapd", jobPid, daemonPid, txnMarker, txnActive);
+
+    static string MarkerJson(string daemonName, string attemptId) => $$"""
+        {"daemon_name":"{{daemonName}}","token":"server_expectation_mismatch","expectation":"https://s","resolved":"https://t","pid":4242,"instance_id":"inst-1","attempt_id":"{{attemptId}}"}
+        """;
+
+    static void PlantMarker(string daemonName, string content) {
+        var path = BootRefusalMarker.MarkerPath(daemonName);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+    }
+
+    /// Drives a suspended poll loop by repeatedly advancing a FakeTimeProvider until the task
+    /// settles — Task.Delay(interval, time, ct)'s continuation resumes synchronously inside
+    /// Advance(), so no real waiting is needed (same pattern as ServiceVerifyStartTests.Drive).
+    static async Task<MutationOutcome> Drive(Task<MutationOutcome> task, FakeTimeProvider time, TimeSpan step) {
+        var guard = 0;
+        while (!task.IsCompleted && guard++ < 500) time.Advance(step);
+        return await task.WaitAsync(Bounded);
+    }
+
+    static Task<MutationOutcome> CannedSucceeded(
+            MutationRequest request, ProcessResult result, IKcapCli executor, IDaemonObservation observation,
+            string? attemptId, CancellationToken ct) =>
+        Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
 
     sealed class RecordingExecutorFactory {
         public readonly List<(MutationRequest Request, string? PinnedPath)> Calls = [];
@@ -37,14 +70,18 @@ public class DaemonMutationLaneTests {
     static DaemonMutationLane MakeLane(
             RecordingExecutorFactory factory, OutcomeChannel? channel = null,
             Func<string?>? cliOverride = null, ILoginShellProbe? shellProbe = null,
-            Func<MutationRequest, IDaemonObservation>? oneShotFactory = null) =>
-        new(
+            Func<MutationRequest, IDaemonObservation>? oneShotFactory = null,
+            TimeProvider? time = null, MutationClassifier? classify = null) {
+        var lane = new DaemonMutationLane(
             shellProbe ?? new FakeLoginShellProbe { KcapPathBehavior = _ => Task.FromResult<string?>(null) },
             channel ?? new OutcomeChannel(),
             cliOverride ?? (() => "/opt/kcap/bin/kcap"),
             factory.Invoke,
             oneShotFactory ?? (_ => new ScriptedObservation()),
-            TimeProvider.System);
+            time ?? TimeProvider.System);
+        if (classify is not null) lane.Classify = classify;
+        return lane;
+    }
 
     static async Task<OutcomeEnvelope> NextEnvelopeAsync(OutcomeChannel channel) {
         using var cts = new CancellationTokenSource();
@@ -75,7 +112,7 @@ public class DaemonMutationLaneTests {
         var gate = new TaskCompletionSource<string?>();
         var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory);
+        var lane = MakeLane(factory, classify: CannedSucceeded);
 
         var t1 = lane.RunAsync(request, CancellationToken.None);
         var t2 = lane.RunAsync(request, CancellationToken.None);
@@ -105,7 +142,7 @@ public class DaemonMutationLaneTests {
         var cliA = new FakeKcapCli { StartVerifiedBehavior = _ => gateA.Task }; // gate the MUTATION, not just the probe
         var cliB = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (req, _) => req.DaemonName == "daemon-a" ? cliA : cliB };
-        var lane = MakeLane(factory);
+        var lane = MakeLane(factory, classify: CannedSucceeded);
 
         var t1 = lane.RunAsync(requestA, CancellationToken.None);
         var t2 = lane.RunAsync(requestB, CancellationToken.None);
@@ -137,7 +174,7 @@ public class DaemonMutationLaneTests {
         var gate = new TaskCompletionSource<string?>();
         var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory);
+        var lane = MakeLane(factory, classify: CannedSucceeded);
 
         using var ctsA = new CancellationTokenSource();
         var tA = lane.RunAsync(request, ctsA.Token);
@@ -233,7 +270,7 @@ public class DaemonMutationLaneTests {
         var gate = new TaskCompletionSource<string?>();
         var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory);
+        var lane = MakeLane(factory, classify: CannedSucceeded);
 
         var t = lane.RunAsync(Req(), CancellationToken.None);
 
@@ -252,7 +289,7 @@ public class DaemonMutationLaneTests {
     public async Task Executor_factory_runs_once_per_action_and_the_same_pinned_path_serves_probe_and_mutation() {
         var cli = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory, cliOverride: () => "/custom/kcap");
+        var lane = MakeLane(factory, cliOverride: () => "/custom/kcap", classify: CannedSucceeded);
 
         var outcome = await lane.RunAsync(Req(), CancellationToken.None);
 
@@ -293,7 +330,7 @@ public class DaemonMutationLaneTests {
         var cliB = new FakeKcapCli();
         var factory = new RecordingExecutorFactory();
         factory.Behavior = (req, _) => req.DaemonName == "daemon-a" ? cliA : cliB;
-        var lane = MakeLane(factory, cliOverride: paths.Dequeue);
+        var lane = MakeLane(factory, cliOverride: paths.Dequeue, classify: CannedSucceeded);
 
         var outcome1 = await lane.RunAsync(Req(daemonName: "daemon-a"), CancellationToken.None);
         var outcome2 = await lane.RunAsync(Req(daemonName: "daemon-b"), CancellationToken.None);
@@ -333,7 +370,7 @@ public class DaemonMutationLaneTests {
     public async Task Install_verb_calls_ServiceInstallVerifiedAsync_with_replace_false() {
         var cli = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory);
+        var lane = MakeLane(factory, classify: CannedSucceeded);
 
         var outcome = await lane.RunAsync(Req(verb: MutationVerb.Install), CancellationToken.None);
 
@@ -348,7 +385,7 @@ public class DaemonMutationLaneTests {
     public async Task Replace_verb_calls_ServiceInstallVerifiedAsync_with_replace_true() {
         var cli = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory);
+        var lane = MakeLane(factory, classify: CannedSucceeded);
 
         var outcome = await lane.RunAsync(Req(verb: MutationVerb.Replace), CancellationToken.None);
 
@@ -363,7 +400,7 @@ public class DaemonMutationLaneTests {
     public async Task StartVerified_verb_calls_ServiceStartVerifiedAsync() {
         var cli = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory);
+        var lane = MakeLane(factory, classify: CannedSucceeded);
 
         var outcome = await lane.RunAsync(Req(verb: MutationVerb.StartVerified), CancellationToken.None);
 
@@ -377,7 +414,7 @@ public class DaemonMutationLaneTests {
     public async Task DetachedStart_verb_calls_the_bootAttemptId_overload_with_an_N_format_guid() {
         var cli = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory);
+        var lane = MakeLane(factory, classify: CannedSucceeded);
 
         var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
 
@@ -395,7 +432,7 @@ public class DaemonMutationLaneTests {
         var cliB = new FakeKcapCli();
         var factory = new RecordingExecutorFactory();
         factory.Behavior = (req, _) => req.DaemonName == "daemon-a" ? cliA : cliB;
-        var lane = MakeLane(factory);
+        var lane = MakeLane(factory, classify: CannedSucceeded);
 
         await lane.RunAsync(Req(verb: MutationVerb.DetachedStart, daemonName: "daemon-a"), CancellationToken.None);
         await lane.RunAsync(Req(verb: MutationVerb.DetachedStart, daemonName: "daemon-b"), CancellationToken.None);
@@ -512,6 +549,21 @@ public class DaemonMutationLaneTests {
         await lane.DisposeAsync(); // idempotent
     }
 
+    // N1: RunAsync arriving after DisposeAsync has already completed must resolve cancelled under
+    // the _gate _disposed check in AttachOrCreate — no action started, nothing enqueued.
+    [Test]
+    public async Task RunAsync_after_dispose_has_completed_resolves_cancelled_and_starts_nothing() {
+        var factory = new RecordingExecutorFactory();
+        var channel = new OutcomeChannel();
+        var lane = MakeLane(factory, channel: channel);
+        await lane.DisposeAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => lane.RunAsync(Req(), CancellationToken.None));
+
+        await Assert.That(factory.Calls.Count).IsEqualTo(0);
+        await AssertChannelEmptyAsync(channel);
+    }
+
     // ---- I2: no outcome silently vanishes ----
 
     [Test, NotInParallel]
@@ -562,7 +614,9 @@ public class DaemonMutationLaneTests {
             Console.SetError(originalError);
         }
 
-        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(-1, nameof(InvalidOperationException), RecoverySurface.Attention));
+        // N2: the exception type/message stay ONLY in the log line — the outcome itself carries a
+        // named, stable exit code and reason token, never a leaked exception identity.
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(DaemonMutationLane.UnexpectedExitCode, "internal_error", RecoverySurface.Attention));
         await Assert.That(stderrWriter.ToString()).Contains(nameof(InvalidOperationException));
 
         var envelope = await NextEnvelopeAsync(channel);
@@ -579,7 +633,7 @@ public class DaemonMutationLaneTests {
         var gate = new TaskCompletionSource<string?>();
         var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory);
+        var lane = MakeLane(factory, classify: CannedSucceeded);
 
         using var cts = new CancellationTokenSource();
         var t = lane.RunAsync(request, cts.Token);
@@ -599,5 +653,444 @@ public class DaemonMutationLaneTests {
         await Assert.That(stderrWriter.ToString()).Contains("waiterless Succeeded");
 
         await lane.DisposeAsync();
+    }
+
+    // ==== Task 9b: outcome classification (service verbs, exit 0) ====
+
+    [Test]
+    public async Task Mutation_failure_beside_matching_evidence_is_not_Succeeded() {
+        var cli = new FakeKcapCli {
+            StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(5, "", "", false)),
+            StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()),
+        };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var observation = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        // A nonzero exit is decisive regardless of what evidence happens to show — never consulted.
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(5, null, RecoverySurface.Attention));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Wrong_server_evidence_on_success_exit_yields_AttentionSkew() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var wrongServer = MatchingEvidence() with { ServerUrl = "https://wrong.example.test" };
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(wrongServer) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.AttentionSkew>();
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Manual_non_owning_job_pid_mismatch_is_not_Succeeded() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership(jobPid: 111, daemonPid: 222)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var evidence = MatchingEvidence(pid: 222);
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(evidence) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsNotEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.AttentionSkew>();
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Unreachable_evidence_with_no_recorded_owner_is_UnconfirmedNoAttach() {
+        var cli = new FakeKcapCli(); // default: exit 0, StatusBehavior returns null (no owner)
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory); // default oneShotFactory's ScriptedObservation returns null evidence
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Unreachable_evidence_with_a_recorded_owner_pid_yields_AttentionSkew() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory); // evidence stays unreachable (default ScriptedObservation)
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.AttentionSkew>();
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Missing_consent_capability_yields_AttentionSkew() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var noCapabilities = MatchingEvidence() with { Capabilities = [] };
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(noCapabilities) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.AttentionSkew>();
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Preslice_evidence_without_pid_or_instance_never_succeeds() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var preslice = new ObservedEvidence(true, ["consent/3"], "1.0.0", "https://cap.example.test", "daemon-a", null, null, false);
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(preslice) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsNotEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.AttentionSkew>();
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Below_floor_daemon_version_at_observation_yields_AttentionSkew() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var oldVersion = MatchingEvidence() with { DaemonVersion = "0.1.0" };
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(oldVersion) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.AttentionSkew>();
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Instance_pid_cross_check_failure_yields_AttentionSkew() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership(jobPid: 333, daemonPid: 333)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var evidence = MatchingEvidence(pid: 111); // ownership.DaemonPid(333) != evidence.Pid(111)
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(evidence) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.AttentionSkew>();
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Stale_txn_marker_on_success_exit_yields_AttentionRepair() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership(txnMarker: true, txnActive: false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.AttentionRepair>();
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Full_matching_evidence_and_ownership_on_exit_zero_is_Succeeded() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Succeeded_outcome_never_reaches_the_channel() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var channel = new OutcomeChannel();
+        var lane = MakeLane(
+            factory, channel: channel,
+            oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) });
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+
+        await AssertChannelEmptyAsync(channel);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task AttentionSkew_outcome_is_enqueued_exactly_once_with_its_own_request() {
+        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var channel = new OutcomeChannel();
+        var wrongServer = MatchingEvidence() with { ServerUrl = "https://wrong.example.test" };
+        var lane = MakeLane(
+            factory, channel: channel,
+            oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(wrongServer) });
+
+        var request = Req();
+        var outcome = await lane.RunAsync(request, CancellationToken.None);
+        await Assert.That(outcome).IsTypeOf<MutationOutcome.AttentionSkew>();
+
+        var envelope = await NextEnvelopeAsync(channel);
+        await Assert.That(envelope.Request).IsEqualTo(request);
+        await Assert.That(envelope.Outcome).IsEqualTo(outcome);
+
+        await lane.DisposeAsync();
+    }
+
+    // ==== Task 9b: outcome classification (service verbs, coded nonzero exits) ====
+
+    [Test]
+    public async Task Exit28_with_a_takeover_routed_token_fails_with_Takeover_surface() {
+        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(28, "", "start_gate_reason=identity_mismatch\n", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(28, "identity_mismatch", RecoverySurface.Takeover));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Exit28_with_a_reinstall_routed_token_fails_with_Reinstall_surface() {
+        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(28, "", "start_gate_reason=package_inconsistent\n", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(28, "package_inconsistent", RecoverySurface.Reinstall));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Exit28_with_zero_reason_lines_fails_closed_to_Attention() {
+        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(28, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(28, null, RecoverySurface.Attention));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Exit28_with_duplicate_conflicting_reason_lines_fails_closed_to_Attention() {
+        var cli = new FakeKcapCli {
+            StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(
+                28, "", "start_gate_reason=identity_mismatch\nstart_gate_reason=foreign_binary\n", false)),
+        };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(28, null, RecoverySurface.Attention));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Exit29_is_Attention_and_the_lane_never_retries_the_mutation() {
+        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(29, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(29, null, RecoverySurface.Attention));
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(1);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Readiness_timeout_with_refusal_reason_is_Refused_with_Takeover() {
+        var cli = new FakeKcapCli {
+            StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(24, "", "refusal_reason=server_expectation_mismatch\n", false)),
+        };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Refused("server_expectation_mismatch", RecoverySurface.Takeover));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Readiness_timeout_without_refusal_reason_is_UnconfirmedNoAttach() {
+        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(24, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Other_nonzero_exit_fails_closed_to_Attention_with_no_reason() {
+        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => Task.FromResult(new ProcessResult(21, "", "verify_viability", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(21, null, RecoverySurface.Attention));
+
+        await lane.DisposeAsync();
+    }
+
+    // ==== Task 9b: outcome classification (DetachedStart) ====
+
+    [Test]
+    public async Task Exit43_with_a_routed_token_fails_with_Reinstall_surface() {
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(43, "", "daemon_start_reason=package_inconsistent\n", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(43, "package_inconsistent", RecoverySurface.Reinstall));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Exit43_with_no_reason_line_fails_closed_to_Attention() {
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(43, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(43, null, RecoverySurface.Attention));
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task DetachedStart_exit_zero_with_immediate_full_evidence_is_Succeeded_without_waiting() {
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var observation = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task DetachedStart_exit_zero_window_expiry_with_no_evidence_and_no_marker_is_UnconfirmedNoAttach() {
+        var time = new FakeTimeProvider();
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory, time: time); // default observation returns null evidence forever
+
+        var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task DetachedStart_wrapper_timeout_with_full_evidence_is_SucceededAfterTimeout() {
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", true)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var observation = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) };
+        var lane = MakeLane(factory, oneShotFactory: _ => observation);
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.SucceededAfterTimeout());
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task DetachedStart_wrapper_timeout_with_incomplete_evidence_is_UnconfirmedNoAttach() {
+        var time = new FakeTimeProvider();
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", true)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory, time: time);
+
+        var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+        var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
+
+        await lane.DisposeAsync();
+    }
+
+    // ==== Task 9b: DetachedStart boot-refusal marker attribution (real filesystem — BootRefusalMarkerTests pattern) ====
+
+    [Test, NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task DetachedStart_exit_zero_with_an_attributed_marker_is_Refused_and_consumes_the_marker() {
+        var dir = Directory.CreateTempSubdirectory("dml-marker-").FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        var cli = new FakeKcapCli();
+        cli.DetachedStartBehavior = _ => {
+            PlantMarker("daemon-a", MarkerJson("daemon-a", cli.LastBootAttemptId!));
+            return Task.FromResult(new ProcessResult(0, "", "", false));
+        };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory); // default observation never shows full evidence
+        try {
+            var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+
+            await Assert.That(outcome).IsEqualTo(new MutationOutcome.Refused("server_expectation_mismatch", RecoverySurface.Takeover));
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath("daemon-a"))).IsFalse();
+        } finally {
+            await lane.DisposeAsync();
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+        }
+    }
+
+    [Test, NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task DetachedStart_exit_zero_with_a_foreign_marker_is_UnconfirmedNoAttach_and_retains_the_marker() {
+        var dir = Directory.CreateTempSubdirectory("dml-marker-").FullName;
+        DaemonLockPaths.OverrideDirectoryForTesting(dir);
+        var time = new FakeTimeProvider();
+        PlantMarker("daemon-a", MarkerJson("daemon-a", "foreign-attempt-id"));
+        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory, time: time);
+        try {
+            var task = lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+            var outcome = await Drive(task, time, TimeSpan.FromMilliseconds(500));
+
+            await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
+            await Assert.That(File.Exists(BootRefusalMarker.MarkerPath("daemon-a"))).IsTrue();
+        } finally {
+            await lane.DisposeAsync();
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+        }
     }
 }

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -13,15 +13,17 @@ public class DaemonMutationLaneTests {
             string server = "https://cap.example.test", string daemonName = "daemon-a") =>
         new(verb, profile, server, daemonName);
 
-    // The lane must route every mutation through the executor factory's IKcapCli, never the raw runner, in 9a.
-    sealed class UnusedProcessRunner : IProcessRunner {
-        public Task<ProcessResult> RunAsync(string fileName, string[] args, RunOptions options, CancellationToken ct) =>
-            throw new InvalidOperationException("DaemonMutationLane must not call IProcessRunner directly.");
+    sealed class ScriptedObservation : IDaemonObservation {
+        public Func<MutationRequest, CancellationToken, Task<ObservedEvidence?>> Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(null);
+        public int CallCount;
+        public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
+            CallCount++;
+            return Behavior(request, ct);
+        }
     }
 
-    sealed class FakeObservation : IDaemonObservation {
-        public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) => Task.FromResult<ObservedEvidence?>(null);
-    }
+    static ObservedEvidence MatchingEvidence(int pid = 111, string instanceId = "inst-1") =>
+        new(true, [], "1.0.0", "https://cap.example.test", "daemon-a", pid, instanceId, true);
 
     sealed class RecordingExecutorFactory {
         public readonly List<(MutationRequest Request, string? PinnedPath)> Calls = [];
@@ -34,14 +36,14 @@ public class DaemonMutationLaneTests {
 
     static DaemonMutationLane MakeLane(
             RecordingExecutorFactory factory, OutcomeChannel? channel = null,
-            Func<string?>? cliOverride = null, ILoginShellProbe? shellProbe = null) =>
+            Func<string?>? cliOverride = null, ILoginShellProbe? shellProbe = null,
+            Func<MutationRequest, IDaemonObservation>? oneShotFactory = null) =>
         new(
-            new UnusedProcessRunner(),
             shellProbe ?? new FakeLoginShellProbe { KcapPathBehavior = _ => Task.FromResult<string?>(null) },
             channel ?? new OutcomeChannel(),
             cliOverride ?? (() => "/opt/kcap/bin/kcap"),
             factory.Invoke,
-            _ => new FakeObservation(),
+            oneShotFactory ?? (_ => new ScriptedObservation()),
             TimeProvider.System);
 
     static async Task<OutcomeEnvelope> NextEnvelopeAsync(OutcomeChannel channel) {
@@ -56,6 +58,15 @@ public class DaemonMutationLaneTests {
         } finally {
             await enumerator.DisposeAsync();
         }
+    }
+
+    static async Task AssertChannelEmptyAsync(OutcomeChannel channel) {
+        using var cts = new CancellationTokenSource();
+        var enumerator = channel.ConsumeAsync(cts.Token).GetAsyncEnumerator();
+        var moveNext = enumerator.MoveNextAsync();
+        await cts.CancelAsync();
+        await Assert.That(async () => await moveNext.AsTask().WaitAsync(Bounded)).Throws<OperationCanceledException>();
+        await enumerator.DisposeAsync();
     }
 
     [Test]
@@ -87,11 +98,11 @@ public class DaemonMutationLaneTests {
     }
 
     [Test]
-    public async Task Different_queued_request_gets_its_own_fresh_probe_only_after_the_first_admits_it() {
+    public async Task Different_queued_request_gets_its_own_fresh_probe_only_after_the_first_reaches_a_terminal_state() {
         var requestA = Req(daemonName: "daemon-a");
         var requestB = Req(daemonName: "daemon-b");
-        var gateA = new TaskCompletionSource<string?>();
-        var cliA = new FakeKcapCli { VersionBehavior = _ => gateA.Task };
+        var gateA = new TaskCompletionSource<ProcessResult>();
+        var cliA = new FakeKcapCli { StartVerifiedBehavior = _ => gateA.Task }; // gate the MUTATION, not just the probe
         var cliB = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (req, _) => req.DaemonName == "daemon-a" ? cliA : cliB };
         var lane = MakeLane(factory);
@@ -99,11 +110,14 @@ public class DaemonMutationLaneTests {
         var t1 = lane.RunAsync(requestA, CancellationToken.None);
         var t2 = lane.RunAsync(requestB, CancellationToken.None);
 
-        // B is a DIFFERENT request: it queues, and must not probe while A is still in flight.
+        // A's own probe already succeeded (VersionAsync resolves synchronously by default) but its
+        // MUTATION is still gated — B (a different, queued request) must not have probed yet.
+        await Assert.That(cliA.VersionCallCount).IsEqualTo(1);
+        await Assert.That(cliA.StartVerifiedCallCount).IsEqualTo(1);
         await Assert.That(factory.Calls.Count).IsEqualTo(1);
         await Assert.That(cliB.VersionCallCount).IsEqualTo(0);
 
-        gateA.SetResult("9.9.9");
+        gateA.SetResult(new ProcessResult(0, "", "", false));
         var outcome1 = await t1;
         var outcome2 = await t2;
 
@@ -177,14 +191,19 @@ public class DaemonMutationLaneTests {
     [Test]
     public async Task Null_pin_refuses_without_ever_building_an_executor() {
         var factory = new RecordingExecutorFactory();
+        var channel = new OutcomeChannel();
         var lane = MakeLane(
-            factory, cliOverride: () => null,
+            factory, channel: channel, cliOverride: () => null,
             shellProbe: new FakeLoginShellProbe { KcapPathBehavior = _ => Task.FromResult<string?>(null) });
 
         var outcome = await lane.RunAsync(Req(), CancellationToken.None);
 
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.Refused("cli_not_found", RecoverySurface.Attention));
         await Assert.That(factory.Calls.Count).IsEqualTo(0);
+
+        var envelope = await NextEnvelopeAsync(channel);
+        await Assert.That(envelope.Request).IsEqualTo(Req());
+        await Assert.That(envelope.Outcome).IsEqualTo(outcome);
 
         await lane.DisposeAsync();
     }
@@ -193,13 +212,18 @@ public class DaemonMutationLaneTests {
     public async Task Below_floor_version_refuses_without_a_mutation_call() {
         var cli = new FakeKcapCli { VersionBehavior = _ => Task.FromResult<string?>("0.1.0") };
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var lane = MakeLane(factory);
+        var channel = new OutcomeChannel();
+        var lane = MakeLane(factory, channel: channel);
 
         var outcome = await lane.RunAsync(Req(), CancellationToken.None);
 
         await Assert.That(outcome).IsEqualTo(new MutationOutcome.Refused("cli_below_floor", RecoverySurface.Attention));
         await Assert.That(cli.VersionCallCount).IsEqualTo(1);
         await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(0);
+
+        var envelope = await NextEnvelopeAsync(channel);
+        await Assert.That(envelope.Request).IsEqualTo(Req());
+        await Assert.That(envelope.Outcome).IsEqualTo(outcome);
 
         await lane.DisposeAsync();
     }
@@ -289,24 +313,290 @@ public class DaemonMutationLaneTests {
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
         var oneShotCalls = 0;
         IDaemonObservation? seen = null;
-        var lane = new DaemonMutationLane(
-            new UnusedProcessRunner(),
-            new FakeLoginShellProbe { KcapPathBehavior = _ => Task.FromResult<string?>(null) },
-            new OutcomeChannel(),
-            () => "/opt/kcap/bin/kcap",
-            factory.Invoke,
-            _ => { oneShotCalls++; return new FakeObservation(); },
-            TimeProvider.System) {
-            Classify = (request, result, executor, observation, attemptId, ct) => {
-                seen = observation;
-                return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
-            },
+        var lane = MakeLane(factory, oneShotFactory: _ => { oneShotCalls++; return new ScriptedObservation(); });
+        lane.Classify = (request, result, executor, observation, attemptId, ct) => {
+            seen = observation;
+            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
         };
 
         await lane.RunAsync(Req(), CancellationToken.None);
 
         await Assert.That(oneShotCalls).IsEqualTo(1);
-        await Assert.That(seen).IsTypeOf<FakeObservation>();
+        await Assert.That(seen).IsTypeOf<ScriptedObservation>();
+
+        await lane.DisposeAsync();
+    }
+
+    // ---- T1: verb coverage ----
+
+    [Test]
+    public async Task Install_verb_calls_ServiceInstallVerifiedAsync_with_replace_false() {
+        var cli = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.Install), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(cli.InstallVerifiedCallCount).IsEqualTo(1);
+        await Assert.That(cli.LastInstallReplace).IsEqualTo(false);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Replace_verb_calls_ServiceInstallVerifiedAsync_with_replace_true() {
+        var cli = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.Replace), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(cli.InstallVerifiedCallCount).IsEqualTo(1);
+        await Assert.That(cli.LastInstallReplace).IsEqualTo(true);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task StartVerified_verb_calls_ServiceStartVerifiedAsync() {
+        var cli = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.StartVerified), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(1);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task DetachedStart_verb_calls_the_bootAttemptId_overload_with_an_N_format_guid() {
+        var cli = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
+        await Assert.That(cli.DetachedStartCallCount).IsEqualTo(1);
+        await Assert.That(cli.LastBootAttemptId).IsNotNull();
+        await Assert.That(Guid.TryParseExact(cli.LastBootAttemptId, "N", out _)).IsTrue();
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Successive_detached_start_actions_get_different_attempt_ids() {
+        var cliA = new FakeKcapCli();
+        var cliB = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory();
+        factory.Behavior = (req, _) => req.DaemonName == "daemon-a" ? cliA : cliB;
+        var lane = MakeLane(factory);
+
+        await lane.RunAsync(Req(verb: MutationVerb.DetachedStart, daemonName: "daemon-a"), CancellationToken.None);
+        await lane.RunAsync(Req(verb: MutationVerb.DetachedStart, daemonName: "daemon-b"), CancellationToken.None);
+
+        await Assert.That(cliA.LastBootAttemptId).IsNotNull();
+        await Assert.That(cliB.LastBootAttemptId).IsNotNull();
+        await Assert.That(cliA.LastBootAttemptId).IsNotEqualTo(cliB.LastBootAttemptId);
+
+        await lane.DisposeAsync();
+    }
+
+    // ---- T2: SetLiveAdapter coverage ----
+
+    [Test]
+    public async Task Live_adapter_with_matching_evidence_is_pinned_and_the_oneshot_factory_is_never_called() {
+        var cli = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var live = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) };
+        var oneShotCalls = 0;
+        IDaemonObservation? seen = null;
+        var lane = MakeLane(factory, oneShotFactory: _ => { oneShotCalls++; return new ScriptedObservation(); });
+        lane.Classify = (request, result, executor, observation, attemptId, ct) => {
+            seen = observation;
+            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        };
+        lane.SetLiveAdapter(live);
+
+        await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(oneShotCalls).IsEqualTo(0);
+        await Assert.That(seen).IsSameReferenceAs(live);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Live_adapter_returning_null_falls_back_to_the_oneshot_factory() {
+        var cli = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var live = new ScriptedObservation(); // default behavior returns null — cannot target this request
+        var oneShotCalls = 0;
+        IDaemonObservation? seen = null;
+        var lane = MakeLane(factory, oneShotFactory: _ => { oneShotCalls++; return new ScriptedObservation(); });
+        lane.Classify = (request, result, executor, observation, attemptId, ct) => {
+            seen = observation;
+            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        };
+        lane.SetLiveAdapter(live);
+
+        await lane.RunAsync(Req(), CancellationToken.None);
+
+        await Assert.That(oneShotCalls).IsEqualTo(1);
+        await Assert.That(seen).IsNotSameReferenceAs(live);
+
+        await lane.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Observation_strategy_pinned_at_action_start_survives_a_mid_action_SetLiveAdapter_swap() {
+        var gate = new TaskCompletionSource<ProcessResult>();
+        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => gate.Task }; // gate AFTER the pin step, not before it
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var originalLive = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) };
+        var otherLive = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence(222, "inst-2")) };
+        IDaemonObservation? seen = null;
+        var lane = MakeLane(factory);
+        lane.Classify = (request, result, executor, observation, attemptId, ct) => {
+            seen = observation;
+            return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+        };
+        lane.SetLiveAdapter(originalLive);
+
+        var t = lane.RunAsync(Req(), CancellationToken.None);
+        // By now the pin step has already run (only the mutation is gated) — a swap here must not change it.
+        lane.SetLiveAdapter(otherLive);
+
+        gate.SetResult(new ProcessResult(0, "", "", false));
+        await t;
+
+        await Assert.That(seen).IsSameReferenceAs(originalLive);
+        await Assert.That(seen).IsNotSameReferenceAs(otherLive);
+
+        await lane.DisposeAsync();
+    }
+
+    // ---- I1: post-dispose admission must never spawn a real mutation ----
+
+    [Test]
+    public async Task Dispose_mid_action_cancels_queued_work_without_starting_a_successor() {
+        var requestA = Req(daemonName: "daemon-a");
+        var requestB = Req(daemonName: "daemon-b");
+        var gateA = new TaskCompletionSource<string?>();
+        var cliA = new FakeKcapCli { VersionBehavior = _ => gateA.Task };
+        var cliB = new FakeKcapCli();
+        var factory = new RecordingExecutorFactory { Behavior = (req, _) => req.DaemonName == "daemon-a" ? cliA : cliB };
+        var lane = MakeLane(factory);
+
+        var tA = lane.RunAsync(requestA, CancellationToken.None);
+        var tB = lane.RunAsync(requestB, CancellationToken.None); // queues behind A
+
+        var disposeTask = lane.DisposeAsync().AsTask(); // drains+cancels the queue synchronously; still awaiting A
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => tB); // B's queued waiter cancels promptly, not waiting for A
+        await Assert.That(disposeTask.IsCompleted).IsFalse(); // still waiting on A's owned task
+
+        gateA.SetResult("9.9.9"); // A observes the cancelled lifetime token at its pre-Dispatch gate
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => tA);
+        await disposeTask.WaitAsync(Bounded);
+
+        await Assert.That(factory.Calls.Count).IsEqualTo(1); // B's executor factory never invoked — no successor started
+        await Assert.That(cliA.StartVerifiedCallCount).IsEqualTo(0); // A never actually dispatched either
+
+        await lane.DisposeAsync(); // idempotent
+    }
+
+    // ---- I2: no outcome silently vanishes ----
+
+    [Test, NotInParallel]
+    public async Task Waiterless_cancellation_from_a_disposed_lane_logs_one_line_and_enqueues_nothing() {
+        var request = Req();
+        var gate = new TaskCompletionSource<string?>();
+        var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var channel = new OutcomeChannel();
+        var lane = MakeLane(factory, channel: channel);
+
+        using var ctsA = new CancellationTokenSource();
+        var tA = lane.RunAsync(request, ctsA.Token);
+        await ctsA.CancelAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => tA); // detaches — zero waiters remain on the owned slot
+
+        var disposeTask = lane.DisposeAsync().AsTask(); // still awaiting the owned action
+
+        var originalError = Console.Error;
+        var stderrWriter = new StringWriter();
+        try {
+            Console.SetError(stderrWriter);
+            gate.SetResult("9.9.9"); // unblocks the (now waiterless) owned action into its pre-Dispatch cancellation throw
+        } finally {
+            Console.SetError(originalError);
+        }
+
+        await disposeTask.WaitAsync(Bounded);
+
+        await Assert.That(stderrWriter.ToString()).Contains("waiterless cancellation");
+        await AssertChannelEmptyAsync(channel); // shutdown is not actionable evidence
+    }
+
+    [Test, NotInParallel]
+    public async Task Unexpected_exception_during_a_mutation_attempt_logs_and_enqueues_a_failed_outcome() {
+        var cli = new FakeKcapCli { StartVerifiedBehavior = _ => throw new InvalidOperationException("boom") };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var channel = new OutcomeChannel();
+        var lane = MakeLane(factory, channel: channel);
+
+        var originalError = Console.Error;
+        var stderrWriter = new StringWriter();
+        MutationOutcome outcome;
+        try {
+            Console.SetError(stderrWriter);
+            outcome = await lane.RunAsync(Req(), CancellationToken.None);
+        } finally {
+            Console.SetError(originalError);
+        }
+
+        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Failed(-1, nameof(InvalidOperationException), RecoverySurface.Attention));
+        await Assert.That(stderrWriter.ToString()).Contains(nameof(InvalidOperationException));
+
+        var envelope = await NextEnvelopeAsync(channel);
+        await Assert.That(envelope.Outcome).IsEqualTo(outcome);
+
+        await lane.DisposeAsync();
+    }
+
+    // ---- M5: waiterless success is logged, not silently dropped ----
+
+    [Test, NotInParallel]
+    public async Task Waiterless_success_logs_one_line_to_console_error() {
+        var request = Req();
+        var gate = new TaskCompletionSource<string?>();
+        var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
+        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
+        var lane = MakeLane(factory);
+
+        using var cts = new CancellationTokenSource();
+        var t = lane.RunAsync(request, cts.Token);
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => t); // detaches — zero waiters remain on the owned slot
+
+        var originalError = Console.Error;
+        var stderrWriter = new StringWriter();
+        try {
+            Console.SetError(stderrWriter);
+            gate.SetResult("9.9.9"); // action still runs to a normal Succeeded outcome with nobody left to observe it
+        } finally {
+            Console.SetError(originalError);
+        }
+
+        await Assert.That(cli.StartVerifiedCallCount).IsEqualTo(1); // the action still completed
+        await Assert.That(stderrWriter.ToString()).Contains("waiterless Succeeded");
 
         await lane.DisposeAsync();
     }

--- a/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonMutationLaneTests.cs
@@ -1,7 +1,6 @@
 using Capacitor.App.Services;
 using Capacitor.App.Services.Mutation;
 using Capacitor.Cli.Core;
-using Capacitor.Cli.Core.LocalIpc;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Capacitor.App.Tests.Unit;
@@ -388,22 +387,29 @@ public class DaemonMutationLaneTests {
         await lane.DisposeAsync();
     }
 
+    // P1 (round 3): the live-observation path is gone — classification evidence is always a fresh
+    // one-shot probe. This pins the ONLY remaining source: the factory runs exactly once per
+    // action, with the action's own request identity, and its result is what Classify sees.
     [Test]
-    public async Task Observation_strategy_is_pinned_once_and_falls_back_to_the_oneshot_factory_when_no_live_adapter_is_set() {
+    public async Task Observation_is_pinned_once_via_the_oneshot_factory_with_the_requests_identity() {
         var cli = new FakeKcapCli();
         var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
         var oneShotCalls = 0;
-        IDaemonObservation? seen = null;
-        var lane = MakeLane(factory, oneShotFactory: _ => { oneShotCalls++; return new ScriptedObservation(); });
+        MutationRequest? seenRequest = null;
+        IDaemonObservation? seenObservation = null;
+        var scripted = new ScriptedObservation();
+        var lane = MakeLane(factory, oneShotFactory: request => { oneShotCalls++; seenRequest = request; return scripted; });
         lane.Classify = (request, result, executor, observation, attemptId, ct) => {
-            seen = observation;
+            seenObservation = observation;
             return Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
         };
 
-        await lane.RunAsync(Req(), CancellationToken.None);
+        var req = Req();
+        await lane.RunAsync(req, CancellationToken.None);
 
         await Assert.That(oneShotCalls).IsEqualTo(1);
-        await Assert.That(seen).IsTypeOf<ScriptedObservation>();
+        await Assert.That(seenRequest).IsEqualTo(req);
+        await Assert.That(seenObservation).IsSameReferenceAs(scripted);
 
         await lane.DisposeAsync();
     }
@@ -484,194 +490,6 @@ public class DaemonMutationLaneTests {
         await Assert.That(cliA.LastBootAttemptId).IsNotNull();
         await Assert.That(cliB.LastBootAttemptId).IsNotNull();
         await Assert.That(cliA.LastBootAttemptId).IsNotEqualTo(cliB.LastBootAttemptId);
-
-        await lane.DisposeAsync();
-    }
-
-    // ---- T2: SetLiveAdapter coverage ----
-
-    // Blocker 1 (final review): the pinned strategy is now a COMPOSITE that tries live first and
-    // falls through to a fresh one-shot only when live's own result is null/not-Reachable — so
-    // `observation` handed to Classify is never the raw live reference any more. These tests drive
-    // the composite through a REAL ObserveAsync call (rather than just capturing the reference) to
-    // prove the try-live-then-fall-through behavior at the classification-attempt level.
-    [Test]
-    public async Task Live_adapter_with_matching_evidence_is_pinned_and_the_oneshot_factory_is_never_called() {
-        var cli = new FakeKcapCli();
-        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var expectedEvidence = MatchingEvidence(); // captured once — Capabilities is a reference type, so two separately-built instances are never record-equal
-        var live = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(expectedEvidence) };
-        var oneShotCalls = 0;
-        ObservedEvidence? observed = null;
-        var lane = MakeLane(factory, oneShotFactory: _ => { oneShotCalls++; return new ScriptedObservation(); });
-        lane.Classify = async (request, result, executor, observation, attemptId, ct) => {
-            observed = await observation.ObserveAsync(request, ct);
-            return new MutationOutcome.Succeeded();
-        };
-        lane.SetLiveAdapter(live);
-
-        await lane.RunAsync(Req(), CancellationToken.None);
-
-        await Assert.That(oneShotCalls).IsEqualTo(0);
-        await Assert.That(live.CallCount).IsEqualTo(1);
-        await Assert.That(observed).IsEqualTo(expectedEvidence);
-
-        await lane.DisposeAsync();
-    }
-
-    [Test]
-    public async Task Live_adapter_returning_null_falls_back_to_the_oneshot_factory() {
-        var cli = new FakeKcapCli();
-        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var live = new ScriptedObservation(); // default behavior returns null — cannot target this request
-        var oneShotEvidence = MatchingEvidence(pid: 999, instanceId: "inst-oneshot");
-        var oneShotCalls = 0;
-        ObservedEvidence? observed = null;
-        var lane = MakeLane(factory, oneShotFactory: _ => {
-            oneShotCalls++;
-            return new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(oneShotEvidence) };
-        });
-        lane.Classify = async (request, result, executor, observation, attemptId, ct) => {
-            observed = await observation.ObserveAsync(request, ct);
-            return new MutationOutcome.Succeeded();
-        };
-        lane.SetLiveAdapter(live);
-
-        await lane.RunAsync(Req(), CancellationToken.None);
-
-        await Assert.That(oneShotCalls).IsEqualTo(1);
-        await Assert.That(observed).IsEqualTo(oneShotEvidence);
-
-        await lane.DisposeAsync();
-    }
-
-    // P1-3(a): the pin now happens BEFORE the first await in ExecuteActionAsync (ahead of the CLI
-    // path resolution and the version probe) — gate the VERSION probe itself (not the mutation
-    // dispatch, which now runs strictly after the pin regardless) so a swap landing here proves the
-    // pin genuinely precedes it, not merely something further downstream.
-    [Test]
-    public async Task Observation_strategy_pinned_at_action_start_survives_a_mid_action_SetLiveAdapter_swap() {
-        var gate = new TaskCompletionSource<string?>();
-        var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task }; // gate the VERSION probe — after the pin, before dispatch
-        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var expectedEvidence = MatchingEvidence(); // captured once — Capabilities is a reference type, so two separately-built instances are never record-equal
-        var originalLive = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(expectedEvidence) };
-        var otherLive = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence(222, "inst-2")) };
-        ObservedEvidence? observed = null;
-        var lane = MakeLane(factory);
-        lane.Classify = async (request, result, executor, observation, attemptId, ct) => {
-            observed = await observation.ObserveAsync(request, ct);
-            return new MutationOutcome.Succeeded();
-        };
-        lane.SetLiveAdapter(originalLive);
-
-        var t = lane.RunAsync(Req(), CancellationToken.None);
-        // By now the pin step has already run (only the version probe is gated) — a swap here must not change it.
-        lane.SetLiveAdapter(otherLive);
-
-        gate.SetResult("9.9.9");
-        await t;
-
-        await Assert.That(observed).IsEqualTo(expectedEvidence);
-        await Assert.That(originalLive.CallCount).IsEqualTo(1);
-        await Assert.That(otherLive.CallCount).IsEqualTo(0);
-
-        await lane.DisposeAsync();
-    }
-
-    // P1-3(c): DetachedStart never trusts the live adapter — even a matching, currently-set one —
-    // because it synchronously replays possibly PRE-mutation status with no fresh-ownership
-    // cross-check to catch it (unlike the service verbs' ServiceStatusAsync daemon_pid ==
-    // evidence.Pid correlation); only a fresh one-shot dial is post-mutation evidence by construction.
-    [Test]
-    public async Task DetachedStart_always_pins_the_oneshot_observation_even_with_a_matching_live_adapter_set() {
-        var cli = new FakeKcapCli { DetachedStartBehavior = _ => Task.FromResult(new ProcessResult(0, "", "", false)) };
-        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var expectedEvidence = MatchingEvidence();
-        var live = new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(expectedEvidence) };
-        var oneShotCalls = 0;
-        var lane = MakeLane(factory, oneShotFactory: _ => {
-            oneShotCalls++;
-            return new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(expectedEvidence) };
-        });
-        lane.SetLiveAdapter(live); // a live adapter IS set and WOULD match this request's identity
-
-        var outcome = await lane.RunAsync(Req(verb: MutationVerb.DetachedStart), CancellationToken.None);
-
-        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
-        await Assert.That(oneShotCalls).IsEqualTo(1); // the one-shot factory was used
-        await Assert.That(live.CallCount).IsEqualTo(0); // the live adapter was never even consulted
-
-        await lane.DisposeAsync();
-    }
-
-    // Blocker 1 (final review) — the reviewer's pinned scenario: a mutation that restarts the
-    // daemon (takeover Replace, StartVerified, DetachedStart) tears down the app's own attach, so
-    // the live adapter replays a stale Reachable=false snapshot. The composite must not let that
-    // stale snapshot stand as the classification's evidence — it falls through to a fresh one-shot
-    // in the SAME classification attempt, and full evidence there still yields Succeeded.
-    [Test]
-    public async Task Live_adapter_unreachable_falls_back_to_a_fresh_oneshot_and_a_full_evidence_result_still_succeeds() {
-        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
-        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var live = new ScriptedObservation {
-            Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(new ObservedEvidence(false, null, null, null, null, null, null, false)),
-        };
-        var lane = MakeLane(factory, oneShotFactory: _ => new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) });
-        lane.SetLiveAdapter(live);
-
-        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
-
-        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
-
-        await lane.DisposeAsync();
-    }
-
-    // Companion to the above: when the fallback one-shot ALSO comes back unreachable (a genuinely
-    // gone daemon, not just a stale app-side attach snapshot), the honest outcome is unchanged —
-    // the composite adds a fallback leg, it never manufactures evidence.
-    [Test]
-    public async Task Live_adapter_unreachable_and_oneshot_unreachable_yields_the_unchanged_honest_outcome() {
-        var cli = new FakeKcapCli(); // default: exit 0, StatusBehavior returns null (no recorded owner)
-        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var live = new ScriptedObservation {
-            Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(new ObservedEvidence(false, null, null, null, null, null, null, false)),
-        };
-        var lane = MakeLane(factory); // default oneShotFactory's ScriptedObservation returns null evidence
-        lane.SetLiveAdapter(live);
-
-        var outcome = await lane.RunAsync(Req(), CancellationToken.None);
-
-        await Assert.That(outcome).IsEqualTo(new MutationOutcome.UnconfirmedNoAttach());
-
-        await lane.DisposeAsync();
-    }
-
-    // P2-3: a REAL LiveGraphObservation over a client whose Status/Snapshots hold only replayed
-    // (pre-mutation) values never completes a fresh pair — the generation barrier times out
-    // (FakeTimeProvider-driven) and the composite falls through to the one-shot factory, proving
-    // the fix at the level that actually matters: the lane never trusts stale live evidence.
-    [Test]
-    public async Task Real_live_graph_observation_with_no_fresh_emission_falls_back_to_the_oneshot_factory() {
-        var client = new FakeDaemonClientService { DaemonName = "daemon-a", ProfileName = "default" };
-        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "https://cap.example.test", pid: 111, instanceId: "inst-1"));
-        client.StatusSubject.OnNext(new AttachStatus(
-            AttachState.Connected, null, ["consent/3"], null, new ConnectedIdentity(111, "inst-1", "daemon-a", "1.0.0")));
-        var time = new FakeTimeProvider();
-        var live = new LiveGraphObservation(client, time);
-        var cli = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Ownership()) };
-        var factory = new RecordingExecutorFactory { Behavior = (_, _) => cli };
-        var oneShotCalls = 0;
-        var lane = MakeLane(factory, oneShotFactory: _ => {
-            oneShotCalls++;
-            return new ScriptedObservation { Behavior = (_, _) => Task.FromResult<ObservedEvidence?>(MatchingEvidence()) };
-        });
-        lane.SetLiveAdapter(live);
-
-        var outcome = await Drive(lane.RunAsync(Req(), CancellationToken.None), time, LiveGraphObservation.FreshEmissionTimeout);
-
-        await Assert.That(outcome).IsEqualTo(new MutationOutcome.Succeeded());
-        await Assert.That(oneShotCalls).IsEqualTo(1);
 
         await lane.DisposeAsync();
     }

--- a/test/Capacitor.App.Tests.Unit/DaemonObservationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonObservationTests.cs
@@ -1,11 +1,9 @@
-using Capacitor.App.Services;
 using Capacitor.App.Services.Mutation;
 using Capacitor.Cli.Core.LocalIpc;
-using Microsoft.Extensions.Time.Testing;
 
 namespace Capacitor.App.Tests.Unit;
 
-/// Plain TUnit tests — OneShotObservation is driven via its scripted Probe seam, LiveGraphObservation via FakeDaemonClientService.
+/// Plain TUnit tests — OneShotObservation is driven via its scripted Probe seam.
 public class DaemonObservationTests {
     static MutationRequest Req(string daemonName = "daemon-a", string server = "http://localhost:9999") =>
         new(MutationVerb.StartVerified, "default", server, daemonName);
@@ -78,114 +76,5 @@ public class DaemonObservationTests {
 
         await Assert.That(seenName).IsEqualTo("daemon-x");
         await Assert.That(seenTimeout).IsEqualTo(TimeSpan.FromSeconds(3));
-    }
-
-    // --- LiveGraphObservation ---
-    //
-    // P2-3: a generation barrier, not a synchronous read — ObserveAsync discards whatever Status/
-    // Snapshots replay synchronously on subscribe and waits for the NEXT (post-subscription)
-    // emission of each. Every test below that expects real evidence therefore pushes onto the
-    // subjects AFTER calling ObserveAsync (the subscriptions are already live by then, since
-    // nothing awaits before them), never before.
-
-    [Test]
-    public async Task LiveGraph_name_mismatch_returns_null() {
-        var client = new FakeDaemonClientService { DaemonName = "daemon-other" };
-        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
-
-        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a"), CancellationToken.None);
-
-        await Assert.That(evidence).IsNull();
-    }
-
-    // P1-3(b): spec §4's live-adapter identity gate is "daemon name + profile/server" — a client
-    // resolved for a DIFFERENT profile can never stand in for this request, even when the daemon
-    // name and server both match (a same-named daemon reachable under two profiles is not the
-    // same target).
-    [Test]
-    public async Task LiveGraph_profile_mismatch_returns_null() {
-        var client = new FakeDaemonClientService { DaemonName = "daemon-a", ProfileName = "other-profile" };
-        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
-
-        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
-
-        await Assert.That(evidence).IsNull();
-    }
-
-    // The timeout leg the composite's fallback depends on: only replayed (pre-subscription)
-    // values ever landed, so no fresh pair ever completes — FreshEmissionTimeout elapses (driven
-    // by FakeTimeProvider, no real sleep) and ObserveAsync degrades to null.
-    [Test]
-    public async Task LiveGraph_no_fresh_emission_within_the_bound_times_out_to_null() {
-        var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
-        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999", pid: 111, instanceId: "inst-1"));
-        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"])); // both pre-subscription — pure replay
-        var time = new FakeTimeProvider();
-        var adapter = new LiveGraphObservation(client, time);
-
-        var task = adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
-        time.Advance(LiveGraphObservation.FreshEmissionTimeout);
-        var evidence = await task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        await Assert.That(evidence).IsNull();
-    }
-
-    [Test]
-    public async Task LiveGraph_server_mismatch_on_a_fresh_snapshot_returns_null() {
-        var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
-        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
-
-        var task = adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
-        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"]));
-        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:1111"));
-        var evidence = await task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        await Assert.That(evidence).IsNull();
-    }
-
-    [Test]
-    public async Task LiveGraph_fresh_connected_matching_identity_is_consistent() {
-        var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
-        var snap = FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999", pid: 111, instanceId: "inst-1");
-        var identity = new ConnectedIdentity(111, "inst-1", "daemon-a", "1.2.3");
-        var caps = new List<string> { "status/1" }; // same reference used below — IReadOnlyList members compare by reference
-        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
-
-        var task = adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
-        client.SnapshotsSubject.OnNext(snap);
-        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, caps, null, identity));
-        var evidence = await task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        await Assert.That(evidence).IsEqualTo(new ObservedEvidence(
-            true, caps, "1.2.3", "http://localhost:9999", "daemon-a", 111, "inst-1", true));
-    }
-
-    [Test]
-    public async Task LiveGraph_fresh_hello_snapshot_pid_mismatch_is_inconsistent() {
-        var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
-        var snap = FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999", pid: 111, instanceId: "inst-1");
-        var identity = new ConnectedIdentity(222, "inst-1", "daemon-a", "1.2.3"); // pid disagrees with the snapshot
-        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
-
-        var task = adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
-        client.SnapshotsSubject.OnNext(snap);
-        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"], null, identity));
-        var evidence = await task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        await Assert.That(evidence!.Reachable).IsTrue();
-        await Assert.That(evidence.IdentityConsistent).IsFalse();
-    }
-
-    [Test]
-    public async Task LiveGraph_fresh_non_connected_is_unreachable_evidence() {
-        var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
-        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
-
-        var task = adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
-        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999"));
-        client.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
-        var evidence = await task.WaitAsync(TimeSpan.FromSeconds(5));
-
-        await Assert.That(evidence).IsEqualTo(new ObservedEvidence(false, null, null, null, null, null, null, false));
     }
 }

--- a/test/Capacitor.App.Tests.Unit/DaemonObservationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonObservationTests.cs
@@ -91,6 +91,22 @@ public class DaemonObservationTests {
         await Assert.That(evidence).IsNull();
     }
 
+    // P1-3(b): spec §4's live-adapter identity gate is "daemon name + profile/server" — a client
+    // resolved for a DIFFERENT profile can never stand in for this request, even when the daemon
+    // name and server both match (a same-named daemon reachable under two profiles is not the
+    // same target).
+    [Test]
+    public async Task LiveGraph_profile_mismatch_returns_null() {
+        var client = new FakeDaemonClientService { DaemonName = "daemon-a", ProfileName = "other-profile" };
+        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999"));
+        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"]));
+        var adapter = new LiveGraphObservation(client);
+
+        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+
+        await Assert.That(evidence).IsNull();
+    }
+
     [Test]
     public async Task LiveGraph_server_mismatch_returns_null() {
         var client = new FakeDaemonClientService { DaemonName = "daemon-a" };

--- a/test/Capacitor.App.Tests.Unit/DaemonObservationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonObservationTests.cs
@@ -1,6 +1,7 @@
 using Capacitor.App.Services;
 using Capacitor.App.Services.Mutation;
 using Capacitor.Cli.Core.LocalIpc;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -80,11 +81,17 @@ public class DaemonObservationTests {
     }
 
     // --- LiveGraphObservation ---
+    //
+    // P2-3: a generation barrier, not a synchronous read — ObserveAsync discards whatever Status/
+    // Snapshots replay synchronously on subscribe and waits for the NEXT (post-subscription)
+    // emission of each. Every test below that expects real evidence therefore pushes onto the
+    // subjects AFTER calling ObserveAsync (the subscriptions are already live by then, since
+    // nothing awaits before them), never before.
 
     [Test]
     public async Task LiveGraph_name_mismatch_returns_null() {
         var client = new FakeDaemonClientService { DaemonName = "daemon-other" };
-        var adapter = new LiveGraphObservation(client);
+        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
 
         var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a"), CancellationToken.None);
 
@@ -98,66 +105,86 @@ public class DaemonObservationTests {
     [Test]
     public async Task LiveGraph_profile_mismatch_returns_null() {
         var client = new FakeDaemonClientService { DaemonName = "daemon-a", ProfileName = "other-profile" };
-        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999"));
-        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"]));
-        var adapter = new LiveGraphObservation(client);
+        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
 
         var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
 
         await Assert.That(evidence).IsNull();
     }
 
+    // The timeout leg the composite's fallback depends on: only replayed (pre-subscription)
+    // values ever landed, so no fresh pair ever completes — FreshEmissionTimeout elapses (driven
+    // by FakeTimeProvider, no real sleep) and ObserveAsync degrades to null.
     [Test]
-    public async Task LiveGraph_server_mismatch_returns_null() {
+    public async Task LiveGraph_no_fresh_emission_within_the_bound_times_out_to_null() {
         var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
-        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:1111"));
-        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"]));
-        var adapter = new LiveGraphObservation(client);
+        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999", pid: 111, instanceId: "inst-1"));
+        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"])); // both pre-subscription — pure replay
+        var time = new FakeTimeProvider();
+        var adapter = new LiveGraphObservation(client, time);
 
-        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+        var task = adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+        time.Advance(LiveGraphObservation.FreshEmissionTimeout);
+        var evidence = await task.WaitAsync(TimeSpan.FromSeconds(5));
 
         await Assert.That(evidence).IsNull();
     }
 
     [Test]
-    public async Task LiveGraph_connected_matching_identity_is_consistent() {
+    public async Task LiveGraph_server_mismatch_on_a_fresh_snapshot_returns_null() {
+        var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
+        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
+
+        var task = adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"]));
+        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:1111"));
+        var evidence = await task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(evidence).IsNull();
+    }
+
+    [Test]
+    public async Task LiveGraph_fresh_connected_matching_identity_is_consistent() {
         var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
         var snap = FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999", pid: 111, instanceId: "inst-1");
         var identity = new ConnectedIdentity(111, "inst-1", "daemon-a", "1.2.3");
         var caps = new List<string> { "status/1" }; // same reference used below — IReadOnlyList members compare by reference
+        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
+
+        var task = adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
         client.SnapshotsSubject.OnNext(snap);
         client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, caps, null, identity));
-        var adapter = new LiveGraphObservation(client);
-
-        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+        var evidence = await task.WaitAsync(TimeSpan.FromSeconds(5));
 
         await Assert.That(evidence).IsEqualTo(new ObservedEvidence(
             true, caps, "1.2.3", "http://localhost:9999", "daemon-a", 111, "inst-1", true));
     }
 
     [Test]
-    public async Task LiveGraph_connected_hello_snapshot_pid_mismatch_is_inconsistent() {
+    public async Task LiveGraph_fresh_hello_snapshot_pid_mismatch_is_inconsistent() {
         var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
         var snap = FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999", pid: 111, instanceId: "inst-1");
         var identity = new ConnectedIdentity(222, "inst-1", "daemon-a", "1.2.3"); // pid disagrees with the snapshot
+        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
+
+        var task = adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
         client.SnapshotsSubject.OnNext(snap);
         client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"], null, identity));
-        var adapter = new LiveGraphObservation(client);
-
-        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+        var evidence = await task.WaitAsync(TimeSpan.FromSeconds(5));
 
         await Assert.That(evidence!.Reachable).IsTrue();
         await Assert.That(evidence.IdentityConsistent).IsFalse();
     }
 
     [Test]
-    public async Task LiveGraph_non_connected_is_unreachable_evidence() {
+    public async Task LiveGraph_fresh_non_connected_is_unreachable_evidence() {
         var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
+        var adapter = new LiveGraphObservation(client, new FakeTimeProvider());
+
+        var task = adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
         client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999"));
         client.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
-        var adapter = new LiveGraphObservation(client);
-
-        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+        var evidence = await task.WaitAsync(TimeSpan.FromSeconds(5));
 
         await Assert.That(evidence).IsEqualTo(new ObservedEvidence(false, null, null, null, null, null, null, false));
     }

--- a/test/Capacitor.App.Tests.Unit/DaemonObservationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonObservationTests.cs
@@ -1,0 +1,148 @@
+using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Plain TUnit tests — OneShotObservation is driven via its scripted Probe seam, LiveGraphObservation via FakeDaemonClientService.
+public class DaemonObservationTests {
+    static MutationRequest Req(string daemonName = "daemon-a", string server = "http://localhost:9999") =>
+        new(MutationVerb.StartVerified, "default", server, daemonName);
+
+    // --- OneShotObservation ---
+
+    [Test]
+    public async Task OneShot_reachable_consistent_maps_hello_and_snapshot_fields() {
+        var hello = new HelloReplyDto(1, "1.2.3", "daemon-a", ["status/1"], Pid: 111, InstanceId: "inst-1");
+        var snap = FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999", pid: 111, instanceId: "inst-1");
+        var probeResult = new ProbeResult(true, hello, snap, IdentityConsistent: true);
+        var adapter = new OneShotObservation(TimeSpan.FromSeconds(1)) { Probe = (_, _, _) => Task.FromResult(probeResult) };
+
+        var evidence = await adapter.ObserveAsync(Req(), CancellationToken.None);
+
+        await Assert.That(evidence).IsEqualTo(new ObservedEvidence(
+            true, hello.Capabilities, "1.2.3", "http://localhost:9999", "daemon-a", 111, "inst-1", true));
+    }
+
+    [Test]
+    public async Task OneShot_reachable_inconsistent_carries_false() {
+        var hello = new HelloReplyDto(1, "1.2.3", "daemon-a", ["status/1"], Pid: 111, InstanceId: "inst-1");
+        var snap = FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999", pid: 222, instanceId: "inst-2");
+        var probeResult = new ProbeResult(true, hello, snap, IdentityConsistent: false);
+        var adapter = new OneShotObservation(TimeSpan.FromSeconds(1)) { Probe = (_, _, _) => Task.FromResult(probeResult) };
+
+        var evidence = await adapter.ObserveAsync(Req(), CancellationToken.None);
+
+        await Assert.That(evidence!.Reachable).IsTrue();
+        await Assert.That(evidence.IdentityConsistent).IsFalse();
+    }
+
+    [Test]
+    public async Task OneShot_unreachable_maps_to_false_evidence() {
+        var probeResult = new ProbeResult(false, null, null, false);
+        var adapter = new OneShotObservation(TimeSpan.FromSeconds(1)) { Probe = (_, _, _) => Task.FromResult(probeResult) };
+
+        var evidence = await adapter.ObserveAsync(Req(), CancellationToken.None);
+
+        await Assert.That(evidence).IsEqualTo(new ObservedEvidence(false, null, null, null, null, null, null, false));
+    }
+
+    [Test]
+    public async Task OneShot_pre_slice_daemon_null_pid_instance_is_inconsistent() {
+        var hello = new HelloReplyDto(1, "1.2.3", "daemon-a", ["status/1"]); // predates Pid/InstanceId
+        var snap = FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999"); // predates Pid/InstanceId
+        var probeResult = new ProbeResult(true, hello, snap, IdentityConsistent: false);
+        var adapter = new OneShotObservation(TimeSpan.FromSeconds(1)) { Probe = (_, _, _) => Task.FromResult(probeResult) };
+
+        var evidence = await adapter.ObserveAsync(Req(), CancellationToken.None);
+
+        await Assert.That(evidence!.IdentityConsistent).IsFalse();
+        await Assert.That(evidence.Pid).IsNull();
+        await Assert.That(evidence.InstanceId).IsNull();
+    }
+
+    [Test]
+    public async Task OneShot_calls_probe_with_the_requests_daemon_name_and_its_own_timeout() {
+        string? seenName = null;
+        TimeSpan? seenTimeout = null;
+        var adapter = new OneShotObservation(TimeSpan.FromSeconds(3)) {
+            Probe = (name, timeout, _) => {
+                seenName = name;
+                seenTimeout = timeout;
+                return Task.FromResult(new ProbeResult(false, null, null, false));
+            }
+        };
+
+        await adapter.ObserveAsync(Req(daemonName: "daemon-x"), CancellationToken.None);
+
+        await Assert.That(seenName).IsEqualTo("daemon-x");
+        await Assert.That(seenTimeout).IsEqualTo(TimeSpan.FromSeconds(3));
+    }
+
+    // --- LiveGraphObservation ---
+
+    [Test]
+    public async Task LiveGraph_name_mismatch_returns_null() {
+        var client = new FakeDaemonClientService { DaemonName = "daemon-other" };
+        var adapter = new LiveGraphObservation(client);
+
+        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a"), CancellationToken.None);
+
+        await Assert.That(evidence).IsNull();
+    }
+
+    [Test]
+    public async Task LiveGraph_server_mismatch_returns_null() {
+        var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
+        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:1111"));
+        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"]));
+        var adapter = new LiveGraphObservation(client);
+
+        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+
+        await Assert.That(evidence).IsNull();
+    }
+
+    [Test]
+    public async Task LiveGraph_connected_matching_identity_is_consistent() {
+        var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
+        var snap = FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999", pid: 111, instanceId: "inst-1");
+        var identity = new ConnectedIdentity(111, "inst-1", "daemon-a", "1.2.3");
+        var caps = new List<string> { "status/1" }; // same reference used below — IReadOnlyList members compare by reference
+        client.SnapshotsSubject.OnNext(snap);
+        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, caps, null, identity));
+        var adapter = new LiveGraphObservation(client);
+
+        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+
+        await Assert.That(evidence).IsEqualTo(new ObservedEvidence(
+            true, caps, "1.2.3", "http://localhost:9999", "daemon-a", 111, "inst-1", true));
+    }
+
+    [Test]
+    public async Task LiveGraph_connected_hello_snapshot_pid_mismatch_is_inconsistent() {
+        var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
+        var snap = FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999", pid: 111, instanceId: "inst-1");
+        var identity = new ConnectedIdentity(222, "inst-1", "daemon-a", "1.2.3"); // pid disagrees with the snapshot
+        client.SnapshotsSubject.OnNext(snap);
+        client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["status/1"], null, identity));
+        var adapter = new LiveGraphObservation(client);
+
+        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+
+        await Assert.That(evidence!.Reachable).IsTrue();
+        await Assert.That(evidence.IdentityConsistent).IsFalse();
+    }
+
+    [Test]
+    public async Task LiveGraph_non_connected_is_unreachable_evidence() {
+        var client = new FakeDaemonClientService { DaemonName = "daemon-a" };
+        client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap("daemon-a", serverUrl: "http://localhost:9999"));
+        client.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+        var adapter = new LiveGraphObservation(client);
+
+        var evidence = await adapter.ObserveAsync(Req(daemonName: "daemon-a", server: "http://localhost:9999"), CancellationToken.None);
+
+        await Assert.That(evidence).IsEqualTo(new ObservedEvidence(false, null, null, null, null, null, null, false));
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/FakeDaemonClientService.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeDaemonClientService.cs
@@ -16,9 +16,6 @@ sealed class FakeDaemonClientService : IDaemonClientService {
     public IObservable<DaemonStatusDto> Snapshots => SnapshotsSubject;
     public SourceCache<AgentStatusDto, string> Agents { get; } = new(a => a.Id);
     public string DaemonName { get; set; } = "daemon-a";
-    // Matches the "default" profile every test's MutationRequest.Profile literal already uses, so
-    // existing LiveGraphObservation tests keep passing without also having to set this explicitly.
-    public string? ProfileName { get; set; } = "default";
 
     public int RestartCount;
     public Task RestartLoopAsync() {

--- a/test/Capacitor.App.Tests.Unit/FakeDaemonClientService.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeDaemonClientService.cs
@@ -15,7 +15,7 @@ sealed class FakeDaemonClientService : IDaemonClientService {
     public IObservable<AttachStatus> Status => StatusSubject;
     public IObservable<DaemonStatusDto> Snapshots => SnapshotsSubject;
     public SourceCache<AgentStatusDto, string> Agents { get; } = new(a => a.Id);
-    public string DaemonName => "daemon-a";
+    public string DaemonName { get; set; } = "daemon-a";
 
     public int RestartCount;
     public Task RestartLoopAsync() {
@@ -32,12 +32,13 @@ sealed class FakeDaemonClientService : IDaemonClientService {
 
     public static DaemonStatusDto Snap(
             string daemon = "daemon-a", string version = "1.2.3", string serverUrl = "http://localhost:9999",
-            string connection = "connected", int active = 0, int max = 5) {
+            string connection = "connected", int active = 0, int max = 5, int? pid = null, string? instanceId = null) {
         var agents = Enumerable.Range(0, active).Select(i => new AgentStatusDto(
             Id: $"a{i}", Kind: "agent", Vendor: "claude", RepoPath: null, Status: "Running",
             FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null,
             RequesterDisplay: null
         )).ToList();
-        return new DaemonStatusDto(new DaemonInfoDto(daemon, version, serverUrl, connection, max, active), agents);
+        return new DaemonStatusDto(
+            new DaemonInfoDto(daemon, version, serverUrl, connection, max, active, pid, instanceId), agents);
     }
 }

--- a/test/Capacitor.App.Tests.Unit/FakeDaemonClientService.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeDaemonClientService.cs
@@ -16,6 +16,9 @@ sealed class FakeDaemonClientService : IDaemonClientService {
     public IObservable<DaemonStatusDto> Snapshots => SnapshotsSubject;
     public SourceCache<AgentStatusDto, string> Agents { get; } = new(a => a.Id);
     public string DaemonName { get; set; } = "daemon-a";
+    // Matches the "default" profile every test's MutationRequest.Profile literal already uses, so
+    // existing LiveGraphObservation tests keep passing without also having to set this explicitly.
+    public string? ProfileName { get; set; } = "default";
 
     public int RestartCount;
     public Task RestartLoopAsync() {

--- a/test/Capacitor.App.Tests.Unit/FakeLifecycleSurface.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeLifecycleSurface.cs
@@ -19,4 +19,11 @@ sealed class FakeLifecycleSurface : ILifecycleSurface {
         Prompts.Add(prompt);
         return ConfirmBehavior(prompt, ct);
     }
+
+    /// Mirrors LifecycleSurface's own contract: an already-cancelled ct never reaches the dialog — null, nothing recorded.
+    public async Task<bool?> TryConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) {
+        if (ct.IsCancellationRequested) return null;
+        Prompts.Add(prompt);
+        return await ConfirmBehavior(prompt, ct).ConfigureAwait(false);
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/KcapCliCompatibilityTests.cs
+++ b/test/Capacitor.App.Tests.Unit/KcapCliCompatibilityTests.cs
@@ -1,0 +1,46 @@
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class KcapCliCompatibilityTests {
+    [Test]
+    [Arguments("0.12.0-beta.1", true)]
+    [Arguments("0.12.0-beta.2", true)]
+    [Arguments("0.12.0", true)]
+    [Arguments("0.12.1-beta.1", true)]
+    [Arguments("0.13.0", true)]
+    [Arguments("0.11.9", false)]
+    [Arguments("0.12.0-beta.0", false)]
+    [Arguments("0.12.0-alpha.9", false)] // alpha < beta
+    [Arguments("01.2.3", false)] // strict parse: leading-zero core
+    [Arguments("0.12.0-beta.01", false)] // strict parse: leading-zero prerelease numeric
+    [Arguments("0.12.0-", false)]
+    [Arguments("0.12", false)]
+    [Arguments("", false)]
+    [Arguments(null, false)]
+    [Arguments("unknown", false)]
+    [Arguments("v0.12.0", false)]
+    [Arguments("0.12.0+build.5", true)] // build metadata ignored
+    [Arguments("0.12.0-beta.1+x", true)]
+    public async Task Satisfies_reports_whether_version_meets_the_floor(string? version, bool expected) {
+        await Assert.That(KcapCliCompatibility.Satisfies(version)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("0.12.0-beta.1", true)]
+    [Arguments("0.12.0", true)]
+    [Arguments("0.11.9", true)] // valid grammar; below-floor is Satisfies' concern, not StrictParse's
+    [Arguments("0.12.0-alpha.9", true)]
+    [Arguments("01.2.3", false)]
+    [Arguments("0.12.0-beta.01", false)]
+    [Arguments("0.12.0-", false)]
+    [Arguments("0.12", false)]
+    [Arguments("", false)]
+    [Arguments("unknown", false)]
+    [Arguments("v0.12.0", false)]
+    [Arguments("0.12.0+build.5", true)]
+    [Arguments("0.12.0-beta.1+x", true)]
+    public async Task StrictParse_validates_the_semver_grammar(string version, bool expected) {
+        await Assert.That(KcapCliCompatibility.StrictParse(version)).IsEqualTo(expected);
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/KcapCliTests.cs
+++ b/test/Capacitor.App.Tests.Unit/KcapCliTests.cs
@@ -158,24 +158,13 @@ public class KcapCliTests {
         var runner = new FakeProcessRunner();
         var cli = MakeCli(runner);
 
-        await cli.DetachedStartAsync(CancellationToken.None);
+        await cli.DetachedStartAsync("boot-attempt-test", CancellationToken.None);
 
         await Assert.That(runner.SeenArgs).IsEquivalentTo(
             ["daemon", "start", "-d", "--name", "daemon-a"], CollectionOrdering.Matching);
         await Assert.That(runner.SeenOptions!.CancelMode).IsEqualTo(CancelMode.AbandonWait);
         await Assert.That(runner.SeenOptions!.Timeout).IsEqualTo(TimeSpan.FromSeconds(75));
         await Assert.That(runner.SeenOptions!.TimeoutKill).IsEqualTo(TimeoutKillScope.ProcessOnly);
-    }
-
-    [Test]
-    public async Task DetachedStartAsync_parameterless_stamps_a_fresh_guid_boot_attempt_id() {
-        var runner = new FakeProcessRunner();
-        var cli = MakeCli(runner);
-
-        await cli.DetachedStartAsync(CancellationToken.None);
-
-        var seen = runner.SeenOptions!.EnvOverlay![KcapCli.BootAttemptVar];
-        await Assert.That(Guid.TryParseExact(seen, "N", out _)).IsTrue();
     }
 
     [Test]
@@ -194,7 +183,7 @@ public class KcapCliTests {
     }
 
     [Test]
-    public async Task DetachedStartAsync_with_null_CliPath_returns_exit_127_without_calling_the_runner_overload() {
+    public async Task DetachedStartAsync_with_null_CliPath_returns_exit_127_without_calling_the_runner() {
         var runner = new FakeProcessRunner();
         var cli = MakeCliWithNullPath(runner);
 
@@ -223,7 +212,7 @@ public class KcapCliTests {
         await cli.ServiceInstallVerifiedAsync(replace: false, CancellationToken.None);
         await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.SpawnNoTelemetryVar]).IsEqualTo("1");
 
-        await cli.DetachedStartAsync(CancellationToken.None);
+        await cli.DetachedStartAsync("boot-attempt-test", CancellationToken.None);
         await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.SpawnNoTelemetryVar]).IsEqualTo("1");
     }
 
@@ -240,7 +229,7 @@ public class KcapCliTests {
         await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.ConsentSeedDefaultVar]).IsEqualTo("prompt");
         await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.ExpectServerUrlVar]).IsEqualTo(CanonicalServer);
 
-        await cli.DetachedStartAsync(CancellationToken.None);
+        await cli.DetachedStartAsync("boot-attempt-test", CancellationToken.None);
         await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.ConsentSeedDefaultVar]).IsEqualTo("prompt");
         await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.ExpectServerUrlVar]).IsEqualTo(CanonicalServer);
     }
@@ -281,15 +270,6 @@ public class KcapCliTests {
 
     [Test]
     public async Task DetachedStartAsync_with_null_canonicalServer_throws_before_any_spawn() {
-        var runner = new FakeProcessRunner();
-        var cli = MakeCli(runner, canonicalServer: null);
-
-        await Assert.ThrowsAsync<InvalidOperationException>(() => cli.DetachedStartAsync(CancellationToken.None));
-        await Assert.That(runner.SeenFileName).IsNull();
-    }
-
-    [Test]
-    public async Task DetachedStartAsync_with_boot_attempt_id_and_null_canonicalServer_throws_before_any_spawn() {
         var runner = new FakeProcessRunner();
         var cli = MakeCli(runner, canonicalServer: null);
 
@@ -341,7 +321,7 @@ public class KcapCliTests {
         await cli.ServiceInstallVerifiedAsync(replace: false, CancellationToken.None);
         await Assert.That(runner.SeenOptions!.EnvOverlay!["KCAP_PROFILE"]).IsEqualTo("work");
 
-        await cli.DetachedStartAsync(CancellationToken.None);
+        await cli.DetachedStartAsync("boot-attempt-test", CancellationToken.None);
         await Assert.That(runner.SeenOptions!.EnvOverlay!["KCAP_PROFILE"]).IsEqualTo("work");
     }
 
@@ -362,7 +342,7 @@ public class KcapCliTests {
         await cli.ServiceStartVerifiedAsync(CancellationToken.None);
         await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey("PATH")).IsFalse();
 
-        await cli.DetachedStartAsync(CancellationToken.None);
+        await cli.DetachedStartAsync("boot-attempt-test", CancellationToken.None);
         await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey("PATH")).IsFalse();
     }
 
@@ -466,17 +446,6 @@ public class KcapCliTests {
         var cli = MakeCliWithNullPath(runner);
 
         var result = await cli.ServiceInstallVerifiedAsync(replace: false, CancellationToken.None);
-
-        await Assert.That(result.ExitCode).IsEqualTo(127);
-        await Assert.That(runner.SeenFileName).IsNull();
-    }
-
-    [Test]
-    public async Task DetachedStartAsync_with_null_CliPath_returns_exit_127_without_calling_the_runner() {
-        var runner = new FakeProcessRunner();
-        var cli = MakeCliWithNullPath(runner);
-
-        var result = await cli.DetachedStartAsync(CancellationToken.None);
 
         await Assert.That(result.ExitCode).IsEqualTo(127);
         await Assert.That(runner.SeenFileName).IsNull();

--- a/test/Capacitor.App.Tests.Unit/KcapCliTests.cs
+++ b/test/Capacitor.App.Tests.Unit/KcapCliTests.cs
@@ -18,8 +18,10 @@ public class KcapCliTests {
         }
     }
 
-    static KcapCli MakeCli(FakeProcessRunner runner, string? terminalPath = null) =>
-        new(runner, "kcap", "daemon-a", "work", _ => Task.FromResult(terminalPath));
+    const string CanonicalServer = "https://cap.example.com:443";
+
+    static KcapCli MakeCli(FakeProcessRunner runner, string? terminalPath = null, string? canonicalServer = CanonicalServer) =>
+        new(runner, "kcap", "daemon-a", "work", _ => Task.FromResult(terminalPath), canonicalServer);
 
     [Test]
     public async Task CliPath_reflects_the_constructor_value() {
@@ -152,7 +154,7 @@ public class KcapCliTests {
     }
 
     [Test]
-    public async Task DetachedStartAsync_argv_uses_abandon_wait_and_no_timeout() {
+    public async Task DetachedStartAsync_argv_uses_abandon_wait_and_a_bounded_process_only_timeout() {
         var runner = new FakeProcessRunner();
         var cli = MakeCli(runner);
 
@@ -161,7 +163,165 @@ public class KcapCliTests {
         await Assert.That(runner.SeenArgs).IsEquivalentTo(
             ["daemon", "start", "-d", "--name", "daemon-a"], CollectionOrdering.Matching);
         await Assert.That(runner.SeenOptions!.CancelMode).IsEqualTo(CancelMode.AbandonWait);
-        await Assert.That(runner.SeenOptions!.Timeout).IsNull();
+        await Assert.That(runner.SeenOptions!.Timeout).IsEqualTo(TimeSpan.FromSeconds(75));
+        await Assert.That(runner.SeenOptions!.TimeoutKill).IsEqualTo(TimeoutKillScope.ProcessOnly);
+    }
+
+    [Test]
+    public async Task DetachedStartAsync_parameterless_stamps_a_fresh_guid_boot_attempt_id() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+
+        await cli.DetachedStartAsync(CancellationToken.None);
+
+        var seen = runner.SeenOptions!.EnvOverlay![KcapCli.BootAttemptVar];
+        await Assert.That(Guid.TryParseExact(seen, "N", out _)).IsTrue();
+    }
+
+    [Test]
+    public async Task DetachedStartAsync_with_boot_attempt_id_stamps_it_verbatim() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+
+        await cli.DetachedStartAsync("boot-attempt-123", CancellationToken.None);
+
+        await Assert.That(runner.SeenArgs).IsEquivalentTo(
+            ["daemon", "start", "-d", "--name", "daemon-a"], CollectionOrdering.Matching);
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.BootAttemptVar]).IsEqualTo("boot-attempt-123");
+        await Assert.That(runner.SeenOptions!.Timeout).IsEqualTo(TimeSpan.FromSeconds(75));
+        await Assert.That(runner.SeenOptions!.TimeoutKill).IsEqualTo(TimeoutKillScope.ProcessOnly);
+        await Assert.That(runner.SeenOptions!.CancelMode).IsEqualTo(CancelMode.AbandonWait);
+    }
+
+    [Test]
+    public async Task DetachedStartAsync_with_null_CliPath_returns_exit_127_without_calling_the_runner_overload() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCliWithNullPath(runner);
+
+        var result = await cli.DetachedStartAsync("boot-attempt-123", CancellationToken.None);
+
+        await Assert.That(result.ExitCode).IsEqualTo(127);
+        await Assert.That(runner.SeenFileName).IsNull();
+    }
+
+    // Every spawn (read-only or mutating) carries the telemetry-suppression marker — Plan A's
+    // Program.cs consumes and removes it before dispatch.
+    [Test]
+    public async Task Every_call_carries_the_app_spawn_no_telemetry_marker() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+
+        await cli.VersionAsync(CancellationToken.None);
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.SpawnNoTelemetryVar]).IsEqualTo("1");
+
+        await cli.ServiceStatusAsync(CancellationToken.None);
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.SpawnNoTelemetryVar]).IsEqualTo("1");
+
+        await cli.ServiceStartVerifiedAsync(CancellationToken.None);
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.SpawnNoTelemetryVar]).IsEqualTo("1");
+
+        await cli.ServiceInstallVerifiedAsync(replace: false, CancellationToken.None);
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.SpawnNoTelemetryVar]).IsEqualTo("1");
+
+        await cli.DetachedStartAsync(CancellationToken.None);
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.SpawnNoTelemetryVar]).IsEqualTo("1");
+    }
+
+    [Test]
+    public async Task Mutation_calls_carry_the_consent_seed_and_server_expectation_overlays() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+
+        await cli.ServiceStartVerifiedAsync(CancellationToken.None);
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.ConsentSeedDefaultVar]).IsEqualTo("prompt");
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.ExpectServerUrlVar]).IsEqualTo(CanonicalServer);
+
+        await cli.ServiceInstallVerifiedAsync(replace: false, CancellationToken.None);
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.ConsentSeedDefaultVar]).IsEqualTo("prompt");
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.ExpectServerUrlVar]).IsEqualTo(CanonicalServer);
+
+        await cli.DetachedStartAsync(CancellationToken.None);
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.ConsentSeedDefaultVar]).IsEqualTo("prompt");
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.ExpectServerUrlVar]).IsEqualTo(CanonicalServer);
+    }
+
+    [Test]
+    public async Task Status_and_version_calls_never_carry_the_seed_or_expectation_overlays() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+
+        await cli.VersionAsync(CancellationToken.None);
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey(KcapCli.ConsentSeedDefaultVar)).IsFalse();
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey(KcapCli.ExpectServerUrlVar)).IsFalse();
+
+        await cli.ServiceStatusAsync(CancellationToken.None);
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey(KcapCli.ConsentSeedDefaultVar)).IsFalse();
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey(KcapCli.ExpectServerUrlVar)).IsFalse();
+    }
+
+    // Mutations are action-scoped (the lane always binds a server); a null canonicalServer here is
+    // a construction bug, so it throws before touching the runner at all — never a degraded result.
+    [Test]
+    public async Task ServiceStartVerifiedAsync_with_null_canonicalServer_throws_before_any_spawn() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner, canonicalServer: null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => cli.ServiceStartVerifiedAsync(CancellationToken.None));
+        await Assert.That(runner.SeenFileName).IsNull();
+    }
+
+    [Test]
+    public async Task ServiceInstallVerifiedAsync_with_null_canonicalServer_throws_before_any_spawn() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner, canonicalServer: null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => cli.ServiceInstallVerifiedAsync(replace: false, CancellationToken.None));
+        await Assert.That(runner.SeenFileName).IsNull();
+    }
+
+    [Test]
+    public async Task DetachedStartAsync_with_null_canonicalServer_throws_before_any_spawn() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner, canonicalServer: null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => cli.DetachedStartAsync(CancellationToken.None));
+        await Assert.That(runner.SeenFileName).IsNull();
+    }
+
+    [Test]
+    public async Task DetachedStartAsync_with_boot_attempt_id_and_null_canonicalServer_throws_before_any_spawn() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner, canonicalServer: null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => cli.DetachedStartAsync("boot-attempt-123", CancellationToken.None));
+        await Assert.That(runner.SeenFileName).IsNull();
+    }
+
+    // The overlay is additive-only over the documented keys — it must never carry the user's own
+    // KCAP_TELEMETRY choice (or anything else ambient) onto a child spawn.
+    [Test]
+    public async Task Read_only_overlay_carries_only_the_documented_keys() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+
+        await cli.VersionAsync(CancellationToken.None);
+
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.Keys).IsEquivalentTo(
+            ["KCAP_PROFILE", KcapCli.SpawnNoTelemetryVar], CollectionOrdering.Any);
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey("KCAP_TELEMETRY")).IsFalse();
+    }
+
+    [Test]
+    public async Task Mutation_overlay_carries_only_the_documented_keys() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+
+        await cli.ServiceStartVerifiedAsync(CancellationToken.None);
+
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.Keys).IsEquivalentTo(
+            ["KCAP_PROFILE", KcapCli.SpawnNoTelemetryVar, KcapCli.ConsentSeedDefaultVar, KcapCli.ExpectServerUrlVar],
+            CollectionOrdering.Any);
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey("KCAP_TELEMETRY")).IsFalse();
     }
 
     [Test]
@@ -231,7 +391,7 @@ public class KcapCliTests {
     [Test]
     public async Task ServiceInstallVerifiedAsync_with_no_resolver_omits_path_overlay() {
         var runner = new FakeProcessRunner();
-        var cli = new KcapCli(runner, "kcap", "daemon-a", "work", terminalPathAsync: null);
+        var cli = new KcapCli(runner, "kcap", "daemon-a", "work", terminalPathAsync: null, CanonicalServer);
 
         await cli.ServiceInstallVerifiedAsync(replace: false, CancellationToken.None);
 
@@ -247,7 +407,7 @@ public class KcapCliTests {
         var cli = new KcapCli(runner, "kcap", "daemon-a", "work", ct => {
             seenToken = ct;
             return Task.FromResult<string?>("/usr/bin:/bin");
-        });
+        }, CanonicalServer);
         using var cts = new CancellationTokenSource();
 
         await cli.ServiceInstallVerifiedAsync(replace: false, cts.Token);
@@ -269,7 +429,7 @@ public class KcapCliTests {
     // throw via a null-forgiving `CliPath!` — the app treats null CliPath as "no CLI", so every
     // call must degrade the same honest way instead of crashing whichever caller hits it.
     static KcapCli MakeCliWithNullPath(FakeProcessRunner runner) =>
-        new(runner, null, "daemon-a", "work", _ => Task.FromResult<string?>(null));
+        new(runner, null, "daemon-a", "work", _ => Task.FromResult<string?>(null), CanonicalServer);
 
     [Test]
     public async Task VersionAsync_with_null_CliPath_returns_null_without_calling_the_runner() {

--- a/test/Capacitor.App.Tests.Unit/LifecycleSurfaceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LifecycleSurfaceTests.cs
@@ -132,4 +132,38 @@ public class LifecycleSurfaceTests {
         var result1 = await task1.WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(result1).IsTrue();
     }
+
+    // P1-2(b): TryConfirmAsync distinguishes "never reached the factory" (null) from a genuinely
+    // shown-and-declined dialog (false) — ConfirmAsync's own `?? false` is what a caller unaware
+    // of the distinction keeps observing, so this is the same scenario as the queued-cancel test
+    // above, asserted through the new method instead.
+    [Test]
+    public async Task TryConfirmAsync_cancelled_while_queued_returns_null_without_showing_a_dialog() {
+        var shower = new ScriptedPromptShower();
+        var surface = new LifecycleSurface(_ => { }, _ => { }, shower.ShowAsync);
+
+        var task1 = surface.ConfirmAsync(Prompt(LifecyclePrompt.KindRepair), CancellationToken.None);
+        await WaitUntilAsync(() => shower.Calls.Count == 1);
+
+        using var cts = new CancellationTokenSource();
+        var task2 = surface.TryConfirmAsync(Prompt(LifecyclePrompt.KindTakeover), cts.Token);
+        cts.Cancel();
+
+        var result2 = await task2.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(result2).IsNull();
+        await Assert.That(shower.Calls.Count).IsEqualTo(1); // task2 never showed
+
+        shower.Calls[0].Tcs.SetResult(true);
+        var result1 = await task1.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(result1).IsTrue();
+    }
+
+    [Test]
+    public async Task TryConfirmAsync_returns_the_dialogs_result_for_a_genuinely_shown_dialog() {
+        var surface = new LifecycleSurface(_ => { }, _ => { }, (_, _) => Task.FromResult(false));
+
+        var result = await surface.TryConfirmAsync(Prompt(LifecyclePrompt.KindRepair), CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsEqualTo(false);
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/LoginShellProbeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LoginShellProbeTests.cs
@@ -23,6 +23,21 @@ public class LoginShellProbeTests {
     static LoginShellProbe Probe(FakeProcessRunner runner, string? shell = "/bin/bash") =>
         new(runner, name => name == "SHELL" ? shell : null);
 
+    readonly List<string> _tempDirs = [];
+
+    string NewTempDir() {
+        var dir = Directory.CreateTempSubdirectory("kcap-loginshell-").FullName;
+        _tempDirs.Add(dir);
+        return dir;
+    }
+
+    [After(Test)]
+    public void CleanupTempDirs() {
+        foreach (var dir in _tempDirs) {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     // --- Parse ---
 
     [Test]
@@ -341,5 +356,147 @@ public class LoginShellProbeTests {
         await probe.KcapOnPathAsync(CancellationToken.None);
 
         await Assert.That(runner.Calls).HasCount().EqualTo(2);
+    }
+
+    // --- KcapPathAsync ---
+
+    [Test]
+    public async Task KcapPathAsync_absolute_existing_file_is_returned_verbatim() {
+        var dir = NewTempDir();
+        var target = Path.Combine(dir, "kcap");
+        File.WriteAllText(target, "cli");
+        var runner = new FakeProcessRunner();
+        runner.Enqueue(new ProcessResult(0, Wrap(target), "", false));
+        var probe = Probe(runner);
+
+        await Assert.That(await probe.KcapPathAsync(CancellationToken.None)).IsEqualTo(target);
+    }
+
+    [Test]
+    public async Task KcapPathAsync_absolute_path_with_spaces_is_returned() {
+        var dir = NewTempDir();
+        var target = Path.Combine(dir, "kcap cli");
+        File.WriteAllText(target, "cli");
+        var runner = new FakeProcessRunner();
+        runner.Enqueue(new ProcessResult(0, Wrap(target), "", false));
+        var probe = Probe(runner);
+
+        await Assert.That(await probe.KcapPathAsync(CancellationToken.None)).IsEqualTo(target);
+    }
+
+    [Test]
+    public async Task KcapPathAsync_relative_path_is_null() {
+        var runner = new FakeProcessRunner();
+        runner.Enqueue(new ProcessResult(0, Wrap("bin/kcap"), "", false));
+        var probe = Probe(runner);
+
+        await Assert.That(await probe.KcapPathAsync(CancellationToken.None)).IsNull();
+    }
+
+    [Test]
+    public async Task KcapPathAsync_bare_word_is_null() {
+        var runner = new FakeProcessRunner();
+        runner.Enqueue(new ProcessResult(0, Wrap("kcap"), "", false));
+        var probe = Probe(runner);
+
+        await Assert.That(await probe.KcapPathAsync(CancellationToken.None)).IsNull();
+    }
+
+    [Test]
+    public async Task KcapPathAsync_alias_output_is_null() {
+        var runner = new FakeProcessRunner();
+        runner.Enqueue(new ProcessResult(0, Wrap("alias kcap='/usr/local/bin/kcap'"), "", false));
+        var probe = Probe(runner);
+
+        await Assert.That(await probe.KcapPathAsync(CancellationToken.None)).IsNull();
+    }
+
+    [Test]
+    public async Task KcapPathAsync_multiline_function_definition_is_null() {
+        var runner = new FakeProcessRunner();
+        runner.Enqueue(new ProcessResult(0, Wrap("kcap () \n{ \n    command kcap \"$@\"\n}"), "", false));
+        var probe = Probe(runner);
+
+        await Assert.That(await probe.KcapPathAsync(CancellationToken.None)).IsNull();
+    }
+
+    [Test]
+    public async Task KcapPathAsync_missing_file_is_null() {
+        var missing = Path.Combine(NewTempDir(), "kcap");
+        var runner = new FakeProcessRunner();
+        runner.Enqueue(new ProcessResult(0, Wrap(missing), "", false));
+        var probe = Probe(runner);
+
+        await Assert.That(await probe.KcapPathAsync(CancellationToken.None)).IsNull();
+    }
+
+    [Test]
+    public async Task KcapPathAsync_directory_is_null() {
+        var dir = NewTempDir();
+        var runner = new FakeProcessRunner();
+        runner.Enqueue(new ProcessResult(0, Wrap(dir), "", false));
+        var probe = Probe(runner);
+
+        await Assert.That(await probe.KcapPathAsync(CancellationToken.None)).IsNull();
+    }
+
+    [Test]
+    public async Task KcapPathAsync_result_is_cached() {
+        var dir = NewTempDir();
+        var target = Path.Combine(dir, "kcap");
+        File.WriteAllText(target, "cli");
+        var runner = new FakeProcessRunner();
+        runner.Enqueue(new ProcessResult(0, Wrap(target), "", false));
+        var probe = Probe(runner);
+
+        await probe.KcapPathAsync(CancellationToken.None);
+        await probe.KcapPathAsync(CancellationToken.None);
+
+        await Assert.That(runner.Calls).HasCount().EqualTo(1);
+    }
+
+    [Test]
+    public async Task KcapPathAsync_forceRefresh_bypasses_and_repopulates_the_cache() {
+        var dir = NewTempDir();
+        var target = Path.Combine(dir, "kcap");
+        File.WriteAllText(target, "cli");
+        var runner = new FakeProcessRunner();
+        runner.Enqueue(new ProcessResult(0, Wrap("kcap"), "", false)); // bare word -> null
+        runner.Enqueue(new ProcessResult(0, Wrap(target), "", false));
+        var probe = Probe(runner);
+
+        var cached = await probe.KcapPathAsync(CancellationToken.None);
+        await Assert.That(cached).IsNull();
+        await Assert.That(runner.Calls).HasCount().EqualTo(1);
+
+        var fresh = await probe.KcapPathAsync(CancellationToken.None, forceRefresh: true);
+        await Assert.That(fresh).IsEqualTo(target);
+        await Assert.That(runner.Calls).HasCount().EqualTo(2); // a real second runner invocation
+
+        // Repopulated: a later non-forced call reads the fresh value without re-running.
+        var second = await probe.KcapPathAsync(CancellationToken.None);
+        await Assert.That(second).IsEqualTo(target);
+        await Assert.That(runner.Calls).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task KcapPathAsync_process_start_failure_is_not_cached_and_retries() {
+        var dir = NewTempDir();
+        var target = Path.Combine(dir, "kcap");
+        File.WriteAllText(target, "cli");
+        var runner = new FakeProcessRunner();
+        runner.EnqueueThrow(new InvalidOperationException("boom"));
+        runner.EnqueueThrow(new InvalidOperationException("boom again"));
+        var probe = Probe(runner);
+
+        var first = await probe.KcapPathAsync(CancellationToken.None);
+        await Assert.That(first).IsNull();
+        await Assert.That(runner.Calls).HasCount().EqualTo(2);
+
+        runner.Enqueue(new ProcessResult(0, Wrap(target), "", false));
+        var second = await probe.KcapPathAsync(CancellationToken.None);
+
+        await Assert.That(second).IsEqualTo(target);
+        await Assert.That(runner.Calls).HasCount().EqualTo(3);
     }
 }

--- a/test/Capacitor.App.Tests.Unit/MutationModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MutationModelTests.cs
@@ -1,0 +1,39 @@
+using Capacitor.App.Services.Mutation;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class MutationModelTests {
+    // ---- ForStartGate (spec §3/§4 pinned table) ----
+
+    [Test]
+    [Arguments("directive_missing", RecoverySurface.Takeover)]
+    [Arguments("directive_invalid", RecoverySurface.Takeover)]
+    [Arguments("identity_mismatch", RecoverySurface.Takeover)]
+    [Arguments("foreign_binary", RecoverySurface.Takeover)]
+    [Arguments("package_inconsistent", RecoverySurface.Reinstall)]
+    [Arguments("evidence_unreadable", RecoverySurface.Attention)]
+    [Arguments("some_unrecognized_token", RecoverySurface.Attention)]
+    public async Task ForStartGate_routes_per_pinned_table(string token, RecoverySurface expected) {
+        await Assert.That(ReasonRouting.ForStartGate(token)).IsEqualTo(expected);
+    }
+
+    // ---- ForDaemonStart (spec §3/§4 pinned table) ----
+
+    [Test]
+    [Arguments("package_inconsistent", RecoverySurface.Reinstall)]
+    [Arguments("some_unrecognized_token", RecoverySurface.Attention)]
+    public async Task ForDaemonStart_routes_per_pinned_table(string token, RecoverySurface expected) {
+        await Assert.That(ReasonRouting.ForDaemonStart(token)).IsEqualTo(expected);
+    }
+
+    // ---- ForBootRefusal (spec §3/§4 pinned table) ----
+
+    [Test]
+    [Arguments("server_expectation_mismatch", RecoverySurface.Takeover)]
+    [Arguments("consent_seed_unwritable", RecoverySurface.Storage)]
+    [Arguments("consent_seed_invalid", RecoverySurface.Takeover)]
+    [Arguments("some_unrecognized_token", RecoverySurface.Attention)]
+    public async Task ForBootRefusal_routes_per_pinned_table(string token, RecoverySurface expected) {
+        await Assert.That(ReasonRouting.ForBootRefusal(token)).IsEqualTo(expected);
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/MutationRequestFactoryTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MutationRequestFactoryTests.cs
@@ -1,0 +1,71 @@
+using Capacitor.App.Services.Mutation;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Binding ruling 1 (Task 10): a caller that cannot bind a canonical server must yield an
+/// honest Refused("no_server_configured") WITHOUT constructing a MutationRequest — this is the one
+/// shared guard every mutation-request boundary (DaemonLifecycleController, DaemonClientService's
+/// injected start delegate) routes through.
+public class MutationRequestFactoryTests {
+    [Test]
+    public async Task Valid_profile_and_server_builds_a_request() {
+        var refusal = MutationRequestFactory.TryBuild(
+            MutationVerb.StartVerified, "default", "https://kcap.example.com", "daemon-a", out var request);
+
+        await Assert.That(refusal).IsNull();
+        await Assert.That(request).IsNotNull();
+        await Assert.That(request!.Verb).IsEqualTo(MutationVerb.StartVerified);
+        await Assert.That(request.Profile).IsEqualTo("default");
+        await Assert.That(request.CanonicalServer).IsEqualTo("https://kcap.example.com:443");
+        await Assert.That(request.DaemonName).IsEqualTo("daemon-a");
+    }
+
+    [Test]
+    public async Task Null_server_url_refuses_without_a_request() {
+        var refusal = MutationRequestFactory.TryBuild(MutationVerb.DetachedStart, "default", null, "daemon-a", out var request);
+
+        await Assert.That(request).IsNull();
+        await Assert.That(refusal).IsTypeOf<MutationOutcome.Refused>();
+        var refused = (MutationOutcome.Refused)refusal!;
+        await Assert.That(refused.Reason).IsEqualTo("no_server_configured");
+        await Assert.That(refused.Surface).IsEqualTo(RecoverySurface.Attention);
+    }
+
+    [Test]
+    public async Task Non_canonicalizable_server_url_refuses_without_a_request() {
+        // Carries a query string — ServerIdentity.Canonicalize rejects it outright.
+        var refusal = MutationRequestFactory.TryBuild(
+            MutationVerb.Install, "default", "https://kcap.example.com?tenant=a", "daemon-a", out var request);
+
+        await Assert.That(request).IsNull();
+        await Assert.That(refusal).IsTypeOf<MutationOutcome.Refused>();
+        await Assert.That(((MutationOutcome.Refused)refusal!).Reason).IsEqualTo("no_server_configured");
+    }
+
+    [Test]
+    public async Task Null_profile_name_refuses_even_with_a_valid_server() {
+        var refusal = MutationRequestFactory.TryBuild(MutationVerb.Replace, null, "https://kcap.example.com", "daemon-a", out var request);
+
+        await Assert.That(request).IsNull();
+        await Assert.That(refusal).IsTypeOf<MutationOutcome.Refused>();
+    }
+
+    [Test]
+    public async Task Whitespace_profile_name_refuses() {
+        var refusal = MutationRequestFactory.TryBuild(MutationVerb.Replace, "   ", "https://kcap.example.com", "daemon-a", out var request);
+
+        await Assert.That(request).IsNull();
+        await Assert.That(refusal).IsTypeOf<MutationOutcome.Refused>();
+    }
+
+    [Test]
+    public async Task Already_canonical_server_url_is_idempotent() {
+        // The controller passes an already-canonicalized server (same value KcapCli itself
+        // receives) — canonicalizing it again must be a no-op, not a second rejection.
+        var refusal = MutationRequestFactory.TryBuild(
+            MutationVerb.StartVerified, "default", "https://kcap.example.com:443", "daemon-a", out var request);
+
+        await Assert.That(refusal).IsNull();
+        await Assert.That(request!.CanonicalServer).IsEqualTo("https://kcap.example.com:443");
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
@@ -93,6 +93,20 @@ public class OnboardingGateTests {
     }
 
     [Test]
+    public async Task Corrupt_config_json_lands_on_InvalidServerUrl_not_a_crash() {
+        // AppConfig.LoadProfileConfig catches JsonException and synthesizes a default profile
+        // (ServerUrl: null) rather than throwing — the gate must ride that degrade to
+        // InvalidServerUrl, not crash or misreport NoProfile (a "default" profile DOES resolve,
+        // it's just unconfigured).
+        Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
+        await File.WriteAllTextAsync(ConfigPath, "{not valid json");
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await AssertIncomplete(result, GateReason.InvalidServerUrl);
+    }
+
+    [Test]
     public async Task Invalid_server_url_rejects_file_scheme_and_App_ValidProfileName_agrees() {
         const string fileUrl = "file:///tmp/x";
         var profile = new Profile { ServerUrl = fileUrl };
@@ -221,6 +235,22 @@ public class OnboardingGateTests {
         var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
 
         await AssertIncomplete(result, GateReason.NoToken);
+    }
+
+    [Test]
+    public async Task Non_none_stamp_does_not_short_circuit_token_rules() {
+        // Only a "none" stamp bypasses the token read (see None_stamp_matching_current_server_is_
+        // Complete_without_any_token_file). A "workos" stamp — even matching the current server —
+        // must still go through the normal expiry/refresh rules: an expired WorkOS token with no
+        // RefreshToken/ClientId is TokenUnusableExpired, stamp or no stamp.
+        var profile = new Profile { ServerUrl = ServerUrl, AuthProvider = new AuthProviderStamp("workos", ServerUrl) };
+        WriteConfig(SingleProfileConfig(profile));
+        await TokenStore.SaveAsync(ProfileName, MakeToken(
+            AuthProvider.WorkOS, expired: true, serverUrl: ServerUrl, refreshToken: null, clientId: null));
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await AssertIncomplete(result, GateReason.TokenUnusableExpired);
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
@@ -285,6 +285,28 @@ public class OnboardingGateTests {
         await Assert.That(result).IsTypeOf<GateResult.Complete>();
     }
 
+    // ── EvaluateResolvedAsync: the shared-resolution seam (Codex P1) ────────
+
+    // App.StartAsync now resolves ONCE (via DaemonClientService.CreateDefaultAsync) and hands that
+    // SAME identity to EvaluateResolvedAsync — proving it never re-resolves is what rules out the
+    // race the P1 finding described: a concurrent active-profile change between two independent
+    // resolves evaluating the gate against a different profile than the one the daemon graph built.
+    [Test]
+    public async Task EvaluateResolvedAsync_never_re_resolves_ignoring_a_config_change_after_capture() {
+        WriteConfig(SingleProfileConfig(
+            new Profile { ServerUrl = ServerUrl, AuthProvider = new AuthProviderStamp(AuthProvider.None, ServerUrl) }));
+        await AppConfig.ResolveActiveProfile([]);
+        var resolved = AppConfig.ResolvedProfile;
+
+        // Mutates the identity underneath the already-captured resolution — a fresh self-resolving
+        // EvaluateAsync call at this point would see NoProfile instead.
+        WriteConfig(new ProfileConfig { ActiveProfile = "ghost", Profiles = new() });
+
+        var result = await OnboardingGate.EvaluateResolvedAsync(resolved?.ProfileName, resolved?.Profile, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<GateResult.Complete>();
+    }
+
     static async Task AssertIncomplete(GateResult result, GateReason expected) {
         await Assert.That(result).IsTypeOf<GateResult.Incomplete>();
         await Assert.That(((GateResult.Incomplete)result).Reason).IsEqualTo(expected);

--- a/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
@@ -1,0 +1,262 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// <summary>
+/// Assembly-wide <c>KCAP_CONFIG_DIR</c> isolation for <see cref="OnboardingGateTests"/> — the
+/// first tests in this assembly to exercise <c>AppConfig</c>/<c>TokenStore</c>'s real,
+/// <c>PathHelpers</c>-based config.json / tokens/ paths. <c>PathHelpers.ConfigDir</c> is
+/// <c>static readonly</c>, captured once per process, so this MUST run via a
+/// <see cref="ModuleInitializerAttribute"/> (the CLR guarantees it runs before any type in the
+/// module is touched) rather than a TUnit <c>[Before(Assembly)]</c> hook, which is not
+/// guaranteed to beat every other static touch. Mirrors
+/// <c>Capacitor.Cli.Tests.Unit.RepoPathStoreGlobalSetup</c> for this assembly.
+/// </summary>
+public static class OnboardingGateGlobalSetup {
+    internal static readonly string SharedConfigDir = Path.Combine(
+        Path.GetTempPath(),
+        "kcap-app-onboarding-tests-" + Guid.NewGuid().ToString("N")[..8]
+    );
+
+    [ModuleInitializer]
+    internal static void SetConfigDir() {
+        Directory.CreateDirectory(SharedConfigDir);
+        Environment.SetEnvironmentVariable("KCAP_CONFIG_DIR", SharedConfigDir);
+    }
+
+    [After(Assembly)]
+    public static void CleanupConfigDir() {
+        Environment.SetEnvironmentVariable("KCAP_CONFIG_DIR", null);
+        try { Directory.Delete(SharedConfigDir, recursive: true); } catch { /* best effort */ }
+    }
+}
+
+/// <summary>
+/// The decision-1 gate matrix (design doc §2 decision 1 / §4's <c>OnboardingGate</c> bullet),
+/// pinned against <see cref="TokenStore"/>'s REAL refresh/binding rules rather than a
+/// reimplementation of them — each test below cites the TokenStore rule it mirrors.
+///
+/// [NotInParallel]: every test shares the one real config.json/tokens/ dir under the shared
+/// KCAP_CONFIG_DIR (see <see cref="OnboardingGateGlobalSetup"/>), same convention as
+/// TokenStoreProfileTests/ConfigMutatorTests in the CLI test assembly.
+/// </summary>
+[NotInParallel(nameof(OnboardingGateTests))]
+public class OnboardingGateTests {
+    const string ProfileName = "acme";
+    const string ServerUrl = "https://acme.example";
+
+    static string ConfigPath => AppConfig.GetConfigPath();
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+
+    [Before(Test)]
+    public void Cleanup() {
+        if (File.Exists(ConfigPath)) File.Delete(ConfigPath);
+        if (Directory.Exists(TokensDir)) Directory.Delete(TokensDir, recursive: true);
+        AppConfig.ResetResolvedStateForTesting();
+
+        // The unauthenticated-path test-isolation rule (CLI test memory): a stray KCAP_URL/
+        // KCAP_PROFILE from the developer's shell must not redirect ResolveActiveProfile.
+        Environment.SetEnvironmentVariable("KCAP_URL", null);
+        Environment.SetEnvironmentVariable("KCAP_PROFILE", null);
+    }
+
+    // ── ValidServerUrl (the shared validator) ───────────────────────────────
+
+    [Test]
+    [Arguments("https://acme.example", true)]
+    [Arguments("http://acme.example", true)]
+    [Arguments("https://acme.example:8443/base", true)]
+    [Arguments("file:///tmp/x", false)]
+    [Arguments("not-a-url", false)]
+    [Arguments("", false)]
+    [Arguments(null, false)]
+    public async Task ValidServerUrl_accepts_only_absolute_http_or_https(string? url, bool expected) {
+        await Assert.That(OnboardingGate.ValidServerUrl(url)).IsEqualTo(expected);
+    }
+
+    // ── Gate matrix ──────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task No_resolvable_profile_yields_NoProfile() {
+        // active_profile names a profile that does not exist in `profiles` — ProfileResolver's
+        // ResolveByName returns Profile: null, ProfileName: null (ProfileResolver.cs:85-96).
+        WriteConfig(new ProfileConfig { ActiveProfile = "ghost", Profiles = new() });
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await AssertIncomplete(result, GateReason.NoProfile);
+    }
+
+    [Test]
+    public async Task Invalid_server_url_rejects_file_scheme_and_App_ValidProfileName_agrees() {
+        const string fileUrl = "file:///tmp/x";
+        var profile = new Profile { ServerUrl = fileUrl };
+        WriteConfig(SingleProfileConfig(profile));
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await AssertIncomplete(result, GateReason.InvalidServerUrl);
+
+        // Decision 2: the gate and App.ValidProfileName must share one validator — before this
+        // task, App.ValidProfileName accepted any absolute URI (including file://).
+        await Assert.That(OnboardingGate.ValidServerUrl(fileUrl)).IsFalse();
+        var resolved = new ResolvedProfile(fileUrl, ProfileName, profile, null);
+        await Assert.That(App.ValidProfileName(resolved)).IsNull();
+    }
+
+    [Test]
+    public async Task No_token_file_yields_NoToken() {
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = ServerUrl }));
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await AssertIncomplete(result, GateReason.NoToken);
+    }
+
+    [Test]
+    public async Task WorkOS_expired_with_refresh_token_and_client_id_is_Complete() {
+        // TokenStore.GetValidTokensForProfileAsync (TokenStore.cs:398): WorkOS refreshes only
+        // when BOTH RefreshToken and ClientId are present.
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = ServerUrl }));
+        await TokenStore.SaveAsync(ProfileName, MakeToken(
+            AuthProvider.WorkOS, expired: true, serverUrl: ServerUrl, refreshToken: "rt", clientId: "cid"));
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<GateResult.Complete>();
+    }
+
+    [Test]
+    public async Task WorkOS_expired_missing_client_id_is_TokenUnusableExpired() {
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = ServerUrl }));
+        await TokenStore.SaveAsync(ProfileName, MakeToken(
+            AuthProvider.WorkOS, expired: true, serverUrl: ServerUrl, refreshToken: "rt", clientId: null));
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await AssertIncomplete(result, GateReason.TokenUnusableExpired);
+    }
+
+    [Test]
+    public async Task GitHubApp_expired_is_always_refresh_capable_and_Complete() {
+        // TokenStore.cs:403-405 / DecideProactiveRefresh: GitHubApp always refreshes via the
+        // server's /auth/refresh, independent of RefreshToken (normally null for this provider).
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = ServerUrl }));
+        await TokenStore.SaveAsync(ProfileName, MakeToken(AuthProvider.GitHubApp, expired: true, serverUrl: ServerUrl));
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<GateResult.Complete>();
+    }
+
+    [Test]
+    public async Task Wrong_server_token_is_TokenUnusableBinding_even_when_unexpired() {
+        // TokenStore.BoundToTarget (TokenStore.cs:339-340) is checked BEFORE expiry — an
+        // unexpired-but-wrong-server token must still be refused, never silently accepted.
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = ServerUrl }));
+        await TokenStore.SaveAsync(ProfileName, MakeToken(
+            AuthProvider.GitHubApp, expired: false, serverUrl: "https://other.example"));
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await AssertIncomplete(result, GateReason.TokenUnusableBinding);
+    }
+
+    [Test]
+    public async Task Legacy_unbound_token_null_server_url_is_treated_as_usable() {
+        // Pinned per TokenStore's REAL treatment: BoundToTarget (TokenStore.cs:339-340) —
+        // "tokens.ServerUrl is null || SameServer(...)" — a pre-upgrade token with no stamp has
+        // nothing to contradict and is let through to ANY server. The gate must agree, not
+        // invent a stricter rule that would strand every pre-upgrade machine behind the wizard.
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = ServerUrl }));
+        await TokenStore.SaveAsync(ProfileName, MakeToken(AuthProvider.GitHubApp, expired: false, serverUrl: null));
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<GateResult.Complete>();
+    }
+
+    [Test]
+    public async Task Corrupt_token_file_yields_NoToken_not_a_crash() {
+        // TokenStore.ReadTokenFileAsync (TokenStore.cs:94-108): a JsonException degrades to
+        // Unusable → null, never throws — the wizard is the recovery path, not a crash.
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = ServerUrl }));
+        Directory.CreateDirectory(TokensDir);
+        var valid = JsonSerializer.Serialize(MakeToken(AuthProvider.GitHubApp, expired: false, serverUrl: ServerUrl),
+            CapacitorJsonContext.Default.StoredTokens);
+        await File.WriteAllTextAsync(Path.Combine(TokensDir, $"{ProfileName}.json"), valid + ",\"x\":1}");
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await AssertIncomplete(result, GateReason.NoToken);
+    }
+
+    [Test]
+    public async Task None_stamp_matching_current_server_is_Complete_without_any_token_file() {
+        var profile = new Profile { ServerUrl = ServerUrl, AuthProvider = new AuthProviderStamp("none", ServerUrl) };
+        WriteConfig(SingleProfileConfig(profile));
+        // Deliberately no tokens/ directory at all — the stamp must short-circuit the token read.
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<GateResult.Complete>();
+        await Assert.That(Directory.Exists(TokensDir)).IsFalse();
+    }
+
+    [Test]
+    public async Task Stale_none_stamp_after_server_url_change_requires_a_token() {
+        // The stamp names a DIFFERENT server than the profile's current one (a server_url edit
+        // since the stamp was written) — SameServer fails, so the stamp is ignored, not honored.
+        var profile = new Profile {
+            ServerUrl    = ServerUrl,
+            AuthProvider = new AuthProviderStamp("none", "https://old.example")
+        };
+        WriteConfig(SingleProfileConfig(profile));
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await AssertIncomplete(result, GateReason.NoToken);
+    }
+
+    [Test]
+    public async Task Legacy_profile_without_a_stamp_still_requires_and_accepts_a_valid_token() {
+        // No auth_provider stamp at all (the common case for every profile before this task):
+        // the gate must fall all the way through to the real token evaluation — proven here by
+        // giving it a genuinely valid token and expecting Complete via THAT path, not some
+        // stamp-shaped shortcut.
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = ServerUrl, AuthProvider = null }));
+        await TokenStore.SaveAsync(ProfileName, MakeToken(AuthProvider.GitHubApp, expired: false, serverUrl: ServerUrl));
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<GateResult.Complete>();
+    }
+
+    static async Task AssertIncomplete(GateResult result, GateReason expected) {
+        await Assert.That(result).IsTypeOf<GateResult.Incomplete>();
+        await Assert.That(((GateResult.Incomplete)result).Reason).IsEqualTo(expected);
+    }
+
+    static ProfileConfig SingleProfileConfig(Profile profile) =>
+        new() { ActiveProfile = ProfileName, Profiles = new() { [ProfileName] = profile } };
+
+    static void WriteConfig(ProfileConfig config) =>
+        File.WriteAllText(ConfigPath, JsonSerializer.Serialize(config, ProfileConfigJsonContext.Default.ProfileConfig));
+
+    static StoredTokens MakeToken(
+            string provider, bool expired, string? serverUrl, string? refreshToken = null, string? clientId = null) =>
+        new() {
+            AccessToken    = "t",
+            ExpiresAt      = expired ? DateTimeOffset.UtcNow.AddHours(-1) : DateTimeOffset.UtcNow.AddHours(1),
+            GitHubUsername = "u",
+            Provider       = provider,
+            ServerUrl      = serverUrl,
+            RefreshToken   = refreshToken,
+            ClientId       = clientId
+        };
+}

--- a/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
@@ -212,7 +212,25 @@ public class OnboardingGateTests {
 
     [Test]
     public async Task None_stamp_matching_current_server_is_Complete_without_any_token_file() {
+        // Deliberately the raw lowercase literal, not AuthProvider.None: the gate's provider
+        // compare must be case-insensitive, proven by this exact-lowercase row still reaching
+        // Complete alongside the AuthProvider.None-constant row below.
         var profile = new Profile { ServerUrl = ServerUrl, AuthProvider = new AuthProviderStamp("none", ServerUrl) };
+        WriteConfig(SingleProfileConfig(profile));
+        // Deliberately no tokens/ directory at all — the stamp must short-circuit the token read.
+
+        var result = await OnboardingGate.EvaluateAsync(CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<GateResult.Complete>();
+        await Assert.That(Directory.Exists(TokensDir)).IsFalse();
+    }
+
+    // Blocker (final review): the stamp WRITER emits AuthProvider.None ("None", capitalized)
+    // verbatim, not a lowercased literal — an ordinal-exact "none" compare would silently never
+    // satisfy the gate for a real stamp. This is the actual production shape the fix targets.
+    [Test]
+    public async Task None_constant_stamp_matching_current_server_is_Complete_without_any_token_file() {
+        var profile = new Profile { ServerUrl = ServerUrl, AuthProvider = new AuthProviderStamp(AuthProvider.None, ServerUrl) };
         WriteConfig(SingleProfileConfig(profile));
         // Deliberately no tokens/ directory at all — the stamp must short-circuit the token read.
 
@@ -228,7 +246,7 @@ public class OnboardingGateTests {
         // since the stamp was written) — SameServer fails, so the stamp is ignored, not honored.
         var profile = new Profile {
             ServerUrl    = ServerUrl,
-            AuthProvider = new AuthProviderStamp("none", "https://old.example")
+            AuthProvider = new AuthProviderStamp(AuthProvider.None, "https://old.example")
         };
         WriteConfig(SingleProfileConfig(profile));
 

--- a/test/Capacitor.App.Tests.Unit/OutcomeChannelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OutcomeChannelTests.cs
@@ -377,6 +377,46 @@ public class OutcomeChannelTests {
         await enumeratorB.DisposeAsync();
     }
 
+    // P1-1: an envelope dequeued-but-never-presented before the transfer must not be permanently
+    // leased and lost — when the OLD (transferred-away) enumeration itself terminates without ever
+    // acking, the still-unresolved lease gets its one requeue, same as any other implicit-cancel
+    // teardown.
+    [Test]
+    public async Task Old_enumeration_ending_unacked_after_transfer_requeues_the_envelope_exactly_once() {
+        var channel = new OutcomeChannel();
+        var env = Env("transferred-unacked");
+        channel.Enqueue(env);
+
+        using var ctsA = new CancellationTokenSource();
+        var enumeratorA = channel.ConsumeAsync(ctsA.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorA)).IsTrue();
+        var lease = enumeratorA.Current; // dequeued but never presented — no Ack, no CancelLease
+
+        channel.TransferConsumer();
+        await enumeratorA.DisposeAsync(); // the old enumeration ends here, still holding the unresolved lease
+
+        using var ctsB = new CancellationTokenSource();
+        var enumeratorB = channel.ConsumeAsync(ctsB.Token).GetAsyncEnumerator();
+        try {
+            await Assert.That(await BoundedMoveNext(enumeratorB)).IsTrue();
+            await Assert.That(enumeratorB.Current.Envelope).IsEqualTo(env); // redelivered to the NEXT consumer
+            enumeratorB.Current.Ack();
+
+            // N-resolutions invariant: the envelope resolves EXACTLY once — a late call on the
+            // stale original lease (already superseded by the redelivered one) is a silent no-op,
+            // never a double free/second requeue.
+            lease.Ack();
+            lease.CancelLease();
+
+            var moveNextB2 = enumeratorB.MoveNextAsync();
+            await ctsB.CancelAsync();
+            await Assert.That(async () => await moveNextB2.AsTask().WaitAsync(Bounded))
+                .Throws<OperationCanceledException>(); // nothing left: not duplicated
+        } finally {
+            await enumeratorB.DisposeAsync();
+        }
+    }
+
     [Test]
     public async Task TransferConsumer_with_no_active_consumer_is_a_noop() {
         var channel = new OutcomeChannel();

--- a/test/Capacitor.App.Tests.Unit/OutcomeChannelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OutcomeChannelTests.cs
@@ -1,0 +1,250 @@
+using Capacitor.App.Services.Mutation;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class OutcomeChannelTests {
+    static readonly TimeSpan Bounded = TimeSpan.FromSeconds(5);
+
+    static OutcomeEnvelope Env(string tag) =>
+        new(new MutationRequest(MutationVerb.Install, "default", "https://example.test", tag),
+            new MutationOutcome.Succeeded());
+
+    static Task<bool> BoundedMoveNext(IAsyncEnumerator<OutcomeLease> e) =>
+        e.MoveNextAsync().AsTask().WaitAsync(Bounded);
+
+    [Test]
+    public async Task Two_enqueues_without_a_consumer_surface_in_FIFO_order_exactly_once() {
+        var channel = new OutcomeChannel();
+        var e1 = Env("e1");
+        var e2 = Env("e2");
+        channel.Enqueue(e1);
+        channel.Enqueue(e2);
+
+        using var cts = new CancellationTokenSource();
+        var enumerator = channel.ConsumeAsync(cts.Token).GetAsyncEnumerator();
+        try {
+            await Assert.That(await BoundedMoveNext(enumerator)).IsTrue();
+            await Assert.That(enumerator.Current.Envelope).IsEqualTo(e1);
+            enumerator.Current.Ack();
+
+            await Assert.That(await BoundedMoveNext(enumerator)).IsTrue();
+            await Assert.That(enumerator.Current.Envelope).IsEqualTo(e2);
+            enumerator.Current.Ack();
+        } finally {
+            await enumerator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Late_enqueue_after_the_consumer_drained_empty_wakes_it() {
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+        var enumerator = channel.ConsumeAsync(cts.Token).GetAsyncEnumerator();
+        try {
+            var moveNext = enumerator.MoveNextAsync(); // queue empty: the synchronous prefix guarantees this suspends on the wakeup before Enqueue runs below
+            var env = Env("late");
+            channel.Enqueue(env);
+
+            await Assert.That(await moveNext.AsTask().WaitAsync(Bounded)).IsTrue();
+            await Assert.That(enumerator.Current.Envelope).IsEqualTo(env);
+            enumerator.Current.Ack();
+        } finally {
+            await enumerator.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Enqueue_racing_TransferConsumer_delivers_to_exactly_one_consumer() {
+        var channel = new OutcomeChannel();
+        using var ctsA = new CancellationTokenSource();
+        var enumeratorA = channel.ConsumeAsync(ctsA.Token).GetAsyncEnumerator();
+        var moveNextA = enumeratorA.MoveNextAsync(); // synchronous prefix: A is a registered waiter before the race below starts
+
+        var env = Env("race");
+        await Task.WhenAll(
+            Task.Run(() => channel.Enqueue(env)),
+            Task.Run(channel.TransferConsumer));
+
+        var gotA = await moveNextA.AsTask().WaitAsync(Bounded); // either A or a fresh B wins the item — "exactly one" is under test, not which one
+        if (gotA) {
+            await Assert.That(enumeratorA.Current.Envelope).IsEqualTo(env);
+            enumeratorA.Current.Ack();
+            await enumeratorA.DisposeAsync();
+
+            using var ctsB = new CancellationTokenSource();
+            var enumeratorB = channel.ConsumeAsync(ctsB.Token).GetAsyncEnumerator();
+            var moveNextB = enumeratorB.MoveNextAsync();
+            await ctsB.CancelAsync();
+            await Assert.That(async () => await moveNextB.AsTask().WaitAsync(Bounded))
+                .Throws<OperationCanceledException>();
+            await enumeratorB.DisposeAsync();
+        } else {
+            await enumeratorA.DisposeAsync();
+
+            using var ctsB = new CancellationTokenSource();
+            var enumeratorB = channel.ConsumeAsync(ctsB.Token).GetAsyncEnumerator();
+            try {
+                await Assert.That(await BoundedMoveNext(enumeratorB)).IsTrue();
+                await Assert.That(enumeratorB.Current.Envelope).IsEqualTo(env);
+                enumeratorB.Current.Ack();
+            } finally {
+                await enumeratorB.DisposeAsync();
+            }
+        }
+    }
+
+    [Test]
+    public async Task CancelLease_requeues_once_and_ack_after_redelivery_consumes_without_further_redelivery() {
+        var channel = new OutcomeChannel();
+        var env = Env("cancel-then-ack");
+        channel.Enqueue(env);
+
+        using var ctsA = new CancellationTokenSource();
+        var enumeratorA = channel.ConsumeAsync(ctsA.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorA)).IsTrue();
+        await Assert.That(enumeratorA.Current.Envelope).IsEqualTo(env);
+        enumeratorA.Current.CancelLease(); // requeue #1 (the only one this envelope ever gets)
+
+        channel.TransferConsumer();
+        await enumeratorA.DisposeAsync();
+
+        using var ctsB = new CancellationTokenSource();
+        var enumeratorB = channel.ConsumeAsync(ctsB.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorB)).IsTrue();
+        await Assert.That(enumeratorB.Current.Envelope).IsEqualTo(env); // redelivered to the next consumer exactly once
+        enumeratorB.Current.Ack();
+
+        var moveNextB2 = enumeratorB.MoveNextAsync();
+        await ctsB.CancelAsync();
+        await Assert.That(async () => await moveNextB2.AsTask().WaitAsync(Bounded))
+            .Throws<OperationCanceledException>(); // nothing left: not duplicated
+        await enumeratorB.DisposeAsync();
+    }
+
+    [Test]
+    public async Task CancelLease_a_second_time_after_redelivery_does_not_requeue_again() {
+        var channel = new OutcomeChannel();
+        var env = Env("double-cancel");
+        channel.Enqueue(env);
+
+        using var ctsA = new CancellationTokenSource();
+        var enumeratorA = channel.ConsumeAsync(ctsA.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorA)).IsTrue();
+        enumeratorA.Current.CancelLease(); // first cancel: uses the one guaranteed requeue
+        channel.TransferConsumer();
+        await enumeratorA.DisposeAsync();
+
+        using var ctsB = new CancellationTokenSource();
+        var enumeratorB = channel.ConsumeAsync(ctsB.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorB)).IsTrue();
+        await Assert.That(enumeratorB.Current.Envelope).IsEqualTo(env);
+        enumeratorB.Current.CancelLease(); // second cancel of the SAME envelope: must not requeue again
+        channel.TransferConsumer();
+        await enumeratorB.DisposeAsync();
+
+        using var ctsC = new CancellationTokenSource();
+        var enumeratorC = channel.ConsumeAsync(ctsC.Token).GetAsyncEnumerator();
+        var moveNextC = enumeratorC.MoveNextAsync();
+        await ctsC.CancelAsync();
+        await Assert.That(async () => await moveNextC.AsTask().WaitAsync(Bounded))
+            .Throws<OperationCanceledException>(); // lost, not redelivered a second time
+        await enumeratorC.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Consumer_ct_cancellation_with_an_unacked_lease_requeues_it() {
+        var channel = new OutcomeChannel();
+        var env = Env("ct-cancel");
+        channel.Enqueue(env);
+
+        using var ctsA = new CancellationTokenSource();
+        var enumeratorA = channel.ConsumeAsync(ctsA.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorA)).IsTrue();
+        // deliberately neither Ack nor CancelLease
+
+        var moveNextAAgain = enumeratorA.MoveNextAsync();
+        await ctsA.CancelAsync();
+        await Assert.That(async () => await moveNextAAgain.AsTask().WaitAsync(Bounded))
+            .Throws<OperationCanceledException>();
+        await enumeratorA.DisposeAsync();
+
+        using var ctsB = new CancellationTokenSource();
+        var enumeratorB = channel.ConsumeAsync(ctsB.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorB)).IsTrue();
+        await Assert.That(enumeratorB.Current.Envelope).IsEqualTo(env);
+        enumeratorB.Current.Ack();
+        await enumeratorB.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Second_concurrent_ConsumeAsync_throws() {
+        var channel = new OutcomeChannel();
+        using var ctsA = new CancellationTokenSource();
+        _ = channel.ConsumeAsync(ctsA.Token); // claims the slot synchronously — no enumeration needed
+
+        using var ctsB = new CancellationTokenSource();
+        await Assert.That(() => channel.ConsumeAsync(ctsB.Token)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Ack_after_transfer_of_an_already_presented_envelope_is_consumed_never_requeued() {
+        var channel = new OutcomeChannel();
+        var env = Env("presented");
+        channel.Enqueue(env);
+
+        using var ctsA = new CancellationTokenSource();
+        var enumeratorA = channel.ConsumeAsync(ctsA.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorA)).IsTrue();
+        var lease = enumeratorA.Current; // "presented to the user" — held directly, not yet resolved
+
+        channel.TransferConsumer();
+        lease.Ack(); // the original, still-valid lease resolves after the handoff
+
+        using var ctsB = new CancellationTokenSource();
+        var enumeratorB = channel.ConsumeAsync(ctsB.Token).GetAsyncEnumerator();
+        var moveNextB = enumeratorB.MoveNextAsync();
+        await ctsB.CancelAsync();
+        await Assert.That(async () => await moveNextB.AsTask().WaitAsync(Bounded))
+            .Throws<OperationCanceledException>(); // never redelivered
+
+        await enumeratorA.DisposeAsync();
+        await enumeratorB.DisposeAsync();
+    }
+
+    [Test]
+    public async Task CancelLease_after_transfer_of_a_presented_envelope_still_uses_its_one_requeue() {
+        // Ambiguous edge, resolved loss-averse: transfer exempts a lease from forced auto-cancel, not from an explicit CancelLease.
+        var channel = new OutcomeChannel();
+        var env = Env("cancel-after-transfer");
+        channel.Enqueue(env);
+
+        using var ctsA = new CancellationTokenSource();
+        var enumeratorA = channel.ConsumeAsync(ctsA.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorA)).IsTrue();
+        var lease = enumeratorA.Current;
+
+        channel.TransferConsumer();
+        lease.CancelLease();
+
+        using var ctsB = new CancellationTokenSource();
+        var enumeratorB = channel.ConsumeAsync(ctsB.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorB)).IsTrue();
+        await Assert.That(enumeratorB.Current.Envelope).IsEqualTo(env);
+        enumeratorB.Current.Ack();
+
+        await enumeratorA.DisposeAsync();
+        await enumeratorB.DisposeAsync();
+    }
+
+    [Test]
+    public async Task TransferConsumer_with_no_active_consumer_is_a_noop() {
+        var channel = new OutcomeChannel();
+        channel.TransferConsumer(); // must not throw
+        channel.Enqueue(Env("after-noop-transfer"));
+
+        using var cts = new CancellationTokenSource();
+        var enumerator = channel.ConsumeAsync(cts.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumerator)).IsTrue();
+        await enumerator.DisposeAsync();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/OutcomeChannelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OutcomeChannelTests.cs
@@ -121,8 +121,8 @@ public class OutcomeChannelTests {
         await enumeratorB.DisposeAsync();
     }
 
-    [Test]
-    public async Task CancelLease_a_second_time_after_redelivery_does_not_requeue_again() {
+    [Test, NotInParallel]
+    public async Task CancelLease_a_second_time_after_redelivery_is_consumed_with_a_logged_warning_not_silently_dropped() {
         var channel = new OutcomeChannel();
         var env = Env("double-cancel");
         channel.Enqueue(env);
@@ -138,9 +138,19 @@ public class OutcomeChannelTests {
         var enumeratorB = channel.ConsumeAsync(ctsB.Token).GetAsyncEnumerator();
         await Assert.That(await BoundedMoveNext(enumeratorB)).IsTrue();
         await Assert.That(enumeratorB.Current.Envelope).IsEqualTo(env);
-        enumeratorB.Current.CancelLease(); // second cancel of the SAME envelope: must not requeue again
+
+        var originalError = Console.Error;
+        var stderrWriter = new StringWriter();
+        try {
+            Console.SetError(stderrWriter);
+            enumeratorB.Current.CancelLease(); // second cancel of the SAME envelope: consumed-with-log, must not requeue again
+        } finally {
+            Console.SetError(originalError);
+        }
         channel.TransferConsumer();
         await enumeratorB.DisposeAsync();
+
+        await Assert.That(stderrWriter.ToString()).Contains("double-cancel"); // never a silent drop
 
         using var ctsC = new CancellationTokenSource();
         var enumeratorC = channel.ConsumeAsync(ctsC.Token).GetAsyncEnumerator();
@@ -149,6 +159,137 @@ public class OutcomeChannelTests {
         await Assert.That(async () => await moveNextC.AsTask().WaitAsync(Bounded))
             .Throws<OperationCanceledException>(); // lost, not redelivered a second time
         await enumeratorC.DisposeAsync();
+
+        // channel remains functional afterward: a fresh envelope still enqueues, delivers, and acks normally.
+        var env2 = Env("after-double-cancel");
+        channel.Enqueue(env2);
+        using var ctsD = new CancellationTokenSource();
+        var enumeratorD = channel.ConsumeAsync(ctsD.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorD)).IsTrue();
+        await Assert.That(enumeratorD.Current.Envelope).IsEqualTo(env2);
+        enumeratorD.Current.Ack();
+        await enumeratorD.DisposeAsync();
+    }
+
+    [Test, NotInParallel]
+    public async Task Teardown_after_redelivery_with_the_lease_still_outstanding_is_consumed_with_a_logged_warning() {
+        var channel = new OutcomeChannel();
+        var env = Env("implicit-double-abandon");
+        channel.Enqueue(env);
+
+        using var ctsA = new CancellationTokenSource();
+        var enumeratorA = channel.ConsumeAsync(ctsA.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorA)).IsTrue();
+        enumeratorA.Current.CancelLease(); // first abandonment (explicit): uses the one guaranteed requeue
+        channel.TransferConsumer();
+        await enumeratorA.DisposeAsync();
+
+        using var ctsB = new CancellationTokenSource();
+        var enumeratorB = channel.ConsumeAsync(ctsB.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorB)).IsTrue();
+        await Assert.That(enumeratorB.Current.Envelope).IsEqualTo(env);
+        // deliberately neither Ack nor CancelLease — tear B down via ct with the redelivered lease still outstanding
+
+        var originalError = Console.Error;
+        var stderrWriter = new StringWriter();
+        var moveNextB2 = enumeratorB.MoveNextAsync();
+        try {
+            Console.SetError(stderrWriter);
+            await ctsB.CancelAsync();
+            await Assert.That(async () => await moveNextB2.AsTask().WaitAsync(Bounded))
+                .Throws<OperationCanceledException>();
+        } finally {
+            Console.SetError(originalError);
+        }
+        await enumeratorB.DisposeAsync();
+
+        await Assert.That(stderrWriter.ToString()).Contains("implicit-double-abandon"); // second abandonment logged, not silent
+
+        using var ctsC = new CancellationTokenSource();
+        var enumeratorC = channel.ConsumeAsync(ctsC.Token).GetAsyncEnumerator();
+        var moveNextC = enumeratorC.MoveNextAsync();
+        await ctsC.CancelAsync();
+        await Assert.That(async () => await moveNextC.AsTask().WaitAsync(Bounded))
+            .Throws<OperationCanceledException>(); // next consumer sees an empty queue
+        await enumeratorC.DisposeAsync();
+
+        // channel remains functional afterward.
+        var env2 = Env("after-implicit-double-abandon");
+        channel.Enqueue(env2);
+        using var ctsD = new CancellationTokenSource();
+        var enumeratorD = channel.ConsumeAsync(ctsD.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumeratorD)).IsTrue();
+        await Assert.That(enumeratorD.Current.Envelope).IsEqualTo(env2);
+        enumeratorD.Current.Ack();
+        await enumeratorD.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Teardown_with_two_outstanding_leases_requeues_both_in_original_FIFO_order() {
+        var channel = new OutcomeChannel();
+        var envA = Env("multi-a");
+        var envB = Env("multi-b");
+        channel.Enqueue(envA);
+        channel.Enqueue(envB);
+
+        using var cts1 = new CancellationTokenSource();
+        var enumerator1 = channel.ConsumeAsync(cts1.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumerator1)).IsTrue();
+        await Assert.That(enumerator1.Current.Envelope).IsEqualTo(envA); // dequeued first, left outstanding
+        await Assert.That(await BoundedMoveNext(enumerator1)).IsTrue();
+        await Assert.That(enumerator1.Current.Envelope).IsEqualTo(envB); // dequeued second, left outstanding too
+
+        var moveNextAgain = enumerator1.MoveNextAsync(); // queue now empty: suspends
+        await cts1.CancelAsync();
+        await Assert.That(async () => await moveNextAgain.AsTask().WaitAsync(Bounded))
+            .Throws<OperationCanceledException>();
+        await enumerator1.DisposeAsync();
+
+        using var cts2 = new CancellationTokenSource();
+        var enumerator2 = channel.ConsumeAsync(cts2.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumerator2)).IsTrue();
+        await Assert.That(enumerator2.Current.Envelope).IsEqualTo(envA); // FIFO preserved: A before B
+        enumerator2.Current.Ack();
+        await Assert.That(await BoundedMoveNext(enumerator2)).IsTrue();
+        await Assert.That(enumerator2.Current.Envelope).IsEqualTo(envB);
+        enumerator2.Current.Ack();
+        await enumerator2.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Teardown_with_one_acked_and_one_outstanding_lease_redelivers_only_the_outstanding_one() {
+        var channel = new OutcomeChannel();
+        var envA = Env("ack-a");
+        var envB = Env("leave-b");
+        channel.Enqueue(envA);
+        channel.Enqueue(envB);
+
+        using var cts1 = new CancellationTokenSource();
+        var enumerator1 = channel.ConsumeAsync(cts1.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumerator1)).IsTrue();
+        await Assert.That(enumerator1.Current.Envelope).IsEqualTo(envA);
+        enumerator1.Current.Ack(); // A resolved before teardown
+
+        await Assert.That(await BoundedMoveNext(enumerator1)).IsTrue();
+        await Assert.That(enumerator1.Current.Envelope).IsEqualTo(envB); // B left outstanding
+
+        var moveNextAgain = enumerator1.MoveNextAsync();
+        await cts1.CancelAsync();
+        await Assert.That(async () => await moveNextAgain.AsTask().WaitAsync(Bounded))
+            .Throws<OperationCanceledException>();
+        await enumerator1.DisposeAsync();
+
+        using var cts2 = new CancellationTokenSource();
+        var enumerator2 = channel.ConsumeAsync(cts2.Token).GetAsyncEnumerator();
+        await Assert.That(await BoundedMoveNext(enumerator2)).IsTrue();
+        await Assert.That(enumerator2.Current.Envelope).IsEqualTo(envB); // only B redelivered
+        enumerator2.Current.Ack();
+
+        var moveNextC = enumerator2.MoveNextAsync();
+        await cts2.CancelAsync();
+        await Assert.That(async () => await moveNextC.AsTask().WaitAsync(Bounded))
+            .Throws<OperationCanceledException>(); // A never resurfaces — it was already acked, not outstanding
+        await enumerator2.DisposeAsync();
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/ProcessRunnerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ProcessRunnerTests.cs
@@ -136,6 +136,77 @@ public class ProcessRunnerTests {
         }
     }
 
+    [Test]
+    public async Task ProcessOnly_timeout_kills_the_shell_but_spares_the_grandchild() {
+        Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
+
+        var runner = new DaemonClientService.ProcessRunner();
+        // Grandchild redirects its own stdio away from the inherited pipe, like a detached daemon.
+        var result = await runner.RunAsync(
+            "/bin/sh", ["-c", "sleep 30 >/dev/null 2>&1 & echo $!; wait"],
+            new RunOptions(Timeout: TimeSpan.FromMilliseconds(500), TimeoutKill: TimeoutKillScope.ProcessOnly),
+            CancellationToken.None);
+
+        await Assert.That(result.TimedOut).IsTrue();
+        var grandchildPid = int.Parse(result.Stdout.Trim());
+        try {
+            var grandchild = Process.GetProcessById(grandchildPid); // throws if already dead
+            await Assert.That(grandchild.HasExited).IsFalse();
+        } finally {
+            try { Process.GetProcessById(grandchildPid).Kill(); }
+            catch (ArgumentException) { /* already gone */ }
+        }
+    }
+
+    [Test]
+    public async Task Tree_timeout_kills_the_grandchild_too() {
+        Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
+
+        var runner = new DaemonClientService.ProcessRunner();
+        var result = await runner.RunAsync(
+            "/bin/sh", ["-c", "sleep 30 & echo $!; wait"],
+            new RunOptions(Timeout: TimeSpan.FromMilliseconds(500), TimeoutKill: TimeoutKillScope.Tree),
+            CancellationToken.None);
+
+        await Assert.That(result.TimedOut).IsTrue();
+        var grandchildPid = int.Parse(result.Stdout.Trim());
+        await WaitUntilAsync(() => !IsAlive(grandchildPid), TimeSpan.FromSeconds(5), "the grandchild to die with the tree");
+    }
+
+    [Test]
+    public async Task KillTree_cancellation_kills_the_tree_even_with_TimeoutKill_ProcessOnly() {
+        Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
+
+        var runner = new DaemonClientService.ProcessRunner();
+        using var cts = new CancellationTokenSource();
+        var startedMarker = Path.Combine(Path.GetTempPath(), $"kcap-processrunner-{Guid.NewGuid():N}");
+        int grandchildPid = -1;
+        try {
+            var runTask = runner.RunAsync(
+                "/bin/sh", ["-c", $"sleep 30 & echo $! > {startedMarker}; wait"],
+                new RunOptions(CancelMode: CancelMode.KillTree, TimeoutKill: TimeoutKillScope.ProcessOnly),
+                cts.Token);
+
+            await WaitUntilAsync(() => File.Exists(startedMarker), TimeSpan.FromSeconds(5), "the grandchild to start and record its PID");
+            grandchildPid = int.Parse((await File.ReadAllTextAsync(startedMarker)).Trim());
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => runTask);
+            await WaitUntilAsync(() => !IsAlive(grandchildPid), TimeSpan.FromSeconds(5), "the grandchild to die with the caller-cancelled tree");
+        } finally {
+            File.Delete(startedMarker);
+            if (grandchildPid > 0) {
+                try { Process.GetProcessById(grandchildPid).Kill(); }
+                catch (ArgumentException) { /* already gone */ }
+            }
+        }
+    }
+
+    static bool IsAlive(int pid) {
+        try { return !Process.GetProcessById(pid).HasExited; }
+        catch (ArgumentException) { return false; }
+    }
+
     static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
         var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
         while (!condition()) {

--- a/test/Capacitor.App.Tests.Unit/ReasonLineTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ReasonLineTests.cs
@@ -1,0 +1,74 @@
+using Capacitor.App.Services.Mutation;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ReasonLineTests {
+    const string Prefix = "start_gate_reason=";
+
+    [Test]
+    public async Task Single_matching_line_returns_its_token() {
+        var stderr = $"{Prefix}directive_missing\n";
+        await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsEqualTo("directive_missing");
+    }
+
+    [Test]
+    public async Task No_matching_line_returns_null() {
+        var stderr = "some unrelated line\nanother line\n";
+        await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsNull();
+    }
+
+    [Test]
+    public async Task Two_lines_with_the_same_token_still_returns_null() {
+        var stderr = $"{Prefix}directive_missing\n{Prefix}directive_missing\n";
+        await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsNull();
+    }
+
+    [Test]
+    public async Task Two_lines_with_different_tokens_return_null() {
+        var stderr = $"{Prefix}directive_missing\n{Prefix}foreign_binary\n";
+        await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsNull();
+    }
+
+    [Test]
+    public async Task Matching_line_surrounded_by_unrelated_stderr_returns_its_token() {
+        var stderr = $"booting...\nsome noise here\n{Prefix}package_inconsistent\ntrailing noise\n";
+        await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsEqualTo("package_inconsistent");
+    }
+
+    [Test]
+    public async Task Prefix_appearing_mid_line_is_not_a_match() {
+        var stderr = $"noise {Prefix}directive_missing\n";
+        await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsNull();
+    }
+
+    [Test]
+    public async Task CarriageReturn_newline_input_is_handled() {
+        var stderr = $"noise\r\n{Prefix}identity_mismatch\r\nmore noise\r\n";
+        await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsEqualTo("identity_mismatch");
+    }
+
+    // Pinned decision: a matching-prefix line with an empty token is conflicting evidence, not
+    // absent evidence — it fails closed to null rather than falling through to "zero matches".
+    [Test]
+    public async Task Single_matching_line_with_an_empty_token_returns_null() {
+        var stderr = $"{Prefix}\n";
+        await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsNull();
+    }
+
+    [Test]
+    public async Task Single_matching_line_with_a_whitespace_only_token_returns_null() {
+        var stderr = $"{Prefix}   \n";
+        await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsNull();
+    }
+
+    [Test]
+    public async Task Token_is_trimmed_of_surrounding_whitespace() {
+        var stderr = $"{Prefix}  directive_missing  \n";
+        await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsEqualTo("directive_missing");
+    }
+
+    [Test]
+    public async Task Empty_stderr_returns_null() {
+        await Assert.That(ReasonLine.TrySingle("", Prefix)).IsNull();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ReasonLineTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ReasonLineTests.cs
@@ -47,8 +47,7 @@ public class ReasonLineTests {
         await Assert.That(ReasonLine.TrySingle(stderr, Prefix)).IsEqualTo("identity_mismatch");
     }
 
-    // Pinned decision: a matching-prefix line with an empty token is conflicting evidence, not
-    // absent evidence — it fails closed to null rather than falling through to "zero matches".
+    // An empty-token match is conflicting evidence, not absence — fails closed to null.
     [Test]
     public async Task Single_matching_line_with_an_empty_token_returns_null() {
         var stderr = $"{Prefix}\n";

--- a/test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs
+++ b/test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs
@@ -13,14 +13,17 @@ namespace Capacitor.App.Tests.Unit;
 sealed class ScriptedLocalControlOps : ILocalControlOps {
     readonly Queue<TaskCompletionSource<ConsentPolicyDto>> _gets = new();
     readonly Queue<TaskCompletionSource<ConsentAckDto>> _puts = new();
+    readonly Queue<TaskCompletionSource<ConsentAckDto>> _putV2s = new();
     readonly Queue<TaskCompletionSource<StopAgentResult>> _stops = new();
     readonly Queue<TaskCompletionSource<ConsentAckDto>> _resolves = new();
 
     public int GetCalls;
     public int PutCalls;
+    public int PutV2Calls;
     public int StopCalls;
     public int ResolveCalls;
     public readonly List<ConsentPolicyDto> PutPayloads = [];
+    public readonly List<ConsentPolicyPutV2Dto> PutV2Payloads = [];
     public readonly List<(string AgentId, bool Force)> StopPayloads = [];
     public readonly List<ConsentResolveDto> ResolvePayloads = [];
 
@@ -41,6 +44,14 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
     }
 
     public void QueueAck(bool ok, string? error) => ArmPut().SetResult(new ConsentAckDto(ok, error, null));
+
+    public TaskCompletionSource<ConsentAckDto> ArmPutV2() {
+        var tcs = new TaskCompletionSource<ConsentAckDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _putV2s.Enqueue(tcs);
+        return tcs;
+    }
+
+    public void QueuePutV2(bool ok, string? error) => ArmPutV2().SetResult(new ConsentAckDto(ok, error, null));
 
     public TaskCompletionSource<StopAgentResult> ArmStop() {
         var tcs = new TaskCompletionSource<StopAgentResult>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -77,6 +88,16 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
         if (ct.IsCancellationRequested) return Task.FromCanceled<ConsentAckDto>(ct);
         if (_puts.Count == 0) throw new InvalidOperationException("ScriptedLocalControlOps: unscripted Put call");
         var tcs = _puts.Dequeue();
+        ct.Register(() => tcs.TrySetCanceled(ct));
+        return tcs.Task;
+    }
+
+    public Task<ConsentAckDto> PutConsentPolicyV2Async(ConsentPolicyPutV2Dto put, CancellationToken ct) {
+        Interlocked.Increment(ref PutV2Calls);
+        PutV2Payloads.Add(put);
+        if (ct.IsCancellationRequested) return Task.FromCanceled<ConsentAckDto>(ct);
+        if (_putV2s.Count == 0) throw new InvalidOperationException("ScriptedLocalControlOps: unscripted PutV2 call");
+        var tcs = _putV2s.Dequeue();
         ct.Register(() => tcs.TrySetCanceled(ct));
         return tcs.Task;
     }

--- a/test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs
+++ b/test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs
@@ -52,6 +52,8 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
     }
 
     public void QueuePutV2(bool ok, string? error) => ArmPutV2().SetResult(new ConsentAckDto(ok, error, null));
+    public void QueuePutV2Failure(string reason) => ArmPutV2().SetException(new LocalControlOpsException(reason, reason));
+    public void QueuePutV2UnmappedFailure(Exception ex) => ArmPutV2().SetException(ex);
 
     public TaskCompletionSource<StopAgentResult> ArmStop() {
         var tcs = new TaskCompletionSource<StopAgentResult>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/test/Capacitor.App.Tests.Unit/ShimOfferCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ShimOfferCoordinatorTests.cs
@@ -63,7 +63,9 @@ public class ShimOfferCoordinatorTests {
         public readonly PathShimInstaller Installer;
         public readonly ShimOfferCoordinator Coordinator;
 
-        public Harness(bool immediatePhaseClosed = false, bool noTarget = false, Func<bool>? isMacOs = null) {
+        public Harness(
+                bool immediatePhaseClosed = false, bool noTarget = false, Func<bool>? isMacOs = null,
+                bool autoOfferSuppressed = false) {
             Target      = noTarget ? null : Path.Combine(TempDir, "target-cli");
             Destination = Path.Combine(TempDir, "kcap");
             Installer   = new PathShimInstaller(Runner, Probe);
@@ -71,7 +73,7 @@ public class ShimOfferCoordinatorTests {
             var phaseClosed = immediatePhaseClosed ? Task.CompletedTask : PhaseClosedSource.Task;
             Coordinator = new ShimOfferCoordinator(
                 phaseClosed, Probe, Installer, Store, Surface, Target, CancellationToken.None, Destination,
-                isMacOs ?? (() => true));
+                isMacOs ?? (() => true), autoOfferSuppressed);
             Coordinator.Offerable.Subscribe(OfferableValues.Add);
         }
 
@@ -180,6 +182,31 @@ public class ShimOfferCoordinatorTests {
         await Assert.That(h.Surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindShim);
         await Assert.That(h.Surface.Prompts[0].Disclosure).IsEqualTo(ShimOfferCoordinator.ShimDisclosure);
         await Assert.That(h.Surface.Prompts[0].PathDegraded).IsFalse();
+    }
+
+    // ---- Task 15 round-1 review: autoOfferSuppressed (carve-out mode) ----
+
+    [Test]
+    public async Task AutoOfferSuppressed_still_becomes_offerable_but_never_shows_the_dialog() {
+        using var h = new Harness(immediatePhaseClosed: true, autoOfferSuppressed: true);
+        h.Probe.KcapOnPathBehavior = _ => Task.FromResult<bool?>(false);
+        h.Coordinator.Start();
+
+        await WaitUntilAsync(() => h.OfferableValues.Contains(true), what: "the item to become visible");
+        await Task.Delay(100); // give a wrongly-firing auto-offer dialog (ConfirmAsync) every chance to appear
+        await Assert.That(h.Surface.Prompts).IsEmpty(); // Prompts records every ConfirmAsync call
+    }
+
+    // Manual install is a separate code path from the suppressed auto-offer — it must still work.
+    [Test]
+    public async Task AutoOfferSuppressed_manual_install_still_works() {
+        using var h = new Harness(autoOfferSuppressed: true);
+        h.Runner.Enqueue(new ProcessResult(0, "", "", false));
+
+        await h.Coordinator.RunManualInstallAsync();
+
+        await Assert.That(h.Runner.Calls.Count).IsEqualTo(1);
+        await Assert.That(h.Surface.Prompts).IsEmpty(); // never a dialog — a direct manual click
     }
 
     // ---- already resolved on a prior run ----

--- a/test/Capacitor.App.Tests.Unit/ShimOfferCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ShimOfferCoordinatorTests.cs
@@ -195,6 +195,9 @@ public class ShimOfferCoordinatorTests {
         await WaitUntilAsync(() => h.OfferableValues.Contains(true), what: "the item to become visible");
         await Task.Delay(100); // give a wrongly-firing auto-offer dialog (ConfirmAsync) every chance to appear
         await Assert.That(h.Surface.Prompts).IsEmpty(); // Prompts records every ConfirmAsync call
+        // The once-ever offer claim must survive a suppressed run — a later complete-gate run still auto-offers.
+        await Assert.That(h.Store.State.ShimOffered).IsFalse();
+        await Assert.That(h.Store.State.ShimDenied).IsFalse();
     }
 
     // Manual install is a separate code path from the suppressed auto-offer — it must still work.

--- a/test/Capacitor.Cli.Tests.Unit/Config/ProfileAuthProviderStampTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Config/ProfileAuthProviderStampTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Tests.Unit.Config;
+
+/// <summary>
+/// Tests for the <c>auth_provider</c> stamp (Task 14, Plan B — additive, read-only this plan;
+/// nothing writes it yet). Pure in-memory serialization, no config.json I/O, so these don't need
+/// the shared <c>KCAP_CONFIG_DIR</c> isolation the disk-touching config tests use.
+/// </summary>
+public class ProfileAuthProviderStampTests {
+    [Test]
+    public async Task Absent_by_default_old_configs_load_with_null() {
+        // An old, already-on-disk config.json — no "auth_provider" key anywhere in it.
+        const string json = """
+            {"version":2,"active_profile":"acme","profiles":{"acme":{"server_url":"https://acme.example"}}}
+            """;
+
+        var config = JsonSerializer.Deserialize(json, ProfileConfigJsonContext.Default.ProfileConfig);
+
+        await Assert.That(config).IsNotNull();
+        await Assert.That(config!.Profiles["acme"].AuthProvider).IsNull();
+    }
+
+    [Test]
+    public async Task Round_trips_through_serialization() {
+        var config = new ProfileConfig {
+            Profiles = new() {
+                ["acme"] = new Profile {
+                    ServerUrl = "https://acme.example",
+                    AuthProvider = new AuthProviderStamp("none", "https://acme.example:443")
+                }
+            }
+        };
+
+        var json     = JsonSerializer.Serialize(config, ProfileConfigJsonContext.Default.ProfileConfig);
+        var restored = JsonSerializer.Deserialize(json, ProfileConfigJsonContext.Default.ProfileConfig);
+
+        var stamp = restored!.Profiles["acme"].AuthProvider;
+        await Assert.That(stamp).IsNotNull();
+        await Assert.That(stamp!.Provider).IsEqualTo("none");
+        await Assert.That(stamp.ServerUrl).IsEqualTo("https://acme.example:443");
+    }
+
+    [Test]
+    public async Task Serializes_with_documented_json_property_names() {
+        var config = new ProfileConfig {
+            Profiles = new() {
+                ["acme"] = new Profile { AuthProvider = new AuthProviderStamp("workos", "https://acme.example") }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(config, ProfileConfigJsonContext.Default.ProfileConfig);
+
+        await Assert.That(json).Contains("\"auth_provider\"");
+        await Assert.That(json).Contains("\"provider\":\"workos\"");
+        await Assert.That(json).Contains("\"server_url\":\"https://acme.example\"");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/LocalIpc/LocalControlOpsV2PutTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalIpc/LocalControlOpsV2PutTests.cs
@@ -1,0 +1,175 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon;
+using Capacitor.Cli.Daemon.Pty;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Tests.Unit.LocalIpc;
+
+/// <summary>
+/// Client-side round trip for <see cref="LocalControlOps.PutConsentPolicyV2Async"/> against a
+/// REAL daemon stack (not a scripted stub) — the identity-mismatch behaviour under test lives in
+/// <see cref="LaunchConsentIpc.HandleRulesPutV2Async"/>, so a fake server that just echoes back an
+/// ack would prove nothing. Harness mirrors
+/// <see cref="Capacitor.Cli.Tests.Unit.Daemon.ConsentRulesPutV2Tests"/> (temp DaemonLockPaths
+/// override, socket-file poll, Windows guard, minimal AgentOrchestrator) but drives the daemon
+/// through <see cref="LocalControlOps"/>, the Core client under test, instead of hand-rolled
+/// frames.
+/// </summary>
+public class LocalControlOpsV2PutTests {
+    sealed class NoopHostLifetime : IHostApplicationLifetime {
+        public CancellationToken ApplicationStarted  => CancellationToken.None;
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+        public CancellationToken ApplicationStopped  => CancellationToken.None;
+        public void StopApplication() { }
+    }
+
+    sealed class NoopPtyProcessFactory : IPtyProcessFactory {
+        public IPtyProcess Spawn(
+                string command, string[] args, string cwd,
+                Dictionary<string, string>? extraEnv = null, ushort cols = 120, ushort rows = 40
+            ) => throw new NotSupportedException("LocalControlOpsV2PutTests never spawns a PTY");
+    }
+
+    sealed class NoopHttpClientFactory : IHttpClientFactory {
+        public HttpClient CreateClient(string name) => new();
+    }
+
+    sealed class NoopRestartStrategy : IRestartStrategy {
+        public RestartOutcome Restart() => RestartOutcome.NoOp;
+    }
+
+    sealed record Harness(LocalControlServer Server, AgentOrchestrator Orchestrator, ServerConnection Connection, DaemonConfig Config, string SockPath);
+
+    static async Task<Harness> StartAsync(string daemonName, CancellationToken ct, string serverUrl = "http://127.0.0.1:1") {
+        var stateDir = Directory.CreateTempSubdirectory("kcap-lcov2-state-").FullName;
+        var store       = new LaunchConsentStore(stateDir, NullLogger.Instance);
+        var broker      = new LaunchConsentBroker();
+        var decisionLog = new LaunchConsentDecisionLog(stateDir, NullLogger.Instance);
+        var gate        = new LaunchConsentGate(store, decisionLog, broker, TimeProvider.System, NullLogger<LaunchConsentGate>.Instance);
+
+        var config = new DaemonConfig {
+            Name         = daemonName,
+            ServerUrl    = serverUrl,
+            StateDir     = stateDir,
+            WorktreeRoot = Path.Combine(Path.GetTempPath(), "kcap-lcov2-wt-" + Guid.NewGuid().ToString("N")[..8]),
+        };
+        var consentIpc = new LaunchConsentIpc(broker, store, config, NullLogger<LaunchConsentIpc>.Instance);
+
+        var connection       = new ServerConnection(config, NullLoggerFactory.Instance, NullLogger<ServerConnection>.Instance);
+        var worktreeManager  = new WorktreeManager(config, NullLogger<WorktreeManager>.Instance);
+        var repoMatcher      = new RepoMatcher(config, NullLogger<RepoMatcher>.Instance);
+        var permissionBridge = new LocalPermissionBridge(connection, NullLogger<LocalPermissionBridge>.Instance);
+
+        var orchestrator = new AgentOrchestrator(
+            config, connection, worktreeManager, repoMatcher, new NoopPtyProcessFactory(), new NoopHttpClientFactory(),
+            permissionBridge, new Dictionary<string, IHostedAgentLauncher>(),
+            new Dictionary<string, IHostedAgentRuntimeFactory>(), new NoopHostLifetime(),
+            NullLogger<AgentOrchestrator>.Instance, gate);
+
+        var statusIpc = new DaemonStatusIpc(config, orchestrator, connection, new DaemonStatusNotifier());
+        var restart = RestartCoordinator.ForTest(daemonName, daemonName, new NoopRestartStrategy());
+        var server = new LocalControlServer(config, orchestrator, restart, consentIpc, statusIpc, NullLogger<LocalControlServer>.Instance);
+        await server.StartAsync(ct);
+
+        var sockPath = LocalSocketPaths.Socket(daemonName);
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (!File.Exists(sockPath) && DateTime.UtcNow < deadline) await Task.Delay(20, ct);
+
+        return new Harness(server, orchestrator, connection, config, sockPath);
+    }
+
+    static async Task StopAsync(Harness h) {
+        await h.Orchestrator.DisposeAsync();
+        await h.Server.StopAsync(CancellationToken.None);
+        h.Server.Dispose();
+        await h.Connection.DisposeAsync();
+    }
+
+    /// Wraps a test body with the temp-dir DaemonLockPaths override + harness lifecycle, mirroring
+    /// ConsentRulesPutV2Tests.RunAsync, and hands the body a LocalControlOps pointed at the same
+    /// daemon name so it can drive Put/Get through the real client under test.
+    static async Task RunAsync(string daemonName, Func<Harness, LocalControlOps, CancellationToken, Task> body, string serverUrl = "http://127.0.0.1:1") {
+        var sockDir = Directory.CreateTempSubdirectory("kcap-lcov2-sock-");
+        DaemonLockPaths.OverrideDirectoryForTesting(sockDir.FullName);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        Harness? h = null;
+        try {
+            h = await StartAsync(daemonName, cts.Token, serverUrl);
+            await Assert.That(File.Exists(h.SockPath)).IsTrue();
+            var ops = new LocalControlOps(daemonName) {
+                ConnectTimeout = TimeSpan.FromSeconds(2),
+                ConsentReplyTimeout = TimeSpan.FromSeconds(5),
+            };
+            await body(h, ops, cts.Token);
+        } finally {
+            if (h is not null) await StopAsync(h);
+            DaemonLockPaths.OverrideDirectoryForTesting(null);
+            try { Directory.Delete(sockDir.FullName, true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Identity_match_applies_and_follow_up_get_sees_it() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("lcov2put-a", async (h, ops, ct) => {
+            var put = new ConsentPolicyPutV2Dto("lcov2put-a", h.Config.ServerUrl,
+                new ConsentPolicyDto("prompt", 45, []));
+            var ack = await ops.PutConsentPolicyV2Async(put, ct);
+
+            await Assert.That(ack.Ok).IsTrue();
+            await Assert.That(ack.Error).IsNull();
+
+            var policy = await ops.GetConsentPolicyAsync(ct);
+            await Assert.That(policy.Default).IsEqualTo("prompt");
+            await Assert.That(policy.PromptTimeoutSeconds).IsEqualTo(45);
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Name_mismatch_acks_identity_mismatch_and_leaves_policy_unchanged() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("lcov2put-b", async (h, ops, ct) => {
+            var before = await ops.GetConsentPolicyAsync(ct);
+
+            var put = new ConsentPolicyPutV2Dto("some-other-daemon", h.Config.ServerUrl,
+                new ConsentPolicyDto("prompt", 45, []));
+            var ack = await ops.PutConsentPolicyV2Async(put, ct);
+
+            await Assert.That(ack.Ok).IsFalse();
+            await Assert.That(ack.Error).IsEqualTo("identity_mismatch");
+
+            var after = await ops.GetConsentPolicyAsync(ct);
+            await Assert.That(after.Default).IsEqualTo(before.Default);
+            await Assert.That(after.PromptTimeoutSeconds).IsEqualTo(before.PromptTimeoutSeconds);
+        });
+    }
+
+    [Test]
+    [NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]
+    public async Task Server_mismatch_acks_identity_mismatch_and_leaves_policy_unchanged() {
+        if (OperatingSystem.IsWindows()) return; // Unix-domain socket path
+
+        await RunAsync("lcov2put-c", async (h, ops, ct) => {
+            var before = await ops.GetConsentPolicyAsync(ct);
+
+            var put = new ConsentPolicyPutV2Dto("lcov2put-c", "https://other-server.example",
+                new ConsentPolicyDto("prompt", 45, []));
+            var ack = await ops.PutConsentPolicyV2Async(put, ct);
+
+            await Assert.That(ack.Ok).IsFalse();
+            await Assert.That(ack.Error).IsEqualTo("identity_mismatch");
+
+            var after = await ops.GetConsentPolicyAsync(ct);
+            await Assert.That(after.Default).IsEqualTo(before.Default);
+            await Assert.That(after.PromptTimeoutSeconds).IsEqualTo(before.PromptTimeoutSeconds);
+        });
+    }
+}


### PR DESCRIPTION
Part of #553. AI-1655 (Plan B of three).

The desktop app's mutation-safety substrate, consuming Plan A's CLI/daemon substrate (#556). Spec: `docs/superpowers/specs/2026-08-12-ai1655-onboarding-wizard-design.md` §4/§6, decisions 1/2/4/7.

## What this delivers

- **`DaemonMutationLane`** — the app-lifetime singleton every daemon mutation routes through: per-action CLI pinning (validated login-shell resolver, strict `0.12.0-beta.1` floor probe per mutation), action-scoped `KcapCli` executor with the safety env overlays (`KCAP_CONSENT_SEED_DEFAULT`, `KCAP_EXPECT_SERVER_URL`, `KCAP_APP_SPAWN_NO_TELEMETRY`, `KCAP_BOOT_ATTEMPT`), instance-bound evidence classification with one shared predicate, boot-refusal-marker attribution by attempt id, bounded detached-start timeout with a new process-only kill scope, and a leased FIFO outcome channel whose single consumer owns all actionable presentation (waiter results are state-only).
- **All three mutation surfaces routed through the lane** (lifecycle controller auto-actions, user Start, main-window detached Start) — no direct spawn remains; the bare-`kcap` fallback is gone.
- **`ConsentFlipClaims` + `ConsentFlipCoordinator`** — durable `{profile, server}`-keyed claims (ConfigFileLock-mutated, quarantine-aside, two-lock conditional clear) applied to pre-existing daemons via the identity-conditional `ConsentRulesPutV2` under the factory guard. New Core op `ILocalControlOps.PutConsentPolicyV2Async`.
- **`OnboardingGate`** — provider-aware eligibility (mirrors `TokenStore`'s real refresh/binding rules), additive `auth_provider` profile stamp (read-only this plan), one shared URL validator with `App.ValidProfileName`.
- **Decision-2 startup carve-out** — gate-incomplete machines build the graph with lifecycle auto-actions permanently closed and the shim auto-offer suppressed (tray item stays visible/usable); a gate evaluation failure degrades to Incomplete, never bricks startup.

## Known residuals (Plan C resolves)

- Claim arming has no production caller yet (the wizard's commit boundary arms; the coordinator is inert until then); the quarantine-ack method has no UI caller.
- The carve-out closes auto-actions only; skew/repair dialogs on a Connected daemon remain reachable on token-less machines until wizard-first startup lands.
- The CLI floor is runtime-enforced only; the spec's build-time app-package assertion belongs to release engineering.
- `TransferConsumer` has no production call site until the wizard handoff.
- `auth_provider` is never written this slice; legacy `AuthProvider.None` profiles stay token-required until a Plan C sign-in stamps them (documented spec residual).
- A boot-refusal marker written after the detached confirm window persists until a passing boot or service transaction clears it (hygiene only; attribution is attempt-id-scoped).

No user-facing CLI surface changed (no README churn). Executed via subagent-driven development: per-task spec+quality reviews with adversarial fix rounds, plus a whole-branch final review; app suite 827/827, both AOT publishes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)