### PR TITLE
[AI-1762] §2.7 A2 cli mirror: report runtime_transport on AgentRegistered

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1991,7 +1991,11 @@ public readonly record struct AgentRegistered(
         // Applied ACP permission preset echo: the preset actually in effect for a hosted interactive
         // ACP launch, non-null only for such a launch. Trailing name-bound field — an older server
         // ignores it, an older daemon never sets it.
-        string? PermissionPreset = null
+        string? PermissionPreset = null,
+        // The runtime transport this agent launched on — "pty" | "app-server". The server validates
+        // it against its own launch decision and refuses a mismatch. Trailing name-bound field — an
+        // older server ignores it, an older daemon never sets it (null there).
+        string? RuntimeTransport = null
     );
 
 public readonly record struct AgentStatusChanged(

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -186,6 +186,9 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     public int?   ExitCode            => _process?.ExitCode;
     public bool   EmitsTerminalOutput => false;
 
+    // The one runtime that reports app-server; every other runtime keeps the interface's "pty" default.
+    public string RuntimeTransport    => CodexTransportDecision.AppServer;
+
     /// <summary>Resolved model from the <c>thread/start</c> response (never the requested one);
     /// null until the handshake completes. Feeds the existing launch-attempt reporting.</summary>
     public string? ResolvedModel => _resolvedModel;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -101,12 +101,10 @@ internal record AgentInstance(
     public string?              PermissionPreset  { get; init; }
 
     /// <summary>The runtime transport this agent actually launched on, reported to the server on
-    /// AgentRegistered so it can validate its launch decision. The codex app-server runtime is the
-    /// ONLY app-server transport; every other runtime (PTY codex, PTY claude, and all ACP vendors) is
-    /// PTY. Derived from the runtime instance so initial registration and every reconnect
-    /// re-registration report the same value (the same instance survives a reconnect).</summary>
-    public string RuntimeTransport =>
-        Runtime is CodexAppServerHostedAgentRuntime ? CodexTransportDecision.AppServer : CodexTransportDecision.Pty;
+    /// AgentRegistered so it can validate its launch decision. Each runtime owns its own transport
+    /// (<see cref="IHostedAgentRuntime.RuntimeTransport"/>), so this reports the same value on initial
+    /// registration and every reconnect re-registration (the same instance survives a reconnect).</summary>
+    public string RuntimeTransport => Runtime.RuntimeTransport;
 
     /// <summary>Phase B (D1): single-flight teardown latch — a plain field (not a property) so
     /// <see cref="System.Threading.Interlocked.CompareExchange(ref int,int,int)"/> can gate it. Exactly

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -100,6 +100,14 @@ internal record AgentInstance(
     /// and every reconnect re-registration report the same value.</summary>
     public string?              PermissionPreset  { get; init; }
 
+    /// <summary>The runtime transport this agent actually launched on, reported to the server on
+    /// AgentRegistered so it can validate its launch decision. The codex app-server runtime is the
+    /// ONLY app-server transport; every other runtime (PTY codex, PTY claude, and all ACP vendors) is
+    /// PTY. Derived from the runtime instance so initial registration and every reconnect
+    /// re-registration report the same value (the same instance survives a reconnect).</summary>
+    public string RuntimeTransport =>
+        Runtime is CodexAppServerHostedAgentRuntime ? CodexTransportDecision.AppServer : CodexTransportDecision.Pty;
+
     /// <summary>Phase B (D1): single-flight teardown latch — a plain field (not a property) so
     /// <see cref="System.Threading.Interlocked.CompareExchange(ref int,int,int)"/> can gate it. Exactly
     /// one teardown runs even if the launch-catch and the read-loop's finally race.</summary>
@@ -3636,7 +3644,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     async Task RegisterAgentAsync(AgentInstance agent) {
         if (agent.IsPrivate) return;
 
-        await _server.AgentRegisteredAsync(agent.Id, agent.Prompt, agent.Model, agent.Effort, agent.RepoPath, agent.SandboxPolicy, agent.ApprovalPolicy, agent.PermissionPreset);
+        await _server.AgentRegisteredAsync(agent.Id, agent.Prompt, agent.Model, agent.Effort, agent.RepoPath, agent.SandboxPolicy, agent.ApprovalPolicy, agent.PermissionPreset, agent.RuntimeTransport);
 
         // Report the PTY size so read-only viewers lock their xterm to it. Best-effort.
         try {
@@ -4036,7 +4044,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             for (var attempt = 1; ; attempt++) {
                 try {
-                    await _server.AgentRegisteredAsync(agent.Id, agent.Prompt, agent.Model, agent.Effort, agent.RepoPath, agent.SandboxPolicy, agent.ApprovalPolicy, agent.PermissionPreset);
+                    await _server.AgentRegisteredAsync(agent.Id, agent.Prompt, agent.Model, agent.Effort, agent.RepoPath, agent.SandboxPolicy, agent.ApprovalPolicy, agent.PermissionPreset, agent.RuntimeTransport);
 
                     // Re-gate the status send atomically under _reapLock, per attempt (finding 1
                     // refinement): the outer pre-check cannot cover a verdict published DURING the

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs
@@ -13,6 +13,13 @@ internal interface IHostedAgentRuntime : IAsyncDisposable {
     /// <summary>Vendor token this runtime hosts ("claude", "codex", "cursor").</summary>
     string Vendor { get; }
 
+    /// <summary>The wire transport label reported to the server on registration so it can validate its
+    /// launch decision against the transport actually used (defense-in-depth). "pty" is the universal
+    /// default — the label every interactive-PTY and ACP runtime reports — matching the server's PTY
+    /// contract; only the Codex app-server runtime overrides it. A runtime owns its own transport, so
+    /// the orchestrator never type-switches to derive it.</summary>
+    string RuntimeTransport => "pty";
+
     /// <summary>OS process id of the hosted agent (for logging).</summary>
     int Pid { get; }
 

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -815,10 +815,11 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     // Outgoing messages to server
     public virtual Task AgentRegisteredAsync(
             string agentId, string? prompt, string? model, string? effort, string? repoPath,
-            string? sandboxPolicy = null, string? approvalPolicy = null, string? permissionPreset = null)
+            string? sandboxPolicy = null, string? approvalPolicy = null, string? permissionPreset = null,
+            string? runtimeTransport = null)
         => _hub.InvokeAsync(
             "AgentRegistered",
-            new AgentRegistered(agentId, prompt, model, effort, repoPath, sandboxPolicy, approvalPolicy, permissionPreset),
+            new AgentRegistered(agentId, prompt, model, effort, repoPath, sandboxPolicy, approvalPolicy, permissionPreset, runtimeTransport),
             cancellationToken: _ct);
 
     /// <summary>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -1,6 +1,7 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Harness.Codex;
+using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
@@ -403,6 +404,18 @@ public class CodexAppServerHostedAgentRuntimeTests {
 
         // "max" maps to "xhigh", mirroring the PTY launcher.
         await Assert.That(fake.LastTurnEffort).IsEqualTo("xhigh");
+        await runtime.DisposeAsync();
+    }
+
+    // The daemon reports "app-server" only for the app-server codex runtime.
+    [Test]
+    public async Task AgentInstance_reports_app_server_transport_for_the_app_server_runtime() {
+        var (runtime, _, _) = Build(_ => new FakeCodexAppServer(), Launch());
+        var agent = new AgentInstance(
+            "a1", null, null, null, "/r", "codex", runtime,
+            new WorktreeInfo("/r", "", "/r", IsStandalone: true), new CancellationTokenSource());
+
+        await Assert.That(agent.RuntimeTransport).IsEqualTo(CodexTransportDecision.AppServer);
         await runtime.DisposeAsync();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
@@ -952,7 +952,7 @@ public class AgentOrchestratorLocalAttachTests {
 
         public override Task SendTerminalDimensionsAsync(string agentId, int cols, int rows) { LastDims = (cols, rows); Calls.Add(nameof(SendTerminalDimensionsAsync)); return Task.CompletedTask; }
         public override Task LaunchFailedAsync(string agentId, string reason) { Calls.Add(nameof(LaunchFailedAsync)); return Task.CompletedTask; }
-        public override Task AgentRegisteredAsync(string agentId, string? prompt, string? model, string? effort, string? repoPath, string? sandboxPolicy = null, string? approvalPolicy = null, string? permissionPreset = null) { Calls.Add(nameof(AgentRegisteredAsync)); return Task.CompletedTask; }
+        public override Task AgentRegisteredAsync(string agentId, string? prompt, string? model, string? effort, string? repoPath, string? sandboxPolicy = null, string? approvalPolicy = null, string? permissionPreset = null, string? runtimeTransport = null) { Calls.Add(nameof(AgentRegisteredAsync)); return Task.CompletedTask; }
         public override Task AgentStatusChangedAsync(string agentId, string status, string? sessionId) { Calls.Add(nameof(AgentStatusChangedAsync)); return Task.CompletedTask; }
         public override Task AgentUnregisteredAsync(string agentId) { Calls.Add(nameof(AgentUnregisteredAsync)); return Task.CompletedTask; }
         public override Task UpdateRepoPathsAsync() { Calls.Add(nameof(UpdateRepoPathsAsync)); return Task.CompletedTask; }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorVendorTests.cs
@@ -80,6 +80,25 @@ public class AgentOrchestratorVendorTests {
         await Assert.That(server.AgentRegisteredCallCount).IsEqualTo(2);
     }
 
+    // A PTY codex runtime reports "pty" on AgentRegistered — the transport rides the runtime TYPE,
+    // not the vendor (a codex agent is not automatically app-server).
+    [Test]
+    public async Task ReRegister_reports_pty_transport_for_a_pty_codex_runtime() {
+        var server = new CaptureServerConnection();
+
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.RegisterAgentForTest(new AgentInstance(
+            "agent-codex-pty", null, "", null, "/tmp", "codex",
+            new PtyHostedAgentRuntime("codex", new StubPtyProcess()), new WorktreeInfo("/tmp", "", "/tmp", IsStandalone: true), new CancellationTokenSource()
+        ));
+
+        await server.ReRegisterAgentsHook!();
+
+        var (_, transport) = server.AgentRegisteredTransports.Single();
+        await Assert.That(transport).IsEqualTo(CodexTransportDecision.Pty);
+    }
+
     [Test]
     public async Task Launch_with_unknown_vendor_emits_launch_failed_and_does_not_spawn_pty() {
         var server     = new CaptureServerConnection();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
@@ -97,13 +97,19 @@ sealed class CaptureServerConnection() : ServerConnection(
     /// initial registration and every reconnect re-registration report the same pair.</summary>
     public List<(string AgentId, string? Sandbox, string? Approval)> AgentRegisteredPostures { get; } = [];
 
+    /// <summary>The runtime transport ("pty" | "app-server") echoed on each registration, in call
+    /// order — proves initial and reconnect re-registration report the same value.</summary>
+    public List<(string AgentId, string? Transport)> AgentRegisteredTransports { get; } = [];
+
     public override async Task AgentRegisteredAsync(
         string  agentId,              string? prompt, string? model, string? effort, string? repoPath,
-        string? sandboxPolicy = null, string? approvalPolicy = null, string? permissionPreset = null) {
+        string? sandboxPolicy = null, string? approvalPolicy = null, string? permissionPreset = null,
+        string? runtimeTransport = null) {
         AgentRegisteredCallCount++;
         lock (AcpCallOrder) AcpCallOrder.Add($"register:{agentId}");
         lock (AgentRegisteredCalls) AgentRegisteredCalls.Add((agentId, model));
         lock (AgentRegisteredPostures) AgentRegisteredPostures.Add((agentId, sandboxPolicy, approvalPolicy));
+        lock (AgentRegisteredTransports) AgentRegisteredTransports.Add((agentId, runtimeTransport));
 
         AgentRegisteredEntered?.TrySetResult();
         if (AgentRegisteredGate is { } gate) await gate.Task.ConfigureAwait(false);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SeqCaptureServerConnection.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SeqCaptureServerConnection.cs
@@ -30,5 +30,6 @@ internal sealed class SeqCaptureServerConnection() : ServerConnection(
 
     public override Task AgentRegisteredAsync(
         string  agentId,              string? prompt, string? model, string? effort, string? repoPath,
-        string? sandboxPolicy = null, string? approvalPolicy = null, string? permissionPreset = null) => Task.CompletedTask;
+        string? sandboxPolicy = null, string? approvalPolicy = null, string? permissionPreset = null,
+        string? runtimeTransport = null) => Task.CompletedTask;
 }


### PR DESCRIPTION
## What & why

AI-1762 §2.7 **A2 cli mirror** — the daemon half of the validated `runtime_transport` fact. The server side merged in kcap-server#1567: the server derives the transport it expects a launch to run on and validates the daemon's reported value on `AgentRegistered`. This PR makes the daemon actually **report** that value.

## How

- `AgentRegistered` (Cli.Core `Models.cs`) gains a trailing `string? RuntimeTransport = null` — additive name-bound field, wire-safe both skew directions, picked up automatically by the source-gen `CapacitorJsonContext`.
- `AgentInstance` gains a computed `RuntimeTransport` property: `Runtime is CodexAppServerHostedAgentRuntime ? "app-server" : "pty"` (reusing `CodexTransportDecision.AppServer`/`.Pty`). The codex app-server runtime is the **only** app-server transport; every other runtime — PTY codex, PTY claude, and all ACP vendors — is `pty`. Deriving from the runtime instance means initial registration and every reconnect re-registration report the same value (the same instance survives a reconnect).
- `ServerConnection.AgentRegisteredAsync` gains a trailing `runtimeTransport` arg, threaded from both call sites in `AgentOrchestrator` (initial `RegisterAgentAsync` and reconnect `ReRegisterAgentsAsync`) as `agent.RuntimeTransport`.

## Scope

Server-first: kcap-server#1567 is merged, so this is safe to land now. It's dormant in practice until B6 turns on the v2 advertisement (no app-server launches happen before that — v1 app-server is retired and v2 isn't advertised yet), so every launch reports `pty` today; `app-server` starts flowing when B6 lands. The wire values `"pty"`/`"app-server"` are the cross-repo literal contract with the server's `RuntimeTransports`.

## Tests

- `CodexAppServerHostedAgentRuntimeTests.AgentInstance_reports_app_server_transport_for_the_app_server_runtime` — the app-server runtime → `app-server`.
- `AgentOrchestratorVendorTests.ReRegister_reports_pty_transport_for_a_pty_codex_runtime` — a PTY *codex* runtime → `pty` end-to-end through `AgentRegisteredAsync` (proves the transport rides the runtime type, not the vendor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
