### PR TITLE
Cursor live hook: honor active profile's default_visibility

### DIFF
--- a/src/Capacitor.Cli/Commands/Harness/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CursorHookCommand.cs
@@ -342,6 +342,19 @@ public static class CursorHookCommand {
             // Skipped for a linked subagent child — its top-level sessionStart is never
             // posted (see below), so there is no session to attach a repository to.
             if (eventName == "sessionStart" && !isSubagentChild) {
+                // Stamp the active profile's default visibility BEFORE the enrichment round-trip
+                // below re-serializes `node`. Server-side VisibilityService treats a null
+                // default_visibility as "org-repo fallback", so without this a private-default
+                // user's Cursor sessions silently go org-visible. Budget-bounded + fail-open: the
+                // hook must never block the agent loop (the import path stamps this separately).
+                try {
+                    if (!BudgetExpired()
+                     && (await AppConfig.GetActiveProfileAsync(ct))?.DefaultVisibility is { } defaultVisibility)
+                        node["default_visibility"] = defaultVisibility;
+                } catch {
+                    // fail-open — visibility is best-effort, never fatal to the hook.
+                }
+
                 // Safe extract: workspace_roots[0] may be absent or a non-string; GetValue<string>
                 // would throw and (via the outer catch) drop the whole sessionStart hook.
                 if (node["workspace_roots"] is JsonArray roots && roots.Count > 0

--- a/test/Capacitor.Cli.Tests.Integration/CursorSessionStartVisibilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CursorSessionStartVisibilityTests.cs
@@ -9,13 +9,10 @@ using WireMock.Server;
 namespace Capacitor.Cli.Tests.Integration;
 
 /// <summary>
-/// #579 — a live Cursor <c>sessionStart</c> hook must stamp the active profile's
-/// <c>default_visibility</c> onto the payload, the same way the Codex hook does. Without it,
-/// Cursor sessions in org repos silently default to org-visible (the server treats a null
-/// <c>default_visibility</c> as the org-visibility fallback), ignoring a private-default
-/// user's preference. The stamp is applied BEFORE the git-enrichment round-trip, so these
-/// tests set <c>workspace_roots</c> to a real dir to force that reparse and prove the field
-/// survives it.
+/// A live Cursor <c>sessionStart</c> hook stamps the active profile's <c>default_visibility</c>
+/// onto the payload (mirrors <c>CodexSessionStartVisibilityTests</c>). <c>workspace_roots</c> is
+/// set so the enrichment reserialization actually runs — the round-trip the stamp must survive.
+/// See #579.
 /// </summary>
 public class CursorSessionStartVisibilityTests : IDisposable {
     readonly WireMockServer _server     = WireMockServer.Start();
@@ -56,10 +53,8 @@ public class CursorSessionStartVisibilityTests : IDisposable {
         _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"provider":"None"}"""));
 
-        // A real (non-git) temp dir under the OS temp root — outside any git repo, so no repository
-        // block is added, but present enough to make the sessionStart enrichment branch actually
-        // run (EnrichWithRepositoryInfoFromCwd reparses the payload), which is the serialization
-        // round-trip the stamped field must survive. transcript_path is omitted → no watcher spawn.
+        // workspace_roots present → the enrichment reparse runs (the round-trip the stamp must
+        // survive); transcript_path omitted → no watcher spawn.
         using var tmp = new TempDir();
         var body =
             $$"""

--- a/test/Capacitor.Cli.Tests.Integration/CursorSessionStartVisibilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/CursorSessionStartVisibilityTests.cs
@@ -1,0 +1,99 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands.Harness;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Integration;
+
+/// <summary>
+/// #579 — a live Cursor <c>sessionStart</c> hook must stamp the active profile's
+/// <c>default_visibility</c> onto the payload, the same way the Codex hook does. Without it,
+/// Cursor sessions in org repos silently default to org-visible (the server treats a null
+/// <c>default_visibility</c> as the org-visibility fallback), ignoring a private-default
+/// user's preference. The stamp is applied BEFORE the git-enrichment round-trip, so these
+/// tests set <c>workspace_roots</c> to a real dir to force that reparse and prove the field
+/// survives it.
+/// </summary>
+public class CursorSessionStartVisibilityTests : IDisposable {
+    readonly WireMockServer _server     = WireMockServer.Start();
+    readonly string         _configPath = PathHelpers.ConfigPath("config.json");
+    readonly string?        _previousConfig;
+
+    public CursorSessionStartVisibilityTests() {
+        _previousConfig = File.Exists(_configPath) ? File.ReadAllText(_configPath) : null;
+    }
+
+    public void Dispose() {
+        _server.Stop();
+
+        if (_previousConfig is null) {
+            if (File.Exists(_configPath)) File.Delete(_configPath);
+        } else {
+            File.WriteAllText(_configPath, _previousConfig);
+        }
+    }
+
+    async Task<JsonNode> RunSessionStartAndCaptureBodyAsync(string defaultVisibility) {
+        var config = new ProfileConfig {
+            ActiveProfile = "work",
+            Profiles = new() {
+                ["work"] = new Profile {
+                    ServerUrl         = _server.Url,
+                    DefaultVisibility = defaultVisibility
+                }
+            }
+        };
+        await ConfigMutator.MutateAsync(_ => config);
+
+        _server.Given(Request.Create().WithPath("/hooks/session-start/cursor").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+        // Best-effort side calls (memory index, auth) must never fail the test.
+        _server.Given(Request.Create().WithPath("/api/*").UsingAnyMethod())
+            .RespondWith(Response.Create().WithStatusCode(404));
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"provider":"None"}"""));
+
+        // A real (non-git) temp dir under the OS temp root — outside any git repo, so no repository
+        // block is added, but present enough to make the sessionStart enrichment branch actually
+        // run (EnrichWithRepositoryInfoFromCwd reparses the payload), which is the serialization
+        // round-trip the stamped field must survive. transcript_path is omitted → no watcher spawn.
+        using var tmp = new TempDir();
+        var body =
+            $$"""
+            {
+              "hook_event_name": "sessionStart",
+              "session_id":      "cursorvistestsession",
+              "model":           "claude-3.5-sonnet",
+              "workspace_roots": ["{{tmp.Path.Replace("\\", "\\\\")}}"]
+            }
+            """;
+
+        using var client = new HttpClient();
+        var spool = new HookSpool(tmp.CreateDir("spool").Path);
+
+        var exit = await CursorHookCommand.HandleCore(client, _server.Url!, new StringReader(body), spool, TimeSpan.FromSeconds(2));
+        await Assert.That(exit).IsEqualTo(0);
+
+        var requests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start/cursor").UsingPost());
+        await Assert.That(requests.Count).IsEqualTo(1);
+
+        return JsonNode.Parse(requests[0].RequestMessage.Body!)!;
+    }
+
+    [Test, NotInParallel("AppConfig_FileState")]
+    public async Task SessionStart_stamps_default_visibility_from_active_profile() {
+        var body = await RunSessionStartAndCaptureBodyAsync("private");
+        await Assert.That(body["default_visibility"]?.GetValue<string>()).IsEqualTo("private");
+    }
+
+    [Test, NotInParallel("AppConfig_FileState")]
+    public async Task SessionStart_stamps_the_profiles_configured_visibility_value() {
+        // Fidelity: the stamped value is the profile's configured visibility, not a hardcoded
+        // constant — a different profile value must round-trip verbatim.
+        var body = await RunSessionStartAndCaptureBodyAsync("public");
+        await Assert.That(body["default_visibility"]?.GetValue<string>()).IsEqualTo("public");
+    }
+}


### PR DESCRIPTION
## What

The live Cursor `sessionStart` hook dispatcher (`CursorHookCommand.HandleCore`) never stamped the active profile's `default_visibility` onto the payload before POSTing to `/hooks/session-start/cursor`, unlike the Codex hook. As a result, a user with `default_visibility: private` still had their live Cursor sessions land **org-visible** in org repos, because the server treats a null `default_visibility` as the org-visibility fallback.

## Change

- Stamp `default_visibility` from `AppConfig.GetActiveProfileAsync` in the `sessionStart && !isSubagentChild` branch, **before** the git-enrichment round-trip (so it survives re-serialization), budget-bounded and fail-open (the hook must never block the agent loop). Mirrors `CodexHookCommand`.
- Adds `CursorSessionStartVisibilityTests` (Linux-gated integration, mirroring `CodexSessionStartVisibilityTests`): a `private` and a `public` profile default each round-trip verbatim onto the POST body, with `workspace_roots` set so the enrichment reparse actually runs.

## Notes

- The historical import path (`ImportCommand`) already stamps `default_visibility`; this is a disjoint code path and is unchanged.
- Requires the companion **kcap-server** change (adds `default_visibility` to the Cursor session-start hook model and packs it into the capacitor block) to take effect; the extra payload field is harmlessly ignored by an old server.

Closes #579
Linear: AI-783