### PR TITLE
Jitter TokenStore concurrent-replace retries to survive Windows contention

### DIFF
--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -167,7 +167,7 @@ public static class TokenStore {
     // backoff; a genuine, persistent failure (e.g. the target is a directory) still surfaces by
     // rethrowing after the budget is spent. File.Move(overwrite: true) is atomic on NTFS, so a
     // reader only ever sees the old or the new complete document, never a splice.
-    const int ReplaceMaxAttempts   = 5;
+    const int ReplaceMaxAttempts   = 10;
     const int ReplaceBackoffBaseMs = 20;
 
     static async Task ReplaceWithRetryAsync(string tempPath, string path, CancellationToken ct = default) {
@@ -178,8 +178,9 @@ public static class TokenStore {
                 return;
             } catch (Exception ex) when ((ex is UnauthorizedAccessException or IOException)
                                          && attempt < ReplaceMaxAttempts) {
-                // Linear backoff (20/40/60/80ms) to let the peer holding the target close it.
-                await Task.Delay(ReplaceBackoffBaseMs * attempt, ct);
+                // Jitter the backoff so concurrent writers don't wake in lockstep and re-collide on
+                // the shared target every attempt (the Windows sharing-violation thundering herd).
+                await Task.Delay(ReplaceBackoffBaseMs * attempt + Random.Shared.Next(ReplaceBackoffBaseMs), ct);
             }
         }
     }


### PR DESCRIPTION
Fixes the Windows-only flake `TokenStoreProfileTests.SaveAsync_concurrent_writes_never_corrupt` (Linear **AI-2129**). No corresponding GitHub issue was filed — this was tracked in Linear.

## Problem
`ReplaceWithRetryAsync` already treated a Windows `UnauthorizedAccessException`/sharing-violation on `File.Move` as transient and retried it, but with a **fixed linear backoff and no jitter**. When many peers publish the same profile at once (the test drives 64; in production hooks/watcher/daemon/MCP/login share the store), the colliding writers wake from the backoff in lockstep and re-collide on every attempt, so the 5-attempt budget can exhaust and the final attempt rethrows the sharing violation. `ubuntu`/macOS never see it (no mandatory file sharing), so it only reddens the `windows-latest` lane.

## Fix
Harden the production replace path (not the test): add per-writer **jitter** to the backoff so concurrent writers desynchronise instead of retrying in unison, and widen the budget from 5 to 10 attempts to drain a burst. Mirrors the repo's existing `Random.Shared`-jitter retry precedent (`LocalPermissionBridge`).

## Verification
All 20 `TokenStoreProfileTests` pass on macOS (the Windows race can't be reproduced off-Windows, but the happy path is preserved). AOT-safe (`Random.Shared.Next` is already used in the daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
