### PR TITLE
[AI-2084] Defer the reviewer lifetime cap while a turn is in flight

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -776,16 +776,26 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <para><b>Decision table</b>, in this order. A <see cref="TimeSpan.Zero"/> config value disables
     /// its own rule:
     /// <list type="number">
-    /// <item><see cref="DaemonConfig.ReviewerMaxLifetime"/> (6h) vs <c>AgeMs</c> ⇒
-    ///   <c>reviewer_ttl_expired</c>. Absolute, checked first — it holds regardless of activity or a
-    ///   held turn.</item>
+    /// <item>the HARD lifetime ceiling — <see cref="DaemonConfig.ReviewerMaxLifetime"/> plus one
+    ///   <see cref="DaemonConfig.ReviewerTurnWedgeCeiling"/> — vs <c>AgeMs</c> ⇒
+    ///   <c>reviewer_ttl_expired</c>, unfenced. Absolute: it holds regardless of activity or a held
+    ///   turn, so a runaway turn (or output stream) that keeps advancing the seq stays mortal.</item>
+    /// <item><see cref="DaemonConfig.ReviewerMaxLifetime"/> (6h) vs <c>AgeMs</c> with NO turn held ⇒
+    ///   <c>reviewer_ttl_expired</c>, FENCED on activity: reaping an actively-working reviewer
+    ///   mid-round burns the dispatched round and its accumulated context, so a held turn defers
+    ///   the cap (bounded by rule 1) and a delivery racing the sweep aborts the claim — the reap
+    ///   lands on the first genuinely quiet sweep past the lifetime instead. A disabled wedge
+    ///   ceiling collapses rule 1 onto the lifetime, restoring the original absolute cap.</item>
     /// <item>a HELD TURN suppresses the idle rule (a long tool run is legitimate) UNLESS
     ///   <c>IdleForMs</c> passes <see cref="DaemonConfig.ReviewerTurnWedgeCeiling"/> ⇒
     ///   <c>turn_wedged</c>. Any mid-turn envelope calls <c>Advance()</c> and re-arms it, so only a
     ///   genuinely frozen turn is wedge-reaped.</item>
     /// <item><see cref="DaemonConfig.ReviewerIdleTimeout"/> (2h) vs <c>IdleForMs</c> ⇒
     ///   <c>reviewer_idle_expired</c>.</item>
-    /// </list></para>
+    /// </list>
+    /// A PTY vendor never sets <c>TurnInFlight</c>, so mid-round it gets only rule 2's activity
+    /// fence (every output chunk advances the seq), not rule 2's held-turn deferral — a quiet
+    /// tool wait past the lifetime can still be reaped there.</para>
     ///
     /// <para><b>The server's <see cref="AgentInstance.InactivityBoundSeconds"/> must never appear in
     /// that table.</b> It is ROUND-SCOPED — the server applies it only while a round is in flight, and
@@ -818,11 +828,26 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             var clock = a.ActivityClock.Snapshot();
 
             if (_config.ReviewerMaxLifetime > TimeSpan.Zero && clock.AgeMs > (ulong) _config.ReviewerMaxLifetime.TotalMilliseconds) {
-                // The absolute cap is deliberately NOT activity-fenced: it fires regardless of how
-                // active the reviewer is (that is what "absolute" means here), so a delivery racing it
-                // must not abort it.
-                result.Add(new ReapCandidate(a, "reviewer_ttl_expired", clock.ActivitySeq, FencedOnActivity: false));
-                continue;
+                var graceMs = _config.ReviewerTurnWedgeCeiling > TimeSpan.Zero
+                    ? (ulong) _config.ReviewerTurnWedgeCeiling.TotalMilliseconds
+                    : 0UL;
+
+                if (clock.AgeMs > (ulong) _config.ReviewerMaxLifetime.TotalMilliseconds + graceMs) {
+                    // The hard ceiling is deliberately NOT activity-fenced: it fires regardless of how
+                    // active the reviewer is (that is what "absolute" means here), so a delivery racing
+                    // it must not abort it.
+                    result.Add(new ReapCandidate(a, "reviewer_ttl_expired", clock.ActivitySeq, FencedOnActivity: false));
+                    continue;
+                }
+
+                if (!clock.TurnInFlight) {
+                    // Fenced: a delivery between this selection and the claim means a round just
+                    // started — abort and let a quieter sweep reap it (decision table rule 2).
+                    result.Add(new ReapCandidate(a, "reviewer_ttl_expired", clock.ActivitySeq, FencedOnActivity: true));
+                    continue;
+                }
+                // Past the lifetime with a held turn: deferred to the hard ceiling. Fall through so
+                // the wedge rule still owns a frozen turn.
             }
 
             if (clock.TurnInFlight) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -774,28 +774,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// share one decision.
     ///
     /// <para><b>Decision table</b>, in this order. A <see cref="TimeSpan.Zero"/> config value disables
-    /// its own rule:
-    /// <list type="number">
-    /// <item>the HARD lifetime ceiling — <see cref="DaemonConfig.ReviewerMaxLifetime"/> plus one
-    ///   <see cref="DaemonConfig.ReviewerTurnWedgeCeiling"/> — vs <c>AgeMs</c> ⇒
-    ///   <c>reviewer_ttl_expired</c>, unfenced. Absolute: it holds regardless of activity or a held
-    ///   turn, so a runaway turn (or output stream) that keeps advancing the seq stays mortal.</item>
-    /// <item><see cref="DaemonConfig.ReviewerMaxLifetime"/> (6h) vs <c>AgeMs</c> with NO turn held ⇒
-    ///   <c>reviewer_ttl_expired</c>, FENCED on activity: reaping an actively-working reviewer
-    ///   mid-round burns the dispatched round and its accumulated context, so a held turn defers
-    ///   the cap (bounded by rule 1) and a delivery racing the sweep aborts the claim — the reap
-    ///   lands on the first genuinely quiet sweep past the lifetime instead. A disabled wedge
-    ///   ceiling collapses rule 1 onto the lifetime, restoring the original absolute cap.</item>
-    /// <item>a HELD TURN suppresses the idle rule (a long tool run is legitimate) UNLESS
-    ///   <c>IdleForMs</c> passes <see cref="DaemonConfig.ReviewerTurnWedgeCeiling"/> ⇒
-    ///   <c>turn_wedged</c>. Any mid-turn envelope calls <c>Advance()</c> and re-arms it, so only a
-    ///   genuinely frozen turn is wedge-reaped.</item>
-    /// <item><see cref="DaemonConfig.ReviewerIdleTimeout"/> (2h) vs <c>IdleForMs</c> ⇒
-    ///   <c>reviewer_idle_expired</c>.</item>
-    /// </list>
-    /// A PTY vendor never sets <c>TurnInFlight</c>, so mid-round it gets only rule 2's activity
-    /// fence (every output chunk advances the seq), not rule 2's held-turn deferral — a quiet
-    /// tool wait past the lifetime can still be reaped there.</para>
+    /// its own rule. The lifetime cap (<see cref="DaemonConfig.ReviewerMaxLifetime"/>, 6h) is
+    /// two-tier: past lifetime + one <see cref="DaemonConfig.ReviewerTurnWedgeCeiling"/> it is
+    /// absolute and unfenced (a runaway turn or output stream must stay mortal, and a disabled
+    /// wedge ceiling collapses this tier onto the lifetime); in between it selects only a
+    /// visibly-at-rest reviewer — a held turn defers it, and so does activity within
+    /// <see cref="LifetimeReapQuietWindow"/>, because reaping mid-round burns the dispatched round
+    /// plus the reviewer's context, and a just-delivered round may not have flagged its turn yet
+    /// (the busy signal is asynchronous — e.g. Pi's <c>agent_start</c>). The wedge rule
+    /// (<c>turn_wedged</c>) and the idle rule (<c>reviewer_idle_expired</c>) are unchanged. A PTY
+    /// vendor never sets <c>TurnInFlight</c>; mid-round it relies on the quiet window and the
+    /// activity fence alone.</para>
     ///
     /// <para><b>The server's <see cref="AgentInstance.InactivityBoundSeconds"/> must never appear in
     /// that table.</b> It is ROUND-SCOPED — the server applies it only while a round is in flight, and
@@ -840,14 +829,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     continue;
                 }
 
-                if (!clock.TurnInFlight) {
-                    // Fenced: a delivery between this selection and the claim means a round just
-                    // started — abort and let a quieter sweep reap it (decision table rule 2).
+                if (!clock.TurnInFlight && clock.IdleForMs > (ulong) LifetimeReapQuietWindow.TotalMilliseconds) {
                     result.Add(new ReapCandidate(a, "reviewer_ttl_expired", clock.ActivitySeq, FencedOnActivity: true));
                     continue;
                 }
-                // Past the lifetime with a held turn: deferred to the hard ceiling. Fall through so
-                // the wedge rule still owns a frozen turn.
+                // Held turn, or activity inside the quiet window (a delivered round whose busy
+                // signal has not landed yet): deferred to the hard ceiling. Fall through so the
+                // wedge rule still owns a frozen turn.
             }
 
             if (clock.TurnInFlight) {
@@ -2752,6 +2740,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// rather than by inflating this wait, which would only restore the deadlock it exists to
     /// prevent.</para></summary>
     internal TimeSpan ReapClaimGateWait { get; set; } = TimeSpan.FromSeconds(20);
+
+    /// <summary>How long a mid-band lifetime candidate (past <see cref="DaemonConfig.ReviewerMaxLifetime"/>,
+    /// under the hard ceiling, no turn held) must have been quiet before selection. One heartbeat:
+    /// long enough for a just-delivered round's asynchronous busy signal to land, short enough that
+    /// a genuinely between-rounds reviewer is reaped on the next sweep.</summary>
+    internal TimeSpan LifetimeReapQuietWindow { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>Execute one selected reap: claim it under the per-agent fence, and stop the agent only
     /// if the claim was WON. Fire-and-forget from the heartbeat, so it contains its own faults —

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ReviewerReapingTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ReviewerReapingTests.cs
@@ -434,11 +434,12 @@ public class ReviewerReapingTests {
         await Assert.That(server.StatusReportCount).IsEqualTo(reportsAtClaim);
     }
 
-    /// <summary>The fence is scoped to the "nothing has happened" rules. The 6h absolute cap is not one
-    /// of them: it reaps a reviewer that is demonstrably active — here one that took a round AFTER
-    /// selection, advancing the very generation the idle/wedge rules would have aborted on — because
-    /// "absolute" is exactly what it means. Without the scoping, the one rule that guarantees a leaked
-    /// daemon slot is eventually reclaimed becomes indefinitely deferrable by traffic.</summary>
+    /// <summary>The fence is scoped to the "nothing has happened" rules. The hard lifetime ceiling
+    /// (lifetime + one wedge ceiling) is not one of them: it reaps a reviewer that is demonstrably
+    /// active — here one that took a round AFTER selection, advancing the very generation the
+    /// idle/wedge rules would have aborted on — because "absolute" is exactly what it means. Without
+    /// the scoping, the one rule that guarantees a leaked daemon slot is eventually reclaimed becomes
+    /// indefinitely deferrable by traffic.</summary>
     [Test]
     public async Task Max_lifetime_reaps_regardless_of_delivery() {
         var server = new CaptureServerConnection();
@@ -451,7 +452,7 @@ public class ReviewerReapingTests {
         var agent = orch.SeedAgentForTest("ttl-reap", LaunchKind.ReviewFlow, status: "Running",
             pty: new RecordingPtyProcess(), activityClock: clock);
 
-        time.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1)); // past the 6h absolute cap
+        time.Advance(TimeSpan.FromHours(7) + TimeSpan.FromMinutes(1)); // past the 6h+60m hard ceiling
 
         var candidate = orch.FindReviewersToReap().Single(c => c.Id == "ttl-reap");
         await Assert.That(candidate.Reason).IsEqualTo("reviewer_ttl_expired");
@@ -507,7 +508,7 @@ public class ReviewerReapingTests {
         var expired = orch.SeedAgentForTest("parked-ttl", LaunchKind.ReviewFlow, status: "Running",
             pty: ttlPty, activityClock: ttlClock);
 
-        ttlTime.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1));
+        ttlTime.Advance(TimeSpan.FromHours(7) + TimeSpan.FromMinutes(1)); // past the 6h+60m hard ceiling
 
         var ttlCandidate = orch.FindReviewersToReap().Single(c => c.Id == "parked-ttl");
         await Assert.That(ttlCandidate.Reason).IsEqualTo("reviewer_ttl_expired");
@@ -586,7 +587,7 @@ public class ReviewerReapingTests {
         var agent = orch.SeedAgentForTest("parked-exit", LaunchKind.ReviewFlow, status: "Running",
             pty: pty, activityClock: clock);
 
-        time.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1));
+        time.Advance(TimeSpan.FromHours(7) + TimeSpan.FromMinutes(1)); // past the 6h+60m hard ceiling
 
         var candidate = orch.FindReviewersToReap().Single(c => c.Id == "parked-exit");
         await Assert.That(candidate.Reason).IsEqualTo("reviewer_ttl_expired");
@@ -641,7 +642,7 @@ public class ReviewerReapingTests {
         var agent = orch.SeedAgentForTest("healthy-in-flight", LaunchKind.ReviewFlow, status: "Running",
             pty: pty, activityClock: clock);
 
-        time.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1));
+        time.Advance(TimeSpan.FromHours(7) + TimeSpan.FromMinutes(1)); // past the 6h+60m hard ceiling
 
         var candidate = orch.FindReviewersToReap().Single(c => c.Id == "healthy-in-flight");
         await Assert.That(candidate.Reason).IsEqualTo("reviewer_ttl_expired");

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ReviewerReapingTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ReviewerReapingTests.cs
@@ -68,7 +68,7 @@ public class ReviewerReapingTests {
 
         var activeTime  = new FakeTimeProvider();
         var activeClock = new AgentActivityClock(activeTime);
-        activeTime.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1));
+        activeTime.Advance(TimeSpan.FromHours(7) + TimeSpan.FromMinutes(1)); // past the 6h+60m hard ceiling
         activeClock.Advance(); // genuinely active at the moment of the check — idle ~0, only the TTL can fire
         orch.SeedAgentForTest("bound-active-old", LaunchKind.ReviewFlow, status: "Running",
             activityClock: activeClock, inactivityBoundSeconds: 600);
@@ -163,7 +163,7 @@ public class ReviewerReapingTests {
 
         var activeTime  = new FakeTimeProvider();
         var activeClock = new AgentActivityClock(activeTime);
-        activeTime.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1));
+        activeTime.Advance(TimeSpan.FromHours(7) + TimeSpan.FromMinutes(1)); // past the 6h+60m hard ceiling
         activeClock.Advance(); // genuinely active right up to the moment of the check — idle ~0
         orch.SeedAgentForTest("active-old", LaunchKind.ReviewFlow, status: "Running", activityClock: activeClock);
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ReviewerTtlTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ReviewerTtlTests.cs
@@ -57,6 +57,99 @@ public class ReviewerTtlTests {
         await Assert.That(reap.Select(r => r.Id)).DoesNotContain("rev-fresh");
     }
 
+    /// <summary>A held turn defers the absolute lifetime cap: past the 6h lifetime but under the
+    /// 6h+60m hard ceiling with a turn in flight (an actively-working reviewer mid-round) must NOT
+    /// be reaped — killing it here burns the dispatched round and the reviewer's accumulated
+    /// context. The wedge rule still owns a frozen turn.</summary>
+    [Test]
+    public async Task Held_turn_defers_the_lifetime_cap_under_the_hard_ceiling() {
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        // defaults: 6h lifetime, 60m wedge ceiling → hard ceiling 7h.
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(10));
+        clock.SetTurnInFlight(true);
+        clock.Advance(); // round input just delivered; the turn is genuinely active (idle ~0)
+
+        orch.SeedAgentForTest("rev-mid-turn", LaunchKind.ReviewFlow, status: "Running", activityClock: clock);
+
+        await Assert.That(orch.FindReviewersToReap().Select(r => r.Id)).DoesNotContain("rev-mid-turn");
+    }
+
+    /// <summary>The deferral is bounded: a held turn past the 6h+60m hard ceiling is reaped
+    /// unfenced (<c>FencedOnActivity: false</c>) however active it is — a runaway turn that keeps
+    /// advancing the seq forever must stay mortal.</summary>
+    [Test]
+    public async Task Held_turn_past_the_hard_ceiling_is_reaped_unfenced() {
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromHours(7) + TimeSpan.FromMinutes(1));
+        clock.SetTurnInFlight(true);
+        clock.Advance(); // still active — activity must not defer the hard ceiling
+
+        orch.SeedAgentForTest("rev-runaway", LaunchKind.ReviewFlow, status: "Running", activityClock: clock);
+
+        var reap = orch.FindReviewersToReap();
+
+        await Assert.That(AgentOrchestratorHarness.Verdicts(reap)).Contains(("rev-runaway", "reviewer_ttl_expired"));
+        await Assert.That(reap.Single(r => r.Id == "rev-runaway").FencedOnActivity).IsFalse();
+    }
+
+    /// <summary>With no turn held, the lifetime candidate under the hard ceiling is fenced on
+    /// activity — a delivery or output racing the sweep (a round just started) aborts the claim,
+    /// and the reviewer is reaped at the first genuinely quiet sweep instead. Past the hard
+    /// ceiling the candidate reverts to unfenced (the absolute backstop).</summary>
+    [Test]
+    public async Task Lifetime_candidate_without_a_turn_is_fenced_until_the_hard_ceiling() {
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var midBandTime  = new FakeTimeProvider();
+        var midBandClock = new AgentActivityClock(midBandTime);
+        midBandTime.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(10));
+        orch.SeedAgentForTest("rev-quiet", LaunchKind.ReviewFlow, status: "Running", activityClock: midBandClock);
+
+        var pastCapTime  = new FakeTimeProvider();
+        var pastCapClock = new AgentActivityClock(pastCapTime);
+        pastCapTime.Advance(TimeSpan.FromHours(7) + TimeSpan.FromMinutes(1));
+        orch.SeedAgentForTest("rev-past-cap", LaunchKind.ReviewFlow, status: "Running", activityClock: pastCapClock);
+
+        var reap = orch.FindReviewersToReap();
+
+        await Assert.That(AgentOrchestratorHarness.Verdicts(reap)).Contains(("rev-quiet", "reviewer_ttl_expired"));
+        await Assert.That(reap.Single(r => r.Id == "rev-quiet").FencedOnActivity).IsTrue();
+        await Assert.That(AgentOrchestratorHarness.Verdicts(reap)).Contains(("rev-past-cap", "reviewer_ttl_expired"));
+        await Assert.That(reap.Single(r => r.Id == "rev-past-cap").FencedOnActivity).IsFalse();
+    }
+
+    /// <summary>A disabled wedge ceiling (<c>Zero</c>) removes the held-turn deferral rather than
+    /// making it unbounded: with no frozen-turn backstop the lifetime cap keeps its original
+    /// absolute, unfenced bite even mid-turn.</summary>
+    [Test]
+    public async Task Disabled_wedge_ceiling_restores_the_absolute_unfenced_cap() {
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            configure: c => c.ReviewerTurnWedgeCeiling = TimeSpan.Zero);
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(1));
+        clock.SetTurnInFlight(true);
+        clock.Advance();
+
+        orch.SeedAgentForTest("rev-no-wedge", LaunchKind.ReviewFlow, status: "Running", activityClock: clock);
+
+        var reap = orch.FindReviewersToReap();
+
+        await Assert.That(AgentOrchestratorHarness.Verdicts(reap)).Contains(("rev-no-wedge", "reviewer_ttl_expired"));
+        await Assert.That(reap.Single(r => r.Id == "rev-no-wedge").FencedOnActivity).IsFalse();
+    }
+
     [Test]
     public async Task FindReviewersToReap_disabled_when_bounds_are_zero() {
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ReviewerTtlTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ReviewerTtlTests.cs
@@ -23,11 +23,11 @@ public class ReviewerTtlTests {
             new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
         // defaults: 6h lifetime / 2h idle, no server-sent bound on any of these agents.
 
-        // Old AND still active: age past the 6h lifetime, but its most recent Advance() was just now
-        // (IdleForMs ~ 0) — proves the absolute cap survives even for an agent that is not idle.
+        // Old AND still active: age past the 6h+60m hard ceiling, most recent Advance() just now
+        // (IdleForMs ~ 0) — proves the absolute tier survives even for an agent that is not idle.
         var oldTime = new FakeTimeProvider();
         var oldClock = new AgentActivityClock(oldTime);
-        oldTime.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(50));
+        oldTime.Advance(TimeSpan.FromHours(7) + TimeSpan.FromMinutes(10));
         oldClock.Advance();
         orch.SeedAgentForTest("rev-old", LaunchKind.ReviewFlow, status: "Running", activityClock: oldClock);
 
@@ -57,10 +57,8 @@ public class ReviewerTtlTests {
         await Assert.That(reap.Select(r => r.Id)).DoesNotContain("rev-fresh");
     }
 
-    /// <summary>A held turn defers the absolute lifetime cap: past the 6h lifetime but under the
-    /// 6h+60m hard ceiling with a turn in flight (an actively-working reviewer mid-round) must NOT
-    /// be reaped — killing it here burns the dispatched round and the reviewer's accumulated
-    /// context. The wedge rule still owns a frozen turn.</summary>
+    /// <summary>Reaping mid-round burns the dispatched round and the reviewer's context — a held
+    /// turn defers the lifetime cap up to the hard ceiling.</summary>
     [Test]
     public async Task Held_turn_defers_the_lifetime_cap_under_the_hard_ceiling() {
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
@@ -78,9 +76,8 @@ public class ReviewerTtlTests {
         await Assert.That(orch.FindReviewersToReap().Select(r => r.Id)).DoesNotContain("rev-mid-turn");
     }
 
-    /// <summary>The deferral is bounded: a held turn past the 6h+60m hard ceiling is reaped
-    /// unfenced (<c>FencedOnActivity: false</c>) however active it is — a runaway turn that keeps
-    /// advancing the seq forever must stay mortal.</summary>
+    /// <summary>A runaway turn that keeps advancing the seq forever must stay mortal — the
+    /// deferral is bounded by the hard ceiling.</summary>
     [Test]
     public async Task Held_turn_past_the_hard_ceiling_is_reaped_unfenced() {
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
@@ -100,10 +97,8 @@ public class ReviewerTtlTests {
         await Assert.That(reap.Single(r => r.Id == "rev-runaway").FencedOnActivity).IsFalse();
     }
 
-    /// <summary>With no turn held, the lifetime candidate under the hard ceiling is fenced on
-    /// activity — a delivery or output racing the sweep (a round just started) aborts the claim,
-    /// and the reviewer is reaped at the first genuinely quiet sweep instead. Past the hard
-    /// ceiling the candidate reverts to unfenced (the absolute backstop).</summary>
+    /// <summary>The mid-band candidate is fenced so a delivery racing the sweep aborts the claim;
+    /// past the hard ceiling it reverts to the unfenced absolute backstop.</summary>
     [Test]
     public async Task Lifetime_candidate_without_a_turn_is_fenced_until_the_hard_ceiling() {
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
@@ -127,9 +122,34 @@ public class ReviewerTtlTests {
         await Assert.That(reap.Single(r => r.Id == "rev-past-cap").FencedOnActivity).IsFalse();
     }
 
-    /// <summary>A disabled wedge ceiling (<c>Zero</c>) removes the held-turn deferral rather than
-    /// making it unbounded: with no frozen-turn backstop the lifetime cap keeps its original
-    /// absolute, unfenced bite even mid-turn.</summary>
+    /// <summary>The busy signal for a delivered round is asynchronous (e.g. Pi flags its turn only
+    /// when <c>agent_start</c> arrives), so a mid-band candidate with activity inside the quiet
+    /// window is not selected at all — the claim fence alone cannot see a delivery that preceded
+    /// selection.</summary>
+    [Test]
+    public async Task Recently_active_lifetime_candidate_is_deferred_until_quiet() {
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        // default LifetimeReapQuietWindow: 30s
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromHours(6) + TimeSpan.FromMinutes(10));
+        clock.Advance(); // the round input was just delivered; no turn flagged yet
+
+        orch.SeedAgentForTest("rev-delivered", LaunchKind.ReviewFlow, status: "Running", activityClock: clock);
+
+        await Assert.That(orch.FindReviewersToReap().Select(r => r.Id)).DoesNotContain("rev-delivered");
+
+        time.Advance(TimeSpan.FromSeconds(31)); // still silent one sweep later — genuinely at rest
+
+        var reap = orch.FindReviewersToReap();
+        await Assert.That(AgentOrchestratorHarness.Verdicts(reap)).Contains(("rev-delivered", "reviewer_ttl_expired"));
+        await Assert.That(reap.Single(r => r.Id == "rev-delivered").FencedOnActivity).IsTrue();
+    }
+
+    /// <summary>A disabled wedge ceiling removes the deferral rather than making it unbounded —
+    /// with no frozen-turn backstop the cap keeps its original absolute bite.</summary>
     [Test]
     public async Task Disabled_wedge_ceiling_restores_the_absolute_unfenced_cap() {
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(


### PR DESCRIPTION
## Defect 1 of AI-2084 (the daemon half; the server-side relaunch wedge was kcap-server #1536)

During a 17-round review flow, the reviewer reaper fired `reviewer_ttl_expired` on **age** (6.0h) with **idle 0.0h** — 21 seconds after round-17 input was delivered and a codex turn had started on it:

```
15:29:05.140  SendInput received for agent b1c67eea (chars=5886)
15:29:07.989  Codex turn started for agent b1c67eea after input
15:29:29.467  Reaping review-flow reviewer b1c67eea (reviewer_ttl_expired); age 6.0h, idle 0.0h
```

That burned the dispatched round (`participant_died`) and the reviewer's accumulated 17-round context. A legitimate multi-round review flow easily keeps one reviewer incarnation alive past any fixed age.

## Change

`FindReviewersToReap`'s lifetime rule becomes three-tiered (no new config):

1. **Hard ceiling** — `ReviewerMaxLifetime + ReviewerTurnWedgeCeiling` (6h+60m default): unfenced, absolute. Fires regardless of a held turn or any amount of activity, so a runaway turn (or output stream) that keeps advancing the seq stays mortal, and the "leaked slot is eventually reclaimed" guarantee survives.
2. **Held turn** (codex app-server, ACP, Pi, Antigravity — every vendor that maintains `TurnInFlight`): the lifetime cap defers entirely up to the hard ceiling. A frozen turn is still `turn_wedged` by the unchanged wedge rule, so deferral can't wedge.
3. **Past the lifetime with no turn held**: the candidate is now `FencedOnActivity: true` — a delivery or PTY output between selection and claim (a round just started) aborts the reap, and it lands on the first genuinely quiet sweep instead: typically between rounds, after the round result was submitted.

A disabled wedge ceiling (`Zero`) collapses the hard ceiling onto the lifetime, restoring the original absolute unfenced behavior — with the frozen-turn backstop off, the cap keeps its bite.

Incident replay under the new table: at 13:29:29 the turn is in flight and age < 7h → deferred; the round completes; the next quiet sweep reaps between rounds, and the (now-fixed) server heal relaunches a fresh reviewer on the following submit.

Known residual: a PTY vendor never sets `TurnInFlight`, so mid-round it gets only tier 3's activity fence (every output chunk advances the seq) — a quiet tool wait past the lifetime can still be reaped there.

## Tests

- `Held_turn_defers_the_lifetime_cap_under_the_hard_ceiling` — the incident shape (6h10m, turn in flight, idle ~0) must not be selected.
- `Held_turn_past_the_hard_ceiling_is_reaped_unfenced` and `Lifetime_candidate_without_a_turn_is_fenced_until_the_hard_ceiling` — the tier boundaries and fence flags.
- `Disabled_wedge_ceiling_restores_the_absolute_unfenced_cap`.
- Mutation-verified: forcing the grace to zero fails exactly the two deferral tests.
- The four `ReviewerReapingTests` that exercise the unfenced-claim machinery (lock-free claim past a parked delivery, bounded graceful-exit, condemned-agent refusal) re-aged from 6h+1m to 7h+1m — the machinery is unchanged, it just lives at the hard ceiling now.
- Full `Capacitor.Cli.Daemon.Tests.Unit`: the only failures are 6 `CodexConfigWriterTests` that fail identically on pristine origin/main in this environment plus 2 parallel-load flakes that pass in isolation on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)