### PR TITLE
Codex app-server: launch-input layer (MCP isolation, posture, hook-trust)

### DIFF
--- a/src/Capacitor.Cli.Core/Harness/Codex/CodexHooksParser.cs
+++ b/src/Capacitor.Cli.Core/Harness/Codex/CodexHooksParser.cs
@@ -34,15 +34,26 @@ public static class CodexHooksParser {
         foreach (var hook in hooks) {
             if (hook?["command"] is JsonValue jv &&
                 jv.TryGetValue<string>(out var cmd) &&
-                (cmd.Contains("kcap hook --codex",      StringComparison.Ordinal)
-              || cmd.Contains("kcap codex-hook",        StringComparison.Ordinal)
-              || cmd.Contains("kapacitor codex-hook",   StringComparison.Ordinal))) {
+                IsCapacitorCodexHookCommand(cmd)) {
                 return true;
             }
         }
 
         return false;
     }
+
+    /// <summary>
+    /// Returns true if <paramref name="command"/> invokes the kcap Codex hook dispatcher —
+    /// the current <c>kcap hook --codex</c> marker or the two earlier forms
+    /// (<c>kcap codex-hook</c>, <c>kapacitor codex-hook</c>). The single source of truth for
+    /// "is this a kcap-owned Codex hook", shared by the hooks.json preflight and the
+    /// app-server <c>hooks/list</c> trust classifier.
+    /// </summary>
+    public static bool IsCapacitorCodexHookCommand(string? command) =>
+        command is not null &&
+        (command.Contains("kcap hook --codex",    StringComparison.Ordinal)
+      || command.Contains("kcap codex-hook",      StringComparison.Ordinal)
+      || command.Contains("kapacitor codex-hook", StringComparison.Ordinal));
 
     /// <summary>
     /// Returns true if every event in <paramref name="events"/> has at least one

--- a/src/Capacitor.Cli.Core/Harness/Codex/CodexHooksParser.cs
+++ b/src/Capacitor.Cli.Core/Harness/Codex/CodexHooksParser.cs
@@ -43,17 +43,39 @@ public static class CodexHooksParser {
     }
 
     /// <summary>
-    /// Returns true if <paramref name="command"/> invokes the kcap Codex hook dispatcher —
-    /// the current <c>kcap hook --codex</c> marker or the two earlier forms
-    /// (<c>kcap codex-hook</c>, <c>kapacitor codex-hook</c>). The single source of truth for
-    /// "is this a kcap-owned Codex hook", shared by the hooks.json preflight and the
-    /// app-server <c>hooks/list</c> trust classifier.
+    /// Returns true if <paramref name="command"/> actually INVOKES the kcap Codex hook dispatcher —
+    /// the current <c>kcap hook --codex</c> form or the two earlier ones (<c>kcap codex-hook</c>,
+    /// <c>kapacitor codex-hook</c>), matched as the command's real executable + arguments rather than
+    /// a substring. Substring matching would let a foreign command spoof ownership by embedding a
+    /// marker (<c>evil # kcap codex-hook</c>) and, since the app-server trust classifier seeds trust
+    /// for the hooks it recognises and project-scope <c>.codex/hooks.json</c> from an untrusted branch
+    /// is overlaid into the reviewer's worktree, that would trust-seed and run an arbitrary hook.
+    /// The executable is compared by basename so a path-qualified <c>/usr/local/bin/kcap</c> still
+    /// matches; anything else fails closed (recognised as NOT kcap-owned, so never seeded).
+    /// The single source of truth for "is this a kcap-owned Codex hook", shared by the hooks.json
+    /// preflight and the app-server <c>hooks/list</c> trust classifier.
     /// </summary>
-    public static bool IsCapacitorCodexHookCommand(string? command) =>
-        command is not null &&
-        (command.Contains("kcap hook --codex",    StringComparison.Ordinal)
-      || command.Contains("kcap codex-hook",      StringComparison.Ordinal)
-      || command.Contains("kapacitor codex-hook", StringComparison.Ordinal));
+    public static bool IsCapacitorCodexHookCommand(string? command) {
+        if (command is null) return false;
+
+        var tokens = command.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0) return false;
+
+        var exe = ExecutableName(tokens[0]);
+
+        // Current form: `kcap hook --codex`.
+        if (exe is "kcap" or "kcap.exe" && tokens is [_, "hook", "--codex"]) return true;
+
+        // Legacy forms: `kcap codex-hook` (pre-consolidation), `kapacitor codex-hook` (pre-rename).
+        return exe is "kcap" or "kcap.exe" or "kapacitor" or "kapacitor.exe" && tokens is [_, "codex-hook"];
+    }
+
+    /// <summary>Basename of a possibly path-qualified executable token, so a path-qualified kcap
+    /// binary still matches while a marker buried in a later argument or comment does not.</summary>
+    static string ExecutableName(string token) {
+        var slash = token.LastIndexOfAny(['/', '\\']);
+        return slash >= 0 ? token[(slash + 1)..] : token;
+    }
 
     /// <summary>
     /// Returns true if every event in <paramref name="events"/> has at least one

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerPosture.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerPosture.cs
@@ -1,0 +1,47 @@
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// Renders a resolved Codex posture — the <c>(sandbox, approval)</c> pair from
+/// <see cref="CodexPosturePolicy.Resolve"/> — into the JSON shapes the <c>codex app-server</c>
+/// protocol expects, mirroring how <see cref="CodexLauncher"/> renders the same pair into PTY argv.
+///
+/// <para>Two invariants pinned by the app-server protocol spike and enforced here:
+/// (1) <c>approvalPolicy</c> is a plain kebab-case STRING — the granular <c>{granular:{…}}</c> object
+/// form crashes the app-server process on <c>turn/start</c> (immediate stdout EOF); and
+/// (2) approvals are always routed to the client (<c>approvalsReviewer = "user"</c>) so a user-config
+/// <c>approvals_reviewer = "auto_review"</c> Guardian can never auto-approve a sandbox escalation.</para>
+/// </summary>
+internal static class CodexAppServerPosture {
+    /// <summary>Approvals always route to the client, never Codex's own auto-review subagent.
+    /// Slotted into <c>thread/start</c>'s <c>approvalsReviewer</c>.</summary>
+    public const string ApprovalsReviewer = "user";
+
+    /// <summary>The <c>sandboxPolicy</c> object for <c>turn/start</c>. <paramref name="writableRoots"/>
+    /// applies only to <c>workspace-write</c> (the reviewer's owned worktree); it is ignored for the
+    /// other postures. <c>networkAccess</c> is left unset (defaults false) — reviewers get no network.</summary>
+    public static JsonObject RenderSandboxPolicy(string sandbox, IReadOnlyList<string> writableRoots) => sandbox switch {
+        "read-only"          => new JsonObject { ["type"] = "readOnly" },
+        "danger-full-access" => new JsonObject { ["type"] = "dangerFullAccess" },
+        "workspace-write"    => RenderWorkspaceWrite(writableRoots),
+        _ => throw new ArgumentOutOfRangeException(nameof(sandbox), sandbox,
+            "Unknown Codex sandbox; app-server posture accepts only read-only, workspace-write, danger-full-access."),
+    };
+
+    static JsonObject RenderWorkspaceWrite(IReadOnlyList<string> writableRoots) {
+        var roots = new JsonArray();
+        foreach (var root in writableRoots) roots.Add((JsonNode?) root);
+        return new JsonObject { ["type"] = "workspaceWrite", ["writableRoots"] = roots };
+    }
+
+    /// <summary>Validates the approval policy is one of the three known kebab-case strings and returns
+    /// it verbatim — the value slotted into <c>turn/start</c>'s <c>approvalPolicy</c>. Anything else is
+    /// rejected loudly: an unknown token or a granular object would either crash the app-server or
+    /// silently loosen containment.</summary>
+    public static string RenderApprovalPolicy(string approval) => approval switch {
+        "never" or "on-request" or "untrusted" => approval,
+        _ => throw new ArgumentOutOfRangeException(nameof(approval), approval,
+            "Unknown Codex approval policy; app-server posture accepts only never, on-request, untrusted."),
+    };
+}

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHookTrust.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHookTrust.cs
@@ -1,0 +1,95 @@
+using Capacitor.Cli.Core.Harness.Codex;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>One hook as reported by the <c>codex app-server</c> <c>hooks/list</c> response.</summary>
+/// <param name="Key">The opaque per-hook key (<c>&lt;hooks.json path&gt;:&lt;event&gt;:i:j</c>), used verbatim
+/// as the <c>hooks.state</c> table key when seeding trust.</param>
+/// <param name="EventName">The hook event (protocol camelCase, e.g. <c>sessionStart</c>).</param>
+/// <param name="Command">The hook's command line — how a kcap-owned hook is identified.</param>
+/// <param name="CurrentHash">The hook's current content hash (<c>sha256:…</c>), or null if the
+/// response omitted it (then the hook cannot be seeded).</param>
+/// <param name="TrustStatus">The reported trust state (<c>trusted</c> / <c>untrusted</c>).</param>
+internal readonly record struct CodexHookEntry(
+    string Key, string EventName, string Command, string? CurrentHash, string TrustStatus);
+
+/// <summary>The classifier's verdict for one launch's <c>hooks/list</c> snapshot.</summary>
+internal abstract record CodexHookTrustDecision {
+    /// <summary>Every required critical event has a trusted kcap-owned hook — launch as-is.</summary>
+    public sealed record Proceed : CodexHookTrustDecision;
+
+    /// <summary>One or more kcap-owned hooks are untrusted but seedable. Restart the app-server
+    /// process with <c>-c &lt;StateOverride&gt;</c>, then re-run <c>hooks/list</c> to verify.</summary>
+    public sealed record SeedAndRestart(string StateOverride) : CodexHookTrustDecision;
+
+    /// <summary>A required critical event has no kcap-owned hook at all — seeding cannot conjure a
+    /// hook that isn't configured. Fail closed (the <c>CodexHooksNotInstalledException</c> case).</summary>
+    public sealed record MissingRequiredHooks(IReadOnlyList<string> MissingEvents) : CodexHookTrustDecision;
+
+    /// <summary>An untrusted kcap-owned hook reported no <c>currentHash</c>, so its trust cannot be
+    /// seeded. Fail closed rather than proceed with a hook that will be silently skipped.</summary>
+    public sealed record Unseedable(IReadOnlyList<string> Keys) : CodexHookTrustDecision;
+}
+
+/// <summary>
+/// Classifies an app-server <c>hooks/list</c> snapshot into a trust decision, and builds the
+/// full-table <c>hooks.state</c> override used to seed trust for kcap-owned hooks.
+///
+/// <para>Why this exists: <c>codex app-server</c> silently SKIPS a hook whose
+/// <c>[hooks.state]</c> <c>trusted_hash</c> is missing or stale — and it does not accept the
+/// TUI/exec-only <c>--dangerously-bypass-hook-trust</c> flag — so a hosted launch whose ingestion
+/// rides those hooks would lose the transcript with no error. The launch path therefore verifies
+/// trust before its first turn: absence of a required hook fails closed (seeding can't create one),
+/// distrust of a present kcap hook is repaired by one seeded restart, and the seed is verified after
+/// the restart (that re-run is the runtime's; this class is the pure classify + build step).</para>
+///
+/// <para>The dotted-KEY <c>-c hooks.state.&lt;key&gt;.trusted_hash=…</c> form silently fails on these
+/// path-shaped keys (the same clap/TOML limitation the <c>mcp_servers</c> override hits), so the
+/// override is emitted as ONE full-table value, exactly like the MCP-isolation table.</para>
+/// </summary>
+internal static class CodexHookTrust {
+    /// <summary>The critical events a hosted launch requires a kcap hook for — single-sourced to
+    /// match <see cref="CodexLauncher"/>'s hooks.json preflight. Compared case-insensitively so the
+    /// protocol's camelCase <c>eventName</c> matches these hooks.json-style names.</summary>
+    static readonly string[] CriticalEvents = ["SessionStart", "Stop", "PermissionRequest"];
+
+    const string TrustedStatus = "trusted";
+
+    public static CodexHookTrustDecision Classify(IReadOnlyList<CodexHookEntry> hooks) {
+        var kcapHooks = hooks.Where(h => CodexHooksParser.IsCapacitorCodexHookCommand(h.Command)).ToArray();
+
+        // Inventory: every critical event must have at least one kcap-owned hook. Seeding never
+        // conjures a hook that isn't configured, so an absent one is a fail-closed launch failure.
+        var missing = CriticalEvents
+            .Where(evt => !kcapHooks.Any(h => EventMatches(h.EventName, evt)))
+            .ToArray();
+
+        if (missing.Length > 0) return new CodexHookTrustDecision.MissingRequiredHooks(missing);
+
+        // Trust: seed EVERY untrusted kcap-owned hook (not only the critical ones — the transcript
+        // hooks must fire too), so a single restart makes the whole kcap hook set trusted.
+        var untrusted = kcapHooks
+            .Where(h => !string.Equals(h.TrustStatus, TrustedStatus, StringComparison.Ordinal))
+            .ToArray();
+
+        if (untrusted.Length == 0) return new CodexHookTrustDecision.Proceed();
+
+        var unseedable = untrusted.Where(h => string.IsNullOrEmpty(h.CurrentHash)).Select(h => h.Key).ToArray();
+
+        if (unseedable.Length > 0) return new CodexHookTrustDecision.Unseedable(unseedable);
+
+        return new CodexHookTrustDecision.SeedAndRestart(BuildStateOverride(untrusted));
+    }
+
+    /// <summary>Builds the <c>hooks.state={ "&lt;key&gt;"={trusted_hash="&lt;hash&gt;"}, … }</c>
+    /// full-table override value for the given (untrusted, seedable) kcap hooks.</summary>
+    static string BuildStateOverride(IReadOnlyList<CodexHookEntry> untrusted) {
+        var entries = untrusted.Select(h =>
+            $"{CodexToml.String(h.Key)}={{trusted_hash={CodexToml.String(h.CurrentHash!)}}}");
+
+        return $"hooks.state={{{string.Join(",", entries)}}}";
+    }
+
+    static bool EventMatches(string reported, string critical) =>
+        string.Equals(reported, critical, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexLauncher.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Commands;
@@ -189,9 +188,7 @@ internal sealed partial class CodexLauncher(
         // Fail-closed: if the inherited set can't be enumerated, DisableInheritedMcpServers
         // throws and the launch is rejected rather than proceeding with nothing disabled.
         if (ctx.IsReviewFlow) {
-            DisableInheritedMcpServers(args, ctx);
-            AddFlowResultServer(args, ctx);
-            AddAllowlistServers(args, ctx);
+            AppendMcpIsolationArgs(args, ctx, appServer: false);
         }
 
         AddModelArg(args, ctx.Model);
@@ -212,6 +209,34 @@ internal sealed partial class CodexLauncher(
         }
 
         return new([.. args], McpConfigPath: null);
+    }
+
+    /// <summary>The shared MCP-isolation pass used by both transports: disable every inherited
+    /// server, force-enable the flow-result server, materialize the allowlist. <paramref name="appServer"/>
+    /// additionally stamps <c>default_tools_approval_mode="approve"</c> on each whitelisted server —
+    /// required only for the <c>codex app-server</c> transport, where the first tool call otherwise
+    /// raises an approval that wedges the turn even under <c>approvalPolicy: never</c> (the PTY TUI
+    /// does not). Emitting them here (rather than duplicating the isolation in the app-server builder)
+    /// keeps the two transports' overrides byte-identical apart from that one arm.</summary>
+    void AppendMcpIsolationArgs(List<string> args, LauncherContext ctx, bool appServer) {
+        DisableInheritedMcpServers(args, ctx);
+        AddFlowResultServer(args, ctx, appServer);
+        AddAllowlistServers(args, ctx, appServer);
+    }
+
+    /// <summary>Builds the argv passed to <c>codex app-server</c> (the tokens after the
+    /// <c>app-server</c> subcommand) for a hosted review-flow reviewer: <c>--disable apps</c> — the
+    /// <c>codex_apps</c> ChatGPT-connector runtime is not an <c>mcp_servers</c> entry and bypasses the
+    /// disable table, so it must be turned off explicitly — plus the shared MCP-isolation <c>-c</c>
+    /// overrides (with the per-whitelisted-server approval-mode arm). Sandbox, approval, model and
+    /// effort are per-turn protocol parameters on the app-server transport, not argv, so none appear
+    /// here.</summary>
+    public IReadOnlyList<string> BuildAppServerLaunchArgs(LauncherContext ctx) {
+        var args = new List<string> { "--disable", "apps" };
+
+        if (ctx.IsReviewFlow) AppendMcpIsolationArgs(args, ctx, appServer: true);
+
+        return args;
     }
 
     /// <summary>
@@ -297,7 +322,7 @@ internal sealed partial class CodexLauncher(
     /// <summary>Registers the reviewer-side result-submission server. Skipped (zero
     /// servers — the recursion-safe default) when the daemon has no server URL or kcap path;
     /// the reviewer then falls back to the transcript marker per the prompt contract.</summary>
-    void AddFlowResultServer(List<string> args, LauncherContext ctx) {
+    void AddFlowResultServer(List<string> args, LauncherContext ctx, bool appServer) {
         if (string.IsNullOrWhiteSpace(config.ServerUrl) || string.IsNullOrWhiteSpace(config.CapacitorPath)) return;
 
         const string name = "kcap-flow-result";
@@ -314,6 +339,7 @@ internal sealed partial class CodexLauncher(
         args.Add($"mcp_servers.{name}.args=[{TomlString("mcp")},{TomlString("flow-result")}]");
         args.Add("-c");
         args.Add($"mcp_servers.{name}.env={{KCAP_URL={TomlString(config.ServerUrl)},KCAP_FLOW_AGENT_ID={TomlString(ctx.AgentId)}}}");
+        AddAppServerApprovalMode(args, name, appServer);
     }
 
     /// <summary> D-c: materializes the flow definition's <see cref="LauncherContext.McpAllowlist"/>
@@ -324,7 +350,7 @@ internal sealed partial class CodexLauncher(
     /// Allowlist servers get KCAP_URL only — never KCAP_FLOW_AGENT_ID, which is exclusive to
     /// the flow-result submission channel. Skipped (same as the flow-result server) when the
     /// daemon has no server URL or kcap path configured.</summary>
-    void AddAllowlistServers(List<string> args, LauncherContext ctx) {
+    void AddAllowlistServers(List<string> args, LauncherContext ctx, bool appServer) {
         if (string.IsNullOrWhiteSpace(config.ServerUrl) || string.IsNullOrWhiteSpace(config.CapacitorPath)) return;
 
         foreach (var name in ctx.McpAllowlist ?? []) {
@@ -355,7 +381,20 @@ internal sealed partial class CodexLauncher(
             args.Add($"mcp_servers.{id}.args=[{argsList}]");
             args.Add("-c");
             args.Add($"mcp_servers.{id}.env={{KCAP_URL={TomlString(config.ServerUrl)}}}");
+            AddAppServerApprovalMode(args, id, appServer);
         }
+    }
+
+    /// <summary>On the app-server transport only, pre-approve a whitelisted server's tools:
+    /// <c>codex app-server</c> raises an approval on the FIRST tool call of an untrusted MCP server
+    /// even under <c>approvalPolicy: never</c>, which would wedge an unattended reviewer's turn.
+    /// <c>default_tools_approval_mode="approve"</c> suppresses it (<c>trust_level</c> does not).
+    /// A no-op for the PTY transport.</summary>
+    static void AddAppServerApprovalMode(List<string> args, string serverId, bool appServer) {
+        if (!appServer) return;
+
+        args.Add("-c");
+        args.Add($"mcp_servers.{serverId}.default_tools_approval_mode=\"approve\"");
     }
 
     /// Append `-m &lt;model&gt;` unless the model is empty or the "default" no-override sentinel.
@@ -415,35 +454,9 @@ internal sealed partial class CodexLauncher(
     /// backslashes, double quotes, and control characters. TOML basic strings forbid
     /// raw control chars, so an unescaped tab/newline/CR would yield invalid TOML and
     /// fail the Codex `-c` config parse. Covers Windows paths and arbitrary URLs.
-    static string TomlString(string value) {
-        var sb = new StringBuilder(value.Length + 2);
-        sb.Append('"');
-
-        foreach (var c in value) {
-            switch (c) {
-                case '\\': sb.Append("\\\\"); break;
-                case '"':  sb.Append("\\\""); break;
-                case '\b': sb.Append("\\b");  break;
-                case '\t': sb.Append("\\t");  break;
-                case '\n': sb.Append("\\n");  break;
-                case '\f': sb.Append("\\f");  break;
-                case '\r': sb.Append("\\r");  break;
-                default:
-                    // Remaining C0 controls (and DEL) have no short escape — emit \uXXXX.
-                    if (c < ' ' || c == (char)0x7f) {
-                        sb.Append("\\u").Append(((int)c).ToString("X4"));
-                    } else {
-                        sb.Append(c);
-                    }
-
-                    break;
-            }
-        }
-
-        sb.Append('"');
-
-        return sb.ToString();
-    }
+    // Shared with the codex app-server argv builder so the two transports encode -c overrides
+    // identically; the implementation lives in CodexToml.
+    static string TomlString(string value) => CodexToml.String(value);
 
     /// Local launch: emit the mandatory daemon-level flags Codex always needs, then append
     /// the user's verbatim post-`--` args. A user duplicate of a mandatory flag is rejected

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexToml.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexToml.cs
@@ -1,0 +1,44 @@
+using System.Text;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// TOML encoding shared by every Codex launch surface that splices values into <c>-c</c> config
+/// overrides — the PTY argv (<see cref="CodexLauncher"/>) and the <c>codex app-server</c> argv.
+/// A single encoder keeps the <c>mcp_servers</c> / <c>hooks.state</c> overrides byte-identical
+/// across transports and stops the escaping rules from drifting apart.
+/// </summary>
+internal static class CodexToml {
+    /// <summary>Encodes <paramref name="value"/> as a TOML basic (double-quoted) string, escaping
+    /// backslash, quote, the short-form control escapes, and any remaining C0 control / DEL as
+    /// <c>\uXXXX</c>. The result includes the surrounding quotes.</summary>
+    public static string String(string value) {
+        var sb = new StringBuilder(value.Length + 2);
+        sb.Append('"');
+
+        foreach (var c in value) {
+            switch (c) {
+                case '\\': sb.Append("\\\\"); break;
+                case '"':  sb.Append("\\\""); break;
+                case '\b': sb.Append("\\b");  break;
+                case '\t': sb.Append("\\t");  break;
+                case '\n': sb.Append("\\n");  break;
+                case '\f': sb.Append("\\f");  break;
+                case '\r': sb.Append("\\r");  break;
+                default:
+                    // Remaining C0 controls (and DEL) have no short escape — emit \uXXXX.
+                    if (c < ' ' || c == (char) 0x7f) {
+                        sb.Append("\\u").Append(((int) c).ToString("X4"));
+                    } else {
+                        sb.Append(c);
+                    }
+
+                    break;
+            }
+        }
+
+        sb.Append('"');
+
+        return sb.ToString();
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexHooksParserTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexHooksParserTests.cs
@@ -74,4 +74,18 @@ public class CodexHooksParserTests {
             await Assert.That(CodexHooksParser.CodexHookEvents[i]).IsEqualTo(expected[i]);
         }
     }
+
+    [Test]
+    [Arguments("rm -rf / # kcap codex-hook")]     // marker buried in a shell comment
+    [Arguments("evil kcap hook --codex")]          // marker is an argument, not the executable
+    [Arguments("kcap-wrapper hook --codex")]       // executable is not kcap
+    public async Task IsCapacitorCodexHookCommand_rejects_embedded_or_spoofed_marker(string command) {
+        await Assert.That(CodexHooksParser.IsCapacitorCodexHookCommand(command)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsCapacitorCodexHookCommand_accepts_path_qualified_kcap() {
+        await Assert.That(CodexHooksParser.IsCapacitorCodexHookCommand("/usr/local/bin/kcap hook --codex")).IsTrue();
+        await Assert.That(CodexHooksParser.IsCapacitorCodexHookCommand("/opt/kcap codex-hook")).IsTrue();
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerLaunchArgsTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerLaunchArgsTests.cs
@@ -1,0 +1,89 @@
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>The app-server argv reuses the exact same MCP-isolation passes as the PTY path (proven
+/// byte-identical by the shared CodexLauncherTests) and adds the two app-server-only arms:
+/// <c>--disable apps</c> and per-whitelisted-server <c>default_tools_approval_mode="approve"</c>.
+/// Sandbox / approval / model / effort are per-turn protocol params on this transport, so none of
+/// the PTY-only flags appear.</summary>
+[NotInParallel("HomeEnvVarMutation")]
+public class CodexAppServerLaunchArgsTests {
+    static CodexLauncher NewLauncher() =>
+        new(new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" },
+            NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServers = static () => [new("kcap-flows"), new("node_repl")]
+        };
+
+    static LauncherContext FlowCtx(string[]? allowlist = null) => new LauncherContext(
+        AgentId: "agent-xyz",
+        SourceRepoPath: "/tmp/repo",
+        Worktree: new WorktreeInfo(Path: "/tmp/wt", Branch: "wt-branch", SourceRepo: "/tmp/repo"),
+        Prompt: null,
+        Model: "gpt-5.3-codex",
+        Effort: "high",
+        Tools: null,
+        IsReview: false,
+        IsReviewFlow: true,
+        Review: null,
+        ReviewLaunch: null
+    ) { McpAllowlist = allowlist };
+
+    static string? DisableTableOverride(IReadOnlyList<string> args) =>
+        args.FirstOrDefault(a => a.StartsWith("mcp_servers={", StringComparison.Ordinal));
+
+    [Test]
+    public async Task Disables_the_codex_apps_connector_runtime() {
+        var args = NewLauncher().BuildAppServerLaunchArgs(FlowCtx());
+        var i = args.ToList().IndexOf("--disable");
+        await Assert.That(i).IsGreaterThan(-1);
+        await Assert.That(args[i + 1]).IsEqualTo("apps");
+    }
+
+    [Test]
+    public async Task Isolates_inherited_servers_and_whitelists_flow_result() {
+        var args = NewLauncher().BuildAppServerLaunchArgs(FlowCtx());
+        // Same isolation table as PTY: every inherited server disabled.
+        await Assert.That(DisableTableOverride(args)!).Contains("\"kcap-flows\"={enabled=false");
+        await Assert.That(DisableTableOverride(args)!).Contains("\"node_repl\"={enabled=false");
+        // Flow-result force-enabled.
+        await Assert.That(args).Contains("mcp_servers.kcap-flow-result.enabled=true");
+    }
+
+    [Test]
+    public async Task Preapproves_flow_result_server_tools() {
+        var args = NewLauncher().BuildAppServerLaunchArgs(FlowCtx());
+        await Assert.That(args).Contains("mcp_servers.kcap-flow-result.default_tools_approval_mode=\"approve\"");
+    }
+
+    [Test]
+    public async Task Preapproves_each_allowlisted_server() {
+        var args = NewLauncher().BuildAppServerLaunchArgs(FlowCtx(["kcap-sessions"]));
+        await Assert.That(args).Contains("mcp_servers.kcap-sessions.enabled=true");
+        await Assert.That(args).Contains("mcp_servers.kcap-sessions.default_tools_approval_mode=\"approve\"");
+    }
+
+    [Test]
+    public async Task Omits_pty_only_flags() {
+        // Sandbox / approval / model / effort / cwd / alt-screen are all protocol params now.
+        var args = NewLauncher().BuildAppServerLaunchArgs(FlowCtx(["kcap-sessions"]));
+        await Assert.That(args).DoesNotContain("--cd");
+        await Assert.That(args).DoesNotContain("--sandbox");
+        await Assert.That(args).DoesNotContain("--ask-for-approval");
+        await Assert.That(args).DoesNotContain("--no-alt-screen");
+        await Assert.That(args).DoesNotContain("-m");
+        await Assert.That(string.Join(' ', args)).DoesNotContain("model_reasoning_effort");
+        // The TUI hook-trust bypass flag is rejected by app-server — never emit it.
+        await Assert.That(args).DoesNotContain("--dangerously-bypass-hook-trust");
+    }
+
+    [Test]
+    public async Task Pty_path_never_gets_the_app_server_arms() {
+        // Regression: BuildArgs (PTY) must not emit --disable apps or default_tools_approval_mode.
+        var pty = NewLauncher().BuildArgs(FlowCtx(["kcap-sessions"])).Args;
+        await Assert.That(string.Join(' ', pty)).DoesNotContain("default_tools_approval_mode");
+        await Assert.That(string.Join(' ', pty)).DoesNotContain("--disable");
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerLaunchArgsTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerLaunchArgsTests.cs
@@ -45,10 +45,8 @@ public class CodexAppServerLaunchArgsTests {
     [Test]
     public async Task Isolates_inherited_servers_and_whitelists_flow_result() {
         var args = NewLauncher().BuildAppServerLaunchArgs(FlowCtx());
-        // Same isolation table as PTY: every inherited server disabled.
         await Assert.That(DisableTableOverride(args)!).Contains("\"kcap-flows\"={enabled=false");
         await Assert.That(DisableTableOverride(args)!).Contains("\"node_repl\"={enabled=false");
-        // Flow-result force-enabled.
         await Assert.That(args).Contains("mcp_servers.kcap-flow-result.enabled=true");
     }
 
@@ -67,7 +65,7 @@ public class CodexAppServerLaunchArgsTests {
 
     [Test]
     public async Task Omits_pty_only_flags() {
-        // Sandbox / approval / model / effort / cwd / alt-screen are all protocol params now.
+        // Sandbox/approval/model/effort/cwd are per-turn protocol params on this transport, not argv.
         var args = NewLauncher().BuildAppServerLaunchArgs(FlowCtx(["kcap-sessions"]));
         await Assert.That(args).DoesNotContain("--cd");
         await Assert.That(args).DoesNotContain("--sandbox");
@@ -75,13 +73,12 @@ public class CodexAppServerLaunchArgsTests {
         await Assert.That(args).DoesNotContain("--no-alt-screen");
         await Assert.That(args).DoesNotContain("-m");
         await Assert.That(string.Join(' ', args)).DoesNotContain("model_reasoning_effort");
-        // The TUI hook-trust bypass flag is rejected by app-server — never emit it.
+        // app-server rejects the TUI-only hook-trust bypass flag — never emit it.
         await Assert.That(args).DoesNotContain("--dangerously-bypass-hook-trust");
     }
 
     [Test]
     public async Task Pty_path_never_gets_the_app_server_arms() {
-        // Regression: BuildArgs (PTY) must not emit --disable apps or default_tools_approval_mode.
         var pty = NewLauncher().BuildArgs(FlowCtx(["kcap-sessions"])).Args;
         await Assert.That(string.Join(' ', pty)).DoesNotContain("default_tools_approval_mode");
         await Assert.That(string.Join(' ', pty)).DoesNotContain("--disable");

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerPostureTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerPostureTests.cs
@@ -1,0 +1,68 @@
+using Capacitor.Cli.Daemon.Harness.Codex;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+public class CodexAppServerPostureTests {
+    [Test]
+    public async Task ReadOnly_renders_type_only_no_writable_roots() {
+        var json = CodexAppServerPosture.RenderSandboxPolicy("read-only", ["/tmp/wt"]).ToJsonString();
+        await Assert.That(json).IsEqualTo("{\"type\":\"readOnly\"}");
+    }
+
+    [Test]
+    public async Task WorkspaceWrite_renders_writable_roots() {
+        var json = CodexAppServerPosture.RenderSandboxPolicy("workspace-write", ["/tmp/wt"]).ToJsonString();
+        await Assert.That(json).IsEqualTo("{\"type\":\"workspaceWrite\",\"writableRoots\":[\"/tmp/wt\"]}");
+    }
+
+    [Test]
+    public async Task WorkspaceWrite_renders_multiple_roots_in_order() {
+        var json = CodexAppServerPosture.RenderSandboxPolicy("workspace-write", ["/a", "/b"]).ToJsonString();
+        await Assert.That(json).IsEqualTo("{\"type\":\"workspaceWrite\",\"writableRoots\":[\"/a\",\"/b\"]}");
+    }
+
+    [Test]
+    public async Task WorkspaceWrite_with_no_roots_emits_empty_array() {
+        var json = CodexAppServerPosture.RenderSandboxPolicy("workspace-write", []).ToJsonString();
+        await Assert.That(json).IsEqualTo("{\"type\":\"workspaceWrite\",\"writableRoots\":[]}");
+    }
+
+    [Test]
+    public async Task DangerFullAccess_renders_type_only() {
+        var json = CodexAppServerPosture.RenderSandboxPolicy("danger-full-access", []).ToJsonString();
+        await Assert.That(json).IsEqualTo("{\"type\":\"dangerFullAccess\"}");
+    }
+
+    [Test]
+    [Arguments("full")]
+    [Arguments("read_only")]
+    [Arguments("")]
+    public async Task Unknown_sandbox_throws(string sandbox) {
+        await Assert.That(() => CodexAppServerPosture.RenderSandboxPolicy(sandbox, []))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    [Arguments("never")]
+    [Arguments("on-request")]
+    [Arguments("untrusted")]
+    public async Task Known_approval_returns_verbatim(string approval) {
+        await Assert.That(CodexAppServerPosture.RenderApprovalPolicy(approval)).IsEqualTo(approval);
+    }
+
+    [Test]
+    [Arguments("on-failure")]   // deprecated in Codex; must not slip through
+    [Arguments("auto_review")]
+    [Arguments("")]
+    public async Task Unknown_approval_throws(string approval) {
+        await Assert.That(() => CodexAppServerPosture.RenderApprovalPolicy(approval))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Approvals_reviewer_is_pinned_to_user() {
+        // The Guardian containment pin: approvals always route to the client, never Codex's
+        // own auto_review subagent.
+        await Assert.That(CodexAppServerPosture.ApprovalsReviewer).IsEqualTo("user");
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHookTrustTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHookTrustTests.cs
@@ -1,0 +1,126 @@
+using Capacitor.Cli.Daemon.Harness.Codex;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+public class CodexHookTrustTests {
+    const string KcapCmd = "kcap hook --codex";
+
+    static CodexHookEntry Hook(
+        string evt, string status, string? hash = "sha256:abc", string cmd = KcapCmd, string? key = null) =>
+        new(Key: key ?? $"/home/u/.codex/hooks.json:{evt}:0:0",
+            EventName: evt, Command: cmd, CurrentHash: hash, TrustStatus: status);
+
+    // A complete, trusted kcap hook set covering the three critical events.
+    static List<CodexHookEntry> TrustedSet() => [
+        Hook("sessionStart",      "trusted"),
+        Hook("stop",              "trusted"),
+        Hook("permissionRequest", "trusted"),
+    ];
+
+    [Test]
+    public async Task All_trusted_kcap_hooks_present_proceeds() {
+        var d = CodexHookTrust.Classify(TrustedSet());
+        await Assert.That(d).IsTypeOf<CodexHookTrustDecision.Proceed>();
+    }
+
+    [Test]
+    public async Task Missing_a_critical_event_fails_closed() {
+        var hooks = TrustedSet();
+        hooks.RemoveAll(h => h.EventName == "stop");
+        var d = CodexHookTrust.Classify(hooks);
+        await Assert.That(d).IsTypeOf<CodexHookTrustDecision.MissingRequiredHooks>();
+        await Assert.That(((CodexHookTrustDecision.MissingRequiredHooks) d).MissingEvents).Contains("Stop");
+    }
+
+    [Test]
+    public async Task No_kcap_hooks_at_all_reports_all_critical_missing() {
+        // A non-kcap hook present for every event must not satisfy the inventory.
+        List<CodexHookEntry> foreign = [
+            Hook("sessionStart",      "trusted", cmd: "/usr/bin/other-hook"),
+            Hook("stop",              "trusted", cmd: "/usr/bin/other-hook"),
+            Hook("permissionRequest", "trusted", cmd: "/usr/bin/other-hook"),
+        ];
+        var d = CodexHookTrust.Classify(foreign);
+        await Assert.That(d).IsTypeOf<CodexHookTrustDecision.MissingRequiredHooks>();
+        await Assert.That(((CodexHookTrustDecision.MissingRequiredHooks) d).MissingEvents.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Untrusted_kcap_hook_seeds_full_table_override() {
+        var hooks = TrustedSet();
+        hooks[0] = hooks[0] with { TrustStatus = "untrusted", CurrentHash = "sha256:deadbeef",
+                                   Key = "/home/u/.codex/hooks.json:session_start:0:0" };
+        var d = CodexHookTrust.Classify(hooks);
+        await Assert.That(d).IsTypeOf<CodexHookTrustDecision.SeedAndRestart>();
+        var ov = ((CodexHookTrustDecision.SeedAndRestart) d).StateOverride;
+        // Full-table value, not a dotted key — the whole thing rides one `-c hooks.state={…}`.
+        await Assert.That(ov).StartsWith("hooks.state={");
+        await Assert.That(ov).Contains("\"/home/u/.codex/hooks.json:session_start:0:0\"={trusted_hash=\"sha256:deadbeef\"}");
+    }
+
+    [Test]
+    public async Task Seed_covers_only_untrusted_hooks() {
+        var hooks = TrustedSet();
+        hooks[1] = hooks[1] with { TrustStatus = "untrusted", Key = "K-stop", CurrentHash = "sha256:h" };
+        var d = CodexHookTrust.Classify(hooks);
+        var ov = ((CodexHookTrustDecision.SeedAndRestart) d).StateOverride;
+        await Assert.That(ov).Contains("\"K-stop\"=");
+        // The already-trusted ones are not re-stamped.
+        await Assert.That(ov).DoesNotContain("sessionStart");
+        await Assert.That(ov).DoesNotContain("permissionRequest");
+    }
+
+    [Test]
+    public async Task Seed_covers_untrusted_non_critical_kcap_hooks_too() {
+        // A transcript hook (preToolUse) that kcap owns must be seeded even though it is not
+        // one of the three critical inventory events.
+        var hooks = TrustedSet();
+        hooks.Add(Hook("preToolUse", "untrusted", hash: "sha256:pre", key: "K-pre"));
+        var d = CodexHookTrust.Classify(hooks);
+        var ov = ((CodexHookTrustDecision.SeedAndRestart) d).StateOverride;
+        await Assert.That(ov).Contains("\"K-pre\"={trusted_hash=\"sha256:pre\"}");
+    }
+
+    [Test]
+    public async Task Untrusted_kcap_hook_without_hash_is_unseedable() {
+        var hooks = TrustedSet();
+        hooks[0] = hooks[0] with { TrustStatus = "untrusted", CurrentHash = null, Key = "K-nohash" };
+        var d = CodexHookTrust.Classify(hooks);
+        await Assert.That(d).IsTypeOf<CodexHookTrustDecision.Unseedable>();
+        await Assert.That(((CodexHookTrustDecision.Unseedable) d).Keys).Contains("K-nohash");
+    }
+
+    [Test]
+    public async Task A_non_kcap_untrusted_hook_never_forces_a_seed() {
+        // A foreign untrusted hook the user owns is never trust-seeded by us.
+        var hooks = TrustedSet();
+        hooks.Add(Hook("stop", "untrusted", cmd: "/opt/other/hook", key: "K-foreign"));
+        var d = CodexHookTrust.Classify(hooks);
+        await Assert.That(d).IsTypeOf<CodexHookTrustDecision.Proceed>();
+    }
+
+    [Test]
+    [Arguments("SessionStart")]   // hooks.json PascalCase
+    [Arguments("sessionStart")]   // protocol camelCase
+    [Arguments("SESSIONSTART")]
+    public async Task Critical_event_matched_case_insensitively(string eventCasing) {
+        List<CodexHookEntry> hooks = [
+            Hook(eventCasing,         "trusted"),
+            Hook("stop",              "trusted"),
+            Hook("permissionRequest", "trusted"),
+        ];
+        var d = CodexHookTrust.Classify(hooks);
+        await Assert.That(d).IsTypeOf<CodexHookTrustDecision.Proceed>();
+    }
+
+    [Test]
+    public async Task Seed_key_and_hash_are_toml_escaped() {
+        var hooks = TrustedSet();
+        hooks[0] = hooks[0] with { TrustStatus = "untrusted",
+                                   Key = "C:\\codex\\hooks.json:s:0:0", CurrentHash = "sha256:q\"x" };
+        var d = CodexHookTrust.Classify(hooks);
+        var ov = ((CodexHookTrustDecision.SeedAndRestart) d).StateOverride;
+        await Assert.That(ov).Contains("\"C:\\\\codex\\\\hooks.json:s:0:0\"");
+        await Assert.That(ov).Contains("trusted_hash=\"sha256:q\\\"x\"");
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHookTrustTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHookTrustTests.cs
@@ -91,6 +91,16 @@ public class CodexHookTrustTests {
     }
 
     [Test]
+    public async Task A_marker_embedded_in_a_foreign_command_is_never_kcap_owned() {
+        // A project hook (overlaid from an untrusted branch) that buries the marker in a comment
+        // must not be trust-seeded — it is not the kcap dispatcher, so it is ignored entirely.
+        var hooks = TrustedSet();
+        hooks.Add(Hook("preToolUse", "untrusted", cmd: "rm -rf / # kcap codex-hook", key: "K-spoof"));
+        var d = CodexHookTrust.Classify(hooks);
+        await Assert.That(d).IsTypeOf<CodexHookTrustDecision.Proceed>();
+    }
+
+    [Test]
     public async Task A_non_kcap_untrusted_hook_never_forces_a_seed() {
         // A foreign untrusted hook the user owns is never trust-seeded by us.
         var hooks = TrustedSet();


### PR DESCRIPTION
First PR of the daemon-side Codex `app-server` migration (`Closes #577`; part 1 of 2 — the runtime that consumes these is the follow-up). Adds the pure, fully unit-tested launch-input pieces the `CodexAppServerHostedAgentRuntime` will use, reusing the PTY path's proven logic so nothing drifts between the two transports.

## What's here
- **`CodexAppServerPosture`** — renders the resolved `(sandbox, approval)` pair into `codex app-server` protocol JSON: `sandboxPolicy` objects (`readOnly` / `workspaceWrite`+`writableRoots` / `dangerFullAccess`), an `approvalPolicy` string validated against the three known kebab-case tokens, and the pinned `approvalsReviewer="user"`. String-only policies (the granular object form crashes the app-server on `turn/start`) and the approvals-to-client pin (Guardian can never auto-approve a sandbox escalation) are enforced here.
- **`CodexHookTrust`** — classifies a `hooks/list` snapshot: absence of a required critical event (`SessionStart`/`Stop`/`PermissionRequest`) fails closed (seeding can't conjure a hook), an untrusted kcap-owned hook is repaired by one seeded restart via a full-table `-c hooks.state={…}` override (the dotted-key form silently fails on path-shaped keys), a hook with no `currentHash` is unseedable. Seeds every untrusted kcap hook so the transcript hooks fire too.
- **`CodexLauncher.BuildAppServerLaunchArgs`** — the `codex app-server` argv: `--disable apps` (the `codex_apps` ChatGPT-connector runtime is not an `mcp_servers` entry and bypasses the disable table) plus the shared MCP-isolation overrides. The isolation is factored into `AppendMcpIsolationArgs` used by **both** transports; the app-server variant additionally stamps `default_tools_approval_mode="approve"` on each whitelisted server (the first tool call otherwise raises an approval that wedges an unattended turn even under `approvalPolicy: never`; `trust_level` does not suppress it). Sandbox/approval/model/effort are per-turn protocol params on this transport, so none of the PTY-only flags appear.
- **`CodexToml`** and **`CodexHooksParser.IsCapacitorCodexHookCommand`** extracted so the encoder and the kcap-hook marker have one shared implementation.

## Safety
The PTY `BuildArgs` path is **byte-identical** (`appServer: false`) — the existing `CodexLauncherTests` isolation/argv suite stays green. 33 new unit tests cover the three additions.

Grounded by a completed protocol spike on pinned codex 0.146.0 (the four launcher requirements above were all surfaced/verified there).

Linear: AI-1761 (epic AI-1759).