### PR TITLE
Proactively suggest an independent second-harness review flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,7 +1109,7 @@ kcap plugin install --codex --if-installed           # refresh Codex hooks only 
 kcap plugin install --if-installed                   # refresh Claude plugin registration only if previously installed (used by npm postinstall)
 ```
 
-Installing any vendor that reads the shared tree — `--codex`, `--cursor`, `--copilot`, `--gemini`, `--pi`, `--opencode` — writes these nine skills under `~/.agents/skills/` (`--skills` installs them alone; Kiro and Antigravity get their own copies, and the bare Claude install uses the plugin bundle). Opt out per vendor with `--skip-<vendor>-skills`:
+Installing any vendor that reads the shared tree — `--codex`, `--cursor`, `--copilot`, `--gemini`, `--pi`, `--opencode` — writes these ten skills under `~/.agents/skills/` (`--skills` installs them alone; Kiro and Antigravity get their own copies, and the bare Claude install uses the plugin bundle). Opt out per vendor with `--skip-<vendor>-skills`:
 
 | Skill | Wraps | Purpose |
 |---|---|---|
@@ -1122,6 +1122,7 @@ Installing any vendor that reads the shared tree — `--codex`, `--cursor`, `--c
 | `kcap-agent-flows` | `kcap mcp flows` | Multi-participant agent flows by `definition_id` or inline `definition_yaml` |
 | `kcap-work-items` | `kcap mcp workitems` | Declare a work item's breakdown and its blocks / blocked-by dependencies |
 | `kcap-guided-tour` | analytics + sessions MCP | Onboarding tour of what Capacitor has recorded |
+| `kcap-suggest-review-flow` | `kcap mcp flows` | Proactively offer an independent second-harness review flow at spec/implementation completion |
 
 The first five (`kcap-recap`, `kcap-errors`, `kcap-hide`, `kcap-disable`, `kcap-validate-plan`) auto-resolve the active session from `CODEX_THREAD_ID`; pass `<sessionId>` explicitly to operate on a different session. `kcap-review-flows` and `kcap-agent-flows` work differently — they operate via flow IDs through `kcap mcp flows` rather than session auto-resolution; see [Flows MCP server (for agents)](#flows-mcp-server-for-agents) for details. `kcap-work-items` declares structure through `kcap mcp workitems` and needs no session id for its breakdown and relation tools. `kcap-guided-tour` shells out to `kcap whoami` and otherwise reads through the `kcap-analytics` and `kcap-sessions` MCP servers, so it needs those registered (setup does it) rather than a session id.
 

--- a/docs/eval/suggest-review-flow.md
+++ b/docs/eval/suggest-review-flow.md
@@ -1,0 +1,83 @@
+# `suggest-review-flow` — triggering eval
+
+The skill is model-driven: its frontmatter `description` is the entire trigger surface. This file is
+the **reproducible acceptance harness** for that surface. It is deliberately kept out of
+`kcap/skills/suggest-review-flow/` because that directory ships verbatim to users' `~/.agents/skills/`.
+
+## Two-layer gate
+
+There is no in-repo skill-triggering eval runner in kcap-cli or kcap-server, so the gate is split:
+
+1. **CI-durable (runs on every build):** the static conformance pins in
+   `test/Capacitor.Cli.Tests.Unit/Commands/SuggestReviewFlowSkillConformanceTests.cs` (the two
+   milestone triggers and the safety guardrails are present in the shipped `SKILL.md`) plus the
+   deterministic `ReviewerVendorLookup` / `DriverVendor` unit tests. These are what actually keep the
+   skill honest release to release.
+2. **Dev-time (run by hand against the corpus below):** the external
+   `anthropic-skills:skill-creator` eval, on the **Claude Code reference harness**, used to tune the
+   `description` until the thresholds are met. Its inputs (this corpus) and its raw results are
+   committed here so a "pass" is reproducible.
+
+## Precommitted thresholds (fixed before running — not chosen after seeing results)
+
+- Positive **recall ≥ 0.95** per milestone family (spec, code).
+- Negative **false-positive rate ≤ 0.05** per family.
+- **N = 5** independent repetitions per case; a case passes if the expected outcome holds in **≥ 4/5**
+  runs; family metrics are computed over all case×repetition outcomes.
+- A case asserts the FULL behavior, not just "did it fire": it triggers (or not) correctly, it calls
+  `list_reviewer_vendors` **exactly once** when it fires, it recommends only vendors the tool
+  returned, its independence claim matches `driver_vendor` known/unknown, and it **never starts a flow
+  without explicit consent**.
+
+## Harness coverage
+
+The fixed supported set is the nine harnesses kcap ships the skill to: Claude Code, Codex, Cursor,
+Copilot, Gemini, Kiro, Pi, OpenCode, Antigravity. The `SKILL.md` is byte-identical across all nine, so
+the trigger surface is the same text everywhere. The skill-creator eval runs on the Claude Code
+reference harness; the other eight are covered by the shared text plus a manual smoke (below).
+**Known gap:** an *automated* multi-harness triggering eval is not buildable without a runner — that is
+future work, and until it exists the eight non-reference harnesses rest on the shared text + manual
+smoke, never on "it passed on Claude so it ships everywhere."
+
+## Corpus
+
+### Positives — SHOULD fire (recommend a reviewer, ask, do not auto-run)
+
+1. `spec` — "Spec's done, I've written it up." (spec just finalized)
+2. `spec` — a design doc was just written and approved this session, about to move to planning.
+3. `code` — "Implementation is complete." after a feature was built.
+4. `code` — "I'm about to open a PR for this."
+5. `code` — "Ready to commit — anything else before I do?"
+6. `both` — one session that finalizes a spec, then later finishes the implementation (two distinct
+   offers, one per artifact).
+7. `code` — a second, different change finished later in the same session (a fresh offer — different
+   target identity).
+
+### Negatives — SHOULD NOT fire
+
+1. "Review this diff for me." (ordinary self-review → do it locally, no offer)
+2. "Code review this PR." (ordinary self-review)
+3. "Look over my spec." (ordinary self-review)
+4. Mid-implementation edit, feature not finished.
+5. Rough mid-stream brainstorming, no finalized spec.
+6. A partial plan, still being drafted.
+7. Known checks are still failing.
+8. A review flow for this artifact is already active / just completed.
+9. The same spec, already offered and declined earlier this session (dedup — no re-offer).
+10. `brainstorming` / `writing-plans` is mid-flow (defer; fire only at the seam).
+
+### Availability / recommendation cases (assert the recommendation, not the trigger)
+
+- `driver_vendor: "claude"`, reviewers `[claude, codex]` → recommend codex (prefer non-driver).
+- `driver_vendor: "codex"`, reviewers `[codex]` only → still offer codex, framed as an independent
+  context-free reviewer.
+- `driver_vendor` absent (unknown) → offer a choice; never claim "a different model".
+- reviewers empty, one case per `diagnostics.reason` → the matching one-line unlock guidance, no
+  dead-end.
+- `list_reviewer_vendors` missing from the session (stale MCP schema) → tell the user to reconnect;
+  do not guess, do not shell out.
+
+## Results
+
+_Pending the dev-time skill-creator run. Record the runner + model versions, per-case pass counts,
+and the computed family metrics here when it is executed._

--- a/kcap/skills/suggest-review-flow/SKILL.md
+++ b/kcap/skills/suggest-review-flow/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: suggest-review-flow
+description: >-
+  Use this skill to PROACTIVELY OFFER an independent review flow at a natural
+  milestone — right after you finish writing or finalizing a spec/design, and
+  right after implementation is complete (a feature or bugfix is functionally
+  finished, or you are about to commit / open a PR / merge). It suggests handing
+  the work to a SEPARATE reviewer harness and, using list_reviewer_vendors,
+  recommends a reviewer that will actually run for this repo. Triggers:
+  "implementation is complete", "I've finished implementing", "the feature is
+  done", "ready to commit", "about to open a PR", "spec is finalized", "just
+  wrote the design". It only OFFERS and asks — it never starts a flow on its
+  own, and it hands execution to the review-flows skill once the user accepts.
+  Do NOT use it when the user asks you to review something yourself ("review
+  this", "code review this", "look over my spec") — just do that review
+  directly; and do not use it to START a flow (that is the review-flows skill).
+---
+
+# Suggest a review flow
+
+You have reached a milestone where an **independent** review adds real value: a
+separate coding-agent session, with none of this session's context, reviews the
+work — and a different model catches what the author's own model glossed over.
+Most people never think to do this. Your job here is to **offer** it at the
+right moment, recommend a reviewer that will actually run, and — only if the
+user says yes — hand off to the `review-flows` skill. **This skill never starts
+a review flow itself.**
+
+## When to offer (and when not to)
+
+Offer at exactly two milestones:
+
+- **Spec complete** — you just produced AND presented a finalized spec/design
+  this session → offer a `spec-review` flow.
+- **Implementation complete** — the change is functionally finished (you say so,
+  or you are about to commit / open a PR / merge) → offer a `code-review` flow.
+
+Do NOT offer (stay silent) when:
+
+- The user asked you to **review something yourself** ("review this", "code
+  review this", "look over the spec"). Just perform that review locally — no
+  offer, no flow.
+- You are only part-way through: rough mid-stream brainstorming, a partial plan,
+  a routine edit, or work whose known checks are still failing.
+- A review flow for this artifact is already engaged, active, or just completed.
+- Another skill (brainstorming, writing-plans, finishing-a-development-branch,
+  requesting-code-review) is mid-flow — let it finish; offer at the seam.
+
+**Offer at most once per artifact.** Key the offer on (milestone type + the
+target's identity + its revision): the same spec or the same change never gets
+offered twice, but a materially revised artifact may be offered again, and a
+second, different artifact of the same kind may be offered on its own. If the
+user declines or moves on, stay silent for that artifact. A failed availability
+lookup counts as the one prompt for that artifact — do not re-prompt.
+
+## How to recommend a reviewer
+
+1. Call **`list_reviewer_vendors`** (read-only; safe to call before offering).
+   It returns `reviewers[]` (vendors that can actually run for this repo now),
+   `driver_vendor` (the harness you are running in, or absent if unknown), and
+   `diagnostics`.
+2. **Prefer a reviewer different from the driver.** A different model is the
+   highest-value review. If one non-driver reviewer is available, recommend it;
+   if several, offer a short choice — never assert one vendor is "better".
+3. **If the only available reviewer is your own vendor, still offer it** —
+   framed as an independent, context-free reviewer session. The value is the
+   clean second look, not necessarily a different model.
+4. **If `driver_vendor` is absent (unknown)**, do NOT claim "a different model";
+   frame the offer as "a separate, independent reviewer session" and offer a
+   choice from `reviewers[]`.
+5. **If `reviewers[]` is empty**, read `diagnostics.reason` and give one line of
+   guidance instead of a dead end:
+   - `no_daemons_connected` → start a daemon (`kcap daemon start -d`).
+   - `no_repo_hosting_daemon` → run a daemon on a machine that has this repo.
+   - `no_unattended_reviewer` → install/certify a second harness as a reviewer.
+   - `repo_unresolved` → the current directory isn't a recognized repo.
+   - `lookup_failed` → couldn't reach the server; suggest checking `kcap status`.
+   - `schema_skew` → the kcap client/server is out of date; suggest updating.
+
+## Handing off (only after the user accepts)
+
+- You MAY run the read-only `list_reviewer_vendors` lookup automatically, but you
+  **MUST NOT start a review flow until the user affirmatively accepts THIS
+  offer.**
+- On acceptance, invoke the **`review-flows`** skill to run it, preserving the
+  chosen `kind` (spec-review / code-review), the target, and the chosen reviewer
+  vendor.
+- If the reviewer vendor turns out to be unavailable at start (a snapshot race),
+  `review-flows` surfaces the reason — do not silently substitute another vendor;
+  re-recommend and get fresh consent.
+
+## If `list_reviewer_vendors` is not available
+
+Your harness caches the kcap MCP tool list when it connects. If kcap was
+upgraded mid-session, `list_reviewer_vendors` may be missing from this session.
+Do NOT guess availability and do NOT shell out as a workaround — tell the user
+to restart the harness (or reconnect the `kcap-flows` MCP server) so the tool
+appears, then offer again.

--- a/src/Capacitor.Cli.Core/AgentsSkillsInstaller.cs
+++ b/src/Capacitor.Cli.Core/AgentsSkillsInstaller.cs
@@ -34,7 +34,8 @@ public static class AgentsSkillsInstaller {
         "review-flows",
         "agent-flows",
         "work-items",
-        "guided-tour"
+        "guided-tour",
+        "suggest-review-flow"
     ];
 
     /// <summary>

--- a/src/Capacitor.Cli.Core/Resources/help-plugin.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-plugin.txt
@@ -155,7 +155,7 @@ Notes:
   nothing, because that session started with the integration.
 
   Skills install to ~/.agents/skills/kcap-{recap,errors,hide,disable,
-  validate-plan,review-flows,agent-flows,work-items,guided-tour}/.
+  validate-plan,review-flows,agent-flows,work-items,guided-tour,suggest-review-flow}/.
   Codex, Cursor, and any other agent that honors the .agents/skills convention
   will pick them up automatically. Every install of a vendor that reads that tree
   writes them, so `install --cursor` alone leaves nothing missing. Kiro and

--- a/src/Capacitor.Cli/Commands/DriverVendor.cs
+++ b/src/Capacitor.Cli/Commands/DriverVendor.cs
@@ -1,0 +1,23 @@
+namespace Capacitor.Cli.Commands;
+
+/// <summary>Best-effort inference of the DRIVER harness — the coding agent running this MCP server —
+/// from the per-process env a harness exports into its children. Only harnesses with a verified,
+/// distinctive marker are inferred; anything else returns null so the skill's unknown-driver fallback
+/// never claims a "different model". No marker is invented: an unverified or ambiguous (nested)
+/// harness stays null rather than risk naming the wrong vendor. Uses the same env evidence as
+/// <see cref="Capacitor.Cli.HarnessRequesterContext"/>, kept here so the reviewer-vendor tool can
+/// echo <c>driver_vendor</c> without widening that type's contract.</summary>
+public static class DriverVendor {
+    public static string? Infer() => Infer(Environment.GetEnvironmentVariable);
+
+    internal static string? Infer(Func<string, string?> getEnv) {
+        var claude = !string.IsNullOrWhiteSpace(getEnv(HarnessRequesterContext.ClaudeSessionIdVar));
+        var codex  = !string.IsNullOrWhiteSpace(getEnv(HarnessRequesterContext.CodexThreadIdVar));
+
+        // Co-present markers mean one harness is nested inside another — neither is provably the
+        // driver, so decline to guess (mirrors HarnessRequesterContext's own nesting stance).
+        if (claude && !codex) return "claude";
+        if (codex && !claude) return "codex";
+        return null;
+    }
+}

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -389,6 +389,14 @@ static class McpFlowsServer {
             // ReviewerVendorLookup). Its own branch — it hits /api/daemons, not a flow URL, and never
             // mutates anything.
             if (toolName is "list_reviewer_vendors") {
+                // repo_unresolved is a local precondition AND the highest-precedence reason — settle it
+                // before any network call, so an unresolved repo can never surface as an auth/lookup
+                // error from GET /api/daemons instead of the contractual repo_unresolved result.
+                if (string.IsNullOrEmpty(repoRoot))
+                    return BuildToolResult(id, JsonSerializer.Serialize(
+                        ReviewerVendorLookup.Aggregate(null, repoRoot, MachineId.Get(), driverVendor),
+                        McpJsonContext.Default.ReviewerVendorsResult));
+
                 using var daemonsResp = await SendWithRefreshRetryAsync(
                     client, apiRoot, (c, ct) => c.GetAsync(apiRoot + "/api/daemons", ct));
 

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -389,12 +389,22 @@ static class McpFlowsServer {
             // ReviewerVendorLookup). Its own branch — it hits /api/daemons, not a flow URL, and never
             // mutates anything.
             if (toolName is "list_reviewer_vendors") {
+                // Surface a NON-sensitive repo id (owner/repo), never the local repoRoot path, which
+                // must not leak to the model — repoRoot is used only for the on-disk hosting match.
+                var repoIdentity = repoInfo is { Owner.Length: > 0, RepoName.Length: > 0 }
+                    ? $"{repoInfo.Owner}/{repoInfo.RepoName}"
+                    : null;
+                // Read-only: never MachineId.Get() here — that would persist machine.json on first
+                // use, breaking this tool's read-only/side-effect-free contract. A null id (no
+                // machine.json yet) just drops the same-machine filter for this call.
+                var machineId = MachineId.ReadPersisted();
+
                 // repo_unresolved is a local precondition AND the highest-precedence reason — settle it
                 // before any network call, so an unresolved repo can never surface as an auth/lookup
                 // error from GET /api/daemons instead of the contractual repo_unresolved result.
                 if (string.IsNullOrEmpty(repoRoot))
                     return BuildToolResult(id, JsonSerializer.Serialize(
-                        ReviewerVendorLookup.Aggregate(null, repoRoot, MachineId.Get(), driverVendor),
+                        ReviewerVendorLookup.Aggregate(null, repoRoot, machineId, driverVendor, repoIdentity: repoIdentity),
                         McpJsonContext.Default.ReviewerVendorsResult));
 
                 using var daemonsResp = await SendWithRefreshRetryAsync(
@@ -405,12 +415,13 @@ static class McpFlowsServer {
 
                 ReviewerVendorsResult result;
                 if (!daemonsResp.IsSuccessStatusCode) {
-                    result = ReviewerVendorLookup.Aggregate(null, repoRoot, MachineId.Get(), driverVendor);
+                    result = ReviewerVendorLookup.Aggregate(null, repoRoot, machineId, driverVendor, repoIdentity: repoIdentity);
                 } else {
                     var daemonsBody = await daemonsResp.Content.ReadAsStringAsync();
                     var (records, skipped, skew) = ReviewerVendorLookup.ParseDaemons(daemonsBody);
                     result = ReviewerVendorLookup.Aggregate(
-                        records, repoRoot, MachineId.Get(), driverVendor, schemaSkew: skew, skippedRecords: skipped);
+                        records, repoRoot, machineId, driverVendor,
+                        schemaSkew: skew, skippedRecords: skipped, repoIdentity: repoIdentity);
                 }
 
                 return BuildToolResult(id, JsonSerializer.Serialize(result, McpJsonContext.Default.ReviewerVendorsResult));

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -21,10 +21,11 @@ static class McpFlowsServer {
         // KCAP_SESSION_ID / process cwd names the launching session instead of this driver. Both the
         // session id and the working directory come from the same resolution, so a flow can never be
         // attributed to one session while being reviewed in another session's checkout.
-        var requester = HarnessRequesterContext.Resolve();
-        var cwd       = requester.ProjectDir ?? Directory.GetCurrentDirectory();
-        var repoRoot  = GitRepository.FindRoot(cwd);
-        var tools     = BuildToolsList();
+        var requester    = HarnessRequesterContext.Resolve();
+        var cwd          = requester.ProjectDir ?? Directory.GetCurrentDirectory();
+        var repoRoot     = GitRepository.FindRoot(cwd);
+        var driverVendor = DriverVendor.Infer();
+        var tools        = BuildToolsList();
 
         RepositoryPayload? repoInfo = null;
         try {
@@ -76,7 +77,7 @@ static class McpFlowsServer {
 
                 return await HandleToolCallAsync(
                     callId, callRequest, client, baseUrl, cwd, repoRoot, repoInfo,
-                    requestingSessionId: requester.SessionId);
+                    requestingSessionId: requester.SessionId, driverVendor: driverVendor);
             } catch (Exception ex) {
                 // Unexpected: log the detail to stderr (not to the client, which could leak local
                 // paths from IO errors) and return a generic tool error, keeping the loop alive.
@@ -170,7 +171,10 @@ static class McpFlowsServer {
             // clock is: the real read resolves a profile from the user's own config file, which a
             // unit test must never depend on. Production passes nothing and gets the real read — a
             // fresh one per consultation, never a cached value (see LoadReviewerVendorPreferenceAsync).
-            Func<Task<SavedReviewerVendor>>? reviewerVendorPreference = null
+            Func<Task<SavedReviewerVendor>>? reviewerVendorPreference = null,
+            // The driver harness, inferred once by RunAsync from the running harness's env, so the
+            // reviewer-vendor lookup can echo driver_vendor without this handler reading the env.
+            string? driverVendor = null
         ) {
         clock                    ??= FlowRetryClock.System;
         backoff                  ??= SettlementBackoff.Default;
@@ -378,6 +382,30 @@ static class McpFlowsServer {
                     ?? throw new ArgumentException("Missing required argument: flow_run_id");
                 var waitResult = await PollStatusUntilTerminalAsync(client, apiRoot, waitFlowRunId, toolName, clock, backoff);
                 return BuildToolResult(id, waitResult.Payload, waitResult.IsError);
+            }
+
+            // Read-only availability lookup: reads GET /api/daemons and computes, client-side, which
+            // reviewer vendors can actually run an unattended review for THIS repo (see
+            // ReviewerVendorLookup). Its own branch — it hits /api/daemons, not a flow URL, and never
+            // mutates anything.
+            if (toolName is "list_reviewer_vendors") {
+                using var daemonsResp = await SendWithRefreshRetryAsync(
+                    client, apiRoot, (c, ct) => c.GetAsync(apiRoot + "/api/daemons", ct));
+
+                if (daemonsResp.StatusCode == HttpStatusCode.Unauthorized)
+                    return BuildToolResult(id, await AuthRejectionNotice.ForPersistentUnauthorizedAsync(apiRoot), isError: true);
+
+                ReviewerVendorsResult result;
+                if (!daemonsResp.IsSuccessStatusCode) {
+                    result = ReviewerVendorLookup.Aggregate(null, repoRoot, MachineId.Get(), driverVendor);
+                } else {
+                    var daemonsBody = await daemonsResp.Content.ReadAsStringAsync();
+                    var (records, skipped, skew) = ReviewerVendorLookup.ParseDaemons(daemonsBody);
+                    result = ReviewerVendorLookup.Aggregate(
+                        records, repoRoot, MachineId.Get(), driverVendor, schemaSkew: skew, skippedRecords: skipped);
+                }
+
+                return BuildToolResult(id, JsonSerializer.Serialize(result, McpJsonContext.Default.ReviewerVendorsResult));
             }
 
             using var httpResponse = toolName switch {
@@ -2197,6 +2225,16 @@ static class McpFlowsServer {
                 },
                 ["flow_run_id"]
             )
+        ),
+        new(
+            "list_reviewer_vendors",
+            "List the reviewer vendors that can ACTUALLY run an unattended review flow for THIS repo right now — installed and certified on a connected daemon that hosts this repository. " +
+            "Read-only and side-effect-free: safe to call before offering a review, so you recommend a reviewer that will not be rejected. " +
+            "Returns reviewers[] (each with the canonical lowercase vendor token; empty when none, and diagnostics.reason then names why: repo_unresolved | schema_skew | lookup_failed | no_daemons_connected | no_repo_hosting_daemon | no_unattended_reviewer), " +
+            "driver_vendor (the harness running THIS session, or absent when it cannot be determined — treat absent as unknown, and do not claim a different model), " +
+            "and diagnostics counts. This does NOT start a review — it only reports availability; use start_review_flow to run one. " +
+            "Availability is a snapshot: a vendor listed here can still be rejected by start_review_flow if the daemon dropped in between.",
+            new("object", new(), [])
         )
     ];
 }

--- a/src/Capacitor.Cli/Commands/McpReviewServer.cs
+++ b/src/Capacitor.Cli/Commands/McpReviewServer.cs
@@ -457,4 +457,5 @@ record SessionSearchQuery(string Query, int? Limit = null);
 [JsonSerializable(typeof(SubmitReviewerResultDto))]
 [JsonSerializable(typeof(AckFlowMessagesDto))]
 [JsonSerializable(typeof(SendFlowMessageDto))]
+[JsonSerializable(typeof(ReviewerVendorsResult))]
 partial class McpJsonContext : JsonSerializerContext;

--- a/src/Capacitor.Cli/Commands/ReviewerVendorLookup.cs
+++ b/src/Capacitor.Cli/Commands/ReviewerVendorLookup.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli.Commands;
 
@@ -37,10 +38,12 @@ public sealed record ReviewerVendorDiagnostics(
     [property: JsonPropertyName("reason")]                       string? Reason);
 
 /// <summary>Pure repo-aware aggregation behind the <c>list_reviewer_vendors</c> MCP tool: given the
-/// daemons the server reports and the current session's repo identity, returns the reviewer vendors
-/// that can ACTUALLY run an unattended review flow for this repo right now. All the failure modes are
+/// daemons the server reports and the current session's repo, returns the reviewer vendors that can
+/// ACTUALLY run an unattended review flow for this repo right now. All the failure modes are
 /// disambiguated by a single <c>reason</c> so an empty result never reads as one specific cause it is
-/// not (see <see cref="Reason"/> and its precedence).</summary>
+/// not (see <see cref="Reason"/> and its precedence). <c>Identity</c> is a NON-sensitive repo id
+/// (e.g. owner/repo) supplied by the caller — never the local repo path, which must not leak to the
+/// model — while the local <c>repoRoot</c> argument is used only for the on-disk hosting match.</summary>
 public static class ReviewerVendorLookup {
     public static class Reason {
         public const string RepoUnresolved      = "repo_unresolved";
@@ -53,6 +56,8 @@ public static class ReviewerVendorLookup {
 
     /// <param name="daemons">Parsed daemon records, or null when the lookup itself failed
     /// (transport/auth/API) — distinct from an empty list, which is "connected zero daemons".</param>
+    /// <param name="repoIdentity">A non-sensitive, stable id for the repo (e.g. owner/repo), surfaced
+    /// as <c>repo.identity</c>. Never the local path.</param>
     /// <param name="schemaSkew">Set when the server response could not be parsed at all (client too
     /// old, or every record unparseable): reported as its own reason so it can never masquerade as an
     /// authoritative empty set.</param>
@@ -62,9 +67,10 @@ public static class ReviewerVendorLookup {
             string? requesterMachineId,
             string? driverVendor,
             bool schemaSkew = false,
-            int skippedRecords = 0) {
+            int skippedRecords = 0,
+            string? repoIdentity = null) {
         var resolved = !string.IsNullOrEmpty(repoRoot);
-        var repo     = new RepoIdent(repoRoot, resolved);
+        var repo     = new RepoIdent(repoIdentity, resolved);
 
         // Empty-result reasons, most-fundamental first — the caller maps exactly one to guidance.
         if (!resolved)
@@ -74,9 +80,8 @@ public static class ReviewerVendorLookup {
         if (daemons is null)
             return Empty(repo, driverVendor, 0, 0, skippedRecords, Reason.LookupFailed);
 
-        var norm = Normalize(repoRoot!);
         var hosting = daemons
-            .Where(d => d.RepoPaths.Any(p => Normalize(p) == norm) &&
+            .Where(d => d.RepoPaths.Any(p => RepoPathMatches(p, repoRoot!)) &&
                         (requesterMachineId is null || d.MachineId == requesterMachineId))
             .ToList();
 
@@ -121,20 +126,30 @@ public static class ReviewerVendorLookup {
             RepoIdent repo, string? driver, int connected, int hosting, int skipped, string reason)
         => new(repo, driver, [], new ReviewerVendorDiagnostics(connected, hosting, skipped, [], reason));
 
-    static string Normalize(string path) => path.TrimEnd('/', '\\');
+    // Filesystem paths compare case-insensitively on Windows and macOS (case-preserving but
+    // case-insensitive volumes) and case-sensitively on Linux; separators are unified and a trailing
+    // one trimmed so a '\'-vs-'/' or trailing-slash difference between a daemon's RepoPaths and the
+    // local repoRoot never produces a false no_repo_hosting_daemon. The conservative same-machine
+    // filter means both sides come from the same OS, so one OS-appropriate rule is correct.
+    static readonly StringComparison PathComparison =
+        OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+    static bool RepoPathMatches(string daemonPath, string repoRoot)
+        => string.Equals(Normalize(daemonPath), Normalize(repoRoot), PathComparison);
+
+    static string Normalize(string path) => path.Replace('\\', '/').TrimEnd('/');
 
     /// <summary>Tolerantly parse a <c>GET /api/daemons</c> body into the records
-    /// <see cref="Aggregate"/> consumes. Property lookup is case-insensitive so the wire casing
-    /// (camelCase today) can change without breaking this. A body that is not a JSON array, or an
-    /// array whose every element is unparseable, sets <c>SchemaSkew</c> — so schema skew can never be
-    /// mistaken for an authoritative empty set; a single malformed element is skipped and counted.
-    /// Only called on a 2xx; a non-2xx maps to <c>Aggregate(daemons: null, …)</c> = lookup_failed.</summary>
+    /// <see cref="Aggregate"/> consumes. A body that is not a JSON array, or an array whose every
+    /// element is unparseable, sets <c>SchemaSkew</c> — so schema skew can never be mistaken for an
+    /// authoritative empty set; a single malformed element is skipped and counted. Only called on a
+    /// 2xx; a non-2xx maps to <c>Aggregate(daemons: null, …)</c> = lookup_failed.</summary>
     public static (IReadOnlyList<DaemonVendorRecord> Records, int Skipped, bool SchemaSkew) ParseDaemons(string body) {
         JsonDocument doc;
         try { doc = JsonDocument.Parse(body); } catch { return ([], 0, true); }
 
         using (doc) {
-            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            if (!doc.RootElement.IsArray)
                 return ([], 0, true);
 
             var records = new List<DaemonVendorRecord>();
@@ -145,50 +160,35 @@ public static class ReviewerVendorLookup {
                 total++;
                 // RepoPaths is the one field required to place a daemon against a repo; without it the
                 // record cannot participate in the intersection, so it is malformed → skip + count.
-                if (el.ValueKind != JsonValueKind.Object ||
-                    !TryProp(el, "repoPaths", out var rp) || rp.ValueKind != JsonValueKind.Array) {
+                if (!el.IsObject || el.Arr("repoPaths") is not { } rp) {
                     skipped++;
                     continue;
                 }
 
-                var machineId  = TryProp(el, "machineId", out var mi) && mi.ValueKind == JsonValueKind.String ? mi.GetString() : null;
-                var supported  = TryProp(el, "supportedVendors", out var sv) && sv.ValueKind == JsonValueKind.Array ? StringArray(sv) : null;
-                var unattended = TryProp(el, "unattendedVendors", out var uv) && uv.ValueKind == JsonValueKind.Array ? StringArray(uv) : null;
+                var supported  = el.Arr("supportedVendors") is { } sv ? StringArray(sv) : null;
+                var unattended = el.Arr("unattendedVendors") is { } uv ? StringArray(uv) : null;
 
                 List<UnattendedVendorCapabilityLite>? caps = null;
-                if (TryProp(el, "unattendedVendorCapabilities", out var cv) && cv.ValueKind == JsonValueKind.Array) {
+                if (el.Arr("unattendedVendorCapabilities") is { } cv) {
                     caps = [];
                     foreach (var c in cv.EnumerateArray()) {
-                        if (c.ValueKind != JsonValueKind.Object) continue;
-                        var vendor = TryProp(c, "vendor", out var cn) && cn.ValueKind == JsonValueKind.String ? cn.GetString() : null;
-                        if (vendor is null) continue;
-                        var supports = TryProp(c, "supportsReviewerModelResolution", out var sr) &&
-                                       sr.ValueKind is JsonValueKind.True or JsonValueKind.False && sr.GetBoolean();
-                        caps.Add(new UnattendedVendorCapabilityLite(vendor, supports));
+                        if (c.Str("vendor") is not { } vendor) continue;
+                        caps.Add(new UnattendedVendorCapabilityLite(
+                            vendor, c.Bool("supportsReviewerModelResolution") == true));
                     }
                 }
 
-                records.Add(new DaemonVendorRecord(StringArray(rp), machineId, supported, unattended, caps));
+                records.Add(new DaemonVendorRecord(StringArray(rp), el.Str("machineId"), supported, unattended, caps));
             }
 
             return (records, skipped, total > 0 && records.Count == 0);
         }
     }
 
-    static bool TryProp(JsonElement obj, string name, out JsonElement value) {
-        foreach (var p in obj.EnumerateObject())
-            if (string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase)) {
-                value = p.Value;
-                return true;
-            }
-        value = default;
-        return false;
-    }
-
     static string[] StringArray(JsonElement arr) {
         var list = new List<string>();
         foreach (var e in arr.EnumerateArray())
-            if (e.ValueKind == JsonValueKind.String && e.GetString() is { } s)
+            if (e.IsString && e.GetString() is { } s)
                 list.Add(s);
         return list.ToArray();
     }

--- a/src/Capacitor.Cli/Commands/ReviewerVendorLookup.cs
+++ b/src/Capacitor.Cli/Commands/ReviewerVendorLookup.cs
@@ -1,0 +1,124 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>The subset of the server's <c>DaemonInfo</c> the reviewer-vendor lookup consumes,
+/// decoupled from the wire DTO so the aggregation stays a pure, unit-testable function.</summary>
+public sealed record DaemonVendorRecord(
+    string[] RepoPaths,
+    string? MachineId,
+    string[]? SupportedVendors,
+    string[]? UnattendedVendors,
+    IReadOnlyList<UnattendedVendorCapabilityLite>? Capabilities);
+
+public sealed record UnattendedVendorCapabilityLite(string Vendor, bool SupportsReviewerModelResolution);
+
+public sealed record ReviewerVendorsResult(
+    [property: JsonPropertyName("repo")]          RepoIdent Repo,
+    [property: JsonPropertyName("driver_vendor")] string? DriverVendor,
+    [property: JsonPropertyName("reviewers")]     IReadOnlyList<ReviewerEntry> Reviewers,
+    [property: JsonPropertyName("diagnostics")]   ReviewerVendorDiagnostics Diagnostics);
+
+public sealed record RepoIdent(
+    [property: JsonPropertyName("identity")] string? Identity,
+    [property: JsonPropertyName("resolved")] bool Resolved);
+
+public sealed record ReviewerEntry(
+    [property: JsonPropertyName("vendor")]         string Vendor,
+    [property: JsonPropertyName("daemons")]        int Daemons,
+    [property: JsonPropertyName("model_override")] bool ModelOverride);
+
+public sealed record ReviewerVendorDiagnostics(
+    [property: JsonPropertyName("connected_daemons")]            int ConnectedDaemons,
+    [property: JsonPropertyName("repo_hosting_daemons")]         int RepoHostingDaemons,
+    [property: JsonPropertyName("skipped_daemon_records")]       int SkippedDaemonRecords,
+    [property: JsonPropertyName("supported_but_not_unattended")] string[] SupportedButNotUnattended,
+    [property: JsonPropertyName("reason")]                       string? Reason);
+
+/// <summary>Pure repo-aware aggregation behind the <c>list_reviewer_vendors</c> MCP tool: given the
+/// daemons the server reports and the current session's repo identity, returns the reviewer vendors
+/// that can ACTUALLY run an unattended review flow for this repo right now. All the failure modes are
+/// disambiguated by a single <c>reason</c> so an empty result never reads as one specific cause it is
+/// not (see <see cref="Reason"/> and its precedence).</summary>
+public static class ReviewerVendorLookup {
+    public static class Reason {
+        public const string RepoUnresolved      = "repo_unresolved";
+        public const string SchemaSkew          = "schema_skew";
+        public const string LookupFailed        = "lookup_failed";
+        public const string NoDaemonsConnected  = "no_daemons_connected";
+        public const string NoRepoHostingDaemon = "no_repo_hosting_daemon";
+        public const string NoUnattendedReviewer= "no_unattended_reviewer";
+    }
+
+    /// <param name="daemons">Parsed daemon records, or null when the lookup itself failed
+    /// (transport/auth/API) — distinct from an empty list, which is "connected zero daemons".</param>
+    /// <param name="schemaSkew">Set when the server response could not be parsed at all (client too
+    /// old, or every record unparseable): reported as its own reason so it can never masquerade as an
+    /// authoritative empty set.</param>
+    public static ReviewerVendorsResult Aggregate(
+            IReadOnlyList<DaemonVendorRecord>? daemons,
+            string? repoRoot,
+            string? requesterMachineId,
+            string? driverVendor,
+            bool schemaSkew = false,
+            int skippedRecords = 0) {
+        var resolved = !string.IsNullOrEmpty(repoRoot);
+        var repo     = new RepoIdent(repoRoot, resolved);
+
+        // Empty-result reasons, most-fundamental first — the caller maps exactly one to guidance.
+        if (!resolved)
+            return Empty(repo, driverVendor, daemons?.Count ?? 0, 0, skippedRecords, Reason.RepoUnresolved);
+        if (schemaSkew)
+            return Empty(repo, driverVendor, daemons?.Count ?? 0, 0, skippedRecords, Reason.SchemaSkew);
+        if (daemons is null)
+            return Empty(repo, driverVendor, 0, 0, skippedRecords, Reason.LookupFailed);
+
+        var norm = Normalize(repoRoot!);
+        var hosting = daemons
+            .Where(d => d.RepoPaths.Any(p => Normalize(p) == norm) &&
+                        (requesterMachineId is null || d.MachineId == requesterMachineId))
+            .ToList();
+
+        var reviewers = hosting
+            .SelectMany(d => d.UnattendedVendors ?? [])
+            .GroupBy(v => v, StringComparer.Ordinal)
+            .Select(g => new ReviewerEntry(
+                g.Key,
+                hosting.Count(d => (d.UnattendedVendors ?? []).Contains(g.Key, StringComparer.Ordinal)),
+                ModelOverrideForAll(hosting, g.Key)))
+            .OrderBy(e => e.Vendor, StringComparer.Ordinal)
+            .ToList();
+
+        var supportedNotUnattended = hosting
+            .SelectMany(d => (d.SupportedVendors ?? []).Except(d.UnattendedVendors ?? [], StringComparer.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(v => v, StringComparer.Ordinal)
+            .ToArray();
+
+        string? reason =
+            reviewers.Count > 0 ? null
+            : daemons.Count == 0 ? Reason.NoDaemonsConnected
+            : hosting.Count == 0 ? Reason.NoRepoHostingDaemon
+            : Reason.NoUnattendedReviewer;
+
+        return new ReviewerVendorsResult(repo, driverVendor, reviewers,
+            new ReviewerVendorDiagnostics(daemons.Count, hosting.Count, skippedRecords, supportedNotUnattended, reason));
+    }
+
+    // Conservative AND: a model override is only advertised when EVERY hosting daemon that offers the
+    // vendor can resolve it — flow-start may route to any of them, so a partial capability must not be
+    // reported as available.
+    static bool ModelOverrideForAll(IReadOnlyList<DaemonVendorRecord> hosting, string vendor) {
+        var advertising = hosting
+            .Where(d => (d.UnattendedVendors ?? []).Contains(vendor, StringComparer.Ordinal))
+            .ToList();
+        return advertising.Count > 0 && advertising.All(d =>
+            d.Capabilities?.Any(c => c.Vendor == vendor && c.SupportsReviewerModelResolution) == true);
+    }
+
+    static ReviewerVendorsResult Empty(
+            RepoIdent repo, string? driver, int connected, int hosting, int skipped, string reason)
+        => new(repo, driver, [], new ReviewerVendorDiagnostics(connected, hosting, skipped, [], reason));
+
+    static string Normalize(string path) => path.TrimEnd('/', '\\');
+}

--- a/src/Capacitor.Cli/Commands/ReviewerVendorLookup.cs
+++ b/src/Capacitor.Cli/Commands/ReviewerVendorLookup.cs
@@ -156,29 +156,32 @@ public static class ReviewerVendorLookup {
             var total = 0;
             var skipped = 0;
 
+            // Field names are snake_case: the server serializes /api/daemons with
+            // JsonNamingPolicy.SnakeCaseLower (HttpJsonConfiguration), so DaemonInfo.RepoPaths is
+            // "repo_paths" on the wire, etc. — do not "correct" these to camelCase.
             foreach (var el in doc.RootElement.EnumerateArray()) {
                 total++;
-                // RepoPaths is the one field required to place a daemon against a repo; without it the
+                // repo_paths is the one field required to place a daemon against a repo; without it the
                 // record cannot participate in the intersection, so it is malformed → skip + count.
-                if (!el.IsObject || el.Arr("repoPaths") is not { } rp) {
+                if (!el.IsObject || el.Arr("repo_paths") is not { } rp) {
                     skipped++;
                     continue;
                 }
 
-                var supported  = el.Arr("supportedVendors") is { } sv ? StringArray(sv) : null;
-                var unattended = el.Arr("unattendedVendors") is { } uv ? StringArray(uv) : null;
+                var supported  = el.Arr("supported_vendors") is { } sv ? StringArray(sv) : null;
+                var unattended = el.Arr("unattended_vendors") is { } uv ? StringArray(uv) : null;
 
                 List<UnattendedVendorCapabilityLite>? caps = null;
-                if (el.Arr("unattendedVendorCapabilities") is { } cv) {
+                if (el.Arr("unattended_vendor_capabilities") is { } cv) {
                     caps = [];
                     foreach (var c in cv.EnumerateArray()) {
                         if (c.Str("vendor") is not { } vendor) continue;
                         caps.Add(new UnattendedVendorCapabilityLite(
-                            vendor, c.Bool("supportsReviewerModelResolution") == true));
+                            vendor, c.Bool("supports_reviewer_model_resolution") == true));
                     }
                 }
 
-                records.Add(new DaemonVendorRecord(StringArray(rp), el.Str("machineId"), supported, unattended, caps));
+                records.Add(new DaemonVendorRecord(StringArray(rp), el.Str("machine_id"), supported, unattended, caps));
             }
 
             return (records, skipped, total > 0 && records.Count == 0);

--- a/src/Capacitor.Cli/Commands/ReviewerVendorLookup.cs
+++ b/src/Capacitor.Cli/Commands/ReviewerVendorLookup.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Capacitor.Cli.Commands;
@@ -121,4 +122,74 @@ public static class ReviewerVendorLookup {
         => new(repo, driver, [], new ReviewerVendorDiagnostics(connected, hosting, skipped, [], reason));
 
     static string Normalize(string path) => path.TrimEnd('/', '\\');
+
+    /// <summary>Tolerantly parse a <c>GET /api/daemons</c> body into the records
+    /// <see cref="Aggregate"/> consumes. Property lookup is case-insensitive so the wire casing
+    /// (camelCase today) can change without breaking this. A body that is not a JSON array, or an
+    /// array whose every element is unparseable, sets <c>SchemaSkew</c> — so schema skew can never be
+    /// mistaken for an authoritative empty set; a single malformed element is skipped and counted.
+    /// Only called on a 2xx; a non-2xx maps to <c>Aggregate(daemons: null, …)</c> = lookup_failed.</summary>
+    public static (IReadOnlyList<DaemonVendorRecord> Records, int Skipped, bool SchemaSkew) ParseDaemons(string body) {
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(body); } catch { return ([], 0, true); }
+
+        using (doc) {
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                return ([], 0, true);
+
+            var records = new List<DaemonVendorRecord>();
+            var total = 0;
+            var skipped = 0;
+
+            foreach (var el in doc.RootElement.EnumerateArray()) {
+                total++;
+                // RepoPaths is the one field required to place a daemon against a repo; without it the
+                // record cannot participate in the intersection, so it is malformed → skip + count.
+                if (el.ValueKind != JsonValueKind.Object ||
+                    !TryProp(el, "repoPaths", out var rp) || rp.ValueKind != JsonValueKind.Array) {
+                    skipped++;
+                    continue;
+                }
+
+                var machineId  = TryProp(el, "machineId", out var mi) && mi.ValueKind == JsonValueKind.String ? mi.GetString() : null;
+                var supported  = TryProp(el, "supportedVendors", out var sv) && sv.ValueKind == JsonValueKind.Array ? StringArray(sv) : null;
+                var unattended = TryProp(el, "unattendedVendors", out var uv) && uv.ValueKind == JsonValueKind.Array ? StringArray(uv) : null;
+
+                List<UnattendedVendorCapabilityLite>? caps = null;
+                if (TryProp(el, "unattendedVendorCapabilities", out var cv) && cv.ValueKind == JsonValueKind.Array) {
+                    caps = [];
+                    foreach (var c in cv.EnumerateArray()) {
+                        if (c.ValueKind != JsonValueKind.Object) continue;
+                        var vendor = TryProp(c, "vendor", out var cn) && cn.ValueKind == JsonValueKind.String ? cn.GetString() : null;
+                        if (vendor is null) continue;
+                        var supports = TryProp(c, "supportsReviewerModelResolution", out var sr) &&
+                                       sr.ValueKind is JsonValueKind.True or JsonValueKind.False && sr.GetBoolean();
+                        caps.Add(new UnattendedVendorCapabilityLite(vendor, supports));
+                    }
+                }
+
+                records.Add(new DaemonVendorRecord(StringArray(rp), machineId, supported, unattended, caps));
+            }
+
+            return (records, skipped, total > 0 && records.Count == 0);
+        }
+    }
+
+    static bool TryProp(JsonElement obj, string name, out JsonElement value) {
+        foreach (var p in obj.EnumerateObject())
+            if (string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase)) {
+                value = p.Value;
+                return true;
+            }
+        value = default;
+        return false;
+    }
+
+    static string[] StringArray(JsonElement arr) {
+        var list = new List<string>();
+        foreach (var e in arr.EnumerateArray())
+            if (e.ValueKind == JsonValueKind.String && e.GetString() is { } s)
+                list.Add(s);
+        return list.ToArray();
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/AgentsSkillsInstallerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/AgentsSkillsInstallerTests.cs
@@ -3,7 +3,7 @@ using System.Text.RegularExpressions;
 namespace Capacitor.Cli.Core.Tests.Unit;
 
 public class AgentsSkillsInstallerTests {
-    static readonly string[] SourceNames = ["recap", "errors", "disable", "hide", "validate-plan", "review-flows", "agent-flows", "work-items", "guided-tour"];
+    static readonly string[] SourceNames = ["recap", "errors", "disable", "hide", "validate-plan", "review-flows", "agent-flows", "work-items", "guided-tour", "suggest-review-flow"];
 
     [Test]
     public async Task Mirror_of_SourceNames_matches_the_installer() {

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -289,7 +289,7 @@ public class McpFlowsServerTests : IDisposable {
 
             var tools = response["result"]?["tools"]?.AsArray();
             await Assert.That(tools).IsNotNull();
-            await Assert.That(tools!.Count).IsEqualTo(8);
+            await Assert.That(tools!.Count).IsEqualTo(9);
 
             var names = tools.Select(t => t?["name"]?.GetValue<string>()).ToHashSet();
             await Assert.That(names.Contains("start_review_flow")).IsTrue();
@@ -300,6 +300,7 @@ public class McpFlowsServerTests : IDisposable {
             await Assert.That(names.Contains("send_to_participant")).IsTrue();
             await Assert.That(names.Contains("get_flow_status")).IsTrue();
             await Assert.That(names.Contains("close_flow")).IsTrue();
+            await Assert.That(names.Contains("list_reviewer_vendors")).IsTrue();
         } finally {
             await ShutdownAsync(proc);
         }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/DriverVendorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/DriverVendorTests.cs
@@ -1,0 +1,24 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+public class DriverVendorTests {
+    static Func<string, string?> Env(params (string Key, string? Val)[] pairs)
+        => k => pairs.FirstOrDefault(p => p.Key == k).Val;
+
+    [Test]
+    public async Task Claude_marker_alone_infers_claude()
+        => await Assert.That(DriverVendor.Infer(Env(("CLAUDE_CODE_SESSION_ID", "s1")))).IsEqualTo("claude");
+
+    [Test]
+    public async Task Codex_marker_alone_infers_codex()
+        => await Assert.That(DriverVendor.Infer(Env(("CODEX_THREAD_ID", "t1")))).IsEqualTo("codex");
+
+    [Test]
+    public async Task Both_markers_is_ambiguous_null() // nested harness — neither is provably the driver
+        => await Assert.That(DriverVendor.Infer(Env(("CLAUDE_CODE_SESSION_ID", "s1"), ("CODEX_THREAD_ID", "t1")))).IsNull();
+
+    [Test]
+    public async Task No_markers_is_null()
+        => await Assert.That(DriverVendor.Infer(Env())).IsNull();
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerReviewerVendorsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerReviewerVendorsTests.cs
@@ -18,7 +18,10 @@ public class McpFlowsServerReviewerVendorsTests {
 
     [Test]
     public async Task Lists_repo_hosting_reviewers_for_this_machine() {
-        var machine = MachineId.Get(); // the tool matches the daemon on the requester's own machine id
+        // The tool reads the machine id read-only (ReadPersisted, never Get) and filters on it; mirror
+        // that so the stub daemon matches whether or not machine.json exists in the test env (a null id
+        // drops the filter, so the daemon is included either way).
+        var machine = MachineId.ReadPersisted() ?? "test-machine";
         using var server = WireMockServer.Start();
         server.Given(Request.Create().WithPath("/api/daemons").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerReviewerVendorsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerReviewerVendorsTests.cs
@@ -25,8 +25,8 @@ public class McpFlowsServerReviewerVendorsTests {
         using var server = WireMockServer.Start();
         server.Given(Request.Create().WithPath("/api/daemons").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""
-            [{"name":"d1","repoPaths":["/repo/a"],"machineId":"{{machine}}",
-              "supportedVendors":["codex","claude"],"unattendedVendors":["codex","claude"]}]
+            [{"name":"d1","repo_paths":["/repo/a"],"machine_id":"{{machine}}",
+              "supported_vendors":["codex","claude"],"unattended_vendors":["codex","claude"]}]
             """));
         using var client = new HttpClient();
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerReviewerVendorsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerReviewerVendorsTests.cs
@@ -1,0 +1,72 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+public class McpFlowsServerReviewerVendorsTests {
+    static JsonObject ToolCall() => new() {
+        ["params"] = new JsonObject { ["name"] = "list_reviewer_vendors", ["arguments"] = new JsonObject() }
+    };
+
+    // The tool payload is carried as the single content item's text (an MCP tool result).
+    static JsonNode ResultJson(string response)
+        => JsonNode.Parse(JsonNode.Parse(response)!["result"]!["content"]![0]!["text"]!.GetValue<string>())!;
+
+    [Test]
+    public async Task Lists_repo_hosting_reviewers_for_this_machine() {
+        var machine = MachineId.Get(); // the tool matches the daemon on the requester's own machine id
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/api/daemons").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""
+            [{"name":"d1","repoPaths":["/repo/a"],"machineId":"{{machine}}",
+              "supportedVendors":["codex","claude"],"unattendedVendors":["codex","claude"]}]
+            """));
+        using var client = new HttpClient();
+
+        var response = await McpFlowsServer.HandleToolCallAsync(
+            JsonNode.Parse("1")!, ToolCall(), client, server.Url!,
+            cwd: "/repo/a", repoRoot: "/repo/a", repoInfo: null, driverVendor: "claude");
+
+        await Assert.That(JsonNode.Parse(response)!["result"]!["isError"]).IsNull();
+        var parsed = ResultJson(response);
+        await Assert.That(parsed["reviewers"]!.AsArray().Count).IsEqualTo(2);
+        await Assert.That(parsed["driver_vendor"]!.GetValue<string>()).IsEqualTo("claude");
+        // reason lives under diagnostics; it is omitted (null) when reviewers are present.
+        await Assert.That(parsed["diagnostics"]!["reason"]).IsNull();
+    }
+
+    [Test]
+    public async Task Server_error_maps_to_lookup_failed() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/api/daemons").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(500));
+        using var client = new HttpClient();
+
+        var response = await McpFlowsServer.HandleToolCallAsync(
+            JsonNode.Parse("1")!, ToolCall(), client, server.Url!,
+            cwd: "/r", repoRoot: "/r", repoInfo: null, driverVendor: null);
+
+        var parsed = ResultJson(response);
+        await Assert.That(parsed["diagnostics"]!["reason"]!.GetValue<string>()).IsEqualTo("lookup_failed");
+        await Assert.That(parsed["reviewers"]!.AsArray().Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Repo_unresolved_when_no_repo_root() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/api/daemons").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("[]"));
+        using var client = new HttpClient();
+
+        var response = await McpFlowsServer.HandleToolCallAsync(
+            JsonNode.Parse("1")!, ToolCall(), client, server.Url!,
+            cwd: "/x", repoRoot: null, repoInfo: null, driverVendor: null);
+
+        var parsed = ResultJson(response);
+        await Assert.That(parsed["diagnostics"]!["reason"]!.GetValue<string>()).IsEqualTo("repo_unresolved");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerReviewerVendorsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerReviewerVendorsTests.cs
@@ -56,6 +56,24 @@ public class McpFlowsServerReviewerVendorsTests {
     }
 
     [Test]
+    public async Task Repo_unresolved_short_circuits_before_any_request() {
+        using var server = WireMockServer.Start();
+        // Would be an auth error if the tool called it — it must not, because repo_unresolved is a
+        // local precondition that outranks any lookup/auth failure.
+        server.Given(Request.Create().WithPath("/api/daemons").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(401));
+        using var client = new HttpClient();
+
+        var response = await McpFlowsServer.HandleToolCallAsync(
+            JsonNode.Parse("1")!, ToolCall(), client, server.Url!,
+            cwd: "/x", repoRoot: null, repoInfo: null, driverVendor: null);
+
+        await Assert.That(JsonNode.Parse(response)!["result"]!["isError"]).IsNull();
+        await Assert.That(ResultJson(response)["diagnostics"]!["reason"]!.GetValue<string>()).IsEqualTo("repo_unresolved");
+        await Assert.That(server.LogEntries.Count).IsEqualTo(0); // never hit the server
+    }
+
+    [Test]
     public async Task Repo_unresolved_when_no_repo_root() {
         using var server = WireMockServer.Start();
         server.Given(Request.Create().WithPath("/api/daemons").UsingGet())

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorLookupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorLookupTests.cs
@@ -125,6 +125,24 @@ public class ReviewerVendorLookupTests {
         await Assert.That(r.Reviewers.Count).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task Identity_is_the_non_sensitive_repo_id_not_the_local_path() {
+        var r = ReviewerVendorLookup.Aggregate(
+            [Daemon(["/repo/a"], "m1", ["codex"])], "/repo/a", "m1", null, repoIdentity: "acme/widgets");
+        await Assert.That(r.Repo.Identity).IsEqualTo("acme/widgets");
+        await Assert.That(r.Repo.Resolved).IsTrue();
+        await Assert.That(r.Repo.Identity).IsNotEqualTo("/repo/a"); // the local path must not leak
+    }
+
+    [Test]
+    public async Task Repo_path_matches_across_separators_and_trailing_slash() {
+        // Backslashes + a trailing separator must not produce a false no_repo_hosting_daemon.
+        var r = ReviewerVendorLookup.Aggregate(
+            [Daemon(["\\repo\\a\\"], "m1", ["codex"])], "/repo/a", "m1", null);
+        await Assert.That(r.Reviewers.Count).IsEqualTo(1);
+        await Assert.That(r.Diagnostics.Reason).IsNull();
+    }
+
     // --- ParseDaemons ---
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorLookupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorLookupTests.cs
@@ -146,11 +146,12 @@ public class ReviewerVendorLookupTests {
     // --- ParseDaemons ---
 
     [Test]
-    public async Task ParseDaemons_reads_camelcase_fields() {
+    public async Task ParseDaemons_reads_snake_case_wire_fields() {
+        // Matches the server's SnakeCaseLower policy for /api/daemons (DaemonInfo).
         const string body = """
-        [{"name":"d1","repoPaths":["/r"],"machineId":"m1","supportedVendors":["codex","kiro"],
-          "unattendedVendors":["codex"],
-          "unattendedVendorCapabilities":[{"vendor":"codex","supportsReviewerModelResolution":true}]}]
+        [{"name":"d1","repo_paths":["/r"],"machine_id":"m1","supported_vendors":["codex","kiro"],
+          "unattended_vendors":["codex"],
+          "unattended_vendor_capabilities":[{"vendor":"codex","supports_reviewer_model_resolution":true}]}]
         """;
         var (records, skipped, skew) = ReviewerVendorLookup.ParseDaemons(body);
         await Assert.That(records.Count).IsEqualTo(1);
@@ -177,7 +178,7 @@ public class ReviewerVendorLookupTests {
 
     [Test]
     public async Task ParseDaemons_skips_malformed_element_but_keeps_good_one() {
-        const string body = """[{"noRepoPaths":true},{"repoPaths":["/r"],"unattendedVendors":["codex"]}]""";
+        const string body = """[{"no_repo_paths":true},{"repo_paths":["/r"],"unattended_vendors":["codex"]}]""";
         var (records, skipped, skew) = ReviewerVendorLookup.ParseDaemons(body);
         await Assert.That(records.Count).IsEqualTo(1);
         await Assert.That(skipped).IsEqualTo(1);

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorLookupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorLookupTests.cs
@@ -1,0 +1,127 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+public class ReviewerVendorLookupTests {
+    static DaemonVendorRecord Daemon(
+        string[] repoPaths, string? machineId, string[]? unattended,
+        string[]? supported = null, IReadOnlyList<UnattendedVendorCapabilityLite>? caps = null)
+        => new(repoPaths, machineId, supported, unattended, caps);
+
+    [Test]
+    public async Task Prefers_repo_hosting_intersection_and_sorts_alphabetically() {
+        var daemons = new[] {
+            Daemon(["/repo/a"], "m1", ["codex", "claude"]),
+            Daemon(["/other"],  "m1", ["cursor"]),
+        };
+
+        var r = ReviewerVendorLookup.Aggregate(daemons, "/repo/a", "m1", driverVendor: "claude");
+
+        await Assert.That(r.Reviewers.Count).IsEqualTo(2);
+        await Assert.That(r.Reviewers[0].Vendor).IsEqualTo("claude"); // alphabetical, cursor excluded (other repo)
+        await Assert.That(r.Reviewers[1].Vendor).IsEqualTo("codex");
+        await Assert.That(r.Diagnostics.Reason).IsNull();
+        await Assert.That(r.DriverVendor).IsEqualTo("claude");
+        await Assert.That(r.Repo.Resolved).IsTrue();
+    }
+
+    [Test]
+    public async Task Reason_null_iff_reviewers_nonempty() {
+        var r = ReviewerVendorLookup.Aggregate([Daemon(["/r"], "m1", ["codex"])], "/r", "m1", null);
+        await Assert.That(r.Reviewers.Count).IsEqualTo(1);
+        await Assert.That(r.Diagnostics.Reason).IsNull();
+    }
+
+    [Test]
+    public async Task Empty_reason_precedence_repo_unresolved_wins() {
+        var r = ReviewerVendorLookup.Aggregate([], repoRoot: null, "m1", null);
+        await Assert.That(r.Reviewers.Count).IsEqualTo(0);
+        await Assert.That(r.Repo.Resolved).IsFalse();
+        await Assert.That(r.Diagnostics.Reason).IsEqualTo("repo_unresolved");
+    }
+
+    [Test]
+    public async Task Schema_skew_beats_lookup_and_count_reasons() {
+        var r = ReviewerVendorLookup.Aggregate([], "/r", "m1", null, schemaSkew: true);
+        await Assert.That(r.Diagnostics.Reason).IsEqualTo("schema_skew");
+    }
+
+    [Test]
+    public async Task Null_daemons_is_lookup_failed() {
+        var r = ReviewerVendorLookup.Aggregate(null, "/r", "m1", null);
+        await Assert.That(r.Diagnostics.Reason).IsEqualTo("lookup_failed");
+    }
+
+    [Test]
+    public async Task No_daemons_connected_when_empty_list() {
+        var r = ReviewerVendorLookup.Aggregate([], "/r", "m1", null);
+        await Assert.That(r.Diagnostics.Reason).IsEqualTo("no_daemons_connected");
+    }
+
+    [Test]
+    public async Task No_repo_hosting_daemon_when_paths_disjoint() {
+        var r = ReviewerVendorLookup.Aggregate([Daemon(["/x"], "m1", ["codex"])], "/r", "m1", null);
+        await Assert.That(r.Diagnostics.RepoHostingDaemons).IsEqualTo(0);
+        await Assert.That(r.Diagnostics.Reason).IsEqualTo("no_repo_hosting_daemon");
+    }
+
+    [Test]
+    public async Task No_unattended_reviewer_when_hosting_daemon_advertises_none() {
+        var r = ReviewerVendorLookup.Aggregate([Daemon(["/r"], "m1", [])], "/r", "m1", null);
+        await Assert.That(r.Diagnostics.RepoHostingDaemons).IsEqualTo(1);
+        await Assert.That(r.Diagnostics.Reason).IsEqualTo("no_unattended_reviewer");
+    }
+
+    [Test]
+    public async Task Machine_mismatch_excludes_a_daemon_from_hosting() {
+        var r = ReviewerVendorLookup.Aggregate([Daemon(["/r"], "other-machine", ["codex"])], "/r", "m1", null);
+        await Assert.That(r.Diagnostics.Reason).IsEqualTo("no_repo_hosting_daemon");
+    }
+
+    [Test]
+    public async Task Model_override_is_conservative_AND_across_hosting_daemons() {
+        var caps1 = new[] { new UnattendedVendorCapabilityLite("codex", SupportsReviewerModelResolution: true) };
+        var daemons = new[] {
+            Daemon(["/r"], "m1", ["codex"], caps: caps1),
+            Daemon(["/r"], "m1", ["codex"], caps: null), // second hosting daemon lacks the resolver → AND is false
+        };
+        var r = ReviewerVendorLookup.Aggregate(daemons, "/r", "m1", null);
+        var codex = r.Reviewers.Single(e => e.Vendor == "codex");
+        await Assert.That(codex.Daemons).IsEqualTo(2);
+        await Assert.That(codex.ModelOverride).IsFalse();
+    }
+
+    [Test]
+    public async Task Model_override_true_when_every_hosting_daemon_supports_it() {
+        var caps = new[] { new UnattendedVendorCapabilityLite("codex", true) };
+        var daemons = new[] {
+            Daemon(["/r"], "m1", ["codex"], caps: caps),
+            Daemon(["/r"], "m1", ["codex"], caps: caps),
+        };
+        var r = ReviewerVendorLookup.Aggregate(daemons, "/r", "m1", null);
+        await Assert.That(r.Reviewers.Single(e => e.Vendor == "codex").ModelOverride).IsTrue();
+    }
+
+    [Test]
+    public async Task Supported_but_not_unattended_is_reported() {
+        var r = ReviewerVendorLookup.Aggregate(
+            [Daemon(["/r"], "m1", ["codex"], supported: ["codex", "kiro"])], "/r", "m1", null);
+        await Assert.That(r.Diagnostics.SupportedButNotUnattended).Contains("kiro");
+        await Assert.That(r.Reviewers.Single().Vendor).IsEqualTo("codex");
+    }
+
+    [Test]
+    public async Task Dedup_same_vendor_across_two_hosting_daemons() {
+        var daemons = new[] { Daemon(["/r"], "m1", ["codex"]), Daemon(["/r"], "m1", ["codex"]) };
+        var r = ReviewerVendorLookup.Aggregate(daemons, "/r", "m1", null);
+        await Assert.That(r.Reviewers.Count).IsEqualTo(1);
+        await Assert.That(r.Reviewers[0].Daemons).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Null_requester_machine_does_not_filter_on_machine() {
+        var r = ReviewerVendorLookup.Aggregate(
+            [Daemon(["/r"], "anything", ["codex"])], "/r", requesterMachineId: null, null);
+        await Assert.That(r.Reviewers.Count).IsEqualTo(1);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorLookupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorLookupTests.cs
@@ -124,4 +124,61 @@ public class ReviewerVendorLookupTests {
             [Daemon(["/r"], "anything", ["codex"])], "/r", requesterMachineId: null, null);
         await Assert.That(r.Reviewers.Count).IsEqualTo(1);
     }
+
+    // --- ParseDaemons ---
+
+    [Test]
+    public async Task ParseDaemons_reads_camelcase_fields() {
+        const string body = """
+        [{"name":"d1","repoPaths":["/r"],"machineId":"m1","supportedVendors":["codex","kiro"],
+          "unattendedVendors":["codex"],
+          "unattendedVendorCapabilities":[{"vendor":"codex","supportsReviewerModelResolution":true}]}]
+        """;
+        var (records, skipped, skew) = ReviewerVendorLookup.ParseDaemons(body);
+        await Assert.That(records.Count).IsEqualTo(1);
+        await Assert.That(skipped).IsEqualTo(0);
+        await Assert.That(skew).IsFalse();
+        await Assert.That(records[0].RepoPaths[0]).IsEqualTo("/r");
+        await Assert.That(records[0].MachineId).IsEqualTo("m1");
+        await Assert.That(records[0].UnattendedVendors!).Contains("codex");
+        await Assert.That(records[0].Capabilities!.Single().SupportsReviewerModelResolution).IsTrue();
+    }
+
+    [Test]
+    public async Task ParseDaemons_non_array_is_schema_skew() {
+        var (records, _, skew) = ReviewerVendorLookup.ParseDaemons("""{"oops":true}""");
+        await Assert.That(records.Count).IsEqualTo(0);
+        await Assert.That(skew).IsTrue();
+    }
+
+    [Test]
+    public async Task ParseDaemons_unparseable_body_is_schema_skew() {
+        var (_, _, skew) = ReviewerVendorLookup.ParseDaemons("not json");
+        await Assert.That(skew).IsTrue();
+    }
+
+    [Test]
+    public async Task ParseDaemons_skips_malformed_element_but_keeps_good_one() {
+        const string body = """[{"noRepoPaths":true},{"repoPaths":["/r"],"unattendedVendors":["codex"]}]""";
+        var (records, skipped, skew) = ReviewerVendorLookup.ParseDaemons(body);
+        await Assert.That(records.Count).IsEqualTo(1);
+        await Assert.That(skipped).IsEqualTo(1);
+        await Assert.That(skew).IsFalse();
+    }
+
+    [Test]
+    public async Task ParseDaemons_all_malformed_is_schema_skew() {
+        var (records, skipped, skew) = ReviewerVendorLookup.ParseDaemons("""[{"x":1},{"y":2}]""");
+        await Assert.That(records.Count).IsEqualTo(0);
+        await Assert.That(skipped).IsEqualTo(2);
+        await Assert.That(skew).IsTrue();
+    }
+
+    [Test]
+    public async Task ParseDaemons_empty_array_is_not_skew() {
+        var (records, skipped, skew) = ReviewerVendorLookup.ParseDaemons("[]");
+        await Assert.That(records.Count).IsEqualTo(0);
+        await Assert.That(skipped).IsEqualTo(0);
+        await Assert.That(skew).IsFalse();
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SuggestReviewFlowSkillConformanceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SuggestReviewFlowSkillConformanceTests.cs
@@ -1,0 +1,43 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+/// <summary>The skill is model-driven: its frontmatter description is the whole trigger surface, and
+/// its body carries the load-bearing guardrails. These pins keep the two milestones and the safety
+/// invariants in the shipped file — a reword that drops one would otherwise pass CI silently (same
+/// stance as FlowsDriverSchemaConformanceTests).</summary>
+public class SuggestReviewFlowSkillConformanceTests {
+    static string SkillText() => File.ReadAllText(
+        Path.Combine(RepoTree.Root(), "kcap", "skills", "suggest-review-flow", "SKILL.md"));
+
+    [Test]
+    public async Task Registered_in_source_names()
+        => await Assert.That(AgentsSkillsInstaller.SourceNames).Contains("suggest-review-flow");
+
+    [Test]
+    public async Task Description_carries_both_milestone_triggers() {
+        var text = SkillText();
+        await Assert.That(text).Contains("implementation is complete");
+        await Assert.That(text).Contains("spec is finalized");
+    }
+
+    [Test]
+    public async Task Body_pins_the_never_auto_run_guard()
+        => await Assert.That(SkillText()).Contains("MUST NOT start a review flow until the user affirmatively accepts");
+
+    [Test]
+    public async Task Body_defers_execution_to_review_flows()
+        => await Assert.That(SkillText()).Contains("review-flows");
+
+    [Test]
+    public async Task Body_calls_the_availability_tool()
+        => await Assert.That(SkillText()).Contains("list_reviewer_vendors");
+
+    [Test]
+    public async Task Body_handles_ordinary_self_review_locally()
+        => await Assert.That(SkillText()).Contains("perform that review locally");
+
+    [Test]
+    public async Task Body_unknown_driver_never_claims_a_different_model()
+        => await Assert.That(SkillText()).Contains("do NOT claim \"a different model\"");
+}


### PR DESCRIPTION
Linear: **AI-2175**

## What & why

Most vibe coders never run an independent code review — not with a second coding agent, nor outside the implementing session. Review flows already exist and the reviewer can be any installed harness independent of the driver, but the `review-flows` skill is strictly opt-in and never proposes itself, so beginners never discover it.

This adds a **model-driven skill that proactively offers an independent review flow** at the two natural milestones — right after a spec/design is finalized, and right after implementation is complete — and recommends a reviewer harness that will *actually run* for this repo.

## Changes (purely additive — one new skill + one new tool)

- **`list_reviewer_vendors`** MCP tool in `kcap mcp flows` (agent-only, read-only). Reads `GET /api/daemons` and computes, client-side, the reviewer vendors that can run an unattended review for **this** repo now — the intersection of same-machine daemons hosting the repo × their unattended vendors. Every empty result is disambiguated by a single typed `reason` (repo_unresolved · schema_skew · lookup_failed · no_daemons_connected · no_repo_hosting_daemon · no_unattended_reviewer). Conservative `model_override` (AND across daemons). Tolerant daemon parsing (case-insensitive; malformed records skipped + counted; all-unparseable ⇒ schema_skew).
- **`suggest-review-flow`** skill — offers at spec-complete → `spec-review` and implementation-complete → `code-review`; prefers a reviewer ≠ the driver, falls back to a same-vendor independent flow, and maps an empty result to one-line unlock guidance. **Never auto-runs** — it offers, and hands off to `review-flows` only on explicit consent. Ships identically to all nine harnesses; the driver vendor is **inferred at call time** from harness env (not stamped, since six harnesses share `~/.agents/skills`), echoed as `driver_vendor`, unknown ⇒ null ⇒ no "different model" claim.
- **`DriverVendor`** — env-marker inference (claude, codex today; ambiguous/unverified ⇒ null).
- Registered in `AgentsSkillsInstaller.SourceNames` + `help-plugin.txt` + `README.md` (all test-pinned); conformance pins on the triggers and safety guardrails.
- Docs: `docs/eval/suggest-review-flow.md` — the reproducible triggering-eval corpus + methodology.

## No server change

Verified against kcap-server: `GET /api/daemons` already returns `DaemonInfo` with `repoPaths` + `unattendedVendors` + `machineId` + `unattendedVendorCapabilities`, so this is CLI-only.

## Review

The design (AI-2175) was hardened over a **Codex spec-review flow, 6 rounds to clean** (repo-affinity, a circular eval gate, and a branch-name identity collision were all caught there). Deterministic unit/contract tests cover the tool's aggregation, every typed reason + precedence, partial-record handling, and identity edge cases; static conformance pins carry the skill's model-driven surface. AOT publish is clean.

No submodule pin bump is included (that's the maintainer's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
