### PR TITLE
[AI-2176] CLI: evidence-based repo association for sessions started outside a repo

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -131,8 +131,8 @@ class WatchState {
     // Non-null only for a Claude session watcher launched outside any repo; see RepoEvidenceScanner.
     // RepositoryFromEvidence, once true, protects Repository from being cleared by a later null
     // cwd-based probe (see WatchCommand.ShouldReplaceRepository).
-    public RepoEvidenceScanner? EvidenceScanner        { get; set; }
-    public bool                 RepositoryFromEvidence { get; set; }
+    public RepoEvidenceScanner<RepositoryPayload>? EvidenceScanner        { get; set; }
+    public bool                                    RepositoryFromEvidence { get; set; }
 
     public bool               InitialTitleSent   { get; set; }
     public bool               TitleGenerated     { get; set; }

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Capacitor.Cli.Core.Harness.Codex;
 using Capacitor.Cli.Core.Harness.Cursor;
+using Capacitor.Cli.Core.RepoEvidence;
 using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.Cli.Core;
@@ -126,6 +127,13 @@ class WatchState {
     public RepositoryPayload? Repository         { get; set; }
     public RepositoryPayload? LastSentRepository { get; set; }
     public DateTimeOffset     LastRepoDetection  { get; set; }
+
+    // Non-null only for a Claude session watcher launched outside any repo; see RepoEvidenceScanner.
+    // RepositoryFromEvidence, once true, protects Repository from being cleared by a later null
+    // cwd-based probe (see WatchCommand.ShouldReplaceRepository).
+    public RepoEvidenceScanner? EvidenceScanner        { get; set; }
+    public bool                 RepositoryFromEvidence { get; set; }
+
     public bool               InitialTitleSent   { get; set; }
     public bool               TitleGenerated     { get; set; }
     public int                TitleAttempts      { get; set; }

--- a/src/Capacitor.Cli.Core/RepoEvidence/RepoEvidenceScanner.cs
+++ b/src/Capacitor.Cli.Core/RepoEvidence/RepoEvidenceScanner.cs
@@ -1,0 +1,91 @@
+using System.Text.Json.Nodes;
+
+namespace Capacitor.Cli.Core.RepoEvidence;
+
+public enum RepoEvidenceKind { Mutation, Read }
+
+/// <summary>
+/// Derives a git root from absolute paths in tool-use inputs, for sessions
+/// launched outside any repo. Two-slot rule: the first mutation-derived root
+/// attributes immediately; the first read-derived root is promoted only at
+/// final drain if no mutation ever landed. Evidence is the tool INPUT —
+/// results are never consulted. Fail-open on every parse or resolver error.
+/// </summary>
+public sealed class RepoEvidenceScanner(Func<string, string?> findRoot) {
+    public string? AttributedRoot   { get; private set; }
+    public string? ReadFallbackRoot { get; private set; }
+    public bool    Done => AttributedRoot is not null;
+
+    public string? OnLine(string vendor, string jsonlLine) {
+        if (Done || vendor != "claude") return null;
+
+        try {
+            foreach (var (path, kind) in ExtractClaudePaths(jsonlLine)) {
+                var dir  = SafeDirectory(path);
+                if (dir is null) continue;
+                var root = Safe(() => findRoot(dir));
+                if (root is null) continue;
+
+                if (kind == RepoEvidenceKind.Mutation) {
+                    AttributedRoot = root;
+                    return root;
+                }
+
+                ReadFallbackRoot ??= root;
+            }
+        } catch {
+            // fail-open: a bad line must never break watching or import
+        }
+
+        return null;
+    }
+
+    public string? PromoteReadFallback() {
+        if (Done || ReadFallbackRoot is null) return null;
+        AttributedRoot = ReadFallbackRoot;
+        return AttributedRoot;
+    }
+
+    public static IReadOnlyList<(string Path, RepoEvidenceKind Kind)> ExtractClaudePaths(string jsonlLine) {
+        var result = new List<(string, RepoEvidenceKind)>();
+
+        try {
+            if (JsonNode.Parse(jsonlLine) is not JsonObject obj) return result;
+            if (obj["type"]?.GetValue<string>() != "assistant") return result;
+            if (obj["message"]?["content"] is not JsonArray content) return result;
+
+            foreach (var item in content) {
+                if (item is not JsonObject block) continue;
+                if (block["type"]?.GetValue<string>() != "tool_use") continue;
+
+                var name  = block["name"]?.GetValue<string>();
+                var input = block["input"] as JsonObject;
+                if (name is null || input is null) continue;
+
+                (string key, RepoEvidenceKind kind)? spec = name switch {
+                    "Edit" or "MultiEdit" or "Write" => ("file_path", RepoEvidenceKind.Mutation),
+                    "NotebookEdit"                   => ("notebook_path", RepoEvidenceKind.Mutation),
+                    "Read"                           => ("file_path", RepoEvidenceKind.Read),
+                    "Glob" or "Grep"                 => ("path", RepoEvidenceKind.Read),
+                    _                                => null,
+                };
+                if (spec is not { } sp) continue;
+
+                var path = input[sp.key]?.GetValue<string>();
+                if (path is not null && path.StartsWith('/')) result.Add((path, sp.kind));
+            }
+        } catch {
+            // fail-open
+        }
+
+        return result;
+    }
+
+    static string? SafeDirectory(string path) {
+        try { return Path.GetDirectoryName(path); } catch { return null; }
+    }
+
+    static T? Safe<T>(Func<T?> f) where T : class {
+        try { return f(); } catch { return null; }
+    }
+}

--- a/src/Capacitor.Cli.Core/RepoEvidence/RepoEvidenceScanner.cs
+++ b/src/Capacitor.Cli.Core/RepoEvidence/RepoEvidenceScanner.cs
@@ -5,33 +5,47 @@ namespace Capacitor.Cli.Core.RepoEvidence;
 public enum RepoEvidenceKind { Mutation, Read }
 
 /// <summary>
-/// Derives a git root from absolute paths in tool-use inputs, for sessions
-/// launched outside any repo. Two-slot rule: the first mutation-derived root
-/// attributes immediately; the first read-derived root is promoted only at
-/// final drain if no mutation ever landed. Evidence is the tool INPUT —
-/// results are never consulted. Fail-open on every parse or resolver error.
+/// Derives a resolved repo from absolute paths in tool-use inputs, for sessions launched
+/// outside any repo. Two-slot rule: the first mutation-derived root that resolves to a
+/// COMPLETE repo (<paramref name="isComplete"/>) wins slot A immediately; the first
+/// read-derived root that resolves complete is remembered as slot B and promoted only at
+/// final drain if slot A never landed. A root that fails to resolve, or resolves incomplete
+/// (e.g. a local repo with no remote), is skipped — scanning continues past it rather than
+/// latching onto something unusable. Each distinct root is resolved at most once (cached), to
+/// bound the resolver's cost. Evidence is the tool INPUT — results are never consulted.
+/// Fail-open on every parse or resolver error. Generic so Capacitor.Cli.Core never depends on
+/// the concrete repo type or how it's resolved — both live in the higher-level Cli project.
 /// </summary>
-public sealed class RepoEvidenceScanner(Func<string, string?> findRoot) {
-    public string? AttributedRoot   { get; private set; }
-    public string? ReadFallbackRoot { get; private set; }
-    public bool    Done => AttributedRoot is not null;
+public sealed class RepoEvidenceScanner<TRepo>(
+        Func<string, string?>      findRoot,
+        Func<string, Task<TRepo?>> resolve,
+        Func<TRepo, bool>          isComplete
+    ) where TRepo : class {
+    readonly Dictionary<string, TRepo?> _resolved = new(StringComparer.Ordinal);
 
-    public string? OnLine(string vendor, string jsonlLine) {
+    public TRepo? Attributed   { get; private set; }
+    public TRepo? ReadFallback { get; private set; }
+    public bool   Done => Attributed is not null;
+
+    public async Task<TRepo?> OnLineAsync(string vendor, string jsonlLine) {
         if (Done || vendor != "claude") return null;
 
         try {
-            foreach (var (path, kind) in ExtractClaudePaths(jsonlLine)) {
+            foreach (var (path, kind) in RepoEvidencePaths.ExtractClaudePaths(jsonlLine)) {
                 var dir  = SafeDirectory(path);
                 if (dir is null) continue;
                 var root = Safe(() => findRoot(dir));
                 if (root is null) continue;
 
+                var repo = await ResolveCachedAsync(root);
+                if (repo is null || !SafeIsComplete(repo)) continue;
+
                 if (kind == RepoEvidenceKind.Mutation) {
-                    AttributedRoot = root;
-                    return root;
+                    Attributed = repo;
+                    return repo;
                 }
 
-                ReadFallbackRoot ??= root;
+                ReadFallback ??= repo;
             }
         } catch {
             // fail-open: a bad line must never break watching or import
@@ -40,12 +54,38 @@ public sealed class RepoEvidenceScanner(Func<string, string?> findRoot) {
         return null;
     }
 
-    public string? PromoteReadFallback() {
-        if (Done || ReadFallbackRoot is null) return null;
-        AttributedRoot = ReadFallbackRoot;
-        return AttributedRoot;
+    public async Task<TRepo?> PromoteReadFallbackAsync() {
+        if (Done || ReadFallback is null) return null;
+        Attributed = ReadFallback;
+        return Attributed;
     }
 
+    async Task<TRepo?> ResolveCachedAsync(string root) {
+        if (_resolved.TryGetValue(root, out var cached)) return cached;
+
+        TRepo? repo;
+        try { repo = await resolve(root); } catch { repo = null; }
+
+        _resolved[root] = repo;
+        return repo;
+    }
+
+    bool SafeIsComplete(TRepo repo) {
+        try { return isComplete(repo); } catch { return false; }
+    }
+
+    static string? SafeDirectory(string path) {
+        try { return Path.GetDirectoryName(path); } catch { return null; }
+    }
+
+    static T? Safe<T>(Func<T?> f) where T : class {
+        try { return f(); } catch { return null; }
+    }
+}
+
+// Not nested inside RepoEvidenceScanner<TRepo>: CA1000 forbids public static members on a
+// generic type, and extraction doesn't depend on TRepo anyway.
+public static class RepoEvidencePaths {
     public static IReadOnlyList<(string Path, RepoEvidenceKind Kind)> ExtractClaudePaths(string jsonlLine) {
         var result = new List<(string, RepoEvidenceKind)>();
 
@@ -79,13 +119,5 @@ public sealed class RepoEvidenceScanner(Func<string, string?> findRoot) {
         }
 
         return result;
-    }
-
-    static string? SafeDirectory(string path) {
-        try { return Path.GetDirectoryName(path); } catch { return null; }
-    }
-
-    static T? Safe<T>(Func<T?> f) where T : class {
-        try { return f(); } catch { return null; }
     }
 }

--- a/src/Capacitor.Cli.Core/RepoEvidence/RepoEvidenceScanner.cs
+++ b/src/Capacitor.Cli.Core/RepoEvidence/RepoEvidenceScanner.cs
@@ -74,8 +74,14 @@ public sealed class RepoEvidenceScanner<TRepo>(
         try { return isComplete(repo); } catch { return false; }
     }
 
+    // Lexical, not Path.GetDirectoryName: that rewrites/misreads the OTHER OS's separator style
+    // (a Unix path fed through Windows' Path becomes garbage, and vice versa), but evidence
+    // paths are native to whichever OS the transcript's own agent ran on, not this process's OS.
     static string? SafeDirectory(string path) {
-        try { return Path.GetDirectoryName(path); } catch { return null; }
+        try {
+            var lastSeparator = path.AsSpan().LastIndexOfAny('/', '\\');
+            return lastSeparator < 0 ? null : path[..lastSeparator];
+        } catch { return null; }
     }
 
     static T? Safe<T>(Func<T?> f) where T : class {
@@ -92,7 +98,11 @@ public static class RepoEvidencePaths {
         try {
             if (JsonNode.Parse(jsonlLine) is not JsonObject obj) return result;
             if (obj["type"]?.GetValue<string>() != "assistant") return result;
-            if (obj["message"]?["content"] is not JsonArray content) return result;
+
+            // A tool_use block can sit at the event's top-level `content` too, not only nested
+            // under `message.content` — both shapes occur in real Claude transcripts.
+            var content = (obj["message"]?["content"] as JsonArray) ?? (obj["content"] as JsonArray);
+            if (content is null) return result;
 
             foreach (var item in content) {
                 if (item is not JsonObject block) continue;
@@ -112,7 +122,7 @@ public static class RepoEvidencePaths {
                 if (spec is not { } sp) continue;
 
                 var path = input[sp.key]?.GetValue<string>();
-                if (path is not null && path.StartsWith('/')) result.Add((path, sp.kind));
+                if (path is not null && IsLexicallyAbsolute(path)) result.Add((path, sp.kind));
             }
         } catch {
             // fail-open
@@ -120,4 +130,20 @@ public static class RepoEvidencePaths {
 
         return result;
     }
+
+    /// <summary>Mirrors <c>Capacitor.Sessions.RepoBackfill.RepoAttributionMatcher.IsLexicallyAbsolute</c>
+    /// in the server repo (reimplemented locally — Cli.Core takes no dependency on the server).
+    /// Unix-rooted, Windows drive-rooted, or UNC — never <c>Path.IsPathRooted</c>/<c>Path.IsPathFullyQualified</c>,
+    /// which judge by whichever OS is running the scan, not whichever OS produced the path (a Unix
+    /// path is rejected by Windows' Path, and a Windows path by Unix's).</summary>
+    internal static bool IsLexicallyAbsolute(string path) {
+        if (string.IsNullOrEmpty(path)) return false;
+        if (path[0] == '/') return true;                                        // Unix
+        if (path.Length >= 2 && path[0] == '\\' && path[1] == '\\') return true; // UNC \\host\share
+        if (path.Length >= 3 && IsAsciiLetter(path[0]) && path[1] == ':'
+            && (path[2] == '\\' || path[2] == '/')) return true;                 // C:\... or C:/...
+        return false;
+    }
+
+    static bool IsAsciiLetter(char c) => (uint)((c | 0x20) - 'a') <= 'z' - 'a';
 }

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -2210,9 +2210,10 @@ static class ImportCommand {
 
     /// <summary>
     /// Path-based overload: reads the transcript INSIDE this method's own try, so an
-    /// invalid/empty path (<c>File.ReadLines</c> validates its argument eagerly, before the
-    /// actual — lazy — file read) degrades to "no evidence" here too, instead of throwing as a
-    /// bare call argument at the caller, outside any try/catch.
+    /// invalid/empty path degrades to "no evidence" here too, instead of throwing as a bare call
+    /// argument at the caller, outside any try/catch. Uses <see cref="WatchCommand.ReadLinesShared"/>
+    /// (FileShare.ReadWrite), not <c>File.ReadLines</c> (FileShare.Read — Windows-mandatory,
+    /// denies the write handle a still-flushing agent owns on its own transcript).
     /// </summary>
     internal static async Task<JsonObject?> TryBuildEvidenceRepositoryNodeAsync(
             string                                 vendor,
@@ -2221,7 +2222,7 @@ static class ImportCommand {
             Func<string, Task<RepositoryPayload?>> detect
         ) {
         try {
-            return await TryBuildEvidenceRepositoryNodeAsync(vendor, File.ReadLines(transcriptPath), findRoot, detect);
+            return await TryBuildEvidenceRepositoryNodeAsync(vendor, WatchCommand.ReadLinesShared(transcriptPath), findRoot, detect);
         } catch {
             return null; // fail-open: an unreadable/invalid path must never break import
         }

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Channels;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.RepoEvidence;
 using Capacitor.Cli.Harness.Claude;
 using Capacitor.Cli.Harness.Cursor;
 using Spectre.Console;
@@ -2174,6 +2175,40 @@ static class ImportCommand {
     }
 
     /// <summary>
+    /// Whole-transcript version of the live watcher's evidence scan (see
+    /// <c>RepoEvidenceScanner</c>): feeds every line through the two-slot mutation/read rule,
+    /// then promotes the read fallback if no mutation ever attributed. Import has no live tail
+    /// to keep scanning, so — unlike the watcher's one-shot prefix scan — this always runs to
+    /// end of file. <paramref name="findRoot"/>/<paramref name="detect"/> are injected so the
+    /// D1 gating in <see cref="ImportSingleSessionAsync"/> is unit-testable without disk.
+    /// </summary>
+    internal static async Task<JsonObject?> TryBuildEvidenceRepositoryNodeAsync(
+            string                                 vendor,
+            IEnumerable<string>                    transcriptLines,
+            Func<string, string?>                  findRoot,
+            Func<string, Task<RepositoryPayload?>> detect
+        ) {
+        try {
+            var scanner = new RepoEvidenceScanner<RepositoryPayload>(
+                findRoot, detect, p => p.Owner is not null && p.RepoName is not null);
+
+            foreach (var line in transcriptLines) {
+                if (await scanner.OnLineAsync(vendor, line) is { } attributed) {
+                    return RepositoryDetection.BuildRepositoryNode(attributed);
+                }
+            }
+
+            if (await scanner.PromoteReadFallbackAsync() is { } fallback) {
+                return RepositoryDetection.BuildRepositoryNode(fallback);
+            }
+
+            return null;
+        } catch {
+            return null; // fail-open: a bad transcript must never break import
+        }
+    }
+
+    /// <summary>
     /// Build a SessionId → repo lookup for every discovered transcript. Repo
     /// detection (git + `gh pr view`) is the slow part of the discovery phase
     /// and previously ran sequentially per-session, making `kcap import`
@@ -2862,6 +2897,22 @@ static class ImportCommand {
 
                 if (repoNode.Count > 0) startHook["repository"] = repoNode;
             }
+        }
+
+        // D1: the cwd itself isn't inside any git repo (or is missing entirely), so neither
+        // workspace_root above nor the cwd-based repository detection could find anything —
+        // fall back to scanning the transcript's own tool-use paths for a resolvable git root,
+        // same evidence rule the live watcher applies for sessions launched outside a repo.
+        if (session.Vendor == "claude"
+            && !startHook.ContainsKey("repository")
+            && (cwd is null || GitRepository.FindRoot(cwd) is null)) {
+            var evidenceNode = await TryBuildEvidenceRepositoryNodeAsync(
+                session.Vendor,
+                File.ReadLines(session.FilePath),
+                GitRepository.FindRoot,
+                root => RepositoryDetection.DetectRepositoryAsync(root, detectPullRequest: false));
+
+            if (evidenceNode is not null) startHook["repository"] = evidenceNode;
         }
 
         // The /hooks/session-start route binds vendor from the URL path

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -2209,6 +2209,25 @@ static class ImportCommand {
     }
 
     /// <summary>
+    /// Path-based overload: reads the transcript INSIDE this method's own try, so an
+    /// invalid/empty path (<c>File.ReadLines</c> validates its argument eagerly, before the
+    /// actual — lazy — file read) degrades to "no evidence" here too, instead of throwing as a
+    /// bare call argument at the caller, outside any try/catch.
+    /// </summary>
+    internal static async Task<JsonObject?> TryBuildEvidenceRepositoryNodeAsync(
+            string                                 vendor,
+            string                                 transcriptPath,
+            Func<string, string?>                  findRoot,
+            Func<string, Task<RepositoryPayload?>> detect
+        ) {
+        try {
+            return await TryBuildEvidenceRepositoryNodeAsync(vendor, File.ReadLines(transcriptPath), findRoot, detect);
+        } catch {
+            return null; // fail-open: an unreadable/invalid path must never break import
+        }
+    }
+
+    /// <summary>
     /// Build a SessionId → repo lookup for every discovered transcript. Repo
     /// detection (git + `gh pr view`) is the slow part of the discovery phase
     /// and previously ran sequentially per-session, making `kcap import`
@@ -2908,7 +2927,7 @@ static class ImportCommand {
             && (cwd is null || GitRepository.FindRoot(cwd) is null)) {
             var evidenceNode = await TryBuildEvidenceRepositoryNodeAsync(
                 session.Vendor,
-                File.ReadLines(session.FilePath),
+                session.FilePath,
                 GitRepository.FindRoot,
                 root => RepositoryDetection.DetectRepositoryAsync(root, detectPullRequest: false));
 

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -492,12 +492,14 @@ static partial class WatchCommand {
         // (agentId is null), matching the scope of the cwd-based detection above — a subagent
         // watcher is always spawned with cwd: null too and has never had its own repo detection.
         if (vendor == "claude" && agentId is null && (cwd is null || GitRepository.FindRoot(cwd) is null)) {
-            state.EvidenceScanner = new RepoEvidenceScanner(GitRepository.FindRoot);
+            state.EvidenceScanner = new RepoEvidenceScanner<RepositoryPayload>(
+                GitRepository.FindRoot, root => RepositoryDetection.DetectRepositoryAsync(root),
+                p => p.Owner is not null && p.RepoName is not null);
 
             try {
                 foreach (var line in File.ReadLines(transcriptPath)) {
-                    if (state.EvidenceScanner.OnLine(vendor, line) is { } root) {
-                        await ApplyEvidenceRootAsync(state, root);
+                    if (await state.EvidenceScanner.OnLineAsync(vendor, line) is { } repo) {
+                        ApplyEvidenceRepo(state, repo);
 
                         break;
                     }
@@ -940,11 +942,12 @@ static partial class WatchCommand {
         // this skip is scoped to idleExit specifically.
         var cursorSuppressesEndPost = CursorSuppressesEndPost(vendor, idleExit);
 
-        // Two-slot rule's second slot: the final drain above never saw a mutation, so promote
-        // whatever read-only evidence it collected — otherwise a parent-exit session-end below
-        // would carry no repository at all.
-        if (state.EvidenceScanner?.PromoteReadFallback() is { } fallbackRoot) {
-            await ApplyEvidenceRootAsync(state, fallbackRoot);
+        // Belt-and-suspenders: normally a no-op by now — the final drain above (inside
+        // DrainNewLines's isFinalDrain branch) already promoted and applied any read fallback as
+        // part of the same batch that reaches the server on a clean exit. This only still matters
+        // if that branch didn't run at all (e.g. the final drain found the transcript file gone).
+        if (state.EvidenceScanner is { } scanner && await scanner.PromoteReadFallbackAsync() is { } fallbackRepo) {
+            ApplyEvidenceRepo(state, fallbackRepo);
         }
 
         if (endReason is not null && agentId is null && state.ThresholdReached && !cursorSuppressesEndPost) {
@@ -2178,15 +2181,23 @@ static partial class WatchCommand {
             }
 
             // Evidence-based repo detection for a session launched outside any repo: feed this
-            // batch's lines to the scanner so a mutation (or, at final drain, a promoted read)
-            // attributes a root. state.EvidenceScanner is null for every other session.
+            // batch's lines to the scanner so a mutation attributes a root immediately.
+            // state.EvidenceScanner is null for every other session.
             if (state.EvidenceScanner is { Done: false } scanner) {
                 foreach (var line in newLines) {
-                    if (scanner.OnLine(vendor, line) is { } root) {
-                        await ApplyEvidenceRootAsync(state, root);
+                    if (await scanner.OnLineAsync(vendor, line) is { } repo) {
+                        ApplyEvidenceRepo(state, repo);
 
                         break;
                     }
+                }
+
+                // Final drain, no mutation ever landed: promote the read fallback (if any) NOW,
+                // before repoToSend below is computed, so it rides THIS batch — the one that
+                // actually reaches the server on a clean session end (PostSessionEndOnParentExitAsync
+                // never fires when endReason is null, so it can't be relied on to deliver this).
+                if (isFinalDrain && await scanner.PromoteReadFallbackAsync() is { } fallback) {
+                    ApplyEvidenceRepo(state, fallback);
                 }
             }
 
@@ -3303,15 +3314,11 @@ static partial class WatchCommand {
     internal static bool ShouldReplaceRepository(RepositoryPayload? detected, bool repositoryFromEvidence) =>
         detected is not null || !repositoryFromEvidence;
 
-    // Shared by the upfront prefix scan, the per-drained-line scan, and the final-drain
-    // read-fallback promotion — all three resolve an evidence-attributed root the same way.
-    static async Task ApplyEvidenceRootAsync(WatchState state, string root) {
-        var repo = await RepositoryDetection.DetectRepositoryAsync(root);
-
-        if (repo?.Owner is not null && repo.RepoName is not null) {
-            state.Repository             = repo;
-            state.RepositoryFromEvidence = true;
-        }
+    // Shared by every EvidenceScanner call site — the scanner already resolved and validated
+    // completeness (RepoEvidenceScanner's isComplete), so this just records the result.
+    static void ApplyEvidenceRepo(WatchState state, RepositoryPayload repo) {
+        state.Repository             = repo;
+        state.RepositoryFromEvidence = true;
     }
 
     static string TruncateForTitle(string text, int maxLength) {

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -2180,26 +2180,10 @@ static partial class WatchCommand {
                 newLines = EnrichKiroContextUsage(newLines, transcriptPath);
             }
 
-            // Evidence-based repo detection for a session launched outside any repo: feed this
-            // batch's lines to the scanner so a mutation attributes a root immediately.
-            // state.EvidenceScanner is null for every other session.
-            if (state.EvidenceScanner is { Done: false } scanner) {
-                foreach (var line in newLines) {
-                    if (await scanner.OnLineAsync(vendor, line) is { } repo) {
-                        ApplyEvidenceRepo(state, repo);
-
-                        break;
-                    }
-                }
-
-                // Final drain, no mutation ever landed: promote the read fallback (if any) NOW,
-                // before repoToSend below is computed, so it rides THIS batch — the one that
-                // actually reaches the server on a clean session end (PostSessionEndOnParentExitAsync
-                // never fires when endReason is null, so it can't be relied on to deliver this).
-                if (isFinalDrain && await scanner.PromoteReadFallbackAsync() is { } fallback) {
-                    ApplyEvidenceRepo(state, fallback);
-                }
-            }
+            // Evidence-based repo detection for a session launched outside any repo — extracted
+            // to ApplyEvidenceScanAsync so the final-drain fallback delivery (the actual send
+            // path, not just the promotion) is directly unit-testable with a fake scanner.
+            await ApplyEvidenceScanAsync(state, vendor, newLines, isFinalDrain);
 
             // Only include repository info when it has changed since last send
             var repoToSend = RepoPayloadChanged(state.Repository, state.LastSentRepository)
@@ -3319,6 +3303,27 @@ static partial class WatchCommand {
     static void ApplyEvidenceRepo(WatchState state, RepositoryPayload repo) {
         state.Repository             = repo;
         state.RepositoryFromEvidence = true;
+    }
+
+    // Extracted out of DrainNewLines so the final-drain fallback DELIVERY (not just
+    // RepoEvidenceScanner's own promotion, which was already covered) is unit-testable with a
+    // fake scanner and no HubConnection: a caller can assert state.Repository directly after
+    // isFinalDrain: true, and that a non-final drain leaves it untouched. No-op when
+    // state.EvidenceScanner is null (every non-Claude / already-in-repo session) or already Done.
+    internal static async Task ApplyEvidenceScanAsync(WatchState state, string vendor, IReadOnlyList<string> newLines, bool isFinalDrain) {
+        if (state.EvidenceScanner is not { Done: false } scanner) return;
+
+        foreach (var line in newLines) {
+            if (await scanner.OnLineAsync(vendor, line) is { } repo) {
+                ApplyEvidenceRepo(state, repo);
+
+                return;
+            }
+        }
+
+        if (isFinalDrain && await scanner.PromoteReadFallbackAsync() is { } fallback) {
+            ApplyEvidenceRepo(state, fallback);
+        }
     }
 
     static string TruncateForTitle(string text, int maxLength) {

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -164,6 +164,18 @@ static partial class WatchCommand {
         return reader.ReadToEnd();
     }
 
+    /// <summary>Line-yielding sibling of <see cref="ReadAllTextShared"/> — same FileShare.ReadWrite
+    /// reasoning, but streamed (like <c>File.ReadLines</c>) rather than materialized, for a
+    /// best-effort evidence scan that wants to stop reading as soon as it finds what it needs.
+    /// <c>File.ReadLines</c> opens FileShare.Read, which is mandatory-exclusive on Windows and can
+    /// block the very agent whose transcript is being scanned mid-flush.</summary>
+    internal static IEnumerable<string> ReadLinesShared(string path) {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+
+        while (reader.ReadLine() is { } line) yield return line;
+    }
+
     /// <summary>
     /// Maximum single wait between heartbeat touches. Comfortably below the
     /// <c>WatcherHeartbeat.Threshold</c> so no chunked wait can ever look stale, and matches the
@@ -497,7 +509,7 @@ static partial class WatchCommand {
                 p => p.Owner is not null && p.RepoName is not null);
 
             try {
-                foreach (var line in File.ReadLines(transcriptPath)) {
+                foreach (var line in ReadLinesShared(transcriptPath)) {
                     if (await state.EvidenceScanner.OnLineAsync(vendor, line) is { } repo) {
                         ApplyEvidenceRepo(state, repo);
 

--- a/src/Capacitor.Cli/Commands/WatchCommand.cs
+++ b/src/Capacitor.Cli/Commands/WatchCommand.cs
@@ -12,6 +12,7 @@ using Capacitor.Cli.Core.Harness.Gemini;
 using Capacitor.Cli.Core.Harness.Kiro;
 using Capacitor.Cli.Core.Harness.OpenCode;
 using Capacitor.Cli.Core.Harness.Pi;
+using Capacitor.Cli.Core.RepoEvidence;
 using Capacitor.Cli.Harness.Antigravity;
 using Capacitor.Cli.Harness.Codex;
 using Capacitor.Cli.Harness.Cursor;
@@ -486,6 +487,26 @@ static partial class WatchCommand {
             state.LastRepoDetection = DateTimeOffset.UtcNow;
         }
 
+        // No cwd-derived repo (launched outside any checkout, or no cwd at all): fall back to
+        // scanning the transcript's own tool-use paths for a git root. Session-watcher only
+        // (agentId is null), matching the scope of the cwd-based detection above — a subagent
+        // watcher is always spawned with cwd: null too and has never had its own repo detection.
+        if (vendor == "claude" && agentId is null && (cwd is null || GitRepository.FindRoot(cwd) is null)) {
+            state.EvidenceScanner = new RepoEvidenceScanner(GitRepository.FindRoot);
+
+            try {
+                foreach (var line in File.ReadLines(transcriptPath)) {
+                    if (state.EvidenceScanner.OnLine(vendor, line) is { } root) {
+                        await ApplyEvidenceRootAsync(state, root);
+
+                        break;
+                    }
+                }
+            } catch {
+                // fail-open: this one-shot prefix scan is best-effort and must never block startup
+            }
+        }
+
         Log($"Watching {transcriptPath} for session {sessionId}" + (agentId is not null ? $" agent {agentId}" : ""));
 
         // Build SignalR hub connection
@@ -711,7 +732,14 @@ static partial class WatchCommand {
 
                 // Periodically refresh repository info (every 60s)
                 if (cwd is not null && DateTimeOffset.UtcNow - state.LastRepoDetection > TimeSpan.FromSeconds(60)) {
-                    state.Repository        = await RepositoryDetection.DetectRepositoryAsync(cwd);
+                    var detected = await RepositoryDetection.DetectRepositoryAsync(cwd);
+
+                    // An evidence-derived repo may only be replaced by another real detection,
+                    // never cleared back to null by a launch-cwd probe that still finds nothing.
+                    if (ShouldReplaceRepository(detected, state.RepositoryFromEvidence)) {
+                        state.Repository = detected;
+                    }
+
                     state.LastRepoDetection = DateTimeOffset.UtcNow;
                 }
 
@@ -911,6 +939,13 @@ static partial class WatchCommand {
         // eventually fires. Cursor's other exit paths (StopWatcher, parent-exit) are unaffected —
         // this skip is scoped to idleExit specifically.
         var cursorSuppressesEndPost = CursorSuppressesEndPost(vendor, idleExit);
+
+        // Two-slot rule's second slot: the final drain above never saw a mutation, so promote
+        // whatever read-only evidence it collected — otherwise a parent-exit session-end below
+        // would carry no repository at all.
+        if (state.EvidenceScanner?.PromoteReadFallback() is { } fallbackRoot) {
+            await ApplyEvidenceRootAsync(state, fallbackRoot);
+        }
 
         if (endReason is not null && agentId is null && state.ThresholdReached && !cursorSuppressesEndPost) {
             await PostSessionEndOnParentExitAsync(baseUrl, sessionId, transcriptPath, cwd, vendor, state.Repository, endReason);
@@ -2142,6 +2177,19 @@ static partial class WatchCommand {
                 newLines = EnrichKiroContextUsage(newLines, transcriptPath);
             }
 
+            // Evidence-based repo detection for a session launched outside any repo: feed this
+            // batch's lines to the scanner so a mutation (or, at final drain, a promoted read)
+            // attributes a root. state.EvidenceScanner is null for every other session.
+            if (state.EvidenceScanner is { Done: false } scanner) {
+                foreach (var line in newLines) {
+                    if (scanner.OnLine(vendor, line) is { } root) {
+                        await ApplyEvidenceRootAsync(state, root);
+
+                        break;
+                    }
+                }
+            }
+
             // Only include repository info when it has changed since last send
             var repoToSend = RepoPayloadChanged(state.Repository, state.LastSentRepository)
                 ? state.Repository
@@ -3247,6 +3295,23 @@ static partial class WatchCommand {
          || current.PrUrl     != lastSent.PrUrl
          || current.PrTitle   != lastSent.PrTitle
          || current.PrHeadRef != lastSent.PrHeadRef;
+    }
+
+    // An evidence-derived repo (from RepoEvidenceScanner, for a session launched outside any
+    // checkout) has no cwd to re-probe, so a periodic cwd-based refresh finding nothing must
+    // never be allowed to clear it back to null.
+    internal static bool ShouldReplaceRepository(RepositoryPayload? detected, bool repositoryFromEvidence) =>
+        detected is not null || !repositoryFromEvidence;
+
+    // Shared by the upfront prefix scan, the per-drained-line scan, and the final-drain
+    // read-fallback promotion — all three resolve an evidence-attributed root the same way.
+    static async Task ApplyEvidenceRootAsync(WatchState state, string root) {
+        var repo = await RepositoryDetection.DetectRepositoryAsync(root);
+
+        if (repo?.Owner is not null && repo.RepoName is not null) {
+            state.Repository             = repo;
+            state.RepositoryFromEvidence = true;
+        }
     }
 
     static string TruncateForTitle(string text, int maxLength) {

--- a/test/Capacitor.Cli.Core.Tests.Unit/RepoEvidenceScannerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/RepoEvidenceScannerTests.cs
@@ -3,95 +3,127 @@ using Capacitor.Cli.Core.RepoEvidence;
 namespace Capacitor.Cli.Core.Tests.Unit;
 
 public class RepoEvidenceScannerTests {
-    // Roots the fake resolver knows; everything else resolves to null (non-repo).
+    sealed record FakeRepo(string? Owner, string? RepoName);
+
+    // Roots the fake findRoot knows; everything else resolves to null (non-repo).
     static string? FakeFindRoot(string dir) =>
         dir.StartsWith("/home/u/dev/repo-a", StringComparison.Ordinal) ? "/home/u/dev/repo-a"
         : dir.StartsWith("/home/u/dev/repo-b", StringComparison.Ordinal) ? "/home/u/dev/repo-b"
+        : dir.StartsWith("/home/u/dev/repo-noremote", StringComparison.Ordinal) ? "/home/u/dev/repo-noremote"
         : null;
+
+    // Roots the fake resolver can turn into a repo. repo-noremote resolves (FindRoot succeeds,
+    // it IS a git dir) but comes back owner/repo null — e.g. a local `git init` with no remote.
+    static readonly Dictionary<string, FakeRepo> Repos = new(StringComparer.Ordinal) {
+        ["/home/u/dev/repo-a"]        = new("acme", "repo-a"),
+        ["/home/u/dev/repo-b"]        = new("acme", "repo-b"),
+        ["/home/u/dev/repo-noremote"] = new(null, null),
+    };
+
+    static Task<FakeRepo?> FakeResolve(string root) => Task.FromResult(Repos.GetValueOrDefault(root));
+
+    static bool IsComplete(FakeRepo r) => r.Owner is not null && r.RepoName is not null;
+
+    static RepoEvidenceScanner<FakeRepo> NewScanner() => new(FakeFindRoot, FakeResolve, IsComplete);
 
     static string Line(string tool, string key, string path) =>
         $$$"""{"type":"assistant","message":{"content":[{"type":"tool_use","name":"{{{tool}}}","input":{"{{{key}}}":"{{{path}}}"}}]}}""";
 
     [Test]
     public async Task First_mutation_path_attributes_immediately() {
-        var s = new RepoEvidenceScanner(FakeFindRoot);
-        var attributed = s.OnLine("claude", Line("Edit", "file_path", "/home/u/dev/repo-a/src/x.cs"));
-        await Assert.That(attributed).IsEqualTo("/home/u/dev/repo-a");
+        var s          = NewScanner();
+        var attributed = await s.OnLineAsync("claude", Line("Edit", "file_path", "/home/u/dev/repo-a/src/x.cs"));
+        await Assert.That(attributed).IsEqualTo(new FakeRepo("acme", "repo-a"));
         await Assert.That(s.Done).IsTrue();
     }
 
     [Test]
     public async Task Read_path_is_remembered_not_attributed() {
-        var s = new RepoEvidenceScanner(FakeFindRoot);
-        var attributed = s.OnLine("claude", Line("Read", "file_path", "/home/u/dev/repo-b/y.cs"));
+        var s          = NewScanner();
+        var attributed = await s.OnLineAsync("claude", Line("Read", "file_path", "/home/u/dev/repo-b/y.cs"));
         await Assert.That(attributed).IsNull();
         await Assert.That(s.Done).IsFalse();
-        await Assert.That(s.ReadFallbackRoot).IsEqualTo("/home/u/dev/repo-b");
+        await Assert.That(s.ReadFallback).IsEqualTo(new FakeRepo("acme", "repo-b"));
     }
 
     [Test]
     public async Task Mutation_after_read_wins_slot_a() {
-        var s = new RepoEvidenceScanner(FakeFindRoot);
-        s.OnLine("claude", Line("Read", "file_path", "/home/u/dev/repo-b/y.cs"));
-        var attributed = s.OnLine("claude", Line("Write", "file_path", "/home/u/dev/repo-a/z.cs"));
-        await Assert.That(attributed).IsEqualTo("/home/u/dev/repo-a");
+        var s = NewScanner();
+        await s.OnLineAsync("claude", Line("Read", "file_path", "/home/u/dev/repo-b/y.cs"));
+        var attributed = await s.OnLineAsync("claude", Line("Write", "file_path", "/home/u/dev/repo-a/z.cs"));
+        await Assert.That(attributed).IsEqualTo(new FakeRepo("acme", "repo-a"));
     }
 
     [Test]
     public async Task Promote_read_fallback_only_when_no_mutation_arrived() {
-        var s = new RepoEvidenceScanner(FakeFindRoot);
-        s.OnLine("claude", Line("Grep", "path", "/home/u/dev/repo-b/sub"));
-        var promoted = s.PromoteReadFallback();
-        await Assert.That(promoted).IsEqualTo("/home/u/dev/repo-b");
+        var s = NewScanner();
+        await s.OnLineAsync("claude", Line("Grep", "path", "/home/u/dev/repo-b/sub"));
+        var promoted = await s.PromoteReadFallbackAsync();
+        await Assert.That(promoted).IsEqualTo(new FakeRepo("acme", "repo-b"));
         await Assert.That(s.Done).IsTrue();
-        await Assert.That(s.PromoteReadFallback()).IsNull(); // idempotent
+        await Assert.That(await s.PromoteReadFallbackAsync()).IsNull(); // idempotent
     }
 
     [Test]
     public async Task Scanner_stops_after_attribution() {
-        var s = new RepoEvidenceScanner(FakeFindRoot);
-        s.OnLine("claude", Line("Edit", "file_path", "/home/u/dev/repo-a/x.cs"));
-        var again = s.OnLine("claude", Line("Edit", "file_path", "/home/u/dev/repo-b/q.cs"));
+        var s = NewScanner();
+        await s.OnLineAsync("claude", Line("Edit", "file_path", "/home/u/dev/repo-a/x.cs"));
+        var again = await s.OnLineAsync("claude", Line("Edit", "file_path", "/home/u/dev/repo-b/q.cs"));
         await Assert.That(again).IsNull(); // no post-attribution hunting (spec D2)
     }
 
     [Test]
     public async Task Relative_temp_and_nonrepo_paths_are_ignored() {
-        var s = new RepoEvidenceScanner(FakeFindRoot);
-        await Assert.That(s.OnLine("claude", Line("Edit", "file_path", "relative/x.cs"))).IsNull();
-        await Assert.That(s.OnLine("claude", Line("Edit", "file_path", "/tmp/scratch/x.cs"))).IsNull();
+        var s = NewScanner();
+        await Assert.That(await s.OnLineAsync("claude", Line("Edit", "file_path", "relative/x.cs"))).IsNull();
+        await Assert.That(await s.OnLineAsync("claude", Line("Edit", "file_path", "/tmp/scratch/x.cs"))).IsNull();
         await Assert.That(s.Done).IsFalse();
-        await Assert.That(s.ReadFallbackRoot).IsNull();
+        await Assert.That(s.ReadFallback).IsNull();
     }
 
     [Test]
     public async Task Mutation_with_failed_tool_result_still_counts() {
         // Evidence is the INPUT (spec D5); tool results are never consulted, so
         // there is nothing on the line that could veto it.
-        var s = new RepoEvidenceScanner(FakeFindRoot);
-        var attributed = s.OnLine("claude", Line("NotebookEdit", "notebook_path", "/home/u/dev/repo-a/n.ipynb"));
-        await Assert.That(attributed).IsEqualTo("/home/u/dev/repo-a");
+        var s          = NewScanner();
+        var attributed = await s.OnLineAsync("claude", Line("NotebookEdit", "notebook_path", "/home/u/dev/repo-a/n.ipynb"));
+        await Assert.That(attributed).IsEqualTo(new FakeRepo("acme", "repo-a"));
     }
 
     [Test]
     public async Task Unknown_vendor_and_malformed_lines_are_fail_open() {
-        var s = new RepoEvidenceScanner(FakeFindRoot);
-        await Assert.That(s.OnLine("gemini", Line("Edit", "file_path", "/home/u/dev/repo-a/x.cs"))).IsNull();
-        await Assert.That(s.OnLine("claude", "not json at all")).IsNull();
-        await Assert.That(s.OnLine("claude", """{"type":"user"}""")).IsNull();
+        var s = NewScanner();
+        await Assert.That(await s.OnLineAsync("gemini", Line("Edit", "file_path", "/home/u/dev/repo-a/x.cs"))).IsNull();
+        await Assert.That(await s.OnLineAsync("claude", "not json at all")).IsNull();
+        await Assert.That(await s.OnLineAsync("claude", """{"type":"user"}""")).IsNull();
+    }
+
+    [Test]
+    public async Task Incomplete_root_does_not_latch_and_a_later_complete_root_wins() {
+        // FindRoot succeeds for repo-noremote (it IS a git dir) but the resolver comes back
+        // owner/repo null — must be skipped, not latched, so a later real repo can still win.
+        var s = NewScanner();
+
+        var firstAttempt = await s.OnLineAsync("claude", Line("Edit", "file_path", "/home/u/dev/repo-noremote/x.cs"));
+        await Assert.That(firstAttempt).IsNull();
+        await Assert.That(s.Done).IsFalse();
+
+        var secondAttempt = await s.OnLineAsync("claude", Line("Edit", "file_path", "/home/u/dev/repo-a/y.cs"));
+        await Assert.That(secondAttempt).IsEqualTo(new FakeRepo("acme", "repo-a"));
+        await Assert.That(s.Done).IsTrue();
     }
 
     [Test]
     public async Task ExtractClaudePaths_classifies_all_v1_tools() {
-        var muts = new[] { ("Edit","file_path"), ("MultiEdit","file_path"), ("Write","file_path"), ("NotebookEdit","notebook_path") };
+        var muts = new[] { ("Edit", "file_path"), ("MultiEdit", "file_path"), ("Write", "file_path"), ("NotebookEdit", "notebook_path") };
         foreach (var (tool, key) in muts) {
-            var got = RepoEvidenceScanner.ExtractClaudePaths(Line(tool, key, "/a/b.cs"));
+            var got = RepoEvidencePaths.ExtractClaudePaths(Line(tool, key, "/a/b.cs"));
             await Assert.That(got).HasSingleItem();
             await Assert.That(got[0].Kind).IsEqualTo(RepoEvidenceKind.Mutation);
         }
-        var reads = new[] { ("Read","file_path"), ("Glob","path"), ("Grep","path") };
+        var reads = new[] { ("Read", "file_path"), ("Glob", "path"), ("Grep", "path") };
         foreach (var (tool, key) in reads) {
-            var got = RepoEvidenceScanner.ExtractClaudePaths(Line(tool, key, "/a/b"));
+            var got = RepoEvidencePaths.ExtractClaudePaths(Line(tool, key, "/a/b"));
             await Assert.That(got).HasSingleItem();
             await Assert.That(got[0].Kind).IsEqualTo(RepoEvidenceKind.Read);
         }

--- a/test/Capacitor.Cli.Core.Tests.Unit/RepoEvidenceScannerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/RepoEvidenceScannerTests.cs
@@ -1,0 +1,99 @@
+using Capacitor.Cli.Core.RepoEvidence;
+
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class RepoEvidenceScannerTests {
+    // Roots the fake resolver knows; everything else resolves to null (non-repo).
+    static string? FakeFindRoot(string dir) =>
+        dir.StartsWith("/home/u/dev/repo-a", StringComparison.Ordinal) ? "/home/u/dev/repo-a"
+        : dir.StartsWith("/home/u/dev/repo-b", StringComparison.Ordinal) ? "/home/u/dev/repo-b"
+        : null;
+
+    static string Line(string tool, string key, string path) =>
+        $$$"""{"type":"assistant","message":{"content":[{"type":"tool_use","name":"{{{tool}}}","input":{"{{{key}}}":"{{{path}}}"}}]}}""";
+
+    [Test]
+    public async Task First_mutation_path_attributes_immediately() {
+        var s = new RepoEvidenceScanner(FakeFindRoot);
+        var attributed = s.OnLine("claude", Line("Edit", "file_path", "/home/u/dev/repo-a/src/x.cs"));
+        await Assert.That(attributed).IsEqualTo("/home/u/dev/repo-a");
+        await Assert.That(s.Done).IsTrue();
+    }
+
+    [Test]
+    public async Task Read_path_is_remembered_not_attributed() {
+        var s = new RepoEvidenceScanner(FakeFindRoot);
+        var attributed = s.OnLine("claude", Line("Read", "file_path", "/home/u/dev/repo-b/y.cs"));
+        await Assert.That(attributed).IsNull();
+        await Assert.That(s.Done).IsFalse();
+        await Assert.That(s.ReadFallbackRoot).IsEqualTo("/home/u/dev/repo-b");
+    }
+
+    [Test]
+    public async Task Mutation_after_read_wins_slot_a() {
+        var s = new RepoEvidenceScanner(FakeFindRoot);
+        s.OnLine("claude", Line("Read", "file_path", "/home/u/dev/repo-b/y.cs"));
+        var attributed = s.OnLine("claude", Line("Write", "file_path", "/home/u/dev/repo-a/z.cs"));
+        await Assert.That(attributed).IsEqualTo("/home/u/dev/repo-a");
+    }
+
+    [Test]
+    public async Task Promote_read_fallback_only_when_no_mutation_arrived() {
+        var s = new RepoEvidenceScanner(FakeFindRoot);
+        s.OnLine("claude", Line("Grep", "path", "/home/u/dev/repo-b/sub"));
+        var promoted = s.PromoteReadFallback();
+        await Assert.That(promoted).IsEqualTo("/home/u/dev/repo-b");
+        await Assert.That(s.Done).IsTrue();
+        await Assert.That(s.PromoteReadFallback()).IsNull(); // idempotent
+    }
+
+    [Test]
+    public async Task Scanner_stops_after_attribution() {
+        var s = new RepoEvidenceScanner(FakeFindRoot);
+        s.OnLine("claude", Line("Edit", "file_path", "/home/u/dev/repo-a/x.cs"));
+        var again = s.OnLine("claude", Line("Edit", "file_path", "/home/u/dev/repo-b/q.cs"));
+        await Assert.That(again).IsNull(); // no post-attribution hunting (spec D2)
+    }
+
+    [Test]
+    public async Task Relative_temp_and_nonrepo_paths_are_ignored() {
+        var s = new RepoEvidenceScanner(FakeFindRoot);
+        await Assert.That(s.OnLine("claude", Line("Edit", "file_path", "relative/x.cs"))).IsNull();
+        await Assert.That(s.OnLine("claude", Line("Edit", "file_path", "/tmp/scratch/x.cs"))).IsNull();
+        await Assert.That(s.Done).IsFalse();
+        await Assert.That(s.ReadFallbackRoot).IsNull();
+    }
+
+    [Test]
+    public async Task Mutation_with_failed_tool_result_still_counts() {
+        // Evidence is the INPUT (spec D5); tool results are never consulted, so
+        // there is nothing on the line that could veto it.
+        var s = new RepoEvidenceScanner(FakeFindRoot);
+        var attributed = s.OnLine("claude", Line("NotebookEdit", "notebook_path", "/home/u/dev/repo-a/n.ipynb"));
+        await Assert.That(attributed).IsEqualTo("/home/u/dev/repo-a");
+    }
+
+    [Test]
+    public async Task Unknown_vendor_and_malformed_lines_are_fail_open() {
+        var s = new RepoEvidenceScanner(FakeFindRoot);
+        await Assert.That(s.OnLine("gemini", Line("Edit", "file_path", "/home/u/dev/repo-a/x.cs"))).IsNull();
+        await Assert.That(s.OnLine("claude", "not json at all")).IsNull();
+        await Assert.That(s.OnLine("claude", """{"type":"user"}""")).IsNull();
+    }
+
+    [Test]
+    public async Task ExtractClaudePaths_classifies_all_v1_tools() {
+        var muts = new[] { ("Edit","file_path"), ("MultiEdit","file_path"), ("Write","file_path"), ("NotebookEdit","notebook_path") };
+        foreach (var (tool, key) in muts) {
+            var got = RepoEvidenceScanner.ExtractClaudePaths(Line(tool, key, "/a/b.cs"));
+            await Assert.That(got).HasSingleItem();
+            await Assert.That(got[0].Kind).IsEqualTo(RepoEvidenceKind.Mutation);
+        }
+        var reads = new[] { ("Read","file_path"), ("Glob","path"), ("Grep","path") };
+        foreach (var (tool, key) in reads) {
+            var got = RepoEvidenceScanner.ExtractClaudePaths(Line(tool, key, "/a/b"));
+            await Assert.That(got).HasSingleItem();
+            await Assert.That(got[0].Kind).IsEqualTo(RepoEvidenceKind.Read);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/RepoEvidenceScannerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/RepoEvidenceScannerTests.cs
@@ -128,4 +128,44 @@ public class RepoEvidenceScannerTests {
             await Assert.That(got[0].Kind).IsEqualTo(RepoEvidenceKind.Read);
         }
     }
+
+    // qodo #3 / Windows CI: a Windows-absolute path must attribute exactly like a Unix one — the
+    // gate and the parent-dir derivation both have to be OS-independent (this suite runs on
+    // ubuntu-latest AND windows-latest), not just accept whatever the running OS calls "absolute".
+    // Line() splices `path` straight into JSON text (no JSON-escaping), so a Windows path's
+    // backslashes must be pre-doubled in the literal here — JsonNode.Parse then unescapes `\\`
+    // back to the real single-backslash path the scanner actually receives (verified: a
+    // single-backslash literal produces invalid JSON, e.g. `\d` is not a legal JSON escape).
+    const string WindowsPathJsonEscaped = @"C:\\dev\\repo-a\\x.cs";
+    const string WindowsPath            = @"C:\dev\repo-a\x.cs";
+
+    [Test]
+    public async Task Windows_absolute_path_attributes_correctly() {
+        static string? WindowsFindRoot(string dir) => dir.StartsWith(@"C:\dev\repo-a", StringComparison.Ordinal) ? @"C:\dev\repo-a" : null;
+
+        var s = new RepoEvidenceScanner<FakeRepo>(
+            WindowsFindRoot, _ => Task.FromResult<FakeRepo?>(new("acme", "repo-a")), IsComplete);
+
+        var attributed = await s.OnLineAsync("claude", Line("Edit", "file_path", WindowsPathJsonEscaped));
+        await Assert.That(attributed).IsEqualTo(new FakeRepo("acme", "repo-a"));
+        await Assert.That(s.Done).IsTrue();
+    }
+
+    [Test]
+    public async Task ExtractClaudePaths_accepts_a_windows_drive_path() {
+        var got = RepoEvidencePaths.ExtractClaudePaths(Line("Edit", "file_path", WindowsPathJsonEscaped));
+        await Assert.That(got).HasSingleItem();
+        await Assert.That(got[0].Path).IsEqualTo(WindowsPath);
+    }
+
+    // qodo #2: a tool_use block can sit at the event's TOP-LEVEL content, not only nested under
+    // message.content — both shapes occur in real Claude transcripts.
+    [Test]
+    public async Task ExtractClaudePaths_reads_top_level_content_too() {
+        const string line = """{"type":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/a/b.cs"}}]}""";
+        var          got  = RepoEvidencePaths.ExtractClaudePaths(line);
+        await Assert.That(got).HasSingleItem();
+        await Assert.That(got[0].Path).IsEqualTo("/a/b.cs");
+        await Assert.That(got[0].Kind).IsEqualTo(RepoEvidenceKind.Mutation);
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ImportRepoEvidenceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ImportRepoEvidenceTests.cs
@@ -39,4 +39,34 @@ public class ImportRepoEvidenceTests {
             "claude", ["""{"type":"user"}"""], _ => null, _ => Task.FromResult<RepositoryPayload?>(null));
         await Assert.That(node).IsNull();
     }
+
+    // Regression guard: File.ReadLines validates its argument eagerly — an empty path throws
+    // ArgumentException synchronously (verified directly: `System.IO.File.ReadLines("")`) even
+    // though the actual file read is lazy. Passed as a plain call argument, that throw would
+    // escape BEFORE the line-based overload's own try/catch ever runs, marking an
+    // otherwise-importable session Errored instead of importing without evidence. Empty (not
+    // null) because that's the reachable real value — session.FilePath is a non-nullable
+    // `required string` that IS empty for some vendor classifications elsewhere in this file.
+    [Test]
+    public async Task Invalid_path_degrades_to_null_instead_of_throwing() {
+        var node = await ImportCommand.TryBuildEvidenceRepositoryNodeAsync(
+            "claude", "", _ => null, _ => Task.FromResult<RepositoryPayload?>(null));
+        await Assert.That(node).IsNull();
+    }
+
+    [Test]
+    public async Task Valid_path_reads_the_file_and_attributes() {
+        using var tmp  = new TempDir();
+        var       path = tmp.CreateFile("transcript.jsonl", [
+            """{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/h/dev/repo-a/x.cs"}}]}}""",
+        ]);
+
+        string? FindRoot(string d) => d.StartsWith("/h/dev/repo-a", StringComparison.Ordinal) ? "/h/dev/repo-a" : null;
+        Task<RepositoryPayload?> Detect(string root) =>
+            Task.FromResult<RepositoryPayload?>(new() { Owner = "acme", RepoName = "repo-a" });
+
+        var node = await ImportCommand.TryBuildEvidenceRepositoryNodeAsync("claude", path, FindRoot, Detect);
+        await Assert.That(node).IsNotNull();
+        await Assert.That(node!["owner"]!.GetValue<string>()).IsEqualTo("acme");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ImportRepoEvidenceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ImportRepoEvidenceTests.cs
@@ -1,0 +1,42 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class ImportRepoEvidenceTests {
+    [Test]
+    public async Task Outside_repo_transcript_gains_a_repository_node() {
+        string? FindRoot(string d) => d.StartsWith("/h/dev/repo-a", StringComparison.Ordinal) ? "/h/dev/repo-a" : null;
+        Task<RepositoryPayload?> Detect(string root) =>
+            Task.FromResult<RepositoryPayload?>(new() { Owner = "acme", RepoName = "repo-a", RemoteUrl = "git@github.com:acme/repo-a.git" });
+
+        var lines = new[] {
+            """{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/h/dev/repo-a/x.cs"}}]}}""",
+        };
+
+        var node = await ImportCommand.TryBuildEvidenceRepositoryNodeAsync("claude", lines, FindRoot, Detect);
+        await Assert.That(node).IsNotNull();
+        await Assert.That(node!["owner"]!.GetValue<string>()).IsEqualTo("acme");
+    }
+
+    [Test]
+    public async Task Read_only_transcript_promotes_the_read_fallback() {
+        string? FindRoot(string d) => d.StartsWith("/h/dev/repo-b", StringComparison.Ordinal) ? "/h/dev/repo-b" : null;
+        Task<RepositoryPayload?> Detect(string root) =>
+            Task.FromResult<RepositoryPayload?>(new() { Owner = "acme", RepoName = "repo-b" });
+
+        var lines = new[] {
+            """{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/h/dev/repo-b/y.cs"}}]}}""",
+        };
+
+        var node = await ImportCommand.TryBuildEvidenceRepositoryNodeAsync("claude", lines, FindRoot, Detect);
+        await Assert.That(node!["repo_name"]!.GetValue<string>()).IsEqualTo("repo-b");
+    }
+
+    [Test]
+    public async Task No_evidence_yields_null() {
+        var node = await ImportCommand.TryBuildEvidenceRepositoryNodeAsync(
+            "claude", ["""{"type":"user"}"""], _ => null, _ => Task.FromResult<RepositoryPayload?>(null));
+        await Assert.That(node).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/WatchRepoEvidenceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchRepoEvidenceTests.cs
@@ -1,0 +1,12 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class WatchRepoEvidenceTests {
+    [Test]
+    public async Task Refresh_never_clears_an_evidence_payload() {
+        await Assert.That(WatchCommand.ShouldReplaceRepository(detected: null, repositoryFromEvidence: true)).IsFalse();
+        await Assert.That(WatchCommand.ShouldReplaceRepository(detected: null, repositoryFromEvidence: false)).IsTrue();
+        await Assert.That(WatchCommand.ShouldReplaceRepository(detected: new(), repositoryFromEvidence: true)).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/WatchRepoEvidenceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchRepoEvidenceTests.cs
@@ -1,4 +1,6 @@
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.RepoEvidence;
 
 namespace Capacitor.Cli.Tests.Unit;
 
@@ -8,5 +10,42 @@ public class WatchRepoEvidenceTests {
         await Assert.That(WatchCommand.ShouldReplaceRepository(detected: null, repositoryFromEvidence: true)).IsFalse();
         await Assert.That(WatchCommand.ShouldReplaceRepository(detected: null, repositoryFromEvidence: false)).IsTrue();
         await Assert.That(WatchCommand.ShouldReplaceRepository(detected: new(), repositoryFromEvidence: true)).IsTrue();
+    }
+
+    static string? FakeFindRoot(string dir) => dir.StartsWith("/h/dev/repo-r", StringComparison.Ordinal) ? "/h/dev/repo-r" : null;
+
+    static Task<RepositoryPayload?> FakeResolve(string root) =>
+        Task.FromResult<RepositoryPayload?>(new() { Owner = "acme", RepoName = "repo-r" });
+
+    static WatchState NewOutsideRepoState() => new() {
+        EvidenceScanner = new RepoEvidenceScanner<RepositoryPayload>(
+            FakeFindRoot, FakeResolve, p => p.Owner is not null && p.RepoName is not null)
+    };
+
+    static readonly string[] ReadOnlyLine = [
+        """{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/h/dev/repo-r/y.cs"}}]}}""",
+    ];
+
+    // Guards the Finding 1 regression directly: the read-only fallback must reach
+    // state.Repository specifically on the FINAL drain, since that's the only batch that still
+    // goes out on a clean session end (PostSessionEndOnParentExitAsync never fires there).
+    [Test]
+    public async Task FinalDrain_delivers_the_read_fallback_to_state_repository() {
+        var state = NewOutsideRepoState();
+
+        await WatchCommand.ApplyEvidenceScanAsync(state, "claude", ReadOnlyLine, isFinalDrain: true);
+
+        await Assert.That(state.Repository).IsNotNull();
+        await Assert.That(state.Repository!.RepoName).IsEqualTo("repo-r");
+        await Assert.That(state.RepositoryFromEvidence).IsTrue();
+    }
+
+    [Test]
+    public async Task NonFinalDrain_does_not_promote_the_read_fallback() {
+        var state = NewOutsideRepoState();
+
+        await WatchCommand.ApplyEvidenceScanAsync(state, "claude", ReadOnlyLine, isFinalDrain: false);
+
+        await Assert.That(state.Repository).IsNull();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/WatchRepoEvidenceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/WatchRepoEvidenceTests.cs
@@ -48,4 +48,19 @@ public class WatchRepoEvidenceTests {
 
         await Assert.That(state.Repository).IsNull();
     }
+
+    // qodo #1: File.ReadLines opens FileShare.Read (Windows-mandatory), which can block the
+    // agent's own flush of the transcript it's actively writing. ReadLinesShared is the
+    // FileShare.ReadWrite replacement (mirrors WatchCommand.ReadAllTextShared's rationale) —
+    // this just guards it still reads lines correctly; the sharing behavior itself is
+    // Windows-specific and not meaningfully observable from a cross-platform unit test.
+    [Test]
+    public async Task ReadLinesShared_reads_lines_from_a_real_file() {
+        using var tmp  = new TempDir();
+        var       path = tmp.CreateFile("transcript.jsonl", ["line one", "line two"]);
+
+        var lines = WatchCommand.ReadLinesShared(path).ToList();
+
+        await Assert.That(lines).IsEquivalentTo(["line one", "line two"]);
+    }
 }


### PR DESCRIPTION
Part of AI-2176.

## What & why

Coding-agent sessions launched **outside** any git repo (e.g. from a parent dir like `~/dev` that holds sibling checkouts) currently never get associated with the repo they actually work in — repo identity is derived once from the launch cwd, and `kcap watch` re-probes that same cwd forever. This is the **live-detection half** of the fix: when the launch cwd is not in a git tree, derive the repo **once from evidence** — the absolute file paths in the session's Claude tool-use inputs — and deliver it over the existing per-batch `repository` payload, so the server's existing first-wins freeze fills the NULL primary. No server change is needed for this path.

(The companion server PR adds the admin backfill for already-recorded sessions. Full design: spec `docs/superpowers/specs/2026-08-21-ai2176-repo-association-evidence-design.md`, rev 7, in the kcap-server repo.)

## Changes

- **`RepoEvidenceScanner<TRepo>`** (`Capacitor.Cli.Core/RepoEvidence/`) — pure, generic scanner. From each Claude `tool_use` input it extracts absolute paths (mutation tools `Edit`/`MultiEdit`/`Write`/`NotebookEdit` first, read tools `Read`/`Glob`/`Grep` as fallback), resolves each candidate root via injected `findRoot` + async `resolve`, and attributes the **first mutation-derived root that resolves to a detectable owner/repo** (read-derived root is the fallback, promoted only if no mutation attributed). Resolution is part of the win condition, so a no-remote/unresolvable root never latches; per-root resolve caching bounds the git cost. Path extraction lives in the non-generic `RepoEvidencePaths`.
- **Watcher** (`WatchCommand.cs`) — creates the scanner only for a Claude session watcher whose launch cwd is not in a repo (in-repo sessions are completely unaffected — D1). One-shot prefix scan on startup (restart/crash recovery), per-drained-line feeding, and final-drain promotion of the read fallback **before** the batch is sent over the live hub (so read-only sessions deliver on a clean session end, not only abnormal exits). The 60s launch-cwd refresh can never clear an evidence-derived payload.
- **Import** (`ImportCommand.cs`) — `kcap import` applies the same scanner to newly-imported transcripts whose launch cwd is not in a repo, attaching a `repository` node to the session-start payload (fail-open on an unreadable transcript).

## Tests

- `RepoEvidenceScannerTests` (10) — two-slot rule, mutation-over-read priority, incomplete-root-doesn't-latch-then-later-complete-root-wins, stop-after-attribution, relative/temp/non-repo paths ignored, fail-open, evidence-is-input (a failed tool result still counts), tool classification.
- `WatchRepoEvidenceTests` (3) — the 60s-refresh guard never clears an evidence payload; final-drain delivers the read fallback to `state.Repository`; non-final drain does not promote.
- `ImportRepoEvidenceTests` (5) — outside-repo transcript gains a `repository` node; read-only promotes the fallback; no evidence → null; invalid path degrades to null.

## Scope notes

- **Unix-absolute paths only** in the live scanner (per the design). Windows Claude sessions started outside a repo get no *live* attribution but are covered by the server-side backfill (which handles `C:\`/`C:/`/UNC forms).
- **Vendor scope**: Claude Code watcher + import in v1 (Cursor and other vendors are follow-ups).
- Very short (<10 transcript line) sessions are dropped by the existing watcher threshold before evidence scanning — a conscious limitation; the server-side backfill re-homes any residual `repo_hash IS NULL` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
