### PR TITLE
[AI-2034] Add --skip-title to import, matching watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,10 +655,13 @@ kcap import --org EventStore --private        # mark every imported session as O
 kcap import --org EventStore --since 2026-01-01  # only sessions on or after this date
 kcap import --org EventStore --cwd /path/to/project  # filter by working directory
 kcap import --org EventStore --session abc123    # single session
+kcap import --org EventStore --skip-title    # don't spend your own agent quota on titles
 kcap import --opencode --session ses_x --reimport  # force one OpenCode session past its ledger entry
 ```
 
 `--reimport` forces OpenCode sessions to re-import even when the local completeness ledger (described above) records them as already loaded — the escape hatch for a session that was deleted server-side (e.g. via `kcap disable`) but is still marked complete locally, which a plain re-run would otherwise skip. Scope it with the usual vendor/`--repo`/`--cwd`/`--session` filters to force just the affected sessions; the re-send is idempotent, and a successful forced import refreshes the ledger entry. It has no effect on other vendors, which already re-classify every run.
+
+Import generates a title for each **Claude and Codex** session it loads by shelling out to your own `claude` / `codex` — once per session, on your subscription, in the background. `--skip-title` turns that off, the same opt-out `kcap watch` takes for the same generator. Sessions are fully searchable without a title; it only affects how recognisable they look to you. The other seven agents never generate one locally, so the flag changes nothing for them: Cursor and Copilot forward the name their transcript already carries, OpenCode forwards its native title, and Antigravity, Gemini, Kiro and Pi leave the server to derive one.
 
 Non-interactive runs (no TTY, e.g. CI) must pass both a scope flag and `--yes`. The command is idempotent and resumable — re-running with the same scope only uploads what's missing or incomplete. A server-side tracker deduplicates events on `(stream, eventId)` so previously-imported turns don't get re-appended.
 

--- a/src/Capacitor.Cli.Core/Resources/help-import.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-import.txt
@@ -53,6 +53,12 @@ Options:
   --cwd <path>            Filter by working directory (composes with scope)
   --session <id>          Import a specific session only (composes with scope)
   --min-lines <n>         Skip sessions shorter than n lines (default: 15)
+  --skip-title            Don't generate titles for imported Claude and Codex
+                          sessions. Titling shells out to your own `claude` /
+                          `codex`, once per session, on your subscription — the
+                          same opt-out `kcap watch` takes. Sessions are searchable
+                          without a title, and the other seven agents never title
+                          locally, so this changes nothing for them.
   --generate-summaries    Also generate per-session what's-done summaries
   --reimport              Force OpenCode sessions to re-import even if a local
                           ledger records them as complete (use after deleting a

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -176,7 +176,11 @@ static class ImportCommand {
                 if (f.Errored    > 0) grid.AddRow("[bold]Errored[/]", $"[red]{f.Errored}[/]");
 
                 if (f.RanBackground) {
-                    grid.AddRow("[bold]Titles[/]", $"{f.TitlesGenerated} generated, {f.TitlesSkipped} skipped, {f.TitlesFailed} failed");
+                    // Gated on the count, not on RanBackground: with --skip-title --generate-summaries
+                    // there is background work but no titling, and a row of zeroes reads as titling that
+                    // found nothing rather than titling that never ran.
+                    if (f.RequestedTitles)
+                        grid.AddRow("[bold]Titles[/]", $"{f.TitlesGenerated} generated, {f.TitlesSkipped} skipped, {f.TitlesFailed} failed");
 
                     if (f.RequestedSummaries)
                         grid.AddRow("[bold]Summaries[/]", $"{f.SummariesGenerated} generated, {f.SummariesFailed} failed");
@@ -215,7 +219,8 @@ static class ImportCommand {
                 if (f.Errored    > 0) Console.WriteLine($"  Errored             {f.Errored}");
 
                 if (f.RanBackground) {
-                    Console.WriteLine($"  Titles              {f.TitlesGenerated} generated, {f.TitlesSkipped} skipped, {f.TitlesFailed} failed");
+                    if (f.RequestedTitles)
+                        Console.WriteLine($"  Titles              {f.TitlesGenerated} generated, {f.TitlesSkipped} skipped, {f.TitlesFailed} failed");
 
                     if (f.RequestedSummaries)
                         Console.WriteLine($"  Summaries           {f.SummariesGenerated} generated, {f.SummariesFailed} failed");
@@ -553,7 +558,8 @@ static class ImportCommand {
             int  SummariesGenerated,
             int  SummariesFailed,
             bool RanBackground,
-            bool RequestedSummaries
+            bool RequestedSummaries,
+            bool RequestedTitles = false
         );
 
     /// <summary>
@@ -594,7 +600,8 @@ static class ImportCommand {
             string?                       storedOrg               = null,
             bool                          autoSkipExclusions      = false,
             string?                       defaultVisibility       = null,
-            bool                          reimport                = false
+            bool                          reimport                = false,
+            bool                          skipTitle               = false
         ) {
         using var httpClient = await HttpClientExtensions.CreateAuthenticatedClientAsync(baseUrl);
         var       display    = ImportDisplay.Create();
@@ -1115,6 +1122,9 @@ static class ImportCommand {
             },
             OnTitleTaskReady = t => {
                 var (sid, fp, _, vnd) = t;
+
+                // Titling shells out to the user's own `claude` / `codex`, on their subscription.
+                if (skipTitle) return;
 
                 // Don't schedule a title task for a source that doesn't support it.
                 // Cursor sets SupportsTitleGeneration=false because the composer
@@ -1637,6 +1647,7 @@ static class ImportCommand {
             SummariesGenerated: summariesGenerated,
             SummariesFailed: summariesFailed,
             RanBackground: hasBackgroundWork,
+            RequestedTitles: titleTaskCount > 0,
             RequestedSummaries: summaryTaskCount > 0
         );
 

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -587,6 +587,7 @@ switch (command) {
 
         var generateSummaries = args.Contains("--generate-summaries");
         var reimport          = args.Contains("--reimport");
+        var skipTitle         = args.Contains("--skip-title");
 
         // Build sources
         var explicitVendorSelection = vsel.Vendors.Count > 0;
@@ -644,7 +645,8 @@ switch (command) {
             currentRepo:             currentRepo,
             needOrgPick:             resolveResult.NeedOrgPick,
             storedOrg:               storedOrg,
-            reimport:                reimport);
+            reimport:                reimport,
+            skipTitle:               skipTitle);
     }
     case "watch" when args.Length < 3:
         Console.Error.WriteLine("Usage: kcap watch <sessionId> <transcriptPath> [--agent-id <agentId>] [--cwd <cwd>] [--skip-title] [--parent-pid <pid>] [--vendor claude|codex|copilot|gemini|kiro|pi|opencode|antigravity|cursor]");

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
@@ -75,10 +75,23 @@ public class ImportDisplayGridTests {
     [Test, NotInParallel]
     public async Task done_grid_renders_titles_and_summaries_rows_when_background_ran() {
         var output = CaptureNonTtyOutput(d => d.WriteDoneGrid(
-            MakeFinal(loaded: 3, ranBackground: true, requestedSummaries: true, titlesGenerated: 3, summariesGenerated: 3),
+            MakeFinal(loaded: 3, ranBackground: true, requestedTitles: true, requestedSummaries: true,
+                      titlesGenerated: 3, summariesGenerated: 3),
             bySource: null));
 
         await Assert.That(output).Contains("Titles");
+        await Assert.That(output).Contains("Summaries");
+    }
+
+    [Test, NotInParallel]
+    public async Task done_grid_omits_the_titles_row_when_titling_was_skipped() {
+        // --skip-title --generate-summaries: background work ran, but no titling did. A row of zeroes
+        // here would read as titling that found nothing.
+        var output = CaptureNonTtyOutput(d => d.WriteDoneGrid(
+            MakeFinal(loaded: 3, ranBackground: true, requestedSummaries: true, summariesGenerated: 3),
+            bySource: null));
+
+        await Assert.That(output).DoesNotContain("Titles");
         await Assert.That(output).Contains("Summaries");
     }
 
@@ -95,6 +108,7 @@ public class ImportDisplayGridTests {
     static ImportCommand.FinalCounts MakeFinal(
             int  loaded,
             bool ranBackground      = false,
+            bool requestedTitles    = false,
             bool requestedSummaries = false,
             int  titlesGenerated    = 0,
             int  summariesGenerated = 0
@@ -112,7 +126,8 @@ public class ImportDisplayGridTests {
         SummariesGenerated: summariesGenerated,
         SummariesFailed: 0,
         RanBackground: ranBackground,
-        RequestedSummaries: requestedSummaries
+        RequestedSummaries: requestedSummaries,
+        RequestedTitles: requestedTitles
     );
 
     static string CaptureNonTtyOutput(Action<ImportCommand.ImportDisplay> render) {

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportSkipTitleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportSkipTitleTests.cs
@@ -10,10 +10,8 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 /// <c>kcap import --skip-title</c>: the opt-out `kcap watch` has always had for the same generator.
 /// </summary>
 /// <remarks>
-/// Titling shells out to the user's own `claude` / `codex` once per imported session, on their
-/// subscription. A fake `claude` shadows the real one on PATH: the positive case has to prove a title
-/// really is posted without it, and going near a live model would make the test slow, unrunnable on CI,
-/// and billed to whoever ran it.
+/// The fake `claude` on PATH shadows a real, authenticated one — the positive control must prove a
+/// title is posted, without that costing a live model call.
 /// </remarks>
 // Mutates PATH, and shares the group the HOME-faking suites use because those are exactly the
 // ones a phantom `claude` on PATH would mislead.

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportSkipTitleTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportSkipTitleTests.cs
@@ -1,0 +1,125 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Harness.Claude;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+/// <summary>
+/// <c>kcap import --skip-title</c>: the opt-out `kcap watch` has always had for the same generator.
+/// </summary>
+/// <remarks>
+/// Titling shells out to the user's own `claude` / `codex` once per imported session, on their
+/// subscription. A fake `claude` shadows the real one on PATH: the positive case has to prove a title
+/// really is posted without it, and going near a live model would make the test slow, unrunnable on CI,
+/// and billed to whoever ran it.
+/// </remarks>
+// Mutates PATH, and shares the group the HOME-faking suites use because those are exactly the
+// ones a phantom `claude` on PATH would mislead.
+[NotInParallel("HomeEnvVarMutation")]
+public class ImportSkipTitleTests : IDisposable {
+    readonly WireMockServer _server = WireMockServer.Start();
+    readonly TempDir        _tmp    = new();
+
+    public void Dispose() {
+        _server.Stop();
+        _tmp.Dispose();
+    }
+
+    // The prompt reaches `claude` as one ~1.4KB argv element full of newlines. A .cmd shim gets it via
+    // `cmd.exe /c`, whose parser does not survive embedded LF, so the fake cannot answer on Windows and
+    // the control would fail for a reason that has nothing to do with the flag. The skip assertion
+    // below is the load-bearing one and runs everywhere.
+    [Test]
+    public async Task import_posts_a_title_per_session_by_default() {
+        Skip.When(OperatingSystem.IsWindows(), "a .cmd shim cannot receive the multi-line title prompt");
+
+        using var fakeCli = new FakeClaudeOnPath();
+        StubHooks();
+
+        var exit = await RunImport("titles-on", skipTitle: false);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(TitlePostCount())
+                    .IsGreaterThan(0)
+                    .Because("without the flag import titles each session — if this stops holding, the "
+                           + "skip-title assertion below proves nothing");
+    }
+
+    [Test]
+    public async Task skip_title_posts_no_title() {
+        using var fakeCli = new FakeClaudeOnPath();
+        StubHooks();
+
+        var exit = await RunImport("titles-off", skipTitle: true);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(TitlePostCount())
+                    .IsEqualTo(0)
+                    .Because("--skip-title exists so a run spends nothing on the user's own agent quota");
+    }
+
+    Task<int> RunImport(string name, bool skipTitle) {
+        var projectsDir = _tmp.CreateDir(name);
+
+        // Real user text, so the generator gets past its own "nothing to title" skip.
+        projectsDir.CreateDir("-tmp-skip-title-proj").CreateFile(
+            $"{name}-session.jsonl",
+            [.. Enumerable.Range(0, 20).Select(i =>
+                $$$"""{"type":"user","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/skip-title-proj","message":{"content":"add a retry to the import loop {{{i}}}"}}""")]);
+
+        return ImportCommand.HandleImport(
+            baseUrl:          _server.Url!,
+            filterCwd:        null,
+            minLines:         1,
+            sources:          [new ClaudeImportSource(projectsDir.Path)],
+            scope:            new ImportScope.All(),
+            skipConfirmation: true,
+            skipTitle:        skipTitle);
+    }
+
+    int TitlePostCount() =>
+        _server.LogEntries.Count(e => e.RequestMessage.Path == "/hooks/session-title");
+
+    void StubHooks() {
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+        foreach (var path in new[] {
+                     "/hooks/transcript", "/hooks/session-start*", "/hooks/subagent-start",
+                     "/hooks/subagent-stop", "/hooks/session-title" })
+            _server.Given(Request.Create().WithPath(path).UsingPost())
+                .RespondWith(Response.Create().WithStatusCode(200));
+
+        _server.Given(Request.Create().WithPath("/hooks/session-end*").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+    }
+
+    /// <summary>
+    /// Puts a `claude` on PATH that prints a title and exits 0. The runner falls back to treating
+    /// non-JSON stdout as the result, so a one-line script satisfies it.
+    /// </summary>
+    sealed class FakeClaudeOnPath : IDisposable {
+        readonly TempDir _bin;
+        readonly string? _previousPath;
+
+        public FakeClaudeOnPath() {
+            _bin          = new TempDir();
+            _previousPath = Environment.GetEnvironmentVariable("PATH");
+
+            var script = _bin.CreateFile("claude", "#!/bin/sh\necho 'Retry the import loop'\n");
+
+            // Only the Unix-only positive control executes this; the guard is for the compiler.
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(script,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+            Environment.SetEnvironmentVariable("PATH", _bin.Path + Path.PathSeparator + _previousPath);
+        }
+
+        public void Dispose() {
+            Environment.SetEnvironmentVariable("PATH", _previousPath);
+            _bin.Dispose();
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/VendorSelectionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/VendorSelectionTests.cs
@@ -156,6 +156,8 @@ public class VendorSelectionTests {
             "--yes",
             "-y",
             "--generate-summaries",
+            "--skip-title",
+            "--reimport",
             "--server-url", "http://x",
             "--no-update-check",
             "--profile", "p"


### PR DESCRIPTION
`kcap import` titles every Claude and Codex session it loads by shelling out to the user's own `claude` (15s) / `codex` (30s), three abreast, with no way to turn it off. At Everything scope that is hundreds of headless calls on their subscription. `kcap watch` has had `--skip-title` for the identical generator all along — `TitleGenerator` is deliberately shared between the two paths — so this is the missing half of a pair rather than a new idea, and it takes the same name.

- **`ImportCommand`** — the flag gates the title task before it is scheduled, next to the `SupportsTitleGeneration` check that answers the same question for a different reason. Counters, the Spectre progress task and `RanBackground` all fall out correctly, since nothing is ever queued.
- **The Done grid's Titles row** now keys off whether titling was *requested* rather than whether any background work ran. With `--skip-title --generate-summaries` the old guard printed `Titles  0 generated, 0 skipped, 0 failed`, which reads as titling that found nothing rather than titling that never happened. That case only exists because of this flag, so the fix belongs here.
- **Summaries are untouched.** They are opt-in through their own flag, and someone who typed `--generate-summaries` has asked for that spend. Worth knowing both lanes share one `SemaphoreSlim(3)`, so the concurrency limit is across all background work, not per kind.
- **Docs name the vendors this actually affects**, because it is easy to assume all nine: `SupportsTitleGeneration` is true for **Claude and Codex only**. The other seven never title locally — Cursor and Copilot forward the name their transcript carries, OpenCode its native title, and Antigravity, Gemini, Kiro and Pi leave the server to derive one — so the flag changes nothing for them. `README.md` and `help-import.txt` both say so.
- **`VendorSelectionTests.global_flags_pass_through`** gains `--skip-title` (and `--reimport`, which was already missing). That test exists so a new global flag cannot be mistaken for a vendor typo.

On the test: it shadows `claude` on PATH with a one-line script rather than letting the real one answer. The positive control has to prove a title really is posted *without* the flag, or the skip assertion proves nothing — and reaching a live model would be slow, unrunnable on CI, and billed to whoever ran it. That control is Unix-only: the prompt arrives as a single ~1.4KB argv element full of newlines, which `cmd.exe` cannot hand to a `.cmd` shim intact, so on Windows it would fail for a reason unrelated to the flag. The skip assertion itself runs everywhere.

Not changed, deliberately: `kcap setup`'s embedded import (`SetupCommand.DefaultImportRunner`) does not pass the flag, so setup still titles the current repo's history. That is one repo rather than a full backfill, and changing it is a product decision rather than part of adding the flag — but it is the one remaining unattended path that spends a first-time user's quota, so it is worth a decision rather than an omission.

AI-2034
