### PR TITLE
[AI-1762] §2.3: in-process approval bridge for interactive hosted Codex

### DIFF
--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -144,6 +144,11 @@ public class DaemonConfig {
     /// Never set from config directly.</summary>
     public bool CodexAppServerActive { get; set; }
 
+    /// <summary>Seconds an interactive hosted Codex approval (<c>*/requestApproval</c>) waits for the
+    /// user before failing closed (deny). Overridable via <c>KCAP_CODEX_APPSERVER_APPROVAL_TIMEOUT_SECONDS</c>.
+    /// Consumed as <c>TimeSpan.FromSeconds(Math.Max(1, …))</c>.</summary>
+    public int CodexAppServerApprovalTimeoutSeconds { get; set; } = 45;
+
     /// <summary>
     /// Path or bare command for the Cursor CLI's ACP entry point, spawned as
     /// <c>{CursorPath} acp</c> by <c>AcpHostedAgentRuntimeFactory</c>. Overridable

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -152,6 +152,10 @@ public static partial class DaemonRunner {
         if (Environment.GetEnvironmentVariable("KCAP_CODEX_TRANSPORT") is { Length: > 0 } envCodexTransport)
             config.CodexTransport = envCodexTransport;
 
+        if (Environment.GetEnvironmentVariable("KCAP_CODEX_APPSERVER_APPROVAL_TIMEOUT_SECONDS") is { Length: > 0 } envApprovalTimeout
+         && int.TryParse(envApprovalTimeout, out var approvalTimeoutSeconds) && approvalTimeoutSeconds > 0)
+            config.CodexAppServerApprovalTimeoutSeconds = approvalTimeoutSeconds;
+
         // One resolved fact for both the launch router and the certification advertisement.
         config.CodexAppServerActive = Harness.Codex.CodexTransportDecision.ResolveActive(
             config.CodexTransport, () => ProbeCliVersion(config.CodexPath));
@@ -431,7 +435,8 @@ public static partial class DaemonRunner {
             return new Harness.Codex.CodexHostedAgentRuntimeFactory(
                 (Harness.Codex.CodexLauncher) codexLauncher, pty,
                 sp.GetRequiredService<DaemonConfig>(),
-                sp.GetRequiredService<ILoggerFactory>());
+                sp.GetRequiredService<ILoggerFactory>(),
+                connection: sp.GetRequiredService<ServerConnection>()); // §2.3 interactive approvals
         });
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
             new AcpHostedAgentRuntimeFactory(

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -136,10 +136,20 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     // lands — the signal the orchestrator confirms on. Null with no initial prompt, or single-phase.
     Task? _firstTurnDispatch;
 
+    // §2.3 interactive approvals: non-null only for an INTERACTIVE launch (approvalPolicy != never) that
+    // was given a requestInteraction delegate — it forwards server-initiated requestApproval to the user
+    // and answers with their decision. Null on the reviewer path (never), which keeps DeclineServerRequestAsync.
+    readonly CodexApprovalBridge? _approvalBridge;
+
+    const double DefaultApprovalTimeoutSeconds = 45;
+
     public CodexAppServerHostedAgentRuntime(
             CodexAppServerSpawn spawn, CodexAppServerLaunch launch, AgentActivityClock? clock,
             ILogger logger, TimeProvider? timeProvider = null, TimeSpan? forwardStallTimeout = null,
-            bool emitEnvelopeTranscript = false, bool deferFirstTurn = false) {
+            bool emitEnvelopeTranscript = false, bool deferFirstTurn = false,
+            string? agentId = null,
+            Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>>? requestInteraction = null,
+            TimeSpan? approvalTimeout = null) {
         _spawn   = spawn;
         _launch  = launch;
         _clock   = clock;
@@ -147,6 +157,14 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         _time    = timeProvider ?? TimeProvider.System;
         _emitEnvelopeTranscript = emitEnvelopeTranscript;
         _deferFirstTurn = deferFirstTurn;
+        // Interactive iff approvals are actually raised (never ⇒ reviewer ⇒ decline path) AND we can both
+        // correlate (agentId) and reach the user (requestInteraction).
+        if (requestInteraction is not null && agentId is not null
+         && !string.Equals(_launch.Approval, "never", StringComparison.Ordinal)) {
+            _approvalBridge = new CodexApprovalBridge(
+                requestInteraction, agentId, logger,
+                approvalTimeout ?? TimeSpan.FromSeconds(DefaultApprovalTimeoutSeconds));
+        }
         _dispatcher = new CodexTurnInputDispatcher(
             startTurn: IssueTurnStartAsync, steerTurn: IssueTurnSteerAsync,
             logger: logger, ct: _cts.Token, onTurnInFlight: flip => _clock?.SetTurnInFlight(flip),
@@ -290,7 +308,9 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         _process    = process;
 
         connection.OnNotification  += HandleNotification;
-        connection.OnServerRequest  = DeclineServerRequestAsync;
+        // Interactive launches forward requestApproval to the user (§2.3); reviewers (approvalPolicy:never)
+        // keep declining, since a request there is a protocol violation, not a prompt.
+        connection.OnServerRequest  = _approvalBridge is { } bridge ? bridge.HandleAsync : DeclineServerRequestAsync;
 
         _childCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
         _runLoop  = RunConnectionAsync(connection, _childCts.Token);

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexApprovalBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexApprovalBridge.cs
@@ -35,9 +35,10 @@ internal sealed class CodexApprovalBridge {
         new("decline",          "Deny",                   null, "reject_once"),
     ];
 
-    // Fail-safe allowlist (mirrors AcpInteractionBridge.AffirmativeOutcomes): only these outcomes can
-    // grant; every other string denies. Keep in sync with the server's decision vocabulary.
-    static readonly HashSet<string> AffirmativeOutcomes = ["allow", "allow_once", "allow_always", "answered"];
+    // Fail-safe allowlist: only these (allow-family) outcomes can grant an APPROVAL; every other string
+    // denies. Deliberately excludes the ACP "answered" outcome — that is an elicitation result, not an
+    // approval grant, and this bridge handles approvals only, so narrowing it here shrinks the grant surface.
+    static readonly HashSet<string> AffirmativeOutcomes = ["allow", "allow_once", "allow_always"];
 
     public CodexApprovalBridge(
             Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> requestInteraction,
@@ -56,52 +57,52 @@ internal sealed class CodexApprovalBridge {
         if (!method.EndsWith("/requestApproval", StringComparison.Ordinal))
             return DeclineNonApproval(method);
 
-        // The permissions grant is a DIFFERENT response shape ({permissions,scope}) with no decision
-        // enum — a bare {decision:"decline"} is malformed for it, so route it separately. Match on the
-        // ITEM-TYPE segment (item/<type>/requestApproval), not a whole-method substring, so an unrelated
-        // path segment can't misroute a command/file-change approval into the grant shape.
+        // Route the permissions grant (a DIFFERENT {permissions,scope} shape, no decision enum) by an
+        // EXACT item-type segment match (item/<type>/requestApproval), not a substring — so neither an
+        // unrelated path segment nor a command-type item whose name merely contains "permission" can
+        // misroute into the grant shape.
         var itemType = ItemType(method);
-        var isPermissionsGrant = itemType.Contains("permission", StringComparison.OrdinalIgnoreCase);
+        var isPermissionsGrant = string.Equals(itemType, "permissions", StringComparison.OrdinalIgnoreCase)
+                              || string.Equals(itemType, "permission",  StringComparison.OrdinalIgnoreCase);
 
         JsonElement Deny() => isPermissionsGrant ? EmptyGrant() : DeclineDecision();
 
-        // Correlate on the request's OWN params (never a closed-over field): no resolvable thread id
-        // means the server cannot correlate this interaction — fail closed.
-        var threadId = TryGetString(request.Params, "threadId");
-        if (string.IsNullOrEmpty(threadId)) {
-            _logger.LogWarning("codex approval: {Method} carried no threadId; cannot correlate, denying.", method);
-            return Deny();
-        }
-
-        var interaction = new AcpInteractionRequest(
-            AgentId:      _agentId,
-            AcpSessionId: threadId,
-            Kind:         "permission",
-            ToolName:     itemType,
-            ToolInput:    request.Params,
-            ToolCallId:   TryGetString(request.Params, "itemId"),
-            Prompt:       null,
-            Options:      ApprovalOptions,
-            IsMultiSelect: false);
-
-        AcpInteractionDecision decision;
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCts.CancelAfter(_timeout);
-
         try {
-            decision = await _requestInteraction(interaction, timeoutCts.Token).ConfigureAwait(false);
+            // Correlate on the request's OWN params (never a closed-over field): no resolvable thread id
+            // means the server cannot correlate this interaction — fail closed.
+            var threadId = TryGetString(request.Params, "threadId");
+            if (string.IsNullOrEmpty(threadId)) {
+                _logger.LogWarning("codex approval: {Method} carried no threadId; cannot correlate, denying.", method);
+                return Deny();
+            }
+
+            var interaction = new AcpInteractionRequest(
+                AgentId:      _agentId,
+                AcpSessionId: threadId,
+                Kind:         "permission",
+                ToolName:     itemType,
+                ToolInput:    request.Params,
+                ToolCallId:   TryGetString(request.Params, "itemId"),
+                Prompt:       null,
+                Options:      ApprovalOptions,
+                IsMultiSelect: false);
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(_timeout);
+
+            var decision = await _requestInteraction(interaction, timeoutCts.Token).ConfigureAwait(false);
+
+            return isPermissionsGrant ? MapPermissionsGrant(decision, request.Params) : MapDecision(decision);
         } catch (OperationCanceledException) {
             // Timeout, connection close, or runtime dispose — deny (fail closed), never an error frame.
             _logger.LogDebug("codex approval: {Method} cancelled or timed out; denying.", method);
             return Deny();
         } catch (Exception ex) {
-            _logger.LogDebug(ex, "codex approval: requestInteraction threw for {Method}; denying.", method);
+            // The handler must NEVER throw: the connection layer would map it to a JSON-RPC -32603. Any
+            // unexpected failure (a thrown delegate, a mapping fault) denies with a valid body instead.
+            _logger.LogWarning(ex, "codex approval: unexpected failure handling {Method}; denying.", method);
             return Deny();
         }
-
-        return isPermissionsGrant
-            ? MapPermissionsGrant(decision, request.Params)
-            : MapDecision(decision);
     }
 
     // command/fileChange requestApproval → {decision: "accept"|"acceptForSession"|"decline"}.
@@ -165,7 +166,11 @@ internal sealed class CodexApprovalBridge {
             ? JsonNode.Parse(value.GetRawText())
             : null;
 
-    // JsonNode → JsonElement without reflection (AOT-safe), matching the runtime's own helper.
-    static JsonElement ToElement(JsonNode node) =>
-        JsonDocument.Parse(node.ToJsonString()).RootElement.Clone();
+    // JsonNode → JsonElement without reflection (AOT-safe). The clone is independent of the parsed
+    // document's pooled buffers, so disposing the document (rather than leaking its rented arrays under
+    // load) is safe.
+    static JsonElement ToElement(JsonNode node) {
+        using var doc = JsonDocument.Parse(node.ToJsonString());
+        return doc.RootElement.Clone();
+    }
 }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexApprovalBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexApprovalBridge.cs
@@ -57,9 +57,11 @@ internal sealed class CodexApprovalBridge {
             return DeclineNonApproval(method);
 
         // The permissions grant is a DIFFERENT response shape ({permissions,scope}) with no decision
-        // enum — a bare {decision:"decline"} is malformed for it, so route it separately.
-        var isPermissionsGrant = method.Contains("permissions", StringComparison.OrdinalIgnoreCase)
-                              || method.Contains("request_permissions", StringComparison.OrdinalIgnoreCase);
+        // enum — a bare {decision:"decline"} is malformed for it, so route it separately. Match on the
+        // ITEM-TYPE segment (item/<type>/requestApproval), not a whole-method substring, so an unrelated
+        // path segment can't misroute a command/file-change approval into the grant shape.
+        var itemType = ItemType(method);
+        var isPermissionsGrant = itemType.Contains("permission", StringComparison.OrdinalIgnoreCase);
 
         JsonElement Deny() => isPermissionsGrant ? EmptyGrant() : DeclineDecision();
 
@@ -75,7 +77,7 @@ internal sealed class CodexApprovalBridge {
             AgentId:      _agentId,
             AcpSessionId: threadId,
             Kind:         "permission",
-            ToolName:     DescribeTool(method),
+            ToolName:     itemType,
             ToolInput:    request.Params,
             ToolCallId:   TryGetString(request.Params, "itemId"),
             Prompt:       null,
@@ -112,13 +114,16 @@ internal sealed class CodexApprovalBridge {
         return DeclineDecision();
     }
 
-    // permissions requestApproval → {permissions, scope}. Grant echoes the requested profile; a denial
-    // is a valid EMPTY grant (the current always-decline bridge emits {decision:decline}, malformed here).
+    // permissions requestApproval → {permissions, scope}. Grant echoes the requested profile ONLY when
+    // it is a well-formed object; an affirmative decision over an absent/non-object profile falls to the
+    // empty grant (deny) rather than an affirmative-scoped empty one — never grant a profile we can't
+    // read back. A denial is likewise a valid EMPTY grant (the always-decline bridge emits
+    // {decision:decline}, which is malformed for this method).
     static JsonElement MapPermissionsGrant(AcpInteractionDecision decision, JsonElement? requestParams) {
         if (AffirmativeOutcomes.Contains(decision.Outcome)
-         && decision.SelectedOptionId is "accept" or "acceptForSession") {
-            var granted = ClonePropertyOrEmpty(requestParams, "permissions");
-            var scope   = decision.SelectedOptionId == "acceptForSession" ? "session" : "turn";
+         && decision.SelectedOptionId is "accept" or "acceptForSession"
+         && TryCloneObject(requestParams, "permissions") is { } granted) {
+            var scope = decision.SelectedOptionId == "acceptForSession" ? "session" : "turn";
             return ToElement(new JsonObject { ["permissions"] = granted, ["scope"] = scope });
         }
 
@@ -139,9 +144,9 @@ internal sealed class CodexApprovalBridge {
             : new JsonObject { ["decision"] = "decline" });
     }
 
-    // A short, non-identifying tool label for the prompt — the item type from the method
-    // (item/<type>/requestApproval). Never the params content.
-    static string DescribeTool(string method) {
+    // The item type from the method (item/<type>/requestApproval) — used both to route the permissions
+    // grant and as a short, non-identifying prompt label. Never the params content.
+    static string ItemType(string method) {
         var parts = method.Split('/');
         return parts.Length >= 2 ? parts[^2] : method;
     }
@@ -152,13 +157,13 @@ internal sealed class CodexApprovalBridge {
             ? value.GetString()
             : null;
 
-    // Deep-copy the requested permissions profile out of the params (detached from the request frame),
-    // or an empty object when absent.
-    static JsonNode ClonePropertyOrEmpty(JsonElement? element, string property) =>
+    // Deep-copy a named OBJECT property out of the params (detached from the request frame), or null when
+    // it is absent or not an object — the caller must decide what a missing profile means.
+    static JsonNode? TryCloneObject(JsonElement? element, string property) =>
         element is { } e && e.ValueKind == JsonValueKind.Object
             && e.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.Object
-            ? JsonNode.Parse(value.GetRawText()) ?? new JsonObject()
-            : new JsonObject();
+            ? JsonNode.Parse(value.GetRawText())
+            : null;
 
     // JsonNode → JsonElement without reflection (AOT-safe), matching the runtime's own helper.
     static JsonElement ToElement(JsonNode node) =>

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexApprovalBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexApprovalBridge.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Harness.Codex;
+
+/// <summary>
+/// Interactive approval bridge for hosted Codex on app-server. A server-initiated
+/// <c>*/requestApproval</c> request is forwarded to the user through the shared ACP interaction
+/// channel (<c>requestInteraction</c>) and the user's decision is mapped back to the codex wire shape.
+/// Mirrors <see cref="Acp.AcpInteractionBridge"/>'s interactive forward path.
+///
+/// <para>Every uncertain outcome fails CLOSED — no params, no thread id, a timeout, a thrown delegate,
+/// a non-affirmative or unresolvable decision all deny. Only a recognized affirmative outcome carrying
+/// a known option id (<c>accept</c>/<c>acceptForSession</c>) grants. The response is always a valid
+/// protocol body, never a JSON-RPC error (a throw would become the connection's <c>-32603</c>, whose
+/// turn effect is Codex's to define).</para>
+///
+/// <para>The reviewer path (<c>approvalPolicy: never</c>) does NOT use this bridge — it keeps the
+/// always-decline handler, since a request there is a protocol violation, not a user prompt.</para>
+/// </summary>
+internal sealed class CodexApprovalBridge {
+    readonly Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> _requestInteraction;
+    readonly string   _agentId;
+    readonly ILogger  _logger;
+    readonly TimeSpan _timeout;
+
+    // The option ids ARE the codex decision strings, so a resolved SelectedOptionId maps straight to
+    // {decision: id}. Kinds let the server render allow-once vs allow-for-session affordances.
+    static readonly AcpInteractionOption[] ApprovalOptions = [
+        new("accept",           "Allow",                  null, "allow_once"),
+        new("acceptForSession", "Allow for this session", null, "allow_always"),
+        new("decline",          "Deny",                   null, "reject_once"),
+    ];
+
+    // Fail-safe allowlist (mirrors AcpInteractionBridge.AffirmativeOutcomes): only these outcomes can
+    // grant; every other string denies. Keep in sync with the server's decision vocabulary.
+    static readonly HashSet<string> AffirmativeOutcomes = ["allow", "allow_once", "allow_always", "answered"];
+
+    public CodexApprovalBridge(
+            Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> requestInteraction,
+            string agentId, ILogger logger, TimeSpan timeout) {
+        _requestInteraction = requestInteraction;
+        _agentId            = agentId;
+        _logger             = logger;
+        _timeout            = timeout;
+    }
+
+    public async Task<JsonElement?> HandleAsync(AcpRequest request, CancellationToken ct) {
+        var method = request.Method;
+
+        // Only approval requests are forwarded to the user; elicitation / requestUserInput / any other
+        // server request keeps the always-decline shapes (interactive elicitation is out of scope here).
+        if (!method.EndsWith("/requestApproval", StringComparison.Ordinal))
+            return DeclineNonApproval(method);
+
+        // The permissions grant is a DIFFERENT response shape ({permissions,scope}) with no decision
+        // enum — a bare {decision:"decline"} is malformed for it, so route it separately.
+        var isPermissionsGrant = method.Contains("permissions", StringComparison.OrdinalIgnoreCase)
+                              || method.Contains("request_permissions", StringComparison.OrdinalIgnoreCase);
+
+        JsonElement Deny() => isPermissionsGrant ? EmptyGrant() : DeclineDecision();
+
+        // Correlate on the request's OWN params (never a closed-over field): no resolvable thread id
+        // means the server cannot correlate this interaction — fail closed.
+        var threadId = TryGetString(request.Params, "threadId");
+        if (string.IsNullOrEmpty(threadId)) {
+            _logger.LogWarning("codex approval: {Method} carried no threadId; cannot correlate, denying.", method);
+            return Deny();
+        }
+
+        var interaction = new AcpInteractionRequest(
+            AgentId:      _agentId,
+            AcpSessionId: threadId,
+            Kind:         "permission",
+            ToolName:     DescribeTool(method),
+            ToolInput:    request.Params,
+            ToolCallId:   TryGetString(request.Params, "itemId"),
+            Prompt:       null,
+            Options:      ApprovalOptions,
+            IsMultiSelect: false);
+
+        AcpInteractionDecision decision;
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(_timeout);
+
+        try {
+            decision = await _requestInteraction(interaction, timeoutCts.Token).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            // Timeout, connection close, or runtime dispose — deny (fail closed), never an error frame.
+            _logger.LogDebug("codex approval: {Method} cancelled or timed out; denying.", method);
+            return Deny();
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "codex approval: requestInteraction threw for {Method}; denying.", method);
+            return Deny();
+        }
+
+        return isPermissionsGrant
+            ? MapPermissionsGrant(decision, request.Params)
+            : MapDecision(decision);
+    }
+
+    // command/fileChange requestApproval → {decision: "accept"|"acceptForSession"|"decline"}.
+    static JsonElement MapDecision(AcpInteractionDecision decision) {
+        if (AffirmativeOutcomes.Contains(decision.Outcome)
+         && decision.SelectedOptionId is "accept" or "acceptForSession") {
+            return ToElement(new JsonObject { ["decision"] = decision.SelectedOptionId });
+        }
+
+        return DeclineDecision();
+    }
+
+    // permissions requestApproval → {permissions, scope}. Grant echoes the requested profile; a denial
+    // is a valid EMPTY grant (the current always-decline bridge emits {decision:decline}, malformed here).
+    static JsonElement MapPermissionsGrant(AcpInteractionDecision decision, JsonElement? requestParams) {
+        if (AffirmativeOutcomes.Contains(decision.Outcome)
+         && decision.SelectedOptionId is "accept" or "acceptForSession") {
+            var granted = ClonePropertyOrEmpty(requestParams, "permissions");
+            var scope   = decision.SelectedOptionId == "acceptForSession" ? "session" : "turn";
+            return ToElement(new JsonObject { ["permissions"] = granted, ["scope"] = scope });
+        }
+
+        return EmptyGrant();
+    }
+
+    static JsonElement DeclineDecision() => ToElement(new JsonObject { ["decision"] = "decline" });
+
+    static JsonElement EmptyGrant() =>
+        ToElement(new JsonObject { ["permissions"] = new JsonObject(), ["scope"] = "turn" });
+
+    // Non-approval server requests keep the pre-existing always-decline shapes.
+    static JsonElement DeclineNonApproval(string method) {
+        var isElicitation = method.Contains("elicitation", StringComparison.Ordinal)
+                         || method.Contains("requestUserInput", StringComparison.Ordinal);
+        return ToElement(isElicitation
+            ? new JsonObject { ["action"]   = "decline" }
+            : new JsonObject { ["decision"] = "decline" });
+    }
+
+    // A short, non-identifying tool label for the prompt — the item type from the method
+    // (item/<type>/requestApproval). Never the params content.
+    static string DescribeTool(string method) {
+        var parts = method.Split('/');
+        return parts.Length >= 2 ? parts[^2] : method;
+    }
+
+    static string? TryGetString(JsonElement? element, string property) =>
+        element is { } e && e.ValueKind == JsonValueKind.Object
+            && e.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    // Deep-copy the requested permissions profile out of the params (detached from the request frame),
+    // or an empty object when absent.
+    static JsonNode ClonePropertyOrEmpty(JsonElement? element, string property) =>
+        element is { } e && e.ValueKind == JsonValueKind.Object
+            && e.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.Object
+            ? JsonNode.Parse(value.GetRawText()) ?? new JsonObject()
+            : new JsonObject();
+
+    // JsonNode → JsonElement without reflection (AOT-safe), matching the runtime's own helper.
+    static JsonElement ToElement(JsonNode node) =>
+        JsonDocument.Parse(node.ToJsonString()).RootElement.Clone();
+}

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexApprovalBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexApprovalBridge.cs
@@ -7,19 +7,15 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Daemon.Harness.Codex;
 
 /// <summary>
-/// Interactive approval bridge for hosted Codex on app-server. A server-initiated
-/// <c>*/requestApproval</c> request is forwarded to the user through the shared ACP interaction
-/// channel (<c>requestInteraction</c>) and the user's decision is mapped back to the codex wire shape.
-/// Mirrors <see cref="Acp.AcpInteractionBridge"/>'s interactive forward path.
+/// Interactive approval bridge for hosted Codex on app-server: a server-initiated
+/// <c>*/requestApproval</c> is forwarded to the user through the shared ACP interaction channel and the
+/// user's decision is mapped back to the codex wire shape. Mirrors <see cref="Acp.AcpInteractionBridge"/>.
 ///
-/// <para>Every uncertain outcome fails CLOSED — no params, no thread id, a timeout, a thrown delegate,
-/// a non-affirmative or unresolvable decision all deny. Only a recognized affirmative outcome carrying
-/// a known option id (<c>accept</c>/<c>acceptForSession</c>) grants. The response is always a valid
-/// protocol body, never a JSON-RPC error (a throw would become the connection's <c>-32603</c>, whose
-/// turn effect is Codex's to define).</para>
-///
-/// <para>The reviewer path (<c>approvalPolicy: never</c>) does NOT use this bridge — it keeps the
-/// always-decline handler, since a request there is a protocol violation, not a user prompt.</para>
+/// <para>Fail-closed by construction: only a recognized affirmative outcome carrying a known option id
+/// grants; every other case (no params, no thread id, timeout, thrown delegate, non-affirmative or
+/// unresolvable decision) denies, and the response is always a valid protocol body — never a JSON-RPC
+/// error, which the connection would map to <c>-32603</c>. The reviewer path (<c>approvalPolicy:never</c>)
+/// does not use this bridge.</para>
 /// </summary>
 internal sealed class CodexApprovalBridge {
     readonly Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> _requestInteraction;
@@ -28,17 +24,20 @@ internal sealed class CodexApprovalBridge {
     readonly TimeSpan _timeout;
 
     // The option ids ARE the codex decision strings, so a resolved SelectedOptionId maps straight to
-    // {decision: id}. Kinds let the server render allow-once vs allow-for-session affordances.
+    // {decision: id}; Kind drives the allow-once / allow-for-session affordances server-side.
     static readonly AcpInteractionOption[] ApprovalOptions = [
         new("accept",           "Allow",                  null, "allow_once"),
         new("acceptForSession", "Allow for this session", null, "allow_always"),
         new("decline",          "Deny",                   null, "reject_once"),
     ];
 
-    // Fail-safe allowlist: only these (allow-family) outcomes can grant an APPROVAL; every other string
-    // denies. Deliberately excludes the ACP "answered" outcome — that is an elicitation result, not an
-    // approval grant, and this bridge handles approvals only, so narrowing it here shrinks the grant surface.
+    // Approval grants only on an allow-family outcome. Excludes the ACP "answered" outcome — that is an
+    // elicitation result, and this bridge handles approvals only.
     static readonly HashSet<string> AffirmativeOutcomes = ["allow", "allow_once", "allow_always"];
+
+    // Bounds CancelAfter (which throws above ~24.8 days) and keeps a misconfigured value sane.
+    static readonly TimeSpan MinTimeout = TimeSpan.FromSeconds(1);
+    static readonly TimeSpan MaxTimeout = TimeSpan.FromHours(1);
 
     public CodexApprovalBridge(
             Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> requestInteraction,
@@ -46,21 +45,20 @@ internal sealed class CodexApprovalBridge {
         _requestInteraction = requestInteraction;
         _agentId            = agentId;
         _logger             = logger;
-        _timeout            = timeout;
+        _timeout            = timeout < MinTimeout ? MinTimeout : timeout > MaxTimeout ? MaxTimeout : timeout;
     }
 
     public async Task<JsonElement?> HandleAsync(AcpRequest request, CancellationToken ct) {
         var method = request.Method;
 
-        // Only approval requests are forwarded to the user; elicitation / requestUserInput / any other
-        // server request keeps the always-decline shapes (interactive elicitation is out of scope here).
+        // Non-approval server requests (elicitation / requestUserInput / unknown) keep the always-decline
+        // shapes; interactive elicitation is out of scope here.
         if (!method.EndsWith("/requestApproval", StringComparison.Ordinal))
             return DeclineNonApproval(method);
 
-        // Route the permissions grant (a DIFFERENT {permissions,scope} shape, no decision enum) by an
-        // EXACT item-type segment match (item/<type>/requestApproval), not a substring — so neither an
-        // unrelated path segment nor a command-type item whose name merely contains "permission" can
-        // misroute into the grant shape.
+        // The permissions grant is a distinct {permissions,scope} response with no decision enum. Route it
+        // by EXACT item-type segment (item/<type>/requestApproval), so a command-type item whose name
+        // merely contains "permission" can't misroute into the grant shape.
         var itemType = ItemType(method);
         var isPermissionsGrant = string.Equals(itemType, "permissions", StringComparison.OrdinalIgnoreCase)
                               || string.Equals(itemType, "permission",  StringComparison.OrdinalIgnoreCase);
@@ -68,9 +66,8 @@ internal sealed class CodexApprovalBridge {
         JsonElement Deny() => isPermissionsGrant ? EmptyGrant() : DeclineDecision();
 
         try {
-            // Correlate on the request's OWN params (never a closed-over field): no resolvable thread id
-            // means the server cannot correlate this interaction — fail closed.
-            var threadId = TryGetString(request.Params, "threadId");
+            // Correlate on the request's OWN params: no thread id means the server can't correlate — deny.
+            var threadId = request.Params?.Str("threadId");
             if (string.IsNullOrEmpty(threadId)) {
                 _logger.LogWarning("codex approval: {Method} carried no threadId; cannot correlate, denying.", method);
                 return Deny();
@@ -82,7 +79,7 @@ internal sealed class CodexApprovalBridge {
                 Kind:         "permission",
                 ToolName:     itemType,
                 ToolInput:    request.Params,
-                ToolCallId:   TryGetString(request.Params, "itemId"),
+                ToolCallId:   request.Params?.Str("itemId"),
                 Prompt:       null,
                 Options:      ApprovalOptions,
                 IsMultiSelect: false);
@@ -94,36 +91,28 @@ internal sealed class CodexApprovalBridge {
 
             return isPermissionsGrant ? MapPermissionsGrant(decision, request.Params) : MapDecision(decision);
         } catch (OperationCanceledException) {
-            // Timeout, connection close, or runtime dispose — deny (fail closed), never an error frame.
             _logger.LogDebug("codex approval: {Method} cancelled or timed out; denying.", method);
             return Deny();
         } catch (Exception ex) {
-            // The handler must NEVER throw: the connection layer would map it to a JSON-RPC -32603. Any
-            // unexpected failure (a thrown delegate, a mapping fault) denies with a valid body instead.
+            // The handler must never throw — the connection maps a throw to -32603. Deny with a valid body.
             _logger.LogWarning(ex, "codex approval: unexpected failure handling {Method}; denying.", method);
             return Deny();
         }
     }
 
-    // command/fileChange requestApproval → {decision: "accept"|"acceptForSession"|"decline"}.
-    static JsonElement MapDecision(AcpInteractionDecision decision) {
-        if (AffirmativeOutcomes.Contains(decision.Outcome)
-         && decision.SelectedOptionId is "accept" or "acceptForSession") {
-            return ToElement(new JsonObject { ["decision"] = decision.SelectedOptionId });
-        }
+    static JsonElement MapDecision(AcpInteractionDecision decision) =>
+        AffirmativeOutcomes.Contains(decision.Outcome) && decision.SelectedOptionId is "accept" or "acceptForSession"
+            ? ToElement(new JsonObject { ["decision"] = decision.SelectedOptionId })
+            : DeclineDecision();
 
-        return DeclineDecision();
-    }
-
-    // permissions requestApproval → {permissions, scope}. Grant echoes the requested profile ONLY when
-    // it is a well-formed object; an affirmative decision over an absent/non-object profile falls to the
-    // empty grant (deny) rather than an affirmative-scoped empty one — never grant a profile we can't
-    // read back. A denial is likewise a valid EMPTY grant (the always-decline bridge emits
-    // {decision:decline}, which is malformed for this method).
+    // Grant echoes the requested profile only when it is a well-formed object — an affirmative decision
+    // over an absent/non-object profile falls to the empty grant rather than an affirmative-scoped empty
+    // one (never grant a profile we can't read back). Deny is a valid empty grant.
     static JsonElement MapPermissionsGrant(AcpInteractionDecision decision, JsonElement? requestParams) {
         if (AffirmativeOutcomes.Contains(decision.Outcome)
          && decision.SelectedOptionId is "accept" or "acceptForSession"
-         && TryCloneObject(requestParams, "permissions") is { } granted) {
+         && requestParams?.Obj("permissions") is { } profile
+         && JsonNode.Parse(profile.GetRawText()) is { } granted) {
             var scope = decision.SelectedOptionId == "acceptForSession" ? "session" : "turn";
             return ToElement(new JsonObject { ["permissions"] = granted, ["scope"] = scope });
         }
@@ -136,7 +125,6 @@ internal sealed class CodexApprovalBridge {
     static JsonElement EmptyGrant() =>
         ToElement(new JsonObject { ["permissions"] = new JsonObject(), ["scope"] = "turn" });
 
-    // Non-approval server requests keep the pre-existing always-decline shapes.
     static JsonElement DeclineNonApproval(string method) {
         var isElicitation = method.Contains("elicitation", StringComparison.Ordinal)
                          || method.Contains("requestUserInput", StringComparison.Ordinal);
@@ -145,30 +133,14 @@ internal sealed class CodexApprovalBridge {
             : new JsonObject { ["decision"] = "decline" });
     }
 
-    // The item type from the method (item/<type>/requestApproval) — used both to route the permissions
-    // grant and as a short, non-identifying prompt label. Never the params content.
+    // The item type from item/<type>/requestApproval — routes the permissions grant and labels the prompt.
     static string ItemType(string method) {
         var parts = method.Split('/');
         return parts.Length >= 2 ? parts[^2] : method;
     }
 
-    static string? TryGetString(JsonElement? element, string property) =>
-        element is { } e && e.ValueKind == JsonValueKind.Object
-            && e.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
-            ? value.GetString()
-            : null;
-
-    // Deep-copy a named OBJECT property out of the params (detached from the request frame), or null when
-    // it is absent or not an object — the caller must decide what a missing profile means.
-    static JsonNode? TryCloneObject(JsonElement? element, string property) =>
-        element is { } e && e.ValueKind == JsonValueKind.Object
-            && e.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.Object
-            ? JsonNode.Parse(value.GetRawText())
-            : null;
-
     // JsonNode → JsonElement without reflection (AOT-safe). The clone is independent of the parsed
-    // document's pooled buffers, so disposing the document (rather than leaking its rented arrays under
-    // load) is safe.
+    // document's pooled buffers, so the document is disposed rather than leaked.
     static JsonElement ToElement(JsonNode node) {
         using var doc = JsonDocument.Parse(node.ToJsonString());
         return doc.RootElement.Clone();

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -31,19 +31,25 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
     readonly ILoggerFactory              _loggerFactory;
     readonly ILogger                     _logger;
     readonly CodexAppServerSpawnFactory  _spawnFactory;
+    readonly ServerConnection?           _connection;
 
     /// <param name="spawnFactory">Test seam only: production passes <see langword="null"/> and the
     /// real <c>codex app-server</c> child is spawned via <see cref="Process"/>. A test can substitute
     /// an in-process fake peer to drive the app-server route without a child process.</param>
+    /// <param name="connection">The server connection whose <c>RequestAcpInteractionAsync</c> forwards an
+    /// interactive launch's approvals to the user (§2.3). Null in tests that never exercise interactive
+    /// approvals; reviewers (approvalPolicy:never) never build an approval bridge regardless.</param>
     public CodexHostedAgentRuntimeFactory(
             CodexLauncher launcher, IHostedAgentRuntimeFactory ptyDelegate, DaemonConfig config,
-            ILoggerFactory loggerFactory, CodexAppServerSpawnFactory? spawnFactory = null) {
+            ILoggerFactory loggerFactory, CodexAppServerSpawnFactory? spawnFactory = null,
+            ServerConnection? connection = null) {
         _launcher      = launcher;
         _pty           = ptyDelegate;
         _config        = config;
         _loggerFactory = loggerFactory;
         _logger        = loggerFactory.CreateLogger<CodexHostedAgentRuntimeFactory>();
         _spawnFactory  = spawnFactory ?? DefaultSpawnFactory;
+        _connection    = connection;
     }
 
     public string Vendor => "codex";
@@ -98,7 +104,10 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
         var runtime = new CodexAppServerHostedAgentRuntime(
             spawn, launch, ctx.ActivityClock,
             _loggerFactory.CreateLogger<CodexAppServerHostedAgentRuntime>(),
-            emitEnvelopeTranscript: emitEnvelopeTranscript);
+            emitEnvelopeTranscript: emitEnvelopeTranscript,
+            agentId: ctx.AgentId,
+            requestInteraction: _connection is { } c ? c.RequestAcpInteractionAsync : null,
+            approvalTimeout: TimeSpan.FromSeconds(Math.Max(1, _config.CodexAppServerApprovalTimeoutSeconds)));
 
         // StartAsync may spawn a child before it throws (a failed hooks/list, thread/start, or initial
         // turn on the fail-closed paths). The orchestrator never receives a runtime it did not get a

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -24,15 +24,17 @@ public class CodexAppServerHostedAgentRuntimeTests {
         public ValueTask DisposeAsync() { HasExited = true; return ValueTask.CompletedTask; }
     }
 
-    static CodexAppServerLaunch Launch(string? model = null, string? prompt = null, string sandbox = "read-only", string? effort = null) =>
+    static CodexAppServerLaunch Launch(string? model = null, string? prompt = null, string sandbox = "read-only",
+            string? effort = null, string approval = "never") =>
         new(Cwd: "/tmp/wt", Model: model, Effort: effort, InitialPrompt: prompt, Sandbox: sandbox,
-            Approval: "never", WritableRoots: ["/tmp/wt"], ClientVersion: "0.146.0");
+            Approval: approval, WritableRoots: ["/tmp/wt"], ClientVersion: "0.146.0");
 
     /// <summary>Builds a spawn delegate that hands each spawn a fresh fake (indexed), recording the
     /// seed passed on each call so the restart path is assertable.</summary>
     static (CodexAppServerHostedAgentRuntime Runtime, List<string?> Seeds, Func<int, FakeCodexAppServer> Fake)
             Build(Func<int, FakeCodexAppServer> fakeFor, CodexAppServerLaunch launch,
-                  bool emitEnvelopes = false, bool deferFirstTurn = false) {
+                  bool emitEnvelopes = false, bool deferFirstTurn = false,
+                  Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>>? requestInteraction = null) {
         var seeds  = new List<string?>();
         var fakes  = new List<FakeCodexAppServer>();
         var index  = 0;
@@ -47,7 +49,10 @@ public class CodexAppServerHostedAgentRuntimeTests {
 
         var runtime = new CodexAppServerHostedAgentRuntime(
             spawn, launch, clock: null, NullLogger.Instance,
-            emitEnvelopeTranscript: emitEnvelopes, deferFirstTurn: deferFirstTurn);
+            emitEnvelopeTranscript: emitEnvelopes, deferFirstTurn: deferFirstTurn,
+            agentId: requestInteraction is null ? null : "agent-1",
+            requestInteraction: requestInteraction,
+            approvalTimeout: TimeSpan.FromSeconds(5));
         return (runtime, seeds, i => fakes[i]);
     }
 
@@ -246,6 +251,26 @@ public class CodexAppServerHostedAgentRuntimeTests {
         // The client answered the approval with a valid decline result, never a JSON-RPC error.
         await Assert.That(fake.ApprovalResponse).IsNotNull();
         await Assert.That(fake.ApprovalResponse!.Value.GetProperty("decision").GetString()).IsEqualTo("decline");
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Interactive_approval_is_forwarded_and_the_user_decision_is_returned_on_the_wire() {
+        // An interactive launch (approvalPolicy != never) with a requestInteraction delegate routes the
+        // server's approval request to the user and answers with their mapped decision — NOT the reviewer
+        // decline. This proves the OnServerRequest wiring reaches the bridge end to end.
+        var fake = new FakeCodexAppServer { InjectApprovalDuringTurn = true };
+        var (runtime, _, _) = Build(_ => fake, Launch(approval: "on-request"),
+            requestInteraction: (_, _) => Task.FromResult(
+                new AcpInteractionDecision("allow", "accept", "Allow", null, null, null)));
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await runtime.SendUserInputAsync("do it").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(fake.ApprovalResponse).IsNotNull();
+        await Assert.That(fake.ApprovalResponse!.Value.GetProperty("decision").GetString()).IsEqualTo("accept");
 
         await runtime.DisposeAsync();
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexApprovalBridgeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexApprovalBridgeTests.cs
@@ -130,6 +130,19 @@ public class CodexApprovalBridgeTests {
         await Assert.That(r.GetProperty("scope").GetString()).IsEqualTo("turn");
     }
 
+    [Test]
+    public async Task Permissions_grant_accept_over_non_object_profile_falls_to_empty_deny() {
+        // Even an affirmative decision must not grant a profile we can't read back as an object — echoing
+        // {} at the affirmative "session" scope could over-grant if the server treats it as defaults.
+        var bridge = Deciding(new AcpInteractionDecision("allow", "accept", null, null, null, null));
+        var paramsJson = """{"threadId":"thread-1","itemId":"item-1","permissions":"all"}"""; // non-object profile
+        var result = await bridge.HandleAsync(ApprovalRequest(PermsMethod, paramsJson), CancellationToken.None);
+
+        var r = result!.Value;
+        await Assert.That(r.GetProperty("permissions").EnumerateObject().Any()).IsFalse(); // empty, not the string
+        await Assert.That(r.GetProperty("scope").GetString()).IsEqualTo("turn");           // deny scope, never "session"
+    }
+
     // ── Non-approval requests keep the always-decline shapes ─────────────────────────────────────
     [Test]
     public async Task Elicitation_request_declines_with_action_shape() {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexApprovalBridgeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexApprovalBridgeTests.cs
@@ -98,6 +98,16 @@ public class CodexApprovalBridgeTests {
     }
 
     [Test]
+    public async Task Oversized_timeout_is_clamped_and_does_not_throw() {
+        // A misconfigured huge timeout must not throw at CancelAfter (which caps ~24.8 days) — the ctor
+        // clamps it, so the normal accept path still works.
+        var bridge = Bridge((_, _) => Task.FromResult(new AcpInteractionDecision("allow", "accept", null, null, null, null)),
+            timeout: TimeSpan.FromDays(100));
+        var result = await bridge.HandleAsync(ApprovalRequest(CommandMethod, CommandParams), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("accept");
+    }
+
+    [Test]
     public async Task Delegate_throwing_declines_never_errors() {
         var bridge = Bridge((_, _) => throw new InvalidOperationException("boom"));
         var result = await bridge.HandleAsync(ApprovalRequest(CommandMethod, CommandParams), CancellationToken.None);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexApprovalBridgeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexApprovalBridgeTests.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>
+/// <see cref="CodexApprovalBridge"/> forwards a server-initiated <c>*/requestApproval</c> to an injected
+/// "ask the user" delegate and maps the decision back to codex's wire shape — always fail-closed. Tested
+/// against the delegate directly (no SignalR). The security invariant: only a recognized affirmative
+/// outcome carrying a known option id grants; everything else denies.
+/// </summary>
+public class CodexApprovalBridgeTests {
+    const string AgentId  = "agent-1";
+    static readonly TimeSpan LongTimeout = TimeSpan.FromSeconds(30);
+
+    static CodexApprovalBridge Bridge(
+            Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> requestInteraction,
+            TimeSpan? timeout = null) =>
+        new(requestInteraction, AgentId, NullLogger.Instance, timeout ?? LongTimeout);
+
+    static CodexApprovalBridge Deciding(AcpInteractionDecision decision, TimeSpan? timeout = null) =>
+        Bridge((_, _) => Task.FromResult(decision), timeout);
+
+    static AcpRequest ApprovalRequest(string method, string paramsJson) =>
+        new(1, method, JsonDocument.Parse(paramsJson).RootElement.Clone());
+
+    const string CommandMethod = "item/commandExecution/requestApproval";
+    const string FileMethod    = "item/fileChange/requestApproval";
+    const string PermsMethod   = "item/permissions/requestApproval";
+    const string CommandParams = """{"threadId":"thread-1","turnId":"turn-1","itemId":"item-1"}""";
+
+    static async Task<string?> Decision(JsonElement? result) =>
+        await Task.FromResult(result is { } r && r.TryGetProperty("decision", out var d) ? d.GetString() : null);
+
+    // ── The grant paths (positive controls) ────────────────────────────────────────────────────
+    [Test]
+    public async Task Command_accept_maps_to_decision_accept() {
+        var bridge = Deciding(new AcpInteractionDecision("allow", "accept", "Allow", null, null, null));
+        var result = await bridge.HandleAsync(ApprovalRequest(CommandMethod, CommandParams), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("accept");
+    }
+
+    [Test]
+    public async Task Command_accept_for_session_maps_to_decision_acceptForSession() {
+        var bridge = Deciding(new AcpInteractionDecision("allow_always", "acceptForSession", "Allow for session", null, null, null));
+        var result = await bridge.HandleAsync(ApprovalRequest(CommandMethod, CommandParams), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("acceptForSession");
+    }
+
+    [Test]
+    public async Task File_change_accept_maps_to_decision_accept() {
+        // The file-change method name is by-convention; the suffix match must still route it.
+        var bridge = Deciding(new AcpInteractionDecision("allow", "accept", "Allow", null, null, null));
+        var result = await bridge.HandleAsync(ApprovalRequest(FileMethod, CommandParams), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("accept");
+    }
+
+    // ── Fail-closed paths ───────────────────────────────────────────────────────────────────────
+    [Test]
+    public async Task Deny_outcome_maps_to_decline() {
+        var bridge = Deciding(new AcpInteractionDecision("deny", null, null, null, null, null));
+        var result = await bridge.HandleAsync(ApprovalRequest(CommandMethod, CommandParams), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("decline");
+    }
+
+    [Test]
+    public async Task Affirmative_outcome_with_unknown_option_id_declines() {
+        // Fail-safe: an affirmative outcome whose SelectedOptionId is NOT one we offered must never grant.
+        var bridge = Deciding(new AcpInteractionDecision("allow", "somethingElse", null, null, null, null));
+        var result = await bridge.HandleAsync(ApprovalRequest(CommandMethod, CommandParams), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("decline");
+    }
+
+    [Test]
+    public async Task Affirmative_outcome_with_null_option_id_declines() {
+        var bridge = Deciding(new AcpInteractionDecision("allow", null, null, null, null, null));
+        var result = await bridge.HandleAsync(ApprovalRequest(CommandMethod, CommandParams), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("decline");
+    }
+
+    [Test]
+    public async Task Missing_thread_id_declines_without_asking() {
+        var asked = false;
+        var bridge = Bridge((_, _) => { asked = true; return Task.FromResult(new AcpInteractionDecision("allow", "accept", null, null, null, null)); });
+        var result = await bridge.HandleAsync(ApprovalRequest(CommandMethod, """{"itemId":"item-1"}"""), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("decline");
+        await Assert.That(asked).IsFalse(); // never correlated → never forwarded to a human
+    }
+
+    [Test]
+    public async Task Timeout_declines() {
+        var bridge = Bridge(async (_, ct) => { await Task.Delay(Timeout.Infinite, ct); return default; }, TimeSpan.FromMilliseconds(50));
+        var result = await bridge.HandleAsync(ApprovalRequest(CommandMethod, CommandParams), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("decline");
+    }
+
+    [Test]
+    public async Task Delegate_throwing_declines_never_errors() {
+        var bridge = Bridge((_, _) => throw new InvalidOperationException("boom"));
+        var result = await bridge.HandleAsync(ApprovalRequest(CommandMethod, CommandParams), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("decline"); // valid body, not a JSON-RPC error
+    }
+
+    // ── Permissions grant shape ({permissions,scope}, not {decision}) ────────────────────────────
+    [Test]
+    public async Task Permissions_grant_accept_echoes_requested_profile() {
+        var bridge = Deciding(new AcpInteractionDecision("allow", "accept", null, null, null, null));
+        var paramsJson = """{"threadId":"thread-1","itemId":"item-1","permissions":{"network":{"allowed":true}}}""";
+        var result = await bridge.HandleAsync(ApprovalRequest(PermsMethod, paramsJson), CancellationToken.None);
+
+        await Assert.That(result).IsNotNull();
+        var r = result!.Value;
+        await Assert.That(r.TryGetProperty("decision", out _)).IsFalse();
+        await Assert.That(r.GetProperty("scope").GetString()).IsEqualTo("turn");
+        await Assert.That(r.GetProperty("permissions").GetProperty("network").GetProperty("allowed").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task Permissions_grant_deny_returns_empty_grant_not_a_decision() {
+        var bridge = Deciding(new AcpInteractionDecision("deny", null, null, null, null, null));
+        var paramsJson = """{"threadId":"thread-1","itemId":"item-1","permissions":{"network":{"allowed":true}}}""";
+        var result = await bridge.HandleAsync(ApprovalRequest(PermsMethod, paramsJson), CancellationToken.None);
+
+        var r = result!.Value;
+        await Assert.That(r.TryGetProperty("decision", out _)).IsFalse();          // never the malformed decision shape
+        await Assert.That(r.GetProperty("permissions").EnumerateObject().Any()).IsFalse(); // empty grant
+        await Assert.That(r.GetProperty("scope").GetString()).IsEqualTo("turn");
+    }
+
+    // ── Non-approval requests keep the always-decline shapes ─────────────────────────────────────
+    [Test]
+    public async Task Elicitation_request_declines_with_action_shape() {
+        var bridge = Deciding(new AcpInteractionDecision("allow", "accept", null, null, null, null));
+        var result = await bridge.HandleAsync(ApprovalRequest("session/elicitation/create", """{"threadId":"t"}"""), CancellationToken.None);
+        await Assert.That(result!.Value.GetProperty("action").GetString()).IsEqualTo("decline");
+    }
+
+    [Test]
+    public async Task Unknown_server_request_declines_with_decision_shape() {
+        var bridge = Deciding(new AcpInteractionDecision("allow", "accept", null, null, null, null));
+        var result = await bridge.HandleAsync(ApprovalRequest("some/other/method", """{"threadId":"t"}"""), CancellationToken.None);
+        await Assert.That(await Decision(result)).IsEqualTo("decline");
+    }
+}


### PR DESCRIPTION
## What

§2.3 of the interactive hosted-Codex-on-app-server work. Interactive Codex needs real allow/deny for server-initiated `*/requestApproval` requests; today the runtime only has an **always-decline** bridge (reviewers run `approvalPolicy:never`, so any request is a protocol violation).

**`CodexApprovalBridge`** (mirrors `AcpInteractionBridge`'s interactive forward path) forwards an approval to the user through the shared, reconnect-durable ACP interaction channel (`ServerConnection.RequestAcpInteractionAsync` + the pend/resolve registry) and maps the decision back to codex's wire shapes.

- **Option ids ARE the codex decision strings** — a resolved `SelectedOptionId` maps straight to `{decision: accept|acceptForSession}`.
- **Fail-closed everywhere:** no params, no `threadId`, a timeout, a thrown delegate, a non-affirmative outcome, or an unresolvable/unknown option id all **deny** — and the response is always a valid protocol body, **never a JSON-RPC error** (a throw would become `-32603`, whose turn effect is Codex's to define).
- **Permissions grant** uses its own `{permissions, scope}` shape (deny = a valid *empty* grant, not the malformed `{decision:decline}` the always-decline bridge would emit for it).
- Non-approval server requests (elicitation / requestUserInput / unknown) keep the pre-existing decline shapes.

## Wiring

- The runtime builds the bridge **only** for an interactive launch (`approvalPolicy != never`) that was given a `requestInteraction` delegate + `agentId`, and routes `OnServerRequest` to it; **reviewers keep `DeclineServerRequestAsync`** unchanged.
- The factory gains the `ServerConnection` (DI-injected in `DaemonRunner`, mirroring the 5 ACP factories) and passes `RequestAcpInteractionAsync` + `ctx.AgentId`.
- Timeout: `DaemonConfig.CodexAppServerApprovalTimeoutSeconds` (default 45, `KCAP_CODEX_APPSERVER_APPROVAL_TIMEOUT_SECONDS`).

## Verified no-ops (documented, not edited)
`--dangerously-bypass-hook-trust` is already absent from `BuildAppServerLaunchArgs`; `approvalsReviewer` is already `"user"`.

## Dormancy
Interactive launches don't route to app-server until the PR6 routing flip, so the bridge is exercised only by tests until then (ships behind the same `codex.transport=app-server` gate). The AI-1760 facts pin the fileChange/permissions **method-name strings** as by-convention (only command-execution is name-pinned in-repo) — the suffix-match routing handles all three, and the live cert (AI-2110) AC2 confirms the exact names.

## Tests
13 bridge units (grant paths + every fail-closed path + permissions-grant shape + non-approval shapes) + 1 end-to-end interactive wiring test (`OnServerRequest` → bridge → mapped `accept` on the wire); the reviewer decline path is unchanged. 43 codex tests green, no regressions.

Part of AI-1762.