### PR TITLE
[AI-2113] memory MCP: audience "project" (create/rescope project-audience memories)

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,9 +566,9 @@ It provides six tools:
 
 - **`search_memories`** — hybrid semantic + keyword search over memories visible to you (your own, your teams', and org-wide). Agents are told to call this before saving a new memory.
 - **`get_memory`** — fetch a memory's full content by id or slug.
-- **`save_memory`** — save a new memory with an `audience` (`user`, `team`, or `org`), `slug`, `description`, `content`, and `kind`. Scoped to the current repo by default; pass `global: true` to save it repo-independent, or `machine_specific: true` (user audience only) to tag it to this machine.
+- **`save_memory`** — save a new memory with an `audience` (`user`, `team`, `org`, or `project`), `slug`, `description`, `content`, and `kind`. For `audience: "project"` pass `audience_project: <slug>` — that project's members can then see and edit it (you must be a member). Scoped to the current repo by default; pass `global: true` to save it repo-independent, or `machine_specific: true` (user audience only) to tag it to this machine.
 - **`update_memory`** — update an existing memory's description, content, and/or kind.
-- **`rescope_memory`** — change a memory's audience (e.g. promote a personal memory to the team or org), or move its home scope to a **project** with `project: <slug>`. A project move is independent of audience and takes precedence over it, so pass `audience` **or** `project` (or both).
+- **`rescope_memory`** — change a memory's **audience** (who can see + edit it — promote a personal memory to the team, the org, or a **project's members** with `audience: "project"` + `audience_project: <slug>`), or move its home **context** to a project with `project: <slug>` (where it surfaces). These are orthogonal axes: `audience_project` sets the people, `project` sets the place — a context move is independent of audience and takes precedence over it, so pass `audience` **or** `project` (or both).
 - **`archive_memory`** — soft-delete a memory.
 
 The server is repo- and machine-aware: it resolves the current working directory to a repo hash and the local persisted machine id at startup, and uses both to scope `save_memory` and to bias `search_memories` / `get_memory` results.

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -296,9 +296,7 @@ static class McpMemoryServer {
             ["content"]           = Req("content"),
             ["kind"]              = Req("kind"),
             ["team"]              = args?["team"]?.GetValue<string>(),
-            // The project slug for audience 'project' (project members become editors) — the AUDIENCE
-            // (people) selector, like team; the server requires it when audience is 'project'. Distinct
-            // from the place/context project used by rescope. Pass through raw; the server validates.
+            // audience 'project' target — the people axis, distinct from rescope's place-axis project.
             ["audience_project"]  = args?["audience_project"]?.GetValue<string>(),
             ["repo_hash"]         = global ? null : cwdRepoHash,
             ["machine_tag"]       = machineSpecific ? machineId : null,
@@ -326,9 +324,8 @@ static class McpMemoryServer {
             ["audience"] = string.IsNullOrWhiteSpace(audience) ? null : audience,
             ["team"]     = args?["team"]?.GetValue<string>(),
             ["project"]  = string.IsNullOrWhiteSpace(project) ? null : project,
-            // The target project slug for audience 'project' (its members become editors) — the AUDIENCE
-            // (people) selector, orthogonal to the place-axis 'project' above. Pass through raw like team;
-            // the server requires it when audience is 'project' and ignores it otherwise.
+            // audience 'project' target (people axis) — distinct from the place-axis 'project' above; raw
+            // like team, not whitespace-nulled, since unlike project it has no precedence branch to guard.
             ["audience_project"] = args?["audience_project"]?.GetValue<string>(),
         };
     }

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -296,6 +296,10 @@ static class McpMemoryServer {
             ["content"]           = Req("content"),
             ["kind"]              = Req("kind"),
             ["team"]              = args?["team"]?.GetValue<string>(),
+            // The project slug for audience 'project' (project members become editors) — the AUDIENCE
+            // (people) selector, like team; the server requires it when audience is 'project'. Distinct
+            // from the place/context project used by rescope. Pass through raw; the server validates.
+            ["audience_project"]  = args?["audience_project"]?.GetValue<string>(),
             ["repo_hash"]         = global ? null : cwdRepoHash,
             ["machine_tag"]       = machineSpecific ? machineId : null,
             ["machine_context"]   = machineId,
@@ -322,6 +326,10 @@ static class McpMemoryServer {
             ["audience"] = string.IsNullOrWhiteSpace(audience) ? null : audience,
             ["team"]     = args?["team"]?.GetValue<string>(),
             ["project"]  = string.IsNullOrWhiteSpace(project) ? null : project,
+            // The target project slug for audience 'project' (its members become editors) — the AUDIENCE
+            // (people) selector, orthogonal to the place-axis 'project' above. Pass through raw like team;
+            // the server requires it when audience is 'project' and ignores it otherwise.
+            ["audience_project"] = args?["audience_project"]?.GetValue<string>(),
         };
     }
 
@@ -408,14 +416,15 @@ static class McpMemoryServer {
                 ["id_or_slug"] = new("string", "Memory id (32 hex) or slug.")
             }, ["id_or_slug"])),
         new("save_memory",
-            "Save a durable learning to the server. audience: 'user' (private), 'team', or 'org' (everyone). Saves are repo-scoped by default (to the cwd's git checkout); if the current repo can't be resolved, pass global: true for a repo-independent memory, or the save fails. Prefer update_memory when the result reports a nearDuplicate.",
+            "Save a durable learning to the server. audience: 'user' (private), 'team', 'org' (everyone), or 'project' (that project's members can see + edit — pass audience_project). Saves are repo-scoped by default (to the cwd's git checkout); if the current repo can't be resolved, pass global: true for a repo-independent memory, or the save fails. Prefer update_memory when the result reports a nearDuplicate.",
             new("object", new() {
-                ["audience"]         = new("string", "user | team | org"),
+                ["audience"]         = new("string", "user | team | org | project"),
                 ["slug"]             = new("string", "kebab-case identifier, unique within the audience+repo pool"),
                 ["description"]      = new("string", "One-line summary (max 300 chars)"),
                 ["content"]          = new("string", "Full memory body (max 64 KiB)"),
                 ["kind"]             = new("string", "preference | feedback | project | reference"),
                 ["team"]             = new("string", "Team name or id — required for audience 'team' if you are in several teams"),
+                ["audience_project"] = new("string", "Project slug — required for audience 'project'; that project's members become editors (you must be a member)"),
                 ["global"]           = new("boolean", "true = not tied to the current repo (required if not run from a git checkout; default: scoped to cwd repo)"),
                 ["machine_specific"] = new("boolean", "true = only relevant on this machine (user audience only)")
             }, ["audience", "slug", "description", "content", "kind"])),
@@ -428,12 +437,13 @@ static class McpMemoryServer {
                 ["kind"]        = new("string", "preference | feedback | project | reference")
             }, ["id"])),
         new("rescope_memory",
-            "Change a memory's audience (e.g. promote your user memory to team or org), or move its context to a project. Pass audience OR project (project takes precedence and is independent of audience).",
+            "Change a memory's audience — who can see + edit it (promote your user memory to team, org, or a project's members) — or move its home context to a project (where it surfaces). Two orthogonal axes: audience_project sets the PEOPLE (audience 'project'); project sets the PLACE (context move — takes precedence and is independent of audience).",
             new("object", new() {
-                ["id"]       = new("string", "Memory id"),
-                ["audience"] = new("string", "user | team | org"),
-                ["team"]     = new("string", "Target team when audience is 'team'"),
-                ["project"]  = new("string", "Target project slug — moves the memory's home scope to that project")
+                ["id"]               = new("string", "Memory id"),
+                ["audience"]         = new("string", "user | team | org | project"),
+                ["team"]             = new("string", "Target team when audience is 'team'"),
+                ["audience_project"] = new("string", "Target project slug when audience is 'project' — the PEOPLE axis (its members become editors; you must be a member). Distinct from 'project' below"),
+                ["project"]          = new("string", "Target project slug — the PLACE axis: moves the memory's home context to that project (takes precedence over audience)")
             }, ["id"])),
         new("archive_memory",
             "Archive (soft-delete) a memory.",

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpMemoryServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpMemoryServerTests.cs
@@ -73,6 +73,25 @@ public class McpMemoryServerTests {
     }
 
     [Test]
+    public async Task Save_body_carries_audience_project_for_project_audience() {
+        var body = McpMemoryServer.BuildSaveBody(
+            Args("""{"audience":"project","slug":"s","description":"d","content":"c","kind":"project","audience_project":"capacitor"}"""),
+            "abc123", "mach-1");
+
+        await Assert.That(body["audience"]!.GetValue<string>()).IsEqualTo("project");
+        await Assert.That(body["audience_project"]!.GetValue<string>()).IsEqualTo("capacitor");
+    }
+
+    [Test]
+    public async Task Save_body_omits_audience_project_when_absent() {
+        var body = McpMemoryServer.BuildSaveBody(
+            Args("""{"audience":"org","slug":"s","description":"d","content":"c","kind":"feedback"}"""),
+            "abc123", "mach-1");
+
+        await Assert.That(body["audience_project"]).IsNull();
+    }
+
+    [Test]
     public async Task Get_url_escapes_slug_and_carries_context() {
         var url = McpMemoryServer.BuildGetUrl("http://x", Args("""{"id_or_slug":"my-slug"}"""), "abc123", "mach-1");
 
@@ -94,6 +113,16 @@ public class McpMemoryServerTests {
 
         await Assert.That(body["project"]!.GetValue<string>()).IsEqualTo("capacitor");
         await Assert.That(body["audience"]).IsNull();
+    }
+
+    [Test]
+    public async Task Rescope_body_carries_audience_project_for_project_audience() {
+        var body = McpMemoryServer.BuildRescopeBody(Args("""{"id":"m1","audience":"project","audience_project":"capacitor"}"""));
+
+        await Assert.That(body["audience"]!.GetValue<string>()).IsEqualTo("project");
+        await Assert.That(body["audience_project"]!.GetValue<string>()).IsEqualTo("capacitor");
+        // Distinct from the place-axis project, which stays absent here.
+        await Assert.That(body["project"]).IsNull();
     }
 
     [Test]


### PR DESCRIPTION
The client half of **AI-1922** (project-audience memories), server-first — the server (kcap-server #1557, merged) now supports `audience: "project"` (a project's members can see + edit the memory), but until now no client could create one. Mirrors AI-2107's CLI follow-up for the place axis.

## What changed (`kcap mcp memory`)
- **`save_memory`** — `audience` accepts `project`; a new **`audience_project`** param carries the target project slug (wire field `audience_project`). That project's members become editors.
- **`rescope_memory`** — same: `audience: "project"` + `audience_project: <slug>` promotes a memory to a project's members. **Distinct** from the existing `project` param (AI-2107's place/context axis) — the two are orthogonal, so a separate param matches the server's separate fields.
- Tool descriptions + README spell out the two axes: `audience_project` = *who* (people), `project` = *where it surfaces* (place; independent of audience, takes precedence).

## Design notes
- `audience_project` is the audience selector's analog of `team` — passed through raw in both builders; the server validates and **membership-gates** (must be a project member) + **plan-gates** (`ProjectsAllowed`) it, rejecting a blank/invalid slug with a clear error. No local fail-fast needed (a missing slug never broadens scope, unlike `global`/`machine_specific`).
- Server precedence unchanged: a place-axis `project` context move still wins over the audience move.

## Tests
- `McpMemoryServerTests` (unit): `audience_project` carried on save + rescope for a project audience; omitted when absent; distinct from the place-axis `project`. 16/16 green locally.

## Follow-up (not in this PR)
- kcap-server submodule pin bump (maintainer's).

Part of the AI-1917 knowledge-scopes epic; completes AI-1922 end-to-end.