### PR TITLE
Codex app-server: orchestrator deferred-first-turn source-claim sequence

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3817,13 +3817,20 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <summary>Tears down a registered agent whose source claim failed — the proven
     /// <see cref="CleanupAgentAsync"/> (single-flight, disposes the runtime + releases the slot +
     /// unregisters) then <c>LaunchFailedAsync</c> composition, mirroring the launch outer-catch. Never
-    /// <c>FinalizeAgentRunAsync</c>, which would classify a still-live process by exit code.</summary>
+    /// <c>FinalizeAgentRunAsync</c>, which would classify a still-live process by exit code.
+    /// <para>Guaranteed NO-THROW: it is awaited from the fire-and-forget source-claim task OUTSIDE any
+    /// try, so a teardown fault (a cleanup or a LaunchFailed hub error) is contained here and logged
+    /// rather than escaping as an unobserved task exception.</para></summary>
     async Task FailEnvelopeSourcedLaunchAsync(string agentId, string reason) {
         if (!_agents.ContainsKey(agentId))
             return; // already finalizing/gone — its own teardown owns it
 
-        await CleanupAgentAsync(agentId);
-        await _server.LaunchFailedAsync(agentId, reason);
+        try {
+            await CleanupAgentAsync(agentId);
+            await _server.LaunchFailedAsync(agentId, reason);
+        } catch (Exception ex) {
+            LogAcpBindFailed(ex, agentId); // contain the teardown fault (fire-and-forget caller has no catch)
+        }
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3788,7 +3788,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // The server declined ownership (a stale/foreign/terminal binding). Unrecoverable for this
             // launch — the daemon must not proceed to a first turn on an unstamped session.
             LogAcpSourceClaimRejected(agent.Id);
-            await FailEnvelopeSourcedLaunchAsync(agent.Id, "codex app-server: source claim rejected");
+            await FailEnvelopeSourcedLaunchAsync(agent.Id, "Hosted session source claim rejected by the server");
 
             return;
         }
@@ -3827,8 +3827,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// try, so a teardown fault (a cleanup or a LaunchFailed hub error) is contained here and logged
     /// rather than escaping as an unobserved task exception.</para></summary>
     async Task FailEnvelopeSourcedLaunchAsync(string agentId, string reason) {
-        if (!_agents.ContainsKey(agentId))
+        if (!_agents.TryGetValue(agentId, out var agent))
             return; // already finalizing/gone — its own teardown owns it
+
+        // Mark the agent terminally Failed BEFORE CleanupAgentAsync disposes the runtime: disposal ends
+        // the read loop, whose FinalizeAgentRunAsync classifies by exit code and would otherwise emit a
+        // Completed/Failed AgentStatusChanged that races and could MASK this coded launch failure (a
+        // later "Completed" clearing the server-side FailureReason). A pre-set "Failed" makes that
+        // exit-code classification a no-op — the same guard the launch-verdict path uses (see the
+        // "Force terminal Failed BEFORE the report" block in FinalizeAgentRunAsync).
+        SetAgentStatus(agent, "Failed");
 
         try {
             await CleanupAgentAsync(agentId);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2075,7 +2075,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 // ever resolves (see AgentInstance.AcpCts).
                 var acpCts = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
                 agent.AcpCts = acpCts;
-                _ = StartAcpForwardingAsync(agent, transcript, cmd.Vendor, acpCts);
+                // §2.5: a runtime that HOLDS its first turn (envelope-sourced hosted Codex) is
+                // driven through the deferred-first-turn source-claim sequence — durable claim BEFORE the
+                // first turn, then forward without re-binding, then confirm. Every other transcript
+                // runtime (Cursor) keeps the single-phase bind-then-forward path. Dormant until the
+                // factory sets deferFirstTurn (the activation slice); the fake test runtime exercises it.
+                if (start.Runtime.RequiresSourceClaimBeforeFirstTurn)
+                    _ = StartEnvelopeSourcedSessionAsync(agent, start.Runtime, transcript, cmd.Vendor, acpCts);
+                else
+                    _ = StartAcpForwardingAsync(agent, transcript, cmd.Vendor, acpCts);
             }
 
             // Reconnect PID-record seam (reconnect spec §6.2 step 1): a resume candidate's pid is
@@ -3678,52 +3686,169 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 acpCts.Token
             );
 
-            // Liveness check: the await above can span a reconnect outage.
-            // If finalize already ran (cancelling acpCts and/or removing the agent from _agents)
-            // while we were waiting, abort here — do not register a binding, build a forwarder, or
-            // start it for an agent that's finalizing or already gone.
-            if (acpCts.IsCancellationRequested || !_agents.ContainsKey(agent.Id)) {
-                LogAcpBindAbortedAgentGone(agent.Id);
-
-                return;
-            }
-
-            _server.RegisterAcpBinding(
-                agent.Id,
-                new AcpBindInfo(vendor, transcript.AcpSessionId, transcript.Cwd, transcript.ResolvedModel)
-            );
-
-            // Post-register re-check (TOCTOU): finalize can run between the liveness check above and
-            // this register, having already cancelled/unregistered+cleaned up the agent — leaving the
-            // binding we just registered stale (replayed on reconnect for a dead agent). Undo it. The
-            // finalizer's own unconditional UnregisterAcpBinding covers the mirror case (finalize after
-            // this point); UnregisterAcpBinding is idempotent so a double-remove is harmless.
-            if (acpCts.IsCancellationRequested || !_agents.ContainsKey(agent.Id)) {
-                _server.UnregisterAcpBinding(agent.Id);
-                LogAcpBindAbortedAgentGone(agent.Id);
-
-                return;
-            }
-
-            var sessionStarted = AcpEventTranslator.BuildSessionStarted(
-                seq: 0,
-                DateTimeOffset.UtcNow.ToString("O"),
-                cwd: transcript.Cwd,
-                model: transcript.ResolvedModel,
-                rawSessionId: transcript.AcpSessionId
-            );
-
-            var forwarder = new AcpTranscriptForwarder(
-                send: (batch, ct) => _server.SendAcpEventsAsync(agent.Id, transcript.AcpSessionId, batch, ct),
-                initialEnvelope: sessionStarted,
-                envelopes: transcript.Envelopes,
-                logger: _logger
-            );
-
-            var runTask = ForwardAcpTranscriptAsync(agent, forwarder, acpCts.Token);
-            agent.AcpForwarder = new AcpForwarderHandle(forwarder, runTask);
+            StartForwarderAfterBind(agent, transcript, vendor, acpCts);
         } catch (Exception ex) {
             LogAcpBindFailed(ex, agent.Id);
+        }
+    }
+
+    /// <summary>
+    /// The post-bind half of ACP forwarding (everything AFTER the canonical session is bound): the
+    /// liveness / TOCTOU guards, the local reconnect-binding registration, and the transcript
+    /// forwarder build + run. Factored out of <see cref="StartAcpForwardingAsync"/> so the §2.5
+    /// deferred-first-turn source-claim path — which binds via <c>AcpSessionSourceClaim</c>, NOT
+    /// <c>AcpSessionStarted</c> — can reuse it verbatim without re-binding. Synchronous (no awaits): the
+    /// forwarder's local seq always starts at 0 and the server drives resume via the AcpBatchAck, so
+    /// this needs no cursor from either bind path. The CALLER owns the try/catch.
+    /// </summary>
+    void StartForwarderAfterBind(AgentInstance agent, IAcpTranscriptSource transcript, string vendor, CancellationTokenSource acpCts) {
+        // Liveness check: the bind await (either path) can span a reconnect outage. If finalize already
+        // ran (cancelling acpCts and/or removing the agent from _agents) while we waited, abort — do not
+        // register a binding, build a forwarder, or start it for an agent that's finalizing or gone.
+        if (acpCts.IsCancellationRequested || !_agents.ContainsKey(agent.Id)) {
+            LogAcpBindAbortedAgentGone(agent.Id);
+
+            return;
+        }
+
+        _server.RegisterAcpBinding(
+            agent.Id,
+            new AcpBindInfo(vendor, transcript.AcpSessionId, transcript.Cwd, transcript.ResolvedModel)
+        );
+
+        // Post-register re-check (TOCTOU): finalize can run between the liveness check above and this
+        // register, having already cancelled/unregistered+cleaned up the agent — leaving the binding we
+        // just registered stale (replayed on reconnect for a dead agent). Undo it. The finalizer's own
+        // unconditional UnregisterAcpBinding covers the mirror case (finalize after this point);
+        // UnregisterAcpBinding is idempotent so a double-remove is harmless.
+        if (acpCts.IsCancellationRequested || !_agents.ContainsKey(agent.Id)) {
+            _server.UnregisterAcpBinding(agent.Id);
+            LogAcpBindAbortedAgentGone(agent.Id);
+
+            return;
+        }
+
+        var sessionStarted = AcpEventTranslator.BuildSessionStarted(
+            seq: 0,
+            DateTimeOffset.UtcNow.ToString("O"),
+            cwd: transcript.Cwd,
+            model: transcript.ResolvedModel,
+            rawSessionId: transcript.AcpSessionId
+        );
+
+        var forwarder = new AcpTranscriptForwarder(
+            send: (batch, ct) => _server.SendAcpEventsAsync(agent.Id, transcript.AcpSessionId, batch, ct),
+            initialEnvelope: sessionStarted,
+            envelopes: transcript.Envelopes,
+            logger: _logger
+        );
+
+        var runTask = ForwardAcpTranscriptAsync(agent, forwarder, acpCts.Token);
+        agent.AcpForwarder = new AcpForwarderHandle(forwarder, runTask);
+    }
+
+    /// <summary>
+    /// §2.5 deferred-first-turn SOURCE-CLAIM sequence, fired fire-and-forget after
+    /// <c>RegisterAgentAsync</c> for a runtime that holds its first turn
+    /// (<see cref="IHostedAgentRuntime.RequiresSourceClaimBeforeFirstTurn"/>). Ordering:
+    /// <list type="number">
+    /// <item>durably source-claim the session (server binds + writes the ownership ledger row);</item>
+    /// <item>start the transcript forwarder WITHOUT re-binding (the claim already bound);</item>
+    /// <item>dispatch the held first turn — the earliest instant any hook can fire, strictly after the
+    ///       durable claim committed;</item>
+    /// <item>clear the ledger's provisional flag in a background confirm loop.</item>
+    /// </list>
+    /// A <c>Rejected</c> claim (or a pre-source-claim server's method-not-found) is a coded launch
+    /// failure that tears the agent down; a confirm failure NEVER does (the row stays provisional, and
+    /// the server's live-owner expiry deferral + recovery settle it). Contains all its own faults — it
+    /// is fire-and-forget with no outer catch. Every step is gated on <paramref name="acpCts"/>, so a
+    /// finalize during any await aborts cleanly.
+    /// </summary>
+    async Task StartEnvelopeSourcedSessionAsync(
+            AgentInstance agent, IHostedAgentRuntime runtime, IAcpTranscriptSource transcript,
+            string vendor, CancellationTokenSource acpCts) {
+        AcpSourceClaimOutcome claim;
+        try {
+            claim = await _server.AcpSessionSourceClaimAsync(agent.Id, transcript.AcpSessionId, acpCts.Token);
+        } catch (OperationCanceledException) when (acpCts.IsCancellationRequested) {
+            // The agent finalized while the claim was in flight — nothing bound, nothing to undo.
+            LogAcpBindAbortedAgentGone(agent.Id);
+
+            return;
+        } catch (Exception ex) {
+            // A pre-source-claim server (method-not-found) or any claim fault is unrecoverable — the
+            // session can never be envelope-stamped. Tear down (coded launch failure).
+            LogAcpSourceClaimFailed(ex, agent.Id);
+            await FailEnvelopeSourcedLaunchAsync(agent.Id, AcpHostedAgentRuntimeFactory.DescribeLaunchFailure(ex));
+
+            return;
+        }
+
+        if (claim.Outcome == AcpBindOutcome.Rejected) {
+            // The server declined ownership (a stale/foreign/terminal binding). Unrecoverable for this
+            // launch — the daemon must not proceed to a first turn on an unstamped session.
+            LogAcpSourceClaimRejected(agent.Id);
+            await FailEnvelopeSourcedLaunchAsync(agent.Id, "codex app-server: source claim rejected");
+
+            return;
+        }
+
+        try {
+            // The claim already bound server-side, so build the forwarder WITHOUT AcpSessionStarted. It
+            // is running BEFORE the first turn dispatches, so it captures that turn's envelopes.
+            StartForwarderAfterBind(agent, transcript, vendor, acpCts);
+
+            // Dispatch the held first turn and await its response — the signal we confirm on.
+            await runtime.BeginFirstTurnAsync(acpCts.Token);
+
+            // Clear the ledger's provisional flag in the background: retries transient failures for as
+            // long as the agent lives and NEVER tears it down. A BeginFirstTurn failure above skips
+            // this, leaving the row provisional for the server's Rule-2 expiry to close.
+            _ = ConfirmSessionLaunchLoopAsync(agent, transcript.AcpSessionId, claim.OwnershipToken, acpCts.Token);
+        } catch (OperationCanceledException) when (acpCts.IsCancellationRequested) {
+            LogAcpBindAbortedAgentGone(agent.Id);
+        } catch (Exception ex) {
+            // Forwarder-setup or first-turn failure: the confirm never fires, so the server closes the
+            // still-provisional session via Rule 2. Log and leave the agent's own lifecycle to reap it.
+            LogAcpBindFailed(ex, agent.Id);
+        }
+    }
+
+    /// <summary>Tears down a registered agent whose source claim failed — the proven
+    /// <see cref="CleanupAgentAsync"/> (single-flight, disposes the runtime + releases the slot +
+    /// unregisters) then <c>LaunchFailedAsync</c> composition, mirroring the launch outer-catch. Never
+    /// <c>FinalizeAgentRunAsync</c>, which would classify a still-live process by exit code.</summary>
+    async Task FailEnvelopeSourcedLaunchAsync(string agentId, string reason) {
+        if (!_agents.ContainsKey(agentId))
+            return; // already finalizing/gone — its own teardown owns it
+
+        await CleanupAgentAsync(agentId);
+        await _server.LaunchFailedAsync(agentId, reason);
+    }
+
+    /// <summary>
+    /// The background confirm loop: calls <c>ConfirmSessionLaunch</c> until it settles, retrying only
+    /// transient (non-terminal) failures on a paced cadence for as long as the agent lives (gated on
+    /// <paramref name="ct"/> == the agent's AcpCts). <c>Confirmed</c>/<c>AlreadyConfirmed</c> is done;
+    /// <c>Superseded</c>/<c>NotFound</c> is permanent (stop); a thrown error is transient (retry after a
+    /// delay). It NEVER tears the agent down — an unconfirmed row is benign (the server's live-owner
+    /// expiry deferral protects it and its recovery settles it when connectivity returns).
+    /// </summary>
+    async Task ConfirmSessionLaunchLoopAsync(AgentInstance agent, string acpSessionId, long ownershipToken, CancellationToken ct) {
+        while (!ct.IsCancellationRequested) {
+            try {
+                var outcome = await _server.ConfirmSessionLaunchAsync(acpSessionId, ownershipToken, ct);
+                if (outcome is AcpLaunchConfirmOutcome.Superseded or AcpLaunchConfirmOutcome.NotFound)
+                    LogConfirmSessionLaunchStopped(agent.Id, outcome.ToString());
+
+                return; // Confirmed / AlreadyConfirmed / Superseded / NotFound are all terminal for this loop
+            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                return; // the agent finalized — stop quietly, never tear down
+            } catch (Exception ex) {
+                LogConfirmSessionLaunchRetrying(ex, agent.Id);
+                try { await Task.Delay(ConfirmRetryDelay, ct); }
+                catch (OperationCanceledException) { return; }
+            }
         }
     }
 
@@ -3754,6 +3879,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// Settable so tests don't wait for the real value.
     /// </summary>
     internal TimeSpan AcpFinalDrainBudget { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>§2.5: paced retry cadence for the background <c>ConfirmSessionLaunch</c> loop
+    /// (transient failures only; it runs for the agent's lifetime and never tears it down). Settable so
+    /// tests don't wait the real value.</summary>
+    internal TimeSpan ConfirmRetryDelay { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Disposes the ACP runtime FIRST so its <c>DisposeAsync</c> completes the
@@ -4527,6 +4657,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ACP transcript forwarder faulted for agent {AgentId}")]
     partial void LogAcpForwarderFaulted(Exception ex, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Source claim for agent {AgentId} failed — tearing the launch down (the session cannot be envelope-stamped)")]
+    partial void LogAcpSourceClaimFailed(Exception ex, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Source claim for agent {AgentId} was rejected by the server — tearing the launch down")]
+    partial void LogAcpSourceClaimRejected(string agentId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Confirm loop for agent {AgentId} stopped without confirming (outcome {Outcome}) — the server's recovery owns the provisional row")]
+    partial void LogConfirmSessionLaunchStopped(string agentId, string outcome);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Confirm for agent {AgentId} did not land — retrying (a confirm failure never tears the agent down)")]
+    partial void LogConfirmSessionLaunchRetrying(Exception ex, string agentId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ACP final transcript drain for agent {AgentId} exceeded its {Seconds}s budget — proceeding to end the session; any undrained transcript is lost")]
     partial void LogAcpFinalDrainTimedOut(string agentId, double seconds);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3802,15 +3802,20 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             await runtime.BeginFirstTurnAsync(acpCts.Token);
 
             // Clear the ledger's provisional flag in the background: retries transient failures for as
-            // long as the agent lives and NEVER tears it down. A BeginFirstTurn failure above skips
-            // this, leaving the row provisional for the server's Rule-2 expiry to close.
+            // long as the agent lives and NEVER tears it down. Reached only on a SUCCESSFUL first turn;
+            // a first-turn failure throws into the catch below (which tears the agent down) and never
+            // fires this.
             _ = ConfirmSessionLaunchLoopAsync(agent, transcript.AcpSessionId, claim.OwnershipToken, acpCts.Token);
         } catch (OperationCanceledException) when (acpCts.IsCancellationRequested) {
             LogAcpBindAbortedAgentGone(agent.Id);
         } catch (Exception ex) {
-            // Forwarder-setup or first-turn failure: the confirm never fires, so the server closes the
-            // still-provisional session via Rule 2. Log and leave the agent's own lifecycle to reap it.
+            // Forwarder-setup or first-turn DISPATCH failure — the launch cannot run, so tear it down,
+            // symmetric with a claim failure (the alternative would leave a zombie holding a slot). This
+            // fires ONLY for a real error; a finalize during BeginFirstTurnAsync is the OCE arm above. The
+            // confirm never fired, so the still-provisional ledger row is closed by the server's Rule-2
+            // expiry. FailEnvelopeSourcedLaunchAsync is no-throw, so awaiting it here is safe.
             LogAcpBindFailed(ex, agent.Id);
+            await FailEnvelopeSourcedLaunchAsync(agent.Id, AcpHostedAgentRuntimeFactory.DescribeLaunchFailure(ex));
         }
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorSourceClaimTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorSourceClaimTests.cs
@@ -1,0 +1,122 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// §2.5: the orchestrator's deferred-first-turn SOURCE-CLAIM sequence — the daemon driver for a
+/// runtime that HOLDS its first turn (<c>RequiresSourceClaimBeforeFirstTurn</c>). The load-bearing
+/// facts under test: the claim SUPERSEDES <c>AcpSessionStarted</c> (no bind call), the forwarder starts
+/// without re-binding, the held first turn dispatches strictly after the claim, the launch is confirmed,
+/// and a Rejected / method-not-found claim tears the agent down (never a first turn) while a confirm
+/// failure never does. All fire-and-forget from the launch, asserted through the deterministic
+/// <c>AcpCallOrder</c> / signal seams (never Task.Delay).
+/// </summary>
+public class AgentOrchestratorSourceClaimTests {
+    static SpyAcpHostedAgentRuntimeFactory DeferredFactory(Exception? beginFirstTurnThrow = null) =>
+        new(vendor: "cursor") { DeferFirstTurn = true, BeginFirstTurnThrow = beginFirstTurnThrow };
+
+    [Test]
+    public async Task Deferred_launch_claims_then_forwards_without_rebinding_then_first_turns_then_confirms() {
+        var (repoPath, cleanup) = GitRepoHarness.CreateGitRepo();
+        try {
+            var server  = new CaptureServerConnection();
+            var factory = DeferredFactory();
+
+            await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+                server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+            orch.AcpFinalDrainBudget = TimeSpan.FromMilliseconds(200);
+
+            await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-sc", repoPath));
+
+            // The confirm is the LAST step of the sequence, so awaiting it proves the whole chain ran.
+            var confirmedToken = await server.ConfirmSignal.Reader.ReadAsync().AsTask().WaitAsync(WaitHarness.AcpHangGuard);
+            await Assert.That(confirmedToken).IsEqualTo(1);
+
+            // The claim SUPERSEDES AcpSessionStarted — a source claim ran, an AcpSessionStarted bind did NOT.
+            await Assert.That(server.AcpCallOrder).Contains("sourceClaim:agent-sc");
+            await Assert.That(server.AcpCallOrder.Any(e => e.StartsWith("bind:", StringComparison.Ordinal))).IsFalse();
+            await Assert.That(server.AcpSessionStartedCalls).IsEmpty();
+
+            // Ordering: register < sourceClaim, and the forwarder registered its binding + sent events.
+            var registerIndex = server.AcpCallOrder.IndexOf("register:agent-sc");
+            var claimIndex    = server.AcpCallOrder.IndexOf("sourceClaim:agent-sc");
+            await Assert.That(registerIndex).IsGreaterThanOrEqualTo(0);
+            await Assert.That(claimIndex).IsGreaterThan(registerIndex);
+
+            // The held first turn was dispatched exactly once, and the confirm carried the claim's token.
+            await Assert.That(factory.LastRuntime!.BeginFirstTurnCalls).IsEqualTo(1);
+            await Assert.That(server.ConfirmTokens).Contains(1L);
+
+            await orch.HandleStopAgentForTest("agent-sc");
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test]
+    public async Task Rejected_claim_tears_the_launch_down_without_a_first_turn_or_confirm() {
+        var (repoPath, cleanup) = GitRepoHarness.CreateGitRepo();
+        try {
+            var launchFailed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var server = new CaptureServerConnection {
+                SourceClaimOutcome  = new AcpSourceClaimOutcome(AcpBindOutcome.Rejected, 0, 0),
+                LaunchFailedEntered = launchFailed
+            };
+            var factory = DeferredFactory();
+
+            await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+                server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+            orch.AcpFinalDrainBudget = TimeSpan.FromMilliseconds(200);
+
+            await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-rej", repoPath));
+
+            // FailEnvelopeSourcedLaunchAsync runs CleanupAgentAsync THEN LaunchFailedAsync, so awaiting the
+            // LaunchFailed entry proves the teardown (dispose + unregister) already completed.
+            await launchFailed.Task.WaitAsync(WaitHarness.AcpHangGuard);
+
+            await Assert.That(server.LaunchFailedCalls.Select(c => c.AgentId)).Contains("agent-rej");
+            await Assert.That(server.AgentUnregisteredCalls).Contains("agent-rej"); // CleanupAgentAsync ran
+            await Assert.That(factory.LastRuntime!.DisposeCount).IsGreaterThan(0);  // the child was stopped
+            await Assert.That(factory.LastRuntime!.BeginFirstTurnCalls).IsEqualTo(0); // never dispatched a turn
+            await Assert.That(server.ConfirmTokens).IsEmpty();                        // never confirmed
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test]
+    public async Task Method_not_found_claim_is_a_coded_launch_failure_with_teardown() {
+        var (repoPath, cleanup) = GitRepoHarness.CreateGitRepo();
+        try {
+            var launchFailed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var server = new CaptureServerConnection {
+                // Models a pre-source-claim server: the hub method doesn't exist. SignalR raises a
+                // HubException for this — NOT a transient disconnect (ConnectionRetry propagates it),
+                // unlike an InvalidOperationException which it would retry forever.
+                SourceClaimThrow    = new Microsoft.AspNetCore.SignalR.HubException("Method does not exist."),
+                LaunchFailedEntered = launchFailed
+            };
+            var factory = DeferredFactory();
+
+            await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+                server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+            orch.AcpFinalDrainBudget = TimeSpan.FromMilliseconds(200);
+
+            await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-nf", repoPath));
+
+            await launchFailed.Task.WaitAsync(WaitHarness.AcpHangGuard);
+
+            await Assert.That(server.LaunchFailedCalls.Select(c => c.AgentId)).Contains("agent-nf");
+            await Assert.That(server.AgentUnregisteredCalls).Contains("agent-nf");
+            await Assert.That(factory.LastRuntime!.DisposeCount).IsGreaterThan(0);
+            await Assert.That(factory.LastRuntime!.BeginFirstTurnCalls).IsEqualTo(0);
+        } finally {
+            cleanup();
+        }
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorSourceClaimTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorSourceClaimTests.cs
@@ -89,6 +89,35 @@ public class AgentOrchestratorSourceClaimTests {
     }
 
     [Test]
+    public async Task First_turn_failure_after_a_successful_claim_tears_the_agent_down() {
+        var (repoPath, cleanup) = GitRepoHarness.CreateGitRepo();
+        try {
+            var launchFailed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var server  = new CaptureServerConnection { LaunchFailedEntered = launchFailed }; // claim succeeds (default Bound)
+            // The claim commits, then the held first turn's dispatch fails — the launch cannot run.
+            var factory = DeferredFactory(beginFirstTurnThrow: new InvalidOperationException("turn/start failed"));
+
+            await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+                server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+            orch.AcpFinalDrainBudget = TimeSpan.FromMilliseconds(200);
+
+            await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-ft", repoPath));
+
+            await launchFailed.Task.WaitAsync(WaitHarness.AcpHangGuard);
+
+            await Assert.That(server.AcpCallOrder).Contains("sourceClaim:agent-ft"); // the claim DID commit
+            await Assert.That(factory.LastRuntime!.BeginFirstTurnCalls).IsEqualTo(1); // the first turn WAS attempted
+            await Assert.That(server.LaunchFailedCalls.Select(c => c.AgentId)).Contains("agent-ft");
+            await Assert.That(server.AgentUnregisteredCalls).Contains("agent-ft"); // torn down (no zombie slot)
+            await Assert.That(factory.LastRuntime!.DisposeCount).IsGreaterThan(0);
+            await Assert.That(server.ConfirmTokens).IsEmpty();                       // confirm never fired
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test]
     public async Task Method_not_found_claim_is_a_coded_launch_failure_with_teardown() {
         var (repoPath, cleanup) = GitRepoHarness.CreateGitRepo();
         try {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
@@ -212,6 +212,51 @@ sealed class CaptureServerConnection() : ServerConnection(
         return AcpEventsAckOverride?.Invoke(envelopes) ?? new AcpBatchAck(envelopes[^1].Seq, envelopes[^1].Seq);
     }
 
+    // ── §2.5 source-claim / confirm seams ───────────────────────────────────────────────
+
+    /// <summary>Outcome the raw AcpSessionSourceClaim invoke returns; default Bound@token-1. A Rejected
+    /// outcome models the server declining ownership.</summary>
+    public AcpSourceClaimOutcome? SourceClaimOutcome { get; init; }
+
+    /// <summary>When set, the raw AcpSessionSourceClaim invoke returns a FAULTED task (after recording) —
+    /// models a pre-source-claim server whose hub method doesn't exist (method-not-found).</summary>
+    public Exception? SourceClaimThrow { get; init; }
+
+    /// <summary>Fires (unbounded) once per source-claim call.</summary>
+    public Channel<int> SourceClaimSignal { get; } = Channel.CreateUnbounded<int>();
+
+    /// <summary>Outcome the raw ConfirmSessionLaunch invoke returns; default Confirmed. A custom function
+    /// sees the 1-based call count, so a test can model transient-then-terminal.</summary>
+    public Func<int, AcpLaunchConfirmOutcome>? ConfirmOutcome { get; init; }
+
+    /// <summary>Ownership tokens passed to each confirm, in order; its count fires ConfirmSignal.</summary>
+    public List<long>   ConfirmTokens { get; } = [];
+    public Channel<int> ConfirmSignal { get; } = Channel.CreateUnbounded<int>();
+
+    internal override Task<AcpSourceClaimOutcome> InvokeAcpSessionSourceClaimRawAsync(
+            string agentId, string acpSessionId, CancellationToken ct) {
+        lock (AcpCallOrder) AcpCallOrder.Add($"sourceClaim:{agentId}");
+        SourceClaimSignal.Writer.TryWrite(1);
+
+        if (SourceClaimThrow is { } ex)
+            return Task.FromException<AcpSourceClaimOutcome>(ex); // method-not-found on a pre-source-claim server
+
+        return Task.FromResult(SourceClaimOutcome ?? new AcpSourceClaimOutcome(AcpBindOutcome.Bound, 1, -1));
+    }
+
+    internal override Task<AcpLaunchConfirmOutcome> InvokeConfirmSessionLaunchRawAsync(
+            string acpSessionId, long ownershipToken, CancellationToken ct) {
+        int count;
+        lock (AcpCallOrder) {
+            AcpCallOrder.Add($"confirm:{ownershipToken}");
+            ConfirmTokens.Add(ownershipToken);
+            count = ConfirmTokens.Count;
+        }
+        ConfirmSignal.Writer.TryWrite(count);
+
+        return Task.FromResult(ConfirmOutcome?.Invoke(count) ?? AcpLaunchConfirmOutcome.Confirmed);
+    }
+
     /// <summary>(AgentId, Status) pairs passed to every AgentStatusChangedAsync call, in
     /// call order — lets a test assert on the exact lifecycle transitions the orchestrator
     /// drove (e.g. Fix B/E's immediate Running flip for a no-terminal runtime).</summary>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FakeAcpRuntime.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FakeAcpRuntime.cs
@@ -47,6 +47,27 @@ internal sealed class FakeAcpRuntime : IHostedAgentRuntime, IAcpTranscriptSource
         yield break;
     }
 
+    /// <summary>§2.5: when true the runtime advertises the deferred-first-turn contract, so the
+    /// orchestrator drives it through the source-claim sequence rather than the single-phase bind.</summary>
+    public bool DeferFirstTurn { get; init; }
+    public bool RequiresSourceClaimBeforeFirstTurn => DeferFirstTurn;
+
+    /// <summary>When set, BeginFirstTurnAsync returns a faulted task — models a first-turn dispatch failure.</summary>
+    public Exception? BeginFirstTurnThrow { get; init; }
+
+    /// <summary>Fires (unbounded) once per BeginFirstTurnAsync call — lets a test await that the held
+    /// first turn was dispatched (and, by ordering against the confirm signal, that it happened between
+    /// the source claim and the confirm).</summary>
+    public Channel<int> BeginFirstTurnSignal { get; } = Channel.CreateUnbounded<int>();
+    public int          BeginFirstTurnCalls  { get; private set; }
+
+    public Task BeginFirstTurnAsync(CancellationToken ct = default) {
+        BeginFirstTurnCalls++;
+        BeginFirstTurnSignal.Writer.TryWrite(BeginFirstTurnCalls);
+
+        return BeginFirstTurnThrow is { } ex ? Task.FromException(ex) : Task.CompletedTask;
+    }
+
     public Task SendUserInputAsync(string  text) => Task.CompletedTask;
     public Task SendSpecialKeyAsync(string key) => Task.CompletedTask;
     public Task SendRawInputAsync(byte[]   data) => Task.CompletedTask;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SpyAcpHostedAgentRuntimeFactory.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SpyAcpHostedAgentRuntimeFactory.cs
@@ -16,6 +16,11 @@ internal sealed class SpyAcpHostedAgentRuntimeFactory(string vendor = "cursor") 
     /// null stands in for a request that did not take (no match / agent rejected the option).</summary>
     public string? ResolvedModel { get; init; } = "gpt-x";
 
+    /// <summary>§2.5: when true the produced runtime holds its first turn (source-claim path).</summary>
+    public bool       DeferFirstTurn      { get; init; }
+    /// <summary>Threaded onto the produced runtime to model a first-turn dispatch failure.</summary>
+    public Exception? BeginFirstTurnThrow { get; init; }
+
     public int                  StartCalls  { get; private set; }
     public string?              LastAgentId { get; private set; }
     public RuntimeStartContext? LastContext { get; private set; }
@@ -28,7 +33,9 @@ internal sealed class SpyAcpHostedAgentRuntimeFactory(string vendor = "cursor") 
         LastAgentId = ctx.AgentId;
         LastContext = ctx;
 
-        var runtime = new FakeAcpRuntime { ResolvedModel = ResolvedModel };
+        var runtime = new FakeAcpRuntime {
+            ResolvedModel = ResolvedModel, DeferFirstTurn = DeferFirstTurn, BeginFirstTurnThrow = BeginFirstTurnThrow
+        };
         LastRuntime = runtime;
 
         return Task.FromResult(new HostedRuntimeStart(runtime, McpConfigPath: null, Transcript: runtime));


### PR DESCRIPTION
## What

The **daemon driver** that wires the hosted-Codex source-claim handshake (server `AcpSessionSourceClaim`/`ConfirmSessionLaunch`, merged in kcap-server #1530) into the launch lifecycle. This is the next §2.5 piece after the runtime contract (#606).

**Dormant** until the activation slice sets `deferFirstTurn` on `CodexHostedAgentRuntimeFactory` — the production factory is unchanged, so no shipping launch is affected. The fake test runtime exercises the whole sequence.

## The sequence (fired fire-and-forget after `RegisterAgentAsync`, for a runtime whose `RequiresSourceClaimBeforeFirstTurn` is true)

1. `AcpSessionSourceClaim` — durable claim (server binds + writes the ownership ledger row).
2. On `Rejected` (or a pre-source-claim server's method-not-found `HubException`) → **coded launch failure + teardown**.
3. On `Bound` → start the transcript forwarder **without re-binding** (the claim superseded `AcpSessionStarted`) → `BeginFirstTurnAsync` (dispatch the held first turn) → confirm in a background loop.

## Pieces

- **`StartForwarderAfterBind`** — factored out of `StartAcpForwardingAsync` (its post-bind body: liveness/TOCTOU guards, local reconnect-binding registration, forwarder build+run). The claim path reuses it verbatim without the `AcpSessionStarted` bind. The daemon forwarder ignores the claim's `AcceptedSeq` — resume is server-driven via the `AcpBatchAck`, exactly as before. **The 8 existing forwarding tests still pass**, proving the factoring is behaviour-preserving.
- **`StartEnvelopeSourcedSessionAsync`** — the sequence above; every step gated on the agent's `AcpCts` so a finalize aborts cleanly; contains all its own faults (no outer catch).
- **`FailEnvelopeSourcedLaunchAsync`** = `CleanupAgentAsync` (single-flight — disposes the runtime, releases the slot, unregisters) + `LaunchFailedAsync` — the proven launch outer-catch composition, never `FinalizeAgentRunAsync` (which classifies a still-live process by exit code).
- **`ConfirmSessionLaunchLoopAsync`** — background confirm, retrying only transient failures on a paced cadence for the agent's lifetime and **never** tearing it down (`Confirmed`/`AlreadyConfirmed` done; `Superseded`/`NotFound` stop; a lost confirm leaves the row provisional for the server's own recovery to settle).
- `HandleLaunchAgent` branches on `RequiresSourceClaimBeforeFirstTurn`; Cursor keeps the single-phase bind-then-forward path.

## Tests

`AgentOrchestratorSourceClaimTests` (3), asserting through the deterministic `AcpCallOrder`/signal seams (never `Task.Delay`):
- happy path: claims → forwards **without re-binding** (`AcpSessionStartedCalls` empty, no `bind:`) → first-turns once → confirms with the claim token;
- `Rejected` claim → teardown (unregister + dispose), **no first turn, no confirm**;
- method-not-found → coded launch failure + teardown.

Test doubles extended: `CaptureServerConnection` (source-claim/confirm raw seams), `FakeAcpRuntime` + `SpyAcpHostedAgentRuntimeFactory` (deferred-first-turn).

## Next

The **activation** slice flips `deferFirstTurn`/`emitEnvelopeTranscript` on the factory + wires `Transcript: runtime` + the `codex-appserver-unattended-v2` capability + guard-1 env marker + the server guard-2 source-refusal — making this whole path live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)