### PR TITLE
[AI-2033] Install the agent skills from every vendor's own plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ In `--no-prompt` mode, the wizard installs hooks for every detected agent by def
 > **Behavior change: `--no-prompt` now also imports this repo's history.** The Step 6 import (above) defaults to yes like every other prompt in the wizard, so `kcap setup --no-prompt` now uploads this repository's past sessions too — when run inside a git repo with an origin remote and authentication requirements are satisfied (including no-auth/provider-`None` servers). Existing unattended/scripted `kcap setup --no-prompt` invocations will start uploading current-repo session history unless you add `--skip-import`.
 
 > **Need hooks for an agent installed after setup, or scoped to a single repo?**
-> Run `kcap plugin install [--codex|--cursor|--copilot|--gemini|--kiro|--pi|--opencode|--antigravity]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Use `--skills` instead of `--codex` if you only want the agent skills without Codex hooks. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). After a `--project` install, also run `codex` once in the repo and accept the workspace trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap`, and `kcap update` refreshes them too (npm 11+ blocks install scripts by default — `kcap update` works regardless, or add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt the postinstall in once).
+> Run `kcap plugin install [--codex|--cursor|--copilot|--gemini|--kiro|--pi|--opencode|--antigravity]` (omit the flag for the Claude Code plugin), or pair Codex with `--project` for a per-repo install. Every per-vendor install also writes the agent skills to `~/.agents/skills/` (Kiro and Antigravity get their own copies under `~/.kiro/skills` and `~/.gemini/skills`), so `--skills` is only needed to install or refresh them on their own — for instance for an agent kcap has no integration for. Cursor uses user-scope only — `--project` has no effect with `--cursor`. After installing Codex hooks, the next `codex` launch prompts to trust the new hooks — accept once to trust them all (run `/hooks` inside Codex if you'd rather trust each entry individually). After a `--project` install, also run `codex` once in the repo and accept the workspace trust prompt. Re-running after a kcap upgrade is rarely needed for user-scope installs — the npm postinstall hook auto-refreshes them on every `npm install -g @kurrent/kcap`, and `kcap update` refreshes them too (npm 11+ blocks install scripts by default — `kcap update` works regardless, or add `allow-scripts[]=@kurrent/kcap` to `~/.npmrc` to opt the postinstall in once).
 
 > **Need at least one agent to capture sessions:** the setup wizard runs to completion without an agent CLI on `PATH` (it'll still configure your profile, auth, and daemon), but kcap only records work once Claude Code or Codex CLI is installed and the hooks are in place.
 
@@ -1095,7 +1095,7 @@ kcap plugin install --codex --if-installed           # refresh Codex hooks only 
 kcap plugin install --if-installed                   # refresh Claude plugin registration only if previously installed (used by npm postinstall)
 ```
 
-Installing with `--codex` (or `--skills`) writes nine skills under `~/.agents/skills/`:
+Installing any vendor that reads the shared tree — `--codex`, `--cursor`, `--copilot`, `--gemini`, `--pi`, `--opencode` — writes these nine skills under `~/.agents/skills/` (`--skills` installs them alone; Kiro and Antigravity get their own copies, and the bare Claude install uses the plugin bundle):
 
 | Skill | Wraps | Purpose |
 |---|---|---|
@@ -1166,7 +1166,7 @@ PR review is supported for hosted Codex agents as well as Claude — the same `k
 Cursor is detected by the presence of `~/.cursor/` — you don't need the `cursor` shell command on `PATH`. If `kcap setup` found Cursor and you said yes, hooks are already in place. Installing also registers the six kcap MCP servers in `~/.cursor/mcp.json` (non-destructive, idempotent); pass `--skip-cursor-mcp` to opt out. To install or remove later:
 
 ```bash
-kcap plugin install --cursor                # writes ~/.cursor/hooks.json + registers kcap MCP servers
+kcap plugin install --cursor                # writes ~/.cursor/hooks.json + agent skills + registers kcap MCP servers
 kcap plugin install --cursor --skip-cursor-mcp  # hooks only, skip ~/.cursor/mcp.json
 kcap plugin remove --cursor                 # remove Cursor hooks + kcap MCP servers
 ```
@@ -1199,7 +1199,7 @@ something you need to run day to day.
 Copilot CLI is detected via `~/.copilot/` (created on Copilot's first run) or the `copilot` binary on `PATH`. kcap writes its own hooks file — Copilot merges every `*.json` under `~/.copilot/hooks/`, so your other hook files are never touched. Copilot loads hook config at startup: restart any running `copilot` session after installing.
 
 ```bash
-kcap plugin install --copilot               # writes ~/.copilot/hooks/kcap.json
+kcap plugin install --copilot               # writes ~/.copilot/hooks/kcap.json + agent skills
 kcap plugin remove --copilot                # deletes ~/.copilot/hooks/kcap.json
 ```
 
@@ -1210,7 +1210,7 @@ Live sessions stream from `~/.copilot/session-state/<session-id>/events.jsonl` (
 Gemini CLI is detected via `~/.gemini/` (created on Gemini's first run) or the `gemini` binary on `PATH`. Gemini keeps its hooks in the shared `~/.gemini/settings.json`, so kcap **merges** its entries into the `hooks` block and preserves your other settings and any hand-authored hook entries. Gemini loads hook config at startup: restart any running `gemini` session after installing.
 
 ```bash
-kcap plugin install --gemini                # merges kcap hooks into ~/.gemini/settings.json
+kcap plugin install --gemini                # merges kcap hooks into ~/.gemini/settings.json, writes agent skills
 kcap plugin remove --gemini                 # removes only kcap's entries
 ```
 
@@ -1244,7 +1244,7 @@ Pi (`badlogic/pi-mono`) is detected via `~/.pi/agent/` or the `pi` binary on `PA
 `kcap` must be on `PATH` (both extensions shell out to it). Restart any running `pi` session after installing.
 
 ```bash
-kcap plugin install --pi                    # write kcap.ts + kcap-mcp.ts + AGENTS.md block
+kcap plugin install --pi                    # write kcap.ts + kcap-mcp.ts + AGENTS.md block + agent skills
 kcap plugin install --pi --skip-pi-mcp      # ingest + steering only, no MCP bridge
 kcap plugin remove --pi                     # delete both extensions + strip the AGENTS.md block
 ```
@@ -1256,11 +1256,11 @@ Live sessions stream from `~/.pi/agent/sessions/` (honours `PI_CODING_AGENT_DIR`
 SST OpenCode is detected via `~/.config/opencode/` (or `~/.local/share/opencode/`) or the `opencode` binary on `PATH`. OpenCode has **no shell hooks** — it exposes an in-process plugin API — so `install --opencode` writes a dependency-free plugin to `~/.config/opencode/plugins/kcap.ts`, which `opencode` auto-loads at startup. Restart any running `opencode` session after installing.
 
 ```bash
-kcap plugin install --opencode              # write ~/.config/opencode/plugins/kcap.ts
+kcap plugin install --opencode              # write ~/.config/opencode/plugins/kcap.ts + agent skills
 kcap plugin remove --opencode               # delete it
 ```
 
-Beyond the capture plugin, `install --opencode` (and `kcap setup`) also **registers the six kcap MCP servers** in `~/.config/opencode/opencode.json` — OpenCode's `mcp` block, each entry `type: "local"` with `command` as an array and `enabled: true` (non-destructive/idempotent, preserving `$schema` and any user servers; opt out `--skip-opencode-mcp`) — and installs a kcap-owned **steering block** into `~/.config/opencode/AGENTS.md` (opt out `--skip-opencode-instructions`). `remove --opencode` reverses all three. (OpenCode reads the agent-agnostic `~/.agents/skills/` for kcap's skills, so no separate skills copy is needed.)
+Beyond the capture plugin, `install --opencode` (and `kcap setup`) also **registers the six kcap MCP servers** in `~/.config/opencode/opencode.json` — OpenCode's `mcp` block, each entry `type: "local"` with `command` as an array and `enabled: true` (non-destructive/idempotent, preserving `$schema` and any user servers; opt out `--skip-opencode-mcp`) — and installs a kcap-owned **steering block** into `~/.config/opencode/AGENTS.md` (opt out `--skip-opencode-instructions`). `remove --opencode` reverses all three. (OpenCode reads the agent-agnostic `~/.agents/skills/`, and `install --opencode` writes it, so no separate `--skills` run is needed.)
 
 On `session.created` the plugin runs `kcap hook --opencode` (POSTs lifecycle + spawns the watcher); on each `session.idle` it fetches the session's full messages via OpenCode's in-process SDK and appends them as native `{info, parts}` JSONL to a file the watcher tails (`vendor=opencode`) — so kcap must be on `PATH`. Since OpenCode has **no session-end event**, the watcher synthesizes session-end when the `opencode` process exits. OpenCode records per-message tokens/cost, so those flow through. Historical `kcap import --opencode` reads the SQLite db directly — see [Loading historical sessions](#loading-historical-sessions).
 

--- a/README.md
+++ b/README.md
@@ -1095,7 +1095,7 @@ kcap plugin install --codex --if-installed           # refresh Codex hooks only 
 kcap plugin install --if-installed                   # refresh Claude plugin registration only if previously installed (used by npm postinstall)
 ```
 
-Installing any vendor that reads the shared tree — `--codex`, `--cursor`, `--copilot`, `--gemini`, `--pi`, `--opencode` — writes these nine skills under `~/.agents/skills/` (`--skills` installs them alone; Kiro and Antigravity get their own copies, and the bare Claude install uses the plugin bundle):
+Installing any vendor that reads the shared tree — `--codex`, `--cursor`, `--copilot`, `--gemini`, `--pi`, `--opencode` — writes these nine skills under `~/.agents/skills/` (`--skills` installs them alone; Kiro and Antigravity get their own copies, and the bare Claude install uses the plugin bundle). Opt out per vendor with `--skip-<vendor>-skills`:
 
 | Skill | Wraps | Purpose |
 |---|---|---|

--- a/npm/kcap/bin/refresh.js
+++ b/npm/kcap/bin/refresh.js
@@ -18,7 +18,9 @@ const fs = require("fs");
 
 // One entry per agent. Order is independent — each refresh is gated by its own
 // marker via `--if-installed`, which no-ops unless the user has previously
-// opted in (marker file present OR pre-marker install detected).
+// opted in (marker file present OR pre-marker install detected). A vendor entry
+// also refreshes the shared ~/.agents/skills tree, but only tops up one that is
+// already there: `plugin remove --skills` must survive an upgrade.
 const REFRESHES = [
   ["plugin", "install", "--skills",  "--if-installed"],
   ["plugin", "install", "--codex",   "--if-installed"],

--- a/src/Capacitor.Cli.Core/AgentsSkillsInstaller.cs
+++ b/src/Capacitor.Cli.Core/AgentsSkillsInstaller.cs
@@ -152,7 +152,9 @@ public static class AgentsSkillsInstaller {
     /// <summary>
     /// True when the on-disk skills already match this build: the version
     /// marker equals <see cref="CurrentVersion"/> AND every owned
-    /// <c>kcap-&lt;name&gt;</c> folder is present. A matching marker whose skill
+    /// <c>kcap-&lt;name&gt;</c> folder holds a SKILL.md. Checked via
+    /// <see cref="HasSkill"/> rather than folder presence, because a failed copy
+    /// leaves an empty folder behind and that must not read as current. A matching marker whose skill
     /// folders were deleted or corrupted reads as NOT current, so callers
     /// reinstall and self-heal — the marker alone can't be trusted to mean the
     /// skills are actually on disk (mirrors the hooks "marker present but host
@@ -161,7 +163,7 @@ public static class AgentsSkillsInstaller {
     /// </summary>
     public static bool IsCurrent(string targetDir) =>
         ReadMarker(targetDir) == CurrentVersion()
-        && SourceNames.All(name => Directory.Exists(Path.Combine(targetDir, "kcap-" + name)));
+        && SourceNames.All(name => HasSkill(targetDir, name));
 
     /// <summary>
     /// Deletes every <c>kcap-&lt;name&gt;</c> folder this installer owns

--- a/src/Capacitor.Cli.Core/Resources/help-plugin.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-plugin.txt
@@ -9,16 +9,17 @@ Subcommands:
 Options:
   --project           Apply hooks to current project only (default: user-wide).
                       Skills are always user-wide; --project only affects hooks.
-  --codex             Target Codex CLI: install hooks AND agent skills.
-  --cursor            Target Cursor IDE: install hooks to ~/.cursor/hooks.json.
-                      Detected by user-dir presence, not PATH, so users without
-                      the cursor shell command are covered.
+  --codex             Target Codex CLI: install hooks and the agent skills.
+  --cursor            Target Cursor IDE: install hooks to ~/.cursor/hooks.json,
+                      plus the agent skills. Detected by user-dir presence, not
+                      PATH, so users without the cursor shell command are covered.
   --copilot           Target GitHub Copilot CLI: write kcap's own hooks file to
-                      ~/.copilot/hooks/kcap.json (honours $COPILOT_HOME). Copilot
-                      merges every *.json in that directory, so user-authored
-                      hook files are never touched.
+                      ~/.copilot/hooks/kcap.json (honours $COPILOT_HOME), plus the
+                      agent skills. Copilot merges every *.json in that directory,
+                      so user-authored hook files are never touched.
   --gemini            Target Gemini CLI: merge kcap's hooks into the SHARED
-                      ~/.gemini/settings.json (honours $GEMINI_CLI_HOME). User-authored
+                      ~/.gemini/settings.json (honours $GEMINI_CLI_HOME), plus the
+                      agent skills. User-authored
                       hook entries and every other settings key are preserved; if
                       the file exists but isn't valid JSON the install fails closed
                       and leaves it untouched.
@@ -37,7 +38,8 @@ Options:
                       (Kiro reads ~/.kiro/skills, not the agent-agnostic
                       ~/.agents/skills) so Kiro is steered to prefer the kcap tools.
   --pi                Target Pi (badlogic/pi-mono): install the live-ingest
-                      extension to ~/.pi/agent/extensions/kcap.ts. Pi has no
+                      extension to ~/.pi/agent/extensions/kcap.ts, plus the agent
+                      skills. Pi has no
                       shell hooks; the extension auto-loads on `pi` startup and
                       streams each session. Also installs the kcap MCP-bridge
                       extension (~/.pi/agent/extensions/kcap-mcp.ts — Pi has no
@@ -46,7 +48,8 @@ Options:
                       block in ~/.pi/agent/AGENTS.md (see --skip-pi-instructions).
                       User-wide only — --project has no effect with --pi.
   --opencode          Target SST OpenCode: install the live-ingest plugin to
-                      ~/.config/opencode/plugins/kcap.ts. OpenCode has no shell
+                      ~/.config/opencode/plugins/kcap.ts, plus the agent skills.
+                      OpenCode has no shell
                       hooks; the plugin auto-loads on `opencode` startup and
                       streams each session. User-wide only — --project has no
                       effect with --opencode.
@@ -60,9 +63,12 @@ Options:
                       hooks.json). Antigravity has no shell hooks; the GUI loads
                       plugins at startup and streams each conversation. User-wide
                       only — --project has no effect with --antigravity.
-  --skills            Install only the agent-agnostic skills to ~/.agents/skills/.
-                      Use this if you only have Cursor (or another agent that
-                      reads ~/.agents/skills/) and don't want Codex hooks.
+  --skills            Install ONLY the agent-agnostic skills to ~/.agents/skills/,
+                      with no hooks or MCP registration. Every per-vendor install
+                      (--codex, --cursor, --copilot, --gemini, --pi, --opencode)
+                      already writes them, so reach for this to refresh the skills
+                      on their own, or to install them for an agent kcap has no
+                      integration for.
   --skip-codex-network-access
                       With --codex: skip enabling Codex sandbox network access.
                       By default `install --codex` also allows Codex's
@@ -130,7 +136,12 @@ Notes:
   Skills install to ~/.agents/skills/kcap-{recap,errors,hide,disable,
   validate-plan,review-flows,agent-flows,work-items,guided-tour}/.
   Codex, Cursor, and any other agent that honors the .agents/skills convention
-  will pick them up automatically.
+  will pick them up automatically. Every install of a vendor that reads that tree
+  writes them, so `install --cursor` alone leaves nothing missing. Kiro and
+  Antigravity get their own copies instead, under ~/.kiro/skills and
+  ~/.gemini/skills, and the bare (Claude) install uses the plugin bundle.
+  The --if-installed refresh only tops up skills you already have: `plugin remove
+  --skills` stays removed until you install a vendor again explicitly.
 
   --codex also writes hooks to ~/.codex/hooks.json (or <repo>/.codex/hooks.json
   with --project). MCP server registration is handled separately by the Codex

--- a/src/Capacitor.Cli.Core/Resources/help-plugin.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-plugin.txt
@@ -53,6 +53,9 @@ Options:
                       hooks; the plugin auto-loads on `opencode` startup and
                       streams each session. User-wide only — --project has no
                       effect with --opencode.
+  --skip-opencode-skills
+                      With --opencode: skip installing the kcap skills into
+                      ~/.agents/skills.
   --skip-opencode-mcp With --opencode: skip registering the kcap MCP servers in
                       ~/.config/opencode/opencode.json (the `mcp` block).
   --skip-opencode-instructions
@@ -77,11 +80,17 @@ Options:
                       ~/.codex/config.toml) so kcap skills work. The
                       --if-installed refresh path never touches this, so the npm
                       postinstall hook leaves config.toml alone.
+  --skip-cursor-skills
+                      With --cursor: skip installing the kcap skills into
+                      ~/.agents/skills.
   --skip-cursor-mcp   With --cursor: skip registering the kcap MCP servers in
                       ~/.cursor/mcp.json. By default `install --cursor` also
                       registers all 6 kcap MCP servers there (non-destructive,
                       idempotent — preserves any user-authored servers) so
                       Cursor picks them up with no manual JSON edit.
+  --skip-copilot-skills
+                      With --copilot: skip installing the kcap skills into
+                      ~/.agents/skills.
   --skip-copilot-mcp  With --copilot: skip registering the kcap MCP servers in
                       ~/.copilot/mcp-config.json. By default `install --copilot`
                       also registers all 6 kcap MCP servers there (non-destructive,
@@ -93,6 +102,9 @@ Options:
                       `install --copilot` writes a small kcap-owned, marker-delimited
                       block (non-destructive — preserves your own instructions) that
                       nudges Copilot to use the kcap tools for why/history questions.
+  --skip-gemini-skills
+                      With --gemini: skip installing the kcap skills into
+                      ~/.agents/skills.
   --skip-gemini-mcp   With --gemini: skip registering the kcap MCP servers in the
                       shared ~/.gemini/settings.json. By default `install --gemini`
                       also registers all 6 kcap MCP servers there (non-destructive,
@@ -114,6 +126,8 @@ Options:
   --skip-antigravity-skills
                       With --antigravity: skip copying the kcap skills into
                       ~/.gemini/skills (where Antigravity reads them, not ~/.agents/skills).
+  --skip-pi-skills    With --pi: skip installing the kcap skills into
+                      ~/.agents/skills.
   --skip-pi-mcp       With --pi: skip installing the kcap MCP-bridge extension
                       (~/.pi/agent/extensions/kcap-mcp.ts). By default `install
                       --pi` writes it so Pi exposes the 6 kcap MCP servers as

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -717,7 +717,8 @@ public static class PluginCommand {
         if (!args.Contains("--skip-cursor-mcp"))
             await RegisterCursorMcpServersAsync(env);
 
-        await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
+        if (!args.Contains("--skip-cursor-skills"))
+            await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
 
         return 0;
     }
@@ -898,7 +899,8 @@ public static class PluginCommand {
         if (!skipInstructions)
             await InstallPiInstructionsAsync(env);
 
-        await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
+        if (!args.Contains("--skip-pi-skills"))
+            await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
 
         // Non-zero only when a FRESH ingest install failed (the integration is incomplete) —
         // the independent MCP bridge + AGENTS.md steering above were still installed.
@@ -1052,7 +1054,8 @@ public static class PluginCommand {
         if (!args.Contains("--skip-opencode-instructions"))
             await InstallOpenCodeInstructionsAsync(env);
 
-        await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
+        if (!args.Contains("--skip-opencode-skills"))
+            await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
 
         return 0;
     }
@@ -1403,7 +1406,8 @@ public static class PluginCommand {
         if (!args.Contains("--skip-copilot-instructions"))
             await InstallCopilotInstructionsAsync(env);
 
-        await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
+        if (!args.Contains("--skip-copilot-skills"))
+            await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
 
         return 0;
     }
@@ -1977,7 +1981,8 @@ public static class PluginCommand {
         if (!args.Contains("--skip-gemini-instructions"))
             await InstallGeminiInstructionsAsync(env);
 
-        await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
+        if (!args.Contains("--skip-gemini-skills"))
+            await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
 
         // Non-zero only when a FRESH hook install failed (the integration is incomplete) — the
         // independent GEMINI.md steering above was still installed.

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -1246,6 +1246,12 @@ public static class PluginCommand {
     static async Task InstallVendorSkillsAsync(
             PluginEnvironment env, string targetDir, string label, bool refreshOnly) {
         if (refreshOnly && !AgentsSkillsInstaller.IsInstalled(targetDir)) return;
+
+        // The sweep runs even when the tree is already current: a Cursor-first install stamps the
+        // marker, so gating it on the copy would mean the stale dir outlives every later install.
+        if (targetDir == env.AgentsSkillsDir)
+            AgentsSkillsInstaller.CleanLegacyCodexSkills(env.LegacyCodexSkills);
+
         if (AgentsSkillsInstaller.IsCurrent(targetDir)) return;
 
         var pluginPath = env.ResolvePluginPath();
@@ -1256,17 +1262,10 @@ public static class PluginCommand {
             return;
         }
 
-        if (AgentsSkillsInstaller.Install(src, targetDir)) {
+        if (AgentsSkillsInstaller.Install(src, targetDir))
             await env.Stdout.WriteLineAsync($"{label} skills installed ({targetDir}).");
-
-            // Every other writer of the shared tree sweeps the legacy ~/.codex/skills after it. Skipping
-            // it here would let a Cursor-first install stamp the marker current, so the next
-            // `--skills --if-installed` fast-paths past the sweep and the stale dir survives.
-            if (targetDir == env.AgentsSkillsDir)
-                AgentsSkillsInstaller.CleanLegacyCodexSkills(env.LegacyCodexSkills);
-        } else {
+        else
             await env.Stderr.WriteLineAsync($"Warning: could not install {label} skills to {targetDir}.");
-        }
     }
 
     /// <summary>Antigravity reads <c>~/.gemini/skills</c>, not the agent-agnostic tree.</summary>

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -717,6 +717,8 @@ public static class PluginCommand {
         if (!args.Contains("--skip-cursor-mcp"))
             await RegisterCursorMcpServersAsync(env);
 
+        await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
+
         return 0;
     }
 
@@ -896,6 +898,8 @@ public static class PluginCommand {
         if (!skipInstructions)
             await InstallPiInstructionsAsync(env);
 
+        await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
+
         // Non-zero only when a FRESH ingest install failed (the integration is incomplete) —
         // the independent MCP bridge + AGENTS.md steering above were still installed.
         return extensionFailed ? 1 : 0;
@@ -1047,6 +1051,8 @@ public static class PluginCommand {
         // tools. Non-destructive (only our marker block) + idempotent. Never fails the install.
         if (!args.Contains("--skip-opencode-instructions"))
             await InstallOpenCodeInstructionsAsync(env);
+
+        await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
 
         return 0;
     }
@@ -1224,25 +1230,48 @@ public static class PluginCommand {
         }
     }
 
-    /// <summary>Copies the kcap skills into <c>~/.gemini/skills</c> (where Antigravity reads them, unlike
-    /// the agent-agnostic <c>~/.agents/skills</c>). Idempotent (version marker); never fails the install.</summary>
-    static async Task InstallAntigravitySkillsAsync(PluginEnvironment env, bool refreshOnly) {
-        // Fast path: on-disk skills already match this build (marker + all folders present).
-        if (AgentsSkillsInstaller.IsCurrent(env.AntigravitySkillsDir)) return;
+    /// <summary>
+    /// Copies the kcap skills into <paramref name="targetDir"/> for a vendor that reads a skills tree.
+    /// Which tree differs by vendor — the agent-agnostic <c>~/.agents/skills</c> for most, their own
+    /// for Kiro and Antigravity — so the caller names it.
+    /// </summary>
+    /// <remarks>
+    /// A refresh tops up a tree the user already has; it never creates one. `plugin remove --skills`
+    /// deletes the marker precisely so an upgrade cannot silently undo it, and the npm postinstall
+    /// runs the `--if-installed` form of every vendor on each `npm install -g` — without this gate a
+    /// deliberate removal would come back on a command the user never ran.
+    /// Never fails the install: hooks and MCP registration are what make capture work, so a skills
+    /// copy that fails is a warning and the vendor is still wired up.
+    /// </remarks>
+    static async Task InstallVendorSkillsAsync(
+            PluginEnvironment env, string targetDir, string label, bool refreshOnly) {
+        if (refreshOnly && !AgentsSkillsInstaller.IsInstalled(targetDir)) return;
+        if (AgentsSkillsInstaller.IsCurrent(targetDir)) return;
 
         var pluginPath = env.ResolvePluginPath();
         var src        = pluginPath is null ? null : Path.Combine(pluginPath, "skills");
         if (src is null || !Directory.Exists(src)) {
             if (!refreshOnly)
-                await env.Stderr.WriteLineAsync("Warning: could not install Antigravity skills — kcap plugin 'skills' folder not found.");
+                await env.Stderr.WriteLineAsync($"Warning: could not install {label} skills — kcap plugin 'skills' folder not found.");
             return;
         }
 
-        if (AgentsSkillsInstaller.Install(src, env.AntigravitySkillsDir))
-            await env.Stdout.WriteLineAsync($"Antigravity skills installed ({env.AntigravitySkillsDir}).");
-        else
-            await env.Stderr.WriteLineAsync($"Warning: could not install Antigravity skills to {env.AntigravitySkillsDir}.");
+        if (AgentsSkillsInstaller.Install(src, targetDir)) {
+            await env.Stdout.WriteLineAsync($"{label} skills installed ({targetDir}).");
+
+            // Every other writer of the shared tree sweeps the legacy ~/.codex/skills after it. Skipping
+            // it here would let a Cursor-first install stamp the marker current, so the next
+            // `--skills --if-installed` fast-paths past the sweep and the stale dir survives.
+            if (targetDir == env.AgentsSkillsDir)
+                AgentsSkillsInstaller.CleanLegacyCodexSkills(env.LegacyCodexSkills);
+        } else {
+            await env.Stderr.WriteLineAsync($"Warning: could not install {label} skills to {targetDir}.");
+        }
     }
+
+    /// <summary>Antigravity reads <c>~/.gemini/skills</c>, not the agent-agnostic tree.</summary>
+    static Task InstallAntigravitySkillsAsync(PluginEnvironment env, bool refreshOnly) =>
+        InstallVendorSkillsAsync(env, env.AntigravitySkillsDir, "Antigravity", refreshOnly);
 
     static async Task<int> RemoveAntigravity(string[] args, PluginEnvironment env) {
         var hooksPath = GetArg(args, "--antigravity-hooks-path") ?? env.AntigravityHooksJson;
@@ -1374,6 +1403,8 @@ public static class PluginCommand {
         // tools. Non-destructive (only our marker block) + idempotent. Never fails the install.
         if (!args.Contains("--skip-copilot-instructions"))
             await InstallCopilotInstructionsAsync(env);
+
+        await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
 
         return 0;
     }
@@ -1604,22 +1635,8 @@ public static class PluginCommand {
     /// toward the kcap MCP tools. Fast-path skips when already at the current version. Never fails the
     /// install: a copy error is a warning.
     /// </summary>
-    static async Task InstallKiroSkillsAsync(PluginEnvironment env, bool refreshOnly) {
-        if (AgentsSkillsInstaller.IsCurrent(env.KiroSkillsDir)) return;
-
-        var pluginPath = env.ResolvePluginPath();
-        var src        = pluginPath is null ? null : Path.Combine(pluginPath, "skills");
-        if (src is null || !Directory.Exists(src)) {
-            if (!refreshOnly)
-                await env.Stderr.WriteLineAsync("Warning: could not install Kiro skills — kcap plugin 'skills' folder not found.");
-            return;
-        }
-
-        if (AgentsSkillsInstaller.Install(src, env.KiroSkillsDir))
-            await env.Stdout.WriteLineAsync($"Kiro skills installed ({env.KiroSkillsDir}).");
-        else
-            await env.Stderr.WriteLineAsync($"Warning: could not install Kiro skills to {env.KiroSkillsDir}.");
-    }
+    static Task InstallKiroSkillsAsync(PluginEnvironment env, bool refreshOnly) =>
+        InstallVendorSkillsAsync(env, env.KiroSkillsDir, "Kiro", refreshOnly);
 
     /// <summary>
     /// Registers the kcap MCP servers in Kiro's <c>~/.kiro/settings/mcp.json</c> (<c>mcpServers</c>
@@ -1960,6 +1977,8 @@ public static class PluginCommand {
         // toward the kcap MCP tools. Non-destructive (only our marker block) + idempotent. Never fails.
         if (!args.Contains("--skip-gemini-instructions"))
             await InstallGeminiInstructionsAsync(env);
+
+        await InstallVendorSkillsAsync(env, env.AgentsSkillsDir, "Agent", refreshOnly);
 
         // Non-zero only when a FRESH hook install failed (the integration is incomplete) — the
         // independent GEMINI.md steering above was still installed.

--- a/test/Capacitor.Cli.Tests.Unit/Commands/FlowsDriverSchemaConformanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/FlowsDriverSchemaConformanceTests.cs
@@ -202,16 +202,6 @@ public class FlowsDriverSchemaConformanceTests {
         public void Dispose() { foreach (var s in _scopes) s.Dispose(); }
     }
 
-    sealed class EnvScope : IDisposable {
-        readonly string  _key;
-        readonly string? _prev;
-        public EnvScope(string key, string? value) {
-            _key = key; _prev = Environment.GetEnvironmentVariable(key);
-            Environment.SetEnvironmentVariable(key, value);
-        }
-        public void Dispose() => Environment.SetEnvironmentVariable(_key, _prev);
-    }
-
     /// <summary>Deterministic native-binary path injected into every installer arm. Registration
     /// writes the resolved binary as the command (default: Environment.ProcessPath) — under the
     /// test host that default would be the test-runner executable, so the suite injects its own

--- a/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandCopilotTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandCopilotTests.cs
@@ -238,16 +238,4 @@ public class PluginCommandCopilotTests {
         Stderr:            TextWriter.Null
     ) { ResolveMcpBinaryPath = () => TestBinaryPath };
 
-    // Sets an env var for the test's lifetime and restores the previous value on Dispose.
-    // Used to clear COPILOT_HOME so CopilotPaths resolves under the fake home.
-    sealed class EnvScope : IDisposable {
-        readonly string  _key;
-        readonly string? _prev;
-        public EnvScope(string key, string? value) {
-            _key  = key;
-            _prev = Environment.GetEnvironmentVariable(key);
-            Environment.SetEnvironmentVariable(key, value);
-        }
-        public void Dispose() => Environment.SetEnvironmentVariable(_key, _prev);
-    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandGeminiTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandGeminiTests.cs
@@ -295,16 +295,4 @@ public class PluginCommandGeminiTests {
         Stderr:            TextWriter.Null
     ) { ResolveMcpBinaryPath = () => TestBinaryPath };
 
-    // Sets an env var for the test's lifetime and restores the previous value on Dispose.
-    // Used to clear GEMINI_CLI_HOME so GeminiPaths resolves under the fake home.
-    sealed class EnvScope : IDisposable {
-        readonly string  _key;
-        readonly string? _prev;
-        public EnvScope(string key, string? value) {
-            _key  = key;
-            _prev = Environment.GetEnvironmentVariable(key);
-            Environment.SetEnvironmentVariable(key, value);
-        }
-        public void Dispose() => Environment.SetEnvironmentVariable(_key, _prev);
-    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandKiroTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandKiroTests.cs
@@ -154,16 +154,4 @@ public class PluginCommandKiroTests {
         Stderr:            TextWriter.Null
     ) { ResolveMcpBinaryPath = () => TestBinaryPath };
 
-    // Sets an env var for the test's lifetime and restores it on Dispose. Clears KIRO_HOME so
-    // KiroPaths resolves under the fake home.
-    sealed class EnvScope : IDisposable {
-        readonly string  _key;
-        readonly string? _prev;
-        public EnvScope(string key, string? value) {
-            _key  = key;
-            _prev = Environment.GetEnvironmentVariable(key);
-            Environment.SetEnvironmentVariable(key, value);
-        }
-        public void Dispose() => Environment.SetEnvironmentVariable(_key, _prev);
-    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandVendorSkillsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandVendorSkillsTests.cs
@@ -91,6 +91,21 @@ public class PluginCommandVendorSkillsTests {
     }
 
     [Test]
+    [MethodDataSource(nameof(Vendors))]
+    public async Task the_skip_flag_declines_the_shared_skills(Vendor vendor) {
+        using var scope = new VendorScope(vendor);
+
+        var exit = await PluginCommand.HandleAsync(
+            [.. vendor.InstallArgs(scope.Home), $"--skip-{vendor.Flag}-skills"], scope.Env);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(Directory.Exists(scope.Env.AgentsSkillsDir))
+                    .IsFalse()
+                    .Because("every other artifact these installs write has a skip flag, so the shared "
+                           + "tree needs one too — nothing else lets you take hooks without it");
+    }
+
+    [Test]
     public async Task install_sweeps_legacy_codex_skills_even_when_the_tree_is_already_current() {
         using var scope = new VendorScope(Vendor.Cursor);
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandVendorSkillsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandVendorSkillsTests.cs
@@ -1,0 +1,179 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+/// <summary>
+/// Every vendor that reads the agent-agnostic <c>~/.agents/skills</c> tree gets it from its own
+/// <c>plugin install</c>, not only from a full <c>kcap setup</c> or an explicit <c>--skills</c>.
+/// </summary>
+/// <remarks>
+/// Without it a Cursor-only user has hooks and MCP and no skills at all, and the tour handoff names a
+/// slash command their agent has never heard of. The target flags are mutually exclusive, so
+/// `--cursor --skills` cannot be one invocation — only the install itself can close the gap.
+///
+/// The refresh (`--if-installed`) counterpart is the opposite property and is tested here too: it may
+/// top a tree up, never create one. The npm postinstall runs it for every vendor on each
+/// `npm install -g`, so creating there would undo a deliberate `plugin remove --skills`.
+///
+/// Cursor reaches the refresh assertions by a different route from the other four: it returns from the
+/// whole method on a current hooks marker, before the skills call, where they fall through to it. Both
+/// end in the same place, so the tests are written the same way — but removing the guard in the helper
+/// reddens four of the five, not all five.
+/// </remarks>
+[NotInParallel("HomeEnvVarMutation")]
+public class PluginCommandVendorSkillsTests {
+    [Test]
+    [MethodDataSource(nameof(Vendors))]
+    public async Task fresh_install_writes_the_shared_agent_skills(Vendor vendor) {
+        using var scope = new VendorScope(vendor);
+
+        var exit = await PluginCommand.HandleAsync(vendor.InstallArgs(scope.Home), scope.Env);
+
+        await Assert.That(exit).IsEqualTo(0);
+
+        foreach (var name in AgentsSkillsInstaller.SourceNames)
+            await Assert.That(AgentsSkillsInstaller.HasSkill(scope.Env.AgentsSkillsDir, name))
+                        .IsTrue()
+                        .Because($"`plugin install --{vendor.Flag}` should have written kcap-{name}");
+    }
+
+    [Test]
+    [MethodDataSource(nameof(Vendors))]
+    public async Task refresh_does_not_create_skills_for_a_vendor_never_installed(Vendor vendor) {
+        using var scope = new VendorScope(vendor);
+
+        var exit = await PluginCommand.HandleAsync(
+            [.. vendor.InstallArgs(scope.Home), "--if-installed"], scope.Env);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(Directory.Exists(scope.Env.AgentsSkillsDir))
+                    .IsFalse()
+                    .Because("the npm postinstall runs this on every upgrade; it must not install "
+                           + "skills for someone who never opted into anything");
+    }
+
+    [Test]
+    [MethodDataSource(nameof(Vendors))]
+    public async Task refresh_does_not_resurrect_skills_the_user_removed(Vendor vendor) {
+        using var scope = new VendorScope(vendor);
+
+        // Install for real, then remove the skills the way a user would.
+        await PluginCommand.HandleAsync(vendor.InstallArgs(scope.Home), scope.Env);
+        await PluginCommand.HandleAsync(["plugin", "remove", "--skills"], scope.Env);
+        await Assert.That(AgentsSkillsInstaller.IsInstalled(scope.Env.AgentsSkillsDir)).IsFalse();
+
+        var exit = await PluginCommand.HandleAsync(
+            [.. vendor.InstallArgs(scope.Home), "--if-installed"], scope.Env);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(AgentsSkillsInstaller.IsInstalled(scope.Env.AgentsSkillsDir))
+                    .IsFalse()
+                    .Because("`remove --skills` drops the marker so an upgrade cannot undo it — a "
+                           + "vendor refresh must respect that too, or the removal comes back on a "
+                           + "command the user never ran");
+    }
+
+    [Test]
+    public async Task fresh_install_kiro_writes_its_own_skills_tree_not_the_shared_one() {
+        using var scope = new VendorScope(Vendor.Kiro);
+
+        await PluginCommand.HandleAsync(["plugin", "install", "--kiro"], scope.Env);
+
+        // Kiro reads ~/.kiro/skills; writing the shared tree instead would be silently useless to it.
+        await Assert.That(AgentsSkillsInstaller.IsInstalled(scope.Env.KiroSkillsDir)).IsTrue();
+        await Assert.That(Directory.Exists(scope.Env.AgentsSkillsDir)).IsFalse();
+    }
+
+    [Test]
+    public async Task fresh_install_antigravity_writes_its_own_skills_tree_not_the_shared_one() {
+        using var scope = new VendorScope(Vendor.Antigravity);
+
+        await PluginCommand.HandleAsync(["plugin", "install", "--antigravity"], scope.Env);
+
+        await Assert.That(AgentsSkillsInstaller.IsInstalled(scope.Env.AntigravitySkillsDir)).IsTrue();
+        await Assert.That(Directory.Exists(scope.Env.AgentsSkillsDir)).IsFalse();
+    }
+
+    /// <summary>The five vendors that read the shared tree. Kiro and Antigravity read their own and
+    /// are covered separately.</summary>
+    public static IEnumerable<Func<Vendor>> Vendors() {
+        yield return () => Vendor.Cursor;
+        yield return () => Vendor.Copilot;
+        yield return () => Vendor.Gemini;
+        yield return () => Vendor.Pi;
+        yield return () => Vendor.OpenCode;
+    }
+
+    public sealed record Vendor(string Flag, string[] ClearedEnvVars) {
+        public static readonly Vendor Cursor      = new("cursor", []);
+        public static readonly Vendor Copilot     = new("copilot", ["COPILOT_HOME"]);
+        public static readonly Vendor Gemini      = new("gemini", ["GEMINI_CLI_HOME"]);
+        public static readonly Vendor Pi          = new("pi", ["PI_CODING_AGENT_DIR"]);
+        public static readonly Vendor Kiro        = new("kiro", ["KIRO_HOME"]);
+        public static readonly Vendor Antigravity = new("antigravity", []);
+
+        // OpenCode resolves its config dir from OPENCODE_CONFIG_DIR then XDG_CONFIG_HOME before the
+        // home it is handed, so both have to go or the install lands in the real user config.
+        public static readonly Vendor OpenCode =
+            new("opencode", ["OPENCODE_CONFIG_DIR", "XDG_CONFIG_HOME"]);
+
+        public string[] InstallArgs(string home) => Flag switch {
+            "cursor"   => ["plugin", "install", "--cursor",
+                           "--cursor-hooks-path", Path.Combine(home, ".cursor", "hooks.json")],
+            "opencode" => ["plugin", "install", "--opencode",
+                           "--opencode-plugin-path",
+                           Path.Combine(home, ".config", "opencode", "plugins", "kcap.ts")],
+            _          => ["plugin", "install", "--" + Flag],
+        };
+
+        public override string ToString() => Flag;
+    }
+
+    /// <summary>
+    /// A fake home with the vendor's own env vars cleared, a resolvable `kcap` on PATH, and a
+    /// <see cref="PluginEnvironment"/> pointed at the shipped skills tree.
+    /// </summary>
+    sealed class VendorScope : IDisposable {
+        readonly FakeUserHome    _home;
+        readonly TempDir         _binDir;
+        readonly List<EnvScope>  _envScopes = [];
+
+        public VendorScope(Vendor vendor) {
+            _home   = new FakeUserHome();
+            _binDir = new TempDir();
+
+            foreach (var key in vendor.ClearedEnvVars)
+                _envScopes.Add(new EnvScope(key, null));
+
+            // The fresh path refuses to install unless `kcap` resolves — it is what the hooks it
+            // writes will invoke. Both names, because the Windows leg matches on PATHEXT.
+            foreach (var name in new[] { "kcap", "kcap.exe" }) {
+                var path = Path.Combine(_binDir.Path, name);
+                File.WriteAllText(path, "");
+                if (!OperatingSystem.IsWindows()) File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+            }
+
+            _envScopes.Add(new EnvScope(
+                "PATH", _binDir.Path + Path.PathSeparator + Environment.GetEnvironmentVariable("PATH")));
+
+            Env = new PluginEnvironment(
+                HomeDirectory:     _home.Path,
+                // The siblings pass `() => null`, which short-circuits the skills copy to a warning and
+                // would make every assertion here vacuous.
+                ResolvePluginPath: RepoTree.KcapDir,
+                Stdout:            TextWriter.Null,
+                Stderr:            TextWriter.Null
+            ) { ResolveMcpBinaryPath = () => Path.Combine(_binDir.Path, "kcap") };
+        }
+
+        public string            Home => _home.Path;
+        public PluginEnvironment Env  { get; }
+
+        public void Dispose() {
+            foreach (var scope in _envScopes) scope.Dispose();
+            _binDir.Dispose();
+            _home.Dispose();
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandVendorSkillsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandVendorSkillsTests.cs
@@ -15,11 +15,6 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 /// The refresh (`--if-installed`) counterpart is the opposite property and is tested here too: it may
 /// top a tree up, never create one. The npm postinstall runs it for every vendor on each
 /// `npm install -g`, so creating there would undo a deliberate `plugin remove --skills`.
-///
-/// Cursor reaches the refresh assertions by a different route from the other four: it returns from the
-/// whole method on a current hooks marker, before the skills call, where they fall through to it. Both
-/// end in the same place, so the tests are written the same way — but removing the guard in the helper
-/// reddens four of the five, not all five.
 /// </remarks>
 [NotInParallel("HomeEnvVarMutation")]
 public class PluginCommandVendorSkillsTests {
@@ -95,6 +90,25 @@ public class PluginCommandVendorSkillsTests {
         await Assert.That(Directory.Exists(scope.Env.AgentsSkillsDir)).IsFalse();
     }
 
+    [Test]
+    public async Task install_sweeps_legacy_codex_skills_even_when_the_tree_is_already_current() {
+        using var scope = new VendorScope(Vendor.Cursor);
+
+        await PluginCommand.HandleAsync(Vendor.Cursor.InstallArgs(scope.Home), scope.Env);
+        await Assert.That(AgentsSkillsInstaller.IsCurrent(scope.Env.AgentsSkillsDir)).IsTrue();
+
+        // A pre-migration machine still carrying the old Codex-only copy.
+        var legacy = Path.Combine(scope.Env.LegacyCodexSkills, "kcap-recap");
+        Directory.CreateDirectory(legacy);
+
+        await PluginCommand.HandleAsync(Vendor.Cursor.InstallArgs(scope.Home), scope.Env);
+
+        await Assert.That(Directory.Exists(legacy))
+                    .IsFalse()
+                    .Because("the tree being current is exactly when the sweep gets skipped, so gating "
+                           + "it on the copy leaves the stale dir behind for good");
+    }
+
     /// <summary>The five vendors that read the shared tree. Kiro and Antigravity read their own and
     /// are covered separately.</summary>
     public static IEnumerable<Func<Vendor>> Vendors() {
@@ -149,9 +163,9 @@ public class PluginCommandVendorSkillsTests {
             // The fresh path refuses to install unless `kcap` resolves — it is what the hooks it
             // writes will invoke. Both names, because the Windows leg matches on PATHEXT.
             foreach (var name in new[] { "kcap", "kcap.exe" }) {
-                var path = Path.Combine(_binDir.Path, name);
-                File.WriteAllText(path, "");
-                if (!OperatingSystem.IsWindows()) File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+                var path = _binDir.CreateFile(name);
+                if (!OperatingSystem.IsWindows())
+                    File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserExecute);
             }
 
             _envScopes.Add(new EnvScope(

--- a/test/Capacitor.Tests.Helpers/EnvScope.cs
+++ b/test/Capacitor.Tests.Helpers/EnvScope.cs
@@ -1,0 +1,24 @@
+namespace Capacitor.Tests.Helpers;
+
+/// <summary>
+/// Sets — or clears, with a null value — an environment variable for the test's lifetime, restoring
+/// the previous value on dispose.
+/// </summary>
+/// <remarks>
+/// Vendor path resolvers consult their own env vars (<c>COPILOT_HOME</c>, <c>GEMINI_CLI_HOME</c>,
+/// <c>PI_CODING_AGENT_DIR</c>, <c>XDG_CONFIG_HOME</c>) before falling back to the home they are
+/// handed, so a test that seeds a fake home without clearing them writes into the developer's real
+/// config instead. Env is process-global: callers need <c>[NotInParallel]</c>.
+/// </remarks>
+public sealed class EnvScope : IDisposable {
+    readonly string  _key;
+    readonly string? _previous;
+
+    public EnvScope(string key, string? value) {
+        _key      = key;
+        _previous = Environment.GetEnvironmentVariable(key);
+        Environment.SetEnvironmentVariable(key, value);
+    }
+
+    public void Dispose() => Environment.SetEnvironmentVariable(_key, _previous);
+}


### PR DESCRIPTION
`kcap plugin install --cursor` wrote hooks and registered MCP servers but installed no skills — same for `--copilot`, `--gemini`, `--pi` and `--opencode`. Only `--codex`, `--skills` and a full `kcap setup` wrote the shared `~/.agents/skills` tree, so five of nine vendors had no `guided-tour` and no `recap`, and the tour handoff named a slash command their agent had never heard of. The target flags are mutually exclusive, so `--cursor --skills` cannot be one invocation — nothing but the install itself can close the gap.

`kcap setup` already treats this as policy and says so in `CodingAgentsStep.HandleAgentSkills`: install the shared tree when any non-Claude agent is detected, *independent of whose hooks were written*. This makes `plugin install` obey the rule setup already documents.

- **`PluginCommand`** — one `InstallVendorSkillsAsync` replaces the two near-identical private helpers Kiro and Antigravity had, rather than adding a third and fourth copy. Their behaviour is unchanged (they still write their own trees, which is what they read), and both are now covered by a test — neither was before.
- **A refresh tops a tree up; it never creates one.** `plugin remove --skills` drops the marker precisely so an upgrade cannot undo it, and `refresh.js` runs the `--if-installed` form of every vendor on each `npm install -g` with output discarded. Without this gate a deliberate removal came back silently, on a command the user never ran. This was caught in review, not by me — the first version of these tests asserted the buggy behaviour.
- **The legacy `~/.codex/skills` sweep** now runs here too, as it does for the shared tree's other two writers. Skipping it let a Cursor-first install stamp the marker current, so the next `--skills --if-installed` fast-pathed past the sweep and the stale directory survived.
- **Skills failing is a warning, not a failed install** — hooks and MCP are what make capture work. Note this differs from `--codex`, which fails the install; see the open question below.
- **Docs** — `README.md` per-command sections and code fences, `help-plugin.txt` per-vendor entries, and the `refresh.js` contract comment, which no longer described what the code does.
- **Tests** — the fresh path (the behaviour being fixed), that a refresh creates nothing for a vendor never installed (the npm-postinstall safety property, previously unpinned and unpinnable — the sibling tests use `ResolvePluginPath: () => null`, so they would pass straight through the regression), and that a removal is not resurrected. The last fails on four of the five vendors without the gate above. `EnvScope` moves to `Helpers` rather than gaining a fifth copy.

- **An opt-out per vendor** — `--skip-cursor-skills`, `--skip-copilot-skills`, `--skip-gemini-skills`, `--skip-pi-skills`, `--skip-opencode-skills`. Kiro and Antigravity already had one and every other artifact these installs write has a skip flag (15 of them, all `--skip-<vendor>-<artifact>`), so the gap was one this branch created: before it the five wrote no skills, so there was nothing to decline. Vendor-scoped rather than a shared `--skip-skills`, which would break that naming and read as a sibling of `--skills` — a target flag, not a skip.

Not changed here, pre-existing, and now filed as AI-2086: `remove --codex` deletes the shared tree while the other seven removes leave it, so removing Codex on a Codex+Cursor machine takes Cursor's skills with it. Six commands write that tree, two remove it, nothing tracks ownership. This branch widens the blast radius rather than causing it.

AI-2033