### PR TITLE
npm refresh: include gemini, kiro, antigravity in upgrade refresh

### DIFF
--- a/npm/kcap/bin/refresh.js
+++ b/npm/kcap/bin/refresh.js
@@ -28,6 +28,9 @@ const REFRESHES = [
   ["plugin", "install", "--copilot", "--if-installed"],
   ["plugin", "install", "--pi",      "--if-installed"], // Pi extension (~/.pi/agent/extensions/kcap.ts)
   ["plugin", "install", "--opencode", "--if-installed"], // OpenCode plugin (~/.config/opencode/plugins/kcap.ts)
+  ["plugin", "install", "--gemini",  "--if-installed"], // Gemini hooks/MCP/instructions (~/.gemini)
+  ["plugin", "install", "--kiro",    "--if-installed"], // Kiro agent hooks (~/.kiro/agents/kcap.json)
+  ["plugin", "install", "--antigravity", "--if-installed"], // Antigravity hooks (~/.gemini/config/plugins/kcap)
   ["plugin", "install",              "--if-installed"], // Claude
 ];
 


### PR DESCRIPTION
`npm/kcap/bin/refresh.js`'s `REFRESHES` list — run by the npm postinstall hook and by `kcap update` — omitted `--gemini`, `--kiro`, and `--antigravity`. So on upgrade, those three integrations were never refreshed even for users who had opted in: their `.kcap-*-version` marker stayed at the old CLI version, and new hook command strings / skills / MCP registrations never landed until the user manually re-ran `kcap plugin install --<vendor>` or `kcap setup`.

Adds the three missing entries. Each is `--if-installed`, so it no-ops unless the vendor was previously installed (marker present or pre-marker install detected) — consistent with the existing entries. Order is independent (each gated by its own marker).

`node bin/refresh.test.js` passes (the file's assertions cover the MCP-config patcher, not the REFRESHES contents, so no test change was needed).

Found while implementing the new-harness detection feature (#625); fixed independently as it predates and is orthogonal to that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)