### PR TITLE
[AI-2079] Hold new dependency versions for 3 days before proposing them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 # Routine sweeps only — security updates are a separate always-on channel in repo settings. Weekly, not
 # daily: Dependabot rebases an open group PR every run, and each rebase re-runs the whole matrix.
 # No `docker`/`npm` — nothing there is a dependency manifest; see the comments at those pins.
+# 3-day cooldown so a poisoned release has time to be yanked; security updates ignore it by design.
 version: 2
 updates:
   # CPM: Directory.Packages.props is the single pin, and setup-dotnet keys its restore cache on it.
@@ -11,6 +12,8 @@ updates:
       day: monday
       time: "05:00"
       timezone: Etc/UTC
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 5
     labels: [dependencies]
     commit-message:
@@ -36,6 +39,8 @@ updates:
       interval: monthly
       time: "05:00"
       timezone: Etc/UTC
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 5
     labels: [dependencies]
     commit-message:
@@ -50,6 +55,8 @@ updates:
       day: monday
       time: "05:00"
       timezone: Etc/UTC
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 5
     labels: [dependencies]
     commit-message:


### PR DESCRIPTION
Adds `cooldown: {default-days: 3}` to all three ecosystems, so a newly published version has to sit
for three days before Dependabot will propose it — long enough for a poisoned release to be yanked.

Follow-up to #587, which merged before this was added.

Closes #601 · AI-2079 (follows AI-2057)

## Why this is safe to do

Cooldown applies to **version** updates only — Dependabot exempts security updates from it. So a
published advisory is still fixed immediately; only the routine weekly sweep waits.

## What it does not cover

It does nothing against a **mutable-tag** attack, which is the likelier vector for the
`github-actions` half of this config. `actions/checkout@v7` is a tag, and a compromised upstream can
re-point it at malicious code without publishing any new version for Dependabot to cool down.
Commit-SHA pinning is the control that closes that, and it's a separate change — Dependabot keeps
SHA pins updated with a trailing version comment, so it costs readability, not maintainability.

## One consequence worth knowing

Cooldown filters candidates at run time, and the sweep is weekly, so the delay is quantised to the
schedule: a release that lands in the three days before a Monday run misses that run and waits for
the next one. Effective delay is 3–10 days, not exactly 3.
