### PR TITLE
[AI-2123] Let the daemon suite finish a run outside CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,13 @@ dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj
 
 - Throwaway directories come from Helpers' `TempDir` — `using var tmp = new TempDir();` — never a per-class copy. Build paths under it with its own members — `tmp.PathTo(…)` for a path that must not exist yet, `tmp.CreateDir(…)`, `tmp.CreateFile(…)` — not `Path.Combine(tmp.Path, …)` + `Directory.CreateDirectory`/`File.WriteAllText`. A class that keeps one as a field must implement `IDisposable` and dispose it: CA1001 is an error, so an `[After(Test)]` hook will not build.
 - Capture console output with `ConsoleOutput.StartCapture()` / `StartErrorCapture()`, never a hand-rolled `Console.SetOut`/`SetError` save-restore — TUnit0055 is an error. Console is process-global, so every caller needs bare `[NotInParallel]`; a group key is not enough.
+- The same bare `[NotInParallel]` applies to any test that reaps a child itself (a raw `waitpid`). Once a pid is reaped the OS may reassign the number, so a concurrent spawn can make the wait land on someone else's child — and stealing one that `System.Diagnostics.Process` owns leaves .NET's SIGCHLD handler with ECHILD, which it answers by FailFast-ing the test host. A whole suite then dies mid-run with no failing assertion to point at.
+- **`Capacitor.Cli.Daemon.Tests.Unit` is not parallel-safe** — it spawns real processes, unix sockets and PTYs, and around 39 of its tests collide concurrently. Run it the way CI does, or it fails for reasons that have nothing to do with your change:
+  ```bash
+  dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj -- --maximum-parallel-tests 1
+  ```
+  A TUnit assembly-level `[ParallelLimiter<T>]` is **not** a substitute: it serialises by wall-clock but still leaves `CodexLauncherTests` failing intermittently, where the command-line flag does not.
+- Never assert that an environment variable is *absent* from a built `ProcessStartInfo`: its environment is seeded from the current process, and the repo's own `.envrc` exports several. Assert what the code under test contributed, by comparing against the inherited value.
 
 ## Running tests
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiHostedLaunchTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiHostedLaunchTests.cs
@@ -97,9 +97,16 @@ public class PiHostedLaunchTests {
 
     [Test]
     public async Task BuildPsi_OmitsServerUrl_WhenContextCarriesNone() {
-        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig(), Ctx(serverUrl: null));
+        // Compared against what the daemon already had, not against absence: ProcessStartInfo seeds
+        // its environment from the current process, and the repo's own .envrc exports KCAP_URL — so
+        // asserting the key is missing tests the developer's shell. The invariant is that BuildPsi
+        // contributes nothing when the context carries no URL, whatever it inherited.
+        var inherited = Environment.GetEnvironmentVariable("KCAP_URL");
 
-        await Assert.That(psi.Environment.ContainsKey("KCAP_URL")).IsFalse();
+        var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig(), Ctx(serverUrl: null));
+        psi.Environment.TryGetValue("KCAP_URL", out var actual);
+
+        await Assert.That(actual).IsEqualTo(inherited);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiHostedLaunchTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiHostedLaunchTests.cs
@@ -97,10 +97,8 @@ public class PiHostedLaunchTests {
 
     [Test]
     public async Task BuildPsi_OmitsServerUrl_WhenContextCarriesNone() {
-        // Compared against what the daemon already had, not against absence: ProcessStartInfo seeds
-        // its environment from the current process, and the repo's own .envrc exports KCAP_URL — so
-        // asserting the key is missing tests the developer's shell. The invariant is that BuildPsi
-        // contributes nothing when the context carries no URL, whatever it inherited.
+        // Not absence: psi inherits this process's environment, and .envrc exports KCAP_URL — so
+        // asserting the key is missing would test the developer's shell.
         var inherited = Environment.GetEnvironmentVariable("KCAP_URL");
 
         var psi = PiRpcHostedAgentRuntimeFactory.BuildPsi(new DaemonConfig(), Ctx(serverUrl: null));

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Unix/PtySpawnTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Unix/PtySpawnTests.cs
@@ -9,12 +9,8 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Pty.Unix;
 /// exercise the raw native contract in isolation.
 /// </summary>
 /// <remarks>
-/// Bare <c>[NotInParallel]</c>, for the same reason Console needs one: child reaping is process-global.
-/// These tests waitpid a pid pty_spawn has already reaped, so the number is free for the OS to
-/// reassign — and a concurrent spawn landing on it turns the wait into a wait on someone else's child.
-/// Winning that race is worse than losing it: System.Diagnostics.Process owns most of the others, and
-/// stealing one leaves .NET's SIGCHLD handler with ECHILD, which it answers by FailFast-ing the host.
-/// The whole suite then dies mid-run with no failing assertion to point at. A group key is not enough.
+/// Bare <c>[NotInParallel]</c>: these waitpid a reaped pid, which the OS can reassign to a concurrent spawn.
+/// Stealing a child System.Diagnostics.Process owns FailFasts the host, killing the whole run.
 /// </remarks>
 [NotInParallel]
 public class PtySpawnTests {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Unix/PtySpawnTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Unix/PtySpawnTests.cs
@@ -8,6 +8,15 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Pty.Unix;
 /// (bypassing UnixPtyProcess/the spawner thread, which Task 4/5 layer on top). These tests
 /// exercise the raw native contract in isolation.
 /// </summary>
+/// <remarks>
+/// Bare <c>[NotInParallel]</c>, for the same reason Console needs one: child reaping is process-global.
+/// These tests waitpid a pid pty_spawn has already reaped, so the number is free for the OS to
+/// reassign — and a concurrent spawn landing on it turns the wait into a wait on someone else's child.
+/// Winning that race is worse than losing it: System.Diagnostics.Process owns most of the others, and
+/// stealing one leaves .NET's SIGCHLD handler with ECHILD, which it answers by FailFast-ing the host.
+/// The whole suite then dies mid-run with no failing assertion to point at. A group key is not enough.
+/// </remarks>
+[NotInParallel]
 public class PtySpawnTests {
     [Test, RunOn(OS.Linux | OS.MacOs)]
     public async Task Successful_spawn_returns_a_reapable_child_and_a_captured_identity() {


### PR DESCRIPTION
Running `Capacitor.Cli.Daemon.Tests.Unit` the documented way — directly, as an executable — aborted with SIGABRT partway through, so most of its 2764 tests never reported. The one suite you can't iterate on locally was the one full of PTYs, sockets and launch lanes. Two causes, neither in the product.

- **`PiHostedLaunchTests`** asserted `KCAP_URL` is *absent* from the built `ProcessStartInfo`. That environment is seeded from the current process and the repo's own `.envrc` exports `KCAP_URL`, so the test was reading the developer's shell — it fails with the variable set and passes under `env -u`, same commit, same machine. `BuildPsi` only ever adds the key from the context and never removes an inherited one, which looks deliberate (a hosted agent falling back to the daemon's own server is reasonable), so the assertion moves to the invariant that actually holds: BuildPsi contributes nothing, whatever it inherited. Comparing against the inherited value needs no `EnvScope` — which would itself have required `[NotInParallel]` and raced the nine other daemon tests that touch `KCAP_URL`.
- **`PtySpawnTests`** caused the abort. It waits on a pid `pty_spawn` has already reaped, so the number is free for the OS to reassign, and a concurrent spawn landing on it turns that into a wait on someone else's child. Winning is worse than losing: `System.Diagnostics.Process` owns most of the others, and stealing one leaves .NET's SIGCHLD handler with `ECHILD`, which it answers by `FailFast`-ing the host. The `UnixSpawnerThread test-forced crash` trace in the log is collateral from that abort, not the cause. Bare `[NotInParallel]`, for the reason Console already has one.
- **`CLAUDE.md`** — both rules generalised, plus the invocation below.

Neither reproduces in isolation, which is why CI has never seen them: it passes `--maximum-parallel-tests 1`.

**That flag is doing more work than it looks.** Underneath the abort the suite has ~39 more tests that collide concurrently — measured, by running the unmodified suite serially (1 failure, the `KCAP_URL` one) against the same suite in parallel (39). It isn't a speed setting, it's the only thing holding the suite together, and it lived in `ci.yml` where nobody running the local loop would find it. Documented now, next to the command.

An assembly-level `[ParallelLimiter<T>]` would have moved that into the project instead of the command line, and I tried it. **It is not equivalent** — it serialises by wall-clock but still leaves `CodexLauncherTests` failing intermittently (4 one run, 2 the next; 59/59 in isolation), where the flag does not. Recorded in `CLAUDE.md` rather than shipped, so the next person doesn't spend the same afternoon on it.

Fixing those ~39 is a separate piece of work and deliberately not attempted here.

`Capacitor.Cli.Daemon.Tests.Unit` 2764 · 0 failed · 27 skipped · 1m 23s.

AI-2123
