### PR TITLE
[AI-2036] Let an import scope name several repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ In `--no-prompt` mode, the wizard installs hooks for every detected agent by def
 kcap import                     # every detected agent (Claude, Codex, Cursor, Copilot, Gemini, Kiro, Pi, OpenCode, Antigravity)
 kcap import --org EventStore    # sessions whose git-remote owner is EventStore
 kcap import --org               # pick an org from your discovered repos (and remember it)
-kcap import --repo owner/repo   # sessions for one specific repo
+kcap import --repo owner/repo   # sessions for one specific repo (repeat --repo for several)
 kcap import --cursor            # only Cursor
 kcap import --copilot           # only Copilot
 kcap import --gemini            # only Gemini
@@ -616,6 +616,7 @@ kcap import --all                            # every discovered session from eve
 kcap import --org EventStore                 # sessions whose git-remote owner is EventStore
 kcap import --org                            # pick an owner from discovered repos, then remember it
 kcap import --repo owner/repo                # one specific repo
+kcap import --repo owner/one --repo owner/two  # several — repeat the flag per repo
 kcap import --repo .                         # the repo at the current cwd (must be a git repo with an origin remote)
 ```
 

--- a/src/Capacitor.Cli.Core/Resources/help-import.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-import.txt
@@ -37,7 +37,8 @@ Scope (one of, required for non-interactive use):
   --org <owner>           Import only sessions whose git-remote owner matches <owner>
   --org                   Bare: pick an org from discovered repos (interactive) and
                           remember it; reuses the remembered org on later runs
-  --repo <owner/name>     Import only sessions from a specific repo
+  --repo <owner/name>     Import only sessions from a specific repo. Repeatable:
+                          pass it once per repo to select several
   --repo .                Import only sessions from the current cwd's repo
 
 The org is the git-remote owner (GitHub org/user), independent of your profile

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -837,12 +837,6 @@ static class ImportCommand {
 
         var totalAfterScope = filteredPerSource.Sum(d => d.Count);
 
-        if (totalAfterScope == 0) {
-            display.Line("No sessions match the selected scope.");
-
-            return 0;
-        }
-
         // --- Confirmation ---
         var sampleRepos = new List<string>();
 
@@ -875,6 +869,12 @@ static class ImportCommand {
                 display.Line(
                     $"No sessions found for {string.Join(", ", missed.Select(m => $"{m.Owner}/{m.Name}"))} — check the spelling, or `kcap remap` if the directory was renamed.");
             }
+        }
+
+        if (totalAfterScope == 0) {
+            display.Line("No sessions match the selected scope.");
+
+            return 0;
         }
 
         var visibilityDesc = forcePrivate

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -858,6 +858,25 @@ static class ImportCommand {
             }
         }
 
+        // A repo that is spelled plausibly but wrongly resolves fine and simply matches nothing, so the
+        // run imports the others and says nothing. Naming the misses is the only way that reads as a
+        // mistake rather than as a smaller history than expected.
+        if (scope is ImportScope.Repo requested) {
+            var matched = new HashSet<(string Owner, string Name)>(ImportScope.RepoComparer);
+
+            foreach (var repo in sampleRepos) {
+                var parts = repo.Split('/');
+                if (parts.Length == 2) matched.Add((parts[0], parts[1]));
+            }
+
+            var missed = requested.Repos.Where(r => !matched.Contains(r)).ToList();
+
+            if (missed.Count > 0) {
+                display.Line(
+                    $"No sessions found for {string.Join(", ", missed.Select(m => $"{m.Owner}/{m.Name}"))} — check the spelling, or `kcap remap` if the directory was renamed.");
+            }
+        }
+
         var visibilityDesc = forcePrivate
             ? "private (--private)"
             : $"{profile?.DefaultVisibility ?? "org_public"} (from profile)";

--- a/src/Capacitor.Cli/Commands/ImportScope.cs
+++ b/src/Capacitor.Cli/Commands/ImportScope.cs
@@ -4,9 +4,48 @@ namespace Capacitor.Cli.Commands;
 /// Selected import scope, resolved from CLI flags or the interactive picker.
 /// </summary>
 public abstract record ImportScope {
-    public sealed record All  : ImportScope;
-    public sealed record Org  (string OrgLogin) : ImportScope;
-    public sealed record Repo (string Owner, string Name) : ImportScope;
+    /// <summary>
+    /// Owner and name compared the way git remotes are: case-insensitively, both halves. Shared so a
+    /// scope's own equality and the filter's lookup can never disagree about what "the same repo" is.
+    /// </summary>
+    public static readonly IEqualityComparer<(string Owner, string Name)> RepoComparer = new RepoEquality();
+
+    public sealed record All : ImportScope;
+    public sealed record Org (string OrgLogin) : ImportScope;
+
+    /// <summary>One or more repositories, matched as a set.</summary>
+    public sealed record Repo : ImportScope {
+        public Repo(IReadOnlyList<(string Owner, string Name)> repos) {
+            // Empty would have to mean either "everything" or "nothing", and a scope that silently
+            // means one when the caller meant the other is worth refusing outright.
+            if (repos.Count == 0) throw new ArgumentException("A repo scope needs at least one repository.", nameof(repos));
+
+            Repos = repos;
+        }
+
+        public Repo(string owner, string name) : this([(owner, name)]) { }
+
+        public IReadOnlyList<(string Owner, string Name)> Repos { get; }
+
+        // A record over a list compares by reference, which would quietly drop the value equality the
+        // single-repo shape had before it held a collection.
+        public bool Equals(Repo? other) =>
+            other is not null && Repos.Count == other.Repos.Count && !Repos.Except(other.Repos, RepoComparer).Any();
+
+        public override int GetHashCode() =>
+            Repos.Aggregate(0, (acc, r) => acc ^ RepoComparer.GetHashCode(r));
+    }
 
     private ImportScope() { }
+
+    sealed class RepoEquality : IEqualityComparer<(string Owner, string Name)> {
+        public bool Equals((string Owner, string Name) a, (string Owner, string Name) b) =>
+            string.Equals(a.Owner, b.Owner, StringComparison.OrdinalIgnoreCase)
+         && string.Equals(a.Name,  b.Name,  StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string Owner, string Name) r) =>
+            HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(r.Owner),
+                StringComparer.OrdinalIgnoreCase.GetHashCode(r.Name));
+    }
 }

--- a/src/Capacitor.Cli/Commands/ImportScope.cs
+++ b/src/Capacitor.Cli/Commands/ImportScope.cs
@@ -20,7 +20,9 @@ public abstract record ImportScope {
             // means one when the caller meant the other is worth refusing outright.
             if (repos.Count == 0) throw new ArgumentException("A repo scope needs at least one repository.", nameof(repos));
 
-            Repos = repos;
+            // Stored deduped, so this really is a set: naming a repo twice is one selection, and
+            // equality and hashing below can agree without reasoning about multiplicity.
+            Repos = [.. repos.Distinct(RepoComparer)];
         }
 
         public Repo(string owner, string name) : this([(owner, name)]) { }
@@ -28,9 +30,12 @@ public abstract record ImportScope {
         public IReadOnlyList<(string Owner, string Name)> Repos { get; }
 
         // A record over a list compares by reference, which would quietly drop the value equality the
-        // single-repo shape had before it held a collection.
+        // single-repo shape had before it held a collection. Sound because Repos is deduped: set
+        // equality and an order-insensitive XOR agree only when neither side repeats an entry.
         public bool Equals(Repo? other) =>
-            other is not null && Repos.Count == other.Repos.Count && !Repos.Except(other.Repos, RepoComparer).Any();
+            other is not null
+         && Repos.Count == other.Repos.Count
+         && !Repos.Except(other.Repos, RepoComparer).Any();
 
         public override int GetHashCode() =>
             Repos.Aggregate(0, (acc, r) => acc ^ RepoComparer.GetHashCode(r));

--- a/src/Capacitor.Cli/Commands/ImportScopeArgs.cs
+++ b/src/Capacitor.Cli/Commands/ImportScopeArgs.cs
@@ -7,12 +7,12 @@ namespace Capacitor.Cli.Commands;
 /// </summary>
 public static class ImportScopeArgs {
     public sealed record ParsedFlags(
-            bool    All,
-            bool    Org,
-            string? RepoArg,
-            bool    Yes,
-            bool    Private,
-            string? OrgArg = null // explicit owner after `--org`, or null for bare `--org`
+            bool                  All,
+            bool                  Org,
+            IReadOnlyList<string> RepoArgs,
+            bool                  Yes,
+            bool                  Private,
+            string?               OrgArg = null // explicit owner after `--org`, or null for bare `--org`
         );
 
     public sealed record ResolveInput(
@@ -32,9 +32,18 @@ public static class ImportScopeArgs {
         );
 
     public static ParsedFlags ParseFlags(string[] args) {
-        string? repo                                = null;
-        var     repoIdx                             = Array.IndexOf(args, "--repo");
-        if (repoIdx >= 0 && repoIdx + 1 < args.Length) repo = args[repoIdx + 1];
+        // Repeatable: one occurrence per repo. A trailing `--repo`, or one followed by another flag,
+        // records the empty string so Resolve can say the value is missing — dropping it silently would
+        // let `--repo a/b --repo` import half of what was asked for and report nothing.
+        var repos = new List<string>();
+
+        for (var i = 0; i < args.Length; i++) {
+            if (args[i] != "--repo") continue;
+
+            var value = i + 1 < args.Length ? args[i + 1] : "";
+
+            repos.Add(value.StartsWith('-') ? "" : value);
+        }
 
         // `--org` may be bare or take an explicit owner. Only treat the next token
         // as the owner when it isn't another flag (so `--org --yes` stays bare).
@@ -45,7 +54,7 @@ public static class ImportScopeArgs {
         return new(
             All: args.Contains("--all"),
             Org: args.Contains("--org"),
-            RepoArg: repo,
+            RepoArgs: repos,
             Yes: args.Contains("--yes") || args.Contains("-y"),
             Private: args.Contains("--private"),
             OrgArg: org
@@ -54,7 +63,7 @@ public static class ImportScopeArgs {
 
     public static ResolveResult Resolve(ResolveInput input) {
         var f     = input.Flags;
-        var count = (f.All ? 1 : 0) + (f.Org ? 1 : 0) + (f.RepoArg is null ? 0 : 1);
+        var count = (f.All ? 1 : 0) + (f.Org ? 1 : 0) + (f.RepoArgs.Count == 0 ? 0 : 1);
 
         switch (count) {
             case > 1:
@@ -115,35 +124,51 @@ public static class ImportScopeArgs {
             );
         }
 
-        // --repo <value>
-        var value = f.RepoArg!;
+        // Every value must parse before any is used: a malformed one is a usage error, and importing
+        // the rest would act on a command the user did not write.
+        var repos = new List<(string Owner, string Name)>();
+        var seen  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        if (value is "." or "current") {
-            if (input.CurrentRepo is null) {
+        foreach (var value in f.RepoArgs) {
+            if (value is "." or "current") {
+                if (input.CurrentRepo is null) {
+                    return new(
+                        null,
+                        f.Yes,
+                        f.Private,
+                        "--repo . requires the current directory to be in a git repo with an origin remote."
+                    );
+                }
+
+                Add(input.CurrentRepo.Value);
+
+                continue;
+            }
+
+            if (value.Length == 0) {
+                return new(null, f.Yes, f.Private, "--repo needs a value: pass `--repo <owner/name>`.");
+            }
+
+            var parts = value.Split('/');
+
+            if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0) {
                 return new(
                     null,
                     f.Yes,
                     f.Private,
-                    "--repo . requires the current directory to be in a git repo with an origin remote."
+                    $"--repo expects owner/name (got '{value}')."
                 );
             }
 
-            var (owner, name) = input.CurrentRepo.Value;
-
-            return new(new ImportScope.Repo(owner, name), f.Yes, f.Private, null);
+            Add((parts[0], parts[1]));
         }
 
-        var parts = value.Split('/');
+        return new(new ImportScope.Repo(repos), f.Yes, f.Private, null);
 
-        if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0) {
-            return new(
-                null,
-                f.Yes,
-                f.Private,
-                $"--repo expects owner/name (got '{value}')."
-            );
+        // `--repo . --repo owner/name` naming the same repo twice must not double-count it in the
+        // confirmation summary.
+        void Add((string Owner, string Name) repo) {
+            if (seen.Add($"{repo.Owner}/{repo.Name}")) repos.Add(repo);
         }
-
-        return new(new ImportScope.Repo(parts[0], parts[1]), f.Yes, f.Private, null);
     }
 }

--- a/src/Capacitor.Cli/Commands/ImportScopeArgs.cs
+++ b/src/Capacitor.Cli/Commands/ImportScopeArgs.cs
@@ -127,7 +127,6 @@ public static class ImportScopeArgs {
         // Every value must parse before any is used: a malformed one is a usage error, and importing
         // the rest would act on a command the user did not write.
         var repos = new List<(string Owner, string Name)>();
-        var seen  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var value in f.RepoArgs) {
             if (value is "." or "current") {
@@ -140,7 +139,7 @@ public static class ImportScopeArgs {
                     );
                 }
 
-                Add(input.CurrentRepo.Value);
+                repos.Add(input.CurrentRepo.Value);
 
                 continue;
             }
@@ -160,15 +159,10 @@ public static class ImportScopeArgs {
                 );
             }
 
-            Add((parts[0], parts[1]));
+            repos.Add((parts[0], parts[1]));
         }
 
+        // `--repo . --repo owner/name` naming the same repo twice is one selection; the scope dedupes.
         return new(new ImportScope.Repo(repos), f.Yes, f.Private, null);
-
-        // `--repo . --repo owner/name` naming the same repo twice must not double-count it in the
-        // confirmation summary.
-        void Add((string Owner, string Name) repo) {
-            if (seen.Add($"{repo.Owner}/{repo.Name}")) repos.Add(repo);
-        }
     }
 }

--- a/src/Capacitor.Cli/Commands/ImportScopeFilter.cs
+++ b/src/Capacitor.Cli/Commands/ImportScopeFilter.cs
@@ -14,6 +14,12 @@ public static class ImportScopeFilter {
         CancellationToken                                                                            ct = default) {
         if (scope is ImportScope.All) return [..transcripts];
 
+        // Hoisted so the set is built once rather than per session, and keyed on the tuple so no
+        // string is allocated inside the loop.
+        var wanted = scope is ImportScope.Repo r
+            ? new HashSet<(string Owner, string Name)>(r.Repos, ImportScope.RepoComparer)
+            : null;
+
         var kept = new List<(string, string, string)>(transcripts.Count);
 
         foreach (var t in transcripts) {
@@ -21,11 +27,9 @@ public static class ImportScopeFilter {
             var (owner, name) = await resolveRepo(t, ct);
 
             var match = (scope, owner, name) switch {
-                (ImportScope.Org o,  not null, _) => string.Equals(owner, o.OrgLogin, StringComparison.OrdinalIgnoreCase),
-                (ImportScope.Repo r, not null, not null) =>
-                    string.Equals(owner, r.Owner, StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(name,  r.Name,  StringComparison.OrdinalIgnoreCase),
-                _ => false,
+                (ImportScope.Org o, not null, _)      => string.Equals(owner, o.OrgLogin, StringComparison.OrdinalIgnoreCase),
+                (ImportScope.Repo, not null, not null) when wanted is not null => wanted.Contains((owner, name)),
+                _                                     => false,
             };
 
             if (match) kept.Add(t);

--- a/src/Capacitor.Cli/Commands/ImportScopePrompt.cs
+++ b/src/Capacitor.Cli/Commands/ImportScopePrompt.cs
@@ -83,7 +83,11 @@ public static partial class ImportScopePrompt {
     static string ScopeLabel(ImportScope scope) => scope switch {
         ImportScope.All    => "everything",
         ImportScope.Org o  => $"org repos only ({o.OrgLogin})",
-        ImportScope.Repo r => $"repository {r.Owner}/{r.Name}",
+        ImportScope.Repo { Repos: [var only] } => $"repository {only.Owner}/{only.Name}",
+        // Named, not counted: the `repos:` line below lists what MATCHED, so a repo that was asked for
+        // and found nothing appears nowhere else — and this is the text a --yes run leaves in CI logs.
+        ImportScope.Repo r                     =>
+            $"{r.Repos.Count} repositories ({RepoLine([.. r.Repos.Select(x => $"{x.Owner}/{x.Name}")])})",
         _                  => "?"
     };
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopeArgsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopeArgsTests.cs
@@ -8,7 +8,7 @@ public class ImportScopeArgsTests {
         var f = ImportScopeArgs.ParseFlags(["import", "--all"]);
         await Assert.That(f.All).IsTrue();
         await Assert.That(f.Org).IsFalse();
-        await Assert.That(f.RepoArg).IsNull();
+        await Assert.That(f.RepoArgs).IsEmpty();
         await Assert.That(f.Yes).IsFalse();
         await Assert.That(f.Private).IsFalse();
     }
@@ -16,7 +16,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task ParseFlags_reads_repo_value() {
         var f = ImportScopeArgs.ParseFlags(["import", "--repo", "EventStore/kcap"]);
-        await Assert.That(f.RepoArg).IsEqualTo("EventStore/kcap");
+        await Assert.That(f.RepoArgs).IsEquivalentTo(["EventStore/kcap"]);
     }
 
     [Test]
@@ -56,7 +56,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_errors_when_two_scope_flags_set() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: true, Org: true, RepoArg: null, Yes: false, Private: false),
+            Flags: new(All: true, Org: true, RepoArgs: [], Yes: false, Private: false),
             ActiveProfile: "EventStore",
             IsInteractive: true,
             CurrentRepo: null);
@@ -71,7 +71,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_returns_All_for_all_flag() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: true, Org: false, RepoArg: null, Yes: false, Private: false),
+            Flags: new(All: true, Org: false, RepoArgs: [], Yes: false, Private: false),
             ActiveProfile: "default",
             IsInteractive: true,
             CurrentRepo: null);
@@ -87,7 +87,7 @@ public class ImportScopeArgsTests {
         // The org comes from the flag value, NOT the profile name — so it works
         // identically under GitHub and WorkOS sign-in.
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false, OrgArg: "EventStore"),
+            Flags: new(All: false, Org: true, RepoArgs: [], Yes: false, Private: false, OrgArg: "EventStore"),
             ActiveProfile: "acme-tenant-slug",
             IsInteractive: true,
             CurrentRepo: null);
@@ -102,7 +102,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_trims_explicit_org_value() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false, OrgArg: "  EventStore  "),
+            Flags: new(All: false, Org: true, RepoArgs: [], Yes: false, Private: false, OrgArg: "  EventStore  "),
             ActiveProfile: "acme-tenant-slug",
             IsInteractive: true,
             CurrentRepo: null);
@@ -115,7 +115,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_whitespace_only_org_value_falls_through_to_pick() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false, OrgArg: "   "),
+            Flags: new(All: false, Org: true, RepoArgs: [], Yes: false, Private: false, OrgArg: "   "),
             ActiveProfile: "acme-tenant-slug",
             IsInteractive: true,
             CurrentRepo: null);
@@ -129,7 +129,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_bare_org_uses_remembered_stored_org() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false),
+            Flags: new(All: false, Org: true, RepoArgs: [], Yes: false, Private: false),
             ActiveProfile: "acme-tenant-slug",
             IsInteractive: true,
             CurrentRepo: null,
@@ -144,7 +144,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_explicit_org_value_overrides_stored_org() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false, OrgArg: "kurrent"),
+            Flags: new(All: false, Org: true, RepoArgs: [], Yes: false, Private: false, OrgArg: "kurrent"),
             ActiveProfile: "acme-tenant-slug",
             IsInteractive: true,
             CurrentRepo: null,
@@ -158,7 +158,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_bare_org_interactive_without_stored_org_needs_pick() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: true, RepoArg: null, Yes: false, Private: false),
+            Flags: new(All: false, Org: true, RepoArgs: [], Yes: false, Private: false),
             ActiveProfile: "default",
             IsInteractive: true,
             CurrentRepo: null);
@@ -173,7 +173,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_bare_org_non_interactive_without_stored_org_errors() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: true, RepoArg: null, Yes: true, Private: false),
+            Flags: new(All: false, Org: true, RepoArgs: [], Yes: true, Private: false),
             ActiveProfile: "default",
             IsInteractive: false,
             CurrentRepo: null);
@@ -188,52 +188,131 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_returns_Repo_for_owner_slash_name() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: false, RepoArg: "EventStore/kcap", Yes: false, Private: false),
+            Flags: new(All: false, Org: false, RepoArgs: ["EventStore/kcap"], Yes: false, Private: false),
             ActiveProfile: "EventStore",
             IsInteractive: true,
             CurrentRepo: null);
 
         var r = ImportScopeArgs.Resolve(input);
 
-        var repo = (ImportScope.Repo)r.Scope!;
-        await Assert.That(repo.Owner).IsEqualTo("EventStore");
-        await Assert.That(repo.Name).IsEqualTo("kcap");
+        await Assert.That(((ImportScope.Repo)r.Scope!).Repos).IsEquivalentTo([("EventStore", "kcap")]);
+    }
+
+    [Test]
+    public async Task ParseFlags_collects_every_repo_flag() {
+        var f = ImportScopeArgs.ParseFlags(["import", "--repo", "a/one", "--repo", "b/two", "--yes"]);
+
+        await Assert.That(f.RepoArgs).IsEquivalentTo(["a/one", "b/two"]);
+    }
+
+    [Test]
+    public async Task ParseFlags_records_a_trailing_repo_as_a_missing_value() {
+        var f = ImportScopeArgs.ParseFlags(["import", "--repo", "a/one", "--repo"]);
+
+        await Assert.That(f.RepoArgs).IsEquivalentTo(["a/one", ""]);
+    }
+
+    [Test]
+    public async Task ParseFlags_does_not_take_a_following_flag_as_the_repo() {
+        // `--org` has always guarded this; `--repo` did not, and repeating it makes the slip likelier.
+        var f = ImportScopeArgs.ParseFlags(["import", "--repo", "--yes"]);
+
+        await Assert.That(f.RepoArgs).IsEquivalentTo([""]);
+        await Assert.That(f.Yes).IsTrue();
+    }
+
+    [Test]
+    public async Task Resolve_reports_a_repo_flag_with_no_value() {
+        var r = ImportScopeArgs.Resolve(new(
+            Flags: new(All: false, Org: false, RepoArgs: ["a/one", ""], Yes: true, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: false,
+            CurrentRepo: null));
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error).Contains("--repo needs a value");
+    }
+
+    [Test]
+    [Arguments("a/one", "a/one")]
+    [Arguments("a/one", "A/ONE")]
+    public async Task Resolve_dedupes_the_same_repo_however_it_is_spelled(string first, string second) {
+        var r = ImportScopeArgs.Resolve(new(
+            Flags: new(All: false, Org: false, RepoArgs: [first, second], Yes: true, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: false,
+            CurrentRepo: null));
+
+        await Assert.That(((ImportScope.Repo)r.Scope!).Repos).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Resolve_keeps_every_named_repo() {
+        var r = ImportScopeArgs.Resolve(new(
+            Flags: new(All: false, Org: false, RepoArgs: ["a/one", "b/two"], Yes: true, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: false,
+            CurrentRepo: null));
+
+        await Assert.That(((ImportScope.Repo)r.Scope!).Repos)
+                    .IsEquivalentTo([("a", "one"), ("b", "two")]);
+    }
+
+    [Test]
+    public async Task Resolve_dedupes_a_repo_named_twice() {
+        // `--repo . --repo EventStore/kcap` from inside that repo is one selection, not two.
+        var r = ImportScopeArgs.Resolve(new(
+            Flags: new(All: false, Org: false, RepoArgs: [".", "eventstore/KCAP"], Yes: true, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: false,
+            CurrentRepo: ("EventStore", "kcap")));
+
+        await Assert.That(((ImportScope.Repo)r.Scope!).Repos).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Resolve_rejects_the_whole_run_when_one_repo_is_malformed() {
+        // Importing the valid four and silently dropping the typo would be worse than saying so.
+        var r = ImportScopeArgs.Resolve(new(
+            Flags: new(All: false, Org: false, RepoArgs: ["a/one", "not-a-repo"], Yes: true, Private: false),
+            ActiveProfile: "EventStore",
+            IsInteractive: false,
+            CurrentRepo: null));
+
+        await Assert.That(r.Scope).IsNull();
+        await Assert.That(r.Error).Contains("not-a-repo");
     }
 
     [Test]
     public async Task Resolve_repo_dot_uses_current_repo() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: false, RepoArg: ".", Yes: false, Private: false),
+            Flags: new(All: false, Org: false, RepoArgs: ["."], Yes: false, Private: false),
             ActiveProfile: "EventStore",
             IsInteractive: true,
             CurrentRepo: ("EventStore", "kcap"));
 
         var r = ImportScopeArgs.Resolve(input);
 
-        var repo = (ImportScope.Repo)r.Scope!;
-        await Assert.That(repo.Owner).IsEqualTo("EventStore");
-        await Assert.That(repo.Name).IsEqualTo("kcap");
+        await Assert.That(((ImportScope.Repo)r.Scope!).Repos).IsEquivalentTo([("EventStore", "kcap")]);
     }
 
     [Test]
     public async Task Resolve_repo_current_alias_uses_current_repo() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: false, RepoArg: "current", Yes: false, Private: false),
+            Flags: new(All: false, Org: false, RepoArgs: ["current"], Yes: false, Private: false),
             ActiveProfile: "EventStore",
             IsInteractive: true,
             CurrentRepo: ("EventStore", "kcap"));
 
         var r = ImportScopeArgs.Resolve(input);
 
-        var repo = (ImportScope.Repo)r.Scope!;
-        await Assert.That(repo.Owner).IsEqualTo("EventStore");
-        await Assert.That(repo.Name).IsEqualTo("kcap");
+        await Assert.That(((ImportScope.Repo)r.Scope!).Repos).IsEquivalentTo([("EventStore", "kcap")]);
     }
 
     [Test]
     public async Task Resolve_repo_dot_errors_when_cwd_has_no_repo() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: false, RepoArg: ".", Yes: false, Private: false),
+            Flags: new(All: false, Org: false, RepoArgs: ["."], Yes: false, Private: false),
             ActiveProfile: "EventStore",
             IsInteractive: true,
             CurrentRepo: null);
@@ -247,7 +326,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_errors_on_malformed_repo_arg() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: false, RepoArg: "no-slash", Yes: false, Private: false),
+            Flags: new(All: false, Org: false, RepoArgs: ["no-slash"], Yes: false, Private: false),
             ActiveProfile: "EventStore",
             IsInteractive: true,
             CurrentRepo: null);
@@ -261,7 +340,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_returns_null_scope_and_null_error_when_no_flag_and_interactive() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: false, RepoArg: null, Yes: false, Private: false),
+            Flags: new(All: false, Org: false, RepoArgs: [], Yes: false, Private: false),
             ActiveProfile: "EventStore",
             IsInteractive: true,
             CurrentRepo: null);
@@ -275,7 +354,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_errors_when_no_flag_and_non_interactive() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: false, Org: false, RepoArg: null, Yes: false, Private: false),
+            Flags: new(All: false, Org: false, RepoArgs: [], Yes: false, Private: false),
             ActiveProfile: "EventStore",
             IsInteractive: false,
             CurrentRepo: null);
@@ -289,7 +368,7 @@ public class ImportScopeArgsTests {
     [Test]
     public async Task Resolve_errors_when_flag_set_and_non_interactive_without_yes() {
         var input = new ImportScopeArgs.ResolveInput(
-            Flags: new(All: true, Org: false, RepoArg: null, Yes: false, Private: false),
+            Flags: new(All: true, Org: false, RepoArgs: [], Yes: false, Private: false),
             ActiveProfile: "EventStore",
             IsInteractive: false,
             CurrentRepo: null);

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopeFilterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopeFilterTests.cs
@@ -105,6 +105,24 @@ public class ImportScopeFilterTests {
     }
 
     [Test]
+    public async Task Repo_scopes_naming_the_same_set_are_equal_however_written() {
+        // A record over a list compares by reference, so this is not free — and the duplicate case is
+        // what makes an Except-based Equals and an XOR hash disagree unless the set is canonical.
+        var a = new ImportScope.Repo([("EventStore", "kcap"), ("Acme", "widgets")]);
+        var b = new ImportScope.Repo([("acme", "WIDGETS"), ("eventstore", "KCAP")]);
+        var c = new ImportScope.Repo([("EventStore", "kcap"), ("EventStore", "kcap"), ("Acme", "widgets")]);
+
+        await Assert.That(a).IsEqualTo(b);
+        await Assert.That(a).IsEqualTo(c);
+        await Assert.That(a.GetHashCode()).IsEqualTo(b.GetHashCode());
+        await Assert.That(a.GetHashCode())
+                    .IsEqualTo(c.GetHashCode())
+                    .Because("equal instances must hash equally, which only holds because the set is "
+                           + "stored deduped");
+        await Assert.That(c.Repos).Count().IsEqualTo(2);
+    }
+
+    [Test]
     public async Task An_empty_repo_set_is_refused_rather_than_guessed_at() {
         // It would have to mean "everything" or "nothing", and a scope that silently picks one when the
         // caller meant the other is worse than a construction that fails.

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopeFilterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopeFilterTests.cs
@@ -69,4 +69,45 @@ public class ImportScopeFilterTests {
 
         await Assert.That(kept.Select(x => x.SessionId).ToArray()).IsEquivalentTo(["a", "c"]);
     }
+
+    [Test]
+    public async Task Repo_scope_keeps_every_named_repo() {
+        var transcripts = new[] { T("a"), T("b"), T("c"), T("d") };
+        var resolver = Resolver(new() {
+            ["a"] = ("EventStore", "kcap"),
+            ["b"] = ("EventStore", "kurrentdb"),
+            ["c"] = ("Acme", "widgets"),
+            ["d"] = ("EventStore", "gaffer"),
+        });
+
+        var kept = await ImportScopeFilter.Apply(
+            transcripts,
+            new ImportScope.Repo([("EventStore", "kcap"), ("Acme", "widgets")]),
+            resolver);
+
+        await Assert.That(kept.Select(x => x.SessionId).ToArray()).IsEquivalentTo(["a", "c"]);
+    }
+
+    [Test]
+    public async Task Repo_scope_matches_each_repo_case_insensitively() {
+        var transcripts = new[] { T("a"), T("b") };
+        var resolver = Resolver(new() {
+            ["a"] = ("EventStore", "kcap"),
+            ["b"] = ("Acme", "Widgets"),
+        });
+
+        var kept = await ImportScopeFilter.Apply(
+            transcripts,
+            new ImportScope.Repo([("eventstore", "KCAP"), ("ACME", "widgets")]),
+            resolver);
+
+        await Assert.That(kept.Select(x => x.SessionId).ToArray()).IsEquivalentTo(["a", "b"]);
+    }
+
+    [Test]
+    public async Task An_empty_repo_set_is_refused_rather_than_guessed_at() {
+        // It would have to mean "everything" or "nothing", and a scope that silently picks one when the
+        // caller meant the other is worse than a construction that fails.
+        await Assert.That(() => new ImportScope.Repo([])).Throws<ArgumentException>();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopePromptTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopePromptTests.cs
@@ -118,6 +118,21 @@ public class ImportScopePromptTests {
     }
 
     [Test]
+    public async Task FormatSummary_multi_repo_names_what_was_asked_for_not_just_a_count() {
+        // The `repos:` line lists what MATCHED, so a repo that was requested and found nothing appears
+        // nowhere else — and with --yes this text is the only record of the run.
+        var s = ImportScopePrompt.FormatSummary(
+            scope: new ImportScope.Repo([("EventStore", "kcap"), ("EventStore", "gaffer")]),
+            matchedCount: 3,
+            repoSamples: ["EventStore/kcap"],
+            visibilityDescription: "org_public (from profile)"
+        );
+
+        await Assert.That(s).Contains("2 repositories");
+        await Assert.That(s).Contains("EventStore/gaffer");
+    }
+
+    [Test]
     public async Task FormatSummary_caps_repo_samples_at_5() {
         var samples = Enumerable.Range(1, 9).Select(i => $"EventStore/r{i}").ToArray();
 


### PR DESCRIPTION
`ImportScope` was a closed `All` / `Org` / `Repo(one)` hierarchy, so a per-repo selection could not be expressed at all — and a decision per repo is the shape the import screen is built around.

- **`ImportScope.Repo` holds a list.** A two-arg constructor keeps every existing single-repo construction compiling (`SetupCommand`, the picker, ~10 tests), so only the two places that actually *read* the pair changed. Adding a fourth case instead would have left two cases meaning "repositories" and every match arm handling both forever.
- **`--repo` is repeatable**, resolved into a deduped set. `ImportScopeFilter` does one set lookup per session, keyed on the tuple so nothing is allocated in the loop, against `ImportScope.RepoComparer` — the single definition of "the same repo", shared with the scope's own equality so the two can't disagree.
- **A `--repo` with no value, or followed by another flag, is now an error.** `--org` has always guarded that; `--repo` never did, and repeating it makes `--repo a/b --repo` a plausible typo that would otherwise import half of what was asked for and say nothing.

Three consequences of the shape change, each of which would have been a silent trap:

- **An empty set is refused at construction.** It would have to mean everything or nothing, and silently picking one when the caller meant the other is worse than failing.
- **A `record` over a list compares by reference**, so the single-repo shape would have quietly lost the value equality it had. Nothing depends on it today — which is precisely why the loss would have gone unnoticed until something did.
- **The confirmation summary named only a count.** The `repos:` line lists what *matched*, so a repo that was requested and found nothing appeared nowhere — and with `--yes` that text is the only record of the run. It now names the requested set.

Separately: a repo spelled plausibly but wrongly (`EventStore/kcpa`) parses fine, matches nothing, and the run imported the others in silence. Misses are now named, pointing at either the spelling or `kcap remap` if the directory was renamed. Worth saying because my first version's comment claimed strict validation prevented this, and it did not — only *malformed* values were caught.

**The model supports the multi-repo shape; no UI reaches it yet.** The interactive picker and the app wizard's import step both still choose exactly one. The browser flow (AI-2037) is the consumer, and AI-2035's per-repo counts build on this shape — which is why it lands first.

Verified: `Cli.Tests.Unit` 3244, `Cli.Core.Tests.Unit` 1887, `App.Tests.Unit` 1141, `Tests.Integration` 225 — all passing; AOT publish clean.

AI-2036
