### PR TITLE
[AI-1762] guard-1: suppress the codex hook watcher for envelope-sourced sessions

### DIFF
--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -76,7 +76,14 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
 
         var (sandbox, approval) = CodexPosturePolicy.Resolve(ctx.Work, ctx.IsReviewFlow, ctx.CodexPosture);
         var appServerArgs = _launcher.BuildAppServerLaunchArgs(launcherCtx);
-        var env           = BuildEnv(ctx);
+
+        // §2.5: an envelope-sourced session is the transcript's exclusive source, so the
+        // KCAP_HOSTED_APPSERVER marker (which makes the codex hook/watcher stand down — guard-1) and the
+        // runtime's own envelope emission must never disagree — both read this ONE decision. It stays
+        // false until the activation slice flips it together with the runtime's Transcript wiring, so
+        // guard-1 lands dormant and the shipped reviewers keep hook ingestion.
+        var emitEnvelopeTranscript = false;
+        var env                    = BuildEnv(ctx, emitEnvelopeTranscript);
 
         var launch = new CodexAppServerLaunch(
             Cwd:           ctx.Worktree.Path,
@@ -93,7 +100,8 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
 
         var runtime = new CodexAppServerHostedAgentRuntime(
             spawn, launch, ctx.ActivityClock,
-            _loggerFactory.CreateLogger<CodexAppServerHostedAgentRuntime>());
+            _loggerFactory.CreateLogger<CodexAppServerHostedAgentRuntime>(),
+            emitEnvelopeTranscript: emitEnvelopeTranscript);
 
         // StartAsync may spawn a child before it throws (a failed hooks/list, thread/start, or initial
         // turn on the fail-closed paths). The orchestrator never receives a runtime it did not get a
@@ -126,7 +134,7 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
         CodexPosture = ctx.CodexPosture,
     };
 
-    static Dictionary<string, string> BuildEnv(RuntimeStartContext ctx) {
+    internal static Dictionary<string, string> BuildEnv(RuntimeStartContext ctx, bool emitEnvelopeTranscript) {
         var env = new Dictionary<string, string> {
             ["KCAP_RENDERED_AGENT"] = "1",
             ["KCAP_AGENT_ID"]       = ctx.AgentId,
@@ -135,6 +143,9 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
         if (!string.IsNullOrEmpty(ctx.DaemonEpoch))     env["KCAP_DAEMON_EPOCH"] = ctx.DaemonEpoch;
         if (!string.IsNullOrEmpty(ctx.ServerUrl))       env["KCAP_URL"]          = ctx.ServerUrl;
         if (!string.IsNullOrEmpty(ctx.DaemonBridgeUrl)) env["KCAP_DAEMON_URL"]   = ctx.DaemonBridgeUrl;
+        // §2.5 guard-1: only an envelope-sourced session carries this marker; the codex hook +
+        // watcher inherit it and stand down so the rollout is not double-ingested alongside the envelopes.
+        if (emitEnvelopeTranscript) env["KCAP_HOSTED_APPSERVER"] = "1";
         return env;
     }
 

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -77,11 +77,8 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
         var (sandbox, approval) = CodexPosturePolicy.Resolve(ctx.Work, ctx.IsReviewFlow, ctx.CodexPosture);
         var appServerArgs = _launcher.BuildAppServerLaunchArgs(launcherCtx);
 
-        // §2.5: an envelope-sourced session is the transcript's exclusive source, so the
-        // KCAP_HOSTED_APPSERVER marker (which makes the codex hook/watcher stand down — guard-1) and the
-        // runtime's own envelope emission must never disagree — both read this ONE decision. It stays
-        // false until the activation slice flips it together with the runtime's Transcript wiring, so
-        // guard-1 lands dormant and the shipped reviewers keep hook ingestion.
+        // Marker stamping (guard-1) and the runtime's envelope emission must use the SAME decision, or a
+        // session could be hook-suppressed with no envelope source. The activation slice flips it on.
         var emitEnvelopeTranscript = false;
         var env                    = BuildEnv(ctx, emitEnvelopeTranscript);
 
@@ -134,6 +131,8 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
         CodexPosture = ctx.CodexPosture,
     };
 
+    internal const string HostedAppServerMarkerEnv = "KCAP_HOSTED_APPSERVER";
+
     internal static Dictionary<string, string> BuildEnv(RuntimeStartContext ctx, bool emitEnvelopeTranscript) {
         var env = new Dictionary<string, string> {
             ["KCAP_RENDERED_AGENT"] = "1",
@@ -143,10 +142,19 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
         if (!string.IsNullOrEmpty(ctx.DaemonEpoch))     env["KCAP_DAEMON_EPOCH"] = ctx.DaemonEpoch;
         if (!string.IsNullOrEmpty(ctx.ServerUrl))       env["KCAP_URL"]          = ctx.ServerUrl;
         if (!string.IsNullOrEmpty(ctx.DaemonBridgeUrl)) env["KCAP_DAEMON_URL"]   = ctx.DaemonBridgeUrl;
-        // §2.5 guard-1: only an envelope-sourced session carries this marker; the codex hook +
-        // watcher inherit it and stand down so the rollout is not double-ingested alongside the envelopes.
-        if (emitEnvelopeTranscript) env["KCAP_HOSTED_APPSERVER"] = "1";
+        // guard-1: only an envelope-sourced session carries this marker; the codex hook + watcher read it
+        // and stand down so the rollout is not double-ingested alongside the envelopes.
+        if (emitEnvelopeTranscript) env[HostedAppServerMarkerEnv] = "1";
         return env;
+    }
+
+    // Materialize the child's environment. The marker must reflect THIS launch's emit decision only —
+    // never a value inherited from the daemon's own environment, or a non-emitting child would suppress
+    // its hook watcher and lose transcript ingestion. Clear any inherited marker, then apply the overlay
+    // (which carries the marker only when emitting).
+    internal static void ApplyChildEnv(IDictionary<string, string?> childEnv, IReadOnlyDictionary<string, string> overlay) {
+        childEnv.Remove(HostedAppServerMarkerEnv);
+        foreach (var (k, v) in overlay) childEnv[k] = v;
     }
 
     /// <summary>The real spawn: <c>codex app-server</c> as a child process, its stdio wrapped by the
@@ -168,7 +176,7 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
             UseShellExecute        = false,
             WorkingDirectory       = cwd,
         };
-        foreach (var (k, v) in env) psi.Environment[k] = v;
+        ApplyChildEnv(psi.Environment, env);
 
         var process = Process.Start(psi)
             ?? throw new InvalidOperationException($"Failed to start '{cliPath} {string.Join(' ', argv)}'.");

--- a/src/Capacitor.Cli/Commands/Harness/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CodexHookCommand.cs
@@ -455,6 +455,14 @@ static class CodexHookCommand {
     // own internal throttle/budget/try-catch make it safe to abandon if the process exits first;
     // reliable delivery for Codex sessions is carried by the daemon's periodic drain pass,
     // not by this opportunistic best-effort attempt.
+    // §2.5 guard-1: a hosted app-server codex session is envelope-sourced — the daemon pushes its
+    // transcript directly, so this hook must NOT spawn a rollout watcher (that would double-ingest the
+    // same session). The daemon stamps the marker on the codex process; the hook inherits it through the
+    // same channel as KCAP_AGENT_ID / KCAP_DAEMON_URL. Absent on every non-hosted and pre-activation
+    // session, so those keep the watcher exactly as before.
+    static bool IsEnvelopeSourcedHostedSession() =>
+        Environment.GetEnvironmentVariable("KCAP_HOSTED_APPSERVER") is "1";
+
     static Task RunPostStdoutWork(
             string baseUrl, HookSpool spool, JsonNode? enrichedNode, string? sessionId, HookPostOutcome outcome) {
         var transcriptSpool = new TranscriptSpool(PathHelpers.ConfigPath("transcript-spool"));
@@ -466,7 +474,7 @@ static class CodexHookCommand {
         var transcript = TryGetString(enrichedNode, "transcript_path");
         var cwd        = TryGetString(enrichedNode, "cwd");
 
-        return sessionId is not null && transcript is not null
+        return sessionId is not null && transcript is not null && !IsEnvelopeSourcedHostedSession()
             ? WatcherManager.EnsureWatcherRunning(
                 baseUrl, sessionId, transcript,
                 agentId: null, sessionIdOverride: null, cwd: cwd,
@@ -492,11 +500,15 @@ static class CodexHookCommand {
         var cwd        = TryGetString(node, "cwd");
 
         if (sessionId is not null && transcript is not null) {
-            await WatcherManager.EnsureWatcherRunning(
-                baseUrl, sessionId, transcript,
-                agentId: null, sessionIdOverride: null, cwd: cwd,
-                skipTitle: false, vendor: "codex"
-            );
+            // Guard-1: skip the watcher restart for an envelope-sourced hosted session (the daemon owns
+            // its transcript); the idle-marker stop POST still fires so the "working" indicator clears.
+            if (!IsEnvelopeSourcedHostedSession()) {
+                await WatcherManager.EnsureWatcherRunning(
+                    baseUrl, sessionId, transcript,
+                    agentId: null, sessionIdOverride: null, cwd: cwd,
+                    skipTitle: false, vendor: "codex"
+                );
+            }
 
             await PostBestEffortAsync(baseUrl, "stop", node, TimeSpan.FromSeconds(2));
         }

--- a/src/Capacitor.Cli/Commands/Harness/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CodexHookCommand.cs
@@ -455,11 +455,8 @@ static class CodexHookCommand {
     // own internal throttle/budget/try-catch make it safe to abandon if the process exits first;
     // reliable delivery for Codex sessions is carried by the daemon's periodic drain pass,
     // not by this opportunistic best-effort attempt.
-    // §2.5 guard-1: a hosted app-server codex session is envelope-sourced — the daemon pushes its
-    // transcript directly, so this hook must NOT spawn a rollout watcher (that would double-ingest the
-    // same session). The daemon stamps the marker on the codex process; the hook inherits it through the
-    // same channel as KCAP_AGENT_ID / KCAP_DAEMON_URL. Absent on every non-hosted and pre-activation
-    // session, so those keep the watcher exactly as before.
+    // guard-1: an envelope-sourced hosted session's transcript comes from the daemon, so spawning a
+    // rollout watcher here would double-ingest it. Marker absent on every other session.
     static bool IsEnvelopeSourcedHostedSession() =>
         Environment.GetEnvironmentVariable("KCAP_HOSTED_APPSERVER") is "1";
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -144,6 +144,53 @@ public class CodexHostedAgentRuntimeFactoryTests {
         }
     }
 
+    // ── Guard-1 marker (§2.5) ──────────────────────────────────────────────────────────
+    [Test]
+    public async Task BuildEnv_stamps_the_hosted_appserver_marker_only_when_emitting_envelopes() {
+        using var wt = new TempDir();
+        var ctx = Ctx(isReviewFlow: true, wt.Path);
+
+        var off = CodexHostedAgentRuntimeFactory.BuildEnv(ctx, emitEnvelopeTranscript: false);
+        var on  = CodexHostedAgentRuntimeFactory.BuildEnv(ctx, emitEnvelopeTranscript: true);
+
+        await Assert.That(off.ContainsKey("KCAP_HOSTED_APPSERVER")).IsFalse();
+        await Assert.That(on["KCAP_HOSTED_APPSERVER"]).IsEqualTo("1");
+    }
+
+    [Test]
+    [NotInParallel("HomeEnvVarMutation")]
+    public async Task App_server_launch_leaves_the_marker_unset_while_dormant() {
+        // The activation slice has not flipped emitEnvelopeTranscript, so a real app-server launch must
+        // NOT stamp the marker — otherwise the shipped reviewers (still hook-ingested) would lose the watcher.
+        var originalHome = Environment.GetEnvironmentVariable("HOME");
+        var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
+        using var home = new TempDir();
+        using var wt   = new TempDir();
+        WriteWorktreeHooks(wt);
+        await using var fake = new FakeCodexAppServer();
+        IReadOnlyDictionary<string, string>? capturedEnv = null;
+
+        try {
+            Environment.SetEnvironmentVariable("HOME", home.Path);
+            Environment.SetEnvironmentVariable("CODEX_HOME", home.PathTo(".codex"));
+
+            CodexAppServerSpawnFactory seam = (_, _, _, _, env, _, _) => {
+                capturedEnv = env;
+                return Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((fake.ConnectClient(), new FakeAcpProcess()));
+            };
+            var factory = Factory(new RecordingPtyFactory(), appServerActive: true, seam);
+
+            var start = await factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None).WaitAsync(HangGuard);
+            await start.Runtime.DisposeAsync();
+        } finally {
+            Environment.SetEnvironmentVariable("HOME", originalHome);
+            Environment.SetEnvironmentVariable("CODEX_HOME", originalCodexHome);
+        }
+
+        await Assert.That(capturedEnv).IsNotNull();
+        await Assert.That(capturedEnv!.ContainsKey("KCAP_HOSTED_APPSERVER")).IsFalse();
+    }
+
     [Test]
     [NotInParallel("HomeEnvVarMutation")]
     public async Task Missing_hooks_on_the_app_server_route_fails_closed() {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -192,6 +192,30 @@ public class CodexHostedAgentRuntimeFactoryTests {
     }
 
     [Test]
+    public async Task ApplyChildEnv_clears_an_inherited_marker_when_the_overlay_does_not_emit() {
+        // A daemon whose OWN environment carries the marker must not leak it to a non-emitting child —
+        // that child's hook would suppress the only watcher and lose the transcript.
+        var childEnv = new Dictionary<string, string?> { ["KCAP_HOSTED_APPSERVER"] = "1", ["PATH"] = "/usr/bin" };
+        var overlay  = new Dictionary<string, string> { ["KCAP_AGENT_ID"] = "agent-1" }; // dormant: no marker
+
+        CodexHostedAgentRuntimeFactory.ApplyChildEnv(childEnv, overlay);
+
+        await Assert.That(childEnv.ContainsKey("KCAP_HOSTED_APPSERVER")).IsFalse();
+        await Assert.That(childEnv["KCAP_AGENT_ID"]).IsEqualTo("agent-1");
+        await Assert.That(childEnv["PATH"]).IsEqualTo("/usr/bin");
+    }
+
+    [Test]
+    public async Task ApplyChildEnv_sets_the_marker_when_the_overlay_emits() {
+        var childEnv = new Dictionary<string, string?>();
+        var overlay  = new Dictionary<string, string> { ["KCAP_HOSTED_APPSERVER"] = "1" };
+
+        CodexHostedAgentRuntimeFactory.ApplyChildEnv(childEnv, overlay);
+
+        await Assert.That(childEnv["KCAP_HOSTED_APPSERVER"]).IsEqualTo("1");
+    }
+
+    [Test]
     [NotInParallel("HomeEnvVarMutation")]
     public async Task Missing_hooks_on_the_app_server_route_fails_closed() {
         var originalHome = Environment.GetEnvironmentVariable("HOME");

--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CodexHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CodexHookCommandTests.cs
@@ -492,7 +492,7 @@ public class CodexHookCommandTests : IDisposable {
 
         try {
             Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", "1");
-            var payload = """{"hook_event_name":"Stop","session_id":"abc","transcript_path":"/tmp/r.jsonl","cwd":"/tmp"}""";
+            var payload = """{"hook_event_name":"Stop","session_id":"g1-stop-suppressed","transcript_path":"/tmp/r.jsonl","cwd":"/tmp"}""";
 
             var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
             await Assert.That(exit).IsEqualTo(0);
@@ -526,7 +526,7 @@ public class CodexHookCommandTests : IDisposable {
 
         try {
             Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", null);
-            var payload = """{"hook_event_name":"Stop","session_id":"abc","transcript_path":"/tmp/r.jsonl","cwd":"/tmp"}""";
+            var payload = """{"hook_event_name":"Stop","session_id":"g1-stop-control","transcript_path":"/tmp/r.jsonl","cwd":"/tmp"}""";
 
             var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
             await Assert.That(exit).IsEqualTo(0);
@@ -550,7 +550,7 @@ public class CodexHookCommandTests : IDisposable {
 
         try {
             Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", "1");
-            var payload = """{"hook_event_name":"SessionStart","session_id":"abc","transcript_path":"/tmp/r.jsonl","cwd":"/tmp"}""";
+            var payload = """{"hook_event_name":"SessionStart","session_id":"g1-start-suppressed","transcript_path":"/tmp/r.jsonl","cwd":"/tmp"}""";
 
             var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
             await Assert.That(exit).IsEqualTo(0);

--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CodexHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CodexHookCommandTests.cs
@@ -477,6 +477,94 @@ public class CodexHookCommandTests : IDisposable {
         }
     }
 
+    // ---- Guard-1: envelope-sourced hosted session suppresses the watcher (§2.5) ----
+
+    [Test, NotInParallel]
+    public async Task Stop_skips_the_watcher_for_an_envelope_sourced_hosted_session() {
+        StubNoAuthRequired();
+        _server.Given(Request.Create().WithPath("/hooks/stop").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        var previousMarker = Environment.GetEnvironmentVariable("KCAP_HOSTED_APPSERVER");
+        var spawned = new List<string>();
+        Capacitor.Cli.WatcherManager.SpawnOverrideForTesting = key => { spawned.Add(key); return Task.CompletedTask; };
+        using var capture = ConsoleOutput.StartCapture();
+
+        try {
+            Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", "1");
+            var payload = """{"hook_event_name":"Stop","session_id":"abc","transcript_path":"/tmp/r.jsonl","cwd":"/tmp"}""";
+
+            var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
+            await Assert.That(exit).IsEqualTo(0);
+
+            // The watcher never spawns for an envelope-sourced session...
+            await Assert.That(spawned.Count).IsEqualTo(0);
+            // ...but only the watcher is suppressed: the idle-marker stop POST still fires.
+            var stopRequests = _server.FindLogEntries(Request.Create().WithPath("/hooks/stop").UsingPost());
+            await Assert.That(stopRequests.Count).IsEqualTo(1);
+
+            var doc = JsonDocument.Parse(capture.GetCapturedOutput());
+            await Assert.That(doc.RootElement.GetProperty("continue").GetBoolean()).IsTrue();
+        } finally {
+            Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", previousMarker);
+            Capacitor.Cli.WatcherManager.SpawnOverrideForTesting = null;
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task Stop_spawns_the_watcher_without_the_hosted_appserver_marker() {
+        // Positive control for the suppression test above: without the marker the watcher spawns, so the
+        // suppression assertion can actually fail if guard-1 regresses.
+        StubNoAuthRequired();
+        _server.Given(Request.Create().WithPath("/hooks/stop").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        var previousMarker = Environment.GetEnvironmentVariable("KCAP_HOSTED_APPSERVER");
+        var spawned = new List<string>();
+        Capacitor.Cli.WatcherManager.SpawnOverrideForTesting = key => { spawned.Add(key); return Task.CompletedTask; };
+        using var capture = ConsoleOutput.StartCapture();
+
+        try {
+            Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", null);
+            var payload = """{"hook_event_name":"Stop","session_id":"abc","transcript_path":"/tmp/r.jsonl","cwd":"/tmp"}""";
+
+            var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
+            await Assert.That(exit).IsEqualTo(0);
+
+            await Assert.That(spawned.Count).IsEqualTo(1);
+        } finally {
+            Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", previousMarker);
+            Capacitor.Cli.WatcherManager.SpawnOverrideForTesting = null;
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task SessionStart_skips_the_watcher_for_an_envelope_sourced_hosted_session() {
+        StubNoAuthRequired();
+        _server.Given(Request.Create().WithPath("/hooks/session-start/codex").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        var previousMarker = Environment.GetEnvironmentVariable("KCAP_HOSTED_APPSERVER");
+        var spawned = new List<string>();
+        Capacitor.Cli.WatcherManager.SpawnOverrideForTesting = key => { spawned.Add(key); return Task.CompletedTask; };
+
+        try {
+            Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", "1");
+            var payload = """{"hook_event_name":"SessionStart","session_id":"abc","transcript_path":"/tmp/r.jsonl","cwd":"/tmp"}""";
+
+            var exit = await CodexHookCommand.Handle(_server.Url!, new StringReader(payload));
+            await Assert.That(exit).IsEqualTo(0);
+
+            // No watcher for an envelope-sourced session; the session-start POST is untouched.
+            await Assert.That(spawned.Count).IsEqualTo(0);
+            var startRequests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start/codex").UsingPost());
+            await Assert.That(startRequests.Count).IsEqualTo(1);
+        } finally {
+            Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", previousMarker);
+            Capacitor.Cli.WatcherManager.SpawnOverrideForTesting = null;
+        }
+    }
+
     // ---- PermissionRequest daemon-bridge tests ----
     //
     // The no-daemon-URL "stub" branch is covered by the regression test


### PR DESCRIPTION
## What

Guard-1 of §2.5's ingestion dedup (the daemon half; guard-2 is the server per-write source refusal). A hosted app-server codex session will — once the activation slice flips it on — push its transcript through the daemon's **envelope** path. This guard stops the rollout **watcher** double-ingesting that same session.

- **Marker (daemon)** — `CodexHostedAgentRuntimeFactory.BuildEnv` stamps `KCAP_HOSTED_APPSERVER=1` on the spawned codex process **only when the runtime is emitting envelopes**. The marker and the runtime's own emission now both read **one** `emitEnvelopeTranscript` decision in `StartAppServerAsync`, so they can never disagree — the activation slice flips both by flipping that single local.
- **Suppression (hook)** — `CodexHookCommand` skips `WatcherManager.EnsureWatcherRunning` at the SessionStart and Stop spawn sites when the inherited marker is present. **Only** the watcher (the transcript-forward vector) is suppressed; the idempotent lifecycle POSTs and the cross-session spool drain are untouched, so the idle-marker stop POST still clears the "working" indicator.

## Dormant

`emitEnvelopeTranscript` is hardcoded `false` here, so the marker is **never stamped** and the shipped reviewers (still hook-ingested) keep their watcher exactly as today. The activation slice (PR6) flips the one decision, and guard-1 + guard-2 + the emission all come alive together.

## Tests

- Daemon: `BuildEnv` stamps the marker **iff** emitting; a real app-server launch stamps **no** marker while dormant.
- Hook: watcher suppressed at both SessionStart and Stop when the marker is set (lifecycle POSTs still fire), with a **positive control** (no marker → watcher spawns) so the suppression assertion can actually fail on a regression.

Comments are Linear-id-free per `scripts/check-linear-ids.sh` (verified locally).

Part of AI-1762.