### PR TITLE
[AI-2057] Set up Dependabot for NuGet, the SDK pin, and workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+# Routine sweeps only — security updates are a separate always-on channel in repo settings. Weekly, not
+# daily: Dependabot rebases an open group PR every run, and each rebase re-runs the whole matrix.
+# No `docker`/`npm` — nothing there is a dependency manifest; see the comments at those pins.
+version: 2
+updates:
+  # CPM: Directory.Packages.props is the single pin, and setup-dotnet keys its restore cache on it.
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels: [dependencies]
+    commit-message:
+      prefix: chore
+    groups:
+      # Each ships as one release train on one version string, so a major split across PRs cannot
+      # build — grouped across all update types, and excluded below rather than trusting group order.
+      avalonia:
+        patterns: ["Avalonia*", "ReactiveUI.Avalonia"]
+      tunit:
+        patterns: ["TUnit*"]
+      # Majors stay ungrouped: one is a judgement call, and must not ride along in a batch.
+      nuget-minor-and-patch:
+        patterns: ["*"]
+        exclude-patterns: ["Avalonia*", "ReactiveUI.Avalonia", "TUnit*"]
+        update-types: [minor, patch]
+
+  # Monthly: rollForward latestFeature means every 10.0.1xx SDK already satisfies the pin, so raising
+  # it only raises every developer machine's floor.
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: monthly
+      time: "05:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels: [dependencies]
+    commit-message:
+      prefix: chore
+
+  # All on major tags, so these arrive as majors — each a runner-version question (v5+ of the
+  # GitHub-owned actions needs runner >= 2.327.1), not a rubber stamp.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    labels: [dependencies]
+    commit-message:
+      prefix: chore
+    groups:
+      actions-minor-and-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,7 @@ jobs:
             daemon-binary: kcap-daemon
           - rid: linux-musl-x64
             os: ubuntu-latest
+            # Dependabot's docker ecosystem does not scan job `container:` — bump by hand.
             container: alpine:3.20
             npm-package: kcap-linux-musl-x64
             cli-binary: kcap

--- a/test-fixtures/acp-elicitation/generate.mjs
+++ b/test-fixtures/acp-elicitation/generate.mjs
@@ -7,6 +7,8 @@
 // export is a variant-discriminator helper only), so the verdict mechanism is ajv 8 compiled
 // against the SDK-shipped schema — recorded here per the design spec's "where the SDK can
 // express that" clause (AI-1733 spec §8, Linear).
+// The exact 1.3.0 in package.json is part of that claim, and CI never runs this generator — so a
+// bump has to be paired with a regeneration by hand. Dependabot is not pointed here.
 //
 // Four-group taxonomy (spec §8):
 //   A: protocol-valid, rendered        — MUST pass schema validation; classifier Renderable.


### PR DESCRIPTION
Three ecosystems: `nuget` (CPM), `dotnet-sdk` (`global.json`), `github-actions`.

Closes kurrent-io/kcap-cli#586 · kurrent-io/kcap-cli#586 (related: [AI-1605](https://linear.app/kurrent/issue/AI-1605/bump-net-runtime-servicing-patch-in-the-kcap-image-datasgc-fixes-land))

## Carried over unchanged from the server review

Minor + patch grouped per ecosystem, majors on their own; weekly not daily; no auto-merge anywhere<br>(`TreatWarningsAsErrors` is on here too); `dependencies` label only; `chore` commit prefix.

## Two deviations from the prompt I was given — both because the premise was wrong

The prompt was written against the `src/cli` submodule pin at **v0.11.25**, which is behind `main`.<br>Re-checking against `main` changed two conclusions:

1. `global.json` **exists** (`10.0.100`, `rollForward: latestFeature`) — the prompt said it didn't and<br>told me not to fold `dotnet-sdk` in. Since the file is already there, the "adding one is a separate<br>decision" reasoning evaporates, so it's configured, monthly, with the same rationale as the server:<br>any 10.0.1xx SDK already satisfies the pin, and raising it raises every dev machine's floor.
2. **The actions are already current** — `checkout@v7`, `setup-dotnet@v6`, `setup-node@v7`,<br>`upload-artifact@v7`, `download-artifact@v8`. The prompt predicted an immediate wave of major PRs<br>from being behind kcap-server; that's no longer true. Only two third-party actions<br>(`lewagon/wait-on-check-action@v1.6.1`, `softprops/action-gh-release@v2`) are live sources of churn.

## One deliberate refinement — say the word and I'll drop it

`Avalonia*` + `ReactiveUI.Avalonia` and `TUnit*` each group across **all** update types, not just<br>minor/patch, and the catch-all excludes them by pattern rather than relying on group-match ordering.<br>Under the plain majors-get-their-own-PR rule, Avalonia 13 would arrive as four separate PRs and TUnit 2<br>as two, each unbuildable in isolation — that's a defect in the split, not a judgement call worth<br>preserving. This is the only place I departed from "the decisions are already made".

## Deliberately not configured, each with a comment at the pin

* `npm` **for** `npm/**` — seven *publishing* manifests: every `version` is a `0.0.0` placeholder and<br>`@kurrent/kcap`'s `optionalDependencies` are self-references to the six platform packages, all<br>rewritten at release. No third-party deps, no lockfiles.
* `npm` **for** `test-fixtures/acp-elicitation` — the prompt left this one open and asked whether the<br>exact `@agentclientprotocol/sdk@1.3.0` pin was documented. It is, thoroughly: `generate.mjs`'s<br>PROVENANCE header records that the fixtures are validated against *that version's* shipped normative<br>JSON Schema, and the generated `ElicitationFixtures.g.cs` is committed. Decisive detail: **CI never****<br>****runs the generator**, so a Dependabot bump would move `package.json`, leave the header asserting<br>1.3.0, and go green while the provenance claim is a lie. Excluded, and the header now says so.
* `docker` — no Dockerfiles. `alpine:3.20` is a job `container:` in `release.yml`, which<br>Dependabot's docker ecosystem does not scan; the note now sits at that pin.

## Reported, not fixed

* **AOT weakens the green check.** `aot-check` does publish AOT in PR CI — both the CLI and the daemon,<br>plus the `IL[23]xxx` grep — but **linux-x64 only**. win-x64, osx-arm64 and the two musl RIDs are<br>exercised only in `release.yml`, so a NuGet bump that breaks trimming or AOT codegen on another RID<br>passes here. Treat a green check on a NuGet PR as partial evidence.
* **Security-updates state is unverifiable from my account** (`admin: false`, so<br>`/vulnerability-alerts` 404s the same way for a disabled repo and an unauthorized caller). Someone<br>with admin needs to confirm Settings → Code security has Dependabot alerts **and** security updates<br>on: `NuGetAudit` warnings are `NU1903`/`NU1904` and `TreatWarningsAsErrors` is `true`, so an<br>advisory against a pinned package fails the build here whether or not Dependabot is watching.
* **A .NET-train observation I did not encode.** `Microsoft.Extensions.*`, `Microsoft.AspNetCore.*` and<br>`Microsoft.Data.Sqlite` all sit at `10.0.11` and would split into five separate PRs on a .NET 11<br>major — but a .NET major is a TFM change, never a Dependabot job, and `Microsoft.Extensions.TimeProvider.Testing`<br>(`10.9.0`) is on a *different* train that a `Microsoft.Extensions.*` pattern would wrongly batch with<br>it. Left alone rather than guessing at an `ignore` rule.

No README change: this touches no user-facing CLI surface.