### PR TITLE
Validate ACP permission preset before the consent gate (+ Qodo cleanups)

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1491,16 +1491,10 @@ public sealed record ExplicitReviewerModelResolvedV1(
     string PolicyVersion,
     string EquivalenceKey);
 
-/// <summary>
-/// Daemon -> server (hub method <c>NotifyAcpAutoApproval</c>): one FIRE-AND-FORGET audit notice that
-/// a launch-time permission preset auto-approved an ACP <c>session/request_permission</c> without a
-/// human. The server validates every field (null-safe shape check, then bounds/allowlists), resolves
-/// the bound ACP session under its terminal-ordering gate, and appends ONE audit event per target
-/// stream. Audit-only and fail-open on the server; the CLI sends it fire-and-forget and swallows any
-/// send fault (missing-method included) so a mixed-version rollout never surfaces it as a failure.
-/// Matches the server wire record shape EXACTLY (field name / type / nullability) — the snake_case
-/// name binding means a rename on either side silently breaks the wire.
-/// </summary>
+/// <summary>Daemon → server (<c>NotifyAcpAutoApproval</c>): a fire-and-forget audit notice that a
+/// launch-time permission preset auto-approved one ACP <c>session/request_permission</c> without a
+/// human. Wire shape must match the server's record EXACTLY — the snake_case name binding means a
+/// rename on either side silently breaks it.</summary>
 public sealed record AcpAutoApprovalNotice(
     string  AgentId,
     string  AcpSessionId,

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -709,23 +709,14 @@ internal sealed partial class AcpInteractionBridge(
     static string OutcomeLabel(JsonElement mapped) =>
         mapped.GetProperty("outcome").GetProperty("outcome").GetString() ?? "cancelled";
 
-    static string? TryGetToolTitle(JsonElement toolCall) =>
-        toolCall.ValueKind == JsonValueKind.Object && toolCall.TryGetProperty("title", out var t) && t.ValueKind == JsonValueKind.String
-            ? t.GetString()
-            : null;
+    static string? TryGetToolTitle(JsonElement toolCall)  => toolCall.Str("title");
 
-    static string? TryGetToolCallId(JsonElement toolCall) =>
-        toolCall.ValueKind == JsonValueKind.Object && toolCall.TryGetProperty("toolCallId", out var id) && id.ValueKind == JsonValueKind.String
-            ? id.GetString()
-            : null;
+    static string? TryGetToolCallId(JsonElement toolCall) => toolCall.Str("toolCallId");
 
     /// <summary>The ACP <c>toolCall.kind</c> token, or null when the frame carries none (defensive,
     /// mirroring <see cref="TryGetToolTitle"/>). A kind-less frame — e.g. kiro-cli's, which carries
     /// only <c>{toolCallId, title}</c> — therefore never matches a preset and keeps prompting.</summary>
-    static string? TryGetToolKind(JsonElement toolCall) =>
-        toolCall.ValueKind == JsonValueKind.Object && toolCall.TryGetProperty("kind", out var k) && k.ValueKind == JsonValueKind.String
-            ? k.GetString()
-            : null;
+    static string? TryGetToolKind(JsonElement toolCall)   => toolCall.Str("kind");
 
     // ── LoggerMessage source-generated methods ──────────────────────────────────────────────────
     // Payload-free by construction: kind ("permission"/"elicitation") and decision

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1537,6 +1537,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         var isReview      = cmd.Kind == LaunchKind.Review;
         var isReviewFlow  = cmd.Kind == LaunchKind.ReviewFlow;
 
+        // A caller-selected ACP permission preset is a pure, side-effect-free rejection (wrong-vendor /
+        // non-interactive / borrowed / unknown token), validated BEFORE the consent gate: an ineligible
+        // preset must fail the launch WITHOUT first prompting the owner or holding the serialized command
+        // lane for the consent timeout on a launch that can never proceed.
+        if (AcpPermissionPresetPolicy.RejectionReason(cmd) is { } presetRejection) {
+            await _server.LaunchFailedAsync(cmd.AgentId, presetRejection);
+
+            return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
+        }
+
         // Owner consent gate. Server-driven launches only — the local 0600 socket path
         // (HandleLocalSpawnAsync) is the owner's by construction and never consults this.
         // NOTE: in prompt mode this can hold the sequenced slot up to PromptTimeoutSeconds (≤300s,
@@ -1614,15 +1624,6 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // rather than being silently dropped or silently honoured.
         if (CodexPosturePolicy.RejectionReason(cmd) is { } postureRejection) {
             await _server.LaunchFailedAsync(cmd.AgentId, postureRejection);
-
-            return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
-        }
-
-        // A caller-selected ACP permission preset is validated here too — same pre-side-effect
-        // guarantee: a preset on a non-ACP-routed, non-interactive or borrowed launch fails the launch
-        // rather than being silently dropped or honoured.
-        if (AcpPermissionPresetPolicy.RejectionReason(cmd) is { } presetRejection) {
-            await _server.LaunchFailedAsync(cmd.AgentId, presetRejection);
 
             return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
         }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpPermissionPresetPolicyTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpPermissionPresetPolicyTests.cs
@@ -43,6 +43,17 @@ public class AcpPermissionPresetPolicyTests {
     }
 
     [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task Preset_with_a_null_or_blank_vendor_is_rejected_not_thrown(string? vendor) {
+        // The policy now runs BEFORE the orchestrator's vendor null-guard, so RoutedVendors.Contains
+        // must tolerate the null/blank vendor a LaunchAgentCommand can carry across the unenforced
+        // SignalR boundary — a clean rejection, never a throw.
+        await Assert.That(AcpPermissionPresetPolicy.RejectionReason(Cmd(vendor: vendor!))).StartsWith("acp_preset_wrong_vendor:");
+    }
+
+    [Test]
     [Arguments(LaunchKind.ReviewFlow)]
     [Arguments(LaunchKind.Review)]
     public async Task Preset_on_a_non_interactive_launch_is_rejected(LaunchKind kind) {


### PR DESCRIPTION
Follow-up to #585 (merged before Qodo's review posted). Addresses all three Qodo findings.

**Linear:** AI-2019

### 1. Reliability bug — preset validated after the consent gate (`AgentOrchestrator`)
`AcpPermissionPresetPolicy.RejectionReason` ran *after* `LaunchConsentGate.DecideAsync`, so an ineligible preset (wrong-vendor / non-interactive / borrowed / unknown token) on an otherwise-valid ACP launch would prompt the owner for consent and occupy the serialized command lane for up to the consent timeout before its guaranteed rejection — delaying unrelated launch/stop commands and presenting consent for a launch that can never proceed. The check is pure and side-effect-free, so it now runs **before** the consent gate.

### 2. Convention — `TryGetToolKind` bypassed the JSON helper (`AcpInteractionBridge`)
`TryGetTool{Kind,Title,CallId}` hand-rolled `ValueKind`/`TryGetProperty` checks. Per the repo convention ("DO use `JsonElementExtensions`"), all three now delegate to `JsonElementExtensions.Str(...)` — byte-for-byte equivalent semantics (object-guarded, string-typed, null otherwise). Converted all three (the two siblings share the identical pattern) for file consistency.

### 3. Comment verbosity — `AcpAutoApprovalNotice` doc (`Models.cs`)
Trimmed the 10-line XML summary to purpose + the one load-bearing constraint (wire shape must match the server record exactly; name-bound).

### Safety of the ordering move
Moving the preset check ahead of the vendor null-guard exposes `RoutedVendors.Contains` to the null/blank vendor a `LaunchAgentCommand` can carry across the unenforced SignalR boundary. Added a test asserting `null` / `""` / `"   "` vendors reject cleanly (`acp_preset_wrong_vendor`) rather than throwing.

### Verification
`dotnet build` clean; daemon unit suites green locally — preset policy 18/18 (incl. the 3 new null/blank cases), preset bridge 17/17, orchestrator 165/165.