### PR TITLE
Codex app-server: schema conformance test (Q7 pinning)

### DIFF
--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/AppServerSchema/codex-app-server-subset.pin.json
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/AppServerSchema/codex-app-server-subset.pin.json
@@ -1,0 +1,5771 @@
+{
+  "codexVersion": "0.147.0",
+  "combinedDefs": {
+    "AbsolutePathBuf": {
+      "description": "A path that is guaranteed to be absolute and normalized (though it is not guaranteed to be canonicalized or exist on the filesystem).\n\nIMPORTANT: When deserializing an \u0060AbsolutePathBuf\u0060, a base path must be set using [AbsolutePathBufGuard::new]. If no base path is set, the deserialization will fail unless the path being deserialized is already absolute.",
+      "type": "string"
+    },
+    "AgentPath": {
+      "type": "string"
+    },
+    "ApprovalsReviewer": {
+      "description": "Configures who approval requests are routed to for review. Examples include sandbox escapes, blocked network access, MCP approval prompts, and ARC escalations. Defaults to \u0060user\u0060. \u0060auto_review\u0060 uses a carefully prompted subagent to gather relevant context and apply a risk-based decision framework before approving or denying the request. The legacy value \u0060guardian_subagent\u0060 is accepted for compatibility.",
+      "enum": [
+        "user",
+        "auto_review",
+        "guardian_subagent"
+      ],
+      "type": "string"
+    },
+    "AskForApproval": {
+      "oneOf": [
+        {
+          "enum": [
+            "untrusted",
+            "on-request",
+            "never"
+          ],
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "granular": {
+              "properties": {
+                "mcp_elicitations": {
+                  "type": "boolean"
+                },
+                "request_permissions": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "rules": {
+                  "type": "boolean"
+                },
+                "sandbox_approval": {
+                  "type": "boolean"
+                },
+                "skill_approval": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "mcp_elicitations",
+                "rules",
+                "sandbox_approval"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "granular"
+          ],
+          "title": "GranularAskForApproval",
+          "type": "object"
+        }
+      ]
+    },
+    "ByteRange": {
+      "properties": {
+        "end": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "start": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "end",
+        "start"
+      ],
+      "type": "object"
+    },
+    "ClientInfo": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "type": "object"
+    },
+    "CodexErrorInfo": {
+      "description": "This translation layer make sure that we expose codex error code in camel case.\n\nWhen an upstream HTTP status is available (for example, from the Responses API or a provider), it is forwarded in \u0060httpStatusCode\u0060 on the relevant \u0060codexErrorInfo\u0060 variant.",
+      "oneOf": [
+        {
+          "enum": [
+            "contextWindowExceeded",
+            "sessionBudgetExceeded",
+            "usageLimitExceeded",
+            "serverOverloaded",
+            "cyberPolicy",
+            "internalServerError",
+            "unauthorized",
+            "badRequest",
+            "threadRollbackFailed",
+            "sandboxError",
+            "other"
+          ],
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "httpConnectionFailed": {
+              "properties": {
+                "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0.0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "httpConnectionFailed"
+          ],
+          "title": "HttpConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Failed to connect to the response SSE stream.",
+          "properties": {
+            "responseStreamConnectionFailed": {
+              "properties": {
+                "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0.0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "responseStreamConnectionFailed"
+          ],
+          "title": "ResponseStreamConnectionFailedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "The response SSE stream disconnected in the middle of a turn before completion.",
+          "properties": {
+            "responseStreamDisconnected": {
+              "properties": {
+                "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0.0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "responseStreamDisconnected"
+          ],
+          "title": "ResponseStreamDisconnectedCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Reached the retry limit for responses.",
+          "properties": {
+            "responseTooManyFailedAttempts": {
+              "properties": {
+                "httpStatusCode": {
+                  "format": "uint16",
+                  "minimum": 0.0,
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "responseTooManyFailedAttempts"
+          ],
+          "title": "ResponseTooManyFailedAttemptsCodexErrorInfo",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Returned when \u0060turn/start\u0060 or \u0060turn/steer\u0060 is submitted while the current active turn cannot accept same-turn steering, for example \u0060/review\u0060 or manual \u0060/compact\u0060.",
+          "properties": {
+            "activeTurnNotSteerable": {
+              "properties": {
+                "turnKind": {
+                  "$ref": "#/definitions/NonSteerableTurnKind"
+                }
+              },
+              "required": [
+                "turnKind"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "activeTurnNotSteerable"
+          ],
+          "title": "ActiveTurnNotSteerableCodexErrorInfo",
+          "type": "object"
+        }
+      ]
+    },
+    "CollabAgentState": {
+      "properties": {
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/CollabAgentStatus"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "type": "object"
+    },
+    "CollabAgentStatus": {
+      "enum": [
+        "pendingInit",
+        "running",
+        "interrupted",
+        "completed",
+        "errored",
+        "shutdown",
+        "notFound"
+      ],
+      "type": "string"
+    },
+    "CollabAgentTool": {
+      "enum": [
+        "spawnAgent",
+        "sendInput",
+        "resumeAgent",
+        "wait",
+        "closeAgent"
+      ],
+      "type": "string"
+    },
+    "CollabAgentToolCallStatus": {
+      "enum": [
+        "inProgress",
+        "completed",
+        "failed"
+      ],
+      "type": "string"
+    },
+    "CommandAction": {
+      "oneOf": [
+        {
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "$ref": "#/definitions/LegacyAppPathString"
+            },
+            "type": {
+              "enum": [
+                "read"
+              ],
+              "title": "ReadCommandActionType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "name",
+            "path",
+            "type"
+          ],
+          "title": "ReadCommandAction",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "listFiles"
+              ],
+              "title": "ListFilesCommandActionType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "type"
+          ],
+          "title": "ListFilesCommandAction",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "query": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "search"
+              ],
+              "title": "SearchCommandActionType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "type"
+          ],
+          "title": "SearchCommandAction",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "unknown"
+              ],
+              "title": "UnknownCommandActionType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "type"
+          ],
+          "title": "UnknownCommandAction",
+          "type": "object"
+        }
+      ]
+    },
+    "CommandExecutionSource": {
+      "enum": [
+        "agent",
+        "userShell",
+        "unifiedExecStartup",
+        "unifiedExecInteraction"
+      ],
+      "type": "string"
+    },
+    "CommandExecutionStatus": {
+      "enum": [
+        "inProgress",
+        "completed",
+        "failed",
+        "declined"
+      ],
+      "type": "string"
+    },
+    "DynamicToolCallOutputContentItem": {
+      "oneOf": [
+        {
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "inputText"
+              ],
+              "title": "InputTextDynamicToolCallOutputContentItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "text",
+            "type"
+          ],
+          "title": "InputTextDynamicToolCallOutputContentItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "imageUrl": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "inputImage"
+              ],
+              "title": "InputImageDynamicToolCallOutputContentItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "imageUrl",
+            "type"
+          ],
+          "title": "InputImageDynamicToolCallOutputContentItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "audioUrl": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "inputAudio"
+              ],
+              "title": "InputAudioDynamicToolCallOutputContentItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "audioUrl",
+            "type"
+          ],
+          "title": "InputAudioDynamicToolCallOutputContentItem",
+          "type": "object"
+        }
+      ]
+    },
+    "DynamicToolCallStatus": {
+      "enum": [
+        "inProgress",
+        "completed",
+        "failed"
+      ],
+      "type": "string"
+    },
+    "FileUpdateChange": {
+      "properties": {
+        "diff": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/PatchChangeKind"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "diff",
+        "kind",
+        "path"
+      ],
+      "type": "object"
+    },
+    "GitInfo": {
+      "properties": {
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "originUrl": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "HookErrorInfo": {
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "path"
+      ],
+      "type": "object"
+    },
+    "HookEventName": {
+      "enum": [
+        "preToolUse",
+        "permissionRequest",
+        "postToolUse",
+        "preCompact",
+        "postCompact",
+        "sessionStart",
+        "sessionEnd",
+        "userPromptSubmit",
+        "subagentStart",
+        "subagentStop",
+        "stop"
+      ],
+      "type": "string"
+    },
+    "HookHandlerType": {
+      "enum": [
+        "command",
+        "prompt",
+        "agent"
+      ],
+      "type": "string"
+    },
+    "HookMetadata": {
+      "properties": {
+        "additionalContextLimit": {
+          "description": "Configured \u0060additionalContext\u0060 spill threshold. \u0060null\u0060 uses 2,500 tokens; \u00600\u0060 disables spilling.",
+          "format": "uint",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "command": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "currentHash": {
+          "type": "string"
+        },
+        "displayOrder": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "eventName": {
+          "$ref": "#/definitions/HookEventName"
+        },
+        "handlerType": {
+          "$ref": "#/definitions/HookHandlerType"
+        },
+        "isManaged": {
+          "type": "boolean"
+        },
+        "key": {
+          "type": "string"
+        },
+        "matcher": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pluginId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "$ref": "#/definitions/HookSource"
+        },
+        "sourcePath": {
+          "$ref": "#/definitions/AbsolutePathBuf"
+        },
+        "statusMessage": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timeoutSec": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "trustStatus": {
+          "$ref": "#/definitions/HookTrustStatus"
+        }
+      },
+      "required": [
+        "currentHash",
+        "displayOrder",
+        "enabled",
+        "eventName",
+        "handlerType",
+        "isManaged",
+        "key",
+        "source",
+        "sourcePath",
+        "timeoutSec",
+        "trustStatus"
+      ],
+      "type": "object"
+    },
+    "HookPromptFragment": {
+      "properties": {
+        "hookRunId": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "hookRunId",
+        "text"
+      ],
+      "type": "object"
+    },
+    "HookSource": {
+      "enum": [
+        "system",
+        "user",
+        "project",
+        "mdm",
+        "sessionFlags",
+        "plugin",
+        "cloudRequirements",
+        "cloudManagedConfig",
+        "legacyManagedConfigFile",
+        "legacyManagedConfigMdm",
+        "unknown"
+      ],
+      "type": "string"
+    },
+    "HookTrustStatus": {
+      "enum": [
+        "managed",
+        "untrusted",
+        "trusted",
+        "modified"
+      ],
+      "type": "string"
+    },
+    "HooksListEntry": {
+      "properties": {
+        "cwd": {
+          "type": "string"
+        },
+        "errors": {
+          "items": {
+            "$ref": "#/definitions/HookErrorInfo"
+          },
+          "type": "array"
+        },
+        "hooks": {
+          "items": {
+            "$ref": "#/definitions/HookMetadata"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "cwd",
+        "errors",
+        "hooks",
+        "warnings"
+      ],
+      "type": "object"
+    },
+    "HooksListParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "cwds": {
+          "description": "When empty, defaults to the current session working directory.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "title": "HooksListParams",
+      "type": "object"
+    },
+    "HooksListResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "data": {
+          "items": {
+            "$ref": "#/definitions/HooksListEntry"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "title": "HooksListResponse",
+      "type": "object"
+    },
+    "ImageDetail": {
+      "enum": [
+        "auto",
+        "low",
+        "high",
+        "original"
+      ],
+      "type": "string"
+    },
+    "InitializeCapabilities": {
+      "description": "Client-declared capabilities negotiated during initialize.",
+      "properties": {
+        "experimentalApi": {
+          "default": false,
+          "description": "Opt into receiving experimental API methods and fields.",
+          "type": "boolean"
+        },
+        "extensions": {
+          "additionalProperties": true,
+          "description": "MCP extension settings declared by the app-server client.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "mcpServerOpenaiFormElicitation": {
+          "description": "Legacy opt-in for the \u0060openai/form\u0060 MCP extension.\n\nNew clients should declare \u0060openai/form\u0060 in [\u0060Self::extensions\u0060].",
+          "type": "boolean"
+        },
+        "optOutNotificationMethods": {
+          "description": "Exact notification method names that should be suppressed for this connection (for example \u0060thread/started\u0060).",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "requestAttestation": {
+          "default": false,
+          "description": "Opt into \u0060attestation/generate\u0060 requests for upstream \u0060x-oai-attestation\u0060.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "InitializeParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "capabilities": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/InitializeCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "clientInfo": {
+          "$ref": "#/definitions/ClientInfo"
+        }
+      },
+      "required": [
+        "clientInfo"
+      ],
+      "title": "InitializeParams",
+      "type": "object"
+    },
+    "LegacyAppPathString": {
+      "type": "string"
+    },
+    "McpToolCallAppContext": {
+      "properties": {
+        "actionName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "appName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "connectorId": {
+          "type": "string"
+        },
+        "linkId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resourceUri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "connectorId"
+      ],
+      "type": "object"
+    },
+    "McpToolCallError": {
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
+    },
+    "McpToolCallResult": {
+      "properties": {
+        "_meta": true,
+        "content": {
+          "items": true,
+          "type": "array"
+        },
+        "structuredContent": true
+      },
+      "required": [
+        "content"
+      ],
+      "type": "object"
+    },
+    "McpToolCallStatus": {
+      "enum": [
+        "inProgress",
+        "completed",
+        "failed"
+      ],
+      "type": "string"
+    },
+    "MemoryCitation": {
+      "properties": {
+        "entries": {
+          "items": {
+            "$ref": "#/definitions/MemoryCitationEntry"
+          },
+          "type": "array"
+        },
+        "threadIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "entries",
+        "threadIds"
+      ],
+      "type": "object"
+    },
+    "MemoryCitationEntry": {
+      "properties": {
+        "lineEnd": {
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "lineStart": {
+          "format": "uint32",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "note": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "lineEnd",
+        "lineStart",
+        "note",
+        "path"
+      ],
+      "type": "object"
+    },
+    "MessagePhase": {
+      "description": "Classifies an assistant message as interim commentary or final answer text.\n\nProviders do not emit this consistently, so callers must treat \u0060None\u0060 as \u0022phase unknown\u0022 and keep compatibility behavior for legacy models.",
+      "oneOf": [
+        {
+          "description": "Mid-turn assistant text (for example preamble/progress narration).\n\nAdditional tool calls or assistant output may follow before turn completion.",
+          "enum": [
+            "commentary"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "The assistant\u0027s terminal answer text for the current turn.",
+          "enum": [
+            "final_answer"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "NetworkAccess": {
+      "enum": [
+        "restricted",
+        "enabled"
+      ],
+      "type": "string"
+    },
+    "NonSteerableTurnKind": {
+      "enum": [
+        "review",
+        "compact"
+      ],
+      "type": "string"
+    },
+    "PatchApplyStatus": {
+      "enum": [
+        "inProgress",
+        "completed",
+        "failed",
+        "declined"
+      ],
+      "type": "string"
+    },
+    "PatchChangeKind": {
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "add"
+              ],
+              "title": "AddPatchChangeKindType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "AddPatchChangeKind",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "delete"
+              ],
+              "title": "DeletePatchChangeKindType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "DeletePatchChangeKind",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "move_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "update"
+              ],
+              "title": "UpdatePatchChangeKindType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "UpdatePatchChangeKind",
+          "type": "object"
+        }
+      ]
+    },
+    "Personality": {
+      "enum": [
+        "none",
+        "friendly",
+        "pragmatic"
+      ],
+      "type": "string"
+    },
+    "ReasoningEffort": {
+      "description": "A non-empty reasoning effort value advertised by the model.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "ReasoningSummary": {
+      "description": "A summary of the reasoning performed by the model. This can be useful for debugging and understanding the model\u0027s reasoning process. See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries",
+      "oneOf": [
+        {
+          "enum": [
+            "auto",
+            "concise",
+            "detailed"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Option to disable reasoning summaries.",
+          "enum": [
+            "none"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "SandboxMode": {
+      "enum": [
+        "read-only",
+        "workspace-write",
+        "danger-full-access"
+      ],
+      "type": "string"
+    },
+    "SandboxPolicy": {
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "dangerFullAccess"
+              ],
+              "title": "DangerFullAccessSandboxPolicyType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "DangerFullAccessSandboxPolicy",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "networkAccess": {
+              "default": false,
+              "type": "boolean"
+            },
+            "type": {
+              "enum": [
+                "readOnly"
+              ],
+              "title": "ReadOnlySandboxPolicyType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "ReadOnlySandboxPolicy",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "networkAccess": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/NetworkAccess"
+                }
+              ],
+              "default": "restricted"
+            },
+            "type": {
+              "enum": [
+                "externalSandbox"
+              ],
+              "title": "ExternalSandboxSandboxPolicyType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "ExternalSandboxSandboxPolicy",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "excludeSlashTmp": {
+              "default": false,
+              "type": "boolean"
+            },
+            "excludeTmpdirEnvVar": {
+              "default": false,
+              "type": "boolean"
+            },
+            "networkAccess": {
+              "default": false,
+              "type": "boolean"
+            },
+            "type": {
+              "enum": [
+                "workspaceWrite"
+              ],
+              "title": "WorkspaceWriteSandboxPolicyType",
+              "type": "string"
+            },
+            "writableRoots": {
+              "default": [],
+              "items": {
+                "$ref": "#/definitions/AbsolutePathBuf"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "WorkspaceWriteSandboxPolicy",
+          "type": "object"
+        }
+      ]
+    },
+    "SessionSource": {
+      "oneOf": [
+        {
+          "enum": [
+            "cli",
+            "vscode",
+            "exec",
+            "appServer",
+            "unknown"
+          ],
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "custom": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "custom"
+          ],
+          "title": "CustomSessionSource",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "subAgent": {
+              "$ref": "#/definitions/SubAgentSource"
+            }
+          },
+          "required": [
+            "subAgent"
+          ],
+          "title": "SubAgentSessionSource",
+          "type": "object"
+        }
+      ]
+    },
+    "SubAgentActivityKind": {
+      "enum": [
+        "started",
+        "interacted",
+        "interrupted"
+      ],
+      "type": "string"
+    },
+    "SubAgentSource": {
+      "oneOf": [
+        {
+          "enum": [
+            "review",
+            "compact",
+            "memory_consolidation"
+          ],
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "thread_spawn": {
+              "properties": {
+                "agent_nickname": {
+                  "default": null,
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "agent_path": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/AgentPath"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null
+                },
+                "agent_role": {
+                  "default": null,
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "depth": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "parent_thread_id": {
+                  "$ref": "#/definitions/ThreadId"
+                }
+              },
+              "required": [
+                "depth",
+                "parent_thread_id"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "thread_spawn"
+          ],
+          "title": "ThreadSpawnSubAgentSource",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "other": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "other"
+          ],
+          "title": "OtherSubAgentSource",
+          "type": "object"
+        }
+      ]
+    },
+    "TextElement": {
+      "properties": {
+        "byteRange": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ByteRange"
+            }
+          ],
+          "description": "Byte range in the parent \u0060text\u0060 buffer that this element occupies."
+        },
+        "placeholder": {
+          "description": "Optional human-readable placeholder for the element, displayed in the UI.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "byteRange"
+      ],
+      "type": "object"
+    },
+    "Thread": {
+      "properties": {
+        "agentNickname": {
+          "description": "Optional random unique nickname assigned to an AgentControl-spawned sub-agent.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "agentRole": {
+          "description": "Optional role (agent_role) assigned to an AgentControl-spawned sub-agent.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cliVersion": {
+          "description": "Version of the CLI that created the thread.",
+          "type": "string"
+        },
+        "createdAt": {
+          "description": "Unix timestamp (in seconds) when the thread was created.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "cwd": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/AbsolutePathBuf"
+            }
+          ],
+          "description": "Working directory captured for the thread."
+        },
+        "ephemeral": {
+          "description": "Whether the thread is ephemeral and should not be materialized on disk.",
+          "type": "boolean"
+        },
+        "forkedFromId": {
+          "description": "Source thread id when this thread was created by forking another thread.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "gitInfo": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GitInfo"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional Git metadata captured when the thread was created."
+        },
+        "id": {
+          "description": "Identifier for this thread. Codex-generated thread IDs are UUIDv7.",
+          "type": "string"
+        },
+        "modelProvider": {
+          "description": "Model provider used for this thread (for example, \u0027openai\u0027).",
+          "type": "string"
+        },
+        "name": {
+          "description": "Optional user-facing thread title.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "parentThreadId": {
+          "description": "The ID of the parent thread. This will only be set if this thread is a subagent.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "description": "[UNSTABLE] Path to the thread on disk.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "preview": {
+          "description": "Usually the first user message in the thread, if available.",
+          "type": "string"
+        },
+        "recencyAt": {
+          "description": "Unix timestamp (in seconds) used for thread recency ordering.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "section": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadSection"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The independently persisted section selected for this thread, if any."
+        },
+        "sectionEnteredAt": {
+          "default": null,
+          "description": "Unix timestamp in seconds when the thread entered its current section.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "sessionId": {
+          "description": "Session id shared by threads that belong to the same session tree.",
+          "type": "string"
+        },
+        "source": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/SessionSource"
+            }
+          ],
+          "description": "Origin of the thread (CLI, VSCode, codex exec, codex app-server, etc.)."
+        },
+        "status": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ThreadStatus"
+            }
+          ],
+          "description": "Current runtime status for the thread."
+        },
+        "threadSource": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadSource"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional analytics source classification for this thread."
+        },
+        "turns": {
+          "description": "Only populated on \u0060thread/resume\u0060, \u0060thread/rollback\u0060, \u0060thread/fork\u0060, and \u0060thread/read\u0060 (when \u0060includeTurns\u0060 is true) responses. For all other responses and notifications returning a Thread, the turns field will be an empty list.",
+          "items": {
+            "$ref": "#/definitions/Turn"
+          },
+          "type": "array"
+        },
+        "updatedAt": {
+          "description": "Unix timestamp (in seconds) when the thread was last updated.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cliVersion",
+        "createdAt",
+        "cwd",
+        "ephemeral",
+        "id",
+        "modelProvider",
+        "preview",
+        "sessionId",
+        "source",
+        "status",
+        "turns",
+        "updatedAt"
+      ],
+      "type": "object"
+    },
+    "ThreadActiveFlag": {
+      "enum": [
+        "waitingOnApproval",
+        "waitingOnUserInput"
+      ],
+      "type": "string"
+    },
+    "ThreadId": {
+      "type": "string"
+    },
+    "ThreadItem": {
+      "oneOf": [
+        {
+          "properties": {
+            "clientId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "content": {
+              "items": {
+                "$ref": "#/definitions/UserInput"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "userMessage"
+              ],
+              "title": "UserMessageThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "content",
+            "id",
+            "type"
+          ],
+          "title": "UserMessageThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "fragments": {
+              "items": {
+                "$ref": "#/definitions/HookPromptFragment"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "hookPrompt"
+              ],
+              "title": "HookPromptThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "fragments",
+            "id",
+            "type"
+          ],
+          "title": "HookPromptThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "memoryCitation": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/MemoryCitation"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "phase": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/MessagePhase"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "agentMessage"
+              ],
+              "title": "AgentMessageThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "text",
+            "type"
+          ],
+          "title": "AgentMessageThreadItem",
+          "type": "object"
+        },
+        {
+          "description": "EXPERIMENTAL - proposed plan item content. The completed plan item is authoritative and may not match the concatenation of \u0060PlanDelta\u0060 text.",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "plan"
+              ],
+              "title": "PlanThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "text",
+            "type"
+          ],
+          "title": "PlanThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "content": {
+              "default": [],
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "summary": {
+              "default": [],
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "reasoning"
+              ],
+              "title": "ReasoningThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "type"
+          ],
+          "title": "ReasoningThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "aggregatedOutput": {
+              "description": "The command\u0027s output, aggregated from stdout and stderr.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "command": {
+              "description": "The command to be executed.",
+              "type": "string"
+            },
+            "commandActions": {
+              "description": "A best-effort parsing of the command to understand the action(s) it will perform. This returns a list of CommandAction objects because a single shell command may be composed of many commands piped together.",
+              "items": {
+                "$ref": "#/definitions/CommandAction"
+              },
+              "type": "array"
+            },
+            "cwd": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/LegacyAppPathString"
+                }
+              ],
+              "description": "The command\u0027s working directory."
+            },
+            "durationMs": {
+              "description": "The duration of the command execution in milliseconds.",
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "exitCode": {
+              "description": "The command\u0027s exit code.",
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "pluginId": {
+              "default": null,
+              "description": "Trusted first-party plugin id when this command resolves to one plugin script.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "processId": {
+              "description": "Identifier for the underlying PTY process (when available).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "scriptPath": {
+              "default": null,
+              "description": "Safe plugin-relative path when this command resolves to one plugin script.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CommandExecutionSource"
+                }
+              ],
+              "default": "agent"
+            },
+            "status": {
+              "$ref": "#/definitions/CommandExecutionStatus"
+            },
+            "type": {
+              "enum": [
+                "commandExecution"
+              ],
+              "title": "CommandExecutionThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "commandActions",
+            "cwd",
+            "id",
+            "status",
+            "type"
+          ],
+          "title": "CommandExecutionThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "changes": {
+              "items": {
+                "$ref": "#/definitions/FileUpdateChange"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "status": {
+              "$ref": "#/definitions/PatchApplyStatus"
+            },
+            "type": {
+              "enum": [
+                "fileChange"
+              ],
+              "title": "FileChangeThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "changes",
+            "id",
+            "status",
+            "type"
+          ],
+          "title": "FileChangeThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "appContext": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/McpToolCallAppContext"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "arguments": true,
+            "durationMs": {
+              "description": "The duration of the MCP tool call in milliseconds.",
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "error": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/McpToolCallError"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "mcpAppResourceUri": {
+              "description": "Deprecated: use \u0060appContext.resourceUri\u0060 instead.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pluginId": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "readOnlyHint": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "result": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/McpToolCallResult"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "server": {
+              "type": "string"
+            },
+            "status": {
+              "$ref": "#/definitions/McpToolCallStatus"
+            },
+            "tool": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "mcpToolCall"
+              ],
+              "title": "McpToolCallThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "arguments",
+            "id",
+            "server",
+            "status",
+            "tool",
+            "type"
+          ],
+          "title": "McpToolCallThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "arguments": true,
+            "contentItems": {
+              "items": {
+                "$ref": "#/definitions/DynamicToolCallOutputContentItem"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "durationMs": {
+              "description": "The duration of the dynamic tool call in milliseconds.",
+              "format": "int64",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "$ref": "#/definitions/DynamicToolCallStatus"
+            },
+            "success": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "tool": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "dynamicToolCall"
+              ],
+              "title": "DynamicToolCallThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "arguments",
+            "id",
+            "status",
+            "tool",
+            "type"
+          ],
+          "title": "DynamicToolCallThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "agentsStates": {
+              "additionalProperties": {
+                "$ref": "#/definitions/CollabAgentState"
+              },
+              "description": "Last known status of the target agents, when available.",
+              "type": "object"
+            },
+            "id": {
+              "description": "Unique identifier for this collab tool call.",
+              "type": "string"
+            },
+            "model": {
+              "description": "Model requested for the spawned agent, when applicable.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "prompt": {
+              "description": "Prompt text sent as part of the collab tool call, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reasoningEffort": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ReasoningEffort"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Reasoning effort requested for the spawned agent, when applicable."
+            },
+            "receiverThreadIds": {
+              "description": "Thread ID of the receiving agent, when applicable. In case of spawn operation, this corresponds to the newly spawned agent.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "senderThreadId": {
+              "description": "Thread ID of the agent issuing the collab request.",
+              "type": "string"
+            },
+            "status": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CollabAgentToolCallStatus"
+                }
+              ],
+              "description": "Current status of the collab tool call."
+            },
+            "tool": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CollabAgentTool"
+                }
+              ],
+              "description": "Name of the collab tool that was invoked."
+            },
+            "type": {
+              "enum": [
+                "collabAgentToolCall"
+              ],
+              "title": "CollabAgentToolCallThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "agentsStates",
+            "id",
+            "receiverThreadIds",
+            "senderThreadId",
+            "status",
+            "tool",
+            "type"
+          ],
+          "title": "CollabAgentToolCallThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "agentPath": {
+              "type": "string"
+            },
+            "agentThreadId": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "kind": {
+              "$ref": "#/definitions/SubAgentActivityKind"
+            },
+            "type": {
+              "enum": [
+                "subAgentActivity"
+              ],
+              "title": "SubAgentActivityThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "agentPath",
+            "agentThreadId",
+            "id",
+            "kind",
+            "type"
+          ],
+          "title": "SubAgentActivityThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "action": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/WebSearchAction"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "query": {
+              "type": "string"
+            },
+            "results": {
+              "default": null,
+              "description": "Structured search results returned out-of-band by standalone web search.\n\nThese stay as opaque JSON at the extension/app-server boundary so new result fields and result types can pass through without a Codex release.",
+              "items": true,
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "webSearch"
+              ],
+              "title": "WebSearchThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "query",
+            "type"
+          ],
+          "title": "WebSearchThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "path": {
+              "$ref": "#/definitions/LegacyAppPathString"
+            },
+            "type": {
+              "enum": [
+                "imageView"
+              ],
+              "title": "ImageViewThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "path",
+            "type"
+          ],
+          "title": "ImageViewThreadItem",
+          "type": "object"
+        },
+        {
+          "description": "Display item emitted by the interruptible \u0060clock.sleep\u0060 tool.",
+          "properties": {
+            "durationMs": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "sleep"
+              ],
+              "title": "SleepThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "durationMs",
+            "id",
+            "type"
+          ],
+          "title": "SleepThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "result": {
+              "type": "string"
+            },
+            "revisedPrompt": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "savedPath": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AbsolutePathBuf"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "transparentBackground": {
+              "default": null,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "imageGeneration"
+              ],
+              "title": "ImageGenerationThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "result",
+            "status",
+            "type"
+          ],
+          "title": "ImageGenerationThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "review": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "enteredReviewMode"
+              ],
+              "title": "EnteredReviewModeThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "review",
+            "type"
+          ],
+          "title": "EnteredReviewModeThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "review": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "exitedReviewMode"
+              ],
+              "title": "ExitedReviewModeThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "review",
+            "type"
+          ],
+          "title": "ExitedReviewModeThreadItem",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "contextCompaction"
+              ],
+              "title": "ContextCompactionThreadItemType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "type"
+          ],
+          "title": "ContextCompactionThreadItem",
+          "type": "object"
+        }
+      ]
+    },
+    "ThreadResumeParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "description": "There are three ways to resume a thread: 1. By thread_id: load the thread from disk by thread_id and resume it. 2. By history: instantiate the thread from memory and resume it. 3. By path: load the thread from disk by path and resume it.\n\nFor non-running threads, the precedence is: history \u003E non-empty path \u003E thread_id. If using history or a non-empty path for a non-running thread, the thread_id param will be ignored.\n\nIf thread_id identifies a running thread, app-server rejoins that thread and treats a non-empty path as a consistency check against the active rollout path. Empty string path values are treated as absent.\n\nPrefer using thread_id whenever possible.",
+      "properties": {
+        "approvalPolicy": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AskForApproval"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "approvalsReviewer": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ApprovalsReviewer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override where approval requests are routed for review on this thread and subsequent turns."
+        },
+        "baseInstructions": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "config": {
+          "additionalProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "cwd": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "developerInstructions": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "description": "Configuration overrides for the resumed thread, if any.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "modelProvider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "personality": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Personality"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sandbox": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SandboxMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "serviceTier": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId"
+      ],
+      "title": "ThreadResumeParams",
+      "type": "object"
+    },
+    "ThreadResumeResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "approvalPolicy": {
+          "$ref": "#/definitions/AskForApproval"
+        },
+        "approvalsReviewer": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApprovalsReviewer"
+            }
+          ],
+          "description": "Reviewer currently used for approval requests on this thread."
+        },
+        "cwd": {
+          "$ref": "#/definitions/AbsolutePathBuf"
+        },
+        "instructionSources": {
+          "default": [],
+          "description": "Environment-native paths to instruction source files currently loaded for this thread.",
+          "items": {
+            "$ref": "#/definitions/LegacyAppPathString"
+          },
+          "type": "array"
+        },
+        "model": {
+          "type": "string"
+        },
+        "modelProvider": {
+          "type": "string"
+        },
+        "reasoningEffort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReasoningEffort"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sandbox": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/SandboxPolicy"
+            }
+          ],
+          "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer \u0060activePermissionProfile\u0060 for profile provenance."
+        },
+        "serviceTier": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "thread": {
+          "$ref": "#/definitions/Thread"
+        }
+      },
+      "required": [
+        "approvalPolicy",
+        "approvalsReviewer",
+        "cwd",
+        "model",
+        "modelProvider",
+        "sandbox",
+        "thread"
+      ],
+      "title": "ThreadResumeResponse",
+      "type": "object"
+    },
+    "ThreadSection": {
+      "description": "An independently persisted, user-visible thread section.",
+      "properties": {
+        "id": {
+          "description": "Opaque UUIDv7 identity that remains stable when the section is renamed.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The current user-visible section name.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "type": "object"
+    },
+    "ThreadSource": {
+      "type": "string"
+    },
+    "ThreadStartParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "approvalPolicy": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AskForApproval"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "approvalsReviewer": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ApprovalsReviewer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override where approval requests are routed for review on this thread and subsequent turns."
+        },
+        "baseInstructions": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "config": {
+          "additionalProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "cwd": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "developerInstructions": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ephemeral": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "modelProvider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "personality": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Personality"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sandbox": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SandboxMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "serviceName": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "serviceTier": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sessionStartSource": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadStartSource"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "threadSource": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ThreadSource"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional client-supplied analytics source classification for this thread."
+        }
+      },
+      "title": "ThreadStartParams",
+      "type": "object"
+    },
+    "ThreadStartResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "approvalPolicy": {
+          "$ref": "#/definitions/AskForApproval"
+        },
+        "approvalsReviewer": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApprovalsReviewer"
+            }
+          ],
+          "description": "Reviewer currently used for approval requests on this thread."
+        },
+        "cwd": {
+          "$ref": "#/definitions/AbsolutePathBuf"
+        },
+        "instructionSources": {
+          "default": [],
+          "description": "Environment-native paths to instruction source files currently loaded for this thread.",
+          "items": {
+            "$ref": "#/definitions/LegacyAppPathString"
+          },
+          "type": "array"
+        },
+        "model": {
+          "type": "string"
+        },
+        "modelProvider": {
+          "type": "string"
+        },
+        "reasoningEffort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReasoningEffort"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sandbox": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/SandboxPolicy"
+            }
+          ],
+          "description": "Legacy sandbox policy retained for compatibility. Experimental clients should prefer \u0060activePermissionProfile\u0060 for profile provenance."
+        },
+        "serviceTier": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "thread": {
+          "$ref": "#/definitions/Thread"
+        }
+      },
+      "required": [
+        "approvalPolicy",
+        "approvalsReviewer",
+        "cwd",
+        "model",
+        "modelProvider",
+        "sandbox",
+        "thread"
+      ],
+      "title": "ThreadStartResponse",
+      "type": "object"
+    },
+    "ThreadStartSource": {
+      "enum": [
+        "startup",
+        "clear"
+      ],
+      "type": "string"
+    },
+    "ThreadStatus": {
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "notLoaded"
+              ],
+              "title": "NotLoadedThreadStatusType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "NotLoadedThreadStatus",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "idle"
+              ],
+              "title": "IdleThreadStatusType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "IdleThreadStatus",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "systemError"
+              ],
+              "title": "SystemErrorThreadStatusType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "SystemErrorThreadStatus",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "activeFlags": {
+              "items": {
+                "$ref": "#/definitions/ThreadActiveFlag"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "active"
+              ],
+              "title": "ActiveThreadStatusType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "activeFlags",
+            "type"
+          ],
+          "title": "ActiveThreadStatus",
+          "type": "object"
+        }
+      ]
+    },
+    "ThreadTokenUsage": {
+      "properties": {
+        "last": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        },
+        "modelContextWindow": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total": {
+          "$ref": "#/definitions/TokenUsageBreakdown"
+        }
+      },
+      "required": [
+        "last",
+        "total"
+      ],
+      "type": "object"
+    },
+    "ThreadTokenUsageUpdatedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        },
+        "tokenUsage": {
+          "$ref": "#/definitions/ThreadTokenUsage"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId",
+        "tokenUsage",
+        "turnId"
+      ],
+      "title": "ThreadTokenUsageUpdatedNotification",
+      "type": "object"
+    },
+    "TokenUsageBreakdown": {
+      "properties": {
+        "cacheWriteInputTokens": {
+          "default": 0,
+          "format": "int64",
+          "type": "integer"
+        },
+        "cachedInputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "inputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "outputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reasoningOutputTokens": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "totalTokens": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cachedInputTokens",
+        "inputTokens",
+        "outputTokens",
+        "reasoningOutputTokens",
+        "totalTokens"
+      ],
+      "type": "object"
+    },
+    "Turn": {
+      "properties": {
+        "completedAt": {
+          "description": "Unix timestamp (in seconds) when the turn completed.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "durationMs": {
+          "description": "Duration between turn start and completion in milliseconds, if known.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "error": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TurnError"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Only populated when the Turn\u0027s status is failed."
+        },
+        "id": {
+          "description": "Identifier for this turn. Codex-generated turn IDs are UUIDv7.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Thread items currently included in this turn payload.",
+          "items": {
+            "$ref": "#/definitions/ThreadItem"
+          },
+          "type": "array"
+        },
+        "itemsView": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/TurnItemsView"
+            }
+          ],
+          "default": "full",
+          "description": "Describes how much of \u0060items\u0060 has been loaded for this turn."
+        },
+        "startedAt": {
+          "description": "Unix timestamp (in seconds) when the turn started.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/TurnStatus"
+        }
+      },
+      "required": [
+        "id",
+        "items",
+        "status"
+      ],
+      "type": "object"
+    },
+    "TurnCompletedNotification": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        },
+        "turn": {
+          "$ref": "#/definitions/Turn"
+        }
+      },
+      "required": [
+        "threadId",
+        "turn"
+      ],
+      "title": "TurnCompletedNotification",
+      "type": "object"
+    },
+    "TurnError": {
+      "properties": {
+        "additionalDetails": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "codexErrorInfo": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CodexErrorInfo"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "message"
+      ],
+      "type": "object"
+    },
+    "TurnInterruptParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "threadId",
+        "turnId"
+      ],
+      "title": "TurnInterruptParams",
+      "type": "object"
+    },
+    "TurnInterruptResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "TurnInterruptResponse",
+      "type": "object"
+    },
+    "TurnItemsView": {
+      "oneOf": [
+        {
+          "description": "\u0060items\u0060 was not loaded for this turn. The field is intentionally empty.",
+          "enum": [
+            "notLoaded"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "\u0060items\u0060 contains only a display summary for this turn.",
+          "enum": [
+            "summary"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "\u0060items\u0060 contains every ThreadItem available from persisted app-server history for this turn.",
+          "enum": [
+            "full"
+          ],
+          "type": "string"
+        }
+      ]
+    },
+    "TurnStartParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "approvalPolicy": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AskForApproval"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the approval policy for this turn and subsequent turns."
+        },
+        "approvalsReviewer": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ApprovalsReviewer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override where approval requests are routed for review on this turn and subsequent turns."
+        },
+        "clientUserMessageId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cwd": {
+          "description": "Override the working directory for this turn and subsequent turns.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "effort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReasoningEffort"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the reasoning effort for this turn and subsequent turns."
+        },
+        "input": {
+          "items": {
+            "$ref": "#/definitions/UserInput"
+          },
+          "type": "array"
+        },
+        "model": {
+          "description": "Override the model for this turn and subsequent turns.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "outputSchema": {
+          "description": "Optional JSON Schema used to constrain the final assistant message for this turn."
+        },
+        "personality": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Personality"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the personality for this turn and subsequent turns."
+        },
+        "sandboxPolicy": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SandboxPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the sandbox policy for this turn and subsequent turns."
+        },
+        "serviceTier": {
+          "description": "Override the service tier for this turn and subsequent turns.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "summary": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReasoningSummary"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Override the reasoning summary for this turn and subsequent turns."
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "input",
+        "threadId"
+      ],
+      "title": "TurnStartParams",
+      "type": "object"
+    },
+    "TurnStartResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "turn": {
+          "$ref": "#/definitions/Turn"
+        }
+      },
+      "required": [
+        "turn"
+      ],
+      "title": "TurnStartResponse",
+      "type": "object"
+    },
+    "TurnStatus": {
+      "enum": [
+        "completed",
+        "interrupted",
+        "failed",
+        "inProgress"
+      ],
+      "type": "string"
+    },
+    "TurnSteerParams": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "clientUserMessageId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expectedTurnId": {
+          "description": "Required active turn id precondition. The request fails when it does not match the currently active turn.",
+          "type": "string"
+        },
+        "input": {
+          "items": {
+            "$ref": "#/definitions/UserInput"
+          },
+          "type": "array"
+        },
+        "threadId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "expectedTurnId",
+        "input",
+        "threadId"
+      ],
+      "title": "TurnSteerParams",
+      "type": "object"
+    },
+    "TurnSteerResponse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "turnId"
+      ],
+      "title": "TurnSteerResponse",
+      "type": "object"
+    },
+    "UserInput": {
+      "oneOf": [
+        {
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "text_elements": {
+              "default": [],
+              "description": "UI-defined spans within \u0060text\u0060 used to render or persist special elements.",
+              "items": {
+                "$ref": "#/definitions/TextElement"
+              },
+              "type": "array"
+            },
+            "type": {
+              "enum": [
+                "text"
+              ],
+              "title": "TextUserInputType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "text",
+            "type"
+          ],
+          "title": "TextUserInput",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ImageDetail"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "type": {
+              "enum": [
+                "image"
+              ],
+              "title": "ImageUserInputType",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "url"
+          ],
+          "title": "ImageUserInput",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ImageDetail"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            },
+            "path": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "localImage"
+              ],
+              "title": "LocalImageUserInputType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "type"
+          ],
+          "title": "LocalImageUserInput",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "audio"
+              ],
+              "title": "AudioUserInputType",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "url"
+          ],
+          "title": "AudioUserInput",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "localAudio"
+              ],
+              "title": "LocalAudioUserInputType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "type"
+          ],
+          "title": "LocalAudioUserInput",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "skill"
+              ],
+              "title": "SkillUserInputType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "path",
+            "type"
+          ],
+          "title": "SkillUserInput",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "mention"
+              ],
+              "title": "MentionUserInputType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "path",
+            "type"
+          ],
+          "title": "MentionUserInput",
+          "type": "object"
+        }
+      ]
+    },
+    "WebSearchAction": {
+      "oneOf": [
+        {
+          "properties": {
+            "queries": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "query": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "search"
+              ],
+              "title": "SearchWebSearchActionType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "SearchWebSearchAction",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "openPage"
+              ],
+              "title": "OpenPageWebSearchActionType",
+              "type": "string"
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "OpenPageWebSearchAction",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "pattern": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "enum": [
+                "findInPage"
+              ],
+              "title": "FindInPageWebSearchActionType",
+              "type": "string"
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "FindInPageWebSearchAction",
+          "type": "object"
+        },
+        {
+          "properties": {
+            "type": {
+              "enum": [
+                "other"
+              ],
+              "title": "OtherWebSearchActionType",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "OtherWebSearchAction",
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "standalone": {
+    "CommandExecutionRequestApprovalParams.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": {
+        "AdditionalFileSystemPermissions": {
+          "properties": {
+            "entries": {
+              "items": {
+                "$ref": "#/definitions/FileSystemSandboxEntry"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "globScanMaxDepth": {
+              "format": "uint",
+              "minimum": 1.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "read": {
+              "description": "This will be removed in favor of \u0060entries\u0060.",
+              "items": {
+                "$ref": "#/definitions/LegacyAppPathString"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "write": {
+              "description": "This will be removed in favor of \u0060entries\u0060.",
+              "items": {
+                "$ref": "#/definitions/LegacyAppPathString"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "AdditionalNetworkPermissions": {
+          "properties": {
+            "enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "AdditionalPermissionProfile": {
+          "properties": {
+            "fileSystem": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AdditionalFileSystemPermissions"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AdditionalNetworkPermissions"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Partial overlay used for per-command permission requests."
+            }
+          },
+          "type": "object"
+        },
+        "CommandAction": {
+          "oneOf": [
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "path": {
+                  "$ref": "#/definitions/LegacyAppPathString"
+                },
+                "type": {
+                  "enum": [
+                    "read"
+                  ],
+                  "title": "ReadCommandActionType",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "command",
+                "name",
+                "path",
+                "type"
+              ],
+              "title": "ReadCommandAction",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "enum": [
+                    "listFiles"
+                  ],
+                  "title": "ListFilesCommandActionType",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "command",
+                "type"
+              ],
+              "title": "ListFilesCommandAction",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "query": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "enum": [
+                    "search"
+                  ],
+                  "title": "SearchCommandActionType",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "command",
+                "type"
+              ],
+              "title": "SearchCommandAction",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "unknown"
+                  ],
+                  "title": "UnknownCommandActionType",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "command",
+                "type"
+              ],
+              "title": "UnknownCommandAction",
+              "type": "object"
+            }
+          ]
+        },
+        "CommandExecutionApprovalDecision": {
+          "oneOf": [
+            {
+              "description": "User approved the command.",
+              "enum": [
+                "accept"
+              ],
+              "type": "string"
+            },
+            {
+              "description": "User approved the command and future prompts in the same session-scoped approval cache should run without prompting.",
+              "enum": [
+                "acceptForSession"
+              ],
+              "type": "string"
+            },
+            {
+              "additionalProperties": false,
+              "description": "User approved the command, and wants to apply the proposed execpolicy amendment so future matching commands can run without prompting.",
+              "properties": {
+                "acceptWithExecpolicyAmendment": {
+                  "properties": {
+                    "execpolicy_amendment": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "execpolicy_amendment"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "acceptWithExecpolicyAmendment"
+              ],
+              "title": "AcceptWithExecpolicyAmendmentCommandExecutionApprovalDecision",
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "User chose a persistent network policy rule (allow/deny) for this host.",
+              "properties": {
+                "applyNetworkPolicyAmendment": {
+                  "properties": {
+                    "network_policy_amendment": {
+                      "$ref": "#/definitions/NetworkPolicyAmendment"
+                    }
+                  },
+                  "required": [
+                    "network_policy_amendment"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "applyNetworkPolicyAmendment"
+              ],
+              "title": "ApplyNetworkPolicyAmendmentCommandExecutionApprovalDecision",
+              "type": "object"
+            },
+            {
+              "description": "User denied the command. The agent will continue the turn.",
+              "enum": [
+                "decline"
+              ],
+              "type": "string"
+            },
+            {
+              "description": "User denied the command. The turn will also be immediately interrupted.",
+              "enum": [
+                "cancel"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "FileSystemAccessMode": {
+          "enum": [
+            "read",
+            "write",
+            "deny"
+          ],
+          "type": "string"
+        },
+        "FileSystemPath": {
+          "oneOf": [
+            {
+              "properties": {
+                "path": {
+                  "$ref": "#/definitions/LegacyAppPathString"
+                },
+                "type": {
+                  "enum": [
+                    "path"
+                  ],
+                  "title": "PathFileSystemPathType",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path",
+                "type"
+              ],
+              "title": "PathFileSystemPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pattern": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "glob_pattern"
+                  ],
+                  "title": "GlobPatternFileSystemPathType",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "pattern",
+                "type"
+              ],
+              "title": "GlobPatternFileSystemPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "special"
+                  ],
+                  "title": "SpecialFileSystemPathType",
+                  "type": "string"
+                },
+                "value": {
+                  "$ref": "#/definitions/FileSystemSpecialPath"
+                }
+              },
+              "required": [
+                "type",
+                "value"
+              ],
+              "title": "SpecialFileSystemPath",
+              "type": "object"
+            }
+          ]
+        },
+        "FileSystemSandboxEntry": {
+          "properties": {
+            "access": {
+              "$ref": "#/definitions/FileSystemAccessMode"
+            },
+            "path": {
+              "$ref": "#/definitions/FileSystemPath"
+            }
+          },
+          "required": [
+            "access",
+            "path"
+          ],
+          "type": "object"
+        },
+        "FileSystemSpecialPath": {
+          "oneOf": [
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "root"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "RootFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "minimal"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "MinimalFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "project_roots"
+                  ],
+                  "type": "string"
+                },
+                "subpath": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/LegacyAppPathString"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "KindFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "tmpdir"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "TmpdirFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "slash_tmp"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "SlashTmpFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "unknown"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "subpath": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/LegacyAppPathString"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "path"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "LegacyAppPathString": {
+          "type": "string"
+        },
+        "NetworkApprovalContext": {
+          "properties": {
+            "host": {
+              "type": "string"
+            },
+            "protocol": {
+              "$ref": "#/definitions/NetworkApprovalProtocol"
+            }
+          },
+          "required": [
+            "host",
+            "protocol"
+          ],
+          "type": "object"
+        },
+        "NetworkApprovalProtocol": {
+          "enum": [
+            "http",
+            "https",
+            "socks5Tcp",
+            "socks5Udp"
+          ],
+          "type": "string"
+        },
+        "NetworkPolicyAmendment": {
+          "properties": {
+            "action": {
+              "$ref": "#/definitions/NetworkPolicyRuleAction"
+            },
+            "host": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "host"
+          ],
+          "type": "object"
+        },
+        "NetworkPolicyRuleAction": {
+          "enum": [
+            "allow",
+            "deny"
+          ],
+          "type": "string"
+        }
+      },
+      "properties": {
+        "approvalId": {
+          "description": "Unique identifier for this specific approval callback.\n\nFor regular shell/unified_exec approvals, this is null.\n\nFor zsh-exec-bridge subcommand approvals, multiple callbacks can belong to one parent \u0060itemId\u0060, so \u0060approvalId\u0060 is a distinct opaque callback id (a UUID) used to disambiguate routing.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "command": {
+          "description": "The command to be executed.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commandActions": {
+          "description": "Best-effort parsed command actions for friendly display.",
+          "items": {
+            "$ref": "#/definitions/CommandAction"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "cwd": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LegacyAppPathString"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The command\u0027s working directory."
+        },
+        "environmentId": {
+          "default": null,
+          "description": "Environment in which the command will run.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "itemId": {
+          "type": "string"
+        },
+        "networkApprovalContext": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NetworkApprovalContext"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional context for a managed-network approval prompt."
+        },
+        "proposedExecpolicyAmendment": {
+          "description": "Optional proposed execpolicy amendment to allow similar commands without prompting.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "proposedNetworkPolicyAmendments": {
+          "description": "Optional proposed network policy amendments (allow/deny host) for future requests.",
+          "items": {
+            "$ref": "#/definitions/NetworkPolicyAmendment"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "reason": {
+          "description": "Optional explanatory reason (e.g. request for network access).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "startedAtMs": {
+          "description": "Unix timestamp (in milliseconds) when this approval request started.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "itemId",
+        "startedAtMs",
+        "threadId",
+        "turnId"
+      ],
+      "title": "CommandExecutionRequestApprovalParams",
+      "type": "object"
+    },
+    "CommandExecutionRequestApprovalResponse.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": {
+        "CommandExecutionApprovalDecision": {
+          "oneOf": [
+            {
+              "description": "User approved the command.",
+              "enum": [
+                "accept"
+              ],
+              "type": "string"
+            },
+            {
+              "description": "User approved the command and future prompts in the same session-scoped approval cache should run without prompting.",
+              "enum": [
+                "acceptForSession"
+              ],
+              "type": "string"
+            },
+            {
+              "additionalProperties": false,
+              "description": "User approved the command, and wants to apply the proposed execpolicy amendment so future matching commands can run without prompting.",
+              "properties": {
+                "acceptWithExecpolicyAmendment": {
+                  "properties": {
+                    "execpolicy_amendment": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "execpolicy_amendment"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "acceptWithExecpolicyAmendment"
+              ],
+              "title": "AcceptWithExecpolicyAmendmentCommandExecutionApprovalDecision",
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "description": "User chose a persistent network policy rule (allow/deny) for this host.",
+              "properties": {
+                "applyNetworkPolicyAmendment": {
+                  "properties": {
+                    "network_policy_amendment": {
+                      "$ref": "#/definitions/NetworkPolicyAmendment"
+                    }
+                  },
+                  "required": [
+                    "network_policy_amendment"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "applyNetworkPolicyAmendment"
+              ],
+              "title": "ApplyNetworkPolicyAmendmentCommandExecutionApprovalDecision",
+              "type": "object"
+            },
+            {
+              "description": "User denied the command. The agent will continue the turn.",
+              "enum": [
+                "decline"
+              ],
+              "type": "string"
+            },
+            {
+              "description": "User denied the command. The turn will also be immediately interrupted.",
+              "enum": [
+                "cancel"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "NetworkPolicyAmendment": {
+          "properties": {
+            "action": {
+              "$ref": "#/definitions/NetworkPolicyRuleAction"
+            },
+            "host": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "host"
+          ],
+          "type": "object"
+        },
+        "NetworkPolicyRuleAction": {
+          "enum": [
+            "allow",
+            "deny"
+          ],
+          "type": "string"
+        }
+      },
+      "properties": {
+        "decision": {
+          "$ref": "#/definitions/CommandExecutionApprovalDecision"
+        }
+      },
+      "required": [
+        "decision"
+      ],
+      "title": "CommandExecutionRequestApprovalResponse",
+      "type": "object"
+    },
+    "FileChangeRequestApprovalParams.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "properties": {
+        "grantRoot": {
+          "description": "[UNSTABLE] When set, the agent is asking the user to allow writes under this root for the remainder of the session (unclear if this is honored today).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "itemId": {
+          "type": "string"
+        },
+        "reason": {
+          "description": "Optional explanatory reason (e.g. request for extra write access).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "startedAtMs": {
+          "description": "Unix timestamp (in milliseconds) when this approval request started.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "itemId",
+        "startedAtMs",
+        "threadId",
+        "turnId"
+      ],
+      "title": "FileChangeRequestApprovalParams",
+      "type": "object"
+    },
+    "FileChangeRequestApprovalResponse.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": {
+        "FileChangeApprovalDecision": {
+          "oneOf": [
+            {
+              "description": "User approved the file changes.",
+              "enum": [
+                "accept"
+              ],
+              "type": "string"
+            },
+            {
+              "description": "User approved the file changes and future changes to the same files should run without prompting.",
+              "enum": [
+                "acceptForSession"
+              ],
+              "type": "string"
+            },
+            {
+              "description": "User denied the file changes. The agent will continue the turn.",
+              "enum": [
+                "decline"
+              ],
+              "type": "string"
+            },
+            {
+              "description": "User denied the file changes. The turn will also be immediately interrupted.",
+              "enum": [
+                "cancel"
+              ],
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "properties": {
+        "decision": {
+          "$ref": "#/definitions/FileChangeApprovalDecision"
+        }
+      },
+      "required": [
+        "decision"
+      ],
+      "title": "FileChangeRequestApprovalResponse",
+      "type": "object"
+    },
+    "McpServerElicitationRequestParams.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": {
+        "McpElicitationArrayType": {
+          "enum": [
+            "array"
+          ],
+          "type": "string"
+        },
+        "McpElicitationBooleanSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "$ref": "#/definitions/McpElicitationBooleanType"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        "McpElicitationBooleanType": {
+          "enum": [
+            "boolean"
+          ],
+          "type": "string"
+        },
+        "McpElicitationConstOption": {
+          "additionalProperties": false,
+          "properties": {
+            "const": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "const",
+            "title"
+          ],
+          "type": "object"
+        },
+        "McpElicitationEnumSchema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McpElicitationSingleSelectEnumSchema"
+            },
+            {
+              "$ref": "#/definitions/McpElicitationMultiSelectEnumSchema"
+            },
+            {
+              "$ref": "#/definitions/McpElicitationLegacyTitledEnumSchema"
+            }
+          ]
+        },
+        "McpElicitationLegacyTitledEnumSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "enum": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "enumNames": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "$ref": "#/definitions/McpElicitationStringType"
+            }
+          },
+          "required": [
+            "enum",
+            "type"
+          ],
+          "type": "object"
+        },
+        "McpElicitationMultiSelectEnumSchema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McpElicitationUntitledMultiSelectEnumSchema"
+            },
+            {
+              "$ref": "#/definitions/McpElicitationTitledMultiSelectEnumSchema"
+            }
+          ]
+        },
+        "McpElicitationNumberSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "maximum": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "minimum": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "$ref": "#/definitions/McpElicitationNumberType"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        "McpElicitationNumberType": {
+          "enum": [
+            "number",
+            "integer"
+          ],
+          "type": "string"
+        },
+        "McpElicitationObjectType": {
+          "enum": [
+            "object"
+          ],
+          "type": "string"
+        },
+        "McpElicitationPrimitiveSchema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McpElicitationEnumSchema"
+            },
+            {
+              "$ref": "#/definitions/McpElicitationStringSchema"
+            },
+            {
+              "$ref": "#/definitions/McpElicitationNumberSchema"
+            },
+            {
+              "$ref": "#/definitions/McpElicitationBooleanSchema"
+            }
+          ]
+        },
+        "McpElicitationSchema": {
+          "additionalProperties": false,
+          "description": "Typed form schema for MCP \u0060elicitation/create\u0060 requests.\n\nThis matches the \u0060requestedSchema\u0060 shape from the MCP 2025-11-25 \u0060ElicitRequestFormParams\u0060 schema.",
+          "properties": {
+            "$schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "properties": {
+              "additionalProperties": {
+                "$ref": "#/definitions/McpElicitationPrimitiveSchema"
+              },
+              "type": "object"
+            },
+            "required": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "type": {
+              "$ref": "#/definitions/McpElicitationObjectType"
+            }
+          },
+          "required": [
+            "properties",
+            "type"
+          ],
+          "type": "object"
+        },
+        "McpElicitationSingleSelectEnumSchema": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/McpElicitationUntitledSingleSelectEnumSchema"
+            },
+            {
+              "$ref": "#/definitions/McpElicitationTitledSingleSelectEnumSchema"
+            }
+          ]
+        },
+        "McpElicitationStringFormat": {
+          "enum": [
+            "email",
+            "uri",
+            "date",
+            "date-time"
+          ],
+          "type": "string"
+        },
+        "McpElicitationStringSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "format": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/McpElicitationStringFormat"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "maxLength": {
+              "format": "uint32",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "minLength": {
+              "format": "uint32",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "$ref": "#/definitions/McpElicitationStringType"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        "McpElicitationStringType": {
+          "enum": [
+            "string"
+          ],
+          "type": "string"
+        },
+        "McpElicitationTitledEnumItems": {
+          "additionalProperties": false,
+          "properties": {
+            "anyOf": {
+              "items": {
+                "$ref": "#/definitions/McpElicitationConstOption"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "anyOf"
+          ],
+          "type": "object"
+        },
+        "McpElicitationTitledMultiSelectEnumSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "items": {
+              "$ref": "#/definitions/McpElicitationTitledEnumItems"
+            },
+            "maxItems": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "minItems": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "$ref": "#/definitions/McpElicitationArrayType"
+            }
+          },
+          "required": [
+            "items",
+            "type"
+          ],
+          "type": "object"
+        },
+        "McpElicitationTitledSingleSelectEnumSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "oneOf": {
+              "items": {
+                "$ref": "#/definitions/McpElicitationConstOption"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "$ref": "#/definitions/McpElicitationStringType"
+            }
+          },
+          "required": [
+            "oneOf",
+            "type"
+          ],
+          "type": "object"
+        },
+        "McpElicitationUntitledEnumItems": {
+          "additionalProperties": false,
+          "properties": {
+            "enum": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "$ref": "#/definitions/McpElicitationStringType"
+            }
+          },
+          "required": [
+            "enum",
+            "type"
+          ],
+          "type": "object"
+        },
+        "McpElicitationUntitledMultiSelectEnumSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "items": {
+              "$ref": "#/definitions/McpElicitationUntitledEnumItems"
+            },
+            "maxItems": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "minItems": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "$ref": "#/definitions/McpElicitationArrayType"
+            }
+          },
+          "required": [
+            "items",
+            "type"
+          ],
+          "type": "object"
+        },
+        "McpElicitationUntitledSingleSelectEnumSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "enum": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "$ref": "#/definitions/McpElicitationStringType"
+            }
+          },
+          "required": [
+            "enum",
+            "type"
+          ],
+          "type": "object"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "_meta": true,
+            "message": {
+              "type": "string"
+            },
+            "mode": {
+              "enum": [
+                "form"
+              ],
+              "type": "string"
+            },
+            "requestedSchema": {
+              "$ref": "#/definitions/McpElicitationSchema"
+            }
+          },
+          "required": [
+            "message",
+            "mode",
+            "requestedSchema"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "_meta": true,
+            "message": {
+              "type": "string"
+            },
+            "mode": {
+              "enum": [
+                "openai/form"
+              ],
+              "type": "string"
+            },
+            "requestedSchema": true
+          },
+          "required": [
+            "message",
+            "mode",
+            "requestedSchema"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "_meta": true,
+            "elicitationId": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "mode": {
+              "enum": [
+                "url"
+              ],
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "elicitationId",
+            "message",
+            "mode",
+            "url"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "serverName": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "description": "Active Codex turn when this elicitation was observed, if app-server could correlate one.\n\nThis is nullable because MCP models elicitation as a standalone server-to-client request identified by the MCP server request id. It may be triggered during a turn, but turn context is app-server correlation rather than part of the protocol identity of the elicitation itself.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "serverName",
+        "threadId"
+      ],
+      "title": "McpServerElicitationRequestParams",
+      "type": "object"
+    },
+    "McpServerElicitationRequestResponse.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": {
+        "McpServerElicitationAction": {
+          "enum": [
+            "accept",
+            "decline",
+            "cancel"
+          ],
+          "type": "string"
+        }
+      },
+      "properties": {
+        "_meta": {
+          "description": "Optional client metadata for form-mode action handling."
+        },
+        "action": {
+          "$ref": "#/definitions/McpServerElicitationAction"
+        },
+        "content": {
+          "description": "Structured user input for accepted elicitations, mirroring RMCP \u0060CreateElicitationResult\u0060.\n\nThis is nullable because decline/cancel responses have no content."
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "title": "McpServerElicitationRequestResponse",
+      "type": "object"
+    },
+    "PermissionsRequestApprovalParams.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": {
+        "AbsolutePathBuf": {
+          "description": "A path that is guaranteed to be absolute and normalized (though it is not guaranteed to be canonicalized or exist on the filesystem).\n\nIMPORTANT: When deserializing an \u0060AbsolutePathBuf\u0060, a base path must be set using [AbsolutePathBufGuard::new]. If no base path is set, the deserialization will fail unless the path being deserialized is already absolute.",
+          "type": "string"
+        },
+        "AdditionalFileSystemPermissions": {
+          "properties": {
+            "entries": {
+              "items": {
+                "$ref": "#/definitions/FileSystemSandboxEntry"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "globScanMaxDepth": {
+              "format": "uint",
+              "minimum": 1.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "read": {
+              "description": "This will be removed in favor of \u0060entries\u0060.",
+              "items": {
+                "$ref": "#/definitions/LegacyAppPathString"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "write": {
+              "description": "This will be removed in favor of \u0060entries\u0060.",
+              "items": {
+                "$ref": "#/definitions/LegacyAppPathString"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "AdditionalNetworkPermissions": {
+          "properties": {
+            "enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "FileSystemAccessMode": {
+          "enum": [
+            "read",
+            "write",
+            "deny"
+          ],
+          "type": "string"
+        },
+        "FileSystemPath": {
+          "oneOf": [
+            {
+              "properties": {
+                "path": {
+                  "$ref": "#/definitions/LegacyAppPathString"
+                },
+                "type": {
+                  "enum": [
+                    "path"
+                  ],
+                  "title": "PathFileSystemPathType",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path",
+                "type"
+              ],
+              "title": "PathFileSystemPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pattern": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "glob_pattern"
+                  ],
+                  "title": "GlobPatternFileSystemPathType",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "pattern",
+                "type"
+              ],
+              "title": "GlobPatternFileSystemPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "special"
+                  ],
+                  "title": "SpecialFileSystemPathType",
+                  "type": "string"
+                },
+                "value": {
+                  "$ref": "#/definitions/FileSystemSpecialPath"
+                }
+              },
+              "required": [
+                "type",
+                "value"
+              ],
+              "title": "SpecialFileSystemPath",
+              "type": "object"
+            }
+          ]
+        },
+        "FileSystemSandboxEntry": {
+          "properties": {
+            "access": {
+              "$ref": "#/definitions/FileSystemAccessMode"
+            },
+            "path": {
+              "$ref": "#/definitions/FileSystemPath"
+            }
+          },
+          "required": [
+            "access",
+            "path"
+          ],
+          "type": "object"
+        },
+        "FileSystemSpecialPath": {
+          "oneOf": [
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "root"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "RootFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "minimal"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "MinimalFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "project_roots"
+                  ],
+                  "type": "string"
+                },
+                "subpath": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/LegacyAppPathString"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "KindFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "tmpdir"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "TmpdirFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "slash_tmp"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "SlashTmpFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "unknown"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "subpath": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/LegacyAppPathString"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "path"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "LegacyAppPathString": {
+          "type": "string"
+        },
+        "RequestPermissionProfile": {
+          "additionalProperties": false,
+          "properties": {
+            "fileSystem": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AdditionalFileSystemPermissions"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AdditionalNetworkPermissions"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        }
+      },
+      "properties": {
+        "cwd": {
+          "$ref": "#/definitions/AbsolutePathBuf"
+        },
+        "environmentId": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "itemId": {
+          "type": "string"
+        },
+        "permissions": {
+          "$ref": "#/definitions/RequestPermissionProfile"
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "startedAtMs": {
+          "description": "Unix timestamp (in milliseconds) when this approval request started.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "cwd",
+        "itemId",
+        "permissions",
+        "startedAtMs",
+        "threadId",
+        "turnId"
+      ],
+      "title": "PermissionsRequestApprovalParams",
+      "type": "object"
+    },
+    "PermissionsRequestApprovalResponse.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": {
+        "AdditionalFileSystemPermissions": {
+          "properties": {
+            "entries": {
+              "items": {
+                "$ref": "#/definitions/FileSystemSandboxEntry"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "globScanMaxDepth": {
+              "format": "uint",
+              "minimum": 1.0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "read": {
+              "description": "This will be removed in favor of \u0060entries\u0060.",
+              "items": {
+                "$ref": "#/definitions/LegacyAppPathString"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "write": {
+              "description": "This will be removed in favor of \u0060entries\u0060.",
+              "items": {
+                "$ref": "#/definitions/LegacyAppPathString"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "AdditionalNetworkPermissions": {
+          "properties": {
+            "enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "FileSystemAccessMode": {
+          "enum": [
+            "read",
+            "write",
+            "deny"
+          ],
+          "type": "string"
+        },
+        "FileSystemPath": {
+          "oneOf": [
+            {
+              "properties": {
+                "path": {
+                  "$ref": "#/definitions/LegacyAppPathString"
+                },
+                "type": {
+                  "enum": [
+                    "path"
+                  ],
+                  "title": "PathFileSystemPathType",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path",
+                "type"
+              ],
+              "title": "PathFileSystemPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "pattern": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "glob_pattern"
+                  ],
+                  "title": "GlobPatternFileSystemPathType",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "pattern",
+                "type"
+              ],
+              "title": "GlobPatternFileSystemPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "special"
+                  ],
+                  "title": "SpecialFileSystemPathType",
+                  "type": "string"
+                },
+                "value": {
+                  "$ref": "#/definitions/FileSystemSpecialPath"
+                }
+              },
+              "required": [
+                "type",
+                "value"
+              ],
+              "title": "SpecialFileSystemPath",
+              "type": "object"
+            }
+          ]
+        },
+        "FileSystemSandboxEntry": {
+          "properties": {
+            "access": {
+              "$ref": "#/definitions/FileSystemAccessMode"
+            },
+            "path": {
+              "$ref": "#/definitions/FileSystemPath"
+            }
+          },
+          "required": [
+            "access",
+            "path"
+          ],
+          "type": "object"
+        },
+        "FileSystemSpecialPath": {
+          "oneOf": [
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "root"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "RootFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "minimal"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "MinimalFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "project_roots"
+                  ],
+                  "type": "string"
+                },
+                "subpath": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/LegacyAppPathString"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "KindFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "tmpdir"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "TmpdirFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "slash_tmp"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind"
+              ],
+              "title": "SlashTmpFileSystemSpecialPath",
+              "type": "object"
+            },
+            {
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "unknown"
+                  ],
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "subpath": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/LegacyAppPathString"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "path"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "GrantedPermissionProfile": {
+          "properties": {
+            "fileSystem": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AdditionalFileSystemPermissions"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "network": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AdditionalNetworkPermissions"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "LegacyAppPathString": {
+          "type": "string"
+        },
+        "PermissionGrantScope": {
+          "enum": [
+            "turn",
+            "session"
+          ],
+          "type": "string"
+        }
+      },
+      "properties": {
+        "permissions": {
+          "$ref": "#/definitions/GrantedPermissionProfile"
+        },
+        "scope": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PermissionGrantScope"
+            }
+          ],
+          "default": "turn"
+        },
+        "strictAutoReview": {
+          "description": "Review every subsequent command in this turn before normal sandboxed execution.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "permissions"
+      ],
+      "title": "PermissionsRequestApprovalResponse",
+      "type": "object"
+    },
+    "ToolRequestUserInputParams.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": {
+        "ToolRequestUserInputOption": {
+          "description": "EXPERIMENTAL. Defines a single selectable option for request_user_input.",
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "description",
+            "label"
+          ],
+          "type": "object"
+        },
+        "ToolRequestUserInputQuestion": {
+          "description": "EXPERIMENTAL. Represents one request_user_input question and its required options.",
+          "properties": {
+            "header": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "isOther": {
+              "default": false,
+              "type": "boolean"
+            },
+            "isSecret": {
+              "default": false,
+              "type": "boolean"
+            },
+            "options": {
+              "items": {
+                "$ref": "#/definitions/ToolRequestUserInputOption"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "question": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "header",
+            "id",
+            "question"
+          ],
+          "type": "object"
+        }
+      },
+      "description": "EXPERIMENTAL. Params sent with a request_user_input event.",
+      "properties": {
+        "autoResolutionMs": {
+          "default": null,
+          "description": "@deprecated Use \u0060isBlocking\u0060 to decide whether the request should block.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "isBlocking": {
+          "type": "boolean"
+        },
+        "itemId": {
+          "type": "string"
+        },
+        "questions": {
+          "items": {
+            "$ref": "#/definitions/ToolRequestUserInputQuestion"
+          },
+          "type": "array"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "turnId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "isBlocking",
+        "itemId",
+        "questions",
+        "threadId",
+        "turnId"
+      ],
+      "title": "ToolRequestUserInputParams",
+      "type": "object"
+    },
+    "ToolRequestUserInputResponse.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "definitions": {
+        "ToolRequestUserInputAnswer": {
+          "description": "EXPERIMENTAL. Captures a user\u0027s answer to a request_user_input question.",
+          "properties": {
+            "answers": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "answers"
+          ],
+          "type": "object"
+        }
+      },
+      "description": "EXPERIMENTAL. Response payload mapping question ids to answers.",
+      "properties": {
+        "answers": {
+          "additionalProperties": {
+            "$ref": "#/definitions/ToolRequestUserInputAnswer"
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "answers"
+      ],
+      "title": "ToolRequestUserInputResponse",
+      "type": "object"
+    }
+  }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaConformanceTests.cs
@@ -1,0 +1,196 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// Schema conformance for the <c>codex app-server</c> protocol. Pins the subset
+/// of the protocol schema the runtime depends on (<see cref="CodexAppServerSchemaSubset"/>) and, on a
+/// machine with <c>codex</c> installed, regenerates that schema from the binary and diffs it against
+/// the vendored pin — so a version that changes a depended-on shape fails HERE instead of silently at
+/// launch.
+///
+/// <para>Two arms: a CI-safe arm that validates the committed pin documents every depended-on shape
+/// (no binary needed — CI has no <c>codex</c>), and a binary-gated arm that catches real upstream
+/// drift (auto-skips when the binary is absent — never a silent pass). Part (b) — the behavioural Q1
+/// isolation / Q2 sandbox probes — lives with the live smoke, not here.</para>
+///
+/// <para>Regenerate the pin after an intended Codex bump (having re-vetted the behavioural probes):
+/// <c>KCAP_CODEX_SCHEMA_PIN_UPDATE=1</c> with <c>codex</c> on PATH rewrites it from the installed
+/// binary through the exact extractor the diff uses.</para>
+/// </summary>
+public class CodexAppServerSchemaConformanceTests {
+    const string PinUpdateEnvVar = "KCAP_CODEX_SCHEMA_PIN_UPDATE";
+    static readonly TimeSpan ProcessGuard = TimeSpan.FromSeconds(30);
+
+    // ── CI-safe arm: the committed pin documents every depended-on shape ───────────────────────
+
+    [Test]
+    public async Task Vendored_pin_documents_every_depended_on_shape() {
+        var pin        = LoadPin();
+        var combined   = pin["combinedDefs"]!.AsObject();
+        var standalone = pin["standalone"]!.AsObject();
+
+        var missingRoots = CodexAppServerSchemaSubset.RootDefs.Where(r => !combined.ContainsKey(r)).ToList();
+        await Assert.That(missingRoots).IsEmpty();
+
+        var missingFiles = CodexAppServerSchemaSubset.StandaloneFiles.Where(f => !standalone.ContainsKey(f)).ToList();
+        await Assert.That(missingFiles).IsEmpty();
+
+        // The exact fields the runtime writes on turn/start and thread/start, and reads off the
+        // usage notification — a corruption guard and a living manifest of what we depend on.
+        await AssertProperties(combined, "TurnStartParams",
+            "threadId", "input", "sandboxPolicy", "approvalPolicy", "approvalsReviewer", "model", "effort");
+        await AssertProperties(combined, "ThreadStartParams",
+            "cwd", "sandbox", "approvalPolicy", "approvalsReviewer", "model");
+        await AssertProperties(combined, "ThreadTokenUsageUpdatedNotification",
+            "threadId", "turnId", "tokenUsage");
+        await AssertProperties(combined, "TokenUsageBreakdown",
+            "inputTokens", "cachedInputTokens", "outputTokens", "reasoningOutputTokens", "totalTokens");
+
+        // The posture depends on these enum tokens being accepted verbatim (SandboxPolicy variant
+        // discriminators and the kebab-case approval strings).
+        await AssertContainsAll(combined["SandboxPolicy"], "readOnly", "workspaceWrite", "dangerFullAccess");
+        await AssertContainsAll(combined["AskForApproval"], "never", "on-request", "untrusted");
+    }
+
+    // ── CI-safe arm: the diff actually catches a depended-on shape change ───────────────────────
+
+    [Test]
+    public async Task Diff_catches_a_mutated_depended_on_shape() {
+        var pin     = LoadPin();
+        var mutated = JsonNode.Parse(pin.ToJsonString())!.AsObject();
+
+        // Remove a load-bearing property from a copy — the drift a real breaking bump would produce.
+        mutated["combinedDefs"]!["TurnStartParams"]!["properties"]!.AsObject().Remove("sandboxPolicy");
+
+        var diff = Diff(pin, mutated);
+        await Assert.That(diff).IsNotNull();
+        await Assert.That(diff!).Contains("TurnStartParams");
+    }
+
+    // ── Binary-gated arm: the installed codex schema still matches the pin ──────────────────────
+
+    [Test]
+    public async Task Installed_codex_schema_matches_the_vendored_pin() {
+        var (found, version) = TryResolveCodexVersion();
+        Skip.When(!found,
+            "codex not resolvable on PATH — the schema-drift check needs a local codex install (shared CI has none).");
+
+        using var outDir = new TempDir();
+        GenerateSchema(outDir.Path);
+        var fresh = CodexAppServerSchemaSubset.Extract(outDir.Path, version);
+
+        if (Environment.GetEnvironmentVariable(PinUpdateEnvVar) == "1") {
+            var path = PinPath();
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            await File.WriteAllTextAsync(path, CodexAppServerSchemaSubset.Serialize(fresh));
+            Skip.Test($"Vendored pin regenerated from codex {version}. Re-run without {PinUpdateEnvVar}=1 to verify.");
+        }
+
+        var pin  = LoadPin();
+        var diff = Diff(pin, fresh);
+
+        var report = diff is null ? null
+            : $"codex app-server schema (installed codex {version}) diverged from the vendored pin "
+            + $"(pinned from codex {pin["codexVersion"]?.GetValue<string>()}):\n{diff}\n"
+            + $"If this is an intended Codex bump, re-vet the Q1/Q2 behavioural probes, then regenerate "
+            + $"the pin with {PinUpdateEnvVar}=1.";
+
+        await Assert.That(report).IsNull();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────────────────────
+
+    static async Task AssertProperties(JsonObject combined, string def, params string[] required) {
+        var props = combined[def]?.AsObject()?["properties"]?.AsObject();
+        await Assert.That(props).IsNotNull();
+
+        var missing = required.Where(r => !props!.ContainsKey(r)).ToList();
+        await Assert.That(missing).IsEmpty();
+    }
+
+    static async Task AssertContainsAll(JsonNode? def, params string[] tokens) {
+        var canonical = CodexAppServerSchemaSubset.Canonical(def);
+        var missing   = tokens.Where(t => !canonical.Contains(t, StringComparison.Ordinal)).ToList();
+        await Assert.That(missing).IsEmpty();
+    }
+
+    /// <summary>Per-key by-value comparison of the two pinnable sections; a readable report of the
+    /// keys that were removed / added / changed, or null when identical.</summary>
+    static string? Diff(JsonObject pin, JsonObject fresh) {
+        var report = new StringBuilder();
+        DiffSection(report, "combinedDefs", pin["combinedDefs"]!.AsObject(), fresh["combinedDefs"]!.AsObject());
+        DiffSection(report, "standalone",   pin["standalone"]!.AsObject(),   fresh["standalone"]!.AsObject());
+        return report.Length == 0 ? null : report.ToString();
+    }
+
+    static void DiffSection(StringBuilder report, string label, JsonObject pin, JsonObject fresh) {
+        var keys = pin.Select(kv => kv.Key).Union(fresh.Select(kv => kv.Key)).OrderBy(k => k, StringComparer.Ordinal);
+        foreach (var key in keys) {
+            var inPin   = pin.ContainsKey(key);
+            var inFresh = fresh.ContainsKey(key);
+            if (!inFresh)
+                report.AppendLine(CultureInfo.InvariantCulture,
+                    $"  [{label}] '{key}': in pin, MISSING from installed codex (removed/renamed upstream).");
+            else if (!inPin)
+                report.AppendLine(CultureInfo.InvariantCulture,
+                    $"  [{label}] '{key}': present in installed codex, NOT in pin (add + re-vet).");
+            else if (CodexAppServerSchemaSubset.Canonical(pin[key]) != CodexAppServerSchemaSubset.Canonical(fresh[key]))
+                report.AppendLine(CultureInfo.InvariantCulture,
+                    $"  [{label}] '{key}': shape changed vs pin.");
+        }
+    }
+
+    static JsonObject LoadPin() {
+        var path = PinPath();
+        if (!File.Exists(path))
+            throw new FileNotFoundException(
+                $"Vendored codex app-server schema pin missing at '{path}'. Generate it on a machine with codex "
+              + $"installed: {PinUpdateEnvVar}=1 dotnet run --project "
+              + "test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj.", path);
+        return JsonNode.Parse(File.ReadAllText(path))!.AsObject();
+    }
+
+    static string PinPath([CallerFilePath] string here = "") =>
+        Path.Combine(Path.GetDirectoryName(here)!, "AppServerSchema", "codex-app-server-subset.pin.json");
+
+    static (bool Found, string Version) TryResolveCodexVersion() {
+        try {
+            var psi = new ProcessStartInfo("codex", ["--version"]) {
+                RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false,
+            };
+            using var process = Process.Start(psi);
+            if (process is null) return (false, "");
+
+            var stdout = process.StandardOutput.ReadToEnd();
+            process.WaitForExit((int) ProcessGuard.TotalMilliseconds);
+
+            var match = Regex.Match(stdout, @"\d+\.\d+\.\d+");
+            return (true, match.Success ? match.Value : stdout.Trim());
+        } catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or FileNotFoundException) {
+            return (false, ""); // codex not on PATH
+        }
+    }
+
+    static void GenerateSchema(string outDir) {
+        var psi = new ProcessStartInfo("codex", ["app-server", "generate-json-schema", "--out", outDir]) {
+            RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false,
+        };
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("codex app-server generate-json-schema did not start.");
+
+        var stderr = process.StandardError.ReadToEnd(); // small; the schema is written to files, not stdout
+        if (!process.WaitForExit((int) ProcessGuard.TotalMilliseconds)) {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            throw new InvalidOperationException("codex app-server generate-json-schema timed out.");
+        }
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"codex app-server generate-json-schema exited {process.ExitCode}: {stderr}");
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaConformanceTests.cs
@@ -8,20 +8,12 @@ using System.Text.RegularExpressions;
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
 
 /// <summary>
-/// Schema conformance for the <c>codex app-server</c> protocol. Pins the subset
-/// of the protocol schema the runtime depends on (<see cref="CodexAppServerSchemaSubset"/>) and, on a
-/// machine with <c>codex</c> installed, regenerates that schema from the binary and diffs it against
-/// the vendored pin — so a version that changes a depended-on shape fails HERE instead of silently at
-/// launch.
-///
-/// <para>Two arms: a CI-safe arm that validates the committed pin documents every depended-on shape
-/// (no binary needed — CI has no <c>codex</c>), and a binary-gated arm that catches real upstream
-/// drift (auto-skips when the binary is absent — never a silent pass). Part (b) — the behavioural Q1
-/// isolation / Q2 sandbox probes — lives with the live smoke, not here.</para>
-///
-/// <para>Regenerate the pin after an intended Codex bump (having re-vetted the behavioural probes):
-/// <c>KCAP_CODEX_SCHEMA_PIN_UPDATE=1</c> with <c>codex</c> on PATH rewrites it from the installed
-/// binary through the exact extractor the diff uses.</para>
+/// Guards the <c>codex app-server</c> protocol shapes the runtime depends on
+/// (<see cref="CodexAppServerSchemaSubset"/>) against upstream drift — a changed shape fails here
+/// rather than silently at launch. The binary-gated arm auto-skips when <c>codex</c> is absent, never
+/// passing silently; regenerate the pin after an intended bump with
+/// <c>KCAP_CODEX_SCHEMA_PIN_UPDATE=1</c>. Behavioural conformance (the isolation / sandbox probes)
+/// lives with the live smoke, not here.
 /// </summary>
 public class CodexAppServerSchemaConformanceTests {
     const string PinUpdateEnvVar = "KCAP_CODEX_SCHEMA_PIN_UPDATE";

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaConformanceTests.cs
@@ -54,8 +54,8 @@ public class CodexAppServerSchemaConformanceTests {
 
         // The posture depends on these enum tokens being accepted verbatim (SandboxPolicy variant
         // discriminators and the kebab-case approval strings).
-        await AssertContainsAll(combined["SandboxPolicy"], "readOnly", "workspaceWrite", "dangerFullAccess");
-        await AssertContainsAll(combined["AskForApproval"], "never", "on-request", "untrusted");
+        await AssertEnumMembers(combined["SandboxPolicy"], "readOnly", "workspaceWrite", "dangerFullAccess");
+        await AssertEnumMembers(combined["AskForApproval"], "never", "on-request", "untrusted");
     }
 
     // ── CI-safe arm: the diff actually catches a depended-on shape change ───────────────────────
@@ -77,12 +77,12 @@ public class CodexAppServerSchemaConformanceTests {
 
     [Test]
     public async Task Installed_codex_schema_matches_the_vendored_pin() {
-        var (found, version) = TryResolveCodexVersion();
+        var (found, version) = await TryResolveCodexVersionAsync();
         Skip.When(!found,
             "codex not resolvable on PATH — the schema-drift check needs a local codex install (shared CI has none).");
 
         using var outDir = new TempDir();
-        GenerateSchema(outDir.Path);
+        await GenerateSchemaAsync(outDir.Path);
         var fresh = CodexAppServerSchemaSubset.Extract(outDir.Path, version);
 
         if (Environment.GetEnvironmentVariable(PinUpdateEnvVar) == "1") {
@@ -114,10 +114,37 @@ public class CodexAppServerSchemaConformanceTests {
         await Assert.That(missing).IsEmpty();
     }
 
-    static async Task AssertContainsAll(JsonNode? def, params string[] tokens) {
-        var canonical = CodexAppServerSchemaSubset.Canonical(def);
-        var missing   = tokens.Where(t => !canonical.Contains(t, StringComparison.Ordinal)).ToList();
+    // Asserts the tokens are real enum MEMBERS of the pinned def (values inside some "enum": [...]),
+    // not just substrings of its serialized JSON — so a token that appears in a description string
+    // can't satisfy the check.
+    static async Task AssertEnumMembers(JsonNode? def, params string[] tokens) {
+        var members = EnumValues(def);
+        var missing = tokens.Where(t => !members.Contains(t)).ToList();
         await Assert.That(missing).IsEmpty();
+    }
+
+    static HashSet<string> EnumValues(JsonNode? node) {
+        var acc = new HashSet<string>(StringComparer.Ordinal);
+        Collect(node, acc);
+        return acc;
+
+        static void Collect(JsonNode? n, HashSet<string> acc) {
+            switch (n) {
+                case JsonObject o:
+                    foreach (var (key, value) in o) {
+                        if (key == "enum" && value is JsonArray items) {
+                            foreach (var item in items)
+                                if (item is JsonValue v && v.TryGetValue<string>(out var s)) acc.Add(s);
+                        } else {
+                            Collect(value, acc);
+                        }
+                    }
+                    break;
+                case JsonArray a:
+                    foreach (var x in a) Collect(x, acc);
+                    break;
+            }
+        }
     }
 
     /// <summary>Per-key by-value comparison of the two pinnable sections; a readable report of the
@@ -159,38 +186,54 @@ public class CodexAppServerSchemaConformanceTests {
     static string PinPath([CallerFilePath] string here = "") =>
         Path.Combine(Path.GetDirectoryName(here)!, "AppServerSchema", "codex-app-server-subset.pin.json");
 
-    static (bool Found, string Version) TryResolveCodexVersion() {
+    static async Task<(bool Found, string Version)> TryResolveCodexVersionAsync() {
+        Process process;
         try {
-            var psi = new ProcessStartInfo("codex", ["--version"]) {
+            var started = Process.Start(new ProcessStartInfo("codex", ["--version"]) {
                 RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false,
-            };
-            using var process = Process.Start(psi);
-            if (process is null) return (false, "");
-
-            var stdout = process.StandardOutput.ReadToEnd();
-            process.WaitForExit((int) ProcessGuard.TotalMilliseconds);
-
-            var match = Regex.Match(stdout, @"\d+\.\d+\.\d+");
-            return (true, match.Success ? match.Value : stdout.Trim());
+            });
+            if (started is null) return (false, "");
+            process = started;
         } catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or FileNotFoundException) {
             return (false, ""); // codex not on PATH
         }
+
+        using (process) {
+            var (stdout, _, _) = await ReadToExitAsync(process);
+            var match = Regex.Match(stdout, @"\d+\.\d+\.\d+");
+            // codex present but no parseable version → treat as not-found and skip, rather than run the
+            // drift arm with an empty, misleading version stamp.
+            return match.Success ? (true, match.Value) : (false, "");
+        }
     }
 
-    static void GenerateSchema(string outDir) {
-        var psi = new ProcessStartInfo("codex", ["app-server", "generate-json-schema", "--out", outDir]) {
+    static async Task GenerateSchemaAsync(string outDir) {
+        using var process = Process.Start(new ProcessStartInfo("codex", ["app-server", "generate-json-schema", "--out", outDir]) {
             RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false,
-        };
-        using var process = Process.Start(psi)
-            ?? throw new InvalidOperationException("codex app-server generate-json-schema did not start.");
+        }) ?? throw new InvalidOperationException("codex app-server generate-json-schema did not start.");
 
-        var stderr = process.StandardError.ReadToEnd(); // small; the schema is written to files, not stdout
-        if (!process.WaitForExit((int) ProcessGuard.TotalMilliseconds)) {
-            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+        var (_, stderr, timedOut) = await ReadToExitAsync(process);
+        if (timedOut)
             throw new InvalidOperationException("codex app-server generate-json-schema timed out.");
-        }
         if (process.ExitCode != 0)
             throw new InvalidOperationException(
                 $"codex app-server generate-json-schema exited {process.ExitCode}: {stderr}");
+    }
+
+    // Drains stdout AND stderr concurrently while waiting for exit, so a full pipe on either stream
+    // can never deadlock a WaitForExit (the classic single-stream-then-wait trap). On timeout the
+    // process tree is killed and TimedOut is returned.
+    static async Task<(string Stdout, string Stderr, bool TimedOut)> ReadToExitAsync(Process process) {
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        using var cts = new CancellationTokenSource(ProcessGuard);
+        try {
+            await process.WaitForExitAsync(cts.Token);
+        } catch (OperationCanceledException) {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            return ("", "", true);
+        }
+        return (await stdoutTask, await stderrTask, false);
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaConformanceTests.cs
@@ -224,6 +224,11 @@ public class CodexAppServerSchemaConformanceTests {
             await process.WaitForExitAsync(cts.Token);
         } catch (OperationCanceledException) {
             try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            // Observe the reads before returning: once the process is dead the pipes close and both
+            // tasks complete promptly. Leaving them unawaited would let the caller's `using` dispose
+            // the streams mid-read, surfacing as an unobserved ObjectDisposedException.
+            try { await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch { /* best effort — reads may fault on the killed process */ }
             return ("", "", true);
         }
         return (await stdoutTask, await stderrTask, false);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaSubset.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaSubset.cs
@@ -20,7 +20,9 @@ internal static class CodexAppServerSchemaSubset {
 
     /// <summary>Root defs in the combined schema the runtime reads. The extractor closes over their
     /// <c>#/definitions/*</c> refs, so a change to a referenced shape is pinned too. Mirrors the exact
-    /// requests/responses/notifications <c>CodexAppServerHostedAgentRuntime</c> issues and parses.</summary>
+    /// requests/responses/notifications <c>CodexAppServerHostedAgentRuntime</c> issues and parses.
+    /// Types outside this set and its ref-closure are intentionally NOT tracked — an unrelated upstream
+    /// addition must not fail the pin; that is the whole point of pinning a subset.</summary>
     public static readonly IReadOnlyList<string> RootDefs = [
         "InitializeParams",
         "ThreadStartParams",   "ThreadStartResponse",

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaSubset.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaSubset.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// Extracts and canonicalizes the subset of the <c>codex app-server</c> protocol JSON schema that the
+/// app-server runtime layer actually reads, so a Codex version that changes a depended-on shape is
+/// caught by a diff instead of failing silently at launch. The full protocol schema drifts benignly
+/// across versions (0.147 adds <c>threadSection/*</c>; the combined schema already carries 557 defs),
+/// so a whole-file diff would be noise — this pins only the byte-stable set the app-server protocol
+/// spike verified, closed over its <c>#/definitions/*</c> refs so a change to any referenced shape is
+/// pinned too.
+/// </summary>
+internal static class CodexAppServerSchemaSubset {
+    /// <summary>The combined all-types schema the generator emits (a <c>definitions</c> map of the
+    /// whole v2 protocol). Its layout is itself part of what we depend on — a rename must fail the
+    /// extractor loudly rather than silently pin nothing.</summary>
+    public const string CombinedSchemaFileName = "codex_app_server_protocol.v2.schemas.json";
+
+    /// <summary>Root defs in the combined schema the runtime reads. The extractor closes over their
+    /// <c>#/definitions/*</c> refs, so a change to a referenced shape is pinned too. Mirrors the exact
+    /// requests/responses/notifications <c>CodexAppServerHostedAgentRuntime</c> issues and parses.</summary>
+    public static readonly IReadOnlyList<string> RootDefs = [
+        "InitializeParams",
+        "ThreadStartParams",   "ThreadStartResponse",
+        "ThreadResumeParams",  "ThreadResumeResponse",
+        "TurnStartParams",     "TurnStartResponse",
+        "TurnSteerParams",     "TurnSteerResponse",
+        "TurnInterruptParams", "TurnInterruptResponse",
+        "TurnCompletedNotification",
+        "ThreadTokenUsageUpdatedNotification",
+        "HooksListParams",     "HooksListResponse",
+        "SandboxPolicy",       "AskForApproval",
+    ];
+
+    /// <summary>Server→client approval / elicitation request+response shapes the decline bridge answers
+    /// — emitted as self-contained schema files, NOT entries in the combined definitions map.</summary>
+    public static readonly IReadOnlyList<string> StandaloneFiles = [
+        "CommandExecutionRequestApprovalParams.json", "CommandExecutionRequestApprovalResponse.json",
+        "FileChangeRequestApprovalParams.json",       "FileChangeRequestApprovalResponse.json",
+        "PermissionsRequestApprovalParams.json",      "PermissionsRequestApprovalResponse.json",
+        "McpServerElicitationRequestParams.json",     "McpServerElicitationRequestResponse.json",
+        "ToolRequestUserInputParams.json",            "ToolRequestUserInputResponse.json",
+    ];
+
+    const string RefPrefix = "#/definitions/";
+
+    static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
+
+    /// <summary>Reads a <c>generate-json-schema --out</c> directory and returns the canonical pin
+    /// object <c>{ codexVersion, combinedDefs, standalone }</c>, every nested object key sorted so
+    /// re-serialization is order-stable within a process.</summary>
+    public static JsonObject Extract(string schemaDir, string codexVersion) {
+        var combinedPath = Path.Combine(schemaDir, CombinedSchemaFileName);
+        if (!File.Exists(combinedPath))
+            throw new FileNotFoundException(
+                $"codex app-server combined schema '{CombinedSchemaFileName}' not found in '{schemaDir}'. "
+              + "The generator layout changed — re-vet the pinning extractor before trusting a pass.", combinedPath);
+
+        var defs = (JsonNode.Parse(File.ReadAllText(combinedPath)) as JsonObject)?["definitions"] as JsonObject
+            ?? throw new InvalidOperationException(
+                "codex app-server combined schema has no 'definitions' map — layout changed, re-vet the extractor.");
+
+        var combinedDefs = new JsonObject();
+        foreach (var name in ComputeClosure(defs).OrderBy(x => x, StringComparer.Ordinal))
+            combinedDefs[name] = Canonicalize(defs[name]);
+
+        var standalone = new JsonObject();
+        foreach (var file in StandaloneFiles.OrderBy(x => x, StringComparer.Ordinal)) {
+            var path = Path.Combine(schemaDir, file);
+            if (!File.Exists(path))
+                throw new FileNotFoundException(
+                    $"codex app-server standalone schema '{file}' not found in '{schemaDir}' — "
+                  + "layout changed, re-vet the extractor.", path);
+            standalone[file] = Canonicalize(JsonNode.Parse(File.ReadAllText(path)));
+        }
+
+        return new JsonObject {
+            ["codexVersion"] = codexVersion,
+            ["combinedDefs"] = combinedDefs,
+            ["standalone"]   = standalone,
+        };
+    }
+
+    /// <summary>Indented serialization — writes the committed pin and, applied to both sides through
+    /// <see cref="Canonical"/>, provides a by-value comparison whose string equality is reliable
+    /// because both operands are re-serialized in the same process.</summary>
+    public static string Serialize(JsonNode node) => node.ToJsonString(Indented);
+
+    /// <summary>Canonical string form of a node (keys sorted, indented) for by-value comparison.</summary>
+    public static string Canonical(JsonNode? node) => Serialize(Canonicalize(node) ?? new JsonObject());
+
+    static HashSet<string> ComputeClosure(JsonObject defs) {
+        var closure  = new HashSet<string>(StringComparer.Ordinal);
+        var frontier = new Queue<string>();
+
+        foreach (var root in RootDefs) {
+            if (!defs.ContainsKey(root))
+                throw new InvalidOperationException(
+                    $"codex app-server schema no longer defines depended-on type '{root}'. "
+                  + "This is a breaking protocol change — re-vet before re-pinning.");
+            if (closure.Add(root)) frontier.Enqueue(root);
+        }
+
+        while (frontier.Count > 0) {
+            var name = frontier.Dequeue();
+            foreach (var referenced in DefinitionRefs(defs[name]))
+                if (defs.ContainsKey(referenced) && closure.Add(referenced))
+                    frontier.Enqueue(referenced);
+        }
+        return closure;
+    }
+
+    // Every #/definitions/NAME ref reachable inside a node (recursively).
+    static IReadOnlyList<string> DefinitionRefs(JsonNode? node) {
+        var acc = new List<string>();
+        Collect(node, acc);
+        return acc;
+
+        static void Collect(JsonNode? n, List<string> acc) {
+            switch (n) {
+                case JsonObject o:
+                    foreach (var (key, value) in o) {
+                        if (key == "$ref" && value is JsonValue v && v.TryGetValue<string>(out var s)
+                            && s.StartsWith(RefPrefix, StringComparison.Ordinal))
+                            acc.Add(s[RefPrefix.Length..]);
+                        else
+                            Collect(value, acc);
+                    }
+                    break;
+                case JsonArray a:
+                    foreach (var x in a) Collect(x, acc);
+                    break;
+            }
+        }
+    }
+
+    // Deep copy with object keys sorted (ordinal) so serialization is order-stable.
+    static JsonNode? Canonicalize(JsonNode? node) {
+        switch (node) {
+            case JsonObject o:
+                var sorted = new JsonObject();
+                foreach (var (key, value) in o.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+                    sorted[key] = Canonicalize(value);
+                return sorted;
+            case JsonArray a:
+                var arr = new JsonArray();
+                foreach (var x in a) arr.Add(Canonicalize(x));
+                return arr;
+            default:
+                return node?.DeepClone();
+        }
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaSubset.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerSchemaSubset.cs
@@ -4,13 +4,10 @@ using System.Text.Json.Nodes;
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
 
 /// <summary>
-/// Extracts and canonicalizes the subset of the <c>codex app-server</c> protocol JSON schema that the
-/// app-server runtime layer actually reads, so a Codex version that changes a depended-on shape is
-/// caught by a diff instead of failing silently at launch. The full protocol schema drifts benignly
-/// across versions (0.147 adds <c>threadSection/*</c>; the combined schema already carries 557 defs),
-/// so a whole-file diff would be noise — this pins only the byte-stable set the app-server protocol
-/// spike verified, closed over its <c>#/definitions/*</c> refs so a change to any referenced shape is
-/// pinned too.
+/// Extracts and canonicalizes the subset of the <c>codex app-server</c> protocol schema the runtime
+/// reads. The full schema drifts benignly across versions (0.147 adds <c>threadSection/*</c>; 557
+/// defs), so a whole-file diff is noise — this pins only the spike-verified depended-on set, closed
+/// over its <c>#/definitions/*</c> refs so a referenced shape's change is caught too.
 /// </summary>
 internal static class CodexAppServerSchemaSubset {
     /// <summary>The combined all-types schema the generator emits (a <c>definitions</c> map of the
@@ -50,9 +47,8 @@ internal static class CodexAppServerSchemaSubset {
 
     static readonly JsonSerializerOptions Indented = new() { WriteIndented = true };
 
-    /// <summary>Reads a <c>generate-json-schema --out</c> directory and returns the canonical pin
-    /// object <c>{ codexVersion, combinedDefs, standalone }</c>, every nested object key sorted so
-    /// re-serialization is order-stable within a process.</summary>
+    /// <summary>The canonical pin <c>{ codexVersion, combinedDefs, standalone }</c> from a
+    /// <c>generate-json-schema --out</c> dir — keys sorted so serialization is order-stable.</summary>
     public static JsonObject Extract(string schemaDir, string codexVersion) {
         var combinedPath = Path.Combine(schemaDir, CombinedSchemaFileName);
         if (!File.Exists(combinedPath))
@@ -85,9 +81,8 @@ internal static class CodexAppServerSchemaSubset {
         };
     }
 
-    /// <summary>Indented serialization — writes the committed pin and, applied to both sides through
-    /// <see cref="Canonical"/>, provides a by-value comparison whose string equality is reliable
-    /// because both operands are re-serialized in the same process.</summary>
+    /// <summary>Indented serialization. Via <see cref="Canonical"/> it gives a by-value comparison:
+    /// both operands are re-serialized in-process, so string equality is reliable.</summary>
     public static string Serialize(JsonNode node) => node.ToJsonString(Indented);
 
     /// <summary>Canonical string form of a node (keys sorted, indented) for by-value comparison.</summary>


### PR DESCRIPTION
Implements the Q7 schema-pinning tail of the Codex app-server epic (AI-2055, under AI-1759): a daemon-suite conformance test that pins the subset of the `codex app-server` protocol schema the runtime actually reads and diffs it against the installed binary.

## Why a subset, not the whole schema
The full protocol schema drifts benignly across Codex versions (0.147 adds `threadSection/*`; the combined schema already carries 557 defs), so a whole-file diff is noise. The runtime depends on a fixed, spike-verified byte-stable set — `initialize`, `thread/start`+`resume`, `turn/start`+`steer`+`interrupt`, the token-usage notification, `SandboxPolicy`/`AskForApproval`, and the five server→client approval/elicitation request+response shapes. The extractor pins exactly that set, closed over its `#/definitions/*` refs (67 combined defs) plus the standalone approval schema files.

## Two arms
- **CI-safe (always runs):** the committed pin documents every depended-on shape and the exact fields the runtime sends/reads; a copy-mutation test proves the diff catches a removed property. No `codex` binary needed.
- **Binary-gated (dev/cert machines):** regenerate the schema from the installed `codex` (`app-server generate-json-schema --out`), extract the same subset, diff against the pin, fail loudly with a per-type report on divergence. **Auto-skips when `codex` is absent (shared CI) — never a silent pass.**

Regenerate the pin after an intended Codex bump (having re-vetted the behavioural Q1/Q2 probes) with `KCAP_CODEX_SCHEMA_PIN_UPDATE=1`. Pin stamped codex 0.147.0.

## Verification (local)
- All 3 tests green against installed codex 0.147 (drift arm: 0 divergence).
- CI condition simulated (codex off PATH): 2 CI-safe arms pass, binary-gated arm skips with reason.
- End-to-end mutation: corrupting the committed pin fails the binary-gated arm loudly (`[combinedDefs] 'TurnStartParams': shape changed vs pin`); pin restored byte-identical.

Test-only; no runtime/production code change. Part (b) behavioural conformance (Q1 isolation / Q2 sandbox probes) stays with the live smoke and is out of scope.

Linear: AI-2055