### PR TITLE
Onboarding wizard: Core auth facade, setup/login re-plumb, wizard-first startup (Plan C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,21 @@ shared URL validator with `App.ValidProfileName`) drives the decision-2 startup 
 gate-incomplete machines build the graph with lifecycle auto-actions permanently closed and the
 shim auto-offer suppressed (item stays visible). Wizard UI + the Core auth façade are Plan C.
 
+**AI-1655 Plan C** (spec §5/§3) is the Core façade and the full wizard. `OnboardingFacade`
+(`Capacitor.Cli.Core/Auth/`) drives login/discover/create through one ordered commit boundary —
+claims (decision 7) → config + provider stamp → tokens — behind a totalized `AuthResult`:
+`Committed`/`Cancelled`/`Failed(AuthFailureReason)`/`Retarget(ServerInput)`. `LoginAsync`'s
+`adoptServer` flag separates `kcap login` (never repoints `server_url`) from `kcap setup`/the
+wizard (adopts — the write that reaches gate-complete); `kcap setup`/`kcap login` re-plumb onto the
+façade as thin Spectre adapters, behavior-preserving. `WizardComposition.BuildGraph`
+(`Capacitor.App/Services/Onboarding/`) composes the 8-step wizard (Shim/Connect/Sign-in/Defaults/
+Agents/Import/Daemon/Done) over that SAME façade via `WizardAuthService` and its decision-7
+`ArmingHook`; `App.RunWizardModeAsync` runs it wizard-first on a gate-incomplete machine (no
+daemon graph, no tray) and hands the outcome channel to the normal graph's consumer via
+`OutcomeChannel.TransferConsumer` once the sign-in lane cancels/quiesces, closing auto-actions
+permanently past the quiesce cap (decision 2/§6a). The §7 streaming `IProcessRunner` backs the
+Import step's live, bounded-tail log pane.
+
 The receive pump no longer awaits launch/stop EXECUTION for either command format: arrival order is
 preserved by routing sequenced AND un-sequenced server-origin launch/stop traffic through the ONE
 existing serial lane (`RunLaneAsync`). Un-sequenced commands commit via a typed, no-ack entry point

--- a/docs/superpowers/plans/2026-08-16-ai1655-plan-c-facade-wizard.md
+++ b/docs/superpowers/plans/2026-08-16-ai1655-plan-c-facade-wizard.md
@@ -401,9 +401,9 @@ public sealed class UiAuthProgress(Action<Action> post) : IAuthProgress { … } 
 
 **Contract.** Composed flows through the REAL shell + real step VMs (scripted externals only): (a) fresh-machine happy path — paste `None` URL → auto-satisfied Sign-in → defaults written → agents/import skipped (no CLI) → daemon step "requires sign-in" absent (gate complete), Done summary correct; (b) abandon-before-sign-in → close → nothing durable (no config/token/claim writes on the temp dirs); (c) sign-in commit → claims armed → quit → relaunch fixture: `ConsentFlipCoordinator` (normal graph) still holds the claim. Spec rider records the Plan C deviations (this plan's pinned list) next to §5's result algebra and §4's adapter text; CLAUDE.md gains the Plan C paragraph (façade + wizard-first summary, ≤16 lines, replacing nothing).
 
-- [ ] **Step 1: Failing composition tests (a)-(c).**
-- [ ] **Step 2-4: red → implement/wire gaps → green.**
-- [ ] **Step 5: Commit** `test(app): wizard composition flows; docs: spec riders`
+- [x] **Step 1: Failing composition tests (a)-(c).**
+- [x] **Step 2-4: red → implement/wire gaps → green.**
+- [x] **Step 5: Commit** `test(app): wizard composition flows; docs: spec riders`
 
 ### Task 18: Final verification sweep
 

--- a/docs/superpowers/plans/2026-08-16-ai1655-plan-c-facade-wizard.md
+++ b/docs/superpowers/plans/2026-08-16-ai1655-plan-c-facade-wizard.md
@@ -1,0 +1,420 @@
+# AI-1655 Plan C — Core Auth Façade, CLI Re-plumb, Onboarding Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the remaining AI-1655 scope: the GUI-neutral Core onboarding façade (§5), the `setup`/`login` re-plumb onto it, the desktop onboarding wizard (§3/§4), the streaming import contract (§7), and wizard-first startup (decision 2) — completing the spec on top of the merged Plan A substrate (#556) and Plan B app lane/claims/gate (#562).
+
+**Architecture:** Bottom-up in four layers. (1) Core: cancellation + async picker threaded through the existing auth flows, a structured progress sink replacing `Console` writes, helper moves, then the `OnboardingFacade` with its ordered commit boundary (before-commit claim hook → config/stamp → tokens, under `CancellationToken.None` once entered). (2) CLI: `kcap login` and `kcap setup` re-plumb onto the façade through thin Spectre adapters, behavior-preserving. (3) App services: streaming process runner, `KcapCli` plugin/import verbs, `WizardAuthService` single-flight driver, claims arming. (4) Wizard UI + wizard-first startup with the `OutcomeChannel.TransferConsumer` handoff.
+
+**Tech Stack:** .NET 10 NativeAOT, Avalonia (headless-testable), TUnit, source-generated JSON. Core façade is BCL-only (no Avalonia/Rx/Spectre types).
+
+**Spec:** `docs/superpowers/specs/2026-08-12-ai1655-onboarding-wizard-design.md` — where this plan and the spec disagree, the spec governs, EXCEPT the deviations pinned below.
+
+## Standing deviations and carry-forwards (binding)
+
+- **One-shot observation only.** Plan B deleted the live-graph observation adapter (spec §4's two-adapter slot machinery): every lane classification uses fresh one-shot probes with the instance-bound sandwich. Plan C does NOT resurrect the live adapter. Flagged in #562.
+- **GitHub setup exchange convergence.** Today `kcap setup`'s GitHub discovery defers token exchange to Step 2 (active profile only) while `kcap login --discover` exchanges every tenant. The façade implements the spec's boundary ("config then one token per tenant", decision 7) — after the re-plumb, setup's GitHub path also publishes one token per discovered tenant and Step 2 reports login complete (as the WorkOS branch already does). User-visible setup output is unchanged in shape; tests that pin the deferred `PreAuthToken` dance are updated, not preserved.
+- **Advisory accept-time revalidation (Plan B Task 10 R2-1): continued deferral.** A takeover Accept issues `Replace` through the lane, which performs its own fresh floor probe, and the CLI's in-transaction gates re-derive all evidence under the per-label lock — the staleness guard is structural. No consumer-side revalidation is added.
+- **`resolveIdentityUnderConfigLock` switches `LoadPure` → `TryLoadPure`** (Plan B adjudication): now that `ConsentFlipClaims.Arm` gains production callers, an unreadable config inside `TryConsume`'s held locks must retain the claim, not throw (Task 10).
+- **Provider stamp vocabulary:** the boundary writes the `AuthProvider` constant verbatim (`"GitHubApp"`, `"workos"`, `"None"`); `OnboardingGate` already compares the `None` stamp case-insensitively. Pinned by test (Task 4).
+- **`AuthResult` has a fourth arm, `Retarget`.** Spec §5 names `Committed | Cancelled | Failed`; the WorkOS "I already have a workspace" answer (§3's retarget transition, §10's ViewModel row) completes the operation with nothing durable and a server input the caller loops on. Modeling it as `Failed` would be dishonest; it is pre-boundary by construction.
+- **Create-workspace is offered only on zero tenants**, mirroring the CLI exactly (`WorkOSDiscovery` consults the provisioner only when discovery finds no tenants). A wizard user choosing "Create a workspace" who turns out to have tenants gets the picker — spec §10 tests only the zero-tenant create row.
+
+## Prior work (do NOT re-implement)
+
+Plan A (#556): daemon boot seed + carriers, `ConsentRulesPutV2`/`consent/3`, `pid`+`instance_id` DTOs, hello↔snapshot correlation, `LocalControlProbe`, gates 28/29/43, embedded digest pipeline, `ServiceEnvironment` allowlist, telemetry spawn marker, decision-10 `ConfigMutator` (+ every CLI writer migrated), **pure `AgentDetection` in Core** (`src/Capacitor.Cli.Core/Setup/AgentDetection.cs` — `Detect(AgentDetectionInputs)`, `FromEnvironment()`), `unit_*` status fields.
+Plan B (#562): `DaemonMutationLane` + `OutcomeChannel` (leased FIFO, `TransferConsumer()`), `KcapCli` action-scoped executor + env overlays + `DetachedStartAsync`, `TimeoutKillScope.ProcessOnly`, `BootRefusalMarker` attribution, `ConsentFlipClaims` (+quarantine) / `ConsentFlipCoordinator` (+`AckQuarantineAsync`, surfacing), `OnboardingGate` + `auth_provider` stamp READ, startup carve-out (`autoActionsPermanentlyClosed`, shim auto-offer suppression), single-consumer presentation (`ConsumeMutationOutcomesAsync`/`PresentOutcomeAsync` in `App.axaml.cs`).
+
+## Global Constraints
+
+- Fail-closed doctrine: nothing classifies toward success on missing/inconsistent evidence; unknown reason tokens → attention, never destructive.
+- The app emits NO telemetry (decision 9): never call `CliTelemetry.Initialize`; every app-spawned CLI child carries `KCAP_APP_SPAWN_NO_TELEMETRY=1` (already in `KcapCli.Env()`). Core `SetupFunnel` calls no-op in the app.
+- Single-presentation rule: `RunAsync` results are waiter-state-only; ONE channel consumer owns actionable presentation; never two prompts from one outcome.
+- Core façade: BCL-only, AOT-clean, source-generated serialization. After ANY Core change: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` AND the same for `src/Capacitor.Cli.Daemon` — both empty.
+- CLI behavior-preserving: existing command tests keep passing except where a pinned deviation says otherwise. No new CLI verbs or flags; no README/help churn (spec §11).
+- Floor literal `0.12.0-beta.1` (`KcapCliCompatibility.Floor`) — do not touch.
+- Comments: max ONE short invariant line (≤200 chars); zero review/task provenance; no Linear IDs in code (GitHub issue numbers only).
+- Tests: TUnit; `--treenode-filter "/*/*/ClassName/*"`; local runs `TMPDIR=/private/tmp`; `Path.Combine` in path assertions (Windows CI leg); Avalonia tests `[NotInParallel("AvaloniaSession")]`; real-socket tests `[NotInParallel(nameof(DaemonLockPaths) + ".OverrideDirectoryForTesting")]` + Windows guard; IDE0005 unused usings are build errors.
+- Never read agent/daemon-owned files with write-denying opens (`FileShare.ReadWrite`).
+- Commit per task; push via `git push https://github.com/kurrent-io/kcap-cli.git <branch>`. ONE PR referencing `Part of #553. AI-1655`.
+
+---
+
+### Task 1: Cancellation + async picker through the existing auth flows
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/Auth/TenantDiscovery.cs` (`ITenantPicker`), `src/Capacitor.Cli.Core/Auth/AuthProxyClient.cs`, `src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs`, `src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs`, `src/Capacitor.Cli/Commands/SpectreTenantPicker.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs`, `test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs`, new `test/Capacitor.Cli.Tests.Unit/AuthCancellationTests.cs`
+
+**Interfaces (produces):**
+```csharp
+public interface ITenantPicker {
+    DiscoveredTenant? Pick(DiscoveredTenant[] tenants);                                   // unchanged
+    Task<DiscoveredTenant?> PickAsync(DiscoveredTenant[] tenants, CancellationToken ct);  // NEW — the counterpart the façade consumes
+}
+public interface IAuthProxyClient {
+    Task<ProxyConfigResponse?> GetConfigAsync(string proxyUrl, CancellationToken ct = default);
+    Task<DiscoveryResult> DiscoverTenantsAsync(string proxyUrl, string githubAccessToken, CancellationToken ct = default);
+    Task<DiscoveryResult> DiscoverWorkOSTenantsAsync(string proxyUrl, string workosAccessToken, CancellationToken ct = default);
+}
+```
+`OAuthLoginFlow` members gain trailing `CancellationToken ct = default`, threaded into every `HttpClient` call, `Task.Delay`, and `browser.InvokeAsync`: `RunDeviceFlowAsync`, `RunGitHubBrowserFlowAsync`, `ExchangeAndSaveAsync` (all three overloads), `AcquireGitHubTokenAsync`, `AuthenticateWorkOSAsync`, `SwitchWorkOSOrgAsync`, `RefreshWorkOSTokenAsync`, `LoginWithDiscoveryAsync`. The device poll (`RunDeviceFlowAsync` L175-211, today `while (true)`) becomes cancellable: `await Task.Delay(interval, ct)` and `ct.ThrowIfCancellationRequested()` per iteration — cancellation surfaces as `OperationCanceledException`, never a mapped error string. `WorkOSDiscovery.RunWithLiveAuthAsync` and `RunAsync` gain `CancellationToken ct = default`; the two dropped tokens are fixed: L42's `orglessRefresh: async (refreshToken, _)` passes the real token through to `RefreshWorkOSTokenAsync`, and L109 passes `ct` into `provisioner.OfferCreateAsync(tokens, ct)`. `WorkOSDiscovery` consumes `picker.PickAsync(result.Tenants, ct)`; `TenantDiscovery.RunAsync` gains `ct` and consumes `PickAsync` too. `SpectreTenantPicker` implements `PickAsync` as `Task.FromResult<DiscoveredTenant?>(Pick(tenants))` (Spectre prompts are not cancellable; the CLI never cancels). Behavior-preserving: default `ct` everywhere, no call-site changes required outside tests.
+
+- [ ] **Step 1: Failing tests** (`AuthCancellationTests` + updates): cancelling during the device poll throws OCE (fake `HttpClient` handler pinning the poll on `authorization_pending`); `WorkOSDiscovery.RunAsync` passes its `ct` into `OfferCreateAsync` (NSubstitute provisioner asserting the received token is the one passed to `RunAsync`, not `default` — use a cancelled-after-start token identity check) and into the `orglessRefresh` delegate; `PickAsync` is what discovery awaits (substitute picker: `PickAsync` returns a tenant, `Pick` configured to throw — flow succeeds); existing `WorkOSDiscoveryTests`/`OAuthFlowTests` updated to stub `PickAsync` instead of `Pick` where discovery is driven.
+- [ ] **Step 2: Run tests — red.**
+- [ ] **Step 3: Implement** (mechanical threading; no logic changes).
+- [ ] **Step 4: Run the full CLI unit suite — green.** AOT publish greps for CLI + daemon — empty.
+- [ ] **Step 5: Commit** `feat(core): cancellation and async tenant picker through the auth flows`
+
+### Task 2: `IAuthProgress` — structured progress sink replaces Console writes
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/Auth/AuthProgress.cs`
+- Modify: `src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs`, `src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs`, `src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/AuthProgressTests.cs`
+
+**Interfaces (produces):**
+```csharp
+public interface IAuthProgress {
+    void Notice(string message);                       // today's stdout informational lines, verbatim
+    void Error(string message);                        // today's stderr lines, verbatim
+    void BrowserOpening(string url);                   // browser-open notice + fallback URL
+    void DeviceCode(string code, string verificationUri);
+    void PollTick();                                   // device-poll "." heartbeat
+}
+public sealed class ConsoleAuthProgress : IAuthProgress { … }   // prints EXACTLY today's strings
+```
+Every `Console.Out/Error` write on the login/discovery/exchange paths in `OAuthLoginFlow` and `WorkOSDiscovery` (the complete inventory: OAuthLoginFlow L37/43/106/112, device flow L138/158-173/192/199/207, browser flow L250-318, exchange L325-455, WorkOS L560-618, loopback fallback L495/497; WorkOSDiscovery L59/73/82-87/99/143/160-198) routes through an `IAuthProgress` parameter (trailing, `IAuthProgress? progress = null`, resolved to `ConsoleAuthProgress` at method top — behavior-preserving for untouched callers). The device-code banner maps to `DeviceCode(code, uri)` + `Notice` for the surrounding lines; the poll `Console.Write(".")` maps to `PollTick()`; browser-open sites (`LoopbackBrowser` L25-27 and the device flow's `Process.Start` notice) map to `BrowserOpening(url)` — `LoopbackBrowser` gains a `IAuthProgress? progress = null` ctor parameter. `ConsoleAuthProgress` reproduces the exact current strings (the mapping table lives in this one class; `DeviceCode` prints today's banner, `BrowserOpening` prints today's two lines, `PollTick` prints `"."` without newline). `SetupFunnel` calls are NOT touched (they no-op in the app per decision 9 and must keep firing for the CLI — WorkOS events stay embedded in `WorkOSDiscovery`).
+
+- [ ] **Step 1: Failing tests:** a recording `IAuthProgress` captures the device-flow sequence (`DeviceCode` once, `PollTick` per poll, `Notice` on completion) from `RunDeviceFlowAsync` under a scripted handler; `WorkOSDiscovery.RunAsync` zero-tenant path emits the exact `"No Capacitor tenants are linked to your account. Ask your admin to invite you."` through `Error`/`Notice` (pin which stream today's code uses) and writes NOTHING to a captured `Console`; `ConsoleAuthProgress.DeviceCode`/`BrowserOpening` byte-compare against today's literals.
+- [ ] **Step 2: red.**
+- [ ] **Step 3: Implement.** Sweep with `grep -n 'Console\.' src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs` — zero hits on the swept paths when done (the file-level sweep is the acceptance check; `HttpClientExtensions.WriteUnreachableError` gets a string-returning overload the flow feeds to `Error`).
+- [ ] **Step 4: Full CLI unit suite green; AOT greps empty.**
+- [ ] **Step 5: Commit** `feat(core): structured auth progress sink with exact-string console adapter`
+
+### Task 3: Helper moves — `ServerInput` to Core, `ValidVisibilities` public
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/Auth/ServerInput.cs`
+- Modify: `src/Capacitor.Cli.Core/Config/AppConfig.cs`, `src/Capacitor.Cli/Commands/SetupCommand.cs`
+- Test: `test/Capacitor.Cli.Tests.Unit/ServerInputTests.cs`
+
+**Interfaces (produces):**
+```csharp
+public static class ServerInput {
+    public static string ToServerOrigin(string input);   // moved verbatim from SetupCommand.ToServerOrigin (L1084)
+    public static string ResolveTenantArg(string arg);   // moved verbatim from SetupCommand.ResolveTenantArg (L1101)
+}
+```
+`AppConfig.ValidVisibilities` becomes `public static readonly string[]` (the app reads it — `Capacitor.App` has no `InternalsVisibleTo`). `SetupCommand.ToServerOrigin`/`ResolveTenantArg` become one-line delegating shims (existing tests reference them) or call sites are updated and the shims deleted — prefer updating call sites and deleting; keep whichever the existing test surface makes cheaper, but the Core implementations are the single source.
+
+- [ ] **Step 1: Failing tests:** `ServerInputTests` ports the existing `ToServerOrigin`/`ResolveTenantArg` coverage from `SetupCommandTests` against the Core class (same cases, verbatim expectations); one test asserts `AppConfig.ValidVisibilities` is `["private", "project", "org_public", "public"]` (order pinned — Spectre prompt order depends on it).
+- [ ] **Step 2-4: red → move → green** (full CLI unit suite).
+- [ ] **Step 5: Commit** `refactor(core): move server-input helpers to Core; publish ValidVisibilities`
+
+### Task 4: `OnboardingFacade` — operations + ordered commit boundary
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs`, `src/Capacitor.Cli.Core/Auth/AuthResult.cs`
+- Modify: `src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs` (publication split), `src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs` (exchange split), `src/Capacitor.Cli.Core/Config/ProfileConfig.cs` only if the stamp helper needs it (stamp record exists from Plan B)
+- Test: `test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs`, `test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs`
+
+**Interfaces (produces):**
+```csharp
+public sealed record AuthIdentity(string Profile, string CanonicalServer);
+
+public abstract record AuthResult {
+    public sealed record Committed(string ActiveProfile, string CanonicalServer, string Provider,
+                                   string? Username, IReadOnlyList<AuthIdentity> Published) : AuthResult;
+    public sealed record Cancelled : AuthResult;                    // strictly pre-boundary, nothing durable
+    public sealed record Failed(string Message) : AuthResult;       // message already rendered via progress
+    public sealed record Retarget(string ServerInput) : AuthResult; // WorkOS "I already have a workspace" — pre-boundary
+}
+
+public sealed class OnboardingFacade(
+        IAuthProgress progress,
+        ITenantPicker picker,
+        ITenantProvisioner? provisioner,
+        Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task>? beforeCommit,  // decision-7 hook; throw = abort, retryable
+        Func<HttpClient>? httpFactory = null) {
+    public Task<AuthResult> LoginAsync(string serverUrl, bool forceDevice, string? profile, CancellationToken ct);
+    public Task<AuthResult> DiscoverAsync(string provider, bool forceDevice, CancellationToken ct);  // provider: AuthProvider.GitHubApp | AuthProvider.WorkOS
+}
+```
+Supporting splits (Core, same task):
+```csharp
+// WorkOSDiscovery: RunAsync stops before persisting; the façade owns publication.
+public abstract record WorkOSDiscoveryFlow {
+    public sealed record Ready(DiscoveredTenant[] Tenants, DiscoveredTenant Picked,
+                               WorkOSAuthResponse SwitchedAuth, string ClientId) : WorkOSDiscoveryFlow;
+    public sealed record Retarget(string ServerInput) : WorkOSDiscoveryFlow;
+    public sealed record NoTenants : WorkOSDiscoveryFlow;
+    public sealed record Failed : WorkOSDiscoveryFlow;               // message already emitted via progress
+}
+public static Task<WorkOSDiscoveryFlow> DiscoverAsync(  /* on WorkOSDiscovery; same deps as RunAsync + progress */ …);
+// OAuthLoginFlow: exchange split at the TokenStore.SaveAsync seam of ExchangeAndSaveAsync(HttpClient,…) L378.
+public static Task<(StoredTokens Tokens, string? Username)?> ExchangeAsync(
+    HttpClient http, string serverUrl, string githubAccessToken, string provider, IAuthProgress progress, CancellationToken ct);
+```
+**Contract.** *`LoginAsync` (login to known server):* GET `/auth/config` (pre-boundary) → dispatch: `None` → boundary with no token (identity = resolved/target profile + canonical server; publications: profile `ServerUrl` write IF the profile doesn't already point there, provider stamp); `GitHubApp` → `AcquireGitHubTokenAsync` (browser/device per today's `ChooseGitHubFlow`) → `ExchangeAsync` (network, pre-boundary) → boundary (token + stamp); `workos` → `AuthenticateWorkOSAsync` for the known server's client id/org → boundary. Unknown provider → `Failed` with today's message. *`DiscoverAsync`:* proxy config → provider branch: GitHub → `AcquireGitHubTokenAsync` → `TenantDiscovery.RunAsync` (picker) → boundary over ALL discovered tenants (`MergeProfiles` then one `ExchangeAsync`+save per tenant — exchange calls are pre-save network but run inside the boundary sequence under `CancellationToken.None`, matching "config then one token per tenant"); WorkOS → `WorkOSDiscovery.DiscoverAsync` → `Ready` → boundary (MergeProfiles + `TokenStore.SaveAsync(picked.ProfileName, …)` from the switched auth — the `StoredTokens` construction moves verbatim from today's `SwitchAndSaveAsync` L184-196), `Retarget` → `AuthResult.Retarget`, `NoTenants`/`Failed` → `Failed`. *The boundary, ordered, both operations:* (1) `beforeCommit(identities, ct)` — the LAST cancellable await; failure or OCE → nothing durable, `Cancelled`/`Failed`; (2) enter: all remaining publications run under `CancellationToken.None` — config (`ConfigMutator.MutateAsync`: MergeProfiles/profile write AND the `auth_provider` stamp for every published identity in the SAME mutation), then token saves in tenant order; a cancel observed after entry still returns `Committed`; (3) crash residue is safe by ordering (claim-without-profile, profile-without-token → gate still fails). *Stamp write:* `profile.AuthProvider = new AuthProviderStamp(provider, canonicalServer)` with the `AuthProvider` constant verbatim; canonical server via `ServerIdentity.Canonicalize`. *Progress:* all rendering through `IAuthProgress`; the façade emits today's success line (`Logged in as …`) via `Notice`.
+
+- [ ] **Step 1: Failing tests** (scripted `HttpClient` handlers, NSubstitute picker/provisioner, recording hook, temp config dir):
+  - **Boundary ordering:** hook called with the FULL identity set before any file exists; hook throw → no config change, no token file, result `Failed`; hook OCE → `Cancelled`, nothing durable.
+  - **Cancellation on both sides of every publication:** cancel during picker await / device poll / exchange network call → `Cancelled` + zero durable writes; cancel signalled after boundary entry (hook completed) → `Committed` with ALL publications present (config + stamp + tokens).
+  - **GitHub discovery:** N tenants → N `AuthIdentity` in the hook, N token files, `MergeProfiles` active = picked; per-tenant exchange failure → that tenant's token absent, others present, `Committed` (matches today's login warning-per-failure), warning via `Error`.
+  - **WorkOS:** `Ready` → boundary writes config then token (`StoredTokens` fields exactly today's: `Provider = AuthProvider.WorkOS`, `ClientId`, canonical `ServerUrl`); `Retarget` → `AuthResult.Retarget`, nothing durable; zero tenants + provisioner Created → switch + boundary; provisioner Declined/InProgress/Failed → `Failed`, nothing durable.
+  - **`None` server:** boundary = profile + stamp, NO token file; gate (`OnboardingGate.EvaluateResolvedAsync`) run against the resulting config returns `Complete` — the stamp-vocabulary pin (`"None"` verbatim honored case-insensitively).
+  - **Provider stamp:** written for every published identity inside the boundary; a cancelled pre-boundary login leaves NO stamp.
+- [ ] **Step 2: red.**
+- [ ] **Step 3: Implement.** `WorkOSDiscovery.RunAsync`/`SwitchAndSaveAsync` become thin composition over `DiscoverAsync` + the façade-shaped publication (existing signature preserved for the interim; the CLI tasks remove remaining direct callers).
+- [ ] **Step 4: Full CLI unit suite green; AOT greps empty (both binaries).**
+- [ ] **Step 5: Commit** `feat(core): onboarding facade with ordered commit boundary and claim hook`
+
+### Task 5: `kcap login` re-plumb onto the façade
+
+**Files:**
+- Modify: `src/Capacitor.Cli/Program.cs` (`case "login":` L299-309, `HandleDiscoverLoginAsync` L839-915)
+- Test: `test/Capacitor.Cli.Tests.Unit/LoginDiscoverTests.cs` (updated), `test/Capacitor.Cli.Tests.Unit/LoginFacadeParityTests.cs`
+
+**Contract.** Both login paths construct ONE façade: `new OnboardingFacade(new ConsoleAuthProgress(), new SpectreTenantPicker(), provisioner: null, beforeCommit: null)`. Known-server: `facade.LoginAsync(baseUrl!, forceDevice, profile: null, CancellationToken.None)`; `--discover`: `facade.DiscoverAsync(chosenProvider, forceDevice, ct)` — provider chosen exactly as today (`ChooseDiscoveryProvider`); `Retarget` prints today's `Run \`kcap setup {target}\` to configure that workspace.` and exits 1; result mapping `Committed → 0`, else `1` with today's messages (already emitted via the progress sink). Funnel parity: the login path emits NO funnel events of its own — only the WorkOS events embedded in discovery fire (unchanged); the GitHub path must emit NOTHING (assert). Exit codes and stdout/stderr shape match today (`Logged in. Active profile: {profile}.` final line preserved — emitted by the adapter after `Committed`, matching L913).
+
+- [ ] **Step 1: Failing tests:** `--discover` GitHub with 2 tenants → 2 token files + merged profiles + active = picked + final active-profile line (parity with the pre-re-plumb behavior pinned in `LoginDiscoverTests`); known-server `None` → exit 0, "no authentication configured" line, stamp written; funnel: a recording telemetry guard asserts zero GitHub funnel events on the login path.
+- [ ] **Step 2-4: red → re-plumb → green** (full CLI unit suite — `LoginDiscoverTests` updated where they pin `HandleDiscoverLoginAsync` internals).
+- [ ] **Step 5: Commit** `refactor(cli): login re-plumbed onto the onboarding facade`
+
+### Task 6: `kcap setup` re-plumb onto the façade
+
+**Files:**
+- Modify: `src/Capacitor.Cli/Commands/SetupCommand.cs` (Step 1/2, `RunDiscoveryAsync` deleted or reduced to the façade call)
+- Test: `test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs` (updated)
+
+**Contract.** The interactive no-server-arg path calls `facade.DiscoverAsync` with `new SpectreTenantProvisioner(new TenantProvisioningClient(new HttpClient()), ProvisioningEndpoint.Url)` when not headless (as today). Funnel asymmetry preserved AT THE ADAPTER: setup emits `SigninOpened(signinMode, provider)` before the operation, `SigninFailed("github_token_denied")` when the GitHub token acquisition fails (façade `Failed` before any identity was published on the GitHub branch), `SigninCompleted(AuthProvider.GitHubApp)` + `TenantNone(AuthProvider.GitHubApp)` from the operation result/progress — WorkOS events remain embedded in Core (unchanged). `Retarget` loops into `ResolveServerAndProviderAsync(ServerInput.ResolveTenantArg(ServerInput.ToServerOrigin(target)))` exactly as today's L857. Step 2 for a `Committed` discovery reports the loginComplete branch (both providers now — the pinned convergence); `serverUrlArg`/`--no-prompt` paths keep `ResolveServerAndProviderAsync` and use `facade.LoginAsync(serverUrl, forceDevice, activeProfile, …)` where Step 2 needs a login. The `preAuthToken` field and its Step-2 exchange branch are DELETED. Everything from Step 3 on is untouched.
+
+- [ ] **Step 1: Failing tests:** GitHub discovery path → tokens for all tenants + Step-2 loginComplete output (updated pins); WorkOS path unchanged output; funnel sequence for setup (`Started` → `SigninOpened` → `SigninCompleted` → … → `Succeeded`) asserted via the existing funnel test harness; `--server-url` + `--no-prompt` behavior byte-identical.
+- [ ] **Step 2-4: red → re-plumb → green** (full CLI unit suite + `SetupFunnelTests`).
+- [ ] **Step 5: Commit** `refactor(cli): setup re-plumbed onto the onboarding facade`
+
+### Task 7: Streaming process runner (§7)
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/IProcessRunner.cs`, `src/Capacitor.App/Services/DaemonClientService.cs` (nested `ProcessRunner`)
+- Test: `test/Capacitor.App.Tests.Unit/StreamingRunnerTests.cs`
+
+**Interfaces (produces):**
+```csharp
+public enum ProcessStreamKind { Stdout, Stderr }
+public sealed record StreamedLine(ProcessStreamKind Kind, string Text);
+public sealed record StreamingResult(int ExitCode, bool TimedOut, IReadOnlyList<StreamedLine> Tail);  // NO full captures
+public interface IProcessRunner {
+    Task<ProcessResult> RunAsync(string fileName, string[] args, RunOptions options, CancellationToken ct);
+    Task<StreamingResult> RunStreamingAsync(string fileName, string[] args, RunOptions options,
+                                            Action<StreamedLine> onLine, CancellationToken ct);
+}
+```
+**Contract.** Each stream line-buffered independently (no cross-stream ordering promise); `onLine` invoked on the pump thread — callback exceptions logged to `Console.Error` and swallowed (never kill the pump); the runner retains only a bounded tail (const `TailLimit = 500` lines total, oldest dropped) mirrored into `StreamingResult.Tail`; full `Stdout`/`Stderr` captures are structurally absent from the result type. Cancellation via `ct` = `KillTree` + await exit (streaming ignores `RunOptions.CancelMode` — §7 pins KillTree); `RunOptions.Timeout` honored with `TimedOut = true` + KillTree.
+
+- [ ] **Step 1: Failing tests** (real child processes — `/bin/sh -c` scripts; Windows-guard where needed): interleaved stdout/stderr lines each tagged with the right kind; a >500-line run: callback sees every line, `Tail` holds exactly the LAST 500; a throwing callback: pump survives, exit code still captured; mid-stream cancel: child tree killed (child writes a marker file on exit-signal absence — assert no orphan by PID liveness), method returns; large-output run: process memory of the result bounded (assert `Tail.Count <= 500` and no full-capture property exists — compile-time by shape).
+- [ ] **Step 2-4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): streaming process runner with bounded tail and KillTree cancel`
+
+### Task 8: `KcapCli` — `PluginInstallAsync` + streaming import
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/KcapCli.cs`
+- Test: `test/Capacitor.App.Tests.Unit/KcapCliTests.cs`
+
+**Interfaces (produces, on `IKcapCli` + `KcapCli`):**
+```csharp
+public enum ImportScopeChoice { Everything, Org, Repo }
+public sealed record ImportRequest(ImportScopeChoice Scope, string? OrgOrRepo, IReadOnlyList<string> VendorFlags);
+Task<ProcessResult> PluginInstallAsync(string? vendorFlag, CancellationToken ct);        // null = Claude (flagless default)
+Task<StreamingResult> ImportAsync(ImportRequest request, Action<StreamedLine> onLine, CancellationToken ct);
+```
+**Contract.** `PluginInstallAsync`: args `["plugin", "install"]` + vendorFlag when non-null (the §5 exclusive flags: `--codex --cursor --copilot --gemini --kiro --pi --opencode --antigravity`); `Env()` overlay (profile + no-telemetry); bounded `MutationTimeout` (60 s); null `CliPath` → `NoCliResult()`. `ImportAsync`: args `["import"]` + scope (`--all` | `--org <o>` | `--repo <r>`) + `--yes` + each vendor flag, `Env()` overlay, `RunStreamingAsync` with NO internal timeout (imports are long; cancellation is the bound), null `CliPath` → a `StreamingResult(-1, false, [])` with a synthesized `Stderr` tail line `kcap CLI not found`. Neither verb overlays mutation env (non-daemon shelling keeps lenient classification, spec §4).
+
+- [ ] **Step 1: Failing tests** (`FakeProcessRunner` in `KcapCliTests`, extended with a streaming recorder): exact argv per scope/vendor combination (Everything+2 vendors; Org; Repo; Claude default flagless); env overlay carries `KCAP_PROFILE` + `KCAP_APP_SPAWN_NO_TELEMETRY` and NOT `KCAP_CONSENT_SEED_DEFAULT`/`KCAP_EXPECT_SERVER_URL`; no-CLI results for both verbs.
+- [ ] **Step 2-4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): KcapCli plugin-install and streaming import verbs`
+
+### Task 9: `WizardAuthService` — single-flight driver, claims arming, close handoff
+
+**Files:**
+- Create: `src/Capacitor.App/Services/Onboarding/WizardAuthService.cs`
+- Test: `test/Capacitor.App.Tests.Unit/WizardAuthServiceTests.cs`
+
+**Interfaces (produces):**
+```csharp
+public abstract record ConnectIntent {
+    public sealed record Paste(string ServerInput) : ConnectIntent;
+    public sealed record Discover(string Provider) : ConnectIntent;   // AuthProvider constant
+    public sealed record Create : ConnectIntent;                       // WorkOS discovery; provisioner-armed
+}
+public sealed class AuthAttempt {
+    public Task<AuthResult> Result { get; }     // terminal task the app awaits at close (decision 2)
+    public void Cancel();                        // pre-boundary: op cancels; post-boundary: Result still ends Committed
+}
+public sealed class WizardAuthService(
+        Func<ConnectIntent, CancellationToken, Task<AuthResult>> runOperation,  // binds the facade + adapters
+        ConsentFlipClaims claims) {
+    public AuthAttempt? Current { get; }
+    public AuthAttempt Begin(ConnectIntent intent);   // single-flight: throws InvalidOperationException while unquiesced
+    public Task QuiescedAsync();                       // completes when no attempt is live
+}
+```
+**Contract.** Single-flight: `Begin` while `Current` is non-terminal throws; a new attempt is admitted only after the previous `Result` completed (cancelled-before-boundary or terminal) — Retry re-runs only after quiesce. Cancellation is a distinct outcome (`AuthResult.Cancelled`), never rendered as failure. The composition root builds `runOperation` to construct an `OnboardingFacade` per attempt with: the Sign-in step's `IAuthProgress` (UI-marshaling), the wizard picker/provisioner bridges (Task 12), and the **before-commit hook** = for each identity, `await Task.Run(() => claims.Arm(new ConsentFlipClaim(id.Profile, id.CanonicalServer)))`; a `false` return throws (`InvalidOperationException("claim_arm_failed")`) → the façade aborts pre-boundary → retryable sign-in error (decision 7: hook failure prevents the commit). `Paste` maps to `LoginAsync(ServerInput.ResolveTenantArg(ServerInput.ToServerOrigin(input)), …)`; `Discover(p)` → `DiscoverAsync(p, …)`; `Create` → `DiscoverAsync(AuthProvider.WorkOS, …)` with the provisioner bridge armed. Close handoff (decision 2): the window's close path calls `Cancel()` and the APP awaits `Result` before resolving configuration/building the graph/completing shutdown (wired in Task 16) — pre-boundary resolves `Cancelled` fast; post-boundary resolves `Committed` after publications.
+
+Same task: `App.ResolveConsentFlipIdentity` (App.axaml.cs L397-404) switches `ConfigMutator.LoadPure` → `TryLoadPure`; an unreadable config returns an identity that matches nothing (e.g. `("", "", "")`) so `TryConsume`'s compare retains the claim — fail-closed, never a throw inside the two-lock section.
+
+- [ ] **Step 1: Failing tests:** single-flight (`Begin` during live attempt throws; after terminal, admitted); hook arms one claim per identity (recording claims store on a temp path — REAL `ConsentFlipClaims`); `Arm` returning false → `Failed`, nothing published (scripted runOperation asserting the hook threw before its publication step); cancel-pre-boundary → `Cancelled` + `QuiescedAsync` completes; cancel-post-boundary (scripted op that enters boundary then observes cancel) → `Committed`; quarantined store: `Arm` during an attempt still lands in the fresh store (never rejected) and `claims.Quarantine()` is non-null after; `TryLoadPure` switch: corrupt config file + `TryConsume` → claim retained, no exception.
+- [ ] **Step 2-4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): wizard auth service with claim-arming hook and close handoff`
+
+### Task 10: Quarantine ack affordance (coordinator path)
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs`
+- Test: `test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs`
+
+**Contract.** `SurfaceQuarantineOnceAsync` upgrades from a bare `Attention` line to `surface.TryConfirmAsync(new LifecyclePrompt(Kind: "quarantine", …, Disclosure: <preserved path + the recovery guidance from Plan B's exact copy>), ct)` with a single affirmative ("Acknowledge"); `true` → `AckQuarantineAsync()`; `false`/`null` (declined, cancelled, or no dialog capability) → NOT acked, surfaces again next start — acknowledgment must be explicit, never inferred from dismissal. `LifecyclePrompt` gains `public const string KindQuarantine = "quarantine";` and `LifecyclePromptViewModel`/`LifecyclePromptWindow` render it with a single-button layout (confirm-only; no destructive action).
+
+- [ ] **Step 1: Failing tests:** quarantine + unacked → one `TryConfirmAsync` with the preserved path in the disclosure; confirm → `ConsentQuarantineAcked` persisted, not re-surfaced on a fresh coordinator; decline → not persisted, re-surfaced; acked state → zero prompts.
+- [ ] **Step 2-4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): quarantine acknowledgment prompt on the coordinator path`
+
+### Task 11: Onboarding shell — window, step machine, navigation
+
+**Files:**
+- Create: `src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml`, `src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml.cs`, `src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs`, `src/Capacitor.App/ViewModels/Onboarding/WizardStep.cs`
+- Test: `test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs`
+
+**Interfaces (produces):**
+```csharp
+public enum WizardStepId { Shim, Connect, SignIn, Defaults, Agents, Import, Daemon, Done }
+public interface IWizardStep {
+    WizardStepId Id { get; }
+    string Title { get; }
+    bool Applicable { get; }        // Shim: macOS + resolvable CLI + kcap NOT on terminal PATH
+    bool Satisfied { get; }         // re-entry shows satisfied state
+    Task OnEnterAsync(CancellationToken ct);
+    Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct);  // SignIn: pre-boundary cancel on Back/Skip
+}
+public enum WizardNavigation { Back, Next, Skip }
+public sealed class OnboardingViewModel : ViewModelBase {
+    public IReadOnlyList<IWizardStep> Steps { get; }        // Applicable-filtered, spec §3 order
+    public IWizardStep Current { get; }
+    public ICommand BackCommand, NextCommand, SkipCommand;
+    public event Action? CloseRequested;                    // Done-step finish or window close
+}
+```
+**Contract.** Linear steps, Back/Next, every step individually skippable and retryable (§3); one window, content switched by `DataTemplate` on the step VM type. Skip advances without satisfying; Back from Sign-in post-commit returns to Connect for a different intent while Sign-in shows satisfied on re-entry. Window close (any time) raises `CloseRequested`; the shell never blocks close — the app's startup sequencing (Task 16) owns the quiesce. Styling follows `MainWindow.axaml` conventions.
+
+- [ ] **Step 1: Failing tests** (`[NotInParallel("AvaloniaSession")]`, headless; fake steps): applicability filtering (Shim absent when not applicable); Next/Back/Skip transitions across the full order; `CanLeaveAsync(false)` holds the step; skip-then-return shows unsatisfied; Done raises `CloseRequested`.
+- [ ] **Step 2-4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): onboarding wizard shell with step state machine`
+
+### Task 12: Sign-in step — progress rendering, picker/provisioner bridges, quarantine notice
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs`, `src/Capacitor.App/ViewModels/Onboarding/ConnectStepViewModel.cs`, `src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs`
+- Test: `test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs`
+
+**Interfaces (produces, in `WizardAuthBridges.cs`):**
+```csharp
+public sealed class WizardTenantPicker : ITenantPicker {        // PickAsync awaits the VM's selection TCS
+    public Task<DiscoveredTenant?> PickAsync(DiscoveredTenant[] tenants, CancellationToken ct);
+    public DiscoveredTenant? Pick(DiscoveredTenant[] tenants) => throw new NotSupportedException();  // facade consumes PickAsync only
+    public event Action<DiscoveredTenant[]>? SelectionRequested;
+    public void Select(DiscoveredTenant? tenant);
+}
+public sealed class WizardTenantProvisioner(TenantProvisioningClient client, string baseUrl) : ITenantProvisioner {
+    public Task<ProvisionOffer> OfferCreateAsync(WorkOSTokenSource tokens, CancellationToken ct);
+    // UI hooks the VM implements: org-name/slug prompts, confirm, poll progress
+    public Func<CancellationToken, Task<string?>>? PromptOrgName;
+    public Func<string, string, CancellationToken, Task<string?>>? PromptSlug;      // (suggestion, availabilityError) → slug|null
+    public Func<string, string, CancellationToken, Task<bool>>? ConfirmCreate;      // (slug, origin)
+    public Action<int, int>? PollProgress;                                          // (attempt, max) — 4 s × 150 mirror
+}
+public sealed class UiAuthProgress(Action<Action> post) : IAuthProgress { … }       // marshals every event to the UI scheduler
+```
+**Contract.** `ConnectStepViewModel` gathers intent only (§3 step 2): paste (validated via `OnboardingGate.ValidServerUrl` after `ServerInput` normalization), discover (provider choice GitHub/WorkOS), create; nothing network, nothing written. `SignInStepViewModel` runs ONE `WizardAuthService.Begin(intent)` rendering: progress notices inline, `BrowserOpening` with clickable fallback URL (`IUrlOpener`), `DeviceCode` display, tenant list on `SelectionRequested` (list UI resolves `Select`), create sub-flow via the provisioner hooks (`SlugValidator.Derive` suggestion, availability re-prompt loop mirroring `SpectreTenantProvisioner.PromptSlugAsync` semantics, provisioning progress `attempt/max`, "still provisioning — finish later by joining `<slug>` from the Connect step" on `InProgress` — the CLI's message GUI-shaped, §9). `Retarget` → back to Connect with the input prefilled. `AuthProvider.None` pasted-URL join auto-satisfies the step on `Committed`. Cancellation ≠ failure in every rendered surface. Quarantine: after any attempt, if `claims.Quarantine()` is non-null and `AppState.ConsentQuarantineAcked` is false → one notice naming the preserved path with an Acknowledge button → `AckQuarantineAsync` (same recovery copy as Task 10). Step transitions per §3: pre-boundary Back/Skip/close → `attempt.Cancel()` + await quiesce via `CanLeaveAsync`; post-boundary → satisfied, Back allowed for a different intent.
+
+- [ ] **Step 1: Failing tests** (headless; scripted `runOperation` via the service): the §10 transition table — pasted URL / GitHub discovery / WorkOS discovery / zero-tenant create / retarget / `None` auto-satisfy; Back and Skip on both sides of the boundary (pre → `Cancelled`, nothing durable per the scripted op; post → satisfied); re-entry recognizes satisfied; device-code and browser-fallback render from progress events; picker TCS resolves the façade await; provisioner hook sequence for the create sub-flow incl. `InProgress` copy; quarantine notice once + ack persisted.
+- [ ] **Step 2-4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): connect and sign-in wizard steps with facade bridges`
+
+### Task 13: Shim, Defaults, Done steps
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/Onboarding/ShimStepViewModel.cs`, `src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs`, `src/Capacitor.App/ViewModels/Onboarding/DoneStepViewModel.cs`
+- Test: `test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs`
+
+**Contract.** *Shim (§3 step 1):* `Applicable` = macOS AND resolved absolute CLI path AND `probe.KcapOnPathAsync` positively `false`; Install runs `PathShimInstaller.InstallAsync(target)` (AppleScript sudo, non-forcing, post-install re-probe — reused as-is) and claims `ShimOffered` via `AppStateStore` so the post-wizard `ShimOfferCoordinator` never re-offers; outcomes map: `Installed` → satisfied; `InstalledButNotOnPath`/`Failed` → message + Retry; `Cancelled` → unsatisfied, skippable. *Defaults (§3 step 4, decision 5):* visibility picker over `AppConfig.ValidVisibilities` with the SAME labels as setup's prompt (copy the four converter strings), default `org_public`; daemon-name field default `Environment.UserName.ToLowerInvariant()`; Next persists via `ConfigMutator.MutateAsync(c => …)` writing `DefaultVisibility` + `Daemon.Name` on the active profile — NO claim maintenance (claims key on `{profile, server}`). *Done (§3 step 8):* summary grid from each step's `Satisfied`/skip state incl. why-skipped notes ("kcap CLI not found", "requires sign-in").
+
+- [ ] **Step 1: Failing tests:** shim applicability matrix (non-macOS / no CLI / kcap-on-PATH / probe-null → not applicable); install claims `ShimOffered` exactly once; defaults write lands both fields and preserves unrelated config (temp config, REAL `ConfigMutator`); done summary reflects skip reasons.
+- [ ] **Step 2-4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): shim, defaults, and done wizard steps`
+
+### Task 14: Agents + Import steps
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/Onboarding/AgentsStepViewModel.cs`, `src/Capacitor.App/ViewModels/Onboarding/ImportStepViewModel.cs`
+- Test: `test/Capacitor.App.Tests.Unit/AgentsImportStepsTests.cs`
+
+**Contract.** *Agents (§3 step 5, decision 8):* inputs = `AgentDetection.FromEnvironment()` overridden with the login-shell PATH — `inputs with { PathEnv = await probe.TerminalPathAsync(ct) ?? inputs.PathEnv }` (the app feed; a null probe result keeps the process PATH); one checkbox per vendor, pre-checked when `Detected`; Install runs `PluginInstallAsync` per selection sequentially (Claude `null` flag; vendor flags per §5's exclusive list); per-vendor exit codes → ⚠ + Retry on failures, successes stand (§9). *Import (§3 step 6, decision 6):* vendor checkboxes (default: the detected set), scope choice mirroring `ImportScopePrompt`'s vocabulary — `Everything` / `All repos in one org` (+ org text field) / `Specific repository` (+ `owner/name` field); Run streams `ImportAsync` into a live log pane bounded to the LAST 500 lines with an "older lines dropped" header once truncation starts, lines marshaled from the pump to the UI scheduler; Cancel = the ct (KillTree in the runner) + await exit; completion ALWAYS appends "if anything failed, run `kcap import` in a terminal to retry" (unconditional — the CLI exits 0 with per-session errors, §7); failure never blocks Next.
+
+- [ ] **Step 1: Failing tests:** detection feed uses the terminal PATH when present, process PATH when probe null (fake probe + crafted `AgentDetectionInputs` asserting a binary only findable via the terminal PATH is detected); per-vendor install argv + failure isolation; import argv per scope; log pane bound at 500 with the drop notice; the unconditional retry line present on success AND failure; cancel kills (scripted runner asserting KillTree-path invoked).
+- [ ] **Step 2-4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): coding-agents and import wizard steps`
+
+### Task 15: Daemon step — the §3 step-7 matrix through the lane
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs`, `src/Capacitor.App/Services/Onboarding/WizardLifecycleSurface.cs`
+- Test: `test/Capacitor.App.Tests.Unit/DaemonStepViewModelTests.cs`
+
+**Interfaces (consumes):** `DaemonMutationLane.RunAsync` (waiter-state-only), `MutationRequestFactory.TryBuild`, `IKcapCli.ServiceStatusAsync`, `ILocalControlOps.PutConsentPolicyV2Async` + `GetConsentPolicyAsync`, `ConsentFlipClaims.Pending()/TryConsume`, `LocalControlCapabilities` via a one-shot `LocalControlProbe`.
+**Produces:** `WizardLifecycleSurface : ILifecycleSurface` — routes `Status`/`Attention` into step-local observable text and `ConfirmAsync`/`TryConfirmAsync` into wizard-owned dialogs (windowed over `OnboardingWindow`), so the SAME `ConsumeMutationOutcomesAsync` consumer runs during wizard-first mode with this surface (Task 16 wires it).
+
+**Contract.** Skipped-login users see "requires sign-in" (§9); gate-complete identity resolved fresh at step entry (post-Sign-in config). On enter: fresh `ServiceStatusAsync` snapshot → classify on AI-1654's FULL matrix (§3 step 7 rows, verbatim recoveries): no unit → `Install`; unit stopped/loaded-inactive + null `daemon_pid` → `StartVerified`; positive ownership + identity match → "already enabled" + apply pending claim via the explicit conditional put (NO factory guard — get is skipped; put carries `{resolved name, claim server}`; ack failure → claim pending + repair guidance); ownership without identity match → takeover offer only; manual daemon identity-matched → takeover dialog with AI-1654 disclosures, decline → visibly incomplete + claim STILL applied via conditional put; manual daemon identity-MISMATCH → no mutation, no claim application, takeover the only offered row; orphan/stale marker → repair affordance; `txn_active` → wait; unparseable → honest message, no mutation. Mutations route through `lane.RunAsync(MutationRequestFactory.TryBuild(...))` — results update step state ONLY (single-presentation rule); actionable outcomes arrive through the channel consumer with the wizard surface. Enablement success = the lane's own `Succeeded` predicate (never a local re-derivation). Claim consumption uses `TryConsume` with the Task-9 `TryLoadPure` resolver.
+
+- [ ] **Step 1: Failing tests** (scripted `IKcapCli` snapshots + `FakeMutationLane`-style recorder + `ScriptedLocalControlOps` + real claims store): every matrix row above → the exact verb (or explicit no-mutation) + offered affordance; claim application on the owning+identity row and on manual-identity-match decline; NO claim application on wrong-server rows; state-only handling of `RunAsync` results (no dialog from the waiter path — recorded surface sees zero prompts when an outcome also travels the channel); "requires sign-in" when gate incomplete.
+- [ ] **Step 2-4: red → implement → green.**
+- [ ] **Step 5: Commit** `feat(app): daemon enablement wizard step on the full state matrix`
+
+### Task 16: Wizard-first startup + consumer handoff
+
+**Files:**
+- Modify: `src/Capacitor.App/App.axaml.cs`
+- Test: `test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs` (extended), `test/Capacitor.App.Tests.Unit/WizardStartupTests.cs`
+
+**Contract (decision 2, replacing Plan B's `Incomplete` arm).** `StartAsync`: lane + channel constructed first (unchanged — app-lifetime). Gate `Complete` → today's startup exactly. Gate `Incomplete` → build NO daemon graph (no `DaemonClientService`, no tray, no lifecycle controller, no shim coordinator): construct the wizard graph — `ConsentFlipClaims.Default()`, `WizardAuthService`, step VMs (Daemon step gets a per-resolved-identity `KcapCli` for status + `LocalControlOps` for the put; `CliResolver` override seam preserved), `OnboardingWindow` as `desktop.MainWindow`, and start `ConsumeMutationOutcomesAsync(channel, wizardSurface, lane.RunAsync, …)` as the consumer. On `CloseRequested` OR window close: (1) `authService.Current?.Cancel()`; (2) await the auth terminal task (post-boundary close runs to `Committed` — decision 2); (3) `AwaitQuiescedAsync(lane.QuiescedAsync, cap)` with the existing §6a post-cap rules (past the cap: proceed, auto-actions closed, attention from re-queried evidence — the lane still owns the live action); (4) `channel.TransferConsumer()`; (5) fresh resolution (re-run the SAME resolution `CreateDefaultAsync` performs — `AppConfig.LoadProfileConfig` → active profile; never the startup-cached `AppConfig.ResolvedProfile`) + `EvaluateResolvedAsync` on it (single-resolution rule); (6) build the normal graph — still-`Incomplete` → the Plan B carve-out arm (auto-actions closed + shim auto-offer suppressed) — and start the root consumer. Shutdown during wizard mode: `OnShutdownRequested` awaits the auth terminal task + lane quiesce under `QuiesceShutdownCap` before disposing (§6a: past the cap, exit with the child detached is safe).
+
+- [ ] **Step 1: Failing tests:** gate-incomplete → NO service/tray/lifecycle/shim constructed (assert via the built-object fields), wizard window is MainWindow, consumer live with the wizard surface (enqueue → wizard-surface presentation); close with gate-now-complete → normal graph against the FRESH profile (config changed between open and close is honored); close with gate-still-failing → carve-out graph (auto-actions closed, shim suppressed) — the §10 decision-2 rows: zero service mutation for valid-URL+no-token+abandon, invalid-URL+abandon, and close during an in-flight pre-boundary auth operation (scripted attempt: cancelled, nothing durable, graph waits for terminal); enqueue racing `TransferConsumer` → delivered exactly once (root surface); post-boundary close → graph build AWAITS `Committed`.
+- [ ] **Step 2-4: red → implement → green** (full app suite; the existing `AppStartupTests`/`AppMutationLaneWiringTests` keep passing).
+- [ ] **Step 5: Commit** `feat(app): wizard-first startup with consumer handoff and fresh re-resolution`
+
+### Task 17: Wizard E2E-shaped composition tests + spec riders
+
+**Files:**
+- Test: `test/Capacitor.App.Tests.Unit/WizardCompositionTests.cs`
+- Modify: `docs/superpowers/specs/2026-08-12-ai1655-onboarding-wizard-design.md` (rider), `CLAUDE.md`
+
+**Contract.** Composed flows through the REAL shell + real step VMs (scripted externals only): (a) fresh-machine happy path — paste `None` URL → auto-satisfied Sign-in → defaults written → agents/import skipped (no CLI) → daemon step "requires sign-in" absent (gate complete), Done summary correct; (b) abandon-before-sign-in → close → nothing durable (no config/token/claim writes on the temp dirs); (c) sign-in commit → claims armed → quit → relaunch fixture: `ConsentFlipCoordinator` (normal graph) still holds the claim. Spec rider records the Plan C deviations (this plan's pinned list) next to §5's result algebra and §4's adapter text; CLAUDE.md gains the Plan C paragraph (façade + wizard-first summary, ≤16 lines, replacing nothing).
+
+- [ ] **Step 1: Failing composition tests (a)-(c).**
+- [ ] **Step 2-4: red → implement/wire gaps → green.**
+- [ ] **Step 5: Commit** `test(app): wizard composition flows; docs: spec riders`
+
+### Task 18: Final verification sweep
+
+- [ ] Full app suite (`dotnet run --project test/Capacitor.App.Tests.Unit/...`), full CLI unit + integration suites (`TMPDIR=/private/tmp`), both AOT publish greps empty.
+- [ ] `grep -rn 'Console\.' src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs` → zero (façade is sink-only); `grep -rn 'AnsiConsole\|Spectre' src/Capacitor.Cli.Core/` → zero (Core stays Spectre-free).
+- [ ] Comment-discipline self-check on the branch diff: `git diff origin/main | grep -inE 'round|review|task [0-9]|plan [abc]|AI-[0-9]'` → only legitimate hits (issue refs in docs).
+- [ ] `README.md` untouched (no CLI surface change) — verify no new flag/verb slipped in.
+- [ ] Commit any stragglers; push; PR: `Part of #553. AI-1655` + the deviation ledger in the description.
+
+## Self-review notes
+
+- Spec §5 coverage: operations (T4), progress sink (T2), cancellation (T1), boundary (T4), async picker (T1), helper moves (T3). §3 steps: 1→T13, 2/3→T12, 4→T13, 5/6→T14, 7→T15, 8→T13. §7→T7/T8/T14. §9 error rows distributed into each step task. §10 rows not already covered by Plans A/B are enumerated inside the owning tasks; E2E stays manual (spec).
+- Type-consistency: `AuthResult`/`AuthIdentity`/`ConnectIntent`/`StreamedLine`/`ImportRequest` defined once (T4/T9/T7/T8) and consumed by name in later tasks.
+- The wizard never calls `CliTelemetry.Initialize`; all shelling goes through `KcapCli` (marker overlay) — no new telemetry surface.

--- a/docs/superpowers/plans/2026-08-16-ai1655-plan-c-facade-wizard.md
+++ b/docs/superpowers/plans/2026-08-16-ai1655-plan-c-facade-wizard.md
@@ -60,11 +60,11 @@ public interface IAuthProxyClient {
 ```
 `OAuthLoginFlow` members gain trailing `CancellationToken ct = default`, threaded into every `HttpClient` call, `Task.Delay`, and `browser.InvokeAsync`: `RunDeviceFlowAsync`, `RunGitHubBrowserFlowAsync`, `ExchangeAndSaveAsync` (all three overloads), `AcquireGitHubTokenAsync`, `AuthenticateWorkOSAsync`, `SwitchWorkOSOrgAsync`, `RefreshWorkOSTokenAsync`, `LoginWithDiscoveryAsync`. The device poll (`RunDeviceFlowAsync` L175-211, today `while (true)`) becomes cancellable: `await Task.Delay(interval, ct)` and `ct.ThrowIfCancellationRequested()` per iteration — cancellation surfaces as `OperationCanceledException`, never a mapped error string. `WorkOSDiscovery.RunWithLiveAuthAsync` and `RunAsync` gain `CancellationToken ct = default`; the two dropped tokens are fixed: L42's `orglessRefresh: async (refreshToken, _)` passes the real token through to `RefreshWorkOSTokenAsync`, and L109 passes `ct` into `provisioner.OfferCreateAsync(tokens, ct)`. `WorkOSDiscovery` consumes `picker.PickAsync(result.Tenants, ct)`; `TenantDiscovery.RunAsync` gains `ct` and consumes `PickAsync` too. `SpectreTenantPicker` implements `PickAsync` as `Task.FromResult<DiscoveredTenant?>(Pick(tenants))` (Spectre prompts are not cancellable; the CLI never cancels). Behavior-preserving: default `ct` everywhere, no call-site changes required outside tests.
 
-- [ ] **Step 1: Failing tests** (`AuthCancellationTests` + updates): cancelling during the device poll throws OCE (fake `HttpClient` handler pinning the poll on `authorization_pending`); `WorkOSDiscovery.RunAsync` passes its `ct` into `OfferCreateAsync` (NSubstitute provisioner asserting the received token is the one passed to `RunAsync`, not `default` — use a cancelled-after-start token identity check) and into the `orglessRefresh` delegate; `PickAsync` is what discovery awaits (substitute picker: `PickAsync` returns a tenant, `Pick` configured to throw — flow succeeds); existing `WorkOSDiscoveryTests`/`OAuthFlowTests` updated to stub `PickAsync` instead of `Pick` where discovery is driven.
-- [ ] **Step 2: Run tests — red.**
-- [ ] **Step 3: Implement** (mechanical threading; no logic changes).
-- [ ] **Step 4: Run the full CLI unit suite — green.** AOT publish greps for CLI + daemon — empty.
-- [ ] **Step 5: Commit** `feat(core): cancellation and async tenant picker through the auth flows`
+- [x] **Step 1: Failing tests** (`AuthCancellationTests` + updates): cancelling during the device poll throws OCE (fake `HttpClient` handler pinning the poll on `authorization_pending`); `WorkOSDiscovery.RunAsync` passes its `ct` into `OfferCreateAsync` (NSubstitute provisioner asserting the received token is the one passed to `RunAsync`, not `default` — use a cancelled-after-start token identity check) and into the `orglessRefresh` delegate; `PickAsync` is what discovery awaits (substitute picker: `PickAsync` returns a tenant, `Pick` configured to throw — flow succeeds); existing `WorkOSDiscoveryTests`/`OAuthFlowTests` updated to stub `PickAsync` instead of `Pick` where discovery is driven.
+- [x] **Step 2: Run tests — red.**
+- [x] **Step 3: Implement** (mechanical threading; no logic changes).
+- [x] **Step 4: Run the full CLI unit suite — green.** AOT publish greps for CLI + daemon — empty.
+- [x] **Step 5: Commit** `feat(core): cancellation and async tenant picker through the auth flows`
 
 ### Task 2: `IAuthProgress` — structured progress sink replaces Console writes
 
@@ -86,11 +86,11 @@ public sealed class ConsoleAuthProgress : IAuthProgress { … }   // prints EXAC
 ```
 Every `Console.Out/Error` write on the login/discovery/exchange paths in `OAuthLoginFlow` and `WorkOSDiscovery` (the complete inventory: OAuthLoginFlow L37/43/106/112, device flow L138/158-173/192/199/207, browser flow L250-318, exchange L325-455, WorkOS L560-618, loopback fallback L495/497; WorkOSDiscovery L59/73/82-87/99/143/160-198) routes through an `IAuthProgress` parameter (trailing, `IAuthProgress? progress = null`, resolved to `ConsoleAuthProgress` at method top — behavior-preserving for untouched callers). The device-code banner maps to `DeviceCode(code, uri)` + `Notice` for the surrounding lines; the poll `Console.Write(".")` maps to `PollTick()`; browser-open sites (`LoopbackBrowser` L25-27 and the device flow's `Process.Start` notice) map to `BrowserOpening(url)` — `LoopbackBrowser` gains a `IAuthProgress? progress = null` ctor parameter. `ConsoleAuthProgress` reproduces the exact current strings (the mapping table lives in this one class; `DeviceCode` prints today's banner, `BrowserOpening` prints today's two lines, `PollTick` prints `"."` without newline). `SetupFunnel` calls are NOT touched (they no-op in the app per decision 9 and must keep firing for the CLI — WorkOS events stay embedded in `WorkOSDiscovery`).
 
-- [ ] **Step 1: Failing tests:** a recording `IAuthProgress` captures the device-flow sequence (`DeviceCode` once, `PollTick` per poll, `Notice` on completion) from `RunDeviceFlowAsync` under a scripted handler; `WorkOSDiscovery.RunAsync` zero-tenant path emits the exact `"No Capacitor tenants are linked to your account. Ask your admin to invite you."` through `Error`/`Notice` (pin which stream today's code uses) and writes NOTHING to a captured `Console`; `ConsoleAuthProgress.DeviceCode`/`BrowserOpening` byte-compare against today's literals.
-- [ ] **Step 2: red.**
-- [ ] **Step 3: Implement.** Sweep with `grep -n 'Console\.' src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs` — zero hits on the swept paths when done (the file-level sweep is the acceptance check; `HttpClientExtensions.WriteUnreachableError` gets a string-returning overload the flow feeds to `Error`).
-- [ ] **Step 4: Full CLI unit suite green; AOT greps empty.**
-- [ ] **Step 5: Commit** `feat(core): structured auth progress sink with exact-string console adapter`
+- [x] **Step 1: Failing tests:** a recording `IAuthProgress` captures the device-flow sequence (`DeviceCode` once, `PollTick` per poll, `Notice` on completion) from `RunDeviceFlowAsync` under a scripted handler; `WorkOSDiscovery.RunAsync` zero-tenant path emits the exact `"No Capacitor tenants are linked to your account. Ask your admin to invite you."` through `Error`/`Notice` (pin which stream today's code uses) and writes NOTHING to a captured `Console`; `ConsoleAuthProgress.DeviceCode`/`BrowserOpening` byte-compare against today's literals.
+- [x] **Step 2: red.**
+- [x] **Step 3: Implement.** Sweep with `grep -n 'Console\.' src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs` — zero hits on the swept paths when done (the file-level sweep is the acceptance check; `HttpClientExtensions.WriteUnreachableError` gets a string-returning overload the flow feeds to `Error`).
+- [x] **Step 4: Full CLI unit suite green; AOT greps empty.**
+- [x] **Step 5: Commit** `feat(core): structured auth progress sink with exact-string console adapter`
 
 ### Task 3: Helper moves — `ServerInput` to Core, `ValidVisibilities` public
 
@@ -108,9 +108,9 @@ public static class ServerInput {
 ```
 `AppConfig.ValidVisibilities` becomes `public static readonly string[]` (the app reads it — `Capacitor.App` has no `InternalsVisibleTo`). `SetupCommand.ToServerOrigin`/`ResolveTenantArg` become one-line delegating shims (existing tests reference them) or call sites are updated and the shims deleted — prefer updating call sites and deleting; keep whichever the existing test surface makes cheaper, but the Core implementations are the single source.
 
-- [ ] **Step 1: Failing tests:** `ServerInputTests` ports the existing `ToServerOrigin`/`ResolveTenantArg` coverage from `SetupCommandTests` against the Core class (same cases, verbatim expectations); one test asserts `AppConfig.ValidVisibilities` is `["private", "project", "org_public", "public"]` (order pinned — Spectre prompt order depends on it).
-- [ ] **Step 2-4: red → move → green** (full CLI unit suite).
-- [ ] **Step 5: Commit** `refactor(core): move server-input helpers to Core; publish ValidVisibilities`
+- [x] **Step 1: Failing tests:** `ServerInputTests` ports the existing `ToServerOrigin`/`ResolveTenantArg` coverage from `SetupCommandTests` against the Core class (same cases, verbatim expectations); one test asserts `AppConfig.ValidVisibilities` is `["private", "project", "org_public", "public"]` (order pinned — Spectre prompt order depends on it).
+- [x] **Step 2-4: red → move → green** (full CLI unit suite).
+- [x] **Step 5: Commit** `refactor(core): move server-input helpers to Core; publish ValidVisibilities`
 
 ### Task 4: `OnboardingFacade` — operations + ordered commit boundary
 
@@ -158,17 +158,17 @@ public static Task<(StoredTokens Tokens, string? Username)?> ExchangeAsync(
 ```
 **Contract.** *`LoginAsync` (login to known server):* GET `/auth/config` (pre-boundary) → dispatch: `None` → boundary with no token (identity = resolved/target profile + canonical server; publications: profile `ServerUrl` write IF the profile doesn't already point there, provider stamp); `GitHubApp` → `AcquireGitHubTokenAsync` (browser/device per today's `ChooseGitHubFlow`) → `ExchangeAsync` (network, pre-boundary) → boundary (token + stamp); `workos` → `AuthenticateWorkOSAsync` for the known server's client id/org → boundary. Unknown provider → `Failed` with today's message. *`DiscoverAsync`:* proxy config → provider branch: GitHub → `AcquireGitHubTokenAsync` → `TenantDiscovery.RunAsync` (picker) → boundary over ALL discovered tenants (`MergeProfiles` then one `ExchangeAsync`+save per tenant — exchange calls are pre-save network but run inside the boundary sequence under `CancellationToken.None`, matching "config then one token per tenant"); WorkOS → `WorkOSDiscovery.DiscoverAsync` → `Ready` → boundary (MergeProfiles + `TokenStore.SaveAsync(picked.ProfileName, …)` from the switched auth — the `StoredTokens` construction moves verbatim from today's `SwitchAndSaveAsync` L184-196), `Retarget` → `AuthResult.Retarget`, `NoTenants`/`Failed` → `Failed`. *The boundary, ordered, both operations:* (1) `beforeCommit(identities, ct)` — the LAST cancellable await; failure or OCE → nothing durable, `Cancelled`/`Failed`; (2) enter: all remaining publications run under `CancellationToken.None` — config (`ConfigMutator.MutateAsync`: MergeProfiles/profile write AND the `auth_provider` stamp for every published identity in the SAME mutation), then token saves in tenant order; a cancel observed after entry still returns `Committed`; (3) crash residue is safe by ordering (claim-without-profile, profile-without-token → gate still fails). *Stamp write:* `profile.AuthProvider = new AuthProviderStamp(provider, canonicalServer)` with the `AuthProvider` constant verbatim; canonical server via `ServerIdentity.Canonicalize`. *Progress:* all rendering through `IAuthProgress`; the façade emits today's success line (`Logged in as …`) via `Notice`.
 
-- [ ] **Step 1: Failing tests** (scripted `HttpClient` handlers, NSubstitute picker/provisioner, recording hook, temp config dir):
+- [x] **Step 1: Failing tests** (scripted `HttpClient` handlers, NSubstitute picker/provisioner, recording hook, temp config dir):
   - **Boundary ordering:** hook called with the FULL identity set before any file exists; hook throw → no config change, no token file, result `Failed`; hook OCE → `Cancelled`, nothing durable.
   - **Cancellation on both sides of every publication:** cancel during picker await / device poll / exchange network call → `Cancelled` + zero durable writes; cancel signalled after boundary entry (hook completed) → `Committed` with ALL publications present (config + stamp + tokens).
   - **GitHub discovery:** N tenants → N `AuthIdentity` in the hook, N token files, `MergeProfiles` active = picked; per-tenant exchange failure → that tenant's token absent, others present, `Committed` (matches today's login warning-per-failure), warning via `Error`.
   - **WorkOS:** `Ready` → boundary writes config then token (`StoredTokens` fields exactly today's: `Provider = AuthProvider.WorkOS`, `ClientId`, canonical `ServerUrl`); `Retarget` → `AuthResult.Retarget`, nothing durable; zero tenants + provisioner Created → switch + boundary; provisioner Declined/InProgress/Failed → `Failed`, nothing durable.
   - **`None` server:** boundary = profile + stamp, NO token file; gate (`OnboardingGate.EvaluateResolvedAsync`) run against the resulting config returns `Complete` — the stamp-vocabulary pin (`"None"` verbatim honored case-insensitively).
   - **Provider stamp:** written for every published identity inside the boundary; a cancelled pre-boundary login leaves NO stamp.
-- [ ] **Step 2: red.**
-- [ ] **Step 3: Implement.** `WorkOSDiscovery.RunAsync`/`SwitchAndSaveAsync` become thin composition over `DiscoverAsync` + the façade-shaped publication (existing signature preserved for the interim; the CLI tasks remove remaining direct callers).
-- [ ] **Step 4: Full CLI unit suite green; AOT greps empty (both binaries).**
-- [ ] **Step 5: Commit** `feat(core): onboarding facade with ordered commit boundary and claim hook`
+- [x] **Step 2: red.**
+- [x] **Step 3: Implement.** `WorkOSDiscovery.RunAsync`/`SwitchAndSaveAsync` become thin composition over `DiscoverAsync` + the façade-shaped publication (existing signature preserved for the interim; the CLI tasks remove remaining direct callers).
+- [x] **Step 4: Full CLI unit suite green; AOT greps empty (both binaries).**
+- [x] **Step 5: Commit** `feat(core): onboarding facade with ordered commit boundary and claim hook`
 
 ### Task 5: `kcap login` re-plumb onto the façade
 
@@ -178,9 +178,9 @@ public static Task<(StoredTokens Tokens, string? Username)?> ExchangeAsync(
 
 **Contract.** Both login paths construct ONE façade: `new OnboardingFacade(new ConsoleAuthProgress(), new SpectreTenantPicker(), provisioner: null, beforeCommit: null)`. Known-server: `facade.LoginAsync(baseUrl!, forceDevice, profile: null, CancellationToken.None)`; `--discover`: `facade.DiscoverAsync(chosenProvider, forceDevice, ct)` — provider chosen exactly as today (`ChooseDiscoveryProvider`); `Retarget` prints today's `Run \`kcap setup {target}\` to configure that workspace.` and exits 1; result mapping `Committed → 0`, else `1` with today's messages (already emitted via the progress sink). Funnel parity: the login path emits NO funnel events of its own — only the WorkOS events embedded in discovery fire (unchanged); the GitHub path must emit NOTHING (assert). Exit codes and stdout/stderr shape match today (`Logged in. Active profile: {profile}.` final line preserved — emitted by the adapter after `Committed`, matching L913).
 
-- [ ] **Step 1: Failing tests:** `--discover` GitHub with 2 tenants → 2 token files + merged profiles + active = picked + final active-profile line (parity with the pre-re-plumb behavior pinned in `LoginDiscoverTests`); known-server `None` → exit 0, "no authentication configured" line, stamp written; funnel: a recording telemetry guard asserts zero GitHub funnel events on the login path.
-- [ ] **Step 2-4: red → re-plumb → green** (full CLI unit suite — `LoginDiscoverTests` updated where they pin `HandleDiscoverLoginAsync` internals).
-- [ ] **Step 5: Commit** `refactor(cli): login re-plumbed onto the onboarding facade`
+- [x] **Step 1: Failing tests:** `--discover` GitHub with 2 tenants → 2 token files + merged profiles + active = picked + final active-profile line (parity with the pre-re-plumb behavior pinned in `LoginDiscoverTests`); known-server `None` → exit 0, "no authentication configured" line, stamp written; funnel: a recording telemetry guard asserts zero GitHub funnel events on the login path.
+- [x] **Step 2-4: red → re-plumb → green** (full CLI unit suite — `LoginDiscoverTests` updated where they pin `HandleDiscoverLoginAsync` internals).
+- [x] **Step 5: Commit** `refactor(cli): login re-plumbed onto the onboarding facade`
 
 ### Task 6: `kcap setup` re-plumb onto the façade
 
@@ -190,9 +190,9 @@ public static Task<(StoredTokens Tokens, string? Username)?> ExchangeAsync(
 
 **Contract.** The interactive no-server-arg path calls `facade.DiscoverAsync` with `new SpectreTenantProvisioner(new TenantProvisioningClient(new HttpClient()), ProvisioningEndpoint.Url)` when not headless (as today). Funnel asymmetry preserved AT THE ADAPTER: setup emits `SigninOpened(signinMode, provider)` before the operation, `SigninFailed("github_token_denied")` when the GitHub token acquisition fails (façade `Failed` before any identity was published on the GitHub branch), `SigninCompleted(AuthProvider.GitHubApp)` + `TenantNone(AuthProvider.GitHubApp)` from the operation result/progress — WorkOS events remain embedded in Core (unchanged). `Retarget` loops into `ResolveServerAndProviderAsync(ServerInput.ResolveTenantArg(ServerInput.ToServerOrigin(target)))` exactly as today's L857. Step 2 for a `Committed` discovery reports the loginComplete branch (both providers now — the pinned convergence); `serverUrlArg`/`--no-prompt` paths keep `ResolveServerAndProviderAsync` and use `facade.LoginAsync(serverUrl, forceDevice, activeProfile, …)` where Step 2 needs a login. The `preAuthToken` field and its Step-2 exchange branch are DELETED. Everything from Step 3 on is untouched.
 
-- [ ] **Step 1: Failing tests:** GitHub discovery path → tokens for all tenants + Step-2 loginComplete output (updated pins); WorkOS path unchanged output; funnel sequence for setup (`Started` → `SigninOpened` → `SigninCompleted` → … → `Succeeded`) asserted via the existing funnel test harness; `--server-url` + `--no-prompt` behavior byte-identical.
-- [ ] **Step 2-4: red → re-plumb → green** (full CLI unit suite + `SetupFunnelTests`).
-- [ ] **Step 5: Commit** `refactor(cli): setup re-plumbed onto the onboarding facade`
+- [x] **Step 1: Failing tests:** GitHub discovery path → tokens for all tenants + Step-2 loginComplete output (updated pins); WorkOS path unchanged output; funnel sequence for setup (`Started` → `SigninOpened` → `SigninCompleted` → … → `Succeeded`) asserted via the existing funnel test harness; `--server-url` + `--no-prompt` behavior byte-identical.
+- [x] **Step 2-4: red → re-plumb → green** (full CLI unit suite + `SetupFunnelTests`).
+- [x] **Step 5: Commit** `refactor(cli): setup re-plumbed onto the onboarding facade`
 
 ### Task 7: Streaming process runner (§7)
 
@@ -213,9 +213,9 @@ public interface IProcessRunner {
 ```
 **Contract.** Each stream line-buffered independently (no cross-stream ordering promise); `onLine` invoked on the pump thread — callback exceptions logged to `Console.Error` and swallowed (never kill the pump); the runner retains only a bounded tail (const `TailLimit = 500` lines total, oldest dropped) mirrored into `StreamingResult.Tail`; full `Stdout`/`Stderr` captures are structurally absent from the result type. Cancellation via `ct` = `KillTree` + await exit (streaming ignores `RunOptions.CancelMode` — §7 pins KillTree); `RunOptions.Timeout` honored with `TimedOut = true` + KillTree.
 
-- [ ] **Step 1: Failing tests** (real child processes — `/bin/sh -c` scripts; Windows-guard where needed): interleaved stdout/stderr lines each tagged with the right kind; a >500-line run: callback sees every line, `Tail` holds exactly the LAST 500; a throwing callback: pump survives, exit code still captured; mid-stream cancel: child tree killed (child writes a marker file on exit-signal absence — assert no orphan by PID liveness), method returns; large-output run: process memory of the result bounded (assert `Tail.Count <= 500` and no full-capture property exists — compile-time by shape).
-- [ ] **Step 2-4: red → implement → green.**
-- [ ] **Step 5: Commit** `feat(app): streaming process runner with bounded tail and KillTree cancel`
+- [x] **Step 1: Failing tests** (real child processes — `/bin/sh -c` scripts; Windows-guard where needed): interleaved stdout/stderr lines each tagged with the right kind; a >500-line run: callback sees every line, `Tail` holds exactly the LAST 500; a throwing callback: pump survives, exit code still captured; mid-stream cancel: child tree killed (child writes a marker file on exit-signal absence — assert no orphan by PID liveness), method returns; large-output run: process memory of the result bounded (assert `Tail.Count <= 500` and no full-capture property exists — compile-time by shape).
+- [x] **Step 2-4: red → implement → green.**
+- [x] **Step 5: Commit** `feat(app): streaming process runner with bounded tail and KillTree cancel`
 
 ### Task 8: `KcapCli` — `PluginInstallAsync` + streaming import
 
@@ -232,9 +232,9 @@ Task<StreamingResult> ImportAsync(ImportRequest request, Action<StreamedLine> on
 ```
 **Contract.** `PluginInstallAsync`: args `["plugin", "install"]` + vendorFlag when non-null (the §5 exclusive flags: `--codex --cursor --copilot --gemini --kiro --pi --opencode --antigravity`); `Env()` overlay (profile + no-telemetry); bounded `MutationTimeout` (60 s); null `CliPath` → `NoCliResult()`. `ImportAsync`: args `["import"]` + scope (`--all` | `--org <o>` | `--repo <r>`) + `--yes` + each vendor flag, `Env()` overlay, `RunStreamingAsync` with NO internal timeout (imports are long; cancellation is the bound), null `CliPath` → a `StreamingResult(-1, false, [])` with a synthesized `Stderr` tail line `kcap CLI not found`. Neither verb overlays mutation env (non-daemon shelling keeps lenient classification, spec §4).
 
-- [ ] **Step 1: Failing tests** (`FakeProcessRunner` in `KcapCliTests`, extended with a streaming recorder): exact argv per scope/vendor combination (Everything+2 vendors; Org; Repo; Claude default flagless); env overlay carries `KCAP_PROFILE` + `KCAP_APP_SPAWN_NO_TELEMETRY` and NOT `KCAP_CONSENT_SEED_DEFAULT`/`KCAP_EXPECT_SERVER_URL`; no-CLI results for both verbs.
-- [ ] **Step 2-4: red → implement → green.**
-- [ ] **Step 5: Commit** `feat(app): KcapCli plugin-install and streaming import verbs`
+- [x] **Step 1: Failing tests** (`FakeProcessRunner` in `KcapCliTests`, extended with a streaming recorder): exact argv per scope/vendor combination (Everything+2 vendors; Org; Repo; Claude default flagless); env overlay carries `KCAP_PROFILE` + `KCAP_APP_SPAWN_NO_TELEMETRY` and NOT `KCAP_CONSENT_SEED_DEFAULT`/`KCAP_EXPECT_SERVER_URL`; no-CLI results for both verbs.
+- [x] **Step 2-4: red → implement → green.**
+- [x] **Step 5: Commit** `feat(app): KcapCli plugin-install and streaming import verbs`
 
 ### Task 9: `WizardAuthService` — single-flight driver, claims arming, close handoff
 
@@ -265,9 +265,9 @@ public sealed class WizardAuthService(
 
 Same task: `App.ResolveConsentFlipIdentity` (App.axaml.cs L397-404) switches `ConfigMutator.LoadPure` → `TryLoadPure`; an unreadable config returns an identity that matches nothing (e.g. `("", "", "")`) so `TryConsume`'s compare retains the claim — fail-closed, never a throw inside the two-lock section.
 
-- [ ] **Step 1: Failing tests:** single-flight (`Begin` during live attempt throws; after terminal, admitted); hook arms one claim per identity (recording claims store on a temp path — REAL `ConsentFlipClaims`); `Arm` returning false → `Failed`, nothing published (scripted runOperation asserting the hook threw before its publication step); cancel-pre-boundary → `Cancelled` + `QuiescedAsync` completes; cancel-post-boundary (scripted op that enters boundary then observes cancel) → `Committed`; quarantined store: `Arm` during an attempt still lands in the fresh store (never rejected) and `claims.Quarantine()` is non-null after; `TryLoadPure` switch: corrupt config file + `TryConsume` → claim retained, no exception.
-- [ ] **Step 2-4: red → implement → green.**
-- [ ] **Step 5: Commit** `feat(app): wizard auth service with claim-arming hook and close handoff`
+- [x] **Step 1: Failing tests:** single-flight (`Begin` during live attempt throws; after terminal, admitted); hook arms one claim per identity (recording claims store on a temp path — REAL `ConsentFlipClaims`); `Arm` returning false → `Failed`, nothing published (scripted runOperation asserting the hook threw before its publication step); cancel-pre-boundary → `Cancelled` + `QuiescedAsync` completes; cancel-post-boundary (scripted op that enters boundary then observes cancel) → `Committed`; quarantined store: `Arm` during an attempt still lands in the fresh store (never rejected) and `claims.Quarantine()` is non-null after; `TryLoadPure` switch: corrupt config file + `TryConsume` → claim retained, no exception.
+- [x] **Step 2-4: red → implement → green.**
+- [x] **Step 5: Commit** `feat(app): wizard auth service with claim-arming hook and close handoff`
 
 ### Task 10: Quarantine ack affordance (coordinator path)
 
@@ -277,9 +277,9 @@ Same task: `App.ResolveConsentFlipIdentity` (App.axaml.cs L397-404) switches `Co
 
 **Contract.** `SurfaceQuarantineOnceAsync` upgrades from a bare `Attention` line to `surface.TryConfirmAsync(new LifecyclePrompt(Kind: "quarantine", …, Disclosure: <preserved path + the recovery guidance from Plan B's exact copy>), ct)` with a single affirmative ("Acknowledge"); `true` → `AckQuarantineAsync()`; `false`/`null` (declined, cancelled, or no dialog capability) → NOT acked, surfaces again next start — acknowledgment must be explicit, never inferred from dismissal. `LifecyclePrompt` gains `public const string KindQuarantine = "quarantine";` and `LifecyclePromptViewModel`/`LifecyclePromptWindow` render it with a single-button layout (confirm-only; no destructive action).
 
-- [ ] **Step 1: Failing tests:** quarantine + unacked → one `TryConfirmAsync` with the preserved path in the disclosure; confirm → `ConsentQuarantineAcked` persisted, not re-surfaced on a fresh coordinator; decline → not persisted, re-surfaced; acked state → zero prompts.
-- [ ] **Step 2-4: red → implement → green.**
-- [ ] **Step 5: Commit** `feat(app): quarantine acknowledgment prompt on the coordinator path`
+- [x] **Step 1: Failing tests:** quarantine + unacked → one `TryConfirmAsync` with the preserved path in the disclosure; confirm → `ConsentQuarantineAcked` persisted, not re-surfaced on a fresh coordinator; decline → not persisted, re-surfaced; acked state → zero prompts.
+- [x] **Step 2-4: red → implement → green.**
+- [x] **Step 5: Commit** `feat(app): quarantine acknowledgment prompt on the coordinator path`
 
 ### Task 11: Onboarding shell — window, step machine, navigation
 
@@ -308,9 +308,9 @@ public sealed class OnboardingViewModel : ViewModelBase {
 ```
 **Contract.** Linear steps, Back/Next, every step individually skippable and retryable (§3); one window, content switched by `DataTemplate` on the step VM type. Skip advances without satisfying; Back from Sign-in post-commit returns to Connect for a different intent while Sign-in shows satisfied on re-entry. Window close (any time) raises `CloseRequested`; the shell never blocks close — the app's startup sequencing (Task 16) owns the quiesce. Styling follows `MainWindow.axaml` conventions.
 
-- [ ] **Step 1: Failing tests** (`[NotInParallel("AvaloniaSession")]`, headless; fake steps): applicability filtering (Shim absent when not applicable); Next/Back/Skip transitions across the full order; `CanLeaveAsync(false)` holds the step; skip-then-return shows unsatisfied; Done raises `CloseRequested`.
-- [ ] **Step 2-4: red → implement → green.**
-- [ ] **Step 5: Commit** `feat(app): onboarding wizard shell with step state machine`
+- [x] **Step 1: Failing tests** (`[NotInParallel("AvaloniaSession")]`, headless; fake steps): applicability filtering (Shim absent when not applicable); Next/Back/Skip transitions across the full order; `CanLeaveAsync(false)` holds the step; skip-then-return shows unsatisfied; Done raises `CloseRequested`.
+- [x] **Step 2-4: red → implement → green.**
+- [x] **Step 5: Commit** `feat(app): onboarding wizard shell with step state machine`
 
 ### Task 12: Sign-in step — progress rendering, picker/provisioner bridges, quarantine notice
 
@@ -338,9 +338,9 @@ public sealed class UiAuthProgress(Action<Action> post) : IAuthProgress { … } 
 ```
 **Contract.** `ConnectStepViewModel` gathers intent only (§3 step 2): paste (validated via `OnboardingGate.ValidServerUrl` after `ServerInput` normalization), discover (provider choice GitHub/WorkOS), create; nothing network, nothing written. `SignInStepViewModel` runs ONE `WizardAuthService.Begin(intent)` rendering: progress notices inline, `BrowserOpening` with clickable fallback URL (`IUrlOpener`), `DeviceCode` display, tenant list on `SelectionRequested` (list UI resolves `Select`), create sub-flow via the provisioner hooks (`SlugValidator.Derive` suggestion, availability re-prompt loop mirroring `SpectreTenantProvisioner.PromptSlugAsync` semantics, provisioning progress `attempt/max`, "still provisioning — finish later by joining `<slug>` from the Connect step" on `InProgress` — the CLI's message GUI-shaped, §9). `Retarget` → back to Connect with the input prefilled. `AuthProvider.None` pasted-URL join auto-satisfies the step on `Committed`. Cancellation ≠ failure in every rendered surface. Quarantine: after any attempt, if `claims.Quarantine()` is non-null and `AppState.ConsentQuarantineAcked` is false → one notice naming the preserved path with an Acknowledge button → `AckQuarantineAsync` (same recovery copy as Task 10). Step transitions per §3: pre-boundary Back/Skip/close → `attempt.Cancel()` + await quiesce via `CanLeaveAsync`; post-boundary → satisfied, Back allowed for a different intent.
 
-- [ ] **Step 1: Failing tests** (headless; scripted `runOperation` via the service): the §10 transition table — pasted URL / GitHub discovery / WorkOS discovery / zero-tenant create / retarget / `None` auto-satisfy; Back and Skip on both sides of the boundary (pre → `Cancelled`, nothing durable per the scripted op; post → satisfied); re-entry recognizes satisfied; device-code and browser-fallback render from progress events; picker TCS resolves the façade await; provisioner hook sequence for the create sub-flow incl. `InProgress` copy; quarantine notice once + ack persisted.
-- [ ] **Step 2-4: red → implement → green.**
-- [ ] **Step 5: Commit** `feat(app): connect and sign-in wizard steps with facade bridges`
+- [x] **Step 1: Failing tests** (headless; scripted `runOperation` via the service): the §10 transition table — pasted URL / GitHub discovery / WorkOS discovery / zero-tenant create / retarget / `None` auto-satisfy; Back and Skip on both sides of the boundary (pre → `Cancelled`, nothing durable per the scripted op; post → satisfied); re-entry recognizes satisfied; device-code and browser-fallback render from progress events; picker TCS resolves the façade await; provisioner hook sequence for the create sub-flow incl. `InProgress` copy; quarantine notice once + ack persisted.
+- [x] **Step 2-4: red → implement → green.**
+- [x] **Step 5: Commit** `feat(app): connect and sign-in wizard steps with facade bridges`
 
 ### Task 13: Shim, Defaults, Done steps
 
@@ -350,9 +350,9 @@ public sealed class UiAuthProgress(Action<Action> post) : IAuthProgress { … } 
 
 **Contract.** *Shim (§3 step 1):* `Applicable` = macOS AND resolved absolute CLI path AND `probe.KcapOnPathAsync` positively `false`; Install runs `PathShimInstaller.InstallAsync(target)` (AppleScript sudo, non-forcing, post-install re-probe — reused as-is) and claims `ShimOffered` via `AppStateStore` so the post-wizard `ShimOfferCoordinator` never re-offers; outcomes map: `Installed` → satisfied; `InstalledButNotOnPath`/`Failed` → message + Retry; `Cancelled` → unsatisfied, skippable. *Defaults (§3 step 4, decision 5):* visibility picker over `AppConfig.ValidVisibilities` with the SAME labels as setup's prompt (copy the four converter strings), default `org_public`; daemon-name field default `Environment.UserName.ToLowerInvariant()`; Next persists via `ConfigMutator.MutateAsync(c => …)` writing `DefaultVisibility` + `Daemon.Name` on the active profile — NO claim maintenance (claims key on `{profile, server}`). *Done (§3 step 8):* summary grid from each step's `Satisfied`/skip state incl. why-skipped notes ("kcap CLI not found", "requires sign-in").
 
-- [ ] **Step 1: Failing tests:** shim applicability matrix (non-macOS / no CLI / kcap-on-PATH / probe-null → not applicable); install claims `ShimOffered` exactly once; defaults write lands both fields and preserves unrelated config (temp config, REAL `ConfigMutator`); done summary reflects skip reasons.
-- [ ] **Step 2-4: red → implement → green.**
-- [ ] **Step 5: Commit** `feat(app): shim, defaults, and done wizard steps`
+- [x] **Step 1: Failing tests:** shim applicability matrix (non-macOS / no CLI / kcap-on-PATH / probe-null → not applicable); install claims `ShimOffered` exactly once; defaults write lands both fields and preserves unrelated config (temp config, REAL `ConfigMutator`); done summary reflects skip reasons.
+- [x] **Step 2-4: red → implement → green.**
+- [x] **Step 5: Commit** `feat(app): shim, defaults, and done wizard steps`
 
 ### Task 14: Agents + Import steps
 
@@ -362,9 +362,9 @@ public sealed class UiAuthProgress(Action<Action> post) : IAuthProgress { … } 
 
 **Contract.** *Agents (§3 step 5, decision 8):* inputs = `AgentDetection.FromEnvironment()` overridden with the login-shell PATH — `inputs with { PathEnv = await probe.TerminalPathAsync(ct) ?? inputs.PathEnv }` (the app feed; a null probe result keeps the process PATH); one checkbox per vendor, pre-checked when `Detected`; Install runs `PluginInstallAsync` per selection sequentially (Claude `null` flag; vendor flags per §5's exclusive list); per-vendor exit codes → ⚠ + Retry on failures, successes stand (§9). *Import (§3 step 6, decision 6):* vendor checkboxes (default: the detected set), scope choice mirroring `ImportScopePrompt`'s vocabulary — `Everything` / `All repos in one org` (+ org text field) / `Specific repository` (+ `owner/name` field); Run streams `ImportAsync` into a live log pane bounded to the LAST 500 lines with an "older lines dropped" header once truncation starts, lines marshaled from the pump to the UI scheduler; Cancel = the ct (KillTree in the runner) + await exit; completion ALWAYS appends "if anything failed, run `kcap import` in a terminal to retry" (unconditional — the CLI exits 0 with per-session errors, §7); failure never blocks Next.
 
-- [ ] **Step 1: Failing tests:** detection feed uses the terminal PATH when present, process PATH when probe null (fake probe + crafted `AgentDetectionInputs` asserting a binary only findable via the terminal PATH is detected); per-vendor install argv + failure isolation; import argv per scope; log pane bound at 500 with the drop notice; the unconditional retry line present on success AND failure; cancel kills (scripted runner asserting KillTree-path invoked).
-- [ ] **Step 2-4: red → implement → green.**
-- [ ] **Step 5: Commit** `feat(app): coding-agents and import wizard steps`
+- [x] **Step 1: Failing tests:** detection feed uses the terminal PATH when present, process PATH when probe null (fake probe + crafted `AgentDetectionInputs` asserting a binary only findable via the terminal PATH is detected); per-vendor install argv + failure isolation; import argv per scope; log pane bound at 500 with the drop notice; the unconditional retry line present on success AND failure; cancel kills (scripted runner asserting KillTree-path invoked).
+- [x] **Step 2-4: red → implement → green.**
+- [x] **Step 5: Commit** `feat(app): coding-agents and import wizard steps`
 
 ### Task 15: Daemon step — the §3 step-7 matrix through the lane
 
@@ -377,9 +377,9 @@ public sealed class UiAuthProgress(Action<Action> post) : IAuthProgress { … } 
 
 **Contract.** Skipped-login users see "requires sign-in" (§9); gate-complete identity resolved fresh at step entry (post-Sign-in config). On enter: fresh `ServiceStatusAsync` snapshot → classify on AI-1654's FULL matrix (§3 step 7 rows, verbatim recoveries): no unit → `Install`; unit stopped/loaded-inactive + null `daemon_pid` → `StartVerified`; positive ownership + identity match → "already enabled" + apply pending claim via the explicit conditional put (NO factory guard — get is skipped; put carries `{resolved name, claim server}`; ack failure → claim pending + repair guidance); ownership without identity match → takeover offer only; manual daemon identity-matched → takeover dialog with AI-1654 disclosures, decline → visibly incomplete + claim STILL applied via conditional put; manual daemon identity-MISMATCH → no mutation, no claim application, takeover the only offered row; orphan/stale marker → repair affordance; `txn_active` → wait; unparseable → honest message, no mutation. Mutations route through `lane.RunAsync(MutationRequestFactory.TryBuild(...))` — results update step state ONLY (single-presentation rule); actionable outcomes arrive through the channel consumer with the wizard surface. Enablement success = the lane's own `Succeeded` predicate (never a local re-derivation). Claim consumption uses `TryConsume` with the Task-9 `TryLoadPure` resolver.
 
-- [ ] **Step 1: Failing tests** (scripted `IKcapCli` snapshots + `FakeMutationLane`-style recorder + `ScriptedLocalControlOps` + real claims store): every matrix row above → the exact verb (or explicit no-mutation) + offered affordance; claim application on the owning+identity row and on manual-identity-match decline; NO claim application on wrong-server rows; state-only handling of `RunAsync` results (no dialog from the waiter path — recorded surface sees zero prompts when an outcome also travels the channel); "requires sign-in" when gate incomplete.
-- [ ] **Step 2-4: red → implement → green.**
-- [ ] **Step 5: Commit** `feat(app): daemon enablement wizard step on the full state matrix`
+- [x] **Step 1: Failing tests** (scripted `IKcapCli` snapshots + `FakeMutationLane`-style recorder + `ScriptedLocalControlOps` + real claims store): every matrix row above → the exact verb (or explicit no-mutation) + offered affordance; claim application on the owning+identity row and on manual-identity-match decline; NO claim application on wrong-server rows; state-only handling of `RunAsync` results (no dialog from the waiter path — recorded surface sees zero prompts when an outcome also travels the channel); "requires sign-in" when gate incomplete.
+- [x] **Step 2-4: red → implement → green.**
+- [x] **Step 5: Commit** `feat(app): daemon enablement wizard step on the full state matrix`
 
 ### Task 16: Wizard-first startup + consumer handoff
 
@@ -389,9 +389,9 @@ public sealed class UiAuthProgress(Action<Action> post) : IAuthProgress { … } 
 
 **Contract (decision 2, replacing Plan B's `Incomplete` arm).** `StartAsync`: lane + channel constructed first (unchanged — app-lifetime). Gate `Complete` → today's startup exactly. Gate `Incomplete` → build NO daemon graph (no `DaemonClientService`, no tray, no lifecycle controller, no shim coordinator): construct the wizard graph — `ConsentFlipClaims.Default()`, `WizardAuthService`, step VMs (Daemon step gets a per-resolved-identity `KcapCli` for status + `LocalControlOps` for the put; `CliResolver` override seam preserved), `OnboardingWindow` as `desktop.MainWindow`, and start `ConsumeMutationOutcomesAsync(channel, wizardSurface, lane.RunAsync, …)` as the consumer. On `CloseRequested` OR window close: (1) `authService.Current?.Cancel()`; (2) await the auth terminal task (post-boundary close runs to `Committed` — decision 2); (3) `AwaitQuiescedAsync(lane.QuiescedAsync, cap)` with the existing §6a post-cap rules (past the cap: proceed, auto-actions closed, attention from re-queried evidence — the lane still owns the live action); (4) `channel.TransferConsumer()`; (5) fresh resolution (re-run the SAME resolution `CreateDefaultAsync` performs — `AppConfig.LoadProfileConfig` → active profile; never the startup-cached `AppConfig.ResolvedProfile`) + `EvaluateResolvedAsync` on it (single-resolution rule); (6) build the normal graph — still-`Incomplete` → the Plan B carve-out arm (auto-actions closed + shim auto-offer suppressed) — and start the root consumer. Shutdown during wizard mode: `OnShutdownRequested` awaits the auth terminal task + lane quiesce under `QuiesceShutdownCap` before disposing (§6a: past the cap, exit with the child detached is safe).
 
-- [ ] **Step 1: Failing tests:** gate-incomplete → NO service/tray/lifecycle/shim constructed (assert via the built-object fields), wizard window is MainWindow, consumer live with the wizard surface (enqueue → wizard-surface presentation); close with gate-now-complete → normal graph against the FRESH profile (config changed between open and close is honored); close with gate-still-failing → carve-out graph (auto-actions closed, shim suppressed) — the §10 decision-2 rows: zero service mutation for valid-URL+no-token+abandon, invalid-URL+abandon, and close during an in-flight pre-boundary auth operation (scripted attempt: cancelled, nothing durable, graph waits for terminal); enqueue racing `TransferConsumer` → delivered exactly once (root surface); post-boundary close → graph build AWAITS `Committed`.
-- [ ] **Step 2-4: red → implement → green** (full app suite; the existing `AppStartupTests`/`AppMutationLaneWiringTests` keep passing).
-- [ ] **Step 5: Commit** `feat(app): wizard-first startup with consumer handoff and fresh re-resolution`
+- [x] **Step 1: Failing tests:** gate-incomplete → NO service/tray/lifecycle/shim constructed (assert via the built-object fields), wizard window is MainWindow, consumer live with the wizard surface (enqueue → wizard-surface presentation); close with gate-now-complete → normal graph against the FRESH profile (config changed between open and close is honored); close with gate-still-failing → carve-out graph (auto-actions closed, shim suppressed) — the §10 decision-2 rows: zero service mutation for valid-URL+no-token+abandon, invalid-URL+abandon, and close during an in-flight pre-boundary auth operation (scripted attempt: cancelled, nothing durable, graph waits for terminal); enqueue racing `TransferConsumer` → delivered exactly once (root surface); post-boundary close → graph build AWAITS `Committed`.
+- [x] **Step 2-4: red → implement → green** (full app suite; the existing `AppStartupTests`/`AppMutationLaneWiringTests` keep passing).
+- [x] **Step 5: Commit** `feat(app): wizard-first startup with consumer handoff and fresh re-resolution`
 
 ### Task 17: Wizard E2E-shaped composition tests + spec riders
 
@@ -407,11 +407,11 @@ public sealed class UiAuthProgress(Action<Action> post) : IAuthProgress { … } 
 
 ### Task 18: Final verification sweep
 
-- [ ] Full app suite (`dotnet run --project test/Capacitor.App.Tests.Unit/...`), full CLI unit + integration suites (`TMPDIR=/private/tmp`), both AOT publish greps empty.
-- [ ] `grep -rn 'Console\.' src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs` → zero (façade is sink-only); `grep -rn 'AnsiConsole\|Spectre' src/Capacitor.Cli.Core/` → zero (Core stays Spectre-free).
-- [ ] Comment-discipline self-check on the branch diff: `git diff origin/main | grep -inE 'round|review|task [0-9]|plan [abc]|AI-[0-9]'` → only legitimate hits (issue refs in docs).
-- [ ] `README.md` untouched (no CLI surface change) — verify no new flag/verb slipped in.
-- [ ] Commit any stragglers; push; PR: `Part of #553. AI-1655` + the deviation ledger in the description.
+- [x] Full app suite (`dotnet run --project test/Capacitor.App.Tests.Unit/...`), full CLI unit + integration suites (`TMPDIR=/private/tmp`), both AOT publish greps empty.
+- [x] `grep -rn 'Console\.' src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs` → zero (façade is sink-only); `grep -rn 'AnsiConsole\|Spectre' src/Capacitor.Cli.Core/` → zero (Core stays Spectre-free).
+- [x] Comment-discipline self-check on the branch diff: `git diff origin/main | grep -inE 'round|review|task [0-9]|plan [abc]|AI-[0-9]'` → only legitimate hits (issue refs in docs).
+- [x] `README.md` untouched (no CLI surface change) — verify no new flag/verb slipped in.
+- [x] Commit any stragglers; push; PR: `Part of #553. AI-1655` + the deviation ledger in the description.
 
 ## Self-review notes
 

--- a/docs/superpowers/specs/2026-08-12-ai1655-onboarding-wizard-design.md
+++ b/docs/superpowers/specs/2026-08-12-ai1655-onboarding-wizard-design.md
@@ -1100,3 +1100,32 @@ rules, `Path.Combine` in path assertions for the Windows CI leg).
   seams (§5), the `auth_provider` server-scoped stamp (§4), the mutation API (decision 10), and
   public `ValidVisibilities`. User-visible CLI behavior is unchanged, so no README/help churn.
 - One PR (references AI-1655 and its GitHub issue).
+
+## Plan C implementation riders (2026-08-17)
+
+- §4/§5 result algebra: `AuthResult` gains `Retarget(ServerInput)` (the WorkOS "I already have a
+  workspace" completion; pre-boundary, nothing durable) and `Failed` carries `AuthFailureReason`
+  `{Other, Unreachable, SigninDenied, NoTenantsFound}` (the setup adapter's funnel discriminator).
+- §5 `LoginAsync` carries `adoptServer` (default `false`): `kcap login` never repoints a profile's
+  `server_url`; `kcap setup` and the wizard's Paste operation pass `true` (the write that makes a
+  fresh profile gate-complete). A `None`-server login on a foreign profile now fails honestly
+  instead of writing nothing.
+- §5 boundary totality: once entered, publication exceptions never escape as raw exceptions —
+  config-commit failure → `Failed` (nothing durable began); post-config failure → `Committed` with
+  a credentials warning; per-tenant exchange failures warn and continue.
+- §3 step 2/3: pasted input uses `ToServerOrigin`+`ResolveTenantArg` plus the pure loopback default
+  (a scheme-less host resolves to `http`) — path-routed self-hosted servers are not expressible in
+  the wizard's Paste field (documented residual; `kcap setup <url>` still accepts them).
+- §6 step-7 claim application: the conditional put preserves the daemon's existing rules and
+  prompt timeout (get-then-put; the v2 identity echo is the guard); an operator-chosen `deny` is
+  respected (no put, claim retained inert).
+- §4 observation: the two-adapter live/one-shot slot design is superseded — every lane
+  classification uses fresh one-shot probes with the instance-bound hello+snapshot correlation
+  (carried from the app-lane slice).
+- Decision 9 note: the wizard's `SetupFunnel` calls inside shared Core/provisioner flows are inert
+  in the app process (`CliTelemetry` never initialized) — kept for CLI parity.
+- §3 step 7: a wizard user with an unresolvable daemon binary sees enable/takeover/repair
+  withdrawn with reinstall guidance (spawn rows only; a running owned daemon still reports
+  enabled).
+- Decision 2: past the wizard-close quiesce cap, the graph is built with auto-actions permanently
+  closed and one attention line (the §6a rule as implemented).

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -391,11 +391,14 @@ public partial class App : Application {
         return (lifecycle, shimOffer, consentFlip, surface, probe);
     }
 
-    // Pure LoadPure read only — TryConsume already holds this same config lock when this delegate runs.
+    // Pure read only — TryConsume already holds this same config lock when this delegate runs, so
+    // unreadable config fails closed to an identity that matches nothing (the claim stays pending)
+    // rather than throwing inside the two-lock section.
     // Deliberately literal ActiveProfile (no KCAP_PROFILE layering) — a divergence there is fail-safe
     // via the daemon's own identity-conditional ack (task-13-report).
     internal static (string Profile, string Server, string DaemonName) ResolveConsentFlipIdentity() {
-        var config      = ConfigMutator.LoadPure(AppConfig.GetConfigPath());
+        if (!ConfigMutator.TryLoadPure(AppConfig.GetConfigPath(), out var config)) return ("", "", "");
+
         var profileName = config.ActiveProfile;
         var profile     = config.Profiles.GetValueOrDefault(profileName);
         var server      = ServerIdentity.Canonicalize(profile?.ServerUrl) ?? profile?.ServerUrl ?? "";

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -69,9 +69,12 @@ public partial class App : Application {
     // same 1 Hz heartbeat.
     UiTicker? _ticker;
     // Wizard-first mode only (spec decision 2): the sign-in driver shutdown cancels and awaits
-    // before anything is disposed, and the window that owns dialogs while no main window exists.
-    // Both are cleared again by the handoff at the end of RunWizardModeAsync.
+    // before anything is disposed, the Import step whose in-flight run shutdown must also kill
+    // (spec §7 — closing the window never navigates through ImportStepViewModel.CanLeaveAsync), and
+    // the window that owns dialogs while no main window exists. All three are cleared again by the
+    // handoff at the end of RunWizardModeAsync.
     WizardAuthService? _wizardAuth;
+    ImportStepViewModel? _wizardImport;
     Window? _wizardWindow;
     bool _shutdownStarted;
     bool _shutdownConfirmed;
@@ -138,6 +141,7 @@ public partial class App : Application {
             // error window here would both lie and outlive the quit.
             _wizardWindow = null;
             _wizardAuth = null;
+            _wizardImport = null;
         } catch (Exception ex) {
             // BEFORE any await: a shutdown request can arrive while cleanup below is still
             // awaiting (or if the helper itself throws), and the deferred path reads this.
@@ -166,6 +170,7 @@ public partial class App : Application {
             _pause = null;
             _activity = null;
             _wizardAuth = null; // its attempt, if any, already settled through the wizard's own close path
+            _wizardImport = null; // same — any in-flight run already settled through the wizard's own close path
             _wizardWindow = null;
         }
     }
@@ -296,8 +301,9 @@ public partial class App : Application {
             WizardComposition.NewOperation,
             surface,
             ResolveCli: () => NewWizardCli(runner, cliPath, probe),
-            ResolveOps: () => new LocalControlOps(ResolveConsentFlipIdentity().DaemonName),
-            ResolveIdentity: ResolveConsentFlipIdentity,
+            ResolveOps: name => new LocalControlOps(name),
+            ResolveIdentity: ResolveWizardIdentity,
+            ResolveConsentFlipIdentity: ResolveConsentFlipIdentity,
             RunMutation: lane.RunAsync,
             Observation: new OneShotObservation(OneShotProbeTimeout),
             AppState: new AppStateStore(PathHelpers.ConfigPath("app-state.json")),
@@ -308,11 +314,12 @@ public partial class App : Application {
             CliPath: cliPath,
             ShimApplicable: shimApplicable,
             ShimTarget: shimTarget,
-            DefaultDaemonName: ResolveConsentFlipIdentity().DaemonName,
+            DefaultDaemonName: ResolveWizardIdentity()?.DaemonName,
             Time: TimeProvider.System,
             ShutdownToken: _shutdown.Token));
 
         _wizardAuth = graph.Auth;
+        _wizardImport = graph.Import;
         var window = ShowWizardWindow(desktop, graph.ViewModel);
         _wizardWindow = window;
 
@@ -324,9 +331,10 @@ public partial class App : Application {
 
         await WaitForWizardCloseAsync(graph.ViewModel, _shutdown.Token);
         var quiesced = await HandoffAfterWizardAsync(
-            graph.Auth, () => lane.QuiescedAsync(CancellationToken.None), QuiesceShutdownCap, channel);
+            graph.Auth, () => lane.QuiescedAsync(CancellationToken.None), QuiesceShutdownCap, channel, graph.Import);
 
         _wizardAuth = null;
+        _wizardImport = null;
         _wizardWindow = null;
         if (window.IsVisible) window.Close(); // shutdown ended the wait with the window still up
 
@@ -398,17 +406,21 @@ public partial class App : Application {
     }
 
     /// <summary>
-    /// The close boundary, in order (spec decision 2): end the sign-in and await its terminal
-    /// answer — pre-boundary that is <c>Cancelled</c> with nothing durable, past it the façade
-    /// still publishes and answers <c>Committed</c>, and the graph must not be built against a
-    /// half-written config either way — then wait the lane out under the existing cap, and only
-    /// then hand the outcome channel to the root consumer. False = the cap was reached with the
-    /// lane still holding a live action (spec §6a: proceed, but the graph must then close its
-    /// automatic actions rather than race the child that is still running).
+    /// The close boundary, in order (spec decision 2, hardened by spec §7): end the sign-in and
+    /// await its terminal answer — pre-boundary that is <c>Cancelled</c> with nothing durable, past
+    /// it the façade still publishes and answers <c>Committed</c>, and the graph must not be built
+    /// against a half-written config either way — kill and await any in-flight import next (closing
+    /// the window never navigates away from the Import step, so its own <c>CanLeaveAsync</c> never
+    /// fires), then wait the lane out under the existing cap, and only then hand the outcome channel
+    /// to the root consumer. False = the cap was reached with the lane still holding a live action
+    /// (spec §6a: proceed, but the graph must then close its automatic actions rather than race the
+    /// child that is still running).
     /// </summary>
     internal static async Task<bool> HandoffAfterWizardAsync(
-            WizardAuthService? auth, Func<Task> laneQuiescedAsync, TimeSpan cap, OutcomeChannel channel) {
+            WizardAuthService? auth, Func<Task> laneQuiescedAsync, TimeSpan cap, OutcomeChannel channel,
+            ImportStepViewModel? import = null) {
         await CancelAndAwaitAuthAsync(auth).ConfigureAwait(false);
+        if (import is not null) await import.CancelActiveRunAsync().ConfigureAwait(false);
         var quiesced = await AwaitQuiescedAsync(laneQuiescedAsync, cap).ConfigureAwait(false);
         channel.TransferConsumer();
 
@@ -612,6 +624,41 @@ public partial class App : Application {
         var server      = ServerIdentity.Canonicalize(profile?.ServerUrl) ?? profile?.ServerUrl ?? "";
         var daemonName  = DaemonNameResolver.Resolve([], profile?.Daemon?.Name);
         return (profileName, server, daemonName);
+    }
+
+    /// <summary>
+    /// A FRESH, env-aware identity resolution for the wizard's OWN daemon-facing operations (finding
+    /// 3) — the SAME precedence chain <see cref="OnboardingGate.EvaluateAsync"/> resolves through
+    /// (<see cref="ProfileResolver"/> over KCAP_URL/KCAP_PROFILE/the active profile), never the
+    /// startup-cached <see cref="AppConfig.ResolvedProfile"/>: a KCAP_PROFILE override set after
+    /// startup must be observed on every call, not just the first. Synchronous and side-effect-free
+    /// (unlike <see cref="AppConfig.ResolveActiveProfile"/>, this never touches
+    /// <see cref="AppConfig.ResolvedProfile"/>) — built from the same <see cref="ProfileResolver"/>
+    /// building block that method wraps around an async config load, over the same
+    /// <see cref="ConfigMutator.TryLoadPure"/> fail-closed read <see cref="ResolveConsentFlipIdentity"/>
+    /// uses (an unreadable config resolves to null here exactly like it resolves to the empty-string
+    /// sentinel there). Returns null — never an empty-string sentinel (finding 4) — when no profile
+    /// resolves or its server_url doesn't canonicalize, which is also what keeps a factory built from
+    /// this identity fail-closed: <see cref="WizardComposition.BuildGraph"/> only ever dials a socket
+    /// once this has already resolved non-null.
+    /// </summary>
+    internal static (string Profile, string Server, string DaemonName)? ResolveWizardIdentity() {
+        if (!ConfigMutator.TryLoadPure(AppConfig.GetConfigPath(), out var config)) return null;
+
+        var envUrl     = Environment.GetEnvironmentVariable("KCAP_URL");
+        var envProfile = Environment.GetEnvironmentVariable("KCAP_PROFILE");
+        var resolved = new ProfileResolver(
+            config, cliServerUrl: null, envUrl, envProfile,
+            repoConfig: null, repoRemoteUrls: [], repoPath: null).Resolve();
+
+        if (resolved.ProfileName is not { Length: > 0 } profileName) return null;
+
+        var canonicalServer = ServerIdentity.Canonicalize(resolved.ServerUrl);
+        if (string.IsNullOrEmpty(canonicalServer)) return null;
+
+        var daemonName = DaemonNameResolver.Resolve([], resolved.Profile?.Daemon?.Name);
+
+        return (profileName, canonicalServer, daemonName);
     }
 
     // Delegates to the ONE shared validator: must agree with OnboardingGate on what counts as a
@@ -946,7 +993,8 @@ public partial class App : Application {
         // spec §3.6 + decision 2: mutations are never abandoned and an in-flight sign-in is never left
         // half-published — both get a bounded chance to settle, while the UI is still up, before teardown.
         if (_wizardAuth is not null || _lifecycle is not null || _lane is not null)
-            await AwaitQuiescedAsync(() => QuiesceAppAsync(_wizardAuth, _lifecycle, _lane), QuiesceShutdownCap).ConfigureAwait(false);
+            await AwaitQuiescedAsync(() => QuiesceAppAsync(_wizardAuth, _wizardImport, _lifecycle, _lane), QuiesceShutdownCap)
+                .ConfigureAwait(false);
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
             // Prompt coordinator BEFORE the consent service (spec §5): the window and its
@@ -982,11 +1030,16 @@ public partial class App : Application {
     }
 
     // Shutdown's whole quiesce: the sign-in is CANCELLED (pre-boundary it ends now, past it the
-    // façade still answers Committed) while the lifecycle/lane waits stay pure waits — started
-    // first so all three settle concurrently under one cap.
+    // façade still answers Committed) — started first and joined at the very end, concurrently with
+    // the lifecycle/lane waits below, same as always. Any in-flight import is killed alongside it
+    // (spec §7 — same reason HandoffAfterWizardAsync does this: closing never navigates through the
+    // step's own CanLeaveAsync), but AWAITED before the lifecycle/lane quiesce begins, so a lane
+    // quiesce can never race a still-running import child.
     internal static async Task QuiesceAppAsync(
-            WizardAuthService? auth, DaemonLifecycleController? lifecycle, DaemonMutationLane? lane) {
+            WizardAuthService? auth, ImportStepViewModel? import,
+            DaemonLifecycleController? lifecycle, DaemonMutationLane? lane) {
         var authTerminal = CancelAndAwaitAuthAsync(auth);
+        if (import is not null) await import.CancelActiveRunAsync().ConfigureAwait(false);
         await QuiesceLifecycleAndLaneAsync(lifecycle, lane).ConfigureAwait(false);
         await authTerminal.ConfigureAwait(false);
     }

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -405,11 +405,7 @@ public partial class App : Application {
         }
     }
 
-    /// <summary>
-    /// The close boundary in order (spec decision 2 / §7): settle the sign-in, kill and await any
-    /// import, wait the lane out under the cap, then transfer the channel. False = §6a's post-cap
-    /// graph, whose automatic actions must stay closed around the child still running.
-    /// </summary>
+    /// <summary>Close boundary: settle sign-in, cancel any import, quiesce the lane under the cap, then transfer the channel.</summary>
     internal static async Task<bool> HandoffAfterWizardAsync(
             WizardAuthService? auth, Func<Task> laneQuiescedAsync, TimeSpan cap, OutcomeChannel channel,
             ImportStepViewModel? import = null) {
@@ -1012,15 +1008,7 @@ public partial class App : Application {
         }
     }
 
-    /// <summary>
-    /// Shutdown's whole quiesce, in two phases. First the wizard's own work, UNCAPPED (decision 2):
-    /// the sign-in is cancelled and its terminal answer awaited — pre-boundary that is immediate,
-    /// past it the façade still publishes and answers <c>Committed</c>, and a cap here would tear
-    /// that publication down — while any in-flight import is killed alongside it (spec §7: closing
-    /// never navigates through the step's own <c>CanLeaveAsync</c>) and joined before phase two, so
-    /// a lane quiesce can never race a still-running import child. Only then the lifecycle/lane
-    /// quiesce, under §6a's cap — the one wait with no other shutdown-token wiring.
-    /// </summary>
+    /// <summary>Quiesces shutdown in two phases: sign-in and import finish uncapped so an in-progress commit isn't torn down, then lifecycle/lane quiesce under the cap.</summary>
     internal static async Task QuiesceAppAsync(
             WizardAuthService? auth, ImportStepViewModel? import,
             DaemonLifecycleController? lifecycle, DaemonMutationLane? lane, TimeSpan cap) {

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -118,17 +118,26 @@ public partial class App : Application {
             _lane = lane;
 
             var gate = await ResolveAndEvaluateGateAsync(_shutdown.Token);
+            // A graph built while the lane still owns a live action must not also drive automatic
+            // ones (spec §6a) — only the wizard's own handoff can answer this with anything but true.
+            var laneQuiesced = true;
 
             // spec decision 2: an incomplete gate builds NO daemon graph at all — the wizard owns
             // the app until it closes, and the graph is then built against a FRESH resolution,
             // because the wizard is exactly what may have changed the answer.
             if (gate is GateResult.Incomplete) {
-                await RunWizardModeAsync(desktop, lane, channel, laneRunner, laneProbe);
+                laneQuiesced = await RunWizardModeAsync(desktop, lane, channel, laneRunner, laneProbe);
                 if (_shutdown.IsCancellationRequested) return; // quit during onboarding — nothing left to build
                 gate = await ResolveAndEvaluateGateAsync(_shutdown.Token);
             }
 
-            BuildDaemonGraph(desktop, lane, channel, gate);
+            BuildDaemonGraph(desktop, lane, channel, gate, laneQuiesced);
+        } catch (OperationCanceledException) when (_shutdown.IsCancellationRequested) {
+            // A quit landing mid-startup (gate evaluation, the wizard's PATH probe, the post-wizard
+            // re-resolve) is not a startup failure: the shutdown path already owns teardown, and an
+            // error window here would both lie and outlive the quit.
+            _wizardWindow = null;
+            _wizardAuth = null;
         } catch (Exception ex) {
             // BEFORE any await: a shutdown request can arrive while cleanup below is still
             // awaiting (or if the helper itself throws), and the deferred path reads this.
@@ -137,6 +146,9 @@ public partial class App : Application {
             // when the failure hit, no tray will ever exist to bring it back, so hide-on-close
             // must not intercept anything from here on — every close on this path is a real one.
             if (_coordinator is not null) _coordinator.QuitInProgress = true;
+            // No orphan wizard beside the error window: it is a dead shell once startup has failed,
+            // and its own close path (the handoff) is exactly what did not run.
+            if (_wizardWindow is { IsVisible: true } wizard) wizard.Close();
             Console.Error.WriteLine($"kcap app failed to start: {ex}");
             await HandleStartupFailureAsync(
                 desktop, ex, _service, _shutdown, [_tray, _trayVm, _promptCoordinator, _consent, _activity, _pause], _lifecycle, _lane);
@@ -158,27 +170,23 @@ public partial class App : Application {
         }
     }
 
-    // The ONE resolution a graph build stands on: the gate verdict and the daemon identity are read
-    // off the same AppConfig.ResolvedProfile, and the post-wizard build re-runs this rather than
-    // reusing a startup value the wizard may have invalidated.
-    internal static async Task<GateResult> ResolveAndEvaluateGateAsync(CancellationToken ct) {
-        await AppConfig.ResolveActiveProfile([]);
-        var resolvedProfile = AppConfig.ResolvedProfile;
-
-        return await EvaluateGateSafelyAsync(
-            token => OnboardingGate.EvaluateResolvedAsync(resolvedProfile?.ProfileName, resolvedProfile?.Profile, token),
-            ct);
-    }
+    // The ONE resolve+evaluate composition (OnboardingGate.EvaluateAsync), wrapped in the
+    // never-brick degrade: the gate verdict and the daemon identity are read off the same
+    // AppConfig.ResolvedProfile it sets, and the post-wizard build re-runs this rather than reusing
+    // a startup value the wizard may have invalidated.
+    internal static Task<GateResult> ResolveAndEvaluateGateAsync(CancellationToken ct) =>
+        EvaluateGateSafelyAsync(OnboardingGate.EvaluateAsync, ct);
 
     // The steady-state graph, over the resolution the gate was evaluated on (never a second resolve).
     void BuildDaemonGraph(
             IClassicDesktopStyleApplicationLifetime desktop, DaemonMutationLane lane, OutcomeChannel channel,
-            GateResult gate) {
+            GateResult gate, bool laneQuiesced) {
         var service = DaemonClientService.CreateResolved(lane.RunAsync);
 
-        // Incomplete after the wizard (abandoned, or sign-in skipped) is the carve-out arm: the
-        // graph is built with every lifecycle auto-action closed and the shim auto-offer suppressed.
-        var autoActionsPermanentlyClosed = AutoActionsPermanentlyClosed(gate);
+        // Incomplete after the wizard (abandoned, or sign-in skipped) is the carve-out arm, and so
+        // is a lane that outran the handoff cap: the graph comes up with every lifecycle
+        // auto-action closed and the shim auto-offer suppressed.
+        var autoActionsPermanentlyClosed = AutoActionsPermanentlyClosed(gate, laneQuiesced);
 
         // One LocalControlOps and one AppNotifier for the whole app: the tray menu and the
         // window rows share a single stop/open-in-web code path (spec §7) and a single
@@ -208,6 +216,9 @@ public partial class App : Application {
 
         consentFlip.Start();
         _consentFlip = consentFlip;
+
+        // Said once, here, because nothing else in the app would: the graph is up but deliberately degraded.
+        AnnounceUnquiescedLane(lifecycleSurface, laneQuiesced);
 
         // Composition-root outcome consumer: shares lifecycle's own surface/probe/CliVersion and the lane itself, so a Takeover accept re-mutates through the same gate.
         _ = ConsumeMutationOutcomesAsync(
@@ -266,14 +277,16 @@ public partial class App : Application {
 
     // Wizard-first mode (spec decision 2): no service, no tray, no lifecycle controller, no
     // coordinators — just the wizard, the app-lifetime lane, and the SAME outcome consumer over a
-    // wizard-local surface. Returns once the wizard has closed AND the channel has been handed on.
-    async Task RunWizardModeAsync(
+    // wizard-local surface. Returns once the wizard has closed AND the channel has been handed on;
+    // false means the lane outran the handoff cap and the graph must close its auto-actions.
+    async Task<bool> RunWizardModeAsync(
             IClassicDesktopStyleApplicationLifetime desktop, DaemonMutationLane lane, OutcomeChannel channel,
             IProcessRunner runner, ILoginShellProbe probe) {
         var cliPath = CliResolver.ResolvePath(Environment.GetEnvironmentVariable, File.Exists);
         // Same rule as the shim coordinator's: only a resolved ABSOLUTE path is linkable.
         var shimTarget = cliPath is not null && Path.IsPathRooted(cliPath) ? cliPath : null;
-        var kcapOnPath = await ProbeKcapOnPathSafelyAsync(probe, _shutdown.Token);
+        var shimApplicable = await ResolveShimApplicableAsync(
+            OperatingSystem.IsMacOS(), shimTarget, ct => probe.KcapOnPathAsync(ct), _shutdown.Token);
         var bridges = WizardComposition.BuildBridges(action => Dispatcher.UIThread.Post(action));
         var surface = new WizardLifecycleSurface(ConfirmLifecyclePromptAsync, action => Dispatcher.UIThread.Post(action));
 
@@ -292,7 +305,8 @@ public partial class App : Application {
             UrlOpener: new ShellUrlOpener(),
             Probe: probe,
             DetectionFeed: AgentsStepViewModel.BuildDetectionFeed,
-            ShimApplicable: ShimStepViewModel.ComputeApplicable(OperatingSystem.IsMacOS(), shimTarget, kcapOnPath),
+            CliPath: cliPath,
+            ShimApplicable: shimApplicable,
             ShimTarget: shimTarget,
             DefaultDaemonName: ResolveConsentFlipIdentity().DaemonName,
             Time: TimeProvider.System,
@@ -309,17 +323,35 @@ public partial class App : Application {
             channel, surface, lane.RunAsync, probe.TerminalPathAsync, () => null, _shutdown.Token);
 
         await WaitForWizardCloseAsync(graph.ViewModel, _shutdown.Token);
-        await HandoffAfterWizardAsync(graph.Auth, () => lane.QuiescedAsync(CancellationToken.None), QuiesceShutdownCap, channel);
+        var quiesced = await HandoffAfterWizardAsync(
+            graph.Auth, () => lane.QuiescedAsync(CancellationToken.None), QuiesceShutdownCap, channel);
 
         _wizardAuth = null;
         _wizardWindow = null;
         if (window.IsVisible) window.Close(); // shutdown ended the wait with the window still up
+
+        return quiesced;
     }
 
-    // A probe failure reads as unknown, never as "offer it anyway" — ComputeApplicable's own null rule.
-    static async Task<bool?> ProbeKcapOnPathSafelyAsync(ILoginShellProbe probe, CancellationToken ct) {
+    /// The shim step's applicability, without paying for an answer that cannot matter: the probe
+    /// costs a login-shell spawn, and on every non-macOS machine (and every machine with no
+    /// resolved absolute CLI) <see cref="ShimStepViewModel.ComputeApplicable"/> is already false.
+    internal static async Task<bool> ResolveShimApplicableAsync(
+            bool isMacOs, string? shimTarget, Func<CancellationToken, Task<bool?>> probeKcapOnPath, CancellationToken ct) {
+        if (!isMacOs || shimTarget is null) return false;
+
+        return ShimStepViewModel.ComputeApplicable(
+            isMacOs, shimTarget, await ProbeKcapOnPathSafelyAsync(probeKcapOnPath, ct).ConfigureAwait(true));
+    }
+
+    // A probe failure reads as unknown, never as "offer it anyway" — ComputeApplicable's own null
+    // rule. A cancellation matching the caller's token is a quit, not an unknown: it propagates, so
+    // no wizard window is built after the app has started shutting down (EvaluateGateSafelyAsync's rule).
+    static async Task<bool?> ProbeKcapOnPathSafelyAsync(Func<CancellationToken, Task<bool?>> probe, CancellationToken ct) {
         try {
-            return await probe.KcapOnPathAsync(ct).ConfigureAwait(true);
+            return await probe(ct).ConfigureAwait(true);
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            throw;
         } catch (Exception ex) {
             Console.Error.WriteLine($"kcap: PATH probe failed — skipping the command-line tool step: {ex.Message}");
             return null;
@@ -369,15 +401,18 @@ public partial class App : Application {
     /// The close boundary, in order (spec decision 2): end the sign-in and await its terminal
     /// answer — pre-boundary that is <c>Cancelled</c> with nothing durable, past it the façade
     /// still publishes and answers <c>Committed</c>, and the graph must not be built against a
-    /// half-written config either way — then wait the lane out under the existing cap (past it,
-    /// proceed: the lane still owns the live action and the carve-out arm surfaces it), and only
-    /// then hand the outcome channel to the root consumer.
+    /// half-written config either way — then wait the lane out under the existing cap, and only
+    /// then hand the outcome channel to the root consumer. False = the cap was reached with the
+    /// lane still holding a live action (spec §6a: proceed, but the graph must then close its
+    /// automatic actions rather than race the child that is still running).
     /// </summary>
-    internal static async Task HandoffAfterWizardAsync(
+    internal static async Task<bool> HandoffAfterWizardAsync(
             WizardAuthService? auth, Func<Task> laneQuiescedAsync, TimeSpan cap, OutcomeChannel channel) {
         await CancelAndAwaitAuthAsync(auth).ConfigureAwait(false);
-        await AwaitQuiescedAsync(laneQuiescedAsync, cap).ConfigureAwait(false);
+        var quiesced = await AwaitQuiescedAsync(laneQuiescedAsync, cap).ConfigureAwait(false);
         channel.TransferConsumer();
+
+        return quiesced;
     }
 
     // AuthAttempt.Result never faults (an operation that throws arrives as Failed), so this is a
@@ -502,11 +537,12 @@ public partial class App : Application {
 
     // The MainWindowCoordinator's window factory, split out of StartAsync so a test can drive
     // "build VM+window, assign, and Show()" against a fake service without needing a real
-    // daemon/profile (CreateDefaultAsync does real config I/O). This is also the actual bug fix:
-    // Avalonia's StartWithClassicDesktopLifetime calls
+    // daemon/profile (the profile resolution behind the graph does real config I/O). This is also
+    // the actual bug fix: Avalonia's StartWithClassicDesktopLifetime calls
     // ShowMainWindow() exactly ONCE, synchronously, right after Start — and at that moment
-    // desktop.MainWindow is still null, because CreateDefaultAsync genuinely awaits (config.json
-    // read). By the time this continuation resumes and assigns desktop.MainWindow, nothing else
+    // desktop.MainWindow is still null, because startup genuinely awaits (the config.json read
+    // behind the gate, and in wizard-first mode the whole wizard). By the time this
+    // continuation resumes and assigns desktop.MainWindow, nothing else
     // will ever call .Show() for us, so this method must call it explicitly. Show() on an
     // already-visible window is a no-op, so this stays correct even if a future edit changes the
     // timing such that ShowMainWindow() DOES still see a non-null MainWindow.
@@ -533,7 +569,7 @@ public partial class App : Application {
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
         var cliPath = CliResolver.ResolvePath(Environment.GetEnvironmentVariable, File.Exists);
         var runner  = new DaemonClientService.ProcessRunner();
-        var profile = AppConfig.ResolvedProfile; // already resolved by CreateDefaultAsync above
+        var profile = AppConfig.ResolvedProfile; // the ONE resolution the gate was evaluated on
         var probe   = new LoginShellProbe(runner, Environment.GetEnvironmentVariable);
         var canonicalServer = ServerIdentity.Canonicalize(profile?.ServerUrl);
         // Shared with the probe above (not re-resolved) — decision 7's PATH overlay on `install`
@@ -588,6 +624,20 @@ public partial class App : Application {
 
     // Decision 2's carve-out switch: Incomplete is the only gate outcome that closes auto-actions.
     internal static bool AutoActionsPermanentlyClosed(GateResult gate) => gate is GateResult.Incomplete;
+
+    // spec §6a's post-cap rule: a lane that outran the handoff cap still owns a live child, so the
+    // graph comes up degraded whatever the gate said — a second automatic mutation would race it.
+    internal static bool AutoActionsPermanentlyClosed(GateResult gate, bool laneQuiesced) =>
+        AutoActionsPermanentlyClosed(gate) || !laneQuiesced;
+
+    internal const string LaneStillBusyAttention =
+        "A daemon operation is still finishing — automatic actions are disabled.";
+
+    // The other half of the post-cap rule: closing auto-actions silently would leave a degraded app
+    // that never says so. Exactly one line, and only when the cap actually fired.
+    internal static void AnnounceUnquiescedLane(ILifecycleSurface surface, bool laneQuiesced) {
+        if (!laneQuiesced) surface.Attention(LaneStillBusyAttention);
+    }
 
     // A gate-evaluation exception must never brick startup — degrades to Incomplete (fail-safe: the app still launches, with auto-actions closed) instead of throwing.
     internal static async Task<GateResult> EvaluateGateSafelyAsync(
@@ -878,8 +928,9 @@ public partial class App : Application {
     //
     // 1. QuitInProgress is flagged on EVERY pass — including the confirmed one, which is why this
     //    runs before the guard below. A coordinator that only comes into existence BETWEEN the
-    //    passes (quit or an OS logout arriving while CreateDefaultAsync is still in flight, with
-    //    StartAsync's continuation then building the window during the deferred disposal's await)
+    //    passes (quit or an OS logout arriving while startup is still resolving — or still showing
+    //    the wizard — with StartAsync's continuation then building the window during the deferred
+    //    disposal's await)
     //    would otherwise still have hide-on-close armed when the second pass closes the windows:
     //    the window cancels its own close, DoShutdown aborts with windows still open, and every
     //    later quit early-returns on _shutdownConfirmed — an app that can only be force-quit.
@@ -951,9 +1002,13 @@ public partial class App : Application {
     // §3.6's cap: QuiescedAsync itself is unbounded (it just waits for the gate), so this is what
     // keeps a stuck internal mutation from hanging shutdown forever — DisposeAsync's own eventual
     // lifetime-cancel is still the backstop if the cap is reached. Static + delegate-shaped so a
-    // test can drive it without a live controller.
-    internal static async Task AwaitQuiescedAsync(Func<Task> quiescedAsync, TimeSpan cap) {
-        await Task.WhenAny(quiescedAsync(), Task.Delay(cap)).ConfigureAwait(false);
+    // test can drive it without a live controller. Returns which arm won: false = the cap fired
+    // with work still live, which the wizard handoff turns into a degraded (auto-actions closed)
+    // graph. A dead heat reads as false — never claim quiescence that wasn't observed.
+    internal static async Task<bool> AwaitQuiescedAsync(Func<Task> quiescedAsync, TimeSpan cap) {
+        var quiesced = quiescedAsync();
+
+        return await Task.WhenAny(quiesced, Task.Delay(cap)).ConfigureAwait(false) == quiesced;
     }
 
     // Split out of DisposeAndShutdownAsync so a test can pin the ordering with a recording list.

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -10,7 +10,9 @@ using Capacitor.App.Services;
 using Capacitor.App.Services.Mutation;
 using Capacitor.App.Services.Onboarding;
 using Capacitor.App.ViewModels;
+using Capacitor.App.ViewModels.Onboarding;
 using Capacitor.App.Views;
+using Capacitor.App.Views.Onboarding;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
@@ -66,6 +68,11 @@ public partial class App : Application {
     // subscriber above IS disposed. Held so the consent prompt and the activity feed share the
     // same 1 Hz heartbeat.
     UiTicker? _ticker;
+    // Wizard-first mode only (spec decision 2): the sign-in driver shutdown cancels and awaits
+    // before anything is disposed, and the window that owns dialogs while no main window exists.
+    // Both are cleared again by the handoff at the end of RunWizardModeAsync.
+    WizardAuthService? _wizardAuth;
+    Window? _wizardWindow;
     bool _shutdownStarted;
     bool _shutdownConfirmed;
     // 0 = normal shutdown. Set to 1 on a startup failure so the DEFERRED shutdown path (Cmd+Q /
@@ -110,98 +117,18 @@ public partial class App : Application {
                 TimeProvider.System);
             _lane = lane;
 
-            var service = await DaemonClientService.CreateDefaultAsync(lane.RunAsync);
+            var gate = await ResolveAndEvaluateGateAsync(_shutdown.Token);
 
-            // Reads the SAME AppConfig.ResolvedProfile CreateDefaultAsync already resolved — the gate verdict and the graph identity can never diverge on a concurrently-changing profile.
-            var resolvedProfile = AppConfig.ResolvedProfile;
-            var gate = await EvaluateGateSafelyAsync(
-                ct => OnboardingGate.EvaluateResolvedAsync(resolvedProfile?.ProfileName, resolvedProfile?.Profile, ct),
-                _shutdown.Token);
-            // Plan C replaces the Incomplete outcome below with wizard-first startup (spec decision 2).
-            var autoActionsPermanentlyClosed = AutoActionsPermanentlyClosed(gate);
+            // spec decision 2: an incomplete gate builds NO daemon graph at all — the wizard owns
+            // the app until it closes, and the graph is then built against a FRESH resolution,
+            // because the wizard is exactly what may have changed the answer.
+            if (gate is GateResult.Incomplete) {
+                await RunWizardModeAsync(desktop, lane, channel, laneRunner, laneProbe);
+                if (_shutdown.IsCancellationRequested) return; // quit during onboarding — nothing left to build
+                gate = await ResolveAndEvaluateGateAsync(_shutdown.Token);
+            }
 
-            // One LocalControlOps and one AppNotifier for the whole app: the tray menu and the
-            // window rows share a single stop/open-in-web code path (spec §7) and a single
-            // toast/stderr channel (spec §11). notifier is built here (not after service.Start()
-            // below) because PauseController/AgentActionService, constructed further down, need it.
-            var ops = new LocalControlOps(service.DaemonName);
-            var notifier = new AppNotifier();
-
-            // spec: BehaviorSubjects, not plain Subjects — MainWindowViewModel and
-            // TrayViewModel don't exist yet at this point in StartAsync (built further down), so a
-            // BehaviorSubject replays its latest value to whichever one subscribes later, meaning a
-            // Status/Attention call this early (the startup-phase reconciliation, e.g.) is never
-            // silently dropped for having no subscriber yet.
-            var lifecycleStatus    = new BehaviorSubject<string?>(null);
-            var lifecycleAttention = new BehaviorSubject<string?>(null);
-
-            // spec subscribe-before-pump: the controller's attach subscription must be live
-            // BEFORE service.Start() begins pumping, or the startup phase could miss the very
-            // first terminal outcome it hinges on (DaemonLifecycleController.Start's own comment).
-            var (lifecycle, shimOffer, consentFlip, lifecycleSurface, lifecycleProbe) = BuildLifecycleController(
-                service, ops, autoActionsPermanentlyClosed, lifecycleStatus.OnNext, lifecycleAttention.OnNext, lane.RunAsync);
-            lifecycle.Start();
-            _lifecycle = lifecycle;
-            // Subscribe-before-run doesn't matter here (Offerable replays); always started so manual install keeps working in Incomplete mode — autoOfferSuppressed skips only the dialog.
-            shimOffer.Start();
-            _shimOffer = shimOffer;
-
-            consentFlip.Start();
-            _consentFlip = consentFlip;
-
-            // Composition-root outcome consumer: shares lifecycle's own surface/probe/CliVersion and the lane itself, so a Takeover accept re-mutates through the same gate.
-            _ = ConsumeMutationOutcomesAsync(
-                channel, lifecycleSurface, lane.RunAsync, lifecycleProbe.TerminalPathAsync, () => lifecycle.CliVersion, _shutdown.Token);
-
-            service.Start();
-            _service = service;
-
-            var ticker = new UiTicker();
-            _ticker = ticker;
-            _pause = new PauseController(ops, notifier.Notify, _shutdown.Token);
-            // ConfirmForceStopAsync reads _coordinator at INVOCATION time (a captured field, not
-            // a captured value) — safe even though _coordinator is still null right here, because
-            // nothing can trigger a protected-kind stop before ShowMainWindow below assigns it.
-            var actions = new AgentActionService(ops, notifier, new ShellUrlOpener(), service.Snapshots, _shutdown.Token, ConfirmForceStopAsync);
-
-            // Constructed once here, like the ticker and consent service (spec §7): the prompt
-            // window factory below and MainWindowViewModel both need the SAME instance — the
-            // former to nudge it on every conclusive ack, the latter to render it.
-            var activity = new ActivityViewModel(
-                () => ConsentDecisionLogReader.ReadTail(service.DaemonName, 200),
-                () => ActivityStatKey(service.DaemonName), ticker);
-            _activity = activity;
-
-            // The prompt window is built per raise, never here: the coordinator owns its lifetime
-            // and each window gets its own ViewModel over the one shared service (spec §6).
-            var consent = new ConsentService(
-                service, ops, ticker, ct => ConsentSubscription.RunAsync(service.DaemonName, ct),
-                TimeProvider.System, _shutdown.Token);
-            _consent = consent;
-            _promptCoordinator = new ConsentPromptCoordinator(consent, () => new ConsentPromptWindow {
-                DataContext = new ConsentPromptViewModel(
-                    consent, notifier, ticker, TimeProvider.System, _shutdown.Token, activity.RequestRefresh),
-                Notifier = notifier,
-            });
-
-            _coordinator = new MainWindowCoordinator(
-                () => BuildAndShowMainWindow(service, actions, notifier, ticker, _shutdown.Token, activity, lifecycle.StartActionAsync, lifecycleStatus));
-            // A shutdown that started before this continuation resumed already ran its first
-            // pass against a null coordinator, so a window built now must never be
-            // close-protected (BeginShutdownPass's rule 1 is the general defense; this is the
-            // by-construction one, and it is why the window below cannot even briefly intercept).
-            _coordinator.QuitInProgress = _shutdownStarted;
-            _coordinator.ShowMainWindow();
-            desktop.MainWindow = _coordinator.Window;
-
-            // LAST, deliberately (spec §9): anything above throwing lands in the catch with no
-            // tray icon ever created, leaving the error window as the only surface.
-            _trayVm = new TrayViewModel(
-                service, _pause, actions, consent, openMainWindow: _coordinator.ShowMainWindow,
-                quit: () => desktop.TryShutdown(), openReviewPrompts: _promptCoordinator.ShowPromptWindow,
-                lifecycleAttention: lifecycleAttention, shimOfferable: shimOffer.Offerable,
-                installShim: shimOffer.RunManualInstallAsync);
-            _tray = new TrayIconManager(this, _trayVm);
+            BuildDaemonGraph(desktop, lane, channel, gate);
         } catch (Exception ex) {
             // BEFORE any await: a shutdown request can arrive while cleanup below is still
             // awaiting (or if the helper itself throws), and the deferred path reads this.
@@ -226,7 +153,252 @@ public partial class App : Application {
             _consent = null;
             _pause = null;
             _activity = null;
+            _wizardAuth = null; // its attempt, if any, already settled through the wizard's own close path
+            _wizardWindow = null;
         }
+    }
+
+    // The ONE resolution a graph build stands on: the gate verdict and the daemon identity are read
+    // off the same AppConfig.ResolvedProfile, and the post-wizard build re-runs this rather than
+    // reusing a startup value the wizard may have invalidated.
+    internal static async Task<GateResult> ResolveAndEvaluateGateAsync(CancellationToken ct) {
+        await AppConfig.ResolveActiveProfile([]);
+        var resolvedProfile = AppConfig.ResolvedProfile;
+
+        return await EvaluateGateSafelyAsync(
+            token => OnboardingGate.EvaluateResolvedAsync(resolvedProfile?.ProfileName, resolvedProfile?.Profile, token),
+            ct);
+    }
+
+    // The steady-state graph, over the resolution the gate was evaluated on (never a second resolve).
+    void BuildDaemonGraph(
+            IClassicDesktopStyleApplicationLifetime desktop, DaemonMutationLane lane, OutcomeChannel channel,
+            GateResult gate) {
+        var service = DaemonClientService.CreateResolved(lane.RunAsync);
+
+        // Incomplete after the wizard (abandoned, or sign-in skipped) is the carve-out arm: the
+        // graph is built with every lifecycle auto-action closed and the shim auto-offer suppressed.
+        var autoActionsPermanentlyClosed = AutoActionsPermanentlyClosed(gate);
+
+        // One LocalControlOps and one AppNotifier for the whole app: the tray menu and the
+        // window rows share a single stop/open-in-web code path (spec §7) and a single
+        // toast/stderr channel (spec §11). notifier is built here (not after service.Start()
+        // below) because PauseController/AgentActionService, constructed further down, need it.
+        var ops = new LocalControlOps(service.DaemonName);
+        var notifier = new AppNotifier();
+
+        // spec: BehaviorSubjects, not plain Subjects — MainWindowViewModel and
+        // TrayViewModel don't exist yet at this point in StartAsync (built further down), so a
+        // BehaviorSubject replays its latest value to whichever one subscribes later, meaning a
+        // Status/Attention call this early (the startup-phase reconciliation, e.g.) is never
+        // silently dropped for having no subscriber yet.
+        var lifecycleStatus    = new BehaviorSubject<string?>(null);
+        var lifecycleAttention = new BehaviorSubject<string?>(null);
+
+        // spec subscribe-before-pump: the controller's attach subscription must be live
+        // BEFORE service.Start() begins pumping, or the startup phase could miss the very
+        // first terminal outcome it hinges on (DaemonLifecycleController.Start's own comment).
+        var (lifecycle, shimOffer, consentFlip, lifecycleSurface, lifecycleProbe) = BuildLifecycleController(
+            service, ops, autoActionsPermanentlyClosed, lifecycleStatus.OnNext, lifecycleAttention.OnNext, lane.RunAsync);
+        lifecycle.Start();
+        _lifecycle = lifecycle;
+        // Subscribe-before-run doesn't matter here (Offerable replays); always started so manual install keeps working in Incomplete mode — autoOfferSuppressed skips only the dialog.
+        shimOffer.Start();
+        _shimOffer = shimOffer;
+
+        consentFlip.Start();
+        _consentFlip = consentFlip;
+
+        // Composition-root outcome consumer: shares lifecycle's own surface/probe/CliVersion and the lane itself, so a Takeover accept re-mutates through the same gate.
+        _ = ConsumeMutationOutcomesAsync(
+            channel, lifecycleSurface, lane.RunAsync, lifecycleProbe.TerminalPathAsync, () => lifecycle.CliVersion, _shutdown.Token);
+
+        service.Start();
+        _service = service;
+
+        var ticker = new UiTicker();
+        _ticker = ticker;
+        _pause = new PauseController(ops, notifier.Notify, _shutdown.Token);
+        // ConfirmForceStopAsync reads _coordinator at INVOCATION time (a captured field, not
+        // a captured value) — safe even though _coordinator is still null right here, because
+        // nothing can trigger a protected-kind stop before ShowMainWindow below assigns it.
+        var actions = new AgentActionService(ops, notifier, new ShellUrlOpener(), service.Snapshots, _shutdown.Token, ConfirmForceStopAsync);
+
+        // Constructed once here, like the ticker and consent service (spec §7): the prompt
+        // window factory below and MainWindowViewModel both need the SAME instance — the
+        // former to nudge it on every conclusive ack, the latter to render it.
+        var activity = new ActivityViewModel(
+            () => ConsentDecisionLogReader.ReadTail(service.DaemonName, 200),
+            () => ActivityStatKey(service.DaemonName), ticker);
+        _activity = activity;
+
+        // The prompt window is built per raise, never here: the coordinator owns its lifetime
+        // and each window gets its own ViewModel over the one shared service (spec §6).
+        var consent = new ConsentService(
+            service, ops, ticker, ct => ConsentSubscription.RunAsync(service.DaemonName, ct),
+            TimeProvider.System, _shutdown.Token);
+        _consent = consent;
+        _promptCoordinator = new ConsentPromptCoordinator(consent, () => new ConsentPromptWindow {
+            DataContext = new ConsentPromptViewModel(
+                consent, notifier, ticker, TimeProvider.System, _shutdown.Token, activity.RequestRefresh),
+            Notifier = notifier,
+        });
+
+        _coordinator = new MainWindowCoordinator(
+            () => BuildAndShowMainWindow(service, actions, notifier, ticker, _shutdown.Token, activity, lifecycle.StartActionAsync, lifecycleStatus));
+        // A shutdown that started before this continuation resumed already ran its first
+        // pass against a null coordinator, so a window built now must never be
+        // close-protected (BeginShutdownPass's rule 1 is the general defense; this is the
+        // by-construction one, and it is why the window below cannot even briefly intercept).
+        _coordinator.QuitInProgress = _shutdownStarted;
+        _coordinator.ShowMainWindow();
+        desktop.MainWindow = _coordinator.Window;
+
+        // LAST, deliberately (spec §9): anything above throwing lands in the catch with no
+        // tray icon ever created, leaving the error window as the only surface.
+        _trayVm = new TrayViewModel(
+            service, _pause, actions, consent, openMainWindow: _coordinator.ShowMainWindow,
+            quit: () => desktop.TryShutdown(), openReviewPrompts: _promptCoordinator.ShowPromptWindow,
+            lifecycleAttention: lifecycleAttention, shimOfferable: shimOffer.Offerable,
+            installShim: shimOffer.RunManualInstallAsync);
+        _tray = new TrayIconManager(this, _trayVm);
+    }
+
+    // Wizard-first mode (spec decision 2): no service, no tray, no lifecycle controller, no
+    // coordinators — just the wizard, the app-lifetime lane, and the SAME outcome consumer over a
+    // wizard-local surface. Returns once the wizard has closed AND the channel has been handed on.
+    async Task RunWizardModeAsync(
+            IClassicDesktopStyleApplicationLifetime desktop, DaemonMutationLane lane, OutcomeChannel channel,
+            IProcessRunner runner, ILoginShellProbe probe) {
+        var cliPath = CliResolver.ResolvePath(Environment.GetEnvironmentVariable, File.Exists);
+        // Same rule as the shim coordinator's: only a resolved ABSOLUTE path is linkable.
+        var shimTarget = cliPath is not null && Path.IsPathRooted(cliPath) ? cliPath : null;
+        var kcapOnPath = await ProbeKcapOnPathSafelyAsync(probe, _shutdown.Token);
+        var bridges = WizardComposition.BuildBridges(action => Dispatcher.UIThread.Post(action));
+        var surface = new WizardLifecycleSurface(ConfirmLifecyclePromptAsync, action => Dispatcher.UIThread.Post(action));
+
+        var graph = WizardComposition.BuildGraph(new WizardGraphOptions(
+            ConsentFlipClaims.Default(),
+            bridges,
+            WizardComposition.NewOperation,
+            surface,
+            ResolveCli: () => NewWizardCli(runner, cliPath, probe),
+            ResolveOps: () => new LocalControlOps(ResolveConsentFlipIdentity().DaemonName),
+            ResolveIdentity: ResolveConsentFlipIdentity,
+            RunMutation: lane.RunAsync,
+            Observation: new OneShotObservation(OneShotProbeTimeout),
+            AppState: new AppStateStore(PathHelpers.ConfigPath("app-state.json")),
+            ShimInstaller: new PathShimInstaller(runner, probe),
+            UrlOpener: new ShellUrlOpener(),
+            Probe: probe,
+            DetectionFeed: AgentsStepViewModel.BuildDetectionFeed,
+            ShimApplicable: ShimStepViewModel.ComputeApplicable(OperatingSystem.IsMacOS(), shimTarget, kcapOnPath),
+            ShimTarget: shimTarget,
+            DefaultDaemonName: ResolveConsentFlipIdentity().DaemonName,
+            Time: TimeProvider.System,
+            ShutdownToken: _shutdown.Token));
+
+        _wizardAuth = graph.Auth;
+        var window = ShowWizardWindow(desktop, graph.ViewModel);
+        _wizardWindow = window;
+
+        // The SAME consumer function, over the wizard's own surface: outcome presentation stays
+        // single-owner while no tray or main window exists. No CLI version to disclose here —
+        // wizard mode builds no lifecycle controller to have probed one.
+        _ = ConsumeMutationOutcomesAsync(
+            channel, surface, lane.RunAsync, probe.TerminalPathAsync, () => null, _shutdown.Token);
+
+        await WaitForWizardCloseAsync(graph.ViewModel, _shutdown.Token);
+        await HandoffAfterWizardAsync(graph.Auth, () => lane.QuiescedAsync(CancellationToken.None), QuiesceShutdownCap, channel);
+
+        _wizardAuth = null;
+        _wizardWindow = null;
+        if (window.IsVisible) window.Close(); // shutdown ended the wait with the window still up
+    }
+
+    // A probe failure reads as unknown, never as "offer it anyway" — ComputeApplicable's own null rule.
+    static async Task<bool?> ProbeKcapOnPathSafelyAsync(ILoginShellProbe probe, CancellationToken ct) {
+        try {
+            return await probe.KcapOnPathAsync(ct).ConfigureAwait(true);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: PATH probe failed — skipping the command-line tool step: {ex.Message}");
+            return null;
+        }
+    }
+
+    // Rebuilt per call (LateBoundKcapCli): the wizard writes the profile, server and daemon name
+    // while its steps run, so a binding pinned at composition time would query the wrong service.
+    static IKcapCli NewWizardCli(IProcessRunner runner, string? cliPath, ILoginShellProbe probe) {
+        var (profile, server, daemonName) = ResolveConsentFlipIdentity();
+
+        return new KcapCli(
+            runner, cliPath, daemonName, string.IsNullOrEmpty(profile) ? "default" : profile,
+            probe.TerminalPathAsync, canonicalServer: ServerIdentity.Canonicalize(server));
+    }
+
+    // ShutdownMode is deliberately untouched (OnExplicitShutdown, pinned in
+    // OnFrameworkInitializationCompleted): closing the wizard hands over to the normal graph,
+    // it never exits the app.
+    internal static OnboardingWindow ShowWizardWindow(
+            IClassicDesktopStyleApplicationLifetime desktop, OnboardingViewModel wizard) {
+        var window = new OnboardingWindow { DataContext = wizard };
+        desktop.MainWindow = window;
+        window.Show();
+
+        return window;
+    }
+
+    // One logical close (the Done step's finish and the window's own Closing both route through
+    // RequestClose, which is idempotent). Shutdown ends the wait too — a quit must never sit
+    // behind a window the user is no longer looking at.
+    internal static async Task WaitForWizardCloseAsync(OnboardingViewModel wizard, CancellationToken ct) {
+        var closed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnCloseRequested() => closed.TrySetResult();
+
+        wizard.CloseRequested += OnCloseRequested;
+        await using var registration = ct.Register(() => closed.TrySetResult());
+        try {
+            await closed.Task.ConfigureAwait(true);
+        } finally {
+            wizard.CloseRequested -= OnCloseRequested;
+        }
+    }
+
+    /// <summary>
+    /// The close boundary, in order (spec decision 2): end the sign-in and await its terminal
+    /// answer — pre-boundary that is <c>Cancelled</c> with nothing durable, past it the façade
+    /// still publishes and answers <c>Committed</c>, and the graph must not be built against a
+    /// half-written config either way — then wait the lane out under the existing cap (past it,
+    /// proceed: the lane still owns the live action and the carve-out arm surfaces it), and only
+    /// then hand the outcome channel to the root consumer.
+    /// </summary>
+    internal static async Task HandoffAfterWizardAsync(
+            WizardAuthService? auth, Func<Task> laneQuiescedAsync, TimeSpan cap, OutcomeChannel channel) {
+        await CancelAndAwaitAuthAsync(auth).ConfigureAwait(false);
+        await AwaitQuiescedAsync(laneQuiescedAsync, cap).ConfigureAwait(false);
+        channel.TransferConsumer();
+    }
+
+    // AuthAttempt.Result never faults (an operation that throws arrives as Failed), so this is a
+    // pattern-match, not a try/catch: only a failure has anything left to say at this point.
+    internal static async Task<AuthResult?> CancelAndAwaitAuthAsync(WizardAuthService? auth) {
+        if (auth?.Current is not { } attempt) return null;
+
+        attempt.Cancel();
+        var result = await attempt.Result.ConfigureAwait(false);
+
+        switch (result) {
+            case AuthResult.Failed failed:
+                Console.Error.WriteLine($"kcap: onboarding sign-in ended with a failure: {failed.Message}");
+                break;
+            case AuthResult.Committed or AuthResult.Cancelled or AuthResult.Retarget:
+                // Committed is already durable and the fresh resolution below reads it; the other
+                // two wrote nothing. Nothing to surface either way.
+                break;
+        }
+
+        return result;
     }
 
     // Split out of the catch so a test can drive "dispose-then-show-error" against a real
@@ -547,9 +719,15 @@ public partial class App : Application {
     };
 
     Task<bool> ConfirmLifecyclePromptAsync(LifecyclePrompt prompt, CancellationToken ct) =>
-        Dispatcher.UIThread.InvokeAsync(() => ShowLifecyclePromptDialogAsync(prompt, ct));
+        Dispatcher.UIThread.InvokeAsync(() => ShowLifecyclePromptDialogAsync(DialogOwner(), prompt, ct));
 
-    Task<bool> ShowLifecyclePromptDialogAsync(LifecyclePrompt prompt, CancellationToken ct) {
+    // The wizard owns dialogs while wizard-first mode is up — no main window exists yet.
+    Window? DialogOwner() =>
+        _wizardWindow is { IsVisible: true } wizard ? wizard
+        : _coordinator?.Window is { IsVisible: true } main ? main
+        : null;
+
+    internal static Task<bool> ShowLifecyclePromptDialogAsync(Window? owner, LifecyclePrompt prompt, CancellationToken ct) {
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var dialog = new LifecyclePromptWindow { DataContext = new LifecyclePromptViewModel(prompt, tcs) };
         // Closing via the titlebar/Esc without Accept/Decline also resolves false —
@@ -558,7 +736,7 @@ public partial class App : Application {
         dialog.Closed += (_, _) => tcs.TrySetResult(false);
         WireDialogCancellation(dialog, tcs, ct);
 
-        if (_coordinator?.Window is { IsVisible: true } owner) {
+        if (owner is not null) {
             dialog.Show(owner);
         } else {
             dialog.Show();
@@ -621,7 +799,7 @@ public partial class App : Application {
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var dialog = BuildConfirmForceStopWindow(label, tcs);
 
-        if (_coordinator?.Window is { IsVisible: true } owner) {
+        if (DialogOwner() is { } owner) {
             dialog.Show(owner);
         } else {
             dialog.Show();
@@ -714,9 +892,10 @@ public partial class App : Application {
     }
 
     async Task DisposeAndShutdownAsync() {
-        // spec §3.6: mutations are never abandoned — give an in-flight lifecycle or lane mutation a bounded chance to finish naturally, while the UI is still up, before tearing anything down.
-        if (_lifecycle is not null || _lane is not null)
-            await AwaitQuiescedAsync(() => QuiesceLifecycleAndLaneAsync(_lifecycle, _lane), QuiesceShutdownCap).ConfigureAwait(false);
+        // spec §3.6 + decision 2: mutations are never abandoned and an in-flight sign-in is never left
+        // half-published — both get a bounded chance to settle, while the UI is still up, before teardown.
+        if (_wizardAuth is not null || _lifecycle is not null || _lane is not null)
+            await AwaitQuiescedAsync(() => QuiesceAppAsync(_wizardAuth, _lifecycle, _lane), QuiesceShutdownCap).ConfigureAwait(false);
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
             // Prompt coordinator BEFORE the consent service (spec §5): the window and its
@@ -749,6 +928,16 @@ public partial class App : Application {
                 Console.Error.WriteLine($"kcap app failed to dispose the daemon mutation lane during shutdown: {ex}");
             }
         }
+    }
+
+    // Shutdown's whole quiesce: the sign-in is CANCELLED (pre-boundary it ends now, past it the
+    // façade still answers Committed) while the lifecycle/lane waits stay pure waits — started
+    // first so all three settle concurrently under one cap.
+    internal static async Task QuiesceAppAsync(
+            WizardAuthService? auth, DaemonLifecycleController? lifecycle, DaemonMutationLane? lane) {
+        var authTerminal = CancelAndAwaitAuthAsync(auth);
+        await QuiesceLifecycleAndLaneAsync(lifecycle, lane).ConfigureAwait(false);
+        await authTerminal.ConfigureAwait(false);
     }
 
     // Composes the controller's QuiescedAsync with the lane's (covers main-window Start/Retry too); CancellationToken.None — the bound is AwaitQuiescedAsync's own race against Task.Delay(cap).

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -406,15 +406,9 @@ public partial class App : Application {
     }
 
     /// <summary>
-    /// The close boundary, in order (spec decision 2, hardened by spec §7): end the sign-in and
-    /// await its terminal answer — pre-boundary that is <c>Cancelled</c> with nothing durable, past
-    /// it the façade still publishes and answers <c>Committed</c>, and the graph must not be built
-    /// against a half-written config either way — kill and await any in-flight import next (closing
-    /// the window never navigates away from the Import step, so its own <c>CanLeaveAsync</c> never
-    /// fires), then wait the lane out under the existing cap, and only then hand the outcome channel
-    /// to the root consumer. False = the cap was reached with the lane still holding a live action
-    /// (spec §6a: proceed, but the graph must then close its automatic actions rather than race the
-    /// child that is still running).
+    /// The close boundary in order (spec decision 2 / §7): settle the sign-in, kill and await any
+    /// import, wait the lane out under the cap, then transfer the channel. False = §6a's post-cap
+    /// graph, whose automatic actions must stay closed around the child still running.
     /// </summary>
     internal static async Task<bool> HandoffAfterWizardAsync(
             WizardAuthService? auth, Func<Task> laneQuiescedAsync, TimeSpan cap, OutcomeChannel channel,
@@ -627,20 +621,10 @@ public partial class App : Application {
     }
 
     /// <summary>
-    /// A FRESH, env-aware identity resolution for the wizard's OWN daemon-facing operations (finding
-    /// 3) — the SAME precedence chain <see cref="OnboardingGate.EvaluateAsync"/> resolves through
-    /// (<see cref="ProfileResolver"/> over KCAP_URL/KCAP_PROFILE/the active profile), never the
-    /// startup-cached <see cref="AppConfig.ResolvedProfile"/>: a KCAP_PROFILE override set after
-    /// startup must be observed on every call, not just the first. Synchronous and side-effect-free
-    /// (unlike <see cref="AppConfig.ResolveActiveProfile"/>, this never touches
-    /// <see cref="AppConfig.ResolvedProfile"/>) — built from the same <see cref="ProfileResolver"/>
-    /// building block that method wraps around an async config load, over the same
-    /// <see cref="ConfigMutator.TryLoadPure"/> fail-closed read <see cref="ResolveConsentFlipIdentity"/>
-    /// uses (an unreadable config resolves to null here exactly like it resolves to the empty-string
-    /// sentinel there). Returns null — never an empty-string sentinel (finding 4) — when no profile
-    /// resolves or its server_url doesn't canonicalize, which is also what keeps a factory built from
-    /// this identity fail-closed: <see cref="WizardComposition.BuildGraph"/> only ever dials a socket
-    /// once this has already resolved non-null.
+    /// A FRESH, env-aware identity for the wizard's own daemon-facing calls: the same
+    /// <see cref="ProfileResolver"/> precedence <see cref="OnboardingGate.EvaluateAsync"/> uses, never
+    /// the startup-cached <see cref="AppConfig.ResolvedProfile"/>, and side-effect-free. Null — never
+    /// an empty-string sentinel — when nothing resolves, which is what keeps its factories fail-closed.
     /// </summary>
     internal static (string Profile, string Server, string DaemonName)? ResolveWizardIdentity() {
         if (!ConfigMutator.TryLoadPure(AppConfig.GetConfigPath(), out var config)) return null;
@@ -990,11 +974,10 @@ public partial class App : Application {
     }
 
     async Task DisposeAndShutdownAsync() {
-        // spec §3.6 + decision 2: mutations are never abandoned and an in-flight sign-in is never left
-        // half-published — both get a bounded chance to settle, while the UI is still up, before teardown.
-        if (_wizardAuth is not null || _lifecycle is not null || _lane is not null)
-            await AwaitQuiescedAsync(() => QuiesceAppAsync(_wizardAuth, _wizardImport, _lifecycle, _lane), QuiesceShutdownCap)
-                .ConfigureAwait(false);
+        // spec §3.6 + decision 2: an in-flight sign-in always settles, mutations get a bounded chance
+        // to — both while the UI is still up, before teardown.
+        if (_wizardAuth is not null || _wizardImport is not null || _lifecycle is not null || _lane is not null)
+            await QuiesceAppAsync(_wizardAuth, _wizardImport, _lifecycle, _lane, QuiesceShutdownCap).ConfigureAwait(false);
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
             // Prompt coordinator BEFORE the consent service (spec §5): the window and its
@@ -1029,19 +1012,22 @@ public partial class App : Application {
         }
     }
 
-    // Shutdown's whole quiesce: the sign-in is CANCELLED (pre-boundary it ends now, past it the
-    // façade still answers Committed) — started first and joined at the very end, concurrently with
-    // the lifecycle/lane waits below, same as always. Any in-flight import is killed alongside it
-    // (spec §7 — same reason HandoffAfterWizardAsync does this: closing never navigates through the
-    // step's own CanLeaveAsync), but AWAITED before the lifecycle/lane quiesce begins, so a lane
-    // quiesce can never race a still-running import child.
+    /// <summary>
+    /// Shutdown's whole quiesce, in two phases. First the wizard's own work, UNCAPPED (decision 2):
+    /// the sign-in is cancelled and its terminal answer awaited — pre-boundary that is immediate,
+    /// past it the façade still publishes and answers <c>Committed</c>, and a cap here would tear
+    /// that publication down — while any in-flight import is killed alongside it (spec §7: closing
+    /// never navigates through the step's own <c>CanLeaveAsync</c>) and joined before phase two, so
+    /// a lane quiesce can never race a still-running import child. Only then the lifecycle/lane
+    /// quiesce, under §6a's cap — the one wait with no other shutdown-token wiring.
+    /// </summary>
     internal static async Task QuiesceAppAsync(
             WizardAuthService? auth, ImportStepViewModel? import,
-            DaemonLifecycleController? lifecycle, DaemonMutationLane? lane) {
+            DaemonLifecycleController? lifecycle, DaemonMutationLane? lane, TimeSpan cap) {
         var authTerminal = CancelAndAwaitAuthAsync(auth);
         if (import is not null) await import.CancelActiveRunAsync().ConfigureAwait(false);
-        await QuiesceLifecycleAndLaneAsync(lifecycle, lane).ConfigureAwait(false);
         await authTerminal.ConfigureAwait(false);
+        await AwaitQuiescedAsync(() => QuiesceLifecycleAndLaneAsync(lifecycle, lane), cap).ConfigureAwait(false);
     }
 
     // Composes the controller's QuiescedAsync with the lane's (covers main-window Start/Retry too); CancellationToken.None — the bound is AwaitQuiescedAsync's own race against Task.Delay(cap).

--- a/src/Capacitor.App/Services/CliResolver.cs
+++ b/src/Capacitor.App/Services/CliResolver.cs
@@ -5,8 +5,8 @@ namespace Capacitor.App.Services;
 public sealed record CliInfo(string? Path, string? Version);
 
 /// Where the app finds `kcap` to shell out to (spec §3.1, decision 1: everything through the
-/// CLI). Pure given its env/filesystem seams, so DaemonClientService.CreateDefaultAsync and every
-/// later lifecycle feature resolve through the same logic.
+/// CLI). Pure given its env/filesystem seams, so the lifecycle graph, the wizard and every later
+/// feature resolve through the same logic.
 public static class CliResolver {
     /// KCAP_APP_CLI_PATH (dev seam, app-shell design decision 6) → *(future: bundle-relative
     /// path arm lands here)* → "kcap" on PATH.

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -281,10 +281,10 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
                 }
             }
 
-            // Line-buffered per stream — no cross-stream ordering promise.
+            // Line-buffered per stream — no cross-stream ordering promise; drains to EOF even under kill.
             async Task PumpAsync(TextReader reader, ProcessStreamKind kind) {
                 string? line;
-                while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
+                while ((line = await reader.ReadLineAsync(CancellationToken.None).ConfigureAwait(false)) is not null)
                     Record(new StreamedLine(kind, line));
             }
 

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -300,8 +300,10 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
                 if (ct.IsCancellationRequested) {
                     // Streaming always kills the tree on cancellation, ignoring RunOptions.CancelMode.
                     await KillAndAwaitAsync(process).ConfigureAwait(false);
-                    Observe(stdoutTask);
-                    Observe(stderrTask);
+                    // Awaited, not fire-and-forget: the pumps end at EOF once the tree is killed
+                    // (same as the timeout arm below) — a fire-and-forget Observe let a callback
+                    // fire AFTER this method had already thrown OCE, racing caller cleanup.
+                    await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
                     throw;
                 }
 

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -150,6 +150,15 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
     public static async Task<DaemonClientService> CreateDefaultAsync(
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
         await AppConfig.ResolveActiveProfile([]);
+
+        return CreateResolved(runMutation);
+    }
+
+    /// The same construction over the profile the caller ALREADY resolved: the app resolves once
+    /// per graph build (for the onboarding gate) and builds from that same resolution, so the gate
+    /// verdict and the daemon identity can never diverge on a concurrently-changing profile.
+    public static DaemonClientService CreateResolved(
+            Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
         var name = DaemonNameResolver.Resolve([], AppConfig.ResolvedProfile?.Profile?.Daemon?.Name);
 
         return new DaemonClientService(

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -143,20 +143,15 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
         _                                            => new(false, outcome.GetType().Name),
     };
 
+    /// <summary>
     /// Resolves the daemon name ONCE via the same chain DaemonCommands.ResolveName uses, so the
     /// watched daemon and the started daemon can never diverge (spec §5). `runMutation` is the
     /// app-lifetime DaemonMutationLane's RunAsync, injected by the composition root so this
-    /// factory never spawns a process of its own.
-    public static async Task<DaemonClientService> CreateDefaultAsync(
-            Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
-        await AppConfig.ResolveActiveProfile([]);
-
-        return CreateResolved(runMutation);
-    }
-
-    /// The same construction over the profile the caller ALREADY resolved: the app resolves once
-    /// per graph build (for the onboarding gate) and builds from that same resolution, so the gate
-    /// verdict and the daemon identity can never diverge on a concurrently-changing profile.
+    /// factory never spawns a process of its own. Built over the profile the caller ALREADY
+    /// resolved: the app resolves once per graph build (evaluating the onboarding gate) and builds
+    /// from that same resolution, so the gate verdict and the daemon identity can never diverge on
+    /// a concurrently-changing profile.
+    /// </summary>
     public static DaemonClientService CreateResolved(
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) {
         var name = DaemonNameResolver.Resolve([], AppConfig.ResolvedProfile?.Profile?.Daemon?.Name);
@@ -170,8 +165,8 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
     /// CURRENTLY resolved profile/server (re-read on every call, never captured once — a profile
     /// resolved after this service was constructed must still be honored) and hands it to
     /// `runMutation`; a caller that cannot bind a canonical server never reaches it (binding
-    /// ruling 1). Extracted from CreateDefaultAsync — whose own AppConfig.ResolveActiveProfile
-    /// call touches real config I/O — so this request-building logic stays unit-testable on its own.
+    /// ruling 1). Extracted from CreateResolved — whose daemon-name resolution reads real config —
+    /// so this request-building logic stays unit-testable on its own.
     internal static Func<CancellationToken, Task<MutationOutcome>> BuildStartDaemon(
             string daemonName, Func<ResolvedProfile?> resolveProfile,
             Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation) =>

--- a/src/Capacitor.App/Services/DaemonClientService.cs
+++ b/src/Capacitor.App/Services/DaemonClientService.cs
@@ -249,6 +249,67 @@ public sealed class DaemonClientService : IDaemonClientService, IAsyncDisposable
             return new ProcessResult(process.ExitCode, stdoutTask.Result, stderrTask.Result, TimedOut: false);
         }
 
+        const int TailLimit = 500;
+
+        public async Task<StreamingResult> RunStreamingAsync(string fileName, string[] args, RunOptions options,
+                Action<StreamedLine> onLine, CancellationToken ct) {
+            var psi = new ProcessStartInfo(fileName) {
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true,
+                UseShellExecute        = false,
+            };
+            foreach (var a in args) psi.ArgumentList.Add(a);
+            if (options.EnvOverlay is not null)
+                foreach (var (key, value) in options.EnvOverlay) psi.Environment[key] = value;
+
+            using var process = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+
+            var tailLock = new object();
+            var tail = new Queue<StreamedLine>(TailLimit + 1);
+
+            void Record(StreamedLine line) {
+                try { onLine(line); }
+                catch (Exception ex) { Console.Error.WriteLine($"kcap: streaming callback threw for '{fileName}': {ex}"); }
+
+                lock (tailLock) {
+                    tail.Enqueue(line);
+                    if (tail.Count > TailLimit) tail.Dequeue();
+                }
+            }
+
+            // Line-buffered per stream — no cross-stream ordering promise.
+            async Task PumpAsync(TextReader reader, ProcessStreamKind kind) {
+                string? line;
+                while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
+                    Record(new StreamedLine(kind, line));
+            }
+
+            var stdoutTask = PumpAsync(process.StandardOutput, ProcessStreamKind.Stdout);
+            var stderrTask = PumpAsync(process.StandardError, ProcessStreamKind.Stderr);
+
+            using var timeoutCts = options.Timeout is { } timeout ? new CancellationTokenSource(timeout) : null;
+            using var waitCts = timeoutCts is null ? null : CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+
+            try {
+                await process.WaitForExitAsync(waitCts?.Token ?? ct).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+                if (ct.IsCancellationRequested) {
+                    // Streaming always kills the tree on cancellation, ignoring RunOptions.CancelMode.
+                    await KillAndAwaitAsync(process).ConfigureAwait(false);
+                    Observe(stdoutTask);
+                    Observe(stderrTask);
+                    throw;
+                }
+
+                await KillAndAwaitAsync(process, options.TimeoutKill == TimeoutKillScope.Tree).ConfigureAwait(false);
+                await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+                lock (tailLock) return new StreamingResult(process.ExitCode, TimedOut: true, tail.ToArray());
+            }
+
+            await Task.WhenAll(stdoutTask, stderrTask).ConfigureAwait(false);
+            lock (tailLock) return new StreamingResult(process.ExitCode, TimedOut: false, tail.ToArray());
+        }
+
         static async Task KillAndAwaitAsync(Process process, bool entireProcessTree = true) {
             try { process.Kill(entireProcessTree); }
             catch (InvalidOperationException) { /* already exited */ }

--- a/src/Capacitor.App/Services/ILifecycleSurface.cs
+++ b/src/Capacitor.App/Services/ILifecycleSurface.cs
@@ -24,4 +24,5 @@ public sealed record LifecyclePrompt(
     public const string KindTakeover      = "takeover";
     public const string KindRepair        = "repair"; // Task 21
     public const string KindShim          = "shim";   // Task 24
+    public const string KindQuarantine    = "quarantine"; // Task 10
 }

--- a/src/Capacitor.App/Services/ILifecycleSurface.cs
+++ b/src/Capacitor.App/Services/ILifecycleSurface.cs
@@ -1,7 +1,7 @@
 namespace Capacitor.App.Services;
 
-/// Everything the controller shows a human (spec §4/§6). The Avalonia implementation (Task
-/// 22/23) renders dialogs/status lines; tests fake it.
+/// Everything the controller shows a human (spec §4/§6). The Avalonia implementation
+/// renders dialogs/status lines; tests fake it.
 public interface ILifecycleSurface {
     /// Honest one-liners — the message lane (e.g. degraded-but-owned, coded-failure surfaces).
     void Status(string message);
@@ -22,7 +22,7 @@ public sealed record LifecyclePrompt(
     string Kind, string? DaemonVersion, string? CliVersion, bool PathDegraded, string Disclosure) {
     public const string KindRestartUpdate = "restart-update";
     public const string KindTakeover      = "takeover";
-    public const string KindRepair        = "repair"; // Task 21
-    public const string KindShim          = "shim";   // Task 24
-    public const string KindQuarantine    = "quarantine"; // Task 10
+    public const string KindRepair        = "repair";
+    public const string KindShim          = "shim";
+    public const string KindQuarantine    = "quarantine";
 }

--- a/src/Capacitor.App/Services/IProcessRunner.cs
+++ b/src/Capacitor.App/Services/IProcessRunner.cs
@@ -21,8 +21,19 @@ public sealed record RunOptions(
     CancelMode CancelMode = CancelMode.AbandonWait,
     TimeoutKillScope TimeoutKill = TimeoutKillScope.Tree);
 
+public enum ProcessStreamKind { Stdout, Stderr }
+
+public sealed record StreamedLine(ProcessStreamKind Kind, string Text);
+
+/// No full Stdout/Stderr captures by design — Tail is only a bounded trailing window.
+public sealed record StreamingResult(int ExitCode, bool TimedOut, IReadOnlyList<StreamedLine> Tail);
+
 /// Seam over process spawning so StartDaemonAsync is testable without touching a real CLI
 /// binary. The production implementation wraps System.Diagnostics.Process.
 public interface IProcessRunner {
     Task<ProcessResult> RunAsync(string fileName, string[] args, RunOptions options, CancellationToken ct);
+
+    /// Cancellation always kills the tree and awaits exit first — unlike RunAsync, ignores RunOptions.CancelMode.
+    Task<StreamingResult> RunStreamingAsync(string fileName, string[] args, RunOptions options,
+        Action<StreamedLine> onLine, CancellationToken ct);
 }

--- a/src/Capacitor.App/Services/KcapCli.cs
+++ b/src/Capacitor.App/Services/KcapCli.cs
@@ -26,6 +26,10 @@ public static class ServiceStateClassifier {
     };
 }
 
+public enum ImportScopeChoice { Everything, Org, Repo }
+
+public sealed record ImportRequest(ImportScopeChoice Scope, string? OrgOrRepo, IReadOnlyList<string> VendorFlags);
+
 /// Typed facade over every CLI call the app shells out to (spec §3.1/§3.6, decision 1:
 /// everything through the CLI). Consumed by the lifecycle controller and faked in tests behind
 /// IProcessRunner.
@@ -47,6 +51,13 @@ public interface IKcapCli {
     /// `daemon start -d --name <name>`, bounded + ProcessOnly-kill, stamped with a boot-attempt id
     /// for the daemon's own boot-carrier correlation — the lane always mints a fresh one per action.
     Task<ProcessResult> DetachedStartAsync(string bootAttemptId, CancellationToken ct);
+
+    /// `plugin install` (+ vendorFlag, when non-null); null = the flagless Claude default.
+    Task<ProcessResult> PluginInstallAsync(string? vendorFlag, CancellationToken ct);
+
+    /// `import` with scope/vendor flags, streamed live via onLine — unbounded internal timeout
+    /// (imports are long; ct cancellation is the only bound).
+    Task<StreamingResult> ImportAsync(ImportRequest request, Action<StreamedLine> onLine, CancellationToken ct);
 }
 
 public sealed class KcapCli : IKcapCli {
@@ -154,6 +165,35 @@ public sealed class KcapCli : IKcapCli {
                     EnvOverlay: env, Timeout: DetachedStartTimeout,
                     CancelMode: CancelMode.AbandonWait, TimeoutKill: TimeoutKillScope.ProcessOnly),
                 ct);
+    }
+
+    // Neither this nor ImportAsync overlays MutationEnv — non-daemon shelling keeps lenient
+    // classification (spec §4); the vendor flag itself is the caller's exclusive-flag choice.
+    public Task<ProcessResult> PluginInstallAsync(string? vendorFlag, CancellationToken ct) {
+        if (CliPath is not { } cliPath) return NoCliResult();
+
+        List<string> args = ["plugin", "install"];
+        if (vendorFlag is not null) args.Add(vendorFlag);
+
+        return Run(cliPath, args.ToArray(), new RunOptions(EnvOverlay: Env(), Timeout: MutationTimeout), ct);
+    }
+
+    public Task<StreamingResult> ImportAsync(ImportRequest request, Action<StreamedLine> onLine, CancellationToken ct) {
+        if (CliPath is not { } cliPath)
+            return Task.FromResult(new StreamingResult(-1, false, [new StreamedLine(ProcessStreamKind.Stderr, "kcap CLI not found")]));
+
+        List<string> args = ["import"];
+        args.Add(request.Scope switch {
+            ImportScopeChoice.Everything => "--all",
+            ImportScopeChoice.Org        => "--org",
+            ImportScopeChoice.Repo       => "--repo",
+            _                            => throw new ArgumentOutOfRangeException(nameof(request)),
+        });
+        if (request.Scope != ImportScopeChoice.Everything) args.Add(request.OrgOrRepo!);
+        args.Add("--yes");
+        args.AddRange(request.VendorFlags);
+
+        return _runner.RunStreamingAsync(cliPath, args.ToArray(), new RunOptions(EnvOverlay: Env()), onLine, ct);
     }
 
     // Deterministic exit 127 ("command not found") rather than throwing on a null CliPath — a

--- a/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
+++ b/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
@@ -126,6 +126,10 @@ public sealed class ConsentFlipCoordinator(
 
     /// Persists the ack so a later launch never re-surfaces this quarantine — called only from
     /// SurfaceQuarantineOnceAsync on an explicit true from TryConfirmAsync.
-    public Task<bool> AckQuarantineAsync() =>
+    public Task<bool> AckQuarantineAsync() => AckQuarantineAsync(appState);
+
+    /// The one ack mutation, shared with the wizard's Sign-in step — which surfaces the same
+    /// disclosure while no coordinator exists (decision 2).
+    internal static Task<bool> AckQuarantineAsync(IAppStateStore appState) =>
         appState.UpdateAsync(s => s.ConsentQuarantineAcked ? s : s with { ConsentQuarantineAcked = true });
 }

--- a/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
+++ b/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
@@ -98,6 +98,10 @@ public sealed class ConsentFlipCoordinator(
         await Task.Run(() => claims.TryConsume(claim, ResolveCanonical, identity.DaemonName), lifetime).ConfigureAwait(false);
     }
 
+    static string QuarantineDisclosure(string preservedPath) =>
+        $"A corrupted consent-flip claims file was found and preserved at {preservedPath}. " +
+        "Pre-existing daemons may need `kcap daemon consent set-default prompt`, or re-run onboarding.";
+
     async Task SurfaceQuarantineOnceAsync() {
         try {
             // A read is what discovers corruption (ConsentFlipClaims quarantines lazily, on any
@@ -107,9 +111,11 @@ public sealed class ConsentFlipCoordinator(
             var state = await appState.LoadAsync().ConfigureAwait(false);
             if (state.ConsentQuarantineAcked) return;
 
-            surface.Attention(
-                $"A corrupted consent-flip claims file was found and preserved at {quarantine.PreservedPath}. " +
-                "Pre-existing daemons may need `kcap daemon consent set-default prompt`, or re-run onboarding.");
+            var prompt = new LifecyclePrompt(
+                LifecyclePrompt.KindQuarantine, null, null, false, QuarantineDisclosure(quarantine.PreservedPath));
+            // true → explicit Acknowledge; false (declined) or null (never shown) must NOT ack — re-surfaces next start.
+            var accepted = await surface.TryConfirmAsync(prompt, lifetime).ConfigureAwait(false);
+            if (accepted == true) await AckQuarantineAsync().ConfigureAwait(false);
         } catch (OperationCanceledException) {
             // shutdown before the surface could complete
         } catch (Exception ex) {
@@ -117,8 +123,8 @@ public sealed class ConsentFlipCoordinator(
         }
     }
 
-    /// Persists the ack so a later launch never re-surfaces this quarantine (invoking this from a
-    /// UI affordance is Plan C — only the method and its persistence are in scope here).
+    /// Persists the ack so a later launch never re-surfaces this quarantine — called only from
+    /// SurfaceQuarantineOnceAsync on an explicit true from TryConfirmAsync.
     public Task<bool> AckQuarantineAsync() =>
         appState.UpdateAsync(s => s.ConsentQuarantineAcked ? s : s with { ConsentQuarantineAcked = true });
 }

--- a/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
+++ b/src/Capacitor.App/Services/Onboarding/ConsentFlipCoordinator.cs
@@ -98,7 +98,8 @@ public sealed class ConsentFlipCoordinator(
         await Task.Run(() => claims.TryConsume(claim, ResolveCanonical, identity.DaemonName), lifetime).ConfigureAwait(false);
     }
 
-    static string QuarantineDisclosure(string preservedPath) =>
+    /// Shared with the wizard's Sign-in step so both surfaces disclose the same recovery.
+    internal static string QuarantineDisclosure(string preservedPath) =>
         $"A corrupted consent-flip claims file was found and preserved at {preservedPath}. " +
         "Pre-existing daemons may need `kcap daemon consent set-default prompt`, or re-run onboarding.";
 

--- a/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
+++ b/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
@@ -29,6 +29,9 @@ public static class OnboardingGate {
     /// </summary>
     public static bool ValidServerUrl(string? url) => ServerIdentity.Canonicalize(url) is not null;
 
+    /// The ONE resolve-then-evaluate composition (App.ResolveAndEvaluateGateAsync wraps this in its
+    /// never-brick degrade): the daemon graph is then built from the very AppConfig.ResolvedProfile
+    /// this call published, so the verdict and the graph identity can never name different profiles.
     public static async Task<GateResult> EvaluateAsync(CancellationToken ct) {
         // Daemon-style resolution — no repo/git discovery, matching decision 1's "local" scope.
         await AppConfig.ResolveActiveProfile([]);
@@ -36,10 +39,9 @@ public static class OnboardingGate {
         return await EvaluateResolvedAsync(resolved?.ProfileName, resolved?.Profile, ct);
     }
 
-    /// Shares a resolution the CALLER already performed (App.StartAsync: DaemonClientService.
-    /// CreateDefaultAsync's own AppConfig.ResolveActiveProfile) instead of resolving a second
-    /// time — two independent resolves racing a concurrent active-profile change could otherwise
-    /// evaluate the gate against a different profile than the one the daemon graph builds for.
+    /// Evaluates a resolution the caller already holds instead of resolving a second time — two
+    /// independent resolves racing a concurrent active-profile change could otherwise evaluate the
+    /// gate against a different profile than the one the daemon graph builds for.
     public static async Task<GateResult> EvaluateResolvedAsync(string? profileName, Profile? profile, CancellationToken ct) {
         if (profile is null || string.IsNullOrEmpty(profileName)) {
             return new GateResult.Incomplete(GateReason.NoProfile);

--- a/src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.App.Services.Onboarding;
@@ -46,7 +47,15 @@ public sealed class WizardTenantPicker : ITenantPicker {
     public async Task<DiscoveredTenant?> PickAsync(DiscoveredTenant[] tenants, CancellationToken ct) {
         var pending = new TaskCompletionSource<DiscoveredTenant?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        lock (_gate) _pending = pending;
+        TaskCompletionSource<DiscoveredTenant?>? displaced;
+
+        lock (_gate) {
+            displaced = _pending;
+            _pending  = pending;
+        }
+
+        // A displaced pick has no view left to resolve it — end it rather than orphan its await.
+        displaced?.TrySetCanceled();
 
         using var registration = ct.Register(() => pending.TrySetCanceled(ct));
 
@@ -206,7 +215,7 @@ public sealed class WizardTenantProvisioner(
 
     async Task<ProvisionOffer> PollAsync(
             WorkOSTokenSource tokens, string slug, string orgName, string origin, CancellationToken ct) {
-        var retry = $"Join '{slug}' from the Connect step";
+        var retry = $"join '{slug}' from the Connect step";
 
         for (var attempt = 0; attempt < MaxPolls; attempt++) {
             await Task.Delay(TimeSpan.FromMilliseconds(PollIntervalMs), _time, ct);
@@ -222,11 +231,11 @@ public sealed class WizardTenantProvisioner(
                 case PollVerdict.ActiveNoOrg:
                     return Failed($"{slug}.kcap.ai is live but isn't linked to an organization. Contact support.", "active_no_org");
                 case PollVerdict.Failed:
-                    return Failed($"Provisioning failed. {retry} to retry.", "provisioning_failed");
+                    return Failed($"Provisioning failed — {retry} to retry.", "provisioning_failed");
                 case PollVerdict.Forbidden:
-                    return Failed($"Verify your email address, then {retry.ToLowerInvariant()}.", "forbidden");
+                    return Failed($"Verify your email address, then {retry}.", "forbidden");
                 case PollVerdict.NotFound:
-                    return Failed($"'{slug}' isn't linked to your account. {retry}.", "not_found");
+                    return Failed($"'{slug}' isn't linked to your account — {retry}.", "not_found");
                 case PollVerdict.Wait:
                     PollProgress?.Invoke(attempt + 1, MaxPolls);
 
@@ -240,7 +249,10 @@ public sealed class WizardTenantProvisioner(
         return ProvisionOffer.InProgress;
     }
 
-    static ProvisionOffer Declined() {
+    // The interface hands the provisioner every non-Created message, so a decline must say so here
+    // or the step renders a bare failure for something the user chose.
+    ProvisionOffer Declined() {
+        progress.Notice("No workspace created.");
         SetupFunnel.WorkspaceDeclined();
 
         return ProvisionOffer.Declined;
@@ -265,12 +277,25 @@ public sealed class WizardTenantProvisioner(
     };
 }
 
-/// The bridge set one wizard run shares: the composition root builds the façade over exactly these.
-public sealed record WizardBridges(
-    UiAuthProgress          Progress,
-    WizardTenantPicker      Picker,
-    WizardTenantProvisioner Provisioner,
-    Action<Action>          Post);
+/// <summary>
+/// The bridge set one wizard run shares; the composition root builds the façade over exactly
+/// these. The sink is built from this object's own <paramref name="post"/> and handed to the
+/// provisioner factory, so a bridge marshalling through a different dispatcher than the rest is
+/// not representable.
+/// </summary>
+public sealed class WizardBridges {
+    public WizardBridges(Action<Action> post, Func<IAuthProgress, WizardTenantProvisioner> provisioner) {
+        Post        = post;
+        Progress    = new UiAuthProgress(post);
+        Picker      = new WizardTenantPicker();
+        Provisioner = provisioner(Progress);
+    }
+
+    public Action<Action>          Post        { get; }
+    public UiAuthProgress          Progress    { get; }
+    public WizardTenantPicker      Picker      { get; }
+    public WizardTenantProvisioner Provisioner { get; }
+}
 
 /// <summary>
 /// The one mapping from a Connect intent to a façade call, used by the composition root to build
@@ -291,18 +316,20 @@ public static class WizardSignInOperation {
     /// <summary>
     /// Origin first, then slug expansion: a pasted page URL must lose its path before
     /// <see cref="ServerInput.ResolveTenantArg"/> decides it already looks like a host. A
-    /// scheme-less host or host:port then defaults to https, because the Connect step reaches no
-    /// network and so has nothing to probe a scheme with.
+    /// scheme-less host or host:port then gets Core's own scheme rule — the pure half of the
+    /// normalizer the CLI probes with, so a loopback server lands on http here too.
     /// </summary>
     public static string ResolveServer(string input) {
         var resolved = ServerInput.ResolveTenantArg(ServerInput.ToServerOrigin(input));
 
-        return HostOnly(resolved) ? $"https://{resolved}" : resolved;
+        return HostOnly(resolved) ? ServerUrlNormalizer.WithLoopbackDefault(resolved) : resolved;
     }
 
-    // A host or host:port; anything naming an unusable scheme ("file:") is left to fail validation.
+    // A host or host:port (bracketed IPv6 included); anything naming an unusable scheme ("file:")
+    // is left alone to fail the server-URL validator.
     static bool HostOnly(string value) {
-        var colon = value.IndexOf(':', StringComparison.Ordinal);
+        var bracketEnd = value.StartsWith('[') ? value.IndexOf(']') : -1;
+        var colon      = value.IndexOf(':', bracketEnd > 0 ? bracketEnd + 1 : 0);
 
         return colon < 0 || (colon + 1 < value.Length && value[(colon + 1)..].All(char.IsAsciiDigit));
     }

--- a/src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs
@@ -55,7 +55,7 @@ public sealed class WizardTenantPicker : ITenantPicker {
         }
 
         // A displaced pick has no view left to resolve it — end it rather than orphan its await.
-        displaced?.TrySetCanceled();
+        displaced?.TrySetCanceled(CancellationToken.None);
 
         using var registration = ct.Register(() => pending.TrySetCanceled(ct));
 
@@ -109,11 +109,11 @@ public sealed class WizardTenantProvisioner(
     readonly TimeProvider _time = time ?? TimeProvider.System;
 
     /// Null hooks answer as "backed out": an unwired provisioner must never provision.
-    public Func<CancellationToken, Task<ProvisionMode>>?               OfferMode;
-    public Func<CancellationToken, Task<string?>>?                     PromptOrgName;
-    public Func<string, string?, CancellationToken, Task<string?>>?    PromptSlug;
-    public Func<string, string, CancellationToken, Task<bool>>?        ConfirmCreate;
-    public Action<int, int>?                                           PollProgress;
+    public Func<CancellationToken, Task<ProvisionMode>>?               OfferMode     { get; set; }
+    public Func<CancellationToken, Task<string?>>?                     PromptOrgName { get; set; }
+    public Func<string, string?, CancellationToken, Task<string?>>?    PromptSlug    { get; set; }
+    public Func<string, string, CancellationToken, Task<bool>>?        ConfirmCreate { get; set; }
+    public Action<int, int>?                                           PollProgress  { get; set; }
 
     public async Task<ProvisionOffer> OfferCreateAsync(WorkOSTokenSource tokens, CancellationToken ct = default) {
         // Says what was actually established, not more: single sign-on returned nothing.
@@ -279,7 +279,7 @@ public sealed class WizardTenantProvisioner(
 
 /// <summary>
 /// The bridge set one wizard run shares; the composition root builds the façade over exactly
-/// these. The sink is built from this object's own <paramref name="post"/> and handed to the
+/// these. The sink is built from this object's own <see cref="Post"/> and handed to the
 /// provisioner factory, so a bridge marshalling through a different dispatcher than the rest is
 /// not representable.
 /// </summary>

--- a/src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs
@@ -1,0 +1,309 @@
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Telemetry;
+
+namespace Capacitor.App.Services.Onboarding;
+
+/// <summary>
+/// The façade's progress sink, re-published as events on the UI scheduler.
+/// <paramref name="post"/> is <c>Dispatcher.UIThread.Post</c> in production and an immediate
+/// invoke in tests — every event crosses it, because the flows raise them from their own threads.
+/// </summary>
+public sealed class UiAuthProgress(Action<Action> post) : IAuthProgress {
+    public event Action<string>?         NoticeReceived;
+    public event Action<string>?         ErrorReceived;
+    public event Action<string>?         BrowserOpened;
+    public event Action<string, string>? DeviceCodeReceived;
+    public event Action?                 PollTicked;
+
+    public void Notice(string message) => post(() => NoticeReceived?.Invoke(message));
+
+    public void Error(string message) => post(() => ErrorReceived?.Invoke(message));
+
+    public void BrowserOpening(string url) => post(() => BrowserOpened?.Invoke(url));
+
+    public void DeviceCode(string code, string verificationUri) =>
+        post(() => DeviceCodeReceived?.Invoke(code, verificationUri));
+
+    public void PollTick() => post(() => PollTicked?.Invoke());
+}
+
+/// <summary>
+/// The tenant pick as a UI round trip: <see cref="PickAsync"/> publishes the tenants and parks on
+/// a completion source the view resolves. A null selection is the user backing out — Core renders
+/// that as "No tenant selected."
+/// </summary>
+public sealed class WizardTenantPicker : ITenantPicker {
+    readonly Lock _gate = new();
+
+    TaskCompletionSource<DiscoveredTenant?>? _pending;
+
+    /// Raised on the flow's own thread; the view model marshals it.
+    public event Action<DiscoveredTenant[]>? SelectionRequested;
+
+    public DiscoveredTenant? Pick(DiscoveredTenant[] tenants) =>
+        throw new NotSupportedException("The wizard picker is asynchronous — the façade consumes PickAsync.");
+
+    public async Task<DiscoveredTenant?> PickAsync(DiscoveredTenant[] tenants, CancellationToken ct) {
+        var pending = new TaskCompletionSource<DiscoveredTenant?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        lock (_gate) _pending = pending;
+
+        using var registration = ct.Register(() => pending.TrySetCanceled(ct));
+
+        SelectionRequested?.Invoke(tenants);
+
+        try {
+            return await pending.Task.ConfigureAwait(false);
+        } finally {
+            lock (_gate) {
+                if (ReferenceEquals(_pending, pending)) _pending = null;
+            }
+        }
+    }
+
+    public void Select(DiscoveredTenant? tenant) {
+        TaskCompletionSource<DiscoveredTenant?>? pending;
+
+        lock (_gate) {
+            pending  = _pending;
+            _pending = null;
+        }
+
+        pending?.TrySetResult(tenant);
+    }
+}
+
+/// The three ways out of a zero-tenant discovery — the CLI's mode menu, GUI-shaped.
+public abstract record ProvisionMode {
+    public sealed record Create : ProvisionMode;
+
+    /// The slug or URL the user would rather point at; resolved by the caller, not here.
+    public sealed record Existing(string Input) : ProvisionMode;
+
+    public sealed record Cancel : ProvisionMode;
+}
+
+/// <summary>
+/// The CLI's Spectre provisioner flow with its prompts hoisted into hooks the Sign-in step
+/// implements: same funnel events, same slug/availability loop, same 4 s × 150 poll contract
+/// and the same terminal outcomes. Messaging for every non-Created outcome stays here (the
+/// interface's contract) and reaches the user through <paramref name="progress"/>.
+/// </summary>
+public sealed class WizardTenantProvisioner(
+        TenantProvisioningClient client,
+        string                   baseUrl,
+        IAuthProgress            progress,
+        TimeProvider?            time = null) : ITenantProvisioner {
+    internal const int PollIntervalMs = 4000;
+    internal const int MaxPolls       = 150; // ~10 minutes (server budget is 15)
+
+    readonly TimeProvider _time = time ?? TimeProvider.System;
+
+    /// Null hooks answer as "backed out": an unwired provisioner must never provision.
+    public Func<CancellationToken, Task<ProvisionMode>>?               OfferMode;
+    public Func<CancellationToken, Task<string?>>?                     PromptOrgName;
+    public Func<string, string?, CancellationToken, Task<string?>>?    PromptSlug;
+    public Func<string, string, CancellationToken, Task<bool>>?        ConfirmCreate;
+    public Action<int, int>?                                           PollProgress;
+
+    public async Task<ProvisionOffer> OfferCreateAsync(WorkOSTokenSource tokens, CancellationToken ct = default) {
+        // Says what was actually established, not more: single sign-on returned nothing.
+        progress.Notice("Single sign-on found no Capacitor workspace for your account.");
+        progress.Notice("A workspace that signs in with the GitHub App won't appear here.");
+        SetupFunnel.WorkspaceOffered();
+
+        var mode = OfferMode is null ? new ProvisionMode.Cancel() : await OfferMode(ct);
+
+        switch (mode) {
+            case ProvisionMode.Existing existing when !string.IsNullOrWhiteSpace(existing.Input):
+                SetupFunnel.WorkspaceRedirected();
+
+                return ProvisionOffer.ExistingWorkspace(existing.Input.Trim());
+            case ProvisionMode.Create:
+                break;
+            default:
+                return Declined();
+        }
+
+        var orgName = PromptOrgName is null ? null : await PromptOrgName(ct);
+
+        if (string.IsNullOrWhiteSpace(orgName)) return Declined();
+
+        orgName = orgName.Trim();
+
+        var slug = await ResolveSlugAsync(orgName, tokens, ct);
+
+        if (slug is null) return Declined();
+
+        var origin = $"https://{slug}.kcap.ai";
+
+        if (ConfirmCreate is null || !await ConfirmCreate(slug, origin, ct)) return Declined();
+
+        SetupFunnel.WorkspaceRequested();
+
+        var outcome = await client.ProvisionAsync(baseUrl, await tokens.GetAsync(ct), orgName, slug, ct);
+
+        switch (outcome.StatusCode) {
+            case 200 when outcome.Body?.WorkosOrgId is { Length: > 0 } orgId:
+                SetupFunnel.WorkspaceProvisioned();
+
+                return ProvisionOffer.Created(new ProvisionedTenant(orgId, slug, orgName, outcome.Body.Url ?? origin));
+            case 202 or 200:
+                return await PollAsync(tokens, slug, orgName, origin, ct);
+            case 400:
+                return Failed(Reason400(outcome.Body?.Reason), outcome.Body?.Reason ?? "invalid_request");
+            case 409:
+                return Failed(Reason409(outcome.Body?.Reason, slug), outcome.Body?.Reason ?? "conflict");
+            case 0:
+                return Failed("Couldn't reach the provisioning service. Check your connection and try again.", "unreachable");
+            default:
+                return Failed($"Provisioning failed (HTTP {outcome.StatusCode}). Try again later.", $"http_{outcome.StatusCode}");
+        }
+    }
+
+    async Task<string?> ResolveSlugAsync(string orgName, WorkOSTokenSource tokens, CancellationToken ct) {
+        var     suggestion = SlugValidator.Derive(orgName);
+        string? error      = null;
+
+        while (true) {
+            if (PromptSlug is null) return null;
+
+            var input = await PromptSlug(suggestion, error, ct);
+
+            if (input is null) return null;
+
+            var slug  = SlugValidator.Canonicalize(input);
+            var check = SlugValidator.Validate(slug);
+
+            suggestion = slug;
+
+            if (!check.Ok) {
+                error = check.Reason == "blocked"
+                    ? $"'{slug}' is reserved — pick another."
+                    : "Use lowercase letters, digits and single hyphens (no leading/trailing hyphen), max 40 characters.";
+
+                continue;
+            }
+
+            var availability = await client.CheckAvailabilityAsync(baseUrl, await tokens.GetAsync(ct), slug, ct);
+
+            if (availability is null) {
+                error = "Couldn't check availability. Try again.";
+
+                continue;
+            }
+
+            if (availability.Available || availability.Reason == "yours") return slug;
+
+            error = availability.Reason switch {
+                "reserved" => $"'{slug}' is being provisioned by someone else — pick another.",
+                "taken"    => $"'{slug}' is taken — pick another.",
+                "blocked"  => $"'{slug}' is reserved — pick another.",
+                _          => $"'{slug}' is unavailable — pick another."
+            };
+        }
+    }
+
+    async Task<ProvisionOffer> PollAsync(
+            WorkOSTokenSource tokens, string slug, string orgName, string origin, CancellationToken ct) {
+        var retry = $"Join '{slug}' from the Connect step";
+
+        for (var attempt = 0; attempt < MaxPolls; attempt++) {
+            await Task.Delay(TimeSpan.FromMilliseconds(PollIntervalMs), _time, ct);
+
+            var status = await client.GetStatusAsync(baseUrl, await tokens.GetAsync(ct), slug, ct);
+
+            switch (ProvisioningPoll.Classify(status.StatusCode, status.Body?.State, status.Body?.WorkosOrgId)) {
+                case PollVerdict.Active:
+                    SetupFunnel.WorkspaceProvisioned();
+
+                    return ProvisionOffer.Created(
+                        new ProvisionedTenant(status.Body!.WorkosOrgId!, slug, orgName, status.Body.Url ?? origin));
+                case PollVerdict.ActiveNoOrg:
+                    return Failed($"{slug}.kcap.ai is live but isn't linked to an organization. Contact support.", "active_no_org");
+                case PollVerdict.Failed:
+                    return Failed($"Provisioning failed. {retry} to retry.", "provisioning_failed");
+                case PollVerdict.Forbidden:
+                    return Failed($"Verify your email address, then {retry.ToLowerInvariant()}.", "forbidden");
+                case PollVerdict.NotFound:
+                    return Failed($"'{slug}' isn't linked to your account. {retry}.", "not_found");
+                case PollVerdict.Wait:
+                    PollProgress?.Invoke(attempt + 1, MaxPolls);
+
+                    break;
+            }
+        }
+
+        progress.Error($"Still provisioning — finish later by joining '{slug}' from the Connect step.");
+        SetupFunnel.WorkspaceFailed("poll_timeout");
+
+        return ProvisionOffer.InProgress;
+    }
+
+    static ProvisionOffer Declined() {
+        SetupFunnel.WorkspaceDeclined();
+
+        return ProvisionOffer.Declined;
+    }
+
+    ProvisionOffer Failed(string message, string reason) {
+        progress.Error(message);
+        SetupFunnel.WorkspaceFailed(reason);
+
+        return ProvisionOffer.Failed;
+    }
+
+    static string Reason400(string? reason) => reason switch {
+        "disposable_email" => "Provisioning requires a non-disposable email address.",
+        "blocked"          => "That slug is reserved. Pick another and try again.",
+        _                  => "Invalid organization name or slug."
+    };
+
+    static string Reason409(string? reason, string slug) => reason switch {
+        "owned_by_other" => $"'{slug}' is owned by someone else. Pick another and try again.",
+        _                => $"'{slug}' is already taken. Pick another and try again."
+    };
+}
+
+/// The bridge set one wizard run shares: the composition root builds the façade over exactly these.
+public sealed record WizardBridges(
+    UiAuthProgress          Progress,
+    WizardTenantPicker      Picker,
+    WizardTenantProvisioner Provisioner,
+    Action<Action>          Post);
+
+/// <summary>
+/// The one mapping from a Connect intent to a façade call, used by the composition root to build
+/// <see cref="WizardAuthService"/>'s operation. Wizard sign-ins adopt the server — that is what
+/// carries <see cref="OnboardingGate"/> to Complete.
+/// </summary>
+public static class WizardSignInOperation {
+    public static Func<ConnectIntent, CancellationToken, Task<AuthResult>> For(OnboardingFacade facade) =>
+        async (intent, ct) => intent switch {
+            ConnectIntent.Paste paste => await facade.LoginAsync(
+                ResolveServer(paste.ServerInput), forceDevice: false, profile: null, ct, adoptServer: true),
+            ConnectIntent.Discover discover => await facade.DiscoverAsync(discover.Provider, forceDevice: false, ct),
+            // Creation runs inside WorkOS discovery, after the org-less sign-in finds no tenant.
+            ConnectIntent.Create => await facade.DiscoverAsync(AuthProvider.WorkOS, forceDevice: false, ct),
+            _                    => new AuthResult.Failed("No connection was chosen.")
+        };
+
+    /// <summary>
+    /// Origin first, then slug expansion: a pasted page URL must lose its path before
+    /// <see cref="ServerInput.ResolveTenantArg"/> decides it already looks like a host. A
+    /// scheme-less host or host:port then defaults to https, because the Connect step reaches no
+    /// network and so has nothing to probe a scheme with.
+    /// </summary>
+    public static string ResolveServer(string input) {
+        var resolved = ServerInput.ResolveTenantArg(ServerInput.ToServerOrigin(input));
+
+        return HostOnly(resolved) ? $"https://{resolved}" : resolved;
+    }
+
+    // A host or host:port; anything naming an unusable scheme ("file:") is left to fail validation.
+    static bool HostOnly(string value) {
+        var colon = value.IndexOf(':', StringComparison.Ordinal);
+
+        return colon < 0 || (colon + 1 < value.Length && value[(colon + 1)..].All(char.IsAsciiDigit));
+    }
+}

--- a/src/Capacitor.App/Services/Onboarding/WizardAuthService.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardAuthService.cs
@@ -1,0 +1,112 @@
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.App.Services.Onboarding;
+
+/// What the Connect step asked for; the composition root binds each case to one façade call.
+public abstract record ConnectIntent {
+    public sealed record Paste(string ServerInput) : ConnectIntent;
+    public sealed record Discover(string Provider) : ConnectIntent;
+    public sealed record Create : ConnectIntent;
+}
+
+/// <summary>
+/// One in-flight sign-in. <see cref="Result"/> is the terminal answer the close path awaits and
+/// never faults — an operation that throws arrives as <see cref="AuthResult.Failed"/> rather than
+/// as an exception nobody is positioned to catch during shutdown.
+/// </summary>
+public sealed class AuthAttempt {
+    readonly CancellationTokenSource _cts = new();
+
+    internal AuthAttempt(Func<CancellationToken, Task<AuthResult>> run) => Result = RunAsync(run);
+
+    public Task<AuthResult> Result { get; }
+
+    /// Pre-boundary this ends the operation as Cancelled; past it the façade publishes and answers Committed.
+    public void Cancel() {
+        try {
+            _cts.Cancel();
+        } catch (ObjectDisposedException) {
+            // already settled — nothing left to cancel
+        }
+    }
+
+    async Task<AuthResult> RunAsync(Func<CancellationToken, Task<AuthResult>> run) {
+        try {
+            return await run(_cts.Token).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (_cts.IsCancellationRequested) {
+            return new AuthResult.Cancelled();
+        } catch (Exception ex) {
+            return new AuthResult.Failed(ex.Message);
+        } finally {
+            _cts.Dispose();
+        }
+    }
+}
+
+/// <summary>
+/// The wizard's single-flight sign-in driver: one attempt at a time, cancellation as a distinct
+/// outcome, and a terminal task the window's close path awaits before the app resolves
+/// configuration. <paramref name="runOperation"/> binds the façade and its bridges, so this type
+/// stays free of auth mechanics.
+/// </summary>
+public sealed class WizardAuthService(
+        Func<ConnectIntent, CancellationToken, Task<AuthResult>> runOperation,
+        ConsentFlipClaims                                        claims) {
+    readonly Lock _gate = new();
+
+    AuthAttempt? _current;
+
+    /// The decision-7 hook the composition root hands each façade it builds for this service.
+    public Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task> BeforeCommit { get; } = ArmingHook(claims);
+
+    public AuthAttempt? Current {
+        get {
+            lock (_gate) return _current;
+        }
+    }
+
+    /// <summary>
+    /// Arms one durable claim per identity before the boundary publishes anything. A false return
+    /// is a store failure, not a cancel: it throws <see cref="InvalidOperationException"/>, because
+    /// the boundary maps ANY <see cref="OperationCanceledException"/> from this hook to
+    /// <see cref="AuthResult.Cancelled"/> — which would render a failed arm as "the user backed out"
+    /// instead of a retryable error.
+    /// </summary>
+    public static Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task> ArmingHook(ConsentFlipClaims claims) =>
+        async (identities, _) => {
+            foreach (var identity in identities) {
+                // No token into Task.Run: arming is fast, and a cancel landing here must not abandon a half-written claim.
+                var armed = await Task
+                    .Run(() => claims.Arm(new ConsentFlipClaim(identity.Profile, identity.CanonicalServer)))
+                    .ConfigureAwait(false);
+
+                if (!armed) throw new InvalidOperationException("claim_arm_failed");
+            }
+        };
+
+    /// <exception cref="InvalidOperationException">An attempt is still live — Retry re-runs only after quiesce.</exception>
+    public AuthAttempt Begin(ConnectIntent intent) {
+        lock (_gate) {
+            if (_current is { Result.IsCompleted: false }) {
+                throw new InvalidOperationException("A sign-in attempt is already running.");
+            }
+
+            return _current = new AuthAttempt(ct => runOperation(intent, ct));
+        }
+    }
+
+    /// Completes when no attempt is live — the close path's await after Cancel (decision 2).
+    public async Task QuiescedAsync() {
+        while (true) {
+            Task<AuthResult> live;
+
+            lock (_gate) {
+                if (_current is not { Result.IsCompleted: false } attempt) return;
+
+                live = attempt.Result;
+            }
+
+            await live.ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Capacitor.App/Services/Onboarding/WizardAuthService.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardAuthService.cs
@@ -50,14 +50,10 @@ public sealed class AuthAttempt {
 /// stays free of auth mechanics.
 /// </summary>
 public sealed class WizardAuthService(
-        Func<ConnectIntent, CancellationToken, Task<AuthResult>> runOperation,
-        ConsentFlipClaims                                        claims) {
+        Func<ConnectIntent, CancellationToken, Task<AuthResult>> runOperation) {
     readonly Lock _gate = new();
 
     AuthAttempt? _current;
-
-    /// The decision-7 hook the composition root hands each façade it builds for this service.
-    public Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task> BeforeCommit { get; } = ArmingHook(claims);
 
     public AuthAttempt? Current {
         get {

--- a/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
@@ -22,11 +22,7 @@ internal sealed record WizardGraph(
     OnboardingViewModel ViewModel, WizardAuthService Auth, IReadOnlyList<IWizardStep> Steps,
     ImportStepViewModel Import);
 
-/// <summary>
-/// Everything wizard-first mode is composed from. The daemon-facing entries are FACTORIES: the
-/// wizard writes config while it runs, so a binding pinned at composition time would silently land
-/// later calls on the wrong daemon.
-/// </summary>
+/// <summary>Everything wizard-first mode is composed from; the daemon-facing entries are factories so a call never lands on a stale daemon.</summary>
 internal sealed record WizardGraphOptions(
     ConsentFlipClaims                                                            Claims,
     WizardBridges                                                                Bridges,
@@ -88,8 +84,7 @@ internal static class WizardComposition {
         var connect  = new ConnectStepViewModel();
         var signIn   = new SignInStepViewModel(auth, connect, options.Bridges, claims, options.AppState, options.UrlOpener);
         var shim     = new ShimStepViewModel(options.ShimApplicable, options.ShimInstaller, options.AppState, options.ShimTarget);
-        // The Defaults step's persist targets the SAME fresh identity the daemon step gates on,
-        // falling back to c.ActiveProfile itself when unresolved.
+        // Defaults persists to the same fresh identity the daemon step gates on, falling back to ActiveProfile.
         var defaults = new DefaultsStepViewModel(options.DefaultDaemonName, () => options.ResolveIdentity()?.Profile);
         // ONE detection feed for both vendor steps: two would probe the login shell twice for the
         // same answer, and the two steps' vendor lists could then disagree.
@@ -98,12 +93,10 @@ internal static class WizardComposition {
         var import = new ImportStepViewModel(cli, detect, options.Bridges.Post);
         var daemon = new DaemonStepViewModel(
             cli, options.RunMutation,
-            // Gated on a COMMITTED sign-in (the RequiresSignIn row is what a skipped sign-in must
-            // read as) and resolved FRESH per call — never the startup-cached profile.
+            // Gated on a committed sign-in and resolved fresh per call, never the startup-cached profile.
             () => signIn.Satisfied ? options.ResolveIdentity() : null,
             options.Observation,
-            // The step's own gate above is what keeps a socket un-dialed: a null resolution never
-            // reaches ResolveOps at all.
+            // The step's own gate above keeps the socket un-dialed: a null resolution never reaches ResolveOps.
             new LateBoundLocalControlOps(() => options.ResolveOps(options.ResolveIdentity() is { } id
                 ? id.DaemonName
                 : options.DefaultDaemonName ?? "daemon")),

--- a/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
@@ -1,0 +1,126 @@
+using Capacitor.App.Services.Mutation;
+using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Core.Setup;
+
+namespace Capacitor.App.Services.Onboarding;
+
+/// The façade's constructor arguments as data, so the composition root's choices — which sink,
+/// which picker, whether a provisioner is armed, which before-commit hook — are inspectable.
+internal sealed record WizardFacadeSpec(
+    IAuthProgress                                              Progress,
+    ITenantPicker                                              Picker,
+    ITenantProvisioner?                                        Provisioner,
+    Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task> BeforeCommit);
+
+/// What wizard-first mode runs on: the shell, the sign-in driver the close path awaits, and every
+/// step (including ones the shell filtered out as inapplicable — the summary still names them).
+internal sealed record WizardGraph(
+    OnboardingViewModel ViewModel, WizardAuthService Auth, IReadOnlyList<IWizardStep> Steps);
+
+/// <summary>
+/// Everything wizard-first mode is composed from. The daemon-facing entries are FACTORIES, not
+/// instances: the wizard writes config while it runs (a sign-in adopts a server, the Defaults step
+/// renames the daemon), so a socket or CLI binding pinned at composition time would land later
+/// calls on the wrong daemon — silently, since a wrong-identity put fails closed.
+/// </summary>
+internal sealed record WizardGraphOptions(
+    ConsentFlipClaims                                                            Claims,
+    WizardBridges                                                                Bridges,
+    Func<WizardFacadeSpec, Func<ConnectIntent, CancellationToken, Task<AuthResult>>> Operation,
+    WizardLifecycleSurface                                                       Surface,
+    Func<IKcapCli>                                                               ResolveCli,
+    Func<ILocalControlOps>                                                       ResolveOps,
+    Func<(string Profile, string Server, string DaemonName)>                     ResolveIdentity,
+    Func<MutationRequest, CancellationToken, Task<MutationOutcome>>              RunMutation,
+    IDaemonObservation                                                           Observation,
+    IAppStateStore                                                               AppState,
+    PathShimInstaller                                                            ShimInstaller,
+    IUrlOpener                                                                   UrlOpener,
+    ILoginShellProbe                                                             Probe,
+    Func<ILoginShellProbe, Func<CancellationToken, Task<AgentDetectionResult>>>  DetectionFeed,
+    bool                                                                         ShimApplicable,
+    string?                                                                      ShimTarget,
+    string?                                                                      DefaultDaemonName,
+    TimeProvider                                                                 Time,
+    CancellationToken                                                            ShutdownToken);
+
+/// The wizard half of the composition root (spec decision 2), split out of App so it can be driven
+/// with fakes: nothing here touches a daemon, a socket or the network until a step is used.
+internal static class WizardComposition {
+    internal const string CliMissingNote     = "kcap CLI not found";
+    internal const string RequiresSignInNote = "requires sign-in";
+
+    /// Production bridges: one marshalling boundary (Avalonia's dispatcher in the app) and a
+    /// provisioner built from the bridges' OWN sink, per WizardBridges' contract.
+    internal static WizardBridges BuildBridges(Action<Action> post) =>
+        new(post, progress => new WizardTenantProvisioner(
+            new TenantProvisioningClient(new HttpClient()), ProvisioningEndpoint.Url, progress));
+
+    /// Production operation: the spec IS the façade's arguments, and WizardSignInOperation owns
+    /// the intent→call map (paste adopts the server; create/discover run WorkOS discovery).
+    internal static Func<ConnectIntent, CancellationToken, Task<AuthResult>> NewOperation(WizardFacadeSpec spec) =>
+        WizardSignInOperation.For(new OnboardingFacade(spec.Progress, spec.Picker, spec.Provisioner, spec.BeforeCommit));
+
+    /// The ONE façade a wizard run signs in through — provisioner armed (a provisioner-less façade
+    /// dead-ends "Create a workspace" at "ask your admin") and the decision-7 arming hook wired as
+    /// before-commit, so a claim exists before anything durable is published.
+    internal static Func<ConnectIntent, CancellationToken, Task<AuthResult>> BuildOperation(
+            WizardBridges bridges, ConsentFlipClaims claims,
+            Func<WizardFacadeSpec, Func<ConnectIntent, CancellationToken, Task<AuthResult>>> operation) =>
+        operation(new WizardFacadeSpec(
+            bridges.Progress, bridges.Picker, bridges.Provisioner, WizardAuthService.ArmingHook(claims)));
+
+    internal static WizardGraph BuildGraph(WizardGraphOptions options) {
+        var claims = options.Claims;
+        var cli    = new LateBoundKcapCli(options.ResolveCli);
+        var auth   = new WizardAuthService(BuildOperation(options.Bridges, claims, options.Operation), claims);
+
+        var connect  = new ConnectStepViewModel();
+        var signIn   = new SignInStepViewModel(auth, connect, options.Bridges, claims, options.AppState, options.UrlOpener);
+        var shim     = new ShimStepViewModel(options.ShimApplicable, options.ShimInstaller, options.AppState, options.ShimTarget);
+        var defaults = new DefaultsStepViewModel(options.DefaultDaemonName);
+        // ONE detection feed for both vendor steps: two would probe the login shell twice for the
+        // same answer, and the two steps' vendor lists could then disagree.
+        var detect = options.DetectionFeed(options.Probe);
+        var agents = new AgentsStepViewModel(cli, detect);
+        var import = new ImportStepViewModel(cli, detect, options.Bridges.Post);
+        var daemon = new DaemonStepViewModel(
+            cli, options.RunMutation,
+            // Gated on a COMMITTED sign-in (the RequiresSignIn row is what a skipped sign-in must
+            // read as) and resolved FRESH per call — never the startup-cached profile.
+            () => signIn.Satisfied ? options.ResolveIdentity() : null,
+            options.Observation, new LateBoundLocalControlOps(options.ResolveOps), claims,
+            options.ResolveIdentity, options.Surface, options.Probe.TerminalPathAsync, options.Time);
+
+        IWizardStep[] configured = [shim, connect, signIn, defaults, agents, import, daemon];
+        // Read on every entry, so a Back-then-forward re-render sees each step's current state.
+        var done = new DoneStepViewModel(() => Summarize(configured, cli.CliPath is not null));
+        IWizardStep[] steps = [.. configured, done];
+
+        return new WizardGraph(new OnboardingViewModel(steps, options.ShutdownToken, options.Surface), auth, steps);
+    }
+
+    /// The Done step's rows: what each earlier step reached and — when it didn't — why it was skipped.
+    internal static IReadOnlyList<(string Title, bool Satisfied, string? Note)> Summarize(
+            IReadOnlyList<IWizardStep> steps, bool cliAvailable) =>
+        steps.Where(step => step.Id != WizardStepId.Done)
+            .Select(step => (step.Title, step.Satisfied, step.Satisfied ? null : SkipNote(step, cliAvailable)))
+            .ToList();
+
+    // A missing CLI dominates: every step that shells out is unreachable for that one reason.
+    static string? SkipNote(IWizardStep step, bool cliAvailable) {
+        if (!cliAvailable && NeedsCli(step.Id)) return CliMissingNote;
+
+        return step switch {
+            DaemonStepViewModel { Row: DaemonRow.RequiresSignIn } => RequiresSignInNote,
+            DaemonStepViewModel daemonStep                        => daemonStep.Message,
+            ShimStepViewModel shimStep                            => shimStep.Message,
+            _                                                     => null,
+        };
+    }
+
+    static bool NeedsCli(WizardStepId id) =>
+        id is WizardStepId.Shim or WizardStepId.Agents or WizardStepId.Import or WizardStepId.Daemon;
+}

--- a/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
@@ -40,6 +40,7 @@ internal sealed record WizardGraphOptions(
     IUrlOpener                                                                   UrlOpener,
     ILoginShellProbe                                                             Probe,
     Func<ILoginShellProbe, Func<CancellationToken, Task<AgentDetectionResult>>>  DetectionFeed,
+    string?                                                                      CliPath,
     bool                                                                         ShimApplicable,
     string?                                                                      ShimTarget,
     string?                                                                      DefaultDaemonName,
@@ -74,7 +75,7 @@ internal static class WizardComposition {
 
     internal static WizardGraph BuildGraph(WizardGraphOptions options) {
         var claims = options.Claims;
-        var cli    = new LateBoundKcapCli(options.ResolveCli);
+        var cli    = new LateBoundKcapCli(options.ResolveCli, options.CliPath);
         var auth   = new WizardAuthService(BuildOperation(options.Bridges, claims, options.Operation), claims);
 
         var connect  = new ConnectStepViewModel();
@@ -99,7 +100,12 @@ internal static class WizardComposition {
         var done = new DoneStepViewModel(() => Summarize(configured, cli.CliPath is not null));
         IWizardStep[] steps = [.. configured, done];
 
-        return new WizardGraph(new OnboardingViewModel(steps, options.ShutdownToken, options.Surface), auth, steps);
+        var wizard = new OnboardingViewModel(steps, options.ShutdownToken, options.Surface);
+        // A WorkOS "I already have a workspace" prefills the Connect step; without the navigation
+        // the prefill would sit on a page the user is not looking at.
+        signIn.RetargetRequested += _ => wizard.TryGoTo(WizardStepId.Connect);
+
+        return new WizardGraph(wizard, auth, steps);
     }
 
     /// The Done step's rows: what each earlier step reached and — when it didn't — why it was skipped.

--- a/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
@@ -14,10 +14,13 @@ internal sealed record WizardFacadeSpec(
     ITenantProvisioner?                                        Provisioner,
     Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task> BeforeCommit);
 
-/// What wizard-first mode runs on: the shell, the sign-in driver the close path awaits, and every
-/// step (including ones the shell filtered out as inapplicable — the summary still names them).
+/// What wizard-first mode runs on: the shell, the sign-in driver the close path awaits, every step
+/// (including ones the shell filtered out as inapplicable — the summary still names them), and the
+/// Import step by name — the close path must cancel its in-flight run directly (spec §7), which
+/// CanLeaveAsync alone does not cover since closing the window never navigates away from a step.
 internal sealed record WizardGraph(
-    OnboardingViewModel ViewModel, WizardAuthService Auth, IReadOnlyList<IWizardStep> Steps);
+    OnboardingViewModel ViewModel, WizardAuthService Auth, IReadOnlyList<IWizardStep> Steps,
+    ImportStepViewModel Import);
 
 /// <summary>
 /// Everything wizard-first mode is composed from. The daemon-facing entries are FACTORIES, not
@@ -31,8 +34,17 @@ internal sealed record WizardGraphOptions(
     Func<WizardFacadeSpec, Func<ConnectIntent, CancellationToken, Task<AuthResult>>> Operation,
     WizardLifecycleSurface                                                       Surface,
     Func<IKcapCli>                                                               ResolveCli,
-    Func<ILocalControlOps>                                                       ResolveOps,
-    Func<(string Profile, string Server, string DaemonName)>                     ResolveIdentity,
+    // Takes the already-resolved identity's daemon name — never re-resolves identity on its own
+    // (finding 3/4: a factory that re-derives its own answer is exactly how the old ("","","")
+    // sentinel leaked in). Invoked only from an identity-non-null path below.
+    Func<string, ILocalControlOps>                                               ResolveOps,
+    // The daemon step's OWN identity — nullable (finding 3): a KCAP_PROFILE override set after
+    // startup, or an unreadable/invalid config, must read as "not ready" rather than a stale or
+    // empty-string sentinel.
+    Func<(string Profile, string Server, string DaemonName)?>                    ResolveIdentity,
+    // The claims path's identity — deliberately the SEPARATE, literal ResolveConsentFlipIdentity
+    // (its own doc comment justifies the literal read); never swapped for ResolveIdentity above.
+    Func<(string Profile, string Server, string DaemonName)>                     ResolveConsentFlipIdentity,
     Func<MutationRequest, CancellationToken, Task<MutationOutcome>>              RunMutation,
     IDaemonObservation                                                           Observation,
     IAppStateStore                                                               AppState,
@@ -81,7 +93,9 @@ internal static class WizardComposition {
         var connect  = new ConnectStepViewModel();
         var signIn   = new SignInStepViewModel(auth, connect, options.Bridges, claims, options.AppState, options.UrlOpener);
         var shim     = new ShimStepViewModel(options.ShimApplicable, options.ShimInstaller, options.AppState, options.ShimTarget);
-        var defaults = new DefaultsStepViewModel(options.DefaultDaemonName);
+        // The Defaults step's persist targets the SAME fresh identity the daemon step gates on
+        // (finding 3) — falling back to c.ActiveProfile itself when unresolved (today's behavior).
+        var defaults = new DefaultsStepViewModel(options.DefaultDaemonName, () => options.ResolveIdentity()?.Profile);
         // ONE detection feed for both vendor steps: two would probe the login shell twice for the
         // same answer, and the two steps' vendor lists could then disagree.
         var detect = options.DetectionFeed(options.Probe);
@@ -92,8 +106,15 @@ internal static class WizardComposition {
             // Gated on a COMMITTED sign-in (the RequiresSignIn row is what a skipped sign-in must
             // read as) and resolved FRESH per call — never the startup-cached profile.
             () => signIn.Satisfied ? options.ResolveIdentity() : null,
-            options.Observation, new LateBoundLocalControlOps(options.ResolveOps), claims,
-            options.ResolveIdentity, options.Surface, options.Probe.TerminalPathAsync, options.Time);
+            options.Observation,
+            // The ops factory only ever runs from this identity-non-null branch (finding 4): a
+            // null resolution never reaches ResolveOps, so there is no name to fail closed on in
+            // the first place — the step's own gate above is what keeps a live socket un-dialed.
+            new LateBoundLocalControlOps(() => options.ResolveOps(options.ResolveIdentity() is { } id
+                ? id.DaemonName
+                : options.DefaultDaemonName ?? "daemon")),
+            claims,
+            options.ResolveConsentFlipIdentity, options.Surface, options.Probe.TerminalPathAsync, options.Time);
 
         IWizardStep[] configured = [shim, connect, signIn, defaults, agents, import, daemon];
         // Read on every entry, so a Back-then-forward re-render sees each step's current state.
@@ -105,7 +126,7 @@ internal static class WizardComposition {
         // the prefill would sit on a page the user is not looking at.
         signIn.RetargetRequested += _ => wizard.TryGoTo(WizardStepId.Connect);
 
-        return new WizardGraph(wizard, auth, steps);
+        return new WizardGraph(wizard, auth, steps, import);
     }
 
     /// The Done step's rows: what each earlier step reached and — when it didn't — why it was skipped.

--- a/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
@@ -76,7 +76,7 @@ internal static class WizardComposition {
     internal static WizardGraph BuildGraph(WizardGraphOptions options) {
         var claims = options.Claims;
         var cli    = new LateBoundKcapCli(options.ResolveCli, options.CliPath);
-        var auth   = new WizardAuthService(BuildOperation(options.Bridges, claims, options.Operation), claims);
+        var auth   = new WizardAuthService(BuildOperation(options.Bridges, claims, options.Operation));
 
         var connect  = new ConnectStepViewModel();
         var signIn   = new SignInStepViewModel(auth, connect, options.Bridges, claims, options.AppState, options.UrlOpener);

--- a/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
@@ -23,10 +23,9 @@ internal sealed record WizardGraph(
     ImportStepViewModel Import);
 
 /// <summary>
-/// Everything wizard-first mode is composed from. The daemon-facing entries are FACTORIES, not
-/// instances: the wizard writes config while it runs (a sign-in adopts a server, the Defaults step
-/// renames the daemon), so a socket or CLI binding pinned at composition time would land later
-/// calls on the wrong daemon — silently, since a wrong-identity put fails closed.
+/// Everything wizard-first mode is composed from. The daemon-facing entries are FACTORIES: the
+/// wizard writes config while it runs, so a binding pinned at composition time would silently land
+/// later calls on the wrong daemon.
 /// </summary>
 internal sealed record WizardGraphOptions(
     ConsentFlipClaims                                                            Claims,
@@ -34,13 +33,9 @@ internal sealed record WizardGraphOptions(
     Func<WizardFacadeSpec, Func<ConnectIntent, CancellationToken, Task<AuthResult>>> Operation,
     WizardLifecycleSurface                                                       Surface,
     Func<IKcapCli>                                                               ResolveCli,
-    // Takes the already-resolved identity's daemon name — never re-resolves identity on its own
-    // (finding 3/4: a factory that re-derives its own answer is exactly how the old ("","","")
-    // sentinel leaked in). Invoked only from an identity-non-null path below.
+    // Takes the already-resolved identity's daemon name — never re-resolves one of its own.
     Func<string, ILocalControlOps>                                               ResolveOps,
-    // The daemon step's OWN identity — nullable (finding 3): a KCAP_PROFILE override set after
-    // startup, or an unreadable/invalid config, must read as "not ready" rather than a stale or
-    // empty-string sentinel.
+    // The daemon step's OWN identity, nullable: an unreadable/invalid config reads as "not ready".
     Func<(string Profile, string Server, string DaemonName)?>                    ResolveIdentity,
     // The claims path's identity — deliberately the SEPARATE, literal ResolveConsentFlipIdentity
     // (its own doc comment justifies the literal read); never swapped for ResolveIdentity above.
@@ -93,8 +88,8 @@ internal static class WizardComposition {
         var connect  = new ConnectStepViewModel();
         var signIn   = new SignInStepViewModel(auth, connect, options.Bridges, claims, options.AppState, options.UrlOpener);
         var shim     = new ShimStepViewModel(options.ShimApplicable, options.ShimInstaller, options.AppState, options.ShimTarget);
-        // The Defaults step's persist targets the SAME fresh identity the daemon step gates on
-        // (finding 3) — falling back to c.ActiveProfile itself when unresolved (today's behavior).
+        // The Defaults step's persist targets the SAME fresh identity the daemon step gates on,
+        // falling back to c.ActiveProfile itself when unresolved.
         var defaults = new DefaultsStepViewModel(options.DefaultDaemonName, () => options.ResolveIdentity()?.Profile);
         // ONE detection feed for both vendor steps: two would probe the login shell twice for the
         // same answer, and the two steps' vendor lists could then disagree.
@@ -107,9 +102,8 @@ internal static class WizardComposition {
             // read as) and resolved FRESH per call — never the startup-cached profile.
             () => signIn.Satisfied ? options.ResolveIdentity() : null,
             options.Observation,
-            // The ops factory only ever runs from this identity-non-null branch (finding 4): a
-            // null resolution never reaches ResolveOps, so there is no name to fail closed on in
-            // the first place — the step's own gate above is what keeps a live socket un-dialed.
+            // The step's own gate above is what keeps a socket un-dialed: a null resolution never
+            // reaches ResolveOps at all.
             new LateBoundLocalControlOps(() => options.ResolveOps(options.ResolveIdentity() is { } id
                 ? id.DaemonName
                 : options.DefaultDaemonName ?? "daemon")),

--- a/src/Capacitor.App/Services/Onboarding/WizardLateBinding.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardLateBinding.cs
@@ -1,0 +1,49 @@
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.Services.Onboarding;
+
+/// <summary>
+/// <see cref="ILocalControlOps"/> that resolves its daemon socket per CALL. The wizard's Defaults
+/// step can rename the daemon after the daemon step was composed, and a pinned name would send the
+/// consent put to a socket nobody answers — which fails closed, and therefore silently.
+/// </summary>
+public sealed class LateBoundLocalControlOps(Func<ILocalControlOps> bind) : ILocalControlOps {
+    public Task<StopAgentResult> StopAgentAsync(string agentId, bool force, CancellationToken ct) =>
+        bind().StopAgentAsync(agentId, force, ct);
+
+    public Task<ConsentPolicyDto> GetConsentPolicyAsync(CancellationToken ct) =>
+        bind().GetConsentPolicyAsync(ct);
+
+    public Task<ConsentAckDto> PutConsentPolicyAsync(ConsentPolicyDto policy, CancellationToken ct) =>
+        bind().PutConsentPolicyAsync(policy, ct);
+
+    public Task<ConsentAckDto> PutConsentPolicyV2Async(ConsentPolicyPutV2Dto put, CancellationToken ct) =>
+        bind().PutConsentPolicyV2Async(put, ct);
+
+    public Task<ConsentAckDto> ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct) =>
+        bind().ResolveConsentAsync(resolve, ct);
+}
+
+/// <see cref="IKcapCli"/> rebound per call, for the same reason: profile, canonical server and
+/// daemon name are all still being written while the wizard is open.
+public sealed class LateBoundKcapCli(Func<IKcapCli> bind) : IKcapCli {
+    public string? CliPath => bind().CliPath;
+
+    public Task<string?> VersionAsync(CancellationToken ct) => bind().VersionAsync(ct);
+
+    public Task<ServiceSnapshot?> ServiceStatusAsync(CancellationToken ct) => bind().ServiceStatusAsync(ct);
+
+    public Task<ProcessResult> ServiceStartVerifiedAsync(CancellationToken ct) => bind().ServiceStartVerifiedAsync(ct);
+
+    public Task<ProcessResult> ServiceInstallVerifiedAsync(bool replace, CancellationToken ct) =>
+        bind().ServiceInstallVerifiedAsync(replace, ct);
+
+    public Task<ProcessResult> DetachedStartAsync(string bootAttemptId, CancellationToken ct) =>
+        bind().DetachedStartAsync(bootAttemptId, ct);
+
+    public Task<ProcessResult> PluginInstallAsync(string? vendorFlag, CancellationToken ct) =>
+        bind().PluginInstallAsync(vendorFlag, ct);
+
+    public Task<StreamingResult> ImportAsync(ImportRequest request, Action<StreamedLine> onLine, CancellationToken ct) =>
+        bind().ImportAsync(request, onLine, ct);
+}

--- a/src/Capacitor.App/Services/Onboarding/WizardLateBinding.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardLateBinding.cs
@@ -24,10 +24,14 @@ public sealed class LateBoundLocalControlOps(Func<ILocalControlOps> bind) : ILoc
         bind().ResolveConsentAsync(resolve, ct);
 }
 
-/// <see cref="IKcapCli"/> rebound per call, for the same reason: profile, canonical server and
-/// daemon name are all still being written while the wizard is open.
-public sealed class LateBoundKcapCli(Func<IKcapCli> bind) : IKcapCli {
-    public string? CliPath => bind().CliPath;
+/// <summary>
+/// <see cref="IKcapCli"/> rebound per CALL, for the same reason: profile, canonical server and
+/// daemon name are all still being written while the wizard is open. <see cref="CliPath"/> is the
+/// exception — the binary can't move mid-wizard, and it is read from UI bindings, which must not
+/// pay a config load per get.
+/// </summary>
+public sealed class LateBoundKcapCli(Func<IKcapCli> bind, string? cliPath) : IKcapCli {
+    public string? CliPath => cliPath;
 
     public Task<string?> VersionAsync(CancellationToken ct) => bind().VersionAsync(ct);
 

--- a/src/Capacitor.App/Services/Onboarding/WizardLifecycleSurface.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardLifecycleSurface.cs
@@ -1,0 +1,42 @@
+using ReactiveUI;
+
+namespace Capacitor.App.Services.Onboarding;
+
+/// ILifecycleSurface for wizard-first mode: decision 2 builds no tray and no main window while
+/// the wizard is open, so Status/Attention become step-local observable text instead of the
+/// tray/start-message lanes, and confirmations open a dialog windowed over OnboardingWindow. The
+/// same ConsumeMutationOutcomesAsync consumer therefore runs unchanged during onboarding. Dialog
+/// serialization is delegated to LifecycleSurface rather than re-implemented — one never-stack
+/// gate, one implementation.
+public sealed class WizardLifecycleSurface : ReactiveObject, ILifecycleSurface {
+    readonly LifecycleSurface _inner;
+
+    string? _statusText;
+    string? _attentionText;
+
+    /// <param name="post">Marshals the text updates onto the UI thread — the outcome consumer runs off it.</param>
+    public WizardLifecycleSurface(Func<LifecyclePrompt, CancellationToken, Task<bool>> showPrompt, Action<Action> post) =>
+        _inner = new LifecycleSurface(
+            message => post(() => StatusText = message),
+            message => post(() => AttentionText = message),
+            showPrompt);
+
+    public string? StatusText {
+        get => _statusText;
+        private set => this.RaiseAndSetIfChanged(ref _statusText, value);
+    }
+
+    /// Kept apart from StatusText so the wizard can render a repair/attention line distinctly.
+    public string? AttentionText {
+        get => _attentionText;
+        private set => this.RaiseAndSetIfChanged(ref _attentionText, value);
+    }
+
+    public void Status(string message) => _inner.Status(message);
+
+    public void Attention(string message) => _inner.Attention(message);
+
+    public Task<bool> ConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) => _inner.ConfirmAsync(prompt, ct);
+
+    public Task<bool?> TryConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) => _inner.TryConfirmAsync(prompt, ct);
+}

--- a/src/Capacitor.App/ViewModels/LifecyclePromptViewModel.cs
+++ b/src/Capacitor.App/ViewModels/LifecyclePromptViewModel.cs
@@ -24,6 +24,11 @@ public sealed class LifecyclePromptViewModel : ReactiveObject {
     public string Disclosure { get; }
     public bool PathDegraded { get; }
 
+    /// False only for KindQuarantine: a confirm-only acknowledgment, never a destructive/declinable action.
+    public bool ShowDeclineButton { get; }
+
+    public string AcceptButtonText { get; }
+
     /// Null when PathDegraded is false — bound with StringConverters.IsNotNullOrEmpty so the
     /// degraded-PATH line collapses instead of reserving dead space (ConsentPromptWindow's same
     /// pattern for its countdown/phase lines).
@@ -37,9 +42,11 @@ public sealed class LifecyclePromptViewModel : ReactiveObject {
     public ReactiveCommand<Unit, Unit> DeclineCommand { get; }
 
     public LifecyclePromptViewModel(LifecyclePrompt prompt, TaskCompletionSource<bool> tcs) {
-        Title        = TitleFor(prompt.Kind);
-        Disclosure   = prompt.Disclosure;
-        PathDegraded = prompt.PathDegraded;
+        Title             = TitleFor(prompt.Kind);
+        Disclosure        = prompt.Disclosure;
+        PathDegraded      = prompt.PathDegraded;
+        ShowDeclineButton = prompt.Kind != LifecyclePrompt.KindQuarantine;
+        AcceptButtonText  = prompt.Kind == LifecyclePrompt.KindQuarantine ? "Acknowledge" : "Continue";
 
         AcceptCommand  = ReactiveCommand.Create(() => Resolve(tcs, true));
         DeclineCommand = ReactiveCommand.Create(() => Resolve(tcs, false));
@@ -58,6 +65,7 @@ public sealed class LifecyclePromptViewModel : ReactiveObject {
         LifecyclePrompt.KindRestartUpdate => "Restart daemon to update",
         LifecyclePrompt.KindTakeover      => "Take over daemon management",
         LifecyclePrompt.KindShim          => "Install command-line tool",
+        LifecyclePrompt.KindQuarantine    => "Corrupted consent claims file",
         _                                 => "Repair daemon service", // KindRepair and any future kind
     };
 }

--- a/src/Capacitor.App/ViewModels/Onboarding/AgentsStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/AgentsStepViewModel.cs
@@ -1,0 +1,218 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.Setup;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels.Onboarding;
+
+/// One coding-agent vendor: label, its exclusive plugin-install flag (null = Claude's flagless
+/// default), and its AgentDetectionResult selector. Order here is display AND sequential-install
+/// order (spec §5's exclusive-flag list, Claude first) — shared by the Agents and Import steps.
+internal sealed record AgentVendor(string Label, string? Flag, Func<AgentDetectionResult, DetectedAgent> Select);
+
+internal static class AgentVendors {
+    public static readonly IReadOnlyList<AgentVendor> All = [
+        new("Claude Code", null,            r => r.Claude),
+        new("Codex",       "--codex",       r => r.Codex),
+        new("Cursor",      "--cursor",      r => r.Cursor),
+        new("Copilot",     "--copilot",     r => r.Copilot),
+        new("Gemini",      "--gemini",      r => r.Gemini),
+        new("Kiro",        "--kiro",        r => r.Kiro),
+        new("Pi",          "--pi",          r => r.Pi),
+        new("OpenCode",    "--opencode",    r => r.OpenCode),
+        new("Antigravity", "--antigravity", r => r.Antigravity),
+    ];
+}
+
+public enum AgentInstallStatus { NotRun, Installing, Succeeded, Failed }
+
+/// One vendor row on the Agents step, with its own checkbox and its own Retry command.
+public sealed class AgentVendorRow : ReactiveObject {
+    internal readonly string? Flag;
+    readonly Func<AgentDetectionResult, DetectedAgent> _select;
+
+    bool _isSelected;
+    AgentInstallStatus _status = AgentInstallStatus.NotRun;
+    string? _message;
+
+    internal AgentVendorRow(AgentVendor vendor, Func<AgentVendorRow, Task> retry, IObservable<bool> canRetry) {
+        Label   = vendor.Label;
+        Flag    = vendor.Flag;
+        _select = vendor.Select;
+
+        RetryCommand = ReactiveCommand.CreateFromTask(() => retry(this), canRetry);
+    }
+
+    public string Label { get; }
+
+    public bool IsSelected {
+        get => _isSelected;
+        set => this.RaiseAndSetIfChanged(ref _isSelected, value);
+    }
+
+    public AgentInstallStatus Status {
+        get => _status;
+        internal set {
+            this.RaiseAndSetIfChanged(ref _status, value);
+            this.RaisePropertyChanged(nameof(Glyph));
+            this.RaisePropertyChanged(nameof(Failed));
+            this.RaisePropertyChanged(nameof(Succeeded));
+        }
+    }
+
+    public string? Message {
+        get => _message;
+        internal set => this.RaiseAndSetIfChanged(ref _message, value);
+    }
+
+    public string Glyph => Status switch {
+        AgentInstallStatus.Succeeded  => "✓",
+        AgentInstallStatus.Failed     => "⚠",
+        AgentInstallStatus.Installing => "…",
+        _                             => "",
+    };
+
+    public bool Failed    => Status == AgentInstallStatus.Failed;
+    public bool Succeeded => Status == AgentInstallStatus.Succeeded;
+
+    public ReactiveCommand<Unit, Unit> RetryCommand { get; }
+
+    internal bool DetectedIn(AgentDetectionResult result) => _select(result).Detected;
+}
+
+/// spec §3 step 5 / decision 8: one checkbox per coding-agent vendor, pre-checked when detected.
+/// Install runs sequentially (Claude first, then §5's exclusive-flag order) so one vendor's
+/// failure never blocks the rest — successes stand, and only the failed row offers Retry.
+public sealed class AgentsStepViewModel : ReactiveObject, IWizardStep {
+    readonly IKcapCli _cli;
+    readonly Func<CancellationToken, Task<AgentDetectionResult>> _detect;
+
+    AgentDetectionResult? _detected;
+    Task? _inFlight;
+    bool _busy;
+    bool _satisfied;
+
+    public AgentsStepViewModel(IKcapCli cli, Func<CancellationToken, Task<AgentDetectionResult>> detect) {
+        _cli    = cli;
+        _detect = detect;
+
+        var idle = this.WhenAnyValue(x => x.Busy, busy => !busy);
+        Rows = AgentVendors.All.Select(v => new AgentVendorRow(v, RetryOneAsync, idle)).ToList();
+        InstallCommand = ReactiveCommand.CreateFromTask(RunInstallAsync, idle.Select(i => i && CliAvailable));
+    }
+
+    public WizardStepId Id         => WizardStepId.Agents;
+    public string       Title      => "Coding agents";
+    public bool         Applicable => true;
+
+    public IReadOnlyList<AgentVendorRow> Rows { get; }
+
+    public bool CliAvailable => _cli.CliPath is not null;
+
+    public string? Message => CliAvailable ? null : "kcap CLI not found";
+
+    public bool Busy {
+        get => _busy;
+        private set {
+            this.RaiseAndSetIfChanged(ref _busy, value);
+            this.RaisePropertyChanged(nameof(Idle));
+        }
+    }
+
+    public bool Idle => !Busy;
+
+    public bool Satisfied {
+        get => _satisfied;
+        private set => this.RaiseAndSetIfChanged(ref _satisfied, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> InstallCommand { get; }
+
+    public async Task OnEnterAsync(CancellationToken ct) {
+        if (_detected is not null) return; // cached: re-entering the step must not stomp user choices
+
+        AgentDetectionResult detected;
+        try { detected = await _detect(ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { return; }
+
+        _detected = detected;
+        foreach (var row in Rows) row.IsSelected = row.DetectedIn(detected);
+    }
+
+    // Never vetoes: installs are short/bounded, so leaving just awaits the in-flight one rather than killing it.
+    public async Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) {
+        if (_inFlight is { } run) {
+            try { await run.ConfigureAwait(false); }
+            catch (Exception ex) { Console.Error.WriteLine($"kcap: wizard agents install failed unexpectedly: {ex.Message}"); }
+        }
+
+        return true;
+    }
+
+    internal Task RunInstallAsync() {
+        if (Busy) return Task.CompletedTask;
+        return _inFlight = RunInstallCoreAsync();
+    }
+
+    async Task RunInstallCoreAsync() {
+        if (!CliAvailable) return;
+
+        Busy = true;
+        try {
+            foreach (var row in Rows.Where(r => r.IsSelected).ToList())
+                await InstallOneAsync(row).ConfigureAwait(false);
+        } finally {
+            Busy = false;
+        }
+    }
+
+    internal Task RetryOneAsync(AgentVendorRow row) {
+        if (Busy) return Task.CompletedTask;
+        return _inFlight = RetryOneCoreAsync(row);
+    }
+
+    async Task RetryOneCoreAsync(AgentVendorRow row) {
+        if (!CliAvailable) return;
+
+        Busy = true;
+        try { await InstallOneAsync(row).ConfigureAwait(false); }
+        finally { Busy = false; }
+    }
+
+    async Task InstallOneAsync(AgentVendorRow row) {
+        row.Status  = AgentInstallStatus.Installing;
+        row.Message = null;
+
+        try {
+            var result = await _cli.PluginInstallAsync(row.Flag, CancellationToken.None).ConfigureAwait(false);
+            if (result.ExitCode == 0) {
+                row.Status = AgentInstallStatus.Succeeded;
+            } else {
+                row.Status  = AgentInstallStatus.Failed;
+                row.Message = string.IsNullOrWhiteSpace(result.Stderr) ? $"Install failed (exit {result.ExitCode})." : result.Stderr;
+            }
+        } catch (Exception ex) {
+            row.Status  = AgentInstallStatus.Failed;
+            row.Message = ex.Message;
+        }
+
+        UpdateSatisfied();
+    }
+
+    void UpdateSatisfied() {
+        var selected = Rows.Where(r => r.IsSelected).ToList();
+        Satisfied = selected.Count > 0 && selected.All(r => r.Status == AgentInstallStatus.Succeeded);
+    }
+
+    /// The app's detection feed (spec §8/decision 8): process env overridden with the login-shell
+    /// terminal PATH when the probe resolves one — a GUI-launched app otherwise only sees its own
+    /// inherited launchd PATH, not whatever the user's shell profile adds.
+    public static Func<CancellationToken, Task<AgentDetectionResult>> BuildDetectionFeed(ILoginShellProbe probe) =>
+        async ct => {
+            var inputs = AgentDetection.FromEnvironment();
+            var terminalPath = await probe.TerminalPathAsync(ct).ConfigureAwait(false);
+            if (terminalPath is not null) inputs = inputs with { PathEnv = terminalPath };
+            return AgentDetection.Detect(inputs);
+        };
+}

--- a/src/Capacitor.App/ViewModels/Onboarding/ConnectStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/ConnectStepViewModel.cs
@@ -1,0 +1,125 @@
+using Capacitor.App.Services.Onboarding;
+using Capacitor.Cli.Core.Auth;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels.Onboarding;
+
+public enum ConnectChoice { Discover, Paste, Create }
+
+/// <summary>
+/// Intent only (spec §3 step 2): nothing here reaches the network or writes anything. The Sign-in
+/// step runs whatever this stages. A pasted server is normalized by the SAME rule the operation
+/// uses, then validated by the gate's shared server-URL validator, so "Next accepted it" and "the
+/// gate can be satisfied by it" can never disagree.
+/// </summary>
+public sealed class ConnectStepViewModel : ReactiveObject, IWizardStep {
+    ConnectChoice _choice = ConnectChoice.Discover;
+    string        _serverInputText = "";
+    string        _discoveryProvider = AuthProvider.GitHubApp;
+    string?       _inputError;
+
+    public WizardStepId Id         => WizardStepId.Connect;
+    public string       Title      => "Connect to Capacitor";
+    public bool         Applicable => true;
+
+    public ConnectChoice Choice {
+        get => _choice;
+        set {
+            this.RaiseAndSetIfChanged(ref _choice, value);
+            Restate();
+        }
+    }
+
+    public string ServerInputText {
+        get => _serverInputText;
+        set {
+            this.RaiseAndSetIfChanged(ref _serverInputText, value);
+            InputError = null; // editing clears the stale complaint
+            Restate();
+        }
+    }
+
+    /// <see cref="AuthProvider.GitHubApp"/> or <see cref="AuthProvider.WorkOS"/>.
+    public string DiscoveryProvider {
+        get => _discoveryProvider;
+        set {
+            this.RaiseAndSetIfChanged(ref _discoveryProvider, value);
+            Restate();
+        }
+    }
+
+    public string? InputError {
+        get => _inputError;
+        private set => this.RaiseAndSetIfChanged(ref _inputError, value);
+    }
+
+    // Radio-button facets: the enum stays the single source of truth.
+    public bool DiscoverSelected {
+        get => Choice == ConnectChoice.Discover;
+        set { if (value) Choice = ConnectChoice.Discover; }
+    }
+
+    public bool PasteSelected {
+        get => Choice == ConnectChoice.Paste;
+        set { if (value) Choice = ConnectChoice.Paste; }
+    }
+
+    public bool CreateSelected {
+        get => Choice == ConnectChoice.Create;
+        set { if (value) Choice = ConnectChoice.Create; }
+    }
+
+    public bool GitHubProvider {
+        get => DiscoveryProvider == AuthProvider.GitHubApp;
+        set { if (value) DiscoveryProvider = AuthProvider.GitHubApp; }
+    }
+
+    public bool WorkOSProvider {
+        get => DiscoveryProvider == AuthProvider.WorkOS;
+        set { if (value) DiscoveryProvider = AuthProvider.WorkOS; }
+    }
+
+    /// What the Sign-in step will run; null while the paste input is unusable.
+    public ConnectIntent? Intent => Choice switch {
+        ConnectChoice.Discover                                 => new ConnectIntent.Discover(DiscoveryProvider),
+        ConnectChoice.Create                                   => new ConnectIntent.Create(),
+        ConnectChoice.Paste when UsableServer() is { } server   => new ConnectIntent.Paste(server),
+        _                                                      => null
+    };
+
+    public bool Satisfied => Intent is not null;
+
+    /// The Sign-in step's answer to a retarget: come back here with the workspace filled in.
+    public void Prefill(string target) {
+        ServerInputText = target;
+        Choice          = ConnectChoice.Paste;
+    }
+
+    public Task OnEnterAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) {
+        if (direction != WizardNavigation.Next || Intent is not null) return Task.FromResult(true);
+
+        InputError = "Enter a workspace name (e.g. acme) or a full https:// server URL.";
+
+        return Task.FromResult(false);
+    }
+
+    string? UsableServer() {
+        if (string.IsNullOrWhiteSpace(ServerInputText)) return null;
+
+        var resolved = WizardSignInOperation.ResolveServer(ServerInputText);
+
+        return OnboardingGate.ValidServerUrl(resolved) ? resolved : null;
+    }
+
+    void Restate() {
+        this.RaisePropertyChanged(nameof(Intent));
+        this.RaisePropertyChanged(nameof(Satisfied));
+        this.RaisePropertyChanged(nameof(DiscoverSelected));
+        this.RaisePropertyChanged(nameof(PasteSelected));
+        this.RaisePropertyChanged(nameof(CreateSelected));
+        this.RaisePropertyChanged(nameof(GitHubProvider));
+        this.RaisePropertyChanged(nameof(WorkOSProvider));
+    }
+}

--- a/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
@@ -18,7 +18,7 @@ public enum DaemonRow {
 /// The single action a row offers, or None.
 public enum DaemonAffordance { None, Install, Start, Takeover, Repair }
 
-/// Daemon enablement over the lifecycle state matrix; outcomes are presented by the channel's single consumer, never by this step directly.
+/// Daemon enablement over the lifecycle state matrix; mutations update this step's status only — dialogs/recovery are presented by the channel's single consumer.
 public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
     internal const string ConsentV3Capability = "consent/3";
 

--- a/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
@@ -10,7 +10,7 @@ namespace Capacitor.App.ViewModels.Onboarding;
 
 /// One classified row of the spec §3 step-7 matrix — the step's whole decision, named.
 public enum DaemonRow {
-    CliMissing, RequiresSignIn, NoServerConfigured, StatusUnknown, TransactionActive,
+    CliMissing, RequiresSignIn, NoServerConfigured, BinaryUnresolved, StatusUnknown, TransactionActive,
     AlreadyEnabled, OwnedIdentityMismatch, ManualIdentityMatch, ManualIdentityMismatch,
     OrphanLabel, StaleMarker, RunningUnconfirmed, Stopped, NotInstalled,
 }
@@ -18,16 +18,18 @@ public enum DaemonRow {
 /// The single action a row offers, or None.
 public enum DaemonAffordance { None, Install, Start, Takeover, Repair }
 
-/// spec §3 step 7: daemon enablement on AI-1654's full state matrix. Every mutation runs through
-/// the injected lane delegate and its result updates THIS step's state only — actionable outcomes
-/// travel the lane's outcome channel to the single consumer (single-presentation rule). The one
-/// dialog this step opens itself is the PRE-mutation takeover/repair consent, which is a user
-/// gate, not outcome presentation.
+/// spec §3 step 7: daemon enablement on the lifecycle slice's full state matrix. Every mutation
+/// runs through the injected lane delegate and its result updates THIS step's state only —
+/// actionable outcomes travel the lane's outcome channel to the single consumer
+/// (single-presentation rule). The one dialog this step opens itself is the PRE-mutation
+/// takeover/repair consent, which is a user gate, not outcome presentation.
 public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
     internal const string ConsentV3Capability = "consent/3";
 
     internal const string CliMissingMessage    = "kcap CLI not found";
     internal const string RequiresSignInMessage = "Enabling the daemon requires sign-in — sign in first, or skip this step.";
+    internal const string NoServerMessage       = "Server not configured — complete the Sign in step first.";
+    internal const string BinaryUnresolvedMessage = "kcap can't resolve its own daemon binary — reinstall kcap.";
     internal const string StatusUnknownMessage = "Could not read the daemon service status — no changes made.";
     internal const string UnrecognizedStateMessage = "The daemon service reported an unrecognized state — no changes made.";
     internal const string TxnWaitingMessage    = "Waiting for a daemon service operation to finish…";
@@ -45,6 +47,8 @@ public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
         "This daemon is too old to accept the consent update — kcap will apply it once the daemon updates.";
     internal const string ClaimFailedMessage =
         "kcap could not update this daemon's consent default — run `kcap daemon consent set-default prompt`, or re-run onboarding.";
+    internal const string ClaimAlreadyStricterMessage =
+        "This daemon already denies launches by default — kcap left that stricter setting alone.";
 
     internal static readonly TimeSpan TxnPollInterval = TimeSpan.FromSeconds(2);
     internal const int MaxTxnPolls = 30; // 30 × 2s ≈ the CLI transaction's own 60s worst case
@@ -209,12 +213,15 @@ public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
             if (MutationRequestFactory.TryBuild(
                     MutationVerb.StartVerified, identity.Profile, identity.Server, identity.DaemonName, out var request)
                 is MutationOutcome.Refused(var guardReason, _)) {
-                Set(DaemonRow.NoServerConfigured, $"kcap: {guardReason}", DaemonAffordance.None);
+                Set(DaemonRow.NoServerConfigured, NoServerMessage, DaemonAffordance.None);
+                Console.Error.WriteLine($"kcap: wizard daemon step refused before status: {guardReason}");
                 return;
             }
 
             _request = request!;
-            await ClassifySnapshotAsync(await ReadStatusAsync(ct).ConfigureAwait(false), ct).ConfigureAwait(false);
+            var snapshot = await ReadStatusAsync(ct).ConfigureAwait(false);
+            await ClassifySnapshotAsync(snapshot, ct).ConfigureAwait(false);
+            WithdrawUnitWritingOfferWithoutBinary(snapshot);
         } catch (OperationCanceledException) {
             // left the step (or shutting down) mid-classification — nothing to surface
         } catch (Exception ex) {
@@ -318,6 +325,16 @@ public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
             DaemonAffordance.Takeover);
     }
 
+    /// The install-only viability precondition: a unit-writing offer without a resolvable daemon
+    /// binary is a guaranteed coded failure, so it is withdrawn rather than offered. The start row
+    /// is exempt — starting an installed unit writes none.
+    void WithdrawUnitWritingOfferWithoutBinary(ServiceSnapshot? snapshot) {
+        if (snapshot?.InstallBinaryPath is not null) return;
+        if (Affordance is not (DaemonAffordance.Install or DaemonAffordance.Takeover or DaemonAffordance.Repair)) return;
+
+        Set(DaemonRow.BinaryUnresolved, BinaryUnresolvedMessage, DaemonAffordance.None);
+    }
+
     static string DescribeForeign(ObservedEvidence? evidence) =>
         evidence is { Reachable: true, ServerUrl: { Length: > 0 } server }
             ? $"a daemon for {server}"
@@ -328,7 +345,7 @@ public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
     static bool IdentityMatches(ObservedEvidence? evidence, MutationRequest request) =>
         evidence is { Reachable: true, IdentityConsistent: true }
         && evidence.DaemonName == request.DaemonName
-        && ServerIdentity.Canonicalize(evidence.ServerUrl) == request.CanonicalServer;
+        && ServerIdentity.Matches(evidence.ServerUrl, request.CanonicalServer);
 
     void Set(DaemonRow row, string message, DaemonAffordance affordance) {
         Row        = row;
@@ -428,6 +445,12 @@ public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
         ConsentAckDto ack;
         try {
             var policy = await _ops.GetConsentPolicyAsync(CancellationToken.None).ConfigureAwait(false);
+            // §6 seeding respects an operator's deny: it is stricter than prompt, so the flip is inert here.
+            if (policy.Default == "deny") {
+                Status = Append(Status, ClaimAlreadyStricterMessage);
+                return;
+            }
+
             var put = new ConsentPolicyPutV2Dto(request.DaemonName, claim.CanonicalServer, policy with { Default = "prompt" });
             ack = await _ops.PutConsentPolicyV2Async(put, CancellationToken.None).ConfigureAwait(false);
         } catch (LocalControlOpsException) {

--- a/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
@@ -1,0 +1,473 @@
+using System.Reactive;
+using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.LocalIpc;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels.Onboarding;
+
+/// One classified row of the spec §3 step-7 matrix — the step's whole decision, named.
+public enum DaemonRow {
+    CliMissing, RequiresSignIn, NoServerConfigured, StatusUnknown, TransactionActive,
+    AlreadyEnabled, OwnedIdentityMismatch, ManualIdentityMatch, ManualIdentityMismatch,
+    OrphanLabel, StaleMarker, RunningUnconfirmed, Stopped, NotInstalled,
+}
+
+/// The single action a row offers, or None.
+public enum DaemonAffordance { None, Install, Start, Takeover, Repair }
+
+/// spec §3 step 7: daemon enablement on AI-1654's full state matrix. Every mutation runs through
+/// the injected lane delegate and its result updates THIS step's state only — actionable outcomes
+/// travel the lane's outcome channel to the single consumer (single-presentation rule). The one
+/// dialog this step opens itself is the PRE-mutation takeover/repair consent, which is a user
+/// gate, not outcome presentation.
+public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
+    internal const string ConsentV3Capability = "consent/3";
+
+    internal const string CliMissingMessage    = "kcap CLI not found";
+    internal const string RequiresSignInMessage = "Enabling the daemon requires sign-in — sign in first, or skip this step.";
+    internal const string StatusUnknownMessage = "Could not read the daemon service status — no changes made.";
+    internal const string UnrecognizedStateMessage = "The daemon service reported an unrecognized state — no changes made.";
+    internal const string TxnWaitingMessage    = "Waiting for a daemon service operation to finish…";
+    internal const string TxnActiveMessage     = "A daemon service operation is still in progress — try again in a moment.";
+    internal const string AlreadyEnabledMessage = "The daemon service is already enabled.";
+    internal const string StaleMarkerNote      = "A previous operation left a stale marker.";
+    internal const string StaleMarkerMessage   = "A previous daemon service operation left a stale marker — repair the service.";
+    internal const string OrphanLabelMessage   = "The daemon service label is loaded but its unit file is missing — repair the service.";
+    internal const string RunningUnconfirmedMessage = "The service reports its job running, but no daemon answers it yet — try again in a moment.";
+    internal const string StoppedMessage       = "The daemon service is installed but not running.";
+    internal const string NotInstalledMessage  = "kcap will install the daemon service and start it.";
+    internal const string TakeoverDeclinedMessage = "Left as it is — the daemon service was not replaced.";
+    internal const string DetachedMessage      = "kcap is still finishing this operation in the background.";
+    internal const string ClaimMissingCapabilityMessage =
+        "This daemon is too old to accept the consent update — kcap will apply it once the daemon updates.";
+    internal const string ClaimFailedMessage =
+        "kcap could not update this daemon's consent default — run `kcap daemon consent set-default prompt`, or re-run onboarding.";
+
+    internal static readonly TimeSpan TxnPollInterval = TimeSpan.FromSeconds(2);
+    internal const int MaxTxnPolls = 30; // 30 × 2s ≈ the CLI transaction's own 60s worst case
+
+    readonly IKcapCli _cli;
+    readonly Func<MutationRequest, CancellationToken, Task<MutationOutcome>> _runMutation;
+    readonly Func<(string Profile, string Server, string DaemonName)?> _resolveIdentity;
+    readonly IDaemonObservation _observation;
+    readonly ILocalControlOps _ops;
+    readonly ConsentFlipClaims _claims;
+    readonly Func<(string Profile, string Server, string DaemonName)> _resolveIdentityUnderConfigLock;
+    readonly ILifecycleSurface _surface;
+    readonly Func<CancellationToken, Task<string?>> _terminalPathAsync;
+    readonly TimeProvider _time;
+
+    MutationRequest? _request;
+    ObservedEvidence? _evidence;
+    CancellationTokenSource? _classifyCts;
+    CancellationTokenSource? _actionCts;
+    Task? _classifyRun;
+    Task? _actionRun;
+
+    DaemonRow _row = DaemonRow.StatusUnknown;
+    DaemonAffordance _affordance;
+    bool _busy;
+    bool _satisfied;
+    string? _message;
+    string? _status;
+
+    public DaemonStepViewModel(
+            IKcapCli cli,
+            Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
+            Func<(string Profile, string Server, string DaemonName)?> resolveIdentity,
+            IDaemonObservation observation,
+            ILocalControlOps ops,
+            ConsentFlipClaims claims,
+            Func<(string Profile, string Server, string DaemonName)> resolveIdentityUnderConfigLock,
+            ILifecycleSurface surface,
+            Func<CancellationToken, Task<string?>> terminalPathAsync,
+            TimeProvider time) {
+        _cli                            = cli;
+        _runMutation                    = runMutation;
+        _resolveIdentity                = resolveIdentity;
+        _observation                    = observation;
+        _ops                            = ops;
+        _claims                         = claims;
+        _resolveIdentityUnderConfigLock = resolveIdentityUnderConfigLock;
+        _surface                        = surface;
+        _terminalPathAsync              = terminalPathAsync;
+        _time                           = time;
+
+        var idle = this.WhenAnyValue(x => x.Busy, busy => !busy);
+        ActionCommand  = ReactiveCommand.CreateFromTask(RunActionAsync,
+            this.WhenAnyValue(x => x.Busy, x => x.Affordance, (busy, affordance) => !busy && affordance != DaemonAffordance.None));
+        RefreshCommand = ReactiveCommand.CreateFromTask(() => RefreshAsync(CancellationToken.None), idle);
+    }
+
+    public WizardStepId Id         => WizardStepId.Daemon;
+    public string       Title      => "Enable the daemon";
+    public bool         Applicable => true;
+
+    /// Set ONLY by the lane's own success outcome or the already-enabled row, and never cleared —
+    /// a later re-classification must not re-derive (or revoke) a mutation's success from a snapshot.
+    public bool Satisfied {
+        get => _satisfied;
+        private set => this.RaiseAndSetIfChanged(ref _satisfied, value);
+    }
+
+    public DaemonRow Row {
+        get => _row;
+        private set => this.RaiseAndSetIfChanged(ref _row, value);
+    }
+
+    public DaemonAffordance Affordance {
+        get => _affordance;
+        private set {
+            this.RaiseAndSetIfChanged(ref _affordance, value);
+            this.RaisePropertyChanged(nameof(ActionLabel));
+        }
+    }
+
+    public string? ActionLabel => Affordance switch {
+        DaemonAffordance.Install  => "Enable daemon",
+        DaemonAffordance.Start    => "Start daemon",
+        DaemonAffordance.Takeover => "Replace daemon service",
+        DaemonAffordance.Repair   => "Repair daemon service",
+        _                         => null,
+    };
+
+    public bool Busy {
+        get => _busy;
+        private set {
+            this.RaiseAndSetIfChanged(ref _busy, value);
+            this.RaisePropertyChanged(nameof(Idle));
+        }
+    }
+
+    public bool Idle => !Busy;
+
+    /// What the current row found — the honest line, present on every row.
+    public string? Message {
+        get => _message;
+        private set => this.RaiseAndSetIfChanged(ref _message, value);
+    }
+
+    /// The last action's result, mapped from the lane's own outcome — never a re-derived one.
+    public string? Status {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> ActionCommand  { get; }
+    public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+
+    public Task OnEnterAsync(CancellationToken ct) => RefreshAsync(ct);
+
+    /// Never vetoes: a running mutation belongs to the LANE (§6a), so cancelling detaches this
+    /// waiter only. A running claim put is untokened and simply awaited (bounded by LocalControlOps).
+    public async Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) {
+        _classifyCts?.Cancel();
+        _actionCts?.Cancel();
+
+        await AwaitQuietlyAsync(_classifyRun).ConfigureAwait(false);
+        await AwaitQuietlyAsync(_actionRun).ConfigureAwait(false);
+
+        return true;
+    }
+
+    static async Task AwaitQuietlyAsync(Task? task) {
+        if (task is null) return;
+        try { await task.ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* leaving mid-work is not a failure */ }
+        catch (Exception ex) { Console.Error.WriteLine($"kcap: wizard daemon step failed unexpectedly: {ex.Message}"); }
+    }
+
+    internal Task RefreshAsync(CancellationToken ct) {
+        if (Busy) return Task.CompletedTask;
+
+        _classifyCts?.Dispose();
+        _classifyCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        return _classifyRun = ClassifyAsync(_classifyCts.Token);
+    }
+
+    async Task ClassifyAsync(CancellationToken ct) {
+        Busy = true;
+        try {
+            _request  = null;
+            _evidence = null;
+            Status    = null;
+
+            if (_cli.CliPath is null) {
+                Set(DaemonRow.CliMissing, CliMissingMessage, DaemonAffordance.None);
+                return;
+            }
+
+            if (_resolveIdentity() is not { } identity) {
+                Set(DaemonRow.RequiresSignIn, RequiresSignInMessage, DaemonAffordance.None);
+                return;
+            }
+
+            // Guarded before any snapshot read — an unbindable server never reaches a mutation.
+            if (MutationRequestFactory.TryBuild(
+                    MutationVerb.StartVerified, identity.Profile, identity.Server, identity.DaemonName, out var request)
+                is MutationOutcome.Refused(var guardReason, _)) {
+                Set(DaemonRow.NoServerConfigured, $"kcap: {guardReason}", DaemonAffordance.None);
+                return;
+            }
+
+            _request = request!;
+            await ClassifySnapshotAsync(await ReadStatusAsync(ct).ConfigureAwait(false), ct).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            // left the step (or shutting down) mid-classification — nothing to surface
+        } catch (Exception ex) {
+            Set(DaemonRow.StatusUnknown, StatusUnknownMessage, DaemonAffordance.None); // unknown, never a positive row
+            Console.Error.WriteLine($"kcap: wizard daemon step classification failed unexpectedly: {ex.Message}");
+        } finally {
+            Busy = false;
+        }
+    }
+
+    /// spec §6a: a held transaction is waited out, never mutated into. Bounded — an orphaned
+    /// grandchild that outlives a force-quit must not wedge the step forever.
+    async Task<ServiceSnapshot?> ReadStatusAsync(CancellationToken ct) {
+        for (var poll = 0; ; poll++) {
+            var snapshot = await _cli.ServiceStatusAsync(ct).ConfigureAwait(false);
+            if (snapshot is null || !snapshot.TxnActive || poll >= MaxTxnPolls) return snapshot;
+
+            Message = TxnWaitingMessage;
+            await Task.Delay(TxnPollInterval, _time, ct).ConfigureAwait(false);
+        }
+    }
+
+    // Precedence: unreadable evidence, live transaction, the pid-keyed ownership rows, then the
+    // repair rows — a stale marker precedes every install/start row, never a blind reinstall (§6a).
+    async Task ClassifySnapshotAsync(ServiceSnapshot? snapshot, CancellationToken ct) {
+        if (snapshot is null) {
+            Set(DaemonRow.StatusUnknown, StatusUnknownMessage, DaemonAffordance.None);
+            return;
+        }
+
+        var state = ServiceStateClassifier.Parse(snapshot.State);
+        if (state == ServiceState.Unknown) {
+            Set(DaemonRow.StatusUnknown, UnrecognizedStateMessage, DaemonAffordance.None);
+            return;
+        }
+
+        if (snapshot.TxnActive) {
+            Set(DaemonRow.TransactionActive, TxnActiveMessage, DaemonAffordance.None);
+            return;
+        }
+
+        if (snapshot.DaemonPid is { } daemonPid) {
+            await ClassifyLiveDaemonAsync(snapshot, daemonPid, ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (state == ServiceState.Installed && !snapshot.UnitPresent) {
+            Set(DaemonRow.OrphanLabel, OrphanLabelMessage, DaemonAffordance.Repair);
+            return;
+        }
+
+        if (snapshot.TxnMarker) {
+            Set(DaemonRow.StaleMarker, StaleMarkerMessage, DaemonAffordance.Repair);
+            return;
+        }
+
+        if (state == ServiceState.Running) {
+            Set(DaemonRow.RunningUnconfirmed, RunningUnconfirmedMessage, DaemonAffordance.None);
+            return;
+        }
+
+        if (snapshot.UnitPresent) {
+            Set(DaemonRow.Stopped, StoppedMessage, DaemonAffordance.Start);
+            return;
+        }
+
+        Set(DaemonRow.NotInstalled, NotInstalledMessage, DaemonAffordance.Install);
+    }
+
+    async Task ClassifyLiveDaemonAsync(ServiceSnapshot snapshot, int daemonPid, CancellationToken ct) {
+        _evidence = await _observation.ObserveAsync(_request!, ct).ConfigureAwait(false);
+        var matched = IdentityMatches(_evidence, _request!);
+        var owned   = snapshot.JobPid is not null && snapshot.JobPid == snapshot.DaemonPid;
+
+        if (owned && matched) {
+            Set(DaemonRow.AlreadyEnabled,
+                snapshot.TxnMarker ? $"{AlreadyEnabledMessage} {StaleMarkerNote}" : AlreadyEnabledMessage,
+                DaemonAffordance.None);
+            Satisfied = true;
+            await ApplyPendingClaimAsync(_request!, _evidence).ConfigureAwait(false);
+            return;
+        }
+
+        if (owned) {
+            Set(DaemonRow.OwnedIdentityMismatch,
+                $"The installed daemon service is running {DescribeForeign(_evidence)} — replacing it re-points the service at this profile.",
+                DaemonAffordance.Takeover);
+            return;
+        }
+
+        if (matched) {
+            // Not enablement: a manual daemon dies at logout and no later startup phase repairs it.
+            Set(DaemonRow.ManualIdentityMatch,
+                $"A daemon is already running outside the service (pid {daemonPid}) — it stops at logout unless kcap manages it.",
+                DaemonAffordance.Takeover);
+            return;
+        }
+
+        Set(DaemonRow.ManualIdentityMismatch,
+            $"{DescribeForeign(_evidence)} is already running under this name (pid {daemonPid}) — kcap changed nothing.",
+            DaemonAffordance.Takeover);
+    }
+
+    static string DescribeForeign(ObservedEvidence? evidence) =>
+        evidence is { Reachable: true, ServerUrl: { Length: > 0 } server }
+            ? $"a daemon for {server}"
+            : "a daemon kcap could not identify";
+
+    /// Fail closed (§6 probe): a positive match needs a reachable daemon whose two probe dials
+    /// provably landed on the SAME process and whose name and canonical server both agree.
+    static bool IdentityMatches(ObservedEvidence? evidence, MutationRequest request) =>
+        evidence is { Reachable: true, IdentityConsistent: true }
+        && evidence.DaemonName == request.DaemonName
+        && ServerIdentity.Canonicalize(evidence.ServerUrl) == request.CanonicalServer;
+
+    void Set(DaemonRow row, string message, DaemonAffordance affordance) {
+        Row        = row;
+        Message    = message;
+        Affordance = affordance;
+    }
+
+    internal Task RunActionAsync() {
+        if (Busy) return Task.CompletedTask;
+
+        _actionCts?.Dispose();
+        _actionCts = new CancellationTokenSource();
+        return _actionRun = RunActionCoreAsync(_actionCts.Token);
+    }
+
+    async Task RunActionCoreAsync(CancellationToken ct) {
+        Busy = true;
+        try {
+            switch (Affordance) {
+                case DaemonAffordance.Install:
+                    await RunMutationAsync(MutationVerb.Install, ct).ConfigureAwait(false);
+                    break;
+                case DaemonAffordance.Start:
+                    await RunMutationAsync(MutationVerb.StartVerified, ct).ConfigureAwait(false);
+                    break;
+                case DaemonAffordance.Takeover:
+                    await RunConsentedReplaceAsync(LifecyclePrompt.KindTakeover, ct).ConfigureAwait(false);
+                    break;
+                case DaemonAffordance.Repair:
+                    await RunConsentedReplaceAsync(LifecyclePrompt.KindRepair, ct).ConfigureAwait(false);
+                    break;
+            }
+        } catch (OperationCanceledException) {
+            Status = DetachedMessage;
+        } catch (Exception ex) {
+            Status = $"The daemon service operation failed unexpectedly: {ex.Message}";
+        } finally {
+            Busy = false;
+        }
+    }
+
+    // The ONLY dialog this step opens: consent BEFORE a unit rewrite (spec decision 3's
+    // disclosure). Outcome presentation belongs to the channel consumer, never to this waiter.
+    async Task RunConsentedReplaceAsync(string kind, CancellationToken ct) {
+        var pathDegraded = await _terminalPathAsync(ct).ConfigureAwait(false) is null;
+        var prompt = new LifecyclePrompt(
+            kind, null, null, pathDegraded, DaemonLifecycleController.TakeoverDisclosure);
+
+        if (!await _surface.ConfirmAsync(prompt, ct).ConfigureAwait(false)) {
+            Status = TakeoverDeclinedMessage;
+            // Decline leaves the step visibly incomplete — but the flip protects the owner
+            // regardless of which process hosts an identity-MATCHED daemon (§3 step 7).
+            if (Row == DaemonRow.ManualIdentityMatch) await ApplyPendingClaimAsync(_request!, _evidence).ConfigureAwait(false);
+            return;
+        }
+
+        await RunMutationAsync(MutationVerb.Replace, ct).ConfigureAwait(false);
+    }
+
+    async Task RunMutationAsync(MutationVerb verb, CancellationToken ct) {
+        var request = _request! with { Verb = verb };
+        var outcome = await _runMutation(request, ct).ConfigureAwait(false);
+
+        // The lane's own outcome IS the predicate — never a status snapshot read afterwards.
+        Status = OutcomeStatus(verb, outcome);
+        if (outcome is not (MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout)) return;
+
+        Satisfied = true;
+        _evidence = await _observation.ObserveAsync(request, ct).ConfigureAwait(false);
+        if (IdentityMatches(_evidence, request)) await ApplyPendingClaimAsync(request, _evidence).ConfigureAwait(false);
+    }
+
+    /// spec §6 step-7 application: the identity-conditional put, with NO factory guard. The live
+    /// policy is still read first because ConsentRulesPutV2 replaces the whole policy — a get-less
+    /// put would silently drop the daemon's own rules and prompt timeout. Untokened by design:
+    /// leaving the step awaits this rather than cancelling between the ack and the claim clear.
+    async Task ApplyPendingClaimAsync(MutationRequest request, ObservedEvidence? evidence) {
+        try {
+            await ApplyPendingClaimCoreAsync(request, evidence).ConfigureAwait(false);
+        } catch (Exception ex) {
+            Status = Append(Status, ClaimFailedMessage); // claim retained for the post-wizard coordinator
+            Console.Error.WriteLine($"kcap: wizard daemon step consent flip failed unexpectedly: {ex.Message}");
+        }
+    }
+
+    async Task ApplyPendingClaimCoreAsync(MutationRequest request, ObservedEvidence? evidence) {
+        var pending = await Task.Run(_claims.Pending).ConfigureAwait(false);
+        var claim = pending.FirstOrDefault(
+            c => c.Profile == request.Profile && c.CanonicalServer == request.CanonicalServer);
+        if (claim is null) return;
+
+        if (evidence?.Capabilities?.Contains(ConsentV3Capability) != true) {
+            Status = Append(Status, ClaimMissingCapabilityMessage);
+            return;
+        }
+
+        ConsentAckDto ack;
+        try {
+            var policy = await _ops.GetConsentPolicyAsync(CancellationToken.None).ConfigureAwait(false);
+            var put = new ConsentPolicyPutV2Dto(request.DaemonName, claim.CanonicalServer, policy with { Default = "prompt" });
+            ack = await _ops.PutConsentPolicyV2Async(put, CancellationToken.None).ConfigureAwait(false);
+        } catch (LocalControlOpsException) {
+            Status = Append(Status, ClaimFailedMessage); // claim retained for the post-wizard coordinator
+            return;
+        }
+
+        if (!ack.Ok) {
+            Status = Append(Status, ClaimFailedMessage); // identity_mismatch or any other rejection
+            return;
+        }
+
+        await Task.Run(() => _claims.TryConsume(claim, ResolveCanonical, request.DaemonName)).ConfigureAwait(false);
+    }
+
+    // Both this step's own match and TryConsume's re-resolve must observe identical canonicalization — the store never re-canonicalizes.
+    (string Profile, string Server, string DaemonName) ResolveCanonical() {
+        var (profile, server, daemonName) = _resolveIdentityUnderConfigLock();
+        return (profile, ServerIdentity.Canonicalize(server) ?? server, daemonName);
+    }
+
+    static string Append(string? status, string sentence) =>
+        string.IsNullOrEmpty(status) ? sentence : $"{status} {sentence}";
+
+    internal static string OutcomeStatus(MutationVerb verb, MutationOutcome outcome) => outcome switch {
+        MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout => "The daemon service is enabled.",
+        MutationOutcome.UnconfirmedNoAttach   => $"The daemon {VerbDisplay(verb)} is not yet confirmed — kcap will follow up.",
+        MutationOutcome.AttentionSkew(var d)  => $"The daemon {VerbDisplay(verb)} needs attention ({d}) — kcap will follow up.",
+        MutationOutcome.AttentionRepair(var d) => $"The daemon {VerbDisplay(verb)} needs attention ({d}) — kcap will follow up.",
+        MutationOutcome.Refused(var reason, _) => $"kcap did not change the daemon service ({reason}).",
+        MutationOutcome.Failed(var exitCode, var reason, _) =>
+            $"The daemon {VerbDisplay(verb)} failed ({reason ?? VerifyExitCodes.Token(exitCode)}).",
+        _ => $"The daemon {VerbDisplay(verb)} did not complete.",
+    };
+
+    static string VerbDisplay(MutationVerb verb) => verb switch {
+        MutationVerb.Install       => "install",
+        MutationVerb.Replace       => "replacement",
+        MutationVerb.StartVerified => "start",
+        MutationVerb.DetachedStart => "start",
+        _                          => verb.ToString(),
+    };
+}

--- a/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
@@ -18,9 +18,7 @@ public enum DaemonRow {
 /// The single action a row offers, or None.
 public enum DaemonAffordance { None, Install, Start, Takeover, Repair }
 
-/// spec §3 step 7: daemon enablement over the lifecycle state matrix. Mutations run through the lane
-/// delegate and update THIS step only — outcomes are presented by the channel's single consumer, and
-/// the one dialog opened here is the PRE-mutation takeover/repair consent.
+/// Daemon enablement over the lifecycle state matrix; outcomes are presented by the channel's single consumer, never by this step directly.
 public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
     internal const string ConsentV3Capability = "consent/3";
 
@@ -416,9 +414,7 @@ public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
         if (IdentityMatches(_evidence, request)) await ApplyPendingClaimAsync(request, _evidence).ConfigureAwait(false);
     }
 
-    /// spec §6 step-7 application: the identity-conditional put, with no factory guard. The live policy
-    /// is read first because ConsentRulesPutV2 replaces it wholesale, and the call is deliberately
-    /// untokened — leaving the step awaits it rather than cancelling between the ack and the claim clear.
+    /// Reads the live policy first because the put replaces it wholesale, and stays untokened so leaving the step awaits rather than cancels mid-claim.
     async Task ApplyPendingClaimAsync(MutationRequest request, ObservedEvidence? evidence) {
         try {
             await ApplyPendingClaimCoreAsync(request, evidence).ConfigureAwait(false);

--- a/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
@@ -18,11 +18,9 @@ public enum DaemonRow {
 /// The single action a row offers, or None.
 public enum DaemonAffordance { None, Install, Start, Takeover, Repair }
 
-/// spec §3 step 7: daemon enablement on the lifecycle slice's full state matrix. Every mutation
-/// runs through the injected lane delegate and its result updates THIS step's state only —
-/// actionable outcomes travel the lane's outcome channel to the single consumer
-/// (single-presentation rule). The one dialog this step opens itself is the PRE-mutation
-/// takeover/repair consent, which is a user gate, not outcome presentation.
+/// spec §3 step 7: daemon enablement over the lifecycle state matrix. Mutations run through the lane
+/// delegate and update THIS step only — outcomes are presented by the channel's single consumer, and
+/// the one dialog opened here is the PRE-mutation takeover/repair consent.
 public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
     internal const string ConsentV3Capability = "consent/3";
 
@@ -418,10 +416,9 @@ public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
         if (IdentityMatches(_evidence, request)) await ApplyPendingClaimAsync(request, _evidence).ConfigureAwait(false);
     }
 
-    /// spec §6 step-7 application: the identity-conditional put, with NO factory guard. The live
-    /// policy is still read first because ConsentRulesPutV2 replaces the whole policy — a get-less
-    /// put would silently drop the daemon's own rules and prompt timeout. Untokened by design:
-    /// leaving the step awaits this rather than cancelling between the ack and the claim clear.
+    /// spec §6 step-7 application: the identity-conditional put, with no factory guard. The live policy
+    /// is read first because ConsentRulesPutV2 replaces it wholesale, and the call is deliberately
+    /// untokened — leaving the step awaits it rather than cancelling between the ack and the claim clear.
     async Task ApplyPendingClaimAsync(MutationRequest request, ObservedEvidence? evidence) {
         try {
             await ApplyPendingClaimCoreAsync(request, evidence).ConfigureAwait(false);

--- a/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
@@ -30,11 +30,9 @@ public sealed class DefaultsStepViewModel : ReactiveObject, IWizardStep {
     string? _message;
 
     /// <param name="resolveProfileName">
-    /// The profile the persist mutation below targets (finding 3) — a FRESH, env-aware resolution
-    /// (the wizard passes <c>App.ResolveWizardIdentity()?.Profile</c>), re-invoked on every persist
-    /// rather than captured once, since a KCAP_PROFILE override or a sign-in mid-wizard can change
-    /// the answer between steps. Null, or a name absent from <c>config.Profiles</c>, falls back to
-    /// <c>c.ActiveProfile</c> — today's behavior, and the only behavior when this is omitted.
+    /// The profile the persist targets, re-invoked per persist rather than captured — a KCAP_PROFILE
+    /// override or a mid-wizard sign-in can change the answer between steps. Null, or a name absent
+    /// from <c>config.Profiles</c>, falls back to <c>c.ActiveProfile</c>.
     /// </param>
     public DefaultsStepViewModel(string? defaultDaemonName = null, Func<string?>? resolveProfileName = null) {
         _daemonName = string.IsNullOrWhiteSpace(defaultDaemonName)

--- a/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
@@ -22,15 +22,25 @@ public sealed class DefaultsStepViewModel : ReactiveObject, IWizardStep {
         new("public",     "All public — others can see all your sessions"),
     ];
 
+    readonly Func<string?>? _resolveProfileName;
+
     string  _visibility = "org_public";
     string  _daemonName;
     bool    _satisfied;
     string? _message;
 
-    public DefaultsStepViewModel(string? defaultDaemonName = null) {
+    /// <param name="resolveProfileName">
+    /// The profile the persist mutation below targets (finding 3) — a FRESH, env-aware resolution
+    /// (the wizard passes <c>App.ResolveWizardIdentity()?.Profile</c>), re-invoked on every persist
+    /// rather than captured once, since a KCAP_PROFILE override or a sign-in mid-wizard can change
+    /// the answer between steps. Null, or a name absent from <c>config.Profiles</c>, falls back to
+    /// <c>c.ActiveProfile</c> — today's behavior, and the only behavior when this is omitted.
+    /// </param>
+    public DefaultsStepViewModel(string? defaultDaemonName = null, Func<string?>? resolveProfileName = null) {
         _daemonName = string.IsNullOrWhiteSpace(defaultDaemonName)
             ? Environment.UserName.ToLowerInvariant()
             : defaultDaemonName;
+        _resolveProfileName = resolveProfileName;
     }
 
     public WizardStepId Id         => WizardStepId.Defaults;
@@ -69,7 +79,10 @@ public sealed class DefaultsStepViewModel : ReactiveObject, IWizardStep {
 
         try {
             await ConfigMutator.MutateAsync(c => {
-                var activeName = string.IsNullOrWhiteSpace(c.ActiveProfile) ? "default" : c.ActiveProfile;
+                var resolvedName = _resolveProfileName?.Invoke();
+                var activeName   = resolvedName is not null && c.Profiles.ContainsKey(resolvedName)
+                    ? resolvedName
+                    : string.IsNullOrWhiteSpace(c.ActiveProfile) ? "default" : c.ActiveProfile;
                 var profile    = c.Profiles.GetValueOrDefault(activeName) ?? new Profile();
 
                 profile = profile with {

--- a/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
@@ -29,11 +29,7 @@ public sealed class DefaultsStepViewModel : ReactiveObject, IWizardStep {
     bool    _satisfied;
     string? _message;
 
-    /// <param name="resolveProfileName">
-    /// The profile the persist targets, re-invoked per persist rather than captured — a KCAP_PROFILE
-    /// override or a mid-wizard sign-in can change the answer between steps. Null, or a name absent
-    /// from <c>config.Profiles</c>, falls back to <c>c.ActiveProfile</c>.
-    /// </param>
+    /// <param name="resolveProfileName">Re-invoked per persist rather than captured; null or unresolved falls back to <c>c.ActiveProfile</c>.</param>
     public DefaultsStepViewModel(string? defaultDaemonName = null, Func<string?>? resolveProfileName = null) {
         _daemonName = string.IsNullOrWhiteSpace(defaultDaemonName)
             ? Environment.UserName.ToLowerInvariant()

--- a/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
@@ -22,9 +22,10 @@ public sealed class DefaultsStepViewModel : ReactiveObject, IWizardStep {
         new("public",     "All public — others can see all your sessions"),
     ];
 
-    string _visibility = "org_public";
-    string _daemonName;
-    bool   _satisfied;
+    string  _visibility = "org_public";
+    string  _daemonName;
+    bool    _satisfied;
+    string? _message;
 
     public DefaultsStepViewModel(string? defaultDaemonName = null) {
         _daemonName = string.IsNullOrWhiteSpace(defaultDaemonName)
@@ -51,25 +52,40 @@ public sealed class DefaultsStepViewModel : ReactiveObject, IWizardStep {
         set => this.RaiseAndSetIfChanged(ref _daemonName, value);
     }
 
+    /// Set when a persist attempt fails, so the veto below is visible, not just logged.
+    public string? Message {
+        get => _message;
+        private set => this.RaiseAndSetIfChanged(ref _message, value);
+    }
+
     public Task OnEnterAsync(CancellationToken ct) => Task.CompletedTask;
 
     /// Persists on Next only — Back and Skip leave the active profile untouched, so re-entering
-    /// this step (or abandoning the wizard) never writes a value the user didn't confirm.
+    /// this step (or abandoning the wizard) never writes a value the user didn't confirm. A
+    /// persist failure vetoes (stays on the step) with a visible Message rather than the shell's
+    /// generic stderr-only catch.
     public async Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) {
         if (direction != WizardNavigation.Next) return true;
 
-        await ConfigMutator.MutateAsync(c => {
-            var activeName = string.IsNullOrWhiteSpace(c.ActiveProfile) ? "default" : c.ActiveProfile;
-            var profile    = c.Profiles.GetValueOrDefault(activeName) ?? new Profile();
+        try {
+            await ConfigMutator.MutateAsync(c => {
+                var activeName = string.IsNullOrWhiteSpace(c.ActiveProfile) ? "default" : c.ActiveProfile;
+                var profile    = c.Profiles.GetValueOrDefault(activeName) ?? new Profile();
 
-            profile = profile with {
-                DefaultVisibility = Visibility,
-                Daemon            = (profile.Daemon ?? new DaemonSettings()) with { Name = DaemonName }
-            };
+                profile = profile with {
+                    DefaultVisibility = Visibility,
+                    Daemon            = (profile.Daemon ?? new DaemonSettings()) with { Name = DaemonName }
+                };
 
-            return c with { Profiles = new Dictionary<string, Profile>(c.Profiles) { [activeName] = profile } };
-        }, ct).ConfigureAwait(false);
+                return c with { Profiles = new Dictionary<string, Profile>(c.Profiles) { [activeName] = profile } };
+            }, ct).ConfigureAwait(false);
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            Message = $"Could not save defaults: {ex.Message}";
 
+            return false;
+        }
+
+        Message   = null;
         Satisfied = true;
 
         return true;

--- a/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
@@ -1,0 +1,77 @@
+using Capacitor.Cli.Core.Config;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels.Onboarding;
+
+/// One entry in the visibility picker (spec §3 step 4). A dedicated record rather than a
+/// ValueTuple — Avalonia's reflection-based bindings need real CLR properties, not a tuple's
+/// compiler-only element-name aliases.
+public sealed record VisibilityOption(string Value, string Label);
+
+/// spec §3 step 4 / decision 5: visibility picker + daemon-name field, written to the active
+/// profile on Next only (decision 10's ConfigMutator). No claim maintenance — claims key on
+/// {profile, server} and resolve the daemon name at application time (decision 7), so a rename
+/// here needs no second-store write.
+public sealed class DefaultsStepViewModel : ReactiveObject, IWizardStep {
+    /// The SAME four labels SetupCommand's interactive visibility prompt uses (Step 3/6), over
+    /// the SAME value set as <see cref="AppConfig.ValidVisibilities"/>.
+    public static readonly IReadOnlyList<VisibilityOption> VisibilityOptions = [
+        new("private",    "All private — only you can see your sessions"),
+        new("project",    "Project repos public to fellow project members, others private"),
+        new("org_public", "Org repos public, others private (default)"),
+        new("public",     "All public — others can see all your sessions"),
+    ];
+
+    string _visibility = "org_public";
+    string _daemonName;
+    bool   _satisfied;
+
+    public DefaultsStepViewModel(string? defaultDaemonName = null) {
+        _daemonName = string.IsNullOrWhiteSpace(defaultDaemonName)
+            ? Environment.UserName.ToLowerInvariant()
+            : defaultDaemonName;
+    }
+
+    public WizardStepId Id         => WizardStepId.Defaults;
+    public string       Title      => "Defaults";
+    public bool         Applicable => true;
+
+    public bool Satisfied {
+        get => _satisfied;
+        private set => this.RaiseAndSetIfChanged(ref _satisfied, value);
+    }
+
+    public string Visibility {
+        get => _visibility;
+        set => this.RaiseAndSetIfChanged(ref _visibility, value);
+    }
+
+    public string DaemonName {
+        get => _daemonName;
+        set => this.RaiseAndSetIfChanged(ref _daemonName, value);
+    }
+
+    public Task OnEnterAsync(CancellationToken ct) => Task.CompletedTask;
+
+    /// Persists on Next only — Back and Skip leave the active profile untouched, so re-entering
+    /// this step (or abandoning the wizard) never writes a value the user didn't confirm.
+    public async Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) {
+        if (direction != WizardNavigation.Next) return true;
+
+        await ConfigMutator.MutateAsync(c => {
+            var activeName = string.IsNullOrWhiteSpace(c.ActiveProfile) ? "default" : c.ActiveProfile;
+            var profile    = c.Profiles.GetValueOrDefault(activeName) ?? new Profile();
+
+            profile = profile with {
+                DefaultVisibility = Visibility,
+                Daemon            = (profile.Daemon ?? new DaemonSettings()) with { Name = DaemonName }
+            };
+
+            return c with { Profiles = new Dictionary<string, Profile>(c.Profiles) { [activeName] = profile } };
+        }, ct).ConfigureAwait(false);
+
+        Satisfied = true;
+
+        return true;
+    }
+}

--- a/src/Capacitor.App/ViewModels/Onboarding/DoneStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DoneStepViewModel.cs
@@ -1,0 +1,39 @@
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels.Onboarding;
+
+/// One line of the Done step's summary (spec §3 step 8). A dedicated record rather than a
+/// ValueTuple — Avalonia's reflection-based bindings need real CLR properties, not a tuple's
+/// compiler-only element-name aliases.
+public sealed record DoneSummaryEntry(string Title, bool Satisfied, string? Note) {
+    public string Glyph => Satisfied ? "✓" : "—";
+}
+
+/// spec §3 step 8: a summary of what the earlier steps set up and what was skipped, and why.
+/// Dumb by design — the composition root aggregates every other step's Satisfied/skip state and
+/// supplies the why-skipped notes ("kcap CLI not found", "requires sign-in", ...).
+public sealed class DoneStepViewModel : ReactiveObject, IWizardStep {
+    readonly Func<IReadOnlyList<(string Title, bool Satisfied, string? Note)>> _summaryProvider;
+
+    public DoneStepViewModel(Func<IReadOnlyList<(string Title, bool Satisfied, string? Note)>> summaryProvider) =>
+        _summaryProvider = summaryProvider;
+
+    public WizardStepId Id         => WizardStepId.Done;
+    public string       Title      => "You're all set";
+    public bool         Applicable => true;
+    public bool         Satisfied  => true; // a summary step is never itself incomplete
+
+    public IReadOnlyList<DoneSummaryEntry> Summary =>
+        _summaryProvider().Select(e => new DoneSummaryEntry(e.Title, e.Satisfied, e.Note)).ToList();
+
+    /// Re-renders on every entry: Back-then-forward can change other steps' state in between,
+    /// and Summary is recomputed fresh from the provider on every read.
+    public Task OnEnterAsync(CancellationToken ct) {
+        this.RaisePropertyChanged(nameof(Summary));
+
+        return Task.CompletedTask;
+    }
+
+    // Next finishes the wizard — the shell's own last-step handling raises CloseRequested.
+    public Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) => Task.FromResult(true);
+}

--- a/src/Capacitor.App/ViewModels/Onboarding/ImportStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/ImportStepViewModel.cs
@@ -60,15 +60,11 @@ public sealed class ImportStepViewModel : ReactiveObject, IWizardStep {
 
         Vendors = AgentVendors.All.Select(v => new ImportVendorRow(v)).ToList();
 
-        var idle = this.WhenAnyValue(x => x.Busy, busy => !busy);
-        var scopeValid = this.WhenAnyValue(x => x.Scope, x => x.OrgText, x => x.RepoText,
-            (scope, org, repo) => scope switch {
-                ImportScopeChoice.Everything => true,
-                ImportScopeChoice.Org        => !string.IsNullOrWhiteSpace(org),
-                ImportScopeChoice.Repo       => !string.IsNullOrWhiteSpace(repo),
-                _                            => false,
-            });
-        var canRun = idle.CombineLatest(scopeValid, (i, v) => i && v && CliAvailable);
+        var idle        = this.WhenAnyValue(x => x.Busy, busy => !busy);
+        var scopeValid  = this.WhenAnyValue(x => x.Scope, x => x.OrgText, x => x.RepoText, (_, _, _) => IsScopeValid());
+        var anySelected = Vendors.Select(v => v.WhenAnyValue(x => x.IsSelected)).CombineLatest()
+            .Select(flags => flags.Any(selected => selected));
+        var canRun = Observable.CombineLatest(idle, scopeValid, anySelected, (i, v, a) => i && v && a && CliAvailable);
 
         RunCommand    = ReactiveCommand.CreateFromTask(RunAsync, canRun);
         CancelCommand = ReactiveCommand.Create(() => _cts?.Cancel());
@@ -179,7 +175,11 @@ public sealed class ImportStepViewModel : ReactiveObject, IWizardStep {
     }
 
     async Task RunCoreAsync() {
+        // Mirrors canRun's gating — a direct call (tests, or a future non-button trigger) must not
+        // bypass any of it.
         if (!CliAvailable) return;
+        if (!IsScopeValid()) return;
+        if (!Vendors.Any(v => v.IsSelected)) return; // empty VendorFlags means "import everything" to the CLI — never silently do that
 
         Log.Clear();
         Truncated = false;
@@ -199,12 +199,22 @@ public sealed class ImportStepViewModel : ReactiveObject, IWizardStep {
                         + " " + RetryHint;
         } catch (OperationCanceledException) {
             Status = "Import cancelled."; // the user chose to stop — no retry hint, unlike a real failure
+        } catch (Exception ex) {
+            Satisfied = false;
+            Status    = $"Import failed: {ex.Message} {RetryHint}";
         } finally {
             Busy = false;
             _cts?.Dispose();
             _cts = null;
         }
     }
+
+    bool IsScopeValid() => Scope switch {
+        ImportScopeChoice.Everything => true,
+        ImportScopeChoice.Org        => !string.IsNullOrWhiteSpace(OrgText),
+        ImportScopeChoice.Repo       => !string.IsNullOrWhiteSpace(RepoText),
+        _                            => false,
+    };
 
     string? OrgOrRepoValue() => Scope switch {
         ImportScopeChoice.Org  => OrgText,

--- a/src/Capacitor.App/ViewModels/Onboarding/ImportStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/ImportStepViewModel.cs
@@ -159,14 +159,21 @@ public sealed class ImportStepViewModel : ReactiveObject, IWizardStep {
     /// A running import is always killed, not abandoned: §7's Cancel/close contract applies to
     /// leaving the step too, so no import survives the wizard moving on.
     public async Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) {
+        await CancelActiveRunAsync().ConfigureAwait(false);
+
+        return true;
+    }
+
+    /// The other half of §7's Cancel/close contract: closing the wizard window never navigates away
+    /// from a step, so it cannot go through <see cref="CanLeaveAsync"/> — the app's close/shutdown
+    /// paths call this directly instead. No-op when idle; never throws.
+    public async Task CancelActiveRunAsync() {
         _cts?.Cancel();
 
         if (_run is { } run) {
             try { await run.ConfigureAwait(false); }
             catch (Exception ex) { Console.Error.WriteLine($"kcap: wizard import run failed unexpectedly: {ex.Message}"); }
         }
-
-        return true;
     }
 
     internal Task RunAsync() {

--- a/src/Capacitor.App/ViewModels/Onboarding/ImportStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/ImportStepViewModel.cs
@@ -1,0 +1,228 @@
+using System.Collections.ObjectModel;
+using System.Reactive;
+using System.Reactive.Linq;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.Setup;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels.Onboarding;
+
+/// One vendor checkbox on the Import step. Unlike plugin-install, `kcap import` has no flagless
+/// Claude default — Claude's own selector is the explicit `--claude` flag.
+public sealed class ImportVendorRow : ReactiveObject {
+    readonly Func<AgentDetectionResult, DetectedAgent> _select;
+
+    internal ImportVendorRow(AgentVendor vendor) {
+        Label   = vendor.Label;
+        Flag    = vendor.Flag ?? "--claude";
+        _select = vendor.Select;
+    }
+
+    public string Label { get; }
+    internal string Flag { get; }
+
+    bool _isSelected;
+    public bool IsSelected {
+        get => _isSelected;
+        set => this.RaiseAndSetIfChanged(ref _isSelected, value);
+    }
+
+    internal bool DetectedIn(AgentDetectionResult result) => _select(result).Detected;
+}
+
+/// spec §3 step 6 / decision 6: scope + vendor selection, streamed `kcap import` into a bounded
+/// log pane. A completed run's exit code never blocks Next — only leaving mid-run kills it (§7).
+public sealed class ImportStepViewModel : ReactiveObject, IWizardStep {
+    internal const int    LogLimit  = 500;
+    internal const string RetryHint = "If anything failed, run `kcap import` in a terminal to retry.";
+
+    readonly IKcapCli _cli;
+    readonly Func<CancellationToken, Task<AgentDetectionResult>> _detect;
+    readonly Action<Action> _post;
+
+    AgentDetectionResult?    _detected;
+    CancellationTokenSource? _cts;
+    Task?                    _run;
+
+    ImportScopeChoice _scope = ImportScopeChoice.Everything;
+    string  _orgText = "";
+    string  _repoText = "";
+    bool    _busy;
+    bool    _satisfied;
+    bool    _truncated;
+    string? _status;
+
+    public ImportStepViewModel(
+            IKcapCli cli, Func<CancellationToken, Task<AgentDetectionResult>> detect, Action<Action> post) {
+        _cli    = cli;
+        _detect = detect;
+        _post   = post;
+
+        Vendors = AgentVendors.All.Select(v => new ImportVendorRow(v)).ToList();
+
+        var idle = this.WhenAnyValue(x => x.Busy, busy => !busy);
+        var scopeValid = this.WhenAnyValue(x => x.Scope, x => x.OrgText, x => x.RepoText,
+            (scope, org, repo) => scope switch {
+                ImportScopeChoice.Everything => true,
+                ImportScopeChoice.Org        => !string.IsNullOrWhiteSpace(org),
+                ImportScopeChoice.Repo       => !string.IsNullOrWhiteSpace(repo),
+                _                            => false,
+            });
+        var canRun = idle.CombineLatest(scopeValid, (i, v) => i && v && CliAvailable);
+
+        RunCommand    = ReactiveCommand.CreateFromTask(RunAsync, canRun);
+        CancelCommand = ReactiveCommand.Create(() => _cts?.Cancel());
+    }
+
+    public WizardStepId Id         => WizardStepId.Import;
+    public string       Title      => "Import past sessions";
+    public bool         Applicable => true;
+
+    public IReadOnlyList<ImportVendorRow> Vendors { get; }
+
+    public ImportScopeChoice Scope {
+        get => _scope;
+        set {
+            this.RaiseAndSetIfChanged(ref _scope, value);
+            RestateScope();
+        }
+    }
+
+    public bool EverythingSelected {
+        get => Scope == ImportScopeChoice.Everything;
+        set { if (value) Scope = ImportScopeChoice.Everything; }
+    }
+
+    public bool OrgSelected {
+        get => Scope == ImportScopeChoice.Org;
+        set { if (value) Scope = ImportScopeChoice.Org; }
+    }
+
+    public bool RepoSelected {
+        get => Scope == ImportScopeChoice.Repo;
+        set { if (value) Scope = ImportScopeChoice.Repo; }
+    }
+
+    public string OrgText {
+        get => _orgText;
+        set => this.RaiseAndSetIfChanged(ref _orgText, value);
+    }
+
+    public string RepoText {
+        get => _repoText;
+        set => this.RaiseAndSetIfChanged(ref _repoText, value);
+    }
+
+    public bool CliAvailable => _cli.CliPath is not null;
+
+    public string? Message => CliAvailable ? null : "kcap CLI not found";
+
+    public bool Busy {
+        get => _busy;
+        private set {
+            this.RaiseAndSetIfChanged(ref _busy, value);
+            this.RaisePropertyChanged(nameof(Idle));
+        }
+    }
+
+    public bool Idle => !Busy;
+
+    public bool Satisfied {
+        get => _satisfied;
+        private set => this.RaiseAndSetIfChanged(ref _satisfied, value);
+    }
+
+    public string? Status {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    /// Set once the log has dropped its first line — the pane shows an "older lines dropped"
+    /// header for the rest of the run instead of pretending the tail is the whole transcript.
+    public bool Truncated {
+        get => _truncated;
+        private set => this.RaiseAndSetIfChanged(ref _truncated, value);
+    }
+
+    public ObservableCollection<string> Log { get; } = [];
+
+    public ReactiveCommand<Unit, Unit> RunCommand    { get; }
+    public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+
+    public async Task OnEnterAsync(CancellationToken ct) {
+        if (_detected is not null) return; // cached: re-entering the step must not stomp user choices
+
+        AgentDetectionResult detected;
+        try { detected = await _detect(ct).ConfigureAwait(false); }
+        catch (OperationCanceledException) { return; }
+
+        _detected = detected;
+        foreach (var row in Vendors) row.IsSelected = row.DetectedIn(detected);
+    }
+
+    /// A running import is always killed, not abandoned: §7's Cancel/close contract applies to
+    /// leaving the step too, so no import survives the wizard moving on.
+    public async Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) {
+        _cts?.Cancel();
+
+        if (_run is { } run) {
+            try { await run.ConfigureAwait(false); }
+            catch (Exception ex) { Console.Error.WriteLine($"kcap: wizard import run failed unexpectedly: {ex.Message}"); }
+        }
+
+        return true;
+    }
+
+    internal Task RunAsync() {
+        if (Busy) return Task.CompletedTask;
+        return _run = RunCoreAsync();
+    }
+
+    async Task RunCoreAsync() {
+        if (!CliAvailable) return;
+
+        Log.Clear();
+        Truncated = false;
+        Status    = null;
+        Busy      = true;
+        _cts      = new CancellationTokenSource();
+
+        var request = new ImportRequest(
+            Scope,
+            OrgOrRepoValue(),
+            Vendors.Where(v => v.IsSelected).Select(v => v.Flag).ToArray());
+
+        try {
+            var result = await _cli.ImportAsync(request, OnLine, _cts.Token).ConfigureAwait(false);
+            Satisfied = result.ExitCode == 0;
+            Status    = (result.ExitCode == 0 ? "Import complete." : $"Import finished with errors (exit {result.ExitCode}).")
+                        + " " + RetryHint;
+        } catch (OperationCanceledException) {
+            Status = "Import cancelled."; // the user chose to stop — no retry hint, unlike a real failure
+        } finally {
+            Busy = false;
+            _cts?.Dispose();
+            _cts = null;
+        }
+    }
+
+    string? OrgOrRepoValue() => Scope switch {
+        ImportScopeChoice.Org  => OrgText,
+        ImportScopeChoice.Repo => RepoText,
+        _                      => null,
+    };
+
+    void OnLine(StreamedLine line) => _post(() => {
+        Log.Add(line.Text);
+        if (Log.Count > LogLimit) {
+            Log.RemoveAt(0);
+            Truncated = true;
+        }
+    });
+
+    void RestateScope() {
+        this.RaisePropertyChanged(nameof(EverythingSelected));
+        this.RaisePropertyChanged(nameof(OrgSelected));
+        this.RaisePropertyChanged(nameof(RepoSelected));
+    }
+}

--- a/src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs
@@ -1,5 +1,6 @@
 using System.Reactive;
 using System.Reactive.Linq;
+using Capacitor.App.Services.Onboarding;
 using ReactiveUI;
 
 namespace Capacitor.App.ViewModels.Onboarding;
@@ -11,6 +12,10 @@ public sealed class OnboardingViewModel : ReactiveObject {
     bool _navigating;
 
     public IReadOnlyList<IWizardStep> Steps { get; }
+
+    /// Wizard-first mode builds no tray and no main window, so the outcome consumer's Status/
+    /// Attention lines are rendered here (spec decision 2). Null in tests that don't need them.
+    public WizardLifecycleSurface? Surface { get; }
 
     int _index;
 
@@ -36,8 +41,11 @@ public sealed class OnboardingViewModel : ReactiveObject {
     /// The constructor's own initial-entry call, exposed so a test can await it deterministically.
     internal Task PendingEnterForTesting { get; }
 
-    public OnboardingViewModel(IEnumerable<IWizardStep> steps, CancellationToken shutdownToken = default) {
+    public OnboardingViewModel(
+            IEnumerable<IWizardStep> steps, CancellationToken shutdownToken = default,
+            WizardLifecycleSurface? surface = null) {
         _shutdownToken = shutdownToken;
+        Surface = surface;
         Steps = steps.Where(s => s.Applicable).ToList();
         if (Steps.Count == 0) throw new ArgumentException("at least one applicable step is required", nameof(steps));
 

--- a/src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs
@@ -70,6 +70,29 @@ public sealed class OnboardingViewModel : ReactiveObject {
         CloseRequested?.Invoke();
     }
 
+    /// <summary>
+    /// Jump straight to a step (the Sign-in step's retarget answer). Goes through the SAME
+    /// serialized gate and the same <see cref="IWizardStep.CanLeaveAsync"/> veto as a button
+    /// transition. False = refused: a navigation is already in flight, or that step isn't part of
+    /// this run (an inapplicable step was filtered out at construction).
+    /// </summary>
+    internal bool TryGoTo(WizardStepId id) {
+        if (_navigating) return false;
+
+        var target = -1;
+        for (var i = 0; i < Steps.Count && target < 0; i++) {
+            if (Steps[i].Id == id) target = i;
+        }
+
+        if (target < 0) return false;
+        if (target == _index) return true; // already there — nothing to transition
+
+        Navigating = true; // claimed here, released by GoToAsync's finally
+        _ = GoToAsync(target);
+
+        return true;
+    }
+
     async Task NavigateAsync(WizardNavigation direction) {
         if (_navigating) return; // defense in depth — canExecute already blocks a bound button
         Navigating = true;
@@ -82,12 +105,30 @@ public sealed class OnboardingViewModel : ReactiveObject {
             }
 
             // Clamp, don't trust the arithmetic — a corrupted _index must never throw here.
-            _index = Math.Clamp(_index + (direction == WizardNavigation.Back ? -1 : 1), 0, Steps.Count - 1);
-            Current = Steps[_index];
-            await SafeEnterAsync(Current);
+            await MoveToAsync(Math.Clamp(_index + (direction == WizardNavigation.Back ? -1 : 1), 0, Steps.Count - 1));
         } finally {
             Navigating = false;
         }
+    }
+
+    // The gate is already held by TryGoTo; direction is reported to the leaving step as the move it
+    // actually is, so a step that vetoes going forward still vetoes a jump forward.
+    async Task GoToAsync(int target) {
+        try {
+            var direction = target < _index ? WizardNavigation.Back : WizardNavigation.Next;
+            if (!await SafeCanLeaveAsync(Current, direction)) return;
+
+            await MoveToAsync(target);
+        } finally {
+            Navigating = false;
+        }
+    }
+
+    // Caller holds the Navigating gate and the leaving step has already released it.
+    async Task MoveToAsync(int index) {
+        _index = index;
+        Current = Steps[_index];
+        await SafeEnterAsync(Current);
     }
 
     // A throwing veto must not crash the app — treat it the same as an honest "no".

--- a/src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs
@@ -1,0 +1,69 @@
+using System.Reactive;
+using System.Reactive.Linq;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels.Onboarding;
+
+/// Back/Next/Skip all funnel through Current's CanLeaveAsync veto; Next on the last step finishes.
+public sealed class OnboardingViewModel : ReactiveObject {
+    readonly CancellationToken _shutdownToken;
+    bool _closed;
+
+    public IReadOnlyList<IWizardStep> Steps { get; }
+
+    int _index;
+
+    IWizardStep _current;
+    public IWizardStep Current {
+        get => _current;
+        private set => this.RaiseAndSetIfChanged(ref _current, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> BackCommand { get; }
+    public ReactiveCommand<Unit, Unit> NextCommand { get; }
+    public ReactiveCommand<Unit, Unit> SkipCommand { get; }
+
+    /// Fires once per logical close: the Done step's finish, or the window closing.
+    public event Action? CloseRequested;
+
+    /// The constructor's own OnEnterAsync(Steps[0]) call, exposed so a test can await it deterministically.
+    internal Task PendingEnterForTesting { get; }
+
+    public OnboardingViewModel(IEnumerable<IWizardStep> steps, CancellationToken shutdownToken = default) {
+        _shutdownToken = shutdownToken;
+        Steps = steps.Where(s => s.Applicable).ToList();
+        if (Steps.Count == 0) throw new ArgumentException("at least one applicable step is required", nameof(steps));
+
+        _current = Steps[0];
+
+        var currentChanged = this.WhenAnyValue(x => x.Current);
+        var canBack = currentChanged.Select(_ => _index > 0);
+        var canSkip = currentChanged.Select(_ => _index < Steps.Count - 1);
+
+        BackCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(WizardNavigation.Back), canBack);
+        SkipCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(WizardNavigation.Skip), canSkip);
+        NextCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(WizardNavigation.Next));
+
+        PendingEnterForTesting = Current.OnEnterAsync(_shutdownToken);
+    }
+
+    /// Idempotent — a Done-finish close and the window's own Closing event both route here.
+    internal void RequestClose() {
+        if (_closed) return;
+        _closed = true;
+        CloseRequested?.Invoke();
+    }
+
+    async Task NavigateAsync(WizardNavigation direction) {
+        if (!await Current.CanLeaveAsync(direction, _shutdownToken)) return;
+
+        if (direction == WizardNavigation.Next && _index == Steps.Count - 1) {
+            RequestClose();
+            return;
+        }
+
+        _index += direction == WizardNavigation.Back ? -1 : 1;
+        Current = Steps[_index];
+        await Current.OnEnterAsync(_shutdownToken);
+    }
+}

--- a/src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs
@@ -8,6 +8,7 @@ namespace Capacitor.App.ViewModels.Onboarding;
 public sealed class OnboardingViewModel : ReactiveObject {
     readonly CancellationToken _shutdownToken;
     bool _closed;
+    bool _navigating;
 
     public IReadOnlyList<IWizardStep> Steps { get; }
 
@@ -19,6 +20,12 @@ public sealed class OnboardingViewModel : ReactiveObject {
         private set => this.RaiseAndSetIfChanged(ref _current, value);
     }
 
+    // Shared across Back/Next/Skip: only one of the three may be mid-transition at a time.
+    bool Navigating {
+        get => _navigating;
+        set => this.RaiseAndSetIfChanged(ref _navigating, value);
+    }
+
     public ReactiveCommand<Unit, Unit> BackCommand { get; }
     public ReactiveCommand<Unit, Unit> NextCommand { get; }
     public ReactiveCommand<Unit, Unit> SkipCommand { get; }
@@ -26,7 +33,7 @@ public sealed class OnboardingViewModel : ReactiveObject {
     /// Fires once per logical close: the Done step's finish, or the window closing.
     public event Action? CloseRequested;
 
-    /// The constructor's own OnEnterAsync(Steps[0]) call, exposed so a test can await it deterministically.
+    /// The constructor's own initial-entry call, exposed so a test can await it deterministically.
     internal Task PendingEnterForTesting { get; }
 
     public OnboardingViewModel(IEnumerable<IWizardStep> steps, CancellationToken shutdownToken = default) {
@@ -37,14 +44,15 @@ public sealed class OnboardingViewModel : ReactiveObject {
         _current = Steps[0];
 
         var currentChanged = this.WhenAnyValue(x => x.Current);
-        var canBack = currentChanged.Select(_ => _index > 0);
-        var canSkip = currentChanged.Select(_ => _index < Steps.Count - 1);
+        var idle = this.WhenAnyValue(x => x.Navigating).Select(busy => !busy);
+        var canBack = currentChanged.CombineLatest(idle, (_, notBusy) => notBusy && _index > 0);
+        var canSkip = currentChanged.CombineLatest(idle, (_, notBusy) => notBusy && _index < Steps.Count - 1);
 
         BackCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(WizardNavigation.Back), canBack);
         SkipCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(WizardNavigation.Skip), canSkip);
-        NextCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(WizardNavigation.Next));
+        NextCommand = ReactiveCommand.CreateFromTask(() => NavigateAsync(WizardNavigation.Next), idle);
 
-        PendingEnterForTesting = Current.OnEnterAsync(_shutdownToken);
+        PendingEnterForTesting = SafeEnterAsync(Current);
     }
 
     /// Idempotent — a Done-finish close and the window's own Closing event both route here.
@@ -55,15 +63,45 @@ public sealed class OnboardingViewModel : ReactiveObject {
     }
 
     async Task NavigateAsync(WizardNavigation direction) {
-        if (!await Current.CanLeaveAsync(direction, _shutdownToken)) return;
+        if (_navigating) return; // defense in depth — canExecute already blocks a bound button
+        Navigating = true;
+        try {
+            if (!await SafeCanLeaveAsync(Current, direction)) return;
 
-        if (direction == WizardNavigation.Next && _index == Steps.Count - 1) {
-            RequestClose();
-            return;
+            if (direction == WizardNavigation.Next && _index == Steps.Count - 1) {
+                RequestClose();
+                return;
+            }
+
+            // Clamp, don't trust the arithmetic — a corrupted _index must never throw here.
+            _index = Math.Clamp(_index + (direction == WizardNavigation.Back ? -1 : 1), 0, Steps.Count - 1);
+            Current = Steps[_index];
+            await SafeEnterAsync(Current);
+        } finally {
+            Navigating = false;
         }
+    }
 
-        _index += direction == WizardNavigation.Back ? -1 : 1;
-        Current = Steps[_index];
-        await Current.OnEnterAsync(_shutdownToken);
+    // A throwing veto must not crash the app — treat it the same as an honest "no".
+    async Task<bool> SafeCanLeaveAsync(IWizardStep step, WizardNavigation direction) {
+        try {
+            return await step.CanLeaveAsync(direction, _shutdownToken);
+        } catch (OperationCanceledException) {
+            return false;
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: wizard step CanLeaveAsync failed unexpectedly: {ex.Message}");
+            return false;
+        }
+    }
+
+    // Entry side effects are best-effort — a throw here must not undo the transition already made.
+    async Task SafeEnterAsync(IWizardStep step) {
+        try {
+            await step.OnEnterAsync(_shutdownToken);
+        } catch (OperationCanceledException) {
+            // shutdown mid-entry: nothing to roll back
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: wizard step OnEnterAsync failed unexpectedly: {ex.Message}");
+        }
     }
 }

--- a/src/Capacitor.App/ViewModels/Onboarding/ShimStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/ShimStepViewModel.cs
@@ -1,0 +1,119 @@
+using System.Reactive;
+using Capacitor.App.Services;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels.Onboarding;
+
+/// spec §3 step 1: the PATH shim. Reuses PathShimInstaller as-is (AppleScript sudo, non-forcing
+/// symlink, post-install re-probe) and claims ShimOffered so the post-wizard ShimOfferCoordinator
+/// never re-offers this machine.
+public sealed class ShimStepViewModel : ReactiveObject, IWizardStep {
+    readonly PathShimInstaller _installer;
+    readonly IAppStateStore    _store;
+    readonly string?           _target;
+    readonly string            _destination;
+
+    bool    _offerClaimed;
+    bool    _busy;
+    bool    _satisfied;
+    string? _message;
+
+    public ShimStepViewModel(bool applicable, PathShimInstaller installer, IAppStateStore store, string? target)
+        : this(applicable, installer, store, target, PathShimInstaller.Destination) { }
+
+    // Test seam mirroring ShimOfferCoordinator's own destination-override constructor (real filesystem taxonomy against a temp path, never the real /usr/local/bin/kcap).
+    internal ShimStepViewModel(
+            bool applicable, PathShimInstaller installer, IAppStateStore store, string? target, string destination) {
+        Applicable   = applicable;
+        _installer   = installer;
+        _store       = store;
+        _target      = target;
+        _destination = destination;
+
+        InstallCommand = ReactiveCommand.CreateFromTask(RunInstallAsync, this.WhenAnyValue(x => x.Idle));
+    }
+
+    /// Pure decision (spec §3 step 1): macOS AND a resolved absolute CLI path AND the login-shell
+    /// probe positively found no kcap on the terminal PATH. A null (unknown) probe fails quiet —
+    /// never offer on an inconclusive read. Called by the composition root with a pre-probed
+    /// value, since Applicable is sync and the probe is async.
+    public static bool ComputeApplicable(bool isMacOs, string? target, bool? kcapOnPath) =>
+        isMacOs && target is not null && kcapOnPath == false;
+
+    public WizardStepId Id         => WizardStepId.Shim;
+    public string       Title      => "Command-line tool";
+    public bool         Applicable { get; }
+
+    public bool Satisfied {
+        get => _satisfied;
+        private set => this.RaiseAndSetIfChanged(ref _satisfied, value);
+    }
+
+    public bool Busy {
+        get => _busy;
+        private set {
+            this.RaiseAndSetIfChanged(ref _busy, value);
+            this.RaisePropertyChanged(nameof(Idle));
+        }
+    }
+
+    public bool Idle => !Busy;
+
+    /// Set on InstalledButNotOnPath/Failed (with recovery guidance); null on Installed/Cancelled.
+    public string? Message {
+        get => _message;
+        private set => this.RaiseAndSetIfChanged(ref _message, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> InstallCommand { get; }
+
+    public Task OnEnterAsync(CancellationToken ct) => Task.CompletedTask;
+
+    // Never vetoes: an unresolved or failed shim link must not block the rest of setup.
+    public Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) => Task.FromResult(true);
+
+    async Task RunInstallAsync() {
+        if (_target is null) {
+            Message = "kcap CLI not found";
+            return;
+        }
+
+        Busy = true;
+        try {
+            await ClaimOfferedOnceAsync().ConfigureAwait(false);
+            Apply(await _installer.InstallAsync(_target, _destination, CancellationToken.None).ConfigureAwait(false));
+        } finally {
+            Busy = false;
+        }
+    }
+
+    // Claim-before-install (mirrors ShimOfferCoordinator): persisted once, before the outcome is known, so a retry click never re-persists.
+    Task ClaimOfferedOnceAsync() {
+        if (_offerClaimed) return Task.CompletedTask;
+        _offerClaimed = true;
+        return _store.UpdateAsync(s => s.ShimOffered ? s : s with { ShimOffered = true });
+    }
+
+    void Apply(ShimResult result) {
+        switch (result.Outcome) {
+            case ShimOutcome.Installed:
+                Satisfied = true;
+                Message   = null;
+                break;
+            case ShimOutcome.InstalledButNotOnPath:
+                Satisfied = false;
+                Message   = result.Detail;
+                break;
+            case ShimOutcome.Cancelled:
+                Satisfied = false;
+                Message   = null; // the user knows they cancelled it — nothing more to say
+                break;
+            default: // Failed
+                Satisfied = false;
+                Message = result.SudoFallback is null
+                    ? result.Detail ?? "Installing the command-line tool failed."
+                    : $"{result.Detail} Or run: {result.SudoFallback}";
+                break;
+        }
+    }
+}

--- a/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
@@ -1,0 +1,487 @@
+using System.Collections.ObjectModel;
+using System.Reactive;
+using Capacitor.App.Services;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.Cli.Core.Auth;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels.Onboarding;
+
+/// <summary>
+/// Runs ONE façade operation for the staged intent and renders its structured progress: notices,
+/// the browser fallback URL, the device code, the tenant list, and the create-workspace prompts.
+/// Nothing starts on entry — the step has an explicit Sign in action, because the operation is the
+/// only thing on the wizard that reaches the network. Cancellation is never rendered as a failure.
+/// </summary>
+public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
+    internal const int LogLimit = 200;
+
+    /// One pending UI answer. The flow parks on <see cref="AskAsync"/>; the view resolves it, a
+    /// cancel releases it, and the prompt is torn down either way.
+    sealed class UiQuestion<T> {
+        TaskCompletionSource<T>? _pending;
+
+        public async Task<T> AskAsync(Action<Action> post, Action show, Action hide, CancellationToken ct) {
+            var pending = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Interlocked.Exchange(ref _pending, pending);
+
+            using var registration = ct.Register(() => pending.TrySetCanceled(ct));
+
+            post(show);
+
+            try {
+                return await pending.Task.ConfigureAwait(false);
+            } finally {
+                Interlocked.CompareExchange(ref _pending, null, pending);
+                post(hide);
+            }
+        }
+
+        public void Answer(T value) => Interlocked.Exchange(ref _pending, null)?.TrySetResult(value);
+    }
+
+    readonly WizardAuthService       _service;
+    readonly ConnectStepViewModel    _connect;
+    readonly WizardTenantPicker      _picker;
+    readonly ConsentFlipClaims       _claims;
+    readonly IAppStateStore          _appState;
+    readonly IUrlOpener              _urlOpener;
+    readonly Action<Action>          _post;
+
+    readonly UiQuestion<ProvisionMode> _mode    = new();
+    readonly UiQuestion<string?>       _orgName = new();
+    readonly UiQuestion<string?>       _slug    = new();
+    readonly UiQuestion<bool>          _confirm = new();
+
+    AuthAttempt?   _attempt;
+    ConnectIntent? _running;
+
+    string  _status = "";
+    bool    _statusIsError;
+    string? _statusDetail;
+    bool    _busy;
+    bool    _satisfied;
+    string? _deviceCode;
+    string? _verificationUri;
+    string? _browserUrl;
+    string? _waitingText;
+    string? _quarantineNotice;
+    bool    _tenantPickerVisible;
+    bool    _modeChoiceVisible;
+    bool    _orgNamePromptVisible;
+    bool    _slugPromptVisible;
+    bool    _confirmVisible;
+    string  _orgNameText = "";
+    string  _slugText = "";
+    string? _slugError;
+    string  _existingWorkspaceInput = "";
+    string  _confirmText = "";
+    string? _provisioningProgress;
+
+    DiscoveredTenant? _selectedTenant;
+
+    public SignInStepViewModel(
+            WizardAuthService    service,
+            ConnectStepViewModel connect,
+            WizardBridges        bridges,
+            ConsentFlipClaims    claims,
+            IAppStateStore       appState,
+            IUrlOpener           urlOpener) {
+        _service   = service;
+        _connect   = connect;
+        _picker    = bridges.Picker;
+        _claims    = claims;
+        _appState  = appState;
+        _urlOpener = urlOpener;
+        _post      = bridges.Post;
+
+        bridges.Progress.NoticeReceived     += Append;
+        bridges.Progress.ErrorReceived      += line => {
+            StatusDetail = line;
+            Append(line);
+        };
+        bridges.Progress.BrowserOpened      += url => {
+            BrowserUrl = url;
+            Append($"Opening your browser. If it doesn't open, visit: {url}");
+        };
+        bridges.Progress.DeviceCodeReceived += (code, verificationUri) => {
+            DeviceCode      = StripClipboardNote(code);
+            VerificationUri = verificationUri;
+            Append($"Enter the code {code} at {verificationUri}");
+        };
+        bridges.Progress.PollTicked += () => WaitingText = "Waiting for you to authorize…";
+
+        _picker.SelectionRequested += tenants => _post(() => {
+            Tenants.Clear();
+            foreach (var tenant in tenants) Tenants.Add(tenant);
+            SelectedTenant      = Tenants.FirstOrDefault();
+            TenantPickerVisible = true;
+        });
+
+        var provisioner = bridges.Provisioner;
+        provisioner.OfferMode     = OfferModeAsync;
+        provisioner.PromptOrgName = ct => _orgName.AskAsync(
+            _post, () => OrgNamePromptVisible = true, () => OrgNamePromptVisible = false, ct);
+        provisioner.PromptSlug = (suggestion, error, ct) => _slug.AskAsync(_post, () => {
+            Slug              = suggestion;
+            SlugError         = error;
+            SlugPromptVisible = true;
+        }, () => SlugPromptVisible = false, ct);
+        provisioner.ConfirmCreate = (slug, origin, ct) => _confirm.AskAsync(_post, () => {
+            ConfirmText    = $"Create the workspace '{slug}' at {origin}?";
+            ConfirmVisible = true;
+        }, () => ConfirmVisible = false, ct);
+        provisioner.PollProgress = (attempt, max) =>
+            _post(() => ProvisioningProgress = $"Setting up your workspace — this can take a few minutes… ({attempt}/{max})");
+
+        SignInCommand = ReactiveCommand.CreateFromTask(SignInAsync);
+        CancelCommand = ReactiveCommand.Create(() => _attempt?.Cancel());
+
+        OpenSignInUrlCommand      = ReactiveCommand.Create(() => Open(BrowserUrl));
+        OpenVerificationUriCommand = ReactiveCommand.Create(() => Open(VerificationUri));
+
+        ConfirmTenantCommand = ReactiveCommand.Create(() => {
+            TenantPickerVisible = false;
+            _picker.Select(SelectedTenant);
+        });
+        CancelTenantCommand = ReactiveCommand.Create(() => {
+            TenantPickerVisible = false;
+            _picker.Select(null);
+        });
+
+        CreateWorkspaceCommand      = ReactiveCommand.Create(() => _mode.Answer(new ProvisionMode.Create()));
+        UseExistingWorkspaceCommand = ReactiveCommand.Create(() => _mode.Answer(new ProvisionMode.Existing(ExistingWorkspaceInput)));
+        CancelWorkspaceCommand      = ReactiveCommand.Create(() => _mode.Answer(new ProvisionMode.Cancel()));
+
+        SubmitOrgNameCommand = ReactiveCommand.Create(() => _orgName.Answer(OrgName));
+        CancelOrgNameCommand = ReactiveCommand.Create(() => _orgName.Answer(null));
+        SubmitSlugCommand    = ReactiveCommand.Create(() => _slug.Answer(Slug));
+        CancelSlugCommand    = ReactiveCommand.Create(() => _slug.Answer(null));
+        ConfirmCreateCommand = ReactiveCommand.Create(() => _confirm.Answer(true));
+        DeclineCreateCommand = ReactiveCommand.Create(() => _confirm.Answer(false));
+
+        AcknowledgeQuarantineCommand = ReactiveCommand.CreateFromTask(AcknowledgeQuarantineAsync);
+    }
+
+    public WizardStepId Id         => WizardStepId.SignIn;
+    public string       Title      => "Sign in";
+    public bool         Applicable => true;
+
+    /// The Sign-in step's answer to a WorkOS "I already have a workspace": the Connect step is
+    /// prefilled here, and the event lets the shell navigate back to it.
+    public event Action<string>? RetargetRequested;
+
+    public ObservableCollection<string>           Log     { get; } = [];
+    public ObservableCollection<DiscoveredTenant> Tenants { get; } = [];
+
+    public ReactiveCommand<Unit, Unit> SignInCommand                { get; }
+    public ReactiveCommand<Unit, Unit> CancelCommand                { get; }
+    public ReactiveCommand<Unit, Unit> OpenSignInUrlCommand         { get; }
+    public ReactiveCommand<Unit, Unit> OpenVerificationUriCommand   { get; }
+    public ReactiveCommand<Unit, Unit> ConfirmTenantCommand         { get; }
+    public ReactiveCommand<Unit, Unit> CancelTenantCommand          { get; }
+    public ReactiveCommand<Unit, Unit> CreateWorkspaceCommand       { get; }
+    public ReactiveCommand<Unit, Unit> UseExistingWorkspaceCommand  { get; }
+    public ReactiveCommand<Unit, Unit> CancelWorkspaceCommand       { get; }
+    public ReactiveCommand<Unit, Unit> SubmitOrgNameCommand         { get; }
+    public ReactiveCommand<Unit, Unit> CancelOrgNameCommand         { get; }
+    public ReactiveCommand<Unit, Unit> SubmitSlugCommand            { get; }
+    public ReactiveCommand<Unit, Unit> CancelSlugCommand            { get; }
+    public ReactiveCommand<Unit, Unit> ConfirmCreateCommand         { get; }
+    public ReactiveCommand<Unit, Unit> DeclineCreateCommand         { get; }
+    public ReactiveCommand<Unit, Unit> AcknowledgeQuarantineCommand { get; }
+
+    public string Status {
+        get => _status;
+        private set => this.RaiseAndSetIfChanged(ref _status, value);
+    }
+
+    public bool StatusIsError {
+        get => _statusIsError;
+        private set => this.RaiseAndSetIfChanged(ref _statusIsError, value);
+    }
+
+    /// The last error line the façade rendered — the detail behind the generic failure headline.
+    public string? StatusDetail {
+        get => _statusDetail;
+        private set => this.RaiseAndSetIfChanged(ref _statusDetail, value);
+    }
+
+    public bool Busy {
+        get => _busy;
+        private set {
+            this.RaiseAndSetIfChanged(ref _busy, value);
+            this.RaisePropertyChanged(nameof(Idle));
+        }
+    }
+
+    public bool Idle => !Busy;
+
+    public bool Satisfied {
+        get => _satisfied;
+        private set => this.RaiseAndSetIfChanged(ref _satisfied, value);
+    }
+
+    public string? DeviceCode {
+        get => _deviceCode;
+        private set => this.RaiseAndSetIfChanged(ref _deviceCode, value);
+    }
+
+    public string? VerificationUri {
+        get => _verificationUri;
+        private set => this.RaiseAndSetIfChanged(ref _verificationUri, value);
+    }
+
+    public string? BrowserUrl {
+        get => _browserUrl;
+        private set => this.RaiseAndSetIfChanged(ref _browserUrl, value);
+    }
+
+    public string? WaitingText {
+        get => _waitingText;
+        private set => this.RaiseAndSetIfChanged(ref _waitingText, value);
+    }
+
+    public string? QuarantineNotice {
+        get => _quarantineNotice;
+        private set => this.RaiseAndSetIfChanged(ref _quarantineNotice, value);
+    }
+
+    public bool TenantPickerVisible {
+        get => _tenantPickerVisible;
+        private set => this.RaiseAndSetIfChanged(ref _tenantPickerVisible, value);
+    }
+
+    public DiscoveredTenant? SelectedTenant {
+        get => _selectedTenant;
+        set => this.RaiseAndSetIfChanged(ref _selectedTenant, value);
+    }
+
+    public bool ModeChoiceVisible {
+        get => _modeChoiceVisible;
+        private set => this.RaiseAndSetIfChanged(ref _modeChoiceVisible, value);
+    }
+
+    public bool OrgNamePromptVisible {
+        get => _orgNamePromptVisible;
+        private set => this.RaiseAndSetIfChanged(ref _orgNamePromptVisible, value);
+    }
+
+    public bool SlugPromptVisible {
+        get => _slugPromptVisible;
+        private set => this.RaiseAndSetIfChanged(ref _slugPromptVisible, value);
+    }
+
+    public bool ConfirmVisible {
+        get => _confirmVisible;
+        private set => this.RaiseAndSetIfChanged(ref _confirmVisible, value);
+    }
+
+    public string OrgName {
+        get => _orgNameText;
+        set => this.RaiseAndSetIfChanged(ref _orgNameText, value);
+    }
+
+    public string Slug {
+        get => _slugText;
+        set => this.RaiseAndSetIfChanged(ref _slugText, value);
+    }
+
+    public string? SlugError {
+        get => _slugError;
+        private set => this.RaiseAndSetIfChanged(ref _slugError, value);
+    }
+
+    public string ExistingWorkspaceInput {
+        get => _existingWorkspaceInput;
+        set => this.RaiseAndSetIfChanged(ref _existingWorkspaceInput, value);
+    }
+
+    public string ConfirmText {
+        get => _confirmText;
+        private set => this.RaiseAndSetIfChanged(ref _confirmText, value);
+    }
+
+    public string? ProvisioningProgress {
+        get => _provisioningProgress;
+        private set => this.RaiseAndSetIfChanged(ref _provisioningProgress, value);
+    }
+
+    public Task OnEnterAsync(CancellationToken ct) {
+        if (!Satisfied && !Busy) SetStatus(ReadyStatus(), isError: false);
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Never vetoes. A live attempt is cancelled and awaited: pre-boundary that ends it with
+    /// nothing durable, past the boundary the operation still answers Committed — the wait is what
+    /// keeps the step's rendered state honest either way. The result task never faults.
+    /// </summary>
+    public async Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) {
+        if (_attempt is { } live) {
+            live.Cancel();
+            await live.Result.ConfigureAwait(true);
+        }
+
+        return true;
+    }
+
+    /// The command's body, reachable directly so a re-entrant call can be asserted as a no-op.
+    internal async Task SignInAsync() {
+        if (Busy) return;
+
+        if (_connect.Intent is not { } intent) {
+            SetStatus("Choose how to connect on the Connect step.", isError: false);
+
+            return;
+        }
+
+        ResetForRun(intent);
+        Busy = true;
+        // Before Begin: a synchronously-rendered error must not have its detail wiped by this.
+        SetStatus("Signing in…", isError: false);
+
+        AuthAttempt attempt;
+
+        try {
+            attempt = _service.Begin(intent);
+        } catch (InvalidOperationException) {
+            Busy = false;
+            SetStatus("Finishing the previous attempt — try again in a moment.", isError: false);
+
+            return;
+        }
+
+        _attempt = attempt;
+
+        var result = await attempt.Result.ConfigureAwait(true);
+
+        _attempt = null;
+        Busy     = false;
+        HidePrompts();
+        Apply(result);
+        await SurfaceQuarantineAsync().ConfigureAwait(true);
+    }
+
+    // The Connect intent IS the mode; only a discovery that found nothing has to ask.
+    Task<ProvisionMode> OfferModeAsync(CancellationToken ct) =>
+        _running is ConnectIntent.Create
+            ? Task.FromResult<ProvisionMode>(new ProvisionMode.Create())
+            : _mode.AskAsync(_post, () => ModeChoiceVisible = true, () => ModeChoiceVisible = false, ct);
+
+    void Apply(AuthResult result) {
+        switch (result) {
+            case AuthResult.Committed committed:
+                Satisfied = true;
+                SetStatus(CommittedStatus(committed), isError: false);
+
+                break;
+            case AuthResult.Cancelled:
+                SetStatus("Sign-in cancelled.", isError: false);
+
+                break;
+            case AuthResult.Retarget retarget:
+                _connect.Prefill(retarget.ServerInput);
+                SetStatus($"Continue with {retarget.ServerInput} from the Connect step.", isError: false);
+                RetargetRequested?.Invoke(retarget.ServerInput);
+
+                break;
+            // The façade already rendered its own error through the sink; the log is the detail.
+            default:
+                Status        = "Sign-in failed.";
+                StatusIsError = true;
+
+                break;
+        }
+    }
+
+    static string CommittedStatus(AuthResult.Committed committed) =>
+        committed.Provider == AuthProvider.None
+            ? "No sign-in required for this server."
+            : committed.Username is { Length: > 0 } username ? $"Signed in as {username}" : "Signed in.";
+
+    string ReadyStatus() => _connect.Intent switch {
+        ConnectIntent.Paste paste       => $"Ready to sign in to {paste.ServerInput}.",
+        ConnectIntent.Discover discover => discover.Provider == AuthProvider.WorkOS
+            ? "Ready to find your workspaces with single sign-on."
+            : "Ready to find your workspaces with GitHub.",
+        ConnectIntent.Create => "Ready to create a workspace.",
+        _                    => "Choose how to connect on the Connect step."
+    };
+
+    async Task SurfaceQuarantineAsync() {
+        try {
+            // A read is what discovers corruption, and a cancelled attempt never armed anything.
+            await Task.Run(_claims.Pending).ConfigureAwait(true);
+
+            if (_claims.Quarantine() is not { } quarantine) return;
+            if ((await _appState.LoadAsync().ConfigureAwait(true)).ConsentQuarantineAcked) return;
+
+            QuarantineNotice = ConsentFlipCoordinator.QuarantineDisclosure(quarantine.PreservedPath);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: consent quarantine surfacing failed unexpectedly: {ex.Message}");
+        }
+    }
+
+    async Task AcknowledgeQuarantineAsync() {
+        QuarantineNotice = null;
+
+        try {
+            await _appState.UpdateAsync(s => s.ConsentQuarantineAcked ? s : s with { ConsentQuarantineAcked = true })
+                .ConfigureAwait(true);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: consent quarantine ack failed unexpectedly: {ex.Message}");
+        }
+    }
+
+    void ResetForRun(ConnectIntent intent) {
+        _running = intent;
+        Log.Clear();
+        HidePrompts();
+        DeviceCode           = null;
+        VerificationUri      = null;
+        BrowserUrl           = null;
+        WaitingText          = null;
+        ProvisioningProgress = null;
+        SlugError            = null;
+        StatusDetail         = null;
+    }
+
+    void HidePrompts() {
+        TenantPickerVisible  = false;
+        ModeChoiceVisible    = false;
+        OrgNamePromptVisible = false;
+        SlugPromptVisible    = false;
+        ConfirmVisible       = false;
+    }
+
+    void SetStatus(string text, bool isError) {
+        Status        = text;
+        StatusIsError = isError;
+        StatusDetail  = isError ? StatusDetail : null;
+    }
+
+    void Append(string line) {
+        Log.Add(line);
+
+        while (Log.Count > LogLimit) Log.RemoveAt(0);
+    }
+
+    void Open(string? url) {
+        if (string.IsNullOrEmpty(url)) return;
+
+        try {
+            _urlOpener.Open(url);
+        } catch (Exception ex) {
+            Append($"Couldn't open the browser: {ex.Message}");
+        }
+    }
+
+    /// The prominent display shows the code alone; the log keeps the line the flow emitted.
+    internal static string StripClipboardNote(string code) {
+        var note = code.IndexOf("  (copied", StringComparison.Ordinal);
+
+        return note < 0 ? code.Trim() : code[..note].Trim();
+    }
+}

--- a/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
@@ -55,6 +55,8 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
 
     AuthAttempt?   _attempt;
     ConnectIntent? _running;
+    Task?          _run;
+    string?        _lastReport;
 
     string  _status = "";
     bool    _statusIsError;
@@ -95,8 +97,13 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
         _urlOpener = urlOpener;
         _post      = bridges.Post;
 
-        bridges.Progress.NoticeReceived     += Append;
-        bridges.Progress.ErrorReceived      += line => {
+        bridges.Progress.NoticeReceived += line => {
+            // Kept as the failure detail's fallback: a decline is reported as a notice, not an error.
+            _lastReport = line;
+            Append(line);
+        };
+        bridges.Progress.ErrorReceived += line => {
+            _lastReport  = line;
             StatusDetail = line;
             Append(line);
         };
@@ -149,11 +156,16 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
             _picker.Select(null);
         });
 
+        // Unofferable rather than declinable: a blank submit must never end the whole run.
+        var hasWorkspace = this.WhenAnyValue(x => x.ExistingWorkspaceInput, input => !string.IsNullOrWhiteSpace(input));
+        var hasOrgName   = this.WhenAnyValue(x => x.OrgName, name => !string.IsNullOrWhiteSpace(name));
+
         CreateWorkspaceCommand      = ReactiveCommand.Create(() => _mode.Answer(new ProvisionMode.Create()));
-        UseExistingWorkspaceCommand = ReactiveCommand.Create(() => _mode.Answer(new ProvisionMode.Existing(ExistingWorkspaceInput)));
+        UseExistingWorkspaceCommand = ReactiveCommand.Create(
+            () => _mode.Answer(new ProvisionMode.Existing(ExistingWorkspaceInput)), hasWorkspace);
         CancelWorkspaceCommand      = ReactiveCommand.Create(() => _mode.Answer(new ProvisionMode.Cancel()));
 
-        SubmitOrgNameCommand = ReactiveCommand.Create(() => _orgName.Answer(OrgName));
+        SubmitOrgNameCommand = ReactiveCommand.Create(() => _orgName.Answer(OrgName), hasOrgName);
         CancelOrgNameCommand = ReactiveCommand.Create(() => _orgName.Answer(null));
         SubmitSlugCommand    = ReactiveCommand.Create(() => _slug.Answer(Slug));
         CancelSlugCommand    = ReactiveCommand.Create(() => _slug.Answer(null));
@@ -314,23 +326,35 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
     }
 
     /// <summary>
-    /// Never vetoes. A live attempt is cancelled and awaited: pre-boundary that ends it with
-    /// nothing durable, past the boundary the operation still answers Committed — the wait is what
-    /// keeps the step's rendered state honest either way. The result task never faults.
+    /// Never vetoes. A live attempt is cancelled, and the RUN — not just the attempt — is awaited:
+    /// pre-boundary that ends it with nothing durable, past the boundary the operation still
+    /// answers Committed, and either way the step's rendered state is final before the wizard
+    /// moves, regardless of which continuation registered first.
     /// </summary>
     public async Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) {
-        if (_attempt is { } live) {
-            live.Cancel();
-            await live.Result.ConfigureAwait(true);
+        _attempt?.Cancel();
+
+        if (_run is { } run) {
+            try {
+                await run.ConfigureAwait(true);
+            } catch (Exception ex) {
+                // A run that failed unexpectedly must not veto the navigation.
+                Console.Error.WriteLine($"kcap: wizard sign-in run failed unexpectedly: {ex.Message}");
+            }
         }
 
         return true;
     }
 
     /// The command's body, reachable directly so a re-entrant call can be asserted as a no-op.
-    internal async Task SignInAsync() {
-        if (Busy) return;
+    internal Task SignInAsync() {
+        // Busy is set before RunAsync's first await, so a re-entrant call never displaces _run.
+        if (Busy) return Task.CompletedTask;
 
+        return _run = RunAsync();
+    }
+
+    async Task RunAsync() {
         if (_connect.Intent is not { } intent) {
             SetStatus("Choose how to connect on the Connect step.", isError: false);
 
@@ -360,6 +384,8 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
         _attempt = null;
         Busy     = false;
         HidePrompts();
+        // Nothing polls a device code or a browser wait once the attempt has settled.
+        ClearTransient();
         Apply(result);
         await SurfaceQuarantineAsync().ConfigureAwait(true);
     }
@@ -387,10 +413,11 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
                 RetargetRequested?.Invoke(retarget.ServerInput);
 
                 break;
-            // The façade already rendered its own error through the sink; the log is the detail.
+            // Already rendered through the sink; the last reported line stands in when none was an error.
             default:
                 Status        = "Sign-in failed.";
                 StatusIsError = true;
+                StatusDetail ??= _lastReport;
 
                 break;
         }
@@ -428,24 +455,28 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
         QuarantineNotice = null;
 
         try {
-            await _appState.UpdateAsync(s => s.ConsentQuarantineAcked ? s : s with { ConsentQuarantineAcked = true })
-                .ConfigureAwait(true);
+            await ConsentFlipCoordinator.AckQuarantineAsync(_appState).ConfigureAwait(true);
         } catch (Exception ex) {
             Console.Error.WriteLine($"kcap: consent quarantine ack failed unexpectedly: {ex.Message}");
         }
     }
 
     void ResetForRun(ConnectIntent intent) {
-        _running = intent;
+        _running    = intent;
+        _lastReport = null;
         Log.Clear();
         HidePrompts();
+        ClearTransient();
+        SlugError    = null;
+        StatusDetail = null;
+    }
+
+    void ClearTransient() {
         DeviceCode           = null;
         VerificationUri      = null;
         BrowserUrl           = null;
         WaitingText          = null;
         ProvisioningProgress = null;
-        SlugError            = null;
-        StatusDetail         = null;
     }
 
     void HidePrompts() {

--- a/src/Capacitor.App/ViewModels/Onboarding/WizardStep.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/WizardStep.cs
@@ -1,0 +1,18 @@
+namespace Capacitor.App.ViewModels.Onboarding;
+
+/// Spec §3 order is also display order.
+public enum WizardStepId { Shim, Connect, SignIn, Defaults, Agents, Import, Daemon, Done }
+
+public enum WizardNavigation { Back, Next, Skip }
+
+/// One wizard page. Applicable is evaluated once, at OnboardingViewModel construction.
+public interface IWizardStep {
+    WizardStepId Id { get; }
+    string Title { get; }
+    bool Applicable { get; }
+    bool Satisfied { get; }
+    Task OnEnterAsync(CancellationToken ct);
+
+    /// False vetoes the navigation and holds the current step.
+    Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct);
+}

--- a/src/Capacitor.App/Views/LifecyclePromptWindow.axaml
+++ b/src/Capacitor.App/Views/LifecyclePromptWindow.axaml
@@ -23,8 +23,9 @@
             </StackPanel>
         </ScrollViewer>
         <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,16,0,0">
-            <Button Content="Not now" Command="{Binding DeclineCommand}" IsCancel="True" />
-            <Button Content="Continue" Command="{Binding AcceptCommand}" IsDefault="True" />
+            <Button Content="Not now" Command="{Binding DeclineCommand}" IsCancel="True"
+                    IsVisible="{Binding ShowDeclineButton}" />
+            <Button Content="{Binding AcceptButtonText}" Command="{Binding AcceptCommand}" IsDefault="True" />
         </StackPanel>
     </Grid>
 </rxui:ReactiveWindow>

--- a/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
+++ b/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
@@ -1,0 +1,25 @@
+<rxui:ReactiveWindow xmlns="https://github.com/avaloniaui"
+                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                     xmlns:rxui="clr-namespace:ReactiveUI.Avalonia;assembly=ReactiveUI.Avalonia"
+                     xmlns:vm="clr-namespace:Capacitor.App.ViewModels.Onboarding"
+                     x:Class="Capacitor.App.Views.Onboarding.OnboardingWindow"
+                     x:TypeArguments="vm:OnboardingViewModel"
+                     x:DataType="vm:OnboardingViewModel"
+                     Title="Kurrent Capacitor Setup"
+                     Icon="avares://Kurrent Capacitor/Assets/kcap-icon.png"
+                     Width="640" Height="480">
+    <Grid Margin="20" RowDefinitions="Auto,*,Auto">
+        <!-- Fallback presenter: always shows the current step's title, template or not. -->
+        <TextBlock Grid.Row="0" x:Name="StepTitleText" Text="{Binding Current.Title}"
+                   FontWeight="Bold" FontSize="18" Margin="0,0,0,16" />
+
+        <!-- No ContentTemplate here: per-step DataTemplates elsewhere would lose to one set here. -->
+        <ContentControl Grid.Row="1" x:Name="StepContent" Content="{Binding Current}" />
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8" Margin="0,16,0,0">
+            <Button x:Name="BackButton" Content="Back" Command="{Binding BackCommand}" />
+            <Button x:Name="SkipButton" Content="Skip" Command="{Binding SkipCommand}" />
+            <Button x:Name="NextButton" Content="Next" Command="{Binding NextCommand}" />
+        </StackPanel>
+    </Grid>
+</rxui:ReactiveWindow>

--- a/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
+++ b/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
@@ -165,6 +165,62 @@
                 </ScrollViewer>
             </Grid>
         </DataTemplate>
+
+        <DataTemplate DataType="vm:ShimStepViewModel">
+            <StackPanel Spacing="10">
+                <TextBlock Text="This links /usr/local/bin/kcap to this app's CLI, so kcap works from any terminal. Installing it prompts once for your admin password."
+                           Opacity="0.7" TextWrapping="Wrap" />
+
+                <Button x:Name="InstallShimButton" Content="Install" Command="{Binding InstallCommand}"
+                        IsEnabled="{Binding Idle}" HorizontalAlignment="Left" />
+
+                <TextBlock x:Name="ShimSuccessText" Text="kcap is now on your terminal PATH."
+                           IsVisible="{Binding Satisfied}" />
+
+                <TextBlock x:Name="ShimMessageText" Text="{Binding Message}" TextWrapping="Wrap" Foreground="#E53935"
+                           IsVisible="{Binding Message, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate DataType="vm:DefaultsStepViewModel">
+            <StackPanel Spacing="14">
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Session visibility" FontWeight="Bold" />
+                    <ComboBox x:Name="VisibilityCombo" ItemsSource="{x:Static vm:DefaultsStepViewModel.VisibilityOptions}"
+                              SelectedValueBinding="{Binding Value}" SelectedValue="{Binding Visibility, Mode=TwoWay}"
+                              HorizontalAlignment="Stretch">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Label}" TextWrapping="Wrap" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </StackPanel>
+
+                <StackPanel Spacing="4">
+                    <TextBlock Text="Daemon name" FontWeight="Bold" />
+                    <TextBox x:Name="DaemonNameBox" Text="{Binding DaemonName, Mode=TwoWay}"
+                             Width="220" HorizontalAlignment="Left" />
+                </StackPanel>
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate DataType="vm:DoneStepViewModel">
+            <ItemsControl x:Name="SummaryList" ItemsSource="{Binding Summary}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,10">
+                            <TextBlock Text="{Binding Glyph}" FontWeight="Bold" VerticalAlignment="Top" />
+                            <StackPanel Spacing="2">
+                                <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding Note}" Opacity="0.7" TextWrapping="Wrap"
+                                           IsVisible="{Binding Note, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                            </StackPanel>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </DataTemplate>
     </Window.DataTemplates>
 
     <Grid Margin="20" RowDefinitions="Auto,*,Auto">

--- a/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
+++ b/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
@@ -2,12 +2,171 @@
                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                      xmlns:rxui="clr-namespace:ReactiveUI.Avalonia;assembly=ReactiveUI.Avalonia"
                      xmlns:vm="clr-namespace:Capacitor.App.ViewModels.Onboarding"
+                     xmlns:auth="clr-namespace:Capacitor.Cli.Core.Auth;assembly=Capacitor.Cli.Core"
                      x:Class="Capacitor.App.Views.Onboarding.OnboardingWindow"
                      x:TypeArguments="vm:OnboardingViewModel"
                      x:DataType="vm:OnboardingViewModel"
                      Title="Kurrent Capacitor Setup"
                      Icon="avares://Kurrent Capacitor/Assets/kcap-icon.png"
                      Width="640" Height="480">
+    <!-- Per-step templates, selected by ViewModel type; the ContentControl below deliberately
+         sets no ContentTemplate, which would win over every one of these. -->
+    <Window.DataTemplates>
+        <DataTemplate DataType="vm:ConnectStepViewModel">
+            <StackPanel Spacing="10">
+                <TextBlock Text="Nothing is contacted or saved on this page — the next step does the signing in."
+                           Opacity="0.7" TextWrapping="Wrap" />
+
+                <RadioButton x:Name="DiscoverChoice" GroupName="Connect" Content="Find my workspaces"
+                             IsChecked="{Binding DiscoverSelected, Mode=TwoWay}" />
+                <StackPanel Orientation="Horizontal" Spacing="16" Margin="26,0,0,0"
+                            IsEnabled="{Binding DiscoverSelected}">
+                    <RadioButton x:Name="GitHubProviderChoice" GroupName="Provider" Content="with GitHub"
+                                 IsChecked="{Binding GitHubProvider, Mode=TwoWay}" />
+                    <RadioButton x:Name="WorkOSProviderChoice" GroupName="Provider" Content="with single sign-on"
+                                 IsChecked="{Binding WorkOSProvider, Mode=TwoWay}" />
+                </StackPanel>
+
+                <RadioButton x:Name="PasteChoice" GroupName="Connect" Content="I have a workspace name or URL"
+                             IsChecked="{Binding PasteSelected, Mode=TwoWay}" />
+                <StackPanel Margin="26,0,0,0" Spacing="4" IsEnabled="{Binding PasteSelected}">
+                    <TextBox x:Name="ServerInputBox" Watermark="acme  ·  https://acme.kcap.ai"
+                             Text="{Binding ServerInputText, Mode=TwoWay}" />
+                    <TextBlock x:Name="ConnectErrorText" Text="{Binding InputError}" TextWrapping="Wrap"
+                               Foreground="#E53935"
+                               IsVisible="{Binding InputError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                </StackPanel>
+
+                <RadioButton x:Name="CreateChoice" GroupName="Connect" Content="Create a new workspace"
+                             IsChecked="{Binding CreateSelected, Mode=TwoWay}" />
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate DataType="vm:SignInStepViewModel">
+            <Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
+                <StackPanel Grid.Row="0" Spacing="4">
+                    <TextBlock x:Name="SignInStatusText" Text="{Binding Status}" TextWrapping="Wrap"
+                               Classes.failed="{Binding StatusIsError}">
+                        <TextBlock.Styles>
+                            <!-- Only a failure is coloured: a cancelled sign-in is not an error. -->
+                            <Style Selector="TextBlock.failed">
+                                <Setter Property="Foreground" Value="#E53935" />
+                            </Style>
+                        </TextBlock.Styles>
+                    </TextBlock>
+                    <TextBlock x:Name="SignInDetailText" Text="{Binding StatusDetail}" TextWrapping="Wrap" Opacity="0.7"
+                               IsVisible="{Binding StatusDetail, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                </StackPanel>
+
+                <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
+                    <Button x:Name="SignInButton" Content="Sign in" Command="{Binding SignInCommand}"
+                            IsEnabled="{Binding Idle}" />
+                    <Button x:Name="CancelSignInButton" Content="Cancel" Command="{Binding CancelCommand}"
+                            IsVisible="{Binding Busy}" />
+                </StackPanel>
+
+                <StackPanel Grid.Row="2" Spacing="6" Margin="0,10,0,0">
+                    <Button x:Name="OpenSignInUrlButton" Content="Open the sign-in page"
+                            Command="{Binding OpenSignInUrlCommand}"
+                            IsVisible="{Binding BrowserUrl, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
+                    <StackPanel Spacing="4"
+                                IsVisible="{Binding DeviceCode, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                        <TextBlock Text="Enter this code to finish signing in:" />
+                        <TextBlock x:Name="DeviceCodeText" Text="{Binding DeviceCode}" FontSize="22" FontWeight="Bold" />
+                        <Button x:Name="OpenVerificationUriButton" Content="{Binding VerificationUri}"
+                                Command="{Binding OpenVerificationUriCommand}" />
+                    </StackPanel>
+
+                    <TextBlock x:Name="WaitingText" Text="{Binding WaitingText}" Opacity="0.7"
+                               IsVisible="{Binding WaitingText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                    <TextBlock x:Name="ProvisioningText" Text="{Binding ProvisioningProgress}" TextWrapping="Wrap"
+                               IsVisible="{Binding ProvisioningProgress, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                </StackPanel>
+
+                <StackPanel Grid.Row="3" Spacing="8" Margin="0,10,0,0">
+                    <StackPanel Spacing="6" IsVisible="{Binding TenantPickerVisible}">
+                        <TextBlock Text="Which workspace would you like to use?" />
+                        <ListBox x:Name="TenantList" MaxHeight="120" ItemsSource="{Binding Tenants}"
+                                 SelectedItem="{Binding SelectedTenant, Mode=TwoWay}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="auth:DiscoveredTenant">
+                                    <TextBlock Text="{Binding Origin}" TextTrimming="CharacterEllipsis" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button x:Name="ConfirmTenantButton" Content="Use this workspace"
+                                    Command="{Binding ConfirmTenantCommand}" />
+                            <Button x:Name="CancelTenantButton" Content="Back" Command="{Binding CancelTenantCommand}" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="6" IsVisible="{Binding ModeChoiceVisible}">
+                        <TextBlock Text="No workspace was found for your account. How would you like to continue?"
+                                   TextWrapping="Wrap" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button x:Name="CreateWorkspaceButton" Content="Create a workspace"
+                                    Command="{Binding CreateWorkspaceCommand}" />
+                            <TextBox x:Name="ExistingWorkspaceBox" Width="180" Watermark="acme"
+                                     Text="{Binding ExistingWorkspaceInput, Mode=TwoWay}" />
+                            <Button x:Name="UseExistingWorkspaceButton" Content="I already have one"
+                                    Command="{Binding UseExistingWorkspaceCommand}" />
+                            <Button x:Name="CancelWorkspaceButton" Content="Cancel"
+                                    Command="{Binding CancelWorkspaceCommand}" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="6" IsVisible="{Binding OrgNamePromptVisible}">
+                        <TextBlock Text="Organization name" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBox x:Name="OrgNameBox" Width="220" Text="{Binding OrgName, Mode=TwoWay}" />
+                            <Button x:Name="SubmitOrgNameButton" Content="Continue" Command="{Binding SubmitOrgNameCommand}" />
+                            <Button x:Name="CancelOrgNameButton" Content="Cancel" Command="{Binding CancelOrgNameCommand}" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="6" IsVisible="{Binding SlugPromptVisible}">
+                        <TextBlock Text="Workspace address" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBox x:Name="SlugBox" Width="220" Text="{Binding Slug, Mode=TwoWay}" />
+                            <TextBlock Text=".kcap.ai" VerticalAlignment="Center" Opacity="0.7" />
+                            <Button x:Name="SubmitSlugButton" Content="Continue" Command="{Binding SubmitSlugCommand}" />
+                            <Button x:Name="CancelSlugButton" Content="Cancel" Command="{Binding CancelSlugCommand}" />
+                        </StackPanel>
+                        <TextBlock x:Name="SlugErrorText" Text="{Binding SlugError}" TextWrapping="Wrap" Foreground="#E53935"
+                                   IsVisible="{Binding SlugError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                    </StackPanel>
+
+                    <StackPanel Spacing="6" IsVisible="{Binding ConfirmVisible}">
+                        <TextBlock x:Name="ConfirmCreateText" Text="{Binding ConfirmText}" TextWrapping="Wrap" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button x:Name="ConfirmCreateButton" Content="Create" Command="{Binding ConfirmCreateCommand}" />
+                            <Button x:Name="DeclineCreateButton" Content="Not now" Command="{Binding DeclineCreateCommand}" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="6"
+                                IsVisible="{Binding QuarantineNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                        <TextBlock x:Name="QuarantineNoticeText" Text="{Binding QuarantineNotice}" TextWrapping="Wrap" />
+                        <Button x:Name="AcknowledgeQuarantineButton" Content="Acknowledge"
+                                Command="{Binding AcknowledgeQuarantineCommand}" HorizontalAlignment="Left" />
+                    </StackPanel>
+                </StackPanel>
+
+                <ScrollViewer Grid.Row="4" Margin="0,10,0,0" VerticalScrollBarVisibility="Auto">
+                    <ItemsControl x:Name="SignInLog" ItemsSource="{Binding Log}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="x:String">
+                                <TextBlock Text="{Binding}" FontSize="12" Opacity="0.7" TextWrapping="Wrap" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Grid>
+        </DataTemplate>
+    </Window.DataTemplates>
+
     <Grid Margin="20" RowDefinitions="Auto,*,Auto">
         <!-- Fallback presenter: always shows the current step's title, template or not. -->
         <TextBlock Grid.Row="0" x:Name="StepTitleText" Text="{Binding Current.Title}"

--- a/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
+++ b/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
@@ -289,6 +289,24 @@
             </Grid>
         </DataTemplate>
 
+        <DataTemplate DataType="vm:DaemonStepViewModel">
+            <StackPanel Spacing="10">
+                <TextBlock Text="The daemon runs kcap's hosted agents and reviews in the background, and starts again after a reboot."
+                           Opacity="0.7" TextWrapping="Wrap" />
+
+                <TextBlock x:Name="DaemonMessageText" Text="{Binding Message}" TextWrapping="Wrap" />
+
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button x:Name="DaemonActionButton" Content="{Binding ActionLabel}" Command="{Binding ActionCommand}"
+                            IsVisible="{Binding ActionLabel, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                    <Button x:Name="DaemonRefreshButton" Content="Check again" Command="{Binding RefreshCommand}" />
+                </StackPanel>
+
+                <TextBlock x:Name="DaemonStatusText" Text="{Binding Status}" TextWrapping="Wrap"
+                           IsVisible="{Binding Status, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+            </StackPanel>
+        </DataTemplate>
+
         <DataTemplate DataType="vm:DoneStepViewModel">
             <ItemsControl x:Name="SummaryList" ItemsSource="{Binding Summary}">
                 <ItemsControl.ItemTemplate>

--- a/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
+++ b/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
@@ -208,6 +208,87 @@
             </StackPanel>
         </DataTemplate>
 
+        <DataTemplate DataType="vm:AgentsStepViewModel">
+            <StackPanel Spacing="10">
+                <TextBlock Text="Install kcap's hooks into the coding agents you use." Opacity="0.7" TextWrapping="Wrap" />
+
+                <TextBlock x:Name="AgentsMessageText" Text="{Binding Message}" TextWrapping="Wrap" Foreground="#E53935"
+                           IsVisible="{Binding Message, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
+                <ItemsControl x:Name="AgentsList" ItemsSource="{Binding Rows}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,6">
+                                <CheckBox x:Name="AgentCheckBox" Content="{Binding Label}" IsChecked="{Binding IsSelected, Mode=TwoWay}" />
+                                <TextBlock x:Name="AgentGlyphText" Text="{Binding Glyph}" FontWeight="Bold" />
+                                <TextBlock x:Name="AgentRowMessageText" Text="{Binding Message}" Opacity="0.7" TextWrapping="Wrap"
+                                           IsVisible="{Binding Message, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                <Button x:Name="AgentRetryButton" Content="Retry" Command="{Binding RetryCommand}"
+                                        IsVisible="{Binding Failed}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <Button x:Name="InstallAgentsButton" Content="Install" Command="{Binding InstallCommand}"
+                        HorizontalAlignment="Left" />
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate DataType="vm:ImportStepViewModel">
+            <Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
+                <TextBlock Grid.Row="0" x:Name="ImportMessageText" Text="{Binding Message}" TextWrapping="Wrap" Foreground="#E53935"
+                           IsVisible="{Binding Message, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
+                <StackPanel Grid.Row="1" Spacing="4" Margin="0,0,0,10">
+                    <TextBlock Text="Which coding agents?" FontWeight="Bold" />
+                    <ItemsControl x:Name="ImportVendorsList" ItemsSource="{Binding Vendors}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox x:Name="ImportVendorCheckBox" Content="{Binding Label}"
+                                          IsChecked="{Binding IsSelected, Mode=TwoWay}" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <StackPanel Grid.Row="2" Spacing="6" Margin="0,0,0,10">
+                    <TextBlock Text="What would you like to import?" FontWeight="Bold" />
+                    <RadioButton x:Name="EverythingChoice" GroupName="ImportScope" Content="Everything"
+                                 IsChecked="{Binding EverythingSelected, Mode=TwoWay}" />
+                    <RadioButton x:Name="OrgChoice" GroupName="ImportScope" Content="All repos in one org"
+                                 IsChecked="{Binding OrgSelected, Mode=TwoWay}" />
+                    <TextBox x:Name="OrgTextBox" Margin="26,0,0,0" Watermark="acme" Width="220" HorizontalAlignment="Left"
+                             Text="{Binding OrgText, Mode=TwoWay}" IsEnabled="{Binding OrgSelected}" />
+                    <RadioButton x:Name="RepoChoice" GroupName="ImportScope" Content="Specific repository"
+                                 IsChecked="{Binding RepoSelected, Mode=TwoWay}" />
+                    <TextBox x:Name="RepoTextBox" Margin="26,0,0,0" Watermark="owner/name" Width="220" HorizontalAlignment="Left"
+                             Text="{Binding RepoText, Mode=TwoWay}" IsEnabled="{Binding RepoSelected}" />
+                </StackPanel>
+
+                <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" Margin="0,0,0,10">
+                    <Button x:Name="RunImportButton" Content="Run" Command="{Binding RunCommand}" />
+                    <Button x:Name="CancelImportButton" Content="Cancel" Command="{Binding CancelCommand}"
+                            IsVisible="{Binding Busy}" />
+                    <TextBlock x:Name="ImportStatusText" Text="{Binding Status}" TextWrapping="Wrap" VerticalAlignment="Center" />
+                </StackPanel>
+
+                <StackPanel Grid.Row="4">
+                    <TextBlock x:Name="ImportTruncationText" Text="…older lines dropped" Opacity="0.6" FontStyle="Italic"
+                               IsVisible="{Binding Truncated}" />
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <ItemsControl x:Name="ImportLog" ItemsSource="{Binding Log}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="x:String">
+                                    <TextBlock Text="{Binding}" FontSize="12" Opacity="0.7" TextWrapping="Wrap" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
         <DataTemplate DataType="vm:DoneStepViewModel">
             <ItemsControl x:Name="SummaryList" ItemsSource="{Binding Summary}">
                 <ItemsControl.ItemTemplate>

--- a/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
+++ b/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
@@ -333,10 +333,23 @@
         <!-- No ContentTemplate here: per-step DataTemplates elsewhere would lose to one set here. -->
         <ContentControl Grid.Row="1" x:Name="StepContent" Content="{Binding Current}" />
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8" Margin="0,16,0,0">
-            <Button x:Name="BackButton" Content="Back" Command="{Binding BackCommand}" />
-            <Button x:Name="SkipButton" Content="Skip" Command="{Binding SkipCommand}" />
-            <Button x:Name="NextButton" Content="Next" Command="{Binding NextCommand}" />
-        </StackPanel>
+        <!-- Left of the buttons: the outcome consumer's lines. Wizard-first mode has no tray and
+             no main window, so this footer is where a lane outcome actually becomes visible. -->
+        <Grid Grid.Row="2" ColumnDefinitions="*,Auto" Margin="0,16,0,0">
+            <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center" Margin="0,0,12,0">
+                <TextBlock x:Name="LifecycleStatusText" Text="{Binding Surface.StatusText}" TextWrapping="Wrap"
+                           Opacity="0.7"
+                           IsVisible="{Binding Surface.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                <TextBlock x:Name="LifecycleAttentionText" Text="{Binding Surface.AttentionText}" TextWrapping="Wrap"
+                           Foreground="#E53935"
+                           IsVisible="{Binding Surface.AttentionText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+            </StackPanel>
+
+            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+                <Button x:Name="BackButton" Content="Back" Command="{Binding BackCommand}" />
+                <Button x:Name="SkipButton" Content="Skip" Command="{Binding SkipCommand}" />
+                <Button x:Name="NextButton" Content="Next" Command="{Binding NextCommand}" />
+            </StackPanel>
+        </Grid>
     </Grid>
 </rxui:ReactiveWindow>

--- a/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
+++ b/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
@@ -191,7 +191,7 @@
                               HorizontalAlignment="Stretch">
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding Label}" TextWrapping="Wrap" />
+                                <TextBlock x:Name="VisibilityLabelText" Text="{Binding Label}" TextWrapping="Wrap" />
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
@@ -202,6 +202,9 @@
                     <TextBox x:Name="DaemonNameBox" Text="{Binding DaemonName, Mode=TwoWay}"
                              Width="220" HorizontalAlignment="Left" />
                 </StackPanel>
+
+                <TextBlock x:Name="DefaultsMessageText" Text="{Binding Message}" TextWrapping="Wrap" Foreground="#E53935"
+                           IsVisible="{Binding Message, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
             </StackPanel>
         </DataTemplate>
 
@@ -210,10 +213,10 @@
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,10">
-                            <TextBlock Text="{Binding Glyph}" FontWeight="Bold" VerticalAlignment="Top" />
+                            <TextBlock x:Name="SummaryGlyphText" Text="{Binding Glyph}" FontWeight="Bold" VerticalAlignment="Top" />
                             <StackPanel Spacing="2">
-                                <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
-                                <TextBlock Text="{Binding Note}" Opacity="0.7" TextWrapping="Wrap"
+                                <TextBlock x:Name="SummaryTitleText" Text="{Binding Title}" FontWeight="SemiBold" />
+                                <TextBlock x:Name="SummaryNoteText" Text="{Binding Note}" Opacity="0.7" TextWrapping="Wrap"
                                            IsVisible="{Binding Note, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                             </StackPanel>
                         </StackPanel>

--- a/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml.cs
+++ b/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml.cs
@@ -1,0 +1,35 @@
+using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
+using Capacitor.App.ViewModels.Onboarding;
+using ReactiveUI;
+using ReactiveUI.Avalonia;
+
+namespace Capacitor.App.Views.Onboarding;
+
+public partial class OnboardingWindow : ReactiveWindow<OnboardingViewModel> {
+    // Guards the Close()<->Closing round trip below from re-entering itself either way.
+    bool _closingProgrammatically;
+
+    public OnboardingWindow() {
+        InitializeComponent();
+
+        this.WhenActivated(disposables => {
+            if (ViewModel is null) return;
+
+            void OnCloseRequested() {
+                if (_closingProgrammatically) return;
+                _closingProgrammatically = true;
+                Close();
+            }
+
+            ViewModel.CloseRequested += OnCloseRequested;
+            Disposable.Create(() => ViewModel.CloseRequested -= OnCloseRequested).DisposeWith(disposables);
+        });
+
+        // Never cancelled — the shell never blocks close, it only notifies the ViewModel.
+        Closing += (_, _) => {
+            _closingProgrammatically = true;
+            ViewModel?.RequestClose();
+        };
+    }
+}

--- a/src/Capacitor.Cli.Core/Auth/AuthProgress.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthProgress.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Capacitor.Cli.Core.Auth;
+
+/// <summary>
+/// Structured sink for auth-flow progress, so a desktop app can render login/discovery steps
+/// without depending on <see cref="Console"/>. Every login/discovery/exchange path accepts one
+/// as a trailing optional parameter and defaults to <see cref="ConsoleAuthProgress"/>.
+/// </summary>
+public interface IAuthProgress {
+    /// <summary>An informational line — today's stdout output, verbatim.</summary>
+    void Notice(string message);
+
+    /// <summary>An error line — today's stderr output, verbatim.</summary>
+    [SuppressMessage("Naming", "CA1716", Justification = "Error names a severity level, mirroring Console.Error — not a cross-language keyword collision here.")]
+    void Error(string message);
+
+    /// <summary>A browser is being opened for an interactive sign-in step; <paramref name="url"/> is the fallback link.</summary>
+    void BrowserOpening(string url);
+
+    /// <summary>A device-flow user code is ready for the user to enter at <paramref name="verificationUri"/>.</summary>
+    void DeviceCode(string code, string verificationUri);
+
+    /// <summary>One device-flow poll attempt came back pending.</summary>
+    void PollTick();
+}
+
+/// <summary>Reproduces exactly what the CLI printed to stdout/stderr before <see cref="IAuthProgress"/> existed.</summary>
+public sealed class ConsoleAuthProgress : IAuthProgress {
+    public static readonly ConsoleAuthProgress Instance = new();
+
+    public void Notice(string message) => Console.Out.WriteLine(message);
+
+    public void Error(string message) => Console.Error.WriteLine(message);
+
+    public void BrowserOpening(string url) {
+        Console.Out.WriteLine("Opening browser for authentication...");
+        Console.Out.WriteLine($"  If the browser doesn't open, visit: {url}");
+    }
+
+    public void DeviceCode(string code, string verificationUri) {
+        Console.Out.WriteLine($"  2. Enter the code: {code}");
+        Console.Out.WriteLine("  3. Approve access when GitHub asks.");
+        Console.Out.WriteLine();
+        Console.Write("Waiting for you to authorize...");
+    }
+
+    public void PollTick() => Console.Write(".");
+}

--- a/src/Capacitor.Cli.Core/Auth/AuthProxyClient.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthProxyClient.cs
@@ -4,30 +4,30 @@ using System.Net.Http.Json;
 namespace Capacitor.Cli.Core.Auth;
 
 public interface IAuthProxyClient {
-    Task<ProxyConfigResponse?> GetConfigAsync(string proxyUrl);
-    Task<DiscoveryResult>      DiscoverTenantsAsync(string proxyUrl, string githubAccessToken);
-    Task<DiscoveryResult>      DiscoverWorkOSTenantsAsync(string proxyUrl, string workosAccessToken);
+    Task<ProxyConfigResponse?> GetConfigAsync(string proxyUrl, CancellationToken ct = default);
+    Task<DiscoveryResult>      DiscoverTenantsAsync(string proxyUrl, string githubAccessToken, CancellationToken ct = default);
+    Task<DiscoveryResult>      DiscoverWorkOSTenantsAsync(string proxyUrl, string workosAccessToken, CancellationToken ct = default);
 }
 
 public class AuthProxyClient(HttpClient http) : IAuthProxyClient {
-    public async Task<ProxyConfigResponse?> GetConfigAsync(string proxyUrl) {
+    public async Task<ProxyConfigResponse?> GetConfigAsync(string proxyUrl, CancellationToken ct = default) {
         try {
-            using var response = await http.GetAsync($"{proxyUrl}/config");
+            using var response = await http.GetAsync($"{proxyUrl}/config", ct);
             if (!response.IsSuccessStatusCode) return null;
-            return await response.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.ProxyConfigResponse);
+            return await response.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.ProxyConfigResponse, ct);
         } catch (Exception e) when (e is HttpRequestException or OperationCanceledException) {
             return null;
         }
     }
 
-    public async Task<DiscoveryResult> DiscoverTenantsAsync(string proxyUrl, string githubAccessToken) {
+    public async Task<DiscoveryResult> DiscoverTenantsAsync(string proxyUrl, string githubAccessToken, CancellationToken ct = default) {
         try {
             using var request = new HttpRequestMessage(HttpMethod.Post, $"{proxyUrl}/discover-tenants");
             request.Headers.Authorization = new("Bearer", githubAccessToken);
-            using var response = await http.SendAsync(request);
+            using var response = await http.SendAsync(request, ct);
 
             return response.StatusCode switch {
-                HttpStatusCode.OK                                       => new(await ReadTenants(response), DiscoveryError.None),
+                HttpStatusCode.OK                                       => new(await ReadTenants(response, ct), DiscoveryError.None),
                 HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new([], DiscoveryError.TokenRejected),
                 _                                                       => new([], DiscoveryError.UpstreamError)
             };
@@ -36,14 +36,14 @@ public class AuthProxyClient(HttpClient http) : IAuthProxyClient {
         }
     }
 
-    public async Task<DiscoveryResult> DiscoverWorkOSTenantsAsync(string proxyUrl, string workosAccessToken) {
+    public async Task<DiscoveryResult> DiscoverWorkOSTenantsAsync(string proxyUrl, string workosAccessToken, CancellationToken ct = default) {
         try {
             using var request = new HttpRequestMessage(HttpMethod.Post, $"{proxyUrl}/discover-tenants-workos");
             request.Headers.Authorization = new("Bearer", workosAccessToken);
-            using var response = await http.SendAsync(request);
+            using var response = await http.SendAsync(request, ct);
 
             return response.StatusCode switch {
-                HttpStatusCode.OK                                       => new(await ReadTenants(response), DiscoveryError.None),
+                HttpStatusCode.OK                                       => new(await ReadTenants(response, ct), DiscoveryError.None),
                 HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new([], DiscoveryError.TokenRejected),
                 _                                                       => new([], DiscoveryError.UpstreamError)
             };
@@ -52,6 +52,6 @@ public class AuthProxyClient(HttpClient http) : IAuthProxyClient {
         }
     }
 
-    static async Task<DiscoveredTenant[]> ReadTenants(HttpResponseMessage response) =>
-        await response.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.DiscoveredTenantArray) ?? [];
+    static async Task<DiscoveredTenant[]> ReadTenants(HttpResponseMessage response, CancellationToken ct) =>
+        await response.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.DiscoveredTenantArray, ct) ?? [];
 }

--- a/src/Capacitor.Cli.Core/Auth/AuthResult.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthResult.cs
@@ -4,6 +4,12 @@ namespace Capacitor.Cli.Core.Auth;
 public sealed record AuthIdentity(string Profile, string CanonicalServer);
 
 /// <summary>
+/// Why an operation failed, for callers that must react differently per cause (the setup funnel
+/// distinguishes a denied sign-in from a tenant-less account). <see cref="Other"/> carries no claim.
+/// </summary>
+public enum AuthFailureReason { Other, Unreachable, SigninDenied, NoTenantsFound }
+
+/// <summary>
 /// Outcome of an onboarding operation. <see cref="Cancelled"/> is strictly pre-boundary — once the
 /// boundary is entered every publication runs to completion and the answer is
 /// <see cref="Committed"/>, never a torn stop. <see cref="Retarget"/> is the WorkOS "I already have
@@ -20,7 +26,7 @@ public abstract record AuthResult {
     public sealed record Cancelled : AuthResult;
 
     /// <param name="Message">Already rendered through <see cref="IAuthProgress"/>; carried for callers that log or re-present it.</param>
-    public sealed record Failed(string Message) : AuthResult;
+    public sealed record Failed(string Message, AuthFailureReason Reason = AuthFailureReason.Other) : AuthResult;
 
     public sealed record Retarget(string ServerInput) : AuthResult;
 }

--- a/src/Capacitor.Cli.Core/Auth/AuthResult.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthResult.cs
@@ -1,0 +1,26 @@
+namespace Capacitor.Cli.Core.Auth;
+
+/// <summary>One profile the commit boundary will publish, with the canonical server it is bound to.</summary>
+public sealed record AuthIdentity(string Profile, string CanonicalServer);
+
+/// <summary>
+/// Outcome of an onboarding operation. <see cref="Cancelled"/> is strictly pre-boundary — once the
+/// boundary is entered every publication runs to completion and the answer is
+/// <see cref="Committed"/>, never a torn stop. <see cref="Retarget"/> is the WorkOS "I already have
+/// a workspace" answer: nothing durable, and the caller resolves the input against its own server.
+/// </summary>
+public abstract record AuthResult {
+    public sealed record Committed(
+        string                      ActiveProfile,
+        string                      CanonicalServer,
+        string                      Provider,
+        string?                     Username,
+        IReadOnlyList<AuthIdentity> Published) : AuthResult;
+
+    public sealed record Cancelled : AuthResult;
+
+    /// <param name="Message">Already rendered through <see cref="IAuthProgress"/>; carried for callers that log or re-present it.</param>
+    public sealed record Failed(string Message) : AuthResult;
+
+    public sealed record Retarget(string ServerInput) : AuthResult;
+}

--- a/src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs
+++ b/src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs
@@ -10,7 +10,8 @@ namespace Capacitor.Cli.Core.Auth;
 /// Opens the system browser to the authorize URL, waits for the redirect callback,
 /// and returns its raw query string. WorkOS documents the loopback exception as
 /// 127.0.0.1 (not localhost). The bind exception is intentionally NOT caught so the
-/// GitHub flow can fall back to device flow on a bind failure.
+/// GitHub flow can fall back to device flow on a bind failure. A caller cancel throws
+/// <see cref="OperationCanceledException"/>; only the independent timeout returns Timeout.
 /// </summary>
 public sealed class LoopbackBrowser(Action<string>? openBrowser = null, IAuthProgress? progress = null) : IBrowser {
     readonly Action<string> _openBrowser = openBrowser ?? OpenSystemBrowser;
@@ -40,6 +41,9 @@ public sealed class LoopbackBrowser(Action<string>? openBrowser = null, IAuthPro
                 listener.Stop();
                 _ = getContext.ContinueWith(t => _ = t.Exception, CancellationToken.None,
                     TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+
+                // The caller's own cancel is not a timeout — it propagates so the flow answers Cancelled.
+                ct.ThrowIfCancellationRequested();
 
                 return new BrowserResult { ResultType = BrowserResultType.Timeout };
             }

--- a/src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs
+++ b/src/Capacitor.Cli.Core/Auth/LoopbackBrowser.cs
@@ -12,8 +12,9 @@ namespace Capacitor.Cli.Core.Auth;
 /// 127.0.0.1 (not localhost). The bind exception is intentionally NOT caught so the
 /// GitHub flow can fall back to device flow on a bind failure.
 /// </summary>
-public sealed class LoopbackBrowser(Action<string>? openBrowser = null) : IBrowser {
+public sealed class LoopbackBrowser(Action<string>? openBrowser = null, IAuthProgress? progress = null) : IBrowser {
     readonly Action<string> _openBrowser = openBrowser ?? OpenSystemBrowser;
+    readonly IAuthProgress  _progress    = progress ?? ConsoleAuthProgress.Instance;
 
     public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken ct = default) {
         var port = new Uri(options.EndUrl).Port;
@@ -22,8 +23,7 @@ public sealed class LoopbackBrowser(Action<string>? openBrowser = null) : IBrows
         listener.Prefixes.Add($"http://127.0.0.1:{port}/");
         listener.Start(); // bind failure propagates (HttpListenerException / PlatformNotSupportedException)
 
-        await Console.Out.WriteLineAsync("Opening browser for authentication...");
-        await Console.Out.WriteLineAsync($"  If the browser doesn't open, visit: {options.StartUrl}");
+        _progress.BrowserOpening(options.StartUrl);
         _openBrowser(options.StartUrl);
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -240,6 +240,7 @@ public static class OAuthLoginFlow {
             new BrowserOptions(state.StartUrl, redirectUri) { Timeout = timeout ?? TimeSpan.FromMinutes(5) }, ct);
 
         if (result.ResultType != BrowserResultType.Success) {
+            ct.ThrowIfCancellationRequested(); // a caller cancel is neither a timeout nor a denial
             progress.Error(result.ResultType == BrowserResultType.Timeout
                 ? "Timed out waiting for authorization. Re-run `kcap login` to try again."
                 : $"Authorization failed: {result.Error ?? result.ResultType.ToString()}");
@@ -282,6 +283,7 @@ public static class OAuthLoginFlow {
                 cancellationToken: cts.Token
             );
         } catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or UriFormatException or InvalidOperationException) {
+            ct.ThrowIfCancellationRequested(); // the caller's cancel aborted the exchange — not a connectivity failure
             progress.Error($"Could not reach the code-exchange endpoint at {codeExchangeUrl}: {ex.Message}");
 
             return null;
@@ -553,6 +555,7 @@ public static class OAuthLoginFlow {
         // Surface the actual reason (timeout / state mismatch / token-endpoint / upstream OIDC error)
         // rather than collapsing every failure to a single opaque "sign-in failed".
         if (result.IsError) {
+            ct.ThrowIfCancellationRequested(); // OidcClient renders a caller cancel as an error result
             progress.Error(WorkOSSignInError(result.Error, result.ErrorDescription));
 
             return null;

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -651,9 +651,9 @@ public static class OAuthLoginFlow {
     /// </summary>
     internal static async Task<(StoredTokens Tokens, string Username)?> WorkOSTokensForServerAsync(
             string serverUrl, string clientId, string? organizationId, IBrowser browser,
-            CancellationToken ct, IAuthProgress progress) {
+            CancellationToken ct, IAuthProgress progress, string apiBase = WorkOSApiBase) {
         // AuthenticateWorkOSAsync already reported the specific failure reason.
-        var json = await AuthenticateWorkOSAsync(clientId, organizationId, browser, ct: ct, progress: progress);
+        var json = await AuthenticateWorkOSAsync(clientId, organizationId, browser, apiBase, ct, progress);
         if (json is null) return null;
 
         // Org gate: a multi-org user must not be "logged in" to the wrong org — every API

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -32,23 +32,9 @@ public static class OAuthLoginFlow {
         // ReSharper disable once ShortLivedHttpClient
         using var http = new HttpClient();
 
-        HttpResponseMessage configResponse;
+        var config = await FetchAuthConfigAsync(http, serverUrl, ct, progress);
 
-        try {
-            configResponse = await http.GetAsync($"{serverUrl}/auth/config", ct);
-        } catch (HttpRequestException ex) {
-            progress.Error(HttpClientExtensions.UnreachableErrorText(serverUrl, ex));
-
-            return 1;
-        }
-
-        if (!configResponse.IsSuccessStatusCode) {
-            progress.Error($"Error: Failed to fetch auth config from {serverUrl}/auth/config");
-
-            return 1;
-        }
-
-        var config = (await configResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.AuthDiscoveryResponse, ct))!;
+        if (config is null) return 1;
 
         return config.Provider switch {
             AuthProvider.None      => HandleNoneLogin(progress),
@@ -56,6 +42,28 @@ public static class OAuthLoginFlow {
             AuthProvider.WorkOS    => await HandleWorkOSLogin(serverUrl, config, profile, ct, progress),
             _                      => HandleUnknownProvider(config.Provider, progress)
         };
+    }
+
+    /// <summary>GET <c>{serverUrl}/auth/config</c>, or <c>null</c> with the failure already reported.</summary>
+    internal static async Task<AuthDiscoveryResponse?> FetchAuthConfigAsync(
+            HttpClient http, string serverUrl, CancellationToken ct, IAuthProgress progress) {
+        HttpResponseMessage configResponse;
+
+        try {
+            configResponse = await http.GetAsync($"{serverUrl}/auth/config", ct);
+        } catch (HttpRequestException ex) {
+            progress.Error(HttpClientExtensions.UnreachableErrorText(serverUrl, ex));
+
+            return null;
+        }
+
+        var config = configResponse.IsSuccessStatusCode
+            ? await configResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.AuthDiscoveryResponse, ct)
+            : null;
+
+        if (config is null) progress.Error($"Error: Failed to fetch auth config from {serverUrl}/auth/config");
+
+        return config;
     }
 
     internal static GitHubFlow ChooseGitHubFlow(bool forceDevice, bool isHeadless, bool hasExchangeUrl)
@@ -136,14 +144,13 @@ public static class OAuthLoginFlow {
             HttpClient http, string clientId, CancellationToken ct = default, IAuthProgress? progress = null) {
         progress ??= ConsoleAuthProgress.Instance;
 
-        var deviceResponse = await http.PostAsync(
+        var deviceResponse = await PostFormForJsonAsync(
+            http,
             "https://github.com/login/device/code",
-            new FormUrlEncodedContent(
-                new Dictionary<string, string> {
-                    ["client_id"] = clientId,
-                    ["scope"]     = "read:user read:org"
-                }
-            ),
+            new() {
+                ["client_id"] = clientId,
+                ["scope"]     = "read:user read:org"
+            },
             ct
         );
 
@@ -186,15 +193,14 @@ public static class OAuthLoginFlow {
             await Task.Delay(TimeSpan.FromSeconds(interval), ct);
             ct.ThrowIfCancellationRequested();
 
-            var tokenResponse = await http.PostAsync(
+            var tokenResponse = await PostFormForJsonAsync(
+                http,
                 "https://github.com/login/oauth/access_token",
-                new FormUrlEncodedContent(
-                    new Dictionary<string, string> {
-                        ["client_id"]   = clientId,
-                        ["device_code"] = device.DeviceCode,
-                        ["grant_type"]  = "urn:ietf:params:oauth:grant-type:device_code"
-                    }
-                ),
+                new() {
+                    ["client_id"]   = clientId,
+                    ["device_code"] = device.DeviceCode,
+                    ["grant_type"]  = "urn:ietf:params:oauth:grant-type:device_code"
+                },
                 ct
             );
 
@@ -221,6 +227,16 @@ public static class OAuthLoginFlow {
                     return null;
             }
         }
+    }
+
+    // Accept rides on the request, not the client: an injected HttpClient (the façade's) would
+    // otherwise get GitHub's form-encoded default and fail to parse.
+    static async Task<HttpResponseMessage> PostFormForJsonAsync(
+            HttpClient http, string url, Dictionary<string, string> form, CancellationToken ct) {
+        using var request = new HttpRequestMessage(HttpMethod.Post, url) { Content = new FormUrlEncodedContent(form) };
+        request.Headers.Accept.Add(new("application/json"));
+
+        return await http.SendAsync(request, ct);
     }
 
     /// <summary>
@@ -340,25 +356,50 @@ public static class OAuthLoginFlow {
             string serverUrl, string githubAccessToken, string provider, CancellationToken ct = default, IAuthProgress? progress = null) {
         progress ??= ConsoleAuthProgress.Instance;
 
+        using var http = new HttpClient();
+
+        var exchanged = await ExchangeAsync(http, serverUrl, githubAccessToken, provider, profile: null, progress, ct);
+
+        if (exchanged is null) return 1;
+
+        await TokenStore.SaveAsync(exchanged.Value.Tokens);
+
+        progress.Notice($"Logged in as {exchanged.Value.Username}");
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Exchanges a GitHub access token for a Capacitor JWT and returns the tokens WITHOUT saving —
+    /// persistence belongs to the caller's commit boundary. <c>null</c> means the exchange failed and
+    /// the reason has already been reported through <paramref name="progress"/>. <paramref name="profile"/>
+    /// only names the profile in that error text.
+    /// </summary>
+    public static async Task<(StoredTokens Tokens, string? Username)?> ExchangeAsync(
+            HttpClient        http,
+            string            serverUrl,
+            string            githubAccessToken,
+            string            provider,
+            string?           profile,
+            IAuthProgress     progress,
+            CancellationToken ct = default) {
         if (provider is not AuthProvider.GitHubApp) {
             progress.Error($"Error: unknown auth provider '{provider}'");
 
-            return 1;
+            return null;
         }
-
-        using var http = new HttpClient();
 
         var exchangeResponse = await http.PostAsJsonAsync(
             $"{serverUrl}/auth/token",
-            new() { GithubAccessToken = githubAccessToken },
+            new TokenExchangeRequest { GithubAccessToken = githubAccessToken },
             CapacitorJsonContext.Default.TokenExchangeRequest,
             cancellationToken: ct
         );
 
         if (!exchangeResponse.IsSuccessStatusCode) {
-            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(ct), profile: null, progress);
+            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(ct), profile, progress);
 
-            return 1;
+            return null;
         }
 
         var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse, ct))!;
@@ -366,22 +407,16 @@ public static class OAuthLoginFlow {
         if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
             progress.Error($"Error: {identityError}");
 
-            return 1;
+            return null;
         }
 
-        await TokenStore.SaveAsync(
-            new() {
-                AccessToken    = exchange.AccessToken,
-                ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(exchange.ExpiresIn),
-                GitHubUsername = exchange.Username,
-                Provider       = provider,
-                ServerUrl      = canonical
-            }
-        );
-
-        progress.Notice($"Logged in as {exchange.Username}");
-
-        return 0;
+        return (new StoredTokens {
+            AccessToken    = exchange.AccessToken,
+            ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(exchange.ExpiresIn),
+            GitHubUsername = exchange.Username,
+            Provider       = provider,
+            ServerUrl      = canonical
+        }, exchange.Username);
     }
 
     /// <summary>
@@ -408,43 +443,11 @@ public static class OAuthLoginFlow {
         ) {
         progress ??= ConsoleAuthProgress.Instance;
 
-        if (provider is not AuthProvider.GitHubApp) {
-            progress.Error($"Error: unknown auth provider '{provider}'");
+        var exchanged = await ExchangeAsync(http, serverUrl, githubAccessToken, provider, profile, progress, ct);
 
-            return 1;
-        }
+        if (exchanged is null) return 1;
 
-        var exchangeResponse = await http.PostAsJsonAsync(
-            $"{serverUrl}/auth/token",
-            new TokenExchangeRequest { GithubAccessToken = githubAccessToken },
-            CapacitorJsonContext.Default.TokenExchangeRequest,
-            cancellationToken: ct
-        );
-
-        if (!exchangeResponse.IsSuccessStatusCode) {
-            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(ct), profile, progress);
-
-            return 1;
-        }
-
-        var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse, ct))!;
-
-        if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
-            progress.Error($"Error: {identityError}");
-
-            return 1;
-        }
-
-        await TokenStore.SaveAsync(
-            profile,
-            new StoredTokens {
-                AccessToken    = exchange.AccessToken,
-                ExpiresAt      = DateTimeOffset.UtcNow.AddSeconds(exchange.ExpiresIn),
-                GitHubUsername = exchange.Username,
-                Provider       = provider,
-                ServerUrl      = canonical
-            }
-        );
+        await TokenStore.SaveAsync(profile, exchanged.Value.Tokens, ct);
 
         return 0;
     }
@@ -511,6 +514,16 @@ public static class OAuthLoginFlow {
 
     internal static async Task<string?> AcquireGitHubTokenAsync(
             string clientId, string? codeExchangeUrl, bool forceDevice, CancellationToken ct = default, IAuthProgress? progress = null) {
+        using var http = new HttpClient();
+
+        return await AcquireGitHubTokenAsync(http, clientId, codeExchangeUrl, forceDevice, ct, progress);
+    }
+
+    // HttpClient-injectable core: the device-flow leg runs on the caller's client so the façade's
+    // one client (and a test's scripted handler) covers it.
+    internal static async Task<string?> AcquireGitHubTokenAsync(
+            HttpClient http, string clientId, string? codeExchangeUrl, bool forceDevice,
+            CancellationToken ct = default, IAuthProgress? progress = null) {
         progress ??= ConsoleAuthProgress.Instance;
 
         var headless = HeadlessEnvironment.IsHeadless();
@@ -530,14 +543,14 @@ public static class OAuthLoginFlow {
             }
         }
 
-        return await RunDeviceFlowAsync(clientId, ct, progress);
+        return await RunDeviceFlowAsync(http, clientId, ct, progress);
     }
 
     static Task<int> HandleWorkOSLogin(
             string serverUrl, AuthDiscoveryResponse config, string? profile, CancellationToken ct, IAuthProgress progress) =>
         LoginWorkOSAsync(serverUrl, config.ClientId!, config.OrganizationId, profile, ct, progress);
 
-    const string WorkOSApiBase = "https://api.workos.com";
+    internal const string WorkOSApiBase = "https://api.workos.com";
 
     /// <summary>
     /// Builds OidcClient options for the WorkOS AuthKit authorization-code-with-PKCE flow.
@@ -617,28 +630,49 @@ public static class OAuthLoginFlow {
 
     static async Task<int> LoginWorkOSAsync(
             string serverUrl, string clientId, string? organizationId, string? profile, CancellationToken ct, IAuthProgress progress) {
+        var authenticated = await WorkOSTokensForServerAsync(
+            serverUrl, clientId, organizationId, new LoopbackBrowser(progress: progress), ct, progress);
+
+        if (authenticated is null) return 1;
+
+        var (saved, username) = authenticated.Value;
+
+        if (profile is null) await TokenStore.SaveAsync(saved);
+        else await TokenStore.SaveAsync(profile, saved);
+
+        progress.Notice($"Logged in as {username}");
+
+        return 0;
+    }
+
+    /// <summary>
+    /// WorkOS sign-in against a KNOWN server: authenticate, enforce the org gate, and build the
+    /// server-bound tokens WITHOUT saving them. <c>null</c> means the reason is already reported.
+    /// </summary>
+    internal static async Task<(StoredTokens Tokens, string Username)?> WorkOSTokensForServerAsync(
+            string serverUrl, string clientId, string? organizationId, IBrowser browser,
+            CancellationToken ct, IAuthProgress progress) {
         // AuthenticateWorkOSAsync already reported the specific failure reason.
-        var json = await AuthenticateWorkOSAsync(
-            clientId, organizationId, new LoopbackBrowser(progress: progress), ct: ct, progress: progress);
-        if (json is null) return 1;
+        var json = await AuthenticateWorkOSAsync(clientId, organizationId, browser, ct: ct, progress: progress);
+        if (json is null) return null;
 
         // Org gate: a multi-org user must not be "logged in" to the wrong org — every API
         // call would then fail the server's org check. Reject before saving tokens.
         if (!string.IsNullOrEmpty(organizationId) && !string.Equals(json.OrganizationId, organizationId, StringComparison.Ordinal)) {
             progress.Error($"Error: signed in to the wrong WorkOS organization (expected {organizationId}). Re-run `kcap login` and pick the correct organization.");
 
-            return 1;
+            return null;
         }
-
-        var username = WorkOSDisplayName(json.User);
 
         if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
             progress.Error($"Error: {identityError}");
 
-            return 1;
+            return null;
         }
 
-        var saved = new StoredTokens {
+        var username = WorkOSDisplayName(json.User);
+
+        return (new StoredTokens {
             AccessToken    = json.AccessToken,
             RefreshToken   = json.RefreshToken,
             ExpiresAt      = TokenStore.JwtExpiry(json.AccessToken),
@@ -648,14 +682,7 @@ public static class OAuthLoginFlow {
             // The kcap server we authenticated FOR — not api.workos.com, which issued the
             // token but says nothing about which Capacitor server will accept it.
             ServerUrl      = canonical
-        };
-
-        if (profile is null) await TokenStore.SaveAsync(saved);
-        else await TokenStore.SaveAsync(profile, saved);
-
-        progress.Notice($"Logged in as {username}");
-
-        return 0;
+        }, username);
     }
 
     /// <summary>Human display name from a WorkOS user (first+last, else email, else "unknown").</summary>

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -25,7 +25,10 @@ public static class OAuthLoginFlow {
     /// deliberately configures the on-disk active profile even when the current directory resolves
     /// to a different one, and its token must land in the same place its config does.
     /// </param>
-    public static async Task<int> LoginWithDiscoveryAsync(string serverUrl, bool forceDevice, string? profile = null, CancellationToken ct = default) {
+    public static async Task<int> LoginWithDiscoveryAsync(
+            string serverUrl, bool forceDevice, string? profile = null, CancellationToken ct = default, IAuthProgress? progress = null) {
+        progress ??= ConsoleAuthProgress.Instance;
+
         // ReSharper disable once ShortLivedHttpClient
         using var http = new HttpClient();
 
@@ -34,13 +37,13 @@ public static class OAuthLoginFlow {
         try {
             configResponse = await http.GetAsync($"{serverUrl}/auth/config", ct);
         } catch (HttpRequestException ex) {
-            HttpClientExtensions.WriteUnreachableError(serverUrl, ex);
+            progress.Error(HttpClientExtensions.UnreachableErrorText(serverUrl, ex));
 
             return 1;
         }
 
         if (!configResponse.IsSuccessStatusCode) {
-            Console.Error.WriteLine($"Error: Failed to fetch auth config from {serverUrl}/auth/config");
+            progress.Error($"Error: Failed to fetch auth config from {serverUrl}/auth/config");
 
             return 1;
         }
@@ -48,10 +51,10 @@ public static class OAuthLoginFlow {
         var config = (await configResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.AuthDiscoveryResponse, ct))!;
 
         return config.Provider switch {
-            AuthProvider.None      => HandleNoneLogin(),
-            AuthProvider.GitHubApp => await HandleGitHubLogin(serverUrl, config, forceDevice, profile, ct),
-            AuthProvider.WorkOS    => await HandleWorkOSLogin(serverUrl, config, profile, ct),
-            _                      => HandleUnknownProvider(config.Provider)
+            AuthProvider.None      => HandleNoneLogin(progress),
+            AuthProvider.GitHubApp => await HandleGitHubLogin(serverUrl, config, forceDevice, profile, ct, progress),
+            AuthProvider.WorkOS    => await HandleWorkOSLogin(serverUrl, config, profile, ct, progress),
+            _                      => HandleUnknownProvider(config.Provider, progress)
         };
     }
 
@@ -102,34 +105,37 @@ public static class OAuthLoginFlow {
     internal static bool ShouldDiscoverLogin(string? baseUrl, string[] args)
         => args.Contains("--discover") || baseUrl is null;
 
-    static int HandleNoneLogin() {
-        Console.Out.WriteLine("Server has no authentication configured — login not required.");
+    static int HandleNoneLogin(IAuthProgress progress) {
+        progress.Notice("Server has no authentication configured — login not required.");
 
         return 0;
     }
 
-    static int HandleUnknownProvider(string provider) {
-        Console.Error.WriteLine($"Error: Unknown auth provider '{provider}'. Update your kcap CLI.");
+    static int HandleUnknownProvider(string provider, IAuthProgress progress) {
+        progress.Error($"Error: Unknown auth provider '{provider}'. Update your kcap CLI.");
 
         return 1;
     }
 
     /// <summary>
-    /// Runs GitHub Device Flow interactively. Prints the user code and verification URL to
-    /// <see cref="Console.Out"/>, opens the system browser to the verification URL, and polls
-    /// GitHub for the access token. Intended for CLI use — not suitable for headless callers.
+    /// Runs GitHub Device Flow interactively. Reports the user code and verification URL, opens the
+    /// system browser to the verification URL, and polls GitHub for the access token, through
+    /// <paramref name="progress"/>. Intended for CLI use — not suitable for headless callers.
     /// </summary>
     /// <returns>The GitHub access token on success, or <c>null</c> on failure.</returns>
-    public static async Task<string?> RunDeviceFlowAsync(string clientId, CancellationToken ct = default) {
+    public static async Task<string?> RunDeviceFlowAsync(string clientId, CancellationToken ct = default, IAuthProgress? progress = null) {
         using var http = new HttpClient();
         http.DefaultRequestHeaders.Accept.Add(new("application/json"));
 
-        return await RunDeviceFlowAsync(http, clientId, ct);
+        return await RunDeviceFlowAsync(http, clientId, ct, progress);
     }
 
     // HttpClient-injectable core — the test seam for pinning the device-code/poll endpoints
     // to a fake handler (RunDeviceFlowAsync(clientId) hardcodes github.com and can't be redirected).
-    internal static async Task<string?> RunDeviceFlowAsync(HttpClient http, string clientId, CancellationToken ct = default) {
+    internal static async Task<string?> RunDeviceFlowAsync(
+            HttpClient http, string clientId, CancellationToken ct = default, IAuthProgress? progress = null) {
+        progress ??= ConsoleAuthProgress.Instance;
+
         var deviceResponse = await http.PostAsync(
             "https://github.com/login/device/code",
             new FormUrlEncodedContent(
@@ -142,7 +148,7 @@ public static class OAuthLoginFlow {
         );
 
         if (!deviceResponse.IsSuccessStatusCode) {
-            Console.Error.WriteLine($"Error requesting device code: {await deviceResponse.Content.ReadAsStringAsync(ct)}");
+            progress.Error($"Error requesting device code: {await deviceResponse.Content.ReadAsStringAsync(ct)}");
 
             return null;
         }
@@ -162,22 +168,19 @@ public static class OAuthLoginFlow {
             browserOpened = false;
         }
 
-        await Console.Out.WriteLineAsync();
-        await Console.Out.WriteLineAsync("To finish signing in to GitHub:");
-        await Console.Out.WriteLineAsync();
-        await Console.Out.WriteLineAsync(
+        progress.Notice("");
+        progress.Notice("To finish signing in to GitHub:");
+        progress.Notice("");
+        progress.Notice(
             browserOpened
                 ? $"  1. Your browser should have opened {device.VerificationUri}"
                 : $"  1. Open {device.VerificationUri} in a browser"
         );
 
-        if (browserOpened) await Console.Out.WriteLineAsync("     (if it didn't open, go to that URL yourself)");
+        if (browserOpened) progress.Notice("     (if it didn't open, go to that URL yourself)");
 
-        await Console.Out.WriteLineAsync($"  2. Enter the code: {device.UserCode}{(copied ? "  (copied to clipboard)" : "")}");
-        await Console.Out.WriteLineAsync("  3. Approve access when GitHub asks.");
-        await Console.Out.WriteLineAsync();
-
-        Console.Write("Waiting for you to authorize...");
+        // Clipboard-copy suffix folds into the code: DeviceCode's contract carries no separate flag for it.
+        progress.DeviceCode(device.UserCode + (copied ? "  (copied to clipboard)" : ""), device.VerificationUri);
 
         while (true) {
             await Task.Delay(TimeSpan.FromSeconds(interval), ct);
@@ -198,14 +201,14 @@ public static class OAuthLoginFlow {
             var tokenResult = (await tokenResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubTokenResponse, ct))!;
 
             if (tokenResult.AccessToken is not null) {
-                await Console.Out.WriteLineAsync(" done!");
+                progress.Notice(" done!");
 
                 return tokenResult.AccessToken;
             }
 
             switch (tokenResult.Error) {
                 case "authorization_pending":
-                    Console.Write(".");
+                    progress.PollTick();
 
                     continue;
                 case "slow_down":
@@ -213,7 +216,7 @@ public static class OAuthLoginFlow {
 
                     continue;
                 default:
-                    Console.Error.WriteLine($"\nError: {tokenResult.Error}");
+                    progress.Error($"\nError: {tokenResult.Error}");
 
                     return null;
             }
@@ -229,8 +232,10 @@ public static class OAuthLoginFlow {
     /// thrown out of <see cref="LoopbackBrowser"/>). <paramref name="browser"/> is the test seam.
     /// </summary>
     public static async Task<string?> RunGitHubBrowserFlowAsync(
-            string clientId, string codeExchangeUrl, IBrowser? browser = null, TimeSpan? timeout = null, CancellationToken ct = default) {
-        browser ??= new LoopbackBrowser();
+            string clientId, string codeExchangeUrl, IBrowser? browser = null, TimeSpan? timeout = null,
+            CancellationToken ct = default, IAuthProgress? progress = null) {
+        progress ??= ConsoleAuthProgress.Instance;
+        browser  ??= new LoopbackBrowser(progress: progress);
         var redirectUri = $"http://127.0.0.1:{GetAvailablePort()}/callback";
 
         var options = new OidcClientOptions {
@@ -256,7 +261,7 @@ public static class OAuthLoginFlow {
             new BrowserOptions(state.StartUrl, redirectUri) { Timeout = timeout ?? TimeSpan.FromMinutes(5) }, ct);
 
         if (result.ResultType != BrowserResultType.Success) {
-            Console.Error.WriteLine(result.ResultType == BrowserResultType.Timeout
+            progress.Error(result.ResultType == BrowserResultType.Timeout
                 ? "Timed out waiting for authorization. Re-run `kcap login` to try again."
                 : $"Authorization failed: {result.Error ?? result.ResultType.ToString()}");
 
@@ -265,17 +270,17 @@ public static class OAuthLoginFlow {
 
         var resp = new AuthorizeResponse(result.Response);
         if (resp.IsError) {
-            Console.Error.WriteLine($"Authorization failed: {resp.Error}");
+            progress.Error($"Authorization failed: {resp.Error}");
 
             return null;
         }
         if (!string.Equals(resp.State, state.State, StringComparison.Ordinal)) {
-            Console.Error.WriteLine("Error: state mismatch — possible CSRF. Aborting.");
+            progress.Error("Error: state mismatch — possible CSRF. Aborting.");
 
             return null;
         }
         if (string.IsNullOrEmpty(resp.Code)) {
-            Console.Error.WriteLine("Authorization failed: no authorization code received.");
+            progress.Error("Authorization failed: no authorization code received.");
 
             return null;
         }
@@ -298,13 +303,13 @@ public static class OAuthLoginFlow {
                 cancellationToken: cts.Token
             );
         } catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or UriFormatException or InvalidOperationException) {
-            Console.Error.WriteLine($"Could not reach the code-exchange endpoint at {codeExchangeUrl}: {ex.Message}");
+            progress.Error($"Could not reach the code-exchange endpoint at {codeExchangeUrl}: {ex.Message}");
 
             return null;
         }
 
         if (!tokenResponse.IsSuccessStatusCode) {
-            Console.Error.WriteLine($"Error exchanging code: {await tokenResponse.Content.ReadAsStringAsync(cts.Token)}");
+            progress.Error($"Error exchanging code: {await tokenResponse.Content.ReadAsStringAsync(cts.Token)}");
 
             return null;
         }
@@ -315,25 +320,28 @@ public static class OAuthLoginFlow {
             tokenResult = await tokenResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubTokenResponse, cancellationToken: cts.Token);
         } catch (JsonException ex) {
             var raw = await tokenResponse.Content.ReadAsStringAsync(cts.Token);
-            Console.Error.WriteLine($"Code-exchange response was not valid JSON ({ex.Message}): {raw}");
+            progress.Error($"Code-exchange response was not valid JSON ({ex.Message}): {raw}");
 
             return null;
         }
 
         if (tokenResult?.AccessToken is null) {
-            Console.Error.WriteLine($"Error: {tokenResult?.Error ?? "no access_token in response"}");
+            progress.Error($"Error: {tokenResult?.Error ?? "no access_token in response"}");
 
             return null;
         }
 
-        await Console.Out.WriteLineAsync("Authorization complete.");
+        progress.Notice("Authorization complete.");
 
         return tokenResult.AccessToken;
     }
 
-    public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider, CancellationToken ct = default) {
+    public static async Task<int> ExchangeAndSaveAsync(
+            string serverUrl, string githubAccessToken, string provider, CancellationToken ct = default, IAuthProgress? progress = null) {
+        progress ??= ConsoleAuthProgress.Instance;
+
         if (provider is not AuthProvider.GitHubApp) {
-            Console.Error.WriteLine($"Error: unknown auth provider '{provider}'");
+            progress.Error($"Error: unknown auth provider '{provider}'");
 
             return 1;
         }
@@ -348,7 +356,7 @@ public static class OAuthLoginFlow {
         );
 
         if (!exchangeResponse.IsSuccessStatusCode) {
-            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(ct), profile: null);
+            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(ct), profile: null, progress);
 
             return 1;
         }
@@ -356,7 +364,7 @@ public static class OAuthLoginFlow {
         var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse, ct))!;
 
         if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
-            Console.Error.WriteLine($"Error: {identityError}");
+            progress.Error($"Error: {identityError}");
 
             return 1;
         }
@@ -371,7 +379,7 @@ public static class OAuthLoginFlow {
             }
         );
 
-        await Console.Out.WriteLineAsync($"Logged in as {exchange.Username}");
+        progress.Notice($"Logged in as {exchange.Username}");
 
         return 0;
     }
@@ -381,10 +389,12 @@ public static class OAuthLoginFlow {
     /// Unlike the single-argument overload, this does NOT print "Logged in as …" — the caller
     /// is responsible for user-facing output. Returns 0 on success, 1 on failure.
     /// </summary>
-    public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider, string profile, CancellationToken ct = default) {
+    public static async Task<int> ExchangeAndSaveAsync(
+            string serverUrl, string githubAccessToken, string provider, string profile,
+            CancellationToken ct = default, IAuthProgress? progress = null) {
         using var http = new HttpClient();
 
-        return await ExchangeAndSaveAsync(http, serverUrl, githubAccessToken, provider, profile, ct);
+        return await ExchangeAndSaveAsync(http, serverUrl, githubAccessToken, provider, profile, ct, progress);
     }
 
     public static async Task<int> ExchangeAndSaveAsync(
@@ -393,10 +403,13 @@ public static class OAuthLoginFlow {
             string            githubAccessToken,
             string            provider,
             string            profile,
-            CancellationToken ct = default
+            CancellationToken ct = default,
+            IAuthProgress?    progress = null
         ) {
+        progress ??= ConsoleAuthProgress.Instance;
+
         if (provider is not AuthProvider.GitHubApp) {
-            Console.Error.WriteLine($"Error: unknown auth provider '{provider}'");
+            progress.Error($"Error: unknown auth provider '{provider}'");
 
             return 1;
         }
@@ -409,7 +422,7 @@ public static class OAuthLoginFlow {
         );
 
         if (!exchangeResponse.IsSuccessStatusCode) {
-            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(ct), profile);
+            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(ct), profile, progress);
 
             return 1;
         }
@@ -417,7 +430,7 @@ public static class OAuthLoginFlow {
         var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse, ct))!;
 
         if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
-            Console.Error.WriteLine($"Error: {identityError}");
+            progress.Error($"Error: {identityError}");
 
             return 1;
         }
@@ -437,12 +450,12 @@ public static class OAuthLoginFlow {
     }
 
     /// <summary>
-    /// Prints the server's <c>/auth/token</c> error to stderr. When the server reports that
-    /// the Capacitor GitHub App isn't installed on the user's org, appends a troubleshooting
-    /// checklist — the most common cause is the device-flow consent being completed under a
-    /// different GitHub account than the one with org membership.
+    /// Reports the server's <c>/auth/token</c> error. When the server reports that the Capacitor
+    /// GitHub App isn't installed on the user's org, appends a troubleshooting checklist — the most
+    /// common cause is the device-flow consent being completed under a different GitHub account than
+    /// the one with org membership.
     /// </summary>
-    static void WriteExchangeError(string body, string? profile) {
+    static void WriteExchangeError(string body, string? profile, IAuthProgress progress) {
         var prefix = profile is null
             ? "Error exchanging token"
             : $"Error exchanging token for profile '{profile}'";
@@ -450,23 +463,23 @@ public static class OAuthLoginFlow {
         var serverMessage = TryParseInstallationMessage(body);
 
         if (serverMessage is null) {
-            Console.Error.WriteLine($"{prefix}: {body}");
+            progress.Error($"{prefix}: {body}");
 
             return;
         }
 
-        Console.Error.WriteLine($"{prefix}: {serverMessage}");
-        Console.Error.WriteLine();
-        Console.Error.WriteLine("This usually means the Capacitor GitHub App isn't visible to your GitHub user.");
-        Console.Error.WriteLine("Common fixes:");
-        Console.Error.WriteLine("  1. Authorize as the right GitHub account. The device-flow page authorizes");
-        Console.Error.WriteLine("     whoever is signed in to your browser — sign in to https://github.com as");
-        Console.Error.WriteLine("     your org user, then re-run `kcap setup ...`.");
-        Console.Error.WriteLine("  2. If your org enforces SAML SSO, authorize SSO for the App at");
-        Console.Error.WriteLine("     https://github.com/settings/apps/authorizations.");
-        Console.Error.WriteLine("  3. Revoke a stale prior authorization at the same URL and retry.");
-        Console.Error.WriteLine();
-        Console.Error.WriteLine("If the App was never installed on your org, an org admin must install it.");
+        progress.Error($"{prefix}: {serverMessage}");
+        progress.Error("");
+        progress.Error("This usually means the Capacitor GitHub App isn't visible to your GitHub user.");
+        progress.Error("Common fixes:");
+        progress.Error("  1. Authorize as the right GitHub account. The device-flow page authorizes");
+        progress.Error("     whoever is signed in to your browser — sign in to https://github.com as");
+        progress.Error("     your org user, then re-run `kcap setup ...`.");
+        progress.Error("  2. If your org enforces SAML SSO, authorize SSO for the App at");
+        progress.Error("     https://github.com/settings/apps/authorizations.");
+        progress.Error("  3. Revoke a stale prior authorization at the same URL and retry.");
+        progress.Error("");
+        progress.Error("If the App was never installed on your org, an org admin must install it.");
     }
 
     internal static string? TryParseInstallationMessage(string body) {
@@ -484,39 +497,45 @@ public static class OAuthLoginFlow {
         }
     }
 
-    static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config, bool forceDevice, string? profile = null, CancellationToken ct = default) {
-        var accessToken = await AcquireGitHubTokenAsync(config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice, ct);
+    static async Task<int> HandleGitHubLogin(
+            string serverUrl, AuthDiscoveryResponse config, bool forceDevice, string? profile,
+            CancellationToken ct, IAuthProgress progress) {
+        var accessToken = await AcquireGitHubTokenAsync(config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice, ct, progress);
 
         if (accessToken is null) return 1;
 
         return profile is null
-            ? await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider, ct)
-            : await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider, profile, ct);
+            ? await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider, ct, progress)
+            : await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider, profile, ct, progress);
     }
 
-    internal static async Task<string?> AcquireGitHubTokenAsync(string clientId, string? codeExchangeUrl, bool forceDevice, CancellationToken ct = default) {
+    internal static async Task<string?> AcquireGitHubTokenAsync(
+            string clientId, string? codeExchangeUrl, bool forceDevice, CancellationToken ct = default, IAuthProgress? progress = null) {
+        progress ??= ConsoleAuthProgress.Instance;
+
         var headless = HeadlessEnvironment.IsHeadless();
         var choice   = ChooseGitHubFlow(forceDevice, headless, hasExchangeUrl: IsValidExchangeUrl(codeExchangeUrl));
 
         if (choice == GitHubFlow.Browser) {
             try {
-                var token = await RunGitHubBrowserFlowAsync(clientId, codeExchangeUrl!, ct: ct);
+                var token = await RunGitHubBrowserFlowAsync(clientId, codeExchangeUrl!, ct: ct, progress: progress);
 
                 return token ??
                     // Browser flow ran but user cancelled / state mismatch — don't silently fall back.
                     null;
             } catch (HttpListenerException ex) {
-                Console.Error.WriteLine($"Could not bind loopback listener ({ex.Message}); falling back to device flow.");
+                progress.Error($"Could not bind loopback listener ({ex.Message}); falling back to device flow.");
             } catch (PlatformNotSupportedException ex) {
-                Console.Error.WriteLine($"Loopback listener not supported on this platform ({ex.Message}); falling back to device flow.");
+                progress.Error($"Loopback listener not supported on this platform ({ex.Message}); falling back to device flow.");
             }
         }
 
-        return await RunDeviceFlowAsync(clientId, ct);
+        return await RunDeviceFlowAsync(clientId, ct, progress);
     }
 
-    static Task<int> HandleWorkOSLogin(string serverUrl, AuthDiscoveryResponse config, string? profile = null, CancellationToken ct = default) =>
-        LoginWorkOSAsync(serverUrl, config.ClientId!, config.OrganizationId, profile, ct);
+    static Task<int> HandleWorkOSLogin(
+            string serverUrl, AuthDiscoveryResponse config, string? profile, CancellationToken ct, IAuthProgress progress) =>
+        LoginWorkOSAsync(serverUrl, config.ClientId!, config.OrganizationId, profile, ct, progress);
 
     const string WorkOSApiBase = "https://api.workos.com";
 
@@ -560,7 +579,10 @@ public static class OAuthLoginFlow {
     /// source-gen context — omitted/nullable fields don't throw. <paramref name="apiBase"/> is the test seam.
     /// </summary>
     public static async Task<WorkOSAuthResponse?> AuthenticateWorkOSAsync(
-            string clientId, string? organizationId, IBrowser browser, string apiBase = WorkOSApiBase, CancellationToken ct = default) {
+            string clientId, string? organizationId, IBrowser browser, string apiBase = WorkOSApiBase,
+            CancellationToken ct = default, IAuthProgress? progress = null) {
+        progress ??= ConsoleAuthProgress.Instance;
+
         var redirectUri = $"http://127.0.0.1:{GetAvailablePort()}/callback";
         var options     = BuildWorkOSOptions(clientId, apiBase, redirectUri);
         options.Browser = browser;
@@ -571,13 +593,13 @@ public static class OAuthLoginFlow {
         // Surface the actual reason (timeout / state mismatch / token-endpoint / upstream OIDC error)
         // rather than collapsing every failure to a single opaque "sign-in failed".
         if (result.IsError) {
-            Console.Error.WriteLine(WorkOSSignInError(result.Error, result.ErrorDescription));
+            progress.Error(WorkOSSignInError(result.Error, result.ErrorDescription));
 
             return null;
         }
 
         if (result.TokenResponse?.Json is not { } json) {
-            Console.Error.WriteLine("WorkOS sign-in failed: empty token response.");
+            progress.Error("WorkOS sign-in failed: empty token response.");
 
             return null;
         }
@@ -593,15 +615,17 @@ public static class OAuthLoginFlow {
                       + (string.IsNullOrEmpty(description) ? "" : $" — {description}")
     };
 
-    static async Task<int> LoginWorkOSAsync(string serverUrl, string clientId, string? organizationId, string? profile = null, CancellationToken ct = default) {
-        // AuthenticateWorkOSAsync already reported the specific failure reason to stderr.
-        var json = await AuthenticateWorkOSAsync(clientId, organizationId, new LoopbackBrowser(), ct: ct);
+    static async Task<int> LoginWorkOSAsync(
+            string serverUrl, string clientId, string? organizationId, string? profile, CancellationToken ct, IAuthProgress progress) {
+        // AuthenticateWorkOSAsync already reported the specific failure reason.
+        var json = await AuthenticateWorkOSAsync(
+            clientId, organizationId, new LoopbackBrowser(progress: progress), ct: ct, progress: progress);
         if (json is null) return 1;
 
         // Org gate: a multi-org user must not be "logged in" to the wrong org — every API
         // call would then fail the server's org check. Reject before saving tokens.
         if (!string.IsNullOrEmpty(organizationId) && !string.Equals(json.OrganizationId, organizationId, StringComparison.Ordinal)) {
-            Console.Error.WriteLine($"Error: signed in to the wrong WorkOS organization (expected {organizationId}). Re-run `kcap login` and pick the correct organization.");
+            progress.Error($"Error: signed in to the wrong WorkOS organization (expected {organizationId}). Re-run `kcap login` and pick the correct organization.");
 
             return 1;
         }
@@ -609,7 +633,7 @@ public static class OAuthLoginFlow {
         var username = WorkOSDisplayName(json.User);
 
         if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
-            Console.Error.WriteLine($"Error: {identityError}");
+            progress.Error($"Error: {identityError}");
 
             return 1;
         }
@@ -629,7 +653,7 @@ public static class OAuthLoginFlow {
         if (profile is null) await TokenStore.SaveAsync(saved);
         else await TokenStore.SaveAsync(profile, saved);
 
-        await Console.Out.WriteLineAsync($"Logged in as {username}");
+        progress.Notice($"Logged in as {username}");
 
         return 0;
     }

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -19,31 +19,6 @@ public static class AuthProvider {
 public enum GitHubFlow { Browser, Device }
 
 public static class OAuthLoginFlow {
-    /// <param name="profile">
-    /// Target profile for the saved token. Null means "whichever profile this process resolved" —
-    /// correct for `kcap login`. `kcap setup` passes its chosen profile explicitly, because it
-    /// deliberately configures the on-disk active profile even when the current directory resolves
-    /// to a different one, and its token must land in the same place its config does.
-    /// </param>
-    public static async Task<int> LoginWithDiscoveryAsync(
-            string serverUrl, bool forceDevice, string? profile = null, CancellationToken ct = default, IAuthProgress? progress = null) {
-        progress ??= ConsoleAuthProgress.Instance;
-
-        // ReSharper disable once ShortLivedHttpClient
-        using var http = new HttpClient();
-
-        var config = await FetchAuthConfigAsync(http, serverUrl, ct, progress);
-
-        if (config is null) return 1;
-
-        return config.Provider switch {
-            AuthProvider.None      => HandleNoneLogin(progress),
-            AuthProvider.GitHubApp => await HandleGitHubLogin(serverUrl, config, forceDevice, profile, ct, progress),
-            AuthProvider.WorkOS    => await HandleWorkOSLogin(serverUrl, config, profile, ct, progress),
-            _                      => HandleUnknownProvider(config.Provider, progress)
-        };
-    }
-
     /// <summary>GET <c>{serverUrl}/auth/config</c>, or <c>null</c> with the failure already reported.</summary>
     internal static async Task<AuthDiscoveryResponse?> FetchAuthConfigAsync(
             HttpClient http, string serverUrl, CancellationToken ct, IAuthProgress progress) {
@@ -112,18 +87,6 @@ public static class OAuthLoginFlow {
     /// </summary>
     internal static bool ShouldDiscoverLogin(string? baseUrl, string[] args)
         => args.Contains("--discover") || baseUrl is null;
-
-    static int HandleNoneLogin(IAuthProgress progress) {
-        progress.Notice("Server has no authentication configured — login not required.");
-
-        return 0;
-    }
-
-    static int HandleUnknownProvider(string provider, IAuthProgress progress) {
-        progress.Error($"Error: Unknown auth provider '{provider}'. Update your kcap CLI.");
-
-        return 1;
-    }
 
     /// <summary>
     /// Runs GitHub Device Flow interactively. Reports the user code and verification URL, opens the
@@ -500,18 +463,6 @@ public static class OAuthLoginFlow {
         }
     }
 
-    static async Task<int> HandleGitHubLogin(
-            string serverUrl, AuthDiscoveryResponse config, bool forceDevice, string? profile,
-            CancellationToken ct, IAuthProgress progress) {
-        var accessToken = await AcquireGitHubTokenAsync(config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice, ct, progress);
-
-        if (accessToken is null) return 1;
-
-        return profile is null
-            ? await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider, ct, progress)
-            : await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider, profile, ct, progress);
-    }
-
     internal static async Task<string?> AcquireGitHubTokenAsync(
             string clientId, string? codeExchangeUrl, bool forceDevice, CancellationToken ct = default, IAuthProgress? progress = null) {
         using var http = new HttpClient();
@@ -545,10 +496,6 @@ public static class OAuthLoginFlow {
 
         return await RunDeviceFlowAsync(http, clientId, ct, progress);
     }
-
-    static Task<int> HandleWorkOSLogin(
-            string serverUrl, AuthDiscoveryResponse config, string? profile, CancellationToken ct, IAuthProgress progress) =>
-        LoginWorkOSAsync(serverUrl, config.ClientId!, config.OrganizationId, profile, ct, progress);
 
     internal const string WorkOSApiBase = "https://api.workos.com";
 
@@ -627,23 +574,6 @@ public static class OAuthLoginFlow {
         _            => $"WorkOS sign-in failed: {error ?? "unknown error"}"
                       + (string.IsNullOrEmpty(description) ? "" : $" — {description}")
     };
-
-    static async Task<int> LoginWorkOSAsync(
-            string serverUrl, string clientId, string? organizationId, string? profile, CancellationToken ct, IAuthProgress progress) {
-        var authenticated = await WorkOSTokensForServerAsync(
-            serverUrl, clientId, organizationId, new LoopbackBrowser(progress: progress), ct, progress);
-
-        if (authenticated is null) return 1;
-
-        var (saved, username) = authenticated.Value;
-
-        if (profile is null) await TokenStore.SaveAsync(saved);
-        else await TokenStore.SaveAsync(profile, saved);
-
-        progress.Notice($"Logged in as {username}");
-
-        return 0;
-    }
 
     /// <summary>
     /// WorkOS sign-in against a KNOWN server: authenticate, enforce the org gate, and build the

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -25,14 +25,14 @@ public static class OAuthLoginFlow {
     /// deliberately configures the on-disk active profile even when the current directory resolves
     /// to a different one, and its token must land in the same place its config does.
     /// </param>
-    public static async Task<int> LoginWithDiscoveryAsync(string serverUrl, bool forceDevice, string? profile = null) {
+    public static async Task<int> LoginWithDiscoveryAsync(string serverUrl, bool forceDevice, string? profile = null, CancellationToken ct = default) {
         // ReSharper disable once ShortLivedHttpClient
         using var http = new HttpClient();
 
         HttpResponseMessage configResponse;
 
         try {
-            configResponse = await http.GetAsync($"{serverUrl}/auth/config");
+            configResponse = await http.GetAsync($"{serverUrl}/auth/config", ct);
         } catch (HttpRequestException ex) {
             HttpClientExtensions.WriteUnreachableError(serverUrl, ex);
 
@@ -45,12 +45,12 @@ public static class OAuthLoginFlow {
             return 1;
         }
 
-        var config = (await configResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.AuthDiscoveryResponse))!;
+        var config = (await configResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.AuthDiscoveryResponse, ct))!;
 
         return config.Provider switch {
             AuthProvider.None      => HandleNoneLogin(),
-            AuthProvider.GitHubApp => await HandleGitHubLogin(serverUrl, config, forceDevice, profile),
-            AuthProvider.WorkOS    => await HandleWorkOSLogin(serverUrl, config, profile),
+            AuthProvider.GitHubApp => await HandleGitHubLogin(serverUrl, config, forceDevice, profile, ct),
+            AuthProvider.WorkOS    => await HandleWorkOSLogin(serverUrl, config, profile, ct),
             _                      => HandleUnknownProvider(config.Provider)
         };
     }
@@ -120,10 +120,16 @@ public static class OAuthLoginFlow {
     /// GitHub for the access token. Intended for CLI use — not suitable for headless callers.
     /// </summary>
     /// <returns>The GitHub access token on success, or <c>null</c> on failure.</returns>
-    public static async Task<string?> RunDeviceFlowAsync(string clientId) {
+    public static async Task<string?> RunDeviceFlowAsync(string clientId, CancellationToken ct = default) {
         using var http = new HttpClient();
         http.DefaultRequestHeaders.Accept.Add(new("application/json"));
 
+        return await RunDeviceFlowAsync(http, clientId, ct);
+    }
+
+    // HttpClient-injectable core — the test seam for pinning the device-code/poll endpoints
+    // to a fake handler (RunDeviceFlowAsync(clientId) hardcodes github.com and can't be redirected).
+    internal static async Task<string?> RunDeviceFlowAsync(HttpClient http, string clientId, CancellationToken ct = default) {
         var deviceResponse = await http.PostAsync(
             "https://github.com/login/device/code",
             new FormUrlEncodedContent(
@@ -131,16 +137,17 @@ public static class OAuthLoginFlow {
                     ["client_id"] = clientId,
                     ["scope"]     = "read:user read:org"
                 }
-            )
+            ),
+            ct
         );
 
         if (!deviceResponse.IsSuccessStatusCode) {
-            Console.Error.WriteLine($"Error requesting device code: {await deviceResponse.Content.ReadAsStringAsync()}");
+            Console.Error.WriteLine($"Error requesting device code: {await deviceResponse.Content.ReadAsStringAsync(ct)}");
 
             return null;
         }
 
-        var device   = (await deviceResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubDeviceCodeResponse))!;
+        var device   = (await deviceResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubDeviceCodeResponse, ct))!;
         var interval = device.Interval;
 
         var copied = Clipboard.TryCopy(device.UserCode);
@@ -173,7 +180,8 @@ public static class OAuthLoginFlow {
         Console.Write("Waiting for you to authorize...");
 
         while (true) {
-            await Task.Delay(TimeSpan.FromSeconds(interval));
+            await Task.Delay(TimeSpan.FromSeconds(interval), ct);
+            ct.ThrowIfCancellationRequested();
 
             var tokenResponse = await http.PostAsync(
                 "https://github.com/login/oauth/access_token",
@@ -183,10 +191,11 @@ public static class OAuthLoginFlow {
                         ["device_code"] = device.DeviceCode,
                         ["grant_type"]  = "urn:ietf:params:oauth:grant-type:device_code"
                     }
-                )
+                ),
+                ct
             );
 
-            var tokenResult = (await tokenResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubTokenResponse))!;
+            var tokenResult = (await tokenResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.GitHubTokenResponse, ct))!;
 
             if (tokenResult.AccessToken is not null) {
                 await Console.Out.WriteLineAsync(" done!");
@@ -220,7 +229,7 @@ public static class OAuthLoginFlow {
     /// thrown out of <see cref="LoopbackBrowser"/>). <paramref name="browser"/> is the test seam.
     /// </summary>
     public static async Task<string?> RunGitHubBrowserFlowAsync(
-            string clientId, string codeExchangeUrl, IBrowser? browser = null, TimeSpan? timeout = null) {
+            string clientId, string codeExchangeUrl, IBrowser? browser = null, TimeSpan? timeout = null, CancellationToken ct = default) {
         browser ??= new LoopbackBrowser();
         var redirectUri = $"http://127.0.0.1:{GetAvailablePort()}/callback";
 
@@ -241,10 +250,10 @@ public static class OAuthLoginFlow {
         options.Policy.Discovery.RequireKeySet = false;
 
         var oidc  = new OidcClient(options);
-        var state = await oidc.PrepareLoginAsync();
+        var state = await oidc.PrepareLoginAsync(cancellationToken: ct);
 
         var result = await browser.InvokeAsync(
-            new BrowserOptions(state.StartUrl, redirectUri) { Timeout = timeout ?? TimeSpan.FromMinutes(5) });
+            new BrowserOptions(state.StartUrl, redirectUri) { Timeout = timeout ?? TimeSpan.FromMinutes(5) }, ct);
 
         if (result.ResultType != BrowserResultType.Success) {
             Console.Error.WriteLine(result.ResultType == BrowserResultType.Timeout
@@ -271,8 +280,10 @@ public static class OAuthLoginFlow {
             return null;
         }
 
-        // Bound the proxy exchange to the login timeout — a stalled endpoint must not hang the CLI.
-        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromMinutes(5));
+        // Bound the proxy exchange to the login timeout — a stalled endpoint must not hang the CLI —
+        // while still observing the caller's own cancellation.
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout ?? TimeSpan.FromMinutes(5));
 
         using var http = new HttpClient();
         http.DefaultRequestHeaders.Accept.Add(new("application/json"));
@@ -320,7 +331,7 @@ public static class OAuthLoginFlow {
         return tokenResult.AccessToken;
     }
 
-    public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider) {
+    public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider, CancellationToken ct = default) {
         if (provider is not AuthProvider.GitHubApp) {
             Console.Error.WriteLine($"Error: unknown auth provider '{provider}'");
 
@@ -332,16 +343,17 @@ public static class OAuthLoginFlow {
         var exchangeResponse = await http.PostAsJsonAsync(
             $"{serverUrl}/auth/token",
             new() { GithubAccessToken = githubAccessToken },
-            CapacitorJsonContext.Default.TokenExchangeRequest
+            CapacitorJsonContext.Default.TokenExchangeRequest,
+            cancellationToken: ct
         );
 
         if (!exchangeResponse.IsSuccessStatusCode) {
-            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(), profile: null);
+            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(ct), profile: null);
 
             return 1;
         }
 
-        var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse))!;
+        var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse, ct))!;
 
         if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
             Console.Error.WriteLine($"Error: {identityError}");
@@ -369,18 +381,19 @@ public static class OAuthLoginFlow {
     /// Unlike the single-argument overload, this does NOT print "Logged in as …" — the caller
     /// is responsible for user-facing output. Returns 0 on success, 1 on failure.
     /// </summary>
-    public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider, string profile) {
+    public static async Task<int> ExchangeAndSaveAsync(string serverUrl, string githubAccessToken, string provider, string profile, CancellationToken ct = default) {
         using var http = new HttpClient();
 
-        return await ExchangeAndSaveAsync(http, serverUrl, githubAccessToken, provider, profile);
+        return await ExchangeAndSaveAsync(http, serverUrl, githubAccessToken, provider, profile, ct);
     }
 
     public static async Task<int> ExchangeAndSaveAsync(
-            HttpClient http,
-            string     serverUrl,
-            string     githubAccessToken,
-            string     provider,
-            string     profile
+            HttpClient        http,
+            string            serverUrl,
+            string            githubAccessToken,
+            string            provider,
+            string            profile,
+            CancellationToken ct = default
         ) {
         if (provider is not AuthProvider.GitHubApp) {
             Console.Error.WriteLine($"Error: unknown auth provider '{provider}'");
@@ -391,16 +404,17 @@ public static class OAuthLoginFlow {
         var exchangeResponse = await http.PostAsJsonAsync(
             $"{serverUrl}/auth/token",
             new TokenExchangeRequest { GithubAccessToken = githubAccessToken },
-            CapacitorJsonContext.Default.TokenExchangeRequest
+            CapacitorJsonContext.Default.TokenExchangeRequest,
+            cancellationToken: ct
         );
 
         if (!exchangeResponse.IsSuccessStatusCode) {
-            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(), profile);
+            WriteExchangeError(await exchangeResponse.Content.ReadAsStringAsync(ct), profile);
 
             return 1;
         }
 
-        var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse))!;
+        var exchange = (await exchangeResponse.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.TokenExchangeResponse, ct))!;
 
         if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
             Console.Error.WriteLine($"Error: {identityError}");
@@ -470,23 +484,23 @@ public static class OAuthLoginFlow {
         }
     }
 
-    static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config, bool forceDevice, string? profile = null) {
-        var accessToken = await AcquireGitHubTokenAsync(config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice);
+    static async Task<int> HandleGitHubLogin(string serverUrl, AuthDiscoveryResponse config, bool forceDevice, string? profile = null, CancellationToken ct = default) {
+        var accessToken = await AcquireGitHubTokenAsync(config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice, ct);
 
         if (accessToken is null) return 1;
 
         return profile is null
-            ? await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider)
-            : await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider, profile);
+            ? await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider, ct)
+            : await ExchangeAndSaveAsync(serverUrl, accessToken, config.Provider, profile, ct);
     }
 
-    internal static async Task<string?> AcquireGitHubTokenAsync(string clientId, string? codeExchangeUrl, bool forceDevice) {
+    internal static async Task<string?> AcquireGitHubTokenAsync(string clientId, string? codeExchangeUrl, bool forceDevice, CancellationToken ct = default) {
         var headless = HeadlessEnvironment.IsHeadless();
         var choice   = ChooseGitHubFlow(forceDevice, headless, hasExchangeUrl: IsValidExchangeUrl(codeExchangeUrl));
 
         if (choice == GitHubFlow.Browser) {
             try {
-                var token = await RunGitHubBrowserFlowAsync(clientId, codeExchangeUrl!);
+                var token = await RunGitHubBrowserFlowAsync(clientId, codeExchangeUrl!, ct: ct);
 
                 return token ??
                     // Browser flow ran but user cancelled / state mismatch — don't silently fall back.
@@ -498,11 +512,11 @@ public static class OAuthLoginFlow {
             }
         }
 
-        return await RunDeviceFlowAsync(clientId);
+        return await RunDeviceFlowAsync(clientId, ct);
     }
 
-    static Task<int> HandleWorkOSLogin(string serverUrl, AuthDiscoveryResponse config, string? profile = null) =>
-        LoginWorkOSAsync(serverUrl, config.ClientId!, config.OrganizationId, profile);
+    static Task<int> HandleWorkOSLogin(string serverUrl, AuthDiscoveryResponse config, string? profile = null, CancellationToken ct = default) =>
+        LoginWorkOSAsync(serverUrl, config.ClientId!, config.OrganizationId, profile, ct);
 
     const string WorkOSApiBase = "https://api.workos.com";
 
@@ -546,13 +560,13 @@ public static class OAuthLoginFlow {
     /// source-gen context — omitted/nullable fields don't throw. <paramref name="apiBase"/> is the test seam.
     /// </summary>
     public static async Task<WorkOSAuthResponse?> AuthenticateWorkOSAsync(
-            string clientId, string? organizationId, IBrowser browser, string apiBase = WorkOSApiBase) {
+            string clientId, string? organizationId, IBrowser browser, string apiBase = WorkOSApiBase, CancellationToken ct = default) {
         var redirectUri = $"http://127.0.0.1:{GetAvailablePort()}/callback";
         var options     = BuildWorkOSOptions(clientId, apiBase, redirectUri);
         options.Browser = browser;
 
         var oidc   = new OidcClient(options);
-        var result = await oidc.LoginAsync(new LoginRequest { FrontChannelExtraParameters = WorkOSFrontChannel(organizationId) });
+        var result = await oidc.LoginAsync(new LoginRequest { FrontChannelExtraParameters = WorkOSFrontChannel(organizationId) }, ct);
 
         // Surface the actual reason (timeout / state mismatch / token-endpoint / upstream OIDC error)
         // rather than collapsing every failure to a single opaque "sign-in failed".
@@ -579,9 +593,9 @@ public static class OAuthLoginFlow {
                       + (string.IsNullOrEmpty(description) ? "" : $" — {description}")
     };
 
-    static async Task<int> LoginWorkOSAsync(string serverUrl, string clientId, string? organizationId, string? profile = null) {
+    static async Task<int> LoginWorkOSAsync(string serverUrl, string clientId, string? organizationId, string? profile = null, CancellationToken ct = default) {
         // AuthenticateWorkOSAsync already reported the specific failure reason to stderr.
-        var json = await AuthenticateWorkOSAsync(clientId, organizationId, new LoopbackBrowser());
+        var json = await AuthenticateWorkOSAsync(clientId, organizationId, new LoopbackBrowser(), ct: ct);
         if (json is null) return 1;
 
         // Org gate: a multi-org user must not be "logged in" to the wrong org — every API
@@ -635,7 +649,7 @@ public static class OAuthLoginFlow {
     /// organization_id. No client secret.
     /// </summary>
     public static async Task<WorkOSAuthResponse?> SwitchWorkOSOrgAsync(
-            HttpClient http, string apiBase, string clientId, string refreshToken, string organizationId) {
+            HttpClient http, string apiBase, string clientId, string refreshToken, string organizationId, CancellationToken ct = default) {
         var resp = await http.PostAsync(
             $"{apiBase.TrimEnd('/')}/user_management/authenticate",
             new FormUrlEncodedContent(new Dictionary<string, string> {
@@ -643,11 +657,11 @@ public static class OAuthLoginFlow {
                 ["client_id"]       = clientId,
                 ["refresh_token"]   = refreshToken,
                 ["organization_id"] = organizationId
-            }));
+            }), ct);
 
         if (!resp.IsSuccessStatusCode) return null;
 
-        return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
+        return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse, ct);
     }
 
     /// <summary>
@@ -656,7 +670,7 @@ public static class OAuthLoginFlow {
     /// provisioning poll, which can outlive WorkOS's ~5-minute access-token TTL. No client secret.
     /// </summary>
     public static async Task<WorkOSAuthResponse?> RefreshWorkOSTokenAsync(
-            HttpClient http, string apiBase, string clientId, string refreshToken) {
+            HttpClient http, string apiBase, string clientId, string refreshToken, CancellationToken ct = default) {
         // Degrade transport/timeout/parse failures to null (mirrors TenantProvisioningClient): this
         // fires automatically and repeatedly during the provisioning poll, so a blip must not throw
         // and abort the flow — the token source keeps the current token and retries next tick.
@@ -667,11 +681,11 @@ public static class OAuthLoginFlow {
                     ["grant_type"]    = "refresh_token",
                     ["client_id"]     = clientId,
                     ["refresh_token"] = refreshToken
-                }));
+                }), ct);
 
             if (!resp.IsSuccessStatusCode) return null;
 
-            return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse);
+            return await resp.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse, ct);
         } catch (Exception e) when (e is HttpRequestException or OperationCanceledException or JsonException or NotSupportedException) {
             return null;
         }

--- a/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
+++ b/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
@@ -7,7 +7,9 @@ namespace Capacitor.Cli.Core.Auth;
 /// <summary>
 /// One durable publication set: the config mutation (profiles + the provider stamp for every
 /// identity) followed by the token writes. <see cref="PublishTokens"/> returns the username to
-/// report, because on the discovery path it is only known once the tokens are exchanged.
+/// report, because on the discovery path it is only known once the tokens are exchanged; it calls
+/// the <see cref="Action"/> it is handed after each token that actually landed, so the boundary
+/// knows whether a failure left anything behind.
 /// </summary>
 sealed record CommitRequest(
     IReadOnlyList<AuthIdentity>         Identities,
@@ -15,16 +17,16 @@ sealed record CommitRequest(
     string                              ActiveProfile,
     string                              CanonicalServer,
     Func<ProfileConfig, ProfileConfig>? ConfigMutation,
-    Func<Task<string?>>?                PublishTokens,
+    Func<Action, Task<string?>>?        PublishTokens,
     // False for a login that must not claim the profile for this server (see LoginTarget.Foreign).
     bool                                WriteStamp = true);
 
 /// <summary>
-/// The ordered commit boundary. The before-commit hook is the LAST cancellable await: it either
-/// completes — after which every publication runs under <see cref="CancellationToken.None"/> to
-/// completion and the answer is <see cref="AuthResult.Committed"/> even if a cancel arrives — or
-/// the operation ends with nothing durable written. Crash residue is safe by this ordering:
-/// claim-without-profile and profile-without-token both leave the start gate failing.
+/// The ordered commit boundary. The before-commit hook is the LAST cancellable await; past it every
+/// publication runs under <see cref="CancellationToken.None"/> and a cancel no longer changes the
+/// answer. <see cref="AuthResult.Committed"/> means something durable landed — a publication failure
+/// with nothing landed is still <see cref="AuthResult.Failed"/>. Crash residue is safe by this
+/// ordering: claim-without-profile and profile-without-token both leave the start gate failing.
 /// </summary>
 static class CommitBoundary {
     internal static async Task<AuthResult> CommitAsync(
@@ -46,7 +48,11 @@ static class CommitBoundary {
             }
         }
 
-        if (request.ConfigMutation is not null || request.WriteStamp) {
+        // A token-only arm (a foreign login writes no config at all) has no config commit to make
+        // the boundary durable, so what landed is tracked rather than assumed.
+        var configPublished = request.ConfigMutation is not null || request.WriteStamp;
+
+        if (configPublished) {
             try {
                 // Profile write and stamp are deliberately ONE mutation: no window where a profile exists unstamped.
                 await ConfigMutator.MutateAsync(config => Stamp(request.ConfigMutation?.Invoke(config) ?? config, request),
@@ -59,12 +65,20 @@ static class CommitBoundary {
             }
         }
 
-        string? username = null;
+        string? username   = null;
+        var     tokenSaved = false;
 
         try {
-            if (request.PublishTokens is not null) username = await request.PublishTokens();
+            if (request.PublishTokens is not null) username = await request.PublishTokens(() => tokenSaved = true);
         } catch (Exception ex) {
-            // Past the config commit the boundary has begun; report what was published rather than a torn stop.
+            // Nothing durable exists, so Committed would be a lie — fail honestly instead.
+            if (!configPublished && !tokenSaved) {
+                progress.Error($"Error: sign-in could not be saved: {ex.Message}");
+
+                return new AuthResult.Failed(ex.Message);
+            }
+
+            // Past a landed publication the boundary has begun; report what was lost rather than a torn stop.
             progress.Error($"Error: some credentials could not be saved: {ex.Message}");
         }
 
@@ -125,9 +139,8 @@ sealed record LoginTarget(string Profile, string CanonicalServer, string ServerU
 /// throwing aborts the operation with nothing written (the caller may retry).
 /// </param>
 /// <param name="httpFactory">
-/// Supplies the client for the auth-config, proxy, token-exchange, device-flow and WorkOS
-/// org-switch legs. The GitHub browser flow and OidcClient still make their own clients. A supplied
-/// factory owns its clients' lifetime; the default creates and disposes one per operation.
+/// The client for every HTTP leg (the GitHub browser flow and OidcClient still make their own). A
+/// supplied factory owns its clients' lifetime; the default creates and disposes one per operation.
 /// </param>
 public sealed class OnboardingFacade(
         IAuthProgress                                               progress,
@@ -249,8 +262,9 @@ public sealed class OnboardingFacade(
         var request = new CommitRequest(
             [new AuthIdentity(target.Profile, target.CanonicalServer)], provider, target.Profile, target.CanonicalServer,
             ConfigMutation: target.ConfigMutation,
-            PublishTokens: async () => {
+            PublishTokens: async saved => {
                 await TokenStore.SaveAsync(target.Profile, tokens, CancellationToken.None);
+                saved();
 
                 return username;
             },
@@ -339,7 +353,7 @@ public sealed class OnboardingFacade(
             identities, AuthProvider.GitHubApp, picked.ProfileName,
             identities.First(i => i.Profile == picked.ProfileName).CanonicalServer,
             ConfigMutation: config => TenantDiscovery.MergeProfiles(config, outcome.Tenants, picked),
-            PublishTokens: () => ExchangeEveryTenantAsync(http, outcome.Tenants, picked, accessToken));
+            PublishTokens: saved => ExchangeEveryTenantAsync(http, outcome.Tenants, picked, accessToken, saved));
 
         return await CommitBoundary.CommitAsync(request, beforeCommit, progress, ct);
     }
@@ -347,7 +361,7 @@ public sealed class OnboardingFacade(
     // Inside the boundary: each tenant's exchange is network-then-save, and ANY failure — mapped or
     // thrown — costs that tenant its token (today's per-tenant warning) rather than the whole commit.
     async Task<string?> ExchangeEveryTenantAsync(
-            HttpClient http, DiscoveredTenant[] tenants, DiscoveredTenant picked, string githubAccessToken) {
+            HttpClient http, DiscoveredTenant[] tenants, DiscoveredTenant picked, string githubAccessToken, Action saved) {
         string? pickedUsername = null;
 
         foreach (var tenant in tenants) {
@@ -363,6 +377,7 @@ public sealed class OnboardingFacade(
                 }
 
                 await TokenStore.SaveAsync(tenant.ProfileName, exchanged.Value.Tokens, CancellationToken.None);
+                saved();
 
                 if (tenant.ProfileName == picked.ProfileName) pickedUsername = exchanged.Value.Username;
             } catch (Exception) {

--- a/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
+++ b/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
@@ -1,0 +1,338 @@
+using Capacitor.Cli.Core.Config;
+using Config_Profile = Capacitor.Cli.Core.Config.Profile;
+
+namespace Capacitor.Cli.Core.Auth;
+
+/// <summary>
+/// One durable publication set: the config mutation (profiles + the provider stamp for every
+/// identity) followed by the token writes. <see cref="PublishTokens"/> returns the username to
+/// report, because on the discovery path it is only known once the tokens are exchanged.
+/// </summary>
+sealed record CommitRequest(
+    IReadOnlyList<AuthIdentity>         Identities,
+    string                              Provider,
+    string                              ActiveProfile,
+    string                              CanonicalServer,
+    Func<ProfileConfig, ProfileConfig>? ConfigMutation,
+    Func<Task<string?>>?                PublishTokens);
+
+/// <summary>
+/// The ordered commit boundary. The before-commit hook is the LAST cancellable await: it either
+/// completes — after which every publication runs under <see cref="CancellationToken.None"/> to
+/// completion and the answer is <see cref="AuthResult.Committed"/> even if a cancel arrives — or
+/// the operation ends with nothing durable written. Crash residue is safe by this ordering:
+/// claim-without-profile and profile-without-token both leave the start gate failing.
+/// </summary>
+static class CommitBoundary {
+    internal static async Task<AuthResult> CommitAsync(
+            CommitRequest                                              request,
+            Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task>? beforeCommit,
+            IAuthProgress                                               progress,
+            CancellationToken                                           ct) {
+        if (ct.IsCancellationRequested) return new AuthResult.Cancelled();
+
+        if (beforeCommit is not null) {
+            try {
+                await beforeCommit(request.Identities, ct);
+            } catch (OperationCanceledException) {
+                return new AuthResult.Cancelled();
+            } catch (Exception ex) {
+                progress.Error($"Error: sign-in could not be prepared: {ex.Message}");
+
+                return new AuthResult.Failed(ex.Message);
+            }
+        }
+
+        await ConfigMutator.MutateAsync(config => Stamp(request.ConfigMutation?.Invoke(config) ?? config, request),
+            CancellationToken.None);
+
+        var username = request.PublishTokens is null ? null : await request.PublishTokens();
+
+        return new AuthResult.Committed(
+            request.ActiveProfile, request.CanonicalServer, request.Provider, username, request.Identities);
+    }
+
+    static ProfileConfig Stamp(ProfileConfig config, CommitRequest request) {
+        var profiles = new Dictionary<string, Config_Profile>(config.Profiles);
+
+        foreach (var identity in request.Identities) {
+            var profile = profiles.GetValueOrDefault(identity.Profile) ?? new Config_Profile();
+            profiles[identity.Profile] = profile with {
+                AuthProvider = new AuthProviderStamp(request.Provider, identity.CanonicalServer)
+            };
+        }
+
+        return config with { Profiles = profiles };
+    }
+
+    /// <summary>Points a profile at the server only when it doesn't already name the same one.</summary>
+    internal static ProfileConfig PointProfileAtServer(ProfileConfig config, string profileName, string serverUrl) {
+        var existing = config.Profiles.GetValueOrDefault(profileName);
+
+        if (existing is not null && ServerIdentity.SameServer(existing.ServerUrl, serverUrl)) return config;
+
+        return config with {
+            Profiles = new Dictionary<string, Config_Profile>(config.Profiles) {
+                [profileName] = (existing ?? new Config_Profile()) with { ServerUrl = AppConfig.NormalizeUrl(serverUrl) }
+            }
+        };
+    }
+}
+
+/// <summary>
+/// GUI-neutral onboarding operations over the existing auth flows: sign in to a known server, or
+/// discover and join a tenant. Every step up to the commit boundary is cancellable and renders
+/// through <paramref name="progress"/> — nothing here touches the console.
+/// </summary>
+/// <param name="beforeCommit">
+/// Runs with every identity the boundary is about to publish, before anything durable exists;
+/// throwing aborts the operation with nothing written (the caller may retry).
+/// </param>
+/// <param name="httpFactory">
+/// Supplies the client for every HTTP leg. A supplied factory owns its clients' lifetime; the
+/// default creates and disposes one per operation.
+/// </param>
+public sealed class OnboardingFacade(
+        IAuthProgress                                               progress,
+        ITenantPicker                                               picker,
+        ITenantProvisioner?                                         provisioner,
+        Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task>? beforeCommit,
+        Func<HttpClient>?                                           httpFactory = null) {
+    /// <summary>Test seam for the one WorkOS effect with no HTTP surface (loopback browser + OidcClient).</summary>
+    internal Func<CancellationToken, Task<WorkOSAuthResponse?>>? WorkOSOrglessLogin { get; init; }
+
+    public async Task<AuthResult> LoginAsync(string serverUrl, bool forceDevice, string? profile, CancellationToken ct) {
+        var http = httpFactory?.Invoke() ?? new HttpClient();
+
+        try {
+            return await GuardAsync(() => LoginCoreAsync(http, serverUrl, forceDevice, profile, ct), ct);
+        } finally {
+            if (httpFactory is null) http.Dispose();
+        }
+    }
+
+    /// <param name="provider"><see cref="AuthProvider.GitHubApp"/> or <see cref="AuthProvider.WorkOS"/>.</param>
+    public async Task<AuthResult> DiscoverAsync(string provider, bool forceDevice, CancellationToken ct) {
+        var http = httpFactory?.Invoke() ?? new HttpClient();
+
+        try {
+            return await GuardAsync(() => DiscoverCoreAsync(http, provider, forceDevice, ct), ct);
+        } finally {
+            if (httpFactory is null) http.Dispose();
+        }
+    }
+
+    async Task<AuthResult> LoginCoreAsync(
+            HttpClient http, string serverUrl, bool forceDevice, string? profile, CancellationToken ct) {
+        var config = await OAuthLoginFlow.FetchAuthConfigAsync(http, serverUrl, ct, progress);
+
+        if (config is null) return Stop($"Failed to fetch auth config from {serverUrl}/auth/config", ct);
+
+        var targetProfile = profile ?? await TokenStore.ResolveActiveProfileAsync(ct);
+
+        if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
+            progress.Error($"Error: {identityError}");
+
+            return Stop(identityError, ct);
+        }
+
+        return config.Provider switch {
+            AuthProvider.None      => await LoginNoneAsync(serverUrl, targetProfile, canonical, ct),
+            AuthProvider.GitHubApp => await LoginGitHubAsync(http, serverUrl, config, forceDevice, targetProfile, canonical, ct),
+            AuthProvider.WorkOS    => await LoginWorkOSAsync(serverUrl, config, targetProfile, canonical, ct),
+            _                      => UnknownProvider(config.Provider)
+        };
+    }
+
+    async Task<AuthResult> LoginNoneAsync(string serverUrl, string targetProfile, string canonical, CancellationToken ct) {
+        var request = new CommitRequest(
+            [new AuthIdentity(targetProfile, canonical)], AuthProvider.None, targetProfile, canonical,
+            ConfigMutation: config => CommitBoundary.PointProfileAtServer(config, targetProfile, serverUrl),
+            PublishTokens: null);
+
+        var result = await CommitBoundary.CommitAsync(request, beforeCommit, progress, ct);
+
+        if (result is AuthResult.Committed) {
+            progress.Notice("Server has no authentication configured — login not required.");
+        }
+
+        return result;
+    }
+
+    async Task<AuthResult> LoginGitHubAsync(
+            HttpClient http, string serverUrl, AuthDiscoveryResponse config, bool forceDevice,
+            string targetProfile, string canonical, CancellationToken ct) {
+        var accessToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(
+            http, config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice, ct, progress);
+
+        if (accessToken is null) return Stop("GitHub sign-in did not complete.", ct);
+
+        var exchanged = await OAuthLoginFlow.ExchangeAsync(
+            http, serverUrl, accessToken, config.Provider, targetProfile, progress, ct);
+
+        if (exchanged is null) return Stop("Token exchange failed.", ct);
+
+        return await CommitTokensAsync(exchanged.Value.Tokens, exchanged.Value.Username, config.Provider, targetProfile, canonical, ct);
+    }
+
+    async Task<AuthResult> LoginWorkOSAsync(
+            string serverUrl, AuthDiscoveryResponse config, string targetProfile, string canonical, CancellationToken ct) {
+        var authenticated = await OAuthLoginFlow.WorkOSTokensForServerAsync(
+            serverUrl, config.ClientId!, config.OrganizationId, new LoopbackBrowser(progress: progress), ct, progress);
+
+        if (authenticated is null) return Stop("WorkOS sign-in did not complete.", ct);
+
+        return await CommitTokensAsync(
+            authenticated.Value.Tokens, authenticated.Value.Username, AuthProvider.WorkOS, targetProfile, canonical, ct);
+    }
+
+    async Task<AuthResult> CommitTokensAsync(
+            StoredTokens tokens, string? username, string provider, string targetProfile, string canonical, CancellationToken ct) {
+        var request = new CommitRequest(
+            [new AuthIdentity(targetProfile, canonical)], provider, targetProfile, canonical,
+            ConfigMutation: null,
+            PublishTokens: async () => {
+                await TokenStore.SaveAsync(targetProfile, tokens, CancellationToken.None);
+
+                return username;
+            });
+
+        var result = await CommitBoundary.CommitAsync(request, beforeCommit, progress, ct);
+
+        if (result is AuthResult.Committed) progress.Notice($"Logged in as {username}");
+
+        return result;
+    }
+
+    async Task<AuthResult> DiscoverCoreAsync(HttpClient http, string provider, bool forceDevice, CancellationToken ct) {
+        var proxy       = new AuthProxyClient(http);
+        var proxyConfig = await proxy.GetConfigAsync(AuthProxyEndpoint.Url, ct);
+
+        if (proxyConfig is null) {
+            progress.Error("Cannot reach the Kurrent auth service.");
+
+            return Stop("Cannot reach the Kurrent auth service.", ct);
+        }
+
+        return provider switch {
+            AuthProvider.WorkOS    => await DiscoverWorkOSAsync(http, proxy, proxyConfig, ct),
+            AuthProvider.GitHubApp => await DiscoverGitHubAsync(http, proxy, proxyConfig, forceDevice, ct),
+            _                      => UnknownProvider(provider)
+        };
+    }
+
+    async Task<AuthResult> DiscoverWorkOSAsync(
+            HttpClient http, IAuthProxyClient proxy, ProxyConfigResponse proxyConfig, CancellationToken ct) {
+        var clientId = proxyConfig.WorkOSClientId ?? "";
+
+        var flow = await WorkOSDiscovery.DiscoverAsync(
+            AuthProxyEndpoint.Url, proxyConfig, proxy, picker,
+            orglessLogin: () => WorkOSOrglessLogin is not null
+                ? WorkOSOrglessLogin(ct)
+                : OAuthLoginFlow.AuthenticateWorkOSAsync(
+                    clientId, organizationId: null, new LoopbackBrowser(progress: progress), ct: ct, progress: progress),
+            orgSwitch: (refreshToken, organizationId) => OAuthLoginFlow.SwitchWorkOSOrgAsync(
+                http, OAuthLoginFlow.WorkOSApiBase, clientId, refreshToken, organizationId, ct),
+            orglessRefresh: (refreshToken, refreshCt) => OAuthLoginFlow.RefreshWorkOSTokenAsync(
+                http, OAuthLoginFlow.WorkOSApiBase, clientId, refreshToken, refreshCt),
+            provisioner: provisioner,
+            ct: ct,
+            progress: progress);
+
+        return flow switch {
+            WorkOSDiscoveryFlow.Ready ready       => await WorkOSDiscovery.PublishAsync(ready, progress, beforeCommit, ct),
+            WorkOSDiscoveryFlow.Retarget retarget => new AuthResult.Retarget(retarget.ServerInput),
+            WorkOSDiscoveryFlow.Failed failed     => Stop(failed.Message, ct),
+            _                                     => Stop("No Capacitor tenants are linked to your account.", ct)
+        };
+    }
+
+    async Task<AuthResult> DiscoverGitHubAsync(
+            HttpClient http, IAuthProxyClient proxy, ProxyConfigResponse proxyConfig, bool forceDevice, CancellationToken ct) {
+        if (string.IsNullOrEmpty(proxyConfig.GitHubClientId)) {
+            progress.Error("Cannot reach the Kurrent auth service.");
+
+            return Stop("Cannot reach the Kurrent auth service.", ct);
+        }
+
+        var accessToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(
+            http, proxyConfig.GitHubClientId, proxyConfig.GitHubCodeExchangeUrl, forceDevice, ct, progress);
+
+        if (accessToken is null) return Stop("GitHub sign-in did not complete.", ct);
+
+        var outcome = await new TenantDiscovery(proxy, picker).RunAsync(AuthProxyEndpoint.Url, accessToken, ct);
+
+        if (outcome.ErrorMessage is not null) {
+            progress.Error(outcome.ErrorMessage);
+
+            return Stop(outcome.ErrorMessage, ct);
+        }
+
+        var identities = new List<AuthIdentity>();
+
+        foreach (var tenant in outcome.Tenants) {
+            if (!ServerIdentity.TryCanonicalizeForStamping(tenant.Origin, out var canonical, out var identityError)) {
+                progress.Error($"Error: {identityError}");
+
+                return Stop(identityError, ct);
+            }
+
+            identities.Add(new(tenant.ProfileName, canonical));
+        }
+
+        var picked = outcome.Picked!;
+
+        var request = new CommitRequest(
+            identities, AuthProvider.GitHubApp, picked.ProfileName,
+            identities.First(i => i.Profile == picked.ProfileName).CanonicalServer,
+            ConfigMutation: config => TenantDiscovery.MergeProfiles(config, outcome.Tenants, picked),
+            PublishTokens: () => ExchangeEveryTenantAsync(http, outcome.Tenants, picked, accessToken));
+
+        return await CommitBoundary.CommitAsync(request, beforeCommit, progress, ct);
+    }
+
+    // Inside the boundary: each tenant's exchange is network-then-save, and a failure costs that
+    // tenant its token (today's per-tenant warning) rather than the whole commit.
+    async Task<string?> ExchangeEveryTenantAsync(
+            HttpClient http, DiscoveredTenant[] tenants, DiscoveredTenant picked, string githubAccessToken) {
+        string? pickedUsername = null;
+
+        foreach (var tenant in tenants) {
+            var exchanged = await OAuthLoginFlow.ExchangeAsync(
+                http, AppConfig.NormalizeUrl(tenant.Origin), githubAccessToken, AuthProvider.GitHubApp,
+                tenant.ProfileName, progress, CancellationToken.None);
+
+            if (exchanged is null) {
+                progress.Error(
+                    $"Warning: token exchange failed for {tenant.ProfileName}. Run 'kcap login' after switching to that profile.");
+
+                continue;
+            }
+
+            await TokenStore.SaveAsync(tenant.ProfileName, exchanged.Value.Tokens, CancellationToken.None);
+
+            if (tenant.ProfileName == picked.ProfileName) pickedUsername = exchanged.Value.Username;
+        }
+
+        return pickedUsername;
+    }
+
+    AuthResult.Failed UnknownProvider(string provider) {
+        progress.Error($"Error: Unknown auth provider '{provider}'. Update your kcap CLI.");
+
+        return new AuthResult.Failed($"Unknown auth provider '{provider}'");
+    }
+
+    static async Task<AuthResult> GuardAsync(Func<Task<AuthResult>> operation, CancellationToken ct) {
+        try {
+            return await operation();
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            return new AuthResult.Cancelled();
+        }
+    }
+
+    // A pre-boundary failure under a live cancel IS a cancel: the proxy client and the WorkOS
+    // refresh map OperationCanceledException onto their own failure results.
+    static AuthResult Stop(string message, CancellationToken ct) =>
+        ct.IsCancellationRequested ? new AuthResult.Cancelled() : new AuthResult.Failed(message);
+}

--- a/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
+++ b/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
@@ -4,13 +4,7 @@ using Config_Profile = Capacitor.Cli.Core.Config.Profile;
 
 namespace Capacitor.Cli.Core.Auth;
 
-/// <summary>
-/// One durable publication set: the config mutation (profiles + the provider stamp for every
-/// identity) followed by the token writes. <see cref="PublishTokens"/> returns the username to
-/// report, because on the discovery path it is only known once the tokens are exchanged; it calls
-/// the <see cref="Action"/> it is handed after each token that actually landed, so the boundary
-/// knows whether a failure left anything behind.
-/// </summary>
+/// <summary>One durable publication set: the config mutation and provider stamp, followed by token writes tracked so a partial failure is known.</summary>
 sealed record CommitRequest(
     IReadOnlyList<AuthIdentity>         Identities,
     string                              Provider,
@@ -21,13 +15,7 @@ sealed record CommitRequest(
     // False for a login that must not claim the profile for this server (see LoginTarget.Foreign).
     bool                                WriteStamp = true);
 
-/// <summary>
-/// The ordered commit boundary. The before-commit hook is the LAST cancellable await; past it every
-/// publication runs under <see cref="CancellationToken.None"/> and a cancel no longer changes the
-/// answer. <see cref="AuthResult.Committed"/> means something durable landed — a publication failure
-/// with nothing landed is still <see cref="AuthResult.Failed"/>. Crash residue is safe by this
-/// ordering: claim-without-profile and profile-without-token both leave the start gate failing.
-/// </summary>
+/// <summary>The ordered commit boundary: the before-commit hook is the last cancellable await, after which every publication is uncancellable.</summary>
 static class CommitBoundary {
     internal static async Task<AuthResult> CommitAsync(
             CommitRequest                                              request,
@@ -48,8 +36,7 @@ static class CommitBoundary {
             }
         }
 
-        // A token-only arm (a foreign login writes no config at all) has no config commit to make
-        // the boundary durable, so what landed is tracked rather than assumed.
+        // A token-only arm has no config commit to make the boundary durable, so what landed is tracked rather than assumed.
         var configPublished = request.ConfigMutation is not null || request.WriteStamp;
 
         if (configPublished) {

--- a/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
+++ b/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Core.Config;
+using Duende.IdentityModel.OidcClient.Browser;
 using Config_Profile = Capacitor.Cli.Core.Config.Profile;
 
 namespace Capacitor.Cli.Core.Auth;
@@ -14,7 +15,9 @@ sealed record CommitRequest(
     string                              ActiveProfile,
     string                              CanonicalServer,
     Func<ProfileConfig, ProfileConfig>? ConfigMutation,
-    Func<Task<string?>>?                PublishTokens);
+    Func<Task<string?>>?                PublishTokens,
+    // False for a login that must not claim the profile for this server (see LoginTarget.Foreign).
+    bool                                WriteStamp = true);
 
 /// <summary>
 /// The ordered commit boundary. The before-commit hook is the LAST cancellable await: it either
@@ -43,16 +46,35 @@ static class CommitBoundary {
             }
         }
 
-        await ConfigMutator.MutateAsync(config => Stamp(request.ConfigMutation?.Invoke(config) ?? config, request),
-            CancellationToken.None);
+        if (request.ConfigMutation is not null || request.WriteStamp) {
+            try {
+                // Profile write and stamp are deliberately ONE mutation: no window where a profile exists unstamped.
+                await ConfigMutator.MutateAsync(config => Stamp(request.ConfigMutation?.Invoke(config) ?? config, request),
+                    CancellationToken.None);
+            } catch (Exception ex) {
+                // The config commit is the boundary's first durable step: if it threw, nothing was published.
+                progress.Error($"Error: sign-in could not be saved: {ex.Message}");
 
-        var username = request.PublishTokens is null ? null : await request.PublishTokens();
+                return new AuthResult.Failed(ex.Message);
+            }
+        }
+
+        string? username = null;
+
+        try {
+            if (request.PublishTokens is not null) username = await request.PublishTokens();
+        } catch (Exception ex) {
+            // Past the config commit the boundary has begun; report what was published rather than a torn stop.
+            progress.Error($"Error: some credentials could not be saved: {ex.Message}");
+        }
 
         return new AuthResult.Committed(
             request.ActiveProfile, request.CanonicalServer, request.Provider, username, request.Identities);
     }
 
     static ProfileConfig Stamp(ProfileConfig config, CommitRequest request) {
+        if (!request.WriteStamp) return config;
+
         var profiles = new Dictionary<string, Config_Profile>(config.Profiles);
 
         foreach (var identity in request.Identities) {
@@ -80,6 +102,20 @@ static class CommitBoundary {
 }
 
 /// <summary>
+/// What a known-server login may write. The stamp claims the profile for this server, so it is
+/// written only when the profile already names it or the caller opted to adopt it; adopting also
+/// writes <c>server_url</c>. A foreign profile with no adoption gets neither.
+/// </summary>
+sealed record LoginTarget(string Profile, string CanonicalServer, string ServerUrl, bool PointsAtServer, bool AdoptServer) {
+    internal bool Adopting  => !PointsAtServer && AdoptServer;
+    internal bool Foreign   => !PointsAtServer && !AdoptServer;
+    internal bool WriteStamp => !Foreign;
+
+    internal Func<ProfileConfig, ProfileConfig>? ConfigMutation =>
+        Adopting ? config => CommitBoundary.PointProfileAtServer(config, Profile, ServerUrl) : null;
+}
+
+/// <summary>
 /// GUI-neutral onboarding operations over the existing auth flows: sign in to a known server, or
 /// discover and join a tenant. Every step up to the commit boundary is cancellable and renders
 /// through <paramref name="progress"/> — nothing here touches the console.
@@ -89,8 +125,9 @@ static class CommitBoundary {
 /// throwing aborts the operation with nothing written (the caller may retry).
 /// </param>
 /// <param name="httpFactory">
-/// Supplies the client for every HTTP leg. A supplied factory owns its clients' lifetime; the
-/// default creates and disposes one per operation.
+/// Supplies the client for the auth-config, proxy, token-exchange, device-flow and WorkOS
+/// org-switch legs. The GitHub browser flow and OidcClient still make their own clients. A supplied
+/// factory owns its clients' lifetime; the default creates and disposes one per operation.
 /// </param>
 public sealed class OnboardingFacade(
         IAuthProgress                                               progress,
@@ -101,11 +138,21 @@ public sealed class OnboardingFacade(
     /// <summary>Test seam for the one WorkOS effect with no HTTP surface (loopback browser + OidcClient).</summary>
     internal Func<CancellationToken, Task<WorkOSAuthResponse?>>? WorkOSOrglessLogin { get; init; }
 
-    public async Task<AuthResult> LoginAsync(string serverUrl, bool forceDevice, string? profile, CancellationToken ct) {
+    /// <summary>Test seams for the known-server WorkOS login, whose OidcClient leg bypasses the http factory.</summary>
+    internal IBrowser? WorkOSBrowser { get; init; }
+
+    internal string? WorkOSApiBaseOverride { get; init; }
+
+    /// <param name="adoptServer">
+    /// When the profile doesn't already name this server: true writes its <c>server_url</c> and the
+    /// provider stamp, false leaves config untouched (a <c>None</c> server then has nothing to sign in with).
+    /// </param>
+    public async Task<AuthResult> LoginAsync(
+            string serverUrl, bool forceDevice, string? profile, CancellationToken ct, bool adoptServer = false) {
         var http = httpFactory?.Invoke() ?? new HttpClient();
 
         try {
-            return await GuardAsync(() => LoginCoreAsync(http, serverUrl, forceDevice, profile, ct), ct);
+            return await GuardAsync(() => LoginCoreAsync(http, serverUrl, forceDevice, profile, adoptServer, ct), ct);
         } finally {
             if (httpFactory is null) http.Dispose();
         }
@@ -123,7 +170,7 @@ public sealed class OnboardingFacade(
     }
 
     async Task<AuthResult> LoginCoreAsync(
-            HttpClient http, string serverUrl, bool forceDevice, string? profile, CancellationToken ct) {
+            HttpClient http, string serverUrl, bool forceDevice, string? profile, bool adoptServer, CancellationToken ct) {
         var config = await OAuthLoginFlow.FetchAuthConfigAsync(http, serverUrl, ct, progress);
 
         if (config is null) return Stop($"Failed to fetch auth config from {serverUrl}/auth/config", ct);
@@ -131,23 +178,34 @@ public sealed class OnboardingFacade(
         var targetProfile = profile ?? await TokenStore.ResolveActiveProfileAsync(ct);
 
         if (!ServerIdentity.TryCanonicalizeForStamping(serverUrl, out var canonical, out var identityError)) {
-            progress.Error($"Error: {identityError}");
-
-            return Stop(identityError, ct);
+            return Fail($"Error: {identityError}", identityError, ct);
         }
 
+        var configured = (await AppConfig.LoadProfileConfig(ct)).Profiles.GetValueOrDefault(targetProfile);
+        var target     = new LoginTarget(
+            targetProfile, canonical, serverUrl,
+            PointsAtServer: ServerIdentity.SameServer(configured?.ServerUrl, serverUrl),
+            AdoptServer: adoptServer);
+
         return config.Provider switch {
-            AuthProvider.None      => await LoginNoneAsync(serverUrl, targetProfile, canonical, ct),
-            AuthProvider.GitHubApp => await LoginGitHubAsync(http, serverUrl, config, forceDevice, targetProfile, canonical, ct),
-            AuthProvider.WorkOS    => await LoginWorkOSAsync(serverUrl, config, targetProfile, canonical, ct),
+            AuthProvider.None      => await LoginNoneAsync(target, ct),
+            AuthProvider.GitHubApp => await LoginGitHubAsync(http, config, forceDevice, target, ct),
+            AuthProvider.WorkOS    => await LoginWorkOSAsync(config, target, ct),
             _                      => UnknownProvider(config.Provider)
         };
     }
 
-    async Task<AuthResult> LoginNoneAsync(string serverUrl, string targetProfile, string canonical, CancellationToken ct) {
+    async Task<AuthResult> LoginNoneAsync(LoginTarget target, CancellationToken ct) {
+        // Nothing to sign in with on a None server, so a profile that doesn't name it stays unconfigured.
+        if (target.Foreign) {
+            return Fail(
+                $"Error: profile '{target.Profile}' is not configured for {target.ServerUrl} — pass --profile or run kcap setup.",
+                $"Profile '{target.Profile}' is not configured for {target.ServerUrl}.", ct);
+        }
+
         var request = new CommitRequest(
-            [new AuthIdentity(targetProfile, canonical)], AuthProvider.None, targetProfile, canonical,
-            ConfigMutation: config => CommitBoundary.PointProfileAtServer(config, targetProfile, serverUrl),
+            [new AuthIdentity(target.Profile, target.CanonicalServer)], AuthProvider.None, target.Profile, target.CanonicalServer,
+            ConfigMutation: target.ConfigMutation,
             PublishTokens: null);
 
         var result = await CommitBoundary.CommitAsync(request, beforeCommit, progress, ct);
@@ -160,42 +218,43 @@ public sealed class OnboardingFacade(
     }
 
     async Task<AuthResult> LoginGitHubAsync(
-            HttpClient http, string serverUrl, AuthDiscoveryResponse config, bool forceDevice,
-            string targetProfile, string canonical, CancellationToken ct) {
+            HttpClient http, AuthDiscoveryResponse config, bool forceDevice, LoginTarget target, CancellationToken ct) {
         var accessToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(
             http, config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice, ct, progress);
 
-        if (accessToken is null) return Stop("GitHub sign-in did not complete.", ct);
+        if (accessToken is null) return Stop("GitHub sign-in did not complete.", ct, AuthFailureReason.SigninDenied);
 
         var exchanged = await OAuthLoginFlow.ExchangeAsync(
-            http, serverUrl, accessToken, config.Provider, targetProfile, progress, ct);
+            http, target.ServerUrl, accessToken, config.Provider, target.Profile, progress, ct);
 
         if (exchanged is null) return Stop("Token exchange failed.", ct);
 
-        return await CommitTokensAsync(exchanged.Value.Tokens, exchanged.Value.Username, config.Provider, targetProfile, canonical, ct);
+        return await CommitTokensAsync(exchanged.Value.Tokens, exchanged.Value.Username, config.Provider, target, ct);
     }
 
-    async Task<AuthResult> LoginWorkOSAsync(
-            string serverUrl, AuthDiscoveryResponse config, string targetProfile, string canonical, CancellationToken ct) {
+    async Task<AuthResult> LoginWorkOSAsync(AuthDiscoveryResponse config, LoginTarget target, CancellationToken ct) {
         var authenticated = await OAuthLoginFlow.WorkOSTokensForServerAsync(
-            serverUrl, config.ClientId!, config.OrganizationId, new LoopbackBrowser(progress: progress), ct, progress);
+            target.ServerUrl, config.ClientId!, config.OrganizationId,
+            WorkOSBrowser ?? new LoopbackBrowser(progress: progress), ct, progress,
+            WorkOSApiBaseOverride ?? OAuthLoginFlow.WorkOSApiBase);
 
-        if (authenticated is null) return Stop("WorkOS sign-in did not complete.", ct);
+        if (authenticated is null) return Stop("WorkOS sign-in did not complete.", ct, AuthFailureReason.SigninDenied);
 
         return await CommitTokensAsync(
-            authenticated.Value.Tokens, authenticated.Value.Username, AuthProvider.WorkOS, targetProfile, canonical, ct);
+            authenticated.Value.Tokens, authenticated.Value.Username, AuthProvider.WorkOS, target, ct);
     }
 
     async Task<AuthResult> CommitTokensAsync(
-            StoredTokens tokens, string? username, string provider, string targetProfile, string canonical, CancellationToken ct) {
+            StoredTokens tokens, string? username, string provider, LoginTarget target, CancellationToken ct) {
         var request = new CommitRequest(
-            [new AuthIdentity(targetProfile, canonical)], provider, targetProfile, canonical,
-            ConfigMutation: null,
+            [new AuthIdentity(target.Profile, target.CanonicalServer)], provider, target.Profile, target.CanonicalServer,
+            ConfigMutation: target.ConfigMutation,
             PublishTokens: async () => {
-                await TokenStore.SaveAsync(targetProfile, tokens, CancellationToken.None);
+                await TokenStore.SaveAsync(target.Profile, tokens, CancellationToken.None);
 
                 return username;
-            });
+            },
+            WriteStamp: target.WriteStamp);
 
         var result = await CommitBoundary.CommitAsync(request, beforeCommit, progress, ct);
 
@@ -209,9 +268,7 @@ public sealed class OnboardingFacade(
         var proxyConfig = await proxy.GetConfigAsync(AuthProxyEndpoint.Url, ct);
 
         if (proxyConfig is null) {
-            progress.Error("Cannot reach the Kurrent auth service.");
-
-            return Stop("Cannot reach the Kurrent auth service.", ct);
+            return Fail("Cannot reach the Kurrent auth service.", ct, AuthFailureReason.Unreachable);
         }
 
         return provider switch {
@@ -243,38 +300,34 @@ public sealed class OnboardingFacade(
             WorkOSDiscoveryFlow.Ready ready       => await WorkOSDiscovery.PublishAsync(ready, progress, beforeCommit, ct),
             WorkOSDiscoveryFlow.Retarget retarget => new AuthResult.Retarget(retarget.ServerInput),
             WorkOSDiscoveryFlow.Failed failed     => Stop(failed.Message, ct),
-            _                                     => Stop("No Capacitor tenants are linked to your account.", ct)
+            _                                     => Stop("No Capacitor tenants are linked to your account.", ct,
+                                                          AuthFailureReason.NoTenantsFound)
         };
     }
 
     async Task<AuthResult> DiscoverGitHubAsync(
             HttpClient http, IAuthProxyClient proxy, ProxyConfigResponse proxyConfig, bool forceDevice, CancellationToken ct) {
         if (string.IsNullOrEmpty(proxyConfig.GitHubClientId)) {
-            progress.Error("Cannot reach the Kurrent auth service.");
-
-            return Stop("Cannot reach the Kurrent auth service.", ct);
+            return Fail("Cannot reach the Kurrent auth service.", ct, AuthFailureReason.Unreachable);
         }
 
         var accessToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(
             http, proxyConfig.GitHubClientId, proxyConfig.GitHubCodeExchangeUrl, forceDevice, ct, progress);
 
-        if (accessToken is null) return Stop("GitHub sign-in did not complete.", ct);
+        if (accessToken is null) return Stop("GitHub sign-in did not complete.", ct, AuthFailureReason.SigninDenied);
 
         var outcome = await new TenantDiscovery(proxy, picker).RunAsync(AuthProxyEndpoint.Url, accessToken, ct);
 
         if (outcome.ErrorMessage is not null) {
-            progress.Error(outcome.ErrorMessage);
-
-            return Stop(outcome.ErrorMessage, ct);
+            return Fail(outcome.ErrorMessage, ct,
+                outcome.NoTenantsFound ? AuthFailureReason.NoTenantsFound : AuthFailureReason.Other);
         }
 
         var identities = new List<AuthIdentity>();
 
         foreach (var tenant in outcome.Tenants) {
             if (!ServerIdentity.TryCanonicalizeForStamping(tenant.Origin, out var canonical, out var identityError)) {
-                progress.Error($"Error: {identityError}");
-
-                return Stop(identityError, ct);
+                return Fail($"Error: {identityError}", identityError, ct);
             }
 
             identities.Add(new(tenant.ProfileName, canonical));
@@ -291,31 +344,37 @@ public sealed class OnboardingFacade(
         return await CommitBoundary.CommitAsync(request, beforeCommit, progress, ct);
     }
 
-    // Inside the boundary: each tenant's exchange is network-then-save, and a failure costs that
-    // tenant its token (today's per-tenant warning) rather than the whole commit.
+    // Inside the boundary: each tenant's exchange is network-then-save, and ANY failure — mapped or
+    // thrown — costs that tenant its token (today's per-tenant warning) rather than the whole commit.
     async Task<string?> ExchangeEveryTenantAsync(
             HttpClient http, DiscoveredTenant[] tenants, DiscoveredTenant picked, string githubAccessToken) {
         string? pickedUsername = null;
 
         foreach (var tenant in tenants) {
-            var exchanged = await OAuthLoginFlow.ExchangeAsync(
-                http, AppConfig.NormalizeUrl(tenant.Origin), githubAccessToken, AuthProvider.GitHubApp,
-                tenant.ProfileName, progress, CancellationToken.None);
+            try {
+                var exchanged = await OAuthLoginFlow.ExchangeAsync(
+                    http, AppConfig.NormalizeUrl(tenant.Origin), githubAccessToken, AuthProvider.GitHubApp,
+                    tenant.ProfileName, progress, CancellationToken.None);
 
-            if (exchanged is null) {
-                progress.Error(
-                    $"Warning: token exchange failed for {tenant.ProfileName}. Run 'kcap login' after switching to that profile.");
+                if (exchanged is null) {
+                    WarnExchangeFailed(tenant.ProfileName);
 
-                continue;
+                    continue;
+                }
+
+                await TokenStore.SaveAsync(tenant.ProfileName, exchanged.Value.Tokens, CancellationToken.None);
+
+                if (tenant.ProfileName == picked.ProfileName) pickedUsername = exchanged.Value.Username;
+            } catch (Exception) {
+                WarnExchangeFailed(tenant.ProfileName);
             }
-
-            await TokenStore.SaveAsync(tenant.ProfileName, exchanged.Value.Tokens, CancellationToken.None);
-
-            if (tenant.ProfileName == picked.ProfileName) pickedUsername = exchanged.Value.Username;
         }
 
         return pickedUsername;
     }
+
+    void WarnExchangeFailed(string profile) =>
+        progress.Error($"Warning: token exchange failed for {profile}. Run 'kcap login' after switching to that profile.");
 
     AuthResult.Failed UnknownProvider(string provider) {
         progress.Error($"Error: Unknown auth provider '{provider}'. Update your kcap CLI.");
@@ -333,6 +392,19 @@ public sealed class OnboardingFacade(
 
     // A pre-boundary failure under a live cancel IS a cancel: the proxy client and the WorkOS
     // refresh map OperationCanceledException onto their own failure results.
-    static AuthResult Stop(string message, CancellationToken ct) =>
-        ct.IsCancellationRequested ? new AuthResult.Cancelled() : new AuthResult.Failed(message);
+    static AuthResult Stop(string message, CancellationToken ct, AuthFailureReason reason = AuthFailureReason.Other) =>
+        ct.IsCancellationRequested ? new AuthResult.Cancelled() : new AuthResult.Failed(message, reason);
+
+    // Same rule for a façade-rendered failure, with the line suppressed under a live cancel: a user
+    // who cancelled must not be shown a transport error the cancel itself caused.
+    AuthResult Fail(string message, CancellationToken ct, AuthFailureReason reason = AuthFailureReason.Other) =>
+        Fail(message, message, ct, reason);
+
+    AuthResult Fail(string rendered, string message, CancellationToken ct, AuthFailureReason reason = AuthFailureReason.Other) {
+        if (ct.IsCancellationRequested) return new AuthResult.Cancelled();
+
+        progress.Error(rendered);
+
+        return new AuthResult.Failed(message, reason);
+    }
 }

--- a/src/Capacitor.Cli.Core/Auth/ServerInput.cs
+++ b/src/Capacitor.Cli.Core/Auth/ServerInput.cs
@@ -1,0 +1,42 @@
+namespace Capacitor.Cli.Core.Auth;
+
+// Normalizes user-supplied server input for `kcap setup`/`kcap login` and the desktop app's
+// onboarding facade — no network access, string shaping only.
+public static class ServerInput {
+    /// <summary>
+    /// Resolves a `kcap setup &lt;tenant&gt;` positional: a bare single label (no scheme/dot/port)
+    /// expands to <c>https://{slug}.kcap.ai</c>; anything that already looks like a URL, FQDN, or
+    /// host:port is returned unchanged for the normal --server-url path. Self-hosted servers should
+    /// pass a full URL.
+    /// </summary>
+    /// <summary>
+    /// Reduces a user-supplied server to its origin, dropping any path/query/fragment. Everything
+    /// downstream appends a fixed root path (<c>/auth/config</c>), so a pasted page URL would probe
+    /// the wrong endpoint and be reported unreachable. Applied to the zero-discovery
+    /// "I already have a workspace" input, which explicitly invites a paste; the pre-existing
+    /// <c>--server-url</c> / <c>&lt;tenant&gt;</c> arguments keep their current behaviour. A bare
+    /// slug passes through untouched for <see cref="ResolveTenantArg"/> to expand.
+    /// </summary>
+    public static string ToServerOrigin(string input) {
+        var trimmed = input.Trim().TrimEnd('/');
+
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var absolute)
+         && (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps)) {
+            return absolute.GetLeftPart(UriPartial.Authority);
+        }
+
+        // Scheme-less: cut at the first path/query/fragment separator. A bracketed IPv6 literal
+        // ("[::1]:5108") must be skipped first or the scan would cut inside the address.
+        var bracketEnd = trimmed.StartsWith('[') ? trimmed.IndexOf(']') : -1;
+        var scanFrom   = bracketEnd > 0 ? bracketEnd + 1 : 0;
+        var cut        = trimmed.IndexOfAny(['/', '?', '#'], scanFrom);
+
+        return cut < 0 ? trimmed : trimmed[..cut].TrimEnd('/');
+    }
+
+    public static string ResolveTenantArg(string arg) =>
+        arg.Contains("://") || arg.Contains('.') || arg.Contains(':')
+        || arg.Equals("localhost", StringComparison.OrdinalIgnoreCase) // bare loopback host, not a kcap.ai slug
+            ? arg
+            : $"https://{arg}.kcap.ai";
+}

--- a/src/Capacitor.Cli.Core/Auth/TenantDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/TenantDiscovery.cs
@@ -19,12 +19,13 @@ public sealed record DiscoveryOutcome(
 );
 
 public interface ITenantPicker {
-    DiscoveredTenant? Pick(DiscoveredTenant[] tenants);
+    DiscoveredTenant?       Pick(DiscoveredTenant[] tenants);
+    Task<DiscoveredTenant?> PickAsync(DiscoveredTenant[] tenants, CancellationToken ct);
 }
 
 public class TenantDiscovery(IAuthProxyClient proxy, ITenantPicker picker) {
-    public async Task<DiscoveryOutcome> RunAsync(string proxyUrl, string githubAccessToken) {
-        var result = await proxy.DiscoverTenantsAsync(proxyUrl, githubAccessToken);
+    public async Task<DiscoveryOutcome> RunAsync(string proxyUrl, string githubAccessToken, CancellationToken ct = default) {
+        var result = await proxy.DiscoverTenantsAsync(proxyUrl, githubAccessToken, ct);
 
         if (result.Error != DiscoveryError.None) {
             return new([], null, result.Error switch {
@@ -43,7 +44,7 @@ public class TenantDiscovery(IAuthProxyClient proxy, ITenantPicker picker) {
 
         var picked = result.Tenants.Length == 1
             ? result.Tenants[0]
-            : picker.Pick(result.Tenants);
+            : await picker.PickAsync(result.Tenants, ct);
 
         if (picked is null) {
             return new(result.Tenants, null, "No tenant selected.");

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -286,7 +286,7 @@ public static class TokenStore {
     public static Task<string> ResolveProfileNameAsync(CancellationToken ct = default) =>
         ResolveActiveProfileAsync(ct);
 
-    static async Task<string> ResolveActiveProfileAsync(CancellationToken ct = default) {
+    internal static async Task<string> ResolveActiveProfileAsync(CancellationToken ct = default) {
         if (AppConfig.ResolvedProfile?.ProfileName is { Length: > 0 } resolved) return resolved;
 
         var cfg = await AppConfig.LoadProfileConfig(ct);

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -1,4 +1,3 @@
-using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.Cli.Core.Auth;
@@ -13,6 +12,27 @@ namespace Capacitor.Cli.Core.Auth;
 public sealed record WorkOSDiscoveryOutcome(int ExitCode, string? RetargetServerInput = null);
 
 /// <summary>
+/// What discovery established, up to but not including any durable write. <see cref="Ready"/>
+/// carries the org-switched auth for the picked (or freshly created) tenant.
+/// </summary>
+public abstract record WorkOSDiscoveryFlow {
+    public sealed record Ready(
+        DiscoveredTenant[]  Tenants,
+        DiscoveredTenant    Picked,
+        WorkOSAuthResponse  SwitchedAuth,
+        string              ClientId,
+        // From the ORG-LESS login response: the org-switch response carries no profile fields.
+        string              Username) : WorkOSDiscoveryFlow;
+
+    public sealed record Retarget(string ServerInput) : WorkOSDiscoveryFlow;
+
+    public sealed record NoTenants : WorkOSDiscoveryFlow;
+
+    /// <param name="Message">Already emitted through <see cref="IAuthProgress"/>.</param>
+    public sealed record Failed(string Message) : WorkOSDiscoveryFlow;
+}
+
+/// <summary>
 /// WorkOS tenant discovery: authenticate org-less against the proxy's shared AuthKit app,
 /// list the user's tenants via the proxy, let them pick, then org-switch into the chosen org
 /// and save an org-scoped profile. The two browser/HTTP effects (org-less login, org-switch)
@@ -20,8 +40,6 @@ public sealed record WorkOSDiscoveryOutcome(int ExitCode, string? RetargetServer
 /// production wiring passes <see cref="OAuthLoginFlow"/>'s loopback + switch helpers.
 /// </summary>
 public static class WorkOSDiscovery {
-    const string WorkOSApiBase = "https://api.workos.com";
-
     /// <summary>
     /// <see cref="RunAsync"/> wired to the real WorkOS effects: an org-less loopback login on the
     /// shared AuthKit app + a refresh-token org-switch (both public-client, no secret). The two call
@@ -39,17 +57,20 @@ public static class WorkOSDiscovery {
                 clientId, organizationId: null, new LoopbackBrowser(progress: progress), ct: ct, progress: progress),
             orgSwitch: async (refreshToken, organizationId) => {
                 using var http = new HttpClient();
-                return await OAuthLoginFlow.SwitchWorkOSOrgAsync(http, WorkOSApiBase, clientId, refreshToken, organizationId, ct);
+                return await OAuthLoginFlow.SwitchWorkOSOrgAsync(
+                    http, OAuthLoginFlow.WorkOSApiBase, clientId, refreshToken, organizationId, ct);
             },
             orglessRefresh: async (refreshToken, refreshCt) => {
                 using var http = new HttpClient();
-                return await OAuthLoginFlow.RefreshWorkOSTokenAsync(http, WorkOSApiBase, clientId, refreshToken, refreshCt);
+                return await OAuthLoginFlow.RefreshWorkOSTokenAsync(
+                    http, OAuthLoginFlow.WorkOSApiBase, clientId, refreshToken, refreshCt);
             },
             provisioner: provisioner,
             ct: ct,
             progress: progress);
     }
 
+    /// <summary>Discovery + publication for callers that want an exit code and no commit hook.</summary>
     public static async Task<WorkOSDiscoveryOutcome> RunAsync(
             string                                          proxyUrl,
             ProxyConfigResponse                             proxyConfig,
@@ -63,149 +84,199 @@ public static class WorkOSDiscovery {
             IAuthProgress?                                  progress = null) {
         progress ??= ConsoleAuthProgress.Instance;
 
-        if (string.IsNullOrEmpty(proxyConfig.WorkOSClientId)) {
-            progress.Error("This server isn't configured for WorkOS sign-in.");
+        var flow = await DiscoverAsync(
+            proxyUrl, proxyConfig, proxy, picker, orglessLogin, orgSwitch, orglessRefresh, provisioner, ct, progress);
 
-            return new(1);
+        return flow switch {
+            WorkOSDiscoveryFlow.Ready ready =>
+                new(await PublishAsync(ready, progress, beforeCommit: null, ct) is AuthResult.Committed ? 0 : 1),
+            WorkOSDiscoveryFlow.Retarget retarget => new(1, retarget.ServerInput),
+            _                                    => new(1)
+        };
+    }
+
+    /// <summary>Everything up to the commit boundary: sign in, enumerate, pick (or create), org-switch.</summary>
+    public static async Task<WorkOSDiscoveryFlow> DiscoverAsync(
+            string                                          proxyUrl,
+            ProxyConfigResponse                             proxyConfig,
+            IAuthProxyClient                                proxy,
+            ITenantPicker                                   picker,
+            Func<Task<WorkOSAuthResponse?>>                 orglessLogin,
+            Func<string, string, Task<WorkOSAuthResponse?>> orgSwitch,     // args: refreshToken, organizationId
+            Func<string, CancellationToken, Task<WorkOSAuthResponse?>>? orglessRefresh = null, // args: refreshToken, ct
+            ITenantProvisioner?                             provisioner = null,
+            CancellationToken                               ct = default,
+            IAuthProgress?                                  progress = null) {
+        progress ??= ConsoleAuthProgress.Instance;
+
+        if (string.IsNullOrEmpty(proxyConfig.WorkOSClientId)) {
+            return Failed(progress, "This server isn't configured for WorkOS sign-in.");
         }
 
         var auth = await orglessLogin();
         if (auth is null || string.IsNullOrEmpty(auth.RefreshToken)) {
-            // Anchored here, not on this method's return: by the time RunAsync returns, it has
+            // Anchored here, not on this method's return: by the time discovery returns, it has
             // also run tenant enumeration and (on the zero-tenant fork) provisioning, so keying
             // signin_completed/failed on the overall outcome would place signin_completed after
             // tenant_none/workspace_provisioned and make signin_failed fire for declined offers,
             // provisioning failures, and the deliberately-non-zero retarget path — none of which
             // are a sign-in failure.
             SetupFunnel.SigninFailed("workos_signin_failed");
-            progress.Error("WorkOS sign-in failed.");
 
-            return new(1);
+            return Failed(progress, "WorkOS sign-in failed.");
         }
 
         SetupFunnel.SigninCompleted(AuthProvider.WorkOS);
 
         var result = await proxy.DiscoverWorkOSTenantsAsync(proxyUrl, auth.AccessToken, ct);
         if (result.Error != DiscoveryError.None) {
-            progress.Error(result.Error switch {
+            return Failed(progress, result.Error switch {
                 DiscoveryError.ProxyUnreachable => "The Kurrent auth service is unreachable.",
                 DiscoveryError.TokenRejected    => "WorkOS rejected the authentication token. Please sign in again.",
                 DiscoveryError.UpstreamError    => "Kurrent auth service returned an error. Try again later.",
                 _                               => "Tenant discovery failed."
             });
-
-            return new(1);
         }
 
         if (result.Tenants.Length == 0) {
-            // Fires before the provisioner-null check below: a headless run (null provisioner,
-            // "ask your admin" dead-end) still reached the fork and must count as such — this is
-            // the denominator for "reached signup".
-            SetupFunnel.TenantNone(AuthProvider.WorkOS);
-
-            if (provisioner is null) {
-                progress.Error("No Capacitor tenants are linked to your account. Ask your admin to invite you.");
-
-                return new(1);
-            }
-
-            // Provisioning + polling can run for minutes, outliving WorkOS's ~5-minute access-token
-            // TTL, so hand the provisioner a refreshing token source rather than the login-time token.
-            var tokens = new WorkOSTokenSource(
-                auth.AccessToken, auth.RefreshToken,
-                orglessRefresh ?? ((_, _) => Task.FromResult<WorkOSAuthResponse?>(null)));
-            var offer = await provisioner.OfferCreateAsync(tokens, ct);
-
-            if (offer.Status == ProvisionOfferStatus.ExistingWorkspace) {
-                // The user belongs to a workspace already and would rather point at it. Hand the
-                // input back unresolved (trimmed, nothing else): only the caller knows how a bare
-                // slug expands, and the target's own /auth/config — not this WorkOS lane — decides
-                // how to log in. Blank input would resolve to a nonsense host, so decline instead.
-                // Trimmed here as well as at the prompt because this interface is public.
-                var target = offer.ExistingWorkspaceInput?.Trim();
-
-                return string.IsNullOrEmpty(target) ? new(1) : new(1, target);
-            }
-
-            if (offer.Status != ProvisionOfferStatus.Created || offer.Tenant is null) {
-                // Declined / InProgress / Failed — the provisioner already printed the
-                // outcome-appropriate message; don't stack the legacy dead-end on top.
-                return new(1);
-            }
-
-            var created = new DiscoveredTenant {
-                Provider       = AuthProvider.WorkOS,
-                OrganizationId = offer.Tenant.OrganizationId,
-                Slug           = offer.Tenant.Slug,
-                DisplayName    = offer.Tenant.DisplayName,
-                Origin         = offer.Tenant.Origin
-            };
-            // Polling may have rotated the org-less refresh token; the org-switch must use the
-            // current one (WorkOS invalidates the old on refresh) or the final switch would 401.
-            var authForSwitch = auth with { RefreshToken = tokens.CurrentRefreshToken ?? auth.RefreshToken };
-            return new(await SwitchAndSaveAsync(created, [created], authForSwitch, proxyConfig.WorkOSClientId!, orgSwitch, progress));
+            return await OfferCreateAsync(proxyConfig, auth, orgSwitch, orglessRefresh, provisioner, ct, progress);
         }
 
         var picked = result.Tenants.Length == 1 ? result.Tenants[0] : await picker.PickAsync(result.Tenants, ct);
         if (picked is null) {
-            progress.Error("No tenant selected.");
-
-            return new(1);
+            return Failed(progress, "No tenant selected.");
         }
 
-        return new(await SwitchAndSaveAsync(picked, result.Tenants, auth, proxyConfig.WorkOSClientId!, orgSwitch, progress));
+        return await SwitchAsync(picked, result.Tenants, auth, proxyConfig.WorkOSClientId!, orgSwitch, progress);
     }
 
-    // Org-switch into the chosen tenant, persist its profile + org-bound tokens.
-    // Shared by the picked-tenant path and the freshly-provisioned-tenant path.
-    static async Task<int> SwitchAndSaveAsync(
-            DiscoveredTenant                                picked,
-            DiscoveredTenant[]                               tenants,
-            WorkOSAuthResponse                               auth,
-            string                                           clientId,
-            Func<string, string, Task<WorkOSAuthResponse?>>  orgSwitch,
-            IAuthProgress                                    progress) {
-        if (string.IsNullOrEmpty(picked.OrganizationId)) {
-            progress.Error($"Tenant {picked.Label} is missing an organization id; cannot complete sign-in.");
+    static async Task<WorkOSDiscoveryFlow> OfferCreateAsync(
+            ProxyConfigResponse                                         proxyConfig,
+            WorkOSAuthResponse                                          auth,
+            Func<string, string, Task<WorkOSAuthResponse?>>             orgSwitch,
+            Func<string, CancellationToken, Task<WorkOSAuthResponse?>>? orglessRefresh,
+            ITenantProvisioner?                                         provisioner,
+            CancellationToken                                           ct,
+            IAuthProgress                                               progress) {
+        // Fires before the provisioner-null check below: a headless run (null provisioner,
+        // "ask your admin" dead-end) still reached the fork and must count as such — this is
+        // the denominator for "reached signup".
+        SetupFunnel.TenantNone(AuthProvider.WorkOS);
 
-            return 1;
+        if (provisioner is null) {
+            progress.Error("No Capacitor tenants are linked to your account. Ask your admin to invite you.");
+
+            return new WorkOSDiscoveryFlow.NoTenants();
+        }
+
+        // Provisioning + polling can run for minutes, outliving WorkOS's ~5-minute access-token
+        // TTL, so hand the provisioner a refreshing token source rather than the login-time token.
+        var tokens = new WorkOSTokenSource(
+            auth.AccessToken, auth.RefreshToken,
+            orglessRefresh ?? ((_, _) => Task.FromResult<WorkOSAuthResponse?>(null)));
+        var offer = await provisioner.OfferCreateAsync(tokens, ct);
+
+        if (offer.Status == ProvisionOfferStatus.ExistingWorkspace) {
+            // The user belongs to a workspace already and would rather point at it. Hand the
+            // input back unresolved (trimmed, nothing else): only the caller knows how a bare
+            // slug expands, and the target's own /auth/config — not this WorkOS lane — decides
+            // how to log in. Blank input would resolve to a nonsense host, so decline instead.
+            // Trimmed here as well as at the prompt because this interface is public.
+            var target = offer.ExistingWorkspaceInput?.Trim();
+
+            return string.IsNullOrEmpty(target)
+                ? new WorkOSDiscoveryFlow.Failed("No workspace named.")
+                : new WorkOSDiscoveryFlow.Retarget(target);
+        }
+
+        if (offer.Status != ProvisionOfferStatus.Created || offer.Tenant is null) {
+            // Declined / InProgress / Failed — the provisioner already printed the
+            // outcome-appropriate message; don't stack the legacy dead-end on top.
+            return new WorkOSDiscoveryFlow.Failed($"Workspace creation did not complete ({offer.Status}).");
+        }
+
+        var created = new DiscoveredTenant {
+            Provider       = AuthProvider.WorkOS,
+            OrganizationId = offer.Tenant.OrganizationId,
+            Slug           = offer.Tenant.Slug,
+            DisplayName    = offer.Tenant.DisplayName,
+            Origin         = offer.Tenant.Origin
+        };
+        // Polling may have rotated the org-less refresh token; the org-switch must use the
+        // current one (WorkOS invalidates the old on refresh) or the final switch would 401.
+        var authForSwitch = auth with { RefreshToken = tokens.CurrentRefreshToken ?? auth.RefreshToken };
+
+        return await SwitchAsync(created, [created], authForSwitch, proxyConfig.WorkOSClientId!, orgSwitch, progress);
+    }
+
+    // Org-switch into the chosen tenant. Shared by the picked-tenant path and the
+    // freshly-provisioned-tenant path; nothing durable is written here.
+    static async Task<WorkOSDiscoveryFlow> SwitchAsync(
+            DiscoveredTenant                                picked,
+            DiscoveredTenant[]                              tenants,
+            WorkOSAuthResponse                              auth,
+            string                                          clientId,
+            Func<string, string, Task<WorkOSAuthResponse?>> orgSwitch,
+            IAuthProgress                                   progress) {
+        if (string.IsNullOrEmpty(picked.OrganizationId)) {
+            return Failed(progress, $"Tenant {picked.Label} is missing an organization id; cannot complete sign-in.");
         }
 
         // Org-switch once into the chosen org. The resulting refresh token stays org-bound
         // (spike-confirmed), so later refreshes need no organization_id.
         var switched = await orgSwitch(auth.RefreshToken!, picked.OrganizationId);
         if (switched is null) {
-            progress.Error($"Could not switch to organization {picked.Label}.");
-
-            return 1;
+            return Failed(progress, $"Could not switch to organization {picked.Label}.");
         }
+
+        return new WorkOSDiscoveryFlow.Ready(tenants, picked, switched, clientId, OAuthLoginFlow.WorkOSDisplayName(auth.User));
+    }
+
+    /// <summary>Publishes a <see cref="WorkOSDiscoveryFlow.Ready"/> through the ordered commit boundary.</summary>
+    internal static async Task<AuthResult> PublishAsync(
+            WorkOSDiscoveryFlow.Ready                                   ready,
+            IAuthProgress                                               progress,
+            Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task>? beforeCommit,
+            CancellationToken                                           ct) {
+        var picked = ready.Picked;
 
         if (!ServerIdentity.TryCanonicalizeForStamping(picked.Origin, out var canonical, out var identityError)) {
             progress.Error($"Error: {identityError}");
 
-            return 1;
+            return new AuthResult.Failed(identityError);
         }
 
-        var username = OAuthLoginFlow.WorkOSDisplayName(auth.User);
+        var tokens = new StoredTokens {
+            AccessToken    = ready.SwitchedAuth.AccessToken,
+            RefreshToken   = ready.SwitchedAuth.RefreshToken,
+            ExpiresAt      = TokenStore.JwtExpiry(ready.SwitchedAuth.AccessToken),
+            GitHubUsername = ready.Username,
+            Provider       = AuthProvider.WorkOS,
+            ClientId       = ready.ClientId,
+            // The tenant's own origin: this token is org-scoped to the tenant we just switched
+            // into, and only that tenant's server will accept it.
+            ServerUrl      = canonical
+        };
 
-        await ConfigMutator.MutateAsync(c => TenantDiscovery.MergeProfiles(c, tenants, picked));
+        var request = new CommitRequest(
+            [new AuthIdentity(picked.ProfileName, canonical)], AuthProvider.WorkOS, picked.ProfileName, canonical,
+            ConfigMutation: config => TenantDiscovery.MergeProfiles(config, ready.Tenants, picked),
+            PublishTokens: async () => {
+                await TokenStore.SaveAsync(picked.ProfileName, tokens, CancellationToken.None);
 
-        await TokenStore.SaveAsync(
-            picked.ProfileName,
-            new StoredTokens {
-                AccessToken    = switched.AccessToken,
-                RefreshToken   = switched.RefreshToken,
-                ExpiresAt      = TokenStore.JwtExpiry(switched.AccessToken),
-                GitHubUsername = username,
-                Provider       = AuthProvider.WorkOS,
-                ClientId       = clientId,
-                // The tenant's own origin: this token is org-scoped to the tenant we just switched
-                // into, and only that tenant's server will accept it.
-                ServerUrl      = canonical
+                return ready.Username;
             });
 
-        progress.Notice($"Logged in as {username} → {picked.Label}");
+        var result = await CommitBoundary.CommitAsync(request, beforeCommit, progress, ct);
 
-        return 0;
+        if (result is AuthResult.Committed) progress.Notice($"Logged in as {ready.Username} → {picked.Label}");
+
+        return result;
+    }
+
+    static WorkOSDiscoveryFlow.Failed Failed(IAuthProgress progress, string message) {
+        progress.Error(message);
+
+        return new WorkOSDiscoveryFlow.Failed(message);
     }
 }

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -123,7 +123,7 @@ public static class WorkOSDiscovery {
             // are a sign-in failure.
             SetupFunnel.SigninFailed("workos_signin_failed");
 
-            return Failed(progress, "WorkOS sign-in failed.");
+            return Failed(progress, "WorkOS sign-in failed.", ct);
         }
 
         SetupFunnel.SigninCompleted(AuthProvider.WorkOS);
@@ -135,7 +135,7 @@ public static class WorkOSDiscovery {
                 DiscoveryError.TokenRejected    => "WorkOS rejected the authentication token. Please sign in again.",
                 DiscoveryError.UpstreamError    => "Kurrent auth service returned an error. Try again later.",
                 _                               => "Tenant discovery failed."
-            });
+            }, ct);
         }
 
         if (result.Tenants.Length == 0) {
@@ -274,8 +274,10 @@ public static class WorkOSDiscovery {
         return result;
     }
 
-    static WorkOSDiscoveryFlow.Failed Failed(IAuthProgress progress, string message) {
-        progress.Error(message);
+    // A live cancel suppresses the line: these two arms map an OperationCanceledException onto a
+    // transport failure the user never caused, and the façade answers Cancelled from the result.
+    static WorkOSDiscoveryFlow.Failed Failed(IAuthProgress progress, string message, CancellationToken ct = default) {
+        if (!ct.IsCancellationRequested) progress.Error(message);
 
         return new WorkOSDiscoveryFlow.Failed(message);
     }

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -30,20 +30,21 @@ public static class WorkOSDiscovery {
     /// </summary>
     public static Task<WorkOSDiscoveryOutcome> RunWithLiveAuthAsync(
             string proxyUrl, ProxyConfigResponse proxyConfig, IAuthProxyClient proxy, ITenantPicker picker,
-            ITenantProvisioner? provisioner = null) {
+            ITenantProvisioner? provisioner = null, CancellationToken ct = default) {
         var clientId = proxyConfig.WorkOSClientId ?? "";
 
         return RunAsync(proxyUrl, proxyConfig, proxy, picker,
-            orglessLogin: () => OAuthLoginFlow.AuthenticateWorkOSAsync(clientId, organizationId: null, new LoopbackBrowser()),
+            orglessLogin: () => OAuthLoginFlow.AuthenticateWorkOSAsync(clientId, organizationId: null, new LoopbackBrowser(), ct: ct),
             orgSwitch: async (refreshToken, organizationId) => {
                 using var http = new HttpClient();
-                return await OAuthLoginFlow.SwitchWorkOSOrgAsync(http, WorkOSApiBase, clientId, refreshToken, organizationId);
+                return await OAuthLoginFlow.SwitchWorkOSOrgAsync(http, WorkOSApiBase, clientId, refreshToken, organizationId, ct);
             },
-            orglessRefresh: async (refreshToken, _) => {
+            orglessRefresh: async (refreshToken, refreshCt) => {
                 using var http = new HttpClient();
-                return await OAuthLoginFlow.RefreshWorkOSTokenAsync(http, WorkOSApiBase, clientId, refreshToken);
+                return await OAuthLoginFlow.RefreshWorkOSTokenAsync(http, WorkOSApiBase, clientId, refreshToken, refreshCt);
             },
-            provisioner: provisioner);
+            provisioner: provisioner,
+            ct: ct);
     }
 
     public static async Task<WorkOSDiscoveryOutcome> RunAsync(
@@ -54,7 +55,8 @@ public static class WorkOSDiscovery {
             Func<Task<WorkOSAuthResponse?>>                 orglessLogin,
             Func<string, string, Task<WorkOSAuthResponse?>> orgSwitch,     // args: refreshToken, organizationId
             Func<string, CancellationToken, Task<WorkOSAuthResponse?>>? orglessRefresh = null, // args: refreshToken, ct
-            ITenantProvisioner?                             provisioner = null) {
+            ITenantProvisioner?                             provisioner = null,
+            CancellationToken                               ct = default) {
         if (string.IsNullOrEmpty(proxyConfig.WorkOSClientId)) {
             await Console.Error.WriteLineAsync("This server isn't configured for WorkOS sign-in.");
 
@@ -77,7 +79,7 @@ public static class WorkOSDiscovery {
 
         SetupFunnel.SigninCompleted(AuthProvider.WorkOS);
 
-        var result = await proxy.DiscoverWorkOSTenantsAsync(proxyUrl, auth.AccessToken);
+        var result = await proxy.DiscoverWorkOSTenantsAsync(proxyUrl, auth.AccessToken, ct);
         if (result.Error != DiscoveryError.None) {
             await Console.Error.WriteLineAsync(result.Error switch {
                 DiscoveryError.ProxyUnreachable => "The Kurrent auth service is unreachable.",
@@ -106,7 +108,7 @@ public static class WorkOSDiscovery {
             var tokens = new WorkOSTokenSource(
                 auth.AccessToken, auth.RefreshToken,
                 orglessRefresh ?? ((_, _) => Task.FromResult<WorkOSAuthResponse?>(null)));
-            var offer = await provisioner.OfferCreateAsync(tokens);
+            var offer = await provisioner.OfferCreateAsync(tokens, ct);
 
             if (offer.Status == ProvisionOfferStatus.ExistingWorkspace) {
                 // The user belongs to a workspace already and would rather point at it. Hand the
@@ -138,7 +140,7 @@ public static class WorkOSDiscovery {
             return new(await SwitchAndSaveAsync(created, [created], authForSwitch, proxyConfig.WorkOSClientId!, orgSwitch));
         }
 
-        var picked = result.Tenants.Length == 1 ? result.Tenants[0] : picker.Pick(result.Tenants);
+        var picked = result.Tenants.Length == 1 ? result.Tenants[0] : await picker.PickAsync(result.Tenants, ct);
         if (picked is null) {
             await Console.Error.WriteLineAsync("No tenant selected.");
 

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -30,11 +30,13 @@ public static class WorkOSDiscovery {
     /// </summary>
     public static Task<WorkOSDiscoveryOutcome> RunWithLiveAuthAsync(
             string proxyUrl, ProxyConfigResponse proxyConfig, IAuthProxyClient proxy, ITenantPicker picker,
-            ITenantProvisioner? provisioner = null, CancellationToken ct = default) {
+            ITenantProvisioner? provisioner = null, CancellationToken ct = default, IAuthProgress? progress = null) {
+        progress ??= ConsoleAuthProgress.Instance;
         var clientId = proxyConfig.WorkOSClientId ?? "";
 
         return RunAsync(proxyUrl, proxyConfig, proxy, picker,
-            orglessLogin: () => OAuthLoginFlow.AuthenticateWorkOSAsync(clientId, organizationId: null, new LoopbackBrowser(), ct: ct),
+            orglessLogin: () => OAuthLoginFlow.AuthenticateWorkOSAsync(
+                clientId, organizationId: null, new LoopbackBrowser(progress: progress), ct: ct, progress: progress),
             orgSwitch: async (refreshToken, organizationId) => {
                 using var http = new HttpClient();
                 return await OAuthLoginFlow.SwitchWorkOSOrgAsync(http, WorkOSApiBase, clientId, refreshToken, organizationId, ct);
@@ -44,7 +46,8 @@ public static class WorkOSDiscovery {
                 return await OAuthLoginFlow.RefreshWorkOSTokenAsync(http, WorkOSApiBase, clientId, refreshToken, refreshCt);
             },
             provisioner: provisioner,
-            ct: ct);
+            ct: ct,
+            progress: progress);
     }
 
     public static async Task<WorkOSDiscoveryOutcome> RunAsync(
@@ -56,9 +59,12 @@ public static class WorkOSDiscovery {
             Func<string, string, Task<WorkOSAuthResponse?>> orgSwitch,     // args: refreshToken, organizationId
             Func<string, CancellationToken, Task<WorkOSAuthResponse?>>? orglessRefresh = null, // args: refreshToken, ct
             ITenantProvisioner?                             provisioner = null,
-            CancellationToken                               ct = default) {
+            CancellationToken                               ct = default,
+            IAuthProgress?                                  progress = null) {
+        progress ??= ConsoleAuthProgress.Instance;
+
         if (string.IsNullOrEmpty(proxyConfig.WorkOSClientId)) {
-            await Console.Error.WriteLineAsync("This server isn't configured for WorkOS sign-in.");
+            progress.Error("This server isn't configured for WorkOS sign-in.");
 
             return new(1);
         }
@@ -72,7 +78,7 @@ public static class WorkOSDiscovery {
             // provisioning failures, and the deliberately-non-zero retarget path — none of which
             // are a sign-in failure.
             SetupFunnel.SigninFailed("workos_signin_failed");
-            await Console.Error.WriteLineAsync("WorkOS sign-in failed.");
+            progress.Error("WorkOS sign-in failed.");
 
             return new(1);
         }
@@ -81,7 +87,7 @@ public static class WorkOSDiscovery {
 
         var result = await proxy.DiscoverWorkOSTenantsAsync(proxyUrl, auth.AccessToken, ct);
         if (result.Error != DiscoveryError.None) {
-            await Console.Error.WriteLineAsync(result.Error switch {
+            progress.Error(result.Error switch {
                 DiscoveryError.ProxyUnreachable => "The Kurrent auth service is unreachable.",
                 DiscoveryError.TokenRejected    => "WorkOS rejected the authentication token. Please sign in again.",
                 DiscoveryError.UpstreamError    => "Kurrent auth service returned an error. Try again later.",
@@ -98,7 +104,7 @@ public static class WorkOSDiscovery {
             SetupFunnel.TenantNone(AuthProvider.WorkOS);
 
             if (provisioner is null) {
-                await Console.Error.WriteLineAsync("No Capacitor tenants are linked to your account. Ask your admin to invite you.");
+                progress.Error("No Capacitor tenants are linked to your account. Ask your admin to invite you.");
 
                 return new(1);
             }
@@ -137,29 +143,30 @@ public static class WorkOSDiscovery {
             // Polling may have rotated the org-less refresh token; the org-switch must use the
             // current one (WorkOS invalidates the old on refresh) or the final switch would 401.
             var authForSwitch = auth with { RefreshToken = tokens.CurrentRefreshToken ?? auth.RefreshToken };
-            return new(await SwitchAndSaveAsync(created, [created], authForSwitch, proxyConfig.WorkOSClientId!, orgSwitch));
+            return new(await SwitchAndSaveAsync(created, [created], authForSwitch, proxyConfig.WorkOSClientId!, orgSwitch, progress));
         }
 
         var picked = result.Tenants.Length == 1 ? result.Tenants[0] : await picker.PickAsync(result.Tenants, ct);
         if (picked is null) {
-            await Console.Error.WriteLineAsync("No tenant selected.");
+            progress.Error("No tenant selected.");
 
             return new(1);
         }
 
-        return new(await SwitchAndSaveAsync(picked, result.Tenants, auth, proxyConfig.WorkOSClientId!, orgSwitch));
+        return new(await SwitchAndSaveAsync(picked, result.Tenants, auth, proxyConfig.WorkOSClientId!, orgSwitch, progress));
     }
 
     // Org-switch into the chosen tenant, persist its profile + org-bound tokens.
     // Shared by the picked-tenant path and the freshly-provisioned-tenant path.
     static async Task<int> SwitchAndSaveAsync(
             DiscoveredTenant                                picked,
-            DiscoveredTenant[]                              tenants,
-            WorkOSAuthResponse                              auth,
-            string                                          clientId,
-            Func<string, string, Task<WorkOSAuthResponse?>> orgSwitch) {
+            DiscoveredTenant[]                               tenants,
+            WorkOSAuthResponse                               auth,
+            string                                           clientId,
+            Func<string, string, Task<WorkOSAuthResponse?>>  orgSwitch,
+            IAuthProgress                                    progress) {
         if (string.IsNullOrEmpty(picked.OrganizationId)) {
-            await Console.Error.WriteLineAsync($"Tenant {picked.Label} is missing an organization id; cannot complete sign-in.");
+            progress.Error($"Tenant {picked.Label} is missing an organization id; cannot complete sign-in.");
 
             return 1;
         }
@@ -168,13 +175,13 @@ public static class WorkOSDiscovery {
         // (spike-confirmed), so later refreshes need no organization_id.
         var switched = await orgSwitch(auth.RefreshToken!, picked.OrganizationId);
         if (switched is null) {
-            await Console.Error.WriteLineAsync($"Could not switch to organization {picked.Label}.");
+            progress.Error($"Could not switch to organization {picked.Label}.");
 
             return 1;
         }
 
         if (!ServerIdentity.TryCanonicalizeForStamping(picked.Origin, out var canonical, out var identityError)) {
-            await Console.Error.WriteLineAsync($"Error: {identityError}");
+            progress.Error($"Error: {identityError}");
 
             return 1;
         }
@@ -197,7 +204,7 @@ public static class WorkOSDiscovery {
                 ServerUrl      = canonical
             });
 
-        await Console.Out.WriteLineAsync($"Logged in as {username} → {picked.Label}");
+        progress.Notice($"Logged in as {username} → {picked.Label}");
 
         return 0;
     }

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -3,15 +3,6 @@ using Capacitor.Cli.Core.Telemetry;
 namespace Capacitor.Cli.Core.Auth;
 
 /// <summary>
-/// Outcome of a discovery run. <see cref="RetargetServerInput"/> is the slug or URL the user
-/// asked to use instead of creating a tenant, and is non-null only when they chose "I already
-/// have a workspace". <see cref="ExitCode"/> is deliberately non-zero in that case: a caller
-/// that does not implement re-targeting then fails visibly, instead of reporting success while
-/// having configured nothing.
-/// </summary>
-public sealed record WorkOSDiscoveryOutcome(int ExitCode, string? RetargetServerInput = null);
-
-/// <summary>
 /// What discovery established, up to but not including any durable write. <see cref="Ready"/>
 /// carries the org-switched auth for the picked (or freshly created) tenant.
 /// </summary>
@@ -40,61 +31,6 @@ public abstract record WorkOSDiscoveryFlow {
 /// production wiring passes <see cref="OAuthLoginFlow"/>'s loopback + switch helpers.
 /// </summary>
 public static class WorkOSDiscovery {
-    /// <summary>
-    /// <see cref="RunAsync"/> wired to the real WorkOS effects: an org-less loopback login on the
-    /// shared AuthKit app + a refresh-token org-switch (both public-client, no secret). The two call
-    /// sites (`kcap login --discover` and `kcap setup`) use this; tests call <see cref="RunAsync"/>
-    /// directly with fakes.
-    /// </summary>
-    public static Task<WorkOSDiscoveryOutcome> RunWithLiveAuthAsync(
-            string proxyUrl, ProxyConfigResponse proxyConfig, IAuthProxyClient proxy, ITenantPicker picker,
-            ITenantProvisioner? provisioner = null, CancellationToken ct = default, IAuthProgress? progress = null) {
-        progress ??= ConsoleAuthProgress.Instance;
-        var clientId = proxyConfig.WorkOSClientId ?? "";
-
-        return RunAsync(proxyUrl, proxyConfig, proxy, picker,
-            orglessLogin: () => OAuthLoginFlow.AuthenticateWorkOSAsync(
-                clientId, organizationId: null, new LoopbackBrowser(progress: progress), ct: ct, progress: progress),
-            orgSwitch: async (refreshToken, organizationId) => {
-                using var http = new HttpClient();
-                return await OAuthLoginFlow.SwitchWorkOSOrgAsync(
-                    http, OAuthLoginFlow.WorkOSApiBase, clientId, refreshToken, organizationId, ct);
-            },
-            orglessRefresh: async (refreshToken, refreshCt) => {
-                using var http = new HttpClient();
-                return await OAuthLoginFlow.RefreshWorkOSTokenAsync(
-                    http, OAuthLoginFlow.WorkOSApiBase, clientId, refreshToken, refreshCt);
-            },
-            provisioner: provisioner,
-            ct: ct,
-            progress: progress);
-    }
-
-    /// <summary>Discovery + publication for callers that want an exit code and no commit hook.</summary>
-    public static async Task<WorkOSDiscoveryOutcome> RunAsync(
-            string                                          proxyUrl,
-            ProxyConfigResponse                             proxyConfig,
-            IAuthProxyClient                                proxy,
-            ITenantPicker                                   picker,
-            Func<Task<WorkOSAuthResponse?>>                 orglessLogin,
-            Func<string, string, Task<WorkOSAuthResponse?>> orgSwitch,     // args: refreshToken, organizationId
-            Func<string, CancellationToken, Task<WorkOSAuthResponse?>>? orglessRefresh = null, // args: refreshToken, ct
-            ITenantProvisioner?                             provisioner = null,
-            CancellationToken                               ct = default,
-            IAuthProgress?                                  progress = null) {
-        progress ??= ConsoleAuthProgress.Instance;
-
-        var flow = await DiscoverAsync(
-            proxyUrl, proxyConfig, proxy, picker, orglessLogin, orgSwitch, orglessRefresh, provisioner, ct, progress);
-
-        return flow switch {
-            WorkOSDiscoveryFlow.Ready ready =>
-                new(await PublishAsync(ready, progress, beforeCommit: null, ct) is AuthResult.Committed ? 0 : 1),
-            WorkOSDiscoveryFlow.Retarget retarget => new(1, retarget.ServerInput),
-            _                                    => new(1)
-        };
-    }
-
     /// <summary>Everything up to the commit boundary: sign in, enumerate, pick (or create), org-switch.</summary>
     public static async Task<WorkOSDiscoveryFlow> DiscoverAsync(
             string                                          proxyUrl,

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -197,8 +197,9 @@ public static class WorkOSDiscovery {
         var request = new CommitRequest(
             [new AuthIdentity(picked.ProfileName, canonical)], AuthProvider.WorkOS, picked.ProfileName, canonical,
             ConfigMutation: config => TenantDiscovery.MergeProfiles(config, ready.Tenants, picked),
-            PublishTokens: async () => {
+            PublishTokens: async saved => {
                 await TokenStore.SaveAsync(picked.ProfileName, tokens, CancellationToken.None);
+                saved();
 
                 return ready.Username;
             });

--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -226,10 +226,11 @@ public static class AppConfig {
 
     /// <summary>The full set of accepted <c>default_visibility</c> values, server-agnostic
     /// (a server that gates Projects off simply treats <c>project</c> as owner-only).
-    /// Internal (not private) so other CLI-side surfaces that validate or offer this
-    /// value — e.g. <c>SetupCommand</c>'s <c>--default-visibility</c> flag and interactive
-    /// wizard choice list — can't drift out of sync with what config actually accepts.</summary>
-    internal static readonly string[] ValidVisibilities = ["private", "project", "org_public", "public"];
+    /// Public (not internal) so other surfaces that validate or offer this value — CLI-side
+    /// (e.g. <c>SetupCommand</c>'s <c>--default-visibility</c> flag and interactive wizard
+    /// choice list) and the desktop app, which has no <c>InternalsVisibleTo</c> grant into
+    /// this assembly — can't drift out of sync with what config actually accepts.</summary>
+    public static readonly string[] ValidVisibilities = ["private", "project", "org_public", "public"];
 
     /// <summary>
     /// Directly assigns <see cref="ResolvedServerUrl"/> and <see cref="ResolvedProfile"/>

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -439,6 +439,10 @@ public static class HttpClientExtensions {
         Console.Error.WriteLine(RenderUnreachableError(baseUrl, ex.Message));
     }
 
+    /// <summary>String-returning twin of <see cref="WriteUnreachableError"/>, for callers that route output through a progress sink instead of Console.</summary>
+    public static string UnreachableErrorText(string baseUrl, HttpRequestException ex) =>
+        RenderUnreachableError(baseUrl, ex.Message);
+
     /// <summary>
     /// Checks if the response is a 401 and prints the server's error message.
     /// Returns true if the response was a 401 (caller should return early).

--- a/src/Capacitor.Cli.Core/Telemetry/SetupFunnel.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/SetupFunnel.cs
@@ -53,7 +53,7 @@ public static class SetupFunnel {
     /// Terminal event for the "I already have a workspace" branch: the user was offered a new
     /// workspace and instead redirected setup at one they already have. Deliberately distinct
     /// from <see cref="WorkspaceDeclined"/> — this is not abandonment, setup continues against a
-    /// different server (see <c>WorkOSDiscoveryOutcome.RetargetServerInput</c>) and may still
+    /// different server (see <c>AuthResult.Retarget</c>) and may still
     /// reach <see cref="Succeeded"/>. Fires before any commitment to THIS offer (no
     /// <see cref="WorkspaceRequested"/> ever follows it), so it stays on the eager path.
     /// </summary>

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3232,7 +3232,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // Task.Run, not a bare discard — WaitAsync can complete synchronously on an uncontended
             // gate, which would otherwise run BuildStatusReport() (disk I/O) inline on this receive
             // loop while still holding BorrowedSnapshotGate.
-            _ = Task.Run(() => SendDaemonStatusReportOnceAsync());
+            _ = Task.Run(SendDaemonStatusReportOnceAsync);
 
             LogSendInputDelivered(agentId, agent.Runtime.Vendor, message.Length);
         } finally {

--- a/src/Capacitor.Cli/Commands/LoginCommand.cs
+++ b/src/Capacitor.Cli/Commands/LoginCommand.cs
@@ -1,0 +1,73 @@
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// `kcap login`: known-server sign-in, or (no configured server, or explicit <c>--discover</c>)
+/// tenant discovery — both driven through <see cref="OnboardingFacade"/>. Every login/discovery
+/// message is already rendered through the facade's <see cref="IAuthProgress"/> sink; this layer
+/// only maps the result to an exit code and, on the discover path, appends today's final line.
+/// </summary>
+public static class LoginCommand {
+    public static Task<int> HandleAsync(string[] args, string? baseUrl) =>
+        HandleAsync(args, baseUrl, NewFacade(), ConsoleAuthProgress.Instance);
+
+    internal static async Task<int> HandleAsync(
+            string[] args, string? baseUrl, OnboardingFacade facade, IAuthProgress progress) {
+        var forceDevice = args.Contains("--device");
+
+        // No configured server (or explicit --discover) → run tenant discovery (pick provider,
+        // then your tenants). Otherwise log into the configured server.
+        if (OAuthLoginFlow.ShouldDiscoverLogin(baseUrl, args)) {
+            return await HandleDiscoverAsync(facade, args, forceDevice, progress);
+        }
+
+        // `kcap login` never adopts a foreign profile onto the server it just signed into — see
+        // OnboardingFacade.LoginAsync's adoptServer doc.
+        var result = await facade.LoginAsync(baseUrl!, forceDevice, profile: null, CancellationToken.None, adoptServer: false);
+
+        return result is AuthResult.Committed ? 0 : 1;
+    }
+
+    static async Task<int> HandleDiscoverAsync(
+            OnboardingFacade facade, string[] args, bool forceDevice, IAuthProgress progress) {
+        // Before any network call: a non-interactive session has no discovery provider, so there
+        // is nothing to ask about (see OAuthLoginFlow.ChooseDiscoveryProvider).
+        var provider = OAuthLoginFlow.ChooseDiscoveryProvider(args, isInteractive: !HeadlessEnvironment.IsHeadless());
+
+        if (provider is null) {
+            await Console.Error.WriteLineAsync(OAuthLoginFlow.HeadlessDiscoveryUnsupportedMessage());
+
+            return 1;
+        }
+
+        var result = await facade.DiscoverAsync(provider, forceDevice, CancellationToken.None);
+
+        return MapDiscoverResult(result, progress);
+    }
+
+    /// <summary>
+    /// Committed → 0 (the GitHub path gets today's trailing "Active profile" line here; WorkOS
+    /// already printed its own "Logged in as … → …" inside the facade). Retarget → today's
+    /// "run kcap setup" hint + 1. Failed/Cancelled → 1 with nothing further — already rendered.
+    /// </summary>
+    internal static int MapDiscoverResult(AuthResult result, IAuthProgress progress) {
+        switch (result) {
+            case AuthResult.Committed committed:
+                if (committed.Provider != AuthProvider.WorkOS) {
+                    progress.Notice($"Logged in. Active profile: {committed.ActiveProfile}.");
+                }
+
+                return 0;
+            case AuthResult.Retarget retarget:
+                progress.Error($"Run `kcap setup {retarget.ServerInput}` to configure that workspace.");
+
+                return 1;
+            default:
+                return 1;
+        }
+    }
+
+    internal static OnboardingFacade NewFacade() =>
+        new(ConsoleAuthProgress.Instance, new SpectreTenantPicker(), provisioner: null, beforeCommit: null);
+}

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -839,27 +839,28 @@ public static class SetupCommand {
             : HeadlessEnvironment.IsHeadless() ? "device" : "browser";
         SetupFunnel.SigninOpened(signinMode, chosen);
 
-        // Offer inline tenant creation only in an interactive WorkOS session; headless setup keeps
-        // the legacy "ask your admin" dead-end (provisioner null). GitHub discovery never provisions.
+        // Headless WorkOS keeps the legacy "ask your admin" dead-end; GitHub never provisions.
         var provisioner = chosen == AuthProvider.WorkOS && !HeadlessEnvironment.IsHeadless()
             ? new SpectreTenantProvisioner(new TenantProvisioningClient(new HttpClient()), ProvisioningEndpoint.Url)
             : null;
 
         var result = await NewFacade(provisioner).DiscoverAsync(chosen, forceDevice, CancellationToken.None);
 
-        // WorkOS's own signin_completed/tenant_none fire from inside Core regardless of caller —
-        // only GitHub needs the adapter to derive them from the final result.
+        // WorkOS's own signin_completed/tenant_none fire from inside Core — only GitHub is derived here.
         if (chosen == AuthProvider.GitHubApp) {
             switch (result) {
                 case AuthResult.Failed { Reason: AuthFailureReason.SigninDenied }:
                     SetupFunnel.SigninFailed("github_token_denied");
 
                     break;
+                // Other and NoTenantsFound only occur once AcquireGitHubTokenAsync already succeeded.
                 case AuthResult.Committed:
+                case AuthResult.Failed { Reason: AuthFailureReason.Other }:
                     SetupFunnel.SigninCompleted(AuthProvider.GitHubApp);
 
                     break;
                 case AuthResult.Failed { Reason: AuthFailureReason.NoTenantsFound }:
+                    SetupFunnel.SigninCompleted(AuthProvider.GitHubApp);
                     SetupFunnel.TenantNone(AuthProvider.GitHubApp);
 
                     break;
@@ -877,8 +878,7 @@ public static class SetupCommand {
                     return null;
                 }
 
-                // WorkOS already reported "Logged in as … → …" through the façade's own progress
-                // sink; GitHub's multi-tenant commit has no such notice, so the adapter prints one.
+                // WorkOS already reported "Logged in as … → …" via the façade; GitHub gets its own line.
                 if (committed.Provider != AuthProvider.WorkOS) {
                     AnsiConsole.MarkupLine(
                         $"  [green]✓[/] Discovered {committed.Published.Count} tenant(s). Active: [cyan]{Markup.Escape(committed.ActiveProfile)}[/]");

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -20,10 +20,7 @@ using Profile = Capacitor.Cli.Core.Config.Profile;
 
 namespace Capacitor.Cli.Commands;
 
-/// <summary>
-/// Setup's step-scoped rendering of façade output: the façade emits flush lines, every other line a
-/// setup step prints is two-space indented, and setup still owns the guidance tail it used to append.
-/// </summary>
+/// <summary>Setup's step-scoped rendering of façade output: every non-flush line is two-space indented, and setup still owns the guidance tail.</summary>
 sealed class SetupAuthProgress(IAuthProgress inner) : IAuthProgress {
     internal const string UnreachableGuidance = "  Retry later, or pass --server-url <url>.";
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -20,6 +20,33 @@ using Profile = Capacitor.Cli.Core.Config.Profile;
 
 namespace Capacitor.Cli.Commands;
 
+/// <summary>
+/// Setup's step-scoped rendering of façade output: the façade emits flush lines, every other line a
+/// setup step prints is two-space indented, and setup still owns the guidance tail it used to append.
+/// </summary>
+sealed class SetupAuthProgress(IAuthProgress inner) : IAuthProgress {
+    internal const string UnreachableGuidance = "  Retry later, or pass --server-url <url>.";
+
+    public void Notice(string message) => inner.Notice(Indent(message));
+
+    public void Error(string message) => inner.Error(Indent(message));
+
+    public void BrowserOpening(string url) => inner.BrowserOpening(url);
+
+    public void DeviceCode(string code, string verificationUri) => inner.DeviceCode(code, verificationUri);
+
+    public void PollTick() => inner.PollTick();
+
+    /// <summary>Mapped off <see cref="AuthFailureReason"/>, never off the rendered text.</summary>
+    public void ReportFailure(AuthResult result) {
+        if (result is AuthResult.Failed { Reason: AuthFailureReason.Unreachable }) inner.Error(UnreachableGuidance);
+    }
+
+    // Blank separators and already-indented copy (the device-flow numbered list) pass through as-is.
+    internal static string Indent(string message) =>
+        string.IsNullOrWhiteSpace(message) || message.StartsWith(' ') ? message : $"  {message}";
+}
+
 public static class SetupCommand {
     public static async Task<int> HandleAsync(string[] args) {
         var serverUrlArg     = GetArg(args, "--server-url");
@@ -776,9 +803,11 @@ public static class SetupCommand {
     /// <summary>Test seam: overrides façade construction for Step 1/2. Reset to null in a finally block.</summary>
     internal static Func<ITenantProvisioner?, OnboardingFacade>? FacadeOverride;
 
+    internal static readonly SetupAuthProgress StepProgress = new(ConsoleAuthProgress.Instance);
+
     static OnboardingFacade NewFacade(ITenantProvisioner? provisioner) =>
         FacadeOverride?.Invoke(provisioner)
-            ?? new OnboardingFacade(ConsoleAuthProgress.Instance, new SpectreTenantPicker(), provisioner, beforeCommit: null);
+            ?? new OnboardingFacade(StepProgress, new SpectreTenantPicker(), provisioner, beforeCommit: null);
 
     /// <summary>
     /// Step 2 (Login) as a standalone step: a discovery-completed sign-in just reports what
@@ -895,7 +924,9 @@ public static class SetupCommand {
                 return retargeted is null ? null : (retargeted.Value.ServerUrl, retargeted.Value.Provider, false);
             }
             default:
-                // Failed/Cancelled — already rendered through the façade's progress sink.
+                // Failed/Cancelled — already rendered through the façade's progress sink, bar the tail setup owns.
+                StepProgress.ReportFailure(result);
+
                 return null;
         }
     }

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -782,9 +782,10 @@ public static class SetupCommand {
 
     /// <summary>
     /// Step 2 (Login) as a standalone step: a discovery-completed sign-in just reports what
-    /// discovery already published, a <c>None</c> provider needs no login, and everything else logs
-    /// into the known server via the façade — adopting it onto the active profile, since setup's
-    /// whole job is configuring that profile for the chosen server.
+    /// discovery already published; everything else — including a <c>None</c> provider, which needs
+    /// no interactive login but still needs its auth_provider stamp written inside the façade's
+    /// commit boundary — goes through the façade, adopting the server onto the active profile,
+    /// since setup's whole job is configuring that profile for the chosen server.
     /// </summary>
     internal static async Task<int> RunLoginStepAsync(
             bool loginComplete, string provider, string serverUrl, bool forceDevice, string activeProfile) {
@@ -796,12 +797,6 @@ public static class SetupCommand {
             return 0;
         }
 
-        if (provider == AuthProvider.None) {
-            await Console.Out.WriteLineAsync("  Auth provider is None — no login required.");
-
-            return 0;
-        }
-
         var result = await NewFacade(provisioner: null)
             .LoginAsync(serverUrl, forceDevice, activeProfile, CancellationToken.None, adoptServer: true);
 
@@ -809,6 +804,11 @@ public static class SetupCommand {
             await Console.Error.WriteLineAsync("  Login failed.");
 
             return 1;
+        }
+
+        if (provider == AuthProvider.None) {
+            // The façade's ConsoleAuthProgress already printed the "no authentication configured" notice.
+            return 0;
         }
 
         var loggedInTokens = await TokenStore.LoadAsync(activeProfile);

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -103,9 +103,8 @@ public static class SetupCommand {
         // Step 1: Server
         AnsiConsole.Write(new Rule("[yellow]Step 1/6 — Server[/]").LeftJustified());
         string serverUrl;
-        string? preAuthToken = null;
         string  provider;
-        bool    loginComplete = false; // WorkOS discovery authenticates inline; skip the Step-2 login.
+        bool    loginComplete = false; // Discovery authenticates inline; skip the Step-2 login.
 
         if (serverUrlArg is not null) {
             var resolved = await ResolveServerAndProviderAsync(serverUrlArg);
@@ -118,7 +117,7 @@ public static class SetupCommand {
         } else {
             var discovered = await RunDiscoveryAsync(args, forceDevice);
             if (discovered is null) return 1;
-            (serverUrl, preAuthToken, provider, loginComplete) = discovered.Value;
+            (serverUrl, provider, loginComplete) = discovered.Value;
 
             // Discovery activates the tenant you picked, so the profile captured before it ran is
             // now stale. Step 2 must save the token under the profile setup will actually
@@ -134,34 +133,8 @@ public static class SetupCommand {
         // Step 2: Login
         AnsiConsole.Write(new Rule("[yellow]Step 2/6 — Login[/]").LeftJustified());
 
-        if (loginComplete) {
-            // WorkOS discovery already authenticated + saved the active (picked) profile.
-            var cfgAfter = await AppConfig.LoadProfileConfig();
-            var tokens   = await TokenStore.LoadAsync(cfgAfter.ActiveProfile);
-            AnsiConsole.MarkupLine($"  [green]✓[/] Logged in as [cyan]{Markup.Escape(tokens?.GitHubUsername ?? "?")}[/]");
-        } else if (provider == AuthProvider.None) {
-            await Console.Out.WriteLineAsync("  Auth provider is None — no login required.");
-        } else if (preAuthToken is not null) {
-            var exchangeResult = await OAuthLoginFlow.ExchangeAndSaveAsync(serverUrl, preAuthToken, provider, activeProfile);
-            if (exchangeResult != 0) {
-                await Console.Error.WriteLineAsync("  Token exchange failed.");
-                return 1;
-            }
-            // Keep formatting consistent with the non-discovery branch
-            var tokens = await TokenStore.LoadAsync(activeProfile);
-            AnsiConsole.MarkupLine($"  [green]✓[/] Logged in as [cyan]{Markup.Escape(tokens?.GitHubUsername ?? "?")}[/]");
-        } else {
-            var loginResult = await OAuthLoginFlow.LoginWithDiscoveryAsync(serverUrl, forceDevice, activeProfile);
-
-            if (loginResult != 0) {
-                await Console.Error.WriteLineAsync("  Login failed.");
-
-                return 1;
-            }
-
-            var tokens = await TokenStore.LoadAsync(activeProfile);
-            await Console.Out.WriteLineAsync($"  ✓ Logged in as {tokens?.GitHubUsername}");
-        }
+        var loginStepResult = await RunLoginStepAsync(loginComplete, provider, serverUrl, forceDevice, activeProfile);
+        if (loginStepResult != 0) return loginStepResult;
 
         await Console.Out.WriteLineAsync();
 
@@ -800,7 +773,51 @@ public static class SetupCommand {
         }
     }
 
-    static async Task<(string ServerUrl, string? PreAuthToken, string Provider, bool LoginComplete)?> RunDiscoveryAsync(
+    /// <summary>Test seam: overrides façade construction for Step 1/2. Reset to null in a finally block.</summary>
+    internal static Func<ITenantProvisioner?, OnboardingFacade>? FacadeOverride;
+
+    static OnboardingFacade NewFacade(ITenantProvisioner? provisioner) =>
+        FacadeOverride?.Invoke(provisioner)
+            ?? new OnboardingFacade(ConsoleAuthProgress.Instance, new SpectreTenantPicker(), provisioner, beforeCommit: null);
+
+    /// <summary>
+    /// Step 2 (Login) as a standalone step: a discovery-completed sign-in just reports what
+    /// discovery already published, a <c>None</c> provider needs no login, and everything else logs
+    /// into the known server via the façade — adopting it onto the active profile, since setup's
+    /// whole job is configuring that profile for the chosen server.
+    /// </summary>
+    internal static async Task<int> RunLoginStepAsync(
+            bool loginComplete, string provider, string serverUrl, bool forceDevice, string activeProfile) {
+        if (loginComplete) {
+            var cfgAfter = await AppConfig.LoadProfileConfig();
+            var tokens   = await TokenStore.LoadAsync(cfgAfter.ActiveProfile);
+            AnsiConsole.MarkupLine($"  [green]✓[/] Logged in as [cyan]{Markup.Escape(tokens?.GitHubUsername ?? "?")}[/]");
+
+            return 0;
+        }
+
+        if (provider == AuthProvider.None) {
+            await Console.Out.WriteLineAsync("  Auth provider is None — no login required.");
+
+            return 0;
+        }
+
+        var result = await NewFacade(provisioner: null)
+            .LoginAsync(serverUrl, forceDevice, activeProfile, CancellationToken.None, adoptServer: true);
+
+        if (result is not AuthResult.Committed) {
+            await Console.Error.WriteLineAsync("  Login failed.");
+
+            return 1;
+        }
+
+        var loggedInTokens = await TokenStore.LoadAsync(activeProfile);
+        await Console.Out.WriteLineAsync($"  ✓ Logged in as {loggedInTokens?.GitHubUsername}");
+
+        return 0;
+    }
+
+    internal static async Task<(string ServerUrl, string Provider, bool LoginComplete)?> RunDiscoveryAsync(
             string[] args, bool forceDevice) {
         // Resolved before contacting the auth service: a non-interactive session has no discovery
         // provider at all, so there is nothing to ask the proxy about.
@@ -814,98 +831,73 @@ public static class SetupCommand {
 
         AnsiConsole.MarkupLine($"  Proxy: [dim]{Markup.Escape(AuthProxyEndpoint.Url)}[/]");
 
-        using var http  = new HttpClient();
-        var proxyClient = new AuthProxyClient(http);
-
-        var proxyConfig = await AnsiConsole.Status().Spinner(Spinner.Known.Dots).StartAsync("Contacting auth service…",
-            async _ => await proxyClient.GetConfigAsync(AuthProxyEndpoint.Url));
-        if (proxyConfig is null) {
-            AnsiConsole.MarkupLine("  [red]✗[/] Cannot reach the Kurrent auth service. Retry later, or pass --server-url <url>.");
-            return null;
-        }
-
-        var provider = chosen;
-        // WorkOS discovery always authenticates via a loopback browser (see
-        // WorkOSDiscovery.RunWithLiveAuthAsync's orglessLogin) — headless never switches it to a
-        // device flow the way GitHub App's AcquireGitHubTokenAsync does, so the label must not
+        // WorkOS discovery always authenticates via a loopback browser — headless never switches it
+        // to a device flow the way GitHub App's AcquireGitHubTokenAsync does, so the label must not
         // vary with headlessness for this provider.
-        var signinMode = provider == AuthProvider.WorkOS
+        var signinMode = chosen == AuthProvider.WorkOS
             ? "browser"
             : HeadlessEnvironment.IsHeadless() ? "device" : "browser";
-        SetupFunnel.SigninOpened(signinMode, provider);
+        SetupFunnel.SigninOpened(signinMode, chosen);
 
-        if (provider == AuthProvider.WorkOS) {
-            // Offer inline tenant creation only in an interactive session; headless
-            // setup keeps the legacy "ask your admin" dead-end (provisioner is null).
-            ITenantProvisioner? provisioner = HeadlessEnvironment.IsHeadless()
-                ? null
-                : new SpectreTenantProvisioner(new TenantProvisioningClient(new HttpClient()), ProvisioningEndpoint.Url);
+        // Offer inline tenant creation only in an interactive WorkOS session; headless setup keeps
+        // the legacy "ask your admin" dead-end (provisioner null). GitHub discovery never provisions.
+        var provisioner = chosen == AuthProvider.WorkOS && !HeadlessEnvironment.IsHeadless()
+            ? new SpectreTenantProvisioner(new TenantProvisioningClient(new HttpClient()), ProvisioningEndpoint.Url)
+            : null;
 
-            // Sign-in events fire inside WorkOSDiscovery.RunAsync itself, right after live auth
-            // succeeds/fails and before tenant enumeration begins — see the comment there for why
-            // anchoring on this call's return (ExitCode) would be wrong.
-            var workosDiscovery = await WorkOSDiscovery.RunWithLiveAuthAsync(
-                AuthProxyEndpoint.Url, proxyConfig, proxyClient, new SpectreTenantPicker(), provisioner);
+        var result = await NewFacade(provisioner).DiscoverAsync(chosen, forceDevice, CancellationToken.None);
 
-            // Checked before ExitCode, which is deliberately non-zero on a re-target. The user has
-            // no WorkOS tenant but does belong to a workspace, so continue setup against that
-            // server: its own /auth/config picks the provider, and Step 2 logs in normally. This is
-            // the path a GitHub-App workspace takes — WorkOS discovery can never return one.
-            if (workosDiscovery.RetargetServerInput is { } target) {
+        // WorkOS's own signin_completed/tenant_none fire from inside Core regardless of caller —
+        // only GitHub needs the adapter to derive them from the final result.
+        if (chosen == AuthProvider.GitHubApp) {
+            switch (result) {
+                case AuthResult.Failed { Reason: AuthFailureReason.SigninDenied }:
+                    SetupFunnel.SigninFailed("github_token_denied");
+
+                    break;
+                case AuthResult.Committed:
+                    SetupFunnel.SigninCompleted(AuthProvider.GitHubApp);
+
+                    break;
+                case AuthResult.Failed { Reason: AuthFailureReason.NoTenantsFound }:
+                    SetupFunnel.TenantNone(AuthProvider.GitHubApp);
+
+                    break;
+            }
+        }
+
+        switch (result) {
+            case AuthResult.Committed committed: {
+                var cfg    = await AppConfig.LoadProfileConfig();
+                var active = cfg.Profiles.GetValueOrDefault(cfg.ActiveProfile);
+
+                if (active?.ServerUrl is null) {
+                    AnsiConsole.MarkupLine("  [red]✗[/] Sign-in did not set an active profile.");
+
+                    return null;
+                }
+
+                // WorkOS already reported "Logged in as … → …" through the façade's own progress
+                // sink; GitHub's multi-tenant commit has no such notice, so the adapter prints one.
+                if (committed.Provider != AuthProvider.WorkOS) {
+                    AnsiConsole.MarkupLine(
+                        $"  [green]✓[/] Discovered {committed.Published.Count} tenant(s). Active: [cyan]{Markup.Escape(committed.ActiveProfile)}[/]");
+                }
+
+                return (active.ServerUrl, committed.Provider, true);
+            }
+            case AuthResult.Retarget retarget: {
                 // Origin first, then slug expansion: a pasted "acme.kcap.ai/sessions" must lose its
                 // path before ResolveTenantArg decides it already looks like a host.
                 var retargeted = await ResolveServerAndProviderAsync(
-                    ServerInput.ResolveTenantArg(ServerInput.ToServerOrigin(target)));
+                    ServerInput.ResolveTenantArg(ServerInput.ToServerOrigin(retarget.ServerInput)));
 
-                return retargeted is null
-                    ? null
-                    : (retargeted.Value.ServerUrl, null, retargeted.Value.Provider, false);
+                return retargeted is null ? null : (retargeted.Value.ServerUrl, retargeted.Value.Provider, false);
             }
-
-            if (workosDiscovery.ExitCode != 0) return null;
-
-            // WorkOSDiscovery saved + activated the picked profile; continue setup against it.
-            var cfg    = await AppConfig.LoadProfileConfig();
-            var active = cfg.Profiles.GetValueOrDefault(cfg.ActiveProfile);
-            if (active?.ServerUrl is null) {
-                AnsiConsole.MarkupLine("  [red]✗[/] WorkOS sign-in did not set an active profile.");
+            default:
+                // Failed/Cancelled — already rendered through the façade's progress sink.
                 return null;
-            }
-            return (active.ServerUrl, null, AuthProvider.WorkOS, true);
         }
-
-        if (string.IsNullOrEmpty(proxyConfig.GitHubClientId)) {
-            AnsiConsole.MarkupLine("  [red]✗[/] Cannot reach the Kurrent auth service. Retry later, or pass --server-url <url>.");
-            return null;
-        }
-
-        var ghToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(
-            proxyConfig.GitHubClientId, proxyConfig.GitHubCodeExchangeUrl, forceDevice);
-        if (ghToken is null) {
-            SetupFunnel.SigninFailed("github_token_denied");
-            return null;
-        }
-        SetupFunnel.SigninCompleted(AuthProvider.GitHubApp);
-
-        var discovery = new TenantDiscovery(proxyClient, new SpectreTenantPicker());
-        var outcome   = await discovery.RunAsync(AuthProxyEndpoint.Url, ghToken);
-
-        // Keyed on the discriminator, not outcome.Tenants.Length == 0: a proxy-unreachable,
-        // token-rejected, or upstream-error outcome ALSO returns zero tenants, and those are
-        // discovery-service failures, not "authenticated but has no tenant" — the funnel's
-        // denominator would otherwise be inflated with outages that never reached signup.
-        if (outcome.NoTenantsFound) SetupFunnel.TenantNone(AuthProvider.GitHubApp);
-
-        if (outcome.ErrorMessage is not null) {
-            AnsiConsole.MarkupLine($"  [red]✗[/] {Markup.Escape(outcome.ErrorMessage)}");
-            return null;
-        }
-
-        await ConfigMutator.MutateAsync(c => TenantDiscovery.MergeProfiles(c, outcome.Tenants, outcome.Picked!));
-
-        AnsiConsole.MarkupLine($"  [green]✓[/] Discovered {outcome.Tenants.Length} tenant(s). Active: [cyan]{Markup.Escape(outcome.Picked!.OrgLogin)}[/]");
-
-        return (AppConfig.NormalizeUrl(outcome.Picked.Origin), ghToken, AuthProvider.GitHubApp, false);
     }
 
     internal static string? ResolvePluginPath(string? overrideDir = null) {

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -27,7 +27,7 @@ public static class SetupCommand {
         // `kcap setup <tenant>`: a leading positional arg (bare slug or full URL) is treated as the
         // server, equivalent to --server-url. A bare single label expands to {slug}.kcap.ai.
         if (serverUrlArg is null && args.Length > 1 && !args[1].StartsWith('-'))
-            serverUrlArg = ResolveTenantArg(args[1]);
+            serverUrlArg = ServerInput.ResolveTenantArg(args[1]);
         var noPrompt         = args.Contains("--no-prompt");
         var forceDevice      = args.Contains("--device");
         var skipClaudeFlag   = args.Contains("--skip-claude-hooks");
@@ -766,7 +766,7 @@ public static class SetupCommand {
 
     /// <summary>
     /// Normalizes a user-supplied server (a full URL, or a bare slug already expanded by
-    /// <see cref="ResolveTenantArg"/>), probes it, and reads the auth provider from the server's
+    /// <see cref="ServerInput.ResolveTenantArg"/>), probes it, and reads the auth provider from the server's
     /// own <c>/auth/config</c>. Returns null after printing the reason. Shared by
     /// `kcap setup &lt;tenant&gt;` / --server-url and by the zero-tenant "I already have a
     /// workspace" path, so provider selection has exactly one implementation.
@@ -854,7 +854,8 @@ public static class SetupCommand {
             if (workosDiscovery.RetargetServerInput is { } target) {
                 // Origin first, then slug expansion: a pasted "acme.kcap.ai/sessions" must lose its
                 // path before ResolveTenantArg decides it already looks like a host.
-                var retargeted = await ResolveServerAndProviderAsync(ResolveTenantArg(ToServerOrigin(target)));
+                var retargeted = await ResolveServerAndProviderAsync(
+                    ServerInput.ResolveTenantArg(ServerInput.ToServerOrigin(target)));
 
                 return retargeted is null
                     ? null
@@ -1066,43 +1067,6 @@ public static class SetupCommand {
 
         return idx >= 0 && idx + 1 < args.Length ? args[idx + 1] : null;
     }
-
-    /// <summary>
-    /// Resolves a `kcap setup &lt;tenant&gt;` positional: a bare single label (no scheme/dot/port)
-    /// expands to <c>https://{slug}.kcap.ai</c>; anything that already looks like a URL, FQDN, or
-    /// host:port is returned unchanged for the normal --server-url path. Self-hosted servers should
-    /// pass a full URL.
-    /// </summary>
-    /// <summary>
-    /// Reduces a user-supplied server to its origin, dropping any path/query/fragment. Everything
-    /// downstream appends a fixed root path (<c>/auth/config</c>), so a pasted page URL would probe
-    /// the wrong endpoint and be reported unreachable. Applied to the zero-discovery
-    /// "I already have a workspace" input, which explicitly invites a paste; the pre-existing
-    /// <c>--server-url</c> / <c>&lt;tenant&gt;</c> arguments keep their current behaviour. A bare
-    /// slug passes through untouched for <see cref="ResolveTenantArg"/> to expand.
-    /// </summary>
-    internal static string ToServerOrigin(string input) {
-        var trimmed = input.Trim().TrimEnd('/');
-
-        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var absolute)
-         && (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps)) {
-            return absolute.GetLeftPart(UriPartial.Authority);
-        }
-
-        // Scheme-less: cut at the first path/query/fragment separator. A bracketed IPv6 literal
-        // ("[::1]:5108") must be skipped first or the scan would cut inside the address.
-        var bracketEnd = trimmed.StartsWith('[') ? trimmed.IndexOf(']') : -1;
-        var scanFrom   = bracketEnd > 0 ? bracketEnd + 1 : 0;
-        var cut        = trimmed.IndexOfAny(['/', '?', '#'], scanFrom);
-
-        return cut < 0 ? trimmed : trimmed[..cut].TrimEnd('/');
-    }
-
-    internal static string ResolveTenantArg(string arg) =>
-        arg.Contains("://") || arg.Contains('.') || arg.Contains(':')
-        || arg.Equals("localhost", StringComparison.OrdinalIgnoreCase) // bare loopback host, not a kcap.ai slug
-            ? arg
-            : $"https://{arg}.kcap.ai";
 
     static readonly JsonSerializerOptions WriteOpts = new() { WriteIndented = true };
 

--- a/src/Capacitor.Cli/Commands/SpectreTenantPicker.cs
+++ b/src/Capacitor.Cli/Commands/SpectreTenantPicker.cs
@@ -12,4 +12,8 @@ public class SpectreTenantPicker : ITenantPicker {
 
         return AnsiConsole.Prompt(prompt);
     }
+
+    // Spectre prompts are not cancellable and the CLI never cancels this path.
+    public Task<DiscoveredTenant?> PickAsync(DiscoveredTenant[] tenants, CancellationToken ct) =>
+        Task.FromResult<DiscoveredTenant?>(Pick(tenants));
 }

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -296,17 +296,8 @@ switch (command) {
 
         return await WhatsDoneCommand.HandleGenerateWhatsDone(baseUrl!, wdSessionId, wdVendor);
     }
-    case "login": {
-        var forceDevice = args.Contains("--device");
-
-        // No configured server (or explicit --discover) → run tenant discovery (pick provider,
-        // then your tenants). Otherwise log into the configured server.
-        if (OAuthLoginFlow.ShouldDiscoverLogin(baseUrl, args)) {
-            return await HandleDiscoverLoginAsync(forceDevice);
-        }
-
-        return await OAuthLoginFlow.LoginWithDiscoveryAsync(baseUrl!, forceDevice);
-    }
+    case "login":
+        return await LoginCommand.HandleAsync(args, baseUrl);
     case "logout": {
         await TokenStore.DeleteAsync();
         await Console.Out.WriteLineAsync("Logged out.");
@@ -835,85 +826,6 @@ static string? GetArg(string[] arguments, string flag) {
 
 string? ResolveSessionId(string[] args, int skipCount = 1, string[]? valueFlags = null) =>
     ArgParsing.ResolveSessionId(args, skipCount, valueFlags);
-
-async Task<int> HandleDiscoverLoginAsync(bool forceDevice) {
-    // Before the proxy call: a non-interactive session has no discovery provider, so there is
-    // nothing to ask about (see OAuthLoginFlow.ChooseDiscoveryProvider).
-    var provider = OAuthLoginFlow.ChooseDiscoveryProvider(args, isInteractive: !HeadlessEnvironment.IsHeadless());
-
-    if (provider is null) {
-        await Console.Error.WriteLineAsync(OAuthLoginFlow.HeadlessDiscoveryUnsupportedMessage());
-
-        return 1;
-    }
-
-    using var http  = new HttpClient();
-    var proxyClient = new AuthProxyClient(http);
-
-    var proxyConfig = await proxyClient.GetConfigAsync(AuthProxyEndpoint.Url);
-
-    if (proxyConfig is null) {
-        await Console.Error.WriteLineAsync("Cannot reach the Kurrent auth service.");
-
-        return 1;
-    }
-
-    if (provider == AuthProvider.WorkOS) {
-        var workosDiscovery = await WorkOSDiscovery.RunWithLiveAuthAsync(
-            AuthProxyEndpoint.Url, proxyConfig, proxyClient, new SpectreTenantPicker());
-
-        // Unreachable today: this call site passes no provisioner, so discovery dead-ends before it
-        // can offer the choice. Kept because RunWithLiveAuthAsync is shared — if login ever gains a
-        // provisioner, point at the command that can configure a workspace instead of failing mutely.
-        if (workosDiscovery.RetargetServerInput is { } target) {
-            await Console.Error.WriteLineAsync($"Run `kcap setup {target}` to configure that workspace.");
-        }
-
-        return workosDiscovery.ExitCode;
-    }
-
-    if (string.IsNullOrEmpty(proxyConfig.GitHubClientId)) {
-        await Console.Error.WriteLineAsync("Cannot reach the Kurrent auth service.");
-
-        return 1;
-    }
-
-    var ghToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(
-        proxyConfig.GitHubClientId, proxyConfig.GitHubCodeExchangeUrl, forceDevice);
-    if (ghToken is null) return 1;
-
-    var discovery = new TenantDiscovery(proxyClient, new SpectreTenantPicker());
-    var outcome   = await discovery.RunAsync(AuthProxyEndpoint.Url, ghToken);
-
-    if (outcome.ErrorMessage is not null) {
-        await Console.Error.WriteLineAsync(outcome.ErrorMessage);
-
-        return 1;
-    }
-
-    // Merge discovered tenants as profiles; the picked one becomes active
-    await ConfigMutator.MutateAsync(c => TenantDiscovery.MergeProfiles(c, outcome.Tenants, outcome.Picked!));
-
-    // Discovery flows only via the shared GitHub App proxy, so every discovered tenant
-    // uses the GitHubApp provider. If DiscoveredTenant ever gains a Provider field, read it here.
-
-    // Exchange tokens for every discovered tenant so switching profiles works immediately.
-    // One HttpClient shared across all per-tenant exchanges to avoid socket/port exhaustion.
-    var exchanges = outcome.Tenants.Select(async tenant => {
-        var origin = AppConfig.NormalizeUrl(tenant.Origin);
-        var exit = await OAuthLoginFlow.ExchangeAndSaveAsync(
-            http, origin, ghToken, AuthProvider.GitHubApp, tenant.OrgLogin);
-        if (exit != 0) {
-            await Console.Error.WriteLineAsync(
-                $"Warning: token exchange failed for {tenant.OrgLogin}. Run 'kcap login' after switching to that profile.");
-        }
-    });
-    await Task.WhenAll(exchanges);
-
-    await Console.Out.WriteLineAsync($"Logged in. Active profile: {outcome.Picked!.OrgLogin}.");
-
-    return 0;
-}
 
 async Task PrintUsage() {
     var text = EmbeddedResources.Load("help-usage.txt");

--- a/test/Capacitor.App.Tests.Unit/AgentsImportStepsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AgentsImportStepsTests.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Threading.Tasks;
+using System.Runtime.Versioning;
 using Avalonia.Controls;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -26,6 +27,7 @@ static class VendorDetection {
 /// terminal PATH when the probe resolves one. Pure static helper — no AvaloniaSession needed.
 public class AgentDetectionFeedTests {
     [Test]
+    [UnsupportedOSPlatform("windows")]
     public async Task Uses_the_probed_terminal_PATH_not_the_process_PATH() {
         Skip.When(OperatingSystem.IsWindows(), "chmod-based executable probe is POSIX-only.");
 

--- a/test/Capacitor.App.Tests.Unit/AgentsImportStepsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AgentsImportStepsTests.cs
@@ -1,0 +1,579 @@
+using System.Reactive.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.App.Views.Onboarding;
+using Capacitor.Cli.Core.Setup;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Shared vendor-detection fixture builder for the Agents/Import step tests below.
+static class VendorDetection {
+    public static AgentDetectionResult Build(params string[] detected) {
+        DetectedAgent Agent(string label) => new(detected.Contains(label), false);
+
+        return new(
+            Claude: Agent("claude"), Codex: Agent("codex"), Cursor: Agent("cursor"), Copilot: Agent("copilot"),
+            Gemini: Agent("gemini"), Kiro: Agent("kiro"), Pi: Agent("pi"), OpenCode: Agent("opencode"),
+            Antigravity: Agent("antigravity"));
+    }
+}
+
+/// spec §8/decision 8: the app's detection feed overrides the process PATH with the login-shell
+/// terminal PATH when the probe resolves one. Pure static helper — no AvaloniaSession needed.
+public class AgentDetectionFeedTests {
+    [Test]
+    public async Task Uses_the_probed_terminal_PATH_not_the_process_PATH() {
+        Skip.When(OperatingSystem.IsWindows(), "chmod-based executable probe is POSIX-only.");
+
+        var emptyDir  = Directory.CreateTempSubdirectory("kcap-agents-empty-").FullName;
+        var claudeDir = Directory.CreateTempSubdirectory("kcap-agents-claude-").FullName;
+        var claudeBin = Path.Combine(claudeDir, "claude");
+        await File.WriteAllTextAsync(claudeBin, "#!/bin/sh\n");
+        File.SetUnixFileMode(claudeBin, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        try {
+            // Same probe, two different crafted PATHs: the outcome must track the probe, not
+            // whatever the real process PATH happens to contain on this machine.
+            var probe = new FakeLoginShellProbe { TerminalPathBehavior = _ => Task.FromResult<string?>(emptyDir) };
+            var withoutClaude = await AgentsStepViewModel.BuildDetectionFeed(probe)(CancellationToken.None);
+
+            probe.TerminalPathBehavior = _ => Task.FromResult<string?>(claudeDir);
+            var withClaude = await AgentsStepViewModel.BuildDetectionFeed(probe)(CancellationToken.None);
+
+            await Assert.That(withoutClaude.Claude.Detected).IsFalse();
+            await Assert.That(withClaude.Claude.Detected).IsTrue();
+        } finally {
+            Directory.Delete(emptyDir, recursive: true);
+            Directory.Delete(claudeDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Falls_back_to_the_process_PATH_when_the_probe_is_inconclusive() {
+        var probe = new FakeLoginShellProbe { TerminalPathBehavior = _ => Task.FromResult<string?>(null) };
+
+        var actual   = await AgentsStepViewModel.BuildDetectionFeed(probe)(CancellationToken.None);
+        var expected = AgentDetection.Detect(AgentDetection.FromEnvironment());
+
+        await Assert.That(actual).IsEqualTo(expected);
+    }
+}
+
+/// spec §3 step 5 / decision 8. Owns ReactiveCommands (per-row Retry + Install), so every test
+/// runs through the real headless session like ShimStepViewModel/SignInStepViewModel.
+public class AgentsStepViewModelTests {
+    sealed class Harness {
+        public readonly FakeKcapCli Cli = new();
+        public readonly AgentDetectionResult Detected;
+        public int DetectCallCount;
+        public readonly AgentsStepViewModel Vm;
+
+        public Harness(AgentDetectionResult? detected = null) {
+            Detected = detected ?? VendorDetection.Build();
+            Vm = new AgentsStepViewModel(Cli, ct => {
+                DetectCallCount++;
+                return Task.FromResult(Detected);
+            });
+        }
+
+        public AgentVendorRow Row(string label) => Vm.Rows.First(r => r.Label == label);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task OnEnterAsync_pre_checks_detected_vendors_only() {
+        var (claude, codex, cursor) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness(VendorDetection.Build("claude", "cursor"));
+            await h.Vm.OnEnterAsync(CancellationToken.None);
+
+            return (h.Row("Claude Code").IsSelected, h.Row("Codex").IsSelected, h.Row("Cursor").IsSelected);
+        });
+
+        await Assert.That(claude).IsTrue();
+        await Assert.That(codex).IsFalse();
+        await Assert.That(cursor).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task OnEnterAsync_detects_once_and_caches_across_repeated_entries() {
+        var calls = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            await h.Vm.OnEnterAsync(CancellationToken.None);
+            await h.Vm.OnEnterAsync(CancellationToken.None);
+
+            return h.DetectCallCount;
+        });
+
+        await Assert.That(calls).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Install_runs_selected_vendors_sequentially_Claude_first_then_flag_order() {
+        var calls = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            // Selection order is deliberately scrambled — the RUN order must follow the vendor
+            // list (Claude first), not click order.
+            h.Row("Cursor").IsSelected      = true;
+            h.Row("Claude Code").IsSelected = true;
+            h.Row("Gemini").IsSelected      = true;
+
+            await h.Vm.InstallCommand.Execute().ToTask();
+
+            return h.Cli.PluginInstallCalls.ToList();
+        });
+
+        await Assert.That(calls).IsEquivalentTo([null, "--cursor", "--gemini"], CollectionOrdering.Matching);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_failed_vendor_does_not_block_the_next_one_successes_stand() {
+        var (codexStatus, cursorStatus, callCount) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Row("Codex").IsSelected  = true;
+            h.Row("Cursor").IsSelected = true;
+            h.Cli.PluginInstallBehavior = (flag, _) => Task.FromResult(
+                flag == "--codex" ? new ProcessResult(1, "", "boom", false) : new ProcessResult(0, "", "", false));
+
+            await h.Vm.InstallCommand.Execute().ToTask();
+
+            return (h.Row("Codex").Status, h.Row("Cursor").Status, h.Cli.PluginInstallCallCount);
+        });
+
+        await Assert.That(codexStatus).IsEqualTo(AgentInstallStatus.Failed);
+        await Assert.That(cursorStatus).IsEqualTo(AgentInstallStatus.Succeeded);
+        await Assert.That(callCount).IsEqualTo(2);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_exception_during_install_marks_the_row_failed_with_the_message() {
+        var (status, message) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Row("Kiro").IsSelected = true;
+            h.Cli.PluginInstallBehavior = (_, _) => throw new InvalidOperationException("spawn failed");
+
+            await h.Vm.InstallCommand.Execute().ToTask();
+
+            return (h.Row("Kiro").Status, h.Row("Kiro").Message);
+        });
+
+        await Assert.That(status).IsEqualTo(AgentInstallStatus.Failed);
+        await Assert.That(message).IsEqualTo("spawn failed");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Retry_only_reinstalls_the_one_row_the_other_success_stands() {
+        var (codexStatus, cursorStatus, callCount) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Row("Codex").IsSelected  = true;
+            h.Row("Cursor").IsSelected = true;
+            h.Cli.PluginInstallBehavior = (flag, _) => Task.FromResult(
+                flag == "--codex" ? new ProcessResult(1, "", "boom", false) : new ProcessResult(0, "", "", false));
+            await h.Vm.InstallCommand.Execute().ToTask();
+
+            h.Cli.PluginInstallBehavior = (_, _) => Task.FromResult(new ProcessResult(0, "", "", false));
+            await h.Row("Codex").RetryCommand.Execute().ToTask();
+
+            return (h.Row("Codex").Status, h.Row("Cursor").Status, h.Cli.PluginInstallCallCount);
+        });
+
+        await Assert.That(codexStatus).IsEqualTo(AgentInstallStatus.Succeeded);
+        await Assert.That(cursorStatus).IsEqualTo(AgentInstallStatus.Succeeded);
+        await Assert.That(callCount).IsEqualTo(3); // 2 initial + 1 retry
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Satisfied_requires_every_selected_vendor_to_succeed_and_at_least_one_selected() {
+        var (noneSelected, oneFails, allSucceed) = await AvaloniaSession.DispatchAsync(async () => {
+            var h1 = new Harness();
+            await h1.Vm.InstallCommand.Execute().ToTask();
+
+            var h2 = new Harness();
+            h2.Row("Codex").IsSelected  = true;
+            h2.Row("Cursor").IsSelected = true;
+            h2.Cli.PluginInstallBehavior = (flag, _) => Task.FromResult(
+                flag == "--codex" ? new ProcessResult(1, "", "", false) : new ProcessResult(0, "", "", false));
+            await h2.Vm.InstallCommand.Execute().ToTask();
+
+            var h3 = new Harness();
+            h3.Row("Codex").IsSelected  = true;
+            h3.Row("Cursor").IsSelected = true;
+            await h3.Vm.InstallCommand.Execute().ToTask();
+
+            return (h1.Vm.Satisfied, h2.Vm.Satisfied, h3.Vm.Satisfied);
+        });
+
+        await Assert.That(noneSelected).IsFalse();
+        await Assert.That(oneFails).IsFalse();
+        await Assert.That(allSucceed).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task No_CLI_shows_the_message_and_never_calls_install() {
+        var (message, cliAvailable, callCount) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Cli.CliPath = null;
+            h.Row("Claude Code").IsSelected = true;
+
+            await h.Vm.RunInstallAsync();
+
+            return (h.Vm.Message, h.Vm.CliAvailable, h.Cli.PluginInstallCallCount);
+        });
+
+        await Assert.That(message).IsEqualTo("kcap CLI not found");
+        await Assert.That(cliAvailable).IsFalse();
+        await Assert.That(callCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task CanLeaveAsync_awaits_an_in_flight_install_and_never_vetoes() {
+        var (held, canLeave, status) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
+            var gate = new TaskCompletionSource<ProcessResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            h.Cli.PluginInstallBehavior = (_, _) => gate.Task;
+
+            var install = h.Vm.RunInstallAsync();
+            var leaving = h.Vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+            var held    = !leaving.IsCompleted; // proves it is genuinely waiting, not a fire-and-forget kill
+
+            gate.SetResult(new ProcessResult(0, "", "", false));
+            var canLeave = await leaving;
+            await install;
+
+            return (held, canLeave, h.Row("Claude Code").Status);
+        });
+
+        await Assert.That(held).IsTrue();
+        await Assert.That(canLeave).IsTrue();
+        await Assert.That(status).IsEqualTo(AgentInstallStatus.Succeeded);
+    }
+}
+
+/// spec §3 step 6 / decision 6. Owns ReactiveCommands too, so also runs through the real headless
+/// session.
+public class ImportStepViewModelTests {
+    sealed class Harness {
+        public readonly FakeKcapCli Cli = new();
+        public readonly AgentDetectionResult Detected;
+        public readonly ImportStepViewModel Vm;
+
+        public Harness(AgentDetectionResult? detected = null) {
+            Detected = detected ?? VendorDetection.Build();
+            Vm = new ImportStepViewModel(Cli, ct => Task.FromResult(Detected), action => action());
+        }
+
+        public ImportVendorRow Row(string label) => Vm.Vendors.First(r => r.Label == label);
+    }
+
+    static bool CanExecute<TParam, TResult>(ReactiveUI.ReactiveCommand<TParam, TResult> command) {
+        var value = false;
+        using var subscription = command.CanExecute.Subscribe(v => value = v); // replayed on subscribe
+        return value;
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task OnEnterAsync_pre_checks_detected_vendors_only() {
+        var (claude, codex) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness(VendorDetection.Build("claude"));
+            await h.Vm.OnEnterAsync(CancellationToken.None);
+
+            return (h.Row("Claude Code").IsSelected, h.Row("Codex").IsSelected);
+        });
+
+        await Assert.That(claude).IsTrue();
+        await Assert.That(codex).IsFalse();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Run_is_disabled_until_the_scoped_text_field_is_filled_in() {
+        var (everythingOk, orgBlank, orgFilled, repoBlank, repoFilled) = await AvaloniaSession.DispatchAsync(() => {
+            var h = new Harness();
+
+            var everythingOk = CanExecute(h.Vm.RunCommand); // default scope
+
+            h.Vm.Scope = ImportScopeChoice.Org;
+            var orgBlank = CanExecute(h.Vm.RunCommand);
+            h.Vm.OrgText = "acme";
+            var orgFilled = CanExecute(h.Vm.RunCommand);
+
+            h.Vm.Scope = ImportScopeChoice.Repo;
+            var repoBlank = CanExecute(h.Vm.RunCommand);
+            h.Vm.RepoText = "acme/widgets";
+            var repoFilled = CanExecute(h.Vm.RunCommand);
+
+            return (everythingOk, orgBlank, orgFilled, repoBlank, repoFilled);
+        });
+
+        await Assert.That(everythingOk).IsTrue();
+        await Assert.That(orgBlank).IsFalse();
+        await Assert.That(orgFilled).IsTrue();
+        await Assert.That(repoBlank).IsFalse();
+        await Assert.That(repoFilled).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Everything_scope_argv_carries_only_the_selected_vendor_flags() {
+        var request = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
+            h.Row("Codex").IsSelected       = true;
+
+            await h.Vm.RunCommand.Execute().ToTask();
+
+            return h.Cli.ImportRequests.Single();
+        });
+
+        await Assert.That(request.Scope).IsEqualTo(ImportScopeChoice.Everything);
+        await Assert.That(request.OrgOrRepo).IsNull();
+        await Assert.That(request.VendorFlags).IsEquivalentTo(["--claude", "--codex"], CollectionOrdering.Matching);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Org_scope_argv_carries_the_org_text() {
+        var request = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Vm.Scope   = ImportScopeChoice.Org;
+            h.Vm.OrgText = "acme";
+
+            await h.Vm.RunCommand.Execute().ToTask();
+
+            return h.Cli.ImportRequests.Single();
+        });
+
+        await Assert.That(request.Scope).IsEqualTo(ImportScopeChoice.Org);
+        await Assert.That(request.OrgOrRepo).IsEqualTo("acme");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Repo_scope_argv_carries_the_owner_slash_name_text() {
+        var request = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Vm.Scope    = ImportScopeChoice.Repo;
+            h.Vm.RepoText = "acme/widgets";
+
+            await h.Vm.RunCommand.Execute().ToTask();
+
+            return h.Cli.ImportRequests.Single();
+        });
+
+        await Assert.That(request.Scope).IsEqualTo(ImportScopeChoice.Repo);
+        await Assert.That(request.OrgOrRepo).IsEqualTo("acme/widgets");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Log_is_bounded_to_500_lines_with_a_drop_notice_once_truncation_starts() {
+        var (count, truncated, first, last) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Cli.ImportBehavior = (_, onLine, _) => {
+                for (var i = 1; i <= 510; i++) onLine(new StreamedLine(ProcessStreamKind.Stdout, $"line {i}"));
+
+                return Task.FromResult(new StreamingResult(0, false, []));
+            };
+
+            await h.Vm.RunCommand.Execute().ToTask();
+
+            return (h.Vm.Log.Count, h.Vm.Truncated, h.Vm.Log[0], h.Vm.Log[^1]);
+        });
+
+        await Assert.That(count).IsEqualTo(500);
+        await Assert.That(truncated).IsTrue();
+        await Assert.That(first).IsEqualTo("line 11"); // the first 10 of 510 fell off the bounded tail
+        await Assert.That(last).IsEqualTo("line 510");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Completion_appends_the_retry_hint_on_success() {
+        var status = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Cli.ImportBehavior = (_, _, _) => Task.FromResult(new StreamingResult(0, false, []));
+
+            await h.Vm.RunCommand.Execute().ToTask();
+
+            return h.Vm.Status;
+        });
+
+        await Assert.That(status).Contains(ImportStepViewModel.RetryHint);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Completion_appends_the_retry_hint_on_failure_too() {
+        var status = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Cli.ImportBehavior = (_, _, _) => Task.FromResult(new StreamingResult(1, false, []));
+
+            await h.Vm.RunCommand.Execute().ToTask();
+
+            return h.Vm.Status;
+        });
+
+        await Assert.That(status).Contains(ImportStepViewModel.RetryHint);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_failed_run_never_blocks_leaving() {
+        var canLeave = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Cli.ImportBehavior = (_, _, _) => Task.FromResult(new StreamingResult(1, false, []));
+            await h.Vm.RunCommand.Execute().ToTask();
+
+            return await h.Vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+        });
+
+        await Assert.That(canLeave).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Cancel_button_stops_the_run_and_reports_cancellation_without_the_retry_hint() {
+        var status = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            var started = new TaskCompletionSource();
+            h.Cli.ImportBehavior = async (_, _, ct) => {
+                started.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct);
+
+                return new StreamingResult(0, false, []);
+            };
+
+            var run = h.Vm.RunAsync();
+            await started.Task;
+            await h.Vm.CancelCommand.Execute().ToTask();
+            await run;
+
+            return h.Vm.Status;
+        });
+
+        await Assert.That(status).IsEqualTo("Import cancelled.");
+        await Assert.That(status).DoesNotContain(ImportStepViewModel.RetryHint);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task CanLeaveAsync_kills_a_running_import_and_never_vetoes() {
+        var (canLeave, status) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            var started = new TaskCompletionSource();
+            h.Cli.ImportBehavior = async (_, _, ct) => {
+                started.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct);
+
+                return new StreamingResult(0, false, []);
+            };
+
+            var run = h.Vm.RunAsync();
+            await started.Task;
+
+            var canLeave = await h.Vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+            await run;
+
+            return (canLeave, h.Vm.Status);
+        });
+
+        await Assert.That(canLeave).IsTrue();
+        await Assert.That(status).IsEqualTo("Import cancelled.");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task No_CLI_shows_the_message_and_never_calls_import() {
+        var (message, cliAvailable, callCount) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Cli.CliPath = null;
+
+            await h.Vm.RunAsync();
+
+            return (h.Vm.Message, h.Vm.CliAvailable, h.Cli.ImportCallCount);
+        });
+
+        await Assert.That(message).IsEqualTo("kcap CLI not found");
+        await Assert.That(cliAvailable).IsFalse();
+        await Assert.That(callCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Satisfied_only_after_a_run_completes_with_exit_zero() {
+        var (afterFailure, afterSuccess) = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Cli.ImportBehavior = (_, _, _) => Task.FromResult(new StreamingResult(1, false, []));
+            await h.Vm.RunCommand.Execute().ToTask();
+            var afterFailure = h.Vm.Satisfied;
+
+            h.Cli.ImportBehavior = (_, _, _) => Task.FromResult(new StreamingResult(0, false, []));
+            await h.Vm.RunCommand.Execute().ToTask();
+            var afterSuccess = h.Vm.Satisfied;
+
+            return (afterFailure, afterSuccess);
+        });
+
+        await Assert.That(afterFailure).IsFalse();
+        await Assert.That(afterSuccess).IsTrue();
+    }
+}
+
+/// Template smoke coverage, mirroring WizardSimpleStepsTests: named controls per template, wired
+/// through the real window and a real navigation from Agents into Import.
+public class AgentsImportTemplateTests {
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_window_selects_a_template_for_Agents_and_Import_steps() {
+        var result = await AvaloniaSession.DispatchAsync(async () => {
+            var cli    = new FakeKcapCli();
+            var detect = new Func<CancellationToken, Task<AgentDetectionResult>>(_ => Task.FromResult(VendorDetection.Build("claude")));
+
+            var agents = new AgentsStepViewModel(cli, detect);
+            var import = new ImportStepViewModel(cli, detect, action => action());
+            var done   = new DoneStepViewModel(() => []);
+
+            var vm = new OnboardingViewModel([agents, import, done]);
+            await vm.PendingEnterForTesting;
+
+            var window = new OnboardingWindow { DataContext = vm };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var installButton   = window.GetVisualDescendants().OfType<Button>().FirstOrDefault(b => b.Name == "InstallAgentsButton");
+            var agentCheckBoxes = window.GetVisualDescendants().OfType<CheckBox>().Where(c => c.Name == "AgentCheckBox").ToList();
+
+            await vm.NextCommand.Execute().ToTask(); // Agents -> Import
+            Dispatcher.UIThread.RunJobs();
+
+            var runButton        = window.GetVisualDescendants().OfType<Button>().FirstOrDefault(b => b.Name == "RunImportButton");
+            var everythingChoice = window.GetVisualDescendants().OfType<RadioButton>().FirstOrDefault(r => r.Name == "EverythingChoice");
+            var vendorCheckBoxes = window.GetVisualDescendants().OfType<CheckBox>().Where(c => c.Name == "ImportVendorCheckBox").ToList();
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return (installButton, AgentRows: agentCheckBoxes.Count, runButton, everythingChoice, ImportRows: vendorCheckBoxes.Count);
+        });
+
+        await Assert.That(result.installButton).IsNotNull();
+        await Assert.That(result.AgentRows).IsEqualTo(9);
+        await Assert.That(result.runButton).IsNotNull();
+        await Assert.That(result.everythingChoice).IsNotNull();
+        await Assert.That(result.everythingChoice!.IsChecked).IsTrue();
+        await Assert.That(result.ImportRows).IsEqualTo(9);
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/AgentsImportStepsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AgentsImportStepsTests.cs
@@ -171,7 +171,7 @@ public class AgentsStepViewModelTests {
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Retry_only_reinstalls_the_one_row_the_other_success_stands() {
-        var (codexStatus, cursorStatus, callCount) = await AvaloniaSession.DispatchAsync(async () => {
+        var (codexStatus, cursorStatus, callCount, satisfied) = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
             h.Row("Codex").IsSelected  = true;
             h.Row("Cursor").IsSelected = true;
@@ -182,12 +182,13 @@ public class AgentsStepViewModelTests {
             h.Cli.PluginInstallBehavior = (_, _) => Task.FromResult(new ProcessResult(0, "", "", false));
             await h.Row("Codex").RetryCommand.Execute().ToTask();
 
-            return (h.Row("Codex").Status, h.Row("Cursor").Status, h.Cli.PluginInstallCallCount);
+            return (h.Row("Codex").Status, h.Row("Cursor").Status, h.Cli.PluginInstallCallCount, h.Vm.Satisfied);
         });
 
         await Assert.That(codexStatus).IsEqualTo(AgentInstallStatus.Succeeded);
         await Assert.That(cursorStatus).IsEqualTo(AgentInstallStatus.Succeeded);
         await Assert.That(callCount).IsEqualTo(3); // 2 initial + 1 retry
+        await Assert.That(satisfied).IsTrue(); // the retried row flipping green makes every selected row green
     }
 
     [Test]
@@ -302,6 +303,7 @@ public class ImportStepViewModelTests {
     public async Task Run_is_disabled_until_the_scoped_text_field_is_filled_in() {
         var (everythingOk, orgBlank, orgFilled, repoBlank, repoFilled) = await AvaloniaSession.DispatchAsync(() => {
             var h = new Harness();
+            h.Row("Claude Code").IsSelected = true; // isolates the scope gate from the vendor-selection gate
 
             var everythingOk = CanExecute(h.Vm.RunCommand); // default scope
 
@@ -327,6 +329,72 @@ public class ImportStepViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
+    public async Task Run_is_disabled_when_no_vendor_is_selected() {
+        var (noneSelected, oneSelected) = await AvaloniaSession.DispatchAsync(() => {
+            var h = new Harness();
+
+            var noneSelected = CanExecute(h.Vm.RunCommand);
+            h.Row("Claude Code").IsSelected = true;
+            var oneSelected = CanExecute(h.Vm.RunCommand);
+
+            return (noneSelected, oneSelected);
+        });
+
+        // Empty VendorFlags means "import everything" to the CLI — the opposite of unchecking every box.
+        await Assert.That(noneSelected).IsFalse();
+        await Assert.That(oneSelected).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_direct_run_with_no_vendor_selected_never_calls_ImportAsync() {
+        var callCount = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness(); // valid scope (Everything) and a real CLI, but zero vendors selected
+
+            await h.Vm.RunAsync();
+
+            return h.Cli.ImportCallCount;
+        });
+
+        await Assert.That(callCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_direct_run_with_a_blank_scope_field_never_calls_ImportAsync() {
+        var callCount = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
+            h.Vm.Scope = ImportScopeChoice.Org; // OrgText left blank
+
+            await h.Vm.RunAsync();
+
+            return h.Cli.ImportCallCount;
+        });
+
+        await Assert.That(callCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_thrown_exception_sets_a_visible_status_with_the_retry_hint() {
+        var status = await AvaloniaSession.DispatchAsync(async () => {
+            var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
+            h.Cli.ImportBehavior = (_, _, _) => throw new InvalidOperationException("spawn failed");
+
+            await h.Vm.RunCommand.Execute().ToTask();
+
+            return h.Vm.Status;
+        });
+
+        await Assert.That(status).IsNotNull();
+        await Assert.That(status).Contains("spawn failed");
+        await Assert.That(status).Contains(ImportStepViewModel.RetryHint);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Everything_scope_argv_carries_only_the_selected_vendor_flags() {
         var request = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
@@ -348,6 +416,7 @@ public class ImportStepViewModelTests {
     public async Task Org_scope_argv_carries_the_org_text() {
         var request = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
             h.Vm.Scope   = ImportScopeChoice.Org;
             h.Vm.OrgText = "acme";
 
@@ -365,6 +434,7 @@ public class ImportStepViewModelTests {
     public async Task Repo_scope_argv_carries_the_owner_slash_name_text() {
         var request = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
             h.Vm.Scope    = ImportScopeChoice.Repo;
             h.Vm.RepoText = "acme/widgets";
 
@@ -382,6 +452,7 @@ public class ImportStepViewModelTests {
     public async Task Log_is_bounded_to_500_lines_with_a_drop_notice_once_truncation_starts() {
         var (count, truncated, first, last) = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
             h.Cli.ImportBehavior = (_, onLine, _) => {
                 for (var i = 1; i <= 510; i++) onLine(new StreamedLine(ProcessStreamKind.Stdout, $"line {i}"));
 
@@ -404,6 +475,7 @@ public class ImportStepViewModelTests {
     public async Task Completion_appends_the_retry_hint_on_success() {
         var status = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
             h.Cli.ImportBehavior = (_, _, _) => Task.FromResult(new StreamingResult(0, false, []));
 
             await h.Vm.RunCommand.Execute().ToTask();
@@ -419,6 +491,7 @@ public class ImportStepViewModelTests {
     public async Task Completion_appends_the_retry_hint_on_failure_too() {
         var status = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
             h.Cli.ImportBehavior = (_, _, _) => Task.FromResult(new StreamingResult(1, false, []));
 
             await h.Vm.RunCommand.Execute().ToTask();
@@ -434,6 +507,7 @@ public class ImportStepViewModelTests {
     public async Task A_failed_run_never_blocks_leaving() {
         var canLeave = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
             h.Cli.ImportBehavior = (_, _, _) => Task.FromResult(new StreamingResult(1, false, []));
             await h.Vm.RunCommand.Execute().ToTask();
 
@@ -448,6 +522,7 @@ public class ImportStepViewModelTests {
     public async Task Cancel_button_stops_the_run_and_reports_cancellation_without_the_retry_hint() {
         var status = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
             var started = new TaskCompletionSource();
             h.Cli.ImportBehavior = async (_, _, ct) => {
                 started.TrySetResult();
@@ -473,6 +548,7 @@ public class ImportStepViewModelTests {
     public async Task CanLeaveAsync_kills_a_running_import_and_never_vetoes() {
         var (canLeave, status) = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
             var started = new TaskCompletionSource();
             h.Cli.ImportBehavior = async (_, _, ct) => {
                 started.TrySetResult();
@@ -516,6 +592,7 @@ public class ImportStepViewModelTests {
     public async Task Satisfied_only_after_a_run_completes_with_exit_zero() {
         var (afterFailure, afterSuccess) = await AvaloniaSession.DispatchAsync(async () => {
             var h = new Harness();
+            h.Row("Claude Code").IsSelected = true;
             h.Cli.ImportBehavior = (_, _, _) => Task.FromResult(new StreamingResult(1, false, []));
             await h.Vm.RunCommand.Execute().ToTask();
             var afterFailure = h.Vm.Satisfied;

--- a/test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs
@@ -7,14 +7,16 @@ using AppUnderTest = Capacitor.App.App;
 
 namespace Capacitor.App.Tests.Unit;
 
-/// Task 15 decision-2 carve-out: App.StartAsync evaluates OnboardingGate.EvaluateAsync() FIRST and
-/// derives whether the lifecycle graph's auto-actions stay open (Complete) or close permanently
-/// (Incomplete). StartAsync itself needs a real daemon/profile — not a unit-test seam, same reason
-/// AppStartupTests drives extracted statics instead (see that file's own header comment) — so this
-/// exercises the two pure seams App exposes for the carve-out: AutoActionsPermanentlyClosed (the
-/// gate→flag switch) and ResolveConsentFlipIdentity (the ConsentFlipCoordinator identity delegate,
-/// MUST-WIRE 1). DaemonLifecycleControllerTests covers the controller-level ctor param behavior
-/// (fake lane, no gate involved) — this file is the App-level wiring half only.
+/// The decision-2 carve-out: App.StartAsync evaluates the onboarding gate FIRST (one resolve, via
+/// OnboardingGate.EvaluateAsync) and branches — Complete builds the daemon graph with auto-actions
+/// open, Incomplete opens the wizard instead and, if it is still Incomplete when the wizard closes,
+/// builds that same graph with auto-actions closed permanently. StartAsync itself needs a real
+/// daemon/profile — not a unit-test seam, same reason AppStartupTests drives extracted statics
+/// instead (see that file's own header comment) — so this exercises the two pure seams App exposes
+/// for the carve-out: AutoActionsPermanentlyClosed (the gate→flag switch) and
+/// ResolveConsentFlipIdentity (the ConsentFlipCoordinator identity delegate, MUST-WIRE 1).
+/// WizardStartupTests owns the wizard-mode half; DaemonLifecycleControllerTests covers the
+/// controller-level ctor param behavior (fake lane, no gate involved).
 ///
 /// [NotInParallel]: shares OnboardingGateTests' one real config.json under the assembly-wide
 /// KCAP_CONFIG_DIR (see OnboardingGateGlobalSetup) — same isolation rule, same shared resource.

--- a/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
@@ -17,12 +17,12 @@ namespace Capacitor.App.Tests.Unit;
 /// kicks off App.StartAsync fire-and-forget and returns immediately; Avalonia's
 /// StartWithClassicDesktopLifetime calls ShowMainWindow() exactly ONCE, synchronously, right
 /// after Start — and at that moment desktop.MainWindow was still null, because
-/// DaemonClientService.CreateDefaultAsync genuinely awaits real config I/O. By the time the
-/// continuation resumed and assigned desktop.MainWindow, nothing else ever called .Show() —
-/// the app booted a dispatcher loop showing nothing.
+/// startup genuinely awaits real config I/O (and, in wizard-first mode, the whole wizard). By the
+/// time the continuation resumed and assigned desktop.MainWindow, nothing else ever called .Show()
+/// — the app booted a dispatcher loop showing nothing.
 ///
-/// CreateDefaultAsync itself needs a real profile/daemon and isn't a seam a unit test can drive,
-/// so this exercises the closest testable seam: App.BuildAndShowMainWindow (internal, exposed to
+/// That composition needs a real profile/daemon and isn't a seam a unit test can drive, so this
+/// exercises the closest testable seam: App.BuildAndShowMainWindow (internal, exposed to
 /// this assembly via InternalsVisibleTo) is the exact "build VM+window, assign, and Show()"
 /// continuation extracted out of StartAsync — this test proves THAT method actually leaves the
 /// window visible, against a fake service, without needing a real desktop lifetime or daemon.
@@ -562,7 +562,7 @@ public class AppStartupTests {
     /// Regression coverage for an Important finding in review: QuitInProgress used to be set
     /// AFTER OnShutdownRequested's `_shutdownConfirmed` guard, so a coordinator that came into
     /// existence BETWEEN the two passes was never flagged. Shape: a quit (or an OS logout) lands
-    /// while CreateDefaultAsync is still in flight — pass 1 sees a null coordinator — and
+    /// while startup is still resolving (or still showing the wizard) — pass 1 sees a null coordinator — and
     /// StartAsync's continuation then builds the window during the deferred disposal's await.
     /// Pass 2 closed the windows with hide-on-close still armed: the window cancelled its own
     /// close, and (decompiler-verified) DoShutdown aborts once a close is cancelled with windows

--- a/test/Capacitor.App.Tests.Unit/ConnectStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConnectStepViewModelTests.cs
@@ -1,0 +1,98 @@
+using Capacitor.App.Services.Onboarding;
+using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Intent only (spec §3 step 2): nothing here reaches the network or writes anything, so these
+/// run without the headless session — the step owns no commands and no Rx subscriptions.
+public class ConnectStepViewModelTests {
+    [Test]
+    [Arguments("acme", "https://acme.kcap.ai")]
+    [Arguments("  acme  ", "https://acme.kcap.ai")]
+    [Arguments("https://acme.kcap.ai/sessions/42", "https://acme.kcap.ai")]
+    [Arguments("acme.kcap.ai", "https://acme.kcap.ai")]
+    [Arguments("http://localhost:5108", "http://localhost:5108")]
+    public async Task Paste_stages_the_normalized_server_and_satisfies_the_step(string typed, string expected) {
+        var vm = new ConnectStepViewModel { Choice = ConnectChoice.Paste, ServerInputText = typed };
+
+        await Assert.That(vm.Intent).IsEqualTo(new ConnectIntent.Paste(expected));
+        await Assert.That(vm.Satisfied).IsTrue();
+        await Assert.That(await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None)).IsTrue();
+        await Assert.That(vm.InputError).IsNull();
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments("file:///tmp/nope")]
+    [Arguments("ftp://acme.example")]
+    public async Task Paste_with_an_unusable_server_blocks_next_with_an_inline_error(string typed) {
+        var vm = new ConnectStepViewModel { Choice = ConnectChoice.Paste, ServerInputText = typed };
+
+        await Assert.That(vm.Intent).IsNull();
+        await Assert.That(vm.Satisfied).IsFalse();
+        await Assert.That(await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None)).IsFalse();
+        await Assert.That(vm.InputError).IsNotNull();
+    }
+
+    [Test]
+    public async Task Editing_the_input_clears_a_stale_inline_error() {
+        var vm = new ConnectStepViewModel { Choice = ConnectChoice.Paste, ServerInputText = "file:///tmp/nope" };
+        await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+
+        vm.ServerInputText = "acme";
+
+        await Assert.That(vm.InputError).IsNull();
+    }
+
+    [Test]
+    [Arguments(AuthProvider.GitHubApp)]
+    [Arguments(AuthProvider.WorkOS)]
+    public async Task Discover_stages_the_chosen_provider(string provider) {
+        var vm = new ConnectStepViewModel { Choice = ConnectChoice.Discover, DiscoveryProvider = provider };
+
+        await Assert.That(vm.Intent).IsEqualTo(new ConnectIntent.Discover(provider));
+        await Assert.That(vm.Satisfied).IsTrue();
+        await Assert.That(await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None)).IsTrue();
+    }
+
+    [Test]
+    public async Task Create_stages_the_create_intent() {
+        var vm = new ConnectStepViewModel { Choice = ConnectChoice.Create };
+
+        await Assert.That(vm.Intent).IsEqualTo(new ConnectIntent.Create());
+        await Assert.That(vm.Satisfied).IsTrue();
+    }
+
+    [Test]
+    public async Task Back_and_skip_are_never_blocked_even_with_an_unusable_input() {
+        var vm = new ConnectStepViewModel { Choice = ConnectChoice.Paste, ServerInputText = "file:///tmp/nope" };
+
+        await Assert.That(await vm.CanLeaveAsync(WizardNavigation.Back, CancellationToken.None)).IsTrue();
+        await Assert.That(await vm.CanLeaveAsync(WizardNavigation.Skip, CancellationToken.None)).IsTrue();
+        await Assert.That(vm.InputError).IsNull(); // no error styling for a step the user is leaving
+    }
+
+    [Test]
+    public async Task Prefill_switches_to_paste_and_populates_the_input() {
+        var vm = new ConnectStepViewModel { Choice = ConnectChoice.Discover };
+
+        vm.Prefill("acme");
+
+        await Assert.That(vm.Choice).IsEqualTo(ConnectChoice.Paste);
+        await Assert.That(vm.ServerInputText).IsEqualTo("acme");
+        await Assert.That(vm.Intent).IsEqualTo(new ConnectIntent.Paste("https://acme.kcap.ai"));
+    }
+
+    [Test]
+    public async Task The_step_identifies_itself_as_the_connect_page_and_is_always_applicable() {
+        var vm = new ConnectStepViewModel();
+
+        await vm.OnEnterAsync(CancellationToken.None);
+
+        await Assert.That(vm.Id).IsEqualTo(WizardStepId.Connect);
+        await Assert.That(vm.Applicable).IsTrue();
+        await Assert.That(vm.Title).IsNotEmpty();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentFlipCoordinatorTests.cs
@@ -363,19 +363,23 @@ public class ConsentFlipCoordinatorTests {
     // ---- quarantine surfacing + ack ----
 
     [Test]
-    public async Task Quarantine_surfaces_once_as_attention_naming_the_preserved_path() {
+    public async Task Quarantine_surfaces_once_as_a_confirm_prompt_naming_the_preserved_path() {
         using var h = new Harness();
         File.WriteAllText(Path.Combine(h.TempDir, "consent-flip-claims.json"), "{not json");
 
         h.Coordinator.Start(); // Start()'s own read discovers the corruption — no pre-read needed
 
-        await WaitUntilAsync(() => h.Surface.AttentionMessages.Count == 1, what: "the quarantine attention line");
+        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the quarantine confirm prompt");
         await Assert.That(h.Claims.Quarantine()).IsNotNull();
-        await Assert.That(h.Surface.AttentionMessages[0]).Contains(h.Claims.Quarantine()!.PreservedPath);
-        await Assert.That(h.Surface.AttentionMessages[0]).Contains("kcap daemon consent set-default prompt");
+        var prompt = h.Surface.Prompts[0];
+        await Assert.That(prompt.Kind).IsEqualTo(LifecyclePrompt.KindQuarantine);
+        await Assert.That(prompt.Disclosure).Contains(h.Claims.Quarantine()!.PreservedPath);
+        await Assert.That(prompt.Disclosure).Contains("kcap daemon consent set-default prompt");
 
         await Task.Delay(150); // give a duplicate surfacing every chance to appear
-        await Assert.That(h.Surface.AttentionMessages.Count).IsEqualTo(1);
+        await Assert.That(h.Surface.Prompts.Count).IsEqualTo(1);
+        // Default FakeLifecycleSurface.ConfirmBehavior declines — declining must never ack.
+        await Assert.That(h.Store.State.ConsentQuarantineAcked).IsFalse();
     }
 
     // ConsentFlipClaims.Quarantine() is in-memory/per-instance and its evidence (the corrupt file)
@@ -385,15 +389,14 @@ public class ConsentFlipCoordinatorTests {
     // AppState must not re-surface, which is exactly what a real relaunch (fresh coordinator,
     // durable AppState, in-memory ConsentFlipClaims singleton) would observe.
     [Test]
-    public async Task Acked_quarantine_is_not_re_surfaced_by_a_fresh_coordinator() {
+    public async Task Confirmed_quarantine_is_acked_and_not_re_surfaced_by_a_fresh_coordinator() {
         using var h = new Harness();
         File.WriteAllText(Path.Combine(h.TempDir, "consent-flip-claims.json"), "{not json");
+        h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
 
         h.Coordinator.Start();
-        await WaitUntilAsync(() => h.Surface.AttentionMessages.Count == 1, what: "the first surfacing");
-
-        await Assert.That(await h.Coordinator.AckQuarantineAsync()).IsTrue();
-        await Assert.That(h.Store.State.ConsentQuarantineAcked).IsTrue();
+        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the confirm prompt");
+        await WaitUntilAsync(() => h.Store.State.ConsentQuarantineAcked, what: "the ack to persist");
 
         var freshSurface = new FakeLifecycleSurface();
         var freshCoordinator = new ConsentFlipCoordinator(
@@ -401,6 +404,54 @@ public class ConsentFlipCoordinatorTests {
         freshCoordinator.Start();
 
         await Task.Delay(150); // give a wrongly-firing re-surfacing every chance to appear
-        await Assert.That(freshSurface.AttentionMessages).IsEmpty();
+        await Assert.That(freshSurface.Prompts).IsEmpty();
+    }
+
+    // Acknowledgment must be explicit — a declined prompt must neither persist nor suppress the
+    // next start's surfacing.
+    [Test]
+    public async Task Declined_quarantine_is_not_persisted_and_re_surfaces_on_a_fresh_coordinator() {
+        using var h = new Harness();
+        File.WriteAllText(Path.Combine(h.TempDir, "consent-flip-claims.json"), "{not json");
+        h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(false);
+
+        h.Coordinator.Start();
+        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the confirm prompt");
+        await Task.Delay(150); // give a wrongly-firing ack every chance to appear
+        await Assert.That(h.Store.State.ConsentQuarantineAcked).IsFalse();
+
+        var freshSurface = new FakeLifecycleSurface();
+        var freshCoordinator = new ConsentFlipCoordinator(
+            h.Client, h.Ops, h.Claims, h.Resolver.Resolve, freshSurface, h.Store, CancellationToken.None);
+        freshCoordinator.Start();
+
+        await WaitUntilAsync(() => freshSurface.Prompts.Count == 1, what: "the re-surfaced prompt");
+    }
+
+    // null means "never reached the dialog" (TryConfirmAsync's own distinction from a genuinely
+    // declined one) — must be treated identically to a decline: never acked.
+    [Test]
+    public async Task Cancelled_confirm_prompt_returns_null_and_is_not_persisted() {
+        using var h = new Harness();
+        File.WriteAllText(Path.Combine(h.TempDir, "consent-flip-claims.json"), "{not json");
+        h.Surface.TryConfirmBehavior = (_, _) => Task.FromResult<bool?>(null);
+
+        h.Coordinator.Start();
+        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the confirm prompt");
+
+        await Task.Delay(150); // give a wrongly-firing ack every chance to appear
+        await Assert.That(h.Store.State.ConsentQuarantineAcked).IsFalse();
+    }
+
+    [Test]
+    public async Task Already_acked_quarantine_never_prompts() {
+        using var h = new Harness();
+        File.WriteAllText(Path.Combine(h.TempDir, "consent-flip-claims.json"), "{not json");
+        await h.Store.UpdateAsync(s => s with { ConsentQuarantineAcked = true });
+
+        h.Coordinator.Start();
+
+        await Task.Delay(150); // give a wrongly-firing surfacing every chance to appear
+        await Assert.That(h.Surface.Prompts).IsEmpty();
     }
 }

--- a/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonClientServiceTests.cs
@@ -469,7 +469,7 @@ public class DaemonClientServiceTests {
     }
 
     // Task 10: DaemonClientService.BuildStartDaemon is the extracted request-building seam
-    // CreateDefaultAsync wires to the real AppConfig.ResolvedProfile — this drives it directly
+    // CreateResolved wires to the real AppConfig.ResolvedProfile — this drives it directly
     // against a scripted profile resolver, proving the main-window Start path produces a
     // DetachedStart MutationRequest through the lane rather than any direct process spawn.
     [Test]

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -1413,19 +1413,23 @@ sealed class FakeKcapCli : IKcapCli {
     }
 
     public int PluginInstallCallCount;
+    public readonly List<string?> PluginInstallCalls = []; // call-order proof for sequential-install tests
     public Func<string?, CancellationToken, Task<ProcessResult>> PluginInstallBehavior =
         (_, _) => Task.FromResult(new ProcessResult(0, "", "", false));
     public Task<ProcessResult> PluginInstallAsync(string? vendorFlag, CancellationToken ct) {
         PluginInstallCallCount++;
+        PluginInstallCalls.Add(vendorFlag);
         return PluginInstallBehavior(vendorFlag, ct);
     }
 
     public int ImportCallCount;
-    public Func<ImportRequest, CancellationToken, Task<StreamingResult>> ImportBehavior =
-        (_, _) => Task.FromResult(new StreamingResult(0, false, []));
+    public readonly List<ImportRequest> ImportRequests = [];
+    public Func<ImportRequest, Action<StreamedLine>, CancellationToken, Task<StreamingResult>> ImportBehavior =
+        (_, _, _) => Task.FromResult(new StreamingResult(0, false, []));
     public Task<StreamingResult> ImportAsync(ImportRequest request, Action<StreamedLine> onLine, CancellationToken ct) {
         ImportCallCount++;
-        return ImportBehavior(request, ct);
+        ImportRequests.Add(request);
+        return ImportBehavior(request, onLine, ct);
     }
 }
 

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -1411,6 +1411,22 @@ sealed class FakeKcapCli : IKcapCli {
         LastBootAttemptId = bootAttemptId;
         return DetachedStartBehavior(ct);
     }
+
+    public int PluginInstallCallCount;
+    public Func<string?, CancellationToken, Task<ProcessResult>> PluginInstallBehavior =
+        (_, _) => Task.FromResult(new ProcessResult(0, "", "", false));
+    public Task<ProcessResult> PluginInstallAsync(string? vendorFlag, CancellationToken ct) {
+        PluginInstallCallCount++;
+        return PluginInstallBehavior(vendorFlag, ct);
+    }
+
+    public int ImportCallCount;
+    public Func<ImportRequest, CancellationToken, Task<StreamingResult>> ImportBehavior =
+        (_, _) => Task.FromResult(new StreamingResult(0, false, []));
+    public Task<StreamingResult> ImportAsync(ImportRequest request, Action<StreamedLine> onLine, CancellationToken ct) {
+        ImportCallCount++;
+        return ImportBehavior(request, ct);
+    }
 }
 
 /// Scripted ILoginShellProbe — the controller only ever calls TerminalPathAsync (the install

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -1040,7 +1040,7 @@ public class DaemonLifecycleControllerTests {
         await WaitUntilAsync(() => h.Surface.Prompts.Count == 2, what: "the re-offered prompt");
     }
 
-    // Finding 7: a terminal can replace the plist/unit while the dialog is open WITHOUT producing
+    // A terminal can replace the plist/unit while the dialog is open WITHOUT producing
     // an attach event — the generation token alone is blind to this. Acceptance must re-query
     // fresh status and re-classify before mutating; a classification flip aborts exactly like the
     // generation-based stale-consent path above.

--- a/test/Capacitor.App.Tests.Unit/DaemonStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonStepViewModelTests.cs
@@ -1,0 +1,810 @@
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.App.Views.Onboarding;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.LocalIpc;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// spec §3 step 7: every row of AI-1654's state matrix → the exact mutation verb (or an explicit
+/// no-mutation) and the affordance offered, plus the decision-7 claim application rules. The lane
+/// is a recording delegate (results are waiter-state-only), the claims store is REAL on temp paths
+/// (so TryConsume's own two-lock compare runs), and the surface records every dialog — the
+/// single-presentation rule is asserted by the surface staying untouched on every waiter outcome.
+public class DaemonStepViewModelTests {
+    const string Profile    = "default";
+    const string RawServer  = "https://example.test";
+    const string DaemonName = "kcap-daemon";
+    static readonly string CanonicalServer = ServerIdentity.Canonicalize(RawServer)!;
+
+    static ServiceSnapshot Snap(
+            string state = "not_installed", bool unitPresent = false, int? jobPid = null, int? daemonPid = null,
+            bool txnMarker = false, bool txnActive = false) =>
+        new(DaemonName, unitPresent, state, "/opt/kcap/kcap-daemon", "/opt/kcap/kcap-daemon", jobPid, daemonPid,
+            txnMarker, txnActive);
+
+    static ObservedEvidence Evidence(
+            string? server = RawServer, string? name = DaemonName, bool reachable = true, bool consistent = true,
+            params string[] capabilities) =>
+        new(reachable, capabilities.Length == 0 ? ["consent/3"] : capabilities, "0.12.0-beta.1", server, name,
+            4242, "instance-1", consistent);
+
+    static ConsentPolicyDto Policy(string @default = "allow", params ConsentRuleDto[] rules) =>
+        new(@default, 300, [.. rules]);
+
+    /// Records every request the step routes through the lane and answers with the scripted
+    /// outcome — the lane's own result IS the step's success predicate.
+    sealed class RecordingLane {
+        public readonly List<MutationRequest> Requests = [];
+        public Func<MutationRequest, CancellationToken, Task<MutationOutcome>> Behavior =
+            (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+
+        public Task<MutationOutcome> RunAsync(MutationRequest request, CancellationToken ct) {
+            Requests.Add(request);
+            return Behavior(request, ct);
+        }
+    }
+
+    sealed class ScriptedObservation : IDaemonObservation {
+        readonly Queue<ObservedEvidence?> _queued = new();
+
+        public int Calls;
+        public readonly List<MutationRequest> Requests = [];
+        public ObservedEvidence? Default;
+
+        public void Queue(ObservedEvidence? evidence) => _queued.Enqueue(evidence);
+
+        public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
+            Calls++;
+            Requests.Add(request);
+            return Task.FromResult(_queued.Count > 0 ? _queued.Dequeue() : Default);
+        }
+    }
+
+    sealed class Harness : IDisposable {
+        public readonly string TempDir = Directory.CreateTempSubdirectory("kcap-daemonstep-").FullName;
+        public readonly FakeKcapCli Cli = new();
+        public readonly RecordingLane Lane = new();
+        public readonly ScriptedObservation Observation = new();
+        public readonly ScriptedLocalControlOps Ops = new();
+        public readonly FakeLifecycleSurface Surface = new();
+        public readonly FakeTimeProvider Clock = new(new DateTimeOffset(2026, 8, 16, 9, 0, 0, TimeSpan.Zero));
+        public readonly TimerCountingTimeProvider Time;
+        public readonly ConsentFlipClaims Claims;
+        public readonly DaemonStepViewModel Vm;
+
+        public (string Profile, string Server, string DaemonName)? Identity = (Profile, RawServer, DaemonName);
+        public (string Profile, string Server, string DaemonName) UnderConfigLock = (Profile, RawServer, DaemonName);
+        public string? TerminalPath = "/usr/bin:/bin";
+
+        public Harness() {
+            Time   = new TimerCountingTimeProvider(Clock);
+            Claims = new ConsentFlipClaims(
+                Path.Combine(TempDir, "consent-flip-claims.json"), Path.Combine(TempDir, "config.json"));
+            Vm = new DaemonStepViewModel(
+                Cli, Lane.RunAsync, () => Identity, Observation, Ops, Claims, () => UnderConfigLock, Surface,
+                _ => Task.FromResult<string?>(TerminalPath), Time);
+        }
+
+        public void ArmClaim() => Claims.Arm(new ConsentFlipClaim(Profile, CanonicalServer));
+
+        public void Status(ServiceSnapshot? snapshot) => Cli.StatusBehavior = _ => Task.FromResult(snapshot);
+
+        public Task Enter() => Vm.OnEnterAsync(CancellationToken.None);
+
+        public Task Act() => Vm.RunActionAsync();
+
+        public void Dispose() {
+            try { Directory.Delete(TempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    static async Task WaitUntilAsync(Func<bool> condition, string what) {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    // ── gate / precondition rows ────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Without_a_committed_sign_in_the_step_offers_nothing_and_never_reads_status() {
+        var (row, affordance, message, statusCalls, mutations) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Identity = null;
+
+            await h.Enter();
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Message, h.Cli.StatusCallCount, h.Lane.Requests.Count);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.RequiresSignIn);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.None);
+        await Assert.That(message).IsEqualTo(DaemonStepViewModel.RequiresSignInMessage);
+        await Assert.That(statusCalls).IsEqualTo(0);
+        await Assert.That(mutations).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Without_a_resolved_CLI_the_step_offers_nothing() {
+        var (row, affordance, message, statusCalls) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Cli.CliPath = null;
+
+            await h.Enter();
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Message, h.Cli.StatusCallCount);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.CliMissing);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.None);
+        await Assert.That(message).IsEqualTo(DaemonStepViewModel.CliMissingMessage);
+        await Assert.That(statusCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_server_that_cannot_be_canonicalized_refuses_before_any_status_read() {
+        var (row, affordance, statusCalls, mutations) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Identity = (Profile, "file:///etc/passwd", DaemonName);
+
+            await h.Enter();
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Cli.StatusCallCount, h.Lane.Requests.Count);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.NoServerConfigured);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.None);
+        await Assert.That(statusCalls).IsEqualTo(0);
+        await Assert.That(mutations).IsEqualTo(0);
+    }
+
+    // ── unreadable / unrecognized evidence: honest message, no mutation ─────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_unreadable_status_is_an_honest_message_with_no_mutation() {
+        var (row, affordance, message, mutations) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(null);
+
+            await h.Enter();
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Message, h.Lane.Requests.Count);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.StatusUnknown);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.None);
+        await Assert.That(message).IsEqualTo(DaemonStepViewModel.StatusUnknownMessage);
+        await Assert.That(mutations).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_unrecognized_service_state_never_reads_as_not_installed() {
+        var (row, affordance, message, mutations) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap(state: "some_future_state"));
+
+            await h.Enter();
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Message, h.Lane.Requests.Count);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.StatusUnknown);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.None);
+        await Assert.That(message).IsEqualTo(DaemonStepViewModel.UnrecognizedStateMessage);
+        await Assert.That(mutations).IsEqualTo(0);
+    }
+
+    // ── install / start rows ────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task No_unit_and_no_live_daemon_offers_install_and_routes_Install_through_the_lane() {
+        var (row, affordance, requests, satisfied) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap());
+
+            await h.Enter();
+            var offered = (h.Vm.Row, h.Vm.Affordance);
+            await h.Act();
+
+            return (offered.Row, offered.Affordance, h.Lane.Requests.ToList(), h.Vm.Satisfied);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.NotInstalled);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.Install);
+        await Assert.That(requests.Count).IsEqualTo(1);
+        await Assert.That(requests[0].Verb).IsEqualTo(MutationVerb.Install);
+        await Assert.That(requests[0].Profile).IsEqualTo(Profile);
+        await Assert.That(requests[0].CanonicalServer).IsEqualTo(CanonicalServer);
+        await Assert.That(requests[0].DaemonName).IsEqualTo(DaemonName);
+        await Assert.That(satisfied).IsTrue();
+    }
+
+    [Test]
+    [Arguments("installed")]    // loaded label, inactive job
+    [Arguments("not_installed")] // unit on disk, no loaded label
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_present_unit_with_no_live_daemon_offers_a_verified_start(string state) {
+        var (row, affordance, requests) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap(state: state, unitPresent: true));
+
+            await h.Enter();
+            var offered = (h.Vm.Row, h.Vm.Affordance);
+            await h.Act();
+
+            return (offered.Row, offered.Affordance, h.Lane.Requests.ToList());
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.Stopped);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.Start);
+        await Assert.That(requests.Count).IsEqualTo(1);
+        await Assert.That(requests[0].Verb).IsEqualTo(MutationVerb.StartVerified);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_running_job_with_no_daemon_evidence_offers_nothing() {
+        var (row, affordance, mutations) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100));
+
+            await h.Enter();
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Lane.Requests.Count);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.RunningUnconfirmed);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.None);
+        await Assert.That(mutations).IsEqualTo(0);
+    }
+
+    // ── ownership rows ──────────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Positive_ownership_with_an_identity_match_is_already_enabled_and_applies_the_claim() {
+        var (row, affordance, satisfied, mutations, putPayloads, pending) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
+            h.Observation.Default = Evidence();
+            h.Ops.QueueGet(Policy());
+            h.Ops.QueuePutV2(true, null);
+
+            await h.Enter();
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Satisfied, h.Lane.Requests.Count,
+                h.Ops.PutV2Payloads.ToList(), h.Claims.Pending().Count);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.AlreadyEnabled);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.None);
+        await Assert.That(satisfied).IsTrue();
+        await Assert.That(mutations).IsEqualTo(0);
+        await Assert.That(putPayloads.Count).IsEqualTo(1);
+        await Assert.That(putPayloads[0].ExpectedName).IsEqualTo(DaemonName);
+        await Assert.That(putPayloads[0].ExpectedServerUrl).IsEqualTo(CanonicalServer);
+        await Assert.That(putPayloads[0].Policy.Default).IsEqualTo("prompt");
+        await Assert.That(pending).IsEqualTo(0); // consumed through the real two-lock clear
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_step_put_preserves_the_daemons_existing_rules() {
+        var payload = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
+            h.Observation.Default = Evidence();
+            h.Ops.QueueGet(Policy("allow", new ConsentRuleDto("deny", "someone", null, null, null)));
+            h.Ops.QueuePutV2(true, null);
+
+            await h.Enter();
+
+            return h.Ops.PutV2Payloads.Single();
+        });
+
+        await Assert.That(payload.Policy.Rules.Count).IsEqualTo(1);
+        await Assert.That(payload.Policy.PromptTimeoutSeconds).IsEqualTo(300);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Ownership_without_an_identity_match_offers_only_the_takeover_and_never_the_claim() {
+        var (row, affordance, satisfied, mutations, puts, pending) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
+            h.Observation.Default = Evidence(server: "https://other.test");
+
+            await h.Enter();
+            await h.Act(); // the surface declines by default
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Satisfied, h.Lane.Requests.Count, h.Ops.PutV2Calls,
+                h.Claims.Pending().Count);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.OwnedIdentityMismatch);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.Takeover);
+        await Assert.That(satisfied).IsFalse();
+        await Assert.That(mutations).IsEqualTo(0);
+        await Assert.That(puts).IsEqualTo(0);
+        await Assert.That(pending).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_unverifiable_daemon_identity_fails_closed_to_the_takeover_row() {
+        var row = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
+            h.Observation.Default = Evidence(consistent: false); // the two probe dials disagree
+
+            await h.Enter();
+
+            return h.Vm.Row;
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.OwnedIdentityMismatch);
+    }
+
+    // ── manual-daemon rows ──────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_identity_matched_manual_daemon_offers_a_disclosed_takeover_that_replaces_on_accept() {
+        var (row, affordance, prompts, requests, satisfied) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap(state: "not_installed", daemonPid: 777));
+            h.Observation.Default = Evidence();
+            h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
+
+            await h.Enter();
+            var offered = (h.Vm.Row, h.Vm.Affordance);
+            await h.Act();
+
+            return (offered.Row, offered.Affordance, h.Surface.Prompts.ToList(), h.Lane.Requests.ToList(), h.Vm.Satisfied);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.ManualIdentityMatch);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.Takeover);
+        await Assert.That(prompts.Count).IsEqualTo(1);
+        await Assert.That(prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindTakeover);
+        await Assert.That(prompts[0].Disclosure).IsEqualTo(DaemonLifecycleController.TakeoverDisclosure);
+        await Assert.That(requests.Count).IsEqualTo(1);
+        await Assert.That(requests[0].Verb).IsEqualTo(MutationVerb.Replace);
+        await Assert.That(satisfied).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Declining_the_manual_takeover_leaves_the_step_incomplete_but_still_applies_the_claim() {
+        var (satisfied, mutations, putPayloads, pending) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap(state: "not_installed", daemonPid: 777));
+            h.Observation.Default = Evidence();
+            h.Ops.QueueGet(Policy());
+            h.Ops.QueuePutV2(true, null);
+
+            await h.Enter();
+            await h.Act(); // declines
+
+            return (h.Vm.Satisfied, h.Lane.Requests.Count, h.Ops.PutV2Payloads.ToList(), h.Claims.Pending().Count);
+        });
+
+        await Assert.That(satisfied).IsFalse();
+        await Assert.That(mutations).IsEqualTo(0);
+        await Assert.That(putPayloads.Count).IsEqualTo(1);
+        await Assert.That(putPayloads[0].ExpectedServerUrl).IsEqualTo(CanonicalServer);
+        await Assert.That(pending).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_manual_daemon_for_another_server_mutates_nothing_and_applies_no_claim() {
+        var (row, affordance, message, mutations, puts, pending) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap(state: "not_installed", daemonPid: 777));
+            h.Observation.Default = Evidence(server: "https://other.test");
+
+            await h.Enter();
+            await h.Act(); // declines
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Message, h.Lane.Requests.Count, h.Ops.PutV2Calls,
+                h.Claims.Pending().Count);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.ManualIdentityMismatch);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.Takeover); // the only offered action
+        await Assert.That(message).Contains("https://other.test");
+        await Assert.That(mutations).IsEqualTo(0);
+        await Assert.That(puts).IsEqualTo(0);
+        await Assert.That(pending).IsEqualTo(1);
+    }
+
+    // ── repair rows ─────────────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_orphan_label_offers_the_repair_affordance() {
+        var (row, affordance, prompts, requests) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap(state: "installed", unitPresent: false));
+            h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
+
+            await h.Enter();
+            var offered = (h.Vm.Row, h.Vm.Affordance);
+            await h.Act();
+
+            return (offered.Row, offered.Affordance, h.Surface.Prompts.ToList(), h.Lane.Requests.ToList());
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.OrphanLabel);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.Repair);
+        await Assert.That(prompts.Single().Kind).IsEqualTo(LifecyclePrompt.KindRepair);
+        await Assert.That(requests.Single().Verb).IsEqualTo(MutationVerb.Replace);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_stale_transaction_marker_offers_repair_instead_of_a_blind_reinstall() {
+        var (row, affordance, mutations) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap(txnMarker: true));
+
+            await h.Enter();
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Lane.Requests.Count);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.StaleMarker);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.Repair);
+        await Assert.That(mutations).IsEqualTo(0);
+    }
+
+    // ── txn_active: wait, never a parallel mutation ─────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_live_transaction_is_waited_out_and_the_matrix_proceeds_once_it_clears() {
+        var (row, affordance, statusCalls) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            var call = 0;
+            h.Cli.StatusBehavior = _ => {
+                call++;
+                return Task.FromResult<ServiceSnapshot?>(call == 1 ? Snap(txnActive: true) : Snap());
+            };
+
+            var enter = h.Enter();
+            await WaitUntilAsync(() => h.Time.TimersCreated >= 1, "the txn-active poll timer to be armed");
+            await Assert.That(h.Lane.Requests).IsEmpty(); // never mutated into the held flock
+            h.Clock.Advance(DaemonStepViewModel.TxnPollInterval);
+            await enter;
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Cli.StatusCallCount);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.NotInstalled);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.Install);
+        await Assert.That(statusCalls).IsEqualTo(2);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_transaction_that_never_clears_ends_in_an_honest_message_with_no_mutation() {
+        var (row, affordance, message, mutations, statusCalls) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap(txnActive: true));
+
+            var enter = h.Enter();
+            for (var poll = 0; poll < DaemonStepViewModel.MaxTxnPolls && !enter.IsCompleted; poll++) {
+                await WaitUntilAsync(() => h.Time.TimersCreated >= poll + 1, "the next txn-active poll timer");
+                h.Clock.Advance(DaemonStepViewModel.TxnPollInterval);
+            }
+            await enter;
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Message, h.Lane.Requests.Count, h.Cli.StatusCallCount);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.TransactionActive);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.None);
+        await Assert.That(message).IsEqualTo(DaemonStepViewModel.TxnActiveMessage);
+        await Assert.That(mutations).IsEqualTo(0);
+        await Assert.That(statusCalls).IsEqualTo(DaemonStepViewModel.MaxTxnPolls + 1);
+    }
+
+    // ── outcome handling: state only, never a second presentation ───────────
+
+    [Test]
+    [Arguments("succeeded", true)]
+    [Arguments("succeeded_after_timeout", true)]
+    [Arguments("unconfirmed", false)]
+    [Arguments("attention_skew", false)]
+    [Arguments("attention_repair", false)]
+    [Arguments("refused", false)]
+    [Arguments("failed", false)]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Satisfied_follows_the_lanes_own_outcome_and_nothing_else(string outcomeKey, bool expected) {
+        var (satisfied, status, prompts, statusLines, attentionLines) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap());
+            h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(outcomeKey switch {
+                "succeeded"               => new MutationOutcome.Succeeded(),
+                "succeeded_after_timeout" => new MutationOutcome.SucceededAfterTimeout(),
+                "unconfirmed"             => new MutationOutcome.UnconfirmedNoAttach(),
+                "attention_skew"          => new MutationOutcome.AttentionSkew("daemon_below_floor"),
+                "attention_repair"        => new MutationOutcome.AttentionRepair("stale_marker"),
+                "refused"                 => new MutationOutcome.Refused("cli_below_floor", RecoverySurface.Attention),
+                _                         => new MutationOutcome.Failed(28, "identity_mismatch", RecoverySurface.Takeover),
+            });
+
+            await h.Enter();
+            await h.Act();
+
+            return (h.Vm.Satisfied, h.Vm.Status, h.Surface.Prompts.Count, h.Surface.StatusMessages.Count,
+                h.Surface.AttentionMessages.Count);
+        });
+
+        await Assert.That(satisfied).IsEqualTo(expected);
+        await Assert.That(status).IsNotNull();
+        // Single presentation: the waiter never opens a dialog and never touches the surface —
+        // actionable outcomes reach the user through the channel consumer instead.
+        await Assert.That(prompts).IsEqualTo(0);
+        await Assert.That(statusLines).IsEqualTo(0);
+        await Assert.That(attentionLines).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_failed_outcome_names_its_coded_reason() {
+        var status = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap());
+            h.Lane.Behavior = (_, _) =>
+                Task.FromResult<MutationOutcome>(new MutationOutcome.Failed(24, null, RecoverySurface.Attention));
+
+            await h.Enter();
+            await h.Act();
+
+            return h.Vm.Status;
+        });
+
+        await Assert.That(status).Contains("verify_readiness_timeout");
+    }
+
+    // ── claim application after a mutation ──────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_successful_install_applies_the_pending_claim_against_the_daemon_it_just_verified() {
+        var (putPayloads, pending) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap());
+            h.Observation.Default = Evidence();
+            h.Ops.QueueGet(Policy());
+            h.Ops.QueuePutV2(true, null);
+
+            await h.Enter();
+            await h.Act();
+
+            return (h.Ops.PutV2Payloads.ToList(), h.Claims.Pending().Count);
+        });
+
+        await Assert.That(putPayloads.Count).IsEqualTo(1);
+        await Assert.That(putPayloads[0].ExpectedName).IsEqualTo(DaemonName);
+        await Assert.That(pending).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_daemon_without_consent_3_gets_no_put_and_keeps_the_claim_pending() {
+        var (gets, puts, pending, status) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
+            h.Observation.Default = Evidence(capabilities: ["consent/1"]);
+
+            await h.Enter();
+
+            return (h.Ops.GetCalls, h.Ops.PutV2Calls, h.Claims.Pending().Count, h.Vm.Status);
+        });
+
+        await Assert.That(gets).IsEqualTo(0);
+        await Assert.That(puts).IsEqualTo(0);
+        await Assert.That(pending).IsEqualTo(1);
+        await Assert.That(status).IsEqualTo(DaemonStepViewModel.ClaimMissingCapabilityMessage);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_rejected_ack_retains_the_claim_and_surfaces_repair_guidance() {
+        var (pending, status) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
+            h.Observation.Default = Evidence();
+            h.Ops.QueueGet(Policy());
+            h.Ops.QueuePutV2(false, "identity_mismatch");
+
+            await h.Enter();
+
+            return (h.Claims.Pending().Count, h.Vm.Status);
+        });
+
+        await Assert.That(pending).IsEqualTo(1);
+        await Assert.That(status).IsEqualTo(DaemonStepViewModel.ClaimFailedMessage);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_ops_failure_retains_the_claim() {
+        var (pending, status) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
+            h.Observation.Default = Evidence();
+            h.Ops.QueueGet(Policy());
+            h.Ops.QueuePutV2Failure("daemon_unreachable");
+
+            await h.Enter();
+
+            return (h.Claims.Pending().Count, h.Vm.Status);
+        });
+
+        await Assert.That(pending).IsEqualTo(1);
+        await Assert.That(status).IsEqualTo(DaemonStepViewModel.ClaimFailedMessage);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_claim_for_another_server_is_never_applied() {
+        var (puts, pending) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Claims.Arm(new ConsentFlipClaim(Profile, ServerIdentity.Canonicalize("https://other.test")!));
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
+            h.Observation.Default = Evidence();
+
+            await h.Enter();
+
+            return (h.Ops.PutV2Calls, h.Claims.Pending().Count);
+        });
+
+        await Assert.That(puts).IsEqualTo(0);
+        await Assert.That(pending).IsEqualTo(1);
+    }
+
+    // ── navigation ──────────────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Leaving_mid_mutation_detaches_the_waiter_and_never_vetoes() {
+        var (observedCancel, canLeave, status) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap());
+            var cancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var entered   = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            h.Lane.Behavior = async (_, ct) => {
+                entered.TrySetResult(true);
+                // The lane owns the child: only the WAITER's token is cancelled here.
+                await using var registration = ct.Register(() => cancelled.TrySetResult(true));
+                await Task.Delay(Timeout.Infinite, ct);
+                return new MutationOutcome.Succeeded();
+            };
+
+            await h.Enter();
+            var action = h.Act();
+            await entered.Task;
+
+            var left = await h.Vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+            await action;
+
+            return (cancelled.Task.IsCompleted, left, h.Vm.Status);
+        });
+
+        await Assert.That(observedCancel).IsTrue();
+        await Assert.That(canLeave).IsTrue();
+        await Assert.That(status).IsEqualTo(DaemonStepViewModel.DetachedMessage);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Leaving_awaits_an_in_flight_claim_put_rather_than_cancelling_it() {
+        var (pending, puts) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
+            h.Observation.Default = Evidence();
+            h.Ops.QueueGet(Policy());
+            var put = h.Ops.ArmPutV2();
+
+            var enter = h.Enter();
+            await WaitUntilAsync(() => h.Ops.PutV2Calls == 1, "the conditional put to reach the ops layer");
+
+            var leaving = h.Vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+            put.SetResult(new ConsentAckDto(true, null, null));
+            await Assert.That(await leaving).IsTrue();
+            await enter;
+
+            return (h.Claims.Pending().Count, h.Ops.PutV2Calls);
+        });
+
+        await Assert.That(pending).IsEqualTo(0); // the put completed and the claim was consumed
+        await Assert.That(puts).IsEqualTo(1);
+    }
+}
+
+/// Template smoke coverage, mirroring the sibling step tests: the daemon step's named controls
+/// resolve through the real window.
+public class DaemonStepTemplateTests {
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_window_selects_a_template_for_the_daemon_step() {
+        var (actionButton, refreshButton, messageText) = await AvaloniaSession.DispatchAsync(async () => {
+            using var temp = new TempClaims();
+            var step = new DaemonStepViewModel(
+                new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(
+                    new ServiceSnapshot("kcap-daemon", false, "not_installed", null, "/opt/kcap/kcap-daemon", null, null, false, false)) },
+                (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded()),
+                () => ("default", "https://example.test", "kcap-daemon"),
+                new NeverObserved(), new ScriptedLocalControlOps(), temp.Claims,
+                () => ("default", "https://example.test", "kcap-daemon"), new FakeLifecycleSurface(),
+                _ => Task.FromResult<string?>("/usr/bin"), TimeProvider.System);
+
+            var vm = new OnboardingViewModel([step, new DoneStepViewModel(() => [])]);
+            await vm.PendingEnterForTesting;
+
+            var window = new OnboardingWindow { DataContext = vm };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var action  = window.GetVisualDescendants().OfType<Button>().FirstOrDefault(b => b.Name == "DaemonActionButton");
+            var refresh = window.GetVisualDescendants().OfType<Button>().FirstOrDefault(b => b.Name == "DaemonRefreshButton");
+            var message = window.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(t => t.Name == "DaemonMessageText");
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return (action, refresh, message?.Text);
+        });
+
+        await Assert.That(actionButton).IsNotNull();
+        await Assert.That(actionButton!.Content).IsEqualTo("Enable daemon");
+        await Assert.That(refreshButton).IsNotNull();
+        await Assert.That(messageText).IsEqualTo(DaemonStepViewModel.NotInstalledMessage);
+    }
+
+    sealed class NeverObserved : IDaemonObservation {
+        public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) =>
+            Task.FromResult<ObservedEvidence?>(null);
+    }
+
+    sealed class TempClaims : IDisposable {
+        public readonly string Dir = Directory.CreateTempSubdirectory("kcap-daemonstep-tpl-").FullName;
+        public readonly ConsentFlipClaims Claims;
+
+        public TempClaims() =>
+            Claims = new ConsentFlipClaims(Path.Combine(Dir, "claims.json"), Path.Combine(Dir, "config.json"));
+
+        public void Dispose() {
+            try { Directory.Delete(Dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/DaemonStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonStepViewModelTests.cs
@@ -12,11 +12,13 @@ using Microsoft.Extensions.Time.Testing;
 
 namespace Capacitor.App.Tests.Unit;
 
-/// spec §3 step 7: every row of AI-1654's state matrix → the exact mutation verb (or an explicit
-/// no-mutation) and the affordance offered, plus the decision-7 claim application rules. The lane
-/// is a recording delegate (results are waiter-state-only), the claims store is REAL on temp paths
-/// (so TryConsume's own two-lock compare runs), and the surface records every dialog — the
-/// single-presentation rule is asserted by the surface staying untouched on every waiter outcome.
+/// spec §3 step 7: every row of the lifecycle slice's state matrix → the exact mutation verb (or
+/// an explicit no-mutation) and the affordance offered, plus the decision-7 claim application
+/// rules. The lane is a recording delegate (results are waiter-state-only), the claims store is
+/// REAL on temp paths (so TryConsume's own two-lock compare runs), and the surface records every
+/// dialog — the single-presentation rule is asserted by the surface staying untouched on every
+/// waiter outcome. Every "no claim application" assertion checks GetCalls, not just PutV2Calls:
+/// the GET is the FIRST ops touch, so a guard that stopped guarding would be invisible otherwise.
 public class DaemonStepViewModelTests {
     const string Profile    = "default";
     const string RawServer  = "https://example.test";
@@ -25,8 +27,8 @@ public class DaemonStepViewModelTests {
 
     static ServiceSnapshot Snap(
             string state = "not_installed", bool unitPresent = false, int? jobPid = null, int? daemonPid = null,
-            bool txnMarker = false, bool txnActive = false) =>
-        new(DaemonName, unitPresent, state, "/opt/kcap/kcap-daemon", "/opt/kcap/kcap-daemon", jobPid, daemonPid,
+            bool txnMarker = false, bool txnActive = false, string? installBinaryPath = "/opt/kcap/kcap-daemon") =>
+        new(DaemonName, unitPresent, state, "/opt/kcap/kcap-daemon", installBinaryPath, jobPid, daemonPid,
             txnMarker, txnActive);
 
     static ObservedEvidence Evidence(
@@ -155,19 +157,77 @@ public class DaemonStepViewModelTests {
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task A_server_that_cannot_be_canonicalized_refuses_before_any_status_read() {
-        var (row, affordance, statusCalls, mutations) = await AvaloniaSession.DispatchAsync(async () => {
+        var (row, affordance, message, statusCalls, mutations) = await AvaloniaSession.DispatchAsync(async () => {
             using var h = new Harness();
             h.Identity = (Profile, "file:///etc/passwd", DaemonName);
 
             await h.Enter();
 
-            return (h.Vm.Row, h.Vm.Affordance, h.Cli.StatusCallCount, h.Lane.Requests.Count);
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Message, h.Cli.StatusCallCount, h.Lane.Requests.Count);
         });
 
         await Assert.That(row).IsEqualTo(DaemonRow.NoServerConfigured);
         await Assert.That(affordance).IsEqualTo(DaemonAffordance.None);
+        await Assert.That(message).IsEqualTo(DaemonStepViewModel.NoServerMessage); // humanized, not the raw token
         await Assert.That(statusCalls).IsEqualTo(0);
         await Assert.That(mutations).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Re_entering_after_a_completed_sign_in_classifies_on_the_now_resolvable_identity() {
+        var (firstRow, secondRow, secondAffordance) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap());
+            h.Identity = null;
+
+            await h.Enter();
+            var first = h.Vm.Row;
+
+            h.Identity = (Profile, RawServer, DaemonName); // the Sign in step committed while we were away
+            await h.Enter();
+
+            return (first, h.Vm.Row, h.Vm.Affordance);
+        });
+
+        await Assert.That(firstRow).IsEqualTo(DaemonRow.RequiresSignIn);
+        await Assert.That(secondRow).IsEqualTo(DaemonRow.NotInstalled);
+        await Assert.That(secondAffordance).IsEqualTo(DaemonAffordance.Install);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_unresolvable_daemon_binary_withdraws_the_unit_writing_offer() {
+        var (row, affordance, message, mutations) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap(installBinaryPath: null));
+
+            await h.Enter();
+            await h.Act(); // no affordance — nothing to run
+
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Message, h.Lane.Requests.Count);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.BinaryUnresolved);
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.None);
+        await Assert.That(message).IsEqualTo(DaemonStepViewModel.BinaryUnresolvedMessage);
+        await Assert.That(mutations).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_unresolvable_daemon_binary_still_allows_the_start_row() {
+        var (row, affordance) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Status(Snap(state: "installed", unitPresent: true, installBinaryPath: null));
+
+            await h.Enter();
+
+            return (h.Vm.Row, h.Vm.Affordance);
+        });
+
+        await Assert.That(row).IsEqualTo(DaemonRow.Stopped); // starting an installed unit writes none
+        await Assert.That(affordance).IsEqualTo(DaemonAffordance.Start);
     }
 
     // ── unreadable / unrecognized evidence: honest message, no mutation ─────
@@ -326,7 +386,7 @@ public class DaemonStepViewModelTests {
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Ownership_without_an_identity_match_offers_only_the_takeover_and_never_the_claim() {
-        var (row, affordance, satisfied, mutations, puts, pending) = await AvaloniaSession.DispatchAsync(async () => {
+        var (row, affordance, satisfied, mutations, gets, puts, pending) = await AvaloniaSession.DispatchAsync(async () => {
             using var h = new Harness();
             h.ArmClaim();
             h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
@@ -335,14 +395,15 @@ public class DaemonStepViewModelTests {
             await h.Enter();
             await h.Act(); // the surface declines by default
 
-            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Satisfied, h.Lane.Requests.Count, h.Ops.PutV2Calls,
-                h.Claims.Pending().Count);
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Satisfied, h.Lane.Requests.Count, h.Ops.GetCalls,
+                h.Ops.PutV2Calls, h.Claims.Pending().Count);
         });
 
         await Assert.That(row).IsEqualTo(DaemonRow.OwnedIdentityMismatch);
         await Assert.That(affordance).IsEqualTo(DaemonAffordance.Takeover);
         await Assert.That(satisfied).IsFalse();
         await Assert.That(mutations).IsEqualTo(0);
+        await Assert.That(gets).IsEqualTo(0); // the claim path was never entered at all
         await Assert.That(puts).IsEqualTo(0);
         await Assert.That(pending).IsEqualTo(1);
     }
@@ -418,7 +479,7 @@ public class DaemonStepViewModelTests {
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task A_manual_daemon_for_another_server_mutates_nothing_and_applies_no_claim() {
-        var (row, affordance, message, mutations, puts, pending) = await AvaloniaSession.DispatchAsync(async () => {
+        var (row, affordance, message, mutations, gets, puts, pending) = await AvaloniaSession.DispatchAsync(async () => {
             using var h = new Harness();
             h.ArmClaim();
             h.Status(Snap(state: "not_installed", daemonPid: 777));
@@ -427,14 +488,15 @@ public class DaemonStepViewModelTests {
             await h.Enter();
             await h.Act(); // declines
 
-            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Message, h.Lane.Requests.Count, h.Ops.PutV2Calls,
-                h.Claims.Pending().Count);
+            return (h.Vm.Row, h.Vm.Affordance, h.Vm.Message, h.Lane.Requests.Count, h.Ops.GetCalls,
+                h.Ops.PutV2Calls, h.Claims.Pending().Count);
         });
 
         await Assert.That(row).IsEqualTo(DaemonRow.ManualIdentityMismatch);
         await Assert.That(affordance).IsEqualTo(DaemonAffordance.Takeover); // the only offered action
         await Assert.That(message).Contains("https://other.test");
         await Assert.That(mutations).IsEqualTo(0);
+        await Assert.That(gets).IsEqualTo(0); // the decline path never enters the claim path on a mismatch
         await Assert.That(puts).IsEqualTo(0);
         await Assert.That(pending).IsEqualTo(1);
     }
@@ -676,7 +738,7 @@ public class DaemonStepViewModelTests {
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task A_claim_for_another_server_is_never_applied() {
-        var (puts, pending) = await AvaloniaSession.DispatchAsync(async () => {
+        var (gets, puts, pending) = await AvaloniaSession.DispatchAsync(async () => {
             using var h = new Harness();
             h.Claims.Arm(new ConsentFlipClaim(Profile, ServerIdentity.Canonicalize("https://other.test")!));
             h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
@@ -684,11 +746,54 @@ public class DaemonStepViewModelTests {
 
             await h.Enter();
 
-            return (h.Ops.PutV2Calls, h.Claims.Pending().Count);
+            return (h.Ops.GetCalls, h.Ops.PutV2Calls, h.Claims.Pending().Count);
         });
 
+        await Assert.That(gets).IsEqualTo(0); // the pending filter, not a later rejection, is what stops this
         await Assert.That(puts).IsEqualTo(0);
         await Assert.That(pending).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_successful_mutation_whose_re_probe_no_longer_matches_applies_no_claim() {
+        var (satisfied, gets, puts, pending) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap());
+            h.Observation.Default = Evidence(server: "https://other.test"); // the post-mutation re-check fails
+
+            await h.Enter();
+            await h.Act();
+
+            return (h.Vm.Satisfied, h.Ops.GetCalls, h.Ops.PutV2Calls, h.Claims.Pending().Count);
+        });
+
+        await Assert.That(satisfied).IsTrue(); // the lane's own outcome still decides enablement
+        await Assert.That(gets).IsEqualTo(0);  // but the claim never reaches a daemon we did not just verify
+        await Assert.That(puts).IsEqualTo(0);
+        await Assert.That(pending).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_operator_chosen_deny_is_left_stricter_than_prompt() {
+        var (gets, puts, pending, status) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.ArmClaim();
+            h.Status(Snap(state: "running", unitPresent: true, jobPid: 100, daemonPid: 100));
+            h.Observation.Default = Evidence();
+            h.Ops.QueueGet(Policy("deny"));
+
+            await h.Enter();
+
+            return (h.Ops.GetCalls, h.Ops.PutV2Calls, h.Claims.Pending().Count, h.Vm.Status);
+        });
+
+        await Assert.That(gets).IsEqualTo(1);
+        await Assert.That(puts).IsEqualTo(0);
+        await Assert.That(pending).IsEqualTo(1); // retained, inert
+        await Assert.That(status).IsEqualTo(DaemonStepViewModel.ClaimAlreadyStricterMessage);
     }
 
     // ── navigation ──────────────────────────────────────────────────────────

--- a/test/Capacitor.App.Tests.Unit/FakeLifecycleSurface.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeLifecycleSurface.cs
@@ -11,6 +11,10 @@ sealed class FakeLifecycleSurface : ILifecycleSurface {
 
     public Func<LifecyclePrompt, CancellationToken, Task<bool>> ConfirmBehavior = (_, _) => Task.FromResult(false);
 
+    /// Scripts TryConfirmAsync's own answer (including null) independent of ConfirmBehavior, so a
+    /// test can drive the "never reached the dialog" case without a real ct race.
+    public Func<LifecyclePrompt, CancellationToken, Task<bool?>>? TryConfirmBehavior;
+
     public void Status(string message) => StatusMessages.Add(message);
 
     public void Attention(string message) => AttentionMessages.Add(message);
@@ -22,6 +26,10 @@ sealed class FakeLifecycleSurface : ILifecycleSurface {
 
     /// Mirrors LifecycleSurface's own contract: an already-cancelled ct never reaches the dialog — null, nothing recorded.
     public async Task<bool?> TryConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) {
+        if (TryConfirmBehavior is { } behavior) {
+            Prompts.Add(prompt);
+            return await behavior(prompt, ct).ConfigureAwait(false);
+        }
         if (ct.IsCancellationRequested) return null;
         Prompts.Add(prompt);
         return await ConfirmBehavior(prompt, ct).ConfigureAwait(false);

--- a/test/Capacitor.App.Tests.Unit/KcapCliTests.cs
+++ b/test/Capacitor.App.Tests.Unit/KcapCliTests.cs
@@ -16,6 +16,9 @@ public class KcapCliTests {
             SeenOptions  = options;
             return (Behavior ?? (_ => Task.FromResult(new ProcessResult(0, "", "", false))))(ct);
         }
+
+        public Task<StreamingResult> RunStreamingAsync(string fileName, string[] args, RunOptions options,
+            Action<StreamedLine> onLine, CancellationToken ct) => throw new NotImplementedException();
     }
 
     const string CanonicalServer = "https://cap.example.com:443";

--- a/test/Capacitor.App.Tests.Unit/KcapCliTests.cs
+++ b/test/Capacitor.App.Tests.Unit/KcapCliTests.cs
@@ -17,8 +17,16 @@ public class KcapCliTests {
             return (Behavior ?? (_ => Task.FromResult(new ProcessResult(0, "", "", false))))(ct);
         }
 
+        public IReadOnlyList<StreamedLine> ScriptedStreamLines = [];
+
         public Task<StreamingResult> RunStreamingAsync(string fileName, string[] args, RunOptions options,
-            Action<StreamedLine> onLine, CancellationToken ct) => throw new NotImplementedException();
+                Action<StreamedLine> onLine, CancellationToken ct) {
+            SeenFileName = fileName;
+            SeenArgs     = args;
+            SeenOptions  = options;
+            foreach (var line in ScriptedStreamLines) onLine(line);
+            return Task.FromResult(new StreamingResult(0, false, ScriptedStreamLines));
+        }
     }
 
     const string CanonicalServer = "https://cap.example.com:443";
@@ -451,6 +459,146 @@ public class KcapCliTests {
         var result = await cli.ServiceInstallVerifiedAsync(replace: false, CancellationToken.None);
 
         await Assert.That(result.ExitCode).IsEqualTo(127);
+        await Assert.That(runner.SeenFileName).IsNull();
+    }
+
+    [Test]
+    public async Task PluginInstallAsync_null_vendor_flag_is_the_flagless_claude_default() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+
+        await cli.PluginInstallAsync(null, CancellationToken.None);
+
+        await Assert.That(runner.SeenArgs).IsEquivalentTo(["plugin", "install"], CollectionOrdering.Matching);
+        await Assert.That(runner.SeenOptions!.Timeout).IsEqualTo(TimeSpan.FromSeconds(60));
+    }
+
+    [Test]
+    public async Task PluginInstallAsync_with_vendor_flag_appends_it() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+
+        await cli.PluginInstallAsync("--codex", CancellationToken.None);
+
+        await Assert.That(runner.SeenArgs).IsEquivalentTo(["plugin", "install", "--codex"], CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task PluginInstallAsync_env_overlay_carries_profile_and_no_telemetry_but_not_mutation_keys() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+
+        await cli.PluginInstallAsync(null, CancellationToken.None);
+
+        await Assert.That(runner.SeenOptions!.EnvOverlay!["KCAP_PROFILE"]).IsEqualTo("work");
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.SpawnNoTelemetryVar]).IsEqualTo("1");
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey(KcapCli.ConsentSeedDefaultVar)).IsFalse();
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey(KcapCli.ExpectServerUrlVar)).IsFalse();
+    }
+
+    [Test]
+    public async Task PluginInstallAsync_with_null_CliPath_returns_exit_127_without_calling_the_runner() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCliWithNullPath(runner);
+
+        var result = await cli.PluginInstallAsync(null, CancellationToken.None);
+
+        await Assert.That(result.ExitCode).IsEqualTo(127);
+        await Assert.That(runner.SeenFileName).IsNull();
+    }
+
+    [Test]
+    public async Task ImportAsync_everything_scope_with_two_vendor_flags_builds_argv_in_order() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+        var request = new ImportRequest(ImportScopeChoice.Everything, null, ["--codex", "--cursor"]);
+
+        await cli.ImportAsync(request, _ => { }, CancellationToken.None);
+
+        await Assert.That(runner.SeenArgs).IsEquivalentTo(
+            ["import", "--all", "--yes", "--codex", "--cursor"], CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task ImportAsync_org_scope_builds_argv() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+        var request = new ImportRequest(ImportScopeChoice.Org, "my-org", []);
+
+        await cli.ImportAsync(request, _ => { }, CancellationToken.None);
+
+        await Assert.That(runner.SeenArgs).IsEquivalentTo(
+            ["import", "--org", "my-org", "--yes"], CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task ImportAsync_repo_scope_builds_argv() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+        var request = new ImportRequest(ImportScopeChoice.Repo, "my-org/my-repo", []);
+
+        await cli.ImportAsync(request, _ => { }, CancellationToken.None);
+
+        await Assert.That(runner.SeenArgs).IsEquivalentTo(
+            ["import", "--repo", "my-org/my-repo", "--yes"], CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task ImportAsync_env_overlay_carries_profile_and_no_telemetry_but_not_mutation_keys() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+        var request = new ImportRequest(ImportScopeChoice.Everything, null, []);
+
+        await cli.ImportAsync(request, _ => { }, CancellationToken.None);
+
+        await Assert.That(runner.SeenOptions!.EnvOverlay!["KCAP_PROFILE"]).IsEqualTo("work");
+        await Assert.That(runner.SeenOptions!.EnvOverlay![KcapCli.SpawnNoTelemetryVar]).IsEqualTo("1");
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey(KcapCli.ConsentSeedDefaultVar)).IsFalse();
+        await Assert.That(runner.SeenOptions!.EnvOverlay!.ContainsKey(KcapCli.ExpectServerUrlVar)).IsFalse();
+    }
+
+    [Test]
+    public async Task ImportAsync_passes_no_internal_timeout() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCli(runner);
+        var request = new ImportRequest(ImportScopeChoice.Everything, null, []);
+
+        await cli.ImportAsync(request, _ => { }, CancellationToken.None);
+
+        await Assert.That(runner.SeenOptions!.Timeout).IsNull();
+    }
+
+    [Test]
+    public async Task ImportAsync_streams_lines_and_returns_the_scripted_result() {
+        var runner = new FakeProcessRunner {
+            ScriptedStreamLines = [
+                new StreamedLine(ProcessStreamKind.Stdout, "importing repo one"),
+                new StreamedLine(ProcessStreamKind.Stderr, "warning: skip"),
+            ],
+        };
+        var cli = MakeCli(runner);
+        var request = new ImportRequest(ImportScopeChoice.Everything, null, []);
+        List<StreamedLine> seen = [];
+
+        var result = await cli.ImportAsync(request, seen.Add, CancellationToken.None);
+
+        await Assert.That(seen).IsEquivalentTo(runner.ScriptedStreamLines, CollectionOrdering.Matching);
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.TimedOut).IsFalse();
+    }
+
+    [Test]
+    public async Task ImportAsync_with_null_CliPath_returns_a_synthesized_no_cli_result_without_calling_the_runner() {
+        var runner = new FakeProcessRunner();
+        var cli = MakeCliWithNullPath(runner);
+        var request = new ImportRequest(ImportScopeChoice.Everything, null, []);
+
+        var result = await cli.ImportAsync(request, _ => { }, CancellationToken.None);
+
+        await Assert.That(result.ExitCode).IsEqualTo(-1);
+        await Assert.That(result.TimedOut).IsFalse();
+        await Assert.That(result.Tail).IsEquivalentTo(
+            [new StreamedLine(ProcessStreamKind.Stderr, "kcap CLI not found")], CollectionOrdering.Matching);
         await Assert.That(runner.SeenFileName).IsNull();
     }
 }

--- a/test/Capacitor.App.Tests.Unit/LifecyclePromptViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LifecyclePromptViewModelTests.cs
@@ -18,11 +18,34 @@ public class LifecyclePromptViewModelTests {
     [Arguments(LifecyclePrompt.KindRestartUpdate, "Restart daemon to update")]
     [Arguments(LifecyclePrompt.KindTakeover, "Take over daemon management")]
     [Arguments(LifecyclePrompt.KindRepair, "Repair daemon service")]
+    [Arguments(LifecyclePrompt.KindQuarantine, "Corrupted consent claims file")]
     public async Task Title_is_kind_specific(string kind, string expectedTitle) {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var vm = new LifecyclePromptViewModel(Prompt(kind), new TaskCompletionSource<bool>());
 
             await Assert.That(vm.Title).IsEqualTo(expectedTitle);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Quarantine_kind_renders_confirm_only_with_an_acknowledge_button() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var vm = new LifecyclePromptViewModel(Prompt(LifecyclePrompt.KindQuarantine), new TaskCompletionSource<bool>());
+
+            await Assert.That(vm.ShowDeclineButton).IsFalse();
+            await Assert.That(vm.AcceptButtonText).IsEqualTo("Acknowledge");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Non_quarantine_kinds_render_both_buttons() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var vm = new LifecyclePromptViewModel(Prompt(LifecyclePrompt.KindRepair), new TaskCompletionSource<bool>());
+
+            await Assert.That(vm.ShowDeclineButton).IsTrue();
+            await Assert.That(vm.AcceptButtonText).IsEqualTo("Continue");
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/LoginShellProbeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LoginShellProbeTests.cs
@@ -317,7 +317,7 @@ public class LoginShellProbeTests {
         await Assert.That(runner.Calls).Count().IsEqualTo(1);
     }
 
-    // Regression (Finding 10): the post-install probe must never reuse the pre-install cached
+    // Regression: the post-install probe must never reuse the pre-install cached
     // answer — forceRefresh bypasses it AND repopulates the cache with the fresh result.
     [Test]
     public async Task KcapOnPathAsync_forceRefresh_bypasses_and_repopulates_the_cache() {

--- a/test/Capacitor.App.Tests.Unit/LoginShellProbeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LoginShellProbeTests.cs
@@ -16,6 +16,9 @@ public class LoginShellProbeTests {
             var step = _steps.Count > 0 ? _steps.Dequeue() : () => Task.FromResult(new ProcessResult(0, "", "", false));
             return step();
         }
+
+        public Task<StreamingResult> RunStreamingAsync(string fileName, string[] args, RunOptions options,
+            Action<StreamedLine> onLine, CancellationToken ct) => throw new NotImplementedException();
     }
 
     static string Wrap(string path) => $"{LoginShellProbe.Sentinel}{path}{LoginShellProbe.Sentinel}";

--- a/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
@@ -287,10 +287,11 @@ public class OnboardingGateTests {
 
     // ── EvaluateResolvedAsync: the shared-resolution seam (Codex P1) ────────
 
-    // App.StartAsync now resolves ONCE (via DaemonClientService.CreateDefaultAsync) and hands that
-    // SAME identity to EvaluateResolvedAsync — proving it never re-resolves is what rules out the
-    // race the P1 finding described: a concurrent active-profile change between two independent
-    // resolves evaluating the gate against a different profile than the one the daemon graph built.
+    // App.StartAsync resolves ONCE (EvaluateAsync's own resolve, which the daemon graph is then
+    // built from) and hands that SAME identity to EvaluateResolvedAsync — proving it never
+    // re-resolves is what rules out the race the P1 finding described: a concurrent active-profile
+    // change between two independent resolves evaluating the gate against a different profile than
+    // the one the daemon graph built.
     [Test]
     public async Task EvaluateResolvedAsync_never_re_resolves_ignoring_a_config_change_after_capture() {
         WriteConfig(SingleProfileConfig(

--- a/test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs
@@ -16,10 +16,12 @@ sealed class FakeWizardStep(WizardStepId id, string? title = null) : IWizardStep
     public bool Applicable { get; init; } = true;
     public bool Satisfied { get; set; }
     public int EnterCount { get; private set; }
+    public bool ThrowOnEnter { get; init; }
     public Func<WizardNavigation, CancellationToken, Task<bool>>? CanLeave { get; init; }
 
     public Task OnEnterAsync(CancellationToken ct) {
         EnterCount++;
+        if (ThrowOnEnter) throw new InvalidOperationException("boom: enter failed");
         return Task.CompletedTask;
     }
 
@@ -262,5 +264,100 @@ public class OnboardingViewModelTests {
         });
 
         await Assert.That(rendered).IsEqualTo("Connect to Capacitor");
+    }
+
+    // ---- Fix round 1 ----
+
+    /// Reviewer repro: Skip suspends on a pending veto check; a directly-invoked Next (bypassing
+    /// the canExecute-driven Button disable a real UI enforces) must be a silent no-op — the
+    /// shared busy gate inside NavigateAsync itself, not just canExecute — rather than racing
+    /// Skip's own _index mutation once the veto later resolves.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Skip_blocked_on_a_pending_veto_cannot_race_a_concurrent_Next() {
+        var currentId = await AvaloniaSession.DispatchAsync(async () => {
+            var gate = new TaskCompletionSource<bool>();
+            var connect = new FakeWizardStep(WizardStepId.Connect) {
+                CanLeave = (direction, _) => direction == WizardNavigation.Skip ? gate.Task : Task.FromResult(true),
+            };
+            var signIn = new FakeWizardStep(WizardStepId.SignIn);
+            var done = new FakeWizardStep(WizardStepId.Done);
+            var vm = new OnboardingViewModel([connect, signIn, done]);
+            await vm.PendingEnterForTesting;
+
+            var skipTask = vm.SkipCommand.Execute().ToTask(); // starts, suspends on gate.Task
+            await vm.NextCommand.Execute().ToTask(); // must be a silent no-op — no exception
+
+            gate.SetResult(true); // release Skip's veto check
+            await skipTask;
+
+            return vm.Current.Id;
+        });
+
+        await Assert.That(currentId).IsEqualTo(WizardStepId.SignIn); // exactly one transition, no double-increment
+    }
+
+    /// The busy gate also drives canExecute itself — a real bound Button disables for all three
+    /// directions the instant one navigation starts, not just the internal early-return above.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task All_three_commands_disable_while_one_navigation_is_in_flight() {
+        var (backWhileBusy, skipWhileBusy, nextWhileBusy, backAfter) = await AvaloniaSession.DispatchAsync(async () => {
+            var gate = new TaskCompletionSource<bool>();
+            var connect = new FakeWizardStep(WizardStepId.Connect) { CanLeave = (_, _) => gate.Task };
+            var signIn = new FakeWizardStep(WizardStepId.SignIn);
+            var vm = new OnboardingViewModel([connect, signIn]);
+            await vm.PendingEnterForTesting;
+
+            var skipTask = vm.SkipCommand.Execute().ToTask(); // starts, suspends on gate.Task
+
+            var backWhileBusy = CanExecute(vm.BackCommand);
+            var skipWhileBusy = CanExecute(vm.SkipCommand);
+            var nextWhileBusy = CanExecute(vm.NextCommand);
+
+            gate.SetResult(true);
+            await skipTask;
+
+            return (backWhileBusy, skipWhileBusy, nextWhileBusy, CanExecute(vm.BackCommand));
+        });
+
+        await Assert.That(backWhileBusy).IsFalse();
+        await Assert.That(skipWhileBusy).IsFalse();
+        await Assert.That(nextWhileBusy).IsFalse();
+        await Assert.That(backAfter).IsTrue(); // idle again once the transition settles
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task CanLeaveAsync_throwing_is_treated_as_a_veto_and_does_not_crash() {
+        var currentId = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect) { CanLeave = (_, _) => throw new InvalidOperationException("boom") };
+            var signIn = new FakeWizardStep(WizardStepId.SignIn);
+            var vm = new OnboardingViewModel([connect, signIn]);
+            await vm.PendingEnterForTesting;
+
+            await vm.NextCommand.Execute().ToTask(); // must not throw out of the command
+
+            return vm.Current.Id;
+        });
+
+        await Assert.That(currentId).IsEqualTo(WizardStepId.Connect); // treated as a veto: stayed
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task OnEnterAsync_throwing_still_completes_the_transition_and_does_not_crash() {
+        var currentId = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect);
+            var signIn = new FakeWizardStep(WizardStepId.SignIn) { ThrowOnEnter = true };
+            var vm = new OnboardingViewModel([connect, signIn]);
+            await vm.PendingEnterForTesting;
+
+            await vm.NextCommand.Execute().ToTask(); // must not throw out of the command
+
+            return vm.Current.Id;
+        });
+
+        await Assert.That(currentId).IsEqualTo(WizardStepId.SignIn); // transition still landed
     }
 }

--- a/test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs
@@ -266,9 +266,9 @@ public class OnboardingViewModelTests {
         await Assert.That(rendered).IsEqualTo("Connect to Capacitor");
     }
 
-    // ---- Fix round 1 ----
+    // ── Busy gate and veto handling ──────────────────────────
 
-    /// Reviewer repro: Skip suspends on a pending veto check; a directly-invoked Next (bypassing
+    /// Skip suspends on a pending veto check; a directly-invoked Next (bypassing
     /// the canExecute-driven Button disable a real UI enforces) must be a silent no-op — the
     /// shared busy gate inside NavigateAsync itself, not just canExecute — rather than racing
     /// Skip's own _index mutation once the veto later resolves.

--- a/test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs
@@ -1,0 +1,266 @@
+using ReactiveUnit = System.Reactive.Unit;
+using System.Reactive.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.App.Views.Onboarding;
+using ReactiveUI;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.App.Tests.Unit;
+
+sealed class FakeWizardStep(WizardStepId id, string? title = null) : IWizardStep {
+    public WizardStepId Id { get; } = id;
+    public string Title { get; } = title ?? id.ToString();
+    public bool Applicable { get; init; } = true;
+    public bool Satisfied { get; set; }
+    public int EnterCount { get; private set; }
+    public Func<WizardNavigation, CancellationToken, Task<bool>>? CanLeave { get; init; }
+
+    public Task OnEnterAsync(CancellationToken ct) {
+        EnterCount++;
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) =>
+        CanLeave?.Invoke(direction, ct) ?? Task.FromResult(true);
+}
+
+/// Dispatches through the real headless session (ConsentPromptViewModelTests' pattern) — the
+/// constructor's WhenAnyValue call trips ReactiveUI's init guard under WithImmediateRxScheduler.
+public class OnboardingViewModelTests {
+    static bool CanExecute(ReactiveCommand<ReactiveUnit, ReactiveUnit> command) {
+        var value = false;
+        using var sub = command.CanExecute.Subscribe(v => value = v);
+        return value;
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Steps_excludes_non_applicable_entries_and_starts_on_the_first_applicable_one() {
+        var (stepIds, currentId) = await AvaloniaSession.DispatchAsync(async () => {
+            var shim = new FakeWizardStep(WizardStepId.Shim) { Applicable = false };
+            var connect = new FakeWizardStep(WizardStepId.Connect);
+            var done = new FakeWizardStep(WizardStepId.Done);
+            var vm = new OnboardingViewModel([shim, connect, done]);
+            await vm.PendingEnterForTesting;
+
+            return (vm.Steps.Select(s => s.Id).ToList(), vm.Current.Id);
+        });
+
+        await Assert.That(stepIds).IsEquivalentTo([WizardStepId.Connect, WizardStepId.Done], CollectionOrdering.Matching);
+        await Assert.That(currentId).IsEqualTo(WizardStepId.Connect);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Next_back_and_skip_move_through_the_full_step_order() {
+        var (afterNext, afterSkip, afterBack1, afterBack2) = await AvaloniaSession.DispatchAsync(async () => {
+            var steps = new[] {
+                new FakeWizardStep(WizardStepId.Connect),
+                new FakeWizardStep(WizardStepId.SignIn),
+                new FakeWizardStep(WizardStepId.Done),
+            };
+            var vm = new OnboardingViewModel(steps);
+            await vm.PendingEnterForTesting;
+
+            await vm.NextCommand.Execute().ToTask();
+            var afterNext = vm.Current.Id;
+
+            await vm.SkipCommand.Execute().ToTask();
+            var afterSkip = vm.Current.Id;
+
+            await vm.BackCommand.Execute().ToTask();
+            var afterBack1 = vm.Current.Id;
+
+            await vm.BackCommand.Execute().ToTask();
+            var afterBack2 = vm.Current.Id;
+
+            return (afterNext, afterSkip, afterBack1, afterBack2);
+        });
+
+        await Assert.That(afterNext).IsEqualTo(WizardStepId.SignIn);
+        await Assert.That(afterSkip).IsEqualTo(WizardStepId.Done);
+        await Assert.That(afterBack1).IsEqualTo(WizardStepId.SignIn);
+        await Assert.That(afterBack2).IsEqualTo(WizardStepId.Connect);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task CanLeaveAsync_false_holds_the_current_step_for_every_direction() {
+        var (afterNext, afterVetoedNext, afterVetoedSkip, afterVetoedBack) = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect);
+            var signIn = new FakeWizardStep(WizardStepId.SignIn) { CanLeave = (_, _) => Task.FromResult(false) };
+            var done = new FakeWizardStep(WizardStepId.Done);
+            var vm = new OnboardingViewModel([connect, signIn, done]);
+            await vm.PendingEnterForTesting;
+
+            await vm.NextCommand.Execute().ToTask(); // Connect -> SignIn, allowed
+            var afterNext = vm.Current.Id;
+
+            await vm.NextCommand.Execute().ToTask(); // vetoed
+            var afterVetoedNext = vm.Current.Id;
+
+            await vm.SkipCommand.Execute().ToTask(); // vetoed
+            var afterVetoedSkip = vm.Current.Id;
+
+            await vm.BackCommand.Execute().ToTask(); // vetoed
+            var afterVetoedBack = vm.Current.Id;
+
+            return (afterNext, afterVetoedNext, afterVetoedSkip, afterVetoedBack);
+        });
+
+        await Assert.That(afterNext).IsEqualTo(WizardStepId.SignIn);
+        await Assert.That(afterVetoedNext).IsEqualTo(WizardStepId.SignIn);
+        await Assert.That(afterVetoedSkip).IsEqualTo(WizardStepId.SignIn);
+        await Assert.That(afterVetoedBack).IsEqualTo(WizardStepId.SignIn);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Skip_then_return_leaves_the_step_unsatisfied() {
+        var (afterSkip, afterBack, satisfied) = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect);
+            var signIn = new FakeWizardStep(WizardStepId.SignIn);
+            var vm = new OnboardingViewModel([connect, signIn]);
+            await vm.PendingEnterForTesting;
+
+            await vm.SkipCommand.Execute().ToTask();
+            var afterSkip = vm.Current.Id;
+
+            await vm.BackCommand.Execute().ToTask();
+            var afterBack = vm.Current.Id;
+
+            return (afterSkip, afterBack, vm.Current.Satisfied);
+        });
+
+        await Assert.That(afterSkip).IsEqualTo(WizardStepId.SignIn);
+        await Assert.That(afterBack).IsEqualTo(WizardStepId.Connect);
+        await Assert.That(satisfied).IsFalse();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task OnEnterAsync_fires_on_initial_entry_and_again_on_re_entry() {
+        var (connectEntersInitially, signInEntersInitially, signInEntersAfterNext, connectEntersAfterBack) =
+            await AvaloniaSession.DispatchAsync(async () => {
+                var connect = new FakeWizardStep(WizardStepId.Connect);
+                var signIn = new FakeWizardStep(WizardStepId.SignIn);
+                var vm = new OnboardingViewModel([connect, signIn]);
+                await vm.PendingEnterForTesting;
+
+                var connectEntersInitially = connect.EnterCount;
+                var signInEntersInitially = signIn.EnterCount;
+
+                await vm.NextCommand.Execute().ToTask();
+                var signInEntersAfterNext = signIn.EnterCount;
+
+                await vm.BackCommand.Execute().ToTask();
+                var connectEntersAfterBack = connect.EnterCount;
+
+                return (connectEntersInitially, signInEntersInitially, signInEntersAfterNext, connectEntersAfterBack);
+            });
+
+        await Assert.That(connectEntersInitially).IsEqualTo(1);
+        await Assert.That(signInEntersInitially).IsEqualTo(0);
+        await Assert.That(signInEntersAfterNext).IsEqualTo(1);
+        await Assert.That(connectEntersAfterBack).IsEqualTo(2); // re-entry
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Back_is_disabled_on_the_first_step_and_skip_is_disabled_on_the_last_step() {
+        var (backOnFirst, skipOnFirst, backOnLast, skipOnLast) = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect);
+            var done = new FakeWizardStep(WizardStepId.Done);
+            var vm = new OnboardingViewModel([connect, done]);
+            await vm.PendingEnterForTesting;
+
+            var backOnFirst = CanExecute(vm.BackCommand);
+            var skipOnFirst = CanExecute(vm.SkipCommand);
+
+            await vm.NextCommand.Execute().ToTask(); // -> Done
+
+            var backOnLast = CanExecute(vm.BackCommand);
+            var skipOnLast = CanExecute(vm.SkipCommand);
+
+            return (backOnFirst, skipOnFirst, backOnLast, skipOnLast);
+        });
+
+        await Assert.That(backOnFirst).IsFalse();
+        await Assert.That(skipOnFirst).IsTrue();
+        await Assert.That(backOnLast).IsTrue();
+        await Assert.That(skipOnLast).IsFalse();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Next_on_the_last_step_finishes_and_raises_CloseRequested_exactly_once() {
+        var (finalStepId, closeCount) = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect);
+            var done = new FakeWizardStep(WizardStepId.Done);
+            var vm = new OnboardingViewModel([connect, done]);
+            await vm.PendingEnterForTesting;
+
+            var count = 0;
+            vm.CloseRequested += () => count++;
+
+            await vm.NextCommand.Execute().ToTask(); // Connect -> Done
+            await vm.NextCommand.Execute().ToTask(); // finish
+
+            return (vm.Current.Id, count);
+        });
+
+        await Assert.That(finalStepId).IsEqualTo(WizardStepId.Done);
+        await Assert.That(closeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Window_close_raises_CloseRequested() {
+        var closeCount = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect);
+            var vm = new OnboardingViewModel([connect]);
+            await vm.PendingEnterForTesting;
+
+            var count = 0;
+            vm.CloseRequested += () => count++;
+
+            var window = new OnboardingWindow { DataContext = vm };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return count;
+        });
+
+        await Assert.That(closeCount).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Window_renders_the_current_steps_title() {
+        var rendered = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect, "Connect to Capacitor");
+            var vm = new OnboardingViewModel([connect]);
+            await vm.PendingEnterForTesting;
+
+            var window = new OnboardingWindow { DataContext = vm };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var text = window.GetVisualDescendants().OfType<TextBlock>()
+                .FirstOrDefault(t => t.Name == "StepTitleText")?.Text;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return text;
+        });
+
+        await Assert.That(rendered).IsEqualTo("Connect to Capacitor");
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs
@@ -360,4 +360,97 @@ public class OnboardingViewModelTests {
 
         await Assert.That(currentId).IsEqualTo(WizardStepId.SignIn); // transition still landed
     }
+
+    // ── TryGoTo: the Sign-in step's retarget jump ────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task TryGoTo_jumps_backwards_and_enters_the_target_step() {
+        var (accepted, currentId, entered) = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect);
+            var signIn = new FakeWizardStep(WizardStepId.SignIn);
+            var vm = new OnboardingViewModel([connect, signIn]);
+            await vm.PendingEnterForTesting;
+            await vm.NextCommand.Execute().ToTask(); // now on Sign-in
+
+            var ok = vm.TryGoTo(WizardStepId.Connect);
+            await WaitForIdleAsync(vm);
+
+            return (ok, vm.Current.Id, connect.EnterCount);
+        });
+
+        await Assert.That(accepted).IsTrue();
+        await Assert.That(currentId).IsEqualTo(WizardStepId.Connect);
+        await Assert.That(entered).IsEqualTo(2); // the initial entry plus the jump
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task TryGoTo_consults_the_current_steps_veto_like_any_transition() {
+        var (accepted, currentId) = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect);
+            var signIn = new FakeWizardStep(WizardStepId.SignIn) { CanLeave = (_, _) => Task.FromResult(false) };
+            var vm = new OnboardingViewModel([connect, signIn]);
+            await vm.PendingEnterForTesting;
+            await vm.NextCommand.Execute().ToTask(); // now on Sign-in, which refuses to leave
+
+            var ok = vm.TryGoTo(WizardStepId.Connect);
+            await WaitForIdleAsync(vm);
+
+            return (ok, vm.Current.Id);
+        });
+
+        await Assert.That(accepted).IsTrue();  // the jump was admitted...
+        await Assert.That(currentId).IsEqualTo(WizardStepId.SignIn); // ...and then vetoed by the step
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task TryGoTo_is_refused_while_another_navigation_is_in_flight() {
+        var (secondAttempt, currentId) = await AvaloniaSession.DispatchAsync(async () => {
+            var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var connect = new FakeWizardStep(WizardStepId.Connect) { CanLeave = (_, _) => gate.Task };
+            var signIn = new FakeWizardStep(WizardStepId.SignIn);
+            var done = new FakeWizardStep(WizardStepId.Done);
+            var vm = new OnboardingViewModel([connect, signIn, done]);
+            await vm.PendingEnterForTesting;
+
+            var first = vm.NextCommand.Execute().ToTask(); // parks inside Connect's CanLeaveAsync
+            var refused = vm.TryGoTo(WizardStepId.Done);
+
+            gate.SetResult(true);
+            await first;
+            await WaitForIdleAsync(vm);
+
+            return (refused, vm.Current.Id);
+        }).WaitAsync(TimeSpan.FromSeconds(20));
+
+        await Assert.That(secondAttempt).IsFalse();
+        await Assert.That(currentId).IsEqualTo(WizardStepId.SignIn); // only the first navigation landed
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task TryGoTo_refuses_a_step_that_is_not_part_of_this_run() {
+        var accepted = await AvaloniaSession.DispatchAsync(async () => {
+            var connect = new FakeWizardStep(WizardStepId.Connect);
+            var shim = new FakeWizardStep(WizardStepId.Shim) { Applicable = false };
+            var vm = new OnboardingViewModel([shim, connect]);
+            await vm.PendingEnterForTesting;
+
+            return vm.TryGoTo(WizardStepId.Shim);
+        });
+
+        await Assert.That(accepted).IsFalse();
+    }
+
+    // TryGoTo's navigation is fire-and-forget by design (it answers the caller immediately), so
+    // tests wait for the shared gate to reopen rather than for a task they were never handed.
+    static async Task WaitForIdleAsync(OnboardingViewModel vm) {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!CanExecute(vm.NextCommand)) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException("the wizard never went idle");
+            await Task.Delay(10);
+        }
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/PathShimInstallerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PathShimInstallerTests.cs
@@ -360,7 +360,7 @@ public class PathShimInstallerTests {
         await Assert.That(runner.Calls).IsEmpty();
     }
 
-    // Regression (Finding 10): ShimOfferCoordinator's offer decision already consumed
+    // Regression: ShimOfferCoordinator's offer decision already consumed
     // KcapOnPathAsync (caching its "absent" answer) before ever calling InstallAsync — the
     // post-install probe must not just replay that stale cached answer.
     [Test]

--- a/test/Capacitor.App.Tests.Unit/PathShimInstallerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PathShimInstallerTests.cs
@@ -14,6 +14,9 @@ public class PathShimInstallerTests {
             Calls.Add((fileName, args, options));
             return _step();
         }
+
+        public Task<StreamingResult> RunStreamingAsync(string fileName, string[] args, RunOptions options,
+            Action<StreamedLine> onLine, CancellationToken ct) => throw new NotImplementedException();
     }
 
     readonly List<string> _tempDirs = [];

--- a/test/Capacitor.App.Tests.Unit/ProcessRunnerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ProcessRunnerTests.cs
@@ -77,6 +77,7 @@ public class ProcessRunnerTests {
     }
 
     [Test]
+    [NotInParallel("StreamingProcessRunner")]
     public async Task Timeout_kills_the_tree_and_returns_promptly() {
         Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
 
@@ -92,6 +93,7 @@ public class ProcessRunnerTests {
     }
 
     [Test]
+    [NotInParallel("StreamingProcessRunner")]
     public async Task AbandonWait_cancelled_ct_throws_and_the_child_survives() {
         Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
 
@@ -114,6 +116,7 @@ public class ProcessRunnerTests {
     }
 
     [Test]
+    [NotInParallel("StreamingProcessRunner")]
     public async Task KillTree_cancelled_ct_kills_the_child_then_throws() {
         Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
 
@@ -137,6 +140,7 @@ public class ProcessRunnerTests {
     }
 
     [Test]
+    [NotInParallel("StreamingProcessRunner")]
     public async Task ProcessOnly_timeout_kills_the_shell_but_spares_the_grandchild() {
         Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
 
@@ -159,6 +163,7 @@ public class ProcessRunnerTests {
     }
 
     [Test]
+    [NotInParallel("StreamingProcessRunner")]
     public async Task Tree_timeout_kills_the_grandchild_too() {
         Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
 
@@ -174,6 +179,7 @@ public class ProcessRunnerTests {
     }
 
     [Test]
+    [NotInParallel("StreamingProcessRunner")]
     public async Task KillTree_cancellation_kills_the_tree_even_with_TimeoutKill_ProcessOnly() {
         Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
 

--- a/test/Capacitor.App.Tests.Unit/ShimOfferCoordinatorTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ShimOfferCoordinatorTests.cs
@@ -28,6 +28,9 @@ public class ShimOfferCoordinatorTests {
             Calls.Add((fileName, args, options));
             return _step();
         }
+
+        public Task<StreamingResult> RunStreamingAsync(string fileName, string[] args, RunOptions options,
+            Action<StreamedLine> onLine, CancellationToken ct) => throw new NotImplementedException();
     }
 
     /// Applies mutations to State only when UpdateSucceeds is true — mirrors AppStateStore's real

--- a/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
@@ -1,0 +1,601 @@
+using System.Net;
+using System.Reactive.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.Services;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.App.Views.Onboarding;
+using Capacitor.Cli.Core.Auth;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The spec §3/§10 transition table for the step that runs ONE façade operation. The service is
+/// driven by a scripted operation (the façade itself is covered in Core), but the picker, the
+/// provisioner and the progress sink are the REAL bridges — they are what this task builds.
+public class SignInStepViewModelTests {
+    static readonly TimeSpan Bounded = TimeSpan.FromSeconds(10);
+
+    static async Task WaitUntil(Func<bool> condition, string what) {
+        var deadline = DateTime.UtcNow + Bounded;
+
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"timed out waiting for {what}");
+
+            await Task.Delay(5);
+        }
+    }
+
+    static DiscoveredTenant Tenant(string login) => new() { OrgLogin = login, Origin = $"https://{login}.kcap.ai" };
+
+    static WorkOSTokenSource Tokens() =>
+        new("access-token", refreshToken: null, (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
+
+    static AuthResult.Committed Committed(string provider = AuthProvider.GitHubApp, string? username = "sam") =>
+        new("acme", "https://acme.kcap.ai:443", provider, username, [new AuthIdentity("acme", "https://acme.kcap.ai:443")]);
+
+    sealed class FakeAppState : IAppStateStore {
+        public AppState State = new();
+        public int Updates;
+
+        public Task<AppState> LoadAsync() => Task.FromResult(State);
+
+        public Task<bool> UpdateAsync(Func<AppState, AppState> mutate) {
+            Updates++;
+            State = mutate(State);
+
+            return Task.FromResult(true);
+        }
+    }
+
+    sealed class Harness : IDisposable {
+        public readonly string                  TempDir = Directory.CreateTempSubdirectory("kcap-signin-").FullName;
+        public readonly ConnectStepViewModel    Connect = new();
+        public readonly WizardTenantPicker      Picker  = new();
+        public readonly ScriptedSignupHandler   Signup  = new();
+        public readonly RecordingOpener         Opener  = new();
+        public readonly FakeAppState            AppState = new();
+        public readonly FakeTimeProvider        Time    = new();
+        public readonly ConsentFlipClaims       Claims;
+        public readonly UiAuthProgress          Progress;
+        public readonly WizardTenantProvisioner Provisioner;
+        public readonly WizardAuthService       Service;
+        public readonly SignInStepViewModel     Vm;
+
+        public int Runs;
+
+        public Func<ConnectIntent, CancellationToken, Task<AuthResult>> Operation =
+            (_, _) => Task.FromResult<AuthResult>(Committed());
+
+        public Harness() {
+            Claims      = new ConsentFlipClaims(ClaimsPath, Path.Combine(TempDir, "config.json"));
+            Progress    = new UiAuthProgress(action => action());
+            Provisioner = new WizardTenantProvisioner(
+                new TenantProvisioningClient(new HttpClient(Signup)), "https://signup.example", Progress, Time);
+            Service = new WizardAuthService((intent, ct) => {
+                Runs++;
+
+                return Operation(intent, ct);
+            }, Claims);
+            Vm = new SignInStepViewModel(
+                Service, Connect, new WizardBridges(Progress, Picker, Provisioner, action => action()), Claims,
+                AppState, Opener);
+        }
+
+        public string ClaimsPath => Path.Combine(TempDir, "consent-flip-claims.json");
+
+        public Task<System.Reactive.Unit> SignIn() => Vm.SignInCommand.Execute().ToTask();
+
+        public void Dispose() {
+            try {
+                Directory.Delete(TempDir, recursive: true);
+            } catch (IOException) {
+                // temp cleanup only
+            }
+        }
+    }
+
+    // ── committed outcomes ───────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    [Arguments(AuthProvider.GitHubApp)]
+    [Arguments(AuthProvider.WorkOS)]
+    public async Task A_committed_discovery_satisfies_the_step_and_names_the_signed_in_user(string provider) {
+        var (satisfied, status, isError) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Discover;
+            h.Connect.DiscoveryProvider = provider;
+            h.Operation = (_, _) => Task.FromResult<AuthResult>(Committed(provider));
+
+            await h.Vm.OnEnterAsync(CancellationToken.None);
+            await h.SignIn();
+
+            return (h.Vm.Satisfied, h.Vm.Status, h.Vm.StatusIsError);
+        });
+
+        await Assert.That(satisfied).IsTrue();
+        await Assert.That(status).IsEqualTo("Signed in as sam");
+        await Assert.That(isError).IsFalse();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_none_provider_join_auto_satisfies_with_the_no_sign_in_copy() {
+        var (satisfied, status, intent) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Paste;
+            h.Connect.ServerInputText = "http://localhost:5108";
+            ConnectIntent? seen = null;
+            h.Operation = (i, _) => {
+                seen = i;
+
+                return Task.FromResult<AuthResult>(Committed(AuthProvider.None, username: null));
+            };
+
+            await h.SignIn();
+
+            return (h.Vm.Satisfied, h.Vm.Status, seen);
+        });
+
+        await Assert.That(satisfied).IsTrue();
+        await Assert.That(status).IsEqualTo("No sign-in required for this server.");
+        await Assert.That(intent).IsEqualTo(new ConnectIntent.Paste("http://localhost:5108"));
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Re_entry_after_a_commit_still_shows_the_step_satisfied() {
+        var (satisfied, status, runs) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+
+            await h.SignIn();
+            await h.Vm.OnEnterAsync(CancellationToken.None); // Back then forward again
+
+            return (h.Vm.Satisfied, h.Vm.Status, h.Runs);
+        });
+
+        await Assert.That(satisfied).IsTrue();
+        await Assert.That(status).IsEqualTo("Signed in as sam");
+        await Assert.That(runs).IsEqualTo(1); // entering the step starts nothing
+    }
+
+    // ── cancellation and failure ─────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Cancelling_is_not_a_failure_and_leaves_the_step_retryable() {
+        var (satisfied, status, isError, detail) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+            h.Operation = (_, _) => Task.FromResult<AuthResult>(new AuthResult.Cancelled());
+
+            await h.SignIn();
+
+            return (h.Vm.Satisfied, h.Vm.Status, h.Vm.StatusIsError, h.Vm.StatusDetail);
+        });
+
+        await Assert.That(satisfied).IsFalse();
+        await Assert.That(status).IsEqualTo("Sign-in cancelled.");
+        await Assert.That(isError).IsFalse();
+        await Assert.That(detail).IsNull();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_failure_shows_one_generic_headline_and_never_re_logs_the_facade_message() {
+        var (status, isError, detail, log, satisfied) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+            h.Operation = (_, _) => {
+                h.Progress.Error("Error: the auth service is unreachable.");
+
+                return Task.FromResult<AuthResult>(new AuthResult.Failed("the auth service is unreachable"));
+            };
+
+            await h.SignIn();
+
+            return (h.Vm.Status, h.Vm.StatusIsError, h.Vm.StatusDetail, h.Vm.Log.ToList(), h.Vm.Satisfied);
+        });
+
+        await Assert.That(status).IsEqualTo("Sign-in failed.");
+        await Assert.That(isError).IsTrue();
+        await Assert.That(satisfied).IsFalse();
+        await Assert.That(detail).IsEqualTo("Error: the auth service is unreachable.");
+        await Assert.That(log).IsEquivalentTo(["Error: the auth service is unreachable."]);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_unexpected_operation_throw_lands_as_a_failure_not_a_crash() {
+        var (status, isError) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+            h.Operation = (_, _) => throw new InvalidOperationException("claim_arm_failed");
+
+            await h.SignIn();
+
+            return (h.Vm.Status, h.Vm.StatusIsError);
+        });
+
+        await Assert.That(status).IsEqualTo("Sign-in failed.");
+        await Assert.That(isError).IsTrue();
+    }
+
+    // ── progress rendering ───────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_device_code_renders_without_the_clipboard_note_and_the_raw_line_stays_in_the_log() {
+        var (code, uri, log) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Discover;
+            h.Operation = (_, _) => {
+                h.Progress.DeviceCode("ABCD-1234  (copied to clipboard)", "https://github.com/login/device");
+
+                return Task.FromResult<AuthResult>(Committed());
+            };
+
+            await h.SignIn();
+
+            return (h.Vm.DeviceCode, h.Vm.VerificationUri, h.Vm.Log.ToList());
+        });
+
+        await Assert.That(code).IsEqualTo("ABCD-1234");
+        await Assert.That(uri).IsEqualTo("https://github.com/login/device"); // the clickable link is the device URI
+        await Assert.That(string.Join("\n", log)).Contains("(copied to clipboard)");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_browser_fallback_url_renders_and_opens_through_the_url_opener() {
+        var (fallback, opened) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Discover;
+            h.Operation = (_, _) => {
+                h.Progress.BrowserOpening("https://auth.example/authorize?x=1");
+
+                return Task.FromResult<AuthResult>(Committed());
+            };
+
+            await h.SignIn();
+            await h.Vm.OpenSignInUrlCommand.Execute().ToTask();
+
+            return (h.Vm.BrowserUrl, h.Opener.Opened.ToList());
+        });
+
+        await Assert.That(fallback).IsEqualTo("https://auth.example/authorize?x=1");
+        await Assert.That(opened).IsEquivalentTo(["https://auth.example/authorize?x=1"]);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_progress_log_stays_bounded() {
+        var (count, last) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+
+            for (var i = 0; i < SignInStepViewModel.LogLimit + 50; i++) h.Progress.Notice($"line {i}");
+
+            await Task.Yield();
+
+            return (h.Vm.Log.Count, h.Vm.Log[^1]);
+        });
+
+        await Assert.That(count).IsEqualTo(SignInStepViewModel.LogLimit);
+        await Assert.That(last).IsEqualTo($"line {SignInStepViewModel.LogLimit + 49}");
+    }
+
+    // ── tenant picker ────────────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Confirming_a_tenant_resolves_the_awaited_pick() {
+        var (offered, satisfied, status, stillVisible) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Discover;
+            h.Operation = async (_, ct) => {
+                var picked = await h.Picker.PickAsync([Tenant("acme"), Tenant("globex")], ct);
+
+                return picked is null
+                    ? new AuthResult.Failed("No tenant selected.")
+                    : Committed(username: picked.OrgLogin);
+            };
+
+            var exec = h.SignIn();
+            await WaitUntil(() => h.Vm.TenantPickerVisible, "the tenant list");
+            var listed = h.Vm.Tenants.Select(t => t.OrgLogin).ToList();
+
+            h.Vm.SelectedTenant = h.Vm.Tenants[1];
+            await h.Vm.ConfirmTenantCommand.Execute().ToTask();
+            await exec;
+
+            return (listed, h.Vm.Satisfied, h.Vm.Status, h.Vm.TenantPickerVisible);
+        });
+
+        await Assert.That(offered).IsEquivalentTo(["acme", "globex"]);
+        await Assert.That(satisfied).IsTrue();
+        await Assert.That(status).IsEqualTo("Signed in as globex");
+        await Assert.That(stillVisible).IsFalse();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Backing_out_of_the_tenant_list_resolves_the_pick_with_nothing() {
+        var (satisfied, status) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Discover;
+            h.Operation = async (_, ct) => {
+                var picked = await h.Picker.PickAsync([Tenant("acme"), Tenant("globex")], ct);
+
+                return picked is null ? new AuthResult.Failed("No tenant selected.") : Committed();
+            };
+
+            var exec = h.SignIn();
+            await WaitUntil(() => h.Vm.TenantPickerVisible, "the tenant list");
+
+            await h.Vm.CancelTenantCommand.Execute().ToTask();
+            await exec;
+
+            return (h.Vm.Satisfied, h.Vm.Status);
+        });
+
+        await Assert.That(satisfied).IsFalse();
+        await Assert.That(status).IsEqualTo("Sign-in failed."); // the façade's own "No tenant selected."
+    }
+
+    // ── create sub-flow ──────────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_create_intent_skips_the_mode_menu_and_walks_the_provisioner_prompts() {
+        var (modeShows, slugSuggestion, confirmText, satisfied, status) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+            h.Signup.Respond = (request, _) => request.RequestUri!.AbsolutePath == "/api/signup/availability"
+                ? (HttpStatusCode.OK, """{"available":true}""")
+                : (HttpStatusCode.OK, """{"slug":"acme","state":"active","workosOrgId":"org_1","url":"https://acme.kcap.ai"}""");
+
+            h.Operation = async (_, ct) => {
+                var offer = await h.Provisioner.OfferCreateAsync(Tokens(), ct);
+
+                return offer.Status == ProvisionOfferStatus.Created
+                    ? Committed(AuthProvider.WorkOS)
+                    : new AuthResult.Failed($"Workspace creation did not complete ({offer.Status}).");
+            };
+
+            var shows = 0;
+            h.Vm.PropertyChanged += (_, e) => {
+                if (e.PropertyName == nameof(SignInStepViewModel.ModeChoiceVisible) && h.Vm.ModeChoiceVisible) shows++;
+            };
+
+            var exec = h.SignIn();
+
+            await WaitUntil(() => h.Vm.OrgNamePromptVisible, "the organization-name prompt");
+            h.Vm.OrgName = "Acme";
+            await h.Vm.SubmitOrgNameCommand.Execute().ToTask();
+
+            await WaitUntil(() => h.Vm.SlugPromptVisible, "the slug prompt");
+            var suggestion = h.Vm.Slug;
+            await h.Vm.SubmitSlugCommand.Execute().ToTask();
+
+            await WaitUntil(() => h.Vm.ConfirmVisible, "the create confirmation");
+            var confirm = h.Vm.ConfirmText;
+            await h.Vm.ConfirmCreateCommand.Execute().ToTask();
+
+            await exec;
+
+            return (shows, suggestion, confirm, h.Vm.Satisfied, h.Vm.Status);
+        });
+
+        await Assert.That(modeShows).IsEqualTo(0); // the Connect intent IS the mode
+        await Assert.That(slugSuggestion).IsEqualTo("acme");
+        await Assert.That(confirmText).Contains("https://acme.kcap.ai");
+        await Assert.That(satisfied).IsTrue();
+        await Assert.That(status).IsEqualTo("Signed in as sam");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_zero_tenant_discovery_offers_the_three_way_choice_and_retargets_to_connect() {
+        var (retargets, choice, prefilled, status, satisfied) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Discover;
+            h.Connect.DiscoveryProvider = AuthProvider.WorkOS;
+            h.Operation = async (_, ct) => {
+                var offer = await h.Provisioner.OfferCreateAsync(Tokens(), ct);
+
+                return offer.Status == ProvisionOfferStatus.ExistingWorkspace
+                    ? new AuthResult.Retarget(offer.ExistingWorkspaceInput!)
+                    : new AuthResult.Failed($"Workspace creation did not complete ({offer.Status}).");
+            };
+
+            var raised = new List<string>();
+            h.Vm.RetargetRequested += target => raised.Add(target);
+
+            var exec = h.SignIn();
+            await WaitUntil(() => h.Vm.ModeChoiceVisible, "the workspace mode choice");
+
+            h.Vm.ExistingWorkspaceInput = "acme";
+            await h.Vm.UseExistingWorkspaceCommand.Execute().ToTask();
+            await exec;
+
+            return (raised, h.Connect.Choice, h.Connect.ServerInputText, h.Vm.Status, h.Vm.Satisfied);
+        });
+
+        await Assert.That(retargets).IsEquivalentTo(["acme"]);
+        await Assert.That(choice).IsEqualTo(ConnectChoice.Paste);
+        await Assert.That(prefilled).IsEqualTo("acme");
+        await Assert.That(status).Contains("Connect step");
+        await Assert.That(satisfied).IsFalse();
+    }
+
+    // ── step transitions across the boundary ─────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Leaving_before_the_boundary_cancels_the_attempt_and_is_allowed() {
+        var (canLeave, satisfied, status, isError, runs) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Discover;
+            var started = new TaskCompletionSource();
+            h.Operation = async (_, ct) => {
+                started.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct); // the pre-boundary lane, cancellable
+
+                return Committed();
+            };
+
+            var exec = h.SignIn();
+            await started.Task.WaitAsync(Bounded);
+
+            await h.Vm.SignInAsync(); // a re-entrant run while one is live must be a silent no-op
+
+            var allowed = await h.Vm.CanLeaveAsync(WizardNavigation.Back, CancellationToken.None);
+            await exec;
+
+            return (allowed, h.Vm.Satisfied, h.Vm.Status, h.Vm.StatusIsError, h.Runs);
+        });
+
+        await Assert.That(canLeave).IsTrue();
+        await Assert.That(satisfied).IsFalse();
+        await Assert.That(status).IsEqualTo("Sign-in cancelled.");
+        await Assert.That(isError).IsFalse();
+        await Assert.That(runs).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Leaving_after_the_boundary_waits_for_the_commit_and_is_allowed() {
+        var (canLeave, satisfied, status) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Discover;
+            var gate = new TaskCompletionSource<AuthResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            h.Operation = (_, _) => gate.Task; // past the boundary: cancellation is ignored
+
+            var exec = h.SignIn();
+            var leaving = h.Vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+
+            gate.SetResult(Committed());
+            var allowed = await leaving.WaitAsync(Bounded);
+            await exec;
+
+            return (allowed, h.Vm.Satisfied, h.Vm.Status);
+        });
+
+        await Assert.That(canLeave).IsTrue();
+        await Assert.That(satisfied).IsTrue();
+        await Assert.That(status).IsEqualTo("Signed in as sam");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Signing_in_without_a_staged_intent_starts_nothing_and_says_where_to_choose() {
+        var (runs, status) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Paste; // nothing typed — no valid intent
+
+            await h.Vm.OnEnterAsync(CancellationToken.None);
+            await h.SignIn();
+
+            return (h.Runs, h.Vm.Status);
+        });
+
+        await Assert.That(runs).IsEqualTo(0);
+        await Assert.That(status).Contains("Connect");
+    }
+
+    // ── quarantine notice ────────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_quarantined_claims_file_surfaces_one_dismissible_notice_and_the_ack_persists() {
+        var (notice, afterAck, acked, updates) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+            await File.WriteAllTextAsync(h.ClaimsPath, "{ this is not json");
+
+            await h.SignIn();
+            var shown = h.Vm.QuarantineNotice;
+
+            await h.Vm.AcknowledgeQuarantineCommand.Execute().ToTask();
+
+            return (shown, h.Vm.QuarantineNotice, h.AppState.State.ConsentQuarantineAcked, h.AppState.Updates);
+        });
+
+        await Assert.That(notice).IsNotNull();
+        await Assert.That(notice!).Contains("consent-flip claims file");
+        await Assert.That(notice).Contains(".quarantined-0.json");
+        await Assert.That(afterAck).IsNull();
+        await Assert.That(acked).IsTrue();
+        await Assert.That(updates).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_already_acknowledged_quarantine_is_never_surfaced_again() {
+        var notice = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+            h.AppState.State = h.AppState.State with { ConsentQuarantineAcked = true };
+            await File.WriteAllTextAsync(h.ClaimsPath, "{ this is not json");
+
+            await h.SignIn();
+
+            return h.Vm.QuarantineNotice;
+        });
+
+        await Assert.That(notice).IsNull();
+    }
+
+    // ── templates ────────────────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_window_selects_a_template_per_step_view_model() {
+        var (connectBox, signInButton, signInStatus) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            var vm = new OnboardingViewModel([h.Connect, h.Vm]);
+            await vm.PendingEnterForTesting;
+
+            var window = new OnboardingWindow { DataContext = vm };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var box = window.GetVisualDescendants().OfType<TextBox>().FirstOrDefault(t => t.Name == "ServerInputBox");
+
+            await vm.NextCommand.Execute().ToTask(); // Connect -> Sign in
+            Dispatcher.UIThread.RunJobs();
+
+            var button = window.GetVisualDescendants().OfType<Button>().FirstOrDefault(b => b.Name == "SignInButton");
+            var status = window.GetVisualDescendants().OfType<TextBlock>()
+                .FirstOrDefault(t => t.Name == "SignInStatusText")?.Text;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return (box, button, status);
+        });
+
+        await Assert.That(connectBox).IsNotNull();
+        await Assert.That(signInButton).IsNotNull();
+        await Assert.That(signInStatus).IsEqualTo("Ready to find your workspaces with GitHub.");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_healthy_claims_store_surfaces_no_notice() {
+        var notice = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+
+            await h.SignIn();
+
+            return h.Vm.QuarantineNotice;
+        });
+
+        await Assert.That(notice).IsNull();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
@@ -93,7 +93,7 @@ public class SignInStepViewModelTests {
                 Runs++;
 
                 return Operation(intent, ct);
-            }, Claims);
+            });
             Vm = new SignInStepViewModel(Service, Connect, bridges, Claims, AppState, Opener);
         }
 

--- a/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
@@ -9,6 +9,7 @@ using Capacitor.App.ViewModels.Onboarding;
 using Capacitor.App.Views.Onboarding;
 using Capacitor.Cli.Core.Auth;
 using Microsoft.Extensions.Time.Testing;
+using ReactiveUI;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -17,6 +18,14 @@ namespace Capacitor.App.Tests.Unit;
 /// provisioner and the progress sink are the REAL bridges — they are what this task builds.
 public class SignInStepViewModelTests {
     static readonly TimeSpan Bounded = TimeSpan.FromSeconds(10);
+
+    static bool CanExecute(ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit> command) {
+        Dispatcher.UIThread.RunJobs(); // canExecute is delivered through the dispatcher scheduler
+        var value = false;
+        using var subscription = command.CanExecute.Subscribe(v => value = v);
+
+        return value;
+    }
 
     static async Task WaitUntil(Func<bool> condition, string what) {
         var deadline = DateTime.UtcNow + Bounded;
@@ -53,7 +62,7 @@ public class SignInStepViewModelTests {
     sealed class Harness : IDisposable {
         public readonly string                  TempDir = Directory.CreateTempSubdirectory("kcap-signin-").FullName;
         public readonly ConnectStepViewModel    Connect = new();
-        public readonly WizardTenantPicker      Picker  = new();
+        public readonly WizardTenantPicker      Picker;
         public readonly ScriptedSignupHandler   Signup  = new();
         public readonly RecordingOpener         Opener  = new();
         public readonly FakeAppState            AppState = new();
@@ -70,18 +79,22 @@ public class SignInStepViewModelTests {
             (_, _) => Task.FromResult<AuthResult>(Committed());
 
         public Harness() {
-            Claims      = new ConsentFlipClaims(ClaimsPath, Path.Combine(TempDir, "config.json"));
-            Progress    = new UiAuthProgress(action => action());
-            Provisioner = new WizardTenantProvisioner(
-                new TenantProvisioningClient(new HttpClient(Signup)), "https://signup.example", Progress, Time);
+            Claims = new ConsentFlipClaims(ClaimsPath, Path.Combine(TempDir, "config.json"));
+
+            var bridges = new WizardBridges(
+                action => action(),
+                progress => new WizardTenantProvisioner(
+                    new TenantProvisioningClient(new HttpClient(Signup)), "https://signup.example", progress, Time));
+
+            Picker      = bridges.Picker;
+            Progress    = bridges.Progress;
+            Provisioner = bridges.Provisioner;
             Service = new WizardAuthService((intent, ct) => {
                 Runs++;
 
                 return Operation(intent, ct);
             }, Claims);
-            Vm = new SignInStepViewModel(
-                Service, Connect, new WizardBridges(Progress, Picker, Provisioner, action => action()), Claims,
-                AppState, Opener);
+            Vm = new SignInStepViewModel(Service, Connect, bridges, Claims, AppState, Opener);
         }
 
         public string ClaimsPath => Path.Combine(TempDir, "consent-flip-claims.json");
@@ -233,15 +246,21 @@ public class SignInStepViewModelTests {
         var (code, uri, log) = await AvaloniaSession.DispatchAsync(async () => {
             using var h = new Harness();
             h.Connect.Choice = ConnectChoice.Discover;
+            var gate = new TaskCompletionSource<AuthResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             h.Operation = (_, _) => {
                 h.Progress.DeviceCode("ABCD-1234  (copied to clipboard)", "https://github.com/login/device");
 
-                return Task.FromResult<AuthResult>(Committed());
+                return gate.Task;
             };
 
-            await h.SignIn();
+            var exec = h.SignIn();
+            // Read while the flow is live: a settled attempt clears the code it no longer polls.
+            var rendered = (h.Vm.DeviceCode, h.Vm.VerificationUri, h.Vm.Log.ToList());
 
-            return (h.Vm.DeviceCode, h.Vm.VerificationUri, h.Vm.Log.ToList());
+            gate.SetResult(Committed());
+            await exec;
+
+            return rendered;
         });
 
         await Assert.That(code).IsEqualTo("ABCD-1234");
@@ -255,16 +274,21 @@ public class SignInStepViewModelTests {
         var (fallback, opened) = await AvaloniaSession.DispatchAsync(async () => {
             using var h = new Harness();
             h.Connect.Choice = ConnectChoice.Discover;
+            var gate = new TaskCompletionSource<AuthResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             h.Operation = (_, _) => {
                 h.Progress.BrowserOpening("https://auth.example/authorize?x=1");
 
-                return Task.FromResult<AuthResult>(Committed());
+                return gate.Task;
             };
 
-            await h.SignIn();
+            var exec = h.SignIn();
+            var url  = h.Vm.BrowserUrl; // the fallback link only exists while the browser wait is live
             await h.Vm.OpenSignInUrlCommand.Execute().ToTask();
 
-            return (h.Vm.BrowserUrl, h.Opener.Opened.ToList());
+            gate.SetResult(Committed());
+            await exec;
+
+            return (url, h.Opener.Opened.ToList());
         });
 
         await Assert.That(fallback).IsEqualTo("https://auth.example/authorize?x=1");
@@ -399,6 +423,72 @@ public class SignInStepViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
+    public async Task Declining_the_create_confirmation_explains_itself_instead_of_a_bare_failure() {
+        var (status, detail, log) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+            h.Signup.Respond = (_, _) => (HttpStatusCode.OK, """{"available":true}""");
+            h.Operation = async (_, ct) => {
+                var offer = await h.Provisioner.OfferCreateAsync(Tokens(), ct);
+
+                return offer.Status == ProvisionOfferStatus.Created
+                    ? Committed(AuthProvider.WorkOS)
+                    : new AuthResult.Failed($"Workspace creation did not complete ({offer.Status}).");
+            };
+
+            var exec = h.SignIn();
+
+            await WaitUntil(() => h.Vm.OrgNamePromptVisible, "the organization-name prompt");
+            h.Vm.OrgName = "Acme";
+            await h.Vm.SubmitOrgNameCommand.Execute().ToTask();
+
+            await WaitUntil(() => h.Vm.SlugPromptVisible, "the slug prompt");
+            await h.Vm.SubmitSlugCommand.Execute().ToTask();
+
+            await WaitUntil(() => h.Vm.ConfirmVisible, "the create confirmation");
+            await h.Vm.DeclineCreateCommand.Execute().ToTask();
+            await exec;
+
+            return (h.Vm.Status, h.Vm.StatusDetail, h.Vm.Log.ToList());
+        });
+
+        await Assert.That(status).IsEqualTo("Sign-in failed.");
+        await Assert.That(detail).IsEqualTo("No workspace created.");
+        await Assert.That(log).Contains("No workspace created.");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_empty_create_prompt_cannot_be_submitted_at_all() {
+        var (orgEmpty, orgBlank, orgNamed, existingEmpty, existingBlank, existingNamed) =
+            await AvaloniaSession.DispatchAsync(() => {
+                using var h = new Harness();
+
+                var orgEmpty = CanExecute(h.Vm.SubmitOrgNameCommand);
+                h.Vm.OrgName = "   ";
+                var orgBlank = CanExecute(h.Vm.SubmitOrgNameCommand);
+                h.Vm.OrgName = "Acme";
+                var orgNamed = CanExecute(h.Vm.SubmitOrgNameCommand);
+
+                var existingEmpty = CanExecute(h.Vm.UseExistingWorkspaceCommand);
+                h.Vm.ExistingWorkspaceInput = "  ";
+                var existingBlank = CanExecute(h.Vm.UseExistingWorkspaceCommand);
+                h.Vm.ExistingWorkspaceInput = "acme";
+                var existingNamed = CanExecute(h.Vm.UseExistingWorkspaceCommand);
+
+                return (orgEmpty, orgBlank, orgNamed, existingEmpty, existingBlank, existingNamed);
+            });
+
+        await Assert.That(orgEmpty).IsFalse();
+        await Assert.That(orgBlank).IsFalse();
+        await Assert.That(orgNamed).IsTrue();
+        await Assert.That(existingEmpty).IsFalse();
+        await Assert.That(existingBlank).IsFalse();
+        await Assert.That(existingNamed).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task A_zero_tenant_discovery_offers_the_three_way_choice_and_retargets_to_connect() {
         var (retargets, choice, prefilled, status, satisfied) = await AvaloniaSession.DispatchAsync(async () => {
             using var h = new Harness();
@@ -436,7 +526,10 @@ public class SignInStepViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Leaving_before_the_boundary_cancels_the_attempt_and_is_allowed() {
+    [Arguments(WizardNavigation.Back)]
+    [Arguments(WizardNavigation.Skip)]
+    [Arguments(WizardNavigation.Next)]
+    public async Task Leaving_before_the_boundary_cancels_the_attempt_and_is_allowed(WizardNavigation direction) {
         var (canLeave, satisfied, status, isError, runs) = await AvaloniaSession.DispatchAsync(async () => {
             using var h = new Harness();
             h.Connect.Choice = ConnectChoice.Discover;
@@ -453,7 +546,7 @@ public class SignInStepViewModelTests {
 
             await h.Vm.SignInAsync(); // a re-entrant run while one is live must be a silent no-op
 
-            var allowed = await h.Vm.CanLeaveAsync(WizardNavigation.Back, CancellationToken.None);
+            var allowed = await h.Vm.CanLeaveAsync(direction, CancellationToken.None);
             await exec;
 
             return (allowed, h.Vm.Satisfied, h.Vm.Status, h.Vm.StatusIsError, h.Runs);
@@ -469,7 +562,7 @@ public class SignInStepViewModelTests {
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Leaving_after_the_boundary_waits_for_the_commit_and_is_allowed() {
-        var (canLeave, satisfied, status) = await AvaloniaSession.DispatchAsync(async () => {
+        var (heldWhileCommitting, canLeave, satisfied, status) = await AvaloniaSession.DispatchAsync(async () => {
             using var h = new Harness();
             h.Connect.Choice = ConnectChoice.Discover;
             var gate = new TaskCompletionSource<AuthResult>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -477,17 +570,82 @@ public class SignInStepViewModelTests {
 
             var exec = h.SignIn();
             var leaving = h.Vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+            var held = !leaving.IsCompleted; // the wizard is genuinely waiting on the commit
 
             gate.SetResult(Committed());
             var allowed = await leaving.WaitAsync(Bounded);
+            // Read before awaiting the command: the leave itself must have settled the state.
+            var (satisfied, status) = (h.Vm.Satisfied, h.Vm.Status);
             await exec;
 
-            return (allowed, h.Vm.Satisfied, h.Vm.Status);
+            return (held, allowed, satisfied, status);
         });
 
+        await Assert.That(heldWhileCommitting).IsTrue();
         await Assert.That(canLeave).IsTrue();
         await Assert.That(satisfied).IsTrue();
         await Assert.That(status).IsEqualTo("Signed in as sam");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Leaving_while_a_create_prompt_is_parked_releases_it_and_cancels() {
+        var (canLeave, promptVisible, status, satisfied) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+            h.Operation = async (_, ct) => {
+                var offer = await h.Provisioner.OfferCreateAsync(Tokens(), ct);
+
+                return offer.Status == ProvisionOfferStatus.Created
+                    ? Committed(AuthProvider.WorkOS)
+                    : new AuthResult.Failed($"Workspace creation did not complete ({offer.Status}).");
+            };
+
+            var exec = h.SignIn();
+            await WaitUntil(() => h.Vm.OrgNamePromptVisible, "the organization-name prompt");
+
+            var allowed = await h.Vm.CanLeaveAsync(WizardNavigation.Back, CancellationToken.None);
+            await exec;
+
+            return (allowed, h.Vm.OrgNamePromptVisible, h.Vm.Status, h.Vm.Satisfied);
+        });
+
+        await Assert.That(canLeave).IsTrue();
+        await Assert.That(promptVisible).IsFalse();
+        await Assert.That(status).IsEqualTo("Sign-in cancelled.");
+        await Assert.That(satisfied).IsFalse();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_settled_attempt_clears_the_device_code_and_browser_surfaces() {
+        var (code, uri, browser, waiting, status) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Discover;
+            var started = new TaskCompletionSource();
+            h.Operation = async (_, ct) => {
+                h.Progress.BrowserOpening("https://auth.example/authorize");
+                h.Progress.DeviceCode("ABCD-1234", "https://github.com/login/device");
+                h.Progress.PollTick();
+                started.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct);
+
+                return Committed();
+            };
+
+            var exec = h.SignIn();
+            await started.Task.WaitAsync(Bounded);
+            await h.Vm.CanLeaveAsync(WizardNavigation.Back, CancellationToken.None);
+            await exec;
+
+            return (h.Vm.DeviceCode, h.Vm.VerificationUri, h.Vm.BrowserUrl, h.Vm.WaitingText, h.Vm.Status);
+        });
+
+        await Assert.That(code).IsNull(); // nothing polls a cancelled device flow
+        await Assert.That(uri).IsNull();
+        await Assert.That(browser).IsNull();
+        await Assert.That(waiting).IsNull();
+        await Assert.That(status).IsEqualTo("Sign-in cancelled.");
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/StreamingRunnerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/StreamingRunnerTests.cs
@@ -157,6 +157,32 @@ public class StreamingRunnerTests {
         await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(10));
     }
 
+    // The ct-cancel branch must await both pumps before throwing — a late onLine after OCE races caller cleanup.
+    [Test]
+    [NotInParallel("StreamingProcessRunner")]
+    public async Task RunStreamingAsync_ct_cancel_awaits_the_pumps_before_throwing_no_late_callbacks() {
+        Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
+
+        var runner = new DaemonClientService.ProcessRunner();
+        using var cts = new CancellationTokenSource();
+        var callbackCount = 0;
+
+        var runTask = runner.RunStreamingAsync(
+            "/bin/sh", ["-c", "while true; do echo tick; sleep 0.01; done"],
+            new RunOptions(), _ => Interlocked.Increment(ref callbackCount), cts.Token);
+
+        await WaitUntilAsync(() => Volatile.Read(ref callbackCount) > 0, TimeSpan.FromSeconds(5), "the first line to arrive");
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => runTask);
+        // By the time RunStreamingAsync has thrown, the fix already awaited both pumps to EOF —
+        // so no callback can fire after this snapshot (the race the old fire-and-forget allowed).
+        var afterThrow = Volatile.Read(ref callbackCount);
+        await Task.Delay(250);
+
+        await Assert.That(Volatile.Read(ref callbackCount)).IsEqualTo(afterThrow);
+    }
+
     [Test]
     public async Task StreamingResult_shape_has_no_full_capture_property() {
         var properties = typeof(StreamingResult).GetProperties().Select(p => p.Name).ToArray();

--- a/test/Capacitor.App.Tests.Unit/StreamingRunnerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/StreamingRunnerTests.cs
@@ -1,0 +1,168 @@
+using System.Diagnostics;
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Drives the REAL ProcessRunner's RunStreamingAsync (real child processes) — same rationale as ProcessRunnerTests.
+public class StreamingRunnerTests {
+    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    static bool IsAlive(int pid) {
+        try { return !Process.GetProcessById(pid).HasExited; }
+        catch (ArgumentException) { return false; }
+    }
+
+    [Test]
+    [NotInParallel("StreamingProcessRunner")]
+    public async Task RunStreamingAsync_tags_interleaved_lines_with_the_right_stream_kind() {
+        Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
+
+        var runner = new DaemonClientService.ProcessRunner();
+        var lines = new List<StreamedLine>();
+        var gate = new object();
+
+        var result = await runner.RunStreamingAsync(
+            "/bin/sh", ["-c", "echo out-1; echo err-1 >&2; echo out-2; echo err-2 >&2"],
+            new RunOptions(), line => { lock (gate) lines.Add(line); }, CancellationToken.None);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.TimedOut).IsFalse();
+        await Assert.That(lines.Count(l => l is { Kind: ProcessStreamKind.Stdout, Text: "out-1" })).IsEqualTo(1);
+        await Assert.That(lines.Count(l => l is { Kind: ProcessStreamKind.Stdout, Text: "out-2" })).IsEqualTo(1);
+        await Assert.That(lines.Count(l => l is { Kind: ProcessStreamKind.Stderr, Text: "err-1" })).IsEqualTo(1);
+        await Assert.That(lines.Count(l => l is { Kind: ProcessStreamKind.Stderr, Text: "err-2" })).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("StreamingProcessRunner")]
+    public async Task RunStreamingAsync_more_than_TailLimit_lines_callback_sees_all_tail_holds_last_500() {
+        Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
+
+        var runner = new DaemonClientService.ProcessRunner();
+        var callbackCount = 0;
+
+        var result = await runner.RunStreamingAsync(
+            "/bin/sh", ["-c", "i=1; while [ $i -le 600 ]; do echo line-$i; i=$((i+1)); done"],
+            new RunOptions(), _ => Interlocked.Increment(ref callbackCount), CancellationToken.None);
+
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(callbackCount).IsEqualTo(600);
+        await Assert.That(result.Tail.Count).IsEqualTo(500);
+        await Assert.That(result.Tail[0].Text).IsEqualTo("line-101");
+        await Assert.That(result.Tail[^1].Text).IsEqualTo("line-600");
+    }
+
+    [Test]
+    [NotInParallel("StreamingProcessRunner")]
+    public async Task RunStreamingAsync_throwing_callback_does_not_kill_the_pump_and_exit_code_is_captured() {
+        Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
+
+        var runner = new DaemonClientService.ProcessRunner();
+        var seen = new List<string>();
+        var gate = new object();
+
+        var result = await runner.RunStreamingAsync(
+            "/bin/sh", ["-c", "echo one; echo two; echo three; exit 7"], new RunOptions(),
+            line => {
+                if (line.Text == "two") throw new InvalidOperationException("boom");
+                lock (gate) seen.Add(line.Text);
+            }, CancellationToken.None);
+
+        await Assert.That(result.ExitCode).IsEqualTo(7);
+        await Assert.That(seen).Contains("one");
+        await Assert.That(seen).Contains("three");
+        // "two" still lands in the tail — only the callback invocation is swallowed.
+        await Assert.That(result.Tail.Any(l => l.Text == "two")).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("StreamingProcessRunner")]
+    public async Task RunStreamingAsync_ct_cancel_kills_the_tree_and_leaves_no_orphan() {
+        Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
+
+        var runner = new DaemonClientService.ProcessRunner();
+        var startedMarker = Path.Combine(Path.GetTempPath(), $"kcap-streamrunner-{Guid.NewGuid():N}");
+        using var cts = new CancellationTokenSource();
+        int grandchildPid = -1;
+        try {
+            var runTask = runner.RunStreamingAsync(
+                "/bin/sh", ["-c", $"sleep 30 & echo $! > {startedMarker}; wait"],
+                new RunOptions(), _ => { }, cts.Token);
+
+            await WaitUntilAsync(() => File.Exists(startedMarker), TimeSpan.FromSeconds(5), "the grandchild to start and record its PID");
+            grandchildPid = int.Parse((await File.ReadAllTextAsync(startedMarker)).Trim());
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => runTask);
+            await WaitUntilAsync(() => !IsAlive(grandchildPid), TimeSpan.FromSeconds(5), "the grandchild to die with the cancelled tree");
+        } finally {
+            File.Delete(startedMarker);
+            if (grandchildPid > 0) {
+                try { Process.GetProcessById(grandchildPid).Kill(); }
+                catch (ArgumentException) { /* already gone */ }
+            }
+        }
+    }
+
+    [Test]
+    [NotInParallel("StreamingProcessRunner")]
+    public async Task RunStreamingAsync_ct_cancel_ignores_AbandonWait_CancelMode_and_still_kills_the_tree() {
+        Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
+
+        var runner = new DaemonClientService.ProcessRunner();
+        var startedMarker = Path.Combine(Path.GetTempPath(), $"kcap-streamrunner-{Guid.NewGuid():N}");
+        using var cts = new CancellationTokenSource();
+        int grandchildPid = -1;
+        try {
+            // AbandonWait would let RunAsync's child survive — streaming must still kill it.
+            var runTask = runner.RunStreamingAsync(
+                "/bin/sh", ["-c", $"sleep 30 & echo $! > {startedMarker}; wait"],
+                new RunOptions(CancelMode: CancelMode.AbandonWait), _ => { }, cts.Token);
+
+            await WaitUntilAsync(() => File.Exists(startedMarker), TimeSpan.FromSeconds(5), "the grandchild to start and record its PID");
+            grandchildPid = int.Parse((await File.ReadAllTextAsync(startedMarker)).Trim());
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => runTask);
+            await WaitUntilAsync(() => !IsAlive(grandchildPid), TimeSpan.FromSeconds(5), "the grandchild to die despite AbandonWait");
+        } finally {
+            File.Delete(startedMarker);
+            if (grandchildPid > 0) {
+                try { Process.GetProcessById(grandchildPid).Kill(); }
+                catch (ArgumentException) { /* already gone */ }
+            }
+        }
+    }
+
+    [Test]
+    [NotInParallel("StreamingProcessRunner")]
+    public async Task RunStreamingAsync_timeout_kills_the_tree_and_reports_TimedOut() {
+        Skip.When(OperatingSystem.IsWindows(), "execs a POSIX binary");
+
+        var runner = new DaemonClientService.ProcessRunner();
+        var sw = Stopwatch.StartNew();
+
+        var result = await runner.RunStreamingAsync(
+            "/bin/sleep", ["30"], new RunOptions(Timeout: TimeSpan.FromMilliseconds(200)), _ => { }, CancellationToken.None);
+        sw.Stop();
+
+        await Assert.That(result.TimedOut).IsTrue();
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(10));
+    }
+
+    [Test]
+    public async Task StreamingResult_shape_has_no_full_capture_property() {
+        var properties = typeof(StreamingResult).GetProperties().Select(p => p.Name).ToArray();
+
+        await Assert.That(properties).Contains(nameof(StreamingResult.ExitCode));
+        await Assert.That(properties).Contains(nameof(StreamingResult.TimedOut));
+        await Assert.That(properties).Contains(nameof(StreamingResult.Tail));
+        await Assert.That(properties.Length).IsEqualTo(3); // no Stdout/Stderr full-capture property, by shape
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/StreamingRunnerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/StreamingRunnerTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using Capacitor.App.Services;
 
 namespace Capacitor.App.Tests.Unit;
@@ -96,7 +97,7 @@ public class StreamingRunnerTests {
                 new RunOptions(), _ => { }, cts.Token);
 
             await WaitUntilAsync(() => File.Exists(startedMarker), TimeSpan.FromSeconds(5), "the grandchild to start and record its PID");
-            grandchildPid = int.Parse((await File.ReadAllTextAsync(startedMarker)).Trim());
+            grandchildPid = int.Parse((await File.ReadAllTextAsync(startedMarker)).Trim(), CultureInfo.InvariantCulture);
             cts.Cancel();
 
             await Assert.ThrowsAsync<OperationCanceledException>(() => runTask);
@@ -126,7 +127,7 @@ public class StreamingRunnerTests {
                 new RunOptions(CancelMode: CancelMode.AbandonWait), _ => { }, cts.Token);
 
             await WaitUntilAsync(() => File.Exists(startedMarker), TimeSpan.FromSeconds(5), "the grandchild to start and record its PID");
-            grandchildPid = int.Parse((await File.ReadAllTextAsync(startedMarker)).Trim());
+            grandchildPid = int.Parse((await File.ReadAllTextAsync(startedMarker)).Trim(), CultureInfo.InvariantCulture);
             cts.Cancel();
 
             await Assert.ThrowsAsync<OperationCanceledException>(() => runTask);

--- a/test/Capacitor.App.Tests.Unit/WizardAuthBridgesTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardAuthBridgesTests.cs
@@ -1,0 +1,314 @@
+using System.Net;
+using System.Text;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.Cli.Core.Auth;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Scripts kcap-web's /api/signup/* surface so the REAL TenantProvisioningClient (a concrete class
+/// with no interface) is exercised end to end — a stubbed client would prove nothing about the
+/// status/body handling the provisioner branches on.
+sealed class ScriptedSignupHandler : HttpMessageHandler {
+    public readonly List<string> Requests = [];
+    public Func<HttpRequestMessage, int, (HttpStatusCode Status, string Body)> Respond =
+        (_, _) => (HttpStatusCode.OK, "{}");
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+        var index = Requests.Count;
+        Requests.Add($"{request.Method} {request.RequestUri!.PathAndQuery}");
+        var (status, body) = Respond(request, index);
+
+        return Task.FromResult(new HttpResponseMessage(status) {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        });
+    }
+}
+
+sealed class RecordingAuthProgress : IAuthProgress {
+    public readonly List<string> Notices = [];
+    public readonly List<string> Errors = [];
+
+    public void Notice(string message) => Notices.Add(message);
+    public void Error(string message) => Errors.Add(message);
+    public void BrowserOpening(string url) { }
+    public void DeviceCode(string code, string verificationUri) { }
+    public void PollTick() { }
+}
+
+public class WizardAuthBridgesTests {
+    const string BaseUrl = "https://signup.example";
+
+    static WorkOSTokenSource Tokens() =>
+        new("access-token", refreshToken: null, (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
+
+    static (WizardTenantProvisioner Provisioner, ScriptedSignupHandler Handler, RecordingAuthProgress Progress, FakeTimeProvider Time)
+            NewProvisioner() {
+        var handler  = new ScriptedSignupHandler();
+        var progress = new RecordingAuthProgress();
+        var time     = new FakeTimeProvider();
+        var client   = new TenantProvisioningClient(new HttpClient(handler));
+
+        return (new WizardTenantProvisioner(client, BaseUrl, progress, time), handler, progress, time);
+    }
+
+    /// The poll's only suspension is Task.Delay(interval, time, ct), whose continuation resumes
+    /// inside Advance() — so the whole flow settles without a real wait (DaemonMutationLaneTests idiom).
+    static async Task<ProvisionOffer> Drive(Task<ProvisionOffer> task, FakeTimeProvider time) {
+        var guard = 0;
+        while (!task.IsCompleted && guard++ < 400) time.Advance(TimeSpan.FromSeconds(4));
+
+        return await task.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    static DiscoveredTenant Tenant(string login) => new() { OrgLogin = login, Origin = $"https://{login}.kcap.ai" };
+
+    // ── tenant picker ────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task PickAsync_publishes_the_tenants_and_completes_on_the_selection() {
+        var picker = new WizardTenantPicker();
+        DiscoveredTenant[]? offered = null;
+        picker.SelectionRequested += tenants => offered = tenants;
+
+        var pick = picker.PickAsync([Tenant("acme"), Tenant("globex")], CancellationToken.None);
+        picker.Select(Tenant("globex"));
+
+        await Assert.That((await pick.WaitAsync(TimeSpan.FromSeconds(5)))!.OrgLogin).IsEqualTo("globex");
+        await Assert.That(offered!.Select(t => t.OrgLogin)).IsEquivalentTo(["acme", "globex"]);
+    }
+
+    [Test]
+    public async Task Selecting_nothing_completes_the_await_with_no_tenant() {
+        var picker = new WizardTenantPicker();
+
+        var pick = picker.PickAsync([Tenant("acme")], CancellationToken.None);
+        picker.Select(null);
+
+        await Assert.That(await pick.WaitAsync(TimeSpan.FromSeconds(5))).IsNull();
+    }
+
+    [Test]
+    public async Task Cancelling_releases_a_pending_pick() {
+        var picker = new WizardTenantPicker();
+        using var cts = new CancellationTokenSource();
+
+        var pick = picker.PickAsync([Tenant("acme")], cts.Token);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await pick.WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Test]
+    public void The_synchronous_pick_is_not_supported() {
+        var picker = new WizardTenantPicker();
+
+        Assert.Throws<NotSupportedException>(() => picker.Pick([Tenant("acme")]));
+    }
+
+    // ── progress bridge ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Every_progress_event_is_marshalled_through_the_post_delegate() {
+        var posts = 0;
+        var progress = new UiAuthProgress(action => {
+            posts++;
+            action();
+        });
+
+        var seen = new List<string>();
+        progress.NoticeReceived     += m => seen.Add($"notice:{m}");
+        progress.ErrorReceived      += m => seen.Add($"error:{m}");
+        progress.BrowserOpened      += u => seen.Add($"browser:{u}");
+        progress.DeviceCodeReceived += (code, uri) => seen.Add($"device:{code}@{uri}");
+        progress.PollTicked         += () => seen.Add("tick");
+
+        progress.Notice("hello");
+        progress.Error("bad");
+        progress.BrowserOpening("https://login.example");
+        progress.DeviceCode("ABCD-1234", "https://github.com/login/device");
+        progress.PollTick();
+
+        await Assert.That(posts).IsEqualTo(5);
+        await Assert.That(seen).IsEquivalentTo([
+            "notice:hello", "error:bad", "browser:https://login.example",
+            "device:ABCD-1234@https://github.com/login/device", "tick"
+        ]);
+    }
+
+    // ── intent → façade call mapping ─────────────────────────────────────────
+
+    [Test]
+    [Arguments("acme", "https://acme.kcap.ai")]
+    [Arguments("https://acme.kcap.ai/sessions/9", "https://acme.kcap.ai")]
+    [Arguments(" http://localhost:5108/ ", "http://localhost:5108")]
+    public async Task A_pasted_server_resolves_through_origin_then_slug_expansion(string typed, string expected) =>
+        await Assert.That(WizardSignInOperation.ResolveServer(typed)).IsEqualTo(expected);
+
+    // ── provisioner: the create sub-flow ─────────────────────────────────────
+
+    [Test]
+    public async Task The_create_flow_re_prompts_on_an_unavailable_slug_then_provisions_and_polls_to_created() {
+        var (provisioner, handler, _, time) = NewProvisioner();
+
+        handler.Respond = (request, _) => request.RequestUri!.AbsolutePath switch {
+            "/api/signup/availability" => request.RequestUri.Query.Contains("slug=acme&") || request.RequestUri.Query.EndsWith("slug=acme")
+                ? (HttpStatusCode.OK, """{"available":false,"reason":"taken"}""")
+                : (HttpStatusCode.OK, """{"available":true}"""),
+            "/api/signup/provision" => (HttpStatusCode.Accepted, """{"slug":"acme-two","state":"provisioning"}"""),
+            "/api/signup/status" => handler.Requests.Count(r => r.Contains("/api/signup/status")) > 1
+                ? (HttpStatusCode.OK, """{"state":"active","workosOrgId":"org_1","url":"https://acme-two.kcap.ai"}""")
+                : (HttpStatusCode.OK, """{"state":"provisioning"}"""),
+            _ => (HttpStatusCode.NotFound, "{}")
+        };
+
+        var slugPrompts = new List<(string Suggestion, string? Error)>();
+        var confirms    = new List<(string Slug, string Origin)>();
+        var polls       = new List<(int Attempt, int Max)>();
+
+        provisioner.OfferMode     = _ => Task.FromResult<ProvisionMode>(new ProvisionMode.Create());
+        provisioner.PromptOrgName = _ => Task.FromResult<string?>("Acme");
+        provisioner.PromptSlug = (suggestion, error, _) => {
+            slugPrompts.Add((suggestion, error));
+
+            return Task.FromResult<string?>(slugPrompts.Count == 1 ? "Acme" : "acme-two");
+        };
+        provisioner.ConfirmCreate = (slug, origin, _) => {
+            confirms.Add((slug, origin));
+
+            return Task.FromResult(true);
+        };
+        provisioner.PollProgress = (attempt, max) => polls.Add((attempt, max));
+
+        var offer = await Drive(provisioner.OfferCreateAsync(Tokens()), time);
+
+        await Assert.That(offer.Status).IsEqualTo(ProvisionOfferStatus.Created);
+        await Assert.That(offer.Tenant).IsEqualTo(new ProvisionedTenant("org_1", "acme-two", "Acme", "https://acme-two.kcap.ai"));
+        await Assert.That(slugPrompts[0]).IsEqualTo(("acme", (string?)null)); // SlugValidator.Derive suggestion
+        await Assert.That(slugPrompts[1].Error).Contains("taken");
+        await Assert.That(confirms).IsEquivalentTo([("acme-two", "https://acme-two.kcap.ai")]);
+        await Assert.That(polls).IsEquivalentTo([(1, WizardTenantProvisioner.MaxPolls)]);
+    }
+
+    [Test]
+    public async Task An_invalid_slug_is_rejected_locally_without_an_availability_call() {
+        var (provisioner, handler, _, time) = NewProvisioner();
+
+        handler.Respond = (request, _) => request.RequestUri!.AbsolutePath == "/api/signup/availability"
+            ? (HttpStatusCode.OK, """{"available":true}""")
+            : (HttpStatusCode.OK, """{"slug":"acme","state":"active","workosOrgId":"org_1"}""");
+
+        var errors = new List<string?>();
+        provisioner.OfferMode     = _ => Task.FromResult<ProvisionMode>(new ProvisionMode.Create());
+        provisioner.PromptOrgName = _ => Task.FromResult<string?>("Acme");
+        provisioner.PromptSlug = (_, error, _) => {
+            errors.Add(error);
+
+            return Task.FromResult<string?>(errors.Count == 1 ? "kcap" : "acme"); // "kcap" is reserved
+        };
+        provisioner.ConfirmCreate = (_, _, _) => Task.FromResult(true);
+
+        var offer = await Drive(provisioner.OfferCreateAsync(Tokens()), time);
+
+        await Assert.That(offer.Status).IsEqualTo(ProvisionOfferStatus.Created);
+        await Assert.That(errors[1]).Contains("reserved");
+        await Assert.That(handler.Requests.Count(r => r.Contains("slug=kcap"))).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task A_poll_that_never_goes_live_ends_in_progress_with_the_join_from_connect_copy() {
+        var (provisioner, handler, progress, time) = NewProvisioner();
+
+        handler.Respond = (request, _) => request.RequestUri!.AbsolutePath switch {
+            "/api/signup/availability" => (HttpStatusCode.OK, """{"available":true}"""),
+            "/api/signup/provision"    => (HttpStatusCode.Accepted, """{"slug":"acme","state":"provisioning"}"""),
+            _                          => (HttpStatusCode.OK, """{"state":"provisioning"}""")
+        };
+
+        var polls = new List<int>();
+        provisioner.OfferMode     = _ => Task.FromResult<ProvisionMode>(new ProvisionMode.Create());
+        provisioner.PromptOrgName = _ => Task.FromResult<string?>("Acme");
+        provisioner.PromptSlug    = (suggestion, _, _) => Task.FromResult<string?>(suggestion);
+        provisioner.ConfirmCreate = (_, _, _) => Task.FromResult(true);
+        provisioner.PollProgress  = (attempt, _) => polls.Add(attempt);
+
+        var offer = await Drive(provisioner.OfferCreateAsync(Tokens()), time);
+
+        await Assert.That(offer.Status).IsEqualTo(ProvisionOfferStatus.InProgress);
+        await Assert.That(polls.Count).IsEqualTo(WizardTenantProvisioner.MaxPolls);
+        await Assert.That(progress.Errors)
+            .Contains("Still provisioning — finish later by joining 'acme' from the Connect step.");
+    }
+
+    [Test]
+    public async Task A_conflicting_slug_fails_the_offer_with_the_servers_reason() {
+        var (provisioner, handler, progress, time) = NewProvisioner();
+
+        handler.Respond = (request, _) => request.RequestUri!.AbsolutePath == "/api/signup/availability"
+            ? (HttpStatusCode.OK, """{"available":true}""")
+            : (HttpStatusCode.Conflict, """{"reason":"owned_by_other"}""");
+
+        provisioner.OfferMode     = _ => Task.FromResult<ProvisionMode>(new ProvisionMode.Create());
+        provisioner.PromptOrgName = _ => Task.FromResult<string?>("Acme");
+        provisioner.PromptSlug    = (suggestion, _, _) => Task.FromResult<string?>(suggestion);
+        provisioner.ConfirmCreate = (_, _, _) => Task.FromResult(true);
+
+        var offer = await Drive(provisioner.OfferCreateAsync(Tokens()), time);
+
+        await Assert.That(offer.Status).IsEqualTo(ProvisionOfferStatus.Failed);
+        await Assert.That(string.Join("\n", progress.Errors)).Contains("owned by someone else");
+    }
+
+    [Test]
+    public async Task Choosing_an_existing_workspace_hands_the_input_back_unresolved() {
+        var (provisioner, handler, _, time) = NewProvisioner();
+        provisioner.OfferMode = _ => Task.FromResult<ProvisionMode>(new ProvisionMode.Existing("  acme  "));
+
+        var offer = await Drive(provisioner.OfferCreateAsync(Tokens()), time);
+
+        await Assert.That(offer.Status).IsEqualTo(ProvisionOfferStatus.ExistingWorkspace);
+        await Assert.That(offer.ExistingWorkspaceInput).IsEqualTo("acme");
+        await Assert.That(handler.Requests).IsEmpty();
+    }
+
+    [Test]
+    [Arguments("cancel")]
+    [Arguments("no-org-name")]
+    [Arguments("no-slug")]
+    [Arguments("declined")]
+    public async Task Backing_out_of_any_create_prompt_declines_without_provisioning(string exit) {
+        var (provisioner, handler, _, time) = NewProvisioner();
+
+        handler.Respond = (_, _) => (HttpStatusCode.OK, """{"available":true}""");
+
+        provisioner.OfferMode = _ => Task.FromResult<ProvisionMode>(
+            exit == "cancel" ? new ProvisionMode.Cancel() : new ProvisionMode.Create());
+        provisioner.PromptOrgName = _ => Task.FromResult(exit == "no-org-name" ? null : "Acme");
+        provisioner.PromptSlug    = (suggestion, _, _) => Task.FromResult(exit == "no-slug" ? null : suggestion);
+        provisioner.ConfirmCreate = (_, _, _) => Task.FromResult(exit != "declined");
+
+        var offer = await Drive(provisioner.OfferCreateAsync(Tokens()), time);
+
+        await Assert.That(offer.Status).IsEqualTo(ProvisionOfferStatus.Declined);
+        await Assert.That(handler.Requests.Any(r => r.Contains("/api/signup/provision"))).IsFalse();
+    }
+
+    [Test]
+    public async Task A_provision_that_returns_the_org_immediately_needs_no_poll() {
+        var (provisioner, handler, _, time) = NewProvisioner();
+
+        handler.Respond = (request, _) => request.RequestUri!.AbsolutePath == "/api/signup/availability"
+            ? (HttpStatusCode.OK, """{"available":true}""")
+            : (HttpStatusCode.OK, """{"slug":"acme","state":"active","workosOrgId":"org_9","url":"https://acme.kcap.ai"}""");
+
+        provisioner.OfferMode     = _ => Task.FromResult<ProvisionMode>(new ProvisionMode.Create());
+        provisioner.PromptOrgName = _ => Task.FromResult<string?>("Acme");
+        provisioner.PromptSlug    = (suggestion, _, _) => Task.FromResult<string?>(suggestion);
+        provisioner.ConfirmCreate = (_, _, _) => Task.FromResult(true);
+
+        var offer = await Drive(provisioner.OfferCreateAsync(Tokens()), time);
+
+        await Assert.That(offer.Tenant).IsEqualTo(new ProvisionedTenant("org_9", "acme", "Acme", "https://acme.kcap.ai"));
+        await Assert.That(handler.Requests.Any(r => r.Contains("/api/signup/status"))).IsFalse();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WizardAuthBridgesTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardAuthBridgesTests.cs
@@ -170,7 +170,7 @@ public class WizardAuthBridgesTests {
         var (provisioner, handler, _, time) = NewProvisioner();
 
         handler.Respond = (request, _) => request.RequestUri!.AbsolutePath switch {
-            "/api/signup/availability" => request.RequestUri.Query.Contains("slug=acme&") || request.RequestUri.Query.EndsWith("slug=acme")
+            "/api/signup/availability" => request.RequestUri.Query.Contains("slug=acme&") || request.RequestUri.Query.EndsWith("slug=acme", StringComparison.Ordinal)
                 ? (HttpStatusCode.OK, """{"available":false,"reason":"taken"}""")
                 : (HttpStatusCode.OK, """{"available":true}"""),
             "/api/signup/provision" => (HttpStatusCode.Accepted, """{"slug":"acme-two","state":"provisioning"}"""),

--- a/test/Capacitor.App.Tests.Unit/WizardAuthBridgesTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardAuthBridgesTests.cs
@@ -136,12 +136,30 @@ public class WizardAuthBridgesTests {
         ]);
     }
 
+    [Test]
+    public async Task A_second_pick_cancels_the_one_it_displaces() {
+        var picker = new WizardTenantPicker();
+
+        var first  = picker.PickAsync([Tenant("acme")], CancellationToken.None);
+        var second = picker.PickAsync([Tenant("globex")], CancellationToken.None);
+        picker.Select(Tenant("globex"));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await first.WaitAsync(TimeSpan.FromSeconds(5)));
+        await Assert.That((await second.WaitAsync(TimeSpan.FromSeconds(5)))!.OrgLogin).IsEqualTo("globex");
+    }
+
     // ── intent → façade call mapping ─────────────────────────────────────────
 
     [Test]
     [Arguments("acme", "https://acme.kcap.ai")]
     [Arguments("https://acme.kcap.ai/sessions/9", "https://acme.kcap.ai")]
     [Arguments(" http://localhost:5108/ ", "http://localhost:5108")]
+    // Core's own scheme rule for scheme-less input: loopback is http, everything else https.
+    [Arguments("localhost:5108", "http://localhost:5108")]
+    [Arguments("127.0.0.1:5108", "http://127.0.0.1:5108")]
+    [Arguments("[::1]:5108", "http://[::1]:5108")]
+    [Arguments("acme.kcap.ai", "https://acme.kcap.ai")]
+    [Arguments("capacitor.example.com", "https://capacitor.example.com")]
     public async Task A_pasted_server_resolves_through_origin_then_slug_expansion(string typed, string expected) =>
         await Assert.That(WizardSignInOperation.ResolveServer(typed)).IsEqualTo(expected);
 
@@ -277,7 +295,7 @@ public class WizardAuthBridgesTests {
     [Arguments("no-slug")]
     [Arguments("declined")]
     public async Task Backing_out_of_any_create_prompt_declines_without_provisioning(string exit) {
-        var (provisioner, handler, _, time) = NewProvisioner();
+        var (provisioner, handler, progress, time) = NewProvisioner();
 
         handler.Respond = (_, _) => (HttpStatusCode.OK, """{"available":true}""");
 
@@ -291,6 +309,8 @@ public class WizardAuthBridgesTests {
 
         await Assert.That(offer.Status).IsEqualTo(ProvisionOfferStatus.Declined);
         await Assert.That(handler.Requests.Any(r => r.Contains("/api/signup/provision"))).IsFalse();
+        // The provisioner owns every non-Created message — a silent decline renders as a bare failure.
+        await Assert.That(progress.Notices).Contains("No workspace created.");
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/WizardAuthServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardAuthServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using System.Text.Json;
 using Capacitor.App.Services.Onboarding;
 using Capacitor.Cli.Core.Auth;
@@ -30,6 +31,7 @@ public class WizardAuthServiceTests {
         return (new ConsentFlipClaims(Path.Combine(dir, "consent-flip-claims.json"), Path.Combine(dir, "config.json")), dir);
     }
 
+    [UnsupportedOSPlatform("windows")]
     static void SetWritable(string dir, bool writable) =>
         File.SetUnixFileMode(dir, writable
             ? UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
@@ -156,6 +158,7 @@ public class WizardAuthServiceTests {
     // InvalidOperationException, never OperationCanceledException: the boundary maps ANY OCE from
     // this hook to Cancelled, which would silently render a store failure as "the user backed out".
     [Test]
+    [UnsupportedOSPlatform("windows")]
     public async Task A_false_arm_throws_claim_arm_failed_rather_than_a_cancellation() {
         Skip.When(OperatingSystem.IsWindows(), "chmod-based read-only directory is POSIX-only.");
 
@@ -172,6 +175,7 @@ public class WizardAuthServiceTests {
     }
 
     [Test]
+    [UnsupportedOSPlatform("windows")]
     public async Task A_false_arm_stops_the_operation_before_anything_is_published() {
         Skip.When(OperatingSystem.IsWindows(), "chmod-based read-only directory is POSIX-only.");
 

--- a/test/Capacitor.App.Tests.Unit/WizardAuthServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardAuthServiceTests.cs
@@ -59,7 +59,7 @@ public class WizardAuthServiceTests {
     [Test]
     public async Task No_attempt_has_run_yet_so_current_is_null_and_the_service_is_quiesced() {
         var (claims, _) = TempClaims();
-        var service = new WizardAuthService((_, _) => Task.FromResult<AuthResult>(Committed(Acme)), claims);
+        var service = new WizardAuthService((_, _) => Task.FromResult<AuthResult>(Committed(Acme)));
 
         await Assert.That(service.Current).IsNull();
         await service.QuiescedAsync().WaitAsync(TimeSpan.FromSeconds(5));
@@ -72,7 +72,7 @@ public class WizardAuthServiceTests {
         var service = new WizardAuthService((intent, _) => {
             seen = intent;
             return Task.FromResult<AuthResult>(Committed(Acme));
-        }, claims);
+        });
 
         var attempt = service.Begin(new ConnectIntent.Paste("acme.example"));
         var result  = await attempt.Result.WaitAsync(TimeSpan.FromSeconds(5));
@@ -86,7 +86,7 @@ public class WizardAuthServiceTests {
     public async Task Begin_while_an_attempt_is_live_throws() {
         var (claims, _) = TempClaims();
         var gate = new TaskCompletionSource<AuthResult>();
-        var service = new WizardAuthService((_, _) => gate.Task, claims);
+        var service = new WizardAuthService((_, _) => gate.Task);
 
         var attempt = service.Begin(new ConnectIntent.Create());
 
@@ -104,7 +104,7 @@ public class WizardAuthServiceTests {
         var service = new WizardAuthService((_, _) => {
             starts++;
             return starts == 1 ? gate.Task : Task.FromResult<AuthResult>(Committed(Work));
-        }, claims);
+        });
 
         var first = service.Begin(new ConnectIntent.Create());
         gate.SetResult(new AuthResult.Failed("nope"));
@@ -132,11 +132,10 @@ public class WizardAuthServiceTests {
     }
 
     [Test]
-    public async Task The_service_exposes_the_same_hook_bound_to_its_own_claims_store() {
+    public async Task The_arming_hook_binds_to_the_claims_store_it_was_built_over() {
         var (claims, _) = TempClaims();
-        var service = new WizardAuthService((_, _) => Task.FromResult<AuthResult>(Committed(Acme)), claims);
 
-        await service.BeforeCommit([Acme], CancellationToken.None);
+        await WizardAuthService.ArmingHook(claims)([Acme], CancellationToken.None);
 
         await Assert.That(claims.Pending()).IsEquivalentTo([new ConsentFlipClaim(Acme.Profile, Acme.CanonicalServer)]);
     }
@@ -182,7 +181,7 @@ public class WizardAuthServiceTests {
         var (claims, dir) = ReadOnlyClaims();
         var published = false;
         var service = new WizardAuthService(
-            (_, ct) => ScriptedCommitAsync(WizardAuthService.ArmingHook(claims), [Acme], () => published = true, ct), claims);
+            (_, ct) => ScriptedCommitAsync(WizardAuthService.ArmingHook(claims), [Acme], () => published = true, ct));
 
         SetWritable(dir, false);
         try {
@@ -204,7 +203,7 @@ public class WizardAuthServiceTests {
         File.WriteAllText(claimsPath, "{not json");
         var claims  = new ConsentFlipClaims(claimsPath, Path.Combine(Path.GetDirectoryName(claimsPath)!, "config.json"));
         var service = new WizardAuthService(
-            (_, ct) => ScriptedCommitAsync(WizardAuthService.ArmingHook(claims), [Acme], () => { }, ct), claims);
+            (_, ct) => ScriptedCommitAsync(WizardAuthService.ArmingHook(claims), [Acme], () => { }, ct));
 
         var result = await service.Begin(new ConnectIntent.Create()).Result.WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -223,7 +222,7 @@ public class WizardAuthServiceTests {
             started.SetResult();
             await Task.Delay(Timeout.Infinite, ct);
             return Committed(Acme);
-        }, claims);
+        });
 
         var attempt = service.Begin(new ConnectIntent.Create());
         await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -245,7 +244,7 @@ public class WizardAuthServiceTests {
             started.SetResult();
             await cancelSeen.Task;
             return Committed(Acme);
-        }, claims);
+        });
 
         var attempt = service.Begin(new ConnectIntent.Create());
         await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -258,7 +257,7 @@ public class WizardAuthServiceTests {
     public async Task QuiescedAsync_waits_for_a_live_attempt_to_settle() {
         var (claims, _) = TempClaims();
         var gate = new TaskCompletionSource<AuthResult>();
-        var service = new WizardAuthService((_, _) => gate.Task, claims);
+        var service = new WizardAuthService((_, _) => gate.Task);
 
         service.Begin(new ConnectIntent.Create());
         var quiesced = service.QuiescedAsync();
@@ -274,7 +273,7 @@ public class WizardAuthServiceTests {
     [Test]
     public async Task An_operation_that_throws_is_reported_as_failed() {
         var (claims, _) = TempClaims();
-        var service = new WizardAuthService((_, _) => throw new InvalidOperationException("boom"), claims);
+        var service = new WizardAuthService((_, _) => throw new InvalidOperationException("boom"));
 
         var result = await service.Begin(new ConnectIntent.Create()).Result.WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -285,7 +284,7 @@ public class WizardAuthServiceTests {
     [Test]
     public async Task Cancelling_a_settled_attempt_is_a_no_op() {
         var (claims, _) = TempClaims();
-        var service = new WizardAuthService((_, _) => Task.FromResult<AuthResult>(Committed(Acme)), claims);
+        var service = new WizardAuthService((_, _) => Task.FromResult<AuthResult>(Committed(Acme)));
 
         var attempt = service.Begin(new ConnectIntent.Create());
         await attempt.Result.WaitAsync(TimeSpan.FromSeconds(5));

--- a/test/Capacitor.App.Tests.Unit/WizardAuthServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardAuthServiceTests.cs
@@ -1,0 +1,354 @@
+using System.Text.Json;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using AppUnderTest = Capacitor.App.App;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// <summary>
+/// The wizard's single-flight sign-in driver and the decision-7 claim-arming hook it hands the
+/// façade. Every claims assertion drives the REAL <see cref="ConsentFlipClaims"/> on a temp path —
+/// a recording double would prove nothing about durability or about the false-return path that
+/// must block a commit.
+/// </summary>
+public class WizardAuthServiceTests {
+    static readonly AuthIdentity Acme = new("acme", "https://acme.example:443");
+    static readonly AuthIdentity Work = new("work", "https://work.example:443");
+
+    static AuthResult.Committed Committed(params AuthIdentity[] identities) =>
+        new("acme", Acme.CanonicalServer, AuthProvider.None, "someone", identities);
+
+    static (ConsentFlipClaims Claims, string ClaimsPath) TempClaims() {
+        var dir        = Directory.CreateTempSubdirectory("kcap-wizardauth-").FullName;
+        var claimsPath = Path.Combine(dir, "consent-flip-claims.json");
+        return (new ConsentFlipClaims(claimsPath, Path.Combine(dir, "config.json")), claimsPath);
+    }
+
+    static (ConsentFlipClaims Claims, string Dir) ReadOnlyClaims() {
+        var dir = Directory.CreateTempSubdirectory("kcap-wizardauth-ro-").FullName;
+        return (new ConsentFlipClaims(Path.Combine(dir, "consent-flip-claims.json"), Path.Combine(dir, "config.json")), dir);
+    }
+
+    static void SetWritable(string dir, bool writable) =>
+        File.SetUnixFileMode(dir, writable
+            ? UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+            : UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+    // Mirrors CommitBoundary's catch shape so the scripted operation classifies a hook failure
+    // exactly as the façade would: OperationCanceledException is a cancel, anything else is Failed.
+    static async Task<AuthResult> ScriptedCommitAsync(
+            Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task> hook,
+            IReadOnlyList<AuthIdentity> identities, Action published, CancellationToken ct) {
+        try {
+            await hook(identities, ct);
+        } catch (OperationCanceledException) {
+            return new AuthResult.Cancelled();
+        } catch (Exception ex) {
+            return new AuthResult.Failed(ex.Message);
+        }
+
+        published();
+        return Committed([.. identities]);
+    }
+
+    // ── single-flight ────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task No_attempt_has_run_yet_so_current_is_null_and_the_service_is_quiesced() {
+        var (claims, _) = TempClaims();
+        var service = new WizardAuthService((_, _) => Task.FromResult<AuthResult>(Committed(Acme)), claims);
+
+        await Assert.That(service.Current).IsNull();
+        await service.QuiescedAsync().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Begin_runs_the_operation_with_the_intent_and_publishes_it_as_current() {
+        var (claims, _) = TempClaims();
+        ConnectIntent? seen = null;
+        var service = new WizardAuthService((intent, _) => {
+            seen = intent;
+            return Task.FromResult<AuthResult>(Committed(Acme));
+        }, claims);
+
+        var attempt = service.Begin(new ConnectIntent.Paste("acme.example"));
+        var result  = await attempt.Result.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(seen).IsEqualTo(new ConnectIntent.Paste("acme.example"));
+        await Assert.That(service.Current).IsSameReferenceAs(attempt);
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+    }
+
+    [Test]
+    public async Task Begin_while_an_attempt_is_live_throws() {
+        var (claims, _) = TempClaims();
+        var gate = new TaskCompletionSource<AuthResult>();
+        var service = new WizardAuthService((_, _) => gate.Task, claims);
+
+        var attempt = service.Begin(new ConnectIntent.Create());
+
+        Assert.Throws<InvalidOperationException>(() => service.Begin(new ConnectIntent.Create()));
+
+        gate.SetResult(Committed(Acme));
+        await attempt.Result.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Begin_is_admitted_again_once_the_previous_result_completed() {
+        var (claims, _) = TempClaims();
+        var gate = new TaskCompletionSource<AuthResult>();
+        var starts = 0;
+        var service = new WizardAuthService((_, _) => {
+            starts++;
+            return starts == 1 ? gate.Task : Task.FromResult<AuthResult>(Committed(Work));
+        }, claims);
+
+        var first = service.Begin(new ConnectIntent.Create());
+        gate.SetResult(new AuthResult.Failed("nope"));
+        await first.Result.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var second = service.Begin(new ConnectIntent.Discover(AuthProvider.WorkOS));
+
+        await Assert.That(await second.Result.WaitAsync(TimeSpan.FromSeconds(5))).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(service.Current).IsSameReferenceAs(second);
+        await Assert.That(starts).IsEqualTo(2);
+    }
+
+    // ── claim-arming hook ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task The_hook_arms_one_claim_per_identity() {
+        var (claims, _) = TempClaims();
+
+        await WizardAuthService.ArmingHook(claims)([Acme, Work], CancellationToken.None);
+
+        await Assert.That(claims.Pending()).IsEquivalentTo([
+            new ConsentFlipClaim(Acme.Profile, Acme.CanonicalServer),
+            new ConsentFlipClaim(Work.Profile, Work.CanonicalServer)
+        ]);
+    }
+
+    [Test]
+    public async Task The_service_exposes_the_same_hook_bound_to_its_own_claims_store() {
+        var (claims, _) = TempClaims();
+        var service = new WizardAuthService((_, _) => Task.FromResult<AuthResult>(Committed(Acme)), claims);
+
+        await service.BeforeCommit([Acme], CancellationToken.None);
+
+        await Assert.That(claims.Pending()).IsEquivalentTo([new ConsentFlipClaim(Acme.Profile, Acme.CanonicalServer)]);
+    }
+
+    // A cancelled token must not turn arming into a half-written claim: the hook never hands the
+    // token to the store, so an already-cancelled attempt still arms rather than throwing an OCE
+    // the façade's boundary would read as a user cancel.
+    [Test]
+    public async Task The_hook_arms_even_under_an_already_cancelled_token() {
+        var (claims, _) = TempClaims();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await WizardAuthService.ArmingHook(claims)([Acme], cts.Token);
+
+        await Assert.That(claims.Pending()).IsEquivalentTo([new ConsentFlipClaim(Acme.Profile, Acme.CanonicalServer)]);
+    }
+
+    // InvalidOperationException, never OperationCanceledException: the boundary maps ANY OCE from
+    // this hook to Cancelled, which would silently render a store failure as "the user backed out".
+    [Test]
+    public async Task A_false_arm_throws_claim_arm_failed_rather_than_a_cancellation() {
+        Skip.When(OperatingSystem.IsWindows(), "chmod-based read-only directory is POSIX-only.");
+
+        var (claims, dir) = ReadOnlyClaims();
+        SetWritable(dir, false);
+        try {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => WizardAuthService.ArmingHook(claims)([Acme], CancellationToken.None));
+
+            await Assert.That(ex!.Message).IsEqualTo("claim_arm_failed");
+        } finally {
+            SetWritable(dir, true);
+        }
+    }
+
+    [Test]
+    public async Task A_false_arm_stops_the_operation_before_anything_is_published() {
+        Skip.When(OperatingSystem.IsWindows(), "chmod-based read-only directory is POSIX-only.");
+
+        var (claims, dir) = ReadOnlyClaims();
+        var published = false;
+        var service = new WizardAuthService(
+            (_, ct) => ScriptedCommitAsync(WizardAuthService.ArmingHook(claims), [Acme], () => published = true, ct), claims);
+
+        SetWritable(dir, false);
+        try {
+            var result = await service.Begin(new ConnectIntent.Create()).Result.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+            await Assert.That(((AuthResult.Failed)result).Message).IsEqualTo("claim_arm_failed");
+            await Assert.That(published).IsFalse();
+        } finally {
+            SetWritable(dir, true);
+        }
+    }
+
+    // Corruption discovered mid-attempt is quarantined aside and the claim lands in the fresh
+    // store — a wizard sign-in is never rejected because a previous claims file was unreadable.
+    [Test]
+    public async Task Arming_into_a_corrupt_store_lands_in_the_fresh_store_and_quarantines_the_old_one() {
+        var (_, claimsPath) = TempClaims();
+        File.WriteAllText(claimsPath, "{not json");
+        var claims  = new ConsentFlipClaims(claimsPath, Path.Combine(Path.GetDirectoryName(claimsPath)!, "config.json"));
+        var service = new WizardAuthService(
+            (_, ct) => ScriptedCommitAsync(WizardAuthService.ArmingHook(claims), [Acme], () => { }, ct), claims);
+
+        var result = await service.Begin(new ConnectIntent.Create()).Result.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(claims.Pending()).IsEquivalentTo([new ConsentFlipClaim(Acme.Profile, Acme.CanonicalServer)]);
+        await Assert.That(claims.Quarantine()).IsNotNull();
+    }
+
+    // ── cancellation and the close handoff ───────────────────────────────────
+
+    [Test]
+    public async Task Cancel_before_the_boundary_yields_cancelled_and_quiesces() {
+        var (claims, _) = TempClaims();
+        var started = new TaskCompletionSource();
+        var service = new WizardAuthService(async (_, ct) => {
+            started.SetResult();
+            await Task.Delay(Timeout.Infinite, ct);
+            return Committed(Acme);
+        }, claims);
+
+        var attempt = service.Begin(new ConnectIntent.Create());
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        attempt.Cancel();
+
+        await Assert.That(await attempt.Result.WaitAsync(TimeSpan.FromSeconds(5))).IsTypeOf<AuthResult.Cancelled>();
+        await service.QuiescedAsync().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // Past the boundary the façade runs its publications under CancellationToken.None and answers
+    // Committed; the service just delivers that answer to the close path.
+    [Test]
+    public async Task Cancel_after_the_boundary_still_yields_committed() {
+        var (claims, _) = TempClaims();
+        var started      = new TaskCompletionSource();
+        var cancelSeen   = new TaskCompletionSource();
+        var service = new WizardAuthService(async (_, ct) => {
+            using var registration = ct.Register(() => cancelSeen.TrySetResult());
+            started.SetResult();
+            await cancelSeen.Task;
+            return Committed(Acme);
+        }, claims);
+
+        var attempt = service.Begin(new ConnectIntent.Create());
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        attempt.Cancel();
+
+        await Assert.That(await attempt.Result.WaitAsync(TimeSpan.FromSeconds(5))).IsTypeOf<AuthResult.Committed>();
+    }
+
+    [Test]
+    public async Task QuiescedAsync_waits_for_a_live_attempt_to_settle() {
+        var (claims, _) = TempClaims();
+        var gate = new TaskCompletionSource<AuthResult>();
+        var service = new WizardAuthService((_, _) => gate.Task, claims);
+
+        service.Begin(new ConnectIntent.Create());
+        var quiesced = service.QuiescedAsync();
+
+        await Assert.That(quiesced.IsCompleted).IsFalse();
+
+        gate.SetResult(Committed(Acme));
+        await quiesced.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // The close path awaits Result during shutdown, so an operation bug must arrive as an outcome
+    // rather than as a faulted task nobody is positioned to catch.
+    [Test]
+    public async Task An_operation_that_throws_is_reported_as_failed() {
+        var (claims, _) = TempClaims();
+        var service = new WizardAuthService((_, _) => throw new InvalidOperationException("boom"), claims);
+
+        var result = await service.Begin(new ConnectIntent.Create()).Result.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(((AuthResult.Failed)result).Message).IsEqualTo("boom");
+    }
+
+    [Test]
+    public async Task Cancelling_a_settled_attempt_is_a_no_op() {
+        var (claims, _) = TempClaims();
+        var service = new WizardAuthService((_, _) => Task.FromResult<AuthResult>(Committed(Acme)), claims);
+
+        var attempt = service.Begin(new ConnectIntent.Create());
+        await attempt.Result.WaitAsync(TimeSpan.FromSeconds(5));
+        attempt.Cancel();
+
+        await Assert.That(await attempt.Result).IsTypeOf<AuthResult.Committed>();
+    }
+}
+
+/// <summary>
+/// <c>App.ResolveConsentFlipIdentity</c> runs INSIDE <see cref="ConsentFlipClaims.TryConsume"/>'s
+/// two-lock section, so an unreadable config must fail closed to an identity that matches nothing
+/// rather than resolve to plausible defaults or let an exception escape the locks.
+///
+/// [NotInParallel]: writes the one real config.json under the assembly-wide KCAP_CONFIG_DIR (see
+/// <c>OnboardingGateGlobalSetup</c>) — same shared resource as AppStartupCarveOutTests.
+/// </summary>
+[NotInParallel(nameof(OnboardingGateTests))]
+public class ConsentFlipIdentityFailClosedTests {
+    static string ConfigPath => AppConfig.GetConfigPath();
+
+    [Before(Test)]
+    public void Cleanup() {
+        if (File.Exists(ConfigPath)) File.Delete(ConfigPath);
+        AppConfig.ResetResolvedStateForTesting();
+    }
+
+    [After(Test)]
+    public void RemoveCorruptConfig() => Cleanup();
+
+    [Test]
+    public async Task Unreadable_config_resolves_an_identity_that_matches_nothing() {
+        File.WriteAllText(ConfigPath, "{not json");
+
+        await Assert.That(AppUnderTest.ResolveConsentFlipIdentity()).IsEqualTo(("", "", ""));
+    }
+
+    [Test]
+    public async Task Unreadable_config_retains_the_claim_instead_of_throwing_inside_TryConsume() {
+        File.WriteAllText(ConfigPath, "{not json");
+        var dir    = Directory.CreateTempSubdirectory("kcap-wizardauth-identity-").FullName;
+        var claims = new ConsentFlipClaims(Path.Combine(dir, "consent-flip-claims.json"), ConfigPath);
+        var claim  = new ConsentFlipClaim("acme", "https://acme.example:443");
+        claims.Arm(claim);
+
+        var consumed = claims.TryConsume(claim, AppUnderTest.ResolveConsentFlipIdentity, "acme-daemon");
+
+        await Assert.That(consumed).IsFalse();
+        await Assert.That(claims.Pending()).IsEquivalentTo([claim]);
+    }
+
+    // Control: a readable config still resolves the live identity, so the fail-closed arm above
+    // cannot be mistaken for "this delegate never resolves anything".
+    [Test]
+    public async Task Readable_config_still_resolves_and_consumes_the_matching_claim() {
+        var profile = new Profile { ServerUrl = "https://acme.example", Daemon = new DaemonSettings { Name = "acme-daemon" } };
+        File.WriteAllText(ConfigPath, JsonSerializer.Serialize(
+            new ProfileConfig { ActiveProfile = "acme", Profiles = new() { ["acme"] = profile } },
+            ProfileConfigJsonContext.Default.ProfileConfig));
+        var dir    = Directory.CreateTempSubdirectory("kcap-wizardauth-identity-").FullName;
+        var claims = new ConsentFlipClaims(Path.Combine(dir, "consent-flip-claims.json"), ConfigPath);
+        var claim  = new ConsentFlipClaim("acme", ServerIdentity.Canonicalize("https://acme.example")!);
+        claims.Arm(claim);
+
+        var consumed = claims.TryConsume(claim, AppUnderTest.ResolveConsentFlipIdentity, "acme-daemon");
+
+        await Assert.That(consumed).IsTrue();
+        await Assert.That(claims.Pending()).IsEmpty();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WizardCompositionTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardCompositionTests.cs
@@ -1,0 +1,269 @@
+using System.Net;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using System.Text.Json;
+using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.LocalIpc;
+using AppUnderTest = Capacitor.App.App;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// <summary>
+/// End-to-end-shaped composition flows: the REAL WizardComposition.BuildGraph, the REAL step view
+/// models and the REAL OnboardingViewModel — only externals (HTTP, process spawns, the daemon
+/// socket) are scripted. WizardStartupTests already pins the composition SEAMS in isolation
+/// (adoptServer:true on Paste via <c>A_pasted_server_is_adopted_and_the_arming_hook_runs_before_the_commit</c>,
+/// the provisioner armed for Create/Discover-WorkOS via <c>Create_and_workos_discovery_route_through_the_auth_proxy</c>,
+/// and beforeCommit==ArmingHook via <c>The_facades_beforeCommit_hook_arms_a_durable_claim_per_identity</c>
+/// plus WizardAuthServiceTests) — those are not duplicated here.
+/// </summary>
+static class WizardCompositionFixtures {
+    /// Answers every request with a None-provider /auth/config body, mirroring
+    /// WizardStartupResolutionTests' StubAuthHandler — a Paste sign-in commits with no further round trip.
+    internal sealed class NoneProviderAuthHandler : HttpMessageHandler {
+        public readonly List<string> Requests = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+            Requests.Add(request.RequestUri!.ToString());
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("""{"provider":"None"}""", Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    internal static string ConfigPath => AppConfig.GetConfigPath();
+
+    internal static void ResetConfig() {
+        if (File.Exists(ConfigPath)) File.Delete(ConfigPath);
+        AppConfig.ResetResolvedStateForTesting();
+        Environment.SetEnvironmentVariable("KCAP_URL", null);
+        Environment.SetEnvironmentVariable("KCAP_PROFILE", null);
+    }
+
+    internal static void WriteConfig(ProfileConfig config) =>
+        File.WriteAllText(ConfigPath, JsonSerializer.Serialize(config, ProfileConfigJsonContext.Default.ProfileConfig));
+}
+
+/// (a) Fresh-machine happy path: a None-provider Paste sign-in through the REAL façade (the only
+/// scripted external is the /auth/config HTTP call), driven through the REAL step VMs and the
+/// REAL OnboardingViewModel all the way to the Done summary — with no kcap CLI resolved anywhere
+/// in the composition, the fresh-machine shape spec §9 documents.
+///
+/// [NotInParallel]: shares OnboardingGateTests' one real config.json (OnboardingGateGlobalSetup)
+/// and the process-global headless session, since composing the wizard constructs ReactiveUI VMs.
+[NotInParallel([nameof(OnboardingGateTests), "AvaloniaSession"])]
+public class WizardCompositionHappyPathTests {
+    const string ProfileName = "acme";
+    const string ServerUrl   = "https://acme.example";
+
+    [Before(Test)]
+    public void Cleanup() => WizardCompositionFixtures.ResetConfig();
+
+    [Test]
+    public async Task Fresh_machine_paste_sign_in_reaches_a_correct_done_summary() {
+        WizardCompositionFixtures.WriteConfig(
+            new ProfileConfig { ActiveProfile = ProfileName, Profiles = new() { [ProfileName] = new Profile() } });
+
+        using var harness = new WizardFixtures.GraphHarness();
+        harness.CliPath        = null; // no kcap CLI resolved anywhere on this fresh machine
+        harness.Cli.CliPath    = null;
+        harness.ShimTarget     = null;
+        harness.ShimApplicable = false;
+        harness.Identity       = (ProfileName, ServerUrl, "daemon-a");
+        using var authHandler = new WizardCompositionFixtures.NoneProviderAuthHandler();
+
+        var options = harness.Options() with {
+            Operation = spec => WizardSignInOperation.For(new OnboardingFacade(
+                spec.Progress, spec.Picker, spec.Provisioner, spec.BeforeCommit,
+                () => new HttpClient(authHandler, false))),
+        };
+
+        var summary = await AvaloniaSession.DispatchAsync(async () => {
+            var graph = WizardComposition.BuildGraph(options);
+            await graph.ViewModel.PendingEnterForTesting;
+
+            var connect = graph.Steps.OfType<ConnectStepViewModel>().Single();
+            connect.Choice          = ConnectChoice.Paste;
+            connect.ServerInputText = ServerUrl;
+            await Assert.That(connect.Satisfied).IsTrue(); // a valid intent is staged before Next
+
+            await graph.ViewModel.NextCommand.Execute().ToTask(); // Connect -> Sign-in
+
+            var signIn = graph.Steps.OfType<SignInStepViewModel>().Single();
+            await signIn.SignInAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+            await Assert.That(signIn.Satisfied).IsTrue();
+            await Assert.That(authHandler.Requests.Any(r => r.Contains("/auth/config"))).IsTrue();
+            await Assert.That(harness.Claims.Pending().Select(c => c.Profile).ToList()).IsEquivalentTo([ProfileName]);
+
+            await graph.ViewModel.NextCommand.Execute().ToTask(); // Sign-in -> Defaults
+            await graph.ViewModel.NextCommand.Execute().ToTask(); // Defaults -> Agents (persists via ConfigMutator)
+
+            var defaults = graph.Steps.OfType<DefaultsStepViewModel>().Single();
+            await Assert.That(defaults.Satisfied).IsTrue();
+            await Assert.That(defaults.Message).IsNull();
+
+            await graph.ViewModel.NextCommand.Execute().ToTask(); // Agents -> Import (no CLI, nothing installable)
+            await graph.ViewModel.NextCommand.Execute().ToTask(); // Import -> Daemon (no CLI, nothing runnable)
+
+            var daemon = graph.Steps.OfType<DaemonStepViewModel>().Single();
+            await Assert.That(daemon.Row).IsEqualTo(DaemonRow.CliMissing);
+
+            await graph.ViewModel.NextCommand.Execute().ToTask(); // Daemon -> Done
+            await Assert.That(graph.ViewModel.Current.Id).IsEqualTo(WizardStepId.Done);
+
+            return graph.Steps.OfType<DoneStepViewModel>().Single().Summary;
+        }).WaitAsync(TimeSpan.FromSeconds(30));
+
+        var byTitle = summary.ToDictionary(e => e.Title);
+
+        await Assert.That(summary.Count).IsEqualTo(7); // every configured step but Done itself
+        await Assert.That(byTitle["Command-line tool"].Satisfied).IsFalse();
+        await Assert.That(byTitle["Command-line tool"].Note).IsEqualTo(WizardComposition.CliMissingNote);
+        await Assert.That(byTitle["Connect to Capacitor"].Satisfied).IsTrue();
+        await Assert.That(byTitle["Connect to Capacitor"].Note).IsNull();
+        await Assert.That(byTitle["Sign in"].Satisfied).IsTrue();
+        await Assert.That(byTitle["Sign in"].Note).IsNull();
+        await Assert.That(byTitle["Defaults"].Satisfied).IsTrue();
+        await Assert.That(byTitle["Defaults"].Note).IsNull();
+        await Assert.That(byTitle["Coding agents"].Satisfied).IsFalse();
+        await Assert.That(byTitle["Coding agents"].Note).IsEqualTo(WizardComposition.CliMissingNote);
+        await Assert.That(byTitle["Import past sessions"].Satisfied).IsFalse();
+        await Assert.That(byTitle["Import past sessions"].Note).IsEqualTo(WizardComposition.CliMissingNote);
+        await Assert.That(byTitle["Enable the daemon"].Satisfied).IsFalse();
+        // The dominant CLI-missing note, never the stale "requires sign-in" — sign-in DID commit.
+        await Assert.That(byTitle["Enable the daemon"].Note).IsEqualTo(WizardComposition.CliMissingNote);
+
+        var config = await AppConfig.LoadProfileConfig();
+        await Assert.That(config.Profiles[ProfileName].ServerUrl).IsEqualTo(ServerUrl);
+        await Assert.That(config.Profiles[ProfileName].AuthProvider?.Provider).IsEqualTo(AuthProvider.None);
+        await Assert.That(config.Profiles[ProfileName].DefaultVisibility).IsEqualTo("org_public");
+        await Assert.That(config.Profiles[ProfileName].Daemon?.Name).IsEqualTo("daemon-a");
+
+        // No daemon touchpoint reached with no CLI resolved: no lane traffic, no IPC, no CLI spawns.
+        await Assert.That(harness.Lane.Requests).IsEmpty();
+        await Assert.That(harness.Ops.GetCalls).IsEqualTo(0);
+        await Assert.That(harness.Ops.PutV2Calls).IsEqualTo(0);
+        await Assert.That(harness.Cli.StatusCallCount).IsEqualTo(0);
+        await Assert.That(harness.Cli.PluginInstallCallCount).IsEqualTo(0);
+        await Assert.That(harness.Cli.ImportCallCount).IsEqualTo(0);
+    }
+}
+
+/// (b) Abandon before sign-in: staging a valid Connect intent and closing WITHOUT ever calling
+/// Begin must leave nothing durable — no claim, no lane traffic, no CLI spawn, and the one real
+/// config file this suite shares untouched.
+///
+/// [NotInParallel]: same shared resources as WizardCompositionHappyPathTests, for the same reason.
+[NotInParallel([nameof(OnboardingGateTests), "AvaloniaSession"])]
+public class WizardCompositionAbandonTests {
+    const string ProfileName = "acme";
+
+    [Before(Test)]
+    public void Cleanup() => WizardCompositionFixtures.ResetConfig();
+
+    [Test]
+    public async Task Staging_connect_input_and_closing_without_signing_in_writes_nothing() {
+        WizardCompositionFixtures.WriteConfig(
+            new ProfileConfig { ActiveProfile = ProfileName, Profiles = new() { [ProfileName] = new Profile() } });
+        var configBefore = await File.ReadAllTextAsync(WizardCompositionFixtures.ConfigPath);
+
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            await graph.ViewModel.PendingEnterForTesting;
+
+            var connect = graph.Steps.OfType<ConnectStepViewModel>().Single();
+            connect.Choice          = ConnectChoice.Paste;
+            connect.ServerInputText = "https://acme.example";
+            await Assert.That(connect.Satisfied).IsTrue(); // a valid intent is staged — Begin is never called
+
+            graph.ViewModel.RequestClose();
+            await AppUnderTest.HandoffAfterWizardAsync(
+                    graph.Auth, () => Task.CompletedTask, TimeSpan.FromSeconds(5), new OutcomeChannel())
+                .WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(harness.Claims.Pending()).IsEmpty();
+            await Assert.That(harness.Lane.Requests).IsEmpty();
+            await Assert.That(harness.Ops.GetCalls).IsEqualTo(0);
+            await Assert.That(harness.Ops.PutV2Calls).IsEqualTo(0);
+            await Assert.That(harness.Cli.StatusCallCount).IsEqualTo(0);
+            await Assert.That(harness.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+            await Assert.That(harness.Cli.StartVerifiedCallCount).IsEqualTo(0);
+            await Assert.That(harness.Cli.PluginInstallCallCount).IsEqualTo(0);
+            await Assert.That(harness.Cli.ImportCallCount).IsEqualTo(0);
+
+            return true;
+        }).WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(await File.ReadAllTextAsync(WizardCompositionFixtures.ConfigPath)).IsEqualTo(configBefore);
+    }
+}
+
+/// (c) Sign-in commit -> claims armed -> relaunch fixture: a claim armed by the wizard's own
+/// composition (the REAL ArmingHook, wired exactly as WizardComposition.BuildGraph wires it) must
+/// still be found and applied by a FRESH ConsentFlipCoordinator over the SAME durable claims file —
+/// modelling a wizard session followed by the normal app's next startup, never a shared in-memory instance.
+[NotInParallel("AvaloniaSession")]
+public class WizardCompositionRelaunchTests {
+    [Test]
+    public async Task A_claim_armed_during_the_wizard_is_applied_by_a_relaunched_coordinator() {
+        using var harness = new WizardFixtures.GraphHarness();
+        var canonicalServer = ServerIdentity.Canonicalize("https://acme.example")!;
+        const string profileName = "acme";
+        const string daemonName  = "daemon-a";
+
+        // Scripted rather than the full network-backed façade: this proves the RELAUNCH seam, not
+        // the boundary itself (already pinned by WizardStartupTests' beforeCommit-wiring tests).
+        // The hook invoked here IS the composition's own WizardFacadeSpec.BeforeCommit.
+        harness.Operation = async (_, ct) => {
+            await harness.Spec!.BeforeCommit([new AuthIdentity(profileName, canonicalServer)], ct);
+            return new AuthResult.Committed(profileName, canonicalServer, AuthProvider.None, null, []);
+        };
+
+        var result = await AvaloniaSession.DispatchAsync(async () => {
+            var graph   = WizardComposition.BuildGraph(harness.Options());
+            var attempt = graph.Auth.Begin(new ConnectIntent.Paste("https://acme.example"));
+            return await attempt.Result;
+        }).WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(harness.Claims.Pending().Select(c => c.Profile).ToList()).IsEquivalentTo([profileName]);
+
+        // The relaunch: a fresh ConsentFlipClaims instance over the SAME file, and a fresh
+        // coordinator — never the wizard's own claims object or WizardAuthService.
+        var relaunchClaims = new ConsentFlipClaims(
+            Path.Combine(harness.Dir, "claims.json"), Path.Combine(harness.Dir, "config.json"));
+        var client   = new FakeDaemonClientService();
+        var ops      = new ScriptedLocalControlOps();
+        var surface  = new FakeLifecycleSurface();
+        var appState = new WizardFixtures.NoopAppStateStore();
+        var coordinator = new ConsentFlipCoordinator(
+            client, ops, relaunchClaims, () => (profileName, canonicalServer, daemonName), surface, appState,
+            CancellationToken.None);
+
+        ops.QueueGet(new ConsentPolicyDto("allow", 30, []));
+        ops.QueuePutV2(true, null);
+
+        coordinator.Start();
+        client.StatusSubject.OnNext(new AttachStatus(
+            AttachState.Connected, null, [ConsentFlipCoordinator.ConsentV3Capability]));
+
+        await WizardFixtures.WaitUntilAsync(
+            () => relaunchClaims.Pending().Count == 0, what: "the relaunched coordinator to consume the claim");
+
+        await Assert.That(ops.PutV2Calls).IsEqualTo(1);
+        var put = ops.PutV2Payloads[0];
+        await Assert.That(put.ExpectedName).IsEqualTo(daemonName);
+        await Assert.That(put.ExpectedServerUrl).IsEqualTo(canonicalServer);
+        await Assert.That(put.Policy.Default).IsEqualTo("prompt");
+        // Same durable file: the wizard's own (now-stale) claims handle agrees the claim is gone.
+        await Assert.That(harness.Claims.Pending()).IsEmpty();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
@@ -1,0 +1,379 @@
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.Cli.Core.Config;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// spec §3 steps 1/4/8: the PATH shim, the visibility/daemon-name defaults, and the closing
+/// summary. Shim owns a ReactiveCommand (WhenAnyValue in its ctor), so it runs through the real
+/// headless session like SignInStepViewModel; Defaults and Done own no commands and run directly,
+/// like ConnectStepViewModel.
+public class WizardSimpleStepsTests {
+    // ── Shim: pure applicability decision ───────────────────────────────────
+
+    [Test]
+    [Arguments(false, "/opt/kcap/kcap", false, false)] // non-macOS
+    [Arguments(true, null, false, false)]               // no resolved CLI
+    [Arguments(true, "/opt/kcap/kcap", true, false)]     // already on PATH
+    [Arguments(true, "/opt/kcap/kcap", null, false)]     // probe inconclusive — fail quiet
+    [Arguments(true, "/opt/kcap/kcap", false, true)]     // macOS + CLI + positively absent
+    public async Task ComputeApplicable_matches_the_spec_decision(bool isMacOs, string? target, bool? onPath, bool expected) {
+        await Assert.That(ShimStepViewModel.ComputeApplicable(isMacOs, target, onPath)).IsEqualTo(expected);
+    }
+
+    // ── Shim: install / claim / outcome mapping ─────────────────────────────
+
+    sealed class FakeProcessRunner : IProcessRunner {
+        Func<Task<ProcessResult>> _step = () => Task.FromResult(new ProcessResult(0, "", "", false));
+
+        public void Enqueue(ProcessResult result) => _step = () => Task.FromResult(result);
+
+        public Task<ProcessResult> RunAsync(string fileName, string[] args, RunOptions options, CancellationToken ct) => _step();
+
+        public Task<StreamingResult> RunStreamingAsync(string fileName, string[] args, RunOptions options,
+            Action<StreamedLine> onLine, CancellationToken ct) => throw new NotImplementedException();
+    }
+
+    sealed class FakeAppStateStore : IAppStateStore {
+        public AppState State = new();
+        public int Updates;
+
+        public Task<AppState> LoadAsync() => Task.FromResult(State);
+
+        public Task<bool> UpdateAsync(Func<AppState, AppState> mutate) {
+            Updates++;
+            State = mutate(State);
+
+            return Task.FromResult(true);
+        }
+    }
+
+    sealed class ShimHarness : IDisposable {
+        public readonly string TempDir = Directory.CreateTempSubdirectory("kcap-shimstep-").FullName;
+        public readonly FakeProcessRunner  Runner = new();
+        public readonly FakeLoginShellProbe Probe = new();
+        public readonly FakeAppStateStore  Store  = new();
+        public readonly PathShimInstaller  Installer;
+        public readonly string             Destination;
+        public readonly string             Target;
+        public readonly ShimStepViewModel  Vm;
+
+        public ShimHarness() {
+            Destination = Path.Combine(TempDir, "kcap");
+            Target      = Path.Combine(TempDir, "target-cli");
+            Installer   = new PathShimInstaller(Runner, Probe);
+            Vm          = new ShimStepViewModel(true, Installer, Store, Target, Destination);
+        }
+
+        public Task Install() => Vm.InstallCommand.Execute().ToTask();
+
+        public void Dispose() {
+            try { Directory.Delete(TempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Install_claims_ShimOffered_exactly_once_across_two_clicks() {
+        var updates = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new ShimHarness();
+            h.Runner.Enqueue(new ProcessResult(0, "", "", false));
+            h.Probe.KcapOnPathBehavior = _ => Task.FromResult<bool?>(true);
+
+            await h.Install();
+            await h.Install();
+
+            return h.Store.Updates;
+        });
+
+        await Assert.That(updates).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Never_installing_never_claims() {
+        var updates = await AvaloniaSession.DispatchAsync(() => {
+            using var h = new ShimHarness();
+
+            return h.Store.Updates;
+        });
+
+        await Assert.That(updates).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Installed_outcome_satisfies_the_step_with_no_message() {
+        var (satisfied, message) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new ShimHarness();
+            h.Runner.Enqueue(new ProcessResult(0, "", "", false));
+            h.Probe.KcapOnPathBehavior = _ => Task.FromResult<bool?>(true);
+
+            await h.Install();
+
+            return (h.Vm.Satisfied, h.Vm.Message);
+        });
+
+        await Assert.That(satisfied).IsTrue();
+        await Assert.That(message).IsNull();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task InstalledButNotOnPath_outcome_is_unsatisfied_with_the_installer_detail() {
+        var (satisfied, message) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new ShimHarness();
+            h.Runner.Enqueue(new ProcessResult(0, "", "", false));
+            h.Probe.KcapOnPathBehavior = _ => Task.FromResult<bool?>(false);
+
+            await h.Install();
+
+            return (h.Vm.Satisfied, h.Vm.Message);
+        });
+
+        await Assert.That(satisfied).IsFalse();
+        await Assert.That(message).IsNotNull();
+        await Assert.That(message).Contains("PATH");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Cancelled_outcome_is_unsatisfied_with_no_message() {
+        var (satisfied, message) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new ShimHarness();
+            h.Runner.Enqueue(new ProcessResult(1, "", "User canceled. (-128)", false));
+
+            await h.Install();
+
+            return (h.Vm.Satisfied, h.Vm.Message);
+        });
+
+        await Assert.That(satisfied).IsFalse();
+        await Assert.That(message).IsNull();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Failed_outcome_is_unsatisfied_with_detail_and_the_sudo_fallback() {
+        var (satisfied, message) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new ShimHarness();
+            h.Runner.Enqueue(new ProcessResult(1, "", "Permission denied", false));
+
+            await h.Install();
+
+            return (h.Vm.Satisfied, h.Vm.Message);
+        });
+
+        await Assert.That(satisfied).IsFalse();
+        await Assert.That(message).IsNotNull();
+        await Assert.That(message).Contains("Permission denied");
+        await Assert.That(message).Contains("sudo mkdir -p /usr/local/bin");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Null_target_reports_kcap_not_found_and_claims_nothing() {
+        var (satisfied, message, updates) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new ShimHarness();
+            var vm = new ShimStepViewModel(true, h.Installer, h.Store, null, h.Destination);
+
+            await vm.InstallCommand.Execute().ToTask();
+
+            return (vm.Satisfied, vm.Message, h.Store.Updates);
+        });
+
+        await Assert.That(satisfied).IsFalse();
+        await Assert.That(message).IsEqualTo("kcap CLI not found");
+        await Assert.That(updates).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task CanLeaveAsync_never_vetoes() {
+        var (next, back, skip) = await AvaloniaSession.DispatchAsync(async () => {
+            var vm = new ShimStepViewModel(false, new PathShimInstaller(
+                new NoopProcessRunner(), new FakeLoginShellProbe()), new NoopAppStateStore(), null);
+
+            return (
+                await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None),
+                await vm.CanLeaveAsync(WizardNavigation.Back, CancellationToken.None),
+                await vm.CanLeaveAsync(WizardNavigation.Skip, CancellationToken.None));
+        });
+
+        await Assert.That(next).IsTrue();
+        await Assert.That(back).IsTrue();
+        await Assert.That(skip).IsTrue();
+    }
+
+    sealed class NoopProcessRunner : IProcessRunner {
+        public Task<ProcessResult> RunAsync(string fileName, string[] args, RunOptions options, CancellationToken ct) =>
+            throw new NotImplementedException();
+
+        public Task<StreamingResult> RunStreamingAsync(string fileName, string[] args, RunOptions options,
+            Action<StreamedLine> onLine, CancellationToken ct) => throw new NotImplementedException();
+    }
+
+    sealed class NoopAppStateStore : IAppStateStore {
+        public Task<AppState> LoadAsync() => Task.FromResult(new AppState());
+        public Task<bool> UpdateAsync(Func<AppState, AppState> mutate) => Task.FromResult(true);
+    }
+}
+
+/// spec §3 step 4 / decision 5. Real ConfigMutator against the assembly's shared config path
+/// (OnboardingGateGlobalSetup) — [NotInParallel(nameof(OnboardingGateTests))] serializes against
+/// every other test class touching that one real config.json.
+[NotInParallel(nameof(OnboardingGateTests))]
+public class DefaultsStepViewModelTests {
+    static string ConfigPath => AppConfig.GetConfigPath();
+
+    [Before(Test)]
+    public void Cleanup() {
+        if (File.Exists(ConfigPath)) File.Delete(ConfigPath);
+        AppConfig.ResetResolvedStateForTesting();
+    }
+
+    [Test]
+    public async Task Defaults_are_org_public_and_the_lowercased_username() {
+        var vm = new DefaultsStepViewModel();
+
+        await Assert.That(vm.Visibility).IsEqualTo("org_public");
+        await Assert.That(vm.DaemonName).IsEqualTo(Environment.UserName.ToLowerInvariant());
+        await Assert.That(vm.Applicable).IsTrue();
+        await Assert.That(vm.Satisfied).IsFalse();
+    }
+
+    [Test]
+    public async Task VisibilityOptions_carry_the_setup_prompts_four_labels_verbatim() {
+        var options = DefaultsStepViewModel.VisibilityOptions;
+
+        await Assert.That(options.Select(o => o.Value)).IsEquivalentTo(AppConfig.ValidVisibilities, CollectionOrdering.Matching);
+        await Assert.That(options.First(o => o.Value == "private").Label)
+            .IsEqualTo("All private — only you can see your sessions");
+        await Assert.That(options.First(o => o.Value == "project").Label)
+            .IsEqualTo("Project repos public to fellow project members, others private");
+        await Assert.That(options.First(o => o.Value == "org_public").Label)
+            .IsEqualTo("Org repos public, others private (default)");
+        await Assert.That(options.First(o => o.Value == "public").Label)
+            .IsEqualTo("All public — others can see all your sessions");
+    }
+
+    [Test]
+    public async Task Next_persists_both_fields_and_preserves_unrelated_config() {
+        var existing = new ProfileConfig {
+            ActiveProfile = "acme",
+            Profiles = new() {
+                ["acme"] = new Profile {
+                    ServerUrl     = "https://acme.example",
+                    ExcludedRepos = ["foo/bar"],
+                    ImportOrg     = "acme-org",
+                    Daemon        = new DaemonSettings { MaxAgents = 9, ClaudePath = "/usr/bin/claude" },
+                }
+            },
+            MachineId = "machine-123",
+        };
+        File.WriteAllText(ConfigPath, JsonSerializer.Serialize(existing, ProfileConfigJsonContext.Default.ProfileConfig));
+
+        var vm = new DefaultsStepViewModel { Visibility = "public", DaemonName = "acme-daemon" };
+
+        var canLeave = await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+
+        await Assert.That(canLeave).IsTrue();
+        await Assert.That(vm.Satisfied).IsTrue();
+
+        var saved   = ConfigMutator.LoadPure(ConfigPath);
+        var profile = saved.Profiles["acme"];
+
+        await Assert.That(profile.DefaultVisibility).IsEqualTo("public");
+        await Assert.That(profile.Daemon!.Name).IsEqualTo("acme-daemon");
+        await Assert.That(profile.Daemon!.MaxAgents).IsEqualTo(9);
+        await Assert.That(profile.Daemon!.ClaudePath).IsEqualTo("/usr/bin/claude");
+        await Assert.That(profile.ServerUrl).IsEqualTo("https://acme.example");
+        await Assert.That(profile.ImportOrg).IsEqualTo("acme-org");
+        await Assert.That(profile.ExcludedRepos).IsEquivalentTo(["foo/bar"]);
+        await Assert.That(saved.MachineId).IsEqualTo("machine-123");
+    }
+
+    [Test]
+    public async Task Skip_and_back_do_not_persist_and_leave_the_step_unsatisfied() {
+        var vm = new DefaultsStepViewModel { Visibility = "public", DaemonName = "acme-daemon" };
+
+        await Assert.That(await vm.CanLeaveAsync(WizardNavigation.Skip, CancellationToken.None)).IsTrue();
+        await Assert.That(await vm.CanLeaveAsync(WizardNavigation.Back, CancellationToken.None)).IsTrue();
+
+        await Assert.That(vm.Satisfied).IsFalse();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+    }
+}
+
+/// spec §3 step 8. Owns no commands and no Rx subscriptions — runs without the headless session,
+/// like ConnectStepViewModelTests.
+public class DoneStepViewModelTests {
+    [Test]
+    public async Task Applicable_and_Satisfied_are_always_true() {
+        var vm = new DoneStepViewModel(() => []);
+
+        await Assert.That(vm.Applicable).IsTrue();
+        await Assert.That(vm.Satisfied).IsTrue();
+    }
+
+    [Test]
+    public async Task Summary_reflects_the_providers_current_output_including_why_skipped_notes() {
+        IReadOnlyList<(string Title, bool Satisfied, string? Note)> current = [
+            ("Command-line tool", false, "kcap CLI not found"),
+            ("Sign in", true, null),
+            ("Enable daemon", false, "requires sign-in"),
+        ];
+        var vm = new DoneStepViewModel(() => current);
+
+        await vm.OnEnterAsync(CancellationToken.None);
+
+        await Assert.That(vm.Summary.Select(e => (e.Title, e.Satisfied, e.Note)))
+            .IsEquivalentTo(current, CollectionOrdering.Matching);
+        await Assert.That(vm.Summary[0].Glyph).IsEqualTo("—");
+        await Assert.That(vm.Summary[1].Glyph).IsEqualTo("✓");
+    }
+
+    [Test]
+    public async Task Summary_re_renders_on_every_entry() {
+        var callCount = 0;
+        var vm = new DoneStepViewModel(() => {
+            callCount++;
+
+            return callCount == 1
+                ? [("Step", false, "not yet")]
+                : [("Step", true, (string?)null)];
+        });
+
+        await vm.OnEnterAsync(CancellationToken.None);
+        var first = vm.Summary[0].Satisfied;
+
+        await vm.OnEnterAsync(CancellationToken.None);
+        var second = vm.Summary[0].Satisfied;
+
+        await Assert.That(first).IsFalse();
+        await Assert.That(second).IsTrue();
+    }
+
+    [Test]
+    public async Task OnEnterAsync_raises_PropertyChanged_for_Summary() {
+        var vm = new DoneStepViewModel(() => []);
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, args) => raised.Add(args.PropertyName);
+
+        await vm.OnEnterAsync(CancellationToken.None);
+
+        await Assert.That(raised).Contains(nameof(DoneStepViewModel.Summary));
+    }
+
+    [Test]
+    public async Task CanLeaveAsync_never_vetoes() {
+        var vm = new DoneStepViewModel(() => []);
+
+        await Assert.That(await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None)).IsTrue();
+        await Assert.That(await vm.CanLeaveAsync(WizardNavigation.Back, CancellationToken.None)).IsTrue();
+        await Assert.That(await vm.CanLeaveAsync(WizardNavigation.Skip, CancellationToken.None)).IsTrue();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
@@ -1,7 +1,11 @@
 using System.Reactive.Threading.Tasks;
 using System.Text.Json;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.App.Views.Onboarding;
 using Capacitor.Cli.Core.Config;
 using TUnit.Assertions.Enums;
 
@@ -208,6 +212,73 @@ public class WizardSimpleStepsTests {
         await Assert.That(skip).IsTrue();
     }
 
+    // ── templates ────────────────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_window_selects_a_template_for_each_simple_step() {
+        var result = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new ShimHarness();
+            var defaults = new DefaultsStepViewModel();
+            var done = new DoneStepViewModel(() => [("Command-line tool", false, "kcap CLI not found")]);
+            var vm = new OnboardingViewModel([h.Vm, defaults, done]);
+            await vm.PendingEnterForTesting;
+
+            var window = new OnboardingWindow { DataContext = vm };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            // Run the install and observe the button/success-text react — a broken Idle/Satisfied binding would leave Avalonia's own base defaults instead of tracking the VM.
+            var installButton = window.GetVisualDescendants().OfType<Button>().FirstOrDefault(b => b.Name == "InstallShimButton");
+            var successBefore = window.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(t => t.Name == "ShimSuccessText")?.IsVisible;
+
+            h.Runner.Enqueue(new ProcessResult(0, "", "", false));
+            h.Probe.KcapOnPathBehavior = _ => Task.FromResult<bool?>(true);
+            await h.Install();
+            Dispatcher.UIThread.RunJobs();
+
+            var successAfter = window.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(t => t.Name == "ShimSuccessText")?.IsVisible;
+            var installEnabledAfter = installButton?.IsEnabled;
+
+            await vm.NextCommand.Execute().ToTask(); // Shim -> Defaults
+            Dispatcher.UIThread.RunJobs();
+
+            var visibilityCombo = window.GetVisualDescendants().OfType<ComboBox>().FirstOrDefault(c => c.Name == "VisibilityCombo");
+            var selectedVisibility = visibilityCombo?.SelectedValue as string;
+            var daemonNameText = window.GetVisualDescendants().OfType<TextBox>().FirstOrDefault(t => t.Name == "DaemonNameBox")?.Text;
+
+            await vm.SkipCommand.Execute().ToTask(); // Defaults -> Done (Skip never persists — no real config write here)
+            Dispatcher.UIThread.RunJobs();
+
+            var summaryList = window.GetVisualDescendants().OfType<ItemsControl>().FirstOrDefault(i => i.Name == "SummaryList");
+            var summaryTitle = window.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(t => t.Name == "SummaryTitleText")?.Text;
+            var summaryNote = window.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(t => t.Name == "SummaryNoteText")?.Text;
+            var summaryGlyph = window.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(t => t.Name == "SummaryGlyphText")?.Text;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return (
+                installButton, successBefore, successAfter, installEnabledAfter,
+                visibilityCombo, selectedVisibility, daemonNameText,
+                summaryList, summaryTitle, summaryNote, summaryGlyph);
+        });
+
+        await Assert.That(result.installButton).IsNotNull();
+        await Assert.That(result.successBefore).IsFalse(); // Satisfied starts false — a broken binding would leave Avalonia's IsVisible default (true)
+        await Assert.That(result.successAfter).IsTrue();   // Satisfied flips true once Installed lands
+        await Assert.That(result.installEnabledAfter).IsTrue();
+
+        await Assert.That(result.visibilityCombo).IsNotNull();
+        await Assert.That(result.selectedVisibility).IsEqualTo("org_public");
+        await Assert.That(result.daemonNameText).IsEqualTo(Environment.UserName.ToLowerInvariant());
+
+        await Assert.That(result.summaryList).IsNotNull();
+        await Assert.That(result.summaryTitle).IsEqualTo("Command-line tool");
+        await Assert.That(result.summaryNote).IsEqualTo("kcap CLI not found");
+        await Assert.That(result.summaryGlyph).IsEqualTo("—");
+    }
+
     sealed class NoopProcessRunner : IProcessRunner {
         public Task<ProcessResult> RunAsync(string fileName, string[] args, RunOptions options, CancellationToken ct) =>
             throw new NotImplementedException();
@@ -305,6 +376,27 @@ public class DefaultsStepViewModelTests {
 
         await Assert.That(vm.Satisfied).IsFalse();
         await Assert.That(File.Exists(ConfigPath)).IsFalse();
+    }
+
+    // A real write failure (read-only config dir), not a fake, proves CanLeaveAsync's own catch.
+    [Test]
+    public async Task A_persist_failure_vetoes_Next_with_a_visible_message() {
+        Skip.When(OperatingSystem.IsWindows(), "chmod-based read-only config dir is POSIX-only.");
+
+        var dir = Path.GetDirectoryName(ConfigPath)!;
+        var vm  = new DefaultsStepViewModel { Visibility = "public", DaemonName = "acme-daemon" };
+
+        File.SetUnixFileMode(dir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        try {
+            var canLeave = await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+
+            await Assert.That(canLeave).IsFalse();
+            await Assert.That(vm.Satisfied).IsFalse();
+            await Assert.That(vm.Message).IsNotNull();
+            await Assert.That(vm.Message).Contains("Could not save defaults");
+        } finally {
+            File.SetUnixFileMode(dir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
     }
 }
 

--- a/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
@@ -368,6 +368,72 @@ public class DefaultsStepViewModelTests {
         await Assert.That(saved.MachineId).IsEqualTo("machine-123");
     }
 
+    // The persist must follow the wizard's resolved identity, not on-disk ActiveProfile (KCAP_PROFILE split).
+    [Test]
+    public async Task Next_persists_to_the_injected_resolved_profile_not_the_active_one() {
+        var existing = new ProfileConfig {
+            ActiveProfile = "acme",
+            Profiles = new() {
+                ["acme"] = new Profile { ServerUrl = "https://acme.example" },
+                ["work"] = new Profile { ServerUrl = "https://work.example" },
+            },
+        };
+        File.WriteAllText(ConfigPath, JsonSerializer.Serialize(existing, ProfileConfigJsonContext.Default.ProfileConfig));
+
+        var vm = new DefaultsStepViewModel(resolveProfileName: () => "work")
+            { Visibility = "public", DaemonName = "work-daemon" };
+
+        var canLeave = await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+
+        await Assert.That(canLeave).IsTrue();
+        await Assert.That(vm.Satisfied).IsTrue();
+
+        var saved = ConfigMutator.LoadPure(ConfigPath);
+
+        await Assert.That(saved.Profiles["work"].DefaultVisibility).IsEqualTo("public");
+        await Assert.That(saved.Profiles["work"].Daemon!.Name).IsEqualTo("work-daemon");
+        // The active profile (acme) is untouched — the mutation targeted the RESOLVED name.
+        await Assert.That(saved.Profiles["acme"].DefaultVisibility).IsEqualTo("org_public");
+        await Assert.That(saved.Profiles["acme"].Daemon).IsNull();
+    }
+
+    [Test]
+    public async Task A_resolved_name_absent_from_config_falls_back_to_the_active_profile() {
+        var existing = new ProfileConfig {
+            ActiveProfile = "acme",
+            Profiles = new() { ["acme"] = new Profile { ServerUrl = "https://acme.example" } },
+        };
+        File.WriteAllText(ConfigPath, JsonSerializer.Serialize(existing, ProfileConfigJsonContext.Default.ProfileConfig));
+
+        var vm = new DefaultsStepViewModel(resolveProfileName: () => "ghost")
+            { Visibility = "public", DaemonName = "acme-daemon" };
+
+        await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+
+        var saved = ConfigMutator.LoadPure(ConfigPath);
+
+        await Assert.That(saved.Profiles["acme"].Daemon!.Name).IsEqualTo("acme-daemon");
+        await Assert.That(saved.Profiles.ContainsKey("ghost")).IsFalse();
+    }
+
+    [Test]
+    public async Task A_null_resolved_name_falls_back_to_the_active_profile() {
+        var existing = new ProfileConfig {
+            ActiveProfile = "acme",
+            Profiles = new() { ["acme"] = new Profile { ServerUrl = "https://acme.example" } },
+        };
+        File.WriteAllText(ConfigPath, JsonSerializer.Serialize(existing, ProfileConfigJsonContext.Default.ProfileConfig));
+
+        var vm = new DefaultsStepViewModel(resolveProfileName: () => null)
+            { Visibility = "public", DaemonName = "acme-daemon" };
+
+        await vm.CanLeaveAsync(WizardNavigation.Next, CancellationToken.None);
+
+        var saved = ConfigMutator.LoadPure(ConfigPath);
+
+        await Assert.That(saved.Profiles["acme"].Daemon!.Name).IsEqualTo("acme-daemon");
+    }
+
     [Test]
     public async Task Skip_and_back_do_not_persist_and_leave_the_step_unsatisfied() {
         var vm = new DefaultsStepViewModel { Visibility = "public", DaemonName = "acme-daemon" };

--- a/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Threading.Tasks;
+using System.Runtime.Versioning;
 using System.Text.Json;
 using Avalonia.Controls;
 using Avalonia.Threading;
@@ -380,6 +381,7 @@ public class DefaultsStepViewModelTests {
 
     // A real write failure (read-only config dir), not a fake, proves CanLeaveAsync's own catch.
     [Test]
+    [UnsupportedOSPlatform("windows")]
     public async Task A_persist_failure_vetoes_Next_with_a_visible_message() {
         Skip.When(OperatingSystem.IsWindows(), "chmod-based read-only config dir is POSIX-only.");
 

--- a/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
@@ -113,9 +113,8 @@ static class WizardFixtures {
             (_, _) => Task.FromResult<AuthResult>(new AuthResult.Cancelled());
 
         public (string Profile, string Server, string DaemonName)? Identity = ("default", "https://acme.example", "daemon-a");
-        // The claims/TryConsume path's identity (ResolveConsentFlipIdentity in production) — kept
-        // separate from Identity above (finding 3): defaults to the same tuple so existing tests
-        // that never diverge the two keep seeing identical behavior.
+        // The claims/TryConsume path's identity (ResolveConsentFlipIdentity in production), kept
+        // separate from Identity above — same default tuple, so tests that never diverge them agree.
         public (string Profile, string Server, string DaemonName) ConsentFlipIdentity = ("default", "https://acme.example", "daemon-a");
         public readonly List<string> OpsFactoryNames = [];
         public bool ShimApplicable = true;
@@ -467,7 +466,7 @@ public class WizardStartupTests {
             var attempt = graph.Auth.Begin(new ConnectIntent.Create());
             await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-            await AppUnderTest.QuiesceAppAsync(graph.Auth, import: null, lifecycle: null, lane: null)
+            await AppUnderTest.QuiesceAppAsync(graph.Auth, import: null, lifecycle: null, lane: null, Cap)
                 .WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(attempt.Result.IsCompleted).IsTrue();
@@ -479,8 +478,65 @@ public class WizardStartupTests {
 
     [Test]
     public async Task Shutdown_quiesce_with_no_wizard_is_the_existing_lifecycle_and_lane_wait() {
-        await AppUnderTest.QuiesceAppAsync(auth: null, import: null, lifecycle: null, lane: null)
+        await AppUnderTest.QuiesceAppAsync(auth: null, import: null, lifecycle: null, lane: null, Cap)
             .WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    /// decision 2: the cap is the LANE's, never the sign-in's — a post-boundary operation that is
+    /// still publishing when the cap window has long expired is awaited to its terminal answer.
+    [Test]
+    public async Task Shutdown_quiesce_awaits_a_post_boundary_sign_in_long_past_the_cap() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            var entered = new TaskCompletionSource();
+            var release = new TaskCompletionSource();
+            harness.Operation = async (_, _) => {
+                entered.TrySetResult();
+                await release.Task;
+                return new AuthResult.Committed("acme", "https://acme.example:443", AuthProvider.None, "someone", []);
+            };
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var attempt = graph.Auth.Begin(new ConnectIntent.Paste("https://acme.example"));
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var quiesce = AppUnderTest.QuiesceAppAsync(
+                graph.Auth, import: null, lifecycle: null, lane: null, TimeSpan.FromMilliseconds(20));
+            await Task.Delay(400); // twenty cap windows
+
+            await Assert.That(quiesce.IsCompleted).IsFalse();
+
+            release.SetResult();
+            await quiesce.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(await attempt.Result).IsTypeOf<AuthResult.Committed>();
+
+            return true;
+        });
+    }
+
+    // The other half: the lifecycle/lane wait is still the capped one (spec §6a).
+    [Test]
+    public async Task Shutdown_quiesce_still_caps_an_in_flight_lane_mutation() {
+        var gate = new TaskCompletionSource<string?>();
+        var cli = new FakeKcapCli { VersionBehavior = _ => gate.Task };
+        await using var lane = new DaemonMutationLane(
+            new FakeLoginShellProbe { KcapPathBehavior = _ => Task.FromResult<string?>(null) },
+            new OutcomeChannel(),
+            () => "/opt/kcap/bin/kcap",
+            (_, _) => cli,
+            _ => new WizardFixtures.NeverObservation(),
+            TimeProvider.System);
+
+        var runTask = lane.RunAsync(
+            new MutationRequest(MutationVerb.StartVerified, "default", "https://kcap.example.com:443", "daemon-a"),
+            CancellationToken.None);
+
+        await AppUnderTest
+            .QuiesceAppAsync(auth: null, import: null, lifecycle: null, lane, TimeSpan.FromMilliseconds(50))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        gate.SetResult("9.9.9");
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     // Spec §7's close contract (KillTree + await exit) must run from the close boundary, not only CanLeaveAsync.
@@ -495,7 +551,7 @@ public class WizardStartupTests {
                 entered.TrySetResult();
                 await using var reg = ct.Register(() => cancelObserved.TrySetResult());
                 await cancelObserved.Task.ConfigureAwait(false);
-                // Mirrors ProcessRunner.RunStreamingAsync (finding 5): the killed tree's pumps drain
+                // Mirrors ProcessRunner.RunStreamingAsync: the killed tree's pumps drain
                 // to EOF before the streaming call itself returns/throws.
                 await release.Task.ConfigureAwait(false);
                 throw new OperationCanceledException(ct);
@@ -553,7 +609,7 @@ public class WizardStartupTests {
             _ = import.RunAsync();
             await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-            await AppUnderTest.QuiesceAppAsync(auth: null, import, lifecycle: null, lane: null)
+            await AppUnderTest.QuiesceAppAsync(auth: null, import, lifecycle: null, lane: null, Cap)
                 .WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(import.Busy).IsFalse();
@@ -1065,8 +1121,8 @@ public class WizardStartupTests {
         }).WaitAsync(TimeSpan.FromSeconds(20));
     }
 
-    // ── finding 3: the daemon step's row/ops identity derives from ResolveIdentity, never the
-    // ── claims identity (ResolveConsentFlipIdentity stays literal, unchanged, for TryConsume only)
+    // ── the daemon step's row/ops identity derives from ResolveIdentity, never the claims
+    // ── identity (ResolveConsentFlipIdentity stays literal, for TryConsume only) ──────
 
     [Test]
     public async Task The_daemon_steps_row_reflects_ResolveIdentity_not_the_claims_identity() {
@@ -1194,7 +1250,7 @@ public class WizardStartupResolutionTests {
         await Assert.That(AppConfig.ResolvedProfile?.ServerUrl).IsEqualTo("https://acme.example");
     }
 
-    // ── finding 3: App.ResolveWizardIdentity's own resolution rules ───────────
+    // ── App.ResolveWizardIdentity's own resolution rules ──────────────────────
 
     [Test]
     public async Task ResolveWizardIdentity_unreadable_config_is_null() {

--- a/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
@@ -50,6 +50,13 @@ static class WizardFixtures {
         }
     }
 
+    /// A fixed-answer observation, for driving the daemon step past ClassifyLiveDaemonAsync's
+    /// owned+matched branch (the only path that actually dials the ops factory).
+    internal sealed class FixedObservation(ObservedEvidence? evidence) : IDaemonObservation {
+        public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) =>
+            Task.FromResult(evidence);
+    }
+
     /// Records every request the wizard routes through the lane — the "zero service mutation"
     /// assertions read this, never a status snapshot.
     internal sealed class RecordingLane {
@@ -105,7 +112,12 @@ static class WizardFixtures {
         public Func<ConnectIntent, CancellationToken, Task<AuthResult>> Operation =
             (_, _) => Task.FromResult<AuthResult>(new AuthResult.Cancelled());
 
-        public (string Profile, string Server, string DaemonName) Identity = ("default", "https://acme.example", "daemon-a");
+        public (string Profile, string Server, string DaemonName)? Identity = ("default", "https://acme.example", "daemon-a");
+        // The claims/TryConsume path's identity (ResolveConsentFlipIdentity in production) — kept
+        // separate from Identity above (finding 3): defaults to the same tuple so existing tests
+        // that never diverge the two keep seeing identical behavior.
+        public (string Profile, string Server, string DaemonName) ConsentFlipIdentity = ("default", "https://acme.example", "daemon-a");
+        public readonly List<string> OpsFactoryNames = [];
         public bool ShimApplicable = true;
         public string? CliPath = "/opt/kcap/bin/kcap";
         public string? ShimTarget = "/opt/kcap/bin/kcap";
@@ -132,11 +144,13 @@ static class WizardFixtures {
                 CliFactoryCalls++;
                 return Cli;
             },
-            ResolveOps: () => {
+            ResolveOps: name => {
                 OpsFactoryCalls++;
+                OpsFactoryNames.Add(name);
                 return Ops;
             },
             ResolveIdentity: () => Identity,
+            ResolveConsentFlipIdentity: () => ConsentFlipIdentity,
             RunMutation: Lane.RunAsync,
             Observation: Observation,
             AppState: new NoopAppStateStore(),
@@ -453,7 +467,8 @@ public class WizardStartupTests {
             var attempt = graph.Auth.Begin(new ConnectIntent.Create());
             await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-            await AppUnderTest.QuiesceAppAsync(graph.Auth, lifecycle: null, lane: null).WaitAsync(TimeSpan.FromSeconds(5));
+            await AppUnderTest.QuiesceAppAsync(graph.Auth, import: null, lifecycle: null, lane: null)
+                .WaitAsync(TimeSpan.FromSeconds(5));
 
             await Assert.That(attempt.Result.IsCompleted).IsTrue();
             await Assert.That(await attempt.Result).IsTypeOf<AuthResult.Cancelled>();
@@ -464,7 +479,87 @@ public class WizardStartupTests {
 
     [Test]
     public async Task Shutdown_quiesce_with_no_wizard_is_the_existing_lifecycle_and_lane_wait() {
-        await AppUnderTest.QuiesceAppAsync(auth: null, lifecycle: null, lane: null).WaitAsync(TimeSpan.FromSeconds(5));
+        await AppUnderTest.QuiesceAppAsync(auth: null, import: null, lifecycle: null, lane: null)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // Spec §7's close contract (KillTree + await exit) must run from the close boundary, not only CanLeaveAsync.
+    [Test]
+    public async Task Handoff_cancels_an_in_flight_import_and_awaits_it_before_transferring() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            var entered = new TaskCompletionSource();
+            var cancelObserved = new TaskCompletionSource();
+            var release = new TaskCompletionSource();
+            harness.Cli.ImportBehavior = async (_, _, ct) => {
+                entered.TrySetResult();
+                await using var reg = ct.Register(() => cancelObserved.TrySetResult());
+                await cancelObserved.Task.ConfigureAwait(false);
+                // Mirrors ProcessRunner.RunStreamingAsync (finding 5): the killed tree's pumps drain
+                // to EOF before the streaming call itself returns/throws.
+                await release.Task.ConfigureAwait(false);
+                throw new OperationCanceledException(ct);
+            };
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var import = graph.Import;
+            import.Vendors[0].IsSelected = true; // RunCoreAsync no-ops with nothing selected
+            _ = import.RunAsync();
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(import.Busy).IsTrue();
+
+            var channel = new OutcomeChannel();
+            using var wizardCts = new CancellationTokenSource();
+            var wizardConsumer = Task.Run(() => AppUnderTest.ConsumeMutationOutcomesAsync(
+                channel, new FakeLifecycleSurface(), WizardFixtures.NeverRunMutation,
+                WizardFixtures.FixedTerminalPath("/usr/bin"), () => null, wizardCts.Token));
+
+            var handoff = AppUnderTest.HandoffAfterWizardAsync(auth: null, () => Task.CompletedTask, Cap, channel, import);
+            await cancelObserved.Task.WaitAsync(TimeSpan.FromSeconds(5)); // CancelActiveRunAsync reached the CLI's own ct
+            await Task.Delay(50);
+
+            await Assert.That(handoff.IsCompleted).IsFalse(); // still draining the killed import
+            Assert.Throws<InvalidOperationException>(() => { _ = channel.ConsumeAsync(CancellationToken.None); });
+
+            release.SetResult();
+            await handoff.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(import.Busy).IsFalse(); // the run fully finished before the handoff returned
+            _ = channel.ConsumeAsync(CancellationToken.None); // transferred only now
+
+            await wizardCts.CancelAsync();
+            await wizardConsumer.WaitAsync(TimeSpan.FromSeconds(5));
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task Shutdown_quiesce_cancels_an_in_flight_import_and_awaits_it() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            var entered = new TaskCompletionSource();
+            var cancelObserved = new TaskCompletionSource();
+            harness.Cli.ImportBehavior = async (_, _, ct) => {
+                entered.TrySetResult();
+                await using var reg = ct.Register(() => cancelObserved.TrySetResult());
+                await cancelObserved.Task.ConfigureAwait(false);
+                throw new OperationCanceledException(ct);
+            };
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var import = graph.Import;
+            import.Vendors[0].IsSelected = true;
+            _ = import.RunAsync();
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await AppUnderTest.QuiesceAppAsync(auth: null, import, lifecycle: null, lane: null)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(import.Busy).IsFalse();
+
+            return true;
+        });
     }
 
     // ── the wizard graph: composition invariants ──────────────────────────────
@@ -969,6 +1064,80 @@ public class WizardStartupTests {
             return true;
         }).WaitAsync(TimeSpan.FromSeconds(20));
     }
+
+    // ── finding 3: the daemon step's row/ops identity derives from ResolveIdentity, never the
+    // ── claims identity (ResolveConsentFlipIdentity stays literal, unchanged, for TryConsume only)
+
+    [Test]
+    public async Task The_daemon_steps_row_reflects_ResolveIdentity_not_the_claims_identity() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            harness.Operation = (_, _) => Task.FromResult<AuthResult>(
+                new AuthResult.Committed("row-profile", "https://row.example:443", AuthProvider.None, "someone", []));
+            // Deliberately different values: if the row-classification gate ever read the claims
+            // identity instead, this server (which the claims identity does NOT name) would still
+            // canonicalize fine and the row would read something other than NoServerConfigured.
+            harness.Identity            = ("row-profile", "file:///etc/passwd", "row-daemon");
+            harness.ConsentFlipIdentity = ("claims-profile", "https://claims.example", "claims-daemon");
+
+            var graph  = WizardComposition.BuildGraph(harness.Options());
+            var daemon = graph.Steps.OfType<DaemonStepViewModel>().Single();
+            var signIn = graph.Steps.OfType<SignInStepViewModel>().Single();
+            await signIn.SignInAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            await daemon.RefreshAsync(CancellationToken.None);
+
+            await Assert.That(daemon.Row).IsEqualTo(DaemonRow.NoServerConfigured);
+            await Assert.That(harness.Cli.StatusCallCount).IsEqualTo(0); // refused before any status read
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task The_ops_factory_receives_the_row_identitys_daemon_name_not_the_claims_identitys() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            harness.Operation = (_, _) => Task.FromResult<AuthResult>(
+                new AuthResult.Committed("row-profile", "https://row.example:443", AuthProvider.None, "someone", []));
+            harness.Identity            = ("row-profile", "https://row.example", "row-daemon");
+            harness.ConsentFlipIdentity = ("claims-profile", "https://claims.example", "claims-daemon");
+            harness.Cli.StatusBehavior  = _ => Task.FromResult<ServiceSnapshot?>(
+                new ServiceSnapshot("row-daemon", true, "running", "/opt/kcap/kcap-daemon", "/opt/kcap/kcap-daemon",
+                    111, 111, false, false));
+
+            var canonical = ServerIdentity.Canonicalize("https://row.example")!;
+            var evidence = new ObservedEvidence(
+                Reachable: true, Capabilities: [DaemonStepViewModel.ConsentV3Capability], DaemonVersion: "1.0.0",
+                ServerUrl: canonical, DaemonName: "row-daemon", Pid: 111, InstanceId: "instance-1", IdentityConsistent: true);
+            var options = harness.Options() with { Observation = new WizardFixtures.FixedObservation(evidence) };
+
+            harness.Ops.QueueGet(new ConsentPolicyDto("allow", 300, []));
+            harness.Ops.QueuePutV2(true, null);
+            harness.Claims.Arm(new ConsentFlipClaim("row-profile", canonical));
+
+            var graph  = WizardComposition.BuildGraph(options);
+            var daemon = graph.Steps.OfType<DaemonStepViewModel>().Single();
+            var signIn = graph.Steps.OfType<SignInStepViewModel>().Single();
+            await signIn.SignInAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+            await daemon.RefreshAsync(CancellationToken.None);
+            await WizardFixtures.WaitUntilAsync(() => harness.Ops.PutV2Calls > 0, what: "the claim to apply");
+
+            await Assert.That(daemon.Row).IsEqualTo(DaemonRow.AlreadyEnabled);
+            await Assert.That(harness.OpsFactoryNames).Contains("row-daemon");
+            await Assert.That(harness.OpsFactoryNames).DoesNotContain("claims-daemon");
+            // The claim was found and PUT (matched against the mutation request, itself built from
+            // the ROW identity) but TryConsume's own re-resolve — resolveIdentityUnderConfigLock,
+            // i.e. ResolveConsentFlipIdentity, deliberately the SEPARATE claims identity — disagrees
+            // with the claim's key, so the claim stays pending. This is the EXACT proof the claims
+            // path stayed decoupled from the row identity, not a bug in this test.
+            await Assert.That(harness.Claims.Pending().Select(c => c.Profile)).IsEquivalentTo(["row-profile"]);
+
+            return true;
+        });
+    }
+
 }
 
 /// <summary>
@@ -1023,6 +1192,71 @@ public class WizardStartupResolutionTests {
         await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(after)).IsFalse();
         // The graph identity comes from the SAME resolution the verdict was read off.
         await Assert.That(AppConfig.ResolvedProfile?.ServerUrl).IsEqualTo("https://acme.example");
+    }
+
+    // ── finding 3: App.ResolveWizardIdentity's own resolution rules ───────────
+
+    [Test]
+    public async Task ResolveWizardIdentity_unreadable_config_is_null() {
+        File.WriteAllText(ConfigPath, "{ this is not valid json");
+
+        var identity = AppUnderTest.ResolveWizardIdentity();
+
+        await Assert.That(identity).IsNull();
+    }
+
+    [Test]
+    public async Task ResolveWizardIdentity_a_profile_with_an_invalid_server_is_null() {
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = "file:///tmp/x" }));
+
+        var identity = AppUnderTest.ResolveWizardIdentity();
+
+        await Assert.That(identity).IsNull();
+    }
+
+    [Test]
+    public async Task ResolveWizardIdentity_a_valid_profile_resolves_the_canonical_tuple() {
+        WriteConfig(SingleProfileConfig(new Profile {
+            ServerUrl = "https://acme.example",
+            Daemon    = new DaemonSettings { Name = "acme-daemon" },
+        }));
+
+        var identity = AppUnderTest.ResolveWizardIdentity();
+
+        await Assert.That(identity).IsNotNull();
+        await Assert.That(identity!.Value.Profile).IsEqualTo(ProfileName);
+        await Assert.That(identity.Value.Server).IsEqualTo(ServerIdentity.Canonicalize("https://acme.example"));
+        await Assert.That(identity.Value.DaemonName).IsEqualTo("acme-daemon");
+    }
+
+    // An empty-name sentinel would dial the sanitized DEFAULT daemon socket — unreadable config must yield null.
+    [Test]
+    public async Task Unreadable_config_shows_the_daemon_steps_not_ready_state_and_makes_no_status_or_ops_call() {
+        File.WriteAllText(ConfigPath, "{ this is not valid json");
+
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            harness.Operation = (_, _) => Task.FromResult<AuthResult>(
+                new AuthResult.Committed("default", "https://acme.example:443", AuthProvider.None, "someone", []));
+
+            var options = harness.Options() with { ResolveIdentity = AppUnderTest.ResolveWizardIdentity };
+            var graph  = WizardComposition.BuildGraph(options);
+            var daemon = graph.Steps.OfType<DaemonStepViewModel>().Single();
+            var signIn = graph.Steps.OfType<SignInStepViewModel>().Single();
+            await signIn.SignInAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(signIn.Satisfied).IsTrue(); // sign-in itself doesn't touch config.json
+
+            await daemon.RefreshAsync(CancellationToken.None);
+
+            await Assert.That(daemon.Row).IsEqualTo(DaemonRow.RequiresSignIn);
+            await Assert.That(harness.Cli.StatusCallCount).IsEqualTo(0);
+            await Assert.That(harness.Ops.GetCalls).IsEqualTo(0);
+            await Assert.That(harness.Ops.PutV2Calls).IsEqualTo(0);
+            await Assert.That(harness.OpsFactoryCalls).IsEqualTo(0);
+            await Assert.That(harness.Lane.Requests).IsEmpty();
+
+            return true;
+        });
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
@@ -107,6 +107,7 @@ static class WizardFixtures {
 
         public (string Profile, string Server, string DaemonName) Identity = ("default", "https://acme.example", "daemon-a");
         public bool ShimApplicable = true;
+        public string? CliPath = "/opt/kcap/bin/kcap";
         public string? ShimTarget = "/opt/kcap/bin/kcap";
         public AgentDetectionResult Detected = VendorDetection.Build("claude");
 
@@ -151,6 +152,7 @@ static class WizardFixtures {
                     return Task.FromResult(Detected);
                 };
             },
+            CliPath: CliPath,
             ShimApplicable: ShimApplicable,
             ShimTarget: ShimTarget,
             DefaultDaemonName: "daemon-a",
@@ -248,17 +250,77 @@ public class WizardStartupTests {
         });
     }
 
+    /// spec §6a: past the cap the handoff proceeds, but it must SAY the lane is still live —
+    /// otherwise the graph comes up driving automatic actions against a child that is still running.
     [Test]
-    public async Task Handoff_proceeds_past_the_cap_when_the_lane_never_quiesces() {
+    public async Task Handoff_past_the_cap_reports_an_unquiesced_lane_and_closes_auto_actions() {
         var never = new TaskCompletionSource();
         var channel = new OutcomeChannel();
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
-        await AppUnderTest.HandoffAfterWizardAsync(auth: null, () => never.Task, TimeSpan.FromMilliseconds(50), channel)
+        var quiesced = await AppUnderTest
+            .HandoffAfterWizardAsync(auth: null, () => never.Task, TimeSpan.FromMilliseconds(50), channel)
             .WaitAsync(TimeSpan.FromSeconds(5));
 
         await Assert.That(sw.ElapsedMilliseconds).IsLessThan(5000);
+        await Assert.That(quiesced).IsFalse();
+        // Even a Complete gate builds the degraded graph while the lane still owns a live action.
+        await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(new GateResult.Complete(), quiesced)).IsTrue();
         _ = channel.ConsumeAsync(CancellationToken.None); // past the cap the channel is still handed over
+    }
+
+    [Test]
+    public async Task Handoff_within_the_cap_reports_a_quiesced_lane_and_leaves_auto_actions_open() {
+        var quiesced = await AppUnderTest
+            .HandoffAfterWizardAsync(auth: null, () => Task.CompletedTask, Cap, new OutcomeChannel())
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(quiesced).IsTrue();
+        await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(new GateResult.Complete(), quiesced)).IsFalse();
+        // An incomplete gate still closes them, quiesced or not.
+        await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(new GateResult.Incomplete(GateReason.NoToken), quiesced))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task An_unquiesced_lane_is_announced_exactly_once_and_a_quiesced_one_says_nothing() {
+        var announced = new FakeLifecycleSurface();
+        var silent = new FakeLifecycleSurface();
+
+        AppUnderTest.AnnounceUnquiescedLane(announced, laneQuiesced: false);
+        AppUnderTest.AnnounceUnquiescedLane(silent, laneQuiesced: true);
+
+        await Assert.That(announced.AttentionMessages).IsEquivalentTo([AppUnderTest.LaneStillBusyAttention]);
+        await Assert.That(silent.AttentionMessages).IsEmpty();
+        await Assert.That(announced.StatusMessages).IsEmpty();
+    }
+
+    /// The mirror of the post-boundary ordering test, for the WITHIN-cap path: the channel stays
+    /// wizard-owned until the lane's own quiesce completes — the transfer is the last step.
+    [Test]
+    public async Task Handoff_transfers_only_after_the_lane_quiesces_within_the_cap() {
+        var quiesce = new TaskCompletionSource();
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+
+        var wizardConsumer = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, new FakeLifecycleSurface(), WizardFixtures.NeverRunMutation,
+            WizardFixtures.FixedTerminalPath("/usr/bin"), () => null, cts.Token);
+
+        var handoff = AppUnderTest.HandoffAfterWizardAsync(
+            auth: null, () => quiesce.Task, TimeSpan.FromSeconds(30), channel);
+        await Task.Delay(50);
+
+        await Assert.That(handoff.IsCompleted).IsFalse();
+        Assert.Throws<InvalidOperationException>(() => { _ = channel.ConsumeAsync(CancellationToken.None); });
+
+        quiesce.SetResult();
+
+        await Assert.That(await handoff.WaitAsync(TimeSpan.FromSeconds(5))).IsTrue();
+        _ = channel.ConsumeAsync(CancellationToken.None); // transferred only now
+
+        await cts.CancelAsync();
+        await wizardConsumer.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [Test]
@@ -473,14 +535,20 @@ public class WizardStartupTests {
     public async Task The_daemon_step_reads_status_through_a_freshly_resolved_cli() {
         await AvaloniaSession.DispatchAsync(async () => {
             using var harness = new WizardFixtures.GraphHarness();
+            harness.Operation = (_, _) => Task.FromResult<AuthResult>(
+                new AuthResult.Committed("default", "https://acme.example:443", AuthProvider.None, "someone", []));
+            harness.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(null);
 
             var graph = WizardComposition.BuildGraph(harness.Options());
             var daemon = graph.Steps.OfType<DaemonStepViewModel>().Single();
+            var signIn = graph.Steps.OfType<SignInStepViewModel>().Single();
+            await signIn.SignInAsync().WaitAsync(TimeSpan.FromSeconds(5)); // the row's own precondition
 
             await daemon.RefreshAsync(CancellationToken.None);
             var afterFirst = harness.CliFactoryCalls;
             await daemon.RefreshAsync(CancellationToken.None);
 
+            // Every status read rebinds — a name written by the Defaults step lands on the next one.
             await Assert.That(afterFirst).IsGreaterThan(0);
             await Assert.That(harness.CliFactoryCalls).IsGreaterThan(afterFirst);
 
@@ -577,6 +645,7 @@ public class WizardStartupTests {
     public async Task A_missing_cli_is_the_summary_note_for_every_step_that_needs_one() {
         await AvaloniaSession.DispatchAsync(async () => {
             using var harness = new WizardFixtures.GraphHarness();
+            harness.CliPath = null;
             harness.Cli.CliPath = null;
 
             var graph = WizardComposition.BuildGraph(harness.Options());
@@ -627,6 +696,82 @@ public class WizardStartupTests {
         });
     }
 
+    // ── the shim step's pre-probe (latency the shipping default must not pay) ─
+
+    [Test]
+    [Arguments(false, "/opt/kcap/bin/kcap")] // not macOS: the answer can't change the outcome
+    [Arguments(true, null)]                  // no linkable target: same
+    public async Task The_path_probe_is_skipped_when_it_cannot_change_the_shim_decision(bool isMacOs, string? target) {
+        var probes = 0;
+
+        var applicable = await AppUnderTest.ResolveShimApplicableAsync(isMacOs, target, _ => {
+            probes++;
+            return Task.FromResult<bool?>(false);
+        }, CancellationToken.None);
+
+        await Assert.That(applicable).IsFalse();
+        await Assert.That(probes).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(false, true)]  // kcap is NOT on the terminal PATH — the step has something to offer
+    [Arguments(true, false)]  // already on PATH
+    [Arguments(null, false)]  // unknown probe: never offer on an inconclusive read
+    public async Task On_macos_with_a_target_the_probe_decides(bool? onPath, bool expected) {
+        var probes = 0;
+
+        var applicable = await AppUnderTest.ResolveShimApplicableAsync(true, "/opt/kcap/bin/kcap", _ => {
+            probes++;
+            return Task.FromResult(onPath);
+        }, CancellationToken.None);
+
+        await Assert.That(applicable).IsEqualTo(expected);
+        await Assert.That(probes).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task A_probe_failure_is_unknown_but_a_quit_during_it_propagates() {
+        var applicable = await AppUnderTest.ResolveShimApplicableAsync(
+            true, "/opt/kcap/bin/kcap", _ => throw new InvalidOperationException("probe boom"), CancellationToken.None);
+
+        await Assert.That(applicable).IsFalse(); // degraded to unknown, never "offer it anyway"
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // A quit mid-probe must not go on to build a wizard window — same rule as the gate's.
+        await Assert.ThrowsAsync<OperationCanceledException>(() => AppUnderTest.ResolveShimApplicableAsync(
+            true, "/opt/kcap/bin/kcap", ct => Task.FromCanceled<bool?>(ct), cts.Token));
+    }
+
+    // ── the sign-in step's retarget answer ────────────────────────────────────
+
+    [Test]
+    public async Task A_retarget_prefills_the_connect_step_and_navigates_back_to_it() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            harness.Operation = (_, _) => Task.FromResult<AuthResult>(new AuthResult.Retarget("acme"));
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var connect = graph.Steps.OfType<ConnectStepViewModel>().Single();
+            var signIn = graph.Steps.OfType<SignInStepViewModel>().Single();
+            await graph.ViewModel.PendingEnterForTesting;
+
+            graph.ViewModel.TryGoTo(WizardStepId.SignIn);
+            await WizardFixtures.WaitUntilAsync(
+                () => graph.ViewModel.Current.Id == WizardStepId.SignIn, what: "the jump to the sign-in step");
+
+            await signIn.SignInAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            await WizardFixtures.WaitUntilAsync(
+                () => graph.ViewModel.Current.Id == WizardStepId.Connect, what: "the retarget navigation");
+
+            await Assert.That(connect.ServerInputText).IsEqualTo("acme");
+            await Assert.That(connect.Choice).IsEqualTo(ConnectChoice.Paste);
+
+            return true;
+        }).WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
     // ── late binding (the adapters the daemon step is composed over) ──────────
 
     [Test]
@@ -656,7 +801,8 @@ public class WizardStartupTests {
         var first = new FakeKcapCli { CliPath = "/one/kcap" };
         var second = new FakeKcapCli { CliPath = "/two/kcap" };
         var current = first;
-        var cli = new LateBoundKcapCli(() => current);
+        var binds = 0;
+        var cli = new LateBoundKcapCli(() => { binds++; return current; }, "/opt/kcap/bin/kcap");
 
         await cli.ServiceStatusAsync(CancellationToken.None);
         current = second;
@@ -664,7 +810,10 @@ public class WizardStartupTests {
 
         await Assert.That(first.StatusCallCount).IsEqualTo(1);
         await Assert.That(second.StatusCallCount).IsEqualTo(1);
-        await Assert.That(cli.CliPath).IsEqualTo("/two/kcap");
+        // CliPath is the captured binary — a UI binding must not pay a config load per get.
+        await Assert.That(cli.CliPath).IsEqualTo("/opt/kcap/bin/kcap");
+        _ = cli.CliPath;
+        await Assert.That(binds).IsEqualTo(2); // the two status calls only
     }
 
     // ── window/dialog routing ─────────────────────────────────────────────────

--- a/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
@@ -1,0 +1,1029 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.Services;
+using Capacitor.App.Services.Mutation;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.App.Views.Onboarding;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Core.Setup;
+using AppUnderTest = Capacitor.App.App;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Shared fixtures for the wizard-first startup composition (decision 2). Kept out of the test
+/// classes so the graph harness, the §10 abandon rows and the rendering tests all compose the
+/// wizard the way App.RunWizardModeAsync does.
+static class WizardFixtures {
+    internal sealed class NoopProcessRunner : IProcessRunner {
+        public Task<ProcessResult> RunAsync(string fileName, string[] args, RunOptions options, CancellationToken ct) =>
+            throw new NotSupportedException("the wizard composition must not spawn a process");
+
+        public Task<StreamingResult> RunStreamingAsync(
+                string fileName, string[] args, RunOptions options, Action<StreamedLine> onLine, CancellationToken ct) =>
+            throw new NotSupportedException("the wizard composition must not spawn a process");
+    }
+
+    internal sealed class NoopAppStateStore : IAppStateStore {
+        public Task<AppState> LoadAsync() => Task.FromResult(new AppState());
+        public Task<bool> UpdateAsync(Func<AppState, AppState> mutate) => Task.FromResult(true);
+    }
+
+    internal sealed class NoopUrlOpener : IUrlOpener {
+        public readonly List<string> Opened = [];
+        public void Open(string url) => Opened.Add(url);
+    }
+
+    internal sealed class NeverObservation : IDaemonObservation {
+        public int Calls;
+
+        public Task<ObservedEvidence?> ObserveAsync(MutationRequest request, CancellationToken ct) {
+            Calls++;
+            return Task.FromResult<ObservedEvidence?>(null);
+        }
+    }
+
+    /// Records every request the wizard routes through the lane — the "zero service mutation"
+    /// assertions read this, never a status snapshot.
+    internal sealed class RecordingLane {
+        public readonly List<MutationRequest> Requests = [];
+        public Func<MutationRequest, CancellationToken, Task<MutationOutcome>> Behavior =
+            (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
+
+        public Task<MutationOutcome> RunAsync(MutationRequest request, CancellationToken ct) {
+            Requests.Add(request);
+            return Behavior(request, ct);
+        }
+    }
+
+    internal static Task<MutationOutcome> NeverRunMutation(MutationRequest request, CancellationToken ct) =>
+        throw new InvalidOperationException("runMutation must not be called");
+
+    internal static Func<CancellationToken, Task<string?>> FixedTerminalPath(string? path) => _ => Task.FromResult(path);
+
+    internal static OutcomeEnvelope Envelope(string token) =>
+        new(new MutationRequest(MutationVerb.StartVerified, "default", "https://kcap.example.com:443", "daemon-a"),
+            new MutationOutcome.Failed(1, token, RecoverySurface.Attention));
+
+    internal static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    /// The whole wizard graph over fakes: every daemon touchpoint is a counting factory, so "the
+    /// wizard built no daemon graph" and "the daemon step's ops/CLI are late-bound" are both
+    /// directly observable.
+    internal sealed class GraphHarness : IDisposable {
+        public readonly string Dir = Directory.CreateTempSubdirectory("kcap-wizard-graph-").FullName;
+        public readonly RecordingLane Lane = new();
+        public readonly ScriptedLocalControlOps Ops = new();
+        public readonly FakeKcapCli Cli = new();
+        public readonly FakeLoginShellProbe Probe = new();
+        public readonly NeverObservation Observation = new();
+        public readonly NoopUrlOpener UrlOpener = new();
+        public readonly ConsentFlipClaims Claims;
+        public readonly WizardBridges Bridges;
+        public readonly WizardLifecycleSurface Surface;
+        public readonly List<LifecyclePrompt> Prompts = [];
+
+        public int CliFactoryCalls;
+        public int OpsFactoryCalls;
+        public int DetectionFactoryCalls;
+        public int DetectCalls;
+
+        public WizardFacadeSpec? Spec;
+        public Func<ConnectIntent, CancellationToken, Task<AuthResult>> Operation =
+            (_, _) => Task.FromResult<AuthResult>(new AuthResult.Cancelled());
+
+        public (string Profile, string Server, string DaemonName) Identity = ("default", "https://acme.example", "daemon-a");
+        public bool ShimApplicable = true;
+        public string? ShimTarget = "/opt/kcap/bin/kcap";
+        public AgentDetectionResult Detected = VendorDetection.Build("claude");
+
+        public GraphHarness() {
+            Claims  = new ConsentFlipClaims(Path.Combine(Dir, "claims.json"), Path.Combine(Dir, "config.json"));
+            Bridges = WizardComposition.BuildBridges(action => action());
+            Surface = new WizardLifecycleSurface((prompt, _) => {
+                Prompts.Add(prompt);
+                return Task.FromResult(false);
+            }, action => action());
+        }
+
+        public WizardGraphOptions Options() => new(
+            Claims,
+            Bridges,
+            spec => {
+                Spec = spec;
+                return Operation;
+            },
+            Surface,
+            ResolveCli: () => {
+                CliFactoryCalls++;
+                return Cli;
+            },
+            ResolveOps: () => {
+                OpsFactoryCalls++;
+                return Ops;
+            },
+            ResolveIdentity: () => Identity,
+            RunMutation: Lane.RunAsync,
+            Observation: Observation,
+            AppState: new NoopAppStateStore(),
+            ShimInstaller: new PathShimInstaller(new NoopProcessRunner(), Probe),
+            UrlOpener: UrlOpener,
+            Probe: Probe,
+            // A NEW feed per call: a composition that built one per step is caught by the factory
+            // count below, and the shared instance's own call count proves both steps used it.
+            DetectionFeed: _ => {
+                DetectionFactoryCalls++;
+                return _ => {
+                    Interlocked.Increment(ref DetectCalls);
+                    return Task.FromResult(Detected);
+                };
+            },
+            ShimApplicable: ShimApplicable,
+            ShimTarget: ShimTarget,
+            DefaultDaemonName: "daemon-a",
+            Time: TimeProvider.System,
+            ShutdownToken: CancellationToken.None);
+
+        public void Dispose() {
+            try { Directory.Delete(Dir, recursive: true); } catch { /* best-effort test cleanup */ }
+        }
+    }
+}
+
+/// <summary>
+/// Decision 2's wizard-first startup: the wizard composition (no daemon graph at all) and the close
+/// boundary — cancel + await the sign-in's terminal answer, wait the lane out under the cap, then
+/// hand the outcome channel over. StartAsync itself needs a real daemon/profile (same reason
+/// AppStartupTests drives extracted statics), so this drives the seams it is composed from.
+///
+/// [NotInParallel]: the step ViewModels are ReactiveObjects whose WhenAnyValue wiring needs the
+/// process-global headless session's ReactiveUI initialization, so every test here runs inside it.
+/// </summary>
+[NotInParallel("AvaloniaSession")]
+public class WizardStartupTests {
+    static readonly TimeSpan Cap = TimeSpan.FromSeconds(5);
+
+    // ── the close boundary (steps 1-4) ────────────────────────────────────────
+
+    [Test]
+    public async Task Handoff_cancels_a_pre_boundary_sign_in_and_ends_it_as_cancelled() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            var started = new TaskCompletionSource();
+            harness.Operation = async (_, ct) => {
+                started.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct);
+                return new AuthResult.Committed("acme", "https://acme.example:443", AuthProvider.None, null, []);
+            };
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var attempt = graph.Auth.Begin(new ConnectIntent.Discover(AuthProvider.GitHubApp));
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await AppUnderTest.HandoffAfterWizardAsync(graph.Auth, () => Task.CompletedTask, Cap, new OutcomeChannel())
+                .WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(await attempt.Result).IsTypeOf<AuthResult.Cancelled>();
+            // Nothing durable: a pre-boundary cancel never armed a claim and never touched the lane.
+            await Assert.That(harness.Claims.Pending()).IsEmpty();
+            await Assert.That(harness.Lane.Requests).IsEmpty();
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task Handoff_waits_for_a_post_boundary_sign_in_to_answer_committed_before_transferring() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            var entered = new TaskCompletionSource();
+            var release = new TaskCompletionSource();
+            // Past the commit boundary the façade ignores the cancel and still publishes.
+            harness.Operation = async (_, _) => {
+                entered.TrySetResult();
+                await release.Task;
+                return new AuthResult.Committed("acme", "https://acme.example:443", AuthProvider.None, "someone", []);
+            };
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var attempt = graph.Auth.Begin(new ConnectIntent.Paste("https://acme.example"));
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            var channel = new OutcomeChannel();
+            using var wizardCts = new CancellationTokenSource();
+            var wizardConsumer = Task.Run(() => AppUnderTest.ConsumeMutationOutcomesAsync(
+                channel, new FakeLifecycleSurface(), WizardFixtures.NeverRunMutation,
+                WizardFixtures.FixedTerminalPath("/usr/bin"), () => null, wizardCts.Token));
+
+            var handoff = AppUnderTest.HandoffAfterWizardAsync(graph.Auth, () => Task.CompletedTask, Cap, channel);
+            await Task.Delay(50);
+
+            await Assert.That(handoff.IsCompleted).IsFalse(); // the graph build waits on the terminal answer
+            // Still owned by the wizard consumer: the transfer is the LAST step of the handoff.
+            Assert.Throws<InvalidOperationException>(() => { _ = channel.ConsumeAsync(CancellationToken.None); });
+
+            release.SetResult();
+            await handoff.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(await attempt.Result).IsTypeOf<AuthResult.Committed>();
+            _ = channel.ConsumeAsync(CancellationToken.None); // transferred: a fresh consumer is admitted
+
+            await wizardCts.CancelAsync();
+            await wizardConsumer.WaitAsync(TimeSpan.FromSeconds(5));
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task Handoff_proceeds_past_the_cap_when_the_lane_never_quiesces() {
+        var never = new TaskCompletionSource();
+        var channel = new OutcomeChannel();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        await AppUnderTest.HandoffAfterWizardAsync(auth: null, () => never.Task, TimeSpan.FromMilliseconds(50), channel)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(sw.ElapsedMilliseconds).IsLessThan(5000);
+        _ = channel.ConsumeAsync(CancellationToken.None); // past the cap the channel is still handed over
+    }
+
+    [Test]
+    public async Task Handoff_with_no_sign_in_attempt_still_transfers() {
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+        var first = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, new FakeLifecycleSurface(), WizardFixtures.NeverRunMutation,
+            WizardFixtures.FixedTerminalPath("/usr/bin"), () => null, cts.Token);
+
+        await AppUnderTest.HandoffAfterWizardAsync(auth: null, () => Task.CompletedTask, Cap, channel)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        _ = channel.ConsumeAsync(CancellationToken.None);
+        await cts.CancelAsync();
+        await first.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // ── the consumer runs unchanged over the wizard's own surface ─────────────
+
+    [Test]
+    public async Task The_outcome_consumer_presents_through_the_wizard_surface() {
+        var surface = new WizardLifecycleSurface((_, _) => Task.FromResult(false), action => action());
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+
+        var consumer = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, surface, WizardFixtures.NeverRunMutation, WizardFixtures.FixedTerminalPath("/usr/bin"),
+            () => null, cts.Token);
+
+        channel.Enqueue(WizardFixtures.Envelope("wizard_visible_token"));
+        await WizardFixtures.WaitUntilAsync(() => surface.AttentionText is not null, what: "the wizard-surface presentation");
+
+        await Assert.That(surface.AttentionText!).Contains("wizard_visible_token");
+
+        await cts.CancelAsync();
+        await consumer.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    /// Blocks its FIRST Attention call on a gate, so the envelope is provably in flight on the
+    /// wizard consumer at the moment the handoff runs.
+    sealed class GatedAttentionSurface(Task gate) : ILifecycleSurface {
+        public int Entered;
+        public int Presented;
+
+        public void Status(string message) { }
+
+        public void Attention(string message) {
+            Interlocked.Increment(ref Entered);
+            gate.GetAwaiter().GetResult();
+            Interlocked.Increment(ref Presented);
+        }
+
+        public Task<bool> ConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) => Task.FromResult(false);
+        public Task<bool?> TryConfirmAsync(LifecyclePrompt prompt, CancellationToken ct) => Task.FromResult<bool?>(false);
+    }
+
+    [Test]
+    public async Task An_envelope_in_flight_across_the_handoff_is_presented_exactly_once() {
+        var gate = new TaskCompletionSource();
+        var wizardSurface = new GatedAttentionSurface(gate.Task);
+        var rootSurface = new FakeLifecycleSurface();
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+
+        var wizardConsumer = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, wizardSurface, WizardFixtures.NeverRunMutation, WizardFixtures.FixedTerminalPath("/usr/bin"),
+            () => null, cts.Token);
+
+        channel.Enqueue(WizardFixtures.Envelope("raced_token"));
+        await WizardFixtures.WaitUntilAsync(() => wizardSurface.Entered == 1, what: "the wizard consumer's presentation");
+
+        await AppUnderTest.HandoffAfterWizardAsync(auth: null, () => Task.CompletedTask, Cap, channel);
+        var rootConsumer = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, rootSurface, WizardFixtures.NeverRunMutation, WizardFixtures.FixedTerminalPath("/usr/bin"),
+            () => null, cts.Token);
+
+        gate.SetResult(); // the wizard consumer finishes its presentation and acks
+        await WizardFixtures.WaitUntilAsync(() => wizardSurface.Presented == 1, what: "the acked presentation");
+        await Task.Delay(150); // give a wrong re-delivery to the root consumer every chance to fire
+
+        await Assert.That(wizardSurface.Presented + rootSurface.AttentionMessages.Count).IsEqualTo(1);
+
+        await cts.CancelAsync();
+        await wizardConsumer.WaitAsync(TimeSpan.FromSeconds(5));
+        await rootConsumer.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task An_envelope_enqueued_after_the_handoff_reaches_the_root_consumer_only() {
+        var wizardSurface = new FakeLifecycleSurface();
+        var rootSurface = new FakeLifecycleSurface();
+        var channel = new OutcomeChannel();
+        using var cts = new CancellationTokenSource();
+
+        var wizardConsumer = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, wizardSurface, WizardFixtures.NeverRunMutation, WizardFixtures.FixedTerminalPath("/usr/bin"),
+            () => null, cts.Token);
+
+        await AppUnderTest.HandoffAfterWizardAsync(auth: null, () => Task.CompletedTask, Cap, channel);
+        var rootConsumer = AppUnderTest.ConsumeMutationOutcomesAsync(
+            channel, rootSurface, WizardFixtures.NeverRunMutation, WizardFixtures.FixedTerminalPath("/usr/bin"),
+            () => null, cts.Token);
+
+        channel.Enqueue(WizardFixtures.Envelope("post_handoff_token"));
+        await WizardFixtures.WaitUntilAsync(() => rootSurface.AttentionMessages.Count == 1, what: "the root presentation");
+
+        await Assert.That(rootSurface.AttentionMessages[0]).Contains("post_handoff_token");
+        await Assert.That(wizardSurface.AttentionMessages).IsEmpty();
+
+        await cts.CancelAsync();
+        await wizardConsumer.WaitAsync(TimeSpan.FromSeconds(5));
+        await rootConsumer.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // ── shutdown during wizard mode ───────────────────────────────────────────
+
+    [Test]
+    public async Task Shutdown_quiesce_cancels_the_wizard_sign_in_and_waits_for_the_lane() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            var started = new TaskCompletionSource();
+            harness.Operation = async (_, ct) => {
+                started.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct);
+                return new AuthResult.Cancelled();
+            };
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var attempt = graph.Auth.Begin(new ConnectIntent.Create());
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            await AppUnderTest.QuiesceAppAsync(graph.Auth, lifecycle: null, lane: null).WaitAsync(TimeSpan.FromSeconds(5));
+
+            await Assert.That(attempt.Result.IsCompleted).IsTrue();
+            await Assert.That(await attempt.Result).IsTypeOf<AuthResult.Cancelled>();
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task Shutdown_quiesce_with_no_wizard_is_the_existing_lifecycle_and_lane_wait() {
+        await AppUnderTest.QuiesceAppAsync(auth: null, lifecycle: null, lane: null).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // ── the wizard graph: composition invariants ──────────────────────────────
+
+    [Test]
+    public async Task The_wizard_graph_builds_every_step_and_touches_no_daemon() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+
+            await Assert.That(graph.Steps.Select(s => s.Id).ToList()).IsEquivalentTo([
+                WizardStepId.Shim, WizardStepId.Connect, WizardStepId.SignIn, WizardStepId.Defaults,
+                WizardStepId.Agents, WizardStepId.Import, WizardStepId.Daemon, WizardStepId.Done,
+            ]);
+            // No mutation, no IPC, no status read: composing the wizard never speaks to a daemon.
+            await Assert.That(harness.Lane.Requests).IsEmpty();
+            await Assert.That(harness.Ops.GetCalls).IsEqualTo(0);
+            await Assert.That(harness.Ops.PutV2Calls).IsEqualTo(0);
+            await Assert.That(harness.Cli.StatusCallCount).IsEqualTo(0);
+            await Assert.That(harness.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+            await Assert.That(harness.Cli.StartVerifiedCallCount).IsEqualTo(0);
+            await Assert.That(harness.Observation.Calls).IsEqualTo(0);
+            // Never composed once: the socket is only bound when a step actually puts to it (the
+            // CLI factory IS consulted here, for the pure CliPath the vendor steps gate on).
+            await Assert.That(harness.OpsFactoryCalls).IsEqualTo(0);
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task An_inapplicable_shim_step_is_dropped_from_the_wizard_but_kept_in_the_summary() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            harness.ShimApplicable = false;
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+
+            await Assert.That(graph.ViewModel.Steps.Any(s => s.Id == WizardStepId.Shim)).IsFalse();
+            await Assert.That(graph.Steps.Any(s => s.Id == WizardStepId.Shim)).IsTrue();
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task The_same_detection_feed_is_shared_by_the_agents_and_import_steps() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var agents = graph.Steps.OfType<AgentsStepViewModel>().Single();
+            var import = graph.Steps.OfType<ImportStepViewModel>().Single();
+
+            await agents.OnEnterAsync(CancellationToken.None);
+            await import.OnEnterAsync(CancellationToken.None);
+
+            // ONE feed instance exists (the factory ran once) and BOTH steps went through it.
+            await Assert.That(harness.DetectionFactoryCalls).IsEqualTo(1);
+            await Assert.That(harness.DetectCalls).IsEqualTo(2);
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task The_daemon_step_reads_status_through_a_freshly_resolved_cli() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var daemon = graph.Steps.OfType<DaemonStepViewModel>().Single();
+
+            await daemon.RefreshAsync(CancellationToken.None);
+            var afterFirst = harness.CliFactoryCalls;
+            await daemon.RefreshAsync(CancellationToken.None);
+
+            await Assert.That(afterFirst).IsGreaterThan(0);
+            await Assert.That(harness.CliFactoryCalls).IsGreaterThan(afterFirst);
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task The_daemon_step_requires_a_committed_sign_in_before_it_resolves_an_identity() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            harness.Operation = (_, _) => Task.FromResult<AuthResult>(
+                new AuthResult.Committed("default", "https://acme.example:443", AuthProvider.None, "someone", []));
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var daemon = graph.Steps.OfType<DaemonStepViewModel>().Single();
+            var connect = graph.Steps.OfType<ConnectStepViewModel>().Single();
+            var signIn = graph.Steps.OfType<SignInStepViewModel>().Single();
+
+            await daemon.RefreshAsync(CancellationToken.None);
+            var beforeSignIn = daemon.Row;
+
+            connect.Choice = ConnectChoice.Paste;
+            connect.ServerInputText = "https://acme.example";
+            await signIn.SignInAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            harness.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(
+                new ServiceSnapshot("daemon-a", false, "not_installed", null, "/opt/kcap/kcapd", null, null, false, false));
+            await daemon.RefreshAsync(CancellationToken.None);
+
+            await Assert.That(beforeSignIn).IsEqualTo(DaemonRow.RequiresSignIn);
+            await Assert.That(signIn.Satisfied).IsTrue();
+            await Assert.That(daemon.Row).IsEqualTo(DaemonRow.NotInstalled);
+
+            return true;
+        });
+    }
+
+    // ── the composition seam: one façade, provisioner armed, arming hook wired ─
+
+    [Test]
+    public async Task The_facade_is_built_from_the_bridges_own_sink_picker_and_provisioner() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+
+            WizardComposition.BuildGraph(harness.Options());
+
+            await Assert.That(harness.Spec).IsNotNull();
+            await Assert.That(harness.Spec!.Progress).IsSameReferenceAs(harness.Bridges.Progress);
+            await Assert.That(harness.Spec.Picker).IsSameReferenceAs(harness.Bridges.Picker);
+            // A provisioner-less façade dead-ends "Create a workspace" at "ask your admin".
+            await Assert.That(harness.Spec.Provisioner).IsSameReferenceAs(harness.Bridges.Provisioner);
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task The_facades_beforeCommit_hook_arms_a_durable_claim_per_identity() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+
+            WizardComposition.BuildGraph(harness.Options());
+            await harness.Spec!.BeforeCommit(
+                [new AuthIdentity("acme", "https://acme.example:443"), new AuthIdentity("work", "https://work.example:443")],
+                CancellationToken.None);
+
+            await Assert.That(harness.Claims.Pending().Select(c => c.Profile).ToList()).IsEquivalentTo(["acme", "work"]);
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task The_production_bridges_marshal_through_the_avalonia_dispatcher() {
+        var (marshalled, hasProvisioner) = await AvaloniaSession.DispatchAsync(async () => {
+            var bridges = WizardComposition.BuildBridges(action => Dispatcher.UIThread.Post(action));
+            var posted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Posted from a background thread, exactly as the façade's flows raise their events.
+            await Task.Run(() => bridges.Post(() => posted.TrySetResult(Dispatcher.UIThread.CheckAccess())));
+            Dispatcher.UIThread.RunJobs();
+
+            // WizardBridges' own contract: the provisioner is built from the bridges' sink.
+            return (await posted.Task.WaitAsync(TimeSpan.FromSeconds(10)), bridges.Provisioner is not null);
+        }).WaitAsync(TimeSpan.FromSeconds(30));
+
+        await Assert.That(marshalled).IsTrue();
+        await Assert.That(hasProvisioner).IsTrue();
+    }
+
+    // ── the Done step's summary (why-skipped notes) ───────────────────────────
+
+    [Test]
+    public async Task A_missing_cli_is_the_summary_note_for_every_step_that_needs_one() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            harness.Cli.CliPath = null;
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var summary = graph.Steps.OfType<DoneStepViewModel>().Single().Summary;
+
+            await Assert.That(summary.Count).IsEqualTo(7); // every step but Done itself
+            foreach (var title in new[] { "Command-line tool", "Coding agents", "Import past sessions", "Enable the daemon" })
+                await Assert.That(summary.Single(e => e.Title == title).Note).IsEqualTo(WizardComposition.CliMissingNote);
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task An_unsigned_in_daemon_step_reads_as_requires_sign_in_in_the_summary() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var daemon = graph.Steps.OfType<DaemonStepViewModel>().Single();
+            var done = graph.Steps.OfType<DoneStepViewModel>().Single();
+
+            await daemon.RefreshAsync(CancellationToken.None);
+
+            await Assert.That(done.Summary.Single(e => e.Title == "Enable the daemon").Note)
+                .IsEqualTo(WizardComposition.RequiresSignInNote);
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task A_satisfied_step_carries_no_note() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var connect = graph.Steps.OfType<ConnectStepViewModel>().Single();
+            var done = graph.Steps.OfType<DoneStepViewModel>().Single();
+
+            connect.Choice = ConnectChoice.Create; // Satisfied without any input
+
+            var entry = done.Summary.Single(e => e.Title == "Connect to Capacitor");
+            await Assert.That(entry.Satisfied).IsTrue();
+            await Assert.That(entry.Note).IsNull();
+
+            return true;
+        });
+    }
+
+    // ── late binding (the adapters the daemon step is composed over) ──────────
+
+    [Test]
+    public async Task Late_bound_ops_resolve_a_fresh_socket_per_call() {
+        var first = new ScriptedLocalControlOps();
+        var second = new ScriptedLocalControlOps();
+        var current = first;
+        var ops = new LateBoundLocalControlOps(() => current);
+
+        first.QueueGet(new ConsentPolicyDto("allow", 300, []));
+        await ops.GetConsentPolicyAsync(CancellationToken.None);
+
+        current = second; // the Defaults step renamed the daemon between calls
+        second.QueuePutV2(true, null);
+        await ops.PutConsentPolicyV2Async(
+            new ConsentPolicyPutV2Dto("renamed", "https://acme.example:443", new ConsentPolicyDto("prompt", 300, [])),
+            CancellationToken.None);
+
+        await Assert.That(first.GetCalls).IsEqualTo(1);
+        await Assert.That(first.PutV2Calls).IsEqualTo(0);
+        await Assert.That(second.PutV2Calls).IsEqualTo(1);
+        await Assert.That(second.PutV2Payloads[0].ExpectedName).IsEqualTo("renamed");
+    }
+
+    [Test]
+    public async Task Late_bound_cli_resolves_a_fresh_binding_per_call() {
+        var first = new FakeKcapCli { CliPath = "/one/kcap" };
+        var second = new FakeKcapCli { CliPath = "/two/kcap" };
+        var current = first;
+        var cli = new LateBoundKcapCli(() => current);
+
+        await cli.ServiceStatusAsync(CancellationToken.None);
+        current = second;
+        await cli.ServiceStatusAsync(CancellationToken.None);
+
+        await Assert.That(first.StatusCallCount).IsEqualTo(1);
+        await Assert.That(second.StatusCallCount).IsEqualTo(1);
+        await Assert.That(cli.CliPath).IsEqualTo("/two/kcap");
+    }
+
+    // ── window/dialog routing ─────────────────────────────────────────────────
+
+    sealed class StubStep(WizardStepId id, string title) : IWizardStep {
+        public WizardStepId Id => id;
+        public string Title => title;
+        public bool Applicable => true;
+        public bool Satisfied => false;
+        public Task OnEnterAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task<bool> CanLeaveAsync(WizardNavigation direction, CancellationToken ct) => Task.FromResult(true);
+    }
+
+    static (OnboardingViewModel Wizard, WizardLifecycleSurface Surface) NewShell() {
+        var surface = new WizardLifecycleSurface((_, _) => Task.FromResult(false), action => action());
+        var wizard = new OnboardingViewModel(
+            [new StubStep(WizardStepId.Connect, "Connect to Capacitor")], CancellationToken.None, surface);
+
+        return (wizard, surface);
+    }
+
+    [Test]
+    public async Task The_wizard_window_renders_the_surfaces_status_line() {
+        var rendered = await AvaloniaSession.DispatchAsync(() => {
+            var (wizard, surface) = NewShell();
+            var window = new OnboardingWindow { DataContext = wizard };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            surface.Status("a status line from the consumer");
+            Dispatcher.UIThread.RunJobs();
+
+            var text = window.GetVisualDescendants().OfType<TextBlock>()
+                .FirstOrDefault(t => t.Name == "LifecycleStatusText")?.Text;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return text;
+        });
+
+        await Assert.That(rendered).IsEqualTo("a status line from the consumer");
+    }
+
+    [Test]
+    public async Task The_wizard_window_renders_the_surfaces_attention_line() {
+        var rendered = await AvaloniaSession.DispatchAsync(() => {
+            var (wizard, surface) = NewShell();
+            var window = new OnboardingWindow { DataContext = wizard };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            surface.Attention("a daemon mutation needs attention (some_token)");
+            Dispatcher.UIThread.RunJobs();
+
+            var text = window.GetVisualDescendants().OfType<TextBlock>()
+                .FirstOrDefault(t => t.Name == "LifecycleAttentionText")?.Text;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return text;
+        });
+
+        await Assert.That(rendered).IsEqualTo("a daemon mutation needs attention (some_token)");
+    }
+
+    [Test]
+    public async Task A_lifecycle_prompt_opens_a_dialog_owned_by_the_wizard_window() {
+        var (owned, settled) = await AvaloniaSession.DispatchAsync(() => {
+            var (wizard, _) = NewShell();
+            var window = new OnboardingWindow { DataContext = wizard };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            using var cts = new CancellationTokenSource();
+            var prompt = new LifecyclePrompt(LifecyclePrompt.KindTakeover, null, null, false, "disclosure text");
+            var answer = AppUnderTest.ShowLifecyclePromptDialogAsync(window, prompt, cts.Token);
+            Dispatcher.UIThread.RunJobs();
+
+            var dialogOpen = window.OwnedWindows.Count > 0;
+
+            cts.Cancel(); // the wizard closing must never strand the dialog
+            Dispatcher.UIThread.RunJobs();
+
+            var resolvedFalse = answer.IsCompletedSuccessfully && !answer.Result;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return (dialogOpen, resolvedFalse);
+        }).WaitAsync(TimeSpan.FromSeconds(20));
+
+        await Assert.That(owned).IsTrue();
+        await Assert.That(settled).IsTrue();
+    }
+
+    [Test]
+    public async Task The_wizard_is_the_main_window_and_closing_it_never_exits_the_app() {
+        var (isWizard, visible, mode) = await AvaloniaSession.DispatchAsync(() => {
+            var (desktop, fake) = FakeClassicDesktopLifetime.Create();
+            desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown; // pinned by OnFrameworkInitializationCompleted
+            var (wizard, _) = NewShell();
+
+            var window = AppUnderTest.ShowWizardWindow(desktop, wizard);
+            Dispatcher.UIThread.RunJobs();
+
+            var result = (ReferenceEquals(fake.MainWindow, window), window.IsVisible, fake.ShutdownMode);
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            return result;
+        });
+
+        await Assert.That(isWizard).IsTrue();
+        await Assert.That(visible).IsTrue();
+        // No Shutdown call and the mode untouched: closing the wizard hands over, it never exits.
+        await Assert.That(mode).IsEqualTo(ShutdownMode.OnExplicitShutdown);
+    }
+
+    [Test]
+    public async Task Closing_the_wizard_window_ends_the_close_wait() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            var (wizard, _) = NewShell();
+            var window = new OnboardingWindow { DataContext = wizard };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var wait = AppUnderTest.WaitForWizardCloseAsync(wizard, CancellationToken.None);
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+
+            await wait.WaitAsync(TimeSpan.FromSeconds(10));
+
+            return true;
+        }).WaitAsync(TimeSpan.FromSeconds(20));
+    }
+
+    [Test]
+    public async Task A_shutdown_while_the_wizard_is_open_ends_the_close_wait() {
+        await AvaloniaSession.DispatchAsync(async () => {
+            var (wizard, _) = NewShell();
+            using var cts = new CancellationTokenSource();
+
+            var wait = AppUnderTest.WaitForWizardCloseAsync(wizard, cts.Token);
+            await Task.Delay(20);
+            await Assert.That(wait.IsCompleted).IsFalse();
+
+            await cts.CancelAsync();
+            await wait.WaitAsync(TimeSpan.FromSeconds(5));
+
+            return true;
+        }).WaitAsync(TimeSpan.FromSeconds(20));
+    }
+}
+
+/// <summary>
+/// The startup decisions that read real config: the single fresh resolution the graph is built on,
+/// and the §10 decision-2 abandon rows (zero service mutation, gate still incomplete afterwards).
+///
+/// [NotInParallel]: shares OnboardingGateTests' one real config.json under the assembly-wide
+/// KCAP_CONFIG_DIR (see OnboardingGateGlobalSetup) AND the process-global headless session, since
+/// composing the wizard constructs ReactiveUI ViewModels.
+/// </summary>
+[NotInParallel([nameof(OnboardingGateTests), "AvaloniaSession"])]
+public class WizardStartupResolutionTests {
+    const string ProfileName = "acme";
+
+    static string ConfigPath => AppConfig.GetConfigPath();
+    static string TokensDir => PathHelpers.ConfigPath("tokens");
+
+    [Before(Test)]
+    public void Cleanup() {
+        if (File.Exists(ConfigPath)) File.Delete(ConfigPath);
+        if (Directory.Exists(TokensDir)) Directory.Delete(TokensDir, recursive: true);
+        AppConfig.ResetResolvedStateForTesting();
+        Environment.SetEnvironmentVariable("KCAP_URL", null);
+        Environment.SetEnvironmentVariable("KCAP_PROFILE", null);
+    }
+
+    static ProfileConfig SingleProfileConfig(Profile profile) =>
+        new() { ActiveProfile = ProfileName, Profiles = new() { [ProfileName] = profile } };
+
+    static void WriteConfig(ProfileConfig config) =>
+        File.WriteAllText(ConfigPath, JsonSerializer.Serialize(config, ProfileConfigJsonContext.Default.ProfileConfig));
+
+    /// The post-wizard build must never reuse the startup-cached resolution: a config written WHILE
+    /// the wizard was open is what the graph is built against.
+    [Test]
+    public async Task The_gate_is_re_resolved_from_the_config_on_every_call() {
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = "file:///tmp/x" }));
+
+        var before = await AppUnderTest.ResolveAndEvaluateGateAsync(CancellationToken.None);
+
+        // What a committed wizard sign-in leaves behind: a real server plus its provider stamp.
+        WriteConfig(SingleProfileConfig(new Profile {
+            ServerUrl = "https://acme.example",
+            AuthProvider = new AuthProviderStamp("none", "https://acme.example"),
+        }));
+
+        var after = await AppUnderTest.ResolveAndEvaluateGateAsync(CancellationToken.None);
+
+        await Assert.That(before).IsTypeOf<GateResult.Incomplete>();
+        await Assert.That(((GateResult.Incomplete)before).Reason).IsEqualTo(GateReason.InvalidServerUrl);
+        await Assert.That(after).IsTypeOf<GateResult.Complete>();
+        await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(after)).IsFalse();
+        // The graph identity comes from the SAME resolution the verdict was read off.
+        await Assert.That(AppConfig.ResolvedProfile?.ServerUrl).IsEqualTo("https://acme.example");
+    }
+
+    [Test]
+    [Arguments("https://acme.example")] // valid URL, no token
+    [Arguments("file:///tmp/x")]        // invalid, non-HTTP URL
+    public async Task Abandoning_the_wizard_mutates_no_service_and_lands_on_the_carve_out_arm(string serverUrl) {
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = serverUrl }));
+        var configBefore = await File.ReadAllTextAsync(ConfigPath);
+
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            var graph = WizardComposition.BuildGraph(harness.Options());
+
+            // Abandon: the window closes without a single step being driven.
+            graph.ViewModel.RequestClose();
+            await AppUnderTest.HandoffAfterWizardAsync(
+                    graph.Auth, () => Task.CompletedTask, TimeSpan.FromSeconds(5), new OutcomeChannel())
+                .WaitAsync(TimeSpan.FromSeconds(5));
+
+            var gate = await AppUnderTest.ResolveAndEvaluateGateAsync(CancellationToken.None);
+
+            await Assert.That(harness.Lane.Requests).IsEmpty();
+            await Assert.That(harness.Ops.GetCalls).IsEqualTo(0);
+            await Assert.That(harness.Ops.PutV2Calls).IsEqualTo(0);
+            await Assert.That(harness.Cli.InstallVerifiedCallCount).IsEqualTo(0);
+            await Assert.That(harness.Cli.StartVerifiedCallCount).IsEqualTo(0);
+            await Assert.That(harness.Claims.Pending()).IsEmpty();
+            await Assert.That(await File.ReadAllTextAsync(ConfigPath)).IsEqualTo(configBefore);
+            await Assert.That(gate).IsTypeOf<GateResult.Incomplete>();
+            // The carve-out arm: auto-actions closed, which is also what suppresses the shim auto-offer.
+            await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(gate)).IsTrue();
+
+            return true;
+        });
+    }
+
+    [Test]
+    public async Task Closing_during_an_in_flight_pre_boundary_sign_in_writes_nothing() {
+        WriteConfig(SingleProfileConfig(new Profile { ServerUrl = "https://acme.example" }));
+        var configBefore = await File.ReadAllTextAsync(ConfigPath);
+
+        await AvaloniaSession.DispatchAsync(async () => {
+            using var harness = new WizardFixtures.GraphHarness();
+            var started = new TaskCompletionSource();
+            harness.Operation = async (_, ct) => {
+                started.TrySetResult();
+                await Task.Delay(Timeout.Infinite, ct); // still pre-boundary when the close arrives
+                return new AuthResult.Committed(ProfileName, "https://acme.example:443", AuthProvider.None, null, []);
+            };
+
+            var graph = WizardComposition.BuildGraph(harness.Options());
+            var attempt = graph.Auth.Begin(new ConnectIntent.Discover(AuthProvider.WorkOS));
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            graph.ViewModel.RequestClose();
+            await AppUnderTest.HandoffAfterWizardAsync(
+                    graph.Auth, () => Task.CompletedTask, TimeSpan.FromSeconds(5), new OutcomeChannel())
+                .WaitAsync(TimeSpan.FromSeconds(5));
+
+            var gate = await AppUnderTest.ResolveAndEvaluateGateAsync(CancellationToken.None);
+
+            await Assert.That(await attempt.Result).IsTypeOf<AuthResult.Cancelled>();
+            await Assert.That(await File.ReadAllTextAsync(ConfigPath)).IsEqualTo(configBefore);
+            await Assert.That(harness.Claims.Pending()).IsEmpty();
+            await Assert.That(harness.Lane.Requests).IsEmpty();
+            await Assert.That(AppUnderTest.AutoActionsPermanentlyClosed(gate)).IsTrue();
+
+            return true;
+        });
+    }
+
+    /// The production operation over a scripted /auth/config: a pasted server is ADOPTED (its
+    /// server_url is written), which is what carries the gate to Complete — a non-adopting login
+    /// would have failed with "profile is not configured for ...".
+    [Test]
+    public async Task A_pasted_server_is_adopted_and_the_arming_hook_runs_before_the_commit() {
+        WriteConfig(new ProfileConfig { ActiveProfile = ProfileName, Profiles = new() { [ProfileName] = new Profile() } });
+
+        var claimsDir = Directory.CreateTempSubdirectory("kcap-wizard-adopt-").FullName;
+        var claims = new ConsentFlipClaims(Path.Combine(claimsDir, "claims.json"), ConfigPath);
+        var bridges = WizardComposition.BuildBridges(action => action());
+        using var handler = new StubAuthHandler();
+
+        try {
+            var operation = WizardComposition.BuildOperation(
+                bridges, claims,
+                spec => WizardSignInOperation.For(new OnboardingFacade(
+                    spec.Progress, spec.Picker, spec.Provisioner, spec.BeforeCommit, () => new HttpClient(handler, false))));
+
+            var result = await operation(new ConnectIntent.Paste("https://acme.example"), CancellationToken.None)
+                .WaitAsync(TimeSpan.FromSeconds(10));
+
+            var config = await AppConfig.LoadProfileConfig();
+
+            await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+            await Assert.That(config.Profiles[ProfileName].ServerUrl).IsEqualTo("https://acme.example");
+            await Assert.That(config.Profiles[ProfileName].AuthProvider?.Provider).IsEqualTo(AuthProvider.None);
+            await Assert.That(claims.Pending().Select(c => c.Profile).ToList()).IsEquivalentTo([ProfileName]);
+            await Assert.That(handler.Requests.Any(r => r.Contains("/auth/config"))).IsTrue();
+        } finally {
+            try { Directory.Delete(claimsDir, recursive: true); } catch { /* best-effort test cleanup */ }
+        }
+    }
+
+    /// Both zero-tenant intents run the DISCOVERY leg (the auth proxy), not a per-server login —
+    /// which is where the armed provisioner offers to create a workspace.
+    [Test]
+    [Arguments("create")]
+    [Arguments("discover")]
+    public async Task Create_and_workos_discovery_route_through_the_auth_proxy(string intentName) {
+        var claimsDir = Directory.CreateTempSubdirectory("kcap-wizard-discover-").FullName;
+        var claims = new ConsentFlipClaims(Path.Combine(claimsDir, "claims.json"), ConfigPath);
+        var bridges = WizardComposition.BuildBridges(action => action());
+        using var handler = new StubAuthHandler { Status = HttpStatusCode.ServiceUnavailable };
+        ConnectIntent intent = intentName == "create"
+            ? new ConnectIntent.Create()
+            : new ConnectIntent.Discover(AuthProvider.WorkOS);
+
+        try {
+            WizardFacadeSpec? spec = null;
+            var operation = WizardComposition.BuildOperation(
+                bridges, claims,
+                s => {
+                    spec = s;
+                    return WizardSignInOperation.For(new OnboardingFacade(
+                        s.Progress, s.Picker, s.Provisioner, s.BeforeCommit, () => new HttpClient(handler, false)));
+                });
+
+            var result = await operation(intent, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+            await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+            await Assert.That(handler.Requests.Any(r => r.Contains("/config"))).IsTrue();
+            await Assert.That(spec!.Provisioner).IsSameReferenceAs(bridges.Provisioner);
+        } finally {
+            try { Directory.Delete(claimsDir, recursive: true); } catch { /* best-effort test cleanup */ }
+        }
+    }
+
+    /// Answers every GET with an auth-config body; the discovery rows flip Status so the proxy leg
+    /// fails fast instead of opening a browser.
+    sealed class StubAuthHandler : HttpMessageHandler {
+        public readonly List<string> Requests = [];
+        public HttpStatusCode Status = HttpStatusCode.OK;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+            Requests.Add(request.RequestUri!.ToString());
+
+            return Task.FromResult(new HttpResponseMessage(Status) {
+                Content = new StringContent("""{"provider":"None"}""", Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/AuthCancellationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthCancellationTests.cs
@@ -8,8 +8,8 @@ namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
 /// CancellationToken threading through the auth flows: the device-poll loop actually stops on
-/// cancellation, WorkOSDiscovery.RunAsync forwards its own ct into both OfferCreateAsync and the
-/// orgless-refresh delegate, and TenantDiscovery awaits the new async picker instead of the sync one.
+/// cancellation, WorkOSDiscovery.DiscoverAsync forwards its own ct into both OfferCreateAsync and
+/// the orgless-refresh delegate, and TenantDiscovery awaits the new async picker instead of the sync one.
 /// </summary>
 public class AuthCancellationTests {
     static string JwtWithExpiry(DateTimeOffset exp) {
@@ -58,7 +58,7 @@ public class AuthCancellationTests {
     }
 
     [Test]
-    public async Task WorkOSDiscovery_RunAsync_threads_its_ct_into_OfferCreateAsync_and_the_orgless_refresh_delegate() {
+    public async Task WorkOSDiscovery_DiscoverAsync_threads_its_ct_into_OfferCreateAsync_and_the_orgless_refresh_delegate() {
         var proxy = Substitute.For<IAuthProxyClient>();
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
              .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
@@ -80,7 +80,7 @@ public class AuthCancellationTests {
 
         var nearExpiry = JwtWithExpiry(DateTimeOffset.UtcNow.AddSeconds(5));
 
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
             proxy, Substitute.For<ITenantPicker>(),
             orglessLogin:   () => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = nearExpiry, RefreshToken = "rt" }),
@@ -89,11 +89,11 @@ public class AuthCancellationTests {
             provisioner:    provisioner,
             ct:             cts.Token);
 
-        await Assert.That(outcome.ExitCode).IsEqualTo(1); // Declined -> non-legacy failure
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Failed>(); // Declined -> non-legacy failure
 
         // Identity, not mere structural default-equality: cancel AFTER capture and confirm the SAME
-        // token observes it — proving RunAsync forwarded its real ct into both call sites rather
-        // than a fresh default(CancellationToken).
+        // token observes it — proving DiscoverAsync forwarded its real ct into both call sites
+        // rather than a fresh default(CancellationToken).
         await Assert.That(offerCt.CanBeCanceled).IsTrue();
         await Assert.That(refreshCt.CanBeCanceled).IsTrue();
         await cts.CancelAsync();

--- a/test/Capacitor.Cli.Tests.Unit/AuthCancellationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthCancellationTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Text;
+using Capacitor.Cli.Core.Auth;
+using NSubstitute;
+using DiscoveryResult = Capacitor.Cli.Core.Auth.DiscoveryResult;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// CancellationToken threading through the auth flows: the device-poll loop actually stops on
+/// cancellation, WorkOSDiscovery.RunAsync forwards its own ct into both OfferCreateAsync and the
+/// orgless-refresh delegate, and TenantDiscovery awaits the new async picker instead of the sync one.
+/// </summary>
+public class AuthCancellationTests {
+    static string JwtWithExpiry(DateTimeOffset exp) {
+        var json = $"{{\"exp\":{exp.ToUnixTimeSeconds()}}}";
+        var b64  = Convert.ToBase64String(Encoding.UTF8.GetBytes(json)).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        return $"header.{b64}.signature";
+    }
+
+    // RunDeviceFlowAsync(clientId) hardcodes github.com with no URL seam, so cancellation is
+    // exercised through the HttpClient-accepting overload against a fake handler instead.
+    sealed class FakeGitHubDeviceHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+            ct.ThrowIfCancellationRequested();
+
+            return Task.FromResult(respond(request));
+        }
+    }
+
+    static HttpResponseMessage JsonResponse(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    [Test]
+    public async Task RunDeviceFlowAsync_cancelling_during_the_poll_throws_operation_canceled() {
+        using var cts = new CancellationTokenSource();
+        var pollCount = 0;
+
+        using var handler = new FakeGitHubDeviceHandler(request => {
+            if (request.RequestUri!.AbsolutePath.Contains("device/code")) {
+                // Empty verification_uri: Process.Start throws synchronously on an empty file name,
+                // so the best-effort browser-open never actually launches anything during the test.
+                return JsonResponse("""{"device_code":"dc","user_code":"UC","verification_uri":"","interval":0}""");
+            }
+
+            // Poll endpoint: pin on authorization_pending, then cancel mid-loop.
+            if (++pollCount == 3) cts.Cancel();
+
+            return JsonResponse("""{"error":"authorization_pending"}""");
+        });
+        using var http = new HttpClient(handler);
+
+        await Assert.That(async () => await OAuthLoginFlow.RunDeviceFlowAsync(http, "client_id", cts.Token))
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(pollCount).IsGreaterThanOrEqualTo(3);
+    }
+
+    [Test]
+    public async Task WorkOSDiscovery_RunAsync_threads_its_ct_into_OfferCreateAsync_and_the_orgless_refresh_delegate() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+             .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
+
+        using var cts = new CancellationTokenSource();
+
+        var offerCt   = CancellationToken.None;
+        var refreshCt = CancellationToken.None;
+
+        var provisioner = Substitute.For<ITenantProvisioner>();
+        provisioner.OfferCreateAsync(Arg.Any<WorkOSTokenSource>(), Arg.Any<CancellationToken>())
+                   .Returns(async ci => {
+                       offerCt = ci.Arg<CancellationToken>();
+                       // Near-expiry access token forces a refresh, exercising the orgless-refresh delegate.
+                       await ci.Arg<WorkOSTokenSource>().GetAsync(offerCt);
+
+                       return ProvisionOffer.Declined;
+                   });
+
+        var nearExpiry = JwtWithExpiry(DateTimeOffset.UtcNow.AddSeconds(5));
+
+        var outcome = await WorkOSDiscovery.RunAsync(
+            "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
+            proxy, Substitute.For<ITenantPicker>(),
+            orglessLogin:   () => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = nearExpiry, RefreshToken = "rt" }),
+            orgSwitch:      (_, _) => Task.FromResult<WorkOSAuthResponse?>(null),
+            orglessRefresh: (_, refreshedCt) => { refreshCt = refreshedCt; return Task.FromResult<WorkOSAuthResponse?>(null); },
+            provisioner:    provisioner,
+            ct:             cts.Token);
+
+        await Assert.That(outcome.ExitCode).IsEqualTo(1); // Declined -> non-legacy failure
+
+        // Identity, not mere structural default-equality: cancel AFTER capture and confirm the SAME
+        // token observes it — proving RunAsync forwarded its real ct into both call sites rather
+        // than a fresh default(CancellationToken).
+        await Assert.That(offerCt.CanBeCanceled).IsTrue();
+        await Assert.That(refreshCt.CanBeCanceled).IsTrue();
+        await cts.CancelAsync();
+        await Assert.That(offerCt.IsCancellationRequested).IsTrue();
+        await Assert.That(refreshCt.IsCancellationRequested).IsTrue();
+    }
+
+    [Test]
+    public async Task TenantDiscovery_RunAsync_awaits_PickAsync_and_never_calls_the_sync_Pick() {
+        DiscoveredTenant[] list = [
+            new() { OrgId = 1, OrgLogin = "acme",    Origin = "https://a.example" },
+            new() { OrgId = 2, OrgLogin = "contoso", Origin = "https://b.example" }
+        ];
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult(list, DiscoveryError.None)));
+
+        var picker = Substitute.For<ITenantPicker>();
+        picker.Pick(Arg.Any<DiscoveredTenant[]>())
+              .Returns(_ => throw new InvalidOperationException("TenantDiscovery must await PickAsync, not call the sync Pick"));
+        picker.PickAsync(list, Arg.Any<CancellationToken>()).Returns(Task.FromResult<DiscoveredTenant?>(list[1]));
+
+        var discovery = new TenantDiscovery(proxy, picker);
+        var outcome   = await discovery.RunAsync("https://proxy", "gh");
+
+        await Assert.That(outcome.Picked!.OrgLogin).IsEqualTo("contoso");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/AuthProgressTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProgressTests.cs
@@ -77,7 +77,7 @@ public class AuthProgressTests {
     }
 
     [Test]
-    public async Task RunAsync_zero_tenant_headless_emits_through_progress_not_console() {
+    public async Task DiscoverAsync_zero_tenant_headless_emits_through_progress_not_console() {
         var proxy = Substitute.For<IAuthProxyClient>();
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
              .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
@@ -91,10 +91,10 @@ public class AuthProgressTests {
         Console.SetOut(capturedOut);
         Console.SetError(capturedErr);
 
-        WorkOSDiscoveryOutcome outcome;
+        WorkOSDiscoveryFlow flow;
 
         try {
-            outcome = await WorkOSDiscovery.RunAsync(
+            flow = await WorkOSDiscovery.DiscoverAsync(
                 "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
                 proxy, Substitute.For<ITenantPicker>(),
                 orglessLogin: () => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
@@ -105,7 +105,7 @@ public class AuthProgressTests {
             Console.SetError(originalErr);
         }
 
-        await Assert.That(outcome.ExitCode).IsEqualTo(1);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.NoTenants>();
         // Today's code writes this line to stderr — pinned so a future stream swap is deliberate.
         await Assert.That(progress.Errors).Contains("No Capacitor tenants are linked to your account. Ask your admin to invite you.");
         await Assert.That(capturedOut.ToString()).IsEmpty();

--- a/test/Capacitor.Cli.Tests.Unit/AuthProgressTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProgressTests.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Text;
+using Capacitor.Cli.Core.Auth;
+using NSubstitute;
+using DiscoveryResult = Capacitor.Cli.Core.Auth.DiscoveryResult;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>Records every call instead of writing to Console — the test seam for asserting call shape.</summary>
+sealed class RecordingAuthProgress : IAuthProgress {
+    public List<string>              Notices         = [];
+    public List<string>               Errors          = [];
+    public List<string>               BrowserOpenings = [];
+    public List<(string Code, string Uri)> DeviceCodes = [];
+    public int                        PollTicks;
+
+    public void Notice(string message) => Notices.Add(message);
+    public void Error(string message) => Errors.Add(message);
+    public void BrowserOpening(string url) => BrowserOpenings.Add(url);
+    public void DeviceCode(string code, string verificationUri) => DeviceCodes.Add((code, verificationUri));
+    public void PollTick() => PollTicks++;
+}
+
+// Console redirection is process-global state; keep every test in this file serialized against
+// each other (and against anything else asserting on captured stdout/stderr).
+[NotInParallel]
+public class AuthProgressTests {
+    sealed class FakeGitHubDeviceHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(respond(request));
+    }
+
+    static HttpResponseMessage JsonResponse(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    [Test]
+    public async Task RunDeviceFlowAsync_reports_progress_through_the_sink_not_console() {
+        var pollCount = 0;
+
+        using var handler = new FakeGitHubDeviceHandler(request => {
+            if (request.RequestUri!.AbsolutePath.Contains("device/code")) {
+                // Empty verification_uri: Process.Start throws synchronously on an empty file name,
+                // so the best-effort browser-open never actually launches anything during the test.
+                return JsonResponse("""{"device_code":"dc","user_code":"UC123","verification_uri":"","interval":0}""");
+            }
+
+            pollCount++;
+
+            return pollCount < 3
+                ? JsonResponse("""{"error":"authorization_pending"}""")
+                : JsonResponse("""{"access_token":"tok"}""");
+        });
+        using var http = new HttpClient(handler);
+
+        var progress = new RecordingAuthProgress();
+
+        var originalOut = Console.Out;
+        var captured    = new StringWriter();
+        Console.SetOut(captured);
+
+        string? token;
+
+        try {
+            token = await OAuthLoginFlow.RunDeviceFlowAsync(http, "client_id", progress: progress);
+        } finally {
+            Console.SetOut(originalOut);
+        }
+
+        await Assert.That(token).IsEqualTo("tok");
+        await Assert.That(progress.DeviceCodes).HasCount(1);
+        // A successful clipboard copy (environment-dependent) appends a suffix to the code.
+        await Assert.That(progress.DeviceCodes[0].Code).StartsWith("UC123");
+        await Assert.That(progress.PollTicks).IsEqualTo(2); // 2 "authorization_pending" polls before success
+        await Assert.That(progress.Notices).Contains(" done!");
+        // Nothing reached Console — everything routed through the recording sink.
+        await Assert.That(captured.ToString()).IsEmpty();
+    }
+
+    [Test]
+    public async Task RunAsync_zero_tenant_headless_emits_through_progress_not_console() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
+
+        var progress = new RecordingAuthProgress();
+
+        var originalOut = Console.Out;
+        var originalErr = Console.Error;
+        var capturedOut = new StringWriter();
+        var capturedErr = new StringWriter();
+        Console.SetOut(capturedOut);
+        Console.SetError(capturedErr);
+
+        WorkOSDiscoveryOutcome outcome;
+
+        try {
+            outcome = await WorkOSDiscovery.RunAsync(
+                "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
+                proxy, Substitute.For<ITenantPicker>(),
+                orglessLogin: () => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
+                orgSwitch: (_, _) => Task.FromResult<WorkOSAuthResponse?>(null),
+                progress: progress);
+        } finally {
+            Console.SetOut(originalOut);
+            Console.SetError(originalErr);
+        }
+
+        await Assert.That(outcome.ExitCode).IsEqualTo(1);
+        // Today's code writes this line to stderr — pinned so a future stream swap is deliberate.
+        await Assert.That(progress.Errors).Contains("No Capacitor tenants are linked to your account. Ask your admin to invite you.");
+        await Assert.That(capturedOut.ToString()).IsEmpty();
+        await Assert.That(capturedErr.ToString()).IsEmpty();
+    }
+
+    [Test]
+    public async Task ConsoleAuthProgress_DeviceCode_matches_todays_banner_lines() {
+        var originalOut = Console.Out;
+        var captured    = new StringWriter();
+        Console.SetOut(captured);
+
+        try {
+            new ConsoleAuthProgress().DeviceCode("UC123", "https://github.com/login/device");
+        } finally {
+            Console.SetOut(originalOut);
+        }
+
+        await Assert.That(captured.ToString()).IsEqualTo(
+            "  2. Enter the code: UC123" + Environment.NewLine
+          + "  3. Approve access when GitHub asks." + Environment.NewLine
+          + Environment.NewLine
+          + "Waiting for you to authorize...");
+    }
+
+    [Test]
+    public async Task ConsoleAuthProgress_BrowserOpening_matches_todays_notice_lines() {
+        var originalOut = Console.Out;
+        var captured    = new StringWriter();
+        Console.SetOut(captured);
+
+        try {
+            new ConsoleAuthProgress().BrowserOpening("https://example.test/authorize");
+        } finally {
+            Console.SetOut(originalOut);
+        }
+
+        await Assert.That(captured.ToString()).IsEqualTo(
+            "Opening browser for authentication..." + Environment.NewLine
+          + "  If the browser doesn't open, visit: https://example.test/authorize" + Environment.NewLine);
+    }
+
+    [Test]
+    public async Task ConsoleAuthProgress_PollTick_writes_dot_without_newline() {
+        var originalOut = Console.Out;
+        var captured    = new StringWriter();
+        Console.SetOut(captured);
+
+        try {
+            new ConsoleAuthProgress().PollTick();
+        } finally {
+            Console.SetOut(originalOut);
+        }
+
+        await Assert.That(captured.ToString()).IsEqualTo(".");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/AuthProgressTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/AuthProgressTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using Capacitor.Cli.Core.Auth;
+using Capacitor.Tests.Helpers;
 using NSubstitute;
 using DiscoveryResult = Capacitor.Cli.Core.Auth.DiscoveryResult;
 
@@ -54,26 +55,18 @@ public class AuthProgressTests {
 
         var progress = new RecordingAuthProgress();
 
-        var originalOut = Console.Out;
-        var captured    = new StringWriter();
-        Console.SetOut(captured);
+        using var capture = ConsoleOutput.StartCapture();
 
-        string? token;
-
-        try {
-            token = await OAuthLoginFlow.RunDeviceFlowAsync(http, "client_id", progress: progress);
-        } finally {
-            Console.SetOut(originalOut);
-        }
+        var token = await OAuthLoginFlow.RunDeviceFlowAsync(http, "client_id", progress: progress);
 
         await Assert.That(token).IsEqualTo("tok");
-        await Assert.That(progress.DeviceCodes).HasCount(1);
+        await Assert.That(progress.DeviceCodes).Count().IsEqualTo(1);
         // A successful clipboard copy (environment-dependent) appends a suffix to the code.
         await Assert.That(progress.DeviceCodes[0].Code).StartsWith("UC123");
         await Assert.That(progress.PollTicks).IsEqualTo(2); // 2 "authorization_pending" polls before success
         await Assert.That(progress.Notices).Contains(" done!");
         // Nothing reached Console — everything routed through the recording sink.
-        await Assert.That(captured.ToString()).IsEmpty();
+        await Assert.That(capture.GetCapturedOutput()).IsEmpty();
     }
 
     [Test]
@@ -84,47 +77,29 @@ public class AuthProgressTests {
 
         var progress = new RecordingAuthProgress();
 
-        var originalOut = Console.Out;
-        var originalErr = Console.Error;
-        var capturedOut = new StringWriter();
-        var capturedErr = new StringWriter();
-        Console.SetOut(capturedOut);
-        Console.SetError(capturedErr);
+        using var capture = ConsoleOutput.StartFullCapture();
 
-        WorkOSDiscoveryFlow flow;
-
-        try {
-            flow = await WorkOSDiscovery.DiscoverAsync(
-                "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-                proxy, Substitute.For<ITenantPicker>(),
-                orglessLogin: () => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
-                orgSwitch: (_, _) => Task.FromResult<WorkOSAuthResponse?>(null),
-                progress: progress);
-        } finally {
-            Console.SetOut(originalOut);
-            Console.SetError(originalErr);
-        }
+        var flow = await WorkOSDiscovery.DiscoverAsync(
+            "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
+            proxy, Substitute.For<ITenantPicker>(),
+            orglessLogin: () => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
+            orgSwitch: (_, _) => Task.FromResult<WorkOSAuthResponse?>(null),
+            progress: progress);
 
         await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.NoTenants>();
         // Today's code writes this line to stderr — pinned so a future stream swap is deliberate.
         await Assert.That(progress.Errors).Contains("No Capacitor tenants are linked to your account. Ask your admin to invite you.");
-        await Assert.That(capturedOut.ToString()).IsEmpty();
-        await Assert.That(capturedErr.ToString()).IsEmpty();
+        await Assert.That(capture.GetCapturedOutput()).IsEmpty();
+        await Assert.That(capture.GetCapturedError()).IsEmpty();
     }
 
     [Test]
     public async Task ConsoleAuthProgress_DeviceCode_matches_todays_banner_lines() {
-        var originalOut = Console.Out;
-        var captured    = new StringWriter();
-        Console.SetOut(captured);
+        using var capture = ConsoleOutput.StartCapture();
 
-        try {
-            new ConsoleAuthProgress().DeviceCode("UC123", "https://github.com/login/device");
-        } finally {
-            Console.SetOut(originalOut);
-        }
+        new ConsoleAuthProgress().DeviceCode("UC123", "https://github.com/login/device");
 
-        await Assert.That(captured.ToString()).IsEqualTo(
+        await Assert.That(capture.GetCapturedOutput()).IsEqualTo(
             "  2. Enter the code: UC123" + Environment.NewLine
           + "  3. Approve access when GitHub asks." + Environment.NewLine
           + Environment.NewLine
@@ -133,33 +108,21 @@ public class AuthProgressTests {
 
     [Test]
     public async Task ConsoleAuthProgress_BrowserOpening_matches_todays_notice_lines() {
-        var originalOut = Console.Out;
-        var captured    = new StringWriter();
-        Console.SetOut(captured);
+        using var capture = ConsoleOutput.StartCapture();
 
-        try {
-            new ConsoleAuthProgress().BrowserOpening("https://example.test/authorize");
-        } finally {
-            Console.SetOut(originalOut);
-        }
+        new ConsoleAuthProgress().BrowserOpening("https://example.test/authorize");
 
-        await Assert.That(captured.ToString()).IsEqualTo(
+        await Assert.That(capture.GetCapturedOutput()).IsEqualTo(
             "Opening browser for authentication..." + Environment.NewLine
           + "  If the browser doesn't open, visit: https://example.test/authorize" + Environment.NewLine);
     }
 
     [Test]
     public async Task ConsoleAuthProgress_PollTick_writes_dot_without_newline() {
-        var originalOut = Console.Out;
-        var captured    = new StringWriter();
-        Console.SetOut(captured);
+        using var capture = ConsoleOutput.StartCapture();
 
-        try {
-            new ConsoleAuthProgress().PollTick();
-        } finally {
-            Console.SetOut(originalOut);
-        }
+        new ConsoleAuthProgress().PollTick();
 
-        await Assert.That(captured.ToString()).IsEqualTo(".");
+        await Assert.That(capture.GetCapturedOutput()).IsEqualTo(".");
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Codex/CodexHookCommandTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
 using Capacitor.Tests.Helpers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -7,6 +8,10 @@ using WireMock.Server;
 
 namespace Capacitor.Cli.Tests.Unit.Codex;
 
+// Keyed on the shared token/profile state: the hook POST path classifies auth via the process-wide
+// provider cache and the ACTIVE profile's token, so a concurrent token-writing test can flip it to
+// WrongServer and the POST silently spools instead of hitting the stub.
+[NotInParallel(nameof(TokenStoreProfileTests))]
 public class CodexHookCommandTests : IDisposable {
     // Every test that mutates Console.Out or the KCAP_DAEMON_URL env
     // var is decorated [NotInParallel] (no group) so it runs strictly alone.
@@ -16,6 +21,11 @@ public class CodexHookCommandTests : IDisposable {
     // race nondeterministically corrupted Console captures (CI).
 
     readonly WireMockServer _server = WireMockServer.Start();
+
+    // First successful discovery wins process-wide regardless of baseUrl — an earlier test's cached
+    // provider would make this class skip its own /auth/config stub.
+    [Before(Test)]
+    public void ResetProviderCache() => HttpClientExtensions.ResetProviderCacheForTesting();
 
     public void Dispose() => _server.Stop();
 

--- a/test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs
@@ -1,0 +1,282 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using NSubstitute;
+using DiscoveryResult = Capacitor.Cli.Core.Auth.DiscoveryResult;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The ordered commit boundary itself: the claim hook runs last-cancellable and sees every
+/// identity before anything durable exists, then config + stamp + tokens publish to completion
+/// even under a cancel. Shares the TokenStoreProfileTests key (one shared KCAP_CONFIG_DIR).
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class CommitBoundaryTests {
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+    static string ConfigPath => AppConfig.GetConfigPath();
+
+    [Before(Test)]
+    public void Cleanup() => SharedConfigDirCleanup.ClearTokenAndProfileState(LegacyPath, TokensDir);
+
+    const string TwoTenants = """
+        [{"org_id":1,"org_login":"acme","origin":"https://acme.kcap.ai"},
+         {"org_id":2,"org_login":"contoso","origin":"https://contoso.kcap.ai"}]
+        """;
+
+    static AuthHttpScript GitHubDiscoveryScript(Func<HttpRequestMessage, HttpResponseMessage>? tokenExchange = null) =>
+        AuthHttp.Script(proxyConfig: """{"github_client_id":"cid"}""", tenants: TwoTenants, tokenExchange: tokenExchange);
+
+    static bool TokenFileExists(string profile) => File.Exists(Path.Combine(TokensDir, $"{profile}.json"));
+
+    [Test]
+    public async Task Hook_receives_every_identity_before_anything_durable_exists() {
+        using var handler = GitHubDiscoveryScript();
+
+        var       identities  = new List<AuthIdentity>();
+        var       configAtHook = true;
+        var       tokensAtHook = true;
+
+        var facade = OnboardingFacadeTests.NewFacade(
+            new RecordingAuthProgress(), handler, OnboardingFacadeTests.PickerReturningFirst(),
+            beforeCommit: (ids, _) => {
+                identities.AddRange(ids);
+                configAtHook = File.Exists(ConfigPath);
+                tokensAtHook = TokenFileExists("acme") || TokenFileExists("contoso");
+
+                return Task.CompletedTask;
+            });
+
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(configAtHook).IsFalse();
+        await Assert.That(tokensAtHook).IsFalse();
+        await Assert.That(identities.Select(i => i.Profile)).IsEquivalentTo(new[] { "acme", "contoso" });
+        await Assert.That(identities.Select(i => i.CanonicalServer))
+            .IsEquivalentTo(new[] { "https://acme.kcap.ai:443", "https://contoso.kcap.ai:443" });
+    }
+
+    [Test]
+    public async Task Hook_failure_aborts_the_commit_with_nothing_durable() {
+        using var handler = GitHubDiscoveryScript();
+
+        var facade = OnboardingFacadeTests.NewFacade(
+            new RecordingAuthProgress(), handler, OnboardingFacadeTests.PickerReturningFirst(),
+            beforeCommit: (_, _) => throw new InvalidOperationException("claim store is unwritable"));
+
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(((AuthResult.Failed)result).Message).Contains("claim store is unwritable");
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+        await Assert.That(TokenFileExists("acme")).IsFalse();
+        await Assert.That(TokenFileExists("contoso")).IsFalse();
+    }
+
+    [Test]
+    public async Task Hook_cancellation_returns_cancelled_with_nothing_durable() {
+        using var handler = GitHubDiscoveryScript();
+
+        var facade = OnboardingFacadeTests.NewFacade(
+            new RecordingAuthProgress(), handler, OnboardingFacadeTests.PickerReturningFirst(),
+            beforeCommit: (_, _) => throw new OperationCanceledException());
+
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Cancelled>();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+        await Assert.That(TokenFileExists("acme")).IsFalse();
+    }
+
+    [Test]
+    public async Task Cancel_signalled_after_the_hook_still_commits_every_publication() {
+        using var cts     = new CancellationTokenSource();
+        using var handler = GitHubDiscoveryScript();
+
+        var facade = OnboardingFacadeTests.NewFacade(
+            new RecordingAuthProgress(), handler, OnboardingFacadeTests.PickerReturningFirst(),
+            beforeCommit: (_, _) => { cts.Cancel(); return Task.CompletedTask; });
+
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, cts.Token);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(TokenFileExists("acme")).IsTrue();
+        await Assert.That(TokenFileExists("contoso")).IsTrue();
+
+        var cfg = ConfigMutator.LoadPure(ConfigPath);
+        await Assert.That(cfg.ActiveProfile).IsEqualTo("acme");
+        await Assert.That(cfg.Profiles["acme"].AuthProvider!.Provider).IsEqualTo(AuthProvider.GitHubApp);
+        await Assert.That(cfg.Profiles["contoso"].AuthProvider!.Provider).IsEqualTo(AuthProvider.GitHubApp);
+    }
+
+    [Test]
+    public async Task Config_and_stamps_are_published_before_the_tokens() {
+        var configWhenExchanging = new List<bool>();
+        var stampWhenExchanging  = new List<bool>();
+
+        using var handler = GitHubDiscoveryScript(tokenExchange: _ => {
+            var cfg = ConfigMutator.LoadPure(ConfigPath);
+            configWhenExchanging.Add(File.Exists(ConfigPath));
+            stampWhenExchanging.Add(cfg.Profiles.GetValueOrDefault("acme")?.AuthProvider is not null);
+
+            return AuthHttp.Json("""{"access_token":"capacitor-jwt","expires_in":3600,"username":"alice"}""");
+        });
+
+        var facade = OnboardingFacadeTests.NewFacade(
+            new RecordingAuthProgress(), handler, OnboardingFacadeTests.PickerReturningFirst());
+
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(configWhenExchanging).HasCount(2);
+        await Assert.That(configWhenExchanging).DoesNotContain(false);
+        await Assert.That(stampWhenExchanging).DoesNotContain(false);
+    }
+
+    [Test]
+    public async Task Stamp_records_each_identitys_own_canonical_server() {
+        using var handler = GitHubDiscoveryScript();
+
+        var facade = OnboardingFacadeTests.NewFacade(
+            new RecordingAuthProgress(), handler, OnboardingFacadeTests.PickerReturningFirst());
+
+        await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        var cfg = ConfigMutator.LoadPure(ConfigPath);
+        await Assert.That(ServerIdentity.SameServer(cfg.Profiles["acme"].AuthProvider!.ServerUrl, "https://acme.kcap.ai")).IsTrue();
+        await Assert.That(ServerIdentity.SameServer(cfg.Profiles["contoso"].AuthProvider!.ServerUrl, "https://contoso.kcap.ai")).IsTrue();
+    }
+
+    [Test]
+    public async Task None_stamp_uses_the_vocabulary_the_start_gate_accepts() {
+        using var handler = AuthHttp.Script(authConfig: """{"provider":"None"}""");
+        var       facade  = OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
+
+        await facade.LoginAsync("https://none.example", forceDevice: false, profile: "solo", CancellationToken.None);
+
+        var profile = ConfigMutator.LoadPure(ConfigPath).Profiles["solo"];
+        var stamp   = profile.AuthProvider;
+
+        // The two comparisons OnboardingGate.EvaluateResolvedAsync makes for a None server.
+        await Assert.That(stamp!.Provider).IsEqualTo("None");
+        await Assert.That(string.Equals(stamp.Provider, AuthProvider.None, StringComparison.OrdinalIgnoreCase)).IsTrue();
+        await Assert.That(ServerIdentity.SameServer(stamp.ServerUrl, profile.ServerUrl)).IsTrue();
+    }
+
+    [Test]
+    public async Task A_login_cancelled_before_the_boundary_leaves_no_stamp() {
+        using var cts   = new CancellationTokenSource();
+        var       polls = 0;
+
+        using var handler = AuthHttp.Script(
+            authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""",
+            devicePoll: () => {
+                if (++polls == 2) cts.Cancel();
+
+                return AuthHttp.Json("""{"error":"authorization_pending"}""");
+            });
+
+        var facade = OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
+
+        var result = await facade.LoginAsync("https://acme.kcap.ai", forceDevice: true, profile: "acme", cts.Token);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Cancelled>();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+    }
+
+    [Test]
+    public async Task WorkOS_ready_publishes_the_config_before_todays_stored_token_fields() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        DiscoveredTenant[] tenants = [
+            new() { Provider = "WorkOS", OrganizationId = "org_a", Slug = "eventuous", DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai" }
+        ];
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+             .Returns(Task.FromResult(new DiscoveryResult(tenants, DiscoveryError.None)));
+
+        var orgless  = new WorkOSAuthResponse { User = new() { Id = "u", FirstName = "Ada" }, AccessToken = "acc", RefreshToken = "rt" };
+        var switched = new WorkOSAuthResponse { User = new() { Id = "u" }, OrganizationId = "org_a", AccessToken = "acc2", RefreshToken = "rt2" };
+
+        var flow = await WorkOSDiscovery.DiscoverAsync(
+            "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
+            proxy, Substitute.For<ITenantPicker>(),
+            orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(orgless),
+            orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(switched));
+
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Ready>();
+
+        var seen   = new List<AuthIdentity>();
+        var result = await WorkOSDiscovery.PublishAsync(
+            (WorkOSDiscoveryFlow.Ready)flow, new RecordingAuthProgress(),
+            beforeCommit: (ids, _) => { seen.AddRange(ids); return Task.CompletedTask; },
+            ct: CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(seen.Select(i => i.Profile)).IsEquivalentTo(new[] { "eventuous" });
+
+        var tokenPath = Path.Combine(TokensDir, "eventuous.json");
+        await Assert.That(File.GetLastWriteTimeUtc(ConfigPath)).IsLessThanOrEqualTo(File.GetLastWriteTimeUtc(tokenPath));
+
+        var stored = await TokenStore.LoadAsync("eventuous");
+        await Assert.That(stored!.AccessToken).IsEqualTo("acc2");
+        await Assert.That(stored.RefreshToken).IsEqualTo("rt2");
+        await Assert.That(stored.Provider).IsEqualTo(AuthProvider.WorkOS);
+        await Assert.That(stored.ClientId).IsEqualTo("client_d");
+        await Assert.That(stored.GitHubUsername).IsEqualTo("Ada");
+        await Assert.That(stored.ServerUrl).IsEqualTo("https://eventuous.kcap.ai:443");
+
+        var cfg = ConfigMutator.LoadPure(ConfigPath);
+        await Assert.That(cfg.ActiveProfile).IsEqualTo("eventuous");
+        await Assert.That(cfg.Profiles["eventuous"].AuthProvider!.Provider).IsEqualTo(AuthProvider.WorkOS);
+    }
+
+    [Test]
+    public async Task WorkOS_ready_with_a_failing_hook_publishes_nothing() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        DiscoveredTenant[] tenants = [
+            new() { Provider = "WorkOS", OrganizationId = "org_a", Slug = "eventuous", DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai" }
+        ];
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+             .Returns(Task.FromResult(new DiscoveryResult(tenants, DiscoveryError.None)));
+
+        var flow = await WorkOSDiscovery.DiscoverAsync(
+            "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
+            proxy, Substitute.For<ITenantPicker>(),
+            orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
+            orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(
+                new WorkOSAuthResponse { OrganizationId = "org_a", AccessToken = "acc2", RefreshToken = "rt2" }));
+
+        var result = await WorkOSDiscovery.PublishAsync(
+            (WorkOSDiscoveryFlow.Ready)flow, new RecordingAuthProgress(),
+            beforeCommit: (_, _) => throw new IOException("claim not persisted"),
+            ct: CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+        await Assert.That(TokenFileExists("eventuous")).IsFalse();
+    }
+
+    [Test]
+    public async Task RunAsync_still_publishes_without_a_hook() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        DiscoveredTenant[] tenants = [
+            new() { Provider = "WorkOS", OrganizationId = "org_a", Slug = "eventuous", DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai" }
+        ];
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+             .Returns(Task.FromResult(new DiscoveryResult(tenants, DiscoveryError.None)));
+
+        var outcome = await WorkOSDiscovery.RunAsync(
+            "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
+            proxy, Substitute.For<ITenantPicker>(),
+            orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(
+                new WorkOSAuthResponse { User = new() { Id = "u", FirstName = "Ada" }, AccessToken = "acc", RefreshToken = "rt" }),
+            orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(
+                new WorkOSAuthResponse { OrganizationId = "org_a", AccessToken = "acc2", RefreshToken = "rt2" }));
+
+        await Assert.That(outcome.ExitCode).IsEqualTo(0);
+        await Assert.That((await TokenStore.LoadAsync("eventuous"))!.AccessToken).IsEqualTo("acc2");
+        await Assert.That(ConfigMutator.LoadPure(ConfigPath).Profiles["eventuous"].AuthProvider!.Provider)
+            .IsEqualTo(AuthProvider.WorkOS);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs
@@ -136,7 +136,7 @@ public class CommitBoundaryTests {
         var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
 
         await Assert.That(result).IsTypeOf<AuthResult.Committed>();
-        await Assert.That(configWhenExchanging).HasCount(2);
+        await Assert.That(configWhenExchanging).Count().IsEqualTo(2);
         await Assert.That(configWhenExchanging).DoesNotContain(false);
         await Assert.That(stampWhenExchanging).DoesNotContain(false);
     }

--- a/test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs
@@ -1,6 +1,7 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Telemetry;
 using NSubstitute;
 using DiscoveryResult = Capacitor.Cli.Core.Auth.DiscoveryResult;
 
@@ -9,9 +10,14 @@ namespace Capacitor.Cli.Tests.Unit;
 /// <summary>
 /// The ordered commit boundary itself: the claim hook runs last-cancellable and sees every
 /// identity before anything durable exists, then config + stamp + tokens publish to completion
-/// even under a cancel. Shares the TokenStoreProfileTests key (one shared KCAP_CONFIG_DIR).
+/// even under a cancel. Shares the TokenStoreProfileTests key (one shared KCAP_CONFIG_DIR) and the
+/// funnel-sink keys (WorkOS discovery emits into CliTelemetry's process-global sink).
 /// </summary>
-[NotInParallel(nameof(TokenStoreProfileTests))]
+[NotInParallel([
+    nameof(TokenStoreProfileTests),
+    nameof(TelemetryState) + "." + nameof(TelemetryState.PathOverride),
+    nameof(TelemetryDeviceId) + "." + nameof(TelemetryDeviceId.PathOverride),
+])]
 public class CommitBoundaryTests {
     static string TokensDir  => PathHelpers.ConfigPath("tokens");
     static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
@@ -154,7 +160,8 @@ public class CommitBoundaryTests {
         using var handler = AuthHttp.Script(authConfig: """{"provider":"None"}""");
         var       facade  = OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
 
-        await facade.LoginAsync("https://none.example", forceDevice: false, profile: "solo", CancellationToken.None);
+        await facade.LoginAsync(
+            "https://none.example", forceDevice: false, profile: "solo", CancellationToken.None, adoptServer: true);
 
         var profile = ConfigMutator.LoadPure(ConfigPath).Profiles["solo"];
         var stamp   = profile.AuthProvider;
@@ -229,6 +236,66 @@ public class CommitBoundaryTests {
         var cfg = ConfigMutator.LoadPure(ConfigPath);
         await Assert.That(cfg.ActiveProfile).IsEqualTo("eventuous");
         await Assert.That(cfg.Profiles["eventuous"].AuthProvider!.Provider).IsEqualTo(AuthProvider.WorkOS);
+    }
+
+    [Test]
+    public async Task A_token_publication_that_throws_still_answers_Committed_for_what_landed() {
+        // A file where the tokens directory belongs: TokenStore.SaveAsync throws out of the boundary.
+        Directory.CreateDirectory(Path.GetDirectoryName(TokensDir)!);
+        await File.WriteAllTextAsync(TokensDir, "not a directory");
+
+        try {
+            var flow     = await ReadyEventuousFlowAsync();
+            var progress = new RecordingAuthProgress();
+
+            var result = await WorkOSDiscovery.PublishAsync(flow, progress, beforeCommit: null, ct: CancellationToken.None);
+
+            // The config commit landed, so the boundary had begun — no torn stop, and the loss is reported.
+            await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+            await Assert.That(progress.Errors.Any(e => e.Contains("could not be saved"))).IsTrue();
+            await Assert.That(ConfigMutator.LoadPure(ConfigPath).Profiles["eventuous"].AuthProvider!.Provider)
+                .IsEqualTo(AuthProvider.WorkOS);
+        } finally {
+            File.Delete(TokensDir);
+        }
+    }
+
+    [Test]
+    public async Task A_config_commit_that_throws_fails_and_publishes_no_token() {
+        // A directory where config.json belongs: the config publish cannot rename over it.
+        Directory.CreateDirectory(ConfigPath);
+
+        try {
+            var flow     = await ReadyEventuousFlowAsync();
+            var progress = new RecordingAuthProgress();
+
+            var result = await WorkOSDiscovery.PublishAsync(flow, progress, beforeCommit: null, ct: CancellationToken.None);
+
+            // Nothing durable began, so this arm is honestly a failure rather than a partial commit.
+            await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+            await Assert.That(TokenFileExists("eventuous")).IsFalse();
+        } finally {
+            Directory.Delete(ConfigPath, recursive: true);
+        }
+    }
+
+    static async Task<WorkOSDiscoveryFlow.Ready> ReadyEventuousFlowAsync() {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        DiscoveredTenant[] tenants = [
+            new() { Provider = "WorkOS", OrganizationId = "org_a", Slug = "eventuous", DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai" }
+        ];
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+             .Returns(Task.FromResult(new DiscoveryResult(tenants, DiscoveryError.None)));
+
+        var flow = await WorkOSDiscovery.DiscoverAsync(
+            "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
+            proxy, Substitute.For<ITenantPicker>(),
+            orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(
+                new WorkOSAuthResponse { User = new() { Id = "u", FirstName = "Ada" }, AccessToken = "acc", RefreshToken = "rt" }),
+            orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(
+                new WorkOSAuthResponse { OrganizationId = "org_a", AccessToken = "acc2", RefreshToken = "rt2" }));
+
+        return (WorkOSDiscoveryFlow.Ready)flow;
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs
@@ -325,7 +325,7 @@ public class CommitBoundaryTests {
     }
 
     [Test]
-    public async Task RunAsync_still_publishes_without_a_hook() {
+    public async Task DiscoverAsync_still_publishes_without_a_hook() {
         var proxy = Substitute.For<IAuthProxyClient>();
         DiscoveredTenant[] tenants = [
             new() { Provider = "WorkOS", OrganizationId = "org_a", Slug = "eventuous", DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai" }
@@ -333,7 +333,7 @@ public class CommitBoundaryTests {
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
              .Returns(Task.FromResult(new DiscoveryResult(tenants, DiscoveryError.None)));
 
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
             proxy, Substitute.For<ITenantPicker>(),
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(
@@ -341,7 +341,10 @@ public class CommitBoundaryTests {
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(
                 new WorkOSAuthResponse { OrganizationId = "org_a", AccessToken = "acc2", RefreshToken = "rt2" }));
 
-        await Assert.That(outcome.ExitCode).IsEqualTo(0);
+        var result = await WorkOSDiscovery.PublishAsync(
+            (WorkOSDiscoveryFlow.Ready)flow, new RecordingAuthProgress(), beforeCommit: null, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
         await Assert.That((await TokenStore.LoadAsync("eventuous"))!.AccessToken).IsEqualTo("acc2");
         await Assert.That(ConfigMutator.LoadPure(ConfigPath).Profiles["eventuous"].AuthProvider!.Provider)
             .IsEqualTo(AuthProvider.WorkOS);

--- a/test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CommitBoundaryTests.cs
@@ -279,6 +279,64 @@ public class CommitBoundaryTests {
         }
     }
 
+    // A foreign login writes no config at all, so the token IS the whole commit: losing it leaves
+    // nothing durable, and Committed (exit 0 + "Logged in as") would be a lie.
+    [Test]
+    public async Task A_token_only_commit_whose_sole_publication_fails_answers_Failed() {
+        await ConfigMutator.MutateAsync(c => c with {
+            Profiles      = new Dictionary<string, Profile> { ["acme"] = new() { ServerUrl = "https://other.example" } },
+            ActiveProfile = "acme",
+        });
+        Directory.CreateDirectory(Path.GetDirectoryName(TokensDir)!);
+        await File.WriteAllTextAsync(TokensDir, "not a directory");
+
+        try {
+            using var handler  = AuthHttp.Script(authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""");
+            var       progress = new RecordingAuthProgress();
+            var       facade   = OnboardingFacadeTests.NewFacade(progress, handler);
+
+            var result = await facade.LoginAsync(
+                "https://acme.kcap.ai", forceDevice: true, profile: "acme", CancellationToken.None);
+
+            await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+            await Assert.That(((AuthResult.Failed)result).Reason).IsEqualTo(AuthFailureReason.Other);
+            await Assert.That(progress.Errors.Any(e => e.Contains("could not be saved"))).IsTrue();
+            await Assert.That(progress.Notices.Any(n => n.StartsWith("Logged in as", StringComparison.Ordinal))).IsFalse();
+
+            var profile = ConfigMutator.LoadPure(ConfigPath).Profiles["acme"];
+            await Assert.That(profile.ServerUrl).IsEqualTo("https://other.example");
+            await Assert.That(profile.AuthProvider).IsNull();
+        } finally {
+            File.Delete(TokensDir);
+        }
+    }
+
+    // The other arm, unchanged: an adopting login's config commit landed, so the lost token is a
+    // warning on top of a real commit rather than a torn stop.
+    [Test]
+    public async Task An_adopt_login_that_loses_its_token_after_the_config_lands_still_answers_Committed() {
+        Directory.CreateDirectory(Path.GetDirectoryName(TokensDir)!);
+        await File.WriteAllTextAsync(TokensDir, "not a directory");
+
+        try {
+            using var handler  = AuthHttp.Script(authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""");
+            var       progress = new RecordingAuthProgress();
+            var       facade   = OnboardingFacadeTests.NewFacade(progress, handler);
+
+            var result = await facade.LoginAsync(
+                "https://acme.kcap.ai", forceDevice: true, profile: "acme", CancellationToken.None, adoptServer: true);
+
+            await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+            await Assert.That(progress.Errors.Any(e => e.Contains("some credentials could not be saved"))).IsTrue();
+
+            var profile = ConfigMutator.LoadPure(ConfigPath).Profiles["acme"];
+            await Assert.That(profile.ServerUrl).IsEqualTo("https://acme.kcap.ai");
+            await Assert.That(profile.AuthProvider!.Provider).IsEqualTo(AuthProvider.GitHubApp);
+        } finally {
+            File.Delete(TokensDir);
+        }
+    }
+
     static async Task<WorkOSDiscoveryFlow.Ready> ReadyEventuousFlowAsync() {
         var proxy = Substitute.For<IAuthProxyClient>();
         DiscoveredTenant[] tenants = [

--- a/test/Capacitor.Cli.Tests.Unit/FakeBrowser.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FakeBrowser.cs
@@ -24,4 +24,12 @@ public sealed class FakeBrowser(Func<string, BrowserResult> respond) : IBrowser 
 
     public static FakeBrowser NonSuccess(BrowserResultType type) =>
         new(_ => new BrowserResult { ResultType = type });
+
+    /// <summary>Cancels the caller mid-wait and answers non-success — a browser that renders a cancel as its own result type.</summary>
+    public static FakeBrowser CancellingCaller(CancellationTokenSource cts, BrowserResultType type = BrowserResultType.Timeout) =>
+        new(_ => {
+            cts.Cancel();
+
+            return new BrowserResult { ResultType = type };
+        });
 }

--- a/test/Capacitor.Cli.Tests.Unit/LocalControlClientTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LocalControlClientTests.cs
@@ -474,7 +474,7 @@ public class LocalControlClientTests {
             // Fires after RunCycleAsync has already returned success (the first valid snapshot
             // was read) but before RunAsync's ct checkpoint/yield — exactly the race the fix
             // closes.
-            client.OnCycleSucceededForTest = () => cts.Cancel();
+            client.OnCycleSucceededForTest = cts.Cancel;
 
             var events = new List<LocalControlEvent>();
             await foreach (var e in client.RunAsync(cts.Token)) events.Add(e);

--- a/test/Capacitor.Cli.Tests.Unit/LoginDiscoverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LoginDiscoverTests.cs
@@ -5,7 +5,9 @@ namespace Capacitor.Cli.Tests.Unit;
 
 /// <summary>
 /// Tests for OAuthLoginFlow.ExchangeAndSaveAsync(string, string, string, string) —
-/// the named-profile overload used by `kcap login --discover`.
+/// the named-profile overload `kcap setup`'s known-server GitHub sign-in still uses.
+/// `kcap login --discover` now exchanges per tenant through OnboardingFacade instead
+/// (see OnboardingFacadeTests/LoginFacadeParityTests).
 ///
 /// Uses the shared KCAP_CONFIG_DIR temp directory set by RepoPathStoreGlobalSetup
 /// so token files land in an isolated directory, not ~/.config/kcap.

--- a/test/Capacitor.Cli.Tests.Unit/LoginFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LoginFacadeParityTests.cs
@@ -116,6 +116,31 @@ public class LoginFacadeParityTests {
         await Assert.That(progress.Errors).Count().IsEqualTo(1);
     }
 
+    // A foreign profile writes no config, so a failed token save leaves nothing behind — `kcap login`
+    // must not exit 0 having saved nothing.
+    [Test]
+    public async Task Login_known_server_token_only_commit_that_saves_nothing_exits_one() {
+        await ConfigMutator.MutateAsync(c => c with {
+            Profiles      = new Dictionary<string, Profile> { ["acme"] = new() { ServerUrl = "https://other.example" } },
+            ActiveProfile = "acme",
+        });
+        Directory.CreateDirectory(Path.GetDirectoryName(TokensDir)!);
+        await File.WriteAllTextAsync(TokensDir, "not a directory");
+
+        try {
+            using var handler  = AuthHttp.Script(authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""");
+            var       progress = new RecordingAuthProgress();
+            var       facade   = OnboardingFacadeTests.NewFacade(progress, handler);
+
+            var exit = await LoginCommand.HandleAsync(["login", "--device"], "https://acme.kcap.ai", facade, progress);
+
+            await Assert.That(exit).IsEqualTo(1);
+            await Assert.That(progress.Notices.Any(n => n.StartsWith("Logged in as", StringComparison.Ordinal))).IsFalse();
+        } finally {
+            File.Delete(TokensDir);
+        }
+    }
+
     // ── discover result mapping (pure) ──────────────────────────────────────
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/LoginFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LoginFacadeParityTests.cs
@@ -1,0 +1,176 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Telemetry;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// `LoginCommand`'s parity with the pre-re-plumb `HandleDiscoverLoginAsync`/
+/// `OAuthLoginFlow.LoginWithDiscoveryAsync`: same exit codes, same final banner line, same
+/// per-tenant token/profile publication, and no funnel events of the login path's own. Shares
+/// the OnboardingFacadeTests keys — it drives the same shared config dir and telemetry sink.
+/// </summary>
+[NotInParallel([
+    nameof(TokenStoreProfileTests),
+    nameof(TelemetryState) + "." + nameof(TelemetryState.PathOverride),
+    nameof(TelemetryDeviceId) + "." + nameof(TelemetryDeviceId.PathOverride),
+])]
+public class LoginFacadeParityTests {
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+    static string ConfigPath => AppConfig.GetConfigPath();
+
+    [Before(Test)]
+    public void Cleanup() {
+        SharedConfigDirCleanup.ClearTokenAndProfileState(LegacyPath, TokensDir);
+        CliTelemetry.Reset();
+    }
+
+    static ProfileConfig ReadConfig() => ConfigMutator.LoadPure(ConfigPath);
+
+    static bool TokenFileExists(string profile) => File.Exists(Path.Combine(TokensDir, $"{profile}.json"));
+
+    // ── discover: GitHub, multiple tenants ──────────────────────────────────
+
+    [Test]
+    public async Task Discover_github_two_tenants_publishes_both_and_prints_todays_final_line() {
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"github_client_id":"cid"}""",
+            tenants: OnboardingFacadeTests.TwoGitHubTenants);
+
+        var progress = new RecordingAuthProgress();
+        var facade   = OnboardingFacadeTests.NewFacade(progress, handler, OnboardingFacadeTests.PickerReturningFirst());
+
+        var exit = await LoginCommand.HandleAsync(["login", "--discover", "--github", "--device"], null, facade, progress);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(TokenFileExists("acme")).IsTrue();
+        await Assert.That(TokenFileExists("contoso")).IsTrue();
+
+        var cfg = ReadConfig();
+        await Assert.That(cfg.ActiveProfile).IsEqualTo("acme");
+        await Assert.That(cfg.Profiles["contoso"].ServerUrl).IsEqualTo("https://contoso.kcap.ai");
+
+        // Pinned parity with the pre-re-plumb HandleDiscoverLoginAsync's final line (today's L913).
+        await Assert.That(progress.Notices).Contains("Logged in. Active profile: acme.");
+    }
+
+    [Test]
+    public async Task Discover_github_zero_funnel_events_of_its_own() {
+        var dir = Path.Combine(Path.GetTempPath(), $"kcap-login-funnel-{Guid.NewGuid():N}");
+        TelemetryState.PathOverride    = Path.Combine(dir, "telemetry.json");
+        TelemetryDeviceId.PathOverride = Path.Combine(dir, "telemetry-device.json");
+        var sink = new List<TelemetryEvent>();
+        CliTelemetry.TestSink = sink;
+        CliTelemetry.Initialize("login", null, loggedIn: false);
+        sink.Clear(); // drop cli_first_run
+
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"github_client_id":"cid"}""",
+            tenants: OnboardingFacadeTests.TwoGitHubTenants);
+
+        var progress = new RecordingAuthProgress();
+        var facade   = OnboardingFacadeTests.NewFacade(progress, handler, OnboardingFacadeTests.PickerReturningFirst());
+
+        var exit = await LoginCommand.HandleAsync(["login", "--discover", "--github", "--device"], null, facade, progress);
+
+        await Assert.That(exit).IsEqualTo(0);
+        // The GitHub discover path has no SetupFunnel calls anywhere in its Core dependency chain
+        // (unlike WorkOS discovery, which fires its embedded signin_completed/tenant_none events
+        // regardless of caller) — login must not have grown any of its own.
+        await Assert.That(sink).IsEmpty();
+    }
+
+    // ── login: known server ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task Login_known_server_none_provider_exits_zero_and_writes_the_stamp() {
+        using var handler  = AuthHttp.Script(authConfig: """{"provider":"None"}""");
+        var       progress = new RecordingAuthProgress();
+        var       facade   = OnboardingFacadeTests.NewFacade(progress, handler);
+
+        await ConfigMutator.MutateAsync(c => c with {
+            Profiles = new Dictionary<string, Profile> { ["solo"] = new() { ServerUrl = "https://none.example" } },
+            ActiveProfile = "solo",
+        });
+
+        var exit = await LoginCommand.HandleAsync(["login"], "https://none.example", facade, progress);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(progress.Notices).Contains("Server has no authentication configured — login not required.");
+        await Assert.That(ReadConfig().Profiles["solo"].AuthProvider!.Provider).IsEqualTo(AuthProvider.None);
+    }
+
+    [Test]
+    public async Task Login_known_server_failure_exits_one_without_a_second_message() {
+        using var handler  = AuthHttp.Script(authConfig: """{"provider":"martian"}""");
+        var       progress = new RecordingAuthProgress();
+        var       facade   = OnboardingFacadeTests.NewFacade(progress, handler);
+
+        var exit = await LoginCommand.HandleAsync(["login"], "https://acme.kcap.ai", facade, progress);
+
+        await Assert.That(exit).IsEqualTo(1);
+        // Rendered once, by the facade itself — the adapter does not re-print AuthResult.Failed.Message.
+        await Assert.That(progress.Errors).HasCount(1);
+    }
+
+    // ── discover result mapping (pure) ──────────────────────────────────────
+
+    [Test]
+    public async Task MapDiscoverResult_github_committed_prints_the_active_profile_line() {
+        var progress = new RecordingAuthProgress();
+        var result   = new AuthResult.Committed("acme", "https://acme.kcap.ai", AuthProvider.GitHubApp, "alice", []);
+
+        var exit = LoginCommand.MapDiscoverResult(result, progress);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(progress.Notices).Contains("Logged in. Active profile: acme.");
+    }
+
+    [Test]
+    public async Task MapDiscoverResult_workos_committed_does_not_duplicate_the_facades_own_notice() {
+        var progress = new RecordingAuthProgress();
+        var result   = new AuthResult.Committed("eventuous", "https://eventuous.kcap.ai", AuthProvider.WorkOS, "Ada", []);
+
+        var exit = LoginCommand.MapDiscoverResult(result, progress);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(progress.Notices).IsEmpty();
+    }
+
+    [Test]
+    public async Task MapDiscoverResult_retarget_prints_todays_setup_hint_and_fails() {
+        var progress = new RecordingAuthProgress();
+        var result   = new AuthResult.Retarget("kurrent");
+
+        var exit = LoginCommand.MapDiscoverResult(result, progress);
+
+        await Assert.That(exit).IsEqualTo(1);
+        await Assert.That(progress.Errors).Contains("Run `kcap setup kurrent` to configure that workspace.");
+    }
+
+    [Test]
+    public async Task MapDiscoverResult_failed_exits_one_without_touching_progress() {
+        var progress = new RecordingAuthProgress();
+        var result   = new AuthResult.Failed("boom");
+
+        var exit = LoginCommand.MapDiscoverResult(result, progress);
+
+        await Assert.That(exit).IsEqualTo(1);
+        await Assert.That(progress.Notices).IsEmpty();
+        await Assert.That(progress.Errors).IsEmpty();
+    }
+
+    [Test]
+    public async Task MapDiscoverResult_cancelled_exits_one_without_touching_progress() {
+        var progress = new RecordingAuthProgress();
+
+        var exit = LoginCommand.MapDiscoverResult(new AuthResult.Cancelled(), progress);
+
+        await Assert.That(exit).IsEqualTo(1);
+        await Assert.That(progress.Notices).IsEmpty();
+        await Assert.That(progress.Errors).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/LoginFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LoginFacadeParityTests.cs
@@ -113,7 +113,7 @@ public class LoginFacadeParityTests {
 
         await Assert.That(exit).IsEqualTo(1);
         // Rendered once, by the facade itself — the adapter does not re-print AuthResult.Failed.Message.
-        await Assert.That(progress.Errors).HasCount(1);
+        await Assert.That(progress.Errors).Count().IsEqualTo(1);
     }
 
     // ── discover result mapping (pure) ──────────────────────────────────────

--- a/test/Capacitor.Cli.Tests.Unit/LoopbackBrowserTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/LoopbackBrowserTests.cs
@@ -38,4 +38,22 @@ public class LoopbackBrowserTests {
 
         await Assert.That(result.ResultType).IsEqualTo(BrowserResultType.Timeout);
     }
+
+    // A caller who closed the wizard did not time out: the cancel propagates so the flow answers
+    // Cancelled, instead of being rendered as "Timed out waiting for authorization".
+    [Test]
+    public async Task Caller_cancellation_propagates_instead_of_reporting_a_timeout() {
+        var port     = OAuthLoginFlow.GetAvailablePort();
+        var redirect = $"http://127.0.0.1:{port}/callback";
+        var browser  = new LoopbackBrowser(openBrowser: _ => { });
+
+        using var cts = new CancellationTokenSource();
+
+        var invoke = browser.InvokeAsync(
+            new BrowserOptions("http://example.test/authorize", redirect) { Timeout = TimeSpan.FromMinutes(5) }, cts.Token);
+
+        await cts.CancelAsync();
+
+        await Assert.That(async () => await invoke).Throws<OperationCanceledException>();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OAuthFlowTests.cs
@@ -175,10 +175,30 @@ public class OAuthFlowTests {
 
     [Test]
     public async Task GitHubBrowser_returns_null_on_non_success_browser_result() {
+        var progress = new RecordingAuthProgress();
+
         var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
-            "Iv1.abc", "http://unused.test/code-exchange", FakeBrowser.NonSuccess(BrowserResultType.Timeout));
+            "Iv1.abc", "http://unused.test/code-exchange", FakeBrowser.NonSuccess(BrowserResultType.Timeout),
+            progress: progress);
 
         await Assert.That(token).IsNull();
+        // The independent timeout keeps its classification and its message.
+        await Assert.That(progress.Errors.Any(e => e.Contains("Timed out waiting for authorization"))).IsTrue();
+    }
+
+    // A caller cancel that the browser rendered as its own non-success result is still a cancel:
+    // it propagates, and nothing is reported as a timeout.
+    [Test]
+    public async Task GitHubBrowser_caller_cancellation_propagates_and_renders_nothing() {
+        using var cts      = new CancellationTokenSource();
+        var       progress = new RecordingAuthProgress();
+
+        await Assert.That(async () => await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
+                "Iv1.abc", "http://unused.test/code-exchange", FakeBrowser.CancellingCaller(cts),
+                ct: cts.Token, progress: progress))
+            .Throws<OperationCanceledException>();
+
+        await Assert.That(progress.Errors).IsEmpty();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs
@@ -3,7 +3,12 @@ using System.Text;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Telemetry;
+using Duende.IdentityModel.OidcClient.Browser;
 using NSubstitute;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -78,9 +83,14 @@ static class AuthHttp {
 /// <summary>
 /// Operation-level contract of <see cref="OnboardingFacade"/>: provider dispatch, discovery over
 /// every tenant, cancellation before the boundary, and the WorkOS retarget/provisioner arms.
-/// Shares the TokenStoreProfileTests key so the one KCAP_CONFIG_DIR isn't raced.
+/// Shares the TokenStoreProfileTests key so the one KCAP_CONFIG_DIR isn't raced, and the funnel-sink
+/// keys because WorkOS discovery emits SetupFunnel events into CliTelemetry's process-global sink.
 /// </summary>
-[NotInParallel(nameof(TokenStoreProfileTests))]
+[NotInParallel([
+    nameof(TokenStoreProfileTests),
+    nameof(TelemetryState) + "." + nameof(TelemetryState.PathOverride),
+    nameof(TelemetryDeviceId) + "." + nameof(TelemetryDeviceId.PathOverride),
+])]
 public class OnboardingFacadeTests {
     static string TokensDir  => PathHelpers.ConfigPath("tokens");
     static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
@@ -92,14 +102,18 @@ public class OnboardingFacadeTests {
     internal static OnboardingFacade NewFacade(
             IAuthProgress                                                     progress,
             HttpMessageHandler                                                handler,
-            ITenantPicker?                                                    picker       = null,
-            ITenantProvisioner?                                               provisioner  = null,
-            Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task>?       beforeCommit = null,
-            Func<CancellationToken, Task<WorkOSAuthResponse?>>?               workosLogin  = null) {
+            ITenantPicker?                                                    picker         = null,
+            ITenantProvisioner?                                               provisioner    = null,
+            Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task>?       beforeCommit   = null,
+            Func<CancellationToken, Task<WorkOSAuthResponse?>>?               workosLogin    = null,
+            IBrowser?                                                         workosBrowser  = null,
+            string?                                                           workosApiBase  = null) {
         var http = new HttpClient(handler, disposeHandler: false);
 
         return new OnboardingFacade(progress, picker ?? Substitute.For<ITenantPicker>(), provisioner, beforeCommit, () => http) {
-            WorkOSOrglessLogin = workosLogin
+            WorkOSOrglessLogin    = workosLogin,
+            WorkOSBrowser         = workosBrowser,
+            WorkOSApiBaseOverride = workosApiBase
         };
     }
 
@@ -123,7 +137,8 @@ public class OnboardingFacadeTests {
         var       progress = new RecordingAuthProgress();
         var       facade   = NewFacade(progress, handler);
 
-        var result = await facade.LoginAsync("https://none.example", forceDevice: false, profile: "solo", CancellationToken.None);
+        var result = await facade.LoginAsync(
+            "https://none.example", forceDevice: false, profile: "solo", CancellationToken.None, adoptServer: true);
 
         await Assert.That(result).IsTypeOf<AuthResult.Committed>();
         var committed = (AuthResult.Committed)result;
@@ -161,7 +176,8 @@ public class OnboardingFacadeTests {
         var       progress = new RecordingAuthProgress();
         var       facade   = NewFacade(progress, handler);
 
-        var result = await facade.LoginAsync("https://acme.kcap.ai", forceDevice: true, profile: "acme", CancellationToken.None);
+        var result = await facade.LoginAsync(
+            "https://acme.kcap.ai", forceDevice: true, profile: "acme", CancellationToken.None, adoptServer: true);
 
         await Assert.That(result).IsTypeOf<AuthResult.Committed>();
         await Assert.That(((AuthResult.Committed)result).Username).IsEqualTo("alice");
@@ -170,10 +186,118 @@ public class OnboardingFacadeTests {
         await Assert.That(stored!.AccessToken).IsEqualTo("capacitor-jwt");
         await Assert.That(stored.Provider).IsEqualTo(AuthProvider.GitHubApp);
 
-        var stamp = ReadConfig().Profiles["acme"].AuthProvider;
-        await Assert.That(stamp!.Provider).IsEqualTo(AuthProvider.GitHubApp);
-        await Assert.That(ServerIdentity.SameServer(stamp.ServerUrl, "https://acme.kcap.ai")).IsTrue();
+        var profile = ReadConfig().Profiles["acme"];
+        await Assert.That(profile.AuthProvider!.Provider).IsEqualTo(AuthProvider.GitHubApp);
+        await Assert.That(ServerIdentity.SameServer(profile.AuthProvider.ServerUrl, "https://acme.kcap.ai")).IsTrue();
+        await Assert.That(profile.ServerUrl).IsEqualTo("https://acme.kcap.ai"); // adopted
         await Assert.That(progress.Notices).Contains("Logged in as alice");
+    }
+
+    [Test]
+    public async Task LoginAsync_without_adopt_keeps_todays_behaviour_on_a_foreign_profile() {
+        await ConfigMutator.MutateAsync(c => c with {
+            Profiles = new Dictionary<string, Profile> { ["acme"] = new() { ServerUrl = "https://other.example" } }
+        });
+
+        using var handler = AuthHttp.Script(authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""");
+        var       facade  = NewFacade(new RecordingAuthProgress(), handler);
+
+        var result = await facade.LoginAsync("https://acme.kcap.ai", forceDevice: true, profile: "acme", CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That((await TokenStore.LoadAsync("acme"))!.AccessToken).IsEqualTo("capacitor-jwt");
+
+        // No repoint and no claim on a server the profile doesn't name.
+        var profile = ReadConfig().Profiles["acme"];
+        await Assert.That(profile.ServerUrl).IsEqualTo("https://other.example");
+        await Assert.That(profile.AuthProvider).IsNull();
+    }
+
+    [Test]
+    public async Task LoginAsync_none_without_adopt_refuses_a_foreign_profile() {
+        using var handler  = AuthHttp.Script(authConfig: """{"provider":"None"}""");
+        var       progress = new RecordingAuthProgress();
+        var       facade   = NewFacade(progress, handler);
+
+        var result = await facade.LoginAsync("https://none.example", forceDevice: false, profile: "solo", CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+        await Assert.That(progress.Errors.Any(e => e.Contains("is not configured for https://none.example"))).IsTrue();
+    }
+
+    [Test]
+    public async Task LoginAsync_workos_known_server_publishes_the_org_scoped_token_and_stamp() {
+        using var workos = WireMockServer.Start();
+        workos.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(200).WithBody(
+                  """{"user":{"id":"user_x","first_name":"Ada"},"organization_id":"org_a","access_token":"acc","refresh_token":"rt"}"""));
+
+        using var handler = AuthHttp.Script(
+            authConfig: """{"provider":"workos","client_id":"client_d","organization_id":"org_a"}""");
+
+        var progress = new RecordingAuthProgress();
+        var facade   = NewFacade(progress, handler,
+            workosBrowser: FakeBrowser.WithCode("the_code"), workosApiBase: workos.Urls[0]);
+
+        var result = await facade.LoginAsync(
+            "https://acme.kcap.ai", forceDevice: false, profile: "acme", CancellationToken.None, adoptServer: true);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+
+        var stored = await TokenStore.LoadAsync("acme");
+        await Assert.That(stored!.AccessToken).IsEqualTo("acc");
+        await Assert.That(stored.RefreshToken).IsEqualTo("rt");
+        await Assert.That(stored.ClientId).IsEqualTo("client_d");
+        await Assert.That(stored.Provider).IsEqualTo(AuthProvider.WorkOS);
+
+        var profile = ReadConfig().Profiles["acme"];
+        await Assert.That(profile.ServerUrl).IsEqualTo("https://acme.kcap.ai");
+        await Assert.That(profile.AuthProvider!.Provider).IsEqualTo(AuthProvider.WorkOS);
+        await Assert.That(progress.Notices).Contains("Logged in as Ada");
+    }
+
+    [Test]
+    public async Task LoginAsync_workos_wrong_organization_publishes_nothing() {
+        using var workos = WireMockServer.Start();
+        workos.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+              .RespondWith(Response.Create().WithStatusCode(200).WithBody(
+                  """{"user":{"id":"user_x"},"organization_id":"org_other","access_token":"acc","refresh_token":"rt"}"""));
+
+        using var handler = AuthHttp.Script(
+            authConfig: """{"provider":"workos","client_id":"client_d","organization_id":"org_a"}""");
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler,
+            workosBrowser: FakeBrowser.WithCode("the_code"), workosApiBase: workos.Urls[0]);
+
+        var result = await facade.LoginAsync(
+            "https://acme.kcap.ai", forceDevice: false, profile: "acme", CancellationToken.None, adoptServer: true);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+        await Assert.That(TokenFileExists("acme")).IsFalse();
+    }
+
+    [Test]
+    public async Task LoginAsync_cancelled_during_the_token_exchange_publishes_nothing() {
+        using var cts = new CancellationTokenSource();
+
+        using var handler = AuthHttp.Script(
+            authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""",
+            tokenExchange: _ => {
+                cts.Cancel();
+
+                throw new OperationCanceledException(cts.Token);
+            });
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler);
+
+        var result = await facade.LoginAsync(
+            "https://acme.kcap.ai", forceDevice: true, profile: "acme", cts.Token, adoptServer: true);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Cancelled>();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+        await Assert.That(TokenFileExists("acme")).IsFalse();
     }
 
     [Test]
@@ -264,6 +388,64 @@ public class OnboardingFacadeTests {
     }
 
     [Test]
+    public async Task DiscoverAsync_github_commits_the_rest_when_one_tenant_exchange_throws() {
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"github_client_id":"cid"}""",
+            tenants: TwoGitHubTenants,
+            tokenExchange: request => request.RequestUri!.Host.StartsWith("acme", StringComparison.Ordinal)
+                ? throw new HttpRequestException("connection reset")
+                : AuthHttp.Json("""{"access_token":"capacitor-jwt","expires_in":3600,"username":"alice"}"""));
+
+        var progress = new RecordingAuthProgress();
+        var facade   = NewFacade(progress, handler, PickerReturningFirst());
+
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        // The throwing tenant loses only its own token; the boundary still finishes the rest.
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(TokenFileExists("acme")).IsFalse();
+        await Assert.That(TokenFileExists("contoso")).IsTrue();
+        await Assert.That(progress.Errors).Contains(
+            "Warning: token exchange failed for acme. Run 'kcap login' after switching to that profile.");
+        await Assert.That(ReadConfig().Profiles["contoso"].AuthProvider!.Provider).IsEqualTo(AuthProvider.GitHubApp);
+    }
+
+    [Test]
+    public async Task DiscoverAsync_github_zero_tenants_reports_the_no_tenants_reason() {
+        using var handler = AuthHttp.Script(proxyConfig: """{"github_client_id":"cid"}""", tenants: "[]");
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler);
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(((AuthResult.Failed)result).Reason).IsEqualTo(AuthFailureReason.NoTenantsFound);
+    }
+
+    [Test]
+    public async Task DiscoverAsync_github_token_denial_reports_the_signin_denied_reason() {
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"github_client_id":"cid"}""",
+            devicePoll: () => AuthHttp.Json("""{"error":"access_denied"}"""));
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler);
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(((AuthResult.Failed)result).Reason).IsEqualTo(AuthFailureReason.SigninDenied);
+    }
+
+    [Test]
+    public async Task DiscoverAsync_unreachable_proxy_reports_the_unreachable_reason() {
+        using var handler = AuthHttp.Script(); // no /config route
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler);
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(((AuthResult.Failed)result).Reason).IsEqualTo(AuthFailureReason.Unreachable);
+    }
+
+    [Test]
     public async Task DiscoverAsync_github_cancelled_at_the_picker_publishes_nothing() {
         using var cts = new CancellationTokenSource();
 
@@ -293,11 +475,63 @@ public class OnboardingFacadeTests {
         using var handler = new AuthHttpScript(_ => throw new OperationCanceledException(cts.Token));
         await cts.CancelAsync();
 
-        var facade = NewFacade(new RecordingAuthProgress(), handler);
+        var progress = new RecordingAuthProgress();
+        var facade   = NewFacade(progress, handler);
 
         var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, cts.Token);
 
         await Assert.That(result).IsTypeOf<AuthResult.Cancelled>();
+        await Assert.That(progress.Errors).IsEmpty(); // a cancel must not paint a transport failure
+    }
+
+    [Test]
+    public async Task DiscoverAsync_github_cancelled_during_tenant_discovery_renders_no_failure() {
+        using var cts = new CancellationTokenSource();
+
+        var progress = new RecordingAuthProgress();
+
+        // /discover-tenants cancels instead of answering; AuthProxyClient maps that to "unreachable".
+        using var cancelling = new AuthHttpScript(request => {
+            if (request.RequestUri!.AbsolutePath == "/discover-tenants") {
+                cts.Cancel();
+
+                throw new OperationCanceledException(cts.Token);
+            }
+
+            if (request.RequestUri.AbsolutePath == "/config") return AuthHttp.Json("""{"github_client_id":"cid"}""");
+            if (request.RequestUri.AbsolutePath == "/login/device/code") return AuthHttp.Json(AuthHttp.DeviceCode);
+
+            return AuthHttp.Json("""{"access_token":"gh-token"}""");
+        });
+
+        var facade = NewFacade(progress, cancelling);
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, cts.Token);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Cancelled>();
+        await Assert.That(progress.Errors).IsEmpty();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+    }
+
+    [Test]
+    public async Task DiscoverAsync_workos_cancelled_during_tenant_discovery_renders_no_failure() {
+        using var cts = new CancellationTokenSource();
+
+        using var handler = new AuthHttpScript(request => {
+            if (request.RequestUri!.AbsolutePath == "/config") return AuthHttp.Json("""{"workos_client_id":"client_d"}""");
+
+            cts.Cancel();
+
+            throw new OperationCanceledException(cts.Token);
+        });
+
+        var progress = new RecordingAuthProgress();
+        var facade   = NewFacade(progress, handler, workosLogin: OrglessAda);
+
+        var result = await facade.DiscoverAsync(AuthProvider.WorkOS, forceDevice: false, cts.Token);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Cancelled>();
+        await Assert.That(progress.Errors).IsEmpty();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
     }
 
     [Test]
@@ -394,14 +628,25 @@ public class OnboardingFacadeTests {
     }
 
     [Test]
-    public async Task DiscoverAsync_workos_declined_provisioning_fails_with_nothing_durable() {
+    public async Task DiscoverAsync_workos_declined_provisioning_fails_with_nothing_durable() =>
+        await AssertProvisionOfferFails(ProvisionOffer.Declined);
+
+    [Test]
+    public async Task DiscoverAsync_workos_in_progress_provisioning_fails_with_nothing_durable() =>
+        await AssertProvisionOfferFails(ProvisionOffer.InProgress);
+
+    [Test]
+    public async Task DiscoverAsync_workos_failed_provisioning_fails_with_nothing_durable() =>
+        await AssertProvisionOfferFails(ProvisionOffer.Failed);
+
+    static async Task AssertProvisionOfferFails(ProvisionOffer offer) {
         using var handler = AuthHttp.Script(
             proxyConfig: """{"workos_client_id":"client_d"}""",
             workosTenants: "[]");
 
         var provisioner = Substitute.For<ITenantProvisioner>();
         provisioner.OfferCreateAsync(Arg.Any<WorkOSTokenSource>(), Arg.Any<CancellationToken>())
-                   .Returns(Task.FromResult(ProvisionOffer.Declined));
+                   .Returns(Task.FromResult(offer));
 
         var facade = NewFacade(new RecordingAuthProgress(), handler, provisioner: provisioner, workosLogin: OrglessAda);
 

--- a/test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs
@@ -1,0 +1,414 @@
+using System.Net;
+using System.Text;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using NSubstitute;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>Every HTTP endpoint the façade can touch, served from one scripted handler.</summary>
+sealed class AuthHttpScript(Func<HttpRequestMessage, HttpResponseMessage> respond) : HttpMessageHandler {
+    public List<string> Seen { get; } = [];
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+        ct.ThrowIfCancellationRequested();
+        Seen.Add($"{request.Method} {request.RequestUri}");
+
+        return Task.FromResult(respond(request));
+    }
+}
+
+static class AuthHttp {
+    public static HttpResponseMessage Json(string body) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    public static HttpResponseMessage Status(HttpStatusCode code, string body = "") =>
+        new(code) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    public const string DeviceCode = """{"device_code":"dc","user_code":"UC","verification_uri":"","interval":0}""";
+
+    /// <param name="tokenExchange">POST {tenant}/auth/token — defaults to a JWT for "alice".</param>
+    public static AuthHttpScript Script(
+            string?                                        authConfig    = null,
+            string?                                        proxyConfig   = null,
+            string?                                        tenants       = null,
+            string?                                        workosTenants = null,
+            string?                                        orgSwitch     = null,
+            Func<HttpRequestMessage, HttpResponseMessage>? tokenExchange = null,
+            Func<HttpResponseMessage>?                     devicePoll    = null) =>
+        new(request => {
+            var path = request.RequestUri!.AbsolutePath;
+
+            if (path.EndsWith("/auth/config", StringComparison.Ordinal)) {
+                return authConfig is null ? Status(HttpStatusCode.NotFound) : Json(authConfig);
+            }
+
+            if (path == "/config") {
+                return proxyConfig is null ? Status(HttpStatusCode.NotFound) : Json(proxyConfig);
+            }
+
+            if (path == "/discover-tenants") {
+                return tenants is null ? Status(HttpStatusCode.InternalServerError) : Json(tenants);
+            }
+
+            if (path == "/discover-tenants-workos") {
+                return workosTenants is null ? Status(HttpStatusCode.InternalServerError) : Json(workosTenants);
+            }
+
+            if (path == "/user_management/authenticate") {
+                return orgSwitch is null ? Status(HttpStatusCode.Unauthorized) : Json(orgSwitch);
+            }
+
+            if (path == "/login/device/code") return Json(DeviceCode);
+
+            if (path == "/login/oauth/access_token") {
+                return devicePoll?.Invoke() ?? Json("""{"access_token":"gh-token"}""");
+            }
+
+            if (path.EndsWith("/auth/token", StringComparison.Ordinal)) {
+                return tokenExchange?.Invoke(request)
+                    ?? Json("""{"access_token":"capacitor-jwt","expires_in":3600,"username":"alice"}""");
+            }
+
+            return Status(HttpStatusCode.NotFound);
+        });
+}
+
+/// <summary>
+/// Operation-level contract of <see cref="OnboardingFacade"/>: provider dispatch, discovery over
+/// every tenant, cancellation before the boundary, and the WorkOS retarget/provisioner arms.
+/// Shares the TokenStoreProfileTests key so the one KCAP_CONFIG_DIR isn't raced.
+/// </summary>
+[NotInParallel(nameof(TokenStoreProfileTests))]
+public class OnboardingFacadeTests {
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+    static string ConfigPath => AppConfig.GetConfigPath();
+
+    [Before(Test)]
+    public void Cleanup() => SharedConfigDirCleanup.ClearTokenAndProfileState(LegacyPath, TokensDir);
+
+    internal static OnboardingFacade NewFacade(
+            IAuthProgress                                                     progress,
+            HttpMessageHandler                                                handler,
+            ITenantPicker?                                                    picker       = null,
+            ITenantProvisioner?                                               provisioner  = null,
+            Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task>?       beforeCommit = null,
+            Func<CancellationToken, Task<WorkOSAuthResponse?>>?               workosLogin  = null) {
+        var http = new HttpClient(handler, disposeHandler: false);
+
+        return new OnboardingFacade(progress, picker ?? Substitute.For<ITenantPicker>(), provisioner, beforeCommit, () => http) {
+            WorkOSOrglessLogin = workosLogin
+        };
+    }
+
+    internal static ITenantPicker PickerReturningFirst() {
+        var picker = Substitute.For<ITenantPicker>();
+        picker.PickAsync(Arg.Any<DiscoveredTenant[]>(), Arg.Any<CancellationToken>())
+              .Returns(ci => Task.FromResult<DiscoveredTenant?>(ci.Arg<DiscoveredTenant[]>()[0]));
+
+        return picker;
+    }
+
+    internal static ProfileConfig ReadConfig() => ConfigMutator.LoadPure(ConfigPath);
+
+    internal static bool TokenFileExists(string profile) => File.Exists(Path.Combine(TokensDir, $"{profile}.json"));
+
+    // ── login to a known server ──────────────────────────────────────────────
+
+    [Test]
+    public async Task LoginAsync_none_provider_publishes_profile_and_stamp_with_no_token() {
+        using var handler  = AuthHttp.Script(authConfig: """{"provider":"None"}""");
+        var       progress = new RecordingAuthProgress();
+        var       facade   = NewFacade(progress, handler);
+
+        var result = await facade.LoginAsync("https://none.example", forceDevice: false, profile: "solo", CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        var committed = (AuthResult.Committed)result;
+        await Assert.That(committed.Provider).IsEqualTo(AuthProvider.None);
+        await Assert.That(committed.ActiveProfile).IsEqualTo("solo");
+        await Assert.That(committed.Published).HasCount(1);
+
+        var profile = ReadConfig().Profiles["solo"];
+        await Assert.That(profile.ServerUrl).IsEqualTo("https://none.example");
+        await Assert.That(profile.AuthProvider!.Provider).IsEqualTo("None");
+        await Assert.That(ServerIdentity.SameServer(profile.AuthProvider.ServerUrl, profile.ServerUrl)).IsTrue();
+        await Assert.That(TokenFileExists("solo")).IsFalse();
+        await Assert.That(progress.Notices).Contains("Server has no authentication configured — login not required.");
+    }
+
+    [Test]
+    public async Task LoginAsync_none_provider_leaves_a_profile_that_already_points_at_the_server_alone() {
+        await ConfigMutator.MutateAsync(c => c with {
+            Profiles = new Dictionary<string, Profile> { ["solo"] = new() { ServerUrl = "https://none.example/" } }
+        });
+
+        using var handler = AuthHttp.Script(authConfig: """{"provider":"None"}""");
+        var       facade  = NewFacade(new RecordingAuthProgress(), handler);
+
+        await facade.LoginAsync("https://none.example", forceDevice: false, profile: "solo", CancellationToken.None);
+
+        var profile = ReadConfig().Profiles["solo"];
+        await Assert.That(profile.ServerUrl).IsEqualTo("https://none.example/"); // same server — not rewritten
+        await Assert.That(profile.AuthProvider!.Provider).IsEqualTo(AuthProvider.None);
+    }
+
+    [Test]
+    public async Task LoginAsync_github_publishes_the_exchanged_token_and_the_stamp() {
+        using var handler  = AuthHttp.Script(authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""");
+        var       progress = new RecordingAuthProgress();
+        var       facade   = NewFacade(progress, handler);
+
+        var result = await facade.LoginAsync("https://acme.kcap.ai", forceDevice: true, profile: "acme", CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(((AuthResult.Committed)result).Username).IsEqualTo("alice");
+
+        var stored = await TokenStore.LoadAsync("acme");
+        await Assert.That(stored!.AccessToken).IsEqualTo("capacitor-jwt");
+        await Assert.That(stored.Provider).IsEqualTo(AuthProvider.GitHubApp);
+
+        var stamp = ReadConfig().Profiles["acme"].AuthProvider;
+        await Assert.That(stamp!.Provider).IsEqualTo(AuthProvider.GitHubApp);
+        await Assert.That(ServerIdentity.SameServer(stamp.ServerUrl, "https://acme.kcap.ai")).IsTrue();
+        await Assert.That(progress.Notices).Contains("Logged in as alice");
+    }
+
+    [Test]
+    public async Task LoginAsync_unknown_provider_fails_with_todays_message() {
+        using var handler  = AuthHttp.Script(authConfig: """{"provider":"martian"}""");
+        var       progress = new RecordingAuthProgress();
+        var       facade   = NewFacade(progress, handler);
+
+        var result = await facade.LoginAsync("https://acme.kcap.ai", forceDevice: true, profile: "acme", CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(progress.Errors).Contains("Error: Unknown auth provider 'martian'. Update your kcap CLI.");
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+    }
+
+    [Test]
+    public async Task LoginAsync_cancelled_during_the_device_poll_publishes_nothing() {
+        using var cts   = new CancellationTokenSource();
+        var       polls = 0;
+
+        using var handler = AuthHttp.Script(
+            authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""",
+            devicePoll: () => {
+                if (++polls == 2) cts.Cancel();
+
+                return AuthHttp.Json("""{"error":"authorization_pending"}""");
+            });
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler);
+
+        var result = await facade.LoginAsync("https://acme.kcap.ai", forceDevice: true, profile: "acme", cts.Token);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Cancelled>();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+        await Assert.That(TokenFileExists("acme")).IsFalse();
+    }
+
+    // ── discovery ────────────────────────────────────────────────────────────
+
+    const string TwoGitHubTenants = """
+        [{"org_id":1,"org_login":"acme","origin":"https://acme.kcap.ai"},
+         {"org_id":2,"org_login":"contoso","origin":"https://contoso.kcap.ai"}]
+        """;
+
+    [Test]
+    public async Task DiscoverAsync_github_publishes_a_token_for_every_discovered_tenant() {
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"github_client_id":"cid"}""",
+            tenants: TwoGitHubTenants);
+
+        var identities = new List<AuthIdentity>();
+        var facade = NewFacade(new RecordingAuthProgress(), handler, PickerReturningFirst(),
+            beforeCommit: (ids, _) => { identities.AddRange(ids); return Task.CompletedTask; });
+
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(((AuthResult.Committed)result).ActiveProfile).IsEqualTo("acme");
+        await Assert.That(identities.Select(i => i.Profile)).IsEquivalentTo(new[] { "acme", "contoso" });
+
+        await Assert.That(TokenFileExists("acme")).IsTrue();
+        await Assert.That(TokenFileExists("contoso")).IsTrue();
+
+        var cfg = ReadConfig();
+        await Assert.That(cfg.ActiveProfile).IsEqualTo("acme");
+        await Assert.That(cfg.Profiles["contoso"].ServerUrl).IsEqualTo("https://contoso.kcap.ai");
+    }
+
+    [Test]
+    public async Task DiscoverAsync_github_commits_the_rest_when_one_tenant_exchange_fails() {
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"github_client_id":"cid"}""",
+            tenants: TwoGitHubTenants,
+            tokenExchange: request => request.RequestUri!.Host.StartsWith("contoso", StringComparison.Ordinal)
+                ? AuthHttp.Status(HttpStatusCode.InternalServerError, """{"error":"nope"}""")
+                : AuthHttp.Json("""{"access_token":"capacitor-jwt","expires_in":3600,"username":"alice"}"""));
+
+        var progress = new RecordingAuthProgress();
+        var facade   = NewFacade(progress, handler, PickerReturningFirst());
+
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That(TokenFileExists("acme")).IsTrue();
+        await Assert.That(TokenFileExists("contoso")).IsFalse();
+        await Assert.That(progress.Errors).Contains(
+            "Warning: token exchange failed for contoso. Run 'kcap login' after switching to that profile.");
+    }
+
+    [Test]
+    public async Task DiscoverAsync_github_cancelled_at_the_picker_publishes_nothing() {
+        using var cts = new CancellationTokenSource();
+
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"github_client_id":"cid"}""",
+            tenants: TwoGitHubTenants);
+
+        var picker = Substitute.For<ITenantPicker>();
+        picker.PickAsync(Arg.Any<DiscoveredTenant[]>(), Arg.Any<CancellationToken>())
+              .Returns<Task<DiscoveredTenant?>>(_ => { cts.Cancel(); throw new OperationCanceledException(cts.Token); });
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler, picker);
+
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, cts.Token);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Cancelled>();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+        await Assert.That(TokenFileExists("acme")).IsFalse();
+    }
+
+    [Test]
+    public async Task DiscoverAsync_reports_a_cancelled_proxy_call_as_cancelled_not_failed() {
+        using var cts = new CancellationTokenSource();
+
+        // AuthProxyClient maps OperationCanceledException onto its own "unreachable" result, so a
+        // live cancel would otherwise be rendered as a transport failure.
+        using var handler = new AuthHttpScript(_ => throw new OperationCanceledException(cts.Token));
+        await cts.CancelAsync();
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler);
+
+        var result = await facade.DiscoverAsync(AuthProvider.GitHubApp, forceDevice: true, cts.Token);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Cancelled>();
+    }
+
+    [Test]
+    public async Task DiscoverAsync_unknown_provider_fails() {
+        using var handler = AuthHttp.Script(proxyConfig: """{"github_client_id":"cid"}""");
+        var       facade  = NewFacade(new RecordingAuthProgress(), handler);
+
+        var result = await facade.DiscoverAsync("martian", forceDevice: true, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+    }
+
+    // ── WorkOS discovery ─────────────────────────────────────────────────────
+
+    internal const string WorkOSTenants = """
+        [{"provider":"WorkOS","organization_id":"org_a","slug":"eventuous","display_name":"Eventuous","origin":"https://eventuous.kcap.ai"},
+         {"provider":"WorkOS","organization_id":"org_b","slug":"contoso","display_name":"Contoso","origin":"https://contoso.kcap.ai"}]
+        """;
+
+    internal static Task<WorkOSAuthResponse?> OrglessAda(CancellationToken ct) =>
+        Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse {
+            User = new() { Id = "user_x", FirstName = "Ada" }, AccessToken = "acc", RefreshToken = "rt"
+        });
+
+    [Test]
+    public async Task DiscoverAsync_workos_publishes_the_picked_profile_and_its_org_scoped_token() {
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"workos_client_id":"client_d"}""",
+            workosTenants: WorkOSTenants,
+            orgSwitch: """{"organization_id":"org_a","access_token":"acc2","refresh_token":"rt2"}""");
+
+        var progress = new RecordingAuthProgress();
+        var facade   = NewFacade(progress, handler, PickerReturningFirst(), workosLogin: OrglessAda);
+
+        var result = await facade.DiscoverAsync(AuthProvider.WorkOS, forceDevice: false, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        var committed = (AuthResult.Committed)result;
+        await Assert.That(committed.ActiveProfile).IsEqualTo("eventuous");
+        await Assert.That(committed.Provider).IsEqualTo(AuthProvider.WorkOS);
+
+        var stored = await TokenStore.LoadAsync("eventuous");
+        await Assert.That(stored!.AccessToken).IsEqualTo("acc2");
+        await Assert.That(stored.RefreshToken).IsEqualTo("rt2");
+        await Assert.That(stored.ClientId).IsEqualTo("client_d");
+        await Assert.That(stored.GitHubUsername).IsEqualTo("Ada");
+        await Assert.That(ServerIdentity.SameServer(stored.ServerUrl, "https://eventuous.kcap.ai")).IsTrue();
+
+        var cfg = ReadConfig();
+        await Assert.That(cfg.ActiveProfile).IsEqualTo("eventuous");
+        await Assert.That(cfg.Profiles["eventuous"].AuthProvider!.Provider).IsEqualTo(AuthProvider.WorkOS);
+        await Assert.That(progress.Notices).Contains("Logged in as Ada → Eventuous");
+    }
+
+    [Test]
+    public async Task DiscoverAsync_workos_retarget_hands_back_the_input_with_nothing_durable() {
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"workos_client_id":"client_d"}""",
+            workosTenants: "[]");
+
+        var provisioner = Substitute.For<ITenantProvisioner>();
+        provisioner.OfferCreateAsync(Arg.Any<WorkOSTokenSource>(), Arg.Any<CancellationToken>())
+                   .Returns(Task.FromResult(ProvisionOffer.ExistingWorkspace("kurrent")));
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler, provisioner: provisioner, workosLogin: OrglessAda);
+
+        var result = await facade.DiscoverAsync(AuthProvider.WorkOS, forceDevice: false, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Retarget>();
+        await Assert.That(((AuthResult.Retarget)result).ServerInput).IsEqualTo("kurrent");
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+    }
+
+    [Test]
+    public async Task DiscoverAsync_workos_provisioned_tenant_is_switched_into_and_published() {
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"workos_client_id":"client_d"}""",
+            workosTenants: "[]",
+            orgSwitch: """{"organization_id":"org_new","access_token":"acc2","refresh_token":"rt2"}""");
+
+        var provisioner = Substitute.For<ITenantProvisioner>();
+        provisioner.OfferCreateAsync(Arg.Any<WorkOSTokenSource>(), Arg.Any<CancellationToken>())
+                   .Returns(Task.FromResult(ProvisionOffer.Created(
+                       new ProvisionedTenant("org_new", "acme", "Acme Inc", "https://acme.kcap.ai"))));
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler, provisioner: provisioner, workosLogin: OrglessAda);
+
+        var result = await facade.DiscoverAsync(AuthProvider.WorkOS, forceDevice: false, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
+        await Assert.That((await TokenStore.LoadAsync("acme"))!.AccessToken).IsEqualTo("acc2");
+        await Assert.That(ReadConfig().Profiles["acme"].AuthProvider!.Provider).IsEqualTo(AuthProvider.WorkOS);
+    }
+
+    [Test]
+    public async Task DiscoverAsync_workos_declined_provisioning_fails_with_nothing_durable() {
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"workos_client_id":"client_d"}""",
+            workosTenants: "[]");
+
+        var provisioner = Substitute.For<ITenantProvisioner>();
+        provisioner.OfferCreateAsync(Arg.Any<WorkOSTokenSource>(), Arg.Any<CancellationToken>())
+                   .Returns(Task.FromResult(ProvisionOffer.Declined));
+
+        var facade = NewFacade(new RecordingAuthProgress(), handler, provisioner: provisioner, workosLogin: OrglessAda);
+
+        var result = await facade.DiscoverAsync(AuthProvider.WorkOS, forceDevice: false, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+        await Assert.That(TokenFileExists("acme")).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs
@@ -337,7 +337,7 @@ public class OnboardingFacadeTests {
 
     // ── discovery ────────────────────────────────────────────────────────────
 
-    const string TwoGitHubTenants = """
+    internal const string TwoGitHubTenants = """
         [{"org_id":1,"org_login":"acme","origin":"https://acme.kcap.ai"},
          {"org_id":2,"org_login":"contoso","origin":"https://contoso.kcap.ai"}]
         """;

--- a/test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs
@@ -144,7 +144,7 @@ public class OnboardingFacadeTests {
         var committed = (AuthResult.Committed)result;
         await Assert.That(committed.Provider).IsEqualTo(AuthProvider.None);
         await Assert.That(committed.ActiveProfile).IsEqualTo("solo");
-        await Assert.That(committed.Published).HasCount(1);
+        await Assert.That(committed.Published).Count().IsEqualTo(1);
 
         var profile = ReadConfig().Profiles["solo"];
         await Assert.That(profile.ServerUrl).IsEqualTo("https://none.example");

--- a/test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/OnboardingFacadeTests.cs
@@ -278,6 +278,29 @@ public class OnboardingFacadeTests {
         await Assert.That(TokenFileExists("acme")).IsFalse();
     }
 
+    // Cancellation is never rendered as failure: closing the wizard while the browser is up must
+    // leave the sink untouched, not report a sign-in error the cancel itself caused.
+    [Test]
+    public async Task LoginAsync_workos_cancelled_during_the_browser_wait_renders_nothing() {
+        using var cts = new CancellationTokenSource();
+
+        using var handler = AuthHttp.Script(
+            authConfig: """{"provider":"workos","client_id":"client_d","organization_id":"org_a"}""");
+
+        var progress = new RecordingAuthProgress();
+        // No token endpoint is stubbed: the cancel lands in the browser, before any WorkOS call.
+        var facade = NewFacade(progress, handler,
+            workosBrowser: FakeBrowser.CancellingCaller(cts), workosApiBase: "http://127.0.0.1:9");
+
+        var result = await facade.LoginAsync(
+            "https://acme.kcap.ai", forceDevice: false, profile: "acme", cts.Token, adoptServer: true);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Cancelled>();
+        await Assert.That(progress.Errors).IsEmpty();
+        await Assert.That(File.Exists(ConfigPath)).IsFalse();
+        await Assert.That(TokenFileExists("acme")).IsFalse();
+    }
+
     [Test]
     public async Task LoginAsync_cancelled_during_the_token_exchange_publishes_nothing() {
         using var cts = new CancellationTokenSource();

--- a/test/Capacitor.Cli.Tests.Unit/ServerInputTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ServerInputTests.cs
@@ -1,0 +1,52 @@
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class ServerInputTests {
+    [Test]
+    public async Task ResolveTenantArg_expands_bare_label_to_kcap_subdomain() {
+        await Assert.That(ServerInput.ResolveTenantArg("eventuous")).IsEqualTo("https://eventuous.kcap.ai");
+    }
+
+    // The zero-discovery "I already have a workspace" prompt invites a paste, and what people paste
+    // is the page they are looking at. Everything downstream appends a fixed root path
+    // (/auth/config), so a path on the input silently probes the wrong endpoint and reports the
+    // server unreachable. Reduce to the origin first.
+    [Test]
+    public async Task ToServerOrigin_reduces_a_pasted_page_url_to_its_origin() {
+        await Assert.That(ServerInput.ToServerOrigin("https://acme.kcap.ai/sessions?tab=all#x"))
+            .IsEqualTo("https://acme.kcap.ai");
+        await Assert.That(ServerInput.ToServerOrigin("acme.kcap.ai/sessions")).IsEqualTo("acme.kcap.ai");
+        await Assert.That(ServerInput.ToServerOrigin("http://localhost:5108/repo/abc")).IsEqualTo("http://localhost:5108");
+        await Assert.That(ServerInput.ToServerOrigin("localhost:5108/repo/abc")).IsEqualTo("localhost:5108");
+    }
+
+    [Test]
+    public async Task ToServerOrigin_leaves_a_bare_slug_origin_or_ipv6_host_alone() {
+        await Assert.That(ServerInput.ToServerOrigin("acme")).IsEqualTo("acme");
+        await Assert.That(ServerInput.ToServerOrigin("https://acme.kcap.ai")).IsEqualTo("https://acme.kcap.ai");
+        await Assert.That(ServerInput.ToServerOrigin("https://acme.kcap.ai/")).IsEqualTo("https://acme.kcap.ai");
+        // Bracketed IPv6 keeps its colons and port — the ':' and '/' scan must not cut inside it.
+        await Assert.That(ServerInput.ToServerOrigin("[::1]:5108")).IsEqualTo("[::1]:5108");
+        await Assert.That(ServerInput.ToServerOrigin("[::1]:5108/x")).IsEqualTo("[::1]:5108");
+        await Assert.That(ServerInput.ToServerOrigin("http://[::1]:5108/x")).IsEqualTo("http://[::1]:5108");
+    }
+
+    [Test]
+    public async Task ResolveTenantArg_leaves_urls_fqdns_and_hosts_untouched() {
+        await Assert.That(ServerInput.ResolveTenantArg("https://x.example")).IsEqualTo("https://x.example");
+        await Assert.That(ServerInput.ResolveTenantArg("self.hosted.example")).IsEqualTo("self.hosted.example");
+        await Assert.That(ServerInput.ResolveTenantArg("localhost:5108")).IsEqualTo("localhost:5108");
+        await Assert.That(ServerInput.ResolveTenantArg("localhost")).IsEqualTo("localhost"); // bare loopback, not a slug
+    }
+
+    // Spectre's --default-visibility prompt offers these as an ordered choice list; changing the
+    // order changes which one a bare Enter picks.
+    [Test]
+    public async Task ValidVisibilities_is_the_pinned_set_and_order() {
+        await Assert.That(AppConfig.ValidVisibilities)
+            .IsEquivalentTo(["private", "project", "org_public", "public"], CollectionOrdering.Matching);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/AntigravityRuntimeLifecycleTests.cs
@@ -247,7 +247,7 @@ public class AntigravityRuntimeLifecycleTests {
     [Test]
     public async Task Spawner_receives_the_prompt_text() {
         var prompts = new List<string>();
-        await using var rt = FakeRuntime(onSpawn: p => prompts.Add(p));
+        await using var rt = FakeRuntime(onSpawn: prompts.Add);
 
         await rt.SendUserInputAsync("do the review").WaitAsync(HangGuard);
         await rt.WaitForConversationIdAsync(CancellationToken.None).WaitAsync(HangGuard);

--- a/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupCommandTests.cs
@@ -567,11 +567,6 @@ public class SetupCommandTests {
             PiMcpExtensionPath:   Path.Combine(root, "pi-mcp.ts"),
             PiAgentsMdPath:       Path.Combine(root, "pi-AGENTS.md"));
 
-    [Test]
-    public async Task ResolveTenantArg_expands_bare_label_to_kcap_subdomain() {
-        await Assert.That(SetupCommand.ResolveTenantArg("eventuous")).IsEqualTo("https://eventuous.kcap.ai");
-    }
-
     // --- Step 6 (RunImportStepAsync) wiring ---
     //
     // SetupCommand.ImportRunnerOverride is process-global static state (mutated by
@@ -720,38 +715,6 @@ public class SetupCommandTests {
         } finally {
             SetupCommand.ImportRunnerOverride = null;
         }
-    }
-
-    // The zero-discovery "I already have a workspace" prompt invites a paste, and what people paste
-    // is the page they are looking at. Everything downstream appends a fixed root path
-    // (/auth/config), so a path on the input silently probes the wrong endpoint and reports the
-    // server unreachable. Reduce to the origin first.
-    [Test]
-    public async Task ToServerOrigin_reduces_a_pasted_page_url_to_its_origin() {
-        await Assert.That(SetupCommand.ToServerOrigin("https://acme.kcap.ai/sessions?tab=all#x"))
-            .IsEqualTo("https://acme.kcap.ai");
-        await Assert.That(SetupCommand.ToServerOrigin("acme.kcap.ai/sessions")).IsEqualTo("acme.kcap.ai");
-        await Assert.That(SetupCommand.ToServerOrigin("http://localhost:5108/repo/abc")).IsEqualTo("http://localhost:5108");
-        await Assert.That(SetupCommand.ToServerOrigin("localhost:5108/repo/abc")).IsEqualTo("localhost:5108");
-    }
-
-    [Test]
-    public async Task ToServerOrigin_leaves_a_bare_slug_origin_or_ipv6_host_alone() {
-        await Assert.That(SetupCommand.ToServerOrigin("acme")).IsEqualTo("acme");
-        await Assert.That(SetupCommand.ToServerOrigin("https://acme.kcap.ai")).IsEqualTo("https://acme.kcap.ai");
-        await Assert.That(SetupCommand.ToServerOrigin("https://acme.kcap.ai/")).IsEqualTo("https://acme.kcap.ai");
-        // Bracketed IPv6 keeps its colons and port — the ':' and '/' scan must not cut inside it.
-        await Assert.That(SetupCommand.ToServerOrigin("[::1]:5108")).IsEqualTo("[::1]:5108");
-        await Assert.That(SetupCommand.ToServerOrigin("[::1]:5108/x")).IsEqualTo("[::1]:5108");
-        await Assert.That(SetupCommand.ToServerOrigin("http://[::1]:5108/x")).IsEqualTo("http://[::1]:5108");
-    }
-
-    [Test]
-    public async Task ResolveTenantArg_leaves_urls_fqdns_and_hosts_untouched() {
-        await Assert.That(SetupCommand.ResolveTenantArg("https://x.example")).IsEqualTo("https://x.example");
-        await Assert.That(SetupCommand.ResolveTenantArg("self.hosted.example")).IsEqualTo("self.hosted.example");
-        await Assert.That(SetupCommand.ResolveTenantArg("localhost:5108")).IsEqualTo("localhost:5108");
-        await Assert.That(SetupCommand.ResolveTenantArg("localhost")).IsEqualTo("localhost"); // bare loopback, not a slug
     }
 
     // =====================================================================

--- a/test/Capacitor.Cli.Tests.Unit/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupFacadeParityTests.cs
@@ -1,0 +1,222 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Telemetry;
+using Capacitor.Cli.Tests.Unit.Telemetry;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// `SetupCommand`'s Step 1 (<see cref="SetupCommand.RunDiscoveryAsync"/>) / Step 2
+/// (<see cref="SetupCommand.RunLoginStepAsync"/>) re-plumb onto <see cref="OnboardingFacade"/>:
+/// GitHub multi-tenant token publication, the funnel mapping the adapter now owns (WorkOS's own
+/// funnel events fire from inside Core regardless of caller — nothing to pin here), and Step 2's
+/// three branches. Shares the OnboardingFacadeTests keys — it drives the same shared config dir
+/// and telemetry sink. Every discovery test forces `--github`: provider selection with no flag
+/// depends on <c>HeadlessEnvironment.IsHeadless()</c>, which reads live env/platform state and
+/// differs between the ubuntu-latest and windows-latest CI legs — not something a unit test can
+/// pin (mirrors why LoginFacadeParityTests always passes --github too).
+/// </summary>
+[NotInParallel([
+    nameof(TokenStoreProfileTests),
+    nameof(TelemetryState) + "." + nameof(TelemetryState.PathOverride),
+    nameof(TelemetryDeviceId) + "." + nameof(TelemetryDeviceId.PathOverride),
+])]
+public class SetupFacadeParityTests {
+    static string TokensDir  => PathHelpers.ConfigPath("tokens");
+    static string LegacyPath => PathHelpers.ConfigPath("tokens.json");
+    static string ConfigPath => AppConfig.GetConfigPath();
+
+    [Before(Test)]
+    public void Cleanup() {
+        SharedConfigDirCleanup.ClearTokenAndProfileState(LegacyPath, TokensDir);
+        CliTelemetry.Reset();
+        SetupCommand.FacadeOverride = null;
+    }
+
+    [After(Test)]
+    public void ResetFacadeOverride() => SetupCommand.FacadeOverride = null;
+
+    static ProfileConfig ReadConfig() => ConfigMutator.LoadPure(ConfigPath);
+
+    static bool TokenFileExists(string profile) => File.Exists(Path.Combine(TokensDir, $"{profile}.json"));
+
+    static List<TelemetryEvent> StartCapturingFunnel() {
+        var dir = Path.Combine(Path.GetTempPath(), $"kcap-setup-facade-funnel-{Guid.NewGuid():N}");
+        TelemetryState.PathOverride    = Path.Combine(dir, "telemetry.json");
+        TelemetryDeviceId.PathOverride = Path.Combine(dir, "telemetry-device.json");
+        var sink = new List<TelemetryEvent>();
+        CliTelemetry.TestSink = sink;
+        CliTelemetry.Initialize("setup", null, loggedIn: false);
+
+        TelemetryTestGuards.AssertEnabled("setup");
+
+        sink.Clear(); // drop cli_first_run
+
+        return sink;
+    }
+
+    // ── Step 1: RunDiscoveryAsync (GitHub) ──────────────────────────────────
+
+    [Test]
+    public async Task RunDiscoveryAsync_github_two_tenants_publishes_both_and_marks_loginComplete() {
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"github_client_id":"cid"}""",
+            tenants: OnboardingFacadeTests.TwoGitHubTenants);
+
+        SetupCommand.FacadeOverride = _ =>
+            OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler, OnboardingFacadeTests.PickerReturningFirst());
+
+        var discovered = await SetupCommand.RunDiscoveryAsync(["--github"], forceDevice: true);
+
+        await Assert.That(discovered).IsNotNull();
+        await Assert.That(discovered!.Value.LoginComplete).IsTrue();
+        await Assert.That(discovered.Value.Provider).IsEqualTo(AuthProvider.GitHubApp);
+        await Assert.That(discovered.Value.ServerUrl).IsEqualTo("https://acme.kcap.ai");
+
+        await Assert.That(TokenFileExists("acme")).IsTrue();
+        await Assert.That(TokenFileExists("contoso")).IsTrue();
+
+        var cfg = ReadConfig();
+        await Assert.That(cfg.ActiveProfile).IsEqualTo("acme");
+        await Assert.That(cfg.Profiles["contoso"].ServerUrl).IsEqualTo("https://contoso.kcap.ai");
+    }
+
+    [Test]
+    public async Task RunDiscoveryAsync_github_committed_fires_signin_opened_then_signin_completed() {
+        var sink = StartCapturingFunnel();
+
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"github_client_id":"cid"}""",
+            tenants: OnboardingFacadeTests.TwoGitHubTenants);
+
+        SetupCommand.FacadeOverride = _ =>
+            OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler, OnboardingFacadeTests.PickerReturningFirst());
+
+        var discovered = await SetupCommand.RunDiscoveryAsync(["--github"], forceDevice: true);
+
+        await Assert.That(discovered).IsNotNull();
+        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+            new[] { "cli_setup_signin_opened", "cli_setup_signin_completed" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task RunDiscoveryAsync_github_zero_tenants_emits_tenant_none_not_a_duplicate_signin_completed() {
+        var sink = StartCapturingFunnel();
+
+        using var handler = AuthHttp.Script(proxyConfig: """{"github_client_id":"cid"}""", tenants: "[]");
+
+        SetupCommand.FacadeOverride = _ => OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
+
+        var discovered = await SetupCommand.RunDiscoveryAsync(["--github"], forceDevice: true);
+
+        await Assert.That(discovered).IsNull();
+        // Faithful to the façade boundary: NoTenantsFound implies token acquisition already
+        // succeeded, but the adapter fires only TenantNone here — see OnboardingFacade's mapping.
+        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+            new[] { "cli_setup_signin_opened", "cli_setup_tenant_none" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task RunDiscoveryAsync_github_signin_denied_emits_signin_failed() {
+        var sink = StartCapturingFunnel();
+
+        using var handler = AuthHttp.Script(
+            proxyConfig: """{"github_client_id":"cid"}""",
+            devicePoll: () => AuthHttp.Json("""{"error":"access_denied"}"""));
+
+        SetupCommand.FacadeOverride = _ => OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
+
+        var discovered = await SetupCommand.RunDiscoveryAsync(["--github"], forceDevice: true);
+
+        await Assert.That(discovered).IsNull();
+        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+            new[] { "cli_setup_signin_opened", "cli_setup_signin_failed" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task RunDiscoveryAsync_github_unreachable_proxy_fires_no_extra_funnel_event() {
+        var sink = StartCapturingFunnel();
+
+        using var handler = AuthHttp.Script(); // no /config route — proxy unreachable
+
+        SetupCommand.FacadeOverride = _ => OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
+
+        var discovered = await SetupCommand.RunDiscoveryAsync(["--github"], forceDevice: true);
+
+        await Assert.That(discovered).IsNull();
+        // Other/Unreachable failures map to nothing beyond SigninOpened — only SigninDenied and
+        // NoTenantsFound get a second event.
+        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+            new[] { "cli_setup_signin_opened" }, CollectionOrdering.Matching);
+    }
+
+    // ── Step 2: RunLoginStepAsync ────────────────────────────────────────────
+
+    [Test]
+    public async Task RunLoginStepAsync_loginComplete_reports_the_already_published_identity_without_a_facade_call() {
+        await ConfigMutator.MutateAsync(c => c with {
+            Profiles      = new Dictionary<string, Profile> { ["acme"] = new() { ServerUrl = "https://acme.kcap.ai" } },
+            ActiveProfile = "acme",
+        });
+        await TokenStore.SaveAsync("acme", new StoredTokens {
+            AccessToken     = "tok",
+            ExpiresAt       = DateTimeOffset.UtcNow.AddHours(1),
+            GitHubUsername  = "alice",
+            Provider        = AuthProvider.GitHubApp,
+            ServerUrl       = "https://acme.kcap.ai",
+        });
+
+        SetupCommand.FacadeOverride = _ => throw new InvalidOperationException("loginComplete must not call the façade");
+
+        var exitCode = await SetupCommand.RunLoginStepAsync(
+            loginComplete: true, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
+            forceDevice: false, activeProfile: "acme");
+
+        await Assert.That(exitCode).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RunLoginStepAsync_none_provider_skips_login_without_a_facade_call() {
+        SetupCommand.FacadeOverride = _ => throw new InvalidOperationException("None provider must not call the façade");
+
+        var exitCode = await SetupCommand.RunLoginStepAsync(
+            loginComplete: false, provider: AuthProvider.None, serverUrl: "https://none.example",
+            forceDevice: false, activeProfile: "default");
+
+        await Assert.That(exitCode).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task RunLoginStepAsync_explicit_login_commits_and_adopts_the_server_onto_the_active_profile() {
+        using var handler = AuthHttp.Script(authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""");
+
+        SetupCommand.FacadeOverride = _ => OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
+
+        var exitCode = await SetupCommand.RunLoginStepAsync(
+            loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
+            forceDevice: true, activeProfile: "acme");
+
+        await Assert.That(exitCode).IsEqualTo(0);
+        await Assert.That(TokenFileExists("acme")).IsTrue();
+        // adoptServer: true — setup's whole job is configuring the active profile for this server.
+        await Assert.That(ReadConfig().Profiles["acme"].ServerUrl).IsEqualTo("https://acme.kcap.ai");
+    }
+
+    [Test]
+    public async Task RunLoginStepAsync_explicit_login_failure_prints_login_failed_and_returns_one() {
+        using var handler = AuthHttp.Script(authConfig: """{"provider":"martian"}""");
+
+        SetupCommand.FacadeOverride = _ => OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
+
+        // The provider param is Step 1's resolved value; Step 2 re-fetches /auth/config for the
+        // actual login, so a server reporting an unrelated/unknown provider by then still fails.
+        var exitCode = await SetupCommand.RunLoginStepAsync(
+            loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
+            forceDevice: false, activeProfile: "acme");
+
+        await Assert.That(exitCode).IsEqualTo(1);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupFacadeParityTests.cs
@@ -4,7 +4,9 @@ using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Telemetry;
 using Capacitor.Cli.Tests.Unit.Telemetry;
+using Spectre.Console;
 using TUnit.Assertions.Enums;
+using Profile = Capacitor.Cli.Core.Config.Profile;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -103,7 +105,7 @@ public class SetupFacadeParityTests {
     }
 
     [Test]
-    public async Task RunDiscoveryAsync_github_zero_tenants_emits_tenant_none_not_a_duplicate_signin_completed() {
+    public async Task RunDiscoveryAsync_github_zero_tenants_emits_signin_completed_and_tenant_none() {
         var sink = StartCapturingFunnel();
 
         using var handler = AuthHttp.Script(proxyConfig: """{"github_client_id":"cid"}""", tenants: "[]");
@@ -113,10 +115,28 @@ public class SetupFacadeParityTests {
         var discovered = await SetupCommand.RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
-        // Faithful to the façade boundary: NoTenantsFound implies token acquisition already
-        // succeeded, but the adapter fires only TenantNone here — see OnboardingFacade's mapping.
+        // Today's setup fires SigninCompleted unconditionally once the token is acquired, and
+        // TenantNone additionally when discovery then finds nothing — the two co-occur here.
         await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
-            new[] { "cli_setup_signin_opened", "cli_setup_tenant_none" }, CollectionOrdering.Matching);
+            new[] { "cli_setup_signin_opened", "cli_setup_signin_completed", "cli_setup_tenant_none" },
+            CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task RunDiscoveryAsync_github_post_acquisition_discovery_error_still_emits_signin_completed() {
+        var sink = StartCapturingFunnel();
+
+        // No `tenants:` stub — /discover-tenants 500s AFTER the device flow already handed out a
+        // token, landing AuthFailureReason.Other (not NoTenantsFound).
+        using var handler = AuthHttp.Script(proxyConfig: """{"github_client_id":"cid"}""");
+
+        SetupCommand.FacadeOverride = _ => OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
+
+        var discovered = await SetupCommand.RunDiscoveryAsync(["--github"], forceDevice: true);
+
+        await Assert.That(discovered).IsNull();
+        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+            new[] { "cli_setup_signin_opened", "cli_setup_signin_completed" }, CollectionOrdering.Matching);
     }
 
     [Test]
@@ -155,7 +175,10 @@ public class SetupFacadeParityTests {
 
     // ── Step 2: RunLoginStepAsync ────────────────────────────────────────────
 
+    // AnsiConsole.Console is process-global state (see below) — fully serialize this test against
+    // everything else, mirroring AuthProgressTests' console-redirection convention.
     [Test]
+    [NotInParallel]
     public async Task RunLoginStepAsync_loginComplete_reports_the_already_published_identity_without_a_facade_call() {
         await ConfigMutator.MutateAsync(c => c with {
             Profiles      = new Dictionary<string, Profile> { ["acme"] = new() { ServerUrl = "https://acme.kcap.ai" } },
@@ -171,11 +194,29 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => throw new InvalidOperationException("loginComplete must not call the façade");
 
-        var exitCode = await SetupCommand.RunLoginStepAsync(
-            loginComplete: true, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
-            forceDevice: false, activeProfile: "acme");
+        // SetupCommand writes Step 2's banner via AnsiConsole (not IAuthProgress, and not plain
+        // Console.Out — Spectre's static AnsiConsole.Console caches its writer at first use, so
+        // Console.SetOut alone doesn't redirect it), so swap the singleton console to capture it.
+        var originalConsole = AnsiConsole.Console;
+        var buffer          = new StringWriter();
+        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings {
+            Ansi        = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out         = new AnsiConsoleOutput(buffer),
+        });
+
+        int exitCode;
+
+        try {
+            exitCode = await SetupCommand.RunLoginStepAsync(
+                loginComplete: true, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
+                forceDevice: false, activeProfile: "acme");
+        } finally {
+            AnsiConsole.Console = originalConsole;
+        }
 
         await Assert.That(exitCode).IsEqualTo(0);
+        await Assert.That(buffer.ToString()).Contains("Logged in as alice");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupFacadeParityTests.cs
@@ -219,15 +219,40 @@ public class SetupFacadeParityTests {
         await Assert.That(buffer.ToString()).Contains("Logged in as alice");
     }
 
+    // A None-provider setup must still mint the auth_provider stamp, and only inside the commit boundary.
     [Test]
-    public async Task RunLoginStepAsync_none_provider_skips_login_without_a_facade_call() {
-        SetupCommand.FacadeOverride = _ => throw new InvalidOperationException("None provider must not call the façade");
+    public async Task RunLoginStepAsync_none_provider_commits_the_stamp_through_the_facade() {
+        using var handler = AuthHttp.Script(authConfig: """{"provider":"None"}""");
+
+        SetupCommand.FacadeOverride = _ => OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
 
         var exitCode = await SetupCommand.RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.None, serverUrl: "https://none.example",
             forceDevice: false, activeProfile: "default");
 
         await Assert.That(exitCode).IsEqualTo(0);
+
+        var profile = ReadConfig().Profiles["default"];
+        await Assert.That(profile.AuthProvider).IsNotNull();
+        await Assert.That(profile.AuthProvider!.Provider).IsEqualTo(AuthProvider.None);
+        // Gate-complete at config level: the stamp's server must match the canonicalized profile server.
+        await Assert.That(ServerIdentity.SameServer(profile.AuthProvider.ServerUrl, profile.ServerUrl)).IsTrue();
+        await Assert.That(TokenFileExists("default")).IsFalse();
+    }
+
+    [Test]
+    public async Task RunLoginStepAsync_none_provider_failure_prints_login_failed_and_returns_one() {
+        // No /auth/config route at all — the façade's re-fetch fails, mirroring the explicit-login
+        // failure test below. A None-provider server that becomes unreachable must fail the same way.
+        using var handler = AuthHttp.Script();
+
+        SetupCommand.FacadeOverride = _ => OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
+
+        var exitCode = await SetupCommand.RunLoginStepAsync(
+            loginComplete: false, provider: AuthProvider.None, serverUrl: "https://none.example",
+            forceDevice: false, activeProfile: "default");
+
+        await Assert.That(exitCode).IsEqualTo(1);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SetupFacadeParityTests.cs
@@ -4,6 +4,7 @@ using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Telemetry;
 using Capacitor.Cli.Tests.Unit.Telemetry;
+using Capacitor.Tests.Helpers;
 using Spectre.Console;
 using TUnit.Assertions.Enums;
 using Profile = Capacitor.Cli.Core.Config.Profile;
@@ -171,6 +172,61 @@ public class SetupFacadeParityTests {
         // NoTenantsFound get a second event.
         await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
             new[] { "cli_setup_signin_opened" }, CollectionOrdering.Matching);
+    }
+
+    // The façade owns the reason line; setup still owns the guidance tail its old single line carried.
+    [Test]
+    [NotInParallel]
+    public async Task RunDiscoveryAsync_unreachable_proxy_still_prints_the_legacy_guidance_tail() {
+        using var handler = AuthHttp.Script(); // no /config route — proxy unreachable
+
+        SetupCommand.FacadeOverride = _ => OnboardingFacadeTests.NewFacade(new RecordingAuthProgress(), handler);
+
+        using var console = ConsoleOutput.StartErrorCapture("\n");
+
+        var discovered = await SetupCommand.RunDiscoveryAsync(["--github"], forceDevice: true);
+
+        await Assert.That(discovered).IsNull();
+        await Assert.That(console.GetCapturedError()).Contains(SetupAuthProgress.UnreachableGuidance);
+    }
+
+    // ── the setup-scoped progress sink ───────────────────────────────────────
+
+    [Test]
+    public async Task SetupAuthProgress_indents_facade_text_and_passes_the_rest_through() {
+        var inner    = new RecordingAuthProgress();
+        var progress = new SetupAuthProgress(inner);
+
+        progress.Notice("Server has no authentication configured — login not required.");
+        progress.Error("Cannot reach the Kurrent auth service.");
+        progress.Notice("");
+        progress.Notice("  1. Open https://github.com/login/device in a browser");
+        progress.BrowserOpening("https://auth.example/authorize");
+        progress.DeviceCode("UC", "https://github.com/login/device");
+        progress.PollTick();
+
+        await Assert.That(inner.Notices).IsEquivalentTo(new[] {
+            "  Server has no authentication configured — login not required.",
+            "",
+            "  1. Open https://github.com/login/device in a browser",
+        });
+        await Assert.That(inner.Errors).IsEquivalentTo(new[] { "  Cannot reach the Kurrent auth service." });
+        await Assert.That(inner.BrowserOpenings).IsEquivalentTo(new[] { "https://auth.example/authorize" });
+        await Assert.That(inner.DeviceCodes).Count().IsEqualTo(1);
+        await Assert.That(inner.PollTicks).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task SetupAuthProgress_appends_the_guidance_tail_only_for_an_unreachable_failure() {
+        var inner    = new RecordingAuthProgress();
+        var progress = new SetupAuthProgress(inner);
+
+        progress.ReportFailure(new AuthResult.Failed("nope", AuthFailureReason.SigninDenied));
+        progress.ReportFailure(new AuthResult.Cancelled());
+        await Assert.That(inner.Errors).IsEmpty();
+
+        progress.ReportFailure(new AuthResult.Failed("Cannot reach the Kurrent auth service.", AuthFailureReason.Unreachable));
+        await Assert.That(inner.Errors).IsEquivalentTo(new[] { SetupAuthProgress.UnreachableGuidance });
     }
 
     // ── Step 2: RunLoginStepAsync ────────────────────────────────────────────

--- a/test/Capacitor.Cli.Tests.Unit/Telemetry/SetupFunnelTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Telemetry/SetupFunnelTests.cs
@@ -139,11 +139,11 @@ public class SetupFunnelTests {
     }
 
     // Call-site coverage, not just SetupFunnel's statics: every test above calls SetupFunnel
-    // directly, so a wiring defect inside WorkOSDiscovery.RunAsync itself — e.g. the original bug
-    // of anchoring signin_completed/signin_failed on RunAsync's overall ExitCode instead of the
+    // directly, so a wiring defect inside WorkOSDiscovery.DiscoverAsync itself — e.g. the original
+    // bug of anchoring signin_completed/signin_failed on the overall outcome instead of the
     // live-auth result — was invisible to this suite. A zero-tenant, no-provisioner run reaches
-    // the legacy "ask your admin" dead-end (ExitCode 1) despite sign-in having fully succeeded,
-    // which is exactly the case that anchoring on ExitCode gets wrong.
+    // the legacy "ask your admin" dead-end (NoTenants) despite sign-in having fully succeeded,
+    // which is exactly the case that anchoring on the overall outcome gets wrong.
     [Test]
     public async Task WorkOSDiscovery_emits_signin_completed_before_tenant_none_for_a_zero_tenant_run() {
         var sink = StartCapturing();
@@ -152,15 +152,15 @@ public class SetupFunnelTests {
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
              .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
 
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
             proxy, Substitute.For<ITenantPicker>(),
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
 
-        // No provisioner passed -> the legacy "ask your admin" dead-end -> ExitCode 1, even though
+        // No provisioner passed -> the legacy "ask your admin" dead-end -> NoTenants, even though
         // sign-in itself worked fine.
-        await Assert.That(outcome.ExitCode).IsEqualTo(1);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.NoTenants>();
 
         await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
             new[] { "cli_setup_signin_completed", "cli_setup_tenant_none" }, CollectionOrdering.Matching);

--- a/test/Capacitor.Cli.Tests.Unit/TenantDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/TenantDiscoveryTests.cs
@@ -23,6 +23,7 @@ public class TenantDiscoveryTests {
         await Assert.That(outcome.Picked).IsNotNull();
         await Assert.That(outcome.Picked!.OrgLogin).IsEqualTo("solo");
         picker.DidNotReceive().Pick(Arg.Any<DiscoveredTenant[]>());
+        await picker.DidNotReceive().PickAsync(Arg.Any<DiscoveredTenant[]>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -36,7 +37,7 @@ public class TenantDiscoveryTests {
              .Returns(Task.FromResult(new DiscoveryResult(list, DiscoveryError.None)));
 
         var picker = Substitute.For<ITenantPicker>();
-        picker.Pick(list).Returns(list[1]);
+        picker.PickAsync(list, Arg.Any<CancellationToken>()).Returns(Task.FromResult<DiscoveredTenant?>(list[1]));
 
         var discovery = new TenantDiscovery(proxy, picker);
         var outcome = await discovery.RunAsync("https://proxy", "gh");
@@ -114,7 +115,7 @@ public class TenantDiscoveryTests {
              .Returns(Task.FromResult(new DiscoveryResult(list, DiscoveryError.None)));
 
         var picker = Substitute.For<ITenantPicker>();
-        picker.Pick(list).Returns((DiscoveredTenant?)null);
+        picker.PickAsync(list, Arg.Any<CancellationToken>()).Returns(Task.FromResult<DiscoveredTenant?>(null));
 
         var discovery = new TenantDiscovery(proxy, picker);
         var outcome = await discovery.RunAsync("https://proxy", "gh");

--- a/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
@@ -38,7 +38,7 @@ public class WorkOSDiscoveryTests {
              .Returns(Task.FromResult(new DiscoveryResult(tenants, DiscoveryError.None)));
 
         var picker = Substitute.For<ITenantPicker>();
-        picker.Pick(tenants).Returns(tenants[0]); // eventuous
+        picker.PickAsync(tenants, Arg.Any<CancellationToken>()).Returns(Task.FromResult<DiscoveredTenant?>(tenants[0])); // eventuous
 
         var orgless  = new WorkOSAuthResponse { User = new() { Id = "user_x", FirstName = "Ada" }, AccessToken = "acc",  RefreshToken = "rt" };
         var switched = new WorkOSAuthResponse { User = new() { Id = "user_x" }, OrganizationId = "org_a", AccessToken = "acc2", RefreshToken = "rt2" };

--- a/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WorkOSDiscoveryTests.cs
@@ -26,7 +26,7 @@ public class WorkOSDiscoveryTests {
     }
 
     [Test]
-    public async Task RunAsync_org_switches_picked_tenant_and_saves_workos_profile() {
+    public async Task DiscoverAsync_org_switches_picked_tenant_and_PublishAsync_saves_workos_profile() {
         var proxyConfig = new ProxyConfigResponse { WorkOSClientId = "client_d", WorkOSAuthKitDomain = "" };
 
         var proxy = Substitute.For<IAuthProxyClient>();
@@ -43,12 +43,17 @@ public class WorkOSDiscoveryTests {
         var orgless  = new WorkOSAuthResponse { User = new() { Id = "user_x", FirstName = "Ada" }, AccessToken = "acc",  RefreshToken = "rt" };
         var switched = new WorkOSAuthResponse { User = new() { Id = "user_x" }, OrganizationId = "org_a", AccessToken = "acc2", RefreshToken = "rt2" };
 
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", proxyConfig, proxy, picker,
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(orgless),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(switched));
 
-        await Assert.That(outcome.ExitCode).IsEqualTo(0);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Ready>();
+
+        var result = await WorkOSDiscovery.PublishAsync(
+            (WorkOSDiscoveryFlow.Ready)flow, new RecordingAuthProgress(), beforeCommit: null, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
 
         var stored = await TokenStore.LoadAsync("eventuous");
         await Assert.That(stored).IsNotNull();
@@ -61,18 +66,18 @@ public class WorkOSDiscoveryTests {
     }
 
     [Test]
-    public async Task RunAsync_errors_when_workos_not_configured() {
-        var outcome = await WorkOSDiscovery.RunAsync(
+    public async Task DiscoverAsync_errors_when_workos_not_configured() {
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "" },
             Substitute.For<IAuthProxyClient>(), Substitute.For<ITenantPicker>(),
             ()     => Task.FromResult<WorkOSAuthResponse?>(null),
             (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
 
-        await Assert.That(outcome.ExitCode).IsEqualTo(1);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Failed>();
     }
 
     [Test]
-    public async Task RunAsync_errors_when_picked_tenant_has_no_org_id() {
+    public async Task DiscoverAsync_errors_when_picked_tenant_has_no_org_id() {
         var proxy = Substitute.For<IAuthProxyClient>();
         DiscoveredTenant[] tenants = [
             new() { Provider = "WorkOS", Slug = "eventuous", DisplayName = "Eventuous", Origin = "https://eventuous.kcap.ai" } // no OrganizationId
@@ -81,33 +86,33 @@ public class WorkOSDiscoveryTests {
              .Returns(Task.FromResult(new DiscoveryResult(tenants, DiscoveryError.None)));
 
         var switchCalled = false;
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
             proxy, Substitute.For<ITenantPicker>(),
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => { switchCalled = true; return Task.FromResult<WorkOSAuthResponse?>(null); });
 
-        await Assert.That(outcome.ExitCode).IsEqualTo(1);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Failed>();
         await Assert.That(switchCalled).IsFalse(); // fail before the org-switch, not during it
     }
 
     [Test]
-    public async Task RunAsync_errors_when_no_tenants() {
+    public async Task DiscoverAsync_returns_NoTenants_when_no_tenants_and_no_provisioner() {
         var proxy = Substitute.For<IAuthProxyClient>();
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
              .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
 
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
             proxy, Substitute.For<ITenantPicker>(),
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
 
-        await Assert.That(outcome.ExitCode).IsEqualTo(1);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.NoTenants>();
     }
 
     [Test]
-    public async Task RunAsync_provisions_when_no_tenants_and_provisioner_creates() {
+    public async Task DiscoverAsync_provisions_when_no_tenants_and_provisioner_creates() {
         var proxyConfig = new ProxyConfigResponse { WorkOSClientId = "client_d" };
         var proxy = Substitute.For<IAuthProxyClient>();
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
@@ -122,13 +127,18 @@ public class WorkOSDiscoveryTests {
         var orgless  = new WorkOSAuthResponse { User = new() { Id = "user_x", FirstName = "Ada" }, AccessToken = "acc", RefreshToken = "rt" };
         var switched = new WorkOSAuthResponse { User = new() { Id = "user_x" }, OrganizationId = "org_new", AccessToken = "acc2", RefreshToken = "rt2" };
 
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", proxyConfig, proxy, Substitute.For<ITenantPicker>(),
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(orgless),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(switched),
             provisioner:  provisioner);
 
-        await Assert.That(outcome.ExitCode).IsEqualTo(0);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Ready>();
+
+        var result = await WorkOSDiscovery.PublishAsync(
+            (WorkOSDiscoveryFlow.Ready)flow, new RecordingAuthProgress(), beforeCommit: null, CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<AuthResult.Committed>();
 
         var stored = await TokenStore.LoadAsync("acme");
         await Assert.That(stored).IsNotNull();
@@ -144,7 +154,7 @@ public class WorkOSDiscoveryTests {
     }
 
     [Test]
-    public async Task RunAsync_uses_rotated_refresh_token_for_org_switch_when_poll_refreshed() {
+    public async Task DiscoverAsync_uses_rotated_refresh_token_for_org_switch_when_poll_refreshed() {
         var proxyConfig = new ProxyConfigResponse { WorkOSClientId = "client_d" };
         var proxy = Substitute.For<IAuthProxyClient>();
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
@@ -164,7 +174,7 @@ public class WorkOSDiscoveryTests {
                    });
 
         string? switchRefreshToken = null;
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", proxyConfig, proxy, Substitute.For<ITenantPicker>(),
             orglessLogin:   ()      => Task.FromResult<WorkOSAuthResponse?>(orgless),
             orgSwitch:      (rt, _) => { switchRefreshToken = rt; return Task.FromResult<WorkOSAuthResponse?>(switched); },
@@ -172,12 +182,12 @@ public class WorkOSDiscoveryTests {
                 new WorkOSAuthResponse { AccessToken = JwtWithExp(DateTimeOffset.UtcNow.AddMinutes(5)), RefreshToken = "R1" }),
             provisioner:    provisioner);
 
-        await Assert.That(outcome.ExitCode).IsEqualTo(0);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Ready>();
         await Assert.That(switchRefreshToken).IsEqualTo("R1"); // rotated token, not the consumed login-time R0
     }
 
     [Test]
-    public async Task RunAsync_hands_back_the_workspace_the_user_already_has_instead_of_provisioning() {
+    public async Task DiscoverAsync_hands_back_the_workspace_the_user_already_has_instead_of_provisioning() {
         var proxy = Substitute.For<IAuthProxyClient>();
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
              .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
@@ -187,7 +197,7 @@ public class WorkOSDiscoveryTests {
                    .Returns(Task.FromResult(ProvisionOffer.ExistingWorkspace("kurrent")));
 
         var switchCalled = false;
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
             proxy, Substitute.For<ITenantPicker>(),
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
@@ -196,11 +206,8 @@ public class WorkOSDiscoveryTests {
 
         // The input comes back unresolved — expanding "kurrent" to a URL, and picking the auth
         // provider from that server, both belong to the caller.
-        await Assert.That(outcome.RetargetServerInput).IsEqualTo("kurrent");
-
-        // Non-zero, so a caller that ignores RetargetServerInput fails loudly rather than
-        // claiming success after configuring nothing.
-        await Assert.That(outcome.ExitCode).IsNotEqualTo(0);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Retarget>();
+        await Assert.That(((WorkOSDiscoveryFlow.Retarget)flow).ServerInput).IsEqualTo("kurrent");
 
         // Nothing WorkOS-shaped happened: no org-switch, no profile, no token.
         await Assert.That(switchCalled).IsFalse();
@@ -208,7 +215,7 @@ public class WorkOSDiscoveryTests {
     }
 
     [Test]
-    public async Task RunAsync_treats_a_blank_existing_workspace_input_as_no_retarget() {
+    public async Task DiscoverAsync_treats_a_blank_existing_workspace_input_as_no_retarget() {
         var proxy = Substitute.For<IAuthProxyClient>();
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
              .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
@@ -217,7 +224,7 @@ public class WorkOSDiscoveryTests {
         provisioner.OfferCreateAsync(Arg.Any<WorkOSTokenSource>(), Arg.Any<CancellationToken>())
                    .Returns(Task.FromResult(ProvisionOffer.ExistingWorkspace("   ")));
 
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
             proxy, Substitute.For<ITenantPicker>(),
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
@@ -226,12 +233,11 @@ public class WorkOSDiscoveryTests {
 
         // Whitespace would resolve to "https://   .kcap.ai" downstream; refuse it here so the
         // caller never probes a nonsense host.
-        await Assert.That(outcome.RetargetServerInput).IsNull();
-        await Assert.That(outcome.ExitCode).IsEqualTo(1);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Failed>();
     }
 
     [Test]
-    public async Task RunAsync_returns_1_without_legacy_error_when_provisioner_declines() {
+    public async Task DiscoverAsync_returns_Failed_without_legacy_error_when_provisioner_declines() {
         var proxy = Substitute.For<IAuthProxyClient>();
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
              .Returns(Task.FromResult(new DiscoveryResult([], DiscoveryError.None)));
@@ -241,14 +247,14 @@ public class WorkOSDiscoveryTests {
                    .Returns(Task.FromResult(ProvisionOffer.Declined));
 
         var switchCalled = false;
-        var outcome = await WorkOSDiscovery.RunAsync(
+        var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
             proxy, Substitute.For<ITenantPicker>(),
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => { switchCalled = true; return Task.FromResult<WorkOSAuthResponse?>(null); },
             provisioner: provisioner);
 
-        await Assert.That(outcome.ExitCode).IsEqualTo(1);
+        await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Failed>();
         await Assert.That(switchCalled).IsFalse();
     }
 }


### PR DESCRIPTION
Part of #553. AI-1655

Completes the AI-1655 onboarding scope on top of the Plan A substrate (#556) and Plan B app lane/claims/gate (#562):

- **Core onboarding façade** (`OnboardingFacade`): GUI-neutral sign-in operations (known-server login, GitHub/WorkOS discover-and-join, create-workspace) over the existing flows, with cancellation + async tenant picker threaded through, a structured `IAuthProgress` sink replacing Console writes (exact-string console adapter for the CLI), and an ordered commit boundary — before-commit claim hook → config + `auth_provider` stamp (one mutation) → tokens, under `CancellationToken.None` once entered. The boundary is total: publication exceptions never escape raw (config failure → `Failed`, post-config → `Committed` + credentials warning, per-tenant exchange failures warn and continue).
- **`kcap setup` / `kcap login` re-plumbed** onto the façade through thin Spectre adapters. Behavior-preserving except the adjudicated list below.
- **Desktop onboarding wizard** (8 steps per the spec §3 flow) with wizard-first startup: gate-incomplete machines boot into the wizard with NO daemon graph; on close the app cancels/awaits the auth lane, quiesces the mutation lane (past the cap → auto-actions permanently closed + attention), transfers the outcome-channel consumer, re-resolves fresh, and builds the normal graph. The daemon step drives AI-1654's full state matrix through the Plan B mutation lane (waiter results state-only; claim application via the identity-checked v2 put).
- **§7 streaming import runner** (bounded 500-line tails, KillTree cancel) + `KcapCli` plugin-install/import verbs + terminal-PATH-fed `AgentDetection`.

**Adjudicated behavior deltas (CLI):**
- Setup's GitHub discovery now publishes one token per discovered tenant inside the boundary (was: deferred exchange for the active profile only); Step 2 reports login complete like the WorkOS branch.
- Tenant exchanges run serially inside the boundary with per-tenant catch (was `Task.WhenAll`).
- `kcap login`/`kcap setup` now write the `auth_provider` stamp (spec-intended recovery); `ExchangeAndSaveAsync`'s save is now cancellable.
- A `None`-server login against a foreign profile (env-override edge) fails honestly instead of silently writing nothing; `kcap login` never repoints `server_url` (`adoptServer` stays false; setup/wizard pass true).
- Setup's "Contacting auth service" spinner is gone (progress now flows through the Core sink); "Discovered N tenant(s)" derives from the committed identity set.

**Notes and accepted residuals:**
- The wizard's step-7 claim put is get-then-put to preserve a pre-existing daemon's rules/timeout (the spec's factory guard is coordinator-scoped; the v2 identity echo is the guard). An operator-chosen `deny` is respected (no put, claim retained).
- Path-routed self-hosted servers are not expressible in the wizard's Paste field (`ToServerOrigin` strips paths per spec §3); `kcap setup <url>` remains the path for them.
- Post-boundary wizard close awaits `Committed` uncapped (decision 2); a façade hang there leaves a windowless app recoverable via Quit (60 s shutdown cap).
- A transient gate-evaluation failure shows the wizard's "requires sign-in" daemon row to an actually-signed-in user (degrade-of-a-degrade, fail-closed).
- A wizard user whose kcap install can't resolve its daemon binary sees enable/takeover/repair withdrawn with reinstall guidance; a claim for a manual matching daemon is then retained for the post-wizard coordinator.
- Multi-identity arm failures can leave an inert pending claim (safe direction, upsert-idempotent); provisioning-timeout keeps a generic headline with the accurate "still provisioning — join `<slug>` from the Connect step" detail (Core signal follow-up).
- Spec riders for all deviations are appended to `docs/superpowers/specs/2026-08-12-ai1655-onboarding-wizard-design.md`; the two-adapter observation design remains superseded by one-shot probes (carried from #562).
- Merged main's warning-regime enforcement mid-plan and conformed the new code; one main-identical daemon line got a method-group conversion (local-SDK IDE0200 skew, no behavior change).

Suites: app 1127/1127, CLI integration 225/225, CLI unit green (documented local flaky families only), AOT publish clean for both binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)