### PR TITLE
[AI-1762] §2.6: activate envelope-sourced transcript for hosted app-server

### DIFF
--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -292,6 +292,12 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     /// With no initial prompt it simply unseals (a subsequent user input becomes the first turn).
     /// </summary>
     public async Task BeginFirstTurnAsync(CancellationToken ct = default) {
+        // A launch cancelled during the source-claim / forwarder setup must NOT release the held first
+        // turn — dispatching turn/start after finalization began races the teardown. Observe the token
+        // BEFORE unsealing: the dispatch runs on CancellationToken.None and can't be recalled once it
+        // leaves, so this is the only safe gate. (A cancel in the sliver between here and Unseal is the
+        // same benign post-unseal race the comment below covers — teardown kills the process.)
+        ct.ThrowIfCancellationRequested();
         _dispatcher.Unseal();
         // If ct fires after the unseal, the held turn/start may already have left (the dispatch used
         // CancellationToken.None) — cancelling this await does NOT recall it. That is fine: a cancel here

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -83,10 +83,12 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
         var (sandbox, approval) = CodexPosturePolicy.Resolve(ctx.Work, ctx.IsReviewFlow, ctx.CodexPosture);
         var appServerArgs = _launcher.BuildAppServerLaunchArgs(launcherCtx);
 
-        // Marker stamping (guard-1) and the runtime's envelope emission must use the SAME decision, or a
-        // session could be hook-suppressed with no envelope source. The activation slice flips it on.
-        var emitEnvelopeTranscript = false;
-        var env                    = BuildEnv(ctx, emitEnvelopeTranscript);
+        // The app-server path is envelope-sourced: the daemon emits the transcript and defers the first
+        // turn behind a source claim, guard-1 stands the rollout watcher down (the marker), and guard-2
+        // backstops server-side. ONE decision drives all four (marker, emission, deferral, forwarder) so
+        // they can never desync. Rollback is codex.transport=pty — this method is not reached then.
+        const bool envelopeSourced = true;
+        var env = BuildEnv(ctx, envelopeSourced);
 
         var launch = new CodexAppServerLaunch(
             Cwd:           ctx.Worktree.Path,
@@ -104,7 +106,8 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
         var runtime = new CodexAppServerHostedAgentRuntime(
             spawn, launch, ctx.ActivityClock,
             _loggerFactory.CreateLogger<CodexAppServerHostedAgentRuntime>(),
-            emitEnvelopeTranscript: emitEnvelopeTranscript,
+            emitEnvelopeTranscript: envelopeSourced,
+            deferFirstTurn: envelopeSourced,
             agentId: ctx.AgentId,
             requestInteraction: _connection is { } c ? c.RequestAcpInteractionAsync : null,
             approvalTimeout: TimeSpan.FromSeconds(Math.Max(1, _config.CodexAppServerApprovalTimeoutSeconds)));
@@ -118,7 +121,10 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
             await runtime.DisposeAsync().ConfigureAwait(false);
             throw;
         }
-        return new HostedRuntimeStart(runtime, McpConfigPath: null);
+        // Transcript: runtime → the orchestrator drains the runtime's envelopes through an
+        // AcpTranscriptForwarder and, because RequiresSourceClaimBeforeFirstTurn is now set, runs the
+        // source-claim → BeginFirstTurn → confirm sequence before the first turn is dispatched.
+        return new HostedRuntimeStart(runtime, McpConfigPath: null, Transcript: runtime);
     }
 
     static LauncherContext BuildLauncherContext(RuntimeStartContext ctx) => new(

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3817,6 +3817,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // is running BEFORE the first turn dispatches, so it captures that turn's envelopes.
             StartForwarderAfterBind(agent, transcript, vendor, acpCts);
 
+            // StartForwarderAfterBind aborts silently if finalize ran (cancelled acpCts and/or removed the
+            // agent) during the bind — re-check the SAME liveness before releasing the held first turn, so a
+            // launch that finalized while binding never dispatches turn/start into a teardown. (The runtime
+            // also observes acpCts inside BeginFirstTurnAsync; this closes the agent-removed-but-token-live
+            // arm StartForwarderAfterBind guards on.)
+            if (acpCts.IsCancellationRequested || !_agents.ContainsKey(agent.Id)) {
+                LogAcpBindAbortedAgentGone(agent.Id);
+
+                return;
+            }
+
             // Dispatch the held first turn and await its response — the signal we confirm on.
             await runtime.BeginFirstTurnAsync(acpCts.Token);
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -141,6 +141,25 @@ public class CodexAppServerHostedAgentRuntimeTests {
     }
 
     [Test]
+    public async Task Cancelled_BeginFirstTurn_does_not_dispatch_the_held_turn() {
+        // A launch cancelled during the source claim must not release the held first turn — BeginFirstTurn
+        // observes the token BEFORE unsealing, so turn/start never leaves for a finalizing agent.
+        var fake = new FakeCodexAppServer();
+        var (runtime, _, _) = Build(_ => fake, Launch(prompt: "review this"), deferFirstTurn: true);
+
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await Assert.That(fake.ReceivedMethods).DoesNotContain("turn/start");
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.That(async () => await runtime.BeginFirstTurnAsync(cts.Token)).Throws<OperationCanceledException>();
+        await Assert.That(fake.ReceivedMethods).DoesNotContain("turn/start"); // never unsealed ⇒ never dispatched
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
     public async Task Single_phase_launch_dispatches_the_initial_prompt_at_start() {
         var fake = new FakeCodexAppServer();
         var (runtime, _, _) = Build(_ => fake, Launch(prompt: "review this")); // deferFirstTurn defaults false

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -159,9 +159,10 @@ public class CodexHostedAgentRuntimeFactoryTests {
 
     [Test]
     [NotInParallel("HomeEnvVarMutation")]
-    public async Task App_server_launch_leaves_the_marker_unset_while_dormant() {
-        // The activation slice has not flipped emitEnvelopeTranscript, so a real app-server launch must
-        // NOT stamp the marker — otherwise the shipped reviewers (still hook-ingested) would lose the watcher.
+    public async Task App_server_launch_is_envelope_sourced_after_activation() {
+        // Activation: a real app-server launch stamps the KCAP_HOSTED_APPSERVER marker (guard-1 stands the
+        // rollout watcher down), carries a Transcript for the forwarder to drain, and defers the first turn
+        // behind the source claim.
         var originalHome = Environment.GetEnvironmentVariable("HOME");
         var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
         using var home = new TempDir();
@@ -181,6 +182,10 @@ public class CodexHostedAgentRuntimeFactoryTests {
             var factory = Factory(new RecordingPtyFactory(), appServerActive: true, seam);
 
             var start = await factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None).WaitAsync(HangGuard);
+
+            await Assert.That(start.Transcript).IsNotNull();
+            await Assert.That(start.Runtime.RequiresSourceClaimBeforeFirstTurn).IsTrue();
+
             await start.Runtime.DisposeAsync();
         } finally {
             Environment.SetEnvironmentVariable("HOME", originalHome);
@@ -188,7 +193,7 @@ public class CodexHostedAgentRuntimeFactoryTests {
         }
 
         await Assert.That(capturedEnv).IsNotNull();
-        await Assert.That(capturedEnv!.ContainsKey("KCAP_HOSTED_APPSERVER")).IsFalse();
+        await Assert.That(capturedEnv!["KCAP_HOSTED_APPSERVER"]).IsEqualTo("1");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -160,9 +160,6 @@ public class CodexHostedAgentRuntimeFactoryTests {
     [Test]
     [NotInParallel("HomeEnvVarMutation")]
     public async Task App_server_launch_is_envelope_sourced_after_activation() {
-        // Activation: a real app-server launch stamps the KCAP_HOSTED_APPSERVER marker (guard-1 stands the
-        // rollout watcher down), carries a Transcript for the forwarder to drain, and defers the first turn
-        // behind the source claim.
         var originalHome = Environment.GetEnvironmentVariable("HOME");
         var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
         using var home = new TempDir();


### PR DESCRIPTION
## What

Flips the hosted-Codex app-server path from the dormant **hook-sourced** transcript to the live **envelope** source. One `envelopeSourced` decision in `StartAppServerAsync` now drives all four coupled facts so they can never desync:
- the **guard-1 marker** (`BuildEnv` → `KCAP_HOSTED_APPSERVER`, stands the rollout watcher down),
- the runtime's **envelope emission** (`emitEnvelopeTranscript`),
- the **deferred first turn** behind the source claim (`deferFirstTurn`),
- the **forwarder wiring** (`Transcript: runtime` on `HostedRuntimeStart`).

## Why it's a 4-value flip, not new machinery

Everything downstream is already built + merged and keys off these values:
- the orchestrator drains the runtime's envelopes through `AcpTranscriptForwarder` and — seeing `RequiresSourceClaimBeforeFirstTurn` — runs source-claim → `BeginFirstTurn` → confirm (#612);
- **guard-2** refuses any stray hook write server-side (#1547);
- **death-close** is the existing `FinalizeAgentRunAsync` → `EndAgentSession`, and the 60-min rollout-idle fallback disengages automatically because the stamped marker suppresses the hook's watcher (#617).

## Scope + safety

- **Reviewers only, for now.** `UsesAppServer` stays `active && IsReviewFlow`; the **interactive routing flip is deliberately the LAST step** (after §2.6 lifecycle + §2.7), so interactive stays on PTY.
- **Opt-in.** Gated behind `codex.transport=app-server` (default `pty`) — a default daemon is byte-unchanged.
- **Server-before-CLI.** Requires a server carrying #1530 (source-claim hub) + #1547 (guard-2); the source-claim fails closed against an old server.
- **Cert-gated.** [AI-2110] (the live cert) validates this before app-server becomes the default.

## Tests
Only the dormant-marker factory test inverts — it now asserts the marker **is** stamped, the `Transcript` is wired, and the first turn is deferred. Runtime (19), orchestrator forwarding (8), and source-claim (4) tests pass unchanged, confirming the built path activates end-to-end.

Part of AI-1762.