### PR TITLE
[AI-1762] §2.7 B6 (cli): daemon resumable park + codex-appserver-unattended-v2 activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1559,6 +1559,7 @@ Hosted review-flow reviewers are *unattended* and count against the daemon's `--
 |----------------------|---------|-------------|
 | `KCAP_REVIEWER_MAX_LIFETIME` | `6h` (`21600`) | Max wall-clock lifetime, **in seconds**, for a hosted review-flow reviewer before the heartbeat reaps it. `0` disables the bound. |
 | `KCAP_REVIEWER_IDLE_TIMEOUT` | `2h` (`7200`)  | Max time, **in seconds**, a reviewer may go without output before the heartbeat reaps it. `0` disables the bound. |
+| `KCAP_REVIEWER_RESUMABLE_IDLE_TIMEOUT` | `10m` (`600`) | Max time, **in seconds**, a **resumable** (Codex app-server) reviewer may go idle before the heartbeat **parks** it — freeing its slot while keeping its thread alive for a later resume — instead of reaping it at `KCAP_REVIEWER_IDLE_TIMEOUT`. Applies only to resume-capable reviewers; all others are unaffected. `0` disables parking, so a resumable reviewer falls through to the ordinary idle reap. |
 
 #### Daemon log verbosity
 

--- a/docs/superpowers/plans/2026-08-21-ai1762-b6-daemon-park.md
+++ b/docs/superpowers/plans/2026-08-21-ai1762-b6-daemon-park.md
@@ -1,0 +1,338 @@
+# AI-1762 §2.7 B6 — Daemon Resumable Park + v2 Activation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the daemon PARK an idle-but-resumable hosted Codex reviewer between flow rounds (instead of reaping it), durably acked by the server, and advertise the v2 app-server launcher policy — the piece that finally activates the §2.7 parking/resume machinery end-to-end.
+
+**Architecture:** A new "arm-A" branch in `AgentOrchestrator.FindReviewersToReap` selects a resumable reviewer once it has been idle ≥ a new short `ReviewerResumableIdleTimeout` (10 min) with no turn in flight and its transcript channel drained; that candidate takes a PARK path (`ParkReviewerAsync`) rather than the end/reap path. Parking calls a new `ServerConnection.ReportParticipantParkedAsync` proxy to the already-merged B1 hub method `ReportParticipantParked(agentId, canonicalSessionId, reason)`; only a durable "Parked" ack completes the teardown AND suppresses the hosted session-end (so the app-server thread survives for B4 resume). An ambiguous ack (network/unknown) leaves a resettable `ParkAttemptInFlight` marker and does NOT tear down — the next sweep retries. The v2 advertisement (`CodexAppServerLauncherPolicyVersion` → `codex-appserver-unattended-v2`) lands only now, because parking must exist before the server routes resume to this daemon.
+
+**Tech Stack:** C# / .NET 10, `Capacitor.Cli.Daemon` (the daemon), TUnit + `FakeCodexAppServer` harness, SignalR hub proxy (`ServerConnection`).
+
+**Spec:** `ai-1762-section27-plan` memory (B6 entry) + `ai-1762-b4-resume-core-design` + `ai-1762-halfb-status` (kcap-server memory dir). This plan implements the B6 row of that plan.
+
+## Global Constraints
+
+- **Repo:** `kcap-cli` only (worktree `/Users/tony/dev/kcap-cli-worktrees/ai-1762-b6`, branch `tonyyoung/ai-1762-b6-daemon-park` off cli `main` `433a8b71`). No server changes — B1/B2/B3/B4/B5 are already merged in `kcap-server`.
+- **Deploy ordering:** server-first is already satisfied (all server §2.7 PRs merged). The v2 advertisement is safe to ship: the server classifier already recognizes `codex-appserver-unattended-v2` (A1, merged) and fails closed on unknown strings.
+- **Launcher-policy constant is a cross-repo lockstep contract:** the v2 string MUST be exactly `codex-appserver-unattended-v2` (matches A1's `CodexLauncherPolicyClassifier`). Do not invent a new spelling.
+- **Reverse-skew safety is inherent:** a v2 daemon talking to a pre-1761 server hits the strict `AcpSessionSourceClaim` unknown-method path → coded fail + teardown. Do not add extra skew handling.
+- **`reviewer_parked_resumable`** is the exact park reason string (matches B1's `FlowStopReasons.ReviewerParkedResumable` and B3's round-result mapping). Do not vary it.
+- Follow existing daemon patterns: per-agent claim fence for teardown (`TryClaimReapAsync`), `AgentActivityClock.Snapshot()` one-shot reads, `PendingEndReason` for end attribution.
+- TDD throughout; commit per task. Tests are TUnit in `test/Capacitor.Cli.Daemon.Tests.Unit`.
+
+---
+
+## Grounding the implementer must do first (Task 0)
+
+B6 touches signals whose EXACT names must be confirmed against the live code before writing tests. Do this reconnaissance once, record the answers inline in the plan as you go, then implement.
+
+### Task 0: Confirm the seams (no code; reconnaissance + notes)
+
+**Files (read-only):**
+- `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — `FindReviewersToReap` (~810), the reap loop (~4317 `foreach (var candidate in FindReviewersToReap()) _ = ReapReviewerAsync(candidate);`), `ReapReviewerAsync`, `TryClaimReapAsync`, `PendingEndReason` (~147), `EndAgentSessionAsync` + `EndAgentSessionBudget` (~515).
+- `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — `AgentActivityClock.Snapshot()` result shape: confirmed fields `AgeMs`, `IdleForMs`, `TurnInFlight`, `ActivitySeq`.
+- `src/Capacitor.Cli.Daemon/DaemonConfig.cs` — `ReviewerIdleTimeout` (2h, `:32`), `ReviewerMaxLifetime`, `ReviewerTurnWedgeCeiling`.
+- `src/Capacitor.Cli.Daemon/DaemonRunner.cs` — `CodexAppServerLauncherPolicyVersion` (`:1342`), `ComputeUnattendedVendorCapabilities` (`:1354`), `ParseSecondsEnv` (`:91` pattern), the codex capability row (`:1368`).
+- `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` — an existing daemon→hub proxy that reports an agent lifecycle event (e.g. the participant-stop / `AgentUnregistered` / stop proxy) to copy the invoke + retry + logging shape for `ReportParticipantParkedAsync`.
+- `kcap-server` (read-only, already merged) `src/Capacitor.Server/Sessions/CapacitorHub.cs:1972` — `public async Task<ParkParticipantOutcome> ReportParticipantParked(string agentId, string canonicalSessionId, string reason)`. Note the arg order/names: **agentId, canonicalSessionId, reason**.
+
+**Record these THREE answers (each blocks a later task):**
+
+1. **Resume-capability predicate** — how does an `AgentInstance` at reap time reveal it is an app-server hosted Codex reviewer whose thread can be resumed? Candidates to check: the instance's hosted runtime type (`CodexAppServerHostedAgentRuntime` vs PTY), a vendor+transport field, or an `AgentInstance` flag set at launch when `UsesAppServer(ctx)` was true. Write the exact expression (e.g. `a.Runtime is CodexAppServerHostedAgentRuntime` or `a.RuntimeTransport == RuntimeTransports.AppServer`). This is the arm-A gate's "declares durable resume" clause.
+2. **Canonical session id at reap time** — the argument `ReportParticipantParked` needs (`canonicalSessionId`). Find where the daemon holds the bound ACP canonical/session id for a hosted agent (likely on `AgentInstance` or its runtime). Write the exact accessor.
+3. **Channel-drained signal** — the transcript/input channel "drained" clause. Check `AcpTranscriptForwarder` (a "drains" API exists ~`:263`) and the hosted input queue. If there is no cheap synchronous "drained" read, the fallback is `!clock.TurnInFlight && clock.IdleForMs > resumable-timeout` alone (turn-not-in-flight already implies no active turn); record the decision. Prefer the simplest correct signal — do not add a new channel-tracking mechanism (YAGNI).
+
+**Step 1: Write the three answers into this file** (replace the bracketed placeholders in Tasks 2–5 below with the confirmed expressions). No commit (doc-only reconnaissance folded into Task 2's commit).
+
+---
+
+## File Structure
+
+- **Modify** `src/Capacitor.Cli.Daemon/DaemonConfig.cs` — add `ReviewerResumableIdleTimeout` (default 10 min).
+- **Modify** `src/Capacitor.Cli.Daemon/DaemonRunner.cs` — env parse for the new timeout; flip `CodexAppServerLauncherPolicyVersion` to v2.
+- **Modify** `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — arm-A selection in `FindReviewersToReap`; `ParkAttemptInFlight` state on `AgentInstance`; a `ParkReviewerAsync` path; route park candidates to it from the reap loop.
+- **Modify** `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` — `ReportParticipantParkedAsync` proxy.
+- **Test** `test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorReviewerParkTests.cs` (new) — arm-A selection + park state machine.
+- **Test** existing `test/Capacitor.Cli.Daemon.Tests.Unit/...` for `ComputeUnattendedVendorCapabilities` — v2 advertisement assertion (find the existing capability test class in Task 5).
+
+Files that change together: the reap-selection rule, the park state, and the park path all live in `AgentOrchestrator.cs` (one responsibility: reviewer lifecycle) — keep them there, following the file's existing structure.
+
+---
+
+### Task 1: Add `ReviewerResumableIdleTimeout` config + env parse
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/DaemonConfig.cs` (near `ReviewerIdleTimeout`, `:32`)
+- Modify: `src/Capacitor.Cli.Daemon/DaemonRunner.cs` (near `ReviewerIdleTimeout` env parse, `:91`)
+
+**Interfaces:**
+- Produces: `DaemonConfig.ReviewerResumableIdleTimeout` (`TimeSpan`, default `TimeSpan.FromMinutes(10)`); env `KCAP_REVIEWER_RESUMABLE_IDLE_TIMEOUT` (seconds).
+
+- [ ] **Step 1: Add the config property.** In `DaemonConfig.cs`, beside `ReviewerIdleTimeout`:
+
+```csharp
+/// <summary>§2.7 B6 arm-A: how long a RESUMABLE hosted reviewer (app-server Codex) may sit idle
+/// between rounds before the daemon PARKS it (freeing the slot, keeping the thread for resume) —
+/// distinct from and shorter than <see cref="ReviewerIdleTimeout"/> (arm-B, the 2h hard reap).</summary>
+public TimeSpan ReviewerResumableIdleTimeout { get; set; } = TimeSpan.FromMinutes(10);
+```
+
+- [ ] **Step 2: Add the env override.** In `DaemonRunner.cs`, beside the `ReviewerIdleTimeout` parse:
+
+```csharp
+config.ReviewerResumableIdleTimeout = ParseSecondsEnv("KCAP_REVIEWER_RESUMABLE_IDLE_TIMEOUT", config.ReviewerResumableIdleTimeout);
+```
+
+- [ ] **Step 3: Build.** Run: `dotnet build src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj -c Debug`. Expected: 0 errors.
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/Capacitor.Cli.Daemon/DaemonConfig.cs src/Capacitor.Cli.Daemon/DaemonRunner.cs
+git commit -m "[AI-1762] B6: add ReviewerResumableIdleTimeout (arm-A park idle bound)"
+```
+
+---
+
+### Task 2: `ReportParticipantParkedAsync` proxy on `ServerConnection`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/ServerConnection.cs` (mirror the existing lifecycle-report proxy identified in Task 0)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs` (new) — only if the existing proxies have unit tests to mirror; otherwise coverage comes via Task 4's orchestrator tests against a fake connection.
+
+**Interfaces:**
+- Consumes: B1 hub `ReportParticipantParked(string agentId, string canonicalSessionId, string reason) → ParkParticipantOutcome`.
+- Produces: `Task<ParkAck> ServerConnection.ReportParticipantParkedAsync(string agentId, string canonicalSessionId, string reason, CancellationToken ct)` where `ParkAck` is an enum `{ Parked, Rejected, Ambiguous }` — `Parked` iff the hub returned a definite "parked" outcome; `Rejected` for a definite negative (not-owner / ledger-refused); `Ambiguous` for any transport/timeout/unknown result (drives the retry, no teardown).
+
+- [ ] **Step 1: Write the failing test** (if mirroring an existing proxy test; else skip to Step 3 and cover via Task 4). Assert a fake hub returning the "parked" outcome yields `ParkAck.Parked`, a thrown `HubException`/timeout yields `ParkAck.Ambiguous`, and a definite negative yields `ParkAck.Rejected`.
+
+```csharp
+[Test]
+public async Task ReportParticipantParked_maps_hub_outcomes_to_ParkAck() {
+    // Arrange a fake SignalR connection returning each outcome; assert the mapping.
+    // (Mirror the existing stop/unregister proxy test harness identified in Task 0.)
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails.** Run: `dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/... -- --treenode-filter "/*/*/ServerConnectionParkProxyTests/*"`. Expected: FAIL (method not defined).
+- [ ] **Step 3: Implement the proxy.** Mirror the existing lifecycle proxy's invoke + error handling. The server returns `ParkParticipantOutcome` (an enum with a `Parked` member — confirm its serialized shape via the existing outcome-returning proxies, e.g. the source-claim/confirm proxies deserialize hub enums). Map: definite parked → `Parked`; definite negative → `Rejected`; `HubException`/`OperationCanceledException`/transport error → `Ambiguous`. Never throw out of this method — an unmapped exception becomes `Ambiguous`.
+- [ ] **Step 4: Run tests, verify pass.**
+- [ ] **Step 5: Commit.**
+
+```bash
+git commit -am "[AI-1762] B6: ServerConnection.ReportParticipantParkedAsync proxy (ack -> ParkAck)"
+```
+
+---
+
+### Task 3: `ParkAttemptInFlight` state on `AgentInstance`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (`AgentInstance`, near `PendingEndReason` `:147`)
+
+**Interfaces:**
+- Produces: `AgentInstance.ParkAttemptInFlight` (`bool`, resettable) — set true while a park ack is outstanding so the reap loop does not re-dispatch a park for the same agent; reset to false on an `Ambiguous` outcome (so the NEXT sweep retries) and left irrelevant after a `Parked` teardown (the agent is gone). Guarded by the same lock/convention `PendingEndReason` uses.
+
+- [ ] **Step 1: Add the field** with a doc comment explaining the ambiguous-retry contract (one line: "true while a park ack is outstanding; a sweep skips an agent already parking; reset on ambiguous ack to allow retry").
+- [ ] **Step 2: Build.** Expected 0 errors.
+- [ ] **Step 3: Commit.**
+
+```bash
+git commit -am "[AI-1762] B6: AgentInstance.ParkAttemptInFlight (arm-A in-flight guard)"
+```
+
+---
+
+### Task 4: Arm-A selection + `ParkReviewerAsync` path
+
+This is the core task. Split the test into (a) selection and (b) the park state machine.
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — `FindReviewersToReap` (arm-A branch), the reap loop (`:4317`, route park candidates), new `ParkReviewerAsync`.
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorReviewerParkTests.cs` (new)
+
+**Interfaces:**
+- Consumes: `ReapCandidate` (add a discriminator — either a new `bool Park` field on `ReapCandidate`, or a distinct reason the loop switches on; prefer a `Park` bool for clarity), `ParkAck`, `ReportParticipantParkedAsync`, `ParkAttemptInFlight`, the Task-0 resume-capability predicate + canonical-id accessor + channel-drained signal.
+- Produces: park candidates flow to `ParkReviewerAsync`; end/reap candidates keep flowing to `ReapReviewerAsync` unchanged.
+
+**Selection rule (arm-A), inserted in `FindReviewersToReap` BEFORE the arm-B idle rule (`:855`), inside the same `!clock.TurnInFlight` region:**
+
+```csharp
+// §2.7 B6 arm-A: a RESUMABLE hosted reviewer idle past the short resumable bound (and not already
+// parking) is PARKED — its slot freed, its Codex thread kept for resume — rather than reaped. Checked
+// before the 2h arm-B idle rule so a resumable reviewer parks at ~10min instead of reaping at 2h.
+// A non-resumable reviewer (PTY, non-codex) never matches and falls through to arm-B unchanged.
+if (<Task0.ResumeCapable(a)> && !a.ParkAttemptInFlight
+    && _config.ReviewerResumableIdleTimeout > TimeSpan.Zero
+    && clock.IdleForMs > (ulong) _config.ReviewerResumableIdleTimeout.TotalMilliseconds
+    && <Task0.ChannelDrained(a)>) {
+    result.Add(new ReapCandidate(a, "reviewer_parked_resumable", clock.ActivitySeq, FencedOnActivity: true) { Park = true });
+    continue;
+}
+```
+
+**`ParkReviewerAsync` (new), mirroring `ReapReviewerAsync`'s claim fence but taking the PARK path:**
+
+```csharp
+async Task ParkReviewerAsync(ReapCandidate candidate) {
+    var a = candidate.Agent;
+    // Guard: one park attempt at a time per agent (reset on ambiguous below).
+    a.ParkAttemptInFlight = true;
+    try {
+        // Claim/revalidate the selection under the per-agent fence, exactly as ReapReviewerAsync does
+        // (activity advance since selection aborts — FencedOnActivity: true). If the claim is lost, bail.
+        if (!await TryClaimReapAsync(candidate)) { a.ParkAttemptInFlight = false; return; }
+
+        var ack = await connection.ReportParticipantParkedAsync(
+            a.Id, <Task0.CanonicalId(a)>, "reviewer_parked_resumable", ct);
+
+        switch (ack) {
+            case ParkAck.Parked:
+                // Durable park acked: complete the arm-A teardown but SUPPRESS the hosted session-end,
+                // so the app-server thread survives for B4 resume. (Contrast ReapReviewerAsync, which
+                // calls EndAgentSessionAsync.) Free the local slot / remove from _agents WITHOUT ending.
+                a.PendingEndReason = "reviewer_parked_resumable";
+                <suppress-session-end local teardown — see below>;
+                break;
+            case ParkAck.Rejected:
+                // The server refused the park (e.g. a terminal close already won): do NOT park. Fall back
+                // to the normal end path so the reviewer is cleaned up, not left dangling.
+                a.ParkAttemptInFlight = false;
+                await ReapReviewerAsync(candidate); // or the existing end path for a rejected park
+                break;
+            case ParkAck.Ambiguous:
+                // Unknown outcome: leave everything intact and let the next sweep retry. Reset the guard.
+                a.ParkAttemptInFlight = false;
+                break;
+        }
+    } catch {
+        a.ParkAttemptInFlight = false; // never strand the guard set on an unexpected throw
+        throw;
+    }
+}
+```
+
+> **Session-end suppression detail (confirm in Task 0):** `ReapReviewerAsync` ends the hosted session via `EndAgentSessionAsync` (budgeted 30s). The park path must do the SAME local teardown (remove from `_agents`, free the slot, stop the local process/runtime) EXCEPT the `SessionEnded` emission — the server's B5 close authority owns the eventual close, and B4 resume needs the thread alive. Identify the exact local-cleanup vs session-end boundary in `ReapReviewerAsync` and factor the shared local teardown so `ParkReviewerAsync` reuses it without the `EndAgentSession` call.
+
+**Reap-loop routing (`:4317`):**
+
+```csharp
+foreach (var candidate in FindReviewersToReap())
+    _ = candidate.Park ? ParkReviewerAsync(candidate) : ReapReviewerAsync(candidate);
+```
+
+- [ ] **Step 1 (selection test): Write the failing test** — arm-A selects a resumable, idle, drained, no-turn reviewer with `Park == true` and reason `reviewer_parked_resumable`; and does NOT select (a) a non-resumable reviewer (falls to arm-B), (b) one with `TurnInFlight`, (c) one already `ParkAttemptInFlight`, (d) one idle < resumable-timeout.
+
+```csharp
+[Test]
+public void Arm_A_parks_a_resumable_idle_drained_reviewer() {
+    var orch = /* build orchestrator with a fake resumable reviewer idle > 10min, !TurnInFlight, drained */;
+    var cands = orch.FindReviewersToReap();
+    var park = cands.Single(c => c.Park);
+    // assertions: park.Reason == "reviewer_parked_resumable", park.Agent == the reviewer, FencedOnActivity
+}
+
+[Test]
+public void Arm_A_ignores_a_non_resumable_reviewer_leaving_it_to_arm_B() { /* PTY/non-codex → no Park candidate */ }
+
+[Test]
+public void Arm_A_skips_a_reviewer_already_parking() { /* ParkAttemptInFlight = true → not re-selected */ }
+
+[Test]
+public void Arm_A_does_not_park_before_the_resumable_idle_bound() { /* idle < 10min → no Park candidate */ }
+```
+
+- [ ] **Step 2: Run, verify fail** (arm-A not implemented / no `Park` field).
+- [ ] **Step 3: Implement** the `Park` discriminator on `ReapCandidate` + the arm-A selection branch.
+- [ ] **Step 4: Run, verify the selection tests pass.**
+- [ ] **Step 5 (state-machine test): Write the failing tests** for `ParkReviewerAsync` against a fake `ServerConnection`:
+
+```csharp
+[Test]
+public async Task Park_on_Parked_ack_suppresses_session_end_and_frees_the_slot() {
+    // fake connection returns Parked; assert: no SessionEnded emitted, agent removed/slot freed,
+    // PendingEndReason == "reviewer_parked_resumable".
+}
+
+[Test]
+public async Task Park_on_Ambiguous_ack_tears_down_nothing_and_allows_retry() {
+    // fake connection returns Ambiguous; assert: agent still present, ParkAttemptInFlight reset false,
+    // no SessionEnded, a subsequent FindReviewersToReap re-selects it for park.
+}
+
+[Test]
+public async Task Park_on_Rejected_ack_falls_back_to_the_normal_end_path() {
+    // fake connection returns Rejected; assert the reviewer is ended (not left dangling).
+}
+
+[Test]
+public async Task Park_aborts_if_activity_advances_after_selection() {
+    // FencedOnActivity: an activity bump between selection and claim aborts the park (TryClaimReapAsync loses).
+}
+```
+
+- [ ] **Step 6: Run, verify fail.**
+- [ ] **Step 7: Implement** `ParkReviewerAsync` + the shared local-teardown-without-session-end factor + the loop routing.
+- [ ] **Step 8: Run, verify all park tests pass.**
+- [ ] **Step 9: Run the whole daemon unit project** to confirm no reap-path regression: `dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj -c Debug`. Expected: all pass.
+- [ ] **Step 10: Commit.**
+
+```bash
+git commit -am "[AI-1762] B6: arm-A resumable park (select + ParkReviewerAsync + ack-gated teardown, session-end suppressed)"
+```
+
+---
+
+### Task 5: v2 launcher-policy advertisement
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/DaemonRunner.cs:1342` (`CodexAppServerLauncherPolicyVersion`)
+- Test: the existing `ComputeUnattendedVendorCapabilities` test (find it: `grep -rn ComputeUnattendedVendorCapabilities test/`)
+
+**Interfaces:**
+- Produces: when `config.CodexAppServerActive`, the codex capability row advertises `codex-appserver-unattended-v2` and reports `runtime_transport=app-server` (the A2-cli mirror already reports transport on `AgentRegistered`; confirm no additional change is needed there).
+
+- [ ] **Step 1: Write/adjust the failing test** — with `CodexAppServerActive = true`, `ComputeUnattendedVendorCapabilities` yields a codex row whose `LauncherPolicyVersion == "codex-appserver-unattended-v2"`.
+- [ ] **Step 2: Run, verify fail** (still v1).
+- [ ] **Step 3: Flip the constant:**
+
+```csharp
+internal const string CodexAppServerLauncherPolicyVersion = "codex-appserver-unattended-v2";
+```
+
+- [ ] **Step 4: Run, verify pass.** Also confirm the non-app-server codex row still advertises `codex-unattended-v1` (the `config.CodexAppServerActive` ternary at `:1368`).
+- [ ] **Step 5: Commit.**
+
+```bash
+git commit -am "[AI-1762] B6: advertise codex-appserver-unattended-v2 (activates server-side resume routing)"
+```
+
+---
+
+### Task 6: Old-server graceful degrade + full-suite green
+
+**Files:** none new — a verification + a targeted test if a seam is missing.
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Reason about / test the old-server degrade.** If `ReportParticipantParkedAsync` reaches a server that does not implement `ReportParticipantParked` (pre-B1), the hub invoke throws unknown-method → the proxy maps it to `ParkAck.Ambiguous` → `ParkReviewerAsync` tears down nothing and retries. Over-retrying a permanently-old server would loop, so add: on an unknown-method/method-not-found error specifically, map to `ParkAck.Rejected` (fall back to normal reap) rather than `Ambiguous`. Add a test: `Park_against_a_server_without_the_hub_method_falls_back_to_reap`.
+- [ ] **Step 2: Implement** the unknown-method → `Rejected` mapping in the proxy (distinguish "method not found" from a transient transport error).
+- [ ] **Step 3: Run the full daemon unit suite.** Expected: all pass.
+- [ ] **Step 4: Commit.**
+
+```bash
+git commit -am "[AI-1762] B6: park proxy degrades to reap against a pre-B1 server (unknown method -> Rejected)"
+```
+
+---
+
+## After implementation (out of plan scope, but the executor should expect it)
+
+- Codex review flow (two-pass, like B5) + address qodo on the PR, CI green, then admin-squash-merge (Tony authorizes merges per-PR).
+- The `src/cli` submodule pin bump in `kcap-server` is Alexey's follow-up, not part of this PR.
+- The cert-gated interactive routing flip (drop `&& ctx.IsReviewFlow` from `CodexHostedAgentRuntimeFactory.UsesAppServer`) is a SEPARATE later PR (AI-2110 → AI-1763), after B6 + a passing live cert.
+
+## Self-review notes
+
+- **Spec coverage:** arm-A select (Task 4), `ParkAttemptInFlight` ambiguous-retry (Tasks 3+4), `ReportParticipantParked` proxy (Task 2), durable-ack-gated teardown + session-end suppression (Task 4), v2 advertisement + `runtime_transport=app-server` (Task 5), old-server degrade (Task 6). All B6 spec bullets mapped.
+- **Open confirmations (Task 0):** the resume-capability predicate, the canonical-id accessor, and the channel-drained signal are the three live-code lookups the implementer must resolve before Tasks 4 — they are named as explicit reconnaissance, not left as silent placeholders.
+- **Type consistency:** `ParkAck { Parked, Rejected, Ambiguous }` and `ReapCandidate.Park` are used consistently across Tasks 2, 4, 6.

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1388,7 +1388,7 @@ public readonly record struct AcpSourceClaimOutcome(AcpBindOutcome Outcome, long
 public enum AcpLaunchConfirmOutcome { Confirmed = 0, AlreadyConfirmed = 1, Superseded = 2, NotFound = 3 }
 
 /// <summary>
-/// AI-1762 §2.7 B6 reply to the server's <c>ReportParticipantParked</c> hub method — a
+/// §2.7 B6 reply to the server's <c>ReportParticipantParked</c> hub method — a
 /// field-for-field mirror of the server-side <c>Capacitor.Events.ParkParticipantOutcome</c>.
 /// <see cref="Parked"/> (including an idempotent re-park) means the daemon may complete its local
 /// park teardown while suppressing the hosted session-end, since the app-server thread survives for

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1395,9 +1395,13 @@ public enum AcpLaunchConfirmOutcome { Confirmed = 0, AlreadyConfirmed = 1, Super
 /// a later resume; <see cref="Rejected"/> is a DEFINITE refusal (wrong reason string, not the owning
 /// connection, an ownership-claim miss, a ledger CAS refusal, or a malformed canonical id) — the
 /// daemon falls back to the normal end path instead of parking. There is no third wire value: an
-/// AMBIGUOUS outcome (transport error, timeout, unknown method against an old server) is the
+/// AMBIGUOUS outcome (a transient transport error or timeout) is the
 /// ABSENCE of a reply — never encoded here. <c>ServerConnection.ReportParticipantParkedAsync</c> is
-/// what folds that absence into the daemon-local <c>ParkAck.Ambiguous</c>.
+/// what folds that absence into the daemon-local <c>ParkAck.Ambiguous</c>. A pre-B1 server with no
+/// <c>ReportParticipantParked</c> handler at all is a separate, PERMANENT case that same method also
+/// handles: it recognizes the resulting "unknown hub method" <c>HubException</c> specifically and maps
+/// it to the daemon-local <c>ParkAck.Rejected</c> instead of Ambiguous, so a permanently-old server
+/// degrades to the normal reap rather than retrying the park forever.
 /// </summary>
 public enum ParkParticipantOutcome { Parked, Rejected }
 

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1082,6 +1082,7 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(AcpBindOutcome))]
 [JsonSerializable(typeof(AcpSourceClaimOutcome))]
 [JsonSerializable(typeof(AcpLaunchConfirmOutcome))]
+[JsonSerializable(typeof(ParkParticipantOutcome))]
 [JsonSerializable(typeof(TranscriptBatchAck))]
 // The AcpSessionStarted hub method's optional metadata argument. Registered as its own root type
 // (not just nested inside another JsonSerializable graph) because SignalR's JsonHubProtocol
@@ -1385,6 +1386,20 @@ public readonly record struct AcpSourceClaimOutcome(AcpBindOutcome Outcome, long
 /// means no ledger row (the claim never committed, or the session closed).
 /// </summary>
 public enum AcpLaunchConfirmOutcome { Confirmed = 0, AlreadyConfirmed = 1, Superseded = 2, NotFound = 3 }
+
+/// <summary>
+/// AI-1762 §2.7 B6 reply to the server's <c>ReportParticipantParked</c> hub method — a
+/// field-for-field mirror of the server-side <c>Capacitor.Events.ParkParticipantOutcome</c>.
+/// <see cref="Parked"/> (including an idempotent re-park) means the daemon may complete its local
+/// park teardown while suppressing the hosted session-end, since the app-server thread survives for
+/// a later resume; <see cref="Rejected"/> is a DEFINITE refusal (wrong reason string, not the owning
+/// connection, an ownership-claim miss, a ledger CAS refusal, or a malformed canonical id) — the
+/// daemon falls back to the normal end path instead of parking. There is no third wire value: an
+/// AMBIGUOUS outcome (transport error, timeout, unknown method against an old server) is the
+/// ABSENCE of a reply — never encoded here. <c>ServerConnection.ReportParticipantParkedAsync</c> is
+/// what folds that absence into the daemon-local <c>ParkAck.Ambiguous</c>.
+/// </summary>
+public enum ParkParticipantOutcome { Parked, Rejected }
 
 /// <summary>
 /// Ack returned from the server's <c>SendTranscriptBatchAcked</c> hub method (D3).

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -31,6 +31,11 @@ public class DaemonConfig {
     public TimeSpan ReviewerMaxLifetime { get; set; } = TimeSpan.FromHours(6);
     public TimeSpan ReviewerIdleTimeout { get; set; } = TimeSpan.FromHours(2);
 
+    /// <summary>§2.7 B6 arm-A: how long a RESUMABLE hosted reviewer (app-server Codex) may sit idle
+    /// between rounds before the daemon PARKS it (freeing the slot, keeping the thread for resume) —
+    /// distinct from and shorter than <see cref="ReviewerIdleTimeout"/> (arm-B, the 2h hard reap).</summary>
+    public TimeSpan ReviewerResumableIdleTimeout { get; set; } = TimeSpan.FromMinutes(10);
+
     /// <summary>
     /// The daemon-local ceiling on a held ACP turn with a frozen activity seq: once <c>TurnInFlight</c>
     /// has stayed true with no further <c>Advance()</c> for longer than this, the reviewer is reaped as

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1340,7 +1340,7 @@ public static partial class DaemonRunner {
     internal const string ClaudeLauncherPolicyVersion = "claude-unattended-v1";
     internal const string CursorLauncherPolicyVersion = "cursor-unattended-v4";
     internal const string CodexLauncherPolicyVersion = "codex-unattended-v1";
-    internal const string CodexAppServerLauncherPolicyVersion = "codex-appserver-unattended-v1";
+    internal const string CodexAppServerLauncherPolicyVersion = "codex-appserver-unattended-v2";
     internal const string CopilotLauncherPolicyVersion = "copilot-unattended-v1";
     internal const string AntigravityLauncherPolicyVersion = "antigravity-unattended-v1";
     internal const string OpenCodeLauncherPolicyVersion = "opencode-unattended-v1";

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -89,6 +89,7 @@ public static partial class DaemonRunner {
         // Phase B (D3): reviewer lifetime/idle backstop overrides from env (seconds; 0 disables).
         config.ReviewerMaxLifetime = ParseSecondsEnv("KCAP_REVIEWER_MAX_LIFETIME", config.ReviewerMaxLifetime);
         config.ReviewerIdleTimeout = ParseSecondsEnv("KCAP_REVIEWER_IDLE_TIMEOUT", config.ReviewerIdleTimeout);
+        config.ReviewerResumableIdleTimeout = ParseSecondsEnv("KCAP_REVIEWER_RESUMABLE_IDLE_TIMEOUT", config.ReviewerResumableIdleTimeout);
         // Task 12: daemon-local held-turn wedge ceiling override (seconds; 0 disables), independent
         // of the server's own Flows:TurnWedgeCeilingSeconds — see DaemonConfig.ReviewerTurnWedgeCeiling.
         config.ReviewerTurnWedgeCeiling = ParseSecondsEnv("KCAP_REVIEWER_TURN_WEDGE_CEILING", config.ReviewerTurnWedgeCeiling);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -146,6 +146,10 @@ internal record AgentInstance(
     /// </summary>
     public string PendingEndReason { get; set; } = "agent_exited";
 
+    /// <summary>True while a park ack is outstanding; a sweep skips an agent already parking; reset
+    /// on ambiguous ack to allow retry.</summary>
+    public bool ParkAttemptInFlight { get; set; }
+
     // ── Local terminal attach (Phase 1) ──────────────────────────────────
     // Internal: these expose the daemon-internal ITerminalSink, so they can't be public
     // on this public record (CS0053). They're only touched inside the daemon assembly.

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -811,6 +811,28 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// can become active in the very next instant. Each candidate therefore carries the activity
     /// generation it was selected against, which <see cref="TryClaimReapAsync"/> re-validates inside
     /// the per-agent fence.</para></summary>
+
+    /// <summary>§2.7 B6 arm-A: the end/park reason for a resumable reviewer parked (not reaped). This
+    /// exact string is BOTH the ack reason sent to the server's <c>ReportParticipantParked</c> AND the
+    /// <see cref="AgentInstance.PendingEndReason"/> that tells <see cref="FinalizeAgentRunAsync"/> to
+    /// SUPPRESS the hosted session-end — so it must match on both sides. Do not vary it.</summary>
+    internal const string ReviewerParkedResumableReason = "reviewer_parked_resumable";
+
+    /// <summary>§2.7 B6 arm-A: the end reason stamped when the server REJECTS a park — the reviewer is
+    /// then ended normally (session-end fires) rather than parked, so this must NOT be
+    /// <see cref="ReviewerParkedResumableReason"/> (which would suppress that end).</summary>
+    const string ReviewerParkRejectedReason = "reviewer_park_rejected";
+
+    /// <summary>§2.7 B6 arm-A resume-capability predicate: true only for an app-server hosted Codex
+    /// reviewer, whose <c>thread/start</c> handshake bound a Codex thread id that a later
+    /// <c>thread/resume</c> can reopen — the one runtime that reports the app-server transport
+    /// (<see cref="Harness.Codex.CodexAppServerHostedAgentRuntime"/>; every other runtime reports the
+    /// "pty" default). A PTY / non-Codex reviewer has no resumable thread and never matches. Read off
+    /// the transport label rather than type-switching the runtime — the same value the server validates
+    /// its launch decision against on registration.</summary>
+    static bool IsResumableReviewer(AgentInstance a) =>
+        a.RuntimeTransport == Harness.Codex.CodexTransportDecision.AppServer;
+
     internal IReadOnlyList<ReapCandidate> FindReviewersToReap() {
         var result = new List<ReapCandidate>();
 
@@ -856,6 +878,26 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 continue; // a held turn suppresses the plain idle rule outright
             }
 
+            // §2.7 B6 arm-A: a RESUMABLE hosted reviewer (app-server Codex, whose thread survives a
+            // process teardown for a later thread/resume) that has been idle past the SHORT resumable
+            // bound — and is not already mid-park — is PARKED rather than reaped: its slot is freed but
+            // its Codex thread is kept. Checked here, BEFORE the 2h arm-B idle rule and inside the same
+            // !clock.TurnInFlight region, so a resumable reviewer parks at ~10min instead of reaping at
+            // 2h. A non-resumable reviewer (PTY / non-Codex) never satisfies the transport gate and
+            // falls through to arm-B unchanged.
+            //
+            // No separate "channel-drained" clause (Task 0): !TurnInFlight already means no active turn,
+            // every input enqueue / turn transition / notification advances this same activity clock (so
+            // idle past the bound already implies the input queue and transcript are quiescent — the
+            // forwarder's unacked buffer flushes within its <=30s retry cadence, far under the bound),
+            // and FencedOnActivity: true re-checks at claim that nothing has advanced since selection.
+            if (IsResumableReviewer(a) && !a.ParkAttemptInFlight
+                && _config.ReviewerResumableIdleTimeout > TimeSpan.Zero
+                && clock.IdleForMs > (ulong) _config.ReviewerResumableIdleTimeout.TotalMilliseconds) {
+                result.Add(new ReapCandidate(a, ReviewerParkedResumableReason, clock.ActivitySeq, FencedOnActivity: true) { Park = true });
+                continue;
+            }
+
             if (_config.ReviewerIdleTimeout > TimeSpan.Zero && clock.IdleForMs > (ulong) _config.ReviewerIdleTimeout.TotalMilliseconds)
                 result.Add(new ReapCandidate(a, "reviewer_idle_expired", clock.ActivitySeq, FencedOnActivity: true));
         }
@@ -876,6 +918,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     internal readonly record struct ReapCandidate(
             AgentInstance Agent, string Reason, ulong ActivityGeneration, bool FencedOnActivity) {
         public string Id => Agent.Id;
+
+        /// <summary>§2.7 B6 arm-A discriminator. When true, the heartbeat routes this candidate to the
+        /// resumable-PARK path (<see cref="AgentOrchestrator.ParkReviewerAsync"/>) instead of the reap
+        /// path: its daemon slot is freed like a reap, but its Codex app-server thread is kept alive
+        /// (the hosted session-end is SUPPRESSED) for a later <c>thread/resume</c>. False for every
+        /// reap rule (TTL / wedge / idle), which keep flowing to
+        /// <see cref="AgentOrchestrator.ReapReviewerAsync"/> unchanged.</summary>
+        public bool Park { get; init; }
     }
 
     // Surface 3: cached machine inventory, recomputed on a 6h in-memory cadence. Deliberately never
@@ -2686,7 +2736,14 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // genuinely long outage falls back to server-side daemon-disconnect reconcile.
             //
             // PrivateLocal agents have no server-side session to end (deny-all).
-            if (!agent.IsPrivate) {
+            //
+            // §2.7 B6 arm-A: a PARKED reviewer (ParkReviewerAsync got a durable Parked ack, which stamped
+            // ReviewerParkedResumableReason here) completes EVERY local-teardown step EXCEPT this hosted
+            // session-end — its Codex app-server thread must survive for a later thread/resume, and the
+            // server's B5 close authority owns the eventual close. Every other teardown step (the ACP
+            // final-drain above, UnregisterAcpBinding + CleanupAgentAsync below) still runs, so the slot
+            // is freed exactly as a reap frees it.
+            if (!agent.IsPrivate && agent.PendingEndReason != ReviewerParkedResumableReason) {
                 var endTask = _server.EndAgentSessionAsync(agent.Id, agent.PendingEndReason);
 
                 try {
@@ -2812,6 +2869,91 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             await StopClaimedReapAsync(candidate);
         } catch (Exception ex) {
             LogReapFailed(ex, candidate.Id, candidate.Reason);
+        }
+    }
+
+    /// <summary>§2.7 B6 arm-A: PARK a resumable reviewer instead of reaping it — free its daemon slot
+    /// while keeping its Codex app-server thread alive for a later <c>thread/resume</c> (B4). Mirrors
+    /// <see cref="ReapReviewerAsync"/>'s claim fence, then, on a DURABLE-park ack, takes the same local
+    /// teardown a reap does (<see cref="StopClaimedReapAsync"/> → stop process, unregister, free slot)
+    /// MINUS the hosted <c>EndAgentSession</c> emission: <see cref="FinalizeAgentRunAsync"/> suppresses
+    /// that when <see cref="AgentInstance.PendingEndReason"/> is <see cref="ReviewerParkedResumableReason"/>,
+    /// because the server's B5 close authority owns the eventual close and a resume needs the thread
+    /// intact. Fire-and-forget from the heartbeat, so — like <see cref="ReapReviewerAsync"/> — it
+    /// contains its own faults, and it never strands <see cref="AgentInstance.ParkAttemptInFlight"/>.
+    ///
+    /// <para>Three-way on the ack (<see cref="ServerConnection.ReportParticipantParkedAsync"/> never
+    /// throws): <see cref="ParkAck.Parked"/> completes the park teardown (session-end suppressed);
+    /// <see cref="ParkAck.Rejected"/> keeps the won claim but restores a normal end reason and ends the
+    /// reviewer through the same stop path (so a refused park is cleaned up, never left dangling — and
+    /// NOT re-claimed, which could now abort on activity and strand it); <see cref="ParkAck.Ambiguous"/>
+    /// tears down NOTHING and RESTORES the pre-attempt state (releasing the reap latch the claim took —
+    /// the one park-specific exception to <see cref="AgentInstance.ReapClaimed"/> being write-once,
+    /// since a claim that neither parks nor reaps must not condemn a live agent) so the next sweep
+    /// re-selects and retries.</para></summary>
+    async Task ParkReviewerAsync(ReapCandidate candidate) {
+        var a = candidate.Agent;
+
+        // One park attempt at a time per agent (a sweep skips an agent already parking); reset on an
+        // ambiguous ack / lost claim / fault below so a later sweep can retry.
+        a.ParkAttemptInFlight = true;
+        try {
+            // Claim/revalidate under the per-agent fence EXACTLY as the reap path does: incarnation +
+            // status + the activity generation captured at selection (FencedOnActivity: true — a
+            // delivery since selection has advanced the seq and the park aborts here). A lost claim
+            // tears down nothing; clear the guard so the next sweep can retry.
+            if (!await TryClaimReapAsync(candidate)) {
+                a.ParkAttemptInFlight = false;
+
+                return;
+            }
+
+            // The canonical session id the server keys the park (and a later resume) on: the app-server
+            // thread id, exposed by the runtime's IAcpTranscriptSource facet.
+            var canonicalSessionId = (a.Runtime as IAcpTranscriptSource)?.AcpSessionId ?? "";
+
+            // Never throws: a transport error / timeout / unknown-method folds to Ambiguous rather than a
+            // false Rejected, so an uncertain reply never triggers a destructive teardown.
+            var ack = await _server.ReportParticipantParkedAsync(
+                a.Id, canonicalSessionId, ReviewerParkedResumableReason, _shutdownCts.Token);
+
+            switch (ack) {
+                case ParkAck.Parked:
+                    // Durable park acked. PendingEndReason is ReviewerParkedResumableReason (set by the
+                    // claim, restated here for locality) — it both attributes the teardown AND drives
+                    // FinalizeAgentRunAsync to SUPPRESS the hosted session-end so the thread survives.
+                    // Complete every other local-teardown step through the shared stop path.
+                    a.PendingEndReason = ReviewerParkedResumableReason;
+                    LogReviewerParked(a.Id, canonicalSessionId);
+                    await StopClaimedReapAsync(candidate);
+                    break;
+
+                case ParkAck.Rejected:
+                    // The server refused the park (e.g. a terminal close already won). End the reviewer
+                    // normally instead of leaving it dangling: keep the won claim, but restore a normal
+                    // end reason so FinalizeAgentRunAsync's session-end FIRES (it is suppressed only for
+                    // the park reason), then run the same stop path.
+                    a.PendingEndReason = ReviewerParkRejectedReason;
+                    LogReviewerParkRejected(a.Id);
+                    await StopClaimedReapAsync(candidate);
+                    break;
+
+                case ParkAck.Ambiguous:
+                    // No definite reply. Tear down NOTHING; restore the pre-attempt state so the next
+                    // sweep re-selects and re-claims. Order matters: clear the reap-reason stamp and
+                    // RELEASE the reap latch (so the retry's claim can win) BEFORE clearing the in-flight
+                    // guard LAST, so no concurrent sweep re-selects a half-restored agent.
+                    a.PendingEndReason = "agent_exited";
+                    Interlocked.Exchange(ref a.ReapClaimed, 0);
+                    LogReviewerParkAmbiguous(a.Id);
+                    a.ParkAttemptInFlight = false;
+                    break;
+            }
+        } catch (Exception ex) {
+            // Fire-and-forget from the heartbeat (matching ReapReviewerAsync): contain the fault, and
+            // NEVER strand the in-flight guard on an unexpected throw.
+            a.ParkAttemptInFlight = false;
+            LogParkFailed(ex, candidate.Id, candidate.Reason);
         }
     }
 
@@ -4318,7 +4460,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // rules — the activity generation this candidate was selected against. The end-reason stamp
             // moved in there with it: an aborted reap must not leave "reviewer_idle_expired" on a live
             // agent for whatever ends it later.
-            foreach (var candidate in FindReviewersToReap()) _ = ReapReviewerAsync(candidate);
+            // §2.7 B6 arm-A: a Park candidate (a resumable reviewer past the short resumable idle bound)
+            // routes to the PARK path — slot freed, Codex thread kept for resume; every reap rule keeps
+            // flowing to the reap path unchanged. Both are fire-and-forget and contain their own faults.
+            foreach (var candidate in FindReviewersToReap())
+                _ = candidate.Park ? ParkReviewerAsync(candidate) : ReapReviewerAsync(candidate);
 
             // PrivateLocal agents get no heartbeats and no stuck-Starting auto-stop (deny-all;
             // the local user is present and drives them directly).
@@ -4670,6 +4816,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     [LoggerMessage(Level = LogLevel.Warning, Message = "Reaping review-flow reviewer {AgentId} ({Reason}) failed")]
     partial void LogReapFailed(Exception ex, string agentId, string reason);
 
+    [LoggerMessage(Level = LogLevel.Information, Message = "Parked resumable review-flow reviewer {AgentId} (canonical session {CanonicalSessionId}): slot freed, Codex thread kept alive for resume; hosted session-end suppressed")]
+    partial void LogReviewerParked(string agentId, string canonicalSessionId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Park of review-flow reviewer {AgentId} was REJECTED by the server — ending it on the normal path instead of parking")]
+    partial void LogReviewerParkRejected(string agentId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Park of review-flow reviewer {AgentId} got no definite reply (ambiguous) — leaving it intact for the next sweep to retry")]
+    partial void LogReviewerParkAmbiguous(string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Parking review-flow reviewer {AgentId} ({Reason}) failed")]
+    partial void LogParkFailed(Exception ex, string agentId, string reason);
+
     // Codex (PTY) turn-start diagnostic — after SendInput is delivered, did Codex act?
     [LoggerMessage(Level = LogLevel.Information, Message = "Codex turn started for agent {AgentId} after input ({ElapsedMs}ms after delivery)")]
     partial void LogCodexTurnStarted(string agentId, long elapsedMs);
@@ -4909,6 +5067,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <summary>Test-only: run ONE selected reap exactly as the heartbeat does (claim, then stop only
     /// if the claim was won) — the seam for driving a candidate selected before some racing event.</summary>
     internal Task ReapReviewerForTest(ReapCandidate candidate) => ReapReviewerAsync(candidate);
+
+    /// <summary>Test-only: run ONE selected PARK exactly as the heartbeat does (claim, report, then the
+    /// ack-gated teardown) — the seam for driving the arm-A park state machine against a fake
+    /// <see cref="ServerConnection"/> whose <see cref="ServerConnection.ReportParticipantParkedAsync"/>
+    /// returns a chosen <see cref="ParkAck"/>.</summary>
+    internal Task ParkReviewerForTest(ReapCandidate candidate) => ParkReviewerAsync(candidate);
 
     /// <summary>Test-only: the claim ALONE, without the teardown it gates. Lets a contention test pin
     /// which side won the section without also driving a stop whose (slow, side-effecting) teardown is

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2919,9 +2919,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             switch (ack) {
                 case ParkAck.Parked:
-                    // Durable park acked. PendingEndReason is ReviewerParkedResumableReason (set by the
-                    // claim, restated here for locality) — it both attributes the teardown AND drives
-                    // FinalizeAgentRunAsync to SUPPRESS the hosted session-end so the thread survives.
+                    // Durable park acked. Stamp ReviewerParkedResumableReason NOW — this is the
+                    // authoritative set (the claim deliberately left a neutral default so a child-exit
+                    // during the ack await above could not suppress an unconfirmed park; see
+                    // TryLatchClaim). It both attributes the teardown AND drives FinalizeAgentRunAsync to
+                    // SUPPRESS the hosted session-end so the thread survives — and it is set strictly
+                    // before StopClaimedReapAsync below, whose stop is what triggers finalization.
                     // Complete every other local-teardown step through the shared stop path.
                     a.PendingEndReason = ReviewerParkedResumableReason;
                     LogReviewerParked(a.Id, canonicalSessionId);
@@ -3132,7 +3135,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return false;
         }
 
-        candidate.Agent.PendingEndReason = candidate.Reason;
+        // §2.7 B6 arm-A: a PARK candidate must NOT stamp its suppress reason
+        // (ReviewerParkedResumableReason) here at claim time. The claim happens BEFORE ParkReviewerAsync
+        // awaits the park ack, and FinalizeAgentRunAsync suppresses the hosted session-end whenever it
+        // sees that exact reason — so if the reviewer's app-server child exits DURING the ack await, the
+        // finalizer would suppress the session-end for a park that was never confirmed, orphaning the
+        // ledger row (neither durably parked nor cleanly closed). Stamp the neutral default instead;
+        // ParkReviewerAsync applies ReviewerParkedResumableReason itself, but only on a definite
+        // ParkAck.Parked and immediately before the stop that drives finalization (an unconfirmed park is
+        // not a park — a mid-await exit must end the session normally). Reap candidates are unchanged.
+        candidate.Agent.PendingEndReason = candidate.Park ? "agent_exited" : candidate.Reason;
 
         return true;
     }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -242,11 +242,18 @@ internal record AgentInstance(
     /// paths cannot share a lock and must share a CAS instead.
     ///
     /// <para>Read via <see cref="IsReapClaimed"/> by <see cref="AgentOrchestrator.HandleSendInput"/>,
-    /// which refuses to deliver to a condemned agent. Never reset: a claimed agent is on its way down,
-    /// and <see cref="AgentOrchestrator.StopAgentCoreAsync"/> flipping the status to "Completed"
-    /// already takes it out of the reap candidate set permanently, so the latch adds no new
+    /// which refuses to deliver to a condemned agent. Effectively write-once: a claimed agent is on its
+    /// way down, and <see cref="AgentOrchestrator.StopAgentCoreAsync"/> flipping the status to
+    /// "Completed" already takes it out of the reap candidate set permanently, so the latch adds no new
     /// terminality — it only makes the losing side of the race observable to the delivery path BEFORE
-    /// teardown has physically closed the transport.</para></summary>
+    /// teardown has physically closed the transport.</para>
+    ///
+    /// <para>The SOLE reset is §2.7 B6 arm-A's <see cref="AgentOrchestrator.ParkReviewerAsync"/> on a
+    /// <see cref="ParkAck.Ambiguous"/> ack: a park that got no definite reply tears down NOTHING, so it
+    /// must un-condemn the still-Running agent (release the latch) for a later sweep to re-claim — a
+    /// claim that neither parks nor reaps may not permanently strand a live reviewer. That reset runs
+    /// while the agent is still Running (no teardown began) and before the in-flight guard is cleared,
+    /// so it never races a path that already assumed terminality.</para></summary>
     public int ReapClaimed;
 
     /// <summary><see cref="ReapClaimed"/> as a bool, through a

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1276,13 +1276,21 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// Unlike those two, this method NEVER throws. The arm-A park state machine
     /// (<c>AgentOrchestrator.ParkReviewerAsync</c>) needs a definite three-way answer rather than a
     /// two-way outcome-or-exception split, because an exception here must NOT be treated as a
-    /// rejection: <see cref="ParkAck.Ambiguous"/> — covering a <c>HubException</c>, an
-    /// <see cref="OperationCanceledException"/> (including daemon shutdown), or any other unmapped
-    /// exception — leaves the reviewer's local state untouched so the next reap sweep retries the
-    /// park, instead of falling back to a destructive end. Only the server's two definite wire
-    /// outcomes (<see cref="ParkParticipantOutcome.Parked"/>/<see cref="ParkParticipantOutcome.Rejected"/>)
-    /// map to their like-named <see cref="ParkAck"/> members; any other/unmapped value degrades to
-    /// <see cref="ParkAck.Ambiguous"/> rather than being assumed successful.
+    /// rejection by default: <see cref="ParkAck.Ambiguous"/> — covering a transient
+    /// <c>HubException</c>, an <see cref="OperationCanceledException"/> (including daemon shutdown),
+    /// or any other unmapped exception — leaves the reviewer's local state untouched so the next reap
+    /// sweep retries the park, instead of falling back to a destructive end. Only the server's two
+    /// definite wire outcomes (<see cref="ParkParticipantOutcome.Parked"/>/
+    /// <see cref="ParkParticipantOutcome.Rejected"/>) map to their like-named <see cref="ParkAck"/>
+    /// members; any other/unmapped value degrades to <see cref="ParkAck.Ambiguous"/> rather than being
+    /// assumed successful.
+    ///
+    /// One exception IS treated as a definite outcome: <see cref="IsUnknownHubMethod"/> singles out
+    /// the <c>HubException</c> a pre-B1 server raises because it has no <c>ReportParticipantParked</c>
+    /// handler at all. That is a PERMANENT degrade, not a transient hiccup — folding it into Ambiguous
+    /// would have <c>ParkReviewerAsync</c> retry the park forever against a server that will never grow
+    /// the method. Mapping it to <see cref="ParkAck.Rejected"/> instead makes the caller fall back to
+    /// the normal reap, same as a definite server-side refusal.
     /// </summary>
     public virtual async Task<ParkAck> ReportParticipantParkedAsync(
             string agentId, string canonicalSessionId, string reason, CancellationToken ct = default
@@ -1301,6 +1309,13 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                 ParkParticipantOutcome.Rejected => ParkAck.Rejected,
                 _                                => ParkAck.Ambiguous, // unmapped/future wire value — never assume success
             };
+        } catch (Exception ex) when (IsUnknownHubMethod(ex)) {
+            // Pre-B1 server: ReportParticipantParked doesn't exist there and never will until the
+            // server is upgraded. Definite degrade, not "no reply" — fall back to the normal reap
+            // instead of retrying this park forever (see the doc comment above).
+            LogReportParticipantParkedUnknownMethod(agentId);
+
+            return ParkAck.Rejected;
         } catch (Exception ex) {
             LogReportParticipantParkedAmbiguous(ex, agentId);
 
@@ -1309,12 +1324,29 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     }
 
     /// <summary>
+    /// True when <paramref name="ex"/> is the <see cref="Microsoft.AspNetCore.SignalR.HubException"/>
+    /// SignalR raises when the connected server has no handler at all for the invoked hub method
+    /// name — the case a pre-B1 server hits for <c>ReportParticipantParked</c>. SignalR's server-side
+    /// message binder can't resolve an unknown target while parsing the invocation and throws a
+    /// <c>HubException</c> reporting the method doesn't exist; this codebase already relies on that
+    /// exact literal text to model the equivalent old-server case for <c>AcpSessionSourceClaim</c> (see
+    /// <c>AgentOrchestratorSourceClaimTests.Method_not_found_claim_is_a_coded_launch_failure_with_teardown</c>).
+    /// Matched case-insensitively on the stable "does not exist" substring rather than the exact
+    /// string (future SignalR/server wording may vary slightly), and narrowly scoped to
+    /// <see cref="Microsoft.AspNetCore.SignalR.HubException"/> only — a genuine transient
+    /// <c>HubException</c> (e.g. "Caller is not a registered daemon") does not contain that phrase and
+    /// is never misclassified as a permanent degrade.
+    /// </summary>
+    static bool IsUnknownHubMethod(Exception ex) =>
+        ex is Microsoft.AspNetCore.SignalR.HubException he
+        && he.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// The actual <c>ReportParticipantParked</c> hub invocation, isolated into its own <c>virtual</c>
     /// method so <see cref="ReportParticipantParkedAsync"/>'s gating/mapping can be tested without a
     /// live hub. A pre-B1 server has no such method, so <c>InvokeAsync</c> throws (method-not-found),
-    /// which <see cref="ReportParticipantParkedAsync"/> currently folds into <see cref="ParkAck.Ambiguous"/>
-    /// like any other exception (a later task tightens this specific case to <see cref="ParkAck.Rejected"/>
-    /// so a permanently-old server degrades to the normal reap path instead of retrying forever).
+    /// which <see cref="ReportParticipantParkedAsync"/> singles out via <see cref="IsUnknownHubMethod"/>
+    /// and maps to <see cref="ParkAck.Rejected"/> rather than treating it like any other exception.
     /// </summary>
     internal virtual Task<ParkParticipantOutcome> InvokeReportParticipantParkedRawAsync(
             string agentId, string canonicalSessionId, string reason, CancellationToken ct
@@ -1557,6 +1589,9 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ReportParticipantParked for agent {AgentId} got no definite reply — treating as ambiguous so the next reap sweep retries the park")]
     partial void LogReportParticipantParkedAmbiguous(Exception ex, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ReportParticipantParked for agent {AgentId} failed because the connected server has no such hub method (pre-B1) — treating as Rejected so the caller falls back to the normal reap instead of retrying forever")]
+    partial void LogReportParticipantParkedUnknownMethod(string agentId);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Reconnect re-bind of ACP session {AcpSessionId} for agent {AgentId} failed (attempt {Attempt}/{MaxAttempts})")]
     partial void LogAcpRebindFailed(Exception ex, string agentId, string acpSessionId, int attempt, int maxAttempts);

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -46,6 +46,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     static readonly TimeSpan PermissionRetryPollInterval = TimeSpan.FromMilliseconds(500);
     static readonly TimeSpan EndSessionRetryPollInterval  = TimeSpan.FromMilliseconds(500);
     static readonly TimeSpan AcpRetryPollInterval         = TimeSpan.FromMilliseconds(500);
+    static readonly TimeSpan ParkRetryPollInterval        = TimeSpan.FromMilliseconds(500);
 
     // Events for incoming commands from server
     public event Func<LaunchAgentCommand, Task>?    OnLaunchAgent;
@@ -1265,6 +1266,61 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         ) => _hub.InvokeAsync<AcpLaunchConfirmOutcome>("ConfirmSessionLaunch", acpSessionId, ownershipToken, cancellationToken: ct);
 
     /// <summary>
+    /// AI-1762 §2.7 B6: reports a settled, resumable hosted reviewer that the daemon is about to
+    /// PARK (freeing its slot while keeping its app-server thread alive for a later resume) to the
+    /// server's <c>ReportParticipantParked</c> hub method, and folds the reply into a
+    /// <see cref="ParkAck"/>. Gated on <see cref="IsReady"/> and wrapped in <see cref="ConnectionRetry"/>
+    /// exactly like <see cref="AcpSessionSourceClaimAsync"/>/<see cref="ConfirmSessionLaunchAsync"/> —
+    /// a transient disconnect is retried transparently rather than surfacing.
+    ///
+    /// Unlike those two, this method NEVER throws. The arm-A park state machine
+    /// (<c>AgentOrchestrator.ParkReviewerAsync</c>) needs a definite three-way answer rather than a
+    /// two-way outcome-or-exception split, because an exception here must NOT be treated as a
+    /// rejection: <see cref="ParkAck.Ambiguous"/> — covering a <c>HubException</c>, an
+    /// <see cref="OperationCanceledException"/> (including daemon shutdown), or any other unmapped
+    /// exception — leaves the reviewer's local state untouched so the next reap sweep retries the
+    /// park, instead of falling back to a destructive end. Only the server's two definite wire
+    /// outcomes (<see cref="ParkParticipantOutcome.Parked"/>/<see cref="ParkParticipantOutcome.Rejected"/>)
+    /// map to their like-named <see cref="ParkAck"/> members; any other/unmapped value degrades to
+    /// <see cref="ParkAck.Ambiguous"/> rather than being assumed successful.
+    /// </summary>
+    public virtual async Task<ParkAck> ReportParticipantParkedAsync(
+            string agentId, string canonicalSessionId, string reason, CancellationToken ct = default
+        ) {
+        try {
+            var outcome = await ConnectionRetry.InvokeWithConnectionRetryAsync(
+                () => InvokeReportParticipantParkedRawAsync(agentId, canonicalSessionId, reason, ct),
+                () => IsReady,
+                ParkRetryPollInterval,
+                attempt => LogReportParticipantParkedRetry(agentId, attempt),
+                ct
+            );
+
+            return outcome switch {
+                ParkParticipantOutcome.Parked   => ParkAck.Parked,
+                ParkParticipantOutcome.Rejected => ParkAck.Rejected,
+                _                                => ParkAck.Ambiguous, // unmapped/future wire value — never assume success
+            };
+        } catch (Exception ex) {
+            LogReportParticipantParkedAmbiguous(ex, agentId);
+
+            return ParkAck.Ambiguous;
+        }
+    }
+
+    /// <summary>
+    /// The actual <c>ReportParticipantParked</c> hub invocation, isolated into its own <c>virtual</c>
+    /// method so <see cref="ReportParticipantParkedAsync"/>'s gating/mapping can be tested without a
+    /// live hub. A pre-B1 server has no such method, so <c>InvokeAsync</c> throws (method-not-found),
+    /// which <see cref="ReportParticipantParkedAsync"/> currently folds into <see cref="ParkAck.Ambiguous"/>
+    /// like any other exception (a later task tightens this specific case to <see cref="ParkAck.Rejected"/>
+    /// so a permanently-old server degrades to the normal reap path instead of retrying forever).
+    /// </summary>
+    internal virtual Task<ParkParticipantOutcome> InvokeReportParticipantParkedRawAsync(
+            string agentId, string canonicalSessionId, string reason, CancellationToken ct
+        ) => _hub.InvokeAsync<ParkParticipantOutcome>("ReportParticipantParked", agentId, canonicalSessionId, reason, cancellationToken: ct);
+
+    /// <summary>
     /// Queues a base64 PTY chunk for the hosted-agent terminal mirror:
     /// chunks are drained by <see cref="TerminalOutputSender"/>'s single ordered loop
     /// instead of being fired at <c>SendAsync</c> fire-and-forget, so they reach the
@@ -1496,6 +1552,12 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     [LoggerMessage(Level = LogLevel.Information, Message = "ConfirmSessionLaunch for session {AcpSessionId} interrupted by a connection drop (retry {Attempt}); waiting for the daemon connection to recover before retrying")]
     partial void LogConfirmSessionLaunchRetry(string acpSessionId, int attempt);
 
+    [LoggerMessage(Level = LogLevel.Information, Message = "ReportParticipantParked for agent {AgentId} interrupted by a connection drop (retry {Attempt}); waiting for the daemon connection to recover before retrying")]
+    partial void LogReportParticipantParkedRetry(string agentId, int attempt);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ReportParticipantParked for agent {AgentId} got no definite reply — treating as ambiguous so the next reap sweep retries the park")]
+    partial void LogReportParticipantParkedAmbiguous(Exception ex, string agentId);
+
     [LoggerMessage(Level = LogLevel.Warning, Message = "Reconnect re-bind of ACP session {AcpSessionId} for agent {AgentId} failed (attempt {Attempt}/{MaxAttempts})")]
     partial void LogAcpRebindFailed(Exception ex, string agentId, string acpSessionId, int attempt, int maxAttempts);
 
@@ -1590,3 +1652,17 @@ internal sealed class AcpBindRejectedException(string agentId, string acpSession
     public string AgentId      { get; } = agentId;
     public string AcpSessionId { get; } = acpSessionId;
 }
+
+/// <summary>
+/// AI-1762 §2.7 B6: the daemon-local result of <see cref="ServerConnection.ReportParticipantParkedAsync"/> —
+/// purely in-memory, never (de)serialized. Widens the server's two-value wire outcome
+/// (<see cref="ParkParticipantOutcome"/>) with a third, daemon-only case the wire never encodes:
+/// <see cref="Ambiguous"/> covers any transport error, timeout, <c>HubException</c>, or otherwise
+/// unmapped result — i.e. no definite reply was received. <see cref="Parked"/> and
+/// <see cref="Rejected"/> mirror the like-named <see cref="ParkParticipantOutcome"/> members
+/// one-for-one. The arm-A park state machine (<c>AgentOrchestrator.ParkReviewerAsync</c>) branches
+/// on this: <c>Parked</c> completes the park teardown (session-end suppressed), <c>Rejected</c>
+/// falls back to the normal end path, and <c>Ambiguous</c> leaves everything intact for the next
+/// reap sweep to retry — never a destructive teardown on an uncertain reply.
+/// </summary>
+internal enum ParkAck { Parked, Rejected, Ambiguous }

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -48,6 +48,15 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     static readonly TimeSpan AcpRetryPollInterval         = TimeSpan.FromMilliseconds(500);
     static readonly TimeSpan ParkRetryPollInterval        = TimeSpan.FromMilliseconds(500);
 
+    /// <summary>§2.7 B6 arm-A: an upper bound on the WHOLE park report (readiness gate + retries).
+    /// <c>ParkReviewerAsync</c> holds the reap claim across this call, so — unlike the other
+    /// <see cref="ConnectionRetry"/> callers, whose waits are bounded only by daemon shutdown — an
+    /// unbounded wait for <see cref="IsReady"/> here would pin an idle reviewer (claimed, slot not freed)
+    /// for the entire outage. On elapse the attempt folds to <see cref="ParkAck.Ambiguous"/>, releasing
+    /// the claim so a later sweep retries the park (park is best-effort; never worth pinning for).
+    /// Settable only so a test need not spend the real 30s proving the bound; production never sets it.</summary>
+    internal TimeSpan ParkAckBudget { get; init; } = TimeSpan.FromSeconds(30);
+
     // Events for incoming commands from server
     public event Func<LaunchAgentCommand, Task>?    OnLaunchAgent;
     public event Func<string, Task>?                OnStopAgent; // agentId
@@ -1295,13 +1304,21 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public virtual async Task<ParkAck> ReportParticipantParkedAsync(
             string agentId, string canonicalSessionId, string reason, CancellationToken ct = default
         ) {
+        // Bound the whole attempt (readiness gate + retries) with ParkAckBudget so a disconnected daemon
+        // can never pin the caller: ParkReviewerAsync holds the reap claim across this await, and the
+        // readiness loop is otherwise bounded only by the shutdown token. On elapse the linked token
+        // cancels, ConnectionRetry surfaces OperationCanceledException, and the generic catch below folds
+        // it to Ambiguous — "no definite reply" — releasing the claim for a later sweep to retry. If
+        // IsReady never came, no report was sent, so there is nothing to reconcile.
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(ParkAckBudget);
         try {
             var outcome = await ConnectionRetry.InvokeWithConnectionRetryAsync(
-                () => InvokeReportParticipantParkedRawAsync(agentId, canonicalSessionId, reason, ct),
+                () => InvokeReportParticipantParkedRawAsync(agentId, canonicalSessionId, reason, timeoutCts.Token),
                 () => IsReady,
                 ParkRetryPollInterval,
                 attempt => LogReportParticipantParkedRetry(agentId, attempt),
-                ct
+                timeoutCts.Token
             );
 
             return outcome switch {

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1326,20 +1326,21 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// <summary>
     /// True when <paramref name="ex"/> is the <see cref="Microsoft.AspNetCore.SignalR.HubException"/>
     /// SignalR raises when the connected server has no handler at all for the invoked hub method
-    /// name — the case a pre-B1 server hits for <c>ReportParticipantParked</c>. SignalR's server-side
-    /// message binder can't resolve an unknown target while parsing the invocation and throws a
-    /// <c>HubException</c> reporting the method doesn't exist; this codebase already relies on that
-    /// exact literal text to model the equivalent old-server case for <c>AcpSessionSourceClaim</c> (see
-    /// <c>AgentOrchestratorSourceClaimTests.Method_not_found_claim_is_a_coded_launch_failure_with_teardown</c>).
-    /// Matched case-insensitively on the stable "does not exist" substring rather than the exact
-    /// string (future SignalR/server wording may vary slightly), and narrowly scoped to
-    /// <see cref="Microsoft.AspNetCore.SignalR.HubException"/> only — a genuine transient
-    /// <c>HubException</c> (e.g. "Caller is not a registered daemon") does not contain that phrase and
-    /// is never misclassified as a permanent degrade.
+    /// name — the case a pre-B1 server hits for <c>ReportParticipantParked</c>. When a client invokes
+    /// a target the server's <c>DefaultHubDispatcher</c> can't resolve, it completes the invocation
+    /// with the error <c>Unknown hub method '&lt;target&gt;'</c> (sent regardless of
+    /// <c>EnableDetailedErrors</c>), surfaced on the client as a <c>HubException</c> carrying that
+    /// message — verified against aspnetcore v10.0.11
+    /// (<c>src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs</c>). Matched case-insensitively
+    /// on the stable <c>"Unknown hub method"</c> substring (robust to the interpolated target name), and
+    /// narrowly scoped to <see cref="Microsoft.AspNetCore.SignalR.HubException"/> only: that phrase is
+    /// SignalR-internal protocol text no hub handler emits deliberately, so a genuine transient
+    /// <c>HubException</c> (e.g. "Caller is not a registered daemon") never contains it and is never
+    /// misclassified as a permanent degrade.
     /// </summary>
     static bool IsUnknownHubMethod(Exception ex) =>
         ex is Microsoft.AspNetCore.SignalR.HubException he
-        && he.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase);
+        && he.Message.Contains("Unknown hub method", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// The actual <c>ReportParticipantParked</c> hub invocation, isolated into its own <c>virtual</c>

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1266,7 +1266,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         ) => _hub.InvokeAsync<AcpLaunchConfirmOutcome>("ConfirmSessionLaunch", acpSessionId, ownershipToken, cancellationToken: ct);
 
     /// <summary>
-    /// AI-1762 §2.7 B6: reports a settled, resumable hosted reviewer that the daemon is about to
+    /// §2.7 B6: reports a settled, resumable hosted reviewer that the daemon is about to
     /// PARK (freeing its slot while keeping its app-server thread alive for a later resume) to the
     /// server's <c>ReportParticipantParked</c> hub method, and folds the reply into a
     /// <see cref="ParkAck"/>. Gated on <see cref="IsReady"/> and wrapped in <see cref="ConnectionRetry"/>
@@ -1689,7 +1689,7 @@ internal sealed class AcpBindRejectedException(string agentId, string acpSession
 }
 
 /// <summary>
-/// AI-1762 §2.7 B6: the daemon-local result of <see cref="ServerConnection.ReportParticipantParkedAsync"/> —
+/// §2.7 B6: the daemon-local result of <see cref="ServerConnection.ReportParticipantParkedAsync"/> —
 /// purely in-memory, never (de)serialized. Widens the server's two-value wire outcome
 /// (<see cref="ParkParticipantOutcome"/>) with a third, daemon-only case the wire never encodes:
 /// <see cref="Ambiguous"/> covers any transport error, timeout, <c>HubException</c>, or otherwise

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerCursorAvailabilityTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerCursorAvailabilityTests.cs
@@ -282,6 +282,37 @@ public class DaemonRunnerCursorAvailabilityTests {
         await Assert.That(capabilities.Single(c => c.Vendor == "claude").SupportsLaunchPosture).IsFalse();
     }
 
+    /// <summary>The advertised codex launcher-policy version is selected from
+    /// <see cref="DaemonConfig.CodexAppServerActive"/> — the SAME resolved field the launch router
+    /// reads — so the certified policy and the transport actually launched can never diverge. Active
+    /// app-server advertises the v2 token (server A1 classifies v2 Active, v1 Retired); the
+    /// non-app-server row is unaffected and keeps advertising the vendor-only v1 token.</summary>
+    [Test]
+    public async Task ComputeUnattendedVendorCapabilities_CodexAppServerActive_AdvertisesV2LauncherPolicy() {
+        IHostedAgentRuntimeFactory[] factories = [
+            new FakeRuntimeFactory("codex", isAvailable: true, supportsUnattended: true),
+        ];
+
+        var capabilities = DaemonRunner.ComputeUnattendedVendorCapabilities(
+            factories, new DaemonConfig { CodexAppServerActive = true });
+
+        await Assert.That(capabilities.Single(c => c.Vendor == "codex").LauncherPolicyVersion)
+            .IsEqualTo("codex-appserver-unattended-v2");
+    }
+
+    [Test]
+    public async Task ComputeUnattendedVendorCapabilities_CodexAppServerInactive_AdvertisesV1LauncherPolicy() {
+        IHostedAgentRuntimeFactory[] factories = [
+            new FakeRuntimeFactory("codex", isAvailable: true, supportsUnattended: true),
+        ];
+
+        var capabilities = DaemonRunner.ComputeUnattendedVendorCapabilities(
+            factories, new DaemonConfig { CodexAppServerActive = false });
+
+        await Assert.That(capabilities.Single(c => c.Vendor == "codex").LauncherPolicyVersion)
+            .IsEqualTo(DaemonRunner.CodexLauncherPolicyVersion);
+    }
+
     // === Trust-by-default borrowed-review advertisement ===
     // (docs/superpowers/specs/2026-07-27-ai1528-trust-by-default-borrowed-review-design.md)
     //

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorReviewerParkTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorReviewerParkTests.cs
@@ -1,0 +1,374 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// AI-1762 §2.7 B6 arm-A: the RESUMABLE-PARK path in <see cref="AgentOrchestrator"/>. A settled,
+/// app-server hosted Codex reviewer idle past the SHORT resumable bound
+/// (<see cref="DaemonConfig.ReviewerResumableIdleTimeout"/>, 10m) is PARKED — its daemon slot freed
+/// like a reap, but its Codex thread kept alive (the hosted session-end suppressed) for a later
+/// <c>thread/resume</c> — rather than reaped at the 2h arm-B idle bound.
+///
+/// <para>Split, like the task brief, into (a) SELECTION — what
+/// <see cref="AgentOrchestrator.FindReviewersToReap"/> flags as a <see cref="AgentOrchestrator.ReapCandidate.Park"/>
+/// candidate — and (b) the PARK STATE MACHINE (<c>ParkReviewerAsync</c>) against a fake
+/// <see cref="ServerConnection"/> whose <c>ReportParticipantParkedAsync</c> returns a chosen
+/// <see cref="ParkAck"/>. Follows the <see cref="ReviewerReapingTests"/> harness patterns
+/// (<c>BuildOrchestrator</c> / <see cref="CaptureServerConnection"/> / a controllable
+/// <see cref="AgentActivityClock"/>).</para>
+///
+/// <para>The resume-capability signal is the runtime TRANSPORT
+/// (<see cref="CodexTransportDecision.AppServer"/>) — the only value the app-server Codex runtime
+/// reports; the canonical session id is that runtime's <see cref="IAcpTranscriptSource.AcpSessionId"/>
+/// (its Codex thread id). <see cref="FakeAppServerRuntime"/> stands in for the real
+/// <c>CodexAppServerHostedAgentRuntime</c> (internal/sealed, heavy ctor) by reporting the same
+/// transport + thread id through those same two facets.</para>
+/// </summary>
+public class AgentOrchestratorReviewerParkTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    // ── (a) SELECTION ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>The positive case: a resumable (app-server) reviewer that has settled its last round
+    /// and gone idle past the 10m resumable bound — no turn in flight — is selected as a PARK candidate
+    /// with the exact park reason and the activity fence armed (a delivery after selection must abort
+    /// it), NOT as a reap.</summary>
+    [Test]
+    public async Task Arm_A_parks_a_resumable_idle_reviewer() {
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        // defaults: 10m resumable / 2h idle / 6h TTL
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromMinutes(11)); // past the 10m resumable bound, far under 2h idle / 6h TTL
+
+        var agent = SeedResumableReviewer(orch, "park-me", clock);
+
+        var park = orch.FindReviewersToReap().Single(c => c.Park);
+
+        await Assert.That(park.Id).IsEqualTo("park-me");
+        await Assert.That(park.Reason).IsEqualTo(AgentOrchestrator.ReviewerParkedResumableReason);
+        await Assert.That(park.FencedOnActivity).IsTrue();
+        await Assert.That(ReferenceEquals(park.Agent, agent)).IsTrue();
+    }
+
+    /// <summary>The transport IS the discriminator: under an IDENTICAL clock idle past the 2h arm-B
+    /// bound, a resumable reviewer PARKS (arm-A pre-empts arm-B) while a non-resumable (PTY) reviewer
+    /// falls through to the unchanged arm-B idle reap. Neither verdict can come from the elapsed time
+    /// alone — only the runtime transport differs.</summary>
+    [Test]
+    public async Task Arm_A_ignores_a_non_resumable_reviewer_leaving_it_to_arm_B() {
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var elapsed = TimeSpan.FromHours(2) + TimeSpan.FromMinutes(1); // past BOTH the 10m and 2h bounds, under 6h TTL
+
+        var resumableTime  = new FakeTimeProvider();
+        var resumableClock = new AgentActivityClock(resumableTime);
+        resumableTime.Advance(elapsed);
+        SeedResumableReviewer(orch, "resumable", resumableClock);
+
+        var ptyTime  = new FakeTimeProvider();
+        var ptyClock = new AgentActivityClock(ptyTime);
+        ptyTime.Advance(elapsed);
+        // A PTY reviewer reports the "pty" transport — never resume-capable.
+        orch.SeedAgentForTest("pty-reviewer", LaunchKind.ReviewFlow, status: "Running", activityClock: ptyClock);
+
+        var reap = orch.FindReviewersToReap();
+
+        // The resumable one is PARKED (arm-A fires before the 2h idle rule)...
+        var park = reap.Single(c => c.Park);
+        await Assert.That(park.Id).IsEqualTo("resumable");
+        await Assert.That(park.Reason).IsEqualTo(AgentOrchestrator.ReviewerParkedResumableReason);
+
+        // ...the PTY one is NOT parked and falls through to the unchanged arm-B idle reap.
+        var pty = reap.Single(c => c.Id == "pty-reviewer");
+        await Assert.That(pty.Park).IsFalse();
+        await Assert.That(pty.Reason).IsEqualTo("reviewer_idle_expired");
+    }
+
+    /// <summary>A held turn suppresses arm-A exactly as it suppresses the plain idle rule: a resumable
+    /// reviewer with <c>TurnInFlight</c> true, idle well past the resumable bound but nowhere near the
+    /// wedge ceiling, is not parked mid-round.</summary>
+    [Test]
+    public async Task Arm_A_does_not_park_a_reviewer_with_a_turn_in_flight() {
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        clock.SetTurnInFlight(true);
+        time.Advance(TimeSpan.FromMinutes(20)); // past the 10m resumable bound, under the 60m wedge ceiling
+
+        SeedResumableReviewer(orch, "mid-turn", clock);
+
+        await Assert.That(orch.FindReviewersToReap().Any(c => c.Park)).IsFalse();
+    }
+
+    /// <summary>A reviewer already mid-park (<see cref="AgentInstance.ParkAttemptInFlight"/> true) is
+    /// skipped by the sweep — one park attempt at a time. A control twin under the identical clock
+    /// WITHOUT the guard IS parked, so the skip is attributable to the guard and nothing else.</summary>
+    [Test]
+    public async Task Arm_A_skips_a_reviewer_already_parking() {
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var elapsed = TimeSpan.FromMinutes(15); // past the 10m resumable bound, under every reap bound
+
+        var parkingTime  = new FakeTimeProvider();
+        var parkingClock = new AgentActivityClock(parkingTime);
+        parkingTime.Advance(elapsed);
+        SeedResumableReviewer(orch, "already-parking", parkingClock, parkInFlight: true);
+
+        var freeTime  = new FakeTimeProvider();
+        var freeClock = new AgentActivityClock(freeTime);
+        freeTime.Advance(elapsed);
+        SeedResumableReviewer(orch, "free", freeClock);
+
+        var reap = orch.FindReviewersToReap();
+
+        await Assert.That(reap.Any(c => c.Id == "already-parking")).IsFalse(); // guard skipped it entirely
+        await Assert.That(reap.Single(c => c.Park).Id).IsEqualTo("free");      // the control still parks
+    }
+
+    /// <summary>Below the resumable bound there is no park: a resumable reviewer idle only 5m (under the
+    /// 10m bound) is not selected at all.</summary>
+    [Test]
+    public async Task Arm_A_does_not_park_before_the_resumable_idle_bound() {
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromMinutes(5)); // under the 10m resumable bound
+
+        SeedResumableReviewer(orch, "too-fresh", clock);
+
+        await Assert.That(orch.FindReviewersToReap().Any(c => c.Id == "too-fresh")).IsFalse();
+    }
+
+    // ── (b) THE PARK STATE MACHINE ──────────────────────────────────────────────────────────────
+
+    /// <summary>A durable <see cref="ParkAck.Parked"/> ack: the reviewer's canonical thread id + the
+    /// park reason are reported to the server, the claim is won (the agent is on its way down), the
+    /// shared stop path runs — and then the read-loop finalizer SUPPRESSES the hosted session-end while
+    /// still freeing the slot (unregister + removal from the live map). The thread survives for a later
+    /// resume precisely because no <c>EndAgentSession</c> was emitted.</summary>
+    [Test]
+    public async Task Park_on_Parked_ack_suppresses_session_end_and_frees_the_slot() {
+        var server = new CaptureServerConnection { ParkOutcome = ParkAck.Parked };
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromMinutes(11));
+
+        var agent = SeedResumableReviewer(orch, "parked", clock, threadId: "thread-xyz");
+
+        var candidate = orch.FindReviewersToReap().Single(c => c.Park);
+        await orch.ParkReviewerForTest(candidate).WaitAsync(HangGuard);
+
+        // Reported to the server with the canonical thread id and the exact park reason.
+        await Assert.That(server.ParkReports).Contains(("parked", "thread-xyz", AgentOrchestrator.ReviewerParkedResumableReason));
+        // Claim won (going down), and the park reason stamped so the finalizer suppresses session-end.
+        await Assert.That(agent.IsReapClaimed).IsTrue();
+        await Assert.That(agent.PendingEndReason).IsEqualTo(AgentOrchestrator.ReviewerParkedResumableReason);
+        // The shared stop path ran (StopAgentCoreAsync emitted Completed); no session-end from the stop.
+        await Assert.That(server.StatusChangedCalls).Contains(("parked", "Completed"));
+        await Assert.That(server.EndSessionReasons).IsEmpty();
+
+        // Now the read loop unwinds (its finally runs the finalizer). Session-end stays SUPPRESSED, but
+        // the rest of the local teardown still frees the slot.
+        await orch.FinalizeAgentRunForTest(agent).WaitAsync(HangGuard);
+
+        await Assert.That(server.EndSessionReasons).IsEmpty();          // hosted session-end suppressed
+        await Assert.That(orch.GetAgentForTest("parked")).IsNull();     // slot freed / removed from the live map
+        await Assert.That(server.AgentUnregisteredCalls).Contains("parked");
+    }
+
+    /// <summary>An <see cref="ParkAck.Ambiguous"/> ack (no definite reply): tear down NOTHING and
+    /// restore the pre-attempt state — the agent stays Running, the in-flight guard AND the reap latch
+    /// are released, no session-end fires — so a later sweep re-selects it for park and can actually
+    /// re-claim and complete the park.</summary>
+    [Test]
+    public async Task Park_on_Ambiguous_ack_tears_down_nothing_and_allows_retry() {
+        var server = new CaptureServerConnection { ParkOutcome = ParkAck.Ambiguous };
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromMinutes(11));
+
+        var agent = SeedResumableReviewer(orch, "ambig", clock);
+
+        var candidate = orch.FindReviewersToReap().Single(c => c.Park);
+        await orch.ParkReviewerForTest(candidate).WaitAsync(HangGuard);
+
+        // Nothing torn down; pre-attempt state restored.
+        await Assert.That(orch.GetAgentForTest("ambig")).IsNotNull();
+        await Assert.That(agent.Status).IsEqualTo("Running");
+        await Assert.That(agent.ParkAttemptInFlight).IsFalse();        // guard released
+        await Assert.That(agent.IsReapClaimed).IsFalse();             // reap latch released so a retry can re-claim
+        await Assert.That(agent.PendingEndReason).IsEqualTo("agent_exited"); // no reap-reason stamp left behind
+        await Assert.That(server.EndSessionReasons).IsEmpty();
+        await Assert.That(server.StatusChangedCalls.Any(c => c.AgentId == "ambig")).IsFalse();
+
+        // The next sweep re-selects it for park...
+        var again = orch.FindReviewersToReap().Single(c => c.Park);
+        await Assert.That(again.Id).IsEqualTo("ambig");
+
+        // ...and with a definite reply this time, the retry actually parks (proves the latch reset was
+        // load-bearing — a still-latched ReapClaimed would have made this re-claim CAS-fail).
+        server.ParkOutcome = ParkAck.Parked;
+        await orch.ParkReviewerForTest(again).WaitAsync(HangGuard);
+
+        await Assert.That(agent.IsReapClaimed).IsTrue();
+        await Assert.That(agent.PendingEndReason).IsEqualTo(AgentOrchestrator.ReviewerParkedResumableReason);
+        await Assert.That(server.ParkReports.Count).IsEqualTo(2);
+    }
+
+    /// <summary>A definite <see cref="ParkAck.Rejected"/> ack: the daemon does NOT park — it falls back
+    /// to the normal end path so the reviewer is cleaned up, not left dangling. The won claim is kept
+    /// (re-claiming could abort on activity and strand it), a NORMAL end reason replaces the park reason
+    /// so the finalizer's session-end FIRES, and the slot is freed.</summary>
+    [Test]
+    public async Task Park_on_Rejected_ack_falls_back_to_the_normal_end_path() {
+        var server = new CaptureServerConnection { ParkOutcome = ParkAck.Rejected };
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromMinutes(11));
+
+        var agent = SeedResumableReviewer(orch, "rejected", clock);
+
+        var candidate = orch.FindReviewersToReap().Single(c => c.Park);
+        await orch.ParkReviewerForTest(candidate).WaitAsync(HangGuard);
+
+        // Ended, not parked: claim kept, a NORMAL end reason (not the park reason), the stop path ran.
+        await Assert.That(agent.IsReapClaimed).IsTrue();
+        await Assert.That(agent.PendingEndReason).IsNotEqualTo(AgentOrchestrator.ReviewerParkedResumableReason);
+        await Assert.That(server.StatusChangedCalls).Contains(("rejected", "Completed"));
+
+        // The read loop unwinds: the session-end FIRES (a rejected park must not be suppressed) and the
+        // slot is freed.
+        await orch.FinalizeAgentRunForTest(agent).WaitAsync(HangGuard);
+
+        await Assert.That(server.EndSessionReasons).Contains(agent.PendingEndReason); // session-end fired
+        await Assert.That(orch.GetAgentForTest("rejected")).IsNull();                 // slot freed
+    }
+
+    /// <summary>The activity fence: a delivery that lands between selection and the claim advances the
+    /// activity generation the candidate was selected against, so the park ABORTS at the claim — before
+    /// the server is ever told. Nothing is reported, nothing is torn down, the guard is released.
+    /// (The park twin of <see cref="ReviewerReapingTests.Stale_reap_selection_aborts_after_delivery"/>.)</summary>
+    [Test]
+    public async Task Park_aborts_if_activity_advances_after_selection() {
+        var server = new CaptureServerConnection { ParkOutcome = ParkAck.Parked }; // would park if the fence let it
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromMinutes(11));
+
+        var agent = SeedResumableReviewer(orch, "raced", clock);
+
+        var candidate = orch.FindReviewersToReap().Single(c => c.Park);
+
+        // A round lands (or a transcript envelope arrives) between selection and the claim.
+        clock.Advance();
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(candidate.ActivityGeneration + 1);
+
+        await orch.ParkReviewerForTest(candidate).WaitAsync(HangGuard);
+
+        await Assert.That(agent.IsReapClaimed).IsFalse();      // claim aborted on the activity advance
+        await Assert.That(agent.Status).IsEqualTo("Running");
+        await Assert.That(agent.ParkAttemptInFlight).IsFalse(); // guard released after the lost claim
+        await Assert.That(agent.PendingEndReason).IsEqualTo("agent_exited");
+        await Assert.That(server.ParkReports).IsEmpty();        // the server was NEVER told — the fence ran first
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Seeds a review-flow reviewer whose runtime reports the app-server transport (so it is
+    /// resume-capable) and exposes a Codex thread id as its canonical session id — the shape arm-A
+    /// keys on. <c>SeedAgentForTest</c> only builds PTY runtimes, so this constructs the
+    /// <see cref="AgentInstance"/> directly (borrowed cwd, so teardown touches no filesystem) and
+    /// registers it exactly as a real launch would.</summary>
+    static AgentInstance SeedResumableReviewer(
+            AgentOrchestrator orch, string id, AgentActivityClock clock,
+            string threadId = "thread-abc", bool parkInFlight = false) {
+        var agent = new AgentInstance(
+            id, "review this", "default", null, "/repo", "codex",
+            new FakeAppServerRuntime(threadId),
+            new WorktreeInfo("/repo", "b", "/repo"),
+            new CancellationTokenSource()) {
+            Kind                = LaunchKind.ReviewFlow,
+            Status              = "Running",
+            ActivityClock       = clock,
+            Work                = WorkLocation.BorrowedCwd, // never remove a checkout in the park-teardown tests
+            ParkAttemptInFlight = parkInFlight
+        };
+
+        orch.RegisterAgentForTest(agent);
+
+        return agent;
+    }
+
+    /// <summary>Stand-in for <c>CodexAppServerHostedAgentRuntime</c> (internal/sealed, heavy ctor): an
+    /// <see cref="IHostedAgentRuntime"/> that reports the app-server transport and, via
+    /// <see cref="IAcpTranscriptSource"/>, a fixed Codex thread id as its canonical session id — the two
+    /// facets arm-A reads. Everything else is a harmless no-op; <see cref="TerminateAsync"/> flips
+    /// <see cref="HasExited"/> so the shared stop path completes.</summary>
+    sealed class FakeAppServerRuntime(string threadId) : IHostedAgentRuntime, IAcpTranscriptSource {
+        readonly TaskCompletionSource _exit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Vendor              => "codex";
+        public string RuntimeTransport    => CodexTransportDecision.AppServer;
+        public int    Pid                 => 4242;
+        public bool   HasExited           => _exit.Task.IsCompleted;
+        public int?   ExitCode            => 0;
+        public bool   EmitsTerminalOutput => false;
+
+        public async IAsyncEnumerable<byte[]> ReadOutputAsync([EnumeratorCancellation] CancellationToken ct = default) {
+            var             ctTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            await using var reg   = ct.Register(() => ctTcs.TrySetResult());
+            await Task.WhenAny(_exit.Task, ctTcs.Task).ConfigureAwait(false);
+
+            yield break;
+        }
+
+        public Task SendUserInputAsync(string  text) => Task.CompletedTask;
+        public Task SendSpecialKeyAsync(string key)  => Task.CompletedTask;
+        public Task SendRawInputAsync(byte[]   data) => Task.CompletedTask;
+        public void Resize(ushort              cols, ushort rows) { }
+        public Task RequestGracefulStopAsync()       => Task.CompletedTask;
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+
+        public Task TerminateAsync(TimeSpan? timeout = null) {
+            _exit.TrySetResult();
+
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => default;
+
+        // IAcpTranscriptSource — the canonical session id accessor arm-A reads for the park report.
+        public string                          AcpSessionId  => threadId;
+        public string                          Cwd           => "/repo";
+        public string?                         ResolvedModel => null;
+        public ChannelReader<AcpEventEnvelope> Envelopes     { get; } = Channel.CreateUnbounded<AcpEventEnvelope>().Reader;
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorReviewerParkTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorReviewerParkTests.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Time.Testing;
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
 /// <summary>
-/// AI-1762 §2.7 B6 arm-A: the RESUMABLE-PARK path in <see cref="AgentOrchestrator"/>. A settled,
+/// §2.7 B6 arm-A: the RESUMABLE-PARK path in <see cref="AgentOrchestrator"/>. A settled,
 /// app-server hosted Codex reviewer idle past the SHORT resumable bound
 /// (<see cref="DaemonConfig.ReviewerResumableIdleTimeout"/>, 10m) is PARKED — its daemon slot freed
 /// like a reap, but its Codex thread kept alive (the hosted session-end suppressed) for a later

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorReviewerParkTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorReviewerParkTests.cs
@@ -195,6 +195,55 @@ public class AgentOrchestratorReviewerParkTests {
         await Assert.That(server.AgentUnregisteredCalls).Contains("parked");
     }
 
+    /// <summary>P1-b regression (codex pre-merge review): the reviewer's app-server child exits DURING
+    /// the park-ack await — before any definite reply. The hosted session-end MUST fire (an unconfirmed
+    /// park is not a park), NOT be suppressed. This holds only because the claim leaves a NEUTRAL end
+    /// reason and <c>ParkReviewerAsync</c> stamps <see cref="AgentOrchestrator.ReviewerParkedResumableReason"/>
+    /// itself, only after a definite <see cref="ParkAck.Parked"/>. Were the suppress reason pre-stamped
+    /// at claim time (the bug), the finalizer running in this window would suppress the session-end for a
+    /// park that never committed, orphaning the ledger row — neither durably parked nor cleanly closed.
+    /// Releasing the ack afterwards must NOT resurrect or double-end the already-gone agent.</summary>
+    [Test]
+    public async Task Child_exit_during_the_park_ack_await_does_not_suppress_the_session_end() {
+        var parkEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var parkGate    = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var server = new CaptureServerConnection {
+            ParkOutcome = ParkAck.Parked, ParkEntered = parkEntered, ParkGate = parkGate
+        };
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+        time.Advance(TimeSpan.FromMinutes(11));
+
+        var agent = SeedResumableReviewer(orch, "raced-exit", clock);
+
+        var candidate = orch.FindReviewersToReap().Single(c => c.Park);
+
+        // Start the park: it wins the claim, then BLOCKS awaiting the park ack (gate held open).
+        var park = orch.ParkReviewerForTest(candidate);
+        await parkEntered.Task.WaitAsync(HangGuard);
+
+        // Claim won, but the suppress reason must NOT be stamped yet — a mid-await exit must end normally.
+        await Assert.That(agent.IsReapClaimed).IsTrue();
+        await Assert.That(agent.PendingEndReason).IsNotEqualTo(AgentOrchestrator.ReviewerParkedResumableReason);
+
+        // The child exits on its own NOW (read loop unwinds → finalizer) while the ack is still in flight.
+        await orch.FinalizeAgentRunForTest(agent).WaitAsync(HangGuard);
+
+        // Session-end FIRED with the neutral reason (park unconfirmed → not suppressed); the slot is freed.
+        await Assert.That(server.EndSessionReasons).Contains("agent_exited");
+        await Assert.That(orch.GetAgentForTest("raced-exit")).IsNull();
+
+        // Release the ack; the park state machine finishes without throwing. The agent is already gone,
+        // so StopClaimedReapAsync no-ops (agent_gone) — no second session-end, no resurrection.
+        parkGate.SetResult();
+        await park.WaitAsync(HangGuard);
+
+        await Assert.That(server.EndSessionReasons.Count).IsEqualTo(1);
+    }
+
     /// <summary>An <see cref="ParkAck.Ambiguous"/> ack (no definite reply): tear down NOTHING and
     /// restore the pre-attempt state — the agent stays Running, the in-flight guard AND the reap latch
     /// are released, no session-end fires — so a later sweep re-selects it for park and can actually

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
@@ -352,6 +352,25 @@ sealed class CaptureServerConnection() : ServerConnection(
         return Task.CompletedTask;
     }
 
+    // ── §2.7 B6 arm-A: participant-park report capture ───────────────────────────────
+    /// <summary>The ack <see cref="ReportParticipantParkedAsync"/> returns; default
+    /// <see cref="ParkAck.Parked"/>. A park state-machine test sets this to drive the three branches
+    /// (Parked / Rejected / Ambiguous) deterministically.</summary>
+    public ParkAck ParkOutcome { get; set; } = ParkAck.Parked;
+
+    /// <summary>Every (agentId, canonicalSessionId, reason) passed to
+    /// <see cref="ReportParticipantParkedAsync"/>, in call order — lets a test assert the canonical
+    /// thread id and reason the daemon reported, and (by emptiness) that a park that aborted at the
+    /// claim never told the server at all.</summary>
+    public List<(string AgentId, string CanonicalSessionId, string Reason)> ParkReports { get; } = [];
+
+    public override Task<ParkAck> ReportParticipantParkedAsync(
+            string agentId, string canonicalSessionId, string reason, CancellationToken ct = default) {
+        lock (ParkReports) ParkReports.Add((agentId, canonicalSessionId, reason));
+
+        return Task.FromResult(ParkOutcome);
+    }
+
     public override async Task<EndAgentSessionResult> EndAgentSessionAsync(string agentId, string reason) {
         EndSessionReasons.Add(reason);
         lock (AcpCallOrder) AcpCallOrder.Add($"endSession:{agentId}");

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
@@ -364,11 +364,23 @@ sealed class CaptureServerConnection() : ServerConnection(
     /// claim never told the server at all.</summary>
     public List<(string AgentId, string CanonicalSessionId, string Reason)> ParkReports { get; } = [];
 
-    public override Task<ParkAck> ReportParticipantParkedAsync(
+    /// <summary>Signalled the moment <see cref="ReportParticipantParkedAsync"/> is entered (the park
+    /// report is in flight) so a test can interleave a racing child-exit/finalize in the ack-await
+    /// window. Null = no signal.</summary>
+    public TaskCompletionSource? ParkEntered { get; init; }
+
+    /// <summary>Held-open gate: when set, <see cref="ReportParticipantParkedAsync"/> awaits it before
+    /// returning <see cref="ParkOutcome"/>, keeping the park ack in flight while a test exercises a
+    /// concurrent finalize. Null = return the ack immediately.</summary>
+    public TaskCompletionSource? ParkGate { get; init; }
+
+    public override async Task<ParkAck> ReportParticipantParkedAsync(
             string agentId, string canonicalSessionId, string reason, CancellationToken ct = default) {
         lock (ParkReports) ParkReports.Add((agentId, canonicalSessionId, reason));
+        ParkEntered?.TrySetResult();
+        if (ParkGate is { } gate) await gate.Task;
 
-        return Task.FromResult(ParkOutcome);
+        return ParkOutcome;
     }
 
     public override async Task<EndAgentSessionResult> EndAgentSessionAsync(string agentId, string reason) {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs
@@ -86,20 +86,23 @@ public class ServerConnectionParkProxyTests {
     }
 
     /// <summary>
-    /// A pre-B1 server has no <c>ReportParticipantParked</c> hub method at all: SignalR's server-side
-    /// message binder can't resolve the target, so the invoke throws a <c>HubException</c> reporting
-    /// the method doesn't exist — the same literal text (see <c>AgentOrchestratorSourceClaimTests
-    /// .Method_not_found_claim_is_a_coded_launch_failure_with_teardown</c>) this codebase already uses
-    /// to model the equivalent old-server case for <c>AcpSessionSourceClaim</c>. Unlike the generic
-    /// transient HubException in <see cref="A_thrown_HubException_maps_to_ParkAck_Ambiguous_never_throws"/>,
-    /// this is a DEFINITE, permanent degrade: mapping it to Ambiguous would have
-    /// <c>AgentOrchestrator.ParkReviewerAsync</c> retry the park forever against a server that will
-    /// never grow the method. Rejected makes it fall back to the normal reap instead.
+    /// A pre-B1 server has no <c>ReportParticipantParked</c> hub method at all: the server's
+    /// <c>DefaultHubDispatcher</c> can't resolve the target and completes the invocation with the error
+    /// <c>Unknown hub method '&lt;target&gt;'</c> (sent regardless of <c>EnableDetailedErrors</c>;
+    /// verified against aspnetcore v10.0.11), surfaced on the client as a <c>HubException</c> carrying
+    /// that message. Unlike the generic transient HubException in
+    /// <see cref="A_thrown_HubException_maps_to_ParkAck_Ambiguous_never_throws"/>, this is a DEFINITE,
+    /// permanent degrade: mapping it to Ambiguous would have <c>AgentOrchestrator.ParkReviewerAsync</c>
+    /// retry the park forever against a server that will never grow the method — and because arm-A park
+    /// precedes arm-B reap in the sweep, the reviewer would never be cleanly reaped and would leak
+    /// capacity indefinitely. Rejected makes it fall back to the normal reap instead. The message string
+    /// this test asserts on is the exact text SignalR produces; matching a fabricated
+    /// "does not exist" phrase (which SignalR never emits) would let this degrade path never fire.
     /// </summary>
     [Test]
     public async Task Park_against_a_server_without_the_hub_method_falls_back_to_reap() {
         var conn = new TestServerConnection {
-            ThrowOnInvoke = new Microsoft.AspNetCore.SignalR.HubException("Method does not exist.")
+            ThrowOnInvoke = new Microsoft.AspNetCore.SignalR.HubException("Unknown hub method 'ReportParticipantParked'")
         };
 
         var ack = await conn.ReportParticipantParkedAsync("agent1", "canon-1", "reviewer_parked_resumable")

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs
@@ -112,6 +112,29 @@ public class ServerConnectionParkProxyTests {
     }
 
     /// <summary>
+    /// High regression (qodo pre-merge review): <c>ParkReviewerAsync</c> holds the reap claim across
+    /// this call, so a disconnected daemon (<see cref="ServerConnection.IsReady"/> never true) must not
+    /// pin it — the readiness gate is bounded by <c>ParkAckBudget</c>. When the budget elapses with no
+    /// reply the call returns <see cref="ParkAck.Ambiguous"/> (release + retry) PROMPTLY (the 5s
+    /// HangGuard, far above the 200ms budget, is what would trip if the bound were absent) and — because
+    /// IsReady was never observed — the hub was never invoked, so there is no half-sent report to
+    /// reconcile.
+    /// </summary>
+    [Test]
+    public async Task A_disconnected_daemon_bounds_the_park_by_the_budget_and_maps_to_Ambiguous() {
+        var conn = new TestServerConnection {
+            Ready         = false,                          // never becomes ready — the outage case
+            ParkAckBudget = TimeSpan.FromMilliseconds(200)
+        };
+
+        var ack = await conn.ReportParticipantParkedAsync("agent1", "canon-1", "reviewer_parked_resumable")
+            .WaitAsync(HangGuard);
+
+        await Assert.That(ack).IsEqualTo(ParkAck.Ambiguous);
+        await Assert.That(conn.Calls).IsEmpty();            // IsReady never true → the hub was never invoked
+    }
+
+    /// <summary>
     /// A cancellation that fires while the daemon is shut down mid-call is exactly the "no definite
     /// reply" case the arm-A park state machine must not treat as a rejection — it must fold to
     /// Ambiguous rather than propagate, so the caller never sees an exception out of this method.

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs
@@ -86,6 +86,29 @@ public class ServerConnectionParkProxyTests {
     }
 
     /// <summary>
+    /// A pre-B1 server has no <c>ReportParticipantParked</c> hub method at all: SignalR's server-side
+    /// message binder can't resolve the target, so the invoke throws a <c>HubException</c> reporting
+    /// the method doesn't exist — the same literal text (see <c>AgentOrchestratorSourceClaimTests
+    /// .Method_not_found_claim_is_a_coded_launch_failure_with_teardown</c>) this codebase already uses
+    /// to model the equivalent old-server case for <c>AcpSessionSourceClaim</c>. Unlike the generic
+    /// transient HubException in <see cref="A_thrown_HubException_maps_to_ParkAck_Ambiguous_never_throws"/>,
+    /// this is a DEFINITE, permanent degrade: mapping it to Ambiguous would have
+    /// <c>AgentOrchestrator.ParkReviewerAsync</c> retry the park forever against a server that will
+    /// never grow the method. Rejected makes it fall back to the normal reap instead.
+    /// </summary>
+    [Test]
+    public async Task Park_against_a_server_without_the_hub_method_falls_back_to_reap() {
+        var conn = new TestServerConnection {
+            ThrowOnInvoke = new Microsoft.AspNetCore.SignalR.HubException("Method does not exist.")
+        };
+
+        var ack = await conn.ReportParticipantParkedAsync("agent1", "canon-1", "reviewer_parked_resumable")
+            .WaitAsync(HangGuard);
+
+        await Assert.That(ack).IsEqualTo(ParkAck.Rejected);
+    }
+
+    /// <summary>
     /// A cancellation that fires while the daemon is shut down mid-call is exactly the "no definite
     /// reply" case the arm-A park state machine must not treat as a rejection — it must fold to
     /// Ambiguous rather than propagate, so the caller never sees an exception out of this method.

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs
@@ -1,0 +1,137 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// AI-1762 §2.7 B6 task 2: covers <see cref="ServerConnection.ReportParticipantParkedAsync"/> — the
+/// daemon→hub park-report proxy — mapping the server's two-value wire outcome
+/// (<see cref="ParkParticipantOutcome"/>) plus "no definite reply" into the daemon-local
+/// <see cref="ParkAck"/>. Mirrors <c>AcpServerConnectionTests</c>'s approach exactly: no live SignalR
+/// transport; <see cref="TestServerConnection"/> overrides the raw hub-invoke seam
+/// (<see cref="ServerConnection.InvokeReportParticipantParkedRawAsync"/>) so each case can be driven
+/// deterministically.
+/// </summary>
+public class ServerConnectionParkProxyTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(5);
+
+    /// <summary>Test double: constructed against an unreachable URL and never started, so the real
+    /// <c>HubConnection</c> is never touched. <see cref="IsReady"/> and the raw park-report invoke are
+    /// the only seams overridden — the same seam shape <c>AcpServerConnectionTests</c> uses.</summary>
+    sealed class TestServerConnection() : ServerConnection(
+        new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+        NullLoggerFactory.Instance,
+        NullLogger<ServerConnection>.Instance
+    ) {
+        public bool Ready { get; set; } = true;
+
+        internal override bool IsReady => Ready;
+
+        public List<(string AgentId, string CanonicalSessionId, string Reason)> Calls { get; } = [];
+
+        /// <summary>When set, the raw invoke returns this outcome. When <see cref="ThrowOnInvoke"/>
+        /// is also set, the exception takes precedence (a definite outcome and a thrown exception
+        /// can never both happen on the same call).</summary>
+        public ParkParticipantOutcome Outcome { get; set; } = ParkParticipantOutcome.Parked;
+
+        public Exception? ThrowOnInvoke { get; set; }
+
+        internal override Task<ParkParticipantOutcome> InvokeReportParticipantParkedRawAsync(
+                string agentId, string canonicalSessionId, string reason, CancellationToken ct
+            ) {
+            Calls.Add((agentId, canonicalSessionId, reason));
+
+            return ThrowOnInvoke is { } ex
+                ? Task.FromException<ParkParticipantOutcome>(ex)
+                : Task.FromResult(Outcome);
+        }
+    }
+
+    [Test]
+    public async Task Definite_Parked_outcome_maps_to_ParkAck_Parked() {
+        var conn = new TestServerConnection { Outcome = ParkParticipantOutcome.Parked };
+
+        var ack = await conn.ReportParticipantParkedAsync("agent1", "canon-1", "reviewer_parked_resumable")
+            .WaitAsync(HangGuard);
+
+        await Assert.That(ack).IsEqualTo(ParkAck.Parked);
+        await Assert.That(conn.Calls.Count).IsEqualTo(1);
+        var call = conn.Calls[0];
+        await Assert.That(call.AgentId).IsEqualTo("agent1");
+        await Assert.That(call.CanonicalSessionId).IsEqualTo("canon-1");
+        await Assert.That(call.Reason).IsEqualTo("reviewer_parked_resumable");
+    }
+
+    [Test]
+    public async Task Definite_Rejected_outcome_maps_to_ParkAck_Rejected() {
+        var conn = new TestServerConnection { Outcome = ParkParticipantOutcome.Rejected };
+
+        var ack = await conn.ReportParticipantParkedAsync("agent1", "canon-1", "reviewer_parked_resumable")
+            .WaitAsync(HangGuard);
+
+        await Assert.That(ack).IsEqualTo(ParkAck.Rejected);
+    }
+
+    [Test]
+    public async Task A_thrown_HubException_maps_to_ParkAck_Ambiguous_never_throws() {
+        var conn = new TestServerConnection {
+            ThrowOnInvoke = new Microsoft.AspNetCore.SignalR.HubException("Caller is not a registered daemon")
+        };
+
+        var ack = await conn.ReportParticipantParkedAsync("agent1", "canon-1", "reviewer_parked_resumable")
+            .WaitAsync(HangGuard);
+
+        await Assert.That(ack).IsEqualTo(ParkAck.Ambiguous);
+    }
+
+    /// <summary>
+    /// A cancellation that fires while the daemon is shut down mid-call is exactly the "no definite
+    /// reply" case the arm-A park state machine must not treat as a rejection — it must fold to
+    /// Ambiguous rather than propagate, so the caller never sees an exception out of this method.
+    /// </summary>
+    [Test]
+    public async Task A_cancellation_maps_to_ParkAck_Ambiguous_never_throws() {
+        using var cts = new CancellationTokenSource();
+        var conn = new TestServerConnection {
+            ThrowOnInvoke = new OperationCanceledException("shutting down")
+        };
+        await cts.CancelAsync();
+
+        var ack = await conn.ReportParticipantParkedAsync("agent1", "canon-1", "reviewer_parked_resumable", cts.Token)
+            .WaitAsync(HangGuard);
+
+        await Assert.That(ack).IsEqualTo(ParkAck.Ambiguous);
+    }
+
+    /// <summary>An unrecognized/future wire value (e.g. a newer server adds a member this daemon
+    /// doesn't know) must degrade to Ambiguous rather than being silently treated as a success.</summary>
+    [Test]
+    public async Task An_unmapped_outcome_value_maps_to_ParkAck_Ambiguous() {
+        var conn = new TestServerConnection { Outcome = (ParkParticipantOutcome) 99 };
+
+        var ack = await conn.ReportParticipantParkedAsync("agent1", "canon-1", "reviewer_parked_resumable")
+            .WaitAsync(HangGuard);
+
+        await Assert.That(ack).IsEqualTo(ParkAck.Ambiguous);
+    }
+
+    /// <summary>
+    /// Unlike the sibling ACP proxies (which let a not-ready timeout's <see cref="OperationCanceledException"/>
+    /// propagate to the caller), this proxy's "never throw" contract applies even to the
+    /// readiness-gating wait itself: a caller that gives up waiting for a registered connection gets
+    /// <see cref="ParkAck.Ambiguous"/> — "no definite reply" — not an exception.
+    /// </summary>
+    [Test]
+    public async Task Not_ready_and_then_cancelled_maps_to_ParkAck_Ambiguous_never_throws() {
+        var conn = new TestServerConnection { Ready = false };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        var ack = await conn.ReportParticipantParkedAsync("agent1", "canon-1", "reviewer_parked_resumable", cts.Token)
+            .WaitAsync(HangGuard);
+
+        await Assert.That(ack).IsEqualTo(ParkAck.Ambiguous);
+        await Assert.That(conn.Calls).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionParkProxyTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
 /// <summary>
-/// AI-1762 §2.7 B6 task 2: covers <see cref="ServerConnection.ReportParticipantParkedAsync"/> — the
+/// §2.7 B6 task 2: covers <see cref="ServerConnection.ReportParticipantParkedAsync"/> — the
 /// daemon→hub park-report proxy — mapping the server's two-value wire outcome
 /// (<see cref="ParkParticipantOutcome"/>) plus "no definite reply" into the daemon-local
 /// <see cref="ParkAck"/>. Mirrors <c>AcpServerConnectionTests</c>'s approach exactly: no live SignalR


### PR DESCRIPTION
## What

The daemon **activation** half of §2.7: the daemon now **parks** an idle-but-resumable hosted Codex reviewer between flow rounds instead of reaping it, durably acked by the server, and flips the launcher policy to `codex-appserver-unattended-v2` — which turns on the server-side resume routing whose pieces are already merged and dormant.

This is the switch that lights up the whole Half-B chain. All prerequisites are in `main`:
- **server:** B1 park hub, B2 terminal-over-park precedence, B3 `/review/start/v4`, B4 resume populate (#1594), B5 close authority + close-before-heal fences (#1611); A-series transport selection routes a v2-advertising daemon to the resume-capable path.
- **cli:** B3 v4 routing (#637), B4 `thread/resume` + `AcceptedSeq`-init forwarding (#639).

Until this PR the daemon only ever reaped reviewers, so none of that machinery fired. With it, an idle reviewer parks, its Codex thread survives, and any v2 daemon can resume it next round.

## How

Six commits, one concern each:

1. **`ReviewerResumableIdleTimeout` (10 min)** — new `DaemonConfig` bound + `KCAP_REVIEWER_RESUMABLE_IDLE_TIMEOUT` override. The arm-A park threshold, well under arm-B's 2h reap.
2. **`ServerConnection.ReportParticipantParkedAsync` → `ParkAck`** — the SignalR proxy for the B1 hub method. Never throws: transport/unexpected errors map to `ParkAck.Ambiguous` (retry), an explicit server refusal to `Rejected`, success to `Parked`.
3. **`AgentInstance.ParkAttemptInFlight`** — a per-agent in-flight guard so arm-A selects a reviewer for park at most once while the async attempt is outstanding.
4. **arm-A park (core)** — `FindReviewersToReap` selects a resumable reviewer (`RuntimeTransport == AppServer`, not already parking, idle > the arm-A bound) *before* arm-B, emitting a `Park` candidate fenced on activity. `ParkReviewerAsync` reports the park and branches on the ack: **Parked** → tear the local agent down but **suppress `SessionEnded`** (the ledger row stays `parked`, resumable) via a surgical gate on `PendingEndReason`; **Rejected** → normal end with a `reviewer_park_rejected` reason; **Ambiguous** → reset the guard + reap-claim and let the next heartbeat retry. Teardown is otherwise identical to a reap (binding unregistered, agent removed) — no half-parked state.
5. **advertise `codex-appserver-unattended-v2`** — the launcher policy token, gated on `CodexAppServerActive` (app-server selected AND Codex build ≥ floor). A PTY/old-Codex daemon still advertises v1, so the server only routes resumes to daemons that actually run the resume-capable runtime.
6. **degrade against a pre-B1 server** — an unknown-hub-method `HubException` ("does not exist") maps to `Rejected` (→ clean reap), while every transient error stays `Ambiguous` (→ retry). Parking is transparently a no-op against a server that predates the park hub.

Suppression is surgical: only `EndAgentSessionAsync` is gated; `AgentStatusChanged("Completed")` still fires (verified against the merged server — it does not close the ledger row), and cleanup runs unconditionally.

## Testing

Full daemon unit suite green: **2796 total / 0 failed / 38 skipped**; build clean (warnings-as-errors). New discriminating coverage: `ServerConnectionParkProxyTests` (ack mapping, never-throws, cancellation, unknown-method → Rejected), `AgentOrchestratorReviewerParkTests` (arm-A selection, park→suppress-SessionEnded, Rejected→normal-end, Ambiguous→retry), and v2-advertisement assertions in `DaemonRunnerCursorAvailabilityTests`.

Built subagent-driven: each task got a spec+quality review, and the whole branch got a final review on the most capable model — verdict READY TO MERGE, no Critical/Important, the park→ack→teardown→resume lifecycle confirmed closed end-to-end and the v2 activation confirmed co-bound to the resume-capable runtime (no mis-routing).

## Follow-up

The `src/cli` submodule pin bump in kcap-server is a separate step. The cert-gated interactive-routing flip (AI-1763) is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
