### PR TITLE
Quiesce shim install wizard tests against shared-session dispatcher leakage (AI-2093)

### DIFF
--- a/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
@@ -74,7 +74,14 @@ public class WizardSimpleStepsTests {
             Vm          = new ShimStepViewModel(true, Installer, Store, Target, Destination);
         }
 
-        public Task Install() => Vm.InstallCommand.Execute().ToTask();
+        // InstallCommand's IsExecuting/CanExecute/End notifications ride the dispatcher scheduler;
+        // drain them on the session thread before returning so this shared-session test leaves no
+        // dispatcher-queued work a sibling's frame could later surface off the UI thread. Also
+        // fully quiesces the first click before a second one starts.
+        public async Task Install() {
+            await Vm.InstallCommand.Execute().ToTask();
+            Dispatcher.UIThread.RunJobs();
+        }
 
         public void Dispose() => _tmp.Dispose();
     }
@@ -185,6 +192,7 @@ public class WizardSimpleStepsTests {
             var vm = new ShimStepViewModel(true, h.Installer, h.Store, null, h.Destination);
 
             await vm.InstallCommand.Execute().ToTask();
+            Dispatcher.UIThread.RunJobs(); // drain the command's dispatcher-scheduled notifications, as ShimHarness.Install does
 
             return (vm.Satisfied, vm.Message, h.Store.Updates);
         });

--- a/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardSimpleStepsTests.cs
@@ -76,8 +76,7 @@ public class WizardSimpleStepsTests {
 
         // InstallCommand's IsExecuting/CanExecute/End notifications ride the dispatcher scheduler;
         // drain them on the session thread before returning so this shared-session test leaves no
-        // dispatcher-queued work a sibling's frame could later surface off the UI thread. Also
-        // fully quiesces the first click before a second one starts.
+        // dispatcher-queued work a sibling's frame could later surface off the UI thread.
         public async Task Install() {
             await Vm.InstallCommand.Execute().ToTask();
             Dispatcher.UIThread.RunJobs();
@@ -242,8 +241,7 @@ public class WizardSimpleStepsTests {
 
             h.Runner.Enqueue(new ProcessResult(0, "", "", false));
             h.Probe.KcapOnPathBehavior = _ => Task.FromResult<bool?>(true);
-            await h.Install();
-            Dispatcher.UIThread.RunJobs();
+            await h.Install(); // Install() already drains the dispatcher
 
             var successAfter = window.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault(t => t.Name == "ShimSuccessText")?.IsVisible;
             var installEnabledAfter = installButton?.IsEnabled;


### PR DESCRIPTION
## What

Defensively hardens the Shim-step onboarding wizard tests (`Capacitor.App.Tests.Unit/WizardSimpleStepsTests`) against the Windows CI thread-affinity flake tracked in **AI-2093** (`Install_claims_ShimOffered_exactly_once_across_two_clicks` — `InvalidOperationException: The calling thread cannot access this object because a different thread owns it`).

After each `InstallCommand` execution the test now drains the dispatcher on the session thread (`Dispatcher.UIThread.RunJobs()`), centralized in `ShimHarness.Install()` so it also runs *between* the two clicks. This is the same quiescence idiom already used by `The_window_selects_a_template_for_each_simple_step` and `SignInStepViewModelTests.CanExecute`: the command's `IsExecuting`/`CanExecute`/`End` notifications ride the `AvaloniaScheduler` (the dispatcher), so draining them before the test returns leaves no dispatcher-queued work a sibling test's frame — in the shared process-global headless session — could later surface off the UI thread.

## Why (and an honest caveat)

I traced the failure by decompiling the exact package versions (Avalonia 12.1.1, ReactiveUI 23.2.28, System.Reactive 6.x). The named test uses synchronous fakes, so `ReactiveCommand.CreateFromTask` on an already-completed task delivers via `Return(…, ImmediateScheduler)`, `AvaloniaScheduler` runs inline on the single session thread, and `HeadlessUnitTestSession.DispatchCore` takes its synchronous fast-path — i.e. the body runs entirely on the session thread and **cannot itself throw** a thread-affinity exception (platform-independent).

The most likely real mechanism is **mis-attribution**: a cross-thread exception leaked from another test in the same `[NotInParallel("AvaloniaSession")]` group surfaces during this test's context. This change makes the Shim tests quiesce cleanly (a genuine improvement) but may not, on its own, stop the flake if the true origin is elsewhere. If it recurs, the reliable follow-up is a global unobserved/cross-thread exception guard in the assembly to capture the real stack + culprit.

Test-only change; no CLI surface touched.

## Verification

- Build succeeded.
- `WizardSimpleStepsTests`: 14/14 pass.
- Full `Capacitor.App.Tests.Unit` assembly: 1141/1141, repeated runs green (plus a 15× stress loop under CPU load with zero thread-affinity hits).

## Issue references

- Linear: AI-2093
- No corresponding GitHub issue (filed directly in Linear).
