### PR TITLE
[AI-1761] Codex app-server: hosted-agent runtime, transport & transport wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1302,6 +1302,18 @@ KCAP_CLAUDE_PATH=/opt/claude/bin/claude kcap daemon
 KCAP_CODEX_PATH=/opt/codex/bin/codex  kcap daemon
 ```
 
+##### Codex transport (`KCAP_CODEX_TRANSPORT`)
+
+Hosted Codex **reviewers** (review flows) can run over the `codex app-server` JSON-RPC protocol instead of the interactive PTY. It is opt-in and env-only:
+
+```bash
+KCAP_CODEX_TRANSPORT=app-server kcap daemon   # opt in; default is `pty`
+```
+
+- **Default `pty`** — the interactive-terminal path, unchanged.
+- **`app-server`** takes effect only for review-flow (unattended) launches and only when the installed Codex meets the minimum version (**0.146.0**); a lower build falls back to `pty` automatically. Interactive launches always use `pty` in this release.
+- Rollback is a restart with the value flipped back to `pty`; it governs new launches only.
+
 The Cursor CLI path (`cursor-agent` by default, used to spawn the `cursor` hosted-agent vendor) is env-only for now — there is no `daemon.cursor_path` profile key yet, so set it per-launch:
 
 ```bash

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -122,6 +122,18 @@ public class DaemonConfig {
     public string ClaudePath { get; set; } = "claude";
     public string CodexPath  { get; set; } = "codex";
 
+    /// <summary>Transport for hosted Codex reviewers: <c>pty</c> (default) or <c>app-server</c>.
+    /// Set via <c>KCAP_CODEX_TRANSPORT</c>. Governs NEW review-flow launches only; interactive
+    /// launches always take the PTY path in this phase. The effective decision (this selection AND
+    /// the version floor) is resolved once into <see cref="CodexAppServerActive"/>.</summary>
+    public string CodexTransport { get; set; } = "pty";
+
+    /// <summary>Resolved once at startup: true when <see cref="CodexTransport"/> is <c>app-server</c>
+    /// AND the installed Codex meets the app-server version floor. Read by BOTH the launch router and
+    /// the certification advertisement so the advertised policy and the transport used are one fact.
+    /// Never set from config directly.</summary>
+    public bool CodexAppServerActive { get; set; }
+
     /// <summary>
     /// Path or bare command for the Cursor CLI's ACP entry point, spawned as
     /// <c>{CursorPath} acp</c> by <c>AcpHostedAgentRuntimeFactory</c>. Overridable

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -149,6 +149,17 @@ public static partial class DaemonRunner {
         if (Environment.GetEnvironmentVariable("KCAP_CODEX_PATH") is { Length: > 0 } envCodexPath)
             config.CodexPath = envCodexPath;
 
+        if (Environment.GetEnvironmentVariable("KCAP_CODEX_TRANSPORT") is { Length: > 0 } envCodexTransport)
+            config.CodexTransport = envCodexTransport;
+
+        // Resolve the effective Codex transport ONCE (operator selection AND the version floor) into
+        // the field both the launch router and the certification advertisement read — see
+        // CodexTransportDecision. Only probe when app-server is actually selected, so a PTY daemon
+        // (the default) pays no startup probe.
+        config.CodexAppServerActive =
+            string.Equals(config.CodexTransport?.Trim(), Harness.Codex.CodexTransportDecision.AppServer, StringComparison.OrdinalIgnoreCase)
+            && Harness.Codex.CodexTransportDecision.MeetsFloor(ProbeCliVersion(config.CodexPath));
+
         if (Environment.GetEnvironmentVariable("KCAP_CURSOR_PATH") is { Length: > 0 } envCursorPath)
             config.CursorPath = envCursorPath;
 
@@ -410,14 +421,22 @@ public static partial class DaemonRunner {
                 sp.GetRequiredService<ILogger<PtyHostedAgentRuntimeFactory>>()
             )
         );
-        builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
-            new PtyHostedAgentRuntimeFactory(
-                sp.GetServices<IHostedAgentLauncher>().SingleOrDefault(l => l.Vendor == "codex")
-                    ?? throw new InvalidOperationException("No IHostedAgentLauncher registered for vendor 'codex'"),
+        // Codex is the ONE vendor with two transports. The composite factory routes review-flow
+        // launches to codex app-server when this daemon resolved it active (config.CodexAppServerActive),
+        // and delegates everything else — every interactive launch, and all launches under the PTY
+        // default — to the wrapped PTY factory, byte-identically to before.
+        builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp => {
+            var codexLauncher = sp.GetServices<IHostedAgentLauncher>().SingleOrDefault(l => l.Vendor == "codex")
+                    ?? throw new InvalidOperationException("No IHostedAgentLauncher registered for vendor 'codex'");
+            var pty = new PtyHostedAgentRuntimeFactory(
+                codexLauncher,
                 sp.GetRequiredService<IPtyProcessFactory>(),
-                sp.GetRequiredService<ILogger<PtyHostedAgentRuntimeFactory>>()
-            )
-        );
+                sp.GetRequiredService<ILogger<PtyHostedAgentRuntimeFactory>>());
+            return new Harness.Codex.CodexHostedAgentRuntimeFactory(
+                (Harness.Codex.CodexLauncher) codexLauncher, pty,
+                sp.GetRequiredService<DaemonConfig>(),
+                sp.GetRequiredService<ILoggerFactory>());
+        });
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
             new AcpHostedAgentRuntimeFactory(
                 AcpVendorDescriptors.Cursor,
@@ -1299,6 +1318,7 @@ public static partial class DaemonRunner {
     internal const string ClaudeLauncherPolicyVersion = "claude-unattended-v1";
     internal const string CursorLauncherPolicyVersion = "cursor-unattended-v4";
     internal const string CodexLauncherPolicyVersion = "codex-unattended-v1";
+    internal const string CodexAppServerLauncherPolicyVersion = "codex-appserver-unattended-v1";
     internal const string CopilotLauncherPolicyVersion = "copilot-unattended-v1";
     internal const string AntigravityLauncherPolicyVersion = "antigravity-unattended-v1";
     internal const string OpenCodeLauncherPolicyVersion = "opencode-unattended-v1";
@@ -1320,7 +1340,11 @@ public static partial class DaemonRunner {
             var (cliPath, policyVersion) = vendor switch {
                 "claude"  => (config.ClaudePath, ClaudeLauncherPolicyVersion),
                 "cursor"  => (config.CursorPath, CursorLauncherPolicyVersion),
-                "codex"   => (config.CodexPath, CodexLauncherPolicyVersion),
+                // The advertised codex policy version is chosen from the SAME resolved field the
+                // launch router uses (config.CodexAppServerActive), so the certified policy and the
+                // transport actually launched can never diverge.
+                "codex"   => (config.CodexPath,
+                              config.CodexAppServerActive ? CodexAppServerLauncherPolicyVersion : CodexLauncherPolicyVersion),
                 "copilot" => (config.CopilotPath, CopilotLauncherPolicyVersion),
                 // Named rather than left to the generic arm, which advertises CliVersion: null — there
                 // is a real configured path here to probe, and the floor is stated in that version.

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -152,13 +152,9 @@ public static partial class DaemonRunner {
         if (Environment.GetEnvironmentVariable("KCAP_CODEX_TRANSPORT") is { Length: > 0 } envCodexTransport)
             config.CodexTransport = envCodexTransport;
 
-        // Resolve the effective Codex transport ONCE (operator selection AND the version floor) into
-        // the field both the launch router and the certification advertisement read — see
-        // CodexTransportDecision. Only probe when app-server is actually selected, so a PTY daemon
-        // (the default) pays no startup probe.
-        config.CodexAppServerActive =
-            string.Equals(config.CodexTransport?.Trim(), Harness.Codex.CodexTransportDecision.AppServer, StringComparison.OrdinalIgnoreCase)
-            && Harness.Codex.CodexTransportDecision.MeetsFloor(ProbeCliVersion(config.CodexPath));
+        // One resolved fact for both the launch router and the certification advertisement.
+        config.CodexAppServerActive = Harness.Codex.CodexTransportDecision.ResolveActive(
+            config.CodexTransport, () => ProbeCliVersion(config.CodexPath));
 
         if (Environment.GetEnvironmentVariable("KCAP_CURSOR_PATH") is { Length: > 0 } envCursorPath)
             config.CursorPath = envCursorPath;

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerConnection.cs
@@ -273,40 +273,49 @@ internal sealed partial class CodexAppServerConnection : IAsyncDisposable {
     /// exception escape to <see cref="DispatchLineAsync"/>'s log-and-skip catch.
     /// </summary>
     async Task HandleServerRequestAsync(JsonElement root, JsonElement idElement, JsonElement methodElement, CancellationToken ct) {
-        var method        = methodElement.GetString() ?? "";
-        var paramsElement = root.TryGetProperty("params", out var p) ? p.Clone() : (JsonElement?) null;
-
         // Preserve the raw id JsonElement verbatim — inbound ids are not guaranteed to fit our own
         // `long` id space (JSON-RPC allows string/number), so we must not force a parse that could
         // throw and kill the read loop.
         var idClone = idElement.Clone();
 
-        JsonElement? result;
-        AcpError?    error = null;
+        JsonElement? result = null;
+        AcpError?    error;
 
-        var handler = OnServerRequest;
-        if (handler is null) {
-            error  = new AcpError(-32601, $"Method not found: {method}", null);
-            result = null;
+        // A wrong-typed `method` (a number, say) must NOT strand the id: the "always one response"
+        // invariant covers this dispatch/validation path too, so answer -32600 with the original id
+        // rather than letting GetString() throw into DispatchLineAsync's log-and-skip catch.
+        if (methodElement.ValueKind != JsonValueKind.String) {
+            _logger.LogDebug("app-server: inbound server request with non-string method (kind={Kind}); responding -32600",
+                methodElement.ValueKind);
+            error = new AcpError(-32600, "Invalid request: method must be a string", null);
         } else {
-            // The handler contract only needs Method/Params — it never reads Id back — so a
-            // placeholder 0 is safe. The response written back uses `idClone`, the ORIGINAL raw
-            // JsonElement, never this placeholder.
-            var request = new AcpRequest(0, method, paramsElement);
+            var method        = methodElement.GetString() ?? "";
+            var paramsElement = root.TryGetProperty("params", out var p) ? p.Clone() : (JsonElement?) null;
+            error = null;
 
-            try {
-                result = await handler(request, ct).ConfigureAwait(false);
-            } catch (Exception ex) {
-                _logger.LogDebug(ex, "app-server: OnServerRequest handler threw for method={Method}", method);
-                error  = new AcpError(-32603, "Internal error", null);
-                result = null;
-            }
+            var handler = OnServerRequest;
+            if (handler is null) {
+                error  = new AcpError(-32601, $"Method not found: {method}", null);
+            } else {
+                // The handler contract only needs Method/Params — it never reads Id back — so a
+                // placeholder 0 is safe. The response written back uses `idClone`, the ORIGINAL raw
+                // JsonElement, never this placeholder.
+                var request = new AcpRequest(0, method, paramsElement);
 
-            // A handler that ran without throwing but returned null means "I don't handle this
-            // method" — treat it exactly like the no-handler branch, never a null-result success.
-            if (result is null && error is null) {
-                _logger.LogDebug("app-server: OnServerRequest handler declined method={Method}; responding -32601 Method not found", method);
-                error = new AcpError(-32601, $"Method not found: {method}", null);
+                try {
+                    result = await handler(request, ct).ConfigureAwait(false);
+                } catch (Exception ex) {
+                    _logger.LogDebug(ex, "app-server: OnServerRequest handler threw for method={Method}", method);
+                    error  = new AcpError(-32603, "Internal error", null);
+                    result = null;
+                }
+
+                // A handler that ran without throwing but returned null means "I don't handle this
+                // method" — treat it exactly like the no-handler branch, never a null-result success.
+                if (result is null && error is null) {
+                    _logger.LogDebug("app-server: OnServerRequest handler declined method={Method}; responding -32601 Method not found", method);
+                    error = new AcpError(-32601, $"Method not found: {method}", null);
+                }
             }
         }
 
@@ -317,12 +326,12 @@ internal sealed partial class CodexAppServerConnection : IAsyncDisposable {
             // throw before a byte goes out, silently violating that invariant.
             await WriteServerResponseAsync(idClone, result, error, CancellationToken.None).ConfigureAwait(false);
         } catch (Exception ex) {
-            _logger.LogDebug(ex, "app-server: failed to write server-request response for method={Method}; sending internal-error fallback", method);
+            _logger.LogDebug(ex, "app-server: failed to write server-request response (method.kind={Kind}); sending internal-error fallback", methodElement.ValueKind);
 
             try {
                 await WriteServerResponseAsync(idClone, null, new AcpError(-32603, "Internal error", null), CancellationToken.None).ConfigureAwait(false);
             } catch (Exception fallbackEx) {
-                _logger.LogDebug(fallbackEx, "app-server: internal-error fallback response also failed to write for method={Method}", method);
+                _logger.LogDebug(fallbackEx, "app-server: internal-error fallback response also failed to write (method.kind={Kind})", methodElement.ValueKind);
             }
         }
     }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerConnection.cs
@@ -1,0 +1,413 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// JSON-RPC 2.0 error surfaced from a <c>codex app-server</c> response's <c>error</c> object.
+/// Thrown by <see cref="CodexAppServerConnection.RequestAsync"/> when the app-server answers a
+/// request with an error instead of a result (e.g. an unsupported method, or an invalid turn on a
+/// dead thread) so the runtime can classify the failure rather than see a bare result.
+/// </summary>
+internal sealed class CodexAppServerRpcException : Exception {
+    public int          Code      { get; }
+    public JsonElement? ErrorData { get; }
+
+    public CodexAppServerRpcException(int code, string message, JsonElement? data = null) : base(message) {
+        Code      = code;
+        ErrorData = data;
+    }
+}
+
+/// <summary>
+/// Newline-delimited JSON-RPC 2.0 stdio transport for <c>codex app-server</c>. Owns framing (one
+/// JSON object per line, UTF-8), outbound request/response correlation, and routing of inbound
+/// notifications and server→client requests. Decoupled from
+/// <see cref="System.Diagnostics.Process"/> — the ctor takes plain <see cref="Stream"/>s so tests
+/// drive it over in-memory pipes; the runtime passes the child process's stdin/stdout.
+///
+/// The app-server speaks the SAME JSON-RPC 2.0 envelope as ACP, so this reuses the shared
+/// <see cref="AcpRequest"/> / <see cref="AcpNotification"/> / <see cref="AcpError"/> wire records
+/// (their names are historical — the layer is protocol-generic and AOT/trim-safe) rather than
+/// defining byte-identical copies. It is a deliberately leaner sibling of
+/// <see cref="AcpConnection"/>: the hosted Codex reviewer is a one-shot unattended run with no
+/// reconnect design, so the ACP connection's reconnect latch / pre-fault hook are omitted — a dead
+/// app-server simply ends the read loop, faults the pending requests, and the orchestrator reaps
+/// the reviewer through the normal death path.
+///
+/// Concurrency model (identical to <see cref="AcpConnection"/>): an <see cref="Interlocked"/> id
+/// counter, a <see cref="ConcurrentDictionary{TKey,TValue}"/> of pending requests each a
+/// <see cref="TaskCompletionSource{TResult}"/> created
+/// <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/>, a single
+/// <see cref="SemaphoreSlim"/> write-gate so concurrent callers never interleave partial frames,
+/// and exactly one read loop (<see cref="RunAsync"/>) that must never exit early on a single bad
+/// line.
+/// </summary>
+internal sealed partial class CodexAppServerConnection : IAsyncDisposable {
+    readonly Stream                                                        _writeStream;
+    readonly Stream                                                        _readStream;
+    readonly ILogger                                                       _logger;
+    readonly bool                                                          _debugFrames;
+    readonly ConcurrentDictionary<long, TaskCompletionSource<JsonElement>> _pending = new();
+    readonly SemaphoreSlim                                                 _writeGate = new(1, 1);
+
+    long _nextId;
+    int  _disposed;
+
+    /// <param name="debugFrames">
+    /// <see cref="DaemonConfig.DebugFrames"/> (<c>KCAP_ACP_DEBUG_FRAMES</c>) — off by default. When
+    /// on, every inbound/outbound JSON-RPC frame is ALSO logged in full (length-capped) at Debug;
+    /// the shape-only Debug logging in <see cref="DispatchLineAsync"/> is unchanged either way.
+    /// </param>
+    public CodexAppServerConnection(Stream writeStream, Stream readStream, ILogger logger, bool debugFrames = false) {
+        _writeStream = writeStream;
+        _readStream  = readStream;
+        _logger      = logger;
+        _debugFrames = debugFrames;
+    }
+
+    /// <summary>Raised for inbound app-server→client notifications (e.g. turn/item events,
+    /// <c>codex/event/*</c>, <c>turn.completed</c>).</summary>
+    public event Action<AcpNotification>? OnNotification;
+
+    /// <summary>
+    /// Handler for inbound app-server→client REQUESTS (e.g. approval requests, or hook-related
+    /// prompts). The read loop echoes the request's id verbatim in the response, with this
+    /// delegate's return value as the JSON-RPC <c>result</c>. If unset — or if the handler returns
+    /// <see langword="null"/> — the connection answers <c>-32601 Method not found</c>, a safe
+    /// default-decline posture (never a null-result success, which would falsely claim we performed
+    /// an operation we never served). A handler must build its own <see cref="JsonElement"/> so the
+    /// shape is AOT-safe and can't fail to serialize at the write site.
+    /// </summary>
+    public Func<AcpRequest, CancellationToken, Task<JsonElement?>>? OnServerRequest { get; set; }
+
+    /// <summary>
+    /// Sends a request and awaits its correlated response. Throws
+    /// <see cref="CodexAppServerRpcException"/> if the app-server answers with an error. If
+    /// <paramref name="ct"/> is cancelled first, the pending correlation is removed and this throws
+    /// <see cref="OperationCanceledException"/>; a running turn is cancelled separately via the
+    /// app-server's own interrupt method (<see cref="NotifyAsync"/> / <see cref="RequestAsync"/>).
+    /// </summary>
+    public async Task<JsonElement> RequestAsync(
+            string method, JsonElement? @params, CancellationToken ct, Action? onWritten = null) {
+        var id  = Interlocked.Increment(ref _nextId);
+        var tcs = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        if (!_pending.TryAdd(id, tcs))
+            throw new InvalidOperationException($"Duplicate app-server request id {id} — id allocation is broken.");
+
+        await using var registration = ct.Register(() => {
+            _pending.TryRemove(id, out _);
+            tcs.TrySetCanceled(ct);
+        }).ConfigureAwait(false);
+
+        var request = new AcpRequest(id, method, @params);
+        var json    = JsonSerializer.Serialize(request, CapacitorJsonContext.Default.AcpRequest);
+
+        try {
+            await WriteLineAsync(json, ct).ConfigureAwait(false);
+            onWritten?.Invoke();
+        } catch {
+            _pending.TryRemove(id, out _);
+            tcs.TrySetCanceled(CancellationToken.None);
+            throw;
+        }
+
+        return await tcs.Task.ConfigureAwait(false);
+    }
+
+    /// <summary>Fire-and-forget notification (no id, no response expected).</summary>
+    public async Task NotifyAsync(string method, JsonElement? @params) {
+        var notification = new AcpNotification(method, @params);
+        var json         = JsonSerializer.Serialize(notification, CapacitorJsonContext.Default.AcpNotification);
+
+        await WriteLineAsync(json, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The read loop: parses newline-delimited JSON frames from the app-server and dispatches by
+    /// shape. Runs until <paramref name="ct"/> is cancelled or the stream ends. A single malformed
+    /// or unrecognized line is logged at debug and skipped — it must never take down the loop, since
+    /// every pending <see cref="RequestAsync"/> call depends on this loop staying alive.
+    /// </summary>
+    public async Task RunAsync(CancellationToken ct) {
+        using var reader = new StreamReader(_readStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, leaveOpen: true);
+
+        try {
+            while (!ct.IsCancellationRequested) {
+                var line = await reader.ReadLineAsync(ct).ConfigureAwait(false);
+                if (line is null)
+                    break; // stream ended (app-server process exited / pipe closed)
+
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+
+                await DispatchLineAsync(line, ct).ConfigureAwait(false);
+            }
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            // normal shutdown
+        } finally {
+            FaultAllPending(new ObjectDisposedException(
+                nameof(CodexAppServerConnection), "codex app-server connection read loop ended with requests still pending."));
+        }
+    }
+
+    async Task DispatchLineAsync(string line, CancellationToken ct) {
+        // KCAP_ACP_DEBUG_FRAMES gate (Off by default) — a frame can carry prompt/tool/file content,
+        // so the FULL frame is only ever logged when the operator has explicitly opted in. The
+        // shape-only Debug logging below is unchanged regardless of this flag.
+        if (_debugFrames)
+            LogInboundFrame(AcpDebugFrameLog.Cap(line));
+
+        JsonDocument doc;
+
+        try {
+            doc = JsonDocument.Parse(line);
+        } catch (JsonException ex) {
+            _logger.LogDebug(ex, "app-server: skipping unparseable line ({Length} chars)", line.Length);
+            return;
+        }
+
+        // Diagnostics captured up front (cheap ValueKind reads, never the actual method/id/params
+        // VALUES) so the catch below can log them without touching `doc` after it may already have
+        // been disposed by the `using` block.
+        var methodKind = "<absent>";
+        var idKind     = "<absent>";
+
+        try {
+            using (doc) {
+                var root = doc.RootElement;
+
+                if (root.ValueKind != JsonValueKind.Object) {
+                    _logger.LogDebug("app-server: skipping non-object frame (kind={Kind})", root.ValueKind);
+                    return;
+                }
+
+                var hasId     = root.TryGetProperty("id", out var idElement);
+                var hasMethod = root.TryGetProperty("method", out var methodElement);
+                var hasResult = root.TryGetProperty("result", out var resultElement);
+                var hasError  = root.TryGetProperty("error", out var errorElement);
+
+                methodKind = hasMethod ? methodElement.ValueKind.ToString() : "<absent>";
+                idKind     = hasId ? idElement.ValueKind.ToString() : "<absent>";
+
+                if (hasId && (hasResult || hasError) && !hasMethod) {
+                    HandleResponse(idElement, hasResult ? resultElement : null, hasError ? errorElement : null);
+                    return;
+                }
+
+                if (hasMethod && hasId) {
+                    await HandleServerRequestAsync(root, idElement, methodElement, ct).ConfigureAwait(false);
+                    return;
+                }
+
+                if (hasMethod && !hasId) {
+                    HandleNotification(root, methodElement);
+                    return;
+                }
+
+                _logger.LogDebug("app-server: skipping frame with unrecognized shape");
+            }
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            // A well-formed JSON frame can still have a field of the wrong JSON type (e.g. a numeric
+            // `method` or a string `error.code`), which throws out of GetString()/GetInt32() after
+            // the parse already succeeded. This must not take down the read loop — every pending
+            // RequestAsync call depends on it staying alive — so we log the frame's shape only
+            // (never params/result/content, which may carry sensitive payloads) and skip the frame.
+            _logger.LogDebug(ex, "app-server: skipping frame with wrong-typed field (method.kind={MethodKind}, id.kind={IdKind})", methodKind, idKind);
+        }
+    }
+
+    void HandleResponse(JsonElement idElement, JsonElement? resultElement, JsonElement? errorElement) {
+        if (!idElement.TryGetInt64(out var id)) {
+            _logger.LogDebug("app-server: response id is not a numeric value we issued; ignoring");
+            return;
+        }
+
+        if (!_pending.TryRemove(id, out var tcs)) {
+            _logger.LogDebug("app-server: no pending request for response id={Id}; ignoring", id);
+            return;
+        }
+
+        if (errorElement is { } error) {
+            // TryRemove already took the pending TCS — from here on we MUST complete it, no matter
+            // how malformed `error` turns out to be. Every read below is TryGetProperty +
+            // ValueKind-gated so this block can never throw and orphan the caller.
+            var code = error.ValueKind == JsonValueKind.Object
+                    && error.TryGetProperty("code", out var codeEl)
+                    && codeEl.ValueKind == JsonValueKind.Number
+                    && codeEl.TryGetInt32(out var codeValue)
+                ? codeValue
+                : 0;
+
+            var message = error.ValueKind == JsonValueKind.Object
+                    && error.TryGetProperty("message", out var msgEl)
+                    && msgEl.ValueKind == JsonValueKind.String
+                ? msgEl.GetString() ?? ""
+                : "";
+
+            JsonElement? data = error.ValueKind == JsonValueKind.Object
+                    && error.TryGetProperty("data", out var dataEl)
+                ? dataEl.Clone()
+                : null;
+
+            tcs.TrySetException(new CodexAppServerRpcException(code, message, data));
+            return;
+        }
+
+        var result = resultElement?.Clone() ?? default;
+        tcs.TrySetResult(result);
+    }
+
+    /// <summary>
+    /// Handles one inbound app-server→client request. MUST write exactly one response frame for
+    /// <paramref name="idElement"/> no matter what happens — a missing response wedges the
+    /// app-server's wait on this id forever. The handler-invoke try/catch and the outer try/catch
+    /// around response serialization+write together guarantee this: any failure falls back to a
+    /// JSON-RPC "Internal error" response keyed on the ORIGINAL id, rather than letting the
+    /// exception escape to <see cref="DispatchLineAsync"/>'s log-and-skip catch.
+    /// </summary>
+    async Task HandleServerRequestAsync(JsonElement root, JsonElement idElement, JsonElement methodElement, CancellationToken ct) {
+        var method        = methodElement.GetString() ?? "";
+        var paramsElement = root.TryGetProperty("params", out var p) ? p.Clone() : (JsonElement?) null;
+
+        // Preserve the raw id JsonElement verbatim — inbound ids are not guaranteed to fit our own
+        // `long` id space (JSON-RPC allows string/number), so we must not force a parse that could
+        // throw and kill the read loop.
+        var idClone = idElement.Clone();
+
+        JsonElement? result;
+        AcpError?    error = null;
+
+        var handler = OnServerRequest;
+        if (handler is null) {
+            error  = new AcpError(-32601, $"Method not found: {method}", null);
+            result = null;
+        } else {
+            // The handler contract only needs Method/Params — it never reads Id back — so a
+            // placeholder 0 is safe. The response written back uses `idClone`, the ORIGINAL raw
+            // JsonElement, never this placeholder.
+            var request = new AcpRequest(0, method, paramsElement);
+
+            try {
+                result = await handler(request, ct).ConfigureAwait(false);
+            } catch (Exception ex) {
+                _logger.LogDebug(ex, "app-server: OnServerRequest handler threw for method={Method}", method);
+                error  = new AcpError(-32603, "Internal error", null);
+                result = null;
+            }
+
+            // A handler that ran without throwing but returned null means "I don't handle this
+            // method" — treat it exactly like the no-handler branch, never a null-result success.
+            if (result is null && error is null) {
+                _logger.LogDebug("app-server: OnServerRequest handler declined method={Method}; responding -32601 Method not found", method);
+                error = new AcpError(-32601, $"Method not found: {method}", null);
+            }
+        }
+
+        try {
+            // The final response write deliberately uses CancellationToken.None: this method
+            // guarantees exactly one response frame "no matter what happens", and `ct` is the same
+            // token DisposeAsync cancels — gating the write on it would make the write-gate wait
+            // throw before a byte goes out, silently violating that invariant.
+            await WriteServerResponseAsync(idClone, result, error, CancellationToken.None).ConfigureAwait(false);
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "app-server: failed to write server-request response for method={Method}; sending internal-error fallback", method);
+
+            try {
+                await WriteServerResponseAsync(idClone, null, new AcpError(-32603, "Internal error", null), CancellationToken.None).ConfigureAwait(false);
+            } catch (Exception fallbackEx) {
+                _logger.LogDebug(fallbackEx, "app-server: internal-error fallback response also failed to write for method={Method}", method);
+            }
+        }
+    }
+
+    void HandleNotification(JsonElement root, JsonElement methodElement) {
+        var method        = methodElement.GetString() ?? "";
+        var paramsElement = root.TryGetProperty("params", out var p) ? p.Clone() : (JsonElement?) null;
+
+        OnNotification?.Invoke(new AcpNotification(method, paramsElement));
+    }
+
+    async Task WriteServerResponseAsync(JsonElement idElement, JsonElement? result, AcpError? error, CancellationToken ct) {
+        var json = SerializeRawIdResponse(idElement, result, error);
+        await WriteLineAsync(json, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Builds a response frame manually so an inbound server-request id of any JSON shape (string,
+    /// number, etc.) round-trips byte-for-byte instead of being forced through a
+    /// <see langword="long"/> parse that could throw.
+    /// </summary>
+    static string SerializeRawIdResponse(JsonElement idElement, JsonElement? result, AcpError? error) {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream)) {
+            writer.WriteStartObject();
+            writer.WriteString("jsonrpc", "2.0");
+            writer.WritePropertyName("id");
+            idElement.WriteTo(writer);
+
+            if (error is not null) {
+                writer.WritePropertyName("error");
+                JsonSerializer.Serialize(writer, error, CapacitorJsonContext.Default.AcpError);
+            } else {
+                writer.WritePropertyName("result");
+                if (result is { } r)
+                    r.WriteTo(writer);
+                else
+                    writer.WriteNullValue();
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    async Task WriteLineAsync(string json, CancellationToken ct) {
+        var bytes = Encoding.UTF8.GetBytes(json + "\n");
+
+        await _writeGate.WaitAsync(ct).ConfigureAwait(false);
+        try {
+            await _writeStream.WriteAsync(bytes, ct).ConfigureAwait(false);
+            await _writeStream.FlushAsync(ct).ConfigureAwait(false);
+
+            // Log the outbound frame only after it is actually on the wire — and still under the
+            // gate, so the debug log order matches wire order.
+            if (_debugFrames)
+                LogOutboundFrame(AcpDebugFrameLog.Cap(json));
+        } finally {
+            _writeGate.Release();
+        }
+    }
+
+    void FaultAllPending(Exception ex) {
+        foreach (var id in _pending.Keys) {
+            if (_pending.TryRemove(id, out var tcs))
+                tcs.TrySetException(ex);
+        }
+    }
+
+    public async ValueTask DisposeAsync() {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        FaultAllPending(new ObjectDisposedException(nameof(CodexAppServerConnection)));
+
+        _writeGate.Dispose();
+
+        await _writeStream.DisposeAsync().ConfigureAwait(false);
+        await _readStream.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "app-server <<< {Frame}")]
+    partial void LogInboundFrame(string frame);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "app-server >>> {Frame}")]
+    partial void LogOutboundFrame(string frame);
+}

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -225,7 +225,11 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     async Task StartThreadAsync(CancellationToken ct) {
         var startParams = new JsonObject {
             ["cwd"]               = _launch.Cwd,
-            ["sandbox"]           = CodexAppServerPosture.RenderSandboxPolicy(_launch.Sandbox, _launch.WritableRoots),
+            // thread/start.sandbox is the coarse SandboxMode STRING (read-only / workspace-write /
+            // danger-full-access) — a different wire shape from turn/start.sandboxPolicy's object.
+            // The resolved posture token already IS that string; the per-turn sandboxPolicy object
+            // is the load-bearing containment.
+            ["sandbox"]           = CodexAppServerPosture.RenderSandboxMode(_launch.Sandbox),
             ["approvalPolicy"]    = CodexAppServerPosture.RenderApprovalPolicy(_launch.Approval),
             ["approvalsReviewer"] = CodexAppServerPosture.ApprovalsReviewer,
         };

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -24,12 +24,15 @@ internal delegate Task<(CodexAppServerConnection Connection, IAcpProcess Process
 /// (<c>read-only</c> / <c>workspace-write</c> / <c>danger-full-access</c>), rendered per turn via
 /// <see cref="CodexAppServerPosture.RenderSandboxPolicy"/>.</param>
 /// <param name="Approval">The resolved approval token — always <c>never</c> for a reviewer.</param>
+/// <param name="Effort">The requested reasoning effort, or null for the vendor default; passed on
+/// every <c>turn/start</c> (the app-server carries effort as a per-turn protocol param, not argv).</param>
 /// <param name="WritableRoots">Writable roots for <c>workspace-write</c> (the owned worktree);
 /// ignored for the other sandboxes.</param>
 /// <param name="ClientVersion">Daemon version stamped into <c>initialize.clientInfo.version</c>.</param>
 internal sealed record CodexAppServerLaunch(
     string                Cwd,
     string?               Model,
+    string?               Effort,
     string?               InitialPrompt,
     string                Sandbox,
     string                Approval,
@@ -65,8 +68,6 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         "item/fileChange/outputDelta",
     ];
 
-    // The three critical hook events whose absence fails the launch closed live in CodexHookTrust;
-    // hooks/list is scoped to the reviewer cwd.
     const string ClientName = "kcap-daemon";
     const int    BackpressureMaxAttempts = 6;
 
@@ -78,16 +79,23 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     readonly CancellationTokenSource _cts = new();
 
     readonly object              _turnGate = new();
-    readonly TaskCompletionSource _runLoopEnded = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    // Whole-runtime terminal signal: completed exactly once, when the LIVE child's read loop ends
+    // (process death) or on dispose — never for the controlled child teardown during a hook-trust
+    // restart. The orchestrator treats ReadOutputAsync ending as the finalize trigger, so this must
+    // not fire early, and WaitForTurnIdleAsync must unblock on it so a round never outlives the child.
+    readonly TaskCompletionSource _runtimeTerminal = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     CodexAppServerConnection? _connection;
     IAcpProcess?              _process;
     Task                      _runLoop = Task.CompletedTask;
+    CancellationTokenSource?  _childCts;   // per-child read-loop token, so a teardown unblocks the loop
+    volatile bool             _restarting; // true only across the hook-trust seed-and-restart window
 
     string?                   _threadId;
     string?                   _resolvedModel;
-    string?                   _currentTurnId;
-    TaskCompletionSource?     _turnCompleted;
+    string?                   _currentTurnId;      // server turn id once the start response lands; null in the request window
+    TaskCompletionSource?     _turnCompleted;      // the current round's waiter
+    (string TurnId, string? Status)? _pendingCompletion; // an early turn/completed whose id we could not match yet
     CodexTokenUsage?          _usage;
     int                       _disposed;
 
@@ -127,7 +135,8 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     /// Runs the full launch sequence. Throws <see cref="CodexHooksNotInstalledException"/> when a
     /// critical hook is missing (the orchestrator maps it to a LaunchFailed with worktree cleanup);
     /// any other failure between spawn and the thread being established likewise propagates as a
-    /// launch failure — the slot is never half-held with no thread to key on.
+    /// launch failure. The factory disposes this runtime on any such failure, so a spawned child is
+    /// never leaked.
     /// </summary>
     public async Task StartAsync(CancellationToken ct) {
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _cts.Token);
@@ -141,8 +150,15 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
 
             case CodexHookTrustDecision.SeedAndRestart seed:
                 _logger.LogInformation("codex app-server: seeding hook trust and restarting the child.");
-                await TeardownChildAsync().ConfigureAwait(false);
-                await SpawnAndInitializeAsync(seed.StateOverride, linked.Token).ConfigureAwait(false);
+                // The teardown of child 1 is CONTROLLED — its read-loop end must not trip the
+                // whole-runtime terminal signal or fault a (nonexistent) turn, so gate that window.
+                _restarting = true;
+                try {
+                    await TeardownChildAsync().ConfigureAwait(false);
+                    await SpawnAndInitializeAsync(seed.StateOverride, linked.Token).ConfigureAwait(false);
+                } finally {
+                    _restarting = false;
+                }
 
                 if (CodexHookTrust.Classify(await ListHooksAsync(linked.Token).ConfigureAwait(false))
                         is not CodexHookTrustDecision.Proceed)
@@ -174,7 +190,8 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         connection.OnNotification  += HandleNotification;
         connection.OnServerRequest  = DeclineServerRequestAsync;
 
-        _runLoop = RunConnectionAsync(connection);
+        _childCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        _runLoop  = RunConnectionAsync(connection, _childCts.Token);
         _clock?.SetLaunchStage("spawned");
 
         var initParams = new JsonObject {
@@ -187,15 +204,17 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         _clock?.SetLaunchStage("initialized");
     }
 
-    async Task RunConnectionAsync(CodexAppServerConnection connection) {
+    async Task RunConnectionAsync(CodexAppServerConnection connection, CancellationToken ct) {
         try {
-            await connection.RunAsync(_cts.Token).ConfigureAwait(false);
+            await connection.RunAsync(ct).ConfigureAwait(false);
         } finally {
-            // The transport ended — the child died or was disposed. Fault any pending turn so
-            // WaitForTurnIdleAsync never hangs past the process it was waiting on.
-            _runLoopEnded.TrySetResult();
-            FaultPendingTurn(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime),
-                "codex app-server connection ended with a turn still in flight."));
+            // A controlled teardown for the hook-trust restart is NOT terminal: only the live child's
+            // read loop ending (death) or dispose flips the whole-runtime terminal signal.
+            if (!_restarting) {
+                _runtimeTerminal.TrySetResult();
+                FaultPendingTurn(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime),
+                    "codex app-server connection ended with a turn still in flight."));
+            }
         }
     }
 
@@ -258,16 +277,19 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
             ["approvalPolicy"]    = CodexAppServerPosture.RenderApprovalPolicy(_launch.Approval),
             ["approvalsReviewer"] = CodexAppServerPosture.ApprovalsReviewer,
         };
-        if (!string.IsNullOrEmpty(_launch.Model))
-            turnParams["model"] = _launch.Model;
+        if (!string.IsNullOrEmpty(_launch.Model))  turnParams["model"]  = _launch.Model;
+        if (!string.IsNullOrEmpty(_launch.Effort)) turnParams["effort"] = MapEffort(_launch.Effort);
 
-        // Arm the completion signal BEFORE the turn is on the wire, so a fast turn/completed can't
-        // race in against a null TCS.
+        // Arm the completion signal + the turn-in-flight clock BEFORE the turn is on the wire, so a
+        // fast turn/completed can neither race a null TCS nor leave the clock flipped back to
+        // in-flight after it was cleared.
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_turnGate) {
-            _turnCompleted = completion;
-            _currentTurnId = null;
+            _turnCompleted     = completion;
+            _currentTurnId     = null;
+            _pendingCompletion = null;
         }
+        _clock?.SetTurnInFlight(true);
 
         JsonElement result;
         try {
@@ -278,15 +300,31 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         }
 
         var turnId = result.TryGetProperty("turn", out var turn) ? Str(turn, "id") : null;
-        lock (_turnGate) _currentTurnId = turnId;
+        if (string.IsNullOrEmpty(turnId)) {
+            var ex = new InvalidOperationException("codex app-server: turn/start returned no turn id.");
+            FaultPendingTurn(ex);
+            throw ex;
+        }
 
-        _clock?.SetTurnInFlight(true);
-
-        // A turn that came back already terminal (status != inProgress) completes now — turn/completed
-        // may have raced ahead of the response.
         var status = turn.ValueKind == JsonValueKind.Object ? Str(turn, "status") : null;
-        if (status is not null and not "inProgress")
-            CompleteTurn(turnId, status);
+
+        // Bind the id, then reconcile against anything that raced ahead of this response:
+        //   - a turn/completed that arrived while the id was unknown (stashed), OR
+        //   - a response that itself came back already terminal.
+        bool completeNow = false;
+        string? completeStatus = null;
+        lock (_turnGate) {
+            _currentTurnId = turnId;
+            if (_pendingCompletion is { } pc && string.Equals(pc.TurnId, turnId, StringComparison.Ordinal)) {
+                completeNow = true;
+                completeStatus = pc.Status;
+            } else if (status is not null and not "inProgress") {
+                completeNow = true;
+                completeStatus = status;
+            }
+            _pendingCompletion = null; // discard a stash that was not ours
+        }
+        if (completeNow) CompleteTurn(turnId, completeStatus);
     }
 
     public Task SendUserInputAsync(string text) => StartTurnAsync(text, _cts.Token);
@@ -300,10 +338,10 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         if (tcs is null) return; // no turn in flight
 
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _cts.Token);
-        var completed = await Task.WhenAny(tcs.Task, _runLoopEnded.Task,
+        var completed = await Task.WhenAny(tcs.Task, _runtimeTerminal.Task,
             Task.Delay(Timeout.Infinite, linked.Token)).ConfigureAwait(false);
 
-        if (completed == tcs.Task || completed == _runLoopEnded.Task)
+        if (completed == tcs.Task || completed == _runtimeTerminal.Task)
             return; // turn settled, or the child died — either way the round is no longer in flight
 
         await completed.ConfigureAwait(false); // propagate cancellation
@@ -316,8 +354,7 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
             case "turn/completed": {
                 var turnId = n.Params is { } p && p.TryGetProperty("turn", out var turn) ? Str(turn, "id") : null;
                 var status = n.Params is { } p2 && p2.TryGetProperty("turn", out var t2) ? Str(t2, "status") : null;
-                _clock?.SetTurnInFlight(false);
-                CompleteTurn(turnId, status);
+                OnTurnCompletedNotification(turnId, status);
                 break;
             }
             case "thread/tokenUsage/updated":
@@ -330,30 +367,55 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         }
     }
 
-    void CompleteTurn(string? turnId, string? status) {
+    void OnTurnCompletedNotification(string? turnId, string? status) {
         lock (_turnGate) {
-            // Ignore a completion for a turn that is not the one we are waiting on (a stray late
-            // notification from a prior round).
-            if (_currentTurnId is not null && turnId is not null && !string.Equals(_currentTurnId, turnId, StringComparison.Ordinal))
+            if (_currentTurnId is null) {
+                // The turn/start response has not identified the current turn yet. Stash this
+                // completion by id; StartTurnAsync applies it iff it matches, else discards it.
+                if (turnId is not null) _pendingCompletion = (turnId, status);
                 return;
-
-            var tcs = _turnCompleted;
-            _turnCompleted = null;
-            _currentTurnId = null;
-            tcs?.TrySetResult();
+            }
+            if (turnId is not null && !string.Equals(_currentTurnId, turnId, StringComparison.Ordinal))
+                return; // a stale completion from another turn
         }
+        CompleteTurn(turnId, status);
+    }
 
+    /// <summary>The single point that settles the current round: clears the waiter under the lock
+    /// (so exactly one caller wins), then — only if there was a waiter — clears the turn-in-flight
+    /// clock and completes the TCS.</summary>
+    void CompleteTurn(string? turnId, string? status) {
+        TaskCompletionSource? tcs;
+        lock (_turnGate) {
+            if (_currentTurnId is not null && turnId is not null
+                && !string.Equals(_currentTurnId, turnId, StringComparison.Ordinal))
+                return; // not the turn we are waiting on
+
+            tcs = _turnCompleted;
+            _turnCompleted     = null;
+            _currentTurnId     = null;
+            _pendingCompletion = null;
+        }
+        if (tcs is null) return;
+
+        _clock?.SetTurnInFlight(false);
+        tcs.TrySetResult();
         if (status is "failed")
             _logger.LogWarning("codex app-server: turn completed with status=failed.");
     }
 
     void FaultPendingTurn(Exception ex) {
+        TaskCompletionSource? tcs;
         lock (_turnGate) {
-            var tcs = _turnCompleted;
-            _turnCompleted = null;
-            _currentTurnId = null;
-            tcs?.TrySetException(ex);
+            tcs = _turnCompleted;
+            _turnCompleted     = null;
+            _currentTurnId     = null;
+            _pendingCompletion = null;
         }
+        if (tcs is null) return;
+
+        _clock?.SetTurnInFlight(false);
+        tcs.TrySetException(ex);
     }
 
     /// <summary>
@@ -380,7 +442,7 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     // ── Backpressure-bounded request helper ────────────────────────────────────────────────────
 
     /// <summary>Every client→server request goes through a bounded retry on the app-server's
-    /// <c>-32001</c> bounded-ingress rejection (Q8); exhaustion surfaces the RPC error rather than
+    /// <c>-32001</c> bounded-ingress rejection; exhaustion surfaces the RPC error rather than
     /// spinning.</summary>
     async Task<JsonElement> RequestAsync(string method, JsonNode @params, CancellationToken ct) {
         var element = ToElement(@params);
@@ -397,10 +459,16 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
 
     // ── Interface members with no protocol meaning for an unattended reviewer ──────────────────
 
-    public IAsyncEnumerable<byte[]> ReadOutputAsync(CancellationToken ct = default) => Empty(ct);
+    /// <summary>The runtime emits no terminal bytes, but this enumerable must NOT complete until the
+    /// runtime is logically terminal: the orchestrator treats its completion as the finalize
+    /// trigger, so an immediate <c>yield break</c> would finalize (and kill) the reviewer seconds
+    /// after launch. Mirrors the ACP runtime — wait on the whole-runtime terminal signal or the
+    /// caller's cancellation, then end.</summary>
+    public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken ct = default) {
+        var ctTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var reg = ct.Register(() => ctTcs.TrySetResult()).ConfigureAwait(false);
 
-    static async IAsyncEnumerable<byte[]> Empty([EnumeratorCancellation] CancellationToken ct) {
-        await Task.CompletedTask.ConfigureAwait(false);
+        await Task.WhenAny(_runtimeTerminal.Task, ctTcs.Task).ConfigureAwait(false);
         yield break;
     }
 
@@ -442,14 +510,30 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         try { await _cts.CancelAsync().ConfigureAwait(false); } catch { /* best-effort */ }
 
         await TeardownChildAsync().ConfigureAwait(false);
+
+        // Ensure the terminal signal is set even if no read loop ever ran (e.g. spawn failed before
+        // the loop started) so a ReadOutputAsync consumer never hangs.
+        _runtimeTerminal.TrySetResult();
+        FaultPendingTurn(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime)));
         _cts.Dispose();
     }
 
+    /// <summary>Tears down the current child + connection and AWAITS its retiring read loop, so a
+    /// replacement (the hook-trust restart) is never installed while the old loop is still live.</summary>
     async Task TeardownChildAsync() {
         var connection = _connection;
         var process    = _process;
+        var runLoop    = _runLoop;
+        var childCts   = _childCts;
         _connection = null;
         _process    = null;
+        _childCts   = null;
+
+        // Cancel the read loop FIRST so it unblocks from ReadLineAsync (disposing the stream alone
+        // does not reliably unblock a pending pipe read), then await the retiring loop before a
+        // replacement is installed.
+        if (childCts is not null) try { await childCts.CancelAsync().ConfigureAwait(false); } catch { /* best-effort */ }
+        try { await runLoop.WaitAsync(TimeSpan.FromSeconds(5), _time).ConfigureAwait(false); } catch { /* best-effort */ }
 
         if (connection is not null) {
             connection.OnNotification -= HandleNotification;
@@ -457,9 +541,13 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         }
         if (process is not null)
             try { await process.DisposeAsync().ConfigureAwait(false); } catch { /* best-effort */ }
+        childCts?.Dispose();
     }
 
     // ── JSON helpers ───────────────────────────────────────────────────────────────────────────
+
+    static string MapEffort(string effort) =>
+        string.Equals(effort, "max", StringComparison.OrdinalIgnoreCase) ? "xhigh" : effort;
 
     static string? Str(JsonElement o, string name) =>
         o.ValueKind == JsonValueKind.Object && o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
@@ -223,18 +224,17 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         var result     = await RequestAsync("hooks/list", listParams, ct).ConfigureAwait(false);
 
         var entries = new List<CodexHookEntry>();
-        if (result.TryGetProperty("data", out var data) && data.ValueKind == JsonValueKind.Array) {
+        if (result.Arr("data") is { } data) {
             foreach (var group in data.EnumerateArray()) {
-                if (!group.TryGetProperty("hooks", out var hooks) || hooks.ValueKind != JsonValueKind.Array)
-                    continue;
+                if (group.Arr("hooks") is not { } hooks) continue;
 
                 foreach (var h in hooks.EnumerateArray()) {
                     entries.Add(new CodexHookEntry(
-                        Key:         Str(h, "key") ?? "",
-                        EventName:   Str(h, "eventName") ?? "",
-                        Command:     Str(h, "command") ?? "",
-                        CurrentHash: Str(h, "currentHash"),
-                        TrustStatus: Str(h, "trustStatus") ?? ""));
+                        Key:         h.Str("key") ?? "",
+                        EventName:   h.Str("eventName") ?? "",
+                        Command:     h.Str("command") ?? "",
+                        CurrentHash: h.Str("currentHash"),
+                        TrustStatus: h.Str("trustStatus") ?? ""));
                 }
             }
         }
@@ -257,8 +257,8 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
 
         var result = await RequestAsync("thread/start", startParams, ct).ConfigureAwait(false);
 
-        _threadId      = result.TryGetProperty("thread", out var thread) ? Str(thread, "id") : null;
-        _resolvedModel = Str(result, "model");
+        _threadId      = result.Obj("thread")?.Str("id");
+        _resolvedModel = result.Str("model");
         _clock?.SetLaunchStage("thread_started");
 
         if (string.IsNullOrEmpty(_threadId))
@@ -299,14 +299,15 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
             throw;
         }
 
-        var turnId = result.TryGetProperty("turn", out var turn) ? Str(turn, "id") : null;
+        var turn   = result.Obj("turn");
+        var turnId = turn?.Str("id");
         if (string.IsNullOrEmpty(turnId)) {
             var ex = new InvalidOperationException("codex app-server: turn/start returned no turn id.");
             FaultPendingTurn(ex);
             throw ex;
         }
 
-        var status = turn.ValueKind == JsonValueKind.Object ? Str(turn, "status") : null;
+        var status = turn?.Str("status");
 
         // Bind the id, then reconcile against anything that raced ahead of this response:
         //   - a turn/completed that arrived while the id was unknown (stashed), OR
@@ -352,9 +353,8 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     void HandleNotification(AcpNotification n) {
         switch (n.Method) {
             case "turn/completed": {
-                var turnId = n.Params is { } p && p.TryGetProperty("turn", out var turn) ? Str(turn, "id") : null;
-                var status = n.Params is { } p2 && p2.TryGetProperty("turn", out var t2) ? Str(t2, "status") : null;
-                OnTurnCompletedNotification(turnId, status);
+                var turn = n.Params is { } p ? p.Obj("turn") : null;
+                OnTurnCompletedNotification(turn?.Str("id"), turn?.Str("status"));
                 break;
             }
             case "thread/tokenUsage/updated":
@@ -549,28 +549,16 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     static string MapEffort(string effort) =>
         string.Equals(effort, "max", StringComparison.OrdinalIgnoreCase) ? "xhigh" : effort;
 
-    static string? Str(JsonElement o, string name) =>
-        o.ValueKind == JsonValueKind.Object && o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
-            ? v.GetString()
-            : null;
-
-    static long Long(JsonElement o, string name) =>
-        o.ValueKind == JsonValueKind.Object && o.TryGetProperty(name, out var v)
-            && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var n)
-            ? n : 0;
-
     static CodexTokenUsage? ParseUsage(JsonElement? paramsEl) {
-        if (paramsEl is not { } p || !p.TryGetProperty("tokenUsage", out var u) || u.ValueKind != JsonValueKind.Object)
-            return null;
-        if (!u.TryGetProperty("total", out var total) || total.ValueKind != JsonValueKind.Object)
+        if (paramsEl is not { } p || p.Obj("tokenUsage") is not { } u || u.Obj("total") is not { } total)
             return null;
 
         return new CodexTokenUsage(
-            InputTokens:     Long(total, "inputTokens"),
-            CachedInputTokens: Long(total, "cachedInputTokens"),
-            OutputTokens:    Long(total, "outputTokens"),
-            ReasoningOutputTokens: Long(total, "reasoningOutputTokens"),
-            TotalTokens:     Long(total, "totalTokens"));
+            InputTokens:           total.Num("inputTokens")           ?? 0,
+            CachedInputTokens:     total.Num("cachedInputTokens")     ?? 0,
+            OutputTokens:          total.Num("outputTokens")          ?? 0,
+            ReasoningOutputTokens: total.Num("reasoningOutputTokens") ?? 0,
+            TotalTokens:           total.Num("totalTokens")           ?? 0);
     }
 
     // JsonNode → JsonElement without reflection (AOT-safe): the node writes its own JSON.

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -1,0 +1,491 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// Spawns one <c>codex app-server</c> child (optionally with a hook-trust seed override appended to
+/// its argv) and returns the JSON-RPC connection over its stdio plus the process handle. The runtime
+/// calls this once for the initial launch and, at most once more, to re-spawn with a
+/// <c>hooks.state</c> seed when the hook-trust preflight requires it. Production wires it to a real
+/// <c>Process.Start</c>; tests wire it to an in-process fake app-server over pipes.
+/// </summary>
+internal delegate Task<(CodexAppServerConnection Connection, IAcpProcess Process)> CodexAppServerSpawn(
+    string? hookStateSeed, CancellationToken ct);
+
+/// <summary>Everything the runtime needs to drive one hosted reviewer's app-server session, resolved
+/// by the factory before the first spawn.</summary>
+/// <param name="Sandbox">The resolved <see cref="CodexPosturePolicy"/> sandbox token
+/// (<c>read-only</c> / <c>workspace-write</c> / <c>danger-full-access</c>), rendered per turn via
+/// <see cref="CodexAppServerPosture.RenderSandboxPolicy"/>.</param>
+/// <param name="Approval">The resolved approval token — always <c>never</c> for a reviewer.</param>
+/// <param name="WritableRoots">Writable roots for <c>workspace-write</c> (the owned worktree);
+/// ignored for the other sandboxes.</param>
+/// <param name="ClientVersion">Daemon version stamped into <c>initialize.clientInfo.version</c>.</param>
+internal sealed record CodexAppServerLaunch(
+    string                Cwd,
+    string?               Model,
+    string?               InitialPrompt,
+    string                Sandbox,
+    string                Approval,
+    IReadOnlyList<string> WritableRoots,
+    string                ClientVersion);
+
+/// <summary>
+/// A <see cref="IHostedAgentRuntime"/> that hosts a Codex reviewer over the <c>codex app-server</c>
+/// JSON-RPC protocol instead of the interactive PTY. It is control-plane only: the transcript is
+/// still recorded through the Codex hooks + <c>kcap watch</c> rollout path (which is why the
+/// hook-trust preflight is load-bearing), so this runtime never aggregates transcript from the
+/// protocol stream and <see cref="EmitsTerminalOutput"/> is <see langword="false"/>.
+///
+/// <para>Lifecycle (<see cref="StartAsync"/>, called by the factory): spawn → <c>initialize</c> →
+/// <c>hooks/list</c> trust preflight (seed + one restart when required) → <c>thread/start</c> →
+/// optional first <c>turn/start</c>. Each review round is a <c>turn/start</c> on the held thread;
+/// <see cref="WaitForTurnIdleAsync"/> resolves from the matching <c>turn/completed</c> notification.
+/// The reaper is fed through <see cref="AgentActivityClock"/> exactly as the ACP runtime feeds it.</para>
+///
+/// <para>Because <c>approvalPolicy</c> is pinned to <c>never</c>, any server-initiated approval
+/// request is a protocol violation — answered with a valid on-the-wire <c>decline</c> (never a
+/// JSON-RPC error, whose turn/process effect is Codex's to define) and logged at Error.</para>
+/// </summary>
+internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRuntime {
+    // Reviewers need lifecycle + usage only; opting out of the high-volume delta streams is a
+    // performance choice (the reader always drains regardless — the app-server blocks rather than
+    // dropping), not a correctness one.
+    static readonly string[] DeltaOptOut = [
+        "item/agentMessage/delta",
+        "item/reasoning/textDelta",
+        "item/reasoning/summaryTextDelta",
+        "item/commandExecution/outputDelta",
+        "item/fileChange/outputDelta",
+    ];
+
+    // The three critical hook events whose absence fails the launch closed live in CodexHookTrust;
+    // hooks/list is scoped to the reviewer cwd.
+    const string ClientName = "kcap-daemon";
+    const int    BackpressureMaxAttempts = 6;
+
+    readonly CodexAppServerSpawn  _spawn;
+    readonly CodexAppServerLaunch _launch;
+    readonly AgentActivityClock?  _clock;
+    readonly ILogger              _logger;
+    readonly TimeProvider         _time;
+    readonly CancellationTokenSource _cts = new();
+
+    readonly object              _turnGate = new();
+    readonly TaskCompletionSource _runLoopEnded = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    CodexAppServerConnection? _connection;
+    IAcpProcess?              _process;
+    Task                      _runLoop = Task.CompletedTask;
+
+    string?                   _threadId;
+    string?                   _resolvedModel;
+    string?                   _currentTurnId;
+    TaskCompletionSource?     _turnCompleted;
+    CodexTokenUsage?          _usage;
+    int                       _disposed;
+
+    public CodexAppServerHostedAgentRuntime(
+            CodexAppServerSpawn spawn, CodexAppServerLaunch launch, AgentActivityClock? clock,
+            ILogger logger, TimeProvider? timeProvider = null) {
+        _spawn   = spawn;
+        _launch  = launch;
+        _clock   = clock;
+        _logger  = logger;
+        _time    = timeProvider ?? TimeProvider.System;
+    }
+
+    // ── IHostedAgentRuntime: identity / lifecycle observables ──────────────────────────────────
+
+    public string Vendor              => "codex";
+    public int    Pid                 => _process?.Pid ?? 0;
+    public bool   HasExited           => _process?.HasExited ?? false;
+    public int?   ExitCode            => _process?.ExitCode;
+    public bool   EmitsTerminalOutput => false;
+
+    /// <summary>Resolved model from the <c>thread/start</c> response (never the requested one);
+    /// null until the handshake completes. Feeds the existing launch-attempt reporting.</summary>
+    public string? ResolvedModel => _resolvedModel;
+
+    /// <summary>Daemon-held thread id — the deterministic session-id correlation that replaces the
+    /// <c>CodexSessionRolloutLocator</c> timestamp race.</summary>
+    public string? ThreadId => _threadId;
+
+    /// <summary>Latest cumulative token usage reported over <c>thread/tokenUsage/updated</c>, or null
+    /// if none has arrived yet.</summary>
+    public CodexTokenUsage? Usage => _usage;
+
+    // ── Startup (called by the factory, not part of the interface) ─────────────────────────────
+
+    /// <summary>
+    /// Runs the full launch sequence. Throws <see cref="CodexHooksNotInstalledException"/> when a
+    /// critical hook is missing (the orchestrator maps it to a LaunchFailed with worktree cleanup);
+    /// any other failure between spawn and the thread being established likewise propagates as a
+    /// launch failure — the slot is never half-held with no thread to key on.
+    /// </summary>
+    public async Task StartAsync(CancellationToken ct) {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _cts.Token);
+
+        await SpawnAndInitializeAsync(hookStateSeed: null, linked.Token).ConfigureAwait(false);
+
+        var decision = CodexHookTrust.Classify(await ListHooksAsync(linked.Token).ConfigureAwait(false));
+        switch (decision) {
+            case CodexHookTrustDecision.Proceed:
+                break;
+
+            case CodexHookTrustDecision.SeedAndRestart seed:
+                _logger.LogInformation("codex app-server: seeding hook trust and restarting the child.");
+                await TeardownChildAsync().ConfigureAwait(false);
+                await SpawnAndInitializeAsync(seed.StateOverride, linked.Token).ConfigureAwait(false);
+
+                if (CodexHookTrust.Classify(await ListHooksAsync(linked.Token).ConfigureAwait(false))
+                        is not CodexHookTrustDecision.Proceed)
+                    throw new InvalidOperationException(
+                        "codex app-server: hook-trust seeding did not take effect after restart.");
+                break;
+
+            case CodexHookTrustDecision.MissingRequiredHooks missing:
+                throw new CodexHooksNotInstalledException(
+                    $"codex app-server: required hooks missing for events [{string.Join(", ", missing.MissingEvents)}].");
+
+            case CodexHookTrustDecision.Unseedable unseedable:
+                throw new InvalidOperationException(
+                    $"codex app-server: untrusted kcap hooks cannot be seeded (no current hash): [{string.Join(", ", unseedable.Keys)}].");
+        }
+
+        await StartThreadAsync(linked.Token).ConfigureAwait(false);
+        _clock?.ClearLaunchStage();
+
+        if (!string.IsNullOrEmpty(_launch.InitialPrompt))
+            await StartTurnAsync(_launch.InitialPrompt, linked.Token).ConfigureAwait(false);
+    }
+
+    async Task SpawnAndInitializeAsync(string? hookStateSeed, CancellationToken ct) {
+        var (connection, process) = await _spawn(hookStateSeed, ct).ConfigureAwait(false);
+        _connection = connection;
+        _process    = process;
+
+        connection.OnNotification  += HandleNotification;
+        connection.OnServerRequest  = DeclineServerRequestAsync;
+
+        _runLoop = RunConnectionAsync(connection);
+        _clock?.SetLaunchStage("spawned");
+
+        var initParams = new JsonObject {
+            ["clientInfo"]   = new JsonObject { ["name"] = ClientName, ["version"] = _launch.ClientVersion },
+            ["capabilities"] = new JsonObject {
+                ["optOutNotificationMethods"] = new JsonArray(DeltaOptOut.Select(m => (JsonNode?) m).ToArray()),
+            },
+        };
+        await RequestAsync("initialize", initParams, ct).ConfigureAwait(false);
+        _clock?.SetLaunchStage("initialized");
+    }
+
+    async Task RunConnectionAsync(CodexAppServerConnection connection) {
+        try {
+            await connection.RunAsync(_cts.Token).ConfigureAwait(false);
+        } finally {
+            // The transport ended — the child died or was disposed. Fault any pending turn so
+            // WaitForTurnIdleAsync never hangs past the process it was waiting on.
+            _runLoopEnded.TrySetResult();
+            FaultPendingTurn(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime),
+                "codex app-server connection ended with a turn still in flight."));
+        }
+    }
+
+    async Task<IReadOnlyList<CodexHookEntry>> ListHooksAsync(CancellationToken ct) {
+        var listParams = new JsonObject { ["cwds"] = new JsonArray((JsonNode?) _launch.Cwd) };
+        var result     = await RequestAsync("hooks/list", listParams, ct).ConfigureAwait(false);
+
+        var entries = new List<CodexHookEntry>();
+        if (result.TryGetProperty("data", out var data) && data.ValueKind == JsonValueKind.Array) {
+            foreach (var group in data.EnumerateArray()) {
+                if (!group.TryGetProperty("hooks", out var hooks) || hooks.ValueKind != JsonValueKind.Array)
+                    continue;
+
+                foreach (var h in hooks.EnumerateArray()) {
+                    entries.Add(new CodexHookEntry(
+                        Key:         Str(h, "key") ?? "",
+                        EventName:   Str(h, "eventName") ?? "",
+                        Command:     Str(h, "command") ?? "",
+                        CurrentHash: Str(h, "currentHash"),
+                        TrustStatus: Str(h, "trustStatus") ?? ""));
+                }
+            }
+        }
+        return entries;
+    }
+
+    async Task StartThreadAsync(CancellationToken ct) {
+        var startParams = new JsonObject {
+            ["cwd"]               = _launch.Cwd,
+            ["sandbox"]           = CodexAppServerPosture.RenderSandboxPolicy(_launch.Sandbox, _launch.WritableRoots),
+            ["approvalPolicy"]    = CodexAppServerPosture.RenderApprovalPolicy(_launch.Approval),
+            ["approvalsReviewer"] = CodexAppServerPosture.ApprovalsReviewer,
+        };
+        if (!string.IsNullOrEmpty(_launch.Model))
+            startParams["model"] = _launch.Model;
+
+        var result = await RequestAsync("thread/start", startParams, ct).ConfigureAwait(false);
+
+        _threadId      = result.TryGetProperty("thread", out var thread) ? Str(thread, "id") : null;
+        _resolvedModel = Str(result, "model");
+        _clock?.SetLaunchStage("thread_started");
+
+        if (string.IsNullOrEmpty(_threadId))
+            throw new InvalidOperationException("codex app-server: thread/start returned no thread id.");
+    }
+
+    // ── Turns / rounds ─────────────────────────────────────────────────────────────────────────
+
+    async Task StartTurnAsync(string prompt, CancellationToken ct) {
+        var threadId = _threadId ?? throw new InvalidOperationException("codex app-server: no thread to start a turn on.");
+
+        var turnParams = new JsonObject {
+            ["threadId"]          = threadId,
+            ["input"]             = new JsonArray(new JsonObject { ["type"] = "text", ["text"] = prompt }),
+            ["sandboxPolicy"]     = CodexAppServerPosture.RenderSandboxPolicy(_launch.Sandbox, _launch.WritableRoots),
+            ["approvalPolicy"]    = CodexAppServerPosture.RenderApprovalPolicy(_launch.Approval),
+            ["approvalsReviewer"] = CodexAppServerPosture.ApprovalsReviewer,
+        };
+        if (!string.IsNullOrEmpty(_launch.Model))
+            turnParams["model"] = _launch.Model;
+
+        // Arm the completion signal BEFORE the turn is on the wire, so a fast turn/completed can't
+        // race in against a null TCS.
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_turnGate) {
+            _turnCompleted = completion;
+            _currentTurnId = null;
+        }
+
+        JsonElement result;
+        try {
+            result = await RequestAsync("turn/start", turnParams, ct).ConfigureAwait(false);
+        } catch {
+            FaultPendingTurn(new OperationCanceledException("codex app-server: turn/start failed."));
+            throw;
+        }
+
+        var turnId = result.TryGetProperty("turn", out var turn) ? Str(turn, "id") : null;
+        lock (_turnGate) _currentTurnId = turnId;
+
+        _clock?.SetTurnInFlight(true);
+
+        // A turn that came back already terminal (status != inProgress) completes now — turn/completed
+        // may have raced ahead of the response.
+        var status = turn.ValueKind == JsonValueKind.Object ? Str(turn, "status") : null;
+        if (status is not null and not "inProgress")
+            CompleteTurn(turnId, status);
+    }
+
+    public Task SendUserInputAsync(string text) => StartTurnAsync(text, _cts.Token);
+
+    public async Task SendUserInputAndWaitForWriteAsync(string text) =>
+        await StartTurnAsync(text, _cts.Token).ConfigureAwait(false);
+
+    public async Task WaitForTurnIdleAsync(CancellationToken ct) {
+        TaskCompletionSource? tcs;
+        lock (_turnGate) tcs = _turnCompleted;
+        if (tcs is null) return; // no turn in flight
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _cts.Token);
+        var completed = await Task.WhenAny(tcs.Task, _runLoopEnded.Task,
+            Task.Delay(Timeout.Infinite, linked.Token)).ConfigureAwait(false);
+
+        if (completed == tcs.Task || completed == _runLoopEnded.Task)
+            return; // turn settled, or the child died — either way the round is no longer in flight
+
+        await completed.ConfigureAwait(false); // propagate cancellation
+    }
+
+    // ── Notifications & the always-decline approval bridge ─────────────────────────────────────
+
+    void HandleNotification(AcpNotification n) {
+        switch (n.Method) {
+            case "turn/completed": {
+                var turnId = n.Params is { } p && p.TryGetProperty("turn", out var turn) ? Str(turn, "id") : null;
+                var status = n.Params is { } p2 && p2.TryGetProperty("turn", out var t2) ? Str(t2, "status") : null;
+                _clock?.SetTurnInFlight(false);
+                CompleteTurn(turnId, status);
+                break;
+            }
+            case "thread/tokenUsage/updated":
+                _usage = ParseUsage(n.Params);
+                _clock?.Advance();
+                break;
+            default:
+                _clock?.Advance();
+                break;
+        }
+    }
+
+    void CompleteTurn(string? turnId, string? status) {
+        lock (_turnGate) {
+            // Ignore a completion for a turn that is not the one we are waiting on (a stray late
+            // notification from a prior round).
+            if (_currentTurnId is not null && turnId is not null && !string.Equals(_currentTurnId, turnId, StringComparison.Ordinal))
+                return;
+
+            var tcs = _turnCompleted;
+            _turnCompleted = null;
+            _currentTurnId = null;
+            tcs?.TrySetResult();
+        }
+
+        if (status is "failed")
+            _logger.LogWarning("codex app-server: turn completed with status=failed.");
+    }
+
+    void FaultPendingTurn(Exception ex) {
+        lock (_turnGate) {
+            var tcs = _turnCompleted;
+            _turnCompleted = null;
+            _currentTurnId = null;
+            tcs?.TrySetException(ex);
+        }
+    }
+
+    /// <summary>
+    /// Under <c>approvalPolicy: never</c> no approval request should ever arrive; if one does it is a
+    /// protocol violation. Answer it with a valid on-the-wire <c>decline</c> (never a JSON-RPC error,
+    /// whose turn/process effect is Codex's to define) and log at Error. The response shape differs
+    /// between the approval requests (<c>{decision:"decline"}</c>) and the MCP elicitation /
+    /// tool-input requests (<c>{action:"decline"}</c>), keyed on the method name.
+    /// </summary>
+    Task<JsonElement?> DeclineServerRequestAsync(AcpRequest request, CancellationToken ct) {
+        _logger.LogError(
+            "codex app-server: unexpected server request '{Method}' under approvalPolicy:never; declining.",
+            request.Method);
+
+        var isElicitation = request.Method.Contains("elicitation", StringComparison.Ordinal)
+                         || request.Method.Contains("requestUserInput", StringComparison.Ordinal);
+        var body = isElicitation
+            ? new JsonObject { ["action"]   = "decline" }
+            : new JsonObject { ["decision"] = "decline" };
+
+        return Task.FromResult<JsonElement?>(ToElement(body));
+    }
+
+    // ── Backpressure-bounded request helper ────────────────────────────────────────────────────
+
+    /// <summary>Every client→server request goes through a bounded retry on the app-server's
+    /// <c>-32001</c> bounded-ingress rejection (Q8); exhaustion surfaces the RPC error rather than
+    /// spinning.</summary>
+    async Task<JsonElement> RequestAsync(string method, JsonNode @params, CancellationToken ct) {
+        var element = ToElement(@params);
+        for (var attempt = 1; ; attempt++) {
+            try {
+                var connection = _connection ?? throw new InvalidOperationException("codex app-server: no connection.");
+                return await connection.RequestAsync(method, element, ct).ConfigureAwait(false);
+            } catch (CodexAppServerRpcException rpc) when (rpc.Code == -32001 && attempt < BackpressureMaxAttempts) {
+                var delay = TimeSpan.FromMilliseconds(50 * attempt + (attempt * 17 % 40));
+                await Task.Delay(delay, _time, ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    // ── Interface members with no protocol meaning for an unattended reviewer ──────────────────
+
+    public IAsyncEnumerable<byte[]> ReadOutputAsync(CancellationToken ct = default) => Empty(ct);
+
+    static async IAsyncEnumerable<byte[]> Empty([EnumeratorCancellation] CancellationToken ct) {
+        await Task.CompletedTask.ConfigureAwait(false);
+        yield break;
+    }
+
+    public Task SendSpecialKeyAsync(string key) => Task.CompletedTask;
+
+    public Task SendRawInputAsync(byte[] data) =>
+        throw new NotSupportedException("codex app-server hosted agents have no local-attach terminal surface.");
+
+    public void Resize(ushort cols, ushort rows) { /* no terminal */ }
+
+    public async Task RequestGracefulStopAsync() {
+        var connection = _connection;
+        var threadId   = _threadId;
+        var turnId     = _currentTurnId;
+        if (connection is null || threadId is null || turnId is null)
+            return;
+
+        try {
+            var interruptParams = ToElement(new JsonObject { ["threadId"] = threadId, ["turnId"] = turnId });
+            await connection.RequestAsync("turn/interrupt", interruptParams, _cts.Token).ConfigureAwait(false);
+            // Bounded wait for the interrupted turn to settle before the caller falls through to
+            // terminate; never let this block teardown.
+            await WaitForTurnIdleAsync(_cts.Token).WaitAsync(TimeSpan.FromSeconds(5), _time).ConfigureAwait(false);
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "codex app-server: graceful stop (turn/interrupt) failed; falling through to terminate.");
+        }
+    }
+
+    public Task WaitForExitAsync(TimeSpan? timeout = null) =>
+        _process?.WaitForExitAsync(timeout) ?? Task.CompletedTask;
+
+    public Task TerminateAsync(TimeSpan? timeout = null) =>
+        _process?.TerminateAsync(timeout) ?? Task.CompletedTask;
+
+    public async ValueTask DisposeAsync() {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        try { await _cts.CancelAsync().ConfigureAwait(false); } catch { /* best-effort */ }
+
+        await TeardownChildAsync().ConfigureAwait(false);
+        _cts.Dispose();
+    }
+
+    async Task TeardownChildAsync() {
+        var connection = _connection;
+        var process    = _process;
+        _connection = null;
+        _process    = null;
+
+        if (connection is not null) {
+            connection.OnNotification -= HandleNotification;
+            try { await connection.DisposeAsync().ConfigureAwait(false); } catch { /* best-effort */ }
+        }
+        if (process is not null)
+            try { await process.DisposeAsync().ConfigureAwait(false); } catch { /* best-effort */ }
+    }
+
+    // ── JSON helpers ───────────────────────────────────────────────────────────────────────────
+
+    static string? Str(JsonElement o, string name) =>
+        o.ValueKind == JsonValueKind.Object && o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    static long Long(JsonElement o, string name) =>
+        o.ValueKind == JsonValueKind.Object && o.TryGetProperty(name, out var v)
+            && v.ValueKind == JsonValueKind.Number && v.TryGetInt64(out var n)
+            ? n : 0;
+
+    static CodexTokenUsage? ParseUsage(JsonElement? paramsEl) {
+        if (paramsEl is not { } p || !p.TryGetProperty("tokenUsage", out var u) || u.ValueKind != JsonValueKind.Object)
+            return null;
+        if (!u.TryGetProperty("total", out var total) || total.ValueKind != JsonValueKind.Object)
+            return null;
+
+        return new CodexTokenUsage(
+            InputTokens:     Long(total, "inputTokens"),
+            CachedInputTokens: Long(total, "cachedInputTokens"),
+            OutputTokens:    Long(total, "outputTokens"),
+            ReasoningOutputTokens: Long(total, "reasoningOutputTokens"),
+            TotalTokens:     Long(total, "totalTokens"));
+    }
+
+    // JsonNode → JsonElement without reflection (AOT-safe): the node writes its own JSON.
+    static JsonElement ToElement(JsonNode node) =>
+        JsonDocument.Parse(node.ToJsonString()).RootElement.Clone();
+}
+
+/// <summary>Cumulative thread token usage from <c>thread/tokenUsage/updated.total</c>.</summary>
+internal readonly record struct CodexTokenUsage(
+    long InputTokens, long CachedInputTokens, long OutputTokens, long ReasoningOutputTokens, long TotalTokens);

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerPosture.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerPosture.cs
@@ -35,6 +35,17 @@ internal static class CodexAppServerPosture {
         return new JsonObject { ["type"] = "workspaceWrite", ["writableRoots"] = roots };
     }
 
+    /// <summary>Validates a resolved sandbox token and returns it as the coarse <c>SandboxMode</c>
+    /// STRING slotted into <c>thread/start</c>'s <c>sandbox</c> — a DIFFERENT wire shape from
+    /// <c>turn/start</c>'s <c>sandboxPolicy</c> object (<see cref="RenderSandboxPolicy"/>), which is
+    /// the load-bearing per-turn containment. The app-server rejects the object form here (verified
+    /// against the pinned binary), so this must stay the plain kebab-case string.</summary>
+    public static string RenderSandboxMode(string sandbox) => sandbox switch {
+        "read-only" or "workspace-write" or "danger-full-access" => sandbox,
+        _ => throw new ArgumentOutOfRangeException(nameof(sandbox), sandbox,
+            "Unknown Codex sandbox; app-server thread/start accepts only read-only, workspace-write, danger-full-access."),
+    };
+
     /// <summary>Validates the approval policy is one of the three known kebab-case strings and returns
     /// it verbatim — the value slotted into <c>turn/start</c>'s <c>approvalPolicy</c>. Anything else is
     /// rejected loudly: an unknown token or a granular object would either crash the app-server or

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -1,0 +1,168 @@
+using System.Diagnostics;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// The single <c>codex</c> runtime factory. It routes a launch to one of two transports and is the
+/// ONLY codex entry in the vendor→factory dictionary:
+/// <list type="bullet">
+/// <item>a review-flow (unattended) launch, when this daemon resolved app-server as active
+/// (<see cref="DaemonConfig.CodexAppServerActive"/> — operator selection + version floor, decided
+/// once by <see cref="CodexTransportDecision"/>), goes to
+/// <see cref="CodexAppServerHostedAgentRuntime"/>;</item>
+/// <item>everything else — every interactive launch, and every launch when the transport is PTY —
+/// delegates to the wrapped <see cref="PtyHostedAgentRuntimeFactory"/>, byte-identically to today.</item>
+/// </list>
+///
+/// <para>Capability advertisement (borrowed-review containment, unattended support, model resolver)
+/// is delegated to the PTY factory unchanged: the transport swaps the LAUNCH mechanism, not the
+/// containment story — a reviewer's read boundary stays <c>native-tool-clamp</c> either way. The
+/// launcher-policy version the server certifies against is chosen in <c>DaemonRunner</c> from the
+/// same <see cref="DaemonConfig.CodexAppServerActive"/> field this factory routes on, so the
+/// advertised policy and the transport used are one fact.</para>
+/// </summary>
+internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactory {
+    readonly CodexLauncher               _launcher;
+    readonly IHostedAgentRuntimeFactory  _pty;
+    readonly DaemonConfig                _config;
+    readonly ILoggerFactory              _loggerFactory;
+    readonly ILogger                     _logger;
+    readonly CodexAppServerSpawnFactory  _spawnFactory;
+
+    /// <param name="spawnFactory">Test seam only: production passes <see langword="null"/> and the
+    /// real <c>codex app-server</c> child is spawned via <see cref="Process"/>. A test can substitute
+    /// an in-process fake peer to drive the app-server route without a child process.</param>
+    public CodexHostedAgentRuntimeFactory(
+            CodexLauncher launcher, IHostedAgentRuntimeFactory ptyDelegate, DaemonConfig config,
+            ILoggerFactory loggerFactory, CodexAppServerSpawnFactory? spawnFactory = null) {
+        _launcher      = launcher;
+        _pty           = ptyDelegate;
+        _config        = config;
+        _loggerFactory = loggerFactory;
+        _logger        = loggerFactory.CreateLogger<CodexHostedAgentRuntimeFactory>();
+        _spawnFactory  = spawnFactory ?? DefaultSpawnFactory;
+    }
+
+    public string Vendor => "codex";
+
+    // Capability advertisement is transport-independent — delegate every member to the PTY factory.
+    public bool             IsAvailable()                              => _pty.IsAvailable();
+    public bool             SupportsUnattended                          => _pty.SupportsUnattended;
+    public UnattendedSupport DescribeUnattendedSupport()               => _pty.DescribeUnattendedSupport();
+    public bool             SupportsBorrowedReviewFlow                  => _pty.SupportsBorrowedReviewFlow;
+    public bool             BorrowedReviewRequiresIndependentSnapshot   => _pty.BorrowedReviewRequiresIndependentSnapshot;
+    public string?          BorrowedReviewContainment                   => _pty.BorrowedReviewContainment;
+    public bool             ReviewFlowRedirectsHome                     => _pty.ReviewFlowRedirectsHome;
+    public IReviewerModelResolver? ReviewerModelResolver               => _pty.ReviewerModelResolver;
+    public bool             SupportsModelSelection                      => _pty.SupportsModelSelection;
+
+    /// <summary>App-server is used for a launch only when the daemon resolved it active AND the
+    /// launch is unattended (review-flow). An interactive launch always takes the PTY path — even
+    /// under an app-server selection — because interactive hosting is a later phase.</summary>
+    internal bool UsesAppServer(RuntimeStartContext ctx) => _config.CodexAppServerActive && ctx.IsReviewFlow;
+
+    public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) =>
+        UsesAppServer(ctx) ? StartAppServerAsync(ctx, ct) : _pty.StartAsync(ctx, ct);
+
+    async Task<HostedRuntimeStart> StartAppServerAsync(RuntimeStartContext ctx, CancellationToken ct) {
+        var launcherCtx = BuildLauncherContext(ctx);
+
+        // Fail-closed hooks preflight + TrustWorktree config, exactly as the PTY path — a missing
+        // critical hook throws CodexHooksNotInstalledException for the orchestrator's cleanup path.
+        _launcher.Prepare(launcherCtx);
+
+        var (sandbox, approval) = CodexPosturePolicy.Resolve(ctx.Work, ctx.IsReviewFlow, ctx.CodexPosture);
+        var appServerArgs = _launcher.BuildAppServerLaunchArgs(launcherCtx);
+        var env           = BuildEnv(ctx);
+
+        var launch = new CodexAppServerLaunch(
+            Cwd:           ctx.Worktree.Path,
+            Model:         ctx.Model,
+            InitialPrompt: ctx.Prompt,
+            Sandbox:       sandbox,
+            Approval:      approval,
+            WritableRoots: [ctx.Worktree.Path],
+            ClientVersion: string.IsNullOrEmpty(_config.Version) ? "0.0.0" : _config.Version);
+
+        CodexAppServerSpawn spawn = (seed, spawnCt) =>
+            _spawnFactory(_launcher.CliPath, appServerArgs, seed, ctx.Worktree.Path, env, _config, _loggerFactory);
+
+        var runtime = new CodexAppServerHostedAgentRuntime(
+            spawn, launch, ctx.ActivityClock,
+            _loggerFactory.CreateLogger<CodexAppServerHostedAgentRuntime>());
+
+        await runtime.StartAsync(ct).ConfigureAwait(false);
+        return new HostedRuntimeStart(runtime, McpConfigPath: null);
+    }
+
+    static LauncherContext BuildLauncherContext(RuntimeStartContext ctx) => new(
+        AgentId:        ctx.AgentId,
+        SourceRepoPath: ctx.SourceRepoPath,
+        Worktree:       ctx.Worktree,
+        Prompt:         ctx.Prompt,
+        Model:          ctx.Model,
+        Effort:         ctx.Effort,
+        Tools:          ctx.Tools,
+        IsReview:       ctx.IsReview,
+        IsReviewFlow:   ctx.IsReviewFlow,
+        Review:         ctx.Review,
+        // App-server review flows carry no PR-review MCP launch (ctx.IsReview is false); the
+        // flow-result + allowlist servers are spliced by BuildAppServerLaunchArgs from IsReviewFlow.
+        ReviewLaunch:   null) {
+        McpAllowlist = ctx.McpAllowlist,
+        Work         = ctx.Work,
+        CodexPosture = ctx.CodexPosture,
+    };
+
+    static Dictionary<string, string> BuildEnv(RuntimeStartContext ctx) {
+        var env = new Dictionary<string, string> {
+            ["KCAP_RENDERED_AGENT"] = "1",
+            ["KCAP_AGENT_ID"]       = ctx.AgentId,
+        };
+        if (!string.IsNullOrEmpty(ctx.DaemonId))        env["KCAP_DAEMON_ID"]    = ctx.DaemonId;
+        if (!string.IsNullOrEmpty(ctx.DaemonEpoch))     env["KCAP_DAEMON_EPOCH"] = ctx.DaemonEpoch;
+        if (!string.IsNullOrEmpty(ctx.ServerUrl))       env["KCAP_URL"]          = ctx.ServerUrl;
+        if (!string.IsNullOrEmpty(ctx.DaemonBridgeUrl)) env["KCAP_DAEMON_URL"]   = ctx.DaemonBridgeUrl;
+        return env;
+    }
+
+    /// <summary>The real spawn: <c>codex app-server</c> as a child process, its stdio wrapped by the
+    /// shared <see cref="AcpChildProcess"/> (stderr drain + terminate) and the JSON-RPC transport.</summary>
+    static Task<(CodexAppServerConnection, IAcpProcess)> DefaultSpawnFactory(
+            string cliPath, IReadOnlyList<string> appServerArgs, string? hookStateSeed, string cwd,
+            IReadOnlyDictionary<string, string> env, DaemonConfig config, ILoggerFactory loggerFactory) {
+        var argv = new List<string> { "app-server" };
+        argv.AddRange(appServerArgs);
+        if (!string.IsNullOrEmpty(hookStateSeed)) {
+            argv.Add("-c");
+            argv.Add(hookStateSeed);
+        }
+
+        var psi = new ProcessStartInfo(cliPath, argv) {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+            WorkingDirectory       = cwd,
+        };
+        foreach (var (k, v) in env) psi.Environment[k] = v;
+
+        var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start '{cliPath} {string.Join(' ', argv)}'.");
+        var child = new AcpChildProcess(process, loggerFactory.CreateLogger<AcpChildProcess>(), config.DebugFrames, "codex");
+        var conn  = new CodexAppServerConnection(
+            process.StandardInput.BaseStream, process.StandardOutput.BaseStream,
+            loggerFactory.CreateLogger<CodexAppServerConnection>(), config.DebugFrames);
+
+        return Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((conn, child));
+    }
+}
+
+/// <summary>Test seam for how a <c>codex app-server</c> child (and its transport) is produced —
+/// production spawns a real process; a test substitutes an in-process fake peer.</summary>
+internal delegate Task<(CodexAppServerConnection Connection, IAcpProcess Process)> CodexAppServerSpawnFactory(
+    string cliPath, IReadOnlyList<string> appServerArgs, string? hookStateSeed, string cwd,
+    IReadOnlyDictionary<string, string> env, DaemonConfig config, ILoggerFactory loggerFactory);

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -81,6 +81,7 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
         var launch = new CodexAppServerLaunch(
             Cwd:           ctx.Worktree.Path,
             Model:         ctx.Model,
+            Effort:        ctx.Effort,
             InitialPrompt: ctx.Prompt,
             Sandbox:       sandbox,
             Approval:      approval,
@@ -94,7 +95,15 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
             spawn, launch, ctx.ActivityClock,
             _loggerFactory.CreateLogger<CodexAppServerHostedAgentRuntime>());
 
-        await runtime.StartAsync(ct).ConfigureAwait(false);
+        // StartAsync may spawn a child before it throws (a failed hooks/list, thread/start, or initial
+        // turn on the fail-closed paths). The orchestrator never receives a runtime it did not get a
+        // HostedRuntimeStart for, so dispose it here to avoid leaking a live Codex child.
+        try {
+            await runtime.StartAsync(ct).ConfigureAwait(false);
+        } catch {
+            await runtime.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
         return new HostedRuntimeStart(runtime, McpConfigPath: null);
     }
 

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTransportDecision.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTransportDecision.cs
@@ -24,8 +24,16 @@ internal static class CodexTransportDecision {
     /// <summary>Resolves the effective transport: app-server only when selected AND the installed
     /// build meets <see cref="VersionFloor"/>. An unknown/unparseable version fails toward PTY.</summary>
     public static bool UsesAppServer(string? transport, string? cliVersion) =>
-        string.Equals(transport?.Trim(), AppServer, StringComparison.OrdinalIgnoreCase)
-        && MeetsFloor(cliVersion);
+        IsAppServerSelected(transport) && MeetsFloor(cliVersion);
+
+    /// <summary>Resolves the daemon-wide <c>CodexAppServerActive</c> at startup. The version probe is
+    /// deferred behind the selection check so a PTY daemon (the default) never pays for it — which is
+    /// why this owns the composition rather than the caller evaluating the probe eagerly.</summary>
+    public static bool ResolveActive(string? transport, Func<string?> probeCliVersion) =>
+        IsAppServerSelected(transport) && MeetsFloor(probeCliVersion());
+
+    static bool IsAppServerSelected(string? transport) =>
+        string.Equals(transport?.Trim(), AppServer, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>True when <paramref name="cliVersion"/> parses and is >= <see cref="VersionFloor"/>.
     /// Tolerant of surrounding text (e.g. <c>"codex-cli 0.146.0"</c>) — it extracts the first

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTransportDecision.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTransportDecision.cs
@@ -17,7 +17,7 @@ internal static class CodexTransportDecision {
     public const string Pty        = "pty";
 
     /// <summary>Spike-pinned minimum Codex version whose app-server method set + behavioural
-    /// containment probes are verified (AI-1760). A lower build runs PTY even under an app-server
+    /// containment probes are verified. A lower build runs PTY even under an app-server
     /// selection.</summary>
     public const string VersionFloor = "0.146.0";
 

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTransportDecision.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTransportDecision.cs
@@ -45,22 +45,22 @@ internal static class CodexTransportDecision {
     static (int Major, int Minor, int Patch)? ParseSemver(string? version) {
         if (string.IsNullOrWhiteSpace(version)) return null;
 
-        // Find the first token shaped `<digits>.<digits>[.<digits>]` so trailing/leading words
-        // (a `codex-cli` prefix, a pre-release suffix) do not defeat the parse.
-        foreach (var token in version.Split([' ', '\t', '\r', '\n', '-', '_'], StringSplitOptions.RemoveEmptyEntries)) {
+        // Accept ONLY a clean numeric release token `<digits>.<digits>[.<digits>]` (a `codex-cli`
+        // prefix word is split off on whitespace and ignored). A prerelease or build-metadata tail
+        // (`0.146.0-rc.1`, `0.146.0+meta`) or a non-numeric part makes that token non-clean, so it
+        // is rejected and the caller fails toward PTY — this gate enables the containment-sensitive
+        // transport, so an RC that is BELOW the verified release must never be normalized upward to it.
+        foreach (var token in version.Split([' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries)) {
             var t = token.TrimStart('v', 'V');
             var parts = t.Split('.');
-            if (parts.Length < 2) continue;
-            if (!int.TryParse(parts[0], out var major) || !int.TryParse(parts[1], out var minor)) continue;
+            if (parts.Length is < 2 or > 3) continue;
+            if (!AllDigits(parts[0]) || !AllDigits(parts[1])) continue;
+            if (parts.Length == 3 && !AllDigits(parts[2])) continue;
 
-            var patch = 0;
-            if (parts.Length >= 3) {
-                // Patch may carry a pre-release tail ("0+meta" / "0rc1"); take the leading digits.
-                var digits = new string(parts[2].TakeWhile(char.IsDigit).ToArray());
-                _ = int.TryParse(digits, out patch);
-            }
-            return (major, minor, patch);
+            return (int.Parse(parts[0]), int.Parse(parts[1]), parts.Length == 3 ? int.Parse(parts[2]) : 0);
         }
         return null;
     }
+
+    static bool AllDigits(string s) => s.Length > 0 && s.All(char.IsAsciiDigit);
 }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTransportDecision.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTransportDecision.cs
@@ -1,0 +1,66 @@
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// The ONE rule that decides whether this daemon hosts Codex reviewers over <c>codex app-server</c>
+/// instead of the interactive PTY. Both the launch router
+/// (<see cref="CodexHostedAgentRuntimeFactory"/>, via the resolved
+/// <c>DaemonConfig.CodexAppServerActive</c>) and the certification advertisement
+/// (<c>DaemonRunner</c>, which sets that same field) read this one function, so the advertised
+/// launcher-policy version and the transport actually used can never diverge.
+///
+/// <para>App-server is used only when the operator selected it AND the installed Codex meets the
+/// spike-pinned floor (0.146.0 — all behavioural probes ran on it). Below the floor with app-server
+/// selected, the daemon falls back to PTY and advertises the PTY policy: one fact, computed once.</para>
+/// </summary>
+internal static class CodexTransportDecision {
+    public const string AppServer  = "app-server";
+    public const string Pty        = "pty";
+
+    /// <summary>Spike-pinned minimum Codex version whose app-server method set + behavioural
+    /// containment probes are verified (AI-1760). A lower build runs PTY even under an app-server
+    /// selection.</summary>
+    public const string VersionFloor = "0.146.0";
+
+    /// <summary>Resolves the effective transport: app-server only when selected AND the installed
+    /// build meets <see cref="VersionFloor"/>. An unknown/unparseable version fails toward PTY.</summary>
+    public static bool UsesAppServer(string? transport, string? cliVersion) =>
+        string.Equals(transport?.Trim(), AppServer, StringComparison.OrdinalIgnoreCase)
+        && MeetsFloor(cliVersion);
+
+    /// <summary>True when <paramref name="cliVersion"/> parses and is >= <see cref="VersionFloor"/>.
+    /// Tolerant of surrounding text (e.g. <c>"codex-cli 0.146.0"</c>) — it extracts the first
+    /// dotted numeric token.</summary>
+    public static bool MeetsFloor(string? cliVersion) {
+        var actual = ParseSemver(cliVersion);
+        var floor  = ParseSemver(VersionFloor);
+        if (actual is null || floor is null) return false;
+
+        var (aMaj, aMin, aPat) = actual.Value;
+        var (fMaj, fMin, fPat) = floor.Value;
+        if (aMaj != fMaj) return aMaj > fMaj;
+        if (aMin != fMin) return aMin > fMin;
+        return aPat >= fPat;
+    }
+
+    static (int Major, int Minor, int Patch)? ParseSemver(string? version) {
+        if (string.IsNullOrWhiteSpace(version)) return null;
+
+        // Find the first token shaped `<digits>.<digits>[.<digits>]` so trailing/leading words
+        // (a `codex-cli` prefix, a pre-release suffix) do not defeat the parse.
+        foreach (var token in version.Split([' ', '\t', '\r', '\n', '-', '_'], StringSplitOptions.RemoveEmptyEntries)) {
+            var t = token.TrimStart('v', 'V');
+            var parts = t.Split('.');
+            if (parts.Length < 2) continue;
+            if (!int.TryParse(parts[0], out var major) || !int.TryParse(parts[1], out var minor)) continue;
+
+            var patch = 0;
+            if (parts.Length >= 3) {
+                // Patch may carry a pre-release tail ("0+meta" / "0rc1"); take the leading digits.
+                var digits = new string(parts[2].TakeWhile(char.IsDigit).ToArray());
+                _ = int.TryParse(digits, out patch);
+            }
+            return (major, minor, patch);
+        }
+        return null;
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerConnectionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerConnectionTests.cs
@@ -408,6 +408,33 @@ public class CodexAppServerConnectionTests {
         await SwallowCancellation(runTask);
     }
 
+    [Test]
+    public async Task Wrong_typed_method_on_a_server_request_answers_invalid_request_with_the_id() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        // A frame with an id but a NUMERIC method must not strand the id — the "always one response"
+        // guarantee covers the dispatch/validation path too.
+        await harness.WriteFrameToConnectionAsync("""{"jsonrpc":"2.0","id":55,"method":123,"params":{}}""");
+
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        using var doc = JsonDocument.Parse(frame);
+        await Assert.That(doc.RootElement.GetProperty("id").GetInt64()).IsEqualTo(55L);
+        await Assert.That(doc.RootElement.TryGetProperty("result", out _)).IsFalse();
+        await Assert.That(doc.RootElement.GetProperty("error").GetProperty("code").GetInt32()).IsEqualTo(-32600);
+
+        // Loop still alive afterward.
+        var tcs = new TaskCompletionSource<AcpNotification>(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Connection.OnNotification += n => tcs.TrySetResult(n);
+        await harness.WriteFrameToConnectionAsync("""{"jsonrpc":"2.0","method":"turn.completed","params":{"threadId":"alive"}}""");
+        var notification = await tcs.Task.WaitAsync(HangGuard);
+        await Assert.That(notification.Params!.Value.GetProperty("threadId").GetString()).IsEqualTo("alive");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
     static async Task SwallowCancellation(Task task) {
         try {
             await task.WaitAsync(HangGuard);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerConnectionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerConnectionTests.cs
@@ -1,0 +1,418 @@
+using System.IO.Pipelines;
+using System.Text;
+using System.Text.Json;
+using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// Exercises <see cref="CodexAppServerConnection"/> over an in-memory duplex "wire" so no real
+/// process is spawned — the same harness shape as <c>AcpConnectionTests</c> (two <see cref="Pipe"/>s
+/// standing in for the app-server's stdin/stdout). The app-server speaks the same JSON-RPC 2.0
+/// envelope as ACP, so these tests pin the transport contract the runtime depends on: id
+/// correlation, out-of-order responses, error faulting, notification fan-out, the always-answered
+/// server-request guarantee, and read-loop resilience to malformed frames.
+/// </summary>
+public class CodexAppServerConnectionTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    sealed class Harness : IAsyncDisposable {
+        readonly Pipe   _toAgent  = new();
+        readonly Pipe   _toClient = new();
+        readonly Stream _agentReadsFromClient;
+        readonly Stream _agentWritesToClient;
+
+        public CodexAppServerConnection Connection { get; }
+
+        public Harness(ILogger? logger = null, bool debugFrames = false) {
+            _agentReadsFromClient = _toAgent.Reader.AsStream();
+            _agentWritesToClient  = _toClient.Writer.AsStream();
+
+            Connection = new CodexAppServerConnection(
+                writeStream: _toAgent.Writer.AsStream(),
+                readStream: _toClient.Reader.AsStream(),
+                logger: logger ?? NullLogger<CodexAppServerConnection>.Instance,
+                debugFrames: debugFrames
+            );
+        }
+
+        public async Task<string> ReadFrameFromConnectionAsync() {
+            var line = await ReadLineAsync(_agentReadsFromClient).WaitAsync(HangGuard);
+            return line ?? throw new InvalidOperationException("stream completed before a frame arrived");
+        }
+
+        public async Task WriteFrameToConnectionAsync(string json) {
+            var bytes = Encoding.UTF8.GetBytes(json + "\n");
+            await _agentWritesToClient.WriteAsync(bytes).AsTask().WaitAsync(HangGuard);
+            await _agentWritesToClient.FlushAsync().WaitAsync(HangGuard);
+        }
+
+        static async Task<string?> ReadLineAsync(Stream stream) {
+            var buffer = new List<byte>();
+            var one    = new byte[1];
+
+            while (true) {
+                var n = await stream.ReadAsync(one);
+                if (n == 0)
+                    return buffer.Count == 0 ? null : Encoding.UTF8.GetString(buffer.ToArray());
+
+                if (one[0] == (byte) '\n')
+                    return Encoding.UTF8.GetString(buffer.ToArray());
+
+                buffer.Add(one[0]);
+            }
+        }
+
+        public ValueTask DisposeAsync() => Connection.DisposeAsync();
+    }
+
+    [Test]
+    public async Task RequestAsync_resolves_with_result_on_matching_response() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        var requestTask = harness.Connection.RequestAsync("initialize", null, CancellationToken.None);
+
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        using var doc = JsonDocument.Parse(frame);
+        var       id  = doc.RootElement.GetProperty("id").GetInt64();
+        await Assert.That(doc.RootElement.GetProperty("method").GetString()).IsEqualTo("initialize");
+        await Assert.That(doc.RootElement.GetProperty("jsonrpc").GetString()).IsEqualTo("2.0");
+
+        await harness.WriteFrameToConnectionAsync(
+            $$$"""{"jsonrpc":"2.0","id":{{{id}}},"result":{"userAgent":"codex"}}"""
+        );
+
+        var result = await requestTask.WaitAsync(HangGuard);
+        await Assert.That(result.GetProperty("userAgent").GetString()).IsEqualTo("codex");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Concurrent_requests_correlate_to_their_own_responses_when_interleaved() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        var requestA = harness.Connection.RequestAsync("newThread", null, CancellationToken.None);
+        var frameA   = await harness.ReadFrameFromConnectionAsync();
+        var idA      = JsonDocument.Parse(frameA).RootElement.GetProperty("id").GetInt64();
+
+        var requestB = harness.Connection.RequestAsync("sendTurn", null, CancellationToken.None);
+        var frameB   = await harness.ReadFrameFromConnectionAsync();
+        var idB      = JsonDocument.Parse(frameB).RootElement.GetProperty("id").GetInt64();
+
+        await Assert.That(idA).IsNotEqualTo(idB);
+
+        // Respond out of order: B's response arrives before A's.
+        await harness.WriteFrameToConnectionAsync($$$"""{"jsonrpc":"2.0","id":{{{idB}}},"result":{"marker":"B"}}""");
+        await harness.WriteFrameToConnectionAsync($$$"""{"jsonrpc":"2.0","id":{{{idA}}},"result":{"marker":"A"}}""");
+
+        var resultA = await requestA.WaitAsync(HangGuard);
+        var resultB = await requestB.WaitAsync(HangGuard);
+
+        await Assert.That(resultA.GetProperty("marker").GetString()).IsEqualTo("A");
+        await Assert.That(resultB.GetProperty("marker").GetString()).IsEqualTo("B");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Error_response_throws_CodexAppServerRpcException_with_code_and_message() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        var requestTask = harness.Connection.RequestAsync("sendTurn", null, CancellationToken.None);
+        var frame       = await harness.ReadFrameFromConnectionAsync();
+        var id          = JsonDocument.Parse(frame).RootElement.GetProperty("id").GetInt64();
+
+        await harness.WriteFrameToConnectionAsync(
+            $$$"""{"jsonrpc":"2.0","id":{{{id}}},"error":{"code":-32602,"message":"invalid thread"}}"""
+        );
+
+        var ex = await Assert.ThrowsAsync<CodexAppServerRpcException>(() => requestTask.WaitAsync(HangGuard));
+        await Assert.That(ex!.Code).IsEqualTo(-32602);
+        await Assert.That(ex.Message).IsEqualTo("invalid thread");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Inbound_notification_raises_OnNotification_with_method_and_params() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        var tcs = new TaskCompletionSource<AcpNotification>(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Connection.OnNotification += n => tcs.TrySetResult(n);
+
+        await harness.WriteFrameToConnectionAsync(
+            """{"jsonrpc":"2.0","method":"turn.completed","params":{"threadId":"t1","usage":{"inputTokens":10}}}"""
+        );
+
+        var notification = await tcs.Task.WaitAsync(HangGuard);
+        await Assert.That(notification.Method).IsEqualTo("turn.completed");
+        await Assert.That(notification.Params).IsNotNull();
+        await Assert.That(notification.Params!.Value.GetProperty("threadId").GetString()).IsEqualTo("t1");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Inbound_server_request_with_handler_set_invokes_handler_and_echoes_id() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        harness.Connection.OnServerRequest = (_, _) =>
+            Task.FromResult<JsonElement?>(JsonSerializer.SerializeToElement(new { decision = "approved" }));
+
+        await harness.WriteFrameToConnectionAsync(
+            """{"jsonrpc":"2.0","id":99,"method":"execCommandApproval","params":{"command":"ls"}}"""
+        );
+
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        using var doc = JsonDocument.Parse(frame);
+        await Assert.That(doc.RootElement.GetProperty("id").GetInt64()).IsEqualTo(99L);
+        await Assert.That(doc.RootElement.TryGetProperty("error", out _)).IsFalse();
+        await Assert.That(doc.RootElement.GetProperty("result").GetProperty("decision").GetString()).IsEqualTo("approved");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Inbound_server_request_handler_throwing_still_writes_an_internal_error_response() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        harness.Connection.OnServerRequest = (_, _) => throw new InvalidOperationException("boom");
+
+        await harness.WriteFrameToConnectionAsync(
+            """{"jsonrpc":"2.0","id":7,"method":"execCommandApproval","params":{}}"""
+        );
+
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        using var doc = JsonDocument.Parse(frame);
+        await Assert.That(doc.RootElement.GetProperty("id").GetInt64()).IsEqualTo(7L);
+        await Assert.That(doc.RootElement.TryGetProperty("result", out _)).IsFalse();
+        await Assert.That(doc.RootElement.GetProperty("error").GetProperty("code").GetInt32()).IsEqualTo(-32603);
+
+        // Loop must still be alive afterward — a wedge would silently swallow this too.
+        var tcs = new TaskCompletionSource<AcpNotification>(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Connection.OnNotification += n => tcs.TrySetResult(n);
+        await harness.WriteFrameToConnectionAsync("""{"jsonrpc":"2.0","method":"turn.completed","params":{"threadId":"alive"}}""");
+        var notification = await tcs.Task.WaitAsync(HangGuard);
+        await Assert.That(notification.Params!.Value.GetProperty("threadId").GetString()).IsEqualTo("alive");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Inbound_server_request_with_no_handler_writes_method_not_found_error() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        // OnServerRequest intentionally left unset (default-decline posture) — an unattended reviewer
+        // never elevates an approval request into a grant.
+        await harness.WriteFrameToConnectionAsync(
+            """{"jsonrpc":"2.0","id":99,"method":"applyPatchApproval","params":{}}"""
+        );
+
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        using var doc = JsonDocument.Parse(frame);
+        await Assert.That(doc.RootElement.GetProperty("id").GetInt64()).IsEqualTo(99L);
+        await Assert.That(doc.RootElement.TryGetProperty("result", out _)).IsFalse();
+        await Assert.That(doc.RootElement.GetProperty("error").GetProperty("code").GetInt32()).IsEqualTo(-32601);
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Inbound_server_request_handler_returning_null_writes_method_not_found_error() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        harness.Connection.OnServerRequest = (_, _) => Task.FromResult<JsonElement?>(null);
+
+        await harness.WriteFrameToConnectionAsync(
+            """{"jsonrpc":"2.0","id":8,"method":"applyPatchApproval","params":{}}"""
+        );
+
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        using var doc = JsonDocument.Parse(frame);
+        await Assert.That(doc.RootElement.GetProperty("id").GetInt64()).IsEqualTo(8L);
+        await Assert.That(doc.RootElement.TryGetProperty("result", out _)).IsFalse();
+        await Assert.That(doc.RootElement.GetProperty("error").GetProperty("code").GetInt32()).IsEqualTo(-32601);
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Server_request_with_string_id_echoes_the_same_string_id_verbatim() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        harness.Connection.OnServerRequest = (_, _) =>
+            Task.FromResult<JsonElement?>(JsonSerializer.SerializeToElement(new { decision = "denied" }));
+
+        await harness.WriteFrameToConnectionAsync(
+            """{"jsonrpc":"2.0","id":"srv-generated-string-id","method":"execCommandApproval","params":{}}"""
+        );
+
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        using var doc = JsonDocument.Parse(frame);
+        var idElement = doc.RootElement.GetProperty("id");
+        await Assert.That(idElement.ValueKind).IsEqualTo(JsonValueKind.String);
+        await Assert.That(idElement.GetString()).IsEqualTo("srv-generated-string-id");
+
+        // Loop still alive after a string-id request (guards a naive long-forcing implementation).
+        var tcs = new TaskCompletionSource<AcpNotification>(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Connection.OnNotification += n => tcs.TrySetResult(n);
+        await harness.WriteFrameToConnectionAsync("""{"jsonrpc":"2.0","method":"turn.completed","params":{"threadId":"alive"}}""");
+        var notification = await tcs.Task.WaitAsync(HangGuard);
+        await Assert.That(notification.Params!.Value.GetProperty("threadId").GetString()).IsEqualTo("alive");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Cancelling_token_abandons_pending_request_without_hanging() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        using var requestCts = new CancellationTokenSource();
+        var       requestTask = harness.Connection.RequestAsync("sendTurn", null, requestCts.Token);
+
+        await harness.ReadFrameFromConnectionAsync();
+        requestCts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => requestTask.WaitAsync(HangGuard));
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Malformed_line_is_skipped_and_loop_still_delivers_next_valid_frame() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        var tcs = new TaskCompletionSource<AcpNotification>(TaskCreationOptions.RunContinuationsAsynchronously);
+        harness.Connection.OnNotification += n => tcs.TrySetResult(n);
+
+        await harness.WriteFrameToConnectionAsync("{not valid json at all");
+        await harness.WriteFrameToConnectionAsync("""{"jsonrpc":"2.0","method":"turn.completed","params":{"threadId":"alive"}}""");
+
+        var notification = await tcs.Task.WaitAsync(HangGuard);
+        await Assert.That(notification.Params!.Value.GetProperty("threadId").GetString()).IsEqualTo("alive");
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Wrong_typed_error_code_on_a_pending_request_faults_the_caller_instead_of_hanging() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        var requestTask = harness.Connection.RequestAsync("sendTurn", null, CancellationToken.None);
+        var frame       = await harness.ReadFrameFromConnectionAsync();
+        var id          = JsonDocument.Parse(frame).RootElement.GetProperty("id").GetInt64();
+
+        // Well-formed JSON with a wrong-typed error.code — must fault the caller, not orphan it.
+        await harness.WriteFrameToConnectionAsync(
+            $$$"""{"jsonrpc":"2.0","id":{{{id}}},"error":{"code":"oops","message":"x"}}"""
+        );
+
+        var ex = await Assert.ThrowsAsync<CodexAppServerRpcException>(() => requestTask.WaitAsync(HangGuard));
+        await Assert.That(ex).IsNotNull();
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Non_object_error_payload_on_a_pending_request_faults_the_caller_instead_of_hanging() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        var requestTask = harness.Connection.RequestAsync("sendTurn", null, CancellationToken.None);
+        var frame       = await harness.ReadFrameFromConnectionAsync();
+        var id          = JsonDocument.Parse(frame).RootElement.GetProperty("id").GetInt64();
+
+        await harness.WriteFrameToConnectionAsync(
+            $$$"""{"jsonrpc":"2.0","id":{{{id}}},"error":"totally-not-an-object"}"""
+        );
+
+        var ex = await Assert.ThrowsAsync<CodexAppServerRpcException>(() => requestTask.WaitAsync(HangGuard));
+        await Assert.That(ex).IsNotNull();
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task Read_loop_ending_faults_a_pending_request_instead_of_hanging() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        var requestTask = harness.Connection.RequestAsync("sendTurn", null, CancellationToken.None);
+        await harness.ReadFrameFromConnectionAsync();
+
+        // The app-server dies mid-turn: cancel the read loop, which must fault every pending request
+        // rather than leave the runtime's turn awaiting forever.
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => requestTask.WaitAsync(HangGuard));
+        await SwallowCancellation(runTask);
+    }
+
+    [Test]
+    public async Task NotifyAsync_writes_notification_frame_without_id() {
+        await using var harness = new Harness();
+        using var       cts     = new CancellationTokenSource();
+        var             runTask = harness.Connection.RunAsync(cts.Token);
+
+        await harness.Connection.NotifyAsync("interruptTurn", null).WaitAsync(HangGuard);
+
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        using var doc = JsonDocument.Parse(frame);
+        await Assert.That(doc.RootElement.GetProperty("method").GetString()).IsEqualTo("interruptTurn");
+        await Assert.That(doc.RootElement.TryGetProperty("id", out _)).IsFalse();
+
+        cts.Cancel();
+        await SwallowCancellation(runTask);
+    }
+
+    static async Task SwallowCancellation(Task task) {
+        try {
+            await task.WaitAsync(HangGuard);
+        } catch (OperationCanceledException) {
+            // expected shutdown path for this test's owned CTS
+        }
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -23,8 +23,8 @@ public class CodexAppServerHostedAgentRuntimeTests {
         public ValueTask DisposeAsync() { HasExited = true; return ValueTask.CompletedTask; }
     }
 
-    static CodexAppServerLaunch Launch(string? model = null, string? prompt = null, string sandbox = "read-only") =>
-        new(Cwd: "/tmp/wt", Model: model, InitialPrompt: prompt, Sandbox: sandbox,
+    static CodexAppServerLaunch Launch(string? model = null, string? prompt = null, string sandbox = "read-only", string? effort = null) =>
+        new(Cwd: "/tmp/wt", Model: model, Effort: effort, InitialPrompt: prompt, Sandbox: sandbox,
             Approval: "never", WritableRoots: ["/tmp/wt"], ClientVersion: "0.146.0");
 
     /// <summary>Builds a spawn delegate that hands each spawn a fresh fake (indexed), recording the
@@ -201,6 +201,63 @@ public class CodexAppServerHostedAgentRuntimeTests {
         await Assert.ThrowsAsync<NotSupportedException>(() => runtime.SendRawInputAsync([1, 2, 3]));
         await Assert.That(runtime.EmitsTerminalOutput).IsFalse();
 
+        await runtime.DisposeAsync();
+    }
+
+    // The orchestrator treats ReadOutputAsync ending as the finalize trigger, so it must NOT complete
+    // until the runtime is terminal — otherwise every reviewer is killed seconds after launch.
+    [Test]
+    public async Task ReadOutput_does_not_complete_until_the_runtime_is_terminal() {
+        var fake = new FakeCodexAppServer();
+        var (runtime, _, _) = Build(_ => fake, Launch());
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await using var e = runtime.ReadOutputAsync().GetAsyncEnumerator();
+        var moveNext = e.MoveNextAsync().AsTask();
+
+        // Still live: the stream must not end while the runtime is running.
+        var early = await Task.WhenAny(moveNext, Task.Delay(300));
+        await Assert.That(early).IsNotSameReferenceAs(moveNext);
+
+        await runtime.DisposeAsync();
+        // Terminal now: the stream ends (no bytes ever, EmitsTerminalOutput=false).
+        await Assert.That(await moveNext.WaitAsync(HangGuard)).IsFalse();
+    }
+
+    // The hook-trust seed-and-restart tears down child 1; its read-loop end must NOT trip the
+    // whole-runtime terminal signal, or a round on child 2 would report idle immediately.
+    [Test]
+    public async Task A_round_after_the_hook_seed_restart_still_settles_from_turn_completed() {
+        var untrusted = new FakeCodexAppServer {
+            HooksData = FakeCodexAppServer.HookData([
+                ("sessionStart", "kcap hook --codex", "untrusted", "sha256:aa"),
+                ("stop", "kcap hook --codex", "trusted", "sha256:b"),
+                ("permissionRequest", "kcap hook --codex", "trusted", "sha256:c"),
+            ]),
+        };
+        var trusted = new FakeCodexAppServer();
+        var (runtime, _, fakeAt) = Build(i => i == 0 ? untrusted : trusted, Launch());
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.SendUserInputAsync("review").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // The turn ran against child 2 (the trusted respawn), and the round genuinely settled.
+        await Assert.That(fakeAt(1).ReceivedMethods).Contains("turn/start");
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Requested_effort_is_mapped_and_passed_on_turn_start() {
+        var fake = new FakeCodexAppServer();
+        var (runtime, _, _) = Build(_ => fake, Launch(effort: "max"));
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.SendUserInputAsync("review").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // "max" maps to "xhigh", mirroring the PTY launcher.
+        await Assert.That(fake.LastTurnEffort).IsEqualTo("xhigh");
         await runtime.DisposeAsync();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -61,7 +61,7 @@ public class CodexAppServerHostedAgentRuntimeTests {
         await Assert.That(fake.ReceivedMethods).Contains("hooks/list");
         await Assert.That(fake.ReceivedMethods).Contains("thread/start");
         await Assert.That(fake.InitializeOptOuts).Contains("item/agentMessage/delta");
-        await Assert.That(fake.LastThreadStartSandboxType).IsEqualTo("readOnly");
+        await Assert.That(fake.LastThreadStartSandbox).IsEqualTo("read-only");
 
         await runtime.DisposeAsync();
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -1,0 +1,206 @@
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// Drives the real <see cref="CodexAppServerHostedAgentRuntime"/> lifecycle against
+/// <see cref="FakeCodexAppServer"/> over in-memory pipes — no child process. Covers the handshake +
+/// hook-trust preflight (proceed / seed-and-restart / missing), a round settling from
+/// <c>turn/completed</c>, the always-decline approval bridge, usage capture, backpressure retry, and
+/// transport-death unblocking a pending round.
+/// </summary>
+public class CodexAppServerHostedAgentRuntimeTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    sealed class FakeProcess : IAcpProcess {
+        public int  Pid       => 4242;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  => HasExited ? 0 : null;
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan? timeout = null) { HasExited = true; return Task.CompletedTask; }
+        public ValueTask DisposeAsync() { HasExited = true; return ValueTask.CompletedTask; }
+    }
+
+    static CodexAppServerLaunch Launch(string? model = null, string? prompt = null, string sandbox = "read-only") =>
+        new(Cwd: "/tmp/wt", Model: model, InitialPrompt: prompt, Sandbox: sandbox,
+            Approval: "never", WritableRoots: ["/tmp/wt"], ClientVersion: "0.146.0");
+
+    /// <summary>Builds a spawn delegate that hands each spawn a fresh fake (indexed), recording the
+    /// seed passed on each call so the restart path is assertable.</summary>
+    static (CodexAppServerHostedAgentRuntime Runtime, List<string?> Seeds, Func<int, FakeCodexAppServer> Fake)
+            Build(Func<int, FakeCodexAppServer> fakeFor, CodexAppServerLaunch launch) {
+        var seeds  = new List<string?>();
+        var fakes  = new List<FakeCodexAppServer>();
+        var index  = 0;
+
+        CodexAppServerSpawn spawn = (seed, _) => {
+            seeds.Add(seed);
+            var fake = fakeFor(index++);
+            fakes.Add(fake);
+            var conn = fake.ConnectClient();
+            return Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((conn, new FakeProcess()));
+        };
+
+        var runtime = new CodexAppServerHostedAgentRuntime(
+            spawn, launch, clock: null, NullLogger.Instance);
+        return (runtime, seeds, i => fakes[i]);
+    }
+
+    [Test]
+    public async Task Handshake_starts_thread_reports_model_and_opts_out_of_deltas() {
+        var fake = new FakeCodexAppServer { Model = "gpt-5.3-codex" };
+        var (runtime, _, _) = Build(_ => fake, Launch());
+
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(runtime.ThreadId).IsEqualTo("thread-abc");
+        await Assert.That(runtime.ResolvedModel).IsEqualTo("gpt-5.3-codex");
+        await Assert.That(fake.ReceivedMethods).Contains("initialize");
+        await Assert.That(fake.ReceivedMethods).Contains("hooks/list");
+        await Assert.That(fake.ReceivedMethods).Contains("thread/start");
+        await Assert.That(fake.InitializeOptOuts).Contains("item/agentMessage/delta");
+        await Assert.That(fake.LastThreadStartSandboxType).IsEqualTo("readOnly");
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Round_settles_from_turn_completed_and_pins_never_approval() {
+        var fake = new FakeCodexAppServer();
+        var (runtime, _, _) = Build(_ => fake, Launch());
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.SendUserInputAsync("please review").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(fake.ReceivedMethods).Contains("turn/start");
+        await Assert.That(fake.LastTurnApprovalPolicy).IsEqualTo("never");
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Initial_prompt_fires_the_first_turn_during_start() {
+        var fake = new FakeCodexAppServer();
+        var (runtime, _, _) = Build(_ => fake, Launch(prompt: "kick off the review"));
+
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(fake.ReceivedMethods).Contains("turn/start");
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Untrusted_kcap_hook_seeds_and_restarts_the_child() {
+        var untrusted = new FakeCodexAppServer {
+            HooksData = FakeCodexAppServer.HookData([
+                ("sessionStart", "kcap hook --codex", "untrusted", "sha256:aa"),
+                ("stop", "kcap hook --codex", "trusted", "sha256:b"),
+                ("permissionRequest", "kcap hook --codex", "trusted", "sha256:c"),
+            ]),
+        };
+        var trusted = new FakeCodexAppServer(); // second spawn sees a fully trusted set
+
+        var (runtime, seeds, _) = Build(i => i == 0 ? untrusted : trusted, Launch());
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // Two spawns: the first with no seed, the second carrying a hooks.state override.
+        await Assert.That(seeds.Count).IsEqualTo(2);
+        await Assert.That(seeds[0]).IsNull();
+        await Assert.That(seeds[1]).IsNotNull();
+        await Assert.That(seeds[1]!).StartsWith("hooks.state={");
+        await Assert.That(runtime.ThreadId).IsEqualTo("thread-abc");
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Missing_critical_hook_fails_the_launch_closed() {
+        var fake = new FakeCodexAppServer {
+            HooksData = FakeCodexAppServer.HookData([
+                ("sessionStart", "kcap hook --codex", "trusted", "sha256:a"),
+                // no Stop, no PermissionRequest
+            ]),
+        };
+        var (runtime, _, _) = Build(_ => fake, Launch());
+
+        await Assert.ThrowsAsync<CodexHooksNotInstalledException>(
+            () => runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard));
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Unexpected_approval_request_is_declined_on_the_wire() {
+        var fake = new FakeCodexAppServer { InjectApprovalDuringTurn = true };
+        var (runtime, _, _) = Build(_ => fake, Launch());
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.SendUserInputAsync("review").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // The client answered the approval with a valid decline result, never a JSON-RPC error.
+        await Assert.That(fake.ApprovalResponse).IsNotNull();
+        await Assert.That(fake.ApprovalResponse!.Value.GetProperty("decision").GetString()).IsEqualTo("decline");
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Token_usage_notification_is_captured() {
+        var fake = new FakeCodexAppServer { EmitUsageOnTurn = (input: 120, output: 40, total: 160) };
+        var (runtime, _, _) = Build(_ => fake, Launch());
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.SendUserInputAsync("review").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(runtime.Usage).IsNotNull();
+        await Assert.That(runtime.Usage!.Value.TotalTokens).IsEqualTo(160L);
+        await Assert.That(runtime.Usage!.Value.InputTokens).IsEqualTo(120L);
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Turn_start_backpressure_is_retried_until_it_succeeds() {
+        var fake = new FakeCodexAppServer { Fail32001TimesOnTurnStart = 2 };
+        var (runtime, _, _) = Build(_ => fake, Launch());
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // Two -32001 rejections then success — the round still settles rather than throwing.
+        await runtime.SendUserInputAsync("review").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(fake.ReceivedMethods.Count(m => m == "turn/start")).IsEqualTo(3);
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Failed_turn_status_still_settles_the_round() {
+        var fake = new FakeCodexAppServer { TurnStatus = "failed" };
+        var (runtime, _, _) = Build(_ => fake, Launch());
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.SendUserInputAsync("review").WaitAsync(HangGuard);
+        // A failed turn is still a completed round — WaitForTurnIdle must return, not hang.
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Local_raw_input_is_unsupported() {
+        var fake = new FakeCodexAppServer();
+        var (runtime, _, _) = Build(_ => fake, Launch());
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => runtime.SendRawInputAsync([1, 2, 3]));
+        await Assert.That(runtime.EmitsTerminalOutput).IsFalse();
+
+        await runtime.DisposeAsync();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerLiveSmokeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerLiveSmokeTests.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// GATED live confirmation of the app-server transport + DTO layer against the REAL <c>codex
+/// app-server</c> binary — the wire-shape parity a fake peer cannot prove. Drives the no-model
+/// handshake surface (<c>initialize</c> → <c>hooks/list</c> → <c>thread/start</c>) through the
+/// production <see cref="CodexAppServerConnection"/> and asserts the responses parse into the exact
+/// shapes <see cref="CodexAppServerHostedAgentRuntime"/> reads. It spends NO model turn, so it needs
+/// no auth, and runs against an ISOLATED <c>CODEX_HOME</c> so it never touches the operator's real
+/// Codex state, hooks, or the running daemon.
+///
+/// <para><b>Gated</b> behind <c>KCAP_CODEX_APPSERVER_SMOKE=1</c>: shared CI has no <c>codex</c>
+/// binary. Re-run it against a new Codex build before recommending that build — a floor-breaking
+/// schema drift fails here instead of silently at launch.</para>
+/// </summary>
+public class CodexAppServerLiveSmokeTests {
+    const string GateEnvVar = "KCAP_CODEX_APPSERVER_SMOKE";
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(30);
+
+    static void Gate() =>
+        Skip.Unless(Environment.GetEnvironmentVariable(GateEnvVar) == "1",
+            $"Gated live confirmation of the codex app-server wire layer — set {GateEnvVar}=1 to run "
+          + "(needs `codex` on PATH; spends no model turn; runs in an isolated CODEX_HOME).");
+
+    [Test]
+    public async Task Real_app_server_initialize_hookslist_and_thread_start_round_trip() {
+        Gate();
+
+        using var codexHome = new TempDir();
+        using var cwd       = new TempDir();
+
+        var psi = new ProcessStartInfo("codex", ["app-server"]) {
+            RedirectStandardInput  = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError  = true,
+            UseShellExecute        = false,
+        };
+        psi.Environment["CODEX_HOME"] = codexHome.Path;
+
+        var process = Process.Start(psi) ?? throw new InvalidOperationException("codex app-server did not start.");
+        await using var child = new AcpChildProcess(process, NullLogger<AcpChildProcess>.Instance, vendor: "codex");
+        await using var conn = new CodexAppServerConnection(
+            process.StandardInput.BaseStream, process.StandardOutput.BaseStream,
+            NullLogger<CodexAppServerConnection>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        var runLoop = conn.RunAsync(cts.Token);
+
+        try {
+            // initialize — clientInfo is required; response carries userAgent.
+            var init = await conn.RequestAsync("initialize", Element(new JsonObject {
+                ["clientInfo"] = new JsonObject { ["name"] = "kcap-daemon", ["version"] = "0.146.0" },
+            }), cts.Token).WaitAsync(HangGuard);
+            await Assert.That(init.ValueKind).IsEqualTo(JsonValueKind.Object);
+
+            // hooks/list — the runtime flattens data[].hooks[] into CodexHookEntry; assert the shape
+            // parses (an isolated CODEX_HOME has no kcap hooks, so the set is empty/managed).
+            var hooks = await conn.RequestAsync("hooks/list", Element(new JsonObject {
+                ["cwds"] = new JsonArray((JsonNode?) cwd.Path),
+            }), cts.Token).WaitAsync(HangGuard);
+            await Assert.That(hooks.TryGetProperty("data", out var data)).IsTrue();
+            await Assert.That(data.ValueKind).IsEqualTo(JsonValueKind.Array);
+
+            // thread/start with the reviewer posture — no model call happens here, so no auth needed.
+            var start = await conn.RequestAsync("thread/start", Element(new JsonObject {
+                ["cwd"]               = cwd.Path,
+                ["sandbox"]           = CodexAppServerPosture.RenderSandboxMode("read-only"),
+                ["approvalPolicy"]    = CodexAppServerPosture.RenderApprovalPolicy("never"),
+                ["approvalsReviewer"] = CodexAppServerPosture.ApprovalsReviewer,
+            }), cts.Token).WaitAsync(HangGuard);
+
+            // The exact fields the runtime reads: thread.id (deterministic identity) + resolved model.
+            await Assert.That(start.TryGetProperty("thread", out var thread)).IsTrue();
+            await Assert.That(thread.GetProperty("id").GetString()).IsNotNull();
+            await Assert.That(thread.GetProperty("sessionId").GetString()).IsEqualTo(thread.GetProperty("id").GetString());
+            await Assert.That(start.GetProperty("model").GetString()).IsNotNull();
+        } finally {
+            await cts.CancelAsync();
+            await child.TerminateAsync(TimeSpan.FromSeconds(5));
+            try { await runLoop.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* shutdown */ }
+        }
+    }
+
+    static JsonElement Element(JsonNode node) => JsonDocument.Parse(node.ToJsonString()).RootElement.Clone();
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -168,6 +168,36 @@ public class CodexHostedAgentRuntimeFactoryTests {
         }
     }
 
+    [Test]
+    [NotInParallel("HomeEnvVarMutation")]
+    public async Task Handshake_failure_disposes_the_spawned_child() {
+        var originalHome = Environment.GetEnvironmentVariable("HOME");
+        var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
+        using var home = new TempDir();
+        using var wt   = new TempDir();
+        WriteWorktreeHooks(wt.Path);
+        await using var fake = new FakeCodexAppServer { ThreadId = "" }; // thread/start returns no id -> StartAsync throws
+
+        try {
+            Environment.SetEnvironmentVariable("HOME", home.Path);
+            Environment.SetEnvironmentVariable("CODEX_HOME", System.IO.Path.Combine(home.Path, ".codex"));
+
+            var process = new FakeAcpProcess();
+            CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
+                Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((fake.ConnectClient(), process));
+            var factory = Factory(new RecordingPtyFactory(), appServerActive: true, seam);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None).WaitAsync(HangGuard));
+
+            // The factory disposed the runtime on the failed handshake, so the spawned child is not leaked.
+            await Assert.That(process.HasExited).IsTrue();
+        } finally {
+            Environment.SetEnvironmentVariable("HOME", originalHome);
+            Environment.SetEnvironmentVariable("CODEX_HOME", originalCodexHome);
+        }
+    }
+
     static void WriteWorktreeHooks(string worktreePath) {
         var dir = System.IO.Path.Combine(worktreePath, ".codex");
         System.IO.Directory.CreateDirectory(dir);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -117,12 +117,12 @@ public class CodexHostedAgentRuntimeFactoryTests {
         var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
         using var home = new TempDir();
         using var wt   = new TempDir();
-        WriteWorktreeHooks(wt.Path);
+        WriteWorktreeHooks(wt);
         await using var fake = new FakeCodexAppServer();
 
         try {
             Environment.SetEnvironmentVariable("HOME", home.Path);
-            Environment.SetEnvironmentVariable("CODEX_HOME", System.IO.Path.Combine(home.Path, ".codex"));
+            Environment.SetEnvironmentVariable("CODEX_HOME", home.PathTo(".codex"));
 
             var pty = new RecordingPtyFactory();
             CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
@@ -154,7 +154,7 @@ public class CodexHostedAgentRuntimeFactoryTests {
 
         try {
             Environment.SetEnvironmentVariable("HOME", home.Path);
-            Environment.SetEnvironmentVariable("CODEX_HOME", System.IO.Path.Combine(home.Path, ".codex"));
+            Environment.SetEnvironmentVariable("CODEX_HOME", home.PathTo(".codex"));
 
             CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
                 throw new InvalidOperationException("spawn must never be reached when hooks are missing");
@@ -175,12 +175,12 @@ public class CodexHostedAgentRuntimeFactoryTests {
         var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
         using var home = new TempDir();
         using var wt   = new TempDir();
-        WriteWorktreeHooks(wt.Path);
+        WriteWorktreeHooks(wt);
         await using var fake = new FakeCodexAppServer { ThreadId = "" }; // thread/start returns no id -> StartAsync throws
 
         try {
             Environment.SetEnvironmentVariable("HOME", home.Path);
-            Environment.SetEnvironmentVariable("CODEX_HOME", System.IO.Path.Combine(home.Path, ".codex"));
+            Environment.SetEnvironmentVariable("CODEX_HOME", home.PathTo(".codex"));
 
             var process = new FakeAcpProcess();
             CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
@@ -198,15 +198,12 @@ public class CodexHostedAgentRuntimeFactoryTests {
         }
     }
 
-    static void WriteWorktreeHooks(string worktreePath) {
-        var dir = System.IO.Path.Combine(worktreePath, ".codex");
-        System.IO.Directory.CreateDirectory(dir);
-        System.IO.File.WriteAllText(System.IO.Path.Combine(dir, "hooks.json"), """
+    static void WriteWorktreeHooks(TempDir worktree) =>
+        worktree.CreateFile([".codex", "hooks.json"], """
             {"hooks":{
                 "SessionStart":[{"hooks":[{"type":"command","command":"kcap hook --codex"}]}],
                 "Stop":[{"hooks":[{"type":"command","command":"kcap hook --codex"}]}],
                 "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap hook --codex"}]}]
             }}
             """);
-    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -1,0 +1,182 @@
+using System.Runtime.CompilerServices;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// The composite codex factory's ROUTING: review-flow launches go to app-server only when the daemon
+/// resolved it active; every interactive launch, and all launches under the PTY default, delegate to
+/// the wrapped PTY factory. The app-server route is exercised through the spawn seam (a fake peer),
+/// so no child process runs; the delegation cases never touch the launcher at all.
+/// </summary>
+public class CodexHostedAgentRuntimeFactoryTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    // ── Test doubles ─────────────────────────────────────────────────────────────────────────
+    sealed class RecordingPtyFactory : IHostedAgentRuntimeFactory {
+        public int StartCalls;
+        public string Vendor => "codex";
+        public bool IsAvailable() => true;
+        public bool SupportsUnattended => true;
+        public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+            StartCalls++;
+            return Task.FromResult(new HostedRuntimeStart(new StubRuntime(), null));
+        }
+    }
+
+    sealed class StubRuntime : IHostedAgentRuntime {
+        public string Vendor => "codex";
+        public int    Pid => 1;
+        public bool   HasExited => false;
+        public int?   ExitCode => null;
+        public bool   EmitsTerminalOutput => true;
+        public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken ct = default) {
+            await Task.CompletedTask; yield break;
+        }
+        public Task SendUserInputAsync(string text) => Task.CompletedTask;
+        public Task SendSpecialKeyAsync(string key) => Task.CompletedTask;
+        public Task SendRawInputAsync(byte[] data) => Task.CompletedTask;
+        public void Resize(ushort cols, ushort rows) { }
+        public Task RequestGracefulStopAsync() => Task.CompletedTask;
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    sealed class FakeAcpProcess : IAcpProcess {
+        public int  Pid => 7;
+        public bool HasExited { get; private set; }
+        public int? ExitCode => HasExited ? 0 : null;
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+        public Task TerminateAsync(TimeSpan? timeout = null) { HasExited = true; return Task.CompletedTask; }
+        public ValueTask DisposeAsync() { HasExited = true; return ValueTask.CompletedTask; }
+    }
+
+    static CodexLauncher NewLauncher() =>
+        new(new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" },
+            NullLogger<CodexLauncher>.Instance) {
+            ReadInheritedMcpServers = static () => [],
+        };
+
+    static RuntimeStartContext Ctx(bool isReviewFlow, string worktreePath) => new(
+        AgentId: "agent-1", Vendor: "codex", SourceRepoPath: worktreePath,
+        Worktree: new WorktreeInfo(Path: worktreePath, Branch: "wt", SourceRepo: worktreePath),
+        Prompt: null, Model: null, Effort: null, Tools: null,
+        IsReview: false, IsReviewFlow: isReviewFlow, Review: null,
+        Cols: 80, Rows: 24, ServerUrl: "https://t.example", DaemonBridgeUrl: null, CapacitorPath: "/opt/kcap");
+
+    static CodexHostedAgentRuntimeFactory Factory(
+            RecordingPtyFactory pty, bool appServerActive, CodexAppServerSpawnFactory? spawn = null) =>
+        new(NewLauncher(), pty,
+            new DaemonConfig { CodexAppServerActive = appServerActive, Version = "0.146.0" },
+            NullLoggerFactory.Instance, spawn);
+
+    // ── Routing decision ─────────────────────────────────────────────────────────────────────
+    [Test]
+    [Arguments(false, true,  false)] // not active -> pty even for a review flow
+    [Arguments(true,  false, false)] // active but interactive -> pty
+    [Arguments(true,  true,  true)]  // active + review flow -> app-server
+    public async Task UsesAppServer_gates_on_active_AND_review_flow(bool active, bool isReviewFlow, bool expected) {
+        using var wt = new TempDir();
+        var factory = Factory(new RecordingPtyFactory(), active);
+        await Assert.That(factory.UsesAppServer(Ctx(isReviewFlow, wt.Path))).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task Pty_transport_delegates_a_review_flow_to_the_pty_factory() {
+        using var wt = new TempDir();
+        var pty = new RecordingPtyFactory();
+        var factory = Factory(pty, appServerActive: false);
+
+        var start = await factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None);
+
+        await Assert.That(pty.StartCalls).IsEqualTo(1);
+        await Assert.That(start.Runtime).IsTypeOf<StubRuntime>();
+    }
+
+    [Test]
+    public async Task Interactive_launch_delegates_to_pty_even_when_app_server_is_active() {
+        using var wt = new TempDir();
+        var pty = new RecordingPtyFactory();
+        var factory = Factory(pty, appServerActive: true);
+
+        var start = await factory.StartAsync(Ctx(isReviewFlow: false, wt.Path), CancellationToken.None);
+
+        await Assert.That(pty.StartCalls).IsEqualTo(1);
+        await Assert.That(start.Runtime).IsTypeOf<StubRuntime>();
+    }
+
+    // ── App-server route (spawn seam; isolated HOME so TrustWorktree touches nothing real) ──────
+    [Test]
+    [NotInParallel("HomeEnvVarMutation")]
+    public async Task Active_review_flow_produces_an_app_server_runtime_via_the_spawn_seam() {
+        var originalHome = Environment.GetEnvironmentVariable("HOME");
+        var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
+        using var home = new TempDir();
+        using var wt   = new TempDir();
+        WriteWorktreeHooks(wt.Path);
+        await using var fake = new FakeCodexAppServer();
+
+        try {
+            Environment.SetEnvironmentVariable("HOME", home.Path);
+            Environment.SetEnvironmentVariable("CODEX_HOME", System.IO.Path.Combine(home.Path, ".codex"));
+
+            var pty = new RecordingPtyFactory();
+            CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
+                Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((fake.ConnectClient(), new FakeAcpProcess()));
+            var factory = Factory(pty, appServerActive: true, seam);
+
+            var start = await factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None).WaitAsync(HangGuard);
+
+            await Assert.That(pty.StartCalls).IsEqualTo(0);
+            await Assert.That(start.Runtime).IsTypeOf<CodexAppServerHostedAgentRuntime>();
+            await Assert.That(start.Runtime.EmitsTerminalOutput).IsFalse();
+            await Assert.That(((CodexAppServerHostedAgentRuntime) start.Runtime).ThreadId).IsEqualTo("thread-abc");
+            await Assert.That(fake.ReceivedMethods).Contains("thread/start");
+
+            await start.Runtime.DisposeAsync();
+        } finally {
+            Environment.SetEnvironmentVariable("HOME", originalHome);
+            Environment.SetEnvironmentVariable("CODEX_HOME", originalCodexHome);
+        }
+    }
+
+    [Test]
+    [NotInParallel("HomeEnvVarMutation")]
+    public async Task Missing_hooks_on_the_app_server_route_fails_closed() {
+        var originalHome = Environment.GetEnvironmentVariable("HOME");
+        var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
+        using var home = new TempDir(); // empty — no user-scope hooks
+        using var wt   = new TempDir(); // empty — no worktree hooks
+
+        try {
+            Environment.SetEnvironmentVariable("HOME", home.Path);
+            Environment.SetEnvironmentVariable("CODEX_HOME", System.IO.Path.Combine(home.Path, ".codex"));
+
+            CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
+                throw new InvalidOperationException("spawn must never be reached when hooks are missing");
+            var factory = Factory(new RecordingPtyFactory(), appServerActive: true, seam);
+
+            await Assert.ThrowsAsync<CodexHooksNotInstalledException>(
+                () => factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None));
+        } finally {
+            Environment.SetEnvironmentVariable("HOME", originalHome);
+            Environment.SetEnvironmentVariable("CODEX_HOME", originalCodexHome);
+        }
+    }
+
+    static void WriteWorktreeHooks(string worktreePath) {
+        var dir = System.IO.Path.Combine(worktreePath, ".codex");
+        System.IO.Directory.CreateDirectory(dir);
+        System.IO.File.WriteAllText(System.IO.Path.Combine(dir, "hooks.json"), """
+            {"hooks":{
+                "SessionStart":[{"hooks":[{"type":"command","command":"kcap hook --codex"}]}],
+                "Stop":[{"hooks":[{"type":"command","command":"kcap hook --codex"}]}],
+                "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap hook --codex"}]}]
+            }}
+            """);
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTransportDecisionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTransportDecisionTests.cs
@@ -16,6 +16,10 @@ public class CodexTransportDecisionTests {
     [Arguments("app-server", null, false)]         // unknown version fails toward pty
     [Arguments("app-server", "", false)]           // empty version fails toward pty
     [Arguments("app-server", "not-a-version", false)]
+    [Arguments("app-server", "0.146.0-rc.1", false)] // a prerelease is BELOW the verified release -> pty
+    [Arguments("app-server", "0.147.0-rc.1", false)] // even above the floor, a prerelease is unverified -> pty
+    [Arguments("app-server", "0.146.0+meta", false)] // build metadata makes the token non-clean -> pty
+    [Arguments("app-server", "0.146.x", false)]      // non-numeric patch -> pty
     [Arguments("App-Server", "0.146.0", true)]     // selection is case-insensitive
     [Arguments("  app-server  ", "0.146.0", true)] // trimmed
     [Arguments("app-server", "codex-cli 0.146.0", true)] // tolerant of surrounding text

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTransportDecisionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTransportDecisionTests.cs
@@ -1,0 +1,34 @@
+using Capacitor.Cli.Daemon.Harness.Codex;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>The single rule that decides PTY vs app-server: operator selection AND the spike-pinned
+/// version floor, failing toward PTY on anything unparseable.</summary>
+public class CodexTransportDecisionTests {
+    [Test]
+    [Arguments("pty", "0.146.0", false)]           // not selected
+    [Arguments(null, "0.146.0", false)]            // unset -> pty
+    [Arguments("app-server", "0.146.0", true)]     // selected + at floor
+    [Arguments("app-server", "0.147.0", true)]     // above floor
+    [Arguments("app-server", "1.2.0", true)]       // well above
+    [Arguments("app-server", "0.145.0", false)]    // below floor
+    [Arguments("app-server", "0.99.0", false)]     // below floor (minor)
+    [Arguments("app-server", null, false)]         // unknown version fails toward pty
+    [Arguments("app-server", "", false)]           // empty version fails toward pty
+    [Arguments("app-server", "not-a-version", false)]
+    [Arguments("App-Server", "0.146.0", true)]     // selection is case-insensitive
+    [Arguments("  app-server  ", "0.146.0", true)] // trimmed
+    [Arguments("app-server", "codex-cli 0.146.0", true)] // tolerant of surrounding text
+    [Arguments("app-server", "v0.146.0", true)]    // v-prefixed
+    public async Task UsesAppServer_truth_table(string? transport, string? version, bool expected) {
+        await Assert.That(CodexTransportDecision.UsesAppServer(transport, version)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task MeetsFloor_is_exactly_the_pinned_floor() {
+        await Assert.That(CodexTransportDecision.MeetsFloor(CodexTransportDecision.VersionFloor)).IsTrue();
+        await Assert.That(CodexTransportDecision.MeetsFloor("0.146.1")).IsTrue();
+        await Assert.That(CodexTransportDecision.MeetsFloor("0.146")).IsTrue(); // patch defaults to 0
+        await Assert.That(CodexTransportDecision.MeetsFloor("0.145.99")).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
@@ -44,6 +44,7 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
     public readonly List<string>       InitializeOptOuts  = [];
     public string?                     LastThreadStartSandbox;
     public string?                     LastTurnApprovalPolicy;
+    public string?                     LastTurnEffort;
     public JsonElement?                ApprovalResponse; // the client's response to the injected request
     int _turnStartCount;
 
@@ -121,6 +122,8 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
                 }
                 if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("approvalPolicy", out var ap))
                     LastTurnApprovalPolicy = ap.GetString();
+                if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("effort", out var ef))
+                    LastTurnEffort = ef.GetString();
 
                 var turnId = "turn-" + _turnStartCount;
                 await RespondAsync(id, new JsonObject {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
@@ -1,0 +1,225 @@
+using System.IO.Pipelines;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// An in-process fake <c>codex app-server</c> peer: it plays the SERVER side of the JSON-RPC stdio
+/// wire over duplex pipes, so <see cref="CodexAppServerHostedAgentRuntime"/>'s real
+/// <c>StartAsync</c>/turn logic runs against a scriptable protocol partner with no child process.
+/// Each instance answers <c>initialize</c> / <c>hooks/list</c> / <c>thread/start</c> /
+/// <c>turn/start</c> / <c>turn/interrupt</c> and can inject a server→client approval request and
+/// token-usage notifications. Behaviour is configured via the public fields before it is handed to a
+/// spawn delegate.
+/// </summary>
+sealed class FakeCodexAppServer : IAsyncDisposable {
+    readonly Pipe   _toServer = new(); // client -> server
+    readonly Pipe   _toClient = new(); // server -> client
+    Stream? _readClient;
+    Stream? _writeClient;
+
+    readonly CancellationTokenSource _cts = new();
+    readonly SemaphoreSlim _writeGate = new(1, 1);
+    Task _loop = Task.CompletedTask;
+    long _nextServerId = 90_000;
+    readonly Dictionary<long, TaskCompletionSource<JsonElement>> _serverPending = new();
+    readonly List<Task> _handlers = [];
+
+    // ── Scripted behaviour ─────────────────────────────────────────────────────────────────────
+    public string      ThreadId  = "thread-abc";
+    public string      Model     = "gpt-5.3-codex";
+    public JsonArray   HooksData = TrustedKcapHooks();
+    public string      TurnStatus = "completed";
+    public bool        InjectApprovalDuringTurn;
+    public string      ApprovalMethod = "item/commandExecution/requestApproval";
+    public int         Fail32001TimesOnTurnStart;
+    public (long input, long output, long total)? EmitUsageOnTurn;
+
+    // ── Observed ───────────────────────────────────────────────────────────────────────────────
+    public readonly List<string>       ReceivedMethods    = [];
+    public readonly List<string>       InitializeOptOuts  = [];
+    public string?                     LastThreadStartSandboxType;
+    public string?                     LastTurnApprovalPolicy;
+    public JsonElement?                ApprovalResponse; // the client's response to the injected request
+    int _turnStartCount;
+
+    public CodexAppServerConnection ConnectClient() {
+        var conn = new CodexAppServerConnection(
+            writeStream: _toServer.Writer.AsStream(),
+            readStream:  _toClient.Reader.AsStream(),
+            logger: NullLogger<CodexAppServerConnection>.Instance);
+        _readClient  = _toServer.Reader.AsStream();
+        _writeClient = _toClient.Writer.AsStream();
+        _loop = RunServerAsync(_cts.Token);
+        return conn;
+    }
+
+    async Task RunServerAsync(CancellationToken ct) {
+        using var reader = new StreamReader(_readClient!, Encoding.UTF8, false, leaveOpen: true);
+        while (!ct.IsCancellationRequested) {
+            string? line;
+            try { line = await reader.ReadLineAsync(ct); }
+            catch (OperationCanceledException) { break; }
+            if (line is null) break;
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            using var doc = JsonDocument.Parse(line);
+            var root = doc.RootElement;
+            var hasId     = root.TryGetProperty("id", out var idEl);
+            var hasMethod = root.TryGetProperty("method", out var methodEl);
+
+            if (hasId && hasMethod) {
+                // Dispatch WITHOUT blocking the read loop: a handler (turn/start) may make a nested
+                // server→client request whose response arrives on this very loop.
+                var cloned = root.Clone();
+                _handlers.Add(HandleRequestAsync(idEl.GetInt64(), methodEl.GetString() ?? "", cloned, ct));
+            } else if (hasId && !hasMethod) {
+                // A response to one of OUR server→client requests.
+                if (_serverPending.Remove(idEl.GetInt64(), out var tcs))
+                    tcs.TrySetResult(root.TryGetProperty("result", out var r) ? r.Clone() : default);
+            }
+        }
+    }
+
+    async Task HandleRequestAsync(long id, string method, JsonElement root, CancellationToken ct) {
+        ReceivedMethods.Add(method);
+        var @params = root.TryGetProperty("params", out var p) ? p : default;
+
+        switch (method) {
+            case "initialize":
+                if (@params.ValueKind == JsonValueKind.Object
+                    && @params.TryGetProperty("capabilities", out var caps)
+                    && caps.TryGetProperty("optOutNotificationMethods", out var opt)
+                    && opt.ValueKind == JsonValueKind.Array)
+                    foreach (var m in opt.EnumerateArray()) InitializeOptOuts.Add(m.GetString() ?? "");
+                await RespondAsync(id, new JsonObject { ["userAgent"] = "codex-fake" }, ct);
+                break;
+
+            case "hooks/list":
+                await RespondAsync(id, new JsonObject { ["data"] = HooksData.DeepClone() }, ct);
+                break;
+
+            case "thread/start":
+                if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("sandbox", out var sb))
+                    LastThreadStartSandboxType = sb.TryGetProperty("type", out var st) ? st.GetString() : null;
+                await RespondAsync(id, new JsonObject {
+                    ["thread"]        = new JsonObject { ["id"] = ThreadId, ["sessionId"] = ThreadId, ["path"] = "/tmp/r.jsonl" },
+                    ["model"]         = Model,
+                    ["modelProvider"] = "openai",
+                }, ct);
+                break;
+
+            case "turn/start": {
+                _turnStartCount++;
+                if (_turnStartCount <= Fail32001TimesOnTurnStart) {
+                    await RespondErrorAsync(id, -32001, "bounded ingress", ct);
+                    break;
+                }
+                if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("approvalPolicy", out var ap))
+                    LastTurnApprovalPolicy = ap.GetString();
+
+                var turnId = "turn-" + _turnStartCount;
+                await RespondAsync(id, new JsonObject {
+                    ["turn"] = new JsonObject { ["id"] = turnId, ["status"] = "inProgress", ["items"] = new JsonArray() },
+                }, ct);
+
+                // Optionally inject an out-of-policy approval request mid-turn.
+                if (InjectApprovalDuringTurn) {
+                    var resp = await ServerRequestAsync(ApprovalMethod,
+                        new JsonObject { ["threadId"] = ThreadId, ["turnId"] = turnId }, ct);
+                    ApprovalResponse = resp;
+                }
+
+                if (EmitUsageOnTurn is { } u)
+                    await NotifyAsync("thread/tokenUsage/updated", new JsonObject {
+                        ["threadId"] = ThreadId, ["turnId"] = turnId,
+                        ["tokenUsage"] = new JsonObject {
+                            ["total"] = new JsonObject {
+                                ["inputTokens"] = u.input, ["cachedInputTokens"] = 0, ["outputTokens"] = u.output,
+                                ["reasoningOutputTokens"] = 0, ["totalTokens"] = u.total },
+                            ["last"] = new JsonObject {
+                                ["inputTokens"] = u.input, ["cachedInputTokens"] = 0, ["outputTokens"] = u.output,
+                                ["reasoningOutputTokens"] = 0, ["totalTokens"] = u.total },
+                        },
+                    }, ct);
+
+                await NotifyAsync("turn/completed", new JsonObject {
+                    ["threadId"] = ThreadId,
+                    ["turn"]     = new JsonObject { ["id"] = turnId, ["status"] = TurnStatus, ["items"] = new JsonArray() },
+                }, ct);
+                break;
+            }
+
+            case "turn/interrupt":
+                await RespondAsync(id, new JsonObject(), ct);
+                await NotifyAsync("turn/completed", new JsonObject {
+                    ["threadId"] = ThreadId,
+                    ["turn"]     = new JsonObject { ["id"] = Str(@params, "turnId") ?? "turn-x", ["status"] = "interrupted", ["items"] = new JsonArray() },
+                }, ct);
+                break;
+
+            default:
+                await RespondErrorAsync(id, -32601, "Method not found: " + method, ct);
+                break;
+        }
+    }
+
+    async Task<JsonElement> ServerRequestAsync(string method, JsonNode @params, CancellationToken ct) {
+        var id  = Interlocked.Increment(ref _nextServerId);
+        var tcs = new TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _serverPending[id] = tcs;
+        await WriteAsync(new JsonObject { ["jsonrpc"] = "2.0", ["id"] = id, ["method"] = method, ["params"] = @params.DeepClone() }, ct);
+        return await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5), ct);
+    }
+
+    Task RespondAsync(long id, JsonNode result, CancellationToken ct) =>
+        WriteAsync(new JsonObject { ["jsonrpc"] = "2.0", ["id"] = id, ["result"] = result }, ct);
+
+    Task RespondErrorAsync(long id, int code, string message, CancellationToken ct) =>
+        WriteAsync(new JsonObject { ["jsonrpc"] = "2.0", ["id"] = id, ["error"] = new JsonObject { ["code"] = code, ["message"] = message } }, ct);
+
+    Task NotifyAsync(string method, JsonNode @params, CancellationToken ct) =>
+        WriteAsync(new JsonObject { ["jsonrpc"] = "2.0", ["method"] = method, ["params"] = @params }, ct);
+
+    async Task WriteAsync(JsonNode frame, CancellationToken ct) {
+        var bytes = Encoding.UTF8.GetBytes(frame.ToJsonString() + "\n");
+        await _writeGate.WaitAsync(ct);
+        try {
+            await _writeClient!.WriteAsync(bytes, ct);
+            await _writeClient!.FlushAsync(ct);
+        } finally {
+            _writeGate.Release();
+        }
+    }
+
+    static string? Str(JsonElement o, string name) =>
+        o.ValueKind == JsonValueKind.Object && o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    public static JsonArray TrustedKcapHooks() => HookData([
+        ("sessionStart", "kcap hook --codex", "trusted", "sha256:a"),
+        ("stop", "kcap hook --codex", "trusted", "sha256:b"),
+        ("permissionRequest", "kcap hook --codex", "trusted", "sha256:c"),
+    ]);
+
+    public static JsonArray HookData(IReadOnlyList<(string evt, string cmd, string trust, string? hash)> hooks) {
+        var arr = new JsonArray();
+        foreach (var (evt, cmd, trust, hash) in hooks)
+            arr.Add(new JsonObject {
+                ["key"] = $"/home/u/.codex/hooks.json:{evt}:0:0", ["eventName"] = evt,
+                ["command"] = cmd, ["currentHash"] = hash, ["trustStatus"] = trust,
+            });
+        return new JsonArray(new JsonObject { ["cwd"] = "/tmp/wt", ["hooks"] = arr, ["errors"] = new JsonArray(), ["warnings"] = new JsonArray() });
+    }
+
+    public async ValueTask DisposeAsync() {
+        await _cts.CancelAsync();
+        try { await _loop.WaitAsync(TimeSpan.FromSeconds(2)); } catch { /* best-effort */ }
+        try { await Task.WhenAll(_handlers).WaitAsync(TimeSpan.FromSeconds(2)); } catch { /* best-effort */ }
+        _writeGate.Dispose();
+        _cts.Dispose();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
@@ -42,7 +42,7 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
     // ── Observed ───────────────────────────────────────────────────────────────────────────────
     public readonly List<string>       ReceivedMethods    = [];
     public readonly List<string>       InitializeOptOuts  = [];
-    public string?                     LastThreadStartSandboxType;
+    public string?                     LastThreadStartSandbox;
     public string?                     LastTurnApprovalPolicy;
     public JsonElement?                ApprovalResponse; // the client's response to the injected request
     int _turnStartCount;
@@ -105,7 +105,7 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
 
             case "thread/start":
                 if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("sandbox", out var sb))
-                    LastThreadStartSandboxType = sb.TryGetProperty("type", out var st) ? st.GetString() : null;
+                    LastThreadStartSandbox = sb.ValueKind == JsonValueKind.String ? sb.GetString() : null;
                 await RespondAsync(id, new JsonObject {
                     ["thread"]        = new JsonObject { ["id"] = ThreadId, ["sessionId"] = ThreadId, ["path"] = "/tmp/r.jsonl" },
                     ["model"]         = Model,


### PR DESCRIPTION
Hosts unattended **Codex reviewers over `codex app-server`** (JSON-RPC 2.0 over stdio) instead of the interactive PTY, behind a `codex.transport` config that defaults to `pty` (so this is fully inert until an operator opts a daemon in). Builds directly on the launch-input layer (#578).

Closes #581. Linear **AI-1761** (epic AI-1759).

### What's here (4 commits)

1. **Transport** — `CodexAppServerConnection`: newline-delimited JSON-RPC 2.0 over stdio, a lean mirror of the proven `AcpConnection` (id correlation, single write-gate, one resilient read loop, always-answered server requests), reusing the shared envelope records and dropping ACP's reconnect-latch machinery a one-shot unattended reviewer has no design for.
2. **Runtime** — `CodexAppServerHostedAgentRuntime`: control-plane only (transcript stays on the hooks + `kcap watch` rollout path, so `EmitsTerminalOutput=false`). Lifecycle: spawn → `initialize` (delta opt-out) → `hooks/list` trust preflight (proceed / seed-and-restart / fail-closed) → `thread/start` (resolved model + deterministic thread-id identity) → per-round `turn/start`. `WaitForTurnIdleAsync` resolves from `turn/completed` (and unblocks on transport death). Approvals pinned to `never`, so any server-initiated approval request is answered with a valid on-the-wire `decline` (never a JSON-RPC error) and logged at Error. Client→server sends are bounded-retried on the `-32001` backpressure rejection. Usage captured from `thread/tokenUsage/updated`; reaper fed via `AgentActivityClock`.
3. **Sandbox fix + live smoke** — driving the **real codex 0.146.0** binary caught a wire bug a fake couldn't: `thread/start.sandbox` is the coarse `SandboxMode` string, a *different* shape from `turn/start.sandboxPolicy`'s object (the object form is rejected there). Fixed and re-verified. Adds a gated (`KCAP_CODEX_APPSERVER_SMOKE=1`) live smoke that drives the no-model handshake surface through the production connection against the installed binary in an isolated `CODEX_HOME` — the schema-drift tripwire for a Codex bump (skips loudly in CI, which has no codex).
4. **Composite factory + wiring** — `CodexHostedAgentRuntimeFactory` is the single "codex" factory: routes review-flow launches to app-server when `DaemonConfig.CodexAppServerActive`, delegates everything else (all interactive launches, all launches under the PTY default) to the wrapped PTY factory byte-identically. `CodexTransportDecision` is the ONE rule (operator selection AND the pinned 0.146.0 floor), resolved once into that field and read by **both** the router and the `codex-appserver-unattended-v1` advertisement, so the advertised policy and the transport used cannot diverge.

### Testing
- **26 new unit tests + 22 factory/decision tests**, all green: transport (15), runtime lifecycle vs an in-process fake app-server (10), transport-decision truth table + factory routing (delegation, app-server route via seam, fail-closed on missing hooks).
- **Live-validated against real codex 0.146.0** (the gated smoke).
- Existing capability-advertisement suites stay green (default config advertises `codex-unattended-v1` unchanged). **AOT clean** (no IL2026/IL3050).
- Grounded on the authoritative schema generated from the pinned binary.

### Scope / follow-ups
- Wires app-server for **review-flow (unattended) launches only**; interactive stays PTY (that's AI-1762).
- The vendored-schema (Q7) conformance test and the server-side `codex-appserver-unattended-v1` classifier (AI-1761 server half / PR 3) are follow-ups; the server already accepts the new policy string via its existing unknown-string handling, so this daemon is safe against an old server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)