### PR TITLE
[AI-1992] Report a provisioning timeout as pending, not as a failed sign-in

### DIFF
--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -427,9 +427,13 @@ public partial class App : Application {
 
         switch (result) {
             // Sign-in succeeded and the workspace is on its way; closing the window mid-poll is not a
-            // failure, and stderr saying so would be untrue.
+            // failure, and stderr saying so would be untrue. The guidance is spelled out here rather
+            // than carried on the message: in the wizard it arrives through the progress sink, and
+            // repeating it there would say the same thing twice — but by now that view is gone, so
+            // this line is the only thing left telling the user how to resume.
             case AuthResult.Failed { Reason: AuthFailureReason.ProvisioningInProgress } pending:
-                Console.Error.WriteLine($"kcap: {pending.Message}");
+                Console.Error.WriteLine(
+                    $"kcap: {pending.Message} Join it from the Connect step once it is ready.");
                 break;
             case AuthResult.Failed failed:
                 Console.Error.WriteLine($"kcap: onboarding sign-in ended with a failure: {failed.Message}");

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -426,6 +426,11 @@ public partial class App : Application {
         var result = await attempt.Result.ConfigureAwait(false);
 
         switch (result) {
+            // Sign-in succeeded and the workspace is on its way; closing the window mid-poll is not a
+            // failure, and stderr saying so would be untrue.
+            case AuthResult.Failed { Reason: AuthFailureReason.ProvisioningInProgress } pending:
+                Console.Error.WriteLine($"kcap: {pending.Message}");
+                break;
             case AuthResult.Failed failed:
                 Console.Error.WriteLine($"kcap: onboarding sign-in ended with a failure: {failed.Message}");
                 break;

--- a/src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs
@@ -243,10 +243,12 @@ public sealed class WizardTenantProvisioner(
             }
         }
 
-        progress.Error($"Still provisioning — finish later by joining '{slug}' from the Connect step.");
+        // Notice, not Error: the workspace is being created, nothing has gone wrong. The reason on the
+        // result is what lets the step headline it as pending rather than failed.
+        progress.Notice($"Still provisioning — finish later by joining '{slug}' from the Connect step.");
         SetupFunnel.WorkspaceFailed("poll_timeout");
 
-        return ProvisionOffer.InProgress;
+        return ProvisionOffer.InProgress(slug);
     }
 
     // The interface hands the provisioner every non-Created message, so a decline must say so here

--- a/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
@@ -413,6 +413,15 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
                 RetargetRequested?.Invoke(retarget.ServerInput);
 
                 break;
+            // Provisioning outran its poll window. Sign-in itself succeeded and the workspace is on its
+            // way, so headlining a failure here would tell the user something untrue.
+            case AuthResult.Failed { Reason: AuthFailureReason.ProvisioningInProgress } pending:
+                SetStatus(pending.Message, isError: false);
+                // The headline is the fact; the sink's line is what to do about it, and SetStatus
+                // drops the detail on a non-error.
+                StatusDetail ??= _lastReport;
+
+                break;
             // Already rendered through the sink; the last reported line stands in when none was an error.
             default:
                 Status        = "Sign-in failed.";

--- a/src/Capacitor.Cli.Core/Auth/AuthResult.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthResult.cs
@@ -7,7 +7,13 @@ public sealed record AuthIdentity(string Profile, string CanonicalServer);
 /// Why an operation failed, for callers that must react differently per cause (the setup funnel
 /// distinguishes a denied sign-in from a tenant-less account). <see cref="Other"/> carries no claim.
 /// </summary>
-public enum AuthFailureReason { Other, Unreachable, SigninDenied, NoTenantsFound }
+/// <remarks>
+/// <see cref="ProvisioningInProgress"/> is not really a failure: the workspace is being created and
+/// the poll simply outlived its window. It rides <see cref="AuthResult.Failed"/> because nothing
+/// durable was published, the same way <see cref="SigninDenied"/> does — but a caller that headlines
+/// it as an error is telling the user something untrue.
+/// </remarks>
+public enum AuthFailureReason { Other, Unreachable, SigninDenied, NoTenantsFound, ProvisioningInProgress }
 
 /// <summary>
 /// Outcome of an onboarding operation. <see cref="Cancelled"/> is strictly pre-boundary — once the
@@ -25,7 +31,9 @@ public abstract record AuthResult {
 
     public sealed record Cancelled : AuthResult;
 
-    /// <param name="Message">Already rendered through <see cref="IAuthProgress"/>; carried for callers that log or re-present it.</param>
+    /// <param name="Message">Rendered through <see cref="IAuthProgress"/> and carried for callers that
+    /// log or re-present it — except for <see cref="AuthFailureReason.ProvisioningInProgress"/>, whose
+    /// message is composed for a headline and complements the sink line rather than repeating it.</param>
     public sealed record Failed(string Message, AuthFailureReason Reason = AuthFailureReason.Other) : AuthResult;
 
     public sealed record Retarget(string ServerInput) : AuthResult;

--- a/src/Capacitor.Cli.Core/Auth/ITenantProvisioner.cs
+++ b/src/Capacitor.Cli.Core/Auth/ITenantProvisioner.cs
@@ -16,11 +16,16 @@ public sealed record ProvisionOffer(
     // expands to {slug}.kcap.ai), so provider selection happens exactly once, against the target
     // server's own /auth/config — which is how this path reaches a GitHub-App tenant that WorkOS
     // discovery structurally cannot return.
-    string?              ExistingWorkspaceInput = null) {
+    string?              ExistingWorkspaceInput = null,
+    // InProgress only: the slug being provisioned, so a caller can name it when telling the user to
+    // come back to it. Null when the poll timed out before a slug was settled on.
+    string?              PendingSlug = null) {
     public static ProvisionOffer Created(ProvisionedTenant t) => new(ProvisionOfferStatus.Created, t);
-    public static readonly ProvisionOffer Declined   = new(ProvisionOfferStatus.Declined,   null);
-    public static readonly ProvisionOffer InProgress = new(ProvisionOfferStatus.InProgress, null);
-    public static readonly ProvisionOffer Failed     = new(ProvisionOfferStatus.Failed,     null);
+    public static readonly ProvisionOffer Declined = new(ProvisionOfferStatus.Declined, null);
+    public static readonly ProvisionOffer Failed   = new(ProvisionOfferStatus.Failed,   null);
+
+    public static ProvisionOffer InProgress(string? slug = null) =>
+        new(ProvisionOfferStatus.InProgress, null, PendingSlug: slug);
 
     public static ProvisionOffer ExistingWorkspace(string input) =>
         new(ProvisionOfferStatus.ExistingWorkspace, null, input);

--- a/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
+++ b/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
@@ -300,7 +300,7 @@ public sealed class OnboardingFacade(
         return flow switch {
             WorkOSDiscoveryFlow.Ready ready       => await WorkOSDiscovery.PublishAsync(ready, progress, beforeCommit, ct),
             WorkOSDiscoveryFlow.Retarget retarget => new AuthResult.Retarget(retarget.ServerInput),
-            WorkOSDiscoveryFlow.Failed failed     => Stop(failed.Message, ct),
+            WorkOSDiscoveryFlow.Failed failed     => Stop(failed.Message, ct, failed.Reason),
             _                                     => Stop("No Capacitor tenants are linked to your account.", ct,
                                                           AuthFailureReason.NoTenantsFound)
         };

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -19,8 +19,12 @@ public abstract record WorkOSDiscoveryFlow {
 
     public sealed record NoTenants : WorkOSDiscoveryFlow;
 
-    /// <param name="Message">Already emitted through <see cref="IAuthProgress"/>.</param>
-    public sealed record Failed(string Message) : WorkOSDiscoveryFlow;
+    /// <param name="Message">Already emitted through <see cref="IAuthProgress"/>, except where the
+    /// reason needs re-presenting in the caller's own words — see
+    /// <see cref="AuthFailureReason.ProvisioningInProgress"/>.</param>
+    public sealed record Failed(
+        string            Message,
+        AuthFailureReason Reason = AuthFailureReason.Other) : WorkOSDiscoveryFlow;
 }
 
 /// <summary>
@@ -125,9 +129,20 @@ public static class WorkOSDiscovery {
                 : new WorkOSDiscoveryFlow.Retarget(target);
         }
 
+        if (offer.Status == ProvisionOfferStatus.InProgress) {
+            // Not a failure: the workspace is being created and the poll outran its window. Carried
+            // with its own reason so the caller headlines a pending state rather than "sign-in failed".
+            // Deliberately just the fact, no guidance — the provisioner's own line says what to do
+            // next, and both land in front of the same reader.
+            var pending = offer.PendingSlug is { Length: > 0 } slug ? $"'{slug}'" : "Your workspace";
+
+            return new WorkOSDiscoveryFlow.Failed(
+                $"{pending} is still being created.", AuthFailureReason.ProvisioningInProgress);
+        }
+
         if (offer.Status != ProvisionOfferStatus.Created || offer.Tenant is null) {
-            // Declined / InProgress / Failed — the provisioner already printed the
-            // outcome-appropriate message; don't stack the legacy dead-end on top.
+            // Declined / Failed — the provisioner already printed the outcome-appropriate message;
+            // don't stack the legacy dead-end on top.
             return new WorkOSDiscoveryFlow.Failed($"Workspace creation did not complete ({offer.Status}).");
         }
 

--- a/src/Capacitor.Cli/Commands/SpectreTenantProvisioner.cs
+++ b/src/Capacitor.Cli/Commands/SpectreTenantProvisioner.cs
@@ -164,7 +164,7 @@ public sealed class SpectreTenantProvisioner(TenantProvisioningClient client, st
             }
             AnsiConsole.MarkupLine($"  [yellow]![/] Still provisioning. {retry} once it's ready.");
             SetupFunnel.WorkspaceFailed("poll_timeout");
-            return ProvisionOffer.InProgress;
+            return ProvisionOffer.InProgress(slug);
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
@@ -192,6 +192,36 @@ public class SignInStepViewModelTests {
         await Assert.That(detail).IsNull();
     }
 
+    // The defect this ticket is about: sign-in succeeded and the workspace is being created, so the
+    // generic failure headline below would tell the user something untrue.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_provisioning_timeout_headlines_the_pending_workspace_and_is_not_an_error() {
+        var (status, isError, detail, satisfied) = await AvaloniaSession.DispatchAsync(async () => {
+            using var h = new Harness();
+            h.Connect.Choice = ConnectChoice.Create;
+            h.Operation = (_, _) => {
+                h.Progress.Notice("Still provisioning — finish later by joining 'acme' from the Connect step.");
+
+                return Task.FromResult<AuthResult>(new AuthResult.Failed(
+                    "'acme' is still being created.", AuthFailureReason.ProvisioningInProgress));
+            };
+
+            await h.SignIn();
+
+            return (h.Vm.Status, h.Vm.StatusIsError, h.Vm.StatusDetail, h.Vm.Satisfied);
+        });
+
+        await Assert.That(status).IsEqualTo("'acme' is still being created.");
+        await Assert.That(isError)
+                    .IsFalse()
+                    .Because("nothing failed — the poll outran its window while the workspace was "
+                           + "still being created");
+        await Assert.That(detail).IsEqualTo("Still provisioning — finish later by joining 'acme' from the Connect step.");
+        // Still not signed in to anything, so the step cannot be satisfied.
+        await Assert.That(satisfied).IsFalse();
+    }
+
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task A_failure_shows_one_generic_headline_and_never_re_logs_the_facade_message() {

--- a/test/Capacitor.App.Tests.Unit/WizardAuthBridgesTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardAuthBridgesTests.cs
@@ -253,8 +253,12 @@ public class WizardAuthBridgesTests {
         var offer = await Drive(provisioner.OfferCreateAsync(Tokens()), time);
 
         await Assert.That(offer.Status).IsEqualTo(ProvisionOfferStatus.InProgress);
+        await Assert.That(offer.PendingSlug)
+            .IsEqualTo("acme")
+            .Because("the caller names the workspace when telling the user to come back to it");
         await Assert.That(polls.Count).IsEqualTo(WizardTenantProvisioner.MaxPolls);
-        await Assert.That(progress.Errors)
+        // A Notice, not an Error: the workspace is being created, nothing has gone wrong.
+        await Assert.That(progress.Notices)
             .Contains("Still provisioning — finish later by joining 'acme' from the Connect step.");
     }
 

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/OnboardingFacadeTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/OnboardingFacadeTests.cs
@@ -555,13 +555,15 @@ public class OnboardingFacadeTests {
 
     [Test]
     public async Task DiscoverAsync_workos_in_progress_provisioning_fails_with_nothing_durable() =>
-        await AssertProvisionOfferFails(ProvisionOffer.InProgress);
+        await AssertProvisionOfferFails(ProvisionOffer.InProgress("acme"),
+                                        AuthFailureReason.ProvisioningInProgress);
 
     [Test]
     public async Task DiscoverAsync_workos_failed_provisioning_fails_with_nothing_durable() =>
         await AssertProvisionOfferFails(ProvisionOffer.Failed);
 
-    static async Task AssertProvisionOfferFails(ProvisionOffer offer) {
+    static async Task AssertProvisionOfferFails(
+            ProvisionOffer offer, AuthFailureReason expected = AuthFailureReason.Other) {
         using var handler = AuthHttp.Script(
             proxyConfig: """{"workos_client_id":"client_d"}""",
             workosTenants: "[]");
@@ -575,6 +577,10 @@ public class OnboardingFacadeTests {
         var result = await facade.DiscoverAsync(AuthProvider.WorkOS, forceDevice: false, CancellationToken.None);
 
         await Assert.That(result).IsTypeOf<AuthResult.Failed>();
+        await Assert.That(((AuthResult.Failed)result).Reason)
+                    .IsEqualTo(expected)
+                    .Because("the reason has to survive the flow-to-AuthResult mapping, or a caller "
+                           + "cannot tell a pending workspace from a failed sign-in");
         await Assert.That(File.Exists(ConfigPath)).IsFalse();
         await Assert.That(TokenFileExists("acme")).IsFalse();
     }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSDiscoveryTests.cs
@@ -255,4 +255,51 @@ public class WorkOSDiscoveryTests {
         await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.Failed>();
         await Assert.That(switchCalled).IsFalse();
     }
+
+    // A provisioning poll that outran its window is a pending workspace, not a failed sign-in — sign-in
+    // already succeeded to get here. Undistinguished, every caller headlines it as a failure.
+    [Test]
+    public async Task DiscoverAsync_reports_a_provisioning_timeout_as_in_progress_and_names_the_slug() {
+        var flow = await DiscoverWithOffer(ProvisionOffer.InProgress("acme"));
+
+        var failed = (WorkOSDiscoveryFlow.Failed)flow;
+
+        await Assert.That(failed.Reason).IsEqualTo(AuthFailureReason.ProvisioningInProgress);
+        await Assert.That(failed.Message)
+                    .Contains("acme")
+                    .Because("the user is being told to come back to it, so it has to be named");
+    }
+
+    [Test]
+    public async Task DiscoverAsync_reports_in_progress_even_when_no_slug_was_settled_on() {
+        var failed = (WorkOSDiscoveryFlow.Failed)await DiscoverWithOffer(ProvisionOffer.InProgress());
+
+        await Assert.That(failed.Reason).IsEqualTo(AuthFailureReason.ProvisioningInProgress);
+        await Assert.That(failed.Message).IsNotEmpty();
+    }
+
+    // A provisioning FAILURE stays undistinguished: it really did fail, and the provisioner has said so.
+    [Test]
+    public async Task DiscoverAsync_leaves_a_provisioning_failure_generic() {
+        var failed = (WorkOSDiscoveryFlow.Failed)await DiscoverWithOffer(ProvisionOffer.Failed);
+
+        await Assert.That(failed.Reason).IsEqualTo(AuthFailureReason.Other);
+    }
+
+    static async Task<WorkOSDiscoveryFlow> DiscoverWithOffer(ProvisionOffer offer) {
+        var proxy = Substitute.For<IAuthProxyClient>();
+        proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
+             .Returns(Task.FromResult(new Cli.Core.Auth.DiscoveryResult([], DiscoveryError.None)));
+
+        var provisioner = Substitute.For<ITenantProvisioner>();
+        provisioner.OfferCreateAsync(Arg.Any<WorkOSTokenSource>(), Arg.Any<CancellationToken>())
+                   .Returns(Task.FromResult(offer));
+
+        return await WorkOSDiscovery.DiscoverAsync(
+            "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_p" },
+            proxy, Substitute.For<ITenantPicker>(),
+            ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
+            (_, _) => Task.FromResult<WorkOSAuthResponse?>(null),
+            provisioner: provisioner);
+    }
 }


### PR DESCRIPTION
When WorkOS workspace provisioning outran its 4s × 150 poll, Core collapsed the `ProvisionOffer.InProgress` outcome into an undistinguished `AuthResult.Failed`, so the wizard's Sign-in step headlined **"Sign-in failed."** over a workspace that was on its way — sign-in had already succeeded to get that far. The accurate copy survived only as a detail line and a log entry.

* `AuthFailureReason` **gains** `ProvisioningInProgress`**.** It rides `Failed` rather than becoming its own `AuthResult` case deliberately: every consumer discriminates on `Committed` and funnels the rest into a catch-all (`SignInStepViewModel:422`, `LoginCommand:66`, `SetupCommand:934`, `App.axaml.cs:429`), so a new case would have landed silently in the very `default:` arm that prints the wrong headline. Riding the reason forces the one switch that had to change to change, and `SetupCommand:50` already sets the `{ Reason: … }` precedent.
* `ProvisionOffer` **carries the pending slug**, so a caller can name the workspace it is telling the user to come back to. `InProgress` becomes a factory, matching the file's existing split between outcomes that carry data (`Created`, `ExistingWorkspace`) and ones that do not.
* **The headline is the fact; the sink's line is what to do about it.** Both land in front of the same reader in a GUI, so the headline is deliberately not a paraphrase of the guidance. `WizardAuthBridges` reports that line as a `Notice` rather than an `Error`, since nothing went wrong.
* `App.axaml.cs` printed the same untruth to stderr when the window was closed mid-poll — narrow, but it is literally the claim this ticket is about.

`kcap setup` **needed no change, which is worth stating rather than implying otherwise.** Its failure path prints nothing for this reason (`SetupAuthProgress.ReportFailure` only speaks for `Unreachable`, and `OnboardingFacade.Stop` never prints), so the only line a terminal user sees is the provisioner's own yellow "Still provisioning" — already correct. The slug is passed there too for symmetry, but nothing reads it on that path yet.

`Declined` **is left generic, and deliberately not pinned by a test.** It is arguably the same defect — the user chose to decline and the step still says sign-in failed — but it is a separate decision from this one, so asserting the current behaviour here would lock the wrong answer in with a passing test. Happy to file it.

Tests: the discovery-level reason and slug, the reason surviving the flow→`AuthResult` mapping, and the wizard headline itself (`SignInStepViewModelTests`) — which is the user-visible half and had no coverage. Verified by reverting each production change in turn and confirming the matching test reddens. `WizardAuthBridgesTests` also now pins `PendingSlug`, which nothing did.

Closes kurrent-io/kcap-cli#573

kurrent-io/kcap-cli#573