### PR TITLE
Release: install openssl in the Alpine musl leg; fail loudly on empty daemon digest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
         if: matrix.container != ''
         shell: sh
         run: |
-          apk add --no-cache bash curl git icu-libs krb5-libs libgcc libstdc++ zlib clang build-base zlib-dev linux-headers
+          apk add --no-cache bash curl git icu-libs krb5-libs libgcc libstdc++ zlib clang build-base zlib-dev linux-headers openssl
 
       - name: Install Linux build dependencies
         if: runner.os == 'Linux' && !matrix.container
@@ -253,7 +253,11 @@ jobs:
         shell: bash
         run: |
           BIN=publish/daemon/${{ matrix.daemon-binary }}
-          echo "DIGEST=$(openssl dgst -sha256 -r "$BIN" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          DIGEST=$(openssl dgst -sha256 -r "$BIN" | cut -d' ' -f1)
+          if [ -z "$DIGEST" ]; then
+            echo "::error::empty daemon digest for $BIN"; exit 1
+          fi
+          echo "DIGEST=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Publish CLI AOT binary
         run: >


### PR DESCRIPTION
Closes #563

## What broke

The v0.11.21 release run failed in exactly one job — `build (linux-musl-x64, alpine:3.20)` — with `openssl: command not found` (exit 127) in the "Assert packaged daemon matches embedded digest" step: https://github.com/kurrent-io/kcap-cli/actions/runs/31824345189

## Root cause

#554 introduced the daemon-digest compute + assert steps, both using `openssl dgst -sha256`. The linux-musl-x64 leg is the only one running in an `alpine:3.20` container, and its `apk add` dependency list didn't include `openssl` (the base image ships without the binary). Every other leg runs on a GitHub-hosted runner where openssl is preinstalled, so v0.11.21 was the first release to exercise these steps on Alpine.

Secondary defect: the compute step's `echo "DIGEST=$(openssl ...)"` swallows the openssl failure (echo exits 0), so the step "succeeded" with an **empty** digest and the musl CLI was built with an empty embedded `KcapDaemonDigest`. Only the later assert step surfaced the problem — without it we'd have shipped silently.

## Fix

- Add `openssl` to the Alpine `apk add` list.
- Split the digest computation into a bare `DIGEST=$(...)` assignment (propagates the failure under the default `bash -e -o pipefail`) plus an explicit empty-digest guard, so a missing/failing digest tool kills the leg at the *compute* step rather than stamping an empty digest.

## Verification

- `docker run alpine:3.20`: confirmed stock image has no `openssl`; with the updated apk list, the exact compute + assert script bodies pass end-to-end.
- Demonstrated old vs. new compute form under `bash -e -o pipefail` with openssl absent: old form exits 0 (silent empty digest), new form exits 127 (loud failure).
- `actionlint`: no new findings (the 5 pre-existing shellcheck warnings on main are unchanged).

## Re-releasing v0.11.21

`@kurrent/kcap@0.11.21` was never published (publish-npm was skipped), so the re-cut-tag guard permits deleting and re-cutting `v0.11.21` on the new main head after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)