### PR TITLE
Surface 3 (client): report harness inventory to the server

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -997,6 +997,10 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(LiveAgentInfo))]
 [JsonSerializable(typeof(QuarantinedAgentInfo))]
 [JsonSerializable(typeof(DaemonStatusReport))]
+// Surface 3 (new-harness detection): per-machine coding-agent inventory carried on the status report.
+[JsonSerializable(typeof(Capacitor.Cli.Core.Setup.HarnessInventory))]
+[JsonSerializable(typeof(Capacitor.Cli.Core.Setup.HarnessInventoryEntry))]
+[JsonSerializable(typeof(Dictionary<string, Capacitor.Cli.Core.Setup.HarnessInventoryEntry>))]
 // Phase B2-b (sequenced-settlement design): report / connect side wire DTOs.
 [JsonSerializable(typeof(ResolvedStartupCandidate))]
 [JsonSerializable(typeof(ResolvedStartupCandidate[]))]
@@ -1653,7 +1657,10 @@ public readonly record struct DaemonStatusReport(
         // Phase B2-b (sequenced-settlement design §5.5): the daemon-lifetime monotonic high-water of the
         // resolved-candidates ledger, advertised alongside ResolvedStartupCandidates so that once sparse
         // acks prune entries the server still knows the generation frontier. Additive/optional.
-        long?                         HighestResolutionGeneration   = null
+        long?                         HighestResolutionGeneration   = null,
+        // Surface 3 (new-harness detection): this machine's coding-agent inventory. Additive/optional
+        // — recomputed by the daemon on its own 6h in-memory cadence, attached to every report.
+        Capacitor.Cli.Core.Setup.HarnessInventory? HarnessInventory = null
     );
 
 // ── Phase B2-b (sequenced-settlement design): startup-completeness / heal-barrier report DTOs ──

--- a/src/Capacitor.Cli.Core/Setup/HarnessInventory.cs
+++ b/src/Capacitor.Cli.Core/Setup/HarnessInventory.cs
@@ -1,0 +1,52 @@
+namespace Capacitor.Cli.Core.Setup;
+
+/// <summary>One vendor's line in a <see cref="HarnessInventory"/>: is the harness installed on this
+/// machine, and is kcap wired into it.</summary>
+public sealed record HarnessInventoryEntry(bool Detected, bool Wired);
+
+/// <summary>
+/// A machine's coding-agent inventory reported to the server (surface 3): for every supported
+/// vendor, whether it's detected and whether kcap is wired in, plus the vendors the user has
+/// dismissed. The server raises the "installed but not configured" notification for a vendor that
+/// is <c>detected &amp;&amp; !wired</c> and not in <see cref="Declined"/>. Additive on the wire — an
+/// older server ignores it; an older client never sends it (the server treats an absent inventory
+/// as "unknown", never "nothing detected").
+///
+/// <para>Serialized snake_case by <c>CapacitorJsonContext</c> (<c>machine_id</c>, <c>vendors</c>,
+/// <c>detected</c>, <c>wired</c>, <c>declined</c>). <c>MachineId</c> is <see cref="Core.MachineId.Get"/>
+/// — the same id the daemon sends on <c>DaemonConnect</c> — so the server correlates a machine's
+/// connect record, status-report inventory, and hook-ingest inventory to one machine.</para>
+/// </summary>
+public sealed record HarnessInventory(
+    string MachineId,
+    Dictionary<string, HarnessInventoryEntry> Vendors,
+    string[] Declined) {
+
+    /// <summary>Pure: computes the inventory from an injected detection snapshot + offer ledger +
+    /// machine id, over every <see cref="HarnessCatalog"/> vendor. No I/O, no throttle — both
+    /// carriers (daemon status report, hook ingest) share this.</summary>
+    public static HarnessInventory Evaluate(AgentDetectionInputs inputs, HarnessOfferLedger ledger, string machineId) =>
+        Evaluate(AgentDetection.Detect(inputs), id => HarnessIntegrationProbe.IsWired(id, inputs), ledger, machineId);
+
+    /// <summary>Injectable core (detection result + wired-probe + ledger already resolved), so the
+    /// vendor→entry mapping is unit-testable without touching the filesystem or PATH.</summary>
+    public static HarnessInventory Evaluate(
+            AgentDetectionResult detected, Func<string, bool> isWired, HarnessOfferLedger ledger, string machineId) {
+        var vendors = new Dictionary<string, HarnessInventoryEntry>(StringComparer.Ordinal);
+        var declined = new List<string>();
+
+        foreach (var h in HarnessCatalog.All) {
+            vendors[h.VendorId] = new HarnessInventoryEntry(
+                Detected: h.Select(detected).Detected,
+                Wired: isWired(h.VendorId));
+            if (ledger.Entry(h.VendorId) is { Declined: true }) declined.Add(h.VendorId);
+        }
+
+        return new HarnessInventory(machineId, vendors, [.. declined]);
+    }
+
+    /// <summary>Production convenience: evaluate from the current process environment, the default
+    /// on-disk offer ledger (read-only — never claims the throttle stamp), and this machine's id.</summary>
+    public static HarnessInventory EvaluateCurrent() =>
+        Evaluate(AgentDetection.FromEnvironment(), HarnessOfferStore.Default().Load(), Core.MachineId.Get());
+}

--- a/src/Capacitor.Cli.Core/Setup/HarnessInventory.cs
+++ b/src/Capacitor.Cli.Core/Setup/HarnessInventory.cs
@@ -5,17 +5,10 @@ namespace Capacitor.Cli.Core.Setup;
 public sealed record HarnessInventoryEntry(bool Detected, bool Wired);
 
 /// <summary>
-/// A machine's coding-agent inventory reported to the server (surface 3): for every supported
-/// vendor, whether it's detected and whether kcap is wired in, plus the vendors the user has
-/// dismissed. The server raises the "installed but not configured" notification for a vendor that
-/// is <c>detected &amp;&amp; !wired</c> and not in <see cref="Declined"/>. Additive on the wire — an
-/// older server ignores it; an older client never sends it (the server treats an absent inventory
-/// as "unknown", never "nothing detected").
-///
-/// <para>Serialized snake_case by <c>CapacitorJsonContext</c> (<c>machine_id</c>, <c>vendors</c>,
-/// <c>detected</c>, <c>wired</c>, <c>declined</c>). <c>MachineId</c> is <see cref="Core.MachineId.Get"/>
-/// — the same id the daemon sends on <c>DaemonConnect</c> — so the server correlates a machine's
-/// connect record, status-report inventory, and hook-ingest inventory to one machine.</para>
+/// A machine's coding-agent inventory (surface 3): per vendor, detected + kcap-wired, plus the
+/// dismissed vendors. Additive on the wire (an old server ignores it; an old client never sends it).
+/// <c>MachineId</c> is <see cref="Core.MachineId.Get"/> — the same id the daemon sends on
+/// <c>DaemonConnect</c> — so the server can correlate one machine's reports.
 /// </summary>
 public sealed record HarnessInventory(
     string MachineId,

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -869,11 +869,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         public string Id => Agent.Id;
     }
 
-    // Surface 3 (new-harness detection): the machine's coding-agent inventory, cached and recomputed
-    // on a 6h in-memory cadence. Deliberately does NOT touch the on-disk nudge throttle stamp
-    // (HarnessOfferStore.TryClaimCheck) — claiming it here would starve the hook/CLI nudge surfaces.
-    // The recompute runs in the send path (RefreshHarnessInventoryIfStale, at most once per 6h);
-    // BuildStatusReport only READS the cache so it stays pure and deterministic for tests.
+    // Surface 3: cached machine inventory, recomputed on a 6h in-memory cadence. Deliberately never
+    // claims the on-disk nudge throttle stamp — that would starve the hook/CLI nudge surfaces.
+    // BuildStatusReport only reads the cache (stays pure); the send path refreshes.
     static readonly TimeSpan HarnessInventoryTtl = TimeSpan.FromHours(6);
     readonly object _harnessInventoryGate = new();
     Capacitor.Cli.Core.Setup.HarnessInventory? _harnessInventory;
@@ -892,10 +890,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 DateTimeOffset.UtcNow - _harnessInventoryEvaluatedAt < HarnessInventoryTtl) return;
             try {
                 _harnessInventory = Capacitor.Cli.Core.Setup.HarnessInventory.EvaluateCurrent();
-                _harnessInventoryEvaluatedAt = DateTimeOffset.UtcNow;
-            } catch {
-                // keep last cached (or null); inventory must never break the report path
+            } catch (Exception ex) {
+                // Keep the last cached value (or null); inventory must never break the report path.
+                _logger.LogDebug(ex, "Harness inventory evaluation failed — keeping last cached");
             }
+            // Advance on success AND failure: a persistently-failing environment (e.g. a read-only
+            // config dir) then backs off to the TTL instead of re-probing on every 60s send. The
+            // evaluation's sub-probes are already defensive, so a throw here is rare/environmental.
+            _harnessInventoryEvaluatedAt = DateTimeOffset.UtcNow;
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -869,6 +869,37 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         public string Id => Agent.Id;
     }
 
+    // Surface 3 (new-harness detection): the machine's coding-agent inventory, cached and recomputed
+    // on a 6h in-memory cadence. Deliberately does NOT touch the on-disk nudge throttle stamp
+    // (HarnessOfferStore.TryClaimCheck) — claiming it here would starve the hook/CLI nudge surfaces.
+    // The recompute runs in the send path (RefreshHarnessInventoryIfStale, at most once per 6h);
+    // BuildStatusReport only READS the cache so it stays pure and deterministic for tests.
+    static readonly TimeSpan HarnessInventoryTtl = TimeSpan.FromHours(6);
+    readonly object _harnessInventoryGate = new();
+    Capacitor.Cli.Core.Setup.HarnessInventory? _harnessInventory;
+    DateTimeOffset _harnessInventoryEvaluatedAt;
+
+    /// <summary>Recomputes the cached harness inventory if it's never been evaluated or is older than
+    /// <see cref="HarnessInventoryTtl"/>. Evaluated outside the lock (filesystem/PATH probes); never
+    /// throws — a probe failure keeps the last cached value so it can't break the status report.</summary>
+    void RefreshHarnessInventoryIfStale() {
+        lock (_harnessInventoryGate) {
+            if (_harnessInventory is not null &&
+                DateTimeOffset.UtcNow - _harnessInventoryEvaluatedAt < HarnessInventoryTtl) return;
+        }
+        Capacitor.Cli.Core.Setup.HarnessInventory? evaluated;
+        try { evaluated = Capacitor.Cli.Core.Setup.HarnessInventory.EvaluateCurrent(); }
+        catch { return; } // keep last cached (or null); inventory must never break the report path
+        lock (_harnessInventoryGate) {
+            _harnessInventory = evaluated;
+            _harnessInventoryEvaluatedAt = DateTimeOffset.UtcNow;
+        }
+    }
+
+    Capacitor.Cli.Core.Setup.HarnessInventory? CurrentHarnessInventory() {
+        lock (_harnessInventoryGate) return _harnessInventory;
+    }
+
     /// <summary>Phase B (D2): the daemon's self-report snapshot — its authoritative
     /// <see cref="ActiveCount"/> plus the live-agent metadata (and, once D4/Task 8 lands, the
     /// kill-quarantine). Pure; the send loop + tests share it.</summary>
@@ -894,7 +925,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             StartupDiscovery: _orphanReaper?.CurrentDiscovery,
             // Phase B2-b (sequenced-settlement design §5.5): the resolved-candidates ledger's monotonic
             // high-water, so once sparse acks prune entries the server still knows the generation frontier.
-            HighestResolutionGeneration: _resolvedLedger?.HighestResolutionGeneration);
+            HighestResolutionGeneration: _resolvedLedger?.HighestResolutionGeneration,
+            // Surface 3 (new-harness detection): the last cached machine inventory (null until the first
+            // send refreshes it); the server raises the "installed but not configured" notification from it.
+            HarnessInventory: CurrentHarnessInventory());
 
     /// <summary>Phase B2-b (sequenced-settlement design): the per-platform startup-reap-complete
     /// roll-up. A blocked known-id candidate (pending_marker / legacy_unresolvable /
@@ -1243,6 +1277,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// dropping the wait here is safe while dropping the invocation itself out from under the gate
     /// would not be.</summary>
     internal async Task SendDaemonStatusReportOnceAsync() {
+        // Surface 3: refresh the machine inventory before building the report. Cheap and self-throttled
+        // (recomputes at most once per 6h); the first send is the effective startup evaluation.
+        RefreshHarnessInventoryIfStale();
+
         try {
             await _statusReportOrderingGate.WaitAsync(_shutdownCts.Token);
         } catch (OperationCanceledException) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -880,19 +880,22 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     DateTimeOffset _harnessInventoryEvaluatedAt;
 
     /// <summary>Recomputes the cached harness inventory if it's never been evaluated or is older than
-    /// <see cref="HarnessInventoryTtl"/>. Evaluated outside the lock (filesystem/PATH probes); never
-    /// throws — a probe failure keeps the last cached value so it can't break the status report.</summary>
+    /// <see cref="HarnessInventoryTtl"/>. Single-flight: the whole check-evaluate-publish runs under
+    /// the gate, so overlapping report calls (periodic loop, OnRequestStatusReport, launch-stage,
+    /// delivered-input) can't each probe, and a slower probe can't overwrite a newer one and reset the
+    /// TTL to stale content. The evaluation is a handful of dir/PATH stats + a small JSON read, so
+    /// holding the gate across it is cheap. Never throws, and a probe failure does NOT advance the
+    /// timestamp — it retries on the next report rather than waiting a full TTL.</summary>
     void RefreshHarnessInventoryIfStale() {
         lock (_harnessInventoryGate) {
             if (_harnessInventory is not null &&
                 DateTimeOffset.UtcNow - _harnessInventoryEvaluatedAt < HarnessInventoryTtl) return;
-        }
-        Capacitor.Cli.Core.Setup.HarnessInventory? evaluated;
-        try { evaluated = Capacitor.Cli.Core.Setup.HarnessInventory.EvaluateCurrent(); }
-        catch { return; } // keep last cached (or null); inventory must never break the report path
-        lock (_harnessInventoryGate) {
-            _harnessInventory = evaluated;
-            _harnessInventoryEvaluatedAt = DateTimeOffset.UtcNow;
+            try {
+                _harnessInventory = Capacitor.Cli.Core.Setup.HarnessInventory.EvaluateCurrent();
+                _harnessInventoryEvaluatedAt = DateTimeOffset.UtcNow;
+            } catch {
+                // keep last cached (or null); inventory must never break the report path
+            }
         }
     }
 

--- a/src/Capacitor.Cli/Commands/Harness/AntigravityHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/AntigravityHookCommand.cs
@@ -168,6 +168,7 @@ static class AntigravityHookCommand {
         if (activeProfile?.DefaultVisibility is { } visibility)
             forwarded["default_visibility"] = visibility;
 
+        SessionStartInventory.Stamp(forwarded);
         var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(forwarded.ToJsonString());
 
         if (activeProfile?.ExcludedRepos is { Length: > 0 } excludedRepos

--- a/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
@@ -289,6 +289,10 @@ public static class ClaudeHookCommand {
                     node["agent_host_id"] = agentHostId;
                 }
 
+                // Surface 3: attach this machine's harness inventory, session-start only (the
+                // injections above apply to every event; the inventory is a session-start signal).
+                if (command == "session-start") SessionStartInventory.Stamp(node.AsObject());
+
                 body = node.ToJsonString();
             }
         } catch {

--- a/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
@@ -153,6 +153,9 @@ public static class ClaudeHookCommand {
             NormalizeGuidField(node, "agent_id");
             if (command == "session-end" && node["ended_at"] is null)
                 node["ended_at"] = DateTimeOffset.UtcNow.ToString("O");
+            // Surface 3: the degraded arm spools via this path and bypasses HandleCore's stamp, so a
+            // replayed session-start must still carry the harness inventory (the hook-ingest carrier).
+            if (command == "session-start") SessionStartInventory.Stamp(node.AsObject());
             return node.ToJsonString();
         } catch { return body; }
     }

--- a/src/Capacitor.Cli/Commands/Harness/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CodexHookCommand.cs
@@ -369,6 +369,7 @@ static class CodexHookCommand {
             node["workspace_root"] = workspaceRoot;
         }
 
+        SessionStartInventory.Stamp(node.AsObject());
         var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(node.ToJsonString());
 
         // Repo exclusion runs here (not above the event switch) so that the

--- a/src/Capacitor.Cli/Commands/Harness/CopilotHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CopilotHookCommand.cs
@@ -259,6 +259,7 @@ static class CopilotHookCommand {
             forwarded["default_visibility"] = visibility;
         }
 
+        SessionStartInventory.Stamp(forwarded);
         var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(forwarded.ToJsonString());
 
         // Repo exclusion after enrichment (fast in-payload path) — mark the

--- a/src/Capacitor.Cli/Commands/Harness/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CursorHookCommand.cs
@@ -254,6 +254,9 @@ public static class CursorHookCommand {
             var agentHostId = Environment.GetEnvironmentVariable("KCAP_AGENT_ID");
             if (agentHostId is not null) node["agent_host_id"] = agentHostId;
 
+            // Surface 3: attach this machine's harness inventory, session-start only.
+            if (eventName == "sessionStart") SessionStartInventory.Stamp(node.AsObject());
+
             if (eventName == "afterAgentThought") {
                 var sid = TryGetString(node, "session_id") ?? "";
                 var gen = TryGetString(node, "generation_id") ?? "";

--- a/src/Capacitor.Cli/Commands/Harness/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/GeminiHookCommand.cs
@@ -327,6 +327,7 @@ static class GeminiHookCommand {
             forwarded["default_visibility"] = visibility;
         }
 
+        SessionStartInventory.Stamp(forwarded);
         var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(forwarded.ToJsonString());
 
         if (activeProfile?.ExcludedRepos is { Length: > 0 } excludedRepos

--- a/src/Capacitor.Cli/Commands/Harness/KiroHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/KiroHookCommand.cs
@@ -214,6 +214,7 @@ static class KiroHookCommand {
             forwarded["model"] = model;
         }
 
+        SessionStartInventory.Stamp(forwarded);
         var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(forwarded.ToJsonString());
 
         if (activeProfile?.ExcludedRepos is { Length: > 0 } excludedRepos

--- a/src/Capacitor.Cli/Commands/Harness/OpenCodeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/OpenCodeHookCommand.cs
@@ -123,6 +123,7 @@ static class OpenCodeHookCommand {
             forwarded["default_visibility"] = visibility;
         }
 
+        SessionStartInventory.Stamp(forwarded);
         var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(forwarded.ToJsonString());
 
         if (activeProfile?.ExcludedRepos is { Length: > 0 } excludedRepos

--- a/src/Capacitor.Cli/Commands/Harness/PiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/PiHookCommand.cs
@@ -136,6 +136,7 @@ static class PiHookCommand {
         // JsonString round-trip (same rationale as the Codex/Copilot dispatchers).
         if (activeProfile?.DefaultVisibility is { } visibility) forwarded["default_visibility"] = visibility;
 
+        SessionStartInventory.Stamp(forwarded);
         var enriched = await RepositoryDetection.EnrichWithRepositoryInfo(forwarded.ToJsonString());
 
         if (activeProfile?.ExcludedRepos is { Length: > 0 } excludedRepos

--- a/src/Capacitor.Cli/SessionStartInventory.cs
+++ b/src/Capacitor.Cli/SessionStartInventory.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Setup;
+
+namespace Capacitor.Cli;
+
+/// <summary>
+/// Surface 3 (new-harness detection), hook carrier: stamps this machine's coding-agent inventory
+/// onto a SessionStart hook body, so a machine with no daemon still reports it whenever a wired
+/// harness is used. The value is the same <see cref="HarnessInventory"/> the daemon attaches to its
+/// status report, serialized through the SAME <see cref="CapacitorJsonContext"/> so the two carriers
+/// are byte-identical on the wire (<c>machine_id</c> travels inside the fragment). Computed fresh —
+/// current-state metadata on an already-happening POST, so no throttle. Never throws: a probe
+/// failure just omits the field (a nudge/inventory must never break a hook).
+/// </summary>
+static class SessionStartInventory {
+    public static void Stamp(JsonObject body) {
+        try {
+            var inv  = HarnessInventory.EvaluateCurrent();
+            var json = JsonSerializer.Serialize(inv, CapacitorJsonContext.Default.HarnessInventory);
+            body["harness_inventory"] = JsonNode.Parse(json);
+        } catch {
+            // best-effort metadata — never break a hook
+        }
+    }
+}

--- a/src/Capacitor.Cli/SessionStartInventory.cs
+++ b/src/Capacitor.Cli/SessionStartInventory.cs
@@ -6,13 +6,10 @@ using Capacitor.Cli.Core.Setup;
 namespace Capacitor.Cli;
 
 /// <summary>
-/// Surface 3 (new-harness detection), hook carrier: stamps this machine's coding-agent inventory
-/// onto a SessionStart hook body, so a machine with no daemon still reports it whenever a wired
-/// harness is used. The value is the same <see cref="HarnessInventory"/> the daemon attaches to its
-/// status report, serialized through the SAME <see cref="CapacitorJsonContext"/> so the two carriers
-/// are byte-identical on the wire (<c>machine_id</c> travels inside the fragment). Computed fresh —
-/// current-state metadata on an already-happening POST, so no throttle. Never throws: a probe
-/// failure just omits the field (a nudge/inventory must never break a hook).
+/// Surface 3 hook carrier: stamps this machine's harness inventory onto a SessionStart body, so a
+/// daemonless machine still reports it. Serialized through the same <see cref="CapacitorJsonContext"/>
+/// as the daemon's copy, so both carriers are byte-identical. Never throws — a probe failure just
+/// omits the field (must never break a hook).
 /// </summary>
 static class SessionStartInventory {
     public static void Stamp(JsonObject body) {

--- a/test/Capacitor.Cli.Core.Tests.Unit/Setup/HarnessInventoryTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Setup/HarnessInventoryTests.cs
@@ -1,0 +1,43 @@
+using Capacitor.Cli.Core.Setup;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Setup;
+
+public class HarnessInventoryTests {
+    static HarnessOfferLedger LedgerWith(params (string Vendor, HarnessOfferEntry Entry)[] rows) =>
+        new() { Vendors = rows.ToDictionary(r => r.Vendor, r => r.Entry, StringComparer.Ordinal) };
+
+    [Test]
+    public async Task Covers_all_nine_vendors_with_detected_and_wired() {
+        var inv = HarnessInventory.Evaluate(
+            HarnessCatalogTests.DetectionWithOnly("cursor", "antigravity"),
+            isWired: id => id == "cursor",
+            new HarnessOfferLedger(),
+            "machine-1");
+
+        await Assert.That(inv.MachineId).IsEqualTo("machine-1");
+        await Assert.That(inv.Vendors.Count).IsEqualTo(9);
+
+        await Assert.That(inv.Vendors["antigravity"]).IsEqualTo(new HarnessInventoryEntry(Detected: true, Wired: false));
+        await Assert.That(inv.Vendors["cursor"]).IsEqualTo(new HarnessInventoryEntry(Detected: true, Wired: true));
+        await Assert.That(inv.Vendors["gemini"]).IsEqualTo(new HarnessInventoryEntry(Detected: false, Wired: false));
+    }
+
+    [Test]
+    public async Task Declined_lists_only_dismissed_vendors() {
+        var inv = HarnessInventory.Evaluate(
+            HarnessCatalogTests.DetectionWithOnly("antigravity"),
+            isWired: _ => false,
+            LedgerWith(("antigravity", new HarnessOfferEntry { Declined = true }),
+                       ("gemini", new HarnessOfferEntry { LastOffered = DateTimeOffset.UtcNow })),
+            "m");
+
+        await Assert.That(inv.Declined).IsEquivalentTo(new[] { "antigravity" });
+    }
+
+    [Test]
+    public async Task No_dismissals_yields_empty_declined() {
+        var inv = HarnessInventory.Evaluate(
+            HarnessCatalogTests.DetectionWithOnly(), _ => false, new HarnessOfferLedger(), "m");
+        await Assert.That(inv.Declined).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/DaemonStatusReportTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/DaemonStatusReportTests.cs
@@ -25,4 +25,20 @@ public class DaemonStatusReportTests {
         await Assert.That(report.LiveAgents.Select(x => x.Id)).IsEquivalentTo(new[] { "a1", "a2" });
         await Assert.That(report.Quarantined).IsEmpty(); // until D4/Task 8
     }
+
+    // Surface 3: a sent status report carries this machine's harness inventory (all nine vendors +
+    // machine id). BuildStatusReport itself only reads the cache; the send path refreshes it first.
+    [Test]
+    public async Task Sent_status_report_carries_harness_inventory() {
+        var capture = new CaptureServerConnection();
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            capture, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        await orch.SendDaemonStatusReportOnceAsync();
+
+        var report = capture.StatusReports[^1];
+        await Assert.That(report.HarnessInventory).IsNotNull();
+        await Assert.That(report.HarnessInventory!.Vendors.Count).IsEqualTo(9);
+        await Assert.That(string.IsNullOrEmpty(report.HarnessInventory!.MachineId)).IsFalse();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Integration/SessionStartVisibilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/SessionStartVisibilityTests.cs
@@ -120,6 +120,33 @@ public class SessionStartVisibilityTests : IDisposable {
         await Assert.That(body["default_visibility"]?.GetValue<string>()).IsEqualTo("org_public");
     }
 
+    // Surface 3: the session-start body carries this machine's harness inventory (machine id + all
+    // nine vendors) — the hook-ingest carrier the server reads when no daemon runs. Same fragment
+    // shape the daemon sends on its status report.
+    [Test, NotInParallel("AppConfig_FileState")]
+    public async Task Stamps_harness_inventory_onto_session_start_body() {
+        var config = new ProfileConfig {
+            ActiveProfile = "work",
+            Profiles = new() { ["work"] = new Profile { ServerUrl = _server.Url } }
+        };
+        await ConfigMutator.MutateAsync(_ => config);
+
+        _server.Given(Request.Create().WithPath("/hooks/session-start").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        await ClaudeHookCommand.Handle(_server.Url!, new StringReader(SessionStartPayloadWithoutTranscriptPath()));
+
+        var requests = _server.FindLogEntries(Request.Create().WithPath("/hooks/session-start").UsingPost());
+        await Assert.That(requests.Count).IsEqualTo(1);
+
+        var body = JsonNode.Parse(requests[0].RequestMessage.Body!)!;
+        var inv  = body["harness_inventory"];
+        await Assert.That(inv).IsNotNull();
+        await Assert.That(string.IsNullOrEmpty(inv!["machine_id"]?.GetValue<string>())).IsFalse();
+        await Assert.That(inv["vendors"]!.AsObject().Count).IsEqualTo(9);
+        await Assert.That(inv["vendors"]!["claude"]!["wired"]).IsNotNull(); // per-vendor {detected,wired} shape
+    }
+
     [Test, NotInParallel("AppConfig_FileState")]
     public async Task Skips_session_start_when_repo_is_excluded_by_active_profile_v2_config() {
         var config = new ProfileConfig {


### PR DESCRIPTION
PR 2 of the new-harness-detection spec (surfaces 1–2 shipped in #626). Attaches a per-machine coding-agent inventory to the two client→server carriers so the **kcap-server** side (PR 3) can raise the "installed but not configured" UI notification and the machine-went-quiet backstop. This PR is client-only and additive — inert until the server consumes it.

## What's here

**Core** — `HarnessInventory { machine_id, vendors: { <vendorId>: { detected, wired } }, declined: [vendorId] }` with a pure `Evaluate` (shared by both carriers), registered in `CapacitorJsonContext` (snake_case wire shape). `machine_id` is `MachineId.Get()` — the same id the daemon already sends on `DaemonConnect` — so the server correlates a machine's connect record, status-report inventory, and hook-ingest inventory to one machine.

**Carrier A — daemon status report:** additive nullable field on `DaemonStatusReport`. `AgentOrchestrator` caches the inventory and recomputes on a **6h in-memory cadence**, deliberately **never** claiming the on-disk nudge throttle stamp (so it can't starve the hook/CLI nudge surfaces). `BuildStatusReport` stays pure (reads the cache); the send path refreshes.

**Carrier B — hook ingest:** `SessionStartInventory.Stamp` serializes the same `HarnessInventory` through the same context (→ byte-identical wire shape) onto each vendor's SessionStart body. Wired into all 9 hook commands (guarded to session-start for the shared-injection Claude/Cursor paths). Computed fresh — current-state metadata on an already-happening POST, so no throttle; never throws.

**Down-level:** additive/nullable — an old server ignores the field; an old client never sends it (the server treats an absent inventory as "unknown", never "nothing detected").

## Testing
- Core `Evaluate`: vendor→entry mapping + `declined` list.
- Daemon: a sent `DaemonStatusReport` carries the inventory (9 vendors + machine id).
- Hook: the session-start body carries `harness_inventory` (integration test, CI-gated like its `SessionStartVisibilityTests` siblings).
- AOT publish clean (no IL2026/IL3050); daemon + Core Harness suites green locally.

AI-2118

🤖 Generated with [Claude Code](https://claude.com/claude-code)