### PR TITLE
Exclude where state is global, use identity where a pid is involved

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Kurrent Capacitor CLI
 
-**File paths:** CLI source at `src/Capacitor.Cli/`, shared core at `src/Capacitor.Cli.Core/`, daemon at `src/Capacitor.Cli.Daemon/`, npm packages at `npm/`, Claude Code plugin at `kcap/`.
+**File paths:** CLI source at `src/Capacitor.Cli/`, shared core at `src/Capacitor.Cli.Core/`, daemon at `src/Capacitor.Cli.Daemon/`, desktop app at `src/Capacitor.App/`, npm packages at `npm/`, Claude Code plugin at `kcap/`.
 
 **Harness layout:** vendor-specific code lives under `Harness/`. Vendors: Antigravity, Claude, Codex, Copilot, Cursor, Gemini, Kiro, OpenCode, Pi.
 
@@ -13,124 +13,46 @@ Namespaces follow the directory (`Capacitor.Cli.Core.Harness.Codex`, `Capacitor.
 
 ## What this project does
 
-The `kcap` CLI records Claude Code sessions by forwarding hook payloads and transcript data to a Kurrent Capacitor server. It also hosts an agent daemon for remote Claude CLI management and provides PR review context via MCP tools.
+The `kcap` CLI records coding-agent sessions by forwarding hook payloads and transcript data to a
+Kurrent Capacitor server. It also hosts an agent daemon for remote agent management and provides PR
+review context via MCP tools.
 
-Review flows use a vendor-neutral catalog-start v2 protocol: reserved `spec-review`/`code-review`
-aliases select an explicit or server-default reviewer independently of the driver. Codex setup
-registers `kcap-flows` without auto-approval and tracks only newly-created global TOML entries in
-`mcp-ownership-v1.json`, so uninstall preserves manual/customized MCP configuration. Daemons retain
-the string unattended-vendor list for compatibility and additionally advertise structured
-per-vendor CLI/launcher-policy capabilities. Cursor serves borrowed review context from a
-daemon-owned snapshot (dirty tracked and non-ignored untracked files, refreshed between rounds),
-because its zero-interaction modes may write; Claude has no borrowed-review containment strategy
-and therefore fails closed to an owned worktree.
+## Invariants
 
-Copilot also borrows from a daemon-owned snapshot, but its read boundary is an **OS sandbox**
-(`BorrowedReviewSandbox`, `sandbox-exec`, `(deny default)`) rather than a tool clamp, because the
-read tools it needs to see the snapshot are the same tools that could be pointed elsewhere. The
-profile grants nothing under the user's home: a per-launch `HOME`/`TMPDIR` state directory replaces
-the vendor's own config and cache grants, `BorrowedReviewAuthBroker` replaces the keychain grant with
-a token from the daemon's own environment, and `BorrowedReviewRuntimeRoots` replaces whole-prefix
-grants with software subdirectories derived from the vendor binary — never the prefix's `etc`/`var`. Support is
-conjunctive: macOS/ARM64 **and** `sandbox-exec` **and** a brokerable token, or the capability is not
-advertised and the server answers `vendor_containment_unreadable` with the `context-only` remedy.
-Enforcement is asserted by tests that run a real process under the profile, because a model-layer
-refusal is not containment evidence.
+Deliberate choices a change can silently undo — each looks like a bug until you know why.
+`docs/CHANGES.md` carries the reasoning per feature; `docs/superpowers/specs/` holds the designs.
 
-The daemon never *looks* for a credential: no keychain read, no prompt, no cache, no persistence, no
-default command. It forwards a token the operator exported, or — for a supervised daemon, whose unit
-file must not hold a secret — runs the single command the operator configured in
-`KCAP_COPILOT_TOKEN_CMD`, and only when an actual borrowed launch needs one. Availability is
-deliberately passive (configuration presence, never execution): probing by running the command at
-startup would mint a credential nobody asked for, so a configured-but-broken command instead fails at
-spawn with the coded `borrowed_review_auth_unavailable`. Service units are written owner-only, and
-installation fails rather than leaving one readable.
-
-Borrowed-review capability is **trust-by-default**: a vendor advertises it whenever its runtime
-factory declares a containment strategy, for whatever build of the vendor CLI is installed and on
-every platform. It is deliberately not gated on the installed binary matching a validated-build
-record — a vendor auto-update would then silently withdraw the capability and reviewers would fall
-back to a stale committed base. The daemon logs the CLI version it probed at startup (a startup
-observation, not a launch-time fact) and does no automated drift detection; a defective vendor
-release is handled by a human report and a corrected record. See
-`docs/superpowers/specs/2026-07-27-ai1528-trust-by-default-borrowed-review-design.md` in kcap-server.
-
-A daemon-owned launch-consent gate (AI-1623, `LaunchConsent*` in `Capacitor.Cli.Daemon/Services`)
-sits in front of every SERVER-driven launch: `LaunchConsentStore` owns `{stateDir}/consent.json` as
-the single writer, degrading a missing/corrupt file to the upgrade-safe default (`allow`, so no
-pre-existing daemon bricks on update) rather than failing closed. Every decision — rule-matched or
-human — is appended to `consent-decisions.jsonl` (1MB rotation, 0600 from first byte) for the
-`kcap daemon consent log` verb and the eventual desktop Activity feed, and a non-owner denial
-surfaces to the server as the coded `launch_denied_by_owner` reason. The policy is queried/edited
-live over the local control socket via the append-only `FrameType` values 11–14
-(`ConsentSubscribe`/`ConsentResolve`/`ConsentRulesGet`/`ConsentRulesPut`) and 72–74
-(`ConsentPending`/`ConsentRules`/`ConsentAck`); `kcap daemon consent {show,set-default,allow,deny,remove,log}`
-is the CLI surface and never blocks a launch waiting on a terminal prompt.
-
-**AI-1648** hardens the local control IPC ahead of the desktop supervisor app (spec:
-`docs/superpowers/specs/2026-08-01-slice2-prework-control-ipc-design.md`). A versioned **hello**
-frame pair (`HelloIpc.cs`) lets a client discover daemon capabilities before assuming any protocol
-shape: `Hello = 15` (client→daemon, optional `ClientHelloDto` — diagnostics only, never trusted)
-draws `HelloReply = 75` (`HelloReplyDto`: protocol/daemon version + a `capabilities` list) from
-`LocalControlServer`, answered and closed like `List`. `LocalControlCapabilities.Current` sits next
-to the routing switch so an entry can never be advertised without a live handler — this PR ships
-`["consent/1"]` only, `"status/1"` is reserved for AI-1649's `StatusSubscribe` handler. A pre-hello
-daemon can't decode frame 15 at all, so down-level discovery is hello-then-EOF, not an `Error` reply.
-The `prompt_no_ui` instant-deny race is closed by a bounded **subscriber grace** in
-`LaunchConsentGate`/`LaunchConsentBroker`: `min(5s, PromptTimeoutSeconds)` burned from one monotonic
-absolute deadline (injectable `TimeProvider`) fixed at prompt-path entry — every later wait
-recomputes `deadline − now` immediately before use rather than accumulating elapsed time, zero
-remaining settles as the existing `prompt_timeout` denial (no special case), and a generational
-subscriber-arrival waiter in the broker (one shared `TaskCompletionSource` per zero-subscriber
-period) lets concurrent waiters converge with arrival winning ties. Cancellation (the launch's own
-shutdown token) aborts the wait and the launch together — no consent decision is ever fabricated.
-
-**AI-1655 Plan B** (spec: `docs/superpowers/specs/2026-08-12-ai1655-onboarding-wizard-design.md` §4/§6)
-is the desktop app's mutation-safety substrate. Every daemon mutation the app performs routes through
-ONE app-lifetime `DaemonMutationLane` (`Capacitor.App/Services/Mutation/`): per-action CLI pinning
-(validated login-shell resolver, strict `0.12.0-beta.1` floor probe per mutation), an action-scoped
-`KcapCli` executor overlaying `KCAP_CONSENT_SEED_DEFAULT`/`KCAP_EXPECT_SERVER_URL`/
-`KCAP_APP_SPAWN_NO_TELEMETRY`/`KCAP_BOOT_ATTEMPT`, instance-bound evidence classification (one
-shared predicate; misclassification-toward-success is the cardinal sin), boot-refusal-marker
-attribution by attempt id, and a leased FIFO outcome channel whose single consumer owns ALL
-actionable presentation (waiter results are state-only; requeue-exactly-once, second abandonment =
-logged consume). `ConsentFlipClaims` (durable, `ConfigFileLock`-mutated, two-lock conditional clear,
-quarantine-aside) + `ConsentFlipCoordinator` (factory guard → `ConsentRulesPutV2`) cover
-pre-existing daemons. `OnboardingGate` (provider-aware, mirrors `TokenStore`'s real refresh rules,
-shared URL validator with `App.ValidProfileName`) drives the decision-2 startup carve-out:
-gate-incomplete machines build the graph with lifecycle auto-actions permanently closed and the
-shim auto-offer suppressed (item stays visible). Wizard UI + the Core auth façade are Plan C.
-
-**AI-1655 Plan C** (spec §5/§3) is the Core façade and the full wizard. `OnboardingFacade`
-(`Capacitor.Cli.Core/Auth/`) drives login/discover/create through one ordered commit boundary —
-claims (decision 7) → config + provider stamp → tokens — behind a totalized `AuthResult`:
-`Committed`/`Cancelled`/`Failed(AuthFailureReason)`/`Retarget(ServerInput)`. `LoginAsync`'s
-`adoptServer` flag separates `kcap login` (never repoints `server_url`) from `kcap setup`/the
-wizard (adopts — the write that reaches gate-complete); `kcap setup`/`kcap login` re-plumb onto the
-façade as thin Spectre adapters, behavior-preserving. `WizardComposition.BuildGraph`
-(`Capacitor.App/Services/Onboarding/`) composes the 8-step wizard (Shim/Connect/Sign-in/Defaults/
-Agents/Import/Daemon/Done) over that SAME façade via `WizardAuthService` and its decision-7
-`ArmingHook`; `App.RunWizardModeAsync` runs it wizard-first on a gate-incomplete machine (no
-daemon graph, no tray) and hands the outcome channel to the normal graph's consumer via
-`OutcomeChannel.TransferConsumer` once the sign-in lane cancels/quiesces, closing auto-actions
-permanently past the quiesce cap (decision 2/§6a). The §7 streaming `IProcessRunner` backs the
-Import step's live, bounded-tail log pane.
-
-The receive pump no longer awaits launch/stop EXECUTION for either command format: arrival order is
-preserved by routing sequenced AND un-sequenced server-origin launch/stop traffic through the ONE
-existing serial lane (`RunLaneAsync`). Un-sequenced commands commit via a typed, no-ack entry point
-— `SequencedCommandProcessor.SubmitUnsequenced(UnsequencedItem)` — whose admissibility check,
-active-launch-instance tracking, and lane commit all happen inside one critical section before the
-call returns. Active launch instances are reference-counted per agent id, so a launch dequeued and
-parked at the consent gate stays an admissible stop target; admissible targets are `_agents` ∪
-durable PID records ∪ active instances — the PID-record arm is load-bearing (it's how the server's
-registry-independent physical stop reclaims a prior incarnation's survivor), not belt-and-braces. A
-per-boot publication barrier makes "no dual domain, ever" structural: one lock guards both handler
-admission and the processor's single null→live transition. Stop coalescing is launch-aware and
-identity-guarded (a launch commit clears all of its id's pending-stop keys; a same-payload retry
-after a faulted stop always commits fresh), and the queued-stop count backs an edge-triggered,
-hysteresis-gated alarm exposed via `QueuedStopDepth`/`QueuedStopHighWater` accessors — additive, with
-no production consumer yet (AI-1649's supervision IPC is the natural one).
+- **A vendor either contains borrowed review or does not offer it.** Cursor and Copilot read a
+  daemon-owned snapshot, Codex its own tool clamp; Claude declares no containment, so a borrowed
+  request fails closed to an owned worktree. Copilot's boundary is an OS sandbox rather than a tool
+  clamp, and its support is conjunctive — macOS/ARM64 and `sandbox-exec` and a brokerable token, or
+  the capability is not advertised. Containment is proven by a real process run under the profile,
+  never by a model-layer refusal.
+- **The daemon never looks for a credential.** No keychain read, prompt, cache, persistence or
+  default command: it forwards what the operator exported, or runs the one command they configured,
+  and only when a borrowed launch needs it. Availability is configuration presence, never execution
+  — probing would mint a credential nobody asked for.
+- **Borrowed-review capability is never gated on the installed vendor build.** A runtime factory
+  declaring a containment strategy is enough to advertise it; version-gating would let a vendor
+  auto-update silently withdraw the capability and drop reviewers back to a stale base.
+- **Every server-driven launch passes the consent gate** (a local spawn on the 0600 socket is the
+  owner's by construction). Its store degrades a missing or corrupt policy to `allow` rather than
+  failing closed, so an update cannot brick a pre-existing daemon. Decisions append to an
+  owner-only log; no gate path blocks a launch on a terminal prompt, and cancellation aborts the
+  launch rather than fabricating a decision.
+- **Local control IPC is append-only and capability-gated.** `FrameType` values are never reused or
+  renumbered, and `LocalControlCapabilities.Current` is assembled beside the routing switch so
+  nothing can be advertised without a live handler.
+- **Server-origin launch and stop share one serial lane**, sequenced and un-sequenced alike, so
+  arrival order survives. One lock guards handler admission and the processor's single null→live
+  transition: there is no second command domain, ever.
+- **Codex MCP setup owns only what it created.** Entries it added are tracked in
+  `mcp-ownership-v1.json`, and uninstall preserves anything it cannot prove it wrote.
+- **Desktop-app daemon mutations go through one app-lifetime lane** with one shared evidence
+  predicate: classifying a failure as success is the cardinal sin.
+- **Auth commits in one ordered boundary** — claims, then config and provider stamp, then tokens —
+  behind a totalized result. `kcap login` never repoints `server_url`; `kcap setup` and the wizard
+  adopt it.
 
 ## Tech stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,13 +154,14 @@ dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj
 - A class whose time goes into real child processes (git, a vendor CLI, a PTY) can draw from `[ParallelLimiter<SubprocessLimit>]` — one pool of half the cores, shared by every class in the assembly that names it. TUnit's own cap is 4x the cores, sized for IO-bound tests; at that width these classes starve each other's timing assertions. Pool the CPU hogs, not the test that failed. Today the pool is the daemon suite's; elsewhere a whole-class `[NotInParallel(nameof(TheClass))]` is the cheaper tool when the point is to keep one class's own tests apart.
 - Spawning the real `kcap` binary goes through Helpers' `KcapProcess`, which requires a `DaemonStore` and pins it for the child. The assembly-wide `KCAP_DAEMONS_DIR` pin is a path that cannot be created, so a hand-rolled spawn dies with a bare ENOTDIR `IOException` instead of quietly resolving the developer's own daemons directory.
 - Capture console output with `ConsoleOutput.StartCapture()` / `StartErrorCapture()`, never a hand-rolled `Console.SetOut`/`SetError` save-restore — TUnit0055 is an error. Console is process-global, so every caller needs bare `[NotInParallel]`; a group key is not enough.
-- The same bare `[NotInParallel]` applies to any test that reaps a child itself (a raw `waitpid`). Once a pid is reaped the OS may reassign the number, so a concurrent spawn can make the wait land on someone else's child — and stealing one that `System.Diagnostics.Process` owns leaves .NET's SIGCHLD handler with ECHILD, which it answers by FailFast-ing the test host. A whole suite then dies mid-run with no failing assertion to point at.
-- **`Capacitor.Cli.Daemon.Tests.Unit` is not parallel-safe** — it spawns real processes, unix sockets and PTYs, and around 39 of its tests collide concurrently. Run it the way CI does, or it fails for reasons that have nothing to do with your change:
-  ```bash
-  dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj -- --maximum-parallel-tests 1
-  ```
-  A TUnit assembly-level `[ParallelLimiter<T>]` is **not** a substitute: it serialises by wall-clock but still leaves `CodexLauncherTests` failing intermittently, where the command-line flag does not.
 - Never assert that an environment variable is *absent* from a built `ProcessStartInfo`: its environment is seeded from the current process, and the repo's own `.envrc` exports several. Assert what the code under test contributed, by comparing against the inherited value.
+
+**Parallelism:** bare `[NotInParallel]` is exclusive against the whole assembly and its tests run last, one at a time; keyed `[NotInParallel("k")]` excludes only tests carrying `k`.
+
+- Bare is what process-global state needs: an environment variable, `Console`, a mutable static in production code, the working directory. Keyed is sound only when every *reader* is in the cohort too, not just every writer — an env var fails that as soon as a concurrent peer spawns a child (it inherits) or calls a path helper (it reads).
+- A method-level `[NotInParallel(…)]` shadows a class-level one: the first constraint wins and the method's comes first. Never carry both.
+- Mutate an environment variable through Helpers' `EnvScope` — `EnvScope.Exclusive(key, value)` for one a child inherits or a path helper reads, the constructor for one whose readers all carry the same key. It checks the constraint and throws naming the fix, so the rule is enforced rather than commented.
+- Reaping a child you forked is safe: the zombie holds its pid until you wait on it. Asserting on a pid you *no longer own* is not — one the shim already reaped, or a grandchild reparented to init. `kill(pid, 0)` reads a squatter as your process still alive, and stealing a wait from a child `System.Diagnostics.Process` owns FailFasts the test host. Use Helpers' `PidIdentity`: `Capture` while alive, then `IsGone`/`WaitUntilGoneAsync`.
 
 ## Running tests
 
@@ -175,6 +176,10 @@ A single suite still runs directly as an executable, which is the faster loop wh
 ```bash
 dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj
 ```
+
+Every suite, the daemon one included, runs green at full parallelism — no flag needed. CI's
+`--maximum-parallel-tests 1` caps only the unconstrained bucket, so it narrows race windows rather
+than closing them; a test that needs exclusion carries the constraint itself.
 
 ## Publishing
 

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,0 +1,143 @@
+# Change notes
+
+Why each feature is the shape it is — the reasoning a reader would otherwise reconstruct from a
+diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full designs.
+
+Not release notes. Each entry is written as of the change that produced it and is not revised as the
+code moves on; where an entry disagrees with the code, the code wins.
+
+
+## Review flows and reviewer selection
+
+Review flows use a vendor-neutral catalog-start v2 protocol: reserved `spec-review`/`code-review`
+aliases select an explicit or server-default reviewer independently of the driver. Codex setup
+registers `kcap-flows` without auto-approval and tracks only newly-created global TOML entries in
+`mcp-ownership-v1.json`, so uninstall preserves manual/customized MCP configuration. Daemons retain
+the string unattended-vendor list for compatibility and additionally advertise structured
+per-vendor CLI/launcher-policy capabilities. Cursor serves borrowed review context from a
+daemon-owned snapshot (dirty tracked and non-ignored untracked files, refreshed between rounds),
+because its zero-interaction modes may write; Claude has no borrowed-review containment strategy
+and therefore fails closed to an owned worktree.
+
+## Borrowed review: containment
+
+Copilot also borrows from a daemon-owned snapshot, but its read boundary is an **OS sandbox**
+(`BorrowedReviewSandbox`, `sandbox-exec`, `(deny default)`) rather than a tool clamp, because the
+read tools it needs to see the snapshot are the same tools that could be pointed elsewhere. The
+profile grants nothing under the user's home: a per-launch `HOME`/`TMPDIR` state directory replaces
+the vendor's own config and cache grants, `BorrowedReviewAuthBroker` replaces the keychain grant with
+a token from the daemon's own environment, and `BorrowedReviewRuntimeRoots` replaces whole-prefix
+grants with software subdirectories derived from the vendor binary — never the prefix's `etc`/`var`. Support is
+conjunctive: macOS/ARM64 **and** `sandbox-exec` **and** a brokerable token, or the capability is not
+advertised and the server answers `vendor_containment_unreadable` with the `context-only` remedy.
+Enforcement is asserted by tests that run a real process under the profile, because a model-layer
+refusal is not containment evidence.
+
+## Borrowed review: credentials
+
+The daemon never *looks* for a credential: no keychain read, no prompt, no cache, no persistence, no
+default command. It forwards a token the operator exported, or — for a supervised daemon, whose unit
+file must not hold a secret — runs the single command the operator configured in
+`KCAP_COPILOT_TOKEN_CMD`, and only when an actual borrowed launch needs one. Availability is
+deliberately passive (configuration presence, never execution): probing by running the command at
+startup would mint a credential nobody asked for, so a configured-but-broken command instead fails at
+spawn with the coded `borrowed_review_auth_unavailable`. Service units are written owner-only, and
+installation fails rather than leaving one readable.
+
+## Borrowed review: capability advertisement
+
+Borrowed-review capability is **trust-by-default**: a vendor advertises it whenever its runtime
+factory declares a containment strategy, for whatever build of the vendor CLI is installed and on
+every platform. It is deliberately not gated on the installed binary matching a validated-build
+record — a vendor auto-update would then silently withdraw the capability and reviewers would fall
+back to a stale committed base. The daemon logs the CLI version it probed at startup (a startup
+observation, not a launch-time fact) and does no automated drift detection; a defective vendor
+release is handled by a human report and a corrected record. See
+`docs/superpowers/specs/2026-07-27-ai1528-trust-by-default-borrowed-review-design.md` in kcap-server.
+
+## Launch consent
+
+A daemon-owned launch-consent gate (AI-1623, `LaunchConsent*` in `Capacitor.Cli.Daemon/Services`)
+sits in front of every SERVER-driven launch: `LaunchConsentStore` owns `{stateDir}/consent.json` as
+the single writer, degrading a missing/corrupt file to the upgrade-safe default (`allow`, so no
+pre-existing daemon bricks on update) rather than failing closed. Every decision — rule-matched or
+human — is appended to `consent-decisions.jsonl` (1MB rotation, 0600 from first byte) for the
+`kcap daemon consent log` verb and the eventual desktop Activity feed, and a non-owner denial
+surfaces to the server as the coded `launch_denied_by_owner` reason. The policy is queried/edited
+live over the local control socket via the append-only `FrameType` values 11–14
+(`ConsentSubscribe`/`ConsentResolve`/`ConsentRulesGet`/`ConsentRulesPut`) and 72–74
+(`ConsentPending`/`ConsentRules`/`ConsentAck`); `kcap daemon consent {show,set-default,allow,deny,remove,log}`
+is the CLI surface and never blocks a launch waiting on a terminal prompt.
+
+## Local control IPC
+
+**AI-1648** hardens the local control IPC ahead of the desktop supervisor app (spec:
+`docs/superpowers/specs/2026-08-01-slice2-prework-control-ipc-design.md`). A versioned **hello**
+frame pair (`HelloIpc.cs`) lets a client discover daemon capabilities before assuming any protocol
+shape: `Hello = 15` (client→daemon, optional `ClientHelloDto` — diagnostics only, never trusted)
+draws `HelloReply = 75` (`HelloReplyDto`: protocol/daemon version + a `capabilities` list) from
+`LocalControlServer`, answered and closed like `List`. `LocalControlCapabilities.Current` sits next
+to the routing switch so an entry can never be advertised without a live handler — this PR ships
+`["consent/1"]` only, `"status/1"` is reserved for AI-1649's `StatusSubscribe` handler. A pre-hello
+daemon can't decode frame 15 at all, so down-level discovery is hello-then-EOF, not an `Error` reply.
+The `prompt_no_ui` instant-deny race is closed by a bounded **subscriber grace** in
+`LaunchConsentGate`/`LaunchConsentBroker`: `min(5s, PromptTimeoutSeconds)` burned from one monotonic
+absolute deadline (injectable `TimeProvider`) fixed at prompt-path entry — every later wait
+recomputes `deadline − now` immediately before use rather than accumulating elapsed time, zero
+remaining settles as the existing `prompt_timeout` denial (no special case), and a generational
+subscriber-arrival waiter in the broker (one shared `TaskCompletionSource` per zero-subscriber
+period) lets concurrent waiters converge with arrival winning ties. Cancellation (the launch's own
+shutdown token) aborts the wait and the launch together — no consent decision is ever fabricated.
+
+## Desktop onboarding: mutation safety
+
+**AI-1655 Plan B** (spec: `docs/superpowers/specs/2026-08-12-ai1655-onboarding-wizard-design.md` §4/§6)
+is the desktop app's mutation-safety substrate. Every daemon mutation the app performs routes through
+ONE app-lifetime `DaemonMutationLane` (`Capacitor.App/Services/Mutation/`): per-action CLI pinning
+(validated login-shell resolver, strict `0.12.0-beta.1` floor probe per mutation), an action-scoped
+`KcapCli` executor overlaying `KCAP_CONSENT_SEED_DEFAULT`/`KCAP_EXPECT_SERVER_URL`/
+`KCAP_APP_SPAWN_NO_TELEMETRY`/`KCAP_BOOT_ATTEMPT`, instance-bound evidence classification (one
+shared predicate; misclassification-toward-success is the cardinal sin), boot-refusal-marker
+attribution by attempt id, and a leased FIFO outcome channel whose single consumer owns ALL
+actionable presentation (waiter results are state-only; requeue-exactly-once, second abandonment =
+logged consume). `ConsentFlipClaims` (durable, `ConfigFileLock`-mutated, two-lock conditional clear,
+quarantine-aside) + `ConsentFlipCoordinator` (factory guard → `ConsentRulesPutV2`) cover
+pre-existing daemons. `OnboardingGate` (provider-aware, mirrors `TokenStore`'s real refresh rules,
+shared URL validator with `App.ValidProfileName`) drives the decision-2 startup carve-out:
+gate-incomplete machines build the graph with lifecycle auto-actions permanently closed and the
+shim auto-offer suppressed (item stays visible). Wizard UI + the Core auth façade are Plan C.
+
+## Desktop onboarding: wizard and auth façade
+
+**AI-1655 Plan C** (spec §5/§3) is the Core façade and the full wizard. `OnboardingFacade`
+(`Capacitor.Cli.Core/Auth/`) drives login/discover/create through one ordered commit boundary —
+claims (decision 7) → config + provider stamp → tokens — behind a totalized `AuthResult`:
+`Committed`/`Cancelled`/`Failed(AuthFailureReason)`/`Retarget(ServerInput)`. `LoginAsync`'s
+`adoptServer` flag separates `kcap login` (never repoints `server_url`) from `kcap setup`/the
+wizard (adopts — the write that reaches gate-complete); `kcap setup`/`kcap login` re-plumb onto the
+façade as thin Spectre adapters, behavior-preserving. `WizardComposition.BuildGraph`
+(`Capacitor.App/Services/Onboarding/`) composes the 8-step wizard (Shim/Connect/Sign-in/Defaults/
+Agents/Import/Daemon/Done) over that SAME façade via `WizardAuthService` and its decision-7
+`ArmingHook`; `App.RunWizardModeAsync` runs it wizard-first on a gate-incomplete machine (no
+daemon graph, no tray) and hands the outcome channel to the normal graph's consumer via
+`OutcomeChannel.TransferConsumer` once the sign-in lane cancels/quiesces, closing auto-actions
+permanently past the quiesce cap (decision 2/§6a). The §7 streaming `IProcessRunner` backs the
+Import step's live, bounded-tail log pane.
+
+## Launch and stop command routing
+
+The receive pump no longer awaits launch/stop EXECUTION for either command format: arrival order is
+preserved by routing sequenced AND un-sequenced server-origin launch/stop traffic through the ONE
+existing serial lane (`RunLaneAsync`). Un-sequenced commands commit via a typed, no-ack entry point
+— `SequencedCommandProcessor.SubmitUnsequenced(UnsequencedItem)` — whose admissibility check,
+active-launch-instance tracking, and lane commit all happen inside one critical section before the
+call returns. Active launch instances are reference-counted per agent id, so a launch dequeued and
+parked at the consent gate stays an admissible stop target; admissible targets are `_agents` ∪
+durable PID records ∪ active instances — the PID-record arm is load-bearing (it's how the server's
+registry-independent physical stop reclaims a prior incarnation's survivor), not belt-and-braces. A
+per-boot publication barrier makes "no dual domain, ever" structural: one lock guards both handler
+admission and the processor's single null→live transition. Stop coalescing is launch-aware and
+identity-guarded (a launch commit clears all of its id's pending-stop keys; a same-payload retry
+after a faulted stop always commits fresh), and the queued-stop count backs an edge-triggered,
+hysteresis-gated alarm exposed via `QueuedStopDepth`/`QueuedStopHighWater` accessors — additive, with
+no production consumer yet (AI-1649's supervision IPC is the natural one).

--- a/docs/superpowers/specs/2026-08-21-test-parallel-safety-exclusion-and-pid-identity-design.md
+++ b/docs/superpowers/specs/2026-08-21-test-parallel-safety-exclusion-and-pid-identity-design.md
@@ -1,0 +1,426 @@
+# Test parallel safety: exclusion where state is global, identity where a pid is involved
+
+**Date:** 2026-08-21
+**Status:** Implemented (rides its implementation PR)
+**Repos:** kcap-cli
+**Issue:** AI-2145 (kurrent-io/kcap-cli#634), under AI-1977
+
+## Problem
+
+`CLAUDE.md` currently tells everyone to run one whole suite one test at a time:
+
+> **`Capacitor.Cli.Daemon.Tests.Unit` is not parallel-safe** — it spawns real processes, unix
+> sockets and PTYs, and around 39 of its tests collide concurrently. Run it the way CI does, or it
+> fails for reasons that have nothing to do with your change:
+> `dotnet run --project … -- --maximum-parallel-tests 1`
+> A TUnit assembly-level `[ParallelLimiter<T>]` is **not** a substitute: it serialises by wall-clock
+> but still leaves `CodexLauncherTests` failing intermittently, where the command-line flag does not.
+
+That guidance costs every local run 2.4–2.9× wall clock, and it is unsound on its own terms: the
+flag does not serialise the suite, and the tests it is supposed to protect are still racing under
+it. Meanwhile the defect it papers over — a handful of tests mutating process-global state behind a
+*keyed* guard that cannot exclude the tests that read it — stays in the tree, invisible.
+
+## Findings
+
+All measurements on this machine (Darwin 25.6.0, 16 logical cores → TUnit default width 64), TUnit
+1.65.31, `Capacitor.Cli.Daemon.Tests.Unit` at 2763 tests.
+
+### F1 — bare `[NotInParallel]` is already exclusive against *everything*
+
+`TUnit.Engine` groups tests into four buckets (`GroupTestsByConstraintsCore`): `Parallel`,
+`KeyedNotInParallel`, `ParallelGroups`, and the unkeyed `NotInParallel`.
+`TestScheduler.ExecuteAllPhasesAsync` runs `(Parallel ∥ Keyed)`, then parallel groups, then
+constrained groups, and only then drains the unkeyed bucket through `ExecuteSequentiallyAsync` —
+one test at a time. On top of the phase order sits `NotInParallelLock`, a writer-preferring async
+reader/writer lock: every test enters it *shared*, an unkeyed-`NotInParallel` test enters it
+*exclusive*, and `TestScheduler` enables it as soon as grouping reports any such test. Both paths
+funnel through `TestRunner.ExecuteTestInternalAsync`, so keyed and parallel tests alike hold the
+read side. The lock exists because `[DependsOn]` can drag a bucket member into another phase.
+
+Three independent confirmations:
+
+- A throwaway TUnit 1.65.31 probe (46 tests: 24 parallel, 6+6 keyed on two keys, a 4-test
+  `[ParallelGroup]`, bare at method and class level) recorded a start/end timeline. Bare tests
+  overlapped **0** peers; every other bucket overlapped as expected.
+- The daemon suite's own report JSON, full parallelism: every one of the 16 bare-marked tests that
+  ran on this platform showed **0** peers inside its window (the 17th is Linux-only and did not
+  run). `PtySpawnTests` — the class the previous PR marked — is among them.
+- Keyed tests in the same run overlapped 14–98 peers each.
+
+One exception, from the same grouping code: a test carrying `[ParallelGroup]` *as well as* bare
+`[NotInParallel]` lands in `ConstrainedParallelGroups`, and only the unkeyed bucket gets
+`RequiresGlobalNotInParallelLock` set (`MarkGlobalNotInParallelTests`) — so that combination is not
+globally exclusive. Nothing in the repo uses `[ParallelGroup]` today, but the guard in §3 checks for
+it rather than assuming that stays true.
+
+**Consequence: the requirement "bare `[NotInParallel]` excludes every other test, including keyed
+ones and unmarked ones" needs no implementation. It is TUnit's behaviour today.** What it costs is
+tail latency: bare tests run last, sequentially. Measured tail for all 36 process-global-state tests
+in the suite: **1.55s** of a 67s wall clock.
+
+### F2 — a method-level constraint silently shadows a class-level one
+
+Grouping takes the *first* `NotInParallelConstraint` in `TestContext.ParallelConstraints`, and the
+method-level attribute comes first. Probe, both directions:
+
+| Attributes | Bucket it landed in |
+|---|---|
+| class `[NotInParallel]` + method `[NotInParallel("A")]` | keyed (ran in the keyed phase, before the parallel groups) |
+| class `[NotInParallel("A")]` + method `[NotInParallel]` | unkeyed (ran last, alone) |
+
+`Services/LocalPermissionBridgeTests.cs:15` has exactly the first shape: a class-level bare
+`[NotInParallel]`, then `[NotInParallel(nameof(LocalPermissionBridgeTests))]` on ~70 test methods.
+The class-level attribute is dead.
+
+### F3 — `--maximum-parallel-tests 1` does not serialise a suite
+
+`GetMaxParallelism` feeds only `ExecuteWithGlobalLimitAsync`'s `Parallel.ForEachAsync`, i.e. the
+unconstrained bucket. `ConstraintKeyScheduler.ExecuteTestsWithConstraintsAsync` has no global-limit
+semaphore at all: it starts every key-disjoint test immediately, and the keyed phase runs
+concurrently with the parallel phase.
+
+Measured, same suite, `--maximum-parallel-tests 1`:
+
+- peak simultaneous tests: **4**, not 1;
+- `CodexLauncherTests`' `HOME` window still overlapped **17** other tests;
+- `CodexHostedAgentRuntimeFactoryTests.Active_review_flow…`' window overlapped **48**.
+
+So the flag narrows the race window; it does not close it. It is a probability reducer that reads
+like a guarantee.
+
+### F4 — the suite is green at full parallelism
+
+Four consecutive full-parallelism runs: **2763 tests, 0 failed**, 67s / 73s / 84s / 90s. The same
+suite under the documented invocation: **3m 13s**. The SIGABRT that motivated the guidance came
+from `PtySpawnTests`, which the same PR fixed with a bare `[NotInParallel]`; the flag was never what
+held the suite together. The "around 39 tests collide" figure is best read as the count of tests
+*touching* process-global state (a static inventory finds 36), not tests that fail.
+
+### F5 — what actually collides: 36 tests, four hazard kinds
+
+Inventory by scanning test bodies for `Environment.SetEnvironmentVariable`, `WorktreeManager.Snapshot*`
+static seams, `ConsoleOutput.Start*`, raw `waitpid`, and raw `kill`, cross-referenced with each
+test's real overlap window from the report JSON:
+
+| Hazard | Tests | Guard today | Peak peers in window |
+|---|---|---|---|
+| Console capture | 3 (`BootRefusalTests`) | bare | 0 |
+| Prod static seam (`WorktreeManager.Snapshot*`) | 4 (`StandaloneSnapshotTests`) | bare | 0 |
+| Env var (`PATH`, `GIT_CONFIG_*`, `ANTHROPIC_API_KEY`) | 6 | bare | 0 |
+| Raw `waitpid` | 4 (`PtySpawnTests`) | bare | 0 (3 of the 4 need no guard — see F6) |
+| Env var (`HOME`, `CODEX_HOME`, `GEMINI_CLI_HOME`) | 11 | keyed `"HomeEnvVarMutation"` | 16–98 |
+| Env var (`KCAP_DAEMON_SUPERVISED`) | 5 (`DeliberateRefusalExitTests`) | keyed | 14–39 |
+| pid liveness poll on a foreign pid | 3 | none | 27–41 |
+
+The keyed guards are unsound because the *readers* are not in the cohort: 18 sites in `src/` read
+`HOME` or the user profile, and 15 files in this suite spawn real `git`, which inherits it. A keyed
+constraint excludes only tests carrying the same key, so a `HOME` redirect is visible to every
+concurrent peer that spawns a child or calls a path helper. `KCAP_DAEMON_SUPERVISED` has the same
+shape via `SupervisionDetector`.
+
+The scan also *undercounts*: `CodexConfigWriterTests` mutates `HOME` through a static `ScopedHome`
+helper, so a body-level grep does not see it. Any static-analysis approach to this problem inherits
+that blind spot; a runtime check does not.
+
+### F6 — the pid hazards split three ways, and only one is dangerous
+
+- **Reaping our own unreaped child is safe.** Three of `PtySpawnTests`' four `waitpid` calls kill a
+  live `sleep`, or reap `sleep 0`'s corpse. A terminated child stays a zombie holding its pid number
+  until its parent reaps it, so the number cannot be reassigned in between. (This would not hold if
+  the test host were PID 1, where .NET reaps every child — it is not, and if it were, these cleanup
+  `waitpid`s would already be failing.)
+- **One call waits on a pid we no longer own.**
+  `PtySpawnTests.Child_side_exec_failure_reports_failed_step_exec_and_reaps_cleanly` asserts
+  `waitpid == -1` on a pid the shim has *already* reaped (`Native/pty_shim.c:573 reap_blocking` runs
+  on the child-side-error cleanup path), so the number is free. This is the call that can steal a
+  recycled `System.Diagnostics.Process` child's status and FailFast the host.
+- **Three liveness polls assert on pids we never owned** — a grandchild reparented to init and
+  reaped by it: `UnixPtyProcessSpawnTests.Terminate_kills_the_leaders_whole_process_group`, and
+  `UnixSpawnerThreadTests`' `Pdeathsig_kills_the_child_when_the_spawner_process_dies` and
+  `Agent_survives_unrelated_pool_thread_churn_while_the_thread_lives`. `kill(pid, 0)` is wrong in
+  both directions here: a recycled pid reads as "still alive" (false failure in the two
+  death-assertions), and in the churn test's *positive* assertion a recycled pid reads as alive when
+  the agent has actually died — a false pass.
+- **Windows has the same defect.** `Pty/Windows/ConPtyJobObjectTests.cs:112`,
+  `IsProcessAlive(int pid) => Process.GetProcessById(pid)`, polled after the job kill to prove the
+  child and grandchild are gone. Windows-only, so no local run here touches it, and CI's serial flag
+  masks it.
+
+The production code already solves this problem exactly: `ProcessStartToken` (public, Core) yields a
+token for a process *incarnation* — `lx:<boot_id>:<starttime-ticks>` from `/proc/pid/stat` field 22
+on Linux, `mac:<bootsessionuuid>:<p_uniqueid>` on macOS (a kernel counter never reused within a boot
+session), `tk:<absolute StartTime ticks>` on Windows — with a tri-state `Matches` that separates "a
+different incarnation" from "cannot compare". `ProcessIdentity` (daemon, internal;
+`Capacitor.Cli.Daemon.Tests.Unit` has `InternalsVisibleTo`) wraps it for the reapers.
+
+### F7 — the CI flag is masking a defect in another suite
+
+Found while verifying this change, not by looking for it: at full parallelism
+`Capacitor.Cli.Tests.Unit`'s `GitProviderRouterTests.Probe_result_is_memoized_per_host` fails
+(`Expected 1, found 0`). The router memoizes into a production static, and the class's
+`[Before(Test)]` `ResetMemoForTests()` is itself a process-global mutation, so a concurrent peer's
+reset — or its memo entry under the same host — decides what the test observes. CI's
+`--maximum-parallel-tests 1` is why nobody has seen it. Fixed here (class-level bare
+`[NotInParallel]`, per §1's rule) because leaving a flake I had just reproduced would be worse than
+the scope creep; the rest of that suite is still unaudited (see Non-goals).
+
+## Goals
+
+- Make the exclusion guarantee load-bearing where state is genuinely process-global, and enforced
+  rather than documented.
+- Replace pid-based liveness assertions with identity-based ones, so they are correct instead of
+  merely serialised.
+- Delete the whole-suite serial invocation from `CLAUDE.md`, and state what the CI flag does and
+  does not buy.
+- Keep the local daemon-suite loop at its full-parallelism wall clock (~70s).
+
+## Non-goals
+
+- Changing CI. `--max-parallel-test-modules 1` (cross-assembly filesystem sharing) and
+  `--maximum-parallel-tests 1` both stay in `ci.yml` for now; this design makes the second one
+  unnecessary for the daemon suite but does not audit the other three.
+- Auditing `Capacitor.Cli.Core.Tests.Unit`, `Capacitor.Cli.Tests.Unit`,
+  `Capacitor.Cli.Tests.Integration` or `Capacitor.App.Tests.Unit`. The 32 classes repo-wide carrying
+  `NotInParallel("HomeEnvVarMutation")` keep working unchanged.
+- Removing the `HOME` mutation altogether by threading a `home` argument through
+  `CodexLauncher.Prepare` (see Follow-ups).
+- An assembly-level `[ParallelLimiter<T>]` for the daemon suite. No CPU-width failure appeared in
+  four runs; the 23 per-class limiters stay as they are.
+
+## Design
+
+### 1. The rule, as `CLAUDE.md` will state it
+
+Three bullets replace the two added by #627 (the `waitpid` bullet and the "not parallel-safe" block):
+
+- **Bare `[NotInParallel]` is exclusive against the whole assembly** — the parallel bucket, every
+  keyed constraint, and every `[ParallelGroup]` — and its tests run last, one at a time. Use it for
+  state that is process-global: an environment variable, `Console`, a mutable static in production
+  code, the working directory.
+- **Keyed `[NotInParallel("k")]` only excludes tests carrying `k`.** It is sound only when every
+  *reader* of the shared thing is in the cohort too, not just every writer. An env var fails that
+  test the moment any concurrent peer spawns a child (it inherits) or calls a path helper (it
+  reads).
+- **A method-level `[NotInParallel(…)]` shadows a class-level one** — the first constraint wins, and
+  the method's comes first. Never carry both.
+
+And, in place of the serial invocation: the daemon suite runs green at full parallelism
+(`dotnet run --project …`); CI's `--maximum-parallel-tests 1` caps only the unconstrained bucket —
+keyed tests bypass it entirely — so it is not a parallel-safety guarantee for anything.
+
+The `waitpid` bullet is replaced by the sharper rule from F6: reaping a child you forked and have
+not yet reaped is safe, because the zombie holds the pid; what needs care is asserting anything
+about a pid you no longer own, and the fix there is identity, not exclusion.
+
+### 2. Marking: env mutation becomes exclusive
+
+Five classes, promoted from keyed to bare. Where a class mutates in a helper (so every test is
+affected) the attribute goes on the class; where only some tests mutate it goes on those methods, and
+the class-level key is deleted rather than promoted.
+
+| File | Scope of the change | Variable |
+|---|---|---|
+| `Harness/Codex/CodexLauncherTests.cs` | delete class key; bare on the 6 `Prepare_*` tests | `HOME` |
+| `Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs` | 4 method keys → bare | `HOME`, `CODEX_HOME` |
+| `Harness/Codex/CodexConfigWriterTests.cs` | class key → class bare (`ScopedHome` helper) | `HOME` |
+| `Harness/Antigravity/AntigravityReviewerHomeTests.cs` | 1 method key → bare | `GEMINI_CLI_HOME` |
+| `DeliberateRefusalExitTests.cs` | class key → class bare | `KCAP_DAEMON_SUPERVISED` |
+
+Three attributes are deleted outright, not promoted:
+
+- `Harness/Codex/CodexAppServerLaunchArgsTests.cs` — carries the `HomeEnvVarMutation` key but never
+  mutates; it only *reads* `CodexPaths.Home`. Once every writer is exclusive, readers need nothing.
+- `Services/AcpHostedAgentRuntimeFactoryTests.cs:1857` — same, a reader comparing a snapshotted
+  `HOME` to a live read.
+- `Services/LocalPermissionBridgeTests.cs:15` — the dead class-level bare from F2. The ~70
+  method-level keys stay: the bridge's loopback listener is a test-owned resource with an
+  enumerable cohort (`AgentOrchestrator*` tests share the key), which is what keyed is for.
+
+### 3. Enforcement: `EnvScope` checks the constraint it needs
+
+`test/Capacitor.Tests.Helpers/EnvScope.cs` exists already (save/restore around one variable, used by
+8 classes in `Capacitor.Cli.Tests.Unit`) and its remarks *ask* for `[NotInParallel]` without
+checking. It grows a check and one factory:
+
+```csharp
+public sealed class EnvScope : IDisposable {
+    // Requires the current test to carry SOME NotInParallel constraint (keyed or bare).
+    public EnvScope(string key, string? value);
+
+    // Requires an UNKEYED constraint: for variables read outside any enumerable cohort
+    // (inherited by spawned children, or read by production path helpers).
+    public static EnvScope Exclusive(string key, string? value);
+}
+```
+
+The check reads the same thing the engine reads, and picks the same winner:
+
+```csharp
+static NotInParallelConstraint? ResolvedConstraint() =>
+    TestContext.Current?.Parallelism.Constraints
+        .OfType<NotInParallelConstraint>()
+        .FirstOrDefault();   // first-wins, exactly like GroupTestsByConstraintsCore
+```
+
+Semantics:
+
+| Situation | `new EnvScope(…)` | `EnvScope.Exclusive(…)` |
+|---|---|---|
+| no `NotInParallel` at all | throw | throw |
+| keyed constraint | pass | throw |
+| unkeyed constraint | pass | pass |
+| class-level bare shadowed by a method-level key | throw (for `Exclusive`) — the shadow is visible because we resolve first-wins | as stated |
+| `TestContext.Current` is null (assembly-level hook, module initializer) | throw | throw |
+
+Throwing on a null context is deliberate: process-wide env pinning that must happen before any test
+(`RepoPathStoreGlobalSetup`'s `[ModuleInitializer]`) is not what this type is for and keeps using
+raw `Environment.SetEnvironmentVariable`. There is no `Unchecked` escape hatch — an unchecked default
+would defeat the point.
+
+Messages name the fix rather than the symptom, e.g. for the keyed case:
+
+> `HOME` is process-global: every child process this suite spawns inherits it and production path
+> helpers read it, so a keyed `[NotInParallel("HomeEnvVarMutation")]` cannot exclude the tests that
+> observe it. Mark this test bare `[NotInParallel]`.
+
+The 8 existing users in `Capacitor.Cli.Tests.Unit` are all keyed and keep working through the
+constructor, unchanged. In the daemon suite all 24 promoted tests adopt `EnvScope.Exclusive` and
+lose their hand-rolled `try/finally` — 16 from F5's keyed rows plus `CodexConfigWriterTests`' 8,
+which F5's body-level scan missed behind the `ScopedHome` helper — and the 6 already-bare env tests
+adopt it too, so the guard covers every env mutation in the suite.
+
+Guard tests (in the daemon suite, next to the convention they enforce): a bare test succeeds and
+restores the previous value; a keyed test calling `Exclusive` throws; an unmarked test calling the
+constructor throws.
+
+### 3b. Not landed: fail the suite on a raw env mutation in test sources
+
+The runtime guard only covers code that goes *through* `EnvScope`. A source-scan test — walking the
+daemon suite's own `.cs` files via `RepoTree.Root()` and failing on any
+`Environment.SetEnvironmentVariable` — would close the bypass for new code. Written and green, then
+dropped from this change as severable; the bypass stays open, and it is listed under Follow-ups.
+
+### 4. `PidIdentity`: identity instead of a pid number
+
+A small addition to `test/Capacitor.Tests.Helpers/`, over the public token, uniform across
+platforms:
+
+```csharp
+public static class PidIdentity {
+    // The incarnation token for a live pid. Throws if it cannot be read: arming a watch on an
+    // unreadable identity would silently degrade to the pid-only check we are removing.
+    public static string Capture(int pid);
+
+    // True once the pid no longer carries `identity`: gone, reaped, or reassigned.
+    public static bool IsGone(int pid, string identity);
+
+    // Polls IsGone to a deadline; on timeout throws naming pid, identity and elapsed time.
+    public static Task WaitUntilGoneAsync(int pid, string identity, TimeSpan timeout);
+}
+```
+
+`IsGone` is `ProcessStartToken.ForPid(pid)` being null (the pid left the process table) or carrying
+a different value under the same scheme (a different incarnation). What that yields per platform:
+
+| Process state | Linux / macOS | Windows |
+|---|---|---|
+| alive, same incarnation | token matches → not gone | `GetProcessById` succeeds, ticks match → not gone |
+| exited, not yet reaped (zombie) | `/proc/pid/stat` still readable, token matches → **not gone** | no zombie concept; `GetProcessById` throws once exited → gone |
+| exited and reaped | token unreadable → gone | gone |
+| pid reassigned to another process | token differs → gone | ticks differ → gone |
+
+The zombie row is the useful one: it makes "the shim reaped the child" assertable directly, which is
+what `Child_side_exec_failure…` is really about, and strictly stronger than `waitpid == -1` — an
+`ECHILD` cannot tell a reaped child from a stolen wait, whereas a surviving zombie keeps its token
+and fails the assertion.
+
+`Capture` throwing (rather than returning null) is what keeps the null-is-gone rule honest: a
+successful capture at arm time proves the token is readable for this pid in this environment, so a
+later null means the process left the table, not that we lack rights. That matters most on Windows,
+where reading `Process.StartTime` needs query rights and a protected or foreign-user process yields
+no token at all. The residual case — a process that changes credentials mid-life and becomes
+unreadable — does not arise for our own descendants.
+
+Applied:
+
+| Test | Change |
+|---|---|
+| `PtySpawnTests.Child_side_exec_failure_reports_failed_step_exec_and_reaps_cleanly` | assert `IsGone(result.Pid, result.StartIdentityString)` instead of `waitpid == -1`. The shim captures identity at `pty_shim.c:688`, before any wait, on this failure path too. |
+| `PtySpawnTests` (class) | drop the class-level bare `[NotInParallel]` — the three remaining `waitpid`s are zombie-protected (F6) |
+| `UnixPtyProcessSpawnTests.Terminate_kills_the_leaders_whole_process_group` | `Capture` the grandchild's token when the `CHILD:<pid>:DONE` line is read (it is alive then), then `WaitUntilGoneAsync` instead of polling `kill(pid, 0)` |
+| `UnixSpawnerThreadTests.Pdeathsig_kills_the_child_when_the_spawner_process_dies` | same shape |
+| `UnixSpawnerThreadTests.Agent_survives_unrelated_pool_thread_churn_while_the_thread_lives` | positive assertion becomes "still the same incarnation" (`!IsGone`), which is what the test means; cleanup `kill`+`waitpid` stays (our own child) |
+| `Pty/Windows/ConPtyJobObjectTests.Disposing_the_process_kills_child_and_grandchild` | `Capture` both pids while alive, then `WaitUntilGoneAsync`; `IsProcessAlive` is deleted |
+
+Net effect on the exclusion set: no pid test needs `[NotInParallel]`, and `PtySpawnTests` loses the
+one it has. The bare set is then exactly the process-global-state set: env, `Console`, prod statics.
+
+**Alternative considered — a Windows-specific handle pin.** Windows does not recycle a pid while any
+handle to the process is open, so holding a `Process`/`SafeProcessHandle` from first sighting makes
+reuse impossible and needs no token at all. It is strictly stronger than `tk:` comparison, which
+rests on (pid, creation-time) and could in principle collide if a pid were recycled *and* the new
+process created within the same system-clock tick. Rejected for uniformity: one primitive, one
+decision table, no platform branch in the tests. The residual risk is a same-tick creation on a
+recycled pid, which is also the granularity Windows itself uses for process identity. If the Windows
+leg ever proves that insufficient, pinning is a local change inside `PidIdentity` — the call sites
+do not move.
+
+## Cost
+
+- Sequential tail, measured after the change: **1.78s** across 44 bare test instances, against a
+  106s wall clock on the slowest of the three runs — inside the 1–2s the design predicted.
+  `PtySpawnTests` left the tail, the promoted env classes joined it.
+- Local daemon-suite loop: 3m13s → 62s / 66s / 107s across three runs, by deleting the documented
+  invocation. (The 107s run is the same suite on a busier machine, not a regression: the flag-free
+  loop is variance-prone in a way a serial run is not — still ~2× faster than 3m13s at its worst.)
+- CI: unchanged.
+
+## Verification
+
+As run, on this machine (Darwin 25.6.0, arm64):
+
+1. Three full-parallelism runs of `Capacitor.Cli.Daemon.Tests.Unit`: **0 failed** (2767/2767/2768
+   tests, 41 skipped), 62s / 66s / 107s.
+2. Overlap analysis over the third run's report JSON: the 44 bare test instances that ran overlapped
+   **0** peers each. The script that computes it is throwaway analysis, not committed.
+3. `Capacitor.Cli.Tests.Unit` at full parallelism surfaced F7 (unrelated to `EnvScope`, which its 8
+   keyed users still reach through the constructor unchanged); green after the F7 fix.
+4. `dotnet test --solution Capacitor.slnx --max-parallel-test-modules 1 -- --maximum-parallel-tests 1`,
+   the way CI runs it.
+5. Two changes are not exercisable here and land verified by review plus the CI leg that runs them —
+   stated so the gap is not silently inherited: `ConPtyJobObjectTests` (Windows only) and
+   `PtySpawnTests.Child_side_exec_failure_reports_failed_step_exec_and_reaps_cleanly`
+   (`[RunOn(OS.Linux)]`, skipped on macOS). The latter is the single most load-bearing pid rewrite in
+   the change, so its Linux leg is the gate on this PR.
+
+## Risks
+
+- **The guard covers only `EnvScope` users.** A test that keeps calling
+  `Environment.SetEnvironmentVariable` directly bypasses the runtime check, and §3b — which would
+  have caught that — is not in this change. The convention is enforced only where adopted; today
+  that is every env mutation in the daemon suite, with nothing stopping the next one.
+- **Promoting to bare hides a class of race rather than removing it.** A test that needs global
+  exclusion still cannot observe what a concurrent peer would do to it. The real removal is passing
+  `home` explicitly (Follow-ups); exclusion is the correct interim guard, not the destination.
+- **`p_uniqueid` is a private macOS ABI.** `ProcessStartToken` already depends on it in production
+  and the suite already asserts `mac:` tokens, so this design adds no new exposure — but a macOS
+  release that changed the flavor would fail `Capture` loudly (by design) rather than silently
+  degrade.
+- **Tail growth is unbounded by construction.** Every future bare mark serialises against the whole
+  assembly. 1–2s today is cheap; a rule that says "when in doubt, bare" would not stay cheap. The
+  `CLAUDE.md` bullets therefore say *when* bare is required, not that it is always safer.
+
+## Follow-ups (not in this change)
+
+- §3b: the source-scan test that fails the daemon suite on a raw `Environment.SetEnvironmentVariable`.
+
+- Thread a `home` argument through `CodexLauncher.Prepare` / `CodexPaths.UserHooksJson` so the six
+  `Prepare_*` tests need no env mutation at all, and the same for `CodexConfigWriterTests`.
+- Run the same inventory over the other three suites, then decide whether CI still needs
+  `--maximum-parallel-tests 1`. F7 is the evidence that at least one of them has a real defect the
+  flag is masking, and one fixed test is not an audit. The 32 `HomeEnvVarMutation` classes repo-wide are the obvious first
+  question: in `Capacitor.Cli.Tests.Unit` most path resolution is pinned by `KCAP_CONFIG_DIR`
+  (`RepoPathStoreGlobalSetup`), which is why the key survives there — worth confirming rather than
+  assuming.
+- Reconsider `--max-parallel-test-modules 1` once the suites stop sharing filesystem state.

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DeliberateRefusalExitTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DeliberateRefusalExitTests.cs
@@ -4,16 +4,13 @@ namespace Capacitor.Cli.Daemon.Tests.Unit;
 /// Decision 6: a supervised daemon's deliberate refusal (local name-lock, server
 /// <c>NameInUse</c>) exits 0 so <c>KeepAlive SuccessfulExit=false</c> doesn't respin it forever;
 /// a manual daemon keeps 2/3 for scripts. Covers the two pure exit-decision functions and the
-/// env-backed <see cref="DaemonRunner.IsSupervised"/> predicate they're driven by — mirrors
-/// <c>DaemonNameResolverTests</c>' env save/restore pattern since <c>IsSupervised</c> reads the
+/// env-backed <see cref="DaemonRunner.IsSupervised"/> predicate they're driven by, which reads the
 /// real process environment via <c>SupervisionDetector.DetectCurrent</c>.
 /// </summary>
-[NotInParallel("KCAP_DAEMON_SUPERVISED")]
+// KCAP_DAEMON_SUPERVISED is read through SupervisionDetector and inherited by every child
+// this suite spawns, so the exclusion has to be assembly-wide rather than keyed.
+[NotInParallel]
 public class DeliberateRefusalExitTests {
-    static readonly string? OriginalEnv = Environment.GetEnvironmentVariable("KCAP_DAEMON_SUPERVISED");
-
-    static void Reset() => Environment.SetEnvironmentVariable("KCAP_DAEMON_SUPERVISED", OriginalEnv);
-
     [Test]
     public async Task LockRefusalExit_Supervised_ReturnsZero() =>
         await Assert.That(DaemonRunner.LockRefusalExit(supervised: true)).IsEqualTo(0);
@@ -32,35 +29,23 @@ public class DeliberateRefusalExitTests {
 
     [Test]
     public async Task IsSupervised_EnvMatchesSanitizedName_ReturnsTrue() {
-        Environment.SetEnvironmentVariable("KCAP_DAEMON_SUPERVISED", "laptop");
+        using var env = EnvScope.Exclusive("KCAP_DAEMON_SUPERVISED", "laptop");
 
-        try {
-            await Assert.That(DaemonRunner.IsSupervised("laptop")).IsTrue();
-        } finally {
-            Reset();
-        }
+        await Assert.That(DaemonRunner.IsSupervised("laptop")).IsTrue();
     }
 
     [Test]
     public async Task IsSupervised_EnvMismatch_ReturnsFalse() {
-        Environment.SetEnvironmentVariable("KCAP_DAEMON_SUPERVISED", "ci");
+        using var env = EnvScope.Exclusive("KCAP_DAEMON_SUPERVISED", "ci");
 
-        try {
-            await Assert.That(DaemonRunner.IsSupervised("laptop")).IsFalse();
-        } finally {
-            Reset();
-        }
+        await Assert.That(DaemonRunner.IsSupervised("laptop")).IsFalse();
     }
 
     [Test]
     public async Task IsSupervised_EnvUnset_ReturnsFalse() {
-        Environment.SetEnvironmentVariable("KCAP_DAEMON_SUPERVISED", null);
+        using var env = EnvScope.Exclusive("KCAP_DAEMON_SUPERVISED", null);
 
-        try {
-            await Assert.That(DaemonRunner.IsSupervised("laptop")).IsFalse();
-        } finally {
-            Reset();
-        }
+        await Assert.That(DaemonRunner.IsSupervised("laptop")).IsFalse();
     }
 
     [Test]
@@ -69,25 +54,17 @@ public class DeliberateRefusalExitTests {
         // it never sanitizes the marker itself. "My Daemon!" sanitizes to "my-daemon", so a marker
         // holding the raw pre-sanitize name is a mismatch even though it "looks like" the same
         // daemon. Pins IsSupervised to that exact existing contract rather than a looser one.
-        Environment.SetEnvironmentVariable("KCAP_DAEMON_SUPERVISED", "My Daemon!");
+        using var env = EnvScope.Exclusive("KCAP_DAEMON_SUPERVISED", "My Daemon!");
 
-        try {
-            await Assert.That(DaemonRunner.IsSupervised("My Daemon!")).IsFalse();
-        } finally {
-            Reset();
-        }
+        await Assert.That(DaemonRunner.IsSupervised("My Daemon!")).IsFalse();
     }
 
     [Test]
     public async Task IsSupervised_EnvMatchesAlreadySanitizedForm_ReturnsTrue() {
         // The unit bakes in the SANITIZED name (ServiceEnvironment), so the real-world match shape
         // is: resolvedName "My Daemon!" (sanitizes to "my-daemon") + marker "my-daemon" → true.
-        Environment.SetEnvironmentVariable("KCAP_DAEMON_SUPERVISED", "my-daemon");
+        using var env = EnvScope.Exclusive("KCAP_DAEMON_SUPERVISED", "my-daemon");
 
-        try {
-            await Assert.That(DaemonRunner.IsSupervised("My Daemon!")).IsTrue();
-        } finally {
-            Reset();
-        }
+        await Assert.That(DaemonRunner.IsSupervised("My Daemon!")).IsTrue();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/EnvScopeGuardTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/EnvScopeGuardTests.cs
@@ -5,40 +5,57 @@ namespace Capacitor.Cli.Daemon.Tests.Unit;
 /// see it break: a keyed constraint does not exclude the readers of a process-global variable, and
 /// no constraint at all excludes nobody.
 /// </summary>
+/// <remarks>
+/// A variable per test, because these carry three different constraints on purpose: a shared name
+/// would let the unmarked test read what the keyed one is holding — the very race the type refuses.
+/// Each assertion compares against a snapshot rather than null, since the host environment is free
+/// to define anything.
+/// </remarks>
 public class EnvScopeGuardTests {
-    const string Probe = "KCAP_ENVSCOPE_GUARD_PROBE";
-
     [Test, NotInParallel]
     public async Task Exclusive_under_a_bare_constraint_sets_and_restores() {
-        var before = Environment.GetEnvironmentVariable(Probe);
+        const string probe = "KCAP_ENVSCOPE_PROBE_BARE";
+        var          before = Environment.GetEnvironmentVariable(probe);
 
-        using (EnvScope.Exclusive(Probe, "set")) {
-            await Assert.That(Environment.GetEnvironmentVariable(Probe)).IsEqualTo("set");
+        using (EnvScope.Exclusive(probe, "set")) {
+            await Assert.That(Environment.GetEnvironmentVariable(probe)).IsEqualTo("set");
         }
 
-        await Assert.That(Environment.GetEnvironmentVariable(Probe)).IsEqualTo(before);
+        await Assert.That(Environment.GetEnvironmentVariable(probe)).IsEqualTo(before);
     }
 
     [Test, NotInParallel("EnvScopeGuardTests")]
     public async Task Exclusive_under_a_keyed_constraint_is_refused() {
-        var ex = Assert.Throws<InvalidOperationException>(() => EnvScope.Exclusive(Probe, "set"));
+        const string probe = "KCAP_ENVSCOPE_PROBE_KEYED_EXCLUSIVE";
+        var          before = Environment.GetEnvironmentVariable(probe);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => EnvScope.Exclusive(probe, "set"));
 
         await Assert.That(ex!.Message).Contains("bare [NotInParallel]");
-        await Assert.That(Environment.GetEnvironmentVariable(Probe)).IsNull();
+        // Refused before it wrote anything.
+        await Assert.That(Environment.GetEnvironmentVariable(probe)).IsEqualTo(before);
     }
 
     [Test, NotInParallel("EnvScopeGuardTests")]
     public async Task The_constructor_accepts_a_keyed_constraint() {
-        using (new EnvScope(Probe, "set")) {
-            await Assert.That(Environment.GetEnvironmentVariable(Probe)).IsEqualTo("set");
+        const string probe = "KCAP_ENVSCOPE_PROBE_KEYED_CTOR";
+        var          before = Environment.GetEnvironmentVariable(probe);
+
+        using (new EnvScope(probe, "set")) {
+            await Assert.That(Environment.GetEnvironmentVariable(probe)).IsEqualTo("set");
         }
+
+        await Assert.That(Environment.GetEnvironmentVariable(probe)).IsEqualTo(before);
     }
 
     [Test]
     public async Task An_unmarked_test_is_refused() {
-        var ex = Assert.Throws<InvalidOperationException>(() => new EnvScope(Probe, "set").Dispose());
+        const string probe = "KCAP_ENVSCOPE_PROBE_UNMARKED";
+        var          before = Environment.GetEnvironmentVariable(probe);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => new EnvScope(probe, "set").Dispose());
 
         await Assert.That(ex!.Message).Contains("[NotInParallel]");
-        await Assert.That(Environment.GetEnvironmentVariable(Probe)).IsNull();
+        await Assert.That(Environment.GetEnvironmentVariable(probe)).IsEqualTo(before);
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/EnvScopeGuardTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/EnvScopeGuardTests.cs
@@ -1,0 +1,44 @@
+namespace Capacitor.Cli.Daemon.Tests.Unit;
+
+/// <summary>
+/// The convention <see cref="EnvScope"/> enforces, asserted where the suite that depends on it can
+/// see it break: a keyed constraint does not exclude the readers of a process-global variable, and
+/// no constraint at all excludes nobody.
+/// </summary>
+public class EnvScopeGuardTests {
+    const string Probe = "KCAP_ENVSCOPE_GUARD_PROBE";
+
+    [Test, NotInParallel]
+    public async Task Exclusive_under_a_bare_constraint_sets_and_restores() {
+        var before = Environment.GetEnvironmentVariable(Probe);
+
+        using (EnvScope.Exclusive(Probe, "set")) {
+            await Assert.That(Environment.GetEnvironmentVariable(Probe)).IsEqualTo("set");
+        }
+
+        await Assert.That(Environment.GetEnvironmentVariable(Probe)).IsEqualTo(before);
+    }
+
+    [Test, NotInParallel("EnvScopeGuardTests")]
+    public async Task Exclusive_under_a_keyed_constraint_is_refused() {
+        var ex = Assert.Throws<InvalidOperationException>(() => EnvScope.Exclusive(Probe, "set"));
+
+        await Assert.That(ex!.Message).Contains("bare [NotInParallel]");
+        await Assert.That(Environment.GetEnvironmentVariable(Probe)).IsNull();
+    }
+
+    [Test, NotInParallel("EnvScopeGuardTests")]
+    public async Task The_constructor_accepts_a_keyed_constraint() {
+        using (new EnvScope(Probe, "set")) {
+            await Assert.That(Environment.GetEnvironmentVariable(Probe)).IsEqualTo("set");
+        }
+    }
+
+    [Test]
+    public async Task An_unmarked_test_is_refused() {
+        var ex = Assert.Throws<InvalidOperationException>(() => new EnvScope(Probe, "set").Dispose());
+
+        await Assert.That(ex!.Message).Contains("[NotInParallel]");
+        await Assert.That(Environment.GetEnvironmentVariable(Probe)).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityReviewerHomeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityReviewerHomeTests.cs
@@ -254,26 +254,20 @@ public class AntigravityReviewerHomeTests {
     /// isolated home. The guard is shared, and settings.json is the file it was extended to cover.
     /// </summary>
     [Test]
-    [NotInParallel("HomeEnvVarMutation")]
+    [NotInParallel]
     public async Task A_daemon_wide_gemini_cli_home_cannot_redirect_the_homes_writes() {
         if (OperatingSystem.IsWindows()) return;
         using var root     = new TempDir();
         using var elsewhere = new TempDir();
 
-        var previous = Environment.GetEnvironmentVariable("GEMINI_CLI_HOME");
+        using var env = EnvScope.Exclusive("GEMINI_CLI_HOME", elsewhere.Path);
 
-        try {
-            Environment.SetEnvironmentVariable("GEMINI_CLI_HOME", elsewhere.Path);
+        var ex = Assert.Throws<InvalidOperationException>(() => AntigravityReviewerHome.Create(
+            root.Path, "epoch1", "agent1", [ResultChannel], grantInjectedMcpTools: true));
 
-            var ex = Assert.Throws<InvalidOperationException>(() => AntigravityReviewerHome.Create(
-                root.Path, "epoch1", "agent1", [ResultChannel], grantInjectedMcpTools: true));
+        await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_home_escaped_root");
 
-            await Assert.That(ex!.Message).StartsWith("antigravity_reviewer_home_escaped_root");
-
-            // Refused, not merely reported: nothing was written into the operator's tree.
-            await Assert.That(Directory.Exists(elsewhere.PathTo(".gemini"))).IsFalse();
-        } finally {
-            Environment.SetEnvironmentVariable("GEMINI_CLI_HOME", previous);
-        }
+        // Refused, not merely reported: nothing was written into the operator's tree.
+        await Assert.That(Directory.Exists(elsewhere.PathTo(".gemini"))).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerLaunchArgsTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerLaunchArgsTests.cs
@@ -9,7 +9,6 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
 /// <c>--disable apps</c> and per-whitelisted-server <c>default_tools_approval_mode="approve"</c>.
 /// Sandbox / approval / model / effort are per-turn protocol params on this transport, so none of
 /// the PTY-only flags appear.</summary>
-[NotInParallel("HomeEnvVarMutation")]
 public class CodexAppServerLaunchArgsTests {
     static CodexLauncher NewLauncher() =>
         new(new DaemonConfig { CodexPath = "codex", CapacitorPath = "/opt/kcap", ServerUrl = "https://t.example" },

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexConfigWriterTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexConfigWriterTests.cs
@@ -6,22 +6,10 @@ using Tomlyn.Model;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
 
-// Tests modify the HOME env var; they must not run in parallel with each other
-// (or with any other test that reads CodexPaths.Home) so that the scoped HOME is stable.
-[NotInParallel("HomeEnvVarMutation")]
+// Every test redirects HOME, which every spawned child inherits and every path helper reads, so
+// the exclusion has to be assembly-wide rather than keyed.
+[NotInParallel]
 public class CodexConfigWriterTests {
-    static TempDir ScopedHome(out string? originalHome) {
-        var tmp = new TempDir("codex");
-        originalHome = Environment.GetEnvironmentVariable("HOME");
-        Environment.SetEnvironmentVariable("HOME", tmp.GetResolvedPath());
-
-        return tmp;
-    }
-
-    static void RestoreHome(string? originalHome) {
-        Environment.SetEnvironmentVariable("HOME", originalHome);
-    }
-
     static TomlTable ReadToml(string path) =>
         TomlSerializer.Deserialize<TomlTable>(File.ReadAllText(path))!;
 
@@ -35,162 +23,154 @@ public class CodexConfigWriterTests {
 
     [Test]
     public async Task Writes_initial_projects_table_when_config_toml_missing() {
-        using var tmp = ScopedHome(out var original);
+        using var tmp  = new TempDir("codex");
+        using var home = EnvScope.Exclusive("HOME", tmp.GetResolvedPath());
 
-        try {
-            tmp.CreateDir(".codex");
-            CodexConfigWriter.TrustWorktree("/tmp/some-worktree", NullLogger.Instance);
+        tmp.CreateDir(".codex");
+        CodexConfigWriter.TrustWorktree("/tmp/some-worktree", NullLogger.Instance);
 
-            var configPath = tmp.PathTo(".codex", "config.toml");
-            await Assert.That(File.Exists(configPath)).IsTrue();
+        var configPath = tmp.PathTo(".codex", "config.toml");
+        await Assert.That(File.Exists(configPath)).IsTrue();
 
-            var root     = ReadToml(configPath);
-            var projects = (TomlTable)root["projects"];
-            var entry    = (TomlTable)projects[Key("/tmp/some-worktree")];
-            await Assert.That((string)entry["trust_level"]).IsEqualTo("trusted");
-        } finally { RestoreHome(original); }
+        var root     = ReadToml(configPath);
+        var projects = (TomlTable)root["projects"];
+        var entry    = (TomlTable)projects[Key("/tmp/some-worktree")];
+        await Assert.That((string)entry["trust_level"]).IsEqualTo("trusted");
     }
 
     [Test]
     public async Task Writes_to_fresh_home_creates_codex_directory() {
-        using var tmp = ScopedHome(out var original);
+        using var tmp  = new TempDir("codex");
+        using var home = EnvScope.Exclusive("HOME", tmp.GetResolvedPath());
 
         // Explicitly NOT pre-creating .codex
-        try {
-            CodexConfigWriter.TrustWorktree("/tmp/wt", NullLogger.Instance);
+        CodexConfigWriter.TrustWorktree("/tmp/wt", NullLogger.Instance);
 
-            var codexDir = tmp.PathTo(".codex");
-            await Assert.That(Directory.Exists(codexDir)).IsTrue();
-            await Assert.That(File.Exists(tmp.PathTo(".codex", "config.toml"))).IsTrue();
-        } finally { RestoreHome(original); }
+        var codexDir = tmp.PathTo(".codex");
+        await Assert.That(Directory.Exists(codexDir)).IsTrue();
+        await Assert.That(File.Exists(tmp.PathTo(".codex", "config.toml"))).IsTrue();
     }
 
     [Test]
     public async Task Adds_entry_to_existing_config_preserving_other_tables() {
-        using var tmp = ScopedHome(out var original);
+        using var tmp  = new TempDir("codex");
+        using var home = EnvScope.Exclusive("HOME", tmp.GetResolvedPath());
 
-        try {
-            var codexDir = tmp.CreateDir(".codex");
+        var codexDir = tmp.CreateDir(".codex");
 
-            codexDir.CreateFile("config.toml",
-                """
-                model = "gpt-5.5"
+        codexDir.CreateFile("config.toml",
+            """
+            model = "gpt-5.5"
 
-                [mcp_servers.linear]
-                url = "https://mcp.linear.app/mcp"
+            [mcp_servers.linear]
+            url = "https://mcp.linear.app/mcp"
 
-                [projects."/existing/path"]
-                trust_level = "trusted"
-                """
-            );
+            [projects."/existing/path"]
+            trust_level = "trusted"
+            """
+        );
 
-            CodexConfigWriter.TrustWorktree("/tmp/new-wt", NullLogger.Instance);
+        CodexConfigWriter.TrustWorktree("/tmp/new-wt", NullLogger.Instance);
 
-            var root = ReadToml(tmp.PathTo(".codex", "config.toml"));
-            await Assert.That((string)root["model"]).IsEqualTo("gpt-5.5");
-            var mcp = (TomlTable)((TomlTable)root["mcp_servers"])["linear"];
-            await Assert.That((string)mcp["url"]).IsEqualTo("https://mcp.linear.app/mcp");
+        var root = ReadToml(tmp.PathTo(".codex", "config.toml"));
+        await Assert.That((string)root["model"]).IsEqualTo("gpt-5.5");
+        var mcp = (TomlTable)((TomlTable)root["mcp_servers"])["linear"];
+        await Assert.That((string)mcp["url"]).IsEqualTo("https://mcp.linear.app/mcp");
 
-            var projects = (TomlTable)root["projects"];
-            await Assert.That((string)((TomlTable)projects["/existing/path"])["trust_level"]).IsEqualTo("trusted");
-            await Assert.That((string)((TomlTable)projects[Key("/tmp/new-wt")])["trust_level"]).IsEqualTo("trusted");
-        } finally { RestoreHome(original); }
+        var projects = (TomlTable)root["projects"];
+        await Assert.That((string)((TomlTable)projects["/existing/path"])["trust_level"]).IsEqualTo("trusted");
+        await Assert.That((string)((TomlTable)projects[Key("/tmp/new-wt")])["trust_level"]).IsEqualTo("trusted");
     }
 
     [Test]
     public async Task Updates_trust_level_if_present_but_not_trusted() {
-        using var tmp = ScopedHome(out var original);
+        using var tmp  = new TempDir("codex");
+        using var home = EnvScope.Exclusive("HOME", tmp.GetResolvedPath());
 
-        try {
-            var codexDir = tmp.CreateDir(".codex");
+        var codexDir = tmp.CreateDir(".codex");
 
-            codexDir.CreateFile("config.toml",
-                $"""
-                 {SeededHeader("/tmp/wt")}
-                 trust_level = "ask"
-                 """
-            );
+        codexDir.CreateFile("config.toml",
+            $"""
+             {SeededHeader("/tmp/wt")}
+             trust_level = "ask"
+             """
+        );
 
-            CodexConfigWriter.TrustWorktree("/tmp/wt", NullLogger.Instance);
+        CodexConfigWriter.TrustWorktree("/tmp/wt", NullLogger.Instance);
 
-            var root  = ReadToml(tmp.PathTo(".codex", "config.toml"));
-            var entry = (TomlTable)((TomlTable)root["projects"])[Key("/tmp/wt")];
-            await Assert.That((string)entry["trust_level"]).IsEqualTo("trusted");
-        } finally { RestoreHome(original); }
+        var root  = ReadToml(tmp.PathTo(".codex", "config.toml"));
+        var entry = (TomlTable)((TomlTable)root["projects"])[Key("/tmp/wt")];
+        await Assert.That((string)entry["trust_level"]).IsEqualTo("trusted");
     }
 
     [Test]
     public async Task No_op_when_trust_level_already_trusted() {
-        using var tmp = ScopedHome(out var original);
+        using var tmp  = new TempDir("codex");
+        using var home = EnvScope.Exclusive("HOME", tmp.GetResolvedPath());
 
-        try {
-            var codexDir   = tmp.CreateDir(".codex");
-            var configPath = tmp.PathTo(".codex", "config.toml");
+        var codexDir   = tmp.CreateDir(".codex");
+        var configPath = tmp.PathTo(".codex", "config.toml");
 
-            codexDir.CreateFile("config.toml",
-                $"""
-                 {SeededHeader("/tmp/wt")}
-                 trust_level = "trusted"
-                 """
-            );
-            var originalMtime = File.GetLastWriteTimeUtc(configPath);
+        codexDir.CreateFile("config.toml",
+            $"""
+             {SeededHeader("/tmp/wt")}
+             trust_level = "trusted"
+             """
+        );
+        var originalMtime = File.GetLastWriteTimeUtc(configPath);
 
-            await Task.Delay(20); // ensure mtime resolution gap
-            CodexConfigWriter.TrustWorktree("/tmp/wt", NullLogger.Instance);
+        await Task.Delay(20); // ensure mtime resolution gap
+        CodexConfigWriter.TrustWorktree("/tmp/wt", NullLogger.Instance);
 
-            await Assert.That(File.GetLastWriteTimeUtc(configPath)).IsEqualTo(originalMtime);
-        } finally { RestoreHome(original); }
+        await Assert.That(File.GetLastWriteTimeUtc(configPath)).IsEqualTo(originalMtime);
     }
 
     [Test]
     public async Task Atomic_rename_leaves_no_tmp_files() {
-        using var tmp = ScopedHome(out var original);
+        using var tmp  = new TempDir("codex");
+        using var home = EnvScope.Exclusive("HOME", tmp.GetResolvedPath());
 
-        try {
-            CodexConfigWriter.TrustWorktree("/tmp/wt-1", NullLogger.Instance);
-            CodexConfigWriter.TrustWorktree("/tmp/wt-2", NullLogger.Instance);
+        CodexConfigWriter.TrustWorktree("/tmp/wt-1", NullLogger.Instance);
+        CodexConfigWriter.TrustWorktree("/tmp/wt-2", NullLogger.Instance);
 
-            var codexDir = tmp.PathTo(".codex");
-            var leftover = Directory.GetFiles(codexDir).Where(f => Path.GetFileName(f).Contains(".tmp-")).ToList();
-            await Assert.That(leftover).IsEmpty();
-        } finally { RestoreHome(original); }
+        var codexDir = tmp.PathTo(".codex");
+        var leftover = Directory.GetFiles(codexDir).Where(f => Path.GetFileName(f).Contains(".tmp-")).ToList();
+        await Assert.That(leftover).IsEmpty();
     }
 
     [Test]
     public async Task Concurrent_writers_serialise_safely() {
-        using var tmp = ScopedHome(out var original);
+        using var tmp  = new TempDir("codex");
+        using var home = EnvScope.Exclusive("HOME", tmp.GetResolvedPath());
 
-        try {
-            var tasks = Enumerable.Range(0, 20)
-                .Select(i => Task.Run(() => CodexConfigWriter.TrustWorktree($"/tmp/wt-{i}", NullLogger.Instance)))
-                .ToArray();
-            await Task.WhenAll(tasks);
+        var tasks = Enumerable.Range(0, 20)
+            .Select(i => Task.Run(() => CodexConfigWriter.TrustWorktree($"/tmp/wt-{i}", NullLogger.Instance)))
+            .ToArray();
+        await Task.WhenAll(tasks);
 
-            var configPath = tmp.PathTo(".codex", "config.toml");
-            var root       = ReadToml(configPath);
-            var projects   = (TomlTable)root["projects"];
+        var configPath = tmp.PathTo(".codex", "config.toml");
+        var root       = ReadToml(configPath);
+        var projects   = (TomlTable)root["projects"];
 
-            for (var i = 0; i < 20; i++) {
-                var entry = (TomlTable)projects[Key($"/tmp/wt-{i}")];
-                await Assert.That((string)entry["trust_level"]).IsEqualTo("trusted");
-            }
-        } finally { RestoreHome(original); }
+        for (var i = 0; i < 20; i++) {
+            var entry = (TomlTable)projects[Key($"/tmp/wt-{i}")];
+            await Assert.That((string)entry["trust_level"]).IsEqualTo("trusted");
+        }
     }
 
     [Test]
     public async Task Malformed_existing_config_is_skipped_not_overwritten() {
-        using var tmp = ScopedHome(out var original);
+        using var tmp  = new TempDir("codex");
+        using var home = EnvScope.Exclusive("HOME", tmp.GetResolvedPath());
 
-        try {
-            var          codexDir   = tmp.CreateDir(".codex");
-            var          configPath = tmp.PathTo(".codex", "config.toml");
-            const string garbage    = "{{{ not valid TOML";
-            codexDir.CreateFile("config.toml", garbage);
+        var          codexDir   = tmp.CreateDir(".codex");
+        var          configPath = tmp.PathTo(".codex", "config.toml");
+        const string garbage    = "{{{ not valid TOML";
+        codexDir.CreateFile("config.toml", garbage);
 
-            CodexConfigWriter.TrustWorktree("/tmp/wt", NullLogger.Instance);
+        CodexConfigWriter.TrustWorktree("/tmp/wt", NullLogger.Instance);
 
-            // File untouched, no throw
-            await Assert.That(File.ReadAllText(configPath)).IsEqualTo(garbage);
-        } finally { RestoreHome(original); }
+        // File untouched, no throw
+        await Assert.That(File.ReadAllText(configPath)).IsEqualTo(garbage);
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -111,37 +111,30 @@ public class CodexHostedAgentRuntimeFactoryTests {
 
     // ── App-server route (spawn seam; isolated HOME so TrustWorktree touches nothing real) ──────
     [Test]
-    [NotInParallel("HomeEnvVarMutation")]
+    [NotInParallel]
     public async Task Active_review_flow_produces_an_app_server_runtime_via_the_spawn_seam() {
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
         using var home = new TempDir();
         using var wt   = new TempDir();
         WriteWorktreeHooks(wt);
         await using var fake = new FakeCodexAppServer();
 
-        try {
-            Environment.SetEnvironmentVariable("HOME", home.Path);
-            Environment.SetEnvironmentVariable("CODEX_HOME", home.PathTo(".codex"));
+        using var homeEnv  = EnvScope.Exclusive("HOME", home.Path);
+        using var codexEnv = EnvScope.Exclusive("CODEX_HOME", home.PathTo(".codex"));
 
-            var pty = new RecordingPtyFactory();
-            CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
-                Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((fake.ConnectClient(), new FakeAcpProcess()));
-            var factory = Factory(pty, appServerActive: true, seam);
+        var pty = new RecordingPtyFactory();
+        CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
+            Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((fake.ConnectClient(), new FakeAcpProcess()));
+        var factory = Factory(pty, appServerActive: true, seam);
 
-            var start = await factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None).WaitAsync(HangGuard);
+        var start = await factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None).WaitAsync(HangGuard);
 
-            await Assert.That(pty.StartCalls).IsEqualTo(0);
-            await Assert.That(start.Runtime).IsTypeOf<CodexAppServerHostedAgentRuntime>();
-            await Assert.That(start.Runtime.EmitsTerminalOutput).IsFalse();
-            await Assert.That(((CodexAppServerHostedAgentRuntime) start.Runtime).ThreadId).IsEqualTo("thread-abc");
-            await Assert.That(fake.ReceivedMethods).Contains("thread/start");
+        await Assert.That(pty.StartCalls).IsEqualTo(0);
+        await Assert.That(start.Runtime).IsTypeOf<CodexAppServerHostedAgentRuntime>();
+        await Assert.That(start.Runtime.EmitsTerminalOutput).IsFalse();
+        await Assert.That(((CodexAppServerHostedAgentRuntime) start.Runtime).ThreadId).IsEqualTo("thread-abc");
+        await Assert.That(fake.ReceivedMethods).Contains("thread/start");
 
-            await start.Runtime.DisposeAsync();
-        } finally {
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-            Environment.SetEnvironmentVariable("CODEX_HOME", originalCodexHome);
-        }
+        await start.Runtime.DisposeAsync();
     }
 
     // ── Guard-1 marker (§2.5) ──────────────────────────────────────────────────────────
@@ -158,36 +151,29 @@ public class CodexHostedAgentRuntimeFactoryTests {
     }
 
     [Test]
-    [NotInParallel("HomeEnvVarMutation")]
+    [NotInParallel]
     public async Task App_server_launch_is_envelope_sourced_after_activation() {
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
         using var home = new TempDir();
         using var wt   = new TempDir();
         WriteWorktreeHooks(wt);
         await using var fake = new FakeCodexAppServer();
         IReadOnlyDictionary<string, string>? capturedEnv = null;
 
-        try {
-            Environment.SetEnvironmentVariable("HOME", home.Path);
-            Environment.SetEnvironmentVariable("CODEX_HOME", home.PathTo(".codex"));
+        using var homeEnv  = EnvScope.Exclusive("HOME", home.Path);
+        using var codexEnv = EnvScope.Exclusive("CODEX_HOME", home.PathTo(".codex"));
 
-            CodexAppServerSpawnFactory seam = (_, _, _, _, env, _, _) => {
-                capturedEnv = env;
-                return Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((fake.ConnectClient(), new FakeAcpProcess()));
-            };
-            var factory = Factory(new RecordingPtyFactory(), appServerActive: true, seam);
+        CodexAppServerSpawnFactory seam = (_, _, _, _, env, _, _) => {
+            capturedEnv = env;
+            return Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((fake.ConnectClient(), new FakeAcpProcess()));
+        };
+        var factory = Factory(new RecordingPtyFactory(), appServerActive: true, seam);
 
-            var start = await factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None).WaitAsync(HangGuard);
+        var start = await factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None).WaitAsync(HangGuard);
 
-            await Assert.That(start.Transcript).IsNotNull();
-            await Assert.That(start.Runtime.RequiresSourceClaimBeforeFirstTurn).IsTrue();
+        await Assert.That(start.Transcript).IsNotNull();
+        await Assert.That(start.Runtime.RequiresSourceClaimBeforeFirstTurn).IsTrue();
 
-            await start.Runtime.DisposeAsync();
-        } finally {
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-            Environment.SetEnvironmentVariable("CODEX_HOME", originalCodexHome);
-        }
+        await start.Runtime.DisposeAsync();
 
         await Assert.That(capturedEnv).IsNotNull();
         await Assert.That(capturedEnv!["KCAP_HOSTED_APPSERVER"]).IsEqualTo("1");
@@ -218,57 +204,43 @@ public class CodexHostedAgentRuntimeFactoryTests {
     }
 
     [Test]
-    [NotInParallel("HomeEnvVarMutation")]
+    [NotInParallel]
     public async Task Missing_hooks_on_the_app_server_route_fails_closed() {
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
         using var home = new TempDir(); // empty — no user-scope hooks
         using var wt   = new TempDir(); // empty — no worktree hooks
 
-        try {
-            Environment.SetEnvironmentVariable("HOME", home.Path);
-            Environment.SetEnvironmentVariable("CODEX_HOME", home.PathTo(".codex"));
+        using var homeEnv  = EnvScope.Exclusive("HOME", home.Path);
+        using var codexEnv = EnvScope.Exclusive("CODEX_HOME", home.PathTo(".codex"));
 
-            CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
-                throw new InvalidOperationException("spawn must never be reached when hooks are missing");
-            var factory = Factory(new RecordingPtyFactory(), appServerActive: true, seam);
+        CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
+            throw new InvalidOperationException("spawn must never be reached when hooks are missing");
+        var factory = Factory(new RecordingPtyFactory(), appServerActive: true, seam);
 
-            await Assert.ThrowsAsync<CodexHooksNotInstalledException>(
-                () => factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None));
-        } finally {
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-            Environment.SetEnvironmentVariable("CODEX_HOME", originalCodexHome);
-        }
+        await Assert.ThrowsAsync<CodexHooksNotInstalledException>(
+            () => factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None));
     }
 
     [Test]
-    [NotInParallel("HomeEnvVarMutation")]
+    [NotInParallel]
     public async Task Handshake_failure_disposes_the_spawned_child() {
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        var originalCodexHome = Environment.GetEnvironmentVariable("CODEX_HOME");
         using var home = new TempDir();
         using var wt   = new TempDir();
         WriteWorktreeHooks(wt);
         await using var fake = new FakeCodexAppServer { ThreadId = "" }; // thread/start returns no id -> StartAsync throws
 
-        try {
-            Environment.SetEnvironmentVariable("HOME", home.Path);
-            Environment.SetEnvironmentVariable("CODEX_HOME", home.PathTo(".codex"));
+        using var homeEnv  = EnvScope.Exclusive("HOME", home.Path);
+        using var codexEnv = EnvScope.Exclusive("CODEX_HOME", home.PathTo(".codex"));
 
-            var process = new FakeAcpProcess();
-            CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
-                Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((fake.ConnectClient(), process));
-            var factory = Factory(new RecordingPtyFactory(), appServerActive: true, seam);
+        var process = new FakeAcpProcess();
+        CodexAppServerSpawnFactory seam = (_, _, _, _, _, _, _) =>
+            Task.FromResult<(CodexAppServerConnection, IAcpProcess)>((fake.ConnectClient(), process));
+        var factory = Factory(new RecordingPtyFactory(), appServerActive: true, seam);
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                () => factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None).WaitAsync(HangGuard));
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => factory.StartAsync(Ctx(isReviewFlow: true, wt.Path), CancellationToken.None).WaitAsync(HangGuard));
 
-            // The factory disposed the runtime on the failed handshake, so the spawned child is not leaked.
-            await Assert.That(process.HasExited).IsTrue();
-        } finally {
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-            Environment.SetEnvironmentVariable("CODEX_HOME", originalCodexHome);
-        }
+        // The factory disposed the runtime on the failed handshake, so the spawned child is not leaked.
+        await Assert.That(process.HasExited).IsTrue();
     }
 
     static void WriteWorktreeHooks(TempDir worktree) =>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexLauncherTests.cs
@@ -9,7 +9,6 @@ using TUnit.Assertions.Enums;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
 
-[NotInParallel("HomeEnvVarMutation")]
 public class CodexLauncherTests {
     // Review-flow arg tests must be deterministic w.r.t. the developer's real
     // ~/.codex/config.toml, so the inherited-server seam defaults to empty. Tests that
@@ -412,32 +411,27 @@ public class CodexLauncherTests {
             .Throws<CodexReviewerMcpIsolationException>();
     }
 
-    [Test]
+    [Test, NotInParallel]
     public async Task Prepare_overlays_codex_settings_dir_from_source_repo() {
         using var tmp = new TempDir();
         var sourceRepo = tmp.CreateDir("src");
         var worktree = tmp.CreateDir("wt");
         var home = tmp.CreateDir("home");
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        Environment.SetEnvironmentVariable("HOME", tmp.GetResolvedPath("home"));
+        using var homeEnv = EnvScope.Exclusive("HOME", tmp.GetResolvedPath("home"));
 
-        try {
-            var srcCodex = sourceRepo.CreateDir(".codex");
-            srcCodex.CreateFile("hooks.json", """
-                {"hooks":{
-                    "SessionStart":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
-                    "Stop":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
-                    "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}]
-                }}
-                """);
+        var srcCodex = sourceRepo.CreateDir(".codex");
+        srcCodex.CreateFile("hooks.json", """
+            {"hooks":{
+                "SessionStart":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
+                "Stop":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
+                "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}]
+            }}
+            """);
 
-            var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
-            NewLauncher().Prepare(ctx);
+        var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
+        NewLauncher().Prepare(ctx);
 
-            await Assert.That(File.Exists(worktree.PathTo(".codex", "hooks.json"))).IsTrue();
-        } finally {
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-        }
+        await Assert.That(File.Exists(worktree.PathTo(".codex", "hooks.json"))).IsTrue();
     }
 
     /// <summary>
@@ -449,149 +443,124 @@ public class CodexLauncherTests {
     /// <para><c>hooks.json</c> must still arrive — that is what the overlay is FOR, and a fix that dropped
     /// it would break project-scope hooks while looking like it had contained something.</para>
     /// </summary>
-    [Test]
+    [Test, NotInParallel]
     public async Task Prepare_does_not_reintroduce_workspace_mcp_config_via_the_codex_overlay() {
         using var tmp = new TempDir();
         var sourceRepo = tmp.CreateDir("src");
         var worktree = tmp.CreateDir("wt");
         var home = tmp.CreateDir("home");
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        Environment.SetEnvironmentVariable("HOME", tmp.GetResolvedPath("home"));
+        using var homeEnv = EnvScope.Exclusive("HOME", tmp.GetResolvedPath("home"));
 
-        try {
-            var srcCodex = sourceRepo.CreateDir(".codex");
-            srcCodex.CreateFile("hooks.json", """
-                {"hooks":{
-                    "SessionStart":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
-                    "Stop":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
-                    "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}]
-                }}
-                """);
-            // The branch-authored file the worktree strip removes; the source still has it.
-            srcCodex.CreateFile("config.toml",
-                "[mcp_servers.pwn]\ncommand = \"/bin/sh\"\n");
+        var srcCodex = sourceRepo.CreateDir(".codex");
+        srcCodex.CreateFile("hooks.json", """
+            {"hooks":{
+                "SessionStart":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
+                "Stop":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
+                "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}]
+            }}
+            """);
+        // The branch-authored file the worktree strip removes; the source still has it.
+        srcCodex.CreateFile("config.toml",
+            "[mcp_servers.pwn]\ncommand = \"/bin/sh\"\n");
 
-            var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
-            NewLauncher().Prepare(ctx);
+        var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
+        NewLauncher().Prepare(ctx);
 
-            await Assert.That(File.Exists(worktree.PathTo(".codex", "config.toml"))).IsFalse();
-            // ...and the thing the overlay exists for still arrives.
-            await Assert.That(File.Exists(worktree.PathTo(".codex", "hooks.json"))).IsTrue();
-        } finally {
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-        }
+        await Assert.That(File.Exists(worktree.PathTo(".codex", "config.toml"))).IsFalse();
+        // ...and the thing the overlay exists for still arrives.
+        await Assert.That(File.Exists(worktree.PathTo(".codex", "hooks.json"))).IsTrue();
     }
 
-    [Test]
+    [Test, NotInParallel]
     public async Task Prepare_throws_when_no_hooks_json_anywhere() {
         using var tmp = new TempDir();
         var sourceRepo = tmp.CreateDir("src");
         var worktree = tmp.CreateDir("wt");
         var home = tmp.CreateDir("home");
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        Environment.SetEnvironmentVariable("HOME", tmp.GetResolvedPath("home"));
+        using var homeEnv = EnvScope.Exclusive("HOME", tmp.GetResolvedPath("home"));
 
-        try {
-            var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
-            var ex = await Assert.ThrowsAsync<CodexHooksNotInstalledException>(async () => {
-                NewLauncher().Prepare(ctx);
-                await Task.CompletedTask;
-            });
-            await Assert.That(ex!.Message).Contains("kcap plugin install --codex");
-        } finally {
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-        }
+        var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
+        var ex = await Assert.ThrowsAsync<CodexHooksNotInstalledException>(async () => {
+            NewLauncher().Prepare(ctx);
+            await Task.CompletedTask;
+        });
+        await Assert.That(ex!.Message).Contains("kcap plugin install --codex");
     }
 
-    [Test]
+    [Test, NotInParallel]
     public async Task Prepare_succeeds_when_user_scope_hooks_json_has_all_three_critical_events() {
         using var tmp = new TempDir();
         var sourceRepo = tmp.CreateDir("src");
         var worktree = tmp.CreateDir("wt");
         var home = tmp.CreateDir("home");
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        Environment.SetEnvironmentVariable("HOME", tmp.GetResolvedPath("home"));
+        using var homeEnv = EnvScope.Exclusive("HOME", tmp.GetResolvedPath("home"));
 
-        try {
-            home.CreateDir(".codex");
-            home.CreateFile([".codex", "hooks.json"], """
-                {"hooks":{
-                    "SessionStart":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
-                    "Stop":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
-                    "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}]
-                }}
-                """);
+        home.CreateDir(".codex");
+        home.CreateFile([".codex", "hooks.json"], """
+            {"hooks":{
+                "SessionStart":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
+                "Stop":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
+                "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}]
+            }}
+            """);
 
-            var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
-            NewLauncher().Prepare(ctx);
+        var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
+        NewLauncher().Prepare(ctx);
 
-            await Assert.That(File.Exists(home.PathTo(".codex", "config.toml"))).IsTrue();
-        } finally {
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-        }
+        await Assert.That(File.Exists(home.PathTo(".codex", "config.toml"))).IsTrue();
     }
 
-    [Test]
+    [Test, NotInParallel]
     public async Task Prepare_succeeds_when_project_scope_hooks_json_present_after_overlay() {
         using var tmp = new TempDir();
         var sourceRepo = tmp.CreateDir("src");
         var worktree = tmp.CreateDir("wt");
         var home = tmp.CreateDir("home");
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        Environment.SetEnvironmentVariable("HOME", tmp.GetResolvedPath("home"));
+        using var homeEnv = EnvScope.Exclusive("HOME", tmp.GetResolvedPath("home"));
 
-        try {
-            sourceRepo.CreateDir(".codex");
-            sourceRepo.CreateFile([".codex", "hooks.json"], """
-                {"hooks":{
-                    "SessionStart":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
-                    "Stop":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
-                    "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}]
-                }}
-                """);
+        sourceRepo.CreateDir(".codex");
+        sourceRepo.CreateFile([".codex", "hooks.json"], """
+            {"hooks":{
+                "SessionStart":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
+                "Stop":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
+                "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}]
+            }}
+            """);
 
-            var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
-            NewLauncher().Prepare(ctx);
-            await Assert.That(File.Exists(home.PathTo(".codex", "config.toml"))).IsTrue();
-        } finally {
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-        }
+        var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
+        NewLauncher().Prepare(ctx);
+        await Assert.That(File.Exists(home.PathTo(".codex", "config.toml"))).IsTrue();
     }
 
-    [Test]
+    [Test, NotInParallel]
     public async Task Prepare_invokes_codex_config_writer_with_worktree_path() {
         using var tmp = new TempDir();
         var sourceRepo = tmp.CreateDir("src");
         var worktree = tmp.CreateDir("wt");
         var home = tmp.CreateDir("home");
-        var originalHome = Environment.GetEnvironmentVariable("HOME");
-        Environment.SetEnvironmentVariable("HOME", tmp.GetResolvedPath("home"));
+        using var homeEnv = EnvScope.Exclusive("HOME", tmp.GetResolvedPath("home"));
 
-        try {
-            home.CreateDir(".codex");
-            home.CreateFile([".codex", "hooks.json"], """
-                {"hooks":{
-                    "SessionStart":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
-                    "Stop":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
-                    "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}]
-                }}
-                """);
+        home.CreateDir(".codex");
+        home.CreateFile([".codex", "hooks.json"], """
+            {"hooks":{
+                "SessionStart":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
+                "Stop":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}],
+                "PermissionRequest":[{"hooks":[{"type":"command","command":"kcap codex-hook"}]}]
+            }}
+            """);
 
-            var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
-            NewLauncher().Prepare(ctx);
+        var ctx = NewCtxWith(source: sourceRepo, worktree: worktree);
+        NewLauncher().Prepare(ctx);
 
-            var configToml = File.ReadAllText(home.PathTo(".codex", "config.toml"));
-            // The key is written in Codex's own normalised form (absolute, lowercased on
-            // Windows — see CodexPaths.NormalizeProjectKey), not the raw worktree path. The TOML
-            // writer then emits it as a basic (double-quoted) key, so backslashes are escaped
-            // per spec (\ → \\); match the escaped form so this holds on Windows too (both are
-            // no-ops on POSIX paths).
-            var escapedWorktree = CodexPaths.NormalizeProjectKey(worktree).Replace("\\", "\\\\");
-            await Assert.That(configToml).Contains($"\"{escapedWorktree}\"");
-            await Assert.That(configToml).Contains("trust_level = \"trusted\"");
-        } finally {
-            Environment.SetEnvironmentVariable("HOME", originalHome);
-        }
+        var configToml = File.ReadAllText(home.PathTo(".codex", "config.toml"));
+        // The key is written in Codex's own normalised form (absolute, lowercased on
+        // Windows — see CodexPaths.NormalizeProjectKey), not the raw worktree path. The TOML
+        // writer then emits it as a basic (double-quoted) key, so backslashes are escaped
+        // per spec (\ → \\); match the escaped form so this holds on Windows too (both are
+        // no-ops on POSIX paths).
+        var escapedWorktree = CodexPaths.NormalizeProjectKey(worktree).Replace("\\", "\\\\");
+        await Assert.That(configToml).Contains($"\"{escapedWorktree}\"");
+        await Assert.That(configToml).Contains("trust_level = \"trusted\"");
     }
 
     static LauncherContext NewCtxWith(string source, string worktree) => new(

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Unix/PtySpawnTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Unix/PtySpawnTests.cs
@@ -8,11 +8,6 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Pty.Unix;
 /// (bypassing UnixPtyProcess/the spawner thread, which Task 4/5 layer on top). These tests
 /// exercise the raw native contract in isolation.
 /// </summary>
-/// <remarks>
-/// Bare <c>[NotInParallel]</c>: these waitpid a reaped pid, which the OS can reassign to a concurrent spawn.
-/// Stealing a child System.Diagnostics.Process owns FailFasts the host, killing the whole run.
-/// </remarks>
-[NotInParallel]
 public class PtySpawnTests {
     [Test, RunOn(OS.Linux | OS.MacOs)]
     public async Task Successful_spawn_returns_a_reapable_child_and_a_captured_identity() {
@@ -58,9 +53,13 @@ public class PtySpawnTests {
             await Assert.That(rc).IsEqualTo(-1);
             await Assert.That(result.FailedStep).IsEqualTo(5 /* PTY_STEP_EXEC */);
             await Assert.That(result.ErrNo).IsEqualTo(2 /* ENOENT */);
-            // No zombie/phantom: waitpid on the reported pid must fail with ECHILD (already reaped by pty_spawn).
-            var wpRc = UnixPtyInterop.waitpid(result.Pid, out _, 0);
-            await Assert.That(wpRc).IsEqualTo(-1);
+            // Capture-binding holds on the failure paths too, so there is an identity to assert
+            // against — without this the IsGone check below could pass vacuously on an empty token.
+            await Assert.That(result.StartIdentityString).IsNotEmpty();
+            // No zombie/phantom: pty_spawn reaped the child, so its identity is gone from the
+            // process table. Stronger than waiting for ECHILD, which cannot tell a reaped child
+            // from a wait some concurrent peer stole — an unreaped zombie still carries its token.
+            await Assert.That(PidIdentity.IsGone(result.Pid, result.StartIdentityString)).IsTrue();
         } finally { Free(plan); }
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Unix/UnixPtyProcessSpawnTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Unix/UnixPtyProcessSpawnTests.cs
@@ -68,20 +68,16 @@ public class UnixPtyProcessSpawnTests {
         try {
             var childPid = await ReadReportedChildPidAsync(proc);
             await Assert.That(childPid).IsGreaterThan(0);
-            // Positive control: the helper is alive before the terminate, so the "dead after"
-            // assertion below cannot pass vacuously on a pid that never existed.
-            await Assert.That(UnixPtyInterop.kill(childPid, 0)).IsEqualTo(0);
+            // Capture while it is provably alive: this is init's child once the leader dies, not
+            // ours, so the pid alone would read as live again the moment the OS reassigns it.
+            var childIdentity = PidIdentity.Capture(childPid);
 
             await proc.TerminateAsync(TimeSpan.FromSeconds(5));
             await Assert.That(proc.HasExited).IsTrue();
 
-            // The orphaned helper is reparented to init, which reaps it once it dies — poll
-            // briefly for ESRCH rather than racing the reap.
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-            while (UnixPtyInterop.kill(childPid, 0) == 0 && DateTime.UtcNow < deadline)
-                await Task.Delay(50);
-
-            await Assert.That(UnixPtyInterop.kill(childPid, 0)).IsNotEqualTo(0);
+            // Reparented to init, which reaps it once it dies — poll for the identity leaving the
+            // process table rather than racing the reap.
+            await PidIdentity.WaitUntilGoneAsync(childPid, childIdentity, TimeSpan.FromSeconds(5));
         } finally {
             await proc.DisposeAsync();
         }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Unix/UnixSpawnerThreadTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Unix/UnixSpawnerThreadTests.cs
@@ -18,14 +18,14 @@ public class UnixSpawnerThreadTests {
 
         using var host = StartHost("spawn-dummy");
         var childPid = await ReadPidLineAsync(host);
+        // The child belongs to the host process, not to us, so once pdeathsig fires and init reaps
+        // it the pid is free — assert on the incarnation, not the number.
+        var childIdentity = PidIdentity.Capture(childPid);
 
         host.Kill(entireProcessTree: false); // simulate an external daemon crash (SIGKILL)
         host.WaitForExit(5000);
 
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-        while (DateTime.UtcNow < deadline && IsAlive(childPid)) await Task.Delay(200);
-
-        await Assert.That(IsAlive(childPid)).IsFalse();
+        await PidIdentity.WaitUntilGoneAsync(childPid, childIdentity, TimeSpan.FromSeconds(10));
     }
 
     [Test]
@@ -67,7 +67,9 @@ public class UnixSpawnerThreadTests {
             await Assert.That(result.Pid).IsGreaterThan(0);
             for (var i = 0; i < 5; i++) await Task.Run(() => { });
             await Task.Delay(300);
-            await Assert.That(IsAlive(result.Pid)).IsTrue();
+            // Still the SAME incarnation. kill(pid, 0) would also pass on a squatter that took the
+            // number over after the agent died — the exact failure this test exists to catch.
+            await Assert.That(PidIdentity.IsGone(result.Pid, result.StartIdentityString)).IsFalse();
         } finally {
             // Guard against pid<=0: kill(0, sig)/kill(-1, sig) have special "whole process
             // group"/"every process" meanings on Unix — never pass through a failed spawn's
@@ -96,8 +98,6 @@ public class UnixSpawnerThreadTests {
 
         await Assert.That(spawner.IsThreadAlive).IsFalse();
     }
-
-    static bool IsAlive(int pid) => UnixPtyInterop.kill(pid, 0) == 0;
 
     static Process StartHost(string mode) {
         var dll = ResolveNativeHostDll();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Windows/ConPtyJobObjectTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Windows/ConPtyJobObjectTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Capacitor.Cli.Daemon.Pty.Windows;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Pty.Windows;
@@ -23,14 +22,15 @@ public class ConPtyJobObjectTests {
 
         await Task.Delay(500); // let the grandchild actually spawn before we kill the job
 
+        // Capture while it is alive: Windows frees the pid as soon as the last handle to the dead
+        // process closes, so a bare GetProcessById would read a reassigned number as still-alive.
+        var identity = PidIdentity.Capture(proc.Pid);
+
         await proc.DisposeAsync();
 
         // Job-handle close is synchronous-ish from the OS's perspective, but process exit
         // notification can lag slightly — poll rather than assert instantly.
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-        while (DateTime.UtcNow < deadline && IsProcessAlive(proc.Pid)) await Task.Delay(200);
-
-        await Assert.That(IsProcessAlive(proc.Pid)).IsFalse();
+        await PidIdentity.WaitUntilGoneAsync(proc.Pid, identity, TimeSpan.FromSeconds(10));
     }
 
     [Test]
@@ -106,10 +106,5 @@ public class ConPtyJobObjectTests {
         }
 
         await Assert.That(threw).IsTrue();
-    }
-
-    static bool IsProcessAlive(int pid) {
-        try { using var p = Process.GetProcessById(pid); return !p.HasExited; }
-        catch { return false; }
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Windows/ConPtyResolveCommandTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/Windows/ConPtyResolveCommandTests.cs
@@ -21,17 +21,13 @@ public class ConPtyResolveCommandTests {
         var cmd = tmp.PathTo(name + ".cmd");
         await File.WriteAllTextAsync(cmd, "@echo off\r\n");
 
-        var savedPath = Environment.GetEnvironmentVariable("PATH");
-        Environment.SetEnvironmentVariable("PATH", $"{tmp.Path}{Path.PathSeparator}{savedPath}");
+        var       savedPath = Environment.GetEnvironmentVariable("PATH");
+        using var pathEnv   = EnvScope.Exclusive("PATH", $"{tmp.Path}{Path.PathSeparator}{savedPath}");
 
-        try {
-            var (resolved, isCmd) = ConPtyProcess.ResolveCommand(name);
+        var (resolved, isCmd) = ConPtyProcess.ResolveCommand(name);
 
-            await Assert.That(resolved).IsEqualTo(cmd, StringComparison.OrdinalIgnoreCase);
-            await Assert.That(isCmd).IsTrue(); // drives the cmd.exe /c wrapper in Spawn
-        } finally {
-            Environment.SetEnvironmentVariable("PATH", savedPath);
-        }
+        await Assert.That(resolved).IsEqualTo(cmd, StringComparison.OrdinalIgnoreCase);
+        await Assert.That(isCmd).IsTrue(); // drives the cmd.exe /c wrapper in Spawn
     }
 
     /// <summary>A plain <c>.exe</c> still resolves and is NOT flagged as a <c>.cmd</c>, so it
@@ -45,16 +41,12 @@ public class ConPtyResolveCommandTests {
         var exe  = tmp.PathTo(name + ".exe");
         await File.WriteAllTextAsync(exe, "");
 
-        var savedPath = Environment.GetEnvironmentVariable("PATH");
-        Environment.SetEnvironmentVariable("PATH", $"{tmp.Path}{Path.PathSeparator}{savedPath}");
+        var       savedPath = Environment.GetEnvironmentVariable("PATH");
+        using var pathEnv   = EnvScope.Exclusive("PATH", $"{tmp.Path}{Path.PathSeparator}{savedPath}");
 
-        try {
-            var (resolved, isCmd) = ConPtyProcess.ResolveCommand(name);
+        var (resolved, isCmd) = ConPtyProcess.ResolveCommand(name);
 
-            await Assert.That(resolved).IsEqualTo(exe, StringComparison.OrdinalIgnoreCase);
-            await Assert.That(isCmd).IsFalse();
-        } finally {
-            Environment.SetEnvironmentVariable("PATH", savedPath);
-        }
+        await Assert.That(resolved).IsEqualTo(exe, StringComparison.OrdinalIgnoreCase);
+        await Assert.That(isCmd).IsFalse();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -1854,7 +1854,6 @@ public class AcpHostedAgentRuntimeFactoryTests : IDisposable {
     /// token. An interactive agent runs as the user, with the user's own vendor profile and
     /// credentials — redirecting those would break it, and doing so silently would be worse.</summary>
     [Test]
-    [NotInParallel("HomeEnvVarMutation")] // psi snapshots HOME; this compares it to a later live read
     public async Task BuildProcessStartInfo_Copilot_NonBorrowedReview_LeavesTheEnvironmentAlone() {
         var ctx = ReviewContext(["kcap-review"]) with { Work = WorkLocation.OwnedWorktree };
         var supported = CopilotBorrowedReviewPolicy.Resolve(

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
@@ -389,36 +389,31 @@ public class AgentOrchestratorLocalAttachTests {
     [NotInParallel]
     public async Task Registered_spawn_env_includes_daemon_bridge_url_and_preserves_api_key() {
         using var tmp = new TempDir();
-        var prevKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
-        Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", "sk-test-key");
+        using var apiKey = EnvScope.Exclusive("ANTHROPIC_API_KEY", "sk-test-key");
+
+        var server    = new TripwireServerConnection();
+        var pty       = new EnvCapturingPtyFactory();
+        var launchers = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = new SpyHostedAgentLauncher("claude", "spy-claude") };
+
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, pty, launchers);
+        await orch.PermissionBridgeForTest.StartAsync(default); // binds 127.0.0.1 + sets BaseUrl
 
         try {
-            var server    = new TripwireServerConnection();
-            var pty       = new EnvCapturingPtyFactory();
-            var launchers = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = new SpyHostedAgentLauncher("claude", "spy-claude") };
+            var readBuf = new MemoryStream();
+            await FrameCodec.WriteAsync(readBuf, LocalFrame.Detach(), default);
+            readBuf.Position = 0;
+            using var client = new DuplexTestStream(readBuf, new MemoryStream());
 
-            await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, pty, launchers);
-            await orch.PermissionBridgeForTest.StartAsync(default); // binds 127.0.0.1 + sets BaseUrl
+            var spawn = FrameCodec.Spawn("claude", WorkLocation.BorrowedCwd, isPrivate: false, tmp.Path, [], 80, 24);
+            await orch.HandleLocalSpawnAsync(spawn, client, default);
 
-            try {
-                var readBuf = new MemoryStream();
-                await FrameCodec.WriteAsync(readBuf, LocalFrame.Detach(), default);
-                readBuf.Position = 0;
-                using var client = new DuplexTestStream(readBuf, new MemoryStream());
+            var deadline = DateTime.UtcNow + WaitHarness.Bounded;
+            while (orch.ActiveAgentCountForTest > 0 && DateTime.UtcNow < deadline) await Task.Delay(20);
 
-                var spawn = FrameCodec.Spawn("claude", WorkLocation.BorrowedCwd, isPrivate: false, tmp.Path, [], 80, 24);
-                await orch.HandleLocalSpawnAsync(spawn, client, default);
-
-                var deadline = DateTime.UtcNow + WaitHarness.Bounded;
-                while (orch.ActiveAgentCountForTest > 0 && DateTime.UtcNow < deadline) await Task.Delay(20);
-
-                await Assert.That(pty.LastEnv!["KCAP_DAEMON_URL"]).IsEqualTo(orch.PermissionBridgeForTest.BaseUrl);
-                await Assert.That(pty.LastEnv!["ANTHROPIC_API_KEY"]).IsEqualTo("sk-test-key");
-            } finally {
-                await orch.PermissionBridgeForTest.StopAsync(default);
-            }
+            await Assert.That(pty.LastEnv!["KCAP_DAEMON_URL"]).IsEqualTo(orch.PermissionBridgeForTest.BaseUrl);
+            await Assert.That(pty.LastEnv!["ANTHROPIC_API_KEY"]).IsEqualTo("sk-test-key");
         } finally {
-            Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", prevKey);
+            await orch.PermissionBridgeForTest.StopAsync(default);
         }
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CliResolverTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CliResolverTests.cs
@@ -48,10 +48,6 @@ public class CliResolverTests {
         await Assert.That(CliResolver.Exists(missing)).IsFalse();
     }
 
-    // NotInParallel: this test mutates the process-global PATH env var,
-    // which races with any other test reading PATH (e.g. plugin installers,
-    // resolver tests below). A unique group key isn't enough because
-    // cross-group tests can still race; running fully alone is safe.
     [Test, NotInParallel]
     public async Task ReturnsTrue_WhenBareCommandResolvesOnPath() {
         // Drop a fake "kcap-pathprobe-{guid}" binary into a temp dir,
@@ -62,14 +58,10 @@ public class CliResolverTests {
         var binaryPath = tmp.CreateFile(binaryName, "");
         MakeExecutable(binaryPath);
 
-        var savedPath = Environment.GetEnvironmentVariable("PATH");
-        Environment.SetEnvironmentVariable("PATH", $"{tmp.Path}{Path.PathSeparator}{savedPath}");
+        var       savedPath = Environment.GetEnvironmentVariable("PATH");
+        using var pathEnv   = EnvScope.Exclusive("PATH", $"{tmp.Path}{Path.PathSeparator}{savedPath}");
 
-        try {
-            await Assert.That(CliResolver.Exists(name)).IsTrue();
-        } finally {
-            Environment.SetEnvironmentVariable("PATH", savedPath);
-        }
+        await Assert.That(CliResolver.Exists(name)).IsTrue();
     }
 
     /// <summary>
@@ -85,14 +77,10 @@ public class CliResolverTests {
         var binaryPath = tmp.CreateFile(name, "");
         File.SetUnixFileMode(binaryPath, UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
 
-        var savedPath = Environment.GetEnvironmentVariable("PATH");
-        Environment.SetEnvironmentVariable("PATH", $"{tmp.Path}{Path.PathSeparator}{savedPath}");
+        var       savedPath = Environment.GetEnvironmentVariable("PATH");
+        using var pathEnv   = EnvScope.Exclusive("PATH", $"{tmp.Path}{Path.PathSeparator}{savedPath}");
 
-        try {
-            await Assert.That(CliResolver.Exists(name)).IsFalse();
-        } finally {
-            Environment.SetEnvironmentVariable("PATH", savedPath);
-        }
+        await Assert.That(CliResolver.Exists(name)).IsFalse();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/GitConfigTransportTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/GitConfigTransportTests.cs
@@ -74,25 +74,15 @@ public class GitConfigTransportTests {
     [Test]
     [NotInParallel]
     public async Task An_inherited_count_is_appended_to_rather_than_overwritten() {
-        var restore = (
-            Count: Environment.GetEnvironmentVariable("GIT_CONFIG_COUNT"),
-            Key: Environment.GetEnvironmentVariable("GIT_CONFIG_KEY_0"),
-            Value: Environment.GetEnvironmentVariable("GIT_CONFIG_VALUE_0"));
-        try {
-            Environment.SetEnvironmentVariable("GIT_CONFIG_COUNT", "1");
-            Environment.SetEnvironmentVariable("GIT_CONFIG_KEY_0", "kcap.inherited");
-            Environment.SetEnvironmentVariable("GIT_CONFIG_VALUE_0", "yes");
+        using var count = EnvScope.Exclusive("GIT_CONFIG_COUNT", "1");
+        using var key   = EnvScope.Exclusive("GIT_CONFIG_KEY_0", "kcap.inherited");
+        using var value = EnvScope.Exclusive("GIT_CONFIG_VALUE_0", "yes");
 
-            var records = await EffectiveConfigAsync(
-                sourceReadOnly: false, new GitConfigOverride("filter.evil=x.smudge", ""));
+        var records = await EffectiveConfigAsync(
+            sourceReadOnly: false, new GitConfigOverride("filter.evil=x.smudge", ""));
 
-            await Assert.That(records).Contains("kcap.inherited\nyes");
-            await Assert.That(records).Contains("filter.evil=x.smudge\n");
-        } finally {
-            Environment.SetEnvironmentVariable("GIT_CONFIG_COUNT", restore.Count);
-            Environment.SetEnvironmentVariable("GIT_CONFIG_KEY_0", restore.Key);
-            Environment.SetEnvironmentVariable("GIT_CONFIG_VALUE_0", restore.Value);
-        }
+        await Assert.That(records).Contains("kcap.inherited\nyes");
+        await Assert.That(records).Contains("filter.evil=x.smudge\n");
     }
 
     /// <summary>A count we cannot parse means we do not know which indices are taken. Refused rather than

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalPermissionBridgeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalPermissionBridgeTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
-[NotInParallel]
 public class LocalPermissionBridgeTests {
     static (LocalPermissionBridge bridge, FakeServerConnection server) CreateBridge(
             Func<string, string?, JsonElement?, JsonElement?, CancellationToken, Task<PermissionDecision>>? respond = null,

--- a/test/Capacitor.Cli.Tests.Unit/PrDetection/GitProviderRouterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/PrDetection/GitProviderRouterTests.cs
@@ -2,6 +2,9 @@ using Capacitor.Cli.PrDetection;
 
 namespace Capacitor.Cli.Tests.Unit.PrDetection;
 
+// The router memoizes into a production static, and the per-test reset that clears it is itself a
+// process-global mutation — a concurrent peer's reset or memo entry decides what this class observes.
+[NotInParallel]
 public class GitProviderRouterTests {
     [Before(Test)]
     public void Reset() => GitProviderRouter.ResetMemoForTests();

--- a/test/Capacitor.Tests.Helpers/EnvScope.cs
+++ b/test/Capacitor.Tests.Helpers/EnvScope.cs
@@ -8,17 +8,75 @@ namespace Capacitor.Tests.Helpers;
 /// Vendor path resolvers consult their own env vars (<c>COPILOT_HOME</c>, <c>GEMINI_CLI_HOME</c>,
 /// <c>PI_CODING_AGENT_DIR</c>, <c>XDG_CONFIG_HOME</c>) before falling back to the home they are
 /// handed, so a test that seeds a fake home without clearing them writes into the developer's real
-/// config instead. Env is process-global: callers need <c>[NotInParallel]</c>.
+/// config instead.
+/// <para>
+/// Env is process-global, so the required <c>[NotInParallel]</c> is checked here rather than asked
+/// for in prose: the constructor needs some constraint, and <see cref="Exclusive"/> needs an
+/// unkeyed one — for variables whose readers are not an enumerable cohort, because every spawned
+/// child inherits them and production path helpers read them.
+/// </para>
 /// </remarks>
 public sealed class EnvScope : IDisposable {
     readonly string  _key;
     readonly string? _previous;
 
-    public EnvScope(string key, string? value) {
+    /// <summary>
+    /// For a variable whose every reader carries the same key. Requires the test to be
+    /// <c>[NotInParallel]</c>, keyed or bare.
+    /// </summary>
+    public EnvScope(string key, string? value) : this(key, value, exclusive: false) { }
+
+    /// <summary>
+    /// For a variable read outside any enumerable cohort — inherited by spawned children, or read
+    /// by a production path helper. Requires a bare <c>[NotInParallel]</c>, which is exclusive
+    /// against the whole assembly.
+    /// </summary>
+    public static EnvScope Exclusive(string key, string? value) => new(key, value, exclusive: true);
+
+    EnvScope(string key, string? value, bool exclusive) {
+        RequireExclusion(key, exclusive);
+
         _key      = key;
         _previous = Environment.GetEnvironmentVariable(key);
         Environment.SetEnvironmentVariable(key, value);
     }
 
     public void Dispose() => Environment.SetEnvironmentVariable(_key, _previous);
+
+    static void RequireExclusion(string key, bool exclusive) {
+        var context = TestContext.Current
+                   ?? throw new InvalidOperationException(
+                          $"EnvScope needs a running test to read '{key}''s parallel constraints from. "
+                        + "A process-wide pin that must be in place before any test runs belongs in "
+                        + "Guards/, setting the variable directly.");
+
+        var constraints = context.Parallelism.Constraints;
+        // The engine takes the FIRST NotInParallelConstraint, and a method-level attribute precedes
+        // the class-level one — so a method key shadows a class bare. Resolving the same way is what
+        // makes a shadowed attribute visible here instead of blessed.
+        var notInParallel = constraints.OfType<NotInParallelConstraint>().FirstOrDefault();
+        var parallelGroup = constraints.OfType<ParallelGroupConstraint>().FirstOrDefault();
+
+        if (notInParallel is null)
+            throw new InvalidOperationException(
+                $"'{key}' is process-global: mark this test [NotInParallel]"
+              + (exclusive ? " (bare — no key)." : "."));
+
+        if (!exclusive) return;
+
+        // A NotInParallel test that ALSO carries a ParallelGroup lands in the constrained-group
+        // scheduler, not the globally-exclusive bucket, so bare is not enough on its own.
+        if (parallelGroup is not null)
+            throw new InvalidOperationException(
+                $"'{key}' needs assembly-wide exclusion, but [ParallelGroup(\"{parallelGroup.Group}\")] "
+              + "puts this test in the constrained-group scheduler instead of the exclusive bucket. "
+              + "Drop the group.");
+
+        if (notInParallel.NotInParallelConstraintKeys.Count > 0)
+            throw new InvalidOperationException(
+                $"'{key}' is process-global: every child process this suite spawns inherits it and "
+              + "production path helpers read it, so a keyed [NotInParallel(\""
+              + string.Join("\", \"", notInParallel.NotInParallelConstraintKeys)
+              + "\")] cannot exclude the tests that observe it. Mark this test bare [NotInParallel].");
+    }
 }

--- a/test/Capacitor.Tests.Helpers/EnvScope.cs
+++ b/test/Capacitor.Tests.Helpers/EnvScope.cs
@@ -46,7 +46,7 @@ public sealed class EnvScope : IDisposable {
     static void RequireExclusion(string key, bool exclusive) {
         var context = TestContext.Current
                    ?? throw new InvalidOperationException(
-                          $"EnvScope needs a running test to read '{key}''s parallel constraints from. "
+                          $"EnvScope needs a running test to read the parallel constraints for '{key}'. "
                         + "A process-wide pin that must be in place before any test runs belongs in "
                         + "Guards/, setting the variable directly.");
 

--- a/test/Capacitor.Tests.Helpers/PidIdentity.cs
+++ b/test/Capacitor.Tests.Helpers/PidIdentity.cs
@@ -1,0 +1,57 @@
+using System.Globalization;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Tests.Helpers;
+
+/// <summary>
+/// Asserts on a process by the identity of its <i>incarnation</i>, not by its pid number, so a pid
+/// the OS has reassigned reads as gone instead of as still-alive.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A pid you no longer own — a reaped child, a grandchild reparented to init — can be reassigned at
+/// any moment, and <c>kill(pid, 0)</c> is then wrong in both directions: a death assertion sees the
+/// squatter and fails, and a liveness assertion sees the squatter and passes though the process it
+/// meant died. <see cref="ProcessStartToken"/> is production's answer to exactly that, and this is
+/// the same primitive with a test-shaped surface.
+/// </para>
+/// <para>
+/// Reaping a child you forked and have not yet reaped needs none of this: the zombie holds its pid
+/// until you wait on it, so the number cannot be reassigned in between.
+/// </para>
+/// </remarks>
+public static class PidIdentity {
+    /// <summary>
+    /// The incarnation token for a pid that must be alive now. Throws rather than returning null:
+    /// arming a watch on an unreadable identity would silently degrade to the pid-only check this
+    /// type exists to replace, and a successful capture is what makes a later null mean "left the
+    /// process table" rather than "we never could read it".
+    /// </summary>
+    public static string Capture(int pid) =>
+        ProcessStartToken.ForPid(pid)
+     ?? throw new InvalidOperationException(
+            $"No start identity for pid {pid}: it is already gone, or its identity is unreadable "
+          + "from here. Capture while the process is provably alive.");
+
+    /// <summary>
+    /// True once <paramref name="pid"/> no longer carries <paramref name="identity"/>: it left the
+    /// process table, or the number belongs to a different incarnation. A Unix zombie is NOT gone —
+    /// its identity stays readable until someone reaps it, which is what makes "the shim reaped it"
+    /// directly assertable.
+    /// </summary>
+    public static bool IsGone(int pid, string identity) => ProcessStartToken.Matches(pid, identity) != true;
+
+    /// <summary>Polls <see cref="IsGone"/> to a deadline; throws naming the pid, identity and elapsed time.</summary>
+    public static async Task WaitUntilGoneAsync(int pid, string identity, TimeSpan timeout) {
+        var start = Environment.TickCount64;
+
+        while (!IsGone(pid, identity)) {
+            if (Environment.TickCount64 - start >= (long) timeout.TotalMilliseconds)
+                throw new TimeoutException(string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"pid {pid} still carries identity '{identity}' after {timeout.TotalSeconds:0.#}s."));
+
+            await Task.Delay(50);
+        }
+    }
+}


### PR DESCRIPTION
Closes kurrent-io/kcap-cli#634 — kurrent-io/kcap-cli#634 (under [AI-1977](https://linear.app/kurrent/issue/AI-1977/kcap-cli-make-the-test-suite-state-independent-instead-of-serialising)).

`CLAUDE.md` told everyone to run `Capacitor.Cli.Daemon.Tests.Unit` with `--maximum-parallel-tests 1`, calling the suite "not parallel-safe". The flag does not serialise a suite — `GetMaxParallelism` feeds only the unconstrained bucket, and `ConstraintKeyScheduler` has no global-limit semaphore — so under that exact invocation peak concurrency was 4, `CodexLauncherTests`' `HOME` window still overlapped 17 other tests, and one `CodexHostedAgentRuntimeFactoryTests` window overlapped 48. The suite meanwhile runs green at full parallelism. So the guidance cost every local run \~2.5× wall clock, guaranteed nothing, and hid the defect it was blamed on.

## What this changes

**Exclusion where the state is genuinely process-global.** Five classes promoted from keyed to bare `[NotInParallel]`. A keyed constraint excludes only tests carrying the same key, which is sound only when every *reader* is in the cohort — and for `HOME`/`CODEX_HOME`/`GEMINI_CLI_HOME`/`KCAP_DAEMON_SUPERVISED` the readers are 18 sites in `src/` plus 15 files in the suite that spawn real `git` and inherit it. Three keys are deleted rather than promoted: two on reader-only tests, and one dead class-level bare in `LocalPermissionBridgeTests` that every method's own attribute had been shadowing.

`EnvScope` **enforces the constraint instead of asking for it.** The constructor requires some `NotInParallel`; `EnvScope.Exclusive` requires an unkeyed one. It resolves first-wins exactly as `GroupTestsByConstraintsCore` does, so a method-level key shadowing a class-level bare is caught rather than blessed, and it rejects a co-present `[ParallelGroup]` (that combination lands in the constrained-group scheduler and never gets `RequiresGlobalNotInParallelLock`). All 24 promoted tests plus the 6 already-bare ones go through it and lose their hand-rolled `try/finally`.

`PidIdentity` **replaces pid-number liveness with incarnation comparison** over the existing `ProcessStartToken`. `kill(pid, 0)` on a pid we no longer own is wrong in both directions: a recycled pid reads as our process still alive, which was a false *pass* in `Agent_survives_unrelated_pool_thread_churn_while_the_thread_lives`. `PtySpawnTests` loses its class-level bare — reaping a child you forked needs no exclusion, since the zombie holds the pid until you wait on it. The one `waitpid` on a shim-reaped pid becomes an identity assertion, which is strictly stronger than `ECHILD`: an unreaped zombie still carries its token, so "the shim reaped it" is now asserted directly rather than inferred from a wait that could equally have been stolen.

**Docs.** `CLAUDE.md`'s rule is rewritten (bare vs keyed vs shadowing, and what CI's flag actually buys); the whole-suite serial invocation is deleted. Separately, the 122-line "What this project does" section of accreted per-PR narrative moves verbatim to `docs/CHANGES.md`, leaving nine invariants behind — see the second commit.

## Verification

* 3× daemon suite at full parallelism: **0 failed** (2767/2767/2768 tests), 62s / 66s / 107s, against 3m13s under the documented invocation.
* Overlap analysis over a run's report JSON: all **44 bare test instances overlapped 0 peers**; sequential tail 1.78s.
* Full solution the way CI runs it: **9390 passed, 0 failed**.

## Also in here

`GitProviderRouterTests` fails at full parallelism for the same class of reason — the router memoizes into a production static and the per-test reset that clears it is itself a global mutation. Found while verifying this change; CI's serial flag is why it had not been seen. Fixed with a class-level bare `[NotInParallel]`. It is one test, not an audit of that suite.

## Reviewer notes

* **CI is unchanged.** Both flags stay in `ci.yml`; this makes `--maximum-parallel-tests 1` unnecessary for the daemon suite but does not audit the other three. Dropping it is a follow-up.
* **Two changes are not exercisable on macOS** and land verified by review plus the CI leg that runs them: `ConPtyJobObjectTests` (Windows) and `PtySpawnTests.Child_side_exec_failure_reports_failed_step_exec_and_reaps_cleanly` (`[RunOn(OS.Linux)]`). The latter is the most load-bearing pid rewrite here, so its Linux leg is the real gate.
* **Promoting to bare hides a race rather than removing it.** Passing `home` explicitly through `CodexLauncher.Prepare` is the actual fix; exclusion is the correct interim guard, not the destination. Follow-up in the design doc.
* A source-scan test that would fail the suite on a raw `Environment.SetEnvironmentVariable` was written and dropped as severable — that bypass stays open, and is listed under Follow-ups.

Design: `docs/superpowers/specs/2026-08-21-test-parallel-safety-exclusion-and-pid-identity-design.md`

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)