### PR TITLE
Codex app-server: interactive input state machine (turn/steer)

### DIFF
--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -79,12 +79,16 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     readonly TimeProvider         _time;
     readonly CancellationTokenSource _cts = new();
 
-    readonly object              _turnGate = new();
     // Whole-runtime terminal signal: completed exactly once, when the LIVE child's read loop ends
     // (process death) or on dispose — never for the controlled child teardown during a hook-trust
     // restart. The orchestrator treats ReadOutputAsync ending as the finalize trigger, so this must
     // not fire early, and WaitForTurnIdleAsync must unblock on it so a round never outlives the child.
     readonly TaskCompletionSource _runtimeTerminal = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    // The single input serializer: all input enqueues here, one dispatcher chooses turn/start vs
+    // turn/steer and owns the completion-window race (§2.2). Turn state (active turn id, in-flight
+    // clock, WaitForTurnIdle) is derived from it — the runtime no longer tracks turns itself.
+    readonly CodexTurnInputDispatcher _dispatcher;
 
     CodexAppServerConnection? _connection;
     IAcpProcess?              _process;
@@ -94,9 +98,6 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
 
     string?                   _threadId;
     string?                   _resolvedModel;
-    string?                   _currentTurnId;      // server turn id once the start response lands; null in the request window
-    TaskCompletionSource?     _turnCompleted;      // the current round's waiter
-    (string TurnId, string? Status)? _pendingCompletion; // an early turn/completed whose id we could not match yet
     CodexTokenUsage?          _usage;
     int                       _disposed;
 
@@ -108,6 +109,9 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         _clock   = clock;
         _logger  = logger;
         _time    = timeProvider ?? TimeProvider.System;
+        _dispatcher = new CodexTurnInputDispatcher(
+            startTurn: IssueTurnStartAsync, steerTurn: IssueTurnSteerAsync,
+            logger: logger, ct: _cts.Token, onTurnInFlight: flip => _clock?.SetTurnInFlight(flip));
     }
 
     // ── IHostedAgentRuntime: identity / lifecycle observables ──────────────────────────────────
@@ -180,7 +184,7 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         _clock?.ClearLaunchStage();
 
         if (!string.IsNullOrEmpty(_launch.InitialPrompt))
-            await StartTurnAsync(_launch.InitialPrompt, linked.Token).ConfigureAwait(false);
+            await _dispatcher.EnqueueAsync(_launch.InitialPrompt).ConfigureAwait(false);
     }
 
     async Task SpawnAndInitializeAsync(string? hookStateSeed, CancellationToken ct) {
@@ -213,8 +217,8 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
             // read loop ending (death) or dispose flips the whole-runtime terminal signal.
             if (!_restarting) {
                 _runtimeTerminal.TrySetResult();
-                FaultPendingTurn(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime),
-                    "codex app-server connection ended with a turn still in flight."));
+                _dispatcher.FaultAll(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime),
+                    "codex app-server connection ended with input still in flight."));
             }
         }
     }
@@ -267,12 +271,15 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
 
     // ── Turns / rounds ─────────────────────────────────────────────────────────────────────────
 
-    async Task StartTurnAsync(string prompt, CancellationToken ct) {
+    // The dispatcher's turn/start sender: builds the per-turn posture params (§2.1 renders them here,
+    // not argv) and issues turn/start, returning the server-assigned turn. A -32001 backpressure
+    // rejection is retried inside RequestAsync.
+    async Task<CodexTurnStarted> IssueTurnStartAsync(string text, CancellationToken ct) {
         var threadId = _threadId ?? throw new InvalidOperationException("codex app-server: no thread to start a turn on.");
 
         var turnParams = new JsonObject {
             ["threadId"]          = threadId,
-            ["input"]             = new JsonArray(new JsonObject { ["type"] = "text", ["text"] = prompt }),
+            ["input"]             = new JsonArray(new JsonObject { ["type"] = "text", ["text"] = text }),
             ["sandboxPolicy"]     = CodexAppServerPosture.RenderSandboxPolicy(_launch.Sandbox, _launch.WritableRoots),
             ["approvalPolicy"]    = CodexAppServerPosture.RenderApprovalPolicy(_launch.Approval),
             ["approvalsReviewer"] = CodexAppServerPosture.ApprovalsReviewer,
@@ -280,70 +287,39 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         if (!string.IsNullOrEmpty(_launch.Model))  turnParams["model"]  = _launch.Model;
         if (!string.IsNullOrEmpty(_launch.Effort)) turnParams["effort"] = MapEffort(_launch.Effort);
 
-        // Arm the completion signal + the turn-in-flight clock BEFORE the turn is on the wire, so a
-        // fast turn/completed can neither race a null TCS nor leave the clock flipped back to
-        // in-flight after it was cleared.
-        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        lock (_turnGate) {
-            _turnCompleted     = completion;
-            _currentTurnId     = null;
-            _pendingCompletion = null;
-        }
-        _clock?.SetTurnInFlight(true);
-
-        JsonElement result;
-        try {
-            result = await RequestAsync("turn/start", turnParams, ct).ConfigureAwait(false);
-        } catch {
-            FaultPendingTurn(new OperationCanceledException("codex app-server: turn/start failed."));
-            throw;
-        }
-
+        var result = await RequestAsync("turn/start", turnParams, ct).ConfigureAwait(false);
         var turn   = result.Obj("turn");
         var turnId = turn?.Str("id");
-        if (string.IsNullOrEmpty(turnId)) {
-            var ex = new InvalidOperationException("codex app-server: turn/start returned no turn id.");
-            FaultPendingTurn(ex);
-            throw ex;
-        }
-
-        var status = turn?.Str("status");
-
-        // Bind the id, then reconcile against anything that raced ahead of this response:
-        //   - a turn/completed that arrived while the id was unknown (stashed), OR
-        //   - a response that itself came back already terminal.
-        bool completeNow = false;
-        string? completeStatus = null;
-        lock (_turnGate) {
-            _currentTurnId = turnId;
-            if (_pendingCompletion is { } pc && string.Equals(pc.TurnId, turnId, StringComparison.Ordinal)) {
-                completeNow = true;
-                completeStatus = pc.Status;
-            } else if (status is not null and not "inProgress") {
-                completeNow = true;
-                completeStatus = status;
-            }
-            _pendingCompletion = null; // discard a stash that was not ours
-        }
-        if (completeNow) CompleteTurn(turnId, completeStatus);
+        if (string.IsNullOrEmpty(turnId))
+            throw new InvalidOperationException("codex app-server: turn/start returned no turn id.");
+        return new CodexTurnStarted(turnId, turn?.Str("status"));
     }
 
-    public Task SendUserInputAsync(string text) => StartTurnAsync(text, _cts.Token);
+    // The dispatcher's turn/steer sender: feeds an input onto the ACTIVE turn (posture is already
+    // pinned by its turn/start). A stale/ended turn answers -32600 as a CodexAppServerRpcException,
+    // which the dispatcher catches and retries once as a turn/start.
+    async Task IssueTurnSteerAsync(string turnId, string text, CancellationToken ct) {
+        var threadId = _threadId ?? throw new InvalidOperationException("codex app-server: no thread to steer.");
+        var steerParams = new JsonObject {
+            ["threadId"]       = threadId,
+            ["expectedTurnId"] = turnId,
+            ["input"]          = new JsonArray(new JsonObject { ["type"] = "text", ["text"] = text }),
+        };
+        await RequestAsync("turn/steer", steerParams, ct).ConfigureAwait(false);
+    }
 
-    public async Task SendUserInputAndWaitForWriteAsync(string text) =>
-        await StartTurnAsync(text, _cts.Token).ConfigureAwait(false);
+    public Task SendUserInputAsync(string text) => _dispatcher.EnqueueAsync(text);
+
+    public Task SendUserInputAndWaitForWriteAsync(string text) => _dispatcher.EnqueueAsync(text);
 
     public async Task WaitForTurnIdleAsync(CancellationToken ct) {
-        TaskCompletionSource? tcs;
-        lock (_turnGate) tcs = _turnCompleted;
-        if (tcs is null) return; // no turn in flight
-
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _cts.Token);
-        var completed = await Task.WhenAny(tcs.Task, _runtimeTerminal.Task,
+        var settled   = _dispatcher.WaitForSettledAsync();
+        var completed = await Task.WhenAny(settled, _runtimeTerminal.Task,
             Task.Delay(Timeout.Infinite, linked.Token)).ConfigureAwait(false);
 
-        if (completed == tcs.Task || completed == _runtimeTerminal.Task)
-            return; // turn settled, or the child died — either way the round is no longer in flight
+        if (completed == settled || completed == _runtimeTerminal.Task)
+            return; // input drained + turn settled, or the child died — the round is no longer in flight
 
         await completed.ConfigureAwait(false); // propagate cancellation
     }
@@ -354,7 +330,9 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         switch (n.Method) {
             case "turn/completed": {
                 var turn = n.Params is { } p ? p.Obj("turn") : null;
-                OnTurnCompletedNotification(turn?.Str("id"), turn?.Str("status"));
+                if (turn?.Str("status") is "failed")
+                    _logger.LogWarning("codex app-server: turn completed with status=failed.");
+                _dispatcher.OnTurnCompleted(turn?.Str("id"));
                 break;
             }
             case "thread/tokenUsage/updated":
@@ -365,57 +343,6 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
                 _clock?.Advance();
                 break;
         }
-    }
-
-    void OnTurnCompletedNotification(string? turnId, string? status) {
-        lock (_turnGate) {
-            if (_currentTurnId is null) {
-                // The turn/start response has not identified the current turn yet. Stash this
-                // completion by id; StartTurnAsync applies it iff it matches, else discards it.
-                if (turnId is not null) _pendingCompletion = (turnId, status);
-                return;
-            }
-            if (turnId is not null && !string.Equals(_currentTurnId, turnId, StringComparison.Ordinal))
-                return; // a stale completion from another turn
-        }
-        CompleteTurn(turnId, status);
-    }
-
-    /// <summary>The single point that settles the current round: clears the waiter under the lock
-    /// (so exactly one caller wins), then — only if there was a waiter — clears the turn-in-flight
-    /// clock and completes the TCS.</summary>
-    void CompleteTurn(string? turnId, string? status) {
-        TaskCompletionSource? tcs;
-        lock (_turnGate) {
-            if (_currentTurnId is not null && turnId is not null
-                && !string.Equals(_currentTurnId, turnId, StringComparison.Ordinal))
-                return; // not the turn we are waiting on
-
-            tcs = _turnCompleted;
-            _turnCompleted     = null;
-            _currentTurnId     = null;
-            _pendingCompletion = null;
-        }
-        if (tcs is null) return;
-
-        _clock?.SetTurnInFlight(false);
-        tcs.TrySetResult();
-        if (status is "failed")
-            _logger.LogWarning("codex app-server: turn completed with status=failed.");
-    }
-
-    void FaultPendingTurn(Exception ex) {
-        TaskCompletionSource? tcs;
-        lock (_turnGate) {
-            tcs = _turnCompleted;
-            _turnCompleted     = null;
-            _currentTurnId     = null;
-            _pendingCompletion = null;
-        }
-        if (tcs is null) return;
-
-        _clock?.SetTurnInFlight(false);
-        tcs.TrySetException(ex);
     }
 
     /// <summary>
@@ -482,7 +409,7 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     public async Task RequestGracefulStopAsync() {
         var connection = _connection;
         var threadId   = _threadId;
-        var turnId     = _currentTurnId;
+        var turnId     = _dispatcher.CurrentTurnId;
         if (connection is null || threadId is null || turnId is null)
             return;
 
@@ -514,7 +441,7 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         // Ensure the terminal signal is set even if no read loop ever ran (e.g. spawn failed before
         // the loop started) so a ReadOutputAsync consumer never hangs.
         _runtimeTerminal.TrySetResult();
-        FaultPendingTurn(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime)));
+        _dispatcher.FaultAll(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime)));
         _cts.Dispose();
     }
 

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -184,7 +184,7 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         _clock?.ClearLaunchStage();
 
         if (!string.IsNullOrEmpty(_launch.InitialPrompt))
-            await _dispatcher.EnqueueAsync(_launch.InitialPrompt).ConfigureAwait(false);
+            await _dispatcher.EnqueueAsync(_launch.InitialPrompt, linked.Token).ConfigureAwait(false);
     }
 
     async Task SpawnAndInitializeAsync(string? hookStateSeed, CancellationToken ct) {

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
@@ -14,13 +14,13 @@ internal readonly record struct CodexTurnStarted(string TurnId, string? Status);
 ///
 /// <para>Two orthogonal fields, deliberately not one flat state, because a notification can arrive
 /// while a request is in flight: <see cref="_pending"/> (the request whose JSON-RPC response is still
-/// outstanding, driven only by that response) and <see cref="_lifecycle"/> (Idle/Active/Completing,
-/// driven only by <c>turn/started</c>/<c>turn/completed</c>). The dispatcher invariant is on
-/// <see cref="_pending"/>: it dispatches the head input only when nothing is pending, so two inputs can
-/// never both observe idle and double-start (the exact hazard the server would accept). A steer the
-/// server rejects with <c>-32600</c> ("no active turn") is retried EXACTLY ONCE as a
-/// <c>turn/start</c> — in the dispatcher, never the enqueuing surface — and never dropped. An input is
-/// acknowledged only after the dispatch that actually carried it succeeds.</para>
+/// outstanding, driven only by that response) and <see cref="_lifecycle"/> (Idle/Active, driven only
+/// by <c>turn/completed</c>). The dispatcher invariant is on <see cref="_pending"/>: it dispatches the
+/// head input only when nothing is pending, so two inputs can never both observe idle and double-start
+/// (the exact hazard the server would accept). A steer the server rejects with <c>-32600</c> ("no
+/// active turn") is retried EXACTLY ONCE as a <c>turn/start</c> — in the dispatcher, never the
+/// enqueuing surface — and never dropped. An input is acknowledged only after the dispatch that
+/// actually carried it succeeds.</para>
 /// </summary>
 internal sealed class CodexTurnInputDispatcher {
     // Sends turn/start with the input as the initial prompt; returns the started turn once the RESPONSE
@@ -29,30 +29,38 @@ internal sealed class CodexTurnInputDispatcher {
     // Sends turn/steer(expectedTurnId, input); returns when the RESPONSE lands. Throws
     // CodexAppServerRpcException(-32600) when the turn is no longer active (the retryable miss).
     readonly Func<string, string, CancellationToken, Task> _steerTurn;
-    readonly ILogger          _logger;
+    // Notified (true/false) as a turn becomes active / goes idle — drives the runtime's turn-in-flight clock.
+    readonly Action<bool>?     _onTurnInFlight;
+    readonly ILogger           _logger;
     readonly CancellationToken _ct;
 
     readonly object            _gate = new();
     readonly Queue<InputItem>  _queue = new();
+    readonly List<TaskCompletionSource> _settledWaiters = [];
 
     Pending   _pending   = Pending.None;
     Lifecycle _lifecycle = Lifecycle.Idle;
-    string?   _activeTurnId;              // set in Active/Completing
+    string?   _activeTurnId;              // set in Active
     string?   _completedBeforeStartResp; // a turn/completed seen while _pending=Start (turn id unknown yet)
     bool      _dispatching;              // guards the fire-outside-lock dispatch against re-entrancy
+    bool      _lastInFlight;             // last value handed to _onTurnInFlight, so it fires only on change
 
     public CodexTurnInputDispatcher(
             Func<string, CancellationToken, Task<CodexTurnStarted>> startTurn,
             Func<string, string, CancellationToken, Task> steerTurn,
-            ILogger logger, CancellationToken ct) {
-        _startTurn = startTurn;
-        _steerTurn = steerTurn;
-        _logger    = logger;
-        _ct        = ct;
+            ILogger logger, CancellationToken ct, Action<bool>? onTurnInFlight = null) {
+        _startTurn      = startTurn;
+        _steerTurn      = steerTurn;
+        _logger         = logger;
+        _ct             = ct;
+        _onTurnInFlight = onTurnInFlight;
     }
 
-    /// <summary>True while a turn is live (Active or Completing) — the runtime's turn-in-flight signal.</summary>
+    /// <summary>True while a turn is live — the runtime's turn-in-flight signal.</summary>
     public bool TurnInFlight { get { lock (_gate) return _lifecycle != Lifecycle.Idle; } }
+
+    /// <summary>The active turn id, or null when idle — the target for a <c>turn/interrupt</c>.</summary>
+    public string? CurrentTurnId { get { lock (_gate) return _lifecycle == Lifecycle.Active ? _activeTurnId : null; } }
 
     /// <summary>Enqueues one input and returns a task that completes when the dispatch carrying it
     /// (a <c>turn/start</c> or an accepted <c>turn/steer</c>) succeeds — the "wait for write" contract.
@@ -62,6 +70,17 @@ internal sealed class CodexTurnInputDispatcher {
         lock (_gate) _queue.Enqueue(item);
         PumpDispatch();
         return item.Ack.Task;
+    }
+
+    /// <summary>Completes when the dispatcher is fully settled — no turn active, nothing pending, queue
+    /// drained. The runtime's <c>WaitForTurnIdleAsync</c> composes this with its terminal signal.</summary>
+    public Task WaitForSettledAsync() {
+        lock (_gate) {
+            if (IsSettledLocked()) return Task.CompletedTask;
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _settledWaiters.Add(tcs);
+            return tcs.Task;
+        }
     }
 
     /// <summary>Fed from the <c>turn/completed</c> notification. Advances the lifecycle and, when a
@@ -80,6 +99,7 @@ internal sealed class CodexTurnInputDispatcher {
             _lifecycle    = Lifecycle.Idle;
             _activeTurnId = null;
         }
+        SignalTransitions();
         PumpDispatch();
     }
 
@@ -95,6 +115,7 @@ internal sealed class CodexTurnInputDispatcher {
             _activeTurnId = null;
         }
         foreach (var item in orphans) item.Ack.TrySetException(ex);
+        SignalTransitions();
     }
 
     // Drains the queue as far as the invariant allows. Only one thread runs the fire-outside-lock body
@@ -165,6 +186,7 @@ internal sealed class CodexTurnInputDispatcher {
         } catch (Exception ex) {
             FailHead(item, ex);
         }
+        SignalTransitions();
     }
 
     async Task DispatchSteerAsync(InputItem item, string turnId) {
@@ -190,6 +212,7 @@ internal sealed class CodexTurnInputDispatcher {
         } catch (Exception ex) {
             FailHead(item, ex);
         }
+        SignalTransitions();
     }
 
     void FailHead(InputItem item, Exception ex) {
@@ -198,6 +221,28 @@ internal sealed class CodexTurnInputDispatcher {
             if (_queue.Count > 0 && ReferenceEquals(_queue.Peek(), item)) _queue.Dequeue();
         }
         item.Ack.TrySetException(ex);
+    }
+
+    bool IsSettledLocked() => _lifecycle == Lifecycle.Idle && _pending == Pending.None && _queue.Count == 0;
+
+    // Fires the in-flight callback on a real change and releases any settled waiters — both OUTSIDE the
+    // lock so a callback can never re-enter the dispatcher under it.
+    void SignalTransitions() {
+        bool inFlight;
+        bool fireInFlight = false;
+        List<TaskCompletionSource>? settled = null;
+
+        lock (_gate) {
+            inFlight = _lifecycle != Lifecycle.Idle;
+            if (inFlight != _lastInFlight) { _lastInFlight = inFlight; fireInFlight = true; }
+            if (IsSettledLocked() && _settledWaiters.Count > 0) {
+                settled = [.. _settledWaiters];
+                _settledWaiters.Clear();
+            }
+        }
+
+        if (fireInFlight) _onTurnInFlight?.Invoke(inFlight);
+        if (settled is not null) foreach (var w in settled) w.TrySetResult();
     }
 
     enum Pending   { None, Start, Steer }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
@@ -8,7 +8,7 @@ internal readonly record struct CodexTurnStarted(string TurnId, string? Status);
 
 /// <summary>
 /// The single serializer for interactive hosted-Codex input. The app server accepts a concurrent
-/// <c>turn/start</c> without error (AI-1760 Q13 — it does NOT serialize turns for you), so
+/// <c>turn/start</c> without error — the protocol spike proved it does NOT serialize turns for you — so
 /// serialization has to live on our side: every input surface enqueues here and ONE dispatcher drains,
 /// choosing <c>turn/start</c> when idle and <c>turn/steer</c> when a turn is active.
 ///
@@ -198,7 +198,7 @@ internal sealed class CodexTurnInputDispatcher {
             }
             item.Ack.TrySetResult(); // accepted onto the active turn before it completed
         } catch (CodexAppServerRpcException rpc) when (rpc.Code == -32600 && !item.RetriedAsStart) {
-            // The turn ended before the steer landed (AI-1760 Q13). Retry this same input EXACTLY ONCE
+            // The turn ended before the steer landed (spike Q13). Retry this same input EXACTLY ONCE
             // as a turn/start — force the lifecycle idle for the missed turn so the retry can't re-steer.
             lock (_gate) {
                 item.RetriedAsStart = true;

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
@@ -44,6 +44,7 @@ internal sealed class CodexTurnInputDispatcher {
     string?   _completedBeforeStartResp; // a turn/completed seen while _pending=Start (turn id unknown yet)
     bool      _dispatching;              // guards the fire-outside-lock dispatch against re-entrancy
     bool      _lastInFlight;             // last value handed to _onTurnInFlight, so it fires only on change
+    bool      _faulted;                 // FaultAll ran; a dispatch resuming after it must not resurrect state
 
     public CodexTurnInputDispatcher(
             Func<string, CancellationToken, Task<CodexTurnStarted>> startTurn,
@@ -110,7 +111,8 @@ internal sealed class CodexTurnInputDispatcher {
     public void FaultAll(Exception ex) {
         List<InputItem> orphans;
         lock (_gate) {
-            orphans = [.. _queue];
+            _faulted      = true;
+            orphans       = [.. _queue];
             _queue.Clear();
             _pending      = Pending.None;
             _lifecycle    = Lifecycle.Idle;
@@ -170,21 +172,27 @@ internal sealed class CodexTurnInputDispatcher {
     async Task DispatchStartAsync(InputItem item) {
         try {
             var started = await _startTurn(item.Text, _ct).ConfigureAwait(false);
+            bool carried = false;
             lock (_gate) {
-                _pending = Pending.None;
-                var alreadyDone = started.Status is not null and not "inProgress"
-                    || string.Equals(_completedBeforeStartResp, started.TurnId, StringComparison.Ordinal);
-                _completedBeforeStartResp = null;
-                if (alreadyDone) {
-                    _lifecycle    = Lifecycle.Idle;
-                    _activeTurnId = null;
-                } else {
-                    _lifecycle    = Lifecycle.Active;
-                    _activeTurnId = started.TurnId;
+                // FaultAll may have run during the await; if so the item is already faulted and the
+                // queue cleared — do NOT resurrect Active state or Dequeue an empty queue.
+                if (!_faulted) {
+                    _pending = Pending.None;
+                    var alreadyDone = started.Status is not null and not "inProgress"
+                        || string.Equals(_completedBeforeStartResp, started.TurnId, StringComparison.Ordinal);
+                    _completedBeforeStartResp = null;
+                    if (alreadyDone) {
+                        _lifecycle    = Lifecycle.Idle;
+                        _activeTurnId = null;
+                    } else {
+                        _lifecycle    = Lifecycle.Active;
+                        _activeTurnId = started.TurnId;
+                    }
+                    _queue.Dequeue();
+                    carried = true;
                 }
-                _queue.Dequeue();
             }
-            item.Ack.TrySetResult(); // the start carried this input (it was the turn's prompt)
+            if (carried) item.Ack.TrySetResult(); // the start carried this input (it was the turn's prompt)
         } catch (Exception ex) {
             FailHead(item, ex);
         }
@@ -194,20 +202,22 @@ internal sealed class CodexTurnInputDispatcher {
     async Task DispatchSteerAsync(InputItem item, string turnId) {
         try {
             await _steerTurn(turnId, item.Text, _ct).ConfigureAwait(false);
+            bool carried = false;
             lock (_gate) {
-                _pending = Pending.None;
-                _queue.Dequeue();
+                if (!_faulted) { _pending = Pending.None; _queue.Dequeue(); carried = true; }
             }
-            item.Ack.TrySetResult(); // accepted onto the active turn before it completed
+            if (carried) item.Ack.TrySetResult(); // accepted onto the active turn before it completed
         } catch (CodexAppServerRpcException rpc) when (rpc.Code == -32600 && !item.RetriedAsStart) {
             // The turn ended before the steer landed (spike Q13). Retry this same input EXACTLY ONCE
             // as a turn/start — force the lifecycle idle for the missed turn so the retry can't re-steer.
             lock (_gate) {
-                item.RetriedAsStart = true;
-                _pending = Pending.None;
-                if (string.Equals(_activeTurnId, turnId, StringComparison.Ordinal)) {
-                    _lifecycle    = Lifecycle.Idle;
-                    _activeTurnId = null;
+                if (!_faulted) {
+                    item.RetriedAsStart = true;
+                    _pending = Pending.None;
+                    if (string.Equals(_activeTurnId, turnId, StringComparison.Ordinal)) {
+                        _lifecycle    = Lifecycle.Idle;
+                        _activeTurnId = null;
+                    }
                 }
             }
             _logger.LogDebug("codex app-server: steer missed turn {TurnId}; retrying the input as turn/start.", turnId);
@@ -243,7 +253,12 @@ internal sealed class CodexTurnInputDispatcher {
             }
         }
 
-        if (fireInFlight) _onTurnInFlight?.Invoke(inFlight);
+        // The in-flight callback is external (the clock); a throw from it must never propagate into the
+        // dispatch loop and strand queued input.
+        if (fireInFlight) {
+            try { _onTurnInFlight?.Invoke(inFlight); }
+            catch (Exception ex) { _logger.LogError(ex, "codex app-server: turn-in-flight callback threw."); }
+        }
         if (settled is not null) foreach (var w in settled) w.TrySetResult();
     }
 

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
@@ -93,9 +93,11 @@ internal sealed class CodexTurnInputDispatcher {
                 if (turnId is not null) _completedBeforeStartResp = turnId;
                 return;
             }
+            // A null turn id means "the active turn completed" (the notification omitted it) — accept it
+            // for whatever is active; a non-null id that doesn't match the active turn is stale.
             if (turnId is not null && _activeTurnId is not null
                 && !string.Equals(_activeTurnId, turnId, StringComparison.Ordinal))
-                return; // a stale completion from another turn
+                return;
             _lifecycle    = Lifecycle.Idle;
             _activeTurnId = null;
         }
@@ -248,6 +250,9 @@ internal sealed class CodexTurnInputDispatcher {
     enum Pending   { None, Start, Steer }
     enum Lifecycle { Idle, Active }
 
+    // An item is only ever touched by the single active dispatch loop (the _dispatching guard admits
+    // exactly one), so its mutable RetriedAsStart needs no synchronization — the per-iteration lock
+    // acquisitions fence the one write against the next iteration's read.
     sealed class InputItem(string text) {
         public string Text { get; } = text;
         public TaskCompletionSource Ack { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
@@ -7,20 +7,14 @@ namespace Capacitor.Cli.Daemon.Harness.Codex;
 internal readonly record struct CodexTurnStarted(string TurnId, string? Status);
 
 /// <summary>
-/// The single serializer for interactive hosted-Codex input. The app server accepts a concurrent
-/// <c>turn/start</c> without error — the protocol spike proved it does NOT serialize turns for you — so
-/// serialization has to live on our side: every input surface enqueues here and ONE dispatcher drains,
-/// choosing <c>turn/start</c> when idle and <c>turn/steer</c> when a turn is active.
+/// Serializes interactive hosted-Codex input. The app server accepts a concurrent <c>turn/start</c>
+/// without error — it does NOT serialize turns for you — so the daemon must: input enqueues and one
+/// dispatcher chooses <c>turn/start</c> (idle) or <c>turn/steer</c> (active).
 ///
-/// <para>Two orthogonal fields, deliberately not one flat state, because a notification can arrive
-/// while a request is in flight: <see cref="_pending"/> (the request whose JSON-RPC response is still
-/// outstanding, driven only by that response) and <see cref="_lifecycle"/> (Idle/Active, driven only
-/// by <c>turn/completed</c>). The dispatcher invariant is on <see cref="_pending"/>: it dispatches the
-/// head input only when nothing is pending, so two inputs can never both observe idle and double-start
-/// (the exact hazard the server would accept). A steer the server rejects with <c>-32600</c> ("no
-/// active turn") is retried EXACTLY ONCE as a <c>turn/start</c> — in the dispatcher, never the
-/// enqueuing surface — and never dropped. An input is acknowledged only after the dispatch that
-/// actually carried it succeeds.</para>
+/// <para>Two orthogonal fields, not one flat state, because a notification can arrive mid-request:
+/// <see cref="_pending"/> (driven by the request response) and <see cref="_lifecycle"/> (driven by
+/// <c>turn/completed</c>). The trap: a steer the server rejects with <c>-32600</c> ("no active turn")
+/// is retried EXACTLY ONCE as a <c>turn/start</c>, in the dispatcher, never dropped.</para>
 /// </summary>
 internal sealed class CodexTurnInputDispatcher {
     // Sends turn/start with the input as the initial prompt; returns the started turn once the RESPONSE
@@ -57,17 +51,21 @@ internal sealed class CodexTurnInputDispatcher {
         _onTurnInFlight = onTurnInFlight;
     }
 
-    /// <summary>True while a turn is live — the runtime's turn-in-flight signal.</summary>
-    public bool TurnInFlight { get { lock (_gate) return _lifecycle != Lifecycle.Idle; } }
+    /// <summary>True while a turn is live — including a <c>turn/start</c> whose response hasn't landed
+    /// yet, so a hung start counts as in-flight (the reaper's turn-wedge ceiling must see it, matching
+    /// the old "arm the clock before sending turn/start" behaviour).</summary>
+    public bool TurnInFlight { get { lock (_gate) return InFlightLocked(); } }
 
     /// <summary>The active turn id, or null when idle — the target for a <c>turn/interrupt</c>.</summary>
     public string? CurrentTurnId { get { lock (_gate) return _lifecycle == Lifecycle.Active ? _activeTurnId : null; } }
 
     /// <summary>Enqueues one input and returns a task that completes when the dispatch carrying it
     /// (a <c>turn/start</c> or an accepted <c>turn/steer</c>) succeeds — the "wait for write" contract.
-    /// Faults if that dispatch errors or the runtime is torn down.</summary>
-    public Task EnqueueAsync(string text) {
-        var item = new InputItem(text);
+    /// Faults if that dispatch errors or the runtime is torn down. An optional per-input token (the
+    /// launch's linked token for the initial prompt) is linked into that input's dispatch so cancelling
+    /// it aborts the send.</summary>
+    public Task EnqueueAsync(string text, CancellationToken ct = default) {
+        var item = new InputItem(text, ct);
         lock (_gate) _queue.Enqueue(item);
         PumpDispatch();
         return item.Ack.Task;
@@ -158,6 +156,7 @@ internal sealed class CodexTurnInputDispatcher {
                 }
             }
 
+            SignalTransitions(); // a pending turn/start is already in-flight — signal before awaiting it
             if (asSteer) await DispatchSteerAsync(item, turnId).ConfigureAwait(false);
             else         await DispatchStartAsync(item).ConfigureAwait(false);
         }
@@ -170,8 +169,9 @@ internal sealed class CodexTurnInputDispatcher {
     }
 
     async Task DispatchStartAsync(InputItem item) {
+        using var linked = LinkInputToken(item);
         try {
-            var started = await _startTurn(item.Text, _ct).ConfigureAwait(false);
+            var started = await _startTurn(item.Text, linked?.Token ?? _ct).ConfigureAwait(false);
             bool carried = false;
             lock (_gate) {
                 // FaultAll may have run during the await; if so the item is already faulted and the
@@ -200,8 +200,9 @@ internal sealed class CodexTurnInputDispatcher {
     }
 
     async Task DispatchSteerAsync(InputItem item, string turnId) {
+        using var linked = LinkInputToken(item);
         try {
-            await _steerTurn(turnId, item.Text, _ct).ConfigureAwait(false);
+            await _steerTurn(turnId, item.Text, linked?.Token ?? _ct).ConfigureAwait(false);
             bool carried = false;
             lock (_gate) {
                 if (!_faulted) { _pending = Pending.None; _queue.Dequeue(); carried = true; }
@@ -227,6 +228,11 @@ internal sealed class CodexTurnInputDispatcher {
         SignalTransitions();
     }
 
+    // Links a per-input token (e.g. the launch's linked token on the initial prompt) with the
+    // runtime-wide token; null when the input carried no cancellable token, so the caller uses _ct.
+    CancellationTokenSource? LinkInputToken(InputItem item) =>
+        item.Ct.CanBeCanceled ? CancellationTokenSource.CreateLinkedTokenSource(_ct, item.Ct) : null;
+
     void FailHead(InputItem item, Exception ex) {
         lock (_gate) {
             _pending = Pending.None;
@@ -237,6 +243,10 @@ internal sealed class CodexTurnInputDispatcher {
 
     bool IsSettledLocked() => _lifecycle == Lifecycle.Idle && _pending == Pending.None && _queue.Count == 0;
 
+    // In-flight spans from a turn/start being SENT (pending Start) through the active turn, matching the
+    // old clock's turn/start-to-turn/completed window — a pending Steer implies Active, so it's covered.
+    bool InFlightLocked() => _lifecycle == Lifecycle.Active || _pending == Pending.Start;
+
     // Fires the in-flight callback on a real change and releases any settled waiters — both OUTSIDE the
     // lock so a callback can never re-enter the dispatcher under it.
     void SignalTransitions() {
@@ -245,7 +255,7 @@ internal sealed class CodexTurnInputDispatcher {
         List<TaskCompletionSource>? settled = null;
 
         lock (_gate) {
-            inFlight = _lifecycle != Lifecycle.Idle;
+            inFlight = InFlightLocked();
             if (inFlight != _lastInFlight) { _lastInFlight = inFlight; fireInFlight = true; }
             if (IsSettledLocked() && _settledWaiters.Count > 0) {
                 settled = [.. _settledWaiters];
@@ -268,8 +278,9 @@ internal sealed class CodexTurnInputDispatcher {
     // An item is only ever touched by the single active dispatch loop (the _dispatching guard admits
     // exactly one), so its mutable RetriedAsStart needs no synchronization — the per-iteration lock
     // acquisitions fence the one write against the next iteration's read.
-    sealed class InputItem(string text) {
+    sealed class InputItem(string text, CancellationToken ct) {
         public string Text { get; } = text;
+        public CancellationToken Ct { get; } = ct;
         public TaskCompletionSource Ack { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public bool RetriedAsStart { get; set; }
     }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
@@ -1,0 +1,211 @@
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>Outcome of a <c>turn/start</c> dispatch — the server-assigned turn id and its status
+/// (<c>inProgress</c> unless the turn came back already terminal).</summary>
+internal readonly record struct CodexTurnStarted(string TurnId, string? Status);
+
+/// <summary>
+/// The single serializer for interactive hosted-Codex input. The app server accepts a concurrent
+/// <c>turn/start</c> without error (AI-1760 Q13 — it does NOT serialize turns for you), so
+/// serialization has to live on our side: every input surface enqueues here and ONE dispatcher drains,
+/// choosing <c>turn/start</c> when idle and <c>turn/steer</c> when a turn is active.
+///
+/// <para>Two orthogonal fields, deliberately not one flat state, because a notification can arrive
+/// while a request is in flight: <see cref="_pending"/> (the request whose JSON-RPC response is still
+/// outstanding, driven only by that response) and <see cref="_lifecycle"/> (Idle/Active/Completing,
+/// driven only by <c>turn/started</c>/<c>turn/completed</c>). The dispatcher invariant is on
+/// <see cref="_pending"/>: it dispatches the head input only when nothing is pending, so two inputs can
+/// never both observe idle and double-start (the exact hazard the server would accept). A steer the
+/// server rejects with <c>-32600</c> ("no active turn") is retried EXACTLY ONCE as a
+/// <c>turn/start</c> — in the dispatcher, never the enqueuing surface — and never dropped. An input is
+/// acknowledged only after the dispatch that actually carried it succeeds.</para>
+/// </summary>
+internal sealed class CodexTurnInputDispatcher {
+    // Sends turn/start with the input as the initial prompt; returns the started turn once the RESPONSE
+    // lands. Throws CodexAppServerRpcException on an error response.
+    readonly Func<string, CancellationToken, Task<CodexTurnStarted>> _startTurn;
+    // Sends turn/steer(expectedTurnId, input); returns when the RESPONSE lands. Throws
+    // CodexAppServerRpcException(-32600) when the turn is no longer active (the retryable miss).
+    readonly Func<string, string, CancellationToken, Task> _steerTurn;
+    readonly ILogger          _logger;
+    readonly CancellationToken _ct;
+
+    readonly object            _gate = new();
+    readonly Queue<InputItem>  _queue = new();
+
+    Pending   _pending   = Pending.None;
+    Lifecycle _lifecycle = Lifecycle.Idle;
+    string?   _activeTurnId;              // set in Active/Completing
+    string?   _completedBeforeStartResp; // a turn/completed seen while _pending=Start (turn id unknown yet)
+    bool      _dispatching;              // guards the fire-outside-lock dispatch against re-entrancy
+
+    public CodexTurnInputDispatcher(
+            Func<string, CancellationToken, Task<CodexTurnStarted>> startTurn,
+            Func<string, string, CancellationToken, Task> steerTurn,
+            ILogger logger, CancellationToken ct) {
+        _startTurn = startTurn;
+        _steerTurn = steerTurn;
+        _logger    = logger;
+        _ct        = ct;
+    }
+
+    /// <summary>True while a turn is live (Active or Completing) — the runtime's turn-in-flight signal.</summary>
+    public bool TurnInFlight { get { lock (_gate) return _lifecycle != Lifecycle.Idle; } }
+
+    /// <summary>Enqueues one input and returns a task that completes when the dispatch carrying it
+    /// (a <c>turn/start</c> or an accepted <c>turn/steer</c>) succeeds — the "wait for write" contract.
+    /// Faults if that dispatch errors or the runtime is torn down.</summary>
+    public Task EnqueueAsync(string text) {
+        var item = new InputItem(text);
+        lock (_gate) _queue.Enqueue(item);
+        PumpDispatch();
+        return item.Ack.Task;
+    }
+
+    /// <summary>Fed from the <c>turn/completed</c> notification. Advances the lifecycle and, when a
+    /// <c>turn/start</c> response has not yet identified its turn, stashes the completion so the
+    /// response can reconcile "this input rode a turn that already finished".</summary>
+    public void OnTurnCompleted(string? turnId) {
+        lock (_gate) {
+            if (_pending is Pending.Start && _activeTurnId is null) {
+                // Completion raced ahead of the start response — remember it by id; the response reconciles.
+                if (turnId is not null) _completedBeforeStartResp = turnId;
+                return;
+            }
+            if (turnId is not null && _activeTurnId is not null
+                && !string.Equals(_activeTurnId, turnId, StringComparison.Ordinal))
+                return; // a stale completion from another turn
+            _lifecycle    = Lifecycle.Idle;
+            _activeTurnId = null;
+        }
+        PumpDispatch();
+    }
+
+    /// <summary>Faults every queued and in-flight input — called on runtime teardown so no
+    /// "wait for write" caller hangs.</summary>
+    public void FaultAll(Exception ex) {
+        List<InputItem> orphans;
+        lock (_gate) {
+            orphans = [.. _queue];
+            _queue.Clear();
+            _pending      = Pending.None;
+            _lifecycle    = Lifecycle.Idle;
+            _activeTurnId = null;
+        }
+        foreach (var item in orphans) item.Ack.TrySetException(ex);
+    }
+
+    // Drains the queue as far as the invariant allows. Only one thread runs the fire-outside-lock body
+    // at a time (_dispatching); other callers just mark that another pass is needed and return.
+    void PumpDispatch() {
+        lock (_gate) {
+            if (_dispatching) return;
+            _dispatching = true;
+        }
+
+        _ = DispatchLoopAsync();
+    }
+
+    async Task DispatchLoopAsync() {
+      try {
+        while (true) {
+            InputItem item;
+            bool asSteer;
+            string turnId;
+
+            lock (_gate) {
+                if (_pending is not Pending.None || _queue.Count == 0) {
+                    _dispatching = false;
+                    return;
+                }
+                item = _queue.Peek();
+                if (_lifecycle == Lifecycle.Active && _activeTurnId is { } t) {
+                    asSteer = true;
+                    turnId  = t;
+                    _pending = Pending.Steer;
+                } else {
+                    asSteer = false;
+                    turnId  = "";
+                    _pending = Pending.Start;
+                    _completedBeforeStartResp = null;
+                }
+            }
+
+            if (asSteer) await DispatchSteerAsync(item, turnId).ConfigureAwait(false);
+            else         await DispatchStartAsync(item).ConfigureAwait(false);
+        }
+      } catch (Exception ex) {
+        // The dispatch primitives handle their own errors; this only fires on an unexpected fault, and
+        // must reset the guard so input dispatch can never wedge on a stuck _dispatching flag.
+        _logger.LogError(ex, "codex app-server: input dispatch loop faulted unexpectedly.");
+        lock (_gate) _dispatching = false;
+      }
+    }
+
+    async Task DispatchStartAsync(InputItem item) {
+        try {
+            var started = await _startTurn(item.Text, _ct).ConfigureAwait(false);
+            lock (_gate) {
+                _pending = Pending.None;
+                var alreadyDone = started.Status is not null and not "inProgress"
+                    || string.Equals(_completedBeforeStartResp, started.TurnId, StringComparison.Ordinal);
+                _completedBeforeStartResp = null;
+                if (alreadyDone) {
+                    _lifecycle    = Lifecycle.Idle;
+                    _activeTurnId = null;
+                } else {
+                    _lifecycle    = Lifecycle.Active;
+                    _activeTurnId = started.TurnId;
+                }
+                _queue.Dequeue();
+            }
+            item.Ack.TrySetResult(); // the start carried this input (it was the turn's prompt)
+        } catch (Exception ex) {
+            FailHead(item, ex);
+        }
+    }
+
+    async Task DispatchSteerAsync(InputItem item, string turnId) {
+        try {
+            await _steerTurn(turnId, item.Text, _ct).ConfigureAwait(false);
+            lock (_gate) {
+                _pending = Pending.None;
+                _queue.Dequeue();
+            }
+            item.Ack.TrySetResult(); // accepted onto the active turn before it completed
+        } catch (CodexAppServerRpcException rpc) when (rpc.Code == -32600 && !item.RetriedAsStart) {
+            // The turn ended before the steer landed (AI-1760 Q13). Retry this same input EXACTLY ONCE
+            // as a turn/start — force the lifecycle idle for the missed turn so the retry can't re-steer.
+            lock (_gate) {
+                item.RetriedAsStart = true;
+                _pending = Pending.None;
+                if (string.Equals(_activeTurnId, turnId, StringComparison.Ordinal)) {
+                    _lifecycle    = Lifecycle.Idle;
+                    _activeTurnId = null;
+                }
+            }
+            _logger.LogDebug("codex app-server: steer missed turn {TurnId}; retrying the input as turn/start.", turnId);
+        } catch (Exception ex) {
+            FailHead(item, ex);
+        }
+    }
+
+    void FailHead(InputItem item, Exception ex) {
+        lock (_gate) {
+            _pending = Pending.None;
+            if (_queue.Count > 0 && ReferenceEquals(_queue.Peek(), item)) _queue.Dequeue();
+        }
+        item.Ack.TrySetException(ex);
+    }
+
+    enum Pending   { None, Start, Steer }
+    enum Lifecycle { Idle, Active }
+
+    sealed class InputItem(string text) {
+        public string Text { get; } = text;
+        public TaskCompletionSource Ack { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public bool RetriedAsStart { get; set; }
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -82,6 +82,25 @@ public class CodexAppServerHostedAgentRuntimeTests {
     }
 
     [Test]
+    public async Task Input_on_an_active_turn_is_steered_not_restarted() {
+        var fake = new FakeCodexAppServer { HoldTurnOpen = true };
+        var (runtime, _, _) = Build(_ => fake, Launch());
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.SendUserInputAsync("first").WaitAsync(HangGuard);  // turn/start — turn stays active
+        await runtime.SendUserInputAsync("second").WaitAsync(HangGuard); // steered onto the active turn
+
+        await Assert.That(fake.ReceivedMethods).Contains("turn/steer");
+        await Assert.That(fake.LastSteerExpectedTurnId).IsEqualTo("turn-1");
+        await Assert.That(fake.LastSteerText).IsEqualTo("second");
+        await Assert.That(fake.ReceivedMethods.Count(m => m == "turn/start")).IsEqualTo(1); // NOT restarted
+
+        await fake.CompleteHeldTurnAsync();
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
     public async Task Initial_prompt_fires_the_first_turn_during_start() {
         var fake = new FakeCodexAppServer();
         var (runtime, _, _) = Build(_ => fake, Launch(prompt: "kick off the review"));

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
@@ -159,6 +159,29 @@ public class CodexTurnInputDispatcherTests {
     }
 
     [Test]
+    public async Task FaultAll_during_an_in_flight_start_does_not_resurrect_active_state() {
+        var sink  = new FakeTurnSink();
+        var flips = new List<bool>();
+        var d = new CodexTurnInputDispatcher(sink.Start, sink.Steer, NullLogger.Instance,
+            CancellationToken.None, onTurnInFlight: f => { lock (flips) flips.Add(f); });
+
+        var ack   = d.EnqueueAsync("a");
+        var start = await sink.NextStart();   // dispatched; the turn/start response is still pending
+
+        d.FaultAll(new ObjectDisposedException("runtime")); // teardown races the in-flight start
+        start.Started("turn-1");                             // the delegate resolves AFTER FaultAll
+
+        await Assert.That(async () => await ack.WaitAsync(Guard)).Throws<ObjectDisposedException>();
+        await Task.Delay(100); // let the post-fault continuation run — if it resurrected state, the checks below catch it
+        await Assert.That(d.TurnInFlight).IsFalse();
+        await Assert.That(d.CurrentTurnId).IsNull();
+        await d.WaitForSettledAsync().WaitAsync(Guard); // settled, never hangs on a ghost-active turn
+        bool wentActive;
+        lock (flips) wentActive = flips.Contains(true);
+        await Assert.That(wentActive).IsFalse(); // never signalled in-flight — no resurrection
+    }
+
+    [Test]
     public async Task FaultAll_faults_queued_and_in_flight_input() {
         var sink = new FakeTurnSink();
         var d    = Dispatcher(sink);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
@@ -1,0 +1,218 @@
+using System.Threading.Channels;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// The interactive input serializer (AI-1762 §2.2). Drives <see cref="CodexTurnInputDispatcher"/>
+/// against a channel-synchronized fake send-sink so each turn/start and turn/steer response — and each
+/// turn/completed notification — is released at a controlled moment, exercising the completion-window
+/// orderings deterministically (no sleeps).
+/// </summary>
+public class CodexTurnInputDispatcherTests {
+    static readonly TimeSpan Guard = TimeSpan.FromSeconds(5);
+
+    static CodexTurnInputDispatcher Dispatcher(FakeTurnSink sink) =>
+        new(sink.Start, sink.Steer, NullLogger.Instance, CancellationToken.None);
+
+    [Test]
+    public async Task Idle_input_dispatches_as_turn_start() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+
+        var ack   = d.EnqueueAsync("hello");
+        var start = await sink.NextStart();
+        await Assert.That(start.Text).IsEqualTo("hello");
+        await Assert.That(ack.IsCompleted).IsFalse();
+
+        start.Started("turn-1");
+        await ack.WaitAsync(Guard);
+        await Assert.That(d.TurnInFlight).IsTrue();
+    }
+
+    [Test]
+    public async Task Active_input_dispatches_as_turn_steer() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+
+        var ack1 = d.EnqueueAsync("a");
+        (await sink.NextStart()).Started("turn-1");
+        await ack1.WaitAsync(Guard);
+
+        var ack2  = d.EnqueueAsync("b");
+        var steer = await sink.NextSteer();
+        await Assert.That(steer.TurnId).IsEqualTo("turn-1");
+        await Assert.That(steer.Text).IsEqualTo("b");
+
+        steer.Accepted();
+        await ack2.WaitAsync(Guard);
+    }
+
+    [Test]
+    public async Task Two_idle_inputs_never_double_start() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+
+        var ack1 = d.EnqueueAsync("a");
+        var ack2 = d.EnqueueAsync("b");
+
+        var start = await sink.NextStart();      // only ONE start while the first is pending
+        await Assert.That(start.Text).IsEqualTo("a");
+        start.Started("turn-1");
+        await ack1.WaitAsync(Guard);
+
+        var steer = await sink.NextSteer();      // the second rode a steer, proving no double-start
+        await Assert.That(steer.Text).IsEqualTo("b");
+        steer.Accepted();
+        await ack2.WaitAsync(Guard);
+
+        await Assert.That(sink.StartCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Completion_before_start_response_reconciles_to_idle() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+
+        var ack   = d.EnqueueAsync("hello");
+        var start = await sink.NextStart();
+
+        d.OnTurnCompleted("turn-1"); // the completion races ahead of the start response
+        start.Started("turn-1");      // response arrives after
+
+        await ack.WaitAsync(Guard);
+        await Assert.That(d.TurnInFlight).IsFalse();
+    }
+
+    [Test]
+    public async Task Completion_before_steer_response_success_does_not_retry() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+
+        var ack1 = d.EnqueueAsync("a");
+        (await sink.NextStart()).Started("turn-1");
+        await ack1.WaitAsync(Guard);
+
+        var ack2  = d.EnqueueAsync("b");
+        var steer = await sink.NextSteer();
+
+        d.OnTurnCompleted("turn-1"); // completion arrives before the steer response
+        steer.Accepted();             // steer still succeeded → the input rode turn-1
+
+        await ack2.WaitAsync(Guard);
+        await Assert.That(sink.StartCount).IsEqualTo(1); // NOT retried as a start
+    }
+
+    [Test]
+    public async Task Steer_missed_retries_exactly_once_as_start() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+
+        var ack1 = d.EnqueueAsync("a");
+        (await sink.NextStart()).Started("turn-1");
+        await ack1.WaitAsync(Guard);
+
+        var ack2  = d.EnqueueAsync("b");
+        var steer = await sink.NextSteer();
+        steer.Missed(); // -32600: the turn ended before the steer landed
+
+        var retry = await sink.NextStart(); // retried as a turn/start for the SAME input
+        await Assert.That(retry.Text).IsEqualTo("b");
+        retry.Started("turn-2");
+
+        await ack2.WaitAsync(Guard);
+        await Assert.That(sink.StartCount).IsEqualTo(2);
+        await Assert.That(sink.SteerCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Steer_missed_retry_start_error_faults_the_input() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+
+        var ack1 = d.EnqueueAsync("a");
+        (await sink.NextStart()).Started("turn-1");
+        await ack1.WaitAsync(Guard);
+
+        var ack2  = d.EnqueueAsync("b");
+        (await sink.NextSteer()).Missed();
+
+        var retry = await sink.NextStart();
+        retry.Error(new InvalidOperationException("boom"));
+
+        await Assert.That(async () => await ack2.WaitAsync(Guard)).Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Input_text_passes_through_verbatim_no_carriage_return_spray() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+
+        var ack   = d.EnqueueAsync("line1\nline2\nline3");
+        var start = await sink.NextStart();
+
+        await Assert.That(start.Text).IsEqualTo("line1\nline2\nline3");
+        await Assert.That(start.Text.Contains('\r')).IsFalse();
+        start.Started("turn-1");
+        await ack.WaitAsync(Guard);
+    }
+
+    [Test]
+    public async Task FaultAll_faults_queued_and_in_flight_input() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+
+        var ack1 = d.EnqueueAsync("a");
+        await sink.NextStart();     // in flight (pending start)
+        var ack2 = d.EnqueueAsync("b"); // queued behind it
+
+        d.FaultAll(new ObjectDisposedException("runtime"));
+
+        await Assert.That(async () => await ack2.WaitAsync(Guard)).Throws<ObjectDisposedException>();
+    }
+
+    // ── Channel-synchronized fake send-sink ─────────────────────────────────────────────────────
+
+    sealed class FakeTurnSink {
+        readonly Channel<StartCall> _starts = Channel.CreateUnbounded<StartCall>();
+        readonly Channel<SteerCall> _steers = Channel.CreateUnbounded<SteerCall>();
+
+        int _startCount;
+        int _steerCount;
+        public int StartCount => Volatile.Read(ref _startCount);
+        public int SteerCount => Volatile.Read(ref _steerCount);
+
+        public Task<CodexTurnStarted> Start(string text, CancellationToken ct) {
+            Interlocked.Increment(ref _startCount);
+            var call = new StartCall(text);
+            _starts.Writer.TryWrite(call);
+            return call.Response.Task;
+        }
+
+        public Task Steer(string turnId, string text, CancellationToken ct) {
+            Interlocked.Increment(ref _steerCount);
+            var call = new SteerCall(turnId, text);
+            _steers.Writer.TryWrite(call);
+            return call.Response.Task;
+        }
+
+        public async Task<StartCall> NextStart() => await _starts.Reader.ReadAsync().AsTask().WaitAsync(Guard);
+        public async Task<SteerCall> NextSteer() => await _steers.Reader.ReadAsync().AsTask().WaitAsync(Guard);
+    }
+
+    sealed class StartCall(string text) {
+        public string Text { get; } = text;
+        public TaskCompletionSource<CodexTurnStarted> Response { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public void Started(string turnId, string status = "inProgress") => Response.TrySetResult(new CodexTurnStarted(turnId, status));
+        public void Error(Exception ex) => Response.TrySetException(ex);
+    }
+
+    sealed class SteerCall(string turnId, string text) {
+        public string TurnId { get; } = turnId;
+        public string Text   { get; } = text;
+        public TaskCompletionSource Response { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public void Accepted() => Response.TrySetResult();
+        public void Missed()   => Response.TrySetException(new CodexAppServerRpcException(-32600, "no active turn to steer"));
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
 
 /// <summary>
-/// The interactive input serializer (AI-1762 §2.2). Drives <see cref="CodexTurnInputDispatcher"/>
+/// The interactive input serializer (the app-server input design). Drives <see cref="CodexTurnInputDispatcher"/>
 /// against a channel-synchronized fake send-sink so each turn/start and turn/steer response — and each
 /// turn/completed notification — is released at a controlled moment, exercising the completion-window
 /// orderings deterministically (no sleeps).

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
@@ -32,6 +32,32 @@ public class CodexTurnInputDispatcherTests {
     }
 
     [Test]
+    public async Task Pending_turn_start_counts_as_in_flight() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+
+        var ack = d.EnqueueAsync("hello");
+        await sink.NextStart(); // dispatched; the turn/start response has NOT arrived yet
+
+        await Assert.That(d.TurnInFlight).IsTrue();                       // a hung start is in-flight (wedge ceiling)
+        await Assert.That(d.WaitForSettledAsync().IsCompleted).IsFalse(); // and not settled
+        await Assert.That(ack.IsCompleted).IsFalse();
+    }
+
+    [Test]
+    public async Task Cancelling_an_input_token_faults_that_dispatch() {
+        var sink = new FakeTurnSink();
+        var d    = Dispatcher(sink);
+        using var cts = new CancellationTokenSource();
+
+        var ack = d.EnqueueAsync("hello", cts.Token);
+        await sink.NextStart(); // dispatched; delegate awaiting the (cancellable) send
+        await cts.CancelAsync();
+
+        await Assert.That(async () => await ack.WaitAsync(Guard)).Throws<OperationCanceledException>();
+    }
+
+    [Test]
     public async Task Active_input_dispatches_as_turn_steer() {
         var sink = new FakeTurnSink();
         var d    = Dispatcher(sink);
@@ -176,9 +202,12 @@ public class CodexTurnInputDispatcherTests {
         await Assert.That(d.TurnInFlight).IsFalse();
         await Assert.That(d.CurrentTurnId).IsNull();
         await d.WaitForSettledAsync().WaitAsync(Guard); // settled, never hangs on a ghost-active turn
-        bool wentActive;
-        lock (flips) wentActive = flips.Contains(true);
-        await Assert.That(wentActive).IsFalse(); // never signalled in-flight — no resurrection
+
+        // In-flight went true (start dispatched) then false (fault); the guarded continuation must not
+        // flip it back to true — a resurrected turn would.
+        bool endedInFlight;
+        lock (flips) endedInFlight = flips.Count > 0 && flips[^1];
+        await Assert.That(endedInFlight).IsFalse();
     }
 
     [Test]
@@ -209,6 +238,7 @@ public class CodexTurnInputDispatcherTests {
         public Task<CodexTurnStarted> Start(string text, CancellationToken ct) {
             Interlocked.Increment(ref _startCount);
             var call = new StartCall(text);
+            ct.Register(() => call.Response.TrySetCanceled(ct)); // honour the dispatch token like the real send
             _starts.Writer.TryWrite(call);
             return call.Response.Task;
         }
@@ -216,6 +246,7 @@ public class CodexTurnInputDispatcherTests {
         public Task Steer(string turnId, string text, CancellationToken ct) {
             Interlocked.Increment(ref _steerCount);
             var call = new SteerCall(turnId, text);
+            ct.Register(() => call.Response.TrySetCanceled(ct));
             _steers.Writer.TryWrite(call);
             return call.Response.Task;
         }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
@@ -38,6 +38,9 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
     public string      ApprovalMethod = "item/commandExecution/requestApproval";
     public int         Fail32001TimesOnTurnStart;
     public (long input, long output, long total)? EmitUsageOnTurn;
+    // When set, turn/start responds inProgress and does NOT auto-emit turn/completed — the turn stays
+    // active so a follow-up input is steered onto it. Complete it with CompleteHeldTurnAsync.
+    public bool        HoldTurnOpen;
 
     // ── Observed ───────────────────────────────────────────────────────────────────────────────
     public readonly List<string>       ReceivedMethods    = [];
@@ -45,8 +48,11 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
     public string?                     LastThreadStartSandbox;
     public string?                     LastTurnApprovalPolicy;
     public string?                     LastTurnEffort;
+    public string?                     LastSteerExpectedTurnId;
+    public string?                     LastSteerText;
     public JsonElement?                ApprovalResponse; // the client's response to the injected request
-    int _turnStartCount;
+    int    _turnStartCount;
+    string _lastTurnId = "turn-x";
 
     public CodexAppServerConnection ConnectClient() {
         var conn = new CodexAppServerConnection(
@@ -126,6 +132,7 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
                     LastTurnEffort = ef.GetString();
 
                 var turnId = "turn-" + _turnStartCount;
+                _lastTurnId = turnId;
                 await RespondAsync(id, new JsonObject {
                     ["turn"] = new JsonObject { ["id"] = turnId, ["status"] = "inProgress", ["items"] = new JsonArray() },
                 }, ct);
@@ -136,6 +143,8 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
                         new JsonObject { ["threadId"] = ThreadId, ["turnId"] = turnId }, ct);
                     ApprovalResponse = resp;
                 }
+
+                if (HoldTurnOpen) break; // stay active for a follow-up turn/steer; test drives completion
 
                 if (EmitUsageOnTurn is { } u)
                     await NotifyAsync("thread/tokenUsage/updated", new JsonObject {
@@ -157,6 +166,14 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
                 break;
             }
 
+            case "turn/steer":
+                LastSteerExpectedTurnId = Str(@params, "expectedTurnId");
+                if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("input", out var steerInput)
+                    && steerInput.ValueKind == JsonValueKind.Array && steerInput.GetArrayLength() > 0)
+                    LastSteerText = Str(steerInput[0], "text");
+                await RespondAsync(id, new JsonObject { ["accepted"] = true }, ct);
+                break;
+
             case "turn/interrupt":
                 await RespondAsync(id, new JsonObject(), ct);
                 await NotifyAsync("turn/completed", new JsonObject {
@@ -170,6 +187,14 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
                 break;
         }
     }
+
+    /// <summary>Emits <c>turn/completed</c> for the most recently started turn — the test's way to end
+    /// a <see cref="HoldTurnOpen"/> turn once it has steered follow-up input onto it.</summary>
+    public Task CompleteHeldTurnAsync(string status = "completed") =>
+        NotifyAsync("turn/completed", new JsonObject {
+            ["threadId"] = ThreadId,
+            ["turn"]     = new JsonObject { ["id"] = _lastTurnId, ["status"] = status, ["items"] = new JsonArray() },
+        }, _cts.Token);
 
     async Task<JsonElement> ServerRequestAsync(string method, JsonNode @params, CancellationToken ct) {
         var id  = Interlocked.Increment(ref _nextServerId);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
@@ -2,6 +2,7 @@ using System.IO.Pipelines;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Harness.Codex;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -167,10 +168,9 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
             }
 
             case "turn/steer":
-                LastSteerExpectedTurnId = Str(@params, "expectedTurnId");
-                if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("input", out var steerInput)
-                    && steerInput.ValueKind == JsonValueKind.Array && steerInput.GetArrayLength() > 0)
-                    LastSteerText = Str(steerInput[0], "text");
+                LastSteerExpectedTurnId = @params.Str("expectedTurnId");
+                if (@params.Arr("input") is { } steerInput && steerInput.GetArrayLength() > 0)
+                    LastSteerText = steerInput[0].Str("text");
                 await RespondAsync(id, new JsonObject { ["accepted"] = true }, ct);
                 break;
 


### PR DESCRIPTION
First PR of the interactive-hosted-Codex phase (AI-1762) of the app-server epic (AI-1759). Daemon-only, behaviour-preserving for the shipped reviewer path.

## What
The hosted Codex app-server runtime gets a real input state machine. `SendUserInputAsync` no longer maps to a bare `turn/start`; all input now flows through `CodexTurnInputDispatcher` — one ordered queue drained by one dispatcher that chooses **`turn/start` when idle** and **`turn/steer` when a turn is active**.

## Why a dispatcher
The app server *accepts a concurrent `turn/start` without error* (the protocol spike proved it does not serialize turns for you), so serialization has to live on our side. The dispatcher keeps two orthogonal fields — `PendingRequest{None,Start,Steer}` (driven by the JSON-RPC response) and `Lifecycle{Idle,Active}` (driven by `turn/completed`) — because a notification can arrive while a request is in flight. Invariant: dispatch the head input only when nothing is pending, so two inputs can never both observe idle and double-start. A steer the server rejects with `-32600` ("no active turn") is retried **exactly once** as a `turn/start`, in the dispatcher, never dropped. Input is acked only after the dispatch that carried it succeeds. No CR-spray — text passes through verbatim.

## Integration
The runtime now derives all turn state from the dispatcher: `WaitForTurnIdleAsync` reads its settled signal, the turn-in-flight clock and the `turn/interrupt` target (`CurrentTurnId`) come from it, and the old per-round `_turnGate`/`_turnCompleted`/`_pendingCompletion` machinery is gone. Reviewers only ever start turns when idle, so the AI-1761 reviewer path is behaviour-preserving.

## Scope / not in this PR
Routing is unchanged — interactive launches still go to PTY (the routing flip is a later PR). Approvals, the envelope transcript, dedup, lifecycle, and slot economics are their own PRs. No new CLI surface, no config, no server changes.

## Tests
- **9 dispatcher unit tests** (channel-synchronized fake sink, no sleeps): all three completion-window orderings, the double-start hazard, the steer-missed single-retry bound, verbatim passthrough (no `\r`), teardown fault propagation.
- **1 new runtime test**: a second input on an active turn is steered (`expectedTurnId` + text), not restarted.
- The **13 existing reviewer runtime tests stay green**; sibling Codex suites (connection/posture/launch-args) unaffected. Daemon AOT publish clean.

Linear: AI-1762