### PR TITLE
Admit native trusted tools in the unattended reviewer (fixes workspace-backed launch reap)

### DIFF
--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -75,14 +75,9 @@ internal sealed partial class AcpInteractionBridge(
     /// caller downstream matches on.</summary>
     static string ForbiddenInteractionReason(string method) => $"unattended_interaction_forbidden:{method}";
 
-    /// <summary>
-    /// Reaps for a <c>session/request_permission</c> frame this launch cannot admit — a tool it does
-    /// not trust, or one it trusts but whose options we can't safely resolve. Logs the untrusted,
-    /// agent-supplied tool title + kind (the same "explicitly untrusted context" convention the
-    /// auto-approve audit uses) so the leaked frame is diagnosable: the coded reason forwarded to the
-    /// server names only the method, and no other record captured the tool. The published coded reason
-    /// is unchanged — always the forbidden-method coding of <c>session/request_permission</c>.
-    /// </summary>
+    /// <summary>Reaps a <c>session/request_permission</c> frame this launch cannot admit. Logs the
+    /// untrusted tool title + kind — the forwarded coded reason names only the method, so nothing else
+    /// records which tool leaked; the coded reason itself is unchanged.</summary>
     JsonElement? ReapForbiddenPermissionFrame(JsonElement toolCall) {
         LogUnattendedPermissionFrameForbidden(
             agentId, TryGetToolTitle(toolCall) ?? "(untitled)", TryGetToolKind(toolCall) ?? "(none)");
@@ -557,9 +552,7 @@ internal sealed partial class AcpInteractionBridge(
     [LoggerMessage(Level = LogLevel.Error, Message = "ACP: unattended reviewer {AgentId} emitted forbidden interaction request {Method}; terminating reviewer")]
     partial void LogUnexpectedUnattendedInteraction(string agentId, string method);
 
-    // The permission-frame reap under AllowlistedAutoApprove. Carries the tool title + kind as
-    // EXPLICITLY untrusted, agent-supplied context (same convention as LogUnattendedAutoApproved) so
-    // the leaked frame is diagnosable — the forwarded coded reason names only the method.
+    // ToolTitle/ToolKind are EXPLICITLY untrusted, agent-supplied context (as in LogUnattendedAutoApproved).
     [LoggerMessage(Level = LogLevel.Error, Message = "ACP: unattended reviewer {AgentId} emitted forbidden session/request_permission frame (tool title, untrusted: {ToolTitle}; kind: {ToolKind}); terminating reviewer")]
     partial void LogUnattendedPermissionFrameForbidden(string agentId, string toolTitle, string toolKind);
 

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -76,6 +76,22 @@ internal sealed partial class AcpInteractionBridge(
     static string ForbiddenInteractionReason(string method) => $"unattended_interaction_forbidden:{method}";
 
     /// <summary>
+    /// Reaps for a <c>session/request_permission</c> frame this launch cannot admit — a tool it does
+    /// not trust, or one it trusts but whose options we can't safely resolve. Logs the untrusted,
+    /// agent-supplied tool title + kind (the same "explicitly untrusted context" convention the
+    /// auto-approve audit uses) so the leaked frame is diagnosable: the coded reason forwarded to the
+    /// server names only the method, and no other record captured the tool. The published coded reason
+    /// is unchanged — always the forbidden-method coding of <c>session/request_permission</c>.
+    /// </summary>
+    JsonElement? ReapForbiddenPermissionFrame(JsonElement toolCall) {
+        LogUnattendedPermissionFrameForbidden(
+            agentId, TryGetToolTitle(toolCall) ?? "(untitled)", TryGetToolKind(toolCall) ?? "(none)");
+        unexpectedUnattendedInteraction?.Invoke(ForbiddenInteractionReason("session/request_permission"));
+
+        return CancelledResult();
+    }
+
+    /// <summary>
     /// Handles one inbound <see cref="AcpRequest"/>. Returns <see langword="null"/> for any method
     /// this bridge doesn't recognize (letting <see cref="AcpConnection.HandleServerRequestAsync"/>'s
     /// existing default-decline posture answer with a JSON-RPC "Method not found" error, unchanged
@@ -172,12 +188,8 @@ internal sealed partial class AcpInteractionBridge(
         // correctly-configured reviewer never raises a frame is measurably false on Kiro, which
         // intermittently prompts for a tool that is in its own trust list.
         if (unattendedPolicy == AcpUnattendedInteractionPolicy.AllowlistedAutoApprove) {
-            if (!UnattendedToolAdmission.IsAdmitted(parsed.ToolCall, admittedToolIds ?? EmptyAdmitted)) {
-                LogUnexpectedUnattendedInteraction(agentId, request.Method);
-                unexpectedUnattendedInteraction?.Invoke(ForbiddenInteractionReason(request.Method));
-
-                return CancelledResult();
-            }
+            if (!UnattendedToolAdmission.IsAdmitted(parsed.ToolCall, admittedToolIds ?? EmptyAdmitted))
+                return ReapForbiddenPermissionFrame(parsed.ToolCall);
 
             var admittedChoice = TrySelectLeastPrivilegeAllow(options);
 
@@ -190,10 +202,7 @@ internal sealed partial class AcpInteractionBridge(
 
             // Admitted tool, but no allow option we can identify. Reap rather than guess: an
             // unrecognised option set is exactly where a wrong pick grants something nobody asked for.
-            LogUnexpectedUnattendedInteraction(agentId, request.Method);
-            unexpectedUnattendedInteraction?.Invoke(ForbiddenInteractionReason(request.Method));
-
-            return CancelledResult();
+            return ReapForbiddenPermissionFrame(parsed.ToolCall);
         }
 
         // Unattended reviewer: auto-approve a least-privilege allow option without a human, fail
@@ -547,6 +556,12 @@ internal sealed partial class AcpInteractionBridge(
 
     [LoggerMessage(Level = LogLevel.Error, Message = "ACP: unattended reviewer {AgentId} emitted forbidden interaction request {Method}; terminating reviewer")]
     partial void LogUnexpectedUnattendedInteraction(string agentId, string method);
+
+    // The permission-frame reap under AllowlistedAutoApprove. Carries the tool title + kind as
+    // EXPLICITLY untrusted, agent-supplied context (same convention as LogUnattendedAutoApproved) so
+    // the leaked frame is diagnosable — the forwarded coded reason names only the method.
+    [LoggerMessage(Level = LogLevel.Error, Message = "ACP: unattended reviewer {AgentId} emitted forbidden session/request_permission frame (tool title, untrusted: {ToolTitle}; kind: {ToolKind}); terminating reviewer")]
+    partial void LogUnattendedPermissionFrameForbidden(string agentId, string toolTitle, string toolKind);
 
     /// <summary>
     /// Maps a resolved <see cref="AcpInteractionDecision"/> to the ACP outcome result shape.

--- a/src/Capacitor.Cli.Daemon/Acp/UnattendedToolAdmission.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/UnattendedToolAdmission.cs
@@ -36,18 +36,11 @@ internal static class UnattendedToolAdmission {
     /// loosely: everything after it must BE an admitted id.</summary>
     const string TitlePrefix = "Running: ";
 
-    /// <summary>The admitted identities for a launch: the SAME set the <c>--trust-tools</c> argv
-    /// grants — the native tools (<c>fs_read</c>, <c>thinking</c>) AND the <c>@server/tool</c>
-    /// namespaced entries — built from the same injected specs and identity, precisely from another
-    /// call of the same deterministic builder over the same context, not a literally shared list. One
-    /// BUILDER: a second would admit a set that does not match what was actually injected.
-    ///
-    /// <para>The native half is load-bearing: the trust argv grants <c>fs_read</c>/<c>thinking</c>
-    /// natively, but the vendor leaks prompts even for tools in its own trust list (measured on Kiro),
-    /// so a workspace-backed launch that reads the mirrored worktree can raise a permission frame for
-    /// <c>fs_read</c>. Admitting only the namespaced half left that frame un-admittable — reaping the
-    /// reviewer at launch. Admission must equal trust, not a subset of it; <c>fs_write</c> and
-    /// <c>execute_bash</c> are in neither, so the read-only floor is unchanged.</para></summary>
+    /// <summary>The admitted identities: the SAME set the <c>--trust-tools</c> argv grants — native
+    /// tools (<c>fs_read</c>, <c>thinking</c>) AND the <c>@server/tool</c> namespaced entries, from one
+    /// shared builder so admission can't diverge from what was injected. The native half is
+    /// load-bearing (the vendor leaks prompts even for trusted tools); <c>fs_write</c>/<c>execute_bash</c>
+    /// are in neither set, so the read-only floor is unchanged.</summary>
     internal static IReadOnlySet<string> AdmittedFor(
             IReadOnlyList<AcpMcpServerSpec> injected, LaunchIdentity identity) =>
         KiroReviewerTrustList.NativeTools

--- a/src/Capacitor.Cli.Daemon/Acp/UnattendedToolAdmission.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/UnattendedToolAdmission.cs
@@ -5,7 +5,8 @@ using Capacitor.Cli.Daemon.Harness.Kiro;
 namespace Capacitor.Cli.Daemon.Acp;
 
 /// <summary>
-/// Decides whether ONE unattended permission frame names exactly one tool this launch injected.
+/// Decides whether ONE unattended permission frame names exactly one tool this launch trusts —
+/// a native tool the trust argv granted (<c>fs_read</c>, <c>thinking</c>) or a server it injected.
 ///
 /// <para><b>Why this exists.</b> The <c>Fail</c> policy assumes a correctly-configured reviewer emits
 /// no interaction frame at all. Measured against kiro-cli 2.16.0 that is false: a frame appears
@@ -35,13 +36,23 @@ internal static class UnattendedToolAdmission {
     /// loosely: everything after it must BE an admitted id.</summary>
     const string TitlePrefix = "Running: ";
 
-    /// <summary>The admitted <c>@server/tool</c> identities for a launch, built from the same injected
-    /// specs and identity the trust argv is built from — precisely, from another call of the same
-    /// deterministic builder over the same context, not a literally shared list. One BUILDER: a
-    /// second would admit a set that does not match what was actually injected.</summary>
+    /// <summary>The admitted identities for a launch: the SAME set the <c>--trust-tools</c> argv
+    /// grants — the native tools (<c>fs_read</c>, <c>thinking</c>) AND the <c>@server/tool</c>
+    /// namespaced entries — built from the same injected specs and identity, precisely from another
+    /// call of the same deterministic builder over the same context, not a literally shared list. One
+    /// BUILDER: a second would admit a set that does not match what was actually injected.
+    ///
+    /// <para>The native half is load-bearing: the trust argv grants <c>fs_read</c>/<c>thinking</c>
+    /// natively, but the vendor leaks prompts even for tools in its own trust list (measured on Kiro),
+    /// so a workspace-backed launch that reads the mirrored worktree can raise a permission frame for
+    /// <c>fs_read</c>. Admitting only the namespaced half left that frame un-admittable — reaping the
+    /// reviewer at launch. Admission must equal trust, not a subset of it; <c>fs_write</c> and
+    /// <c>execute_bash</c> are in neither, so the read-only floor is unchanged.</para></summary>
     internal static IReadOnlySet<string> AdmittedFor(
             IReadOnlyList<AcpMcpServerSpec> injected, LaunchIdentity identity) =>
-        KiroReviewerTrustList.NamespacedEntries(injected, identity).ToHashSet(StringComparer.Ordinal);
+        KiroReviewerTrustList.NativeTools
+            .Concat(KiroReviewerTrustList.NamespacedEntries(injected, identity))
+            .ToHashSet(StringComparer.Ordinal);
 
     /// <summary>
     /// True when this frame's title is EXACTLY one admitted tool, modulo the measured prefix.

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/UnattendedToolAdmissionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/UnattendedToolAdmissionTests.cs
@@ -87,12 +87,14 @@ public class UnattendedToolAdmissionTests {
             Admitted("@kcap-flow-result-abc/submit_review_result"))).IsFalse();
 
     /// <summary>
-    /// The admitted set and the trust list are ONE derivation. If they diverged, the reviewer could be
-    /// trusted to call a tool the policy then refuses to approve — a round that dies on its own
-    /// result call, which is the failure this whole policy exists to remove.
+    /// The admitted set and the trust list are ONE derivation — the WHOLE list, native tools
+    /// included, not just its namespaced half. If admission were narrower than trust, the reviewer
+    /// could be trusted to call a tool (e.g. the native <c>fs_read</c> the trust argv grants) that the
+    /// policy then refuses to approve when the vendor leaks a prompt for it — the exact
+    /// workspace-backed launch reap this admission set exists to remove.
     /// </summary>
     [Test]
-    public async Task TheAdmittedSetIsExactlyTheTrustListsNamespacedHalf() {
+    public async Task TheAdmittedSetIsExactlyTheTrustList() {
         var identity = LaunchIdentity.ForLaunch(aliasResultChannel: true);
         var specs = new List<AcpMcpServerSpec> {
             new(identity.ResultChannelWireName, "kcap", ["mcp", "flow-result"], []),
@@ -102,14 +104,51 @@ public class UnattendedToolAdmissionTests {
         var admitted = UnattendedToolAdmission.AdmittedFor(specs, identity);
         var trusted  = KiroReviewerTrustList.Build(specs, identity)
                                             .Split(',')
-                                            .Where(e => e.StartsWith('@'))
                                             .ToHashSet(StringComparer.Ordinal);
 
         await Assert.That(admitted.SetEquals(trusted)).IsTrue();
 
-        // And it really does cover both injected servers, so the equality above is not vacuous.
+        // Not vacuous: it covers the native trusted tools AND both injected servers.
+        await Assert.That(admitted).Contains("fs_read");
+        await Assert.That(admitted).Contains("thinking");
         await Assert.That(admitted).Contains(
             $"@{identity.ResultChannelWireName}/{KcapMcpRegistry.ReservedResultChannelTools[0].Name}");
         await Assert.That(admitted.Any(e => e.Contains("kcap-review", StringComparison.Ordinal))).IsTrue();
+    }
+
+    /// <summary>
+    /// A frame naming a NATIVE tool the launch trusts (<c>--trust-tools fs_read,thinking</c>) is
+    /// admitted, so a vendor prompt leaked for it on the workspace path is auto-approved rather than
+    /// reaping the reviewer. Kiro leaks prompts even for trusted tools, so this closes the same gap
+    /// for native tools that the namespaced entries already close for the injected result channel.
+    /// </summary>
+    [Test]
+    [Arguments("Running: fs_read")]
+    [Arguments("fs_read")]
+    [Arguments("Running: thinking")]
+    public async Task AdmitsANativeTrustedToolFrame(string title) {
+        var identity = LaunchIdentity.ForLaunch(aliasResultChannel: true);
+        var specs = new List<AcpMcpServerSpec> {
+            new(identity.ResultChannelWireName, "kcap", ["mcp", "flow-result"], []),
+        };
+
+        await Assert.That(UnattendedToolAdmission.IsAdmitted(
+            ToolCall(title), UnattendedToolAdmission.AdmittedFor(specs, identity))).IsTrue();
+    }
+
+    /// <summary>The containment floor holds: <c>fs_write</c> and <c>execute_bash</c> are in neither the
+    /// trust argv nor the admitted set, so a leaked prompt for either still reaps.</summary>
+    [Test]
+    [Arguments("Running: fs_write")]
+    [Arguments("Running: execute_bash")]
+    [Arguments("execute_bash")]
+    public async Task RefusesAnUntrustedNativeToolFrame(string title) {
+        var identity = LaunchIdentity.ForLaunch(aliasResultChannel: true);
+        var specs = new List<AcpMcpServerSpec> {
+            new(identity.ResultChannelWireName, "kcap", ["mcp", "flow-result"], []),
+        };
+
+        await Assert.That(UnattendedToolAdmission.IsAdmitted(
+            ToolCall(title), UnattendedToolAdmission.AdmittedFor(specs, identity))).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/UnattendedToolAdmissionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/UnattendedToolAdmissionTests.cs
@@ -86,13 +86,8 @@ public class UnattendedToolAdmissionTests {
             JsonSerializer.Deserialize<JsonElement>(json),
             Admitted("@kcap-flow-result-abc/submit_review_result"))).IsFalse();
 
-    /// <summary>
-    /// The admitted set and the trust list are ONE derivation — the WHOLE list, native tools
-    /// included, not just its namespaced half. If admission were narrower than trust, the reviewer
-    /// could be trusted to call a tool (e.g. the native <c>fs_read</c> the trust argv grants) that the
-    /// policy then refuses to approve when the vendor leaks a prompt for it — the exact
-    /// workspace-backed launch reap this admission set exists to remove.
-    /// </summary>
+    /// <summary>Admission must equal the WHOLE trust list, native tools included — if it were narrower,
+    /// a leaked prompt for a trusted-but-unadmitted tool (e.g. native <c>fs_read</c>) reaps the reviewer.</summary>
     [Test]
     public async Task TheAdmittedSetIsExactlyTheTrustList() {
         var identity = LaunchIdentity.ForLaunch(aliasResultChannel: true);
@@ -116,12 +111,8 @@ public class UnattendedToolAdmissionTests {
         await Assert.That(admitted.Any(e => e.Contains("kcap-review", StringComparison.Ordinal))).IsTrue();
     }
 
-    /// <summary>
-    /// A frame naming a NATIVE tool the launch trusts (<c>--trust-tools fs_read,thinking</c>) is
-    /// admitted, so a vendor prompt leaked for it on the workspace path is auto-approved rather than
-    /// reaping the reviewer. Kiro leaks prompts even for trusted tools, so this closes the same gap
-    /// for native tools that the namespaced entries already close for the injected result channel.
-    /// </summary>
+    /// <summary>A frame naming a native trusted tool (<c>fs_read</c>/<c>thinking</c>) is admitted, so a
+    /// leaked prompt for it is auto-approved instead of reaping.</summary>
     [Test]
     [Arguments("Running: fs_read")]
     [Arguments("fs_read")]


### PR DESCRIPTION
## Problem

A workspace-backed unattended review flow with an ACP reviewer (observed with **kiro**) is reaped at launch:

```
Error (participant_launch_failed): Participant 'reviewer' agent '…' failed to launch: unattended_interaction_forbidden:session/request_permission
```

Context-only mode (diff inlined) reviews cleanly with the same vendor, so the frame is provoked by the workspace-backed mode reading the mirrored worktree, not by the vendor being broken.

## Root cause

Under `AllowlistedAutoApprove`, the daemon admits a leaked `session/request_permission` frame only if it names a tool the launch trusts. But `UnattendedToolAdmission.AdmittedFor` was built from **only the `@server/tool` namespaced half** of the trust list, while the `--trust-tools` argv (`KiroReviewerTrustList.Build`) also grants the **native tools** `fs_read` and `thinking`.

So a leaked prompt for `fs_read` — a tool the launch already trusts, which the vendor prompts for intermittently even when trusted (the same leak that motivated `AllowlistedAutoApprove` for the injected result channel) — was *refused* by admission and reaped. A workspace-backed launch reads the mirrored worktree and hits `fs_read`; context-only reads nothing and never does.

The factory already states the intended invariant — the admitted set is "built from the SAME injected specs and identity the trust argv is built from … Two derivations would let the reviewer be TRUSTED to call a tool the policy then refuses to approve" — so admission being *narrower* than trust is the defect.

## Fix

1. **`AdmittedFor` returns the full trust set** — native tools ∪ namespaced entries — so admission equals trust. `fs_write`/`execute_bash` are in neither, so the read-only containment floor is unchanged.
2. **Reap diagnostics**: the `AllowlistedAutoApprove` permission-frame reap now logs the (untrusted, agent-supplied) tool **title + kind**. Previously only the method was logged, so the leaked frame was undiagnosable even from the daemon log.

## Caveat

The match stays a **complete-title** comparison (the deliberate anti-substring rule). Kiro's MCP-tool titles are `Running: @server/tool`; a native-tool title shape was never captured by probe, so if a native frame's title is presentation text rather than `fs_read`, the fix is inert for that frame and fails closed — the new diagnostic (2) is what will let us refine `IsAdmitted` with the real title. The companion kcap-server change surfaces a `context-only` remediation hint on this coded reason so the workaround no longer needs tribal knowledge.

## Testing

- `UnattendedToolAdmissionTests`: the previously-pinned "namespaced half" test is now "the full trust list"; added native-tool admitted cases (`fs_read`, `thinking`) and the containment-floor refusals (`fs_write`, `execute_bash`).
- Existing `AcpInteractionBridgeTests` / preset tests remain green; AOT publish is IL-clean.

Closes #614
Linear: AI-2096
