### PR TITLE
[AI-1762] §2.7 B4 (cli): resume a parked reviewer via thread/resume + AcceptedSeq-init forwarding

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1480,7 +1480,11 @@ public readonly record struct LaunchAgentCommand(
         // orchestrator's pre-flight AcpPermissionPresetPolicy fails closed on a preset supplied for a
         // review-flow / borrowed / non-ACP-routed launch. Appended last so the SignalR positional
         // binding stays wire-compatible — old daemons ignore it, old servers never set it.
-        string?           AcpPermissionPreset = null
+        string?           AcpPermissionPreset = null,
+        // §2.7 B4: the hosted Codex thread to RESUME (via thread/resume, no second SessionStarted) instead
+        // of starting fresh — set by the server only for a parked-reviewer relaunch, else null. Appended
+        // last so the SignalR positional binding stays wire-compatible with old daemons.
+        string?           ResumeSessionId = null
     );
 
 /// <summary>Caller-selected Codex launch posture. Valid ONLY for interactive, daemon-owned-worktree

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -31,6 +31,10 @@ internal delegate Task<(CodexAppServerConnection Connection, IAcpProcess Process
 /// <param name="WritableRoots">Writable roots for <c>workspace-write</c> (the owned worktree);
 /// ignored for the other sandboxes.</param>
 /// <param name="ClientVersion">Daemon version stamped into <c>initialize.clientInfo.version</c>.</param>
+/// <param name="ResumeSessionId">A parked Codex thread id to REOPEN via <c>thread/resume</c> instead of
+/// minting a fresh one with <c>thread/start</c>. Non-null only for a parked reviewer relaunch; the
+/// resumed thread keeps its id, so no second SessionStarted is emitted. A resume that the app-server
+/// rejects fails the launch (coded) rather than silently starting a new thread.</param>
 internal sealed record CodexAppServerLaunch(
     string                Cwd,
     string?               Model,
@@ -39,7 +43,8 @@ internal sealed record CodexAppServerLaunch(
     string                Sandbox,
     string                Approval,
     IReadOnlyList<string> WritableRoots,
-    string                ClientVersion);
+    string                ClientVersion,
+    string?               ResumeSessionId = null);
 
 /// <summary>
 /// A <see cref="IHostedAgentRuntime"/> that hosts a Codex agent over the <c>codex app-server</c>
@@ -376,9 +381,19 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
     }
 
     async Task StartThreadAsync(CancellationToken ct) {
+        // §2.7 B4: a non-null ResumeSessionId REOPENS that thread via thread/resume (no round-1 replay, no
+        // second SessionStarted); null ⇒ first launch via thread/start. A present-but-blank id is NOT a
+        // valid "no resume" sentinel — treating it as absent would silently thread/start and FORK the
+        // transcript, breaking the never-silently-fork invariant — so fail the launch loudly instead.
+        var isResume = _launch.ResumeSessionId is not null;
+        if (isResume && string.IsNullOrWhiteSpace(_launch.ResumeSessionId))
+            throw new InvalidOperationException(
+                "codex app-server: ResumeSessionId is present but blank; refusing to silently start a fresh thread.");
+        var method = isResume ? "thread/resume" : "thread/start";
+
         var startParams = new JsonObject {
             ["cwd"]               = _launch.Cwd,
-            // thread/start.sandbox is the coarse SandboxMode STRING (read-only / workspace-write /
+            // thread/{start,resume}.sandbox is the coarse SandboxMode STRING (read-only / workspace-write /
             // danger-full-access) — a different wire shape from turn/start.sandboxPolicy's object.
             // The resolved posture token already IS that string; the per-turn sandboxPolicy object
             // is the load-bearing containment.
@@ -388,15 +403,26 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         };
         if (!string.IsNullOrEmpty(_launch.Model))
             startParams["model"] = _launch.Model;
+        if (isResume)
+            startParams["threadId"] = _launch.ResumeSessionId; // resume-by-thread_id; response.thread.id == this id
 
-        var result = await RequestAsync("thread/start", startParams, ct).ConfigureAwait(false);
+        // A resume the app-server rejects is a clean JSON-RPC error out of RequestAsync -> the launch fails
+        // coded; it NEVER silently starts a new thread (that would fork the transcript).
+        var result = await RequestAsync(method, startParams, ct).ConfigureAwait(false);
 
-        _threadId      = result.Obj("thread")?.Str("id");
+        _threadId      = result.Obj("thread")?.Str("id"); // same read for both start and resume
         _resolvedModel = result.Str("model");
-        _clock?.SetLaunchStage("thread_started");
+        _clock?.SetLaunchStage(isResume ? "thread_resumed" : "thread_started");
 
         if (string.IsNullOrEmpty(_threadId))
-            throw new InvalidOperationException("codex app-server: thread/start returned no thread id.");
+            throw new InvalidOperationException($"codex app-server: {method} returned no thread id.");
+
+        // §2.7 B4 usage baseline: on resume the first thread/tokenUsage/updated carries the thread-CUMULATIVE
+        // total, so baseline off the next snapshot (emits nothing) to avoid double-counting round 1 as the
+        // first delta. Bounded fallback (an exact thread/read baseline is a follow-up); set before the
+        // deferred first turn so it lands ahead of any post-resume usage notification.
+        if (isResume)
+            _mapper.UsageBaselineOnNextNotification();
     }
 
     // ── Turns / rounds ─────────────────────────────────────────────────────────────────────────

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -70,8 +70,17 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
     /// under an app-server selection — because interactive hosting is a later phase.</summary>
     internal bool UsesAppServer(RuntimeStartContext ctx) => _config.CodexAppServerActive && ctx.IsReviewFlow;
 
-    public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) =>
-        UsesAppServer(ctx) ? StartAppServerAsync(ctx, ct) : _pty.StartAsync(ctx, ct);
+    public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+        // §2.7 B4: resume is app-server-only (thread/resume). A resume request routed to the PTY path can't
+        // be honored and would silently start a FRESH session — forking the transcript, breaking the
+        // never-silently-fork invariant — so fail the launch instead. (Server-side, resume must also be
+        // capability-gated to app-server-capable daemons before B6 activates parking.)
+        if (ctx.ResumeSessionId is not null && !UsesAppServer(ctx))
+            throw new InvalidOperationException(
+                "codex: a resume (ResumeSessionId set) requires the app-server route; refusing to start a fresh PTY session.");
+
+        return UsesAppServer(ctx) ? StartAppServerAsync(ctx, ct) : _pty.StartAsync(ctx, ct);
+    }
 
     async Task<HostedRuntimeStart> StartAppServerAsync(RuntimeStartContext ctx, CancellationToken ct) {
         var launcherCtx = BuildLauncherContext(ctx);
@@ -98,7 +107,11 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
             Sandbox:       sandbox,
             Approval:      approval,
             WritableRoots: [ctx.Worktree.Path],
-            ClientVersion: string.IsNullOrEmpty(_config.Version) ? "0.0.0" : _config.Version);
+            ClientVersion: string.IsNullOrEmpty(_config.Version) ? "0.0.0" : _config.Version,
+            // Non-null only for a parked reviewer relaunch: the runtime reopens this thread via
+            // thread/resume instead of thread/start (and the orchestrator suppresses the second
+            // SessionStarted, since the resumed thread keeps its canonical id).
+            ResumeSessionId: ctx.ResumeSessionId);
 
         CodexAppServerSpawn spawn = (seed, spawnCt) =>
             _spawnFactory(_launcher.CliPath, appServerArgs, seed, ctx.Worktree.Path, env, _config, _loggerFactory);

--- a/src/Capacitor.Cli.Daemon/Services/AcpTranscriptForwarder.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpTranscriptForwarder.cs
@@ -49,10 +49,14 @@ namespace Capacitor.Cli.Daemon.Services;
 /// advances its <c>ExpectedNextSeq</c> each round and so never trips the guard. Deeper reconnect
 /// resilience beyond this remains.
 ///
-/// Out of scope here: building/emitting the <c>SessionStarted</c> envelope (it is passed
+/// Out of scope here: building/emitting the <c>SessionStarted</c> envelope (a fresh session passes it
 /// in pre-built as <c>initialEnvelope</c>) or calling <c>AcpSessionStarted</c> — the bind
 /// always precedes starting this forwarder. This forwarder also never emits a <c>session_ended</c>
 /// envelope; the server's <c>EndAgentSession</c> is the sole <c>SessionEnded</c> owner.
+///
+/// <para>§2.7 B4 resume/rebind: a rebind passes null <c>initialEnvelope</c> and <c>resumeFromSeq</c> =
+/// the source-claim's canonical <c>AcceptedSeq</c> — the forwarder sends NO SessionStarted and numbers the
+/// first new event at <c>AcceptedSeq + 1</c>, so round-2 events aren't deduped (<c>≤ AcceptedSeq</c>) and lost.</para>
 /// </summary>
 internal sealed class AcpTranscriptForwarder {
     static readonly TimeSpan DefaultInitialSendRetryDelay = TimeSpan.FromSeconds(1);
@@ -63,7 +67,7 @@ internal sealed class AcpTranscriptForwarder {
     readonly Func<AcpEventEnvelope[], CancellationToken, Task<AcpBatchAck>> _send;
     readonly ChannelReader<AcpEventEnvelope>                                _envelopes;
     readonly ILogger                                                       _logger;
-    readonly AcpEventEnvelope                                              _initialEnvelope;
+    readonly AcpEventEnvelope?                                             _initialEnvelope;
     readonly TimeSpan                                                      _initialSendRetryDelay;
     readonly TimeSpan                                                      _maxSendRetryDelay;
     readonly int                                                           _maxStalledGapResends;
@@ -101,20 +105,35 @@ internal sealed class AcpTranscriptForwarder {
     /// (production) but are overridable so unit tests can exercise <see cref="SendWithRetryAsync"/>'s
     /// backoff without real sleeping.
     /// </summary>
+    /// <param name="resumeFromSeq">
+    /// §2.7 B4 resume/rebind: the canonical AcceptedSeq this forwarder resumes from. When set, do NOT
+    /// (re)send SessionStarted and number the first new event at <paramref name="resumeFromSeq"/>+1, so a
+    /// resumed incarnation's events land at the next canonical sequence instead of being deduped against
+    /// the prior incarnation's cursor. Null = a fresh session (SessionStarted@0, today's behaviour).
+    /// </param>
     public AcpTranscriptForwarder(
             Func<AcpEventEnvelope[], CancellationToken, Task<AcpBatchAck>> send,
-            AcpEventEnvelope                                               initialEnvelope,
+            AcpEventEnvelope?                                              initialEnvelope,
             ChannelReader<AcpEventEnvelope>                                envelopes,
             ILogger                                                        logger,
             TimeSpan?                                                      initialSendRetryDelay = null,
             TimeSpan?                                                      maxSendRetryDelay = null,
             int?                                                           maxStalledGapResends = null,
-            TimeSpan?                                                      stalledGapResendDelay = null
+            TimeSpan?                                                      stalledGapResendDelay = null,
+            long?                                                          resumeFromSeq = null
         ) {
         _send                   = send;
         _envelopes              = envelopes;
         _logger                 = logger;
-        _initialEnvelope        = initialEnvelope with { Seq = 0 };
+        if (resumeFromSeq is { } rs) {
+            // Resume/rebind: canonical already holds events through rs. No SessionStarted (the source-claim
+            // rebind is idempotent by thread id), and new events start at rs+1.
+            _initialEnvelope = null;
+            _nextSeq         = rs + 1;
+            _highestSent     = rs;
+        } else {
+            _initialEnvelope = (initialEnvelope ?? throw new ArgumentNullException(nameof(initialEnvelope))) with { Seq = 0 };
+        }
         _initialSendRetryDelay  = initialSendRetryDelay ?? DefaultInitialSendRetryDelay;
         _maxSendRetryDelay      = maxSendRetryDelay ?? DefaultMaxSendRetryDelay;
         _maxStalledGapResends   = maxStalledGapResends ?? DefaultMaxStalledGapResends;
@@ -135,7 +154,9 @@ internal sealed class AcpTranscriptForwarder {
     /// </summary>
     public async Task RunAsync(CancellationToken ct) {
         try {
-            var    pendingInitial = true;
+            // Resume mode (_initialEnvelope null) skips the initial-send branch entirely and drains new
+            // envelopes straight from _nextSeq (== resumeFromSeq+1); a fresh session sends SessionStarted@0.
+            var    pendingInitial = _initialEnvelope is not null;
             long?  resendFrom     = null;
 
             while (true) {
@@ -156,9 +177,12 @@ internal sealed class AcpTranscriptForwarder {
                     }
                 } else if (pendingInitial) {
                     pendingInitial = false;
-                    _unacked[_initialEnvelope.Seq] = _initialEnvelope;
-                    _highestSent = _initialEnvelope.Seq;
-                    batch = [_initialEnvelope];
+                    // Only reachable when pendingInitial started true, i.e. _initialEnvelope is non-null
+                    // (fresh session); resume mode never sets pendingInitial and so never dereferences it.
+                    var initial = _initialEnvelope!.Value;
+                    _unacked[initial.Seq] = initial;
+                    _highestSent = initial.Seq;
+                    batch = [initial];
                 } else {
                     var drained = await DrainNewEnvelopesAsync(ct).ConfigureAwait(false);
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1979,7 +1979,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 ActivityClock: activityClock,
                 // Carried verbatim; the ACP factory resolves it (non-review-flow launches only) into the
                 // interaction bridge's preset.
-                AcpPermissionPreset: cmd.AcpPermissionPreset
+                AcpPermissionPreset: cmd.AcpPermissionPreset,
+                // Carried verbatim; the Codex app-server factory branches thread/start -> thread/resume
+                // on it for a parked reviewer relaunch. Ignored by every other runtime.
+                ResumeSessionId: cmd.ResumeSessionId
             );
 
             HostedRuntimeStart start;
@@ -3753,7 +3756,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 acpCts.Token
             );
 
-            StartForwarderAfterBind(agent, transcript, vendor, acpCts);
+            // Non-envelope AcpSessionStarted bind: no source-claim cursor, so always a fresh forwarder
+            // (SessionStarted@0). §2.7 B4's rebind cursor rides ONLY the source-claim path below.
+            StartForwarderAfterBind(agent, transcript, vendor, acpCts, acceptedSeq: -1);
         } catch (Exception ex) {
             LogAcpBindFailed(ex, agent.Id);
         }
@@ -3764,11 +3769,17 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// liveness / TOCTOU guards, the local reconnect-binding registration, and the transcript
     /// forwarder build + run. Factored out of <see cref="StartAcpForwardingAsync"/> so the §2.5
     /// deferred-first-turn source-claim path — which binds via <c>AcpSessionSourceClaim</c>, NOT
-    /// <c>AcpSessionStarted</c> — can reuse it verbatim without re-binding. Synchronous (no awaits): the
-    /// forwarder's local seq always starts at 0 and the server drives resume via the AcpBatchAck, so
-    /// this needs no cursor from either bind path. The CALLER owns the try/catch.
+    /// <c>AcpSessionStarted</c> — can reuse it verbatim without re-binding. Synchronous (no awaits). The
+    /// CALLER owns the try/catch.
+    ///
+    /// <para><paramref name="acceptedSeq"/> (§2.7 B4): a FRESH bind (<c>-1</c>, the default) builds the
+    /// SessionStarted@0 initial envelope and the forwarder's local seq starts at 0. An envelope-sourced
+    /// REBIND (a parked reviewer relaunch, <c>≥ 0</c>) initializes the forwarder from the source-claim's
+    /// canonical <c>AcceptedSeq</c> instead — no SessionStarted, new events numbered from that seq + 1
+    /// (see §2.5 item 6). Only the <see cref="StartEnvelopeSourcedSessionAsync"/> source-claim path can
+    /// carry a cursor; the non-envelope <see cref="StartAcpForwardingAsync"/> path always passes -1.</para>
     /// </summary>
-    void StartForwarderAfterBind(AgentInstance agent, IAcpTranscriptSource transcript, string vendor, CancellationTokenSource acpCts) {
+    void StartForwarderAfterBind(AgentInstance agent, IAcpTranscriptSource transcript, string vendor, CancellationTokenSource acpCts, long acceptedSeq = -1) {
         // Liveness check: the bind await (either path) can span a reconnect outage. If finalize already
         // ran (cancelling acpCts and/or removing the agent from _agents) while we waited, abort — do not
         // register a binding, build a forwarder, or start it for an agent that's finalizing or gone.
@@ -3795,7 +3806,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return;
         }
 
-        var sessionStarted = AcpEventTranslator.BuildSessionStarted(
+        // §2.7 B4: a fresh bind (acceptedSeq < 0) synthesizes SessionStarted@0 and starts the local seq at
+        // 0; an envelope-sourced rebind (acceptedSeq >= 0) suppresses SessionStarted and resumes numbering
+        // from the canonical cursor, so round-2 events aren't deduped away against round-1's high-water.
+        var isRebind = acceptedSeq >= 0;
+
+        var sessionStarted = isRebind ? (AcpEventEnvelope?) null : AcpEventTranslator.BuildSessionStarted(
             seq: 0,
             DateTimeOffset.UtcNow.ToString("O"),
             cwd: transcript.Cwd,
@@ -3807,7 +3823,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             send: (batch, ct) => _server.SendAcpEventsAsync(agent.Id, transcript.AcpSessionId, batch, ct),
             initialEnvelope: sessionStarted,
             envelopes: transcript.Envelopes,
-            logger: _logger
+            logger: _logger,
+            resumeFromSeq: isRebind ? acceptedSeq : null
         );
 
         var runTask = ForwardAcpTranscriptAsync(agent, forwarder, acpCts.Token);
@@ -3862,8 +3879,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         try {
             // The claim already bound server-side, so build the forwarder WITHOUT AcpSessionStarted. It
-            // is running BEFORE the first turn dispatches, so it captures that turn's envelopes.
-            StartForwarderAfterBind(agent, transcript, vendor, acpCts);
+            // is running BEFORE the first turn dispatches, so it captures that turn's envelopes. §2.7 B4:
+            // pass the claim's canonical AcceptedSeq — -1 for a brand-new session (fresh SessionStarted@0),
+            // or the resume high-water for a parked-reviewer rebind (suppress SessionStarted, resume seq).
+            StartForwarderAfterBind(agent, transcript, vendor, acpCts, acceptedSeq: claim.AcceptedSeq);
 
             // StartForwarderAfterBind aborts silently if finalize ran (cancelled acpCts and/or removed the
             // agent) during the bind — re-check the SAME liveness before releasing the held first turn, so a

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -231,5 +231,10 @@ internal sealed record RuntimeStartContext(
         // LaunchAgentCommand.AcpPermissionPreset. The ACP factory resolves it (for non-review-flow
         // launches only) into an AcpLaunchPermissionPreset and wires it onto the interaction bridge.
         // Null for every non-preset launch and constructions predating this field.
-        string?             AcpPermissionPreset = null
+        string?             AcpPermissionPreset = null,
+        // The hosted Codex thread to RESUME, carried verbatim from LaunchAgentCommand.ResumeSessionId.
+        // Non-null only for a parked reviewer relaunch: the Codex app-server runtime reopens this thread
+        // via thread/resume instead of thread/start, and suppresses the second SessionStarted. Null for
+        // a fresh launch, every non-Codex/non-app-server launch, and constructions predating this field.
+        string?             ResumeSessionId = null
     );

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -26,9 +26,10 @@ public class CodexAppServerHostedAgentRuntimeTests {
     }
 
     static CodexAppServerLaunch Launch(string? model = null, string? prompt = null, string sandbox = "read-only",
-            string? effort = null, string approval = "never") =>
+            string? effort = null, string approval = "never", string? resumeSessionId = null) =>
         new(Cwd: "/tmp/wt", Model: model, Effort: effort, InitialPrompt: prompt, Sandbox: sandbox,
-            Approval: approval, WritableRoots: ["/tmp/wt"], ClientVersion: "0.146.0");
+            Approval: approval, WritableRoots: ["/tmp/wt"], ClientVersion: "0.146.0",
+            ResumeSessionId: resumeSessionId);
 
     /// <summary>Builds a spawn delegate that hands each spawn a fresh fake (indexed), recording the
     /// seed passed on each call so the restart path is assertable.</summary>
@@ -169,6 +170,89 @@ public class CodexAppServerHostedAgentRuntimeTests {
 
         await Assert.That(runtime.RequiresSourceClaimBeforeFirstTurn).IsFalse();
         await Assert.That(fake.ReceivedMethods).Contains("turn/start"); // no deferral ⇒ the prompt drives the first turn at start
+
+        await runtime.DisposeAsync();
+    }
+
+    // ── §2.7 B4: resume routing (thread/resume vs thread/start) ────────────────────────────────────
+
+    [Test]
+    public async Task Resume_launch_issues_thread_resume_carrying_the_thread_id() {
+        // A parked reviewer relaunch (ResumeSessionId set) must REOPEN the existing thread via
+        // thread/resume — carrying its threadId — never thread/start (which would fork the transcript).
+        var fake = new FakeCodexAppServer { Model = "gpt-5.3-codex" };
+        var (runtime, _, _) = Build(_ => fake, Launch(resumeSessionId: "thread-parked-1"));
+
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(fake.ReceivedMethods).Contains("thread/resume");
+        await Assert.That(fake.ReceivedMethods).DoesNotContain("thread/start");
+        await Assert.That(fake.LastResumeThreadId).IsEqualTo("thread-parked-1");
+        // response.thread.id echoes the requested id, so the runtime keeps the resumed thread's canonical id.
+        await Assert.That(runtime.ThreadId).IsEqualTo("thread-parked-1");
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Fresh_launch_issues_thread_start_not_resume() {
+        // The discriminating companion: with no ResumeSessionId the runtime mints a fresh thread —
+        // thread/start, never thread/resume, and no threadId carried.
+        var fake = new FakeCodexAppServer();
+        var (runtime, _, _) = Build(_ => fake, Launch());
+
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(fake.ReceivedMethods).Contains("thread/start");
+        await Assert.That(fake.ReceivedMethods).DoesNotContain("thread/resume");
+        await Assert.That(fake.LastResumeThreadId).IsNull();
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Resume_with_blank_id_fails_the_launch_and_never_forks() {
+        // §2.7 B4 safety: a present-but-BLANK ResumeSessionId is resume INTENT with an invalid id — it must
+        // fail the launch, NOT silently fall back to thread/start (which would fork the transcript). Guards
+        // a bad persisted/wire value against the no-silent-fork invariant.
+        var fake = new FakeCodexAppServer();
+        var (runtime, _, _) = Build(_ => fake, Launch(resumeSessionId: ""));
+
+        await Assert.That(async () => await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard))
+            .Throws<InvalidOperationException>();
+
+        // Neither thread verb was issued — the launch failed before forking.
+        await Assert.That(fake.ReceivedMethods).DoesNotContain("thread/start");
+        await Assert.That(fake.ReceivedMethods).DoesNotContain("thread/resume");
+
+        await runtime.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Resume_baselines_first_usage_then_emits_a_correct_incremental_delta() {
+        // On resume the runtime calls UsageBaselineOnNextNotification: the first post-resume usage snapshot
+        // (thread-CUMULATIVE, round 1 included) is consumed as the baseline and emits NO token_usage; the
+        // next snapshot yields the incremental delta. Pre-fix (no baseline on resume) the first snapshot
+        // would emit the whole cumulative total as a delta — a double-count of round 1.
+        var fake = new FakeCodexAppServer { Model = "gpt-5.3-codex", EmitUsageOnTurn = (input: 120, output: 40, total: 160) };
+        var (runtime, _, _) = Build(_ => fake, Launch(resumeSessionId: "thread-parked-1"), emitEnvelopes: true);
+
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await Assert.That(fake.ReceivedMethods).Contains("thread/resume");
+
+        // Round-2 turn 1: the cumulative usage (120/40) is the baseline — NO token_usage envelope emitted.
+        await runtime.SendUserInputAsync("round 2 turn 1").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await Assert.That(DrainAvailable(runtime).Any(e => e.Kind == AcpEventKind.TokenUsage)).IsFalse();
+
+        // Round-2 turn 2: a HIGHER cumulative (200/70) yields the incremental delta 80/30, NOT the raw 200/70.
+        fake.EmitUsageOnTurn = (input: 200, output: 70, total: 270);
+        await runtime.SendUserInputAsync("round 2 turn 2").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        var usage = DrainAvailable(runtime).Single(e => e.Kind == AcpEventKind.TokenUsage);
+        await Assert.That(usage.UsageInputTokens).IsEqualTo(80L);
+        await Assert.That(usage.UsageOutputTokens).IsEqualTo(30L);
 
         await runtime.DisposeAsync();
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
@@ -47,6 +47,7 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
     public readonly List<string>       ReceivedMethods    = [];
     public readonly List<string>       InitializeOptOuts  = [];
     public string?                     LastThreadStartSandbox;
+    public string?                     LastResumeThreadId; // §2.7 B4: the threadId carried on thread/resume
     public string?                     LastTurnApprovalPolicy;
     public string?                     LastTurnEffort;
     public string?                     LastSteerExpectedTurnId;
@@ -120,6 +121,19 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
                     ["modelProvider"] = "openai",
                 }, ct);
                 break;
+
+            case "thread/resume": {
+                // §2.7 B4 resume-by-thread_id: echo the requested thread id back (response.thread.id ==
+                // the requested id, per the app-server schema). The daemon reads it exactly as thread/start.
+                LastResumeThreadId = Str(@params, "threadId");
+                var resumedId = LastResumeThreadId ?? ThreadId;
+                await RespondAsync(id, new JsonObject {
+                    ["thread"]        = new JsonObject { ["id"] = resumedId, ["sessionId"] = resumedId, ["path"] = "/tmp/r.jsonl" },
+                    ["model"]         = Model,
+                    ["modelProvider"] = "openai",
+                }, ct);
+                break;
+            }
 
             case "turn/start": {
                 _turnStartCount++;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpTranscriptForwarderTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpTranscriptForwarderTests.cs
@@ -63,6 +63,66 @@ public class AcpTranscriptForwarderTests {
         await Assert.That(sentSeqsInCallOrder).IsEquivalentTo(new long[] { 0, 1, 2, 3 });
     }
 
+    // ── §2.7 B4: resume/rebind seq initialization ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task Resume_mode_suppresses_SessionStarted_and_numbers_new_events_from_resumeFromSeq_plus_one() {
+        // A parked-reviewer rebind: initialEnvelope null + resumeFromSeq = the canonical AcceptedSeq. The
+        // forwarder must send NO SessionStarted and number round-2's first new event at AcceptedSeq+1.
+        // Pre-fix the forwarder ALWAYS started at seq 0, so seq 6/7 here would be <= AcceptedSeq(5) and the
+        // server would silently dedup (LOSE) them — this assertion is what catches that.
+        const long resumeFromSeq = 5;
+
+        var channel = NewChannel();
+        channel.Writer.TryWrite(NewTextEnvelope("a"));
+        channel.Writer.TryWrite(NewTextEnvelope("b"));
+        channel.Writer.Complete();
+
+        var sent = new List<AcpEventEnvelope>();
+
+        Task<AcpBatchAck> Send(AcpEventEnvelope[] batch, CancellationToken _) {
+            sent.AddRange(batch);
+            return Task.FromResult(new AcpBatchAck(batch[^1].Seq, batch[^1].Seq));
+        }
+
+        var forwarder = new AcpTranscriptForwarder(
+            send: Send, initialEnvelope: null, envelopes: channel.Reader, logger: NullLogger.Instance,
+            initialSendRetryDelay: FastRetryDelay, maxSendRetryDelay: FastRetryDelay, resumeFromSeq: resumeFromSeq);
+
+        await forwarder.RunAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(sent[0].Seq).IsEqualTo(resumeFromSeq + 1);
+        await Assert.That(sent.Select(e => e.Seq)).IsEquivalentTo(new[] { resumeFromSeq + 1, resumeFromSeq + 2 });
+        // No SessionStarted, and nothing at seq 0, is ever sent on a resume.
+        await Assert.That(sent.Any(e => e.Seq == 0)).IsFalse();
+        await Assert.That(sent.Any(e => e.Kind == AcpEventKind.SessionStarted)).IsFalse();
+        await Assert.That(forwarder.IsTerminal).IsFalse();
+        await Assert.That(forwarder.UnackedCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Fresh_mode_still_sends_SessionStarted_at_seq_0_first() {
+        // The discriminating companion: with resumeFromSeq null (default) and a non-null initialEnvelope,
+        // today's behaviour is unchanged — SessionStarted rides seq 0 as the very first thing on the wire.
+        var channel = NewChannel();
+        channel.Writer.TryWrite(NewTextEnvelope("a"));
+        channel.Writer.Complete();
+
+        var sent = new List<AcpEventEnvelope>();
+
+        Task<AcpBatchAck> Send(AcpEventEnvelope[] batch, CancellationToken _) {
+            sent.AddRange(batch);
+            return Task.FromResult(new AcpBatchAck(batch[^1].Seq, batch[^1].Seq));
+        }
+
+        var forwarder = NewForwarder(Send, channel.Reader); // resumeFromSeq null, initialEnvelope non-null
+
+        await forwarder.RunAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(sent[0].Seq).IsEqualTo(0L);
+        await Assert.That(sent[0].Kind).IsEqualTo(AcpEventKind.SessionStarted);
+    }
+
     // ── Unacked buffer ───────────────────────────────────────────────────────────────────────────
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorSourceClaimTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorSourceClaimTests.cs
@@ -56,6 +56,77 @@ public class AgentOrchestratorSourceClaimTests {
         }
     }
 
+    // ── §2.7 B4: the source-claim AcceptedSeq drives the forwarder's resume/fresh mode ─────────────
+
+    [Test]
+    public async Task Deferred_rebind_resumes_the_forwarder_from_the_claim_seq_with_no_second_SessionStarted() {
+        // A parked-reviewer relaunch's source claim returns a canonical AcceptedSeq >= 0. The bind seam
+        // must build the forwarder in RESUME mode: NO SessionStarted, and the first new envelope numbered
+        // at AcceptedSeq+1 — otherwise round-2 events (seq'd from 0 by the pre-fix forwarder) would be
+        // <= AcceptedSeq and the server would silently dedup (LOSE) them.
+        const long acceptedSeq = 7;
+
+        var (repoPath, cleanup) = GitRepoHarness.CreateGitRepo();
+        try {
+            var server = new CaptureServerConnection {
+                SourceClaimOutcome = new AcpSourceClaimOutcome(AcpBindOutcome.Bound, 1, acceptedSeq)
+            };
+            var factory = DeferredFactory();
+
+            await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+                server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+            orch.AcpFinalDrainBudget = TimeSpan.FromMilliseconds(200);
+
+            await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-rebind", repoPath));
+
+            // The claim ran (the forwarder is built right after it). A round-2 canonical envelope — the
+            // unbounded transcript channel buffers it until the forwarder drains it.
+            await server.SourceClaimSignal.Reader.ReadAsync().AsTask().WaitAsync(WaitHarness.AcpHangGuard);
+            factory.LastRuntime!.EnvelopesWriter.TryWrite(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: "round 2"));
+
+            await server.AcpEventsCallSignal.Reader.ReadAsync().AsTask().WaitAsync(WaitHarness.AcpHangGuard);
+
+            // The VERY FIRST thing forwarded is the round-2 envelope at AcceptedSeq+1 — never a SessionStarted@0.
+            var firstBatch = server.AcpEventsCalls[0].Envelopes;
+            await Assert.That(firstBatch[0].Kind).IsEqualTo(AcpEventKind.AssistantText);
+            await Assert.That(firstBatch[0].Seq).IsEqualTo(acceptedSeq + 1);
+            await Assert.That(server.AcpEventsCalls.SelectMany(c => c.Envelopes).Any(e => e.Kind == AcpEventKind.SessionStarted)).IsFalse();
+
+            await orch.HandleStopAgentForTest("agent-rebind");
+        } finally {
+            cleanup();
+        }
+    }
+
+    [Test]
+    public async Task Deferred_fresh_claim_still_sends_SessionStarted_at_seq_0() {
+        // The discriminating companion: a brand-new envelope-sourced session's claim returns AcceptedSeq
+        // -1 (the default), so the bind seam stays on today's fresh path — SessionStarted@0 first.
+        var (repoPath, cleanup) = GitRepoHarness.CreateGitRepo();
+        try {
+            var server  = new CaptureServerConnection(); // default claim: Bound@1, AcceptedSeq -1
+            var factory = DeferredFactory();
+
+            await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+                server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+                allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+            orch.AcpFinalDrainBudget = TimeSpan.FromMilliseconds(200);
+
+            await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-fresh", repoPath));
+
+            await server.AcpEventsCallSignal.Reader.ReadAsync().AsTask().WaitAsync(WaitHarness.AcpHangGuard);
+
+            var firstBatch = server.AcpEventsCalls[0].Envelopes;
+            await Assert.That(firstBatch[0].Kind).IsEqualTo(AcpEventKind.SessionStarted);
+            await Assert.That(firstBatch[0].Seq).IsEqualTo(0);
+
+            await orch.HandleStopAgentForTest("agent-fresh");
+        } finally {
+            cleanup();
+        }
+    }
+
     [Test]
     public async Task Rejected_claim_tears_the_launch_down_without_a_first_turn_or_confirm() {
         var (repoPath, cleanup) = GitRepoHarness.CreateGitRepo();


### PR DESCRIPTION
## What (DRAFT — do not merge until the server B4 close-before-heal fences land)

The daemon half of §2.7 B4 `resume_session_id` (server half: kurrent-io/kcap-server#1594). When the server carries a parked Codex thread id, the runtime reopens that thread via `thread/resume` and the transcript forwarder continues the one canonical sequence.

**Held as draft:** codex review of the server half found two lifecycle P1s (a close-race and ledger-lineage non-uniqueness) that need the close-before-heal fence to land first, so the resume feature never ships without its safety fences. This cli half is complete + verified but blocked on that. The feature is also dormant until B6 activates parking, so nothing resumes yet regardless.

## How

- `LaunchAgentCommand` mirror + `RuntimeStartContext` + `CodexAppServerLaunch` carry `ResumeSessionId`; the factory threads it in.
- `StartThreadAsync`: `thread/resume` (carrying `threadId`) when a resume id is present, else `thread/start`. A rejected resume is a clean JSON-RPC error → coded launch failure, never a silent new thread.
- **`AcpTranscriptForwarder` resume mode:** given the source-claim's canonical `AcceptedSeq`, it sends **no** `SessionStarted` and numbers the first new event at `AcceptedSeq+1`, so round-2 events land at the next canonical sequence instead of being deduped (`≤ AcceptedSeq`) and lost.
- `StartForwarderAfterBind` takes the `AcceptedSeq`; a rebind (`≥0`) initializes the forwarder in resume mode. Only the envelope-sourced bind passes a real cursor; the non-envelope bind and every reconnect keep today's from-0 behaviour (reconnect reuses the live forwarder, never re-binds).
- Usage baseline: on resume the next token snapshot is consumed as the baseline (bounded, documented fallback) so post-resume deltas don't re-count prior usage. Exact `thread/read` baselining is a follow-up (the pinned app-server build carries no cumulative-total shape on the resume/read response).

## Testing

Mutation-verified discriminating tests (each fails against the pre-fix code): forwarder resume-mode seq-init + no `SessionStarted`; `thread/resume` routing; bind-seam end-to-end (round-2 at `AcceptedSeq+1`, no second `SessionStarted`); usage rebaseline delta. 66 tests across 6 affected classes green; build clean (warnings-as-errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)