### PR TITLE
Codex app-server: deferred-first-turn source-claim contract (runtime side)

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1076,6 +1076,8 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(AcpEventEnvelope[]))]
 [JsonSerializable(typeof(AcpBatchAck))]
 [JsonSerializable(typeof(AcpBindOutcome))]
+[JsonSerializable(typeof(AcpSourceClaimOutcome))]
+[JsonSerializable(typeof(AcpLaunchConfirmOutcome))]
 [JsonSerializable(typeof(TranscriptBatchAck))]
 // The AcpSessionStarted hub method's optional metadata argument. Registered as its own root type
 // (not just nested inside another JsonSerializable graph) because SignalR's JsonHubProtocol
@@ -1355,6 +1357,30 @@ public readonly record struct AcpBatchAck(long AcceptedSeq, long PersistedSeq, l
 /// declined a stale/foreign/conflicting binding; the daemon stands down without a retry storm.
 /// </summary>
 public enum AcpBindOutcome { Bound = 0, Rejected = 1 }
+
+/// <summary>
+/// Ack of the server's <c>AcpSessionSourceClaim</c> hub method — the durable, deferred-first-turn
+/// source claim that binds the canonical session AND writes the hosted-session ownership ledger row
+/// before the orchestrator dispatches the first turn. A field-for-field mirror of the server-side
+/// <c>Capacitor.Server.Core.Acp.AcpSourceClaimOutcome</c>. <see cref="Outcome"/> mirrors
+/// <see cref="AcpBindOutcome"/> (a stale/foreign bind is <c>Rejected</c> and the daemon stands down);
+/// on <see cref="AcpBindOutcome.Bound"/> the <see cref="OwnershipToken"/> is the ledger's claim/rebind
+/// revision to pass back to <c>ConfirmSessionLaunch</c> after the first <c>turn/start</c> succeeds, and
+/// <see cref="AcceptedSeq"/> is the canonical cursor the forwarder resumes from (<c>-1</c> for a
+/// brand-new session). Both numeric fields are meaningless on a <c>Rejected</c> outcome.
+/// </summary>
+public readonly record struct AcpSourceClaimOutcome(AcpBindOutcome Outcome, long OwnershipToken, long AcceptedSeq);
+
+/// <summary>
+/// Token-fenced outcome of the server's <c>ConfirmSessionLaunch</c> hub method — clearing the ledger
+/// row's provisional flag once the first turn is dispatched. A mirror of the server-side
+/// <c>Capacitor.Server.Core.Acp.AcpLaunchConfirmOutcome</c>. <see cref="Confirmed"/> is <c>0</c> so an
+/// OLD server's void return decodes to it (legacy success). Idempotent under the token
+/// (<see cref="AlreadyConfirmed"/> on a retry after the clear landed); <see cref="Superseded"/> is
+/// permanent (a rebind advanced the token past the caller's — stop retrying); <see cref="NotFound"/>
+/// means no ledger row (the claim never committed, or the session closed).
+/// </summary>
+public enum AcpLaunchConfirmOutcome { Confirmed = 0, AlreadyConfirmed = 1, Superseded = 2, NotFound = 3 }
 
 /// <summary>
 /// Ack returned from the server's <c>SendTranscriptBatchAcked</c> hub method (D3).

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -562,6 +562,13 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         // the loop started) so a ReadOutputAsync consumer never hangs.
         _runtimeTerminal.TrySetResult();
         _dispatcher.FaultAll(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime)));
+
+        // A deferred first turn that was HELD but never begun (teardown before the source claim reached
+        // BeginFirstTurnAsync) leaves _firstTurnDispatch faulted-but-unawaited by the FaultAll above —
+        // observe it so it never surfaces as an unobserved task exception. Harmless if it was already
+        // awaited (the normal path) or completed.
+        _ = _firstTurnDispatch?.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+
         _forwardBuffer.Complete(); // end the envelope stream so a draining forwarder's ReadAllAsync completes
         _cts.Dispose();
     }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -275,6 +275,11 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     /// </summary>
     public async Task BeginFirstTurnAsync(CancellationToken ct = default) {
         _dispatcher.Unseal();
+        // If ct fires after the unseal, the held turn/start may already have left (the dispatch used
+        // CancellationToken.None) — cancelling this await does NOT recall it. That is fine: a cancel here
+        // means the orchestrator is aborting the launch and will tear this runtime down, killing the
+        // process; any dispatched turn dies with it, and its late response hits the dispatcher's faulted
+        // guard and is discarded.
         if (_firstTurnDispatch is { } dispatch)
             await dispatch.WaitAsync(ct).ConfigureAwait(false);
     }
@@ -564,10 +569,12 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         _dispatcher.FaultAll(new ObjectDisposedException(nameof(CodexAppServerHostedAgentRuntime)));
 
         // A deferred first turn that was HELD but never begun (teardown before the source claim reached
-        // BeginFirstTurnAsync) leaves _firstTurnDispatch faulted-but-unawaited by the FaultAll above —
-        // observe it so it never surfaces as an unobserved task exception. Harmless if it was already
-        // awaited (the normal path) or completed.
-        _ = _firstTurnDispatch?.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+        // BeginFirstTurnAsync) leaves _firstTurnDispatch faulted-but-unawaited by the FaultAll above.
+        // Await it with SuppressThrowing to OBSERVE the fault (never an unobserved task exception) and to
+        // let Dispose complete only once it settles — it is already faulted/completed here (FaultAll just
+        // ran, or the normal path already awaited it), so this returns immediately.
+        if (_firstTurnDispatch is { } firstTurn)
+            await firstTurn.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 
         _forwardBuffer.Complete(); // end the envelope stream so a draining forwarder's ReadAllAsync completes
         _cts.Dispose();

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -124,19 +124,35 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     // together with the factory's Transcript wiring and the dedup guards.
     readonly bool _emitEnvelopeTranscript;
 
+    // Whether the FIRST turn is deferred behind a source claim (the §2.5 deferred-first-turn contract).
+    // Distinct from _emitEnvelopeTranscript (envelope EMISSION, §2.4): the two are logically separable
+    // (emission needs no seal; a seal needs no emission) and each is independently testable, even
+    // though production flips BOTH together at the envelope-source activation.
+    readonly bool _deferFirstTurn;
+
+    // The held initial prompt's dispatch, when the first turn is DEFERRED: its turn/start is enqueued
+    // sealed at StartAsync (so it sits at the head) but not sent until the orchestrator's source claim
+    // acks and calls BeginFirstTurnAsync. The task completes when that first turn/start's RESPONSE
+    // lands — the signal the orchestrator confirms on. Null with no initial prompt, or single-phase.
+    Task? _firstTurnDispatch;
+
     public CodexAppServerHostedAgentRuntime(
             CodexAppServerSpawn spawn, CodexAppServerLaunch launch, AgentActivityClock? clock,
             ILogger logger, TimeProvider? timeProvider = null, TimeSpan? forwardStallTimeout = null,
-            bool emitEnvelopeTranscript = false) {
+            bool emitEnvelopeTranscript = false, bool deferFirstTurn = false) {
         _spawn   = spawn;
         _launch  = launch;
         _clock   = clock;
         _logger  = logger;
         _time    = timeProvider ?? TimeProvider.System;
         _emitEnvelopeTranscript = emitEnvelopeTranscript;
+        _deferFirstTurn = deferFirstTurn;
         _dispatcher = new CodexTurnInputDispatcher(
             startTurn: IssueTurnStartAsync, steerTurn: IssueTurnSteerAsync,
-            logger: logger, ct: _cts.Token, onTurnInFlight: flip => _clock?.SetTurnInFlight(flip));
+            logger: logger, ct: _cts.Token, onTurnInFlight: flip => _clock?.SetTurnInFlight(flip),
+            // Deferring the first turn seals the dispatcher — externally-reachable input arriving during
+            // the source-claim window enqueues and waits; BeginFirstTurnAsync unseals it.
+            sealedAtStart: deferFirstTurn);
         _mapper = new CodexNotificationMapper(() => _resolvedModel, logger);
         _forwardBuffer = new CodexForwardBuffer(
             ForwardBufferCapacity,
@@ -227,8 +243,40 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         await StartThreadAsync(linked.Token).ConfigureAwait(false);
         _clock?.ClearLaunchStage();
 
-        if (!string.IsNullOrEmpty(_launch.InitialPrompt))
-            await _dispatcher.EnqueueAsync(_launch.InitialPrompt, linked.Token).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(_launch.InitialPrompt)) {
+            if (_deferFirstTurn) {
+                // DEFERRED first turn: the dispatcher is sealed, so this enqueue parks the prompt at the
+                // head of the queue and dispatches NOTHING now — we must NOT await it (the ack cannot
+                // complete until BeginFirstTurnAsync unseals). Use CancellationToken.None as the per-input
+                // token because StartAsync's `linked` is disposed on return, long before the deferred
+                // send; the dispatcher's own runtime token (_cts.Token) still aborts it on teardown.
+                _firstTurnDispatch = _dispatcher.EnqueueAsync(_launch.InitialPrompt, CancellationToken.None);
+            } else {
+                await _dispatcher.EnqueueAsync(_launch.InitialPrompt, linked.Token).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// When true, <see cref="StartAsync"/> has established the thread and HELD the first turn (sealed
+    /// the input dispatcher) instead of dispatching it — the orchestrator must durably source-claim
+    /// this session, then call <see cref="BeginFirstTurnAsync"/>, before any turn (and therefore any
+    /// hook or rollout line) can exist. Driven by the deferred-first-turn flag (production flips it with
+    /// the envelope-source activation); every single-phase launch keeps the immediate first turn.
+    /// </summary>
+    public bool RequiresSourceClaimBeforeFirstTurn => _deferFirstTurn;
+
+    /// <summary>
+    /// Unseals the input dispatcher — dispatching the held initial prompt as the first <c>turn/start</c>,
+    /// then any input that arrived during the sealed claim window FIFO — and awaits the first turn's
+    /// JSON-RPC RESPONSE (the signal the orchestrator confirms the launch on). Called once, only when
+    /// <see cref="RequiresSourceClaimBeforeFirstTurn"/> is true and only after the source claim acks.
+    /// With no initial prompt it simply unseals (a subsequent user input becomes the first turn).
+    /// </summary>
+    public async Task BeginFirstTurnAsync(CancellationToken ct = default) {
+        _dispatcher.Unseal();
+        if (_firstTurnDispatch is { } dispatch)
+            await dispatch.WaitAsync(ct).ConfigureAwait(false);
     }
 
     async Task SpawnAndInitializeAsync(string? hookStateSeed, CancellationToken ct) {

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
@@ -39,16 +39,29 @@ internal sealed class CodexTurnInputDispatcher {
     bool      _dispatching;              // guards the fire-outside-lock dispatch against re-entrancy
     bool      _lastInFlight;             // last value handed to _onTurnInFlight, so it fires only on change
     bool      _faulted;                 // FaultAll ran; a dispatch resuming after it must not resurrect state
+    bool      _sealed;                  // pre-first-turn seal: input enqueues and WAITS; nothing dispatches until Unseal
 
     public CodexTurnInputDispatcher(
             Func<string, CancellationToken, Task<CodexTurnStarted>> startTurn,
             Func<string, string, CancellationToken, Task> steerTurn,
-            ILogger logger, CancellationToken ct, Action<bool>? onTurnInFlight = null) {
+            ILogger logger, CancellationToken ct, Action<bool>? onTurnInFlight = null,
+            bool sealedAtStart = false) {
         _startTurn      = startTurn;
         _steerTurn      = steerTurn;
         _logger         = logger;
         _ct             = ct;
         _onTurnInFlight = onTurnInFlight;
+        _sealed         = sealedAtStart;
+    }
+
+    /// <summary>Lifts the pre-first-turn seal and pumps the queue. Called once, from the runtime's
+    /// <c>BeginFirstTurnAsync</c>, after the server's source claim acks — so the held initial prompt
+    /// (enqueued first, at the head) dispatches as the first <c>turn/start</c>, then any input that
+    /// arrived during the sealed claim window drains FIFO behind it. Idempotent: a second call is a
+    /// harmless pump.</summary>
+    public void Unseal() {
+        lock (_gate) _sealed = false;
+        PumpDispatch();
     }
 
     /// <summary>True while a turn is live — including a <c>turn/start</c> whose response hasn't landed
@@ -139,7 +152,9 @@ internal sealed class CodexTurnInputDispatcher {
             string turnId;
 
             lock (_gate) {
-                if (_pending is not Pending.None || _queue.Count == 0) {
+                // While sealed, input stays queued and NOTHING dispatches — no turn/* request leaves,
+                // so no hook can fire before the source claim commits (the guard-2 ordering).
+                if (_sealed || _pending is not Pending.None || _queue.Count == 0) {
                     _dispatching = false;
                     return;
                 }

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs
@@ -68,6 +68,23 @@ internal interface IHostedAgentRuntime : IAsyncDisposable {
     Task WaitForTurnIdleAsync(CancellationToken ct) => Task.CompletedTask;
 
     /// <summary>
+    /// True when this runtime returns from its start WITHOUT dispatching the first turn — it holds the
+    /// initial prompt and seals input — and the orchestrator MUST durably source-claim the session and
+    /// then call <see cref="BeginFirstTurnAsync"/>. Only the envelope-sourced hosted-Codex runtime does
+    /// this; every other runtime keeps the single-phase launch (default false), so the orchestrator
+    /// skips the extra handshake for them.
+    /// </summary>
+    bool RequiresSourceClaimBeforeFirstTurn => false;
+
+    /// <summary>
+    /// Dispatch the held initial prompt as the first turn and unseal any queued input, completing when
+    /// the first turn's transport response has landed. Called once by the orchestrator after the source
+    /// claim acks, only when <see cref="RequiresSourceClaimBeforeFirstTurn"/> is true. No-op default for
+    /// every single-phase runtime.
+    /// </summary>
+    Task BeginFirstTurnAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+    /// <summary>
     /// Hosted-UI special key (server <c>SendSpecialKey</c>). PTY runtimes translate via
     /// <see cref="SpecialKeyMap"/> and write the bytes; the ACP runtime maps or ignores.
     /// </summary>

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1210,6 +1210,60 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         ) => _hub.InvokeAsync<AcpBatchAck>("AcpSessionEvents", agentId, acpSessionId, envelopes, cancellationToken: ct);
 
     /// <summary>
+    /// The deferred-first-turn SOURCE CLAIM: durably records this hosted session's ownership (the
+    /// guard-2 substrate) BEFORE the orchestrator dispatches the first turn. Gated exactly like
+    /// <see cref="AcpSessionStartedAsync"/> — <see cref="ConnectionRetry"/> waits for
+    /// <see cref="IsReady"/> before every attempt. Returns the server's full outcome (bind result +
+    /// ownership token + canonical resume cursor); the caller acts on <see cref="AcpBindOutcome.Rejected"/>
+    /// (coded launch failure + teardown) and carries the token to <see cref="ConfirmSessionLaunchAsync"/>.
+    /// </summary>
+    public virtual Task<AcpSourceClaimOutcome> AcpSessionSourceClaimAsync(
+            string agentId, string acpSessionId, CancellationToken ct = default
+        ) => ConnectionRetry.InvokeWithConnectionRetryAsync(
+            () => InvokeAcpSessionSourceClaimRawAsync(agentId, acpSessionId, ct),
+            () => IsReady,
+            AcpRetryPollInterval,
+            attempt => LogAcpSourceClaimRetry(agentId, attempt),
+            ct
+        );
+
+    /// <summary>
+    /// The token-fenced CONFIRM: clears the ledger row's provisional flag once the first turn has been
+    /// dispatched. Gated on <see cref="IsReady"/>. Returns the token-fenced outcome; the caller's
+    /// confirm loop treats <see cref="AcpLaunchConfirmOutcome.Confirmed"/>/<see cref="AcpLaunchConfirmOutcome.AlreadyConfirmed"/>
+    /// as done, <see cref="AcpLaunchConfirmOutcome.Superseded"/>/<see cref="AcpLaunchConfirmOutcome.NotFound"/>
+    /// as terminal-stop, and a transient connection failure as a retry — a confirm failure never tears
+    /// down the running agent.
+    /// </summary>
+    public virtual Task<AcpLaunchConfirmOutcome> ConfirmSessionLaunchAsync(
+            string acpSessionId, long ownershipToken, CancellationToken ct = default
+        ) => ConnectionRetry.InvokeWithConnectionRetryAsync(
+            () => InvokeConfirmSessionLaunchRawAsync(acpSessionId, ownershipToken, ct),
+            () => IsReady,
+            AcpRetryPollInterval,
+            attempt => LogConfirmSessionLaunchRetry(acpSessionId, attempt),
+            ct
+        );
+
+    /// <summary>
+    /// The actual <c>AcpSessionSourceClaim</c> hub invocation, isolated into its own <c>virtual</c>
+    /// method so <see cref="AcpSessionSourceClaimAsync"/>'s gating can be tested without a live hub.
+    /// A pre-source-claim server has no such method, so <c>InvokeAsync</c> throws (method-not-found) —
+    /// which the launch path treats as a coded launch failure (the reverse-skew contract).
+    /// </summary>
+    internal virtual Task<AcpSourceClaimOutcome> InvokeAcpSessionSourceClaimRawAsync(
+            string agentId, string acpSessionId, CancellationToken ct
+        ) => _hub.InvokeAsync<AcpSourceClaimOutcome>("AcpSessionSourceClaim", agentId, acpSessionId, cancellationToken: ct);
+
+    /// <summary>
+    /// The actual <c>ConfirmSessionLaunch</c> hub invocation, isolated into its own <c>virtual</c>
+    /// method so <see cref="ConfirmSessionLaunchAsync"/>'s gating can be tested without a live hub.
+    /// </summary>
+    internal virtual Task<AcpLaunchConfirmOutcome> InvokeConfirmSessionLaunchRawAsync(
+            string acpSessionId, long ownershipToken, CancellationToken ct
+        ) => _hub.InvokeAsync<AcpLaunchConfirmOutcome>("ConfirmSessionLaunch", acpSessionId, ownershipToken, cancellationToken: ct);
+
+    /// <summary>
     /// Queues a base64 PTY chunk for the hosted-agent terminal mirror:
     /// chunks are drained by <see cref="TerminalOutputSender"/>'s single ordered loop
     /// instead of being fired at <c>SendAsync</c> fire-and-forget, so they reach the
@@ -1434,6 +1488,12 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
     [LoggerMessage(Level = LogLevel.Information, Message = "AcpSessionEvents for agent {AgentId} interrupted by a connection drop (retry {Attempt}); waiting for the daemon connection to recover before retrying")]
     partial void LogAcpEventsRetry(string agentId, int attempt);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "AcpSessionSourceClaim for agent {AgentId} interrupted by a connection drop (retry {Attempt}); waiting for the daemon connection to recover before retrying")]
+    partial void LogAcpSourceClaimRetry(string agentId, int attempt);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ConfirmSessionLaunch for session {AcpSessionId} interrupted by a connection drop (retry {Attempt}); waiting for the daemon connection to recover before retrying")]
+    partial void LogConfirmSessionLaunchRetry(string acpSessionId, int attempt);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Reconnect re-bind of ACP session {AcpSessionId} for agent {AgentId} failed (attempt {Attempt}/{MaxAttempts})")]
     partial void LogAcpRebindFailed(Exception ex, string agentId, string acpSessionId, int attempt, int maxAttempts);

--- a/test/Capacitor.Cli.Core.Tests.Unit/AcpEventEnvelopeWireCompatTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/AcpEventEnvelopeWireCompatTests.cs
@@ -175,4 +175,41 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(json).Contains(@"""accepted_seq"":10");
         await Assert.That(json).Contains(@"""expected_next_seq"":null");
     }
+
+    // ── Source-claim / confirm outcomes (mirror the server's AcpSessionSourceClaim / ConfirmSessionLaunch) ──
+    // These are RETURNED BY the server hub methods, so the daemon only ever DESERIALIZES them (never
+    // sends them). The contract is therefore: the daemon must decode the exact shape the server emits —
+    // snake_case properties + camelCase enum values (JsonNamingPolicy.CamelCase on the server's
+    // JsonStringEnumConverter). JsonStringEnumConverter deserialization is case-insensitive, so the
+    // server's camelCase maps onto the daemon's members; these tests lock that in against the real
+    // server wire strings.
+
+    [Test]
+    public async Task AcpSourceClaimOutcome_deserializes_the_servers_wire_shape() {
+        // Exactly what the server's AcpSessionSourceClaim emits for a Bound claim.
+        var bound = JsonSerializer.Deserialize(
+            @"{""outcome"":""bound"",""ownership_token"":3,""accepted_seq"":-1}",
+            CapacitorJsonContext.Default.AcpSourceClaimOutcome);
+        await Assert.That(bound.Outcome).IsEqualTo(AcpBindOutcome.Bound);
+        await Assert.That(bound.OwnershipToken).IsEqualTo(3L);
+        await Assert.That(bound.AcceptedSeq).IsEqualTo(-1L);
+
+        var rejected = JsonSerializer.Deserialize(
+            @"{""outcome"":""rejected"",""ownership_token"":0,""accepted_seq"":0}",
+            CapacitorJsonContext.Default.AcpSourceClaimOutcome);
+        await Assert.That(rejected.Outcome).IsEqualTo(AcpBindOutcome.Rejected);
+    }
+
+    [Test]
+    public async Task AcpLaunchConfirmOutcome_deserializes_every_server_camelCase_value() {
+        // Including the multi-word member, which rides the wire as "alreadyConfirmed" — the one most
+        // likely to silently mismatch a naming policy.
+        await Assert.That(Decode(@"""confirmed""")).IsEqualTo(AcpLaunchConfirmOutcome.Confirmed);
+        await Assert.That(Decode(@"""alreadyConfirmed""")).IsEqualTo(AcpLaunchConfirmOutcome.AlreadyConfirmed);
+        await Assert.That(Decode(@"""superseded""")).IsEqualTo(AcpLaunchConfirmOutcome.Superseded);
+        await Assert.That(Decode(@"""notFound""")).IsEqualTo(AcpLaunchConfirmOutcome.NotFound);
+
+        static AcpLaunchConfirmOutcome Decode(string json) =>
+            JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.AcpLaunchConfirmOutcome);
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -31,7 +31,8 @@ public class CodexAppServerHostedAgentRuntimeTests {
     /// <summary>Builds a spawn delegate that hands each spawn a fresh fake (indexed), recording the
     /// seed passed on each call so the restart path is assertable.</summary>
     static (CodexAppServerHostedAgentRuntime Runtime, List<string?> Seeds, Func<int, FakeCodexAppServer> Fake)
-            Build(Func<int, FakeCodexAppServer> fakeFor, CodexAppServerLaunch launch, bool emitEnvelopes = false) {
+            Build(Func<int, FakeCodexAppServer> fakeFor, CodexAppServerLaunch launch,
+                  bool emitEnvelopes = false, bool deferFirstTurn = false) {
         var seeds  = new List<string?>();
         var fakes  = new List<FakeCodexAppServer>();
         var index  = 0;
@@ -45,7 +46,8 @@ public class CodexAppServerHostedAgentRuntimeTests {
         };
 
         var runtime = new CodexAppServerHostedAgentRuntime(
-            spawn, launch, clock: null, NullLogger.Instance, emitEnvelopeTranscript: emitEnvelopes);
+            spawn, launch, clock: null, NullLogger.Instance,
+            emitEnvelopeTranscript: emitEnvelopes, deferFirstTurn: deferFirstTurn);
         return (runtime, seeds, i => fakes[i]);
     }
 
@@ -109,6 +111,42 @@ public class CodexAppServerHostedAgentRuntimeTests {
         await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
 
         await Assert.That(DrainAvailable(runtime)).IsEmpty();
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Deferred_first_turn_holds_the_initial_prompt_until_BeginFirstTurn() {
+        // Envelope-source path: StartAsync establishes the thread but must NOT dispatch the first turn —
+        // it seals the dispatcher and holds the prompt, so nothing can fire a hook before the source
+        // claim commits. The orchestrator drives the first turn via BeginFirstTurnAsync after the claim.
+        var fake = new FakeCodexAppServer();
+        var (runtime, _, _) = Build(_ => fake, Launch(prompt: "review this"), deferFirstTurn: true);
+
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(runtime.RequiresSourceClaimBeforeFirstTurn).IsTrue();
+        await Assert.That(runtime.ThreadId).IsEqualTo("thread-abc");
+        await Assert.That(fake.ReceivedMethods).DoesNotContain("turn/start"); // held — no first turn yet
+
+        await runtime.BeginFirstTurnAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(fake.ReceivedMethods).Contains("turn/start"); // unsealed — the held prompt dispatched
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Single_phase_launch_dispatches_the_initial_prompt_at_start() {
+        // Reviewer/control-plane path (gate off): the runtime keeps the single-phase launch — the initial
+        // prompt is dispatched at StartAsync, and no source claim is required.
+        var fake = new FakeCodexAppServer();
+        var (runtime, _, _) = Build(_ => fake, Launch(prompt: "review this")); // emitEnvelopes defaults false
+
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(runtime.RequiresSourceClaimBeforeFirstTurn).IsFalse();
+        await Assert.That(fake.ReceivedMethods).Contains("turn/start"); // self-driven at start, no BeginFirstTurn
 
         await runtime.DisposeAsync();
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -117,9 +117,8 @@ public class CodexAppServerHostedAgentRuntimeTests {
 
     [Test]
     public async Task Deferred_first_turn_holds_the_initial_prompt_until_BeginFirstTurn() {
-        // Envelope-source path: StartAsync establishes the thread but must NOT dispatch the first turn —
-        // it seals the dispatcher and holds the prompt, so nothing can fire a hook before the source
-        // claim commits. The orchestrator drives the first turn via BeginFirstTurnAsync after the claim.
+        // The load-bearing ordering: with deferral on, StartAsync must establish the thread but leave NO
+        // turn/start behind (a hook could otherwise fire before the source claim commits).
         var fake = new FakeCodexAppServer();
         var (runtime, _, _) = Build(_ => fake, Launch(prompt: "review this"), deferFirstTurn: true);
 
@@ -127,26 +126,24 @@ public class CodexAppServerHostedAgentRuntimeTests {
 
         await Assert.That(runtime.RequiresSourceClaimBeforeFirstTurn).IsTrue();
         await Assert.That(runtime.ThreadId).IsEqualTo("thread-abc");
-        await Assert.That(fake.ReceivedMethods).DoesNotContain("turn/start"); // held — no first turn yet
+        await Assert.That(fake.ReceivedMethods).DoesNotContain("turn/start");
 
         await runtime.BeginFirstTurnAsync(CancellationToken.None).WaitAsync(HangGuard);
 
-        await Assert.That(fake.ReceivedMethods).Contains("turn/start"); // unsealed — the held prompt dispatched
+        await Assert.That(fake.ReceivedMethods).Contains("turn/start");
 
         await runtime.DisposeAsync();
     }
 
     [Test]
     public async Task Single_phase_launch_dispatches_the_initial_prompt_at_start() {
-        // Reviewer/control-plane path (gate off): the runtime keeps the single-phase launch — the initial
-        // prompt is dispatched at StartAsync, and no source claim is required.
         var fake = new FakeCodexAppServer();
-        var (runtime, _, _) = Build(_ => fake, Launch(prompt: "review this")); // emitEnvelopes defaults false
+        var (runtime, _, _) = Build(_ => fake, Launch(prompt: "review this")); // deferFirstTurn defaults false
 
         await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
 
         await Assert.That(runtime.RequiresSourceClaimBeforeFirstTurn).IsFalse();
-        await Assert.That(fake.ReceivedMethods).Contains("turn/start"); // self-driven at start, no BeginFirstTurn
+        await Assert.That(fake.ReceivedMethods).Contains("turn/start"); // no deferral ⇒ the prompt drives the first turn at start
 
         await runtime.DisposeAsync();
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
@@ -224,6 +224,73 @@ public class CodexTurnInputDispatcherTests {
         await Assert.That(async () => await ack2.WaitAsync(Guard)).Throws<ObjectDisposedException>();
     }
 
+    // ── Deferred-first-turn seal ─────────────────────────────────────────────────────────────────
+
+    static CodexTurnInputDispatcher Sealed(FakeTurnSink sink) =>
+        new(sink.Start, sink.Steer, NullLogger.Instance, CancellationToken.None, sealedAtStart: true);
+
+    [Test]
+    public async Task Sealed_dispatcher_holds_input_and_reads_idle_until_unseal() {
+        var sink = new FakeTurnSink();
+        var d    = Sealed(sink);
+
+        var ack = d.EnqueueAsync("held-prompt"); // enqueues behind the seal — nothing dispatches
+
+        await Task.Delay(100); // give any (erroneous) dispatch a chance to fire
+        await Assert.That(sink.StartCount).IsEqualTo(0);   // sealed ⇒ no turn/start left
+        await Assert.That(d.TurnInFlight).IsFalse();       // and the reaper sees it idle, not wedged
+        await Assert.That(ack.IsCompleted).IsFalse();
+
+        d.Unseal();
+
+        var start = await sink.NextStart();
+        await Assert.That(start.Text).IsEqualTo("held-prompt");
+        start.Started("turn-1");
+        await ack.WaitAsync(Guard);
+    }
+
+    [Test]
+    public async Task Unseal_dispatches_the_held_prompt_first_then_queued_input_fifo() {
+        var sink = new FakeTurnSink();
+        var d    = Sealed(sink);
+
+        // The held initial prompt is enqueued first (the head); input that "arrived during the claim
+        // window" enqueues behind it — all while sealed.
+        var promptAck   = d.EnqueueAsync("initial-prompt");
+        var externalAck = d.EnqueueAsync("external-input");
+
+        await Task.Delay(50);
+        await Assert.That(sink.StartCount).IsEqualTo(0);
+
+        d.Unseal();
+
+        var start = await sink.NextStart();               // the held prompt dispatches FIRST
+        await Assert.That(start.Text).IsEqualTo("initial-prompt");
+        start.Started("turn-1");
+        await promptAck.WaitAsync(Guard);
+
+        var steer = await sink.NextSteer();               // then the queued input, FIFO, onto the turn
+        await Assert.That(steer.Text).IsEqualTo("external-input");
+        steer.Accepted();
+        await externalAck.WaitAsync(Guard);
+
+        await Assert.That(sink.StartCount).IsEqualTo(1);  // exactly one start — no double-start
+    }
+
+    [Test]
+    public async Task Unseal_is_idempotent() {
+        var sink = new FakeTurnSink();
+        var d    = Sealed(sink);
+
+        var ack = d.EnqueueAsync("hello");
+        d.Unseal();
+        d.Unseal(); // a second unseal is a harmless pump, not a double-dispatch
+
+        (await sink.NextStart()).Started("turn-1");
+        await ack.WaitAsync(Guard);
+        await Assert.That(sink.StartCount).IsEqualTo(1);
+    }
+
     // ── Channel-synchronized fake send-sink ─────────────────────────────────────────────────────
 
     sealed class FakeTurnSink {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
@@ -234,11 +234,11 @@ public class CodexTurnInputDispatcherTests {
         var sink = new FakeTurnSink();
         var d    = Sealed(sink);
 
-        var ack = d.EnqueueAsync("held-prompt"); // enqueues behind the seal — nothing dispatches
+        var ack = d.EnqueueAsync("held-prompt");
 
-        await Task.Delay(100); // give any (erroneous) dispatch a chance to fire
-        await Assert.That(sink.StartCount).IsEqualTo(0);   // sealed ⇒ no turn/start left
-        await Assert.That(d.TurnInFlight).IsFalse();       // and the reaper sees it idle, not wedged
+        await Task.Delay(100); // an erroneous dispatch would surface within this window; sealed, none does
+        await Assert.That(sink.StartCount).IsEqualTo(0);
+        await Assert.That(d.TurnInFlight).IsFalse(); // sealed must read idle so the reaper can't wedge it
         await Assert.That(ack.IsCompleted).IsFalse();
 
         d.Unseal();
@@ -254,8 +254,8 @@ public class CodexTurnInputDispatcherTests {
         var sink = new FakeTurnSink();
         var d    = Sealed(sink);
 
-        // The held initial prompt is enqueued first (the head); input that "arrived during the claim
-        // window" enqueues behind it — all while sealed.
+        // Both enqueued while sealed: the held prompt first (the head), then input that "arrived during
+        // the claim window". Unseal must dispatch the prompt as the turn/start and the rest FIFO behind it.
         var promptAck   = d.EnqueueAsync("initial-prompt");
         var externalAck = d.EnqueueAsync("external-input");
 
@@ -264,17 +264,17 @@ public class CodexTurnInputDispatcherTests {
 
         d.Unseal();
 
-        var start = await sink.NextStart();               // the held prompt dispatches FIRST
+        var start = await sink.NextStart();
         await Assert.That(start.Text).IsEqualTo("initial-prompt");
         start.Started("turn-1");
         await promptAck.WaitAsync(Guard);
 
-        var steer = await sink.NextSteer();               // then the queued input, FIFO, onto the turn
+        var steer = await sink.NextSteer();
         await Assert.That(steer.Text).IsEqualTo("external-input");
         steer.Accepted();
         await externalAck.WaitAsync(Guard);
 
-        await Assert.That(sink.StartCount).IsEqualTo(1);  // exactly one start — no double-start
+        await Assert.That(sink.StartCount).IsEqualTo(1); // one start — the second input rode a steer, no double-start
     }
 
     [Test]
@@ -284,11 +284,11 @@ public class CodexTurnInputDispatcherTests {
 
         var ack = d.EnqueueAsync("hello");
         d.Unseal();
-        d.Unseal(); // a second unseal is a harmless pump, not a double-dispatch
+        d.Unseal();
 
         (await sink.NextStart()).Started("turn-1");
         await ack.WaitAsync(Guard);
-        await Assert.That(sink.StartCount).IsEqualTo(1);
+        await Assert.That(sink.StartCount).IsEqualTo(1); // the second Unseal was a harmless pump, not a re-dispatch
     }
 
     // ── Channel-synchronized fake send-sink ─────────────────────────────────────────────────────


### PR DESCRIPTION
## What

The **daemon half of the hosted-Codex source-claim handshake** (the runtime-side contract). It pairs with the kcap-server hub methods `AcpSessionSourceClaim` / `ConfirmSessionLaunch` — the durable ownership ledger that makes late-watcher double-ingest impossible for hosted app-server Codex sessions.

**All dormant** behind the new `deferFirstTurn` flag: the runtime factory does not set it yet (the envelope-source *activation* flips it together with the transcript wiring), exactly mirroring how the server shipped the hub methods without a caller. Zero behaviour change to any shipping path.

## Pieces

- **`Cli.Core` wire mirrors** — `AcpSourceClaimOutcome {Outcome, OwnershipToken, AcceptedSeq}` + `AcpLaunchConfirmOutcome {Confirmed, AlreadyConfirmed, Superseded, NotFound}`, registered in `CapacitorJsonContext`. These are **returned by** the server hub methods, so the daemon only ever deserializes them; wire-compat tests pin that it decodes the server's snake_case props + camelCase enum values (case-insensitively) — including the multi-word `alreadyConfirmed`, the member most likely to silently mismatch a naming policy.
- **`ServerConnection`** — `AcpSessionSourceClaimAsync` + `ConfirmSessionLaunchAsync` proxies (IsReady-gated via `ConnectionRetry`, `virtual` raw invocations for testability, own retry-log helpers). The claim returns the full outcome so the caller acts on `Rejected` (coded launch failure) and carries the token to the confirm.
- **`CodexTurnInputDispatcher`** — a pre-first-turn **`Sealed`** state (`sealedAtStart` + `Unseal()`): while sealed, input enqueues and *waits* — nothing dispatches, so no `turn/*` request leaves and no hook can fire before the source claim commits. `Unseal()` dispatches the held prompt (the head of the queue) first, then queued input FIFO.
- **`CodexAppServerHostedAgentRuntime`** — a distinct `deferFirstTurn` flag (separate from the §2.4 `emitEnvelopeTranscript` *emission* flag; the two are logically independent and each is tested in isolation, though production flips both at activation). When deferring, `StartAsync` holds the prompt behind the seal; `RequiresSourceClaimBeforeFirstTurn` advertises the contract; `BeginFirstTurnAsync` unseals and awaits the first `turn/start`'s response (the signal the orchestrator confirms on).
- **`IHostedAgentRuntime`** gains the two default members (`false` / no-op) so every single-phase runtime is unaffected.

## Tests

- `CodexTurnInputDispatcherTests` — 15 (3 new: sealed holds + reads idle, unseal dispatches held-prompt-first then FIFO, unseal idempotent).
- `CodexAppServerHostedAgentRuntimeTests` — 18 (2 new: deferred holds the prompt until `BeginFirstTurn`; single-phase self-dispatches at start).
- `AcpEventEnvelopeWireCompatTests` — 9 (2 new outcome deserialize tests).

All green.

## Follow-up (activation change)

The orchestrator `register → claim → BeginFirstTurn → confirm` sequence + the guard-1 env marker land with the envelope-source activation, because they couple to the transcript forwarder's bind reconciliation (the claim supersedes `AcpSessionStarted` for the envelope path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)