### PR TITLE
[AI-2060] Skip nested git worktrees when overlaying .claude/ into agent worktrees

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/FileSystemOverlay.cs
+++ b/src/Capacitor.Cli.Daemon/Services/FileSystemOverlay.cs
@@ -19,6 +19,13 @@ internal static class FileSystemOverlay {
         }
 
         foreach (var dir in Directory.GetDirectories(source, "*", skipReparsePoints)) {
+            // Never recurse into a nested git working tree / repo. A dotfile overlay copies local
+            // config (settings, commands, skills) — never a checked-out repo. Some setups keep whole
+            // worktrees under .claude/worktrees/ (the superpowers using-git-worktrees convention); a
+            // repo root can hold hundreds, and recursing in copies gigabytes into the agent worktree
+            // and wedges the daemon for many minutes per launch. A ".git" entry marks one — a
+            // directory for a normal repo, a pointer file for a linked worktree.
+            if (Path.Exists(Path.Combine(dir, ".git"))) continue;
             OverlayDirectory(dir, Path.Combine(dest, Path.GetFileName(dir)));
         }
     }

--- a/src/Capacitor.Cli.Daemon/Services/FileSystemOverlay.cs
+++ b/src/Capacitor.Cli.Daemon/Services/FileSystemOverlay.cs
@@ -19,12 +19,9 @@ internal static class FileSystemOverlay {
         }
 
         foreach (var dir in Directory.GetDirectories(source, "*", skipReparsePoints)) {
-            // Never recurse into a nested git working tree / repo. A dotfile overlay copies local
-            // config (settings, commands, skills) — never a checked-out repo. Some setups keep whole
-            // worktrees under .claude/worktrees/ (the superpowers using-git-worktrees convention); a
-            // repo root can hold hundreds, and recursing in copies gigabytes into the agent worktree
-            // and wedges the daemon for many minutes per launch. A ".git" entry marks one — a
-            // directory for a normal repo, a pointer file for a linked worktree.
+            // Skip nested repos/worktrees: a dotfile overlay copies config, not checked-out repos —
+            // and a repo root with worktrees under .claude/worktrees/ would be copied wholesale. A
+            // ".git" entry (dir for a repo, file for a linked worktree) marks one.
             if (Path.Exists(Path.Combine(dir, ".git"))) continue;
             OverlayDirectory(dir, Path.Combine(dest, Path.GetFileName(dir)));
         }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FileSystemOverlayTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FileSystemOverlayTests.cs
@@ -68,49 +68,48 @@ public class FileSystemOverlayTests {
     public async Task OverlayDirectory_does_not_recurse_into_nested_git_worktree() {
         using var tmp = new OverlayDirs();
 
-        // A normal config subdir IS copied.
-        var commands = Path.Combine(tmp.Source, "commands");
-        Directory.CreateDirectory(commands);
-        File.WriteAllText(Path.Combine(commands, "cmd.md"), "do a thing");
+        // A normal config subdir is copied.
+        tmp.SourceDir.CreateDir("commands").CreateFile("cmd.md", "do a thing");
 
-        // A nested worktree (marked by a .git pointer FILE) must NOT be recursed into — this is the
-        // .claude/worktrees/<x> shape that ballooned the overlay to gigabytes and wedged the daemon.
-        var nested = Path.Combine(tmp.Source, "worktrees", "feature-x");
-        Directory.CreateDirectory(nested);
-        File.WriteAllText(Path.Combine(nested, ".git"), "gitdir: /repo/.git/worktrees/feature-x");
-        File.WriteAllText(Path.Combine(nested, "huge.bin"), "pretend this is gigabytes");
+        // A nested worktree, marked by a .git pointer file, must not be recursed into.
+        var worktree = tmp.SourceDir.CreateDir("worktrees", "feature-x");
+        worktree.CreateFile(".git", "gitdir: /repo/.git/worktrees/feature-x");
+        worktree.CreateFile("huge.bin", "x");
 
         FileSystemOverlay.OverlayDirectory(tmp.Source, tmp.Dest);
 
-        await Assert.That(File.Exists(Path.Combine(tmp.Dest, "commands", "cmd.md"))).IsTrue();
-        await Assert.That(File.Exists(Path.Combine(tmp.Dest, "worktrees", "feature-x", "huge.bin"))).IsFalse();
+        await Assert.That(File.Exists(tmp.DestDir.PathTo("commands", "cmd.md"))).IsTrue();
+        await Assert.That(File.Exists(tmp.DestDir.PathTo("worktrees", "feature-x", "huge.bin"))).IsFalse();
     }
 
     [Test]
     public async Task OverlayDirectory_does_not_recurse_into_nested_git_repo() {
         using var tmp = new OverlayDirs();
 
-        // A regular nested repo, marked by a .git DIRECTORY, must also be skipped.
-        var repo = Path.Combine(tmp.Source, "vendored");
-        Directory.CreateDirectory(Path.Combine(repo, ".git"));
-        File.WriteAllText(Path.Combine(repo, "code.cs"), "class C {}");
+        // A nested repo, marked by a .git directory, must also be skipped.
+        var repo = tmp.SourceDir.CreateDir("vendored");
+        repo.CreateDir(".git");
+        repo.CreateFile("code.cs", "class C {}");
 
         FileSystemOverlay.OverlayDirectory(tmp.Source, tmp.Dest);
 
-        await Assert.That(File.Exists(Path.Combine(tmp.Dest, "vendored", "code.cs"))).IsFalse();
+        await Assert.That(File.Exists(tmp.DestDir.PathTo("vendored", "code.cs"))).IsFalse();
     }
 
     sealed class OverlayDirs : IDisposable {
         readonly TempDir _root = new();
 
-        public string Source { get; }
-        public string Dest { get; }
+        public TempDirHandle SourceDir { get; }
+        public TempDirHandle DestDir { get; }
+
+        public string Source => SourceDir;
+        public string Dest => DestDir;
         public string External { get; }
 
         public OverlayDirs() {
-            Source   = _root.CreateDir("source");
-            Dest     = _root.CreateDir("dest");
-            External = _root.CreateDir("external");
+            SourceDir = _root.CreateDir("source");
+            DestDir   = _root.CreateDir("dest");
+            External  = _root.CreateDir("external");
         }
 
         public void Dispose() => _root.Dispose();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FileSystemOverlayTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FileSystemOverlayTests.cs
@@ -64,6 +64,42 @@ public class FileSystemOverlayTests {
         await Assert.That(Directory.Exists(Path.Combine(tmp.Dest, "loop"))).IsFalse();
     }
 
+    [Test]
+    public async Task OverlayDirectory_does_not_recurse_into_nested_git_worktree() {
+        using var tmp = new OverlayDirs();
+
+        // A normal config subdir IS copied.
+        var commands = Path.Combine(tmp.Source, "commands");
+        Directory.CreateDirectory(commands);
+        File.WriteAllText(Path.Combine(commands, "cmd.md"), "do a thing");
+
+        // A nested worktree (marked by a .git pointer FILE) must NOT be recursed into — this is the
+        // .claude/worktrees/<x> shape that ballooned the overlay to gigabytes and wedged the daemon.
+        var nested = Path.Combine(tmp.Source, "worktrees", "feature-x");
+        Directory.CreateDirectory(nested);
+        File.WriteAllText(Path.Combine(nested, ".git"), "gitdir: /repo/.git/worktrees/feature-x");
+        File.WriteAllText(Path.Combine(nested, "huge.bin"), "pretend this is gigabytes");
+
+        FileSystemOverlay.OverlayDirectory(tmp.Source, tmp.Dest);
+
+        await Assert.That(File.Exists(Path.Combine(tmp.Dest, "commands", "cmd.md"))).IsTrue();
+        await Assert.That(File.Exists(Path.Combine(tmp.Dest, "worktrees", "feature-x", "huge.bin"))).IsFalse();
+    }
+
+    [Test]
+    public async Task OverlayDirectory_does_not_recurse_into_nested_git_repo() {
+        using var tmp = new OverlayDirs();
+
+        // A regular nested repo, marked by a .git DIRECTORY, must also be skipped.
+        var repo = Path.Combine(tmp.Source, "vendored");
+        Directory.CreateDirectory(Path.Combine(repo, ".git"));
+        File.WriteAllText(Path.Combine(repo, "code.cs"), "class C {}");
+
+        FileSystemOverlay.OverlayDirectory(tmp.Source, tmp.Dest);
+
+        await Assert.That(File.Exists(Path.Combine(tmp.Dest, "vendored", "code.cs"))).IsFalse();
+    }
+
     sealed class OverlayDirs : IDisposable {
         readonly TempDir _root = new();
 


### PR DESCRIPTION
## Problem

Hosted **Claude** agent launches "hang / never start" with no error. `FileSystemOverlay.OverlayDirectory` recursively copies the source repo's `.claude/` into each new agent worktree (`Harness/Claude/ClaudeLauncher.cs`). It already skips symlinks, but **descends into real nested git worktrees**.

The `superpowers:using-git-worktrees` convention keeps whole worktrees under `.claude/worktrees/`. Launching a Claude agent with cwd = the **main repo root** (holding ~200 worktrees, each a full checkout) therefore recursively copies **~185 GB / millions of files per launch** — ~16 minutes each. Because the copy is wrapped in `try/catch`, nothing is logged; the daemon just goes silent after `Launching agent X`. The server's launch-reservation TTL expires (`no live launch reservation … TTL-evicted launch`), and since the daemon serialises launches, every following launch is blocked too.

Observed on the `kurrent.kcap.ai` tenant (daemon v0.11.28): two Claude + one Kiro launch failed in a 15-min window; ~296 GB of bloated `.capacitor/worktrees/agent-*` had to be reclaimed by hand.

## Fix

Skip any subdirectory that is a git working tree/repo when overlaying — `Path.Exists(<dir>/.git)` catches both a `.git` directory (normal repo) and a `.git` pointer file (linked worktree). A dotfile overlay is never meant to duplicate a repo.

Two unit tests pin both the worktree (`.git` file) and repo (`.git` dir) cases, alongside a positive case that ordinary config subdirs still copy.

## Test

`FileSystemOverlayTests` — 6/6 pass locally (Release).

Fixes AI-2060.
