### PR TITLE
Codex app-server: envelope transcript source (mapper + forward buffer)

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1230,6 +1230,14 @@ public static class AcpEventKind {
     /// cursor (verified against <c>CapacitorHub.AcpSessionEvents</c>'s unrecognised-Kind branch), so
     /// a newer daemon degrades to log-only rather than wedging the forwarder.</summary>
     public const string SystemNote         = "system_note";
+
+    /// <summary>A full plan snapshot (codex app-server <c>turn/plan/updated</c>, which always sends
+    /// complete revisions). Canonical, latest-snapshot-wins; the server maps it to
+    /// <c>PlanContentUpdatedEvent</c>, landing envelope-sourced sessions on the same native-plan path
+    /// <c>PlanArtifactExtractor</c> already consumes. Additive for other ACP vendors (their translator
+    /// may keep dropping plan updates until wired). An older server treats it as an unrecognised Kind
+    /// (dropped, cursor still advances).</summary>
+    public const string Plan               = "plan";
 }
 
 /// <summary>
@@ -1285,7 +1293,21 @@ public readonly record struct AcpEventEnvelope(
         long?   ContextWindowTokens = null,
 
         // transcript-authoritative time (ISO-8601); server falls back to now if absent
-        string? TimestampIso      = null
+        string? TimestampIso      = null,
+
+        // Ephemeral live lane (codex app-server envelope transcript). Additive/default-false, so
+        // ContractVersion stays 1: an older server ignores both and its canonical-only path is
+        // unchanged. Ephemeral=true marks a transient live chunk (accumulated content-so-far for its
+        // item) that is relayed but NEVER persisted and carries NO seq — it consumes no canonical
+        // sequence number and is excluded from the dup/gap logic (the server relays it in batch order).
+        // The pure-replacement viewer rule (state[ItemId] = latest ephemeral payload; the item's
+        // canonical completed envelope replaces and finalizes it) makes a dropped/duplicated ephemeral
+        // harmless. ItemId is the app-server item id — the stable key a viewer uses to know which
+        // transient state a completed item supersedes; it rides BOTH the ephemeral envelopes and their
+        // item's canonical completed envelope, and the server stamps it into the canonical event's
+        // METADATA (the event records are not ours to change).
+        bool    Ephemeral         = false,
+        string? ItemId            = null
     );
 
 /// <summary>

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1241,7 +1241,8 @@ public static class AcpEventKind {
 
     /// <summary>A per-event additive token-usage DELTA (codex app-server <c>thread/tokenUsage/updated</c>,
     /// daemon-converted from cumulative to delta and attributed to the model resolved at that instant).
-    /// Distinct from <see cref="Usage"/>, which is context-window OCCUPANCY (AI-1531 D4), not additive
+    /// Distinct from <see cref="Usage"/>, which is context-window OCCUPANCY (the ACP context-usage
+    /// reading), not additive
     /// billing buckets. The server stamps these buckets into Eventuous <c>$usage</c> metadata so the
     /// existing additive folds (session totals, per-model attribution, cost) count them unchanged. An
     /// older server treats it as an unrecognised Kind (dropped, cursor still advances).</summary>

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1238,6 +1238,14 @@ public static class AcpEventKind {
     /// may keep dropping plan updates until wired). An older server treats it as an unrecognised Kind
     /// (dropped, cursor still advances).</summary>
     public const string Plan               = "plan";
+
+    /// <summary>A per-event additive token-usage DELTA (codex app-server <c>thread/tokenUsage/updated</c>,
+    /// daemon-converted from cumulative to delta and attributed to the model resolved at that instant).
+    /// Distinct from <see cref="Usage"/>, which is context-window OCCUPANCY (AI-1531 D4), not additive
+    /// billing buckets. The server stamps these buckets into Eventuous <c>$usage</c> metadata so the
+    /// existing additive folds (session totals, per-model attribution, cost) count them unchanged. An
+    /// older server treats it as an unrecognised Kind (dropped, cursor still advances).</summary>
+    public const string TokenUsage         = "token_usage";
 }
 
 /// <summary>
@@ -1307,7 +1315,19 @@ public readonly record struct AcpEventEnvelope(
         // item's canonical completed envelope, and the server stamps it into the canonical event's
         // METADATA (the event records are not ours to change).
         bool    Ephemeral         = false,
-        string? ItemId            = null
+        string? ItemId            = null,
+
+        // token_usage — a per-event additive token DELTA (codex app-server). Additive/nullable, so
+        // ContractVersion stays 1: an older server ignores them. The model rides the Model field
+        // above (attributed to the model resolved at the delta's instant — correct across a reroute).
+        // input is GROSS (server converts to net = input − cached before stamping $usage, matching
+        // UsageMetadataHelper's cross-vendor contract). cache-write is the cache-CREATION tier, billed
+        // separately from cached reads. total is derived server-side and not carried.
+        long?   UsageInputTokens       = null,
+        long?   UsageCachedInputTokens = null,
+        long?   UsageCacheWriteInputTokens = null,
+        long?   UsageOutputTokens      = null,
+        long?   UsageReasoningTokens   = null
     );
 
 /// <summary>

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -243,10 +243,14 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         _runLoop  = RunConnectionAsync(connection, _childCts.Token);
         _clock?.SetLaunchStage("spawned");
 
+        // With the envelope transcript ON, the mapper's ephemeral lane consumes exactly the delta streams
+        // DeltaOptOut suppresses, so opting out would silence the live lane the gate is meant to enable —
+        // receive everything. With it OFF (reviewer path), keep the perf opt-out.
+        var optOut = _emitEnvelopeTranscript ? Array.Empty<string>() : DeltaOptOut;
         var initParams = new JsonObject {
             ["clientInfo"]   = new JsonObject { ["name"] = ClientName, ["version"] = _launch.ClientVersion },
             ["capabilities"] = new JsonObject {
-                ["optOutNotificationMethods"] = new JsonArray(DeltaOptOut.Select(m => (JsonNode?) m).ToArray()),
+                ["optOutNotificationMethods"] = new JsonArray(optOut.Select(m => (JsonNode?) m).ToArray()),
             },
         };
         await RequestAsync("initialize", initParams, ct).ConfigureAwait(false);

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -480,13 +480,7 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         if (paramsEl is not { } p || p.Obj("tokenUsage") is not { } u || u.Obj("total") is not { } total)
             return null;
 
-        return new CodexTokenUsage(
-            InputTokens:            total.Num("inputTokens")            ?? 0,
-            CachedInputTokens:      total.Num("cachedInputTokens")      ?? 0,
-            CacheWriteInputTokens:  total.Num("cacheWriteInputTokens")  ?? 0,
-            OutputTokens:           total.Num("outputTokens")           ?? 0,
-            ReasoningOutputTokens:  total.Num("reasoningOutputTokens")  ?? 0,
-            TotalTokens:            total.Num("totalTokens")            ?? 0);
+        return CodexTokenUsage.FromTotal(total);
     }
 
     // JsonNode → JsonElement without reflection (AOT-safe): the node writes its own JSON.
@@ -500,4 +494,22 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
 /// drops a billed bucket.</summary>
 internal readonly record struct CodexTokenUsage(
     long InputTokens, long CachedInputTokens, long CacheWriteInputTokens,
-    long OutputTokens, long ReasoningOutputTokens, long TotalTokens);
+    long OutputTokens, long ReasoningOutputTokens, long TotalTokens) {
+
+    /// <summary>Reads a <c>TokenUsageBreakdown</c> object (<c>thread/tokenUsage/updated.total</c> or
+    /// <c>.last</c>). Missing fields read as 0 (the schema defaults <c>cacheWriteInputTokens</c> to 0
+    /// and the others are required).</summary>
+    public static CodexTokenUsage FromTotal(JsonElement total) => new(
+        InputTokens:           total.Num("inputTokens")           ?? 0,
+        CachedInputTokens:     total.Num("cachedInputTokens")     ?? 0,
+        CacheWriteInputTokens: total.Num("cacheWriteInputTokens") ?? 0,
+        OutputTokens:          total.Num("outputTokens")          ?? 0,
+        ReasoningOutputTokens: total.Num("reasoningOutputTokens") ?? 0,
+        TotalTokens:           total.Num("totalTokens")           ?? 0);
+
+    /// <summary>True when every additive bucket is zero — a delta carrying no information, which the
+    /// mapper drops rather than stamping an empty <c>$usage</c>.</summary>
+    public bool IsZero =>
+        InputTokens == 0 && CachedInputTokens == 0 && CacheWriteInputTokens == 0
+     && OutputTokens == 0 && ReasoningOutputTokens == 0 && TotalTokens == 0;
+}

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Threading.Channels;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
 using Capacitor.Cli.Daemon.Acp;
@@ -41,11 +42,13 @@ internal sealed record CodexAppServerLaunch(
     string                ClientVersion);
 
 /// <summary>
-/// A <see cref="IHostedAgentRuntime"/> that hosts a Codex reviewer over the <c>codex app-server</c>
-/// JSON-RPC protocol instead of the interactive PTY. It is control-plane only: the transcript is
-/// still recorded through the Codex hooks + <c>kcap watch</c> rollout path (which is why the
-/// hook-trust preflight is load-bearing), so this runtime never aggregates transcript from the
-/// protocol stream and <see cref="EmitsTerminalOutput"/> is <see langword="false"/>.
+/// A <see cref="IHostedAgentRuntime"/> that hosts a Codex agent over the <c>codex app-server</c>
+/// JSON-RPC protocol instead of the interactive PTY. It exposes <see cref="IAcpTranscriptSource"/>
+/// (§2.4): every app-server notification is translated by <see cref="CodexNotificationMapper"/> into the
+/// canonical/ephemeral <see cref="AcpEventEnvelope"/> vocabulary and drained through a bounded
+/// <see cref="CodexForwardBuffer"/>, so the envelope transcript — not the hooks + <c>kcap watch</c>
+/// rollout path — is the ingestion source for hosted app-server sessions. <see cref="EmitsTerminalOutput"/>
+/// stays <see langword="false"/> (this is a structured, not terminal, view).
 ///
 /// <para>Lifecycle (<see cref="StartAsync"/>, called by the factory): spawn → <c>initialize</c> →
 /// <c>hooks/list</c> trust preflight (seed + one restart when required) → <c>thread/start</c> →
@@ -57,7 +60,7 @@ internal sealed record CodexAppServerLaunch(
 /// request is a protocol violation — answered with a valid on-the-wire <c>decline</c> (never a
 /// JSON-RPC error, whose turn/process effect is Codex's to define) and logged at Error.</para>
 /// </summary>
-internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRuntime {
+internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscriptSource {
     // Reviewers need lifecycle + usage only; opting out of the high-volume delta streams is a
     // performance choice (the reader always drains regardless — the app-server blocks rather than
     // dropping), not a correctness one.
@@ -71,6 +74,13 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
 
     const string ClientName = "kcap-daemon";
     const int    BackpressureMaxAttempts = 6;
+
+    // §2.4 forward buffer sizing. The capacity trades memory for the SignalR-outage window a canonical
+    // burst can ride before the read loop blocks; the stall timeout bounds that block before a
+    // deterministic terminal fault. `codex.appServer.forwardStallSeconds` (spec-named) maps to the
+    // injectable stall timeout below; the default engages when the caller passes none.
+    const int    ForwardBufferCapacity      = 1024;
+    const double DefaultForwardStallSeconds = 30;
 
     readonly CodexAppServerSpawn  _spawn;
     readonly CodexAppServerLaunch _launch;
@@ -90,6 +100,11 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     // clock, WaitForTurnIdle) is derived from it — the runtime no longer tracks turns itself.
     readonly CodexTurnInputDispatcher _dispatcher;
 
+    // §2.4 envelope transcript: the mapper translates every app-server notification into
+    // canonical/ephemeral envelopes, drained through the bounded forward buffer (IAcpTranscriptSource).
+    readonly CodexNotificationMapper _mapper;
+    readonly CodexForwardBuffer      _forwardBuffer;
+
     CodexAppServerConnection? _connection;
     IAcpProcess?              _process;
     Task                      _runLoop = Task.CompletedTask;
@@ -101,17 +116,32 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     CodexTokenUsage?          _usage;
     int                       _disposed;
 
+    // §2.4 envelope emission is gated OFF until §2.5 activates the envelope-source ingestion (deferred
+    // first-turn, source claim, and the hooks/watch dedup). Feeding the buffer while it is NOT drained
+    // by an attached AcpTranscriptForwarder would fill it and stall the read loop; draining it WITHOUT
+    // the §2.5 dedup would double-ingest a reviewer session (hooks + envelopes). So the transcript
+    // surface (IAcpTranscriptSource, mapper, buffer) ships here dormant; §2.5 flips this one flag
+    // together with the factory's Transcript wiring and the dedup guards.
+    readonly bool _emitEnvelopeTranscript;
+
     public CodexAppServerHostedAgentRuntime(
             CodexAppServerSpawn spawn, CodexAppServerLaunch launch, AgentActivityClock? clock,
-            ILogger logger, TimeProvider? timeProvider = null) {
+            ILogger logger, TimeProvider? timeProvider = null, TimeSpan? forwardStallTimeout = null,
+            bool emitEnvelopeTranscript = false) {
         _spawn   = spawn;
         _launch  = launch;
         _clock   = clock;
         _logger  = logger;
         _time    = timeProvider ?? TimeProvider.System;
+        _emitEnvelopeTranscript = emitEnvelopeTranscript;
         _dispatcher = new CodexTurnInputDispatcher(
             startTurn: IssueTurnStartAsync, steerTurn: IssueTurnSteerAsync,
             logger: logger, ct: _cts.Token, onTurnInFlight: flip => _clock?.SetTurnInFlight(flip));
+        _mapper = new CodexNotificationMapper(() => _resolvedModel, logger);
+        _forwardBuffer = new CodexForwardBuffer(
+            ForwardBufferCapacity,
+            forwardStallTimeout ?? TimeSpan.FromSeconds(DefaultForwardStallSeconds),
+            _cts.Token, OnForwardStall);
     }
 
     // ── IHostedAgentRuntime: identity / lifecycle observables ──────────────────────────────────
@@ -133,6 +163,19 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     /// <summary>Latest cumulative token usage reported over <c>thread/tokenUsage/updated</c>, or null
     /// if none has arrived yet.</summary>
     public CodexTokenUsage? Usage => _usage;
+
+    // ── IAcpTranscriptSource (§2.4 envelope transcript) ──────────────────────────────────────────
+    // The canonical session id is the app-server thread id (== the rollout filename id and the hook
+    // payload session_id — AI-1760 Q5), read only after the thread/start handshake sets it.
+
+    /// <inheritdoc cref="IAcpTranscriptSource.AcpSessionId"/>
+    public string AcpSessionId => _threadId ?? "";
+
+    /// <inheritdoc cref="IAcpTranscriptSource.Cwd"/>
+    string IAcpTranscriptSource.Cwd => _launch.Cwd;
+
+    /// <inheritdoc cref="IAcpTranscriptSource.Envelopes"/>
+    public ChannelReader<AcpEventEnvelope> Envelopes => _forwardBuffer.Reader;
 
     // ── Startup (called by the factory, not part of the interface) ─────────────────────────────
 
@@ -339,10 +382,34 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
                 _usage = ParseUsage(n.Params);
                 _clock?.Advance();
                 break;
+            case "model/rerouted":
+                // The resolved model changed mid-thread; the mapper attributes each subsequent token
+                // delta to the model-at-instant, so per-interval attribution across a reroute is correct.
+                if (n.Params?.Str("model") is { } rerouted) _resolvedModel = rerouted;
+                _clock?.Advance();
+                break;
             default:
                 _clock?.Advance();
                 break;
         }
+
+        // §2.4 envelope transcript: translate every notification into canonical/ephemeral envelopes and
+        // drain them through the forward buffer. Runs on the read-loop thread, so a full buffer blocks
+        // here (a canonical emit) — the intended lossless backpressure onto the app-server's stdout.
+        // Gated off until §2.5 activates envelope-source ingestion (see _emitEnvelopeTranscript).
+        if (_emitEnvelopeTranscript)
+            foreach (var env in _mapper.Map(n.Method, n.Params))
+                _forwardBuffer.Emit(env);
+    }
+
+    // §2.4 stall watchdog: the forward buffer stayed full of canonical envelopes past the stall timeout
+    // (the SignalR leg is wedged). Fault the runtime deterministically rather than wedging the read loop
+    // forever — the truncated canonical tail is reported here, never dropped silently.
+    void OnForwardStall(TimeSpan stallTimeout) {
+        _logger.LogError(
+            "codex app-server: forward buffer stalled for {StallSeconds}s (SignalR forwarding wedged); faulting the session — canonical tail truncated.",
+            stallTimeout.TotalSeconds);
+        _runtimeTerminal.TrySetResult();
     }
 
     /// <summary>
@@ -442,6 +509,7 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         // the loop started) so a ReadOutputAsync consumer never hangs.
         _runtimeTerminal.TrySetResult();
         _dispatcher.FaultAll(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime)));
+        _forwardBuffer.Complete(); // end the envelope stream so a draining forwarder's ReadAllAsync completes
         _cts.Dispose();
     }
 

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -166,7 +166,8 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
 
     // ── IAcpTranscriptSource (§2.4 envelope transcript) ──────────────────────────────────────────
     // The canonical session id is the app-server thread id (== the rollout filename id and the hook
-    // payload session_id — AI-1760 Q5), read only after the thread/start handshake sets it.
+    // payload session_id, established by the app-server protocol spike), read only after the
+    // thread/start handshake sets it.
 
     /// <inheritdoc cref="IAcpTranscriptSource.AcpSessionId"/>
     public string AcpSessionId => _threadId ?? "";

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -481,11 +481,12 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
             return null;
 
         return new CodexTokenUsage(
-            InputTokens:           total.Num("inputTokens")           ?? 0,
-            CachedInputTokens:     total.Num("cachedInputTokens")     ?? 0,
-            OutputTokens:          total.Num("outputTokens")          ?? 0,
-            ReasoningOutputTokens: total.Num("reasoningOutputTokens") ?? 0,
-            TotalTokens:           total.Num("totalTokens")           ?? 0);
+            InputTokens:            total.Num("inputTokens")            ?? 0,
+            CachedInputTokens:      total.Num("cachedInputTokens")      ?? 0,
+            CacheWriteInputTokens:  total.Num("cacheWriteInputTokens")  ?? 0,
+            OutputTokens:           total.Num("outputTokens")           ?? 0,
+            ReasoningOutputTokens:  total.Num("reasoningOutputTokens")  ?? 0,
+            TotalTokens:            total.Num("totalTokens")            ?? 0);
     }
 
     // JsonNode → JsonElement without reflection (AOT-safe): the node writes its own JSON.
@@ -493,6 +494,10 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         JsonDocument.Parse(node.ToJsonString()).RootElement.Clone();
 }
 
-/// <summary>Cumulative thread token usage from <c>thread/tokenUsage/updated.total</c>.</summary>
+/// <summary>Cumulative thread token usage from <c>thread/tokenUsage/updated.total</c> (the app-server
+/// <c>TokenUsageBreakdown</c>). <see cref="CacheWriteInputTokens"/> is the cache-CREATION tier, billed
+/// separately from <see cref="CachedInputTokens"/> reads — kept so the delta converter never silently
+/// drops a billed bucket.</summary>
 internal readonly record struct CodexTokenUsage(
-    long InputTokens, long CachedInputTokens, long OutputTokens, long ReasoningOutputTokens, long TotalTokens);
+    long InputTokens, long CachedInputTokens, long CacheWriteInputTokens,
+    long OutputTokens, long ReasoningOutputTokens, long TotalTokens);

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexEphemeralAccumulator.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexEphemeralAccumulator.cs
@@ -1,0 +1,37 @@
+using System.Text;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// Accumulates codex app-server per-item deltas (<c>item/agentMessage/delta</c>, reasoning deltas,
+/// <c>item/commandExecution/outputDelta</c>, …) into the CUMULATIVE content-so-far that each ephemeral
+/// envelope carries. §2.4 fixes the contract: ephemeral payloads are the item's whole accumulated
+/// content (idempotent replacement at the viewer), never an increment — so a dropped or duplicated
+/// ephemeral is harmless, and the canonical <c>item/completed</c> snapshot supersedes it. There is no
+/// increment reassembly anywhere; <see cref="Complete"/> drops the item's transient state once its
+/// authoritative snapshot has been mapped.
+///
+/// <para>Not thread-safe: driven from the single notification-handling path.</para>
+/// </summary>
+internal sealed class CodexEphemeralAccumulator {
+    readonly Dictionary<string, StringBuilder> _byItem = new(StringComparer.Ordinal);
+
+    /// <summary>Appends a delta to the item's buffer and returns the accumulated content so far — the
+    /// payload of the ephemeral envelope for this item.</summary>
+    public string Accumulate(string itemId, string chunk) {
+        if (!_byItem.TryGetValue(itemId, out var sb)) {
+            sb = new StringBuilder();
+            _byItem[itemId] = sb;
+        }
+        sb.Append(chunk);
+        return sb.ToString();
+    }
+
+    /// <summary>Drops the item's transient buffer — called once the canonical completed envelope for it
+    /// has been produced (that snapshot finalizes the viewer's state for the item).</summary>
+    public void Complete(string itemId) => _byItem.Remove(itemId);
+
+    /// <summary>Number of items with live transient state (for the forward buffer's eviction bookkeeping
+    /// and tests).</summary>
+    public int ActiveItems => _byItem.Count;
+}

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexForwardBuffer.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexForwardBuffer.cs
@@ -75,9 +75,12 @@ internal sealed class CodexForwardBuffer : IDisposable {
         try {
             // Blocks the read-loop thread until space frees — the app-server blocks on stdout (lossless).
             _channel.Writer.WriteAsync(env, stall.Token).AsTask().GetAwaiter().GetResult();
-        } catch (OperationCanceledException) when (!_shutdown.IsCancellationRequested) {
-            // Buffer stayed full past the stall timeout → deterministic terminal fault. The undrained
-            // canonical tail is lost by design and reported loudly by onStall (never silently).
+        } catch (OperationCanceledException) {
+            // Shutdown fired mid-wait: we are tearing down, so drop this envelope silently (the session
+            // is ending anyway) rather than propagating out of the read-loop notification handler.
+            if (_shutdown.IsCancellationRequested) return;
+            // Otherwise the buffer stayed full past the stall timeout → deterministic terminal fault. The
+            // undrained canonical tail is lost by design and reported loudly by onStall (never silently).
             if (Interlocked.Exchange(ref _stalled, 1) == 0) _onStall(_stallTimeout);
         }
     }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexForwardBuffer.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexForwardBuffer.cs
@@ -1,0 +1,89 @@
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// The §2.4 bounded forward buffer that decouples the codex app-server stdout reader from SignalR
+/// envelope forwarding. Envelopes are emitted synchronously from the single notification-handling path
+/// (the app-server read loop); the SignalR forwarder drains <see cref="Reader"/> independently.
+///
+/// <para>Overflow policy, fixed by §2.4:</para>
+/// <list type="bullet">
+/// <item><description><b>Canonical envelopes are NEVER dropped.</b> When the buffer is full a canonical
+/// emit BLOCKS the caller — the read loop stops consuming stdout and the app-server blocks on its
+/// writes, which is lossless (a slow reader loses nothing; the app-server buffers/blocks). A gap in the
+/// canonical stream would corrupt the transcript permanently; a stall does not.</description></item>
+/// <item><description><b>Ephemeral envelopes are DROPPABLE.</b> When the buffer is full an ephemeral
+/// emit is dropped rather than blocking (counted in <see cref="DroppedEphemeralCount"/>). The ephemeral
+/// payloads are cumulative content-so-far and the item's canonical completed snapshot converges the
+/// viewer, so a dropped ephemeral is harmless.</description></item>
+/// <item><description><b>Stall watchdog.</b> If a canonical emit stays blocked past
+/// <c>forwardStallSeconds</c>, the buffer fires <c>onStall</c> ONCE (a deterministic terminal fault) and
+/// stops accepting — never an indefinite wedge, and never a silently incomplete canonical transcript
+/// (the fault makes the truncation loud).</description></item>
+/// </list>
+/// Not thread-safe for concurrent emit (single writer = the read loop); the reader side is a standard
+/// channel reader consumed by one forwarder.
+/// </summary>
+internal sealed class CodexForwardBuffer : IDisposable {
+    readonly Channel<AcpEventEnvelope> _channel;
+    readonly TimeSpan          _stallTimeout;
+    readonly CancellationToken _shutdown;
+    readonly Action<TimeSpan>  _onStall;
+    int _droppedEphemeral;
+    int _stalled;
+
+    public CodexForwardBuffer(int capacity, TimeSpan stallTimeout, CancellationToken shutdown, Action<TimeSpan> onStall) {
+        _channel = Channel.CreateBounded<AcpEventEnvelope>(new BoundedChannelOptions(capacity) {
+            SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.Wait });
+        _stallTimeout = stallTimeout;
+        _shutdown     = shutdown;
+        _onStall      = onStall;
+    }
+
+    /// <summary>The forwarder's drain side — FIFO, real seq assigned downstream (envelopes carry the
+    /// placeholder <c>Seq=0</c>).</summary>
+    public ChannelReader<AcpEventEnvelope> Reader => _channel.Reader;
+
+    /// <summary>Ephemeral envelopes dropped because the buffer was full — a liveness-only loss, never a
+    /// transcript gap.</summary>
+    public int DroppedEphemeralCount => Volatile.Read(ref _droppedEphemeral);
+
+    /// <summary>True once the stall watchdog has fired; further emits are no-ops (the agent is being
+    /// faulted and its canonical tail is deliberately truncated, loudly, by <c>onStall</c>).</summary>
+    public bool Stalled => Volatile.Read(ref _stalled) == 1;
+
+    /// <summary>Emit one envelope from the read loop. Canonical blocks when full (backpressure);
+    /// ephemeral drops when full. A no-op once stalled.</summary>
+    public void Emit(AcpEventEnvelope env) {
+        if (Stalled) return;
+
+        if (env.Ephemeral) {
+            if (!_channel.Writer.TryWrite(env)) Interlocked.Increment(ref _droppedEphemeral);
+            return;
+        }
+
+        // Canonical: never dropped. TryWrite is the fast path when there is room.
+        if (_channel.Writer.TryWrite(env)) return;
+        WriteCanonicalBlocking(env);
+    }
+
+    void WriteCanonicalBlocking(AcpEventEnvelope env) {
+        using var stall = CancellationTokenSource.CreateLinkedTokenSource(_shutdown);
+        stall.CancelAfter(_stallTimeout);
+        try {
+            // Blocks the read-loop thread until space frees — the app-server blocks on stdout (lossless).
+            _channel.Writer.WriteAsync(env, stall.Token).AsTask().GetAwaiter().GetResult();
+        } catch (OperationCanceledException) when (!_shutdown.IsCancellationRequested) {
+            // Buffer stayed full past the stall timeout → deterministic terminal fault. The undrained
+            // canonical tail is lost by design and reported loudly by onStall (never silently).
+            if (Interlocked.Exchange(ref _stalled, 1) == 0) _onStall(_stallTimeout);
+        }
+    }
+
+    /// <summary>Signals the reader no more envelopes will arrive (session ended / teardown).</summary>
+    public void Complete() => _channel.Writer.TryComplete();
+
+    public void Dispose() => _channel.Writer.TryComplete();
+}

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
@@ -237,12 +237,24 @@ internal sealed partial class CodexNotificationMapper {
     static string? IsoFromMs(long? ms) =>
         ms is { } v ? DateTimeOffset.FromUnixTimeMilliseconds(v).ToString("O", CultureInfo.InvariantCulture) : null;
 
-    // Reasoning renders its content blocks, falling back to the summary blocks when content is empty.
+    // Reasoning content/summary are arrays of plain STRINGS (per the pinned schema), so join the string
+    // elements directly — falling back to the summary blocks when content is empty.
     static string RenderReasoning(JsonElement item) {
-        var content = JoinTexts(item.Arr("content"));
-        return content.Length > 0 ? content : JoinTexts(item.Arr("summary"));
+        var content = JoinStrings(item.Arr("content"));
+        return content.Length > 0 ? content : JoinStrings(item.Arr("summary"));
     }
 
+    // For a string[] (reasoning content/summary): join the non-empty string elements.
+    static string JoinStrings(JsonElement? arr) {
+        if (arr is not { } a) return "";
+        var parts = new List<string>();
+        foreach (var el in a.EnumerateArray())
+            if (el.IsString && el.GetString() is { Length: > 0 } s) parts.Add(s);
+        return string.Join("\n", parts);
+    }
+
+    // For a UserInput[] (userMessage content): each element is an object with a `text` field (image
+    // inputs have no text and are skipped).
     static string JoinTexts(JsonElement? arr) {
         if (arr is not { } a) return "";
         var parts = new List<string>();
@@ -308,29 +320,21 @@ internal sealed partial class CodexNotificationMapper {
 
     // MCP arguments are opaque JSON — forwarded only when they are an object (the server expects a JSON
     // object string for tool arguments); otherwise omitted rather than passing a non-object through.
-    static string? McpArguments(JsonElement item) =>
-        item.TryGetProperty("arguments", out var a) && a.ValueKind == JsonValueKind.Object ? a.GetRawText() : null;
+    static string? McpArguments(JsonElement item) => item.Obj("arguments")?.GetRawText();
 
-    static string RenderMcpResult(JsonElement item) {
+    static string RenderMcpResult(JsonElement item) =>
         // Error content wins over result: a failed call that also carries a result body must not render
         // the result as if it succeeded (keeps the payload consistent with IsMcpError's flag).
-        if (TryContent(item, "error", out var e))  return e;
-        if (TryContent(item, "result", out var r)) return r;
-        return "";
-    }
+        Content(item, "error") ?? Content(item, "result") ?? "";
 
-    static bool TryContent(JsonElement item, string property, out string value) {
-        if (item.TryGetProperty(property, out var v) && v.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined) {
-            value = v.ValueKind == JsonValueKind.String ? v.GetString() ?? "" : v.GetRawText();
-            return true;
-        }
-        value = "";
-        return false;
-    }
+    // A property rendered as a string: the string value if it is a string, else the raw JSON of an
+    // object/array. Null when absent or JSON null. Uses the JsonElementExtensions accessors rather than
+    // inspecting ValueKind directly.
+    static string? Content(JsonElement item, string property) =>
+        item.Str(property) ?? item.Obj(property)?.GetRawText() ?? item.Arr(property)?.GetRawText();
 
     static bool IsMcpError(JsonElement item) =>
-        (item.TryGetProperty("error", out var e) && e.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
-     || item.Str("status") == "failed";
+        Content(item, "error") is not null || item.Str("status") == "failed";
 
     static bool IsCommandError(JsonElement item) =>
         item.Str("status") is "failed" or "declined" || item.Num("exitCode") is { } code && code != 0;

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
@@ -312,8 +312,10 @@ internal sealed partial class CodexNotificationMapper {
         item.TryGetProperty("arguments", out var a) && a.ValueKind == JsonValueKind.Object ? a.GetRawText() : null;
 
     static string RenderMcpResult(JsonElement item) {
-        if (TryContent(item, "result", out var r)) return r;
+        // Error content wins over result: a failed call that also carries a result body must not render
+        // the result as if it succeeded (keeps the payload consistent with IsMcpError's flag).
         if (TryContent(item, "error", out var e))  return e;
+        if (TryContent(item, "result", out var r)) return r;
         return "";
     }
 

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
@@ -1,0 +1,339 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// Translates codex app-server JSON-RPC notifications into the daemon-local wire
+/// <see cref="AcpEventEnvelope"/> vocabulary (§2.4 envelope transcript). Stateful — it composes the
+/// per-item <see cref="CodexEphemeralAccumulator"/> and the cumulative→delta
+/// <see cref="CodexUsageDeltaConverter"/> — so it is one-per-session and driven from the single
+/// notification-handling path (NOT thread-safe).
+///
+/// <para>Two lanes, per §2.4:</para>
+/// <list type="bullet">
+/// <item><description><b>Canonical</b>: only terminal facts become sequenced envelopes —
+/// <c>item/completed</c> snapshots (the one authoritative event for an item's content), the tool-call
+/// OPEN on <c>item/started</c> for executions, <c>turn/plan/updated</c> full snapshots, and the
+/// per-event token DELTA. Append-only: a completed item is the single event for its content, and its
+/// <see cref="AcpEventEnvelope.ItemId"/> lets a viewer finalize the item's transient ephemeral state.</description></item>
+/// <item><description><b>Ephemeral</b>: delta notifications become <see cref="AcpEventEnvelope.Ephemeral"/>
+/// envelopes carrying the item's ACCUMULATED content-so-far (idempotent replacement at the viewer; no
+/// seq, never persisted). A dropped/duplicated ephemeral is harmless and the completed snapshot converges
+/// the viewer.</description></item>
+/// </list>
+/// Every emitted envelope carries a placeholder <see cref="AcpEventEnvelope.Seq"/> of <c>0</c> — the
+/// forwarder assigns the real monotonic seq to canonical envelopes and leaves ephemeral ones unsequenced.
+/// An unrecognised item type surfaces as a generic-labeled tool call and bumps
+/// <see cref="UnmappedKindCount"/> so vocabulary drift is visible rather than silently dropped.
+/// </summary>
+internal sealed partial class CodexNotificationMapper {
+    static readonly IReadOnlyList<AcpEventEnvelope> None = [];
+
+    readonly CodexEphemeralAccumulator _ephemeral = new();
+    readonly CodexUsageDeltaConverter  _usage     = new();
+    readonly Func<string?>             _modelAtInstant;
+    readonly ILogger                   _logger;
+    readonly HashSet<string>           _loggedUnknownTypes = new(StringComparer.Ordinal);
+    int _unmappedKindCount;
+
+    public CodexNotificationMapper(Func<string?> modelAtInstant, ILogger logger) {
+        _modelAtInstant = modelAtInstant;
+        _logger         = logger;
+    }
+
+    /// <summary>Count of <c>item/completed</c> notifications whose item type this mapper did not
+    /// recognise (surfaced generically, never dropped). A rising count means the app-server vocabulary
+    /// grew past this mapper — the signal to widen the switch below.</summary>
+    public int UnmappedKindCount => _unmappedKindCount;
+
+    /// <summary>Exact post-resume usage baseline (from <c>thread/read</c>) so the next token delta is
+    /// exact. Mirrors <see cref="CodexUsageDeltaConverter.SetExactBaseline"/>.</summary>
+    public void SetUsageBaseline(CodexTokenUsage baseline) => _usage.SetExactBaseline(baseline);
+
+    /// <summary>Fallback when no exact resume baseline is available: the next usage snapshot becomes the
+    /// baseline and emits nothing. Mirrors <see cref="CodexUsageDeltaConverter.BaselineOnNextNotification"/>.</summary>
+    public void UsageBaselineOnNextNotification() => _usage.BaselineOnNextNotification();
+
+    /// <summary>Maps ONE app-server notification to its (0..n) envelopes. Never throws: a malformed or
+    /// wrong-typed field reads as absent (the <see cref="JsonElementExtensions"/> contract) and yields
+    /// an empty result rather than bubbling out and taking down the notification pump.</summary>
+    public IReadOnlyList<AcpEventEnvelope> Map(string method, JsonElement? @params) {
+        var p = @params ?? default;
+        switch (method) {
+            case "item/completed":            return MapItemCompleted(p);
+            case "item/started":              return MapItemStarted(p);
+            case "turn/plan/updated":         return MapPlanUpdated(p);
+            case "thread/tokenUsage/updated": return MapTokenUsage(p);
+
+            // Ephemeral live lane — incremental deltas accumulate into content-so-far.
+            case "item/agentMessage/delta":           return EphemeralText(AcpEventKind.AssistantText, p);
+            case "item/reasoning/textDelta":          return EphemeralText(AcpEventKind.AssistantThinking, p);
+            case "item/reasoning/summaryTextDelta":   return EphemeralText(AcpEventKind.AssistantThinking, p);
+            case "item/plan/delta":                   return EphemeralText(AcpEventKind.Plan, p);
+            case "item/commandExecution/outputDelta": return EphemeralToolProgress(p);
+            case "item/fileChange/outputDelta":       return EphemeralToolProgress(p);
+            // patchUpdated is a full-snapshot delta (the changes array), not an increment — replace,
+            // never accumulate.
+            case "item/fileChange/patchUpdated":      return EphemeralPatchSnapshot(p);
+
+            // Everything else (thread/*, turn/started, turn/completed — dispatcher-owned — turn/diff,
+            // approval reviews, realtime audio, …) is not transcript content: dropped, not drift.
+            default: return None;
+        }
+    }
+
+    // ── Canonical: completed items are the one authoritative event per item ─────────────────────
+    IReadOnlyList<AcpEventEnvelope> MapItemCompleted(JsonElement p) {
+        if (p.Obj("item") is not { } item) return None;
+        var id   = item.Str("id");
+        var type = item.Str("type");
+        var ts   = IsoFromMs(p.Num("completedAtMs"));
+
+        // The completed snapshot supersedes any transient ephemeral state for this item.
+        if (id is not null) _ephemeral.Complete(id);
+
+        switch (type) {
+            case "agentMessage":
+                return One(new AcpEventEnvelope(
+                    Kind: AcpEventKind.AssistantText, Text: item.Str("text") ?? "",
+                    ItemId: id, TimestampIso: ts));
+
+            case "reasoning":
+                return One(new AcpEventEnvelope(
+                    Kind: AcpEventKind.AssistantThinking, Text: RenderReasoning(item),
+                    ItemId: id, TimestampIso: ts));
+
+            case "plan":
+                return One(new AcpEventEnvelope(
+                    Kind: AcpEventKind.Plan, Text: item.Str("text") ?? "",
+                    ItemId: id, TimestampIso: ts));
+
+            case "userMessage":
+                return One(new AcpEventEnvelope(
+                    Kind: AcpEventKind.UserMessage, Text: JoinTexts(item.Arr("content")),
+                    ItemId: id, TimestampIso: ts));
+
+            case "commandExecution":
+                // The tool-call OPEN came from item/started; the completed item is the authoritative result.
+                return One(new AcpEventEnvelope(
+                    Kind: AcpEventKind.ToolResult, ToolCallId: id,
+                    ToolResult: item.Str("aggregatedOutput") ?? "", ToolIsError: IsCommandError(item),
+                    ItemId: id, TimestampIso: ts));
+
+            case "fileChange":
+                // A file edit surfaces as a tool call carrying the diff content (spec §2.4 table).
+                return One(new AcpEventEnvelope(
+                    Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: "apply_patch",
+                    ToolInputJson: RenderChanges(item.Arr("changes")), ItemId: id, TimestampIso: ts));
+
+            case "mcpToolCall":
+                return One(new AcpEventEnvelope(
+                    Kind: AcpEventKind.ToolResult, ToolCallId: id,
+                    ToolResult: RenderMcpResult(item), ToolIsError: IsMcpError(item),
+                    ItemId: id, TimestampIso: ts));
+
+            default:
+                return Unmapped(type, id, item, ts);
+        }
+    }
+
+    // ── Canonical: tool-call OPEN for executions (the only item/started that carries a canonical row) ──
+    static IReadOnlyList<AcpEventEnvelope> MapItemStarted(JsonElement p) {
+        if (p.Obj("item") is not { } item) return None;
+        var id   = item.Str("id");
+        var type = item.Str("type");
+        var ts   = IsoFromMs(p.Num("startedAtMs"));
+
+        switch (type) {
+            case "commandExecution":
+                return One(new AcpEventEnvelope(
+                    Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: "shell",
+                    ToolInputJson: RenderCommandOpen(item), ItemId: id, TimestampIso: ts));
+
+            case "mcpToolCall":
+                return One(new AcpEventEnvelope(
+                    Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: McpToolName(item),
+                    ToolInputJson: McpArguments(item), ItemId: id, TimestampIso: ts));
+
+            // Text/reasoning/plan/userMessage/fileChange have no separate "open" row — their content
+            // arrives via deltas + the completed snapshot. An unknown type is counted once at completion,
+            // not here (a start+complete pair would otherwise double-count).
+            default: return None;
+        }
+    }
+
+    // ── Canonical: turn-level full plan snapshot → the NEW Plan kind (latest-wins server-side) ────
+    static IReadOnlyList<AcpEventEnvelope> MapPlanUpdated(JsonElement p) {
+        var text = RenderPlan(p.Arr("plan"), p.Str("explanation"));
+        return text is null ? None : One(new AcpEventEnvelope(Kind: AcpEventKind.Plan, Text: text));
+    }
+
+    // ── Canonical: cumulative token usage → per-event additive DELTA (attributed to model-at-instant) ──
+    IReadOnlyList<AcpEventEnvelope> MapTokenUsage(JsonElement p) {
+        if (p.Obj("tokenUsage") is not { } tu || tu.Obj("total") is not { } total) return None;
+
+        var delta = _usage.Convert(CodexTokenUsage.FromTotal(total));
+        if (delta is not { } d || d.IsZero) return None; // baseline consumed, or a no-op reading
+
+        return One(new AcpEventEnvelope(
+            Kind: AcpEventKind.TokenUsage, Model: _modelAtInstant(),
+            UsageInputTokens:           d.InputTokens,
+            UsageCachedInputTokens:     d.CachedInputTokens,
+            UsageCacheWriteInputTokens: d.CacheWriteInputTokens,
+            UsageOutputTokens:          d.OutputTokens,
+            UsageReasoningTokens:       d.ReasoningOutputTokens));
+    }
+
+    // ── Ephemeral lane ───────────────────────────────────────────────────────────────────────────
+    IReadOnlyList<AcpEventEnvelope> EphemeralText(string kind, JsonElement p) {
+        var itemId = p.Str("itemId");
+        var delta  = p.Str("delta");
+        if (itemId is null || delta is null) return None;
+
+        return One(new AcpEventEnvelope(
+            Kind: kind, Text: _ephemeral.Accumulate(itemId, delta), Ephemeral: true, ItemId: itemId));
+    }
+
+    IReadOnlyList<AcpEventEnvelope> EphemeralToolProgress(JsonElement p) {
+        var itemId = p.Str("itemId");
+        var delta  = p.Str("delta");
+        if (itemId is null || delta is null) return None;
+
+        return One(new AcpEventEnvelope(
+            Kind: AcpEventKind.ToolResult, ToolCallId: itemId,
+            ToolResult: _ephemeral.Accumulate(itemId, delta), Ephemeral: true, ItemId: itemId));
+    }
+
+    static IReadOnlyList<AcpEventEnvelope> EphemeralPatchSnapshot(JsonElement p) {
+        var itemId = p.Str("itemId");
+        if (itemId is null || p.Arr("changes") is not { } changes) return None;
+
+        // A full-snapshot delta: the changes array IS the cumulative patch, so it replaces (never
+        // accumulates) — the ephemeral replacement rule makes a dropped one harmless.
+        return One(new AcpEventEnvelope(
+            Kind: AcpEventKind.ToolCall, ToolCallId: itemId, ToolName: "apply_patch",
+            ToolInputJson: RenderChanges(changes), Ephemeral: true, ItemId: itemId));
+    }
+
+    IReadOnlyList<AcpEventEnvelope> Unmapped(string? type, string? id, JsonElement item, string? ts) {
+        _unmappedKindCount++;
+        if (type is not null && _loggedUnknownTypes.Add(type))
+            LogUnknownItemType(_logger, type);
+
+        // Surface the unknown item's content as a generic tool call rather than dropping it — the raw
+        // item is a JSON object, so it rides as the tool's arguments for a viewer to inspect.
+        return One(new AcpEventEnvelope(
+            Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: type ?? "unknown",
+            ToolInputJson: item.GetRawText(), ItemId: id, TimestampIso: ts));
+    }
+
+    // ── Rendering helpers (pure) ──────────────────────────────────────────────────────────────────
+    static IReadOnlyList<AcpEventEnvelope> One(AcpEventEnvelope e) => [e];
+
+    static string? IsoFromMs(long? ms) =>
+        ms is { } v ? DateTimeOffset.FromUnixTimeMilliseconds(v).ToString("O", CultureInfo.InvariantCulture) : null;
+
+    // Reasoning renders its content blocks, falling back to the summary blocks when content is empty.
+    static string RenderReasoning(JsonElement item) {
+        var content = JoinTexts(item.Arr("content"));
+        return content.Length > 0 ? content : JoinTexts(item.Arr("summary"));
+    }
+
+    static string JoinTexts(JsonElement? arr) {
+        if (arr is not { } a) return "";
+        var parts = new List<string>();
+        foreach (var el in a.EnumerateArray()) {
+            var t = el.Str("text");
+            if (!string.IsNullOrEmpty(t)) parts.Add(t);
+        }
+        return string.Join("\n", parts);
+    }
+
+    static string? RenderPlan(JsonElement? planArr, string? explanation) {
+        var sb = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(explanation)) sb.Append(explanation).Append('\n');
+        if (planArr is { } a)
+            foreach (var step in a.EnumerateArray()) {
+                var text = step.Str("step");
+                if (string.IsNullOrEmpty(text)) continue;
+                sb.Append("- [").Append(step.Str("status") ?? "").Append("] ").Append(text).Append('\n');
+            }
+        var s = sb.ToString().TrimEnd('\n');
+        return s.Length == 0 ? null : s;
+    }
+
+    // A ToolInputJson must be a JSON OBJECT string (the server parses it into the tool's arguments), so
+    // the file-change array is wrapped under a "changes" key. Built with Utf8JsonWriter — the JsonNode
+    // Add<T> path is not AOT-safe (IL2026/IL3050).
+    static string RenderChanges(JsonElement? changes) {
+        using var buffer = new MemoryStream();
+        using (var w = new Utf8JsonWriter(buffer)) {
+            w.WriteStartObject();
+            w.WriteStartArray("changes");
+            if (changes is { } a)
+                foreach (var ch in a.EnumerateArray()) {
+                    w.WriteStartObject();
+                    WriteNullable(w, "path", ch.Str("path"));
+                    WriteNullable(w, "kind", ch.Str("kind"));
+                    WriteNullable(w, "diff", ch.Str("diff"));
+                    w.WriteEndObject();
+                }
+            w.WriteEndArray();
+            w.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    static string RenderCommandOpen(JsonElement item) {
+        using var buffer = new MemoryStream();
+        using (var w = new Utf8JsonWriter(buffer)) {
+            w.WriteStartObject();
+            WriteNullable(w, "command", item.Str("command"));
+            WriteNullable(w, "cwd", item.Str("cwd"));
+            w.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    static void WriteNullable(Utf8JsonWriter w, string name, string? value) {
+        if (value is null) w.WriteNull(name);
+        else w.WriteString(name, value);
+    }
+
+    static string McpToolName(JsonElement item) => $"{item.Str("server")}.{item.Str("tool")}";
+
+    // MCP arguments are opaque JSON — forwarded only when they are an object (the server expects a JSON
+    // object string for tool arguments); otherwise omitted rather than passing a non-object through.
+    static string? McpArguments(JsonElement item) =>
+        item.TryGetProperty("arguments", out var a) && a.ValueKind == JsonValueKind.Object ? a.GetRawText() : null;
+
+    static string RenderMcpResult(JsonElement item) {
+        if (TryContent(item, "result", out var r)) return r;
+        if (TryContent(item, "error", out var e))  return e;
+        return "";
+    }
+
+    static bool TryContent(JsonElement item, string property, out string value) {
+        if (item.TryGetProperty(property, out var v) && v.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined) {
+            value = v.ValueKind == JsonValueKind.String ? v.GetString() ?? "" : v.GetRawText();
+            return true;
+        }
+        value = "";
+        return false;
+    }
+
+    static bool IsMcpError(JsonElement item) =>
+        (item.TryGetProperty("error", out var e) && e.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+     || item.Str("status") == "failed";
+
+    static bool IsCommandError(JsonElement item) =>
+        item.Str("status") is "failed" or "declined" || item.Num("exitCode") is { } code && code != 0;
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "codex app-server: unmapped item type '{ItemType}' surfaced as a generic tool call")]
+    static partial void LogUnknownItemType(ILogger logger, string itemType);
+}

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
@@ -125,10 +125,16 @@ internal sealed partial class CodexNotificationMapper {
                     ItemId: id, TimestampIso: ts));
 
             case "fileChange":
-                // A file edit surfaces as a tool call carrying the diff content (spec §2.4 table).
-                return One(new AcpEventEnvelope(
-                    Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: "apply_patch",
-                    ToolInputJson: RenderChanges(item.Arr("changes")), ItemId: id, TimestampIso: ts));
+                // A completed file edit surfaces as a PAIRED tool call (carrying the diff) + result (the
+                // apply status), mirroring commandExecution/mcp so a consumer never sees an orphan tool
+                // call. fileChange has no item/started, so both envelopes come from the completed item.
+                return Two(
+                    new AcpEventEnvelope(
+                        Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: "apply_patch",
+                        ToolInputJson: RenderChanges(item.Arr("changes")), ItemId: id, TimestampIso: ts),
+                    new AcpEventEnvelope(
+                        Kind: AcpEventKind.ToolResult, ToolCallId: id, ToolResult: item.Str("status") ?? "",
+                        ToolIsError: item.Str("status") is "failed" or "declined", ItemId: id, TimestampIso: ts));
 
             case "mcpToolCall":
                 return One(new AcpEventEnvelope(
@@ -213,7 +219,8 @@ internal sealed partial class CodexNotificationMapper {
         if (itemId is null || p.Arr("changes") is not { } changes) return None;
 
         // A full-snapshot delta: the changes array IS the cumulative patch, so it replaces (never
-        // accumulates) — the ephemeral replacement rule makes a dropped one harmless.
+        // accumulates — deliberately bypasses _ephemeral, unlike outputDelta which shares this itemId;
+        // the completed item's canonical envelopes are authoritative either way).
         return One(new AcpEventEnvelope(
             Kind: AcpEventKind.ToolCall, ToolCallId: itemId, ToolName: "apply_patch",
             ToolInputJson: RenderChanges(changes), Ephemeral: true, ItemId: itemId));
@@ -233,6 +240,7 @@ internal sealed partial class CodexNotificationMapper {
 
     // ── Rendering helpers (pure) ──────────────────────────────────────────────────────────────────
     static IReadOnlyList<AcpEventEnvelope> One(AcpEventEnvelope e) => [e];
+    static IReadOnlyList<AcpEventEnvelope> Two(AcpEventEnvelope a, AcpEventEnvelope b) => [a, b];
 
     static string? IsoFromMs(long? ms) =>
         ms is { } v ? DateTimeOffset.FromUnixTimeMilliseconds(v).ToString("O", CultureInfo.InvariantCulture) : null;

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexUsageDeltaConverter.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexUsageDeltaConverter.cs
@@ -53,6 +53,7 @@ internal sealed class CodexUsageDeltaConverter {
     static bool IsReset(CodexTokenUsage prev, CodexTokenUsage now) =>
         now.InputTokens           < prev.InputTokens
      || now.CachedInputTokens     < prev.CachedInputTokens
+     || now.CacheWriteInputTokens < prev.CacheWriteInputTokens
      || now.OutputTokens          < prev.OutputTokens
      || now.ReasoningOutputTokens < prev.ReasoningOutputTokens
      || now.TotalTokens           < prev.TotalTokens;
@@ -60,6 +61,7 @@ internal sealed class CodexUsageDeltaConverter {
     static CodexTokenUsage Delta(CodexTokenUsage prev, CodexTokenUsage now) => new(
         InputTokens:           now.InputTokens           - prev.InputTokens,
         CachedInputTokens:     now.CachedInputTokens     - prev.CachedInputTokens,
+        CacheWriteInputTokens: now.CacheWriteInputTokens - prev.CacheWriteInputTokens,
         OutputTokens:          now.OutputTokens          - prev.OutputTokens,
         ReasoningOutputTokens: now.ReasoningOutputTokens - prev.ReasoningOutputTokens,
         TotalTokens:           now.TotalTokens           - prev.TotalTokens);

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexUsageDeltaConverter.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexUsageDeltaConverter.cs
@@ -1,0 +1,66 @@
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// Converts codex app-server cumulative token-usage snapshots (<c>thread/tokenUsage/updated.total</c>)
+/// into per-event DELTAS. The canonical usage pipeline SUMS per-event usage, so feeding it cumulative
+/// totals would double-count; and attributing a thread-cumulative total to the latest model would
+/// mis-attribute everything before a <c>model/rerouted</c>. So the daemon deltas here and the caller
+/// attributes each delta to the model resolved at that instant.
+///
+/// <para>Not thread-safe: driven from the single notification-handling path.</para>
+/// </summary>
+internal sealed class CodexUsageDeltaConverter {
+    CodexTokenUsage? _previous;
+    bool _baselineOnNext; // resume fallback: consume the next snapshot as baseline, emit nothing
+
+    /// <summary>The per-event delta for a new cumulative snapshot, or <see langword="null"/> when the
+    /// snapshot was consumed as a resume baseline and nothing should be emitted.</summary>
+    public CodexTokenUsage? Convert(CodexTokenUsage total) {
+        if (_baselineOnNext) {
+            // A resumed round with no exact baseline: this snapshot is the baseline, emit nothing. Exact
+            // when it precedes the round's first request; otherwise a bounded, fallback-only undercount.
+            _baselineOnNext = false;
+            _previous       = total;
+            return null;
+        }
+
+        var previous = _previous;
+        _previous = total;
+
+        if (previous is not { } prev)
+            return total; // first snapshot: the baseline was zero, so the whole total is the first delta
+
+        if (IsReset(prev, total))
+            return total; // a lower/reset cumulative total is a fresh baseline — contribute total_now
+
+        return Delta(prev, total);
+    }
+
+    /// <summary>Sets an exact post-resume baseline (from <c>thread/read</c>) so conversion stays exact —
+    /// no loss, no double-count across a resume.</summary>
+    public void SetExactBaseline(CodexTokenUsage baseline) {
+        _previous       = baseline;
+        _baselineOnNext = false;
+    }
+
+    /// <summary>Fallback when no exact baseline is available: the next snapshot becomes the baseline and
+    /// emits nothing.</summary>
+    public void BaselineOnNextNotification() => _baselineOnNext = true;
+
+    // A cumulative counter that dropped in any component means the thread reset/rebaselined; the caller
+    // then contributes the whole new total, so Delta below is only ever reached on non-decreasing input
+    // and never produces a negative component.
+    static bool IsReset(CodexTokenUsage prev, CodexTokenUsage now) =>
+        now.InputTokens           < prev.InputTokens
+     || now.CachedInputTokens     < prev.CachedInputTokens
+     || now.OutputTokens          < prev.OutputTokens
+     || now.ReasoningOutputTokens < prev.ReasoningOutputTokens
+     || now.TotalTokens           < prev.TotalTokens;
+
+    static CodexTokenUsage Delta(CodexTokenUsage prev, CodexTokenUsage now) => new(
+        InputTokens:           now.InputTokens           - prev.InputTokens,
+        CachedInputTokens:     now.CachedInputTokens     - prev.CachedInputTokens,
+        OutputTokens:          now.OutputTokens          - prev.OutputTokens,
+        ReasoningOutputTokens: now.ReasoningOutputTokens - prev.ReasoningOutputTokens,
+        TotalTokens:           now.TotalTokens           - prev.TotalTokens);
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/AcpEventEnvelopeWireCompatTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/AcpEventEnvelopeWireCompatTests.cs
@@ -38,7 +38,9 @@ public class AcpEventEnvelopeWireCompatTests {
             EndReason:         "completed",
             ContextUsedTokens:   142_000,
             ContextWindowTokens: 200_000,
-            TimestampIso:      "2026-07-08T00:00:00Z"
+            TimestampIso:      "2026-07-08T00:00:00Z",
+            Ephemeral:         true,
+            ItemId:            "item-42"
         );
 
         var json = JsonSerializer.Serialize(env, CapacitorJsonContext.Default.AcpEventEnvelope);
@@ -62,6 +64,8 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(json).Contains(@"""context_used_tokens"":142000");
         await Assert.That(json).Contains(@"""context_window_tokens"":200000");
         await Assert.That(json).Contains(@"""timestamp_iso"":""2026-07-08T00:00:00Z""");
+        await Assert.That(json).Contains(@"""ephemeral"":true");
+        await Assert.That(json).Contains(@"""item_id"":""item-42""");
 
         var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.AcpEventEnvelope);
         await Assert.That(back.Seq).IsEqualTo(7L);
@@ -70,6 +74,21 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(back.ToolIsError).IsTrue();
         await Assert.That(back.ContextUsedTokens).IsEqualTo(142_000L);
         await Assert.That(back.ContextWindowTokens).IsEqualTo(200_000L);
+        await Assert.That(back.Ephemeral).IsTrue();
+        await Assert.That(back.ItemId).IsEqualTo("item-42");
+    }
+
+    [Test]
+    public async Task AcpEventEnvelope_defaults_the_ephemeral_lane_fields_to_canonical() {
+        // A canonical envelope leaves the ephemeral lane fields at their defaults — Ephemeral=false so
+        // the server sequences/persists it as today, and no ItemId unless the mapper stamps one.
+        var env = new AcpEventEnvelope(Seq: 4, Kind: AcpEventKind.AssistantText, Text: "hi");
+
+        await Assert.That(env.Ephemeral).IsFalse();
+        await Assert.That(env.ItemId).IsNull();
+
+        var json = JsonSerializer.Serialize(env, CapacitorJsonContext.Default.AcpEventEnvelope);
+        await Assert.That(json).Contains(@"""ephemeral"":false");
     }
 
     [Test]
@@ -96,6 +115,8 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(AcpEventKind.SessionTitle).IsEqualTo("session_title");
         await Assert.That(AcpEventKind.SessionEnded).IsEqualTo("session_ended");
         await Assert.That(AcpEventKind.Usage).IsEqualTo("usage");
+        await Assert.That(AcpEventKind.SystemNote).IsEqualTo("system_note");
+        await Assert.That(AcpEventKind.Plan).IsEqualTo("plan");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Core.Tests.Unit/AcpEventEnvelopeWireCompatTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/AcpEventEnvelopeWireCompatTests.cs
@@ -117,6 +117,37 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(AcpEventKind.Usage).IsEqualTo("usage");
         await Assert.That(AcpEventKind.SystemNote).IsEqualTo("system_note");
         await Assert.That(AcpEventKind.Plan).IsEqualTo("plan");
+        await Assert.That(AcpEventKind.TokenUsage).IsEqualTo("token_usage");
+    }
+
+    [Test]
+    public async Task TokenUsage_envelope_carries_every_additive_bucket_under_its_snake_case_name() {
+        // The additive-billing delta lane (§2.4). Distinct from the context-occupancy Usage kind —
+        // the server stamps these into $usage metadata. Field-for-field vs the server mirror.
+        var env = new AcpEventEnvelope(
+            Kind:                       AcpEventKind.TokenUsage,
+            Model:                      "gpt-5-codex",
+            UsageInputTokens:           1200,
+            UsageCachedInputTokens:     300,
+            UsageCacheWriteInputTokens: 64,
+            UsageOutputTokens:          450,
+            UsageReasoningTokens:       128);
+
+        var json = JsonSerializer.Serialize(env, CapacitorJsonContext.Default.AcpEventEnvelope);
+        await Assert.That(json).Contains(@"""kind"":""token_usage""");
+        await Assert.That(json).Contains(@"""usage_input_tokens"":1200");
+        await Assert.That(json).Contains(@"""usage_cached_input_tokens"":300");
+        await Assert.That(json).Contains(@"""usage_cache_write_input_tokens"":64");
+        await Assert.That(json).Contains(@"""usage_output_tokens"":450");
+        await Assert.That(json).Contains(@"""usage_reasoning_tokens"":128");
+
+        var back = JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.AcpEventEnvelope);
+        await Assert.That(back.UsageInputTokens).IsEqualTo(1200L);
+        await Assert.That(back.UsageCachedInputTokens).IsEqualTo(300L);
+        await Assert.That(back.UsageCacheWriteInputTokens).IsEqualTo(64L);
+        await Assert.That(back.UsageOutputTokens).IsEqualTo(450L);
+        await Assert.That(back.UsageReasoningTokens).IsEqualTo(128L);
+        await Assert.That(back.Model).IsEqualTo("gpt-5-codex");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Core.Tests.Unit/AcpEventEnvelopeWireCompatTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/AcpEventEnvelopeWireCompatTests.cs
@@ -80,8 +80,6 @@ public class AcpEventEnvelopeWireCompatTests {
 
     [Test]
     public async Task AcpEventEnvelope_defaults_the_ephemeral_lane_fields_to_canonical() {
-        // A canonical envelope leaves the ephemeral lane fields at their defaults — Ephemeral=false so
-        // the server sequences/persists it as today, and no ItemId unless the mapper stamps one.
         var env = new AcpEventEnvelope(Seq: 4, Kind: AcpEventKind.AssistantText, Text: "hi");
 
         await Assert.That(env.Ephemeral).IsFalse();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -81,6 +81,10 @@ public class CodexAppServerHostedAgentRuntimeTests {
         var (runtime, _, _) = Build(_ => fake, Launch(), emitEnvelopes: true);
         await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
 
+        // With the transcript on, the mapper needs the delta streams, so initialize must opt out of none
+        // (otherwise the app-server would never send the ephemeral notifications the gate is meant to enable).
+        await Assert.That(fake.InitializeOptOuts).IsEmpty();
+
         await runtime.SendUserInputAsync("go").WaitAsync(HangGuard);
         await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -96,7 +96,7 @@ public class CodexAppServerHostedAgentRuntimeTests {
     [Test]
     public async Task Envelope_transcript_is_dormant_when_the_gate_is_off() {
         // Default (reviewer path): the notification pump never feeds the buffer, so Envelopes stays empty
-        // even after a turn with usage — the AI-1761 control-plane behavior is byte-unchanged.
+        // even after a turn with usage — the shipped reviewer control-plane behavior is byte-unchanged.
         var fake = new FakeCodexAppServer { EmitUsageOnTurn = (input: 120, output: 40, total: 160) };
         var (runtime, _, _) = Build(_ => fake, Launch()); // emitEnvelopes defaults false
         await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Harness.Codex;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -30,7 +31,7 @@ public class CodexAppServerHostedAgentRuntimeTests {
     /// <summary>Builds a spawn delegate that hands each spawn a fresh fake (indexed), recording the
     /// seed passed on each call so the restart path is assertable.</summary>
     static (CodexAppServerHostedAgentRuntime Runtime, List<string?> Seeds, Func<int, FakeCodexAppServer> Fake)
-            Build(Func<int, FakeCodexAppServer> fakeFor, CodexAppServerLaunch launch) {
+            Build(Func<int, FakeCodexAppServer> fakeFor, CodexAppServerLaunch launch, bool emitEnvelopes = false) {
         var seeds  = new List<string?>();
         var fakes  = new List<FakeCodexAppServer>();
         var index  = 0;
@@ -44,8 +45,14 @@ public class CodexAppServerHostedAgentRuntimeTests {
         };
 
         var runtime = new CodexAppServerHostedAgentRuntime(
-            spawn, launch, clock: null, NullLogger.Instance);
+            spawn, launch, clock: null, NullLogger.Instance, emitEnvelopeTranscript: emitEnvelopes);
         return (runtime, seeds, i => fakes[i]);
+    }
+
+    static List<AcpEventEnvelope> DrainAvailable(CodexAppServerHostedAgentRuntime runtime) {
+        var list = new List<AcpEventEnvelope>();
+        while (runtime.Envelopes.TryRead(out var e)) list.Add(e);
+        return list;
     }
 
     [Test]
@@ -62,6 +69,42 @@ public class CodexAppServerHostedAgentRuntimeTests {
         await Assert.That(fake.ReceivedMethods).Contains("thread/start");
         await Assert.That(fake.InitializeOptOuts).Contains("item/agentMessage/delta");
         await Assert.That(fake.LastThreadStartSandbox).IsEqualTo("read-only");
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Envelope_transcript_emits_a_token_usage_delta_through_the_forward_buffer() {
+        // Gate ON: the real HandleNotification path feeds the mapper + forward buffer, so a turn's usage
+        // notification surfaces as a token_usage envelope on IAcpTranscriptSource.Envelopes.
+        var fake = new FakeCodexAppServer { Model = "gpt-5.3-codex", EmitUsageOnTurn = (input: 120, output: 40, total: 160) };
+        var (runtime, _, _) = Build(_ => fake, Launch(), emitEnvelopes: true);
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.SendUserInputAsync("go").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        // The read loop processes usage BEFORE turn/completed (which unblocked the wait), so it is buffered.
+        var usage = DrainAvailable(runtime).Single(e => e.Kind == AcpEventKind.TokenUsage);
+        await Assert.That(usage.UsageInputTokens).IsEqualTo(120L);
+        await Assert.That(usage.UsageOutputTokens).IsEqualTo(40L);
+        await Assert.That(usage.Model).IsEqualTo("gpt-5.3-codex");
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Envelope_transcript_is_dormant_when_the_gate_is_off() {
+        // Default (reviewer path): the notification pump never feeds the buffer, so Envelopes stays empty
+        // even after a turn with usage — the AI-1761 control-plane behavior is byte-unchanged.
+        var fake = new FakeCodexAppServer { EmitUsageOnTurn = (input: 120, output: 40, total: 160) };
+        var (runtime, _, _) = Build(_ => fake, Launch()); // emitEnvelopes defaults false
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.SendUserInputAsync("go").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(DrainAvailable(runtime)).IsEmpty();
 
         await runtime.DisposeAsync();
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexEphemeralAccumulatorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexEphemeralAccumulatorTests.cs
@@ -1,0 +1,36 @@
+using Capacitor.Cli.Daemon.Harness.Codex;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>The per-item ephemeral accumulator (§2.4): deltas fold into cumulative content-so-far,
+/// items are independent, and completion drops an item's transient state.</summary>
+public class CodexEphemeralAccumulatorTests {
+    [Test]
+    public async Task Deltas_fold_into_cumulative_content() {
+        var acc = new CodexEphemeralAccumulator();
+        await Assert.That(acc.Accumulate("i1", "Hel")).IsEqualTo("Hel");
+        await Assert.That(acc.Accumulate("i1", "lo, ")).IsEqualTo("Hello, ");
+        await Assert.That(acc.Accumulate("i1", "world")).IsEqualTo("Hello, world");
+    }
+
+    [Test]
+    public async Task Items_accumulate_independently() {
+        var acc = new CodexEphemeralAccumulator();
+        acc.Accumulate("i1", "alpha");
+        acc.Accumulate("i2", "beta");
+        await Assert.That(acc.Accumulate("i1", "-1")).IsEqualTo("alpha-1");
+        await Assert.That(acc.Accumulate("i2", "-2")).IsEqualTo("beta-2");
+        await Assert.That(acc.ActiveItems).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Complete_drops_the_items_transient_state() {
+        var acc = new CodexEphemeralAccumulator();
+        acc.Accumulate("i1", "first");
+        acc.Complete("i1");
+        await Assert.That(acc.ActiveItems).IsEqualTo(0);
+
+        // A later delta for the same id starts a fresh buffer (a completed item never re-accumulates).
+        await Assert.That(acc.Accumulate("i1", "again")).IsEqualTo("again");
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexForwardBufferTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexForwardBufferTests.cs
@@ -1,0 +1,96 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Harness.Codex;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// The §2.4 forward buffer: canonical envelopes are never dropped (they block the emitter when full),
+/// ephemeral envelopes drop when full, and a canonical stall past the timeout fires the terminal fault
+/// exactly once.
+/// </summary>
+public class CodexForwardBufferTests {
+    static AcpEventEnvelope Canonical(string text) => new(Kind: AcpEventKind.AssistantText, Text: text);
+    static AcpEventEnvelope Ephemeral(string text) =>
+        new(Kind: AcpEventKind.AssistantText, Text: text, Ephemeral: true, ItemId: "i1");
+
+    static CodexForwardBuffer New(int capacity, TimeSpan stall, Action<TimeSpan>? onStall = null) =>
+        new(capacity, stall, CancellationToken.None, onStall ?? (_ => { }));
+
+    [Test]
+    public async Task Canonical_envelopes_are_delivered_in_order() {
+        using var buf = New(8, TimeSpan.FromSeconds(5));
+        buf.Emit(Canonical("a"));
+        buf.Emit(Canonical("b"));
+        buf.Emit(Canonical("c"));
+        buf.Complete();
+
+        var texts = new List<string?>();
+        await foreach (var e in buf.Reader.ReadAllAsync()) texts.Add(e.Text);
+        await Assert.That(string.Join(",", texts)).IsEqualTo("a,b,c");
+    }
+
+    [Test]
+    public async Task Ephemeral_is_dropped_when_full_but_canonical_is_retained() {
+        using var buf = New(capacity: 2, TimeSpan.FromSeconds(5));
+        buf.Emit(Canonical("c1"));   // fills 1/2
+        buf.Emit(Canonical("c2"));   // fills 2/2 → full
+        buf.Emit(Ephemeral("live")); // full → dropped
+
+        await Assert.That(buf.DroppedEphemeralCount).IsEqualTo(1);
+
+        // Drain: the two canonical envelopes survived, the ephemeral did not.
+        buf.Complete();
+        var texts = new List<string?>();
+        await foreach (var e in buf.Reader.ReadAllAsync()) texts.Add(e.Text);
+        await Assert.That(string.Join(",", texts)).IsEqualTo("c1,c2");
+    }
+
+    [Test]
+    public async Task Ephemeral_passes_through_when_there_is_room() {
+        using var buf = New(8, TimeSpan.FromSeconds(5));
+        buf.Emit(Ephemeral("partial"));
+        buf.Complete();
+
+        var read = await buf.Reader.ReadAsync();
+        await Assert.That(read.Ephemeral).IsTrue();
+        await Assert.That(read.Text).IsEqualTo("partial");
+        await Assert.That(buf.DroppedEphemeralCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task A_full_buffer_blocks_a_canonical_emit_until_the_reader_drains() {
+        using var buf = New(capacity: 1, TimeSpan.FromSeconds(30));
+        buf.Emit(Canonical("first")); // fills 1/1
+
+        var second = Task.Run(() => buf.Emit(Canonical("second"))); // blocks: buffer full
+        await Task.Delay(100);
+        await Assert.That(second.IsCompleted).IsFalse(); // still blocked — canonical never dropped
+
+        var a = await buf.Reader.ReadAsync();             // drain one → frees a slot
+        await second;                                     // the blocked emit now completes
+        var b = await buf.Reader.ReadAsync();
+
+        await Assert.That(a.Text).IsEqualTo("first");
+        await Assert.That(b.Text).IsEqualTo("second");
+        await Assert.That(buf.Stalled).IsFalse();
+    }
+
+    [Test]
+    public async Task A_canonical_stall_past_the_timeout_fires_the_fault_once_and_stops_accepting() {
+        var stalls = new List<TimeSpan>();
+        using var buf = New(capacity: 1, TimeSpan.FromMilliseconds(150), stalls.Add);
+        buf.Emit(Canonical("first")); // fills 1/1; no reader will ever drain
+
+        // This canonical emit blocks (full) and stalls out after the timeout, firing the fault.
+        var blocked = Task.Run(() => buf.Emit(Canonical("stalled")));
+        await blocked.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(buf.Stalled).IsTrue();
+        await Assert.That(stalls.Count).IsEqualTo(1);
+
+        // Once stalled, further emits are no-ops (the agent is faulting).
+        buf.Emit(Canonical("after"));
+        buf.Emit(Ephemeral("after"));
+        await Assert.That(buf.DroppedEphemeralCount).IsEqualTo(0); // not even counted — buffer is dead
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexNotificationMapperTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexNotificationMapperTests.cs
@@ -38,8 +38,9 @@ public class CodexNotificationMapperTests {
 
     [Test]
     public async Task Reasoning_completed_renders_content_blocks_preferring_content_over_summary() {
+        // content/summary are arrays of plain strings per the pinned schema.
         var e = Single(Run(NewMapper(), "item/completed",
-            """{"item":{"type":"reasoning","id":"r1","content":[{"type":"reasoning_text","text":"step A"},{"type":"text","text":"step B"}],"summary":[{"type":"summary_text","text":"S"}]}}"""));
+            """{"item":{"type":"reasoning","id":"r1","content":["step A","step B"],"summary":["S"]}}"""));
         await Assert.That(e.Kind).IsEqualTo(AcpEventKind.AssistantThinking);
         await Assert.That(e.Text).IsEqualTo("step A\nstep B");
         await Assert.That(e.ItemId).IsEqualTo("r1");
@@ -48,7 +49,7 @@ public class CodexNotificationMapperTests {
     [Test]
     public async Task Reasoning_completed_falls_back_to_summary_when_content_empty() {
         var e = Single(Run(NewMapper(), "item/completed",
-            """{"item":{"type":"reasoning","id":"r1","content":[],"summary":[{"type":"summary_text","text":"the gist"}]}}"""));
+            """{"item":{"type":"reasoning","id":"r1","content":[],"summary":["the gist"]}}"""));
         await Assert.That(e.Text).IsEqualTo("the gist");
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexNotificationMapperTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexNotificationMapperTests.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// The codex app-server notification → <see cref="AcpEventEnvelope"/> mapper (§2.4). Canonical lane =
+/// completed snapshots / tool opens / plan / token deltas; ephemeral lane = accumulated live deltas;
+/// unknown item types surface generically and bump the drift counter. Shapes are grounded on codex
+/// 0.147.0's generated JSON schema.
+/// </summary>
+public class CodexNotificationMapperTests {
+    static CodexNotificationMapper NewMapper(string? model = "gpt-5-codex") =>
+        new(() => model, NullLogger.Instance);
+
+    static IReadOnlyList<AcpEventEnvelope> Run(CodexNotificationMapper m, string method, string paramsJson) {
+        using var doc = JsonDocument.Parse(paramsJson);
+        return m.Map(method, doc.RootElement);
+    }
+
+    static AcpEventEnvelope Single(IReadOnlyList<AcpEventEnvelope> r) {
+        if (r.Count != 1) throw new InvalidOperationException($"expected exactly one envelope, got {r.Count}");
+        return r[0];
+    }
+
+    [Test]
+    public async Task AgentMessage_completed_maps_to_canonical_assistant_text_with_item_id() {
+        var e = Single(Run(NewMapper(), "item/completed",
+            """{"item":{"type":"agentMessage","id":"i1","text":"Hello"},"threadId":"t","turnId":"u","completedAtMs":1699999999000}"""));
+        await Assert.That(e.Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(e.Text).IsEqualTo("Hello");
+        await Assert.That(e.ItemId).IsEqualTo("i1");
+        await Assert.That(e.Ephemeral).IsFalse();
+        await Assert.That(e.TimestampIso).IsNotNull();
+    }
+
+    [Test]
+    public async Task Reasoning_completed_renders_content_blocks_preferring_content_over_summary() {
+        var e = Single(Run(NewMapper(), "item/completed",
+            """{"item":{"type":"reasoning","id":"r1","content":[{"type":"reasoning_text","text":"step A"},{"type":"text","text":"step B"}],"summary":[{"type":"summary_text","text":"S"}]}}"""));
+        await Assert.That(e.Kind).IsEqualTo(AcpEventKind.AssistantThinking);
+        await Assert.That(e.Text).IsEqualTo("step A\nstep B");
+        await Assert.That(e.ItemId).IsEqualTo("r1");
+    }
+
+    [Test]
+    public async Task Reasoning_completed_falls_back_to_summary_when_content_empty() {
+        var e = Single(Run(NewMapper(), "item/completed",
+            """{"item":{"type":"reasoning","id":"r1","content":[],"summary":[{"type":"summary_text","text":"the gist"}]}}"""));
+        await Assert.That(e.Text).IsEqualTo("the gist");
+    }
+
+    [Test]
+    public async Task CommandExecution_started_opens_a_shell_tool_call() {
+        var e = Single(Run(NewMapper(), "item/started",
+            """{"item":{"type":"commandExecution","id":"c1","command":"ls -la","cwd":"/repo","status":"inProgress"},"startedAtMs":1699999999000}"""));
+        await Assert.That(e.Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(e.ToolCallId).IsEqualTo("c1");
+        await Assert.That(e.ToolName).IsEqualTo("shell");
+        await Assert.That(e.ToolInputJson!).Contains("ls -la");
+        await Assert.That(e.ToolInputJson!).Contains("/repo");
+    }
+
+    [Test]
+    public async Task CommandExecution_completed_is_the_authoritative_result_with_error_from_exit_code() {
+        var ok = Single(Run(NewMapper(), "item/completed",
+            """{"item":{"type":"commandExecution","id":"c1","command":"ls","cwd":"/r","aggregatedOutput":"total 0","exitCode":0,"status":"completed"}}"""));
+        await Assert.That(ok.Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(ok.ToolCallId).IsEqualTo("c1");
+        await Assert.That(ok.ToolResult).IsEqualTo("total 0");
+        await Assert.That(ok.ToolIsError).IsFalse();
+
+        var bad = Single(Run(NewMapper(), "item/completed",
+            """{"item":{"type":"commandExecution","id":"c2","command":"false","cwd":"/r","aggregatedOutput":"boom","exitCode":2,"status":"failed"}}"""));
+        await Assert.That(bad.ToolIsError).IsTrue();
+    }
+
+    [Test]
+    public async Task FileChange_completed_maps_to_a_tool_call_carrying_the_diff() {
+        var e = Single(Run(NewMapper(), "item/completed",
+            """{"item":{"type":"fileChange","id":"f1","status":"completed","changes":[{"path":"a.txt","kind":"update","diff":"@@ -1 +1 @@"}]}}"""));
+        await Assert.That(e.Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(e.ToolName).IsEqualTo("apply_patch");
+        await Assert.That(e.ToolInputJson!).Contains("a.txt");
+        await Assert.That(e.ToolInputJson!).Contains("changes");
+        // ToolInputJson must be a JSON object the server can parse into tool arguments.
+        using var doc = JsonDocument.Parse(e.ToolInputJson!);
+        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+    }
+
+    [Test]
+    public async Task McpToolCall_completed_maps_to_tool_result_and_flags_an_error() {
+        var ok = Single(Run(NewMapper(), "item/completed",
+            """{"item":{"type":"mcpToolCall","id":"m1","server":"srv","tool":"do","status":"completed","result":{"ok":true}}}"""));
+        await Assert.That(ok.Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(ok.ToolIsError).IsFalse();
+
+        var bad = Single(Run(NewMapper(), "item/completed",
+            """{"item":{"type":"mcpToolCall","id":"m2","server":"srv","tool":"do","status":"failed","error":"nope"}}"""));
+        await Assert.That(bad.ToolIsError).IsTrue();
+        await Assert.That(bad.ToolResult!).Contains("nope");
+    }
+
+    [Test]
+    public async Task Turn_plan_update_maps_to_a_canonical_plan_snapshot() {
+        var e = Single(Run(NewMapper(), "turn/plan/updated",
+            """{"threadId":"t","turnId":"u","explanation":"Roadmap","plan":[{"step":"Do X","status":"pending"},{"step":"Do Y","status":"completed"}]}"""));
+        await Assert.That(e.Kind).IsEqualTo(AcpEventKind.Plan);
+        await Assert.That(e.Text!).Contains("Do X");
+        await Assert.That(e.Text!).Contains("Do Y");
+        await Assert.That(e.Text!).Contains("Roadmap");
+        await Assert.That(e.ItemId).IsNull();     // turn-level, not item-level
+        await Assert.That(e.Ephemeral).IsFalse();
+    }
+
+    [Test]
+    public async Task AgentMessage_deltas_accumulate_into_ephemeral_content_and_completion_finalizes() {
+        var m = NewMapper();
+        var d1 = Single(Run(m, "item/agentMessage/delta", """{"itemId":"i1","delta":"Hel","threadId":"t","turnId":"u"}"""));
+        await Assert.That(d1.Ephemeral).IsTrue();
+        await Assert.That(d1.Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(d1.Text).IsEqualTo("Hel");
+        await Assert.That(d1.ItemId).IsEqualTo("i1");
+
+        var d2 = Single(Run(m, "item/agentMessage/delta", """{"itemId":"i1","delta":"lo","threadId":"t","turnId":"u"}"""));
+        await Assert.That(d2.Text).IsEqualTo("Hello");
+
+        // The completed snapshot supersedes and finalizes the item's transient state.
+        Run(m, "item/completed", """{"item":{"type":"agentMessage","id":"i1","text":"Hello"}}""");
+        var after = Single(Run(m, "item/agentMessage/delta", """{"itemId":"i1","delta":"!","threadId":"t","turnId":"u"}"""));
+        await Assert.That(after.Text).IsEqualTo("!"); // fresh buffer — the completed item dropped the old state
+    }
+
+    [Test]
+    public async Task Command_output_deltas_ride_the_ephemeral_tool_result_lane() {
+        var m = NewMapper();
+        Run(m, "item/commandExecution/outputDelta", """{"itemId":"c1","delta":"line1\n","threadId":"t","turnId":"u"}""");
+        var d = Single(Run(m, "item/commandExecution/outputDelta", """{"itemId":"c1","delta":"line2\n","threadId":"t","turnId":"u"}"""));
+        await Assert.That(d.Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(d.Ephemeral).IsTrue();
+        await Assert.That(d.ToolCallId).IsEqualTo("c1");
+        await Assert.That(d.ToolResult).IsEqualTo("line1\nline2\n");
+    }
+
+    [Test]
+    public async Task PatchUpdated_is_a_snapshot_not_accumulated() {
+        var m = NewMapper();
+        var a = Single(Run(m, "item/fileChange/patchUpdated",
+            """{"itemId":"f1","threadId":"t","turnId":"u","changes":[{"path":"a.txt","kind":"update","diff":"v1"}]}"""));
+        await Assert.That(a.Ephemeral).IsTrue();
+        await Assert.That(a.Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(a.ToolInputJson!).Contains("v1");
+
+        // A second snapshot reflects only its own changes — never appended to the first.
+        var b = Single(Run(m, "item/fileChange/patchUpdated",
+            """{"itemId":"f1","threadId":"t","turnId":"u","changes":[{"path":"a.txt","kind":"update","diff":"v2"}]}"""));
+        await Assert.That(b.ToolInputJson!).Contains("v2");
+        await Assert.That(b.ToolInputJson!).DoesNotContain("v1");
+    }
+
+    [Test]
+    public async Task Token_usage_emits_the_first_whole_total_then_a_component_delta() {
+        var m = NewMapper();
+        var first = Single(Run(m, "thread/tokenUsage/updated",
+            """{"threadId":"t","turnId":"u","tokenUsage":{"total":{"inputTokens":100,"cachedInputTokens":20,"cacheWriteInputTokens":5,"outputTokens":40,"reasoningOutputTokens":8,"totalTokens":165}}}"""));
+        await Assert.That(first.Kind).IsEqualTo(AcpEventKind.TokenUsage);
+        await Assert.That(first.Model).IsEqualTo("gpt-5-codex");
+        await Assert.That(first.UsageInputTokens).IsEqualTo(100L);
+        await Assert.That(first.UsageCacheWriteInputTokens).IsEqualTo(5L);
+
+        var second = Single(Run(m, "thread/tokenUsage/updated",
+            """{"threadId":"t","turnId":"u","tokenUsage":{"total":{"inputTokens":150,"cachedInputTokens":30,"cacheWriteInputTokens":5,"outputTokens":60,"reasoningOutputTokens":12,"totalTokens":245}}}"""));
+        await Assert.That(second.UsageInputTokens).IsEqualTo(50L);
+        await Assert.That(second.UsageCachedInputTokens).IsEqualTo(10L);
+        await Assert.That(second.UsageCacheWriteInputTokens).IsEqualTo(0L);
+        await Assert.That(second.UsageOutputTokens).IsEqualTo(20L);
+    }
+
+    [Test]
+    public async Task Token_usage_zero_delta_emits_nothing() {
+        var m = NewMapper();
+        const string snapshot =
+            """{"tokenUsage":{"total":{"inputTokens":10,"cachedInputTokens":2,"cacheWriteInputTokens":0,"outputTokens":5,"reasoningOutputTokens":1,"totalTokens":18}}}""";
+        Run(m, "thread/tokenUsage/updated", snapshot);          // first: whole total
+        var repeat = Run(m, "thread/tokenUsage/updated", snapshot); // unchanged cumulative → zero delta
+        await Assert.That(repeat).IsEmpty();
+    }
+
+    [Test]
+    public async Task Unknown_item_type_becomes_a_generic_tool_call_and_counts_drift() {
+        var m = NewMapper();
+        var e = Single(Run(m, "item/completed",
+            """{"item":{"type":"quantumThing","id":"q1","payload":42}}"""));
+        await Assert.That(e.Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(e.ToolName).IsEqualTo("quantumThing");
+        await Assert.That(e.ToolCallId).IsEqualTo("q1");
+        await Assert.That(m.UnmappedKindCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Unmapped_methods_and_malformed_params_yield_nothing() {
+        var m = NewMapper();
+        await Assert.That(Run(m, "thread/archived", "{}")).IsEmpty();
+        await Assert.That(Run(m, "turn/started", """{"turnId":"u"}""")).IsEmpty();
+        await Assert.That(Run(m, "item/completed", "{}")).IsEmpty();                 // no item
+        await Assert.That(Run(m, "item/agentMessage/delta", """{"itemId":"i1"}""")).IsEmpty(); // no delta
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexNotificationMapperTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexNotificationMapperTests.cs
@@ -79,16 +79,33 @@ public class CodexNotificationMapperTests {
     }
 
     [Test]
-    public async Task FileChange_completed_maps_to_a_tool_call_carrying_the_diff() {
-        var e = Single(Run(NewMapper(), "item/completed",
-            """{"item":{"type":"fileChange","id":"f1","status":"completed","changes":[{"path":"a.txt","kind":"update","diff":"@@ -1 +1 @@"}]}}"""));
-        await Assert.That(e.Kind).IsEqualTo(AcpEventKind.ToolCall);
-        await Assert.That(e.ToolName).IsEqualTo("apply_patch");
-        await Assert.That(e.ToolInputJson!).Contains("a.txt");
-        await Assert.That(e.ToolInputJson!).Contains("changes");
+    public async Task FileChange_completed_maps_to_a_paired_tool_call_and_result() {
+        var r = Run(NewMapper(), "item/completed",
+            """{"item":{"type":"fileChange","id":"f1","status":"completed","changes":[{"path":"a.txt","kind":"update","diff":"@@ -1 +1 @@"}]}}""");
+        await Assert.That(r.Count).IsEqualTo(2);
+
+        var call = r[0];
+        await Assert.That(call.Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(call.ToolName).IsEqualTo("apply_patch");
+        await Assert.That(call.ToolCallId).IsEqualTo("f1");
+        await Assert.That(call.ToolInputJson!).Contains("a.txt");
         // ToolInputJson must be a JSON object the server can parse into tool arguments.
-        using var doc = JsonDocument.Parse(e.ToolInputJson!);
+        using var doc = JsonDocument.Parse(call.ToolInputJson!);
         await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+
+        var result = r[1];
+        await Assert.That(result.Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(result.ToolCallId).IsEqualTo("f1"); // paired with the call
+        await Assert.That(result.ToolIsError).IsFalse();
+    }
+
+    [Test]
+    public async Task FileChange_failed_apply_flags_the_result_as_error() {
+        var r = Run(NewMapper(), "item/completed",
+            """{"item":{"type":"fileChange","id":"f2","status":"failed","changes":[{"path":"a.txt","kind":"update","diff":"x"}]}}""");
+        await Assert.That(r.Count).IsEqualTo(2);
+        await Assert.That(r[1].Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(r[1].ToolIsError).IsTrue();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexNotificationMapperTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexNotificationMapperTests.cs
@@ -101,6 +101,14 @@ public class CodexNotificationMapperTests {
             """{"item":{"type":"mcpToolCall","id":"m2","server":"srv","tool":"do","status":"failed","error":"nope"}}"""));
         await Assert.That(bad.ToolIsError).IsTrue();
         await Assert.That(bad.ToolResult!).Contains("nope");
+
+        // A failed call carrying BOTH a result and an error must render the error — the payload must stay
+        // consistent with the ToolIsError flag rather than showing the result as if it succeeded.
+        var both = Single(Run(NewMapper(), "item/completed",
+            """{"item":{"type":"mcpToolCall","id":"m3","server":"srv","tool":"do","status":"failed","result":{"ok":true},"error":"boom"}}"""));
+        await Assert.That(both.ToolIsError).IsTrue();
+        await Assert.That(both.ToolResult!).Contains("boom");
+        await Assert.That(both.ToolResult!).DoesNotContain("ok");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexUsageDeltaConverterTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexUsageDeltaConverterTests.cs
@@ -1,0 +1,69 @@
+using Capacitor.Cli.Daemon.Harness.Codex;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// The daemon-side usage delta converter (§2.4): cumulative app-server totals → per-event deltas, so
+/// the additive usage pipeline neither double-counts nor mis-attributes across a model reroute. Covers
+/// the first snapshot, steady deltas, a cumulative reset, and the two resume baseline modes.
+/// </summary>
+public class CodexUsageDeltaConverterTests {
+    static CodexTokenUsage U(long input, long cached, long output, long reasoning, long total) =>
+        new(input, cached, output, reasoning, total);
+
+    [Test]
+    public async Task First_snapshot_emits_the_whole_total() {
+        var c = new CodexUsageDeltaConverter();
+        var d = c.Convert(U(10, 2, 5, 1, 15));
+        await Assert.That(d).IsEqualTo(U(10, 2, 5, 1, 15));
+    }
+
+    [Test]
+    public async Task Subsequent_snapshot_emits_the_component_wise_delta() {
+        var c = new CodexUsageDeltaConverter();
+        c.Convert(U(10, 2, 5, 1, 15));
+        var d = c.Convert(U(25, 5, 12, 3, 37));
+        await Assert.That(d).IsEqualTo(U(15, 3, 7, 2, 22));
+    }
+
+    [Test]
+    public async Task Equal_snapshot_emits_a_zero_delta() {
+        var c = new CodexUsageDeltaConverter();
+        c.Convert(U(10, 2, 5, 1, 15));
+        var d = c.Convert(U(10, 2, 5, 1, 15));
+        await Assert.That(d).IsEqualTo(U(0, 0, 0, 0, 0));
+    }
+
+    [Test]
+    public async Task A_lower_cumulative_total_is_treated_as_a_fresh_baseline() {
+        var c = new CodexUsageDeltaConverter();
+        c.Convert(U(100, 20, 50, 10, 150));
+        var d = c.Convert(U(8, 1, 4, 0, 12)); // dropped → reset: contribute the whole new total
+        await Assert.That(d).IsEqualTo(U(8, 1, 4, 0, 12));
+
+        var next = c.Convert(U(20, 3, 9, 1, 29)); // deltas resume from the reset baseline
+        await Assert.That(next).IsEqualTo(U(12, 2, 5, 1, 17));
+    }
+
+    [Test]
+    public async Task Exact_resume_baseline_makes_the_next_delta_exact() {
+        var c = new CodexUsageDeltaConverter();
+        c.Convert(U(10, 2, 5, 1, 15));
+        c.SetExactBaseline(U(40, 8, 20, 4, 60)); // thread/read reported this cumulative total on resume
+        var d = c.Convert(U(55, 11, 27, 6, 82));
+        await Assert.That(d).IsEqualTo(U(15, 3, 7, 2, 22));
+    }
+
+    [Test]
+    public async Task Fallback_baseline_consumes_the_next_snapshot_and_emits_nothing() {
+        var c = new CodexUsageDeltaConverter();
+        c.Convert(U(10, 2, 5, 1, 15));
+        c.BaselineOnNextNotification();
+
+        var baseline = c.Convert(U(60, 12, 30, 6, 90)); // consumed as baseline
+        await Assert.That(baseline).IsNull();
+
+        var d = c.Convert(U(75, 15, 37, 8, 112)); // deltas resume against the fallback baseline
+        await Assert.That(d).IsEqualTo(U(15, 3, 7, 2, 22));
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexUsageDeltaConverterTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexUsageDeltaConverterTests.cs
@@ -8,62 +8,63 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
 /// the first snapshot, steady deltas, a cumulative reset, and the two resume baseline modes.
 /// </summary>
 public class CodexUsageDeltaConverterTests {
-    static CodexTokenUsage U(long input, long cached, long output, long reasoning, long total) =>
-        new(input, cached, output, reasoning, total);
+    // (input, cached, cacheWrite, output, reasoning, total) — mirrors the app-server TokenUsageBreakdown.
+    static CodexTokenUsage U(long input, long cached, long cacheWrite, long output, long reasoning, long total) =>
+        new(input, cached, cacheWrite, output, reasoning, total);
 
     [Test]
     public async Task First_snapshot_emits_the_whole_total() {
         var c = new CodexUsageDeltaConverter();
-        var d = c.Convert(U(10, 2, 5, 1, 15));
-        await Assert.That(d).IsEqualTo(U(10, 2, 5, 1, 15));
+        var d = c.Convert(U(10, 2, 1, 5, 1, 15));
+        await Assert.That(d).IsEqualTo(U(10, 2, 1, 5, 1, 15));
     }
 
     [Test]
     public async Task Subsequent_snapshot_emits_the_component_wise_delta() {
         var c = new CodexUsageDeltaConverter();
-        c.Convert(U(10, 2, 5, 1, 15));
-        var d = c.Convert(U(25, 5, 12, 3, 37));
-        await Assert.That(d).IsEqualTo(U(15, 3, 7, 2, 22));
+        c.Convert(U(10, 2, 1, 5, 1, 15));
+        var d = c.Convert(U(25, 5, 4, 12, 3, 37));
+        await Assert.That(d).IsEqualTo(U(15, 3, 3, 7, 2, 22));
     }
 
     [Test]
     public async Task Equal_snapshot_emits_a_zero_delta() {
         var c = new CodexUsageDeltaConverter();
-        c.Convert(U(10, 2, 5, 1, 15));
-        var d = c.Convert(U(10, 2, 5, 1, 15));
-        await Assert.That(d).IsEqualTo(U(0, 0, 0, 0, 0));
+        c.Convert(U(10, 2, 1, 5, 1, 15));
+        var d = c.Convert(U(10, 2, 1, 5, 1, 15));
+        await Assert.That(d).IsEqualTo(U(0, 0, 0, 0, 0, 0));
     }
 
     [Test]
     public async Task A_lower_cumulative_total_is_treated_as_a_fresh_baseline() {
         var c = new CodexUsageDeltaConverter();
-        c.Convert(U(100, 20, 50, 10, 150));
-        var d = c.Convert(U(8, 1, 4, 0, 12)); // dropped → reset: contribute the whole new total
-        await Assert.That(d).IsEqualTo(U(8, 1, 4, 0, 12));
+        c.Convert(U(100, 20, 10, 50, 10, 150));
+        var d = c.Convert(U(8, 1, 1, 4, 0, 12)); // dropped → reset: contribute the whole new total
+        await Assert.That(d).IsEqualTo(U(8, 1, 1, 4, 0, 12));
 
-        var next = c.Convert(U(20, 3, 9, 1, 29)); // deltas resume from the reset baseline
-        await Assert.That(next).IsEqualTo(U(12, 2, 5, 1, 17));
+        var next = c.Convert(U(20, 3, 2, 9, 1, 29)); // deltas resume from the reset baseline
+        await Assert.That(next).IsEqualTo(U(12, 2, 1, 5, 1, 17));
     }
 
     [Test]
     public async Task Exact_resume_baseline_makes_the_next_delta_exact() {
         var c = new CodexUsageDeltaConverter();
-        c.Convert(U(10, 2, 5, 1, 15));
-        c.SetExactBaseline(U(40, 8, 20, 4, 60)); // thread/read reported this cumulative total on resume
-        var d = c.Convert(U(55, 11, 27, 6, 82));
-        await Assert.That(d).IsEqualTo(U(15, 3, 7, 2, 22));
+        c.Convert(U(10, 2, 1, 5, 1, 15));
+        c.SetExactBaseline(U(40, 8, 4, 20, 4, 60)); // thread/read reported this cumulative total on resume
+        var d = c.Convert(U(55, 11, 7, 27, 6, 82));
+        await Assert.That(d).IsEqualTo(U(15, 3, 3, 7, 2, 22));
     }
 
     [Test]
     public async Task Fallback_baseline_consumes_the_next_snapshot_and_emits_nothing() {
         var c = new CodexUsageDeltaConverter();
-        c.Convert(U(10, 2, 5, 1, 15));
+        c.Convert(U(10, 2, 1, 5, 1, 15));
         c.BaselineOnNextNotification();
 
-        var baseline = c.Convert(U(60, 12, 30, 6, 90)); // consumed as baseline
+        var baseline = c.Convert(U(60, 12, 6, 30, 6, 90)); // consumed as baseline
         await Assert.That(baseline).IsNull();
 
-        var d = c.Convert(U(75, 15, 37, 8, 112)); // deltas resume against the fallback baseline
-        await Assert.That(d).IsEqualTo(U(15, 3, 7, 2, 22));
+        var d = c.Convert(U(75, 15, 9, 37, 8, 112)); // deltas resume against the fallback baseline
+        await Assert.That(d).IsEqualTo(U(15, 3, 3, 7, 2, 22));
     }
 }


### PR DESCRIPTION
Second PR of the interactive-hosted-Codex phase (AI-1762) of the app-server epic (AI-1759). Daemon-only; the shipped reviewer path is **byte-unchanged** because the new envelope emission is gated OFF (§2.5 activates it).

## What
Implements the §2.4 envelope transcript for hosted `codex app-server` sessions — the daemon translates the app-server's JSON-RPC notification stream into the existing `AcpEventEnvelope` vocabulary, so hosted Codex sessions can be ingested from the protocol stream (like the other ACP vendors) instead of the hooks + `kcap watch` rollout path.

- **Envelope fields (both repos, additive):** `Ephemeral`/`ItemId` (the ephemeral live lane + the item key a viewer uses to finalize transient state), a `Plan` kind (`turn/plan/updated` full snapshots), and a `token_usage` kind with additive bucket fields. All default so `ContractVersion` stays 1 — an older server ignores them. Both `AcpEventEnvelopeWireCompatTests` pin each other.
- **`CodexNotificationMapper`** — canonical lane = `item/completed` snapshots + command/mcp tool opens on `item/started` + `turn/plan/updated` + per-event token deltas; ephemeral lane = delta notifications accumulated into content-so-far (`patchUpdated` replaces). Unknown item types surface as a generic tool call and bump a drift counter. Shapes grounded on codex 0.147.0's generated JSON schema; JSON built with `Utf8JsonWriter` (AOT-safe).
- **`CodexUsageDeltaConverter` / `CodexEphemeralAccumulator`** — the cumulative→delta usage semantics (attributed to the model-at-instant, correct across `model/rerouted`) and the per-item cumulative ephemeral content. `CodexTokenUsage` gains `CacheWriteInputTokens` (a billed cache-creation bucket that was being dropped).
- **`CodexForwardBuffer`** — the bounded §2.4 buffer: **canonical envelopes are never dropped** (a full buffer blocks the emit → the read loop stops consuming stdout → the app-server blocks, which is lossless); **ephemeral envelopes drop when full**; a canonical stall past `forwardStallSeconds` fires a one-shot terminal fault (never an indefinite wedge, never a silently incomplete transcript).
- **Runtime** implements `IAcpTranscriptSource` and feeds every notification through the mapper into the buffer.

## Why gated off
The emission is behind `emitEnvelopeTranscript` (default false). Feeding the buffer with no attached forwarder would stall it, and draining it *without* the §2.5 hooks/watch dedup would double-ingest a reviewer session. So this PR ships the transcript surface **dormant**; §2.5 flips the one flag together with the factory `Transcript` wiring and the guard-1/2 dedup. A regression test pins the dormant behavior.

## Tests
Usage converter (6), ephemeral accumulator (3), notification mapper (15), forward buffer (5, incl. backpressure + stall), runtime integration (gate on and off), both wire-compat suites. Daemon AOT publish clean.

Linear: AI-1762