### PR TITLE
Desktop shell: repository list on Home

### DIFF
--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -599,7 +599,7 @@ public partial class App : Application {
         // none (a test) gets an unheld one, which owns nothing until a launch is actually made.
         var home = new HomeViewModel(
             service, new AppStateStore(PathHelpers.ConfigPath("app-state.json")),
-            launch ?? new ServerLaunchClient(), shutdownToken);
+            launch ?? new ServerLaunchClient(), RepoPathStore.GetSortedPathsAsync, shutdownToken);
         var window = new MainWindow {
             DataContext = new MainWindowViewModel(service, actions, ticker, shutdownToken, activity, startAction, lifecycleStatus, home: home),
             Notifier = notifier,

--- a/src/Capacitor.App/Services/HostedHarnessCatalog.cs
+++ b/src/Capacitor.App/Services/HostedHarnessCatalog.cs
@@ -53,6 +53,12 @@ public static class HostedHarnessCatalog {
         return options;
     }
 
+    /// Display label for a vendor token: the option's Label when the list carries one, the raw
+    /// token otherwise (before the first daemon snapshot, or a token this build has never heard
+    /// of). Shared by the harness chip and the repository menu's remembered-harness pill.
+    public static string LabelFor(IReadOnlyList<HarnessOption> options, string vendor) =>
+        options.FirstOrDefault(o => string.Equals(o.Vendor, vendor, StringComparison.OrdinalIgnoreCase))?.Label ?? vendor;
+
     public static string DescriptionFor(HarnessOption option) => option.TransportFamily switch {
         "pty" => "PTY · terminal + chat",
         "acp" => "ACP · chat",

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -4,6 +4,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using Capacitor.App.Services;
+using Capacitor.Cli.Core;
 using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI;
@@ -163,8 +164,11 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
 
         foreach (var key in byRepo?.Keys ?? [])
             Add(key);
+        // An agent's RepoPath can be a worktree checkout (review flows launch into the
+        // requester's worktree) — the menu offers the repository, never the checkout (GH #655).
         foreach (var agent in _daemon.Agents.Items)
-            Add(agent.RepoPath);
+            if (agent.RepoPath is { Length: > 0 } repoPath)
+                Add(GitRepository.ResolveMainRepoRoot(repoPath));
         foreach (var repo in known)
             Add(repo);
         Add(SelectedRepoPath);

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -10,6 +10,11 @@ using ReactiveUI;
 
 namespace Capacitor.App.ViewModels;
 
+/// One entry of the repository chip's menu. Vendor is the remembered harness for RepoPath, or
+/// HomeViewModel.DefaultVendor when none was ever chosen there; Selected marks the entry that
+/// matches SelectedRepoPath under HomeViewModel's own path comparison.
+public sealed record RepositoryOption(string RepoPath, string Vendor, bool Selected);
+
 /// The Home tab's view-model: repository + harness picker, a free-text goal, and
 /// the Start action that launches a session through ILaunchClient. Constructed once, like
 /// TrayViewModel/ActivityViewModel — not gated behind IActivatableViewModel — since Harnesses and
@@ -131,6 +136,40 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
 
         var repoPath = SelectedRepoPath;
         await _state.UpdateAsync(s => s with { HarnessByRepo = WithEntry(s.HarnessByRepo, repoPath, vendor) });
+    }
+
+    /// The repository chip's menu, assembled per open rather than kept as a live projection — the
+    /// flyout is transient, so reading at click time is always fresh with no extra subscription.
+    /// Sources: remembered HarnessByRepo keys, distinct agent RepoPaths, and the current selection
+    /// (a picker-added repo with no remembered harness and no agent yet lives nowhere else).
+    /// Deduped under PathComparer with remembered keys added first, so where two casings are one
+    /// repository the casing the user picked is the one displayed. Scratch is always last; the
+    /// view renders it separated.
+    public async Task<IReadOnlyList<RepositoryOption>> ListRepositoriesAsync() {
+        var byRepo = (await _state.LoadAsync()).HarnessByRepo;
+
+        var seen = new HashSet<string>(PathComparer);
+        var paths = new List<string>();
+        void Add(string? path) {
+            if (!string.IsNullOrEmpty(path) && seen.Add(path)) paths.Add(path);
+        }
+
+        foreach (var key in byRepo?.Keys ?? [])
+            Add(key);
+        foreach (var agent in _daemon.Agents.Items)
+            Add(agent.RepoPath);
+        Add(SelectedRepoPath);
+
+        var selected = SelectedRepoPath;
+        var options = paths
+            .OrderBy(p => RepoLabel.Leaf(p), StringComparer.OrdinalIgnoreCase)
+            .ThenBy(p => p, StringComparer.Ordinal)
+            .Select(p => new RepositoryOption(p, Lookup(byRepo, p) ?? DefaultVendor, PathComparer.Equals(p, selected)))
+            .ToList();
+
+        options.Add(new RepositoryOption(
+            ScratchRepoPath, Lookup(byRepo, ScratchRepoPath) ?? DefaultVendor, selected.Length == 0));
+        return options;
     }
 
     /// Sets the repository and restores that repository's remembered harness, or DefaultVendor

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -38,6 +38,7 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     readonly IDaemonClientService _daemon;
     readonly IAppStateStore _state;
     readonly ILaunchClient _launch;
+    readonly Func<Task<string[]>> _knownRepos;
     readonly CompositeDisposable _disposables = new();
 
     string _selectedRepoPath = ScratchRepoPath;
@@ -89,12 +90,16 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// shutdown, so an in-flight hub invoke holding no token races that teardown.
     readonly CancellationToken _shutdown;
 
+    /// knownRepos is RepoPathStore.GetSortedPathsAsync in production — the same persisted list
+    /// DaemonConnect.RepoPaths feeds the server's launch dialog. Required (no defaulted overload)
+    /// so a test can never silently read the developer's own ~/.config/kcap/repos.json.
     public HomeViewModel(
             IDaemonClientService daemon, IAppStateStore state, ILaunchClient launch,
-            CancellationToken shutdown = default) {
+            Func<Task<string[]>> knownRepos, CancellationToken shutdown = default) {
         _daemon = daemon;
         _state = state;
         _launch = launch;
+        _knownRepos = knownRepos;
         _shutdown = shutdown;
 
         // Never starts empty: a null SupportedVendors means "daemon
@@ -140,13 +145,15 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
 
     /// The repository chip's menu, assembled per open rather than kept as a live projection — the
     /// flyout is transient, so reading at click time is always fresh with no extra subscription.
-    /// Sources: remembered HarnessByRepo keys, distinct agent RepoPaths, and the current selection
-    /// (a picker-added repo with no remembered harness and no agent yet lives nowhere else).
+    /// Sources: remembered HarnessByRepo keys, distinct agent RepoPaths, the daemon's persisted
+    /// known repos (what the server's launch dialog sees), and the current selection (a
+    /// picker-added repo with no remembered harness and no agent yet lives nowhere else).
     /// Deduped under PathComparer with remembered keys added first, so where two casings are one
     /// repository the casing the user picked is the one displayed. Scratch is always last; the
     /// view renders it separated.
     public async Task<IReadOnlyList<RepositoryOption>> ListRepositoriesAsync() {
         var byRepo = (await _state.LoadAsync()).HarnessByRepo;
+        var known = await _knownRepos();
 
         var seen = new HashSet<string>(PathComparer);
         var paths = new List<string>();
@@ -158,6 +165,8 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
             Add(key);
         foreach (var agent in _daemon.Agents.Items)
             Add(agent.RepoPath);
+        foreach (var repo in known)
+            Add(repo);
         Add(SelectedRepoPath);
 
         var selected = SelectedRepoPath;

--- a/src/Capacitor.App/Views/HomeView.axaml.cs
+++ b/src/Capacitor.App/Views/HomeView.axaml.cs
@@ -45,7 +45,6 @@ public partial class HomeView : UserControl {
         var left = new StackPanel { Spacing = 2, VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
         left.Children.Add(new TextBlock {
             Text = isScratch ? "No repository" : RepoLabel.Leaf(option.RepoPath),
-            FontWeight = Avalonia.Media.FontWeight.SemiBold,
         });
         if (!isScratch)
             left.Children.Add(new TextBlock { Text = option.RepoPath, FontSize = 10.5, Foreground = muted });

--- a/src/Capacitor.App/Views/HomeView.axaml.cs
+++ b/src/Capacitor.App/Views/HomeView.axaml.cs
@@ -1,7 +1,9 @@
 using System.Globalization;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data.Converters;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 using Avalonia.Platform.Storage;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
@@ -16,11 +18,66 @@ public partial class HomeView : UserControl {
 
     void OnNewSessionClick(object? sender, RoutedEventArgs e) => GoalInput.Focus();
 
-    // Repository picker: this slice has no repository registry, so
-    // the only affordance is "add one" via a native folder picker — SelectRepositoryAsync persists
-    // the choice through AppState.HarnessByRepo like any other repository.
+    // Repository picker: one flyout item per ListRepositoriesAsync entry — leaf name over full
+    // path, remembered-harness pill on the right, per the settled design. The scratch entry and
+    // the folder-picker affordance sit last, each behind a separator.
     async void OnRepositoryChipClick(object? sender, RoutedEventArgs e) {
-        if (DataContext is not HomeViewModel vm) return;
+        if (DataContext is not HomeViewModel vm || sender is not Control anchor) return;
+
+        var flyout = new MenuFlyout();
+        foreach (var option in await vm.ListRepositoriesAsync()) {
+            if (option.RepoPath.Length == 0) flyout.Items.Add(new Separator());
+            flyout.Items.Add(RepositoryItem(vm, option));
+        }
+        flyout.Items.Add(new Separator());
+
+        var add = new MenuItem { Header = "Add repository…" };
+        add.Click += async (_, _) => await AddRepositoryAsync(vm);
+        flyout.Items.Add(add);
+
+        flyout.ShowAt(anchor);
+    }
+
+    MenuItem RepositoryItem(HomeViewModel vm, RepositoryOption option) {
+        var isScratch = option.RepoPath.Length == 0;
+        var muted = (IBrush)this.FindResource("KcapMutedBrush")!;
+
+        var left = new StackPanel { Spacing = 2, VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
+        left.Children.Add(new TextBlock {
+            Text = isScratch ? "No repository" : RepoLabel.Leaf(option.RepoPath),
+            FontWeight = Avalonia.Media.FontWeight.SemiBold,
+        });
+        if (!isScratch)
+            left.Children.Add(new TextBlock { Text = option.RepoPath, FontSize = 10.5, Foreground = muted });
+
+        var pill = new Border {
+            Background = (IBrush)this.FindResource("KcapSurfaceRaisedBrush")!,
+            CornerRadius = new CornerRadius(999), Padding = new Thickness(7, 2),
+            Margin = new Thickness(12, 0, 0, 0), VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Child = new TextBlock {
+                Text = HostedHarnessCatalog.LabelFor(vm.Harnesses, option.Vendor),
+                FontSize = 10, Foreground = muted,
+            },
+        };
+
+        var header = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto"), MinWidth = 260 };
+        header.Children.Add(left);
+        Grid.SetColumn(pill, 1);
+        header.Children.Add(pill);
+
+        var item = new MenuItem {
+            Header = header,
+            ToggleType = MenuItemToggleType.Radio,
+            IsChecked = option.Selected,
+        };
+        var path = option.RepoPath;
+        item.Click += async (_, _) => await vm.SelectRepositoryAsync(path);
+        return item;
+    }
+
+    // "Add one" via a native folder picker — SelectRepositoryAsync then treats the choice like
+    // any other repository, so it shows up in the menu from the next open on.
+    async Task AddRepositoryAsync(HomeViewModel vm) {
         if (TopLevel.GetTopLevel(this)?.StorageProvider is not { } storage) return;
 
         var folders = await storage.OpenFolderPickerAsync(new FolderPickerOpenOptions {
@@ -65,18 +122,15 @@ public sealed class RepositoryLabelConverter : IValueConverter {
         throw new NotSupportedException();
 }
 
-/// HarnessChip's label: SelectedVendor's own HarnessOption.Label when the current Harnesses list
-/// carries one, falling back to the raw vendor token otherwise (e.g. before the first daemon
-/// snapshot narrows the list, or a vendor token this build has never heard of).
+/// HarnessChip's label: SelectedVendor resolved through HostedHarnessCatalog.LabelFor (see its
+/// fallback rules).
 public sealed class HarnessChipTextConverter : IMultiValueConverter {
     public static readonly HarnessChipTextConverter Instance = new();
 
-    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) {
-        if (values is not [IReadOnlyList<HarnessOption> options, string vendor]) return "";
-
-        var match = options.FirstOrDefault(o => string.Equals(o.Vendor, vendor, StringComparison.OrdinalIgnoreCase));
-        return match?.Label ?? vendor;
-    }
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
+        values is [IReadOnlyList<HarnessOption> options, string vendor]
+            ? HostedHarnessCatalog.LabelFor(options, vendor)
+            : "";
 }
 
 /// Single-purpose converter, not a general int-to-bool one — mirrors Views/Converters.cs's

--- a/src/Capacitor.Cli.Core/Config/RepoPathStore.cs
+++ b/src/Capacitor.Cli.Core/Config/RepoPathStore.cs
@@ -22,14 +22,36 @@ public static class RepoPathStore {
 
         try {
             var json = await File.ReadAllTextAsync(StorePath);
-            return JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.RepoEntryArray) ?? [];
+            return Collapse(JsonSerializer.Deserialize(json, CapacitorJsonContext.Default.RepoEntryArray) ?? []);
         } catch {
             return [];
         }
     }
 
+    /// Worktree entries written before AddAsync resolved them (GH #655) collapse on read into
+    /// their main repository, newest last_used winning — so historical pollution disappears from
+    /// every consumer without a migration, and the next write persists the cleaned list.
+    static RepoEntry[] Collapse(RepoEntry[] entries) {
+        if (entries.Length == 0) return entries;
+
+        var comparer = PathComparison == StringComparison.Ordinal
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
+        var byRepo = new Dictionary<string, RepoEntry>(comparer);
+        foreach (var entry in entries) {
+            var resolved = NormalizePath(GitRepository.ResolveMainRepoRoot(entry.Path));
+            if (!byRepo.TryGetValue(resolved, out var existing) || entry.LastUsed > existing.LastUsed)
+                byRepo[resolved] = entry with { Path = resolved };
+        }
+
+        return [..byRepo.Values];
+    }
+
     public static async Task AddAsync(string path) {
-        var normalized = NormalizePath(path);
+        // A linked worktree registers as its main repository: user-facing repo lists show actual
+        // repositories, and review flows launching into a requester's worktree must not mint a
+        // "known repo" out of it (GH #655).
+        var normalized = NormalizePath(GitRepository.ResolveMainRepoRoot(path));
 
         await Lock.WaitAsync();
 

--- a/src/Capacitor.Cli.Core/GitRepository.cs
+++ b/src/Capacitor.Cli.Core/GitRepository.cs
@@ -27,4 +27,53 @@ public static class GitRepository {
     }
 
     public static bool IsInsideRepo(string startDir) => FindRoot(startDir) is not null;
+
+    /// <summary>
+    /// Resolves a LINKED-WORKTREE checkout to its main repository root, so user-facing repository
+    /// lists show actual repositories (GH #655). A linked worktree's <c>.git</c> is a file whose
+    /// <c>gitdir:</c> target points into <c>&lt;main&gt;/.git/worktrees/&lt;name&gt;</c> — that
+    /// main root is returned. A submodule's <c>.git</c> file points into <c>.git/modules</c>
+    /// instead and is left alone: a submodule is a real repository of its own. A path whose
+    /// directory is gone (a removed worktree) can't be read, so it falls back to stripping the
+    /// agent-infra patterns (<c>/.claude/worktrees/&lt;leaf&gt;</c>,
+    /// <c>/.capacitor/worktrees/&lt;leaf&gt;</c>). Anything unrecognized comes back unchanged;
+    /// never throws — a heuristic, like <see cref="FindRoot"/>.
+    /// </summary>
+    public static string ResolveMainRepoRoot(string path) {
+        if (string.IsNullOrEmpty(path)) return path;
+
+        try {
+            var dotGit = Path.Combine(path, ".git");
+            if (File.Exists(dotGit)) {
+                var line = File.ReadLines(dotGit).FirstOrDefault(l => l.StartsWith("gitdir:", StringComparison.Ordinal));
+                var target = line?["gitdir:".Length..].Trim();
+                if (string.IsNullOrEmpty(target)) return path;
+
+                if (!Path.IsPathRooted(target)) target = Path.Combine(path, target);
+                target = Path.GetFullPath(target);
+
+                // Replace only swaps separators, so an index into the normalized copy slices the
+                // original string correctly.
+                var marker = target.Replace('\\', '/').LastIndexOf("/.git/worktrees/", StringComparison.Ordinal);
+                return marker > 0 ? Path.GetFullPath(target[..marker]) : path;
+            }
+
+            if (Directory.Exists(path)) return path;
+        } catch {
+            // I/O errors — same "heuristic, not authoritative" stance as FindRoot.
+        }
+
+        return StripAgentWorktreeTail(path);
+    }
+
+    static string StripAgentWorktreeTail(string path) {
+        var normalized = path.Replace('\\', '/');
+        foreach (var infra in (string[])["/.claude/worktrees/", "/.capacitor/worktrees/"]) {
+            var i = normalized.LastIndexOf(infra, StringComparison.Ordinal);
+            if (i > 0 && i + infra.Length < normalized.Length)
+                return path[..i];
+        }
+
+        return path;
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -1,6 +1,8 @@
 using System.Reactive.Linq;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -171,6 +173,134 @@ public class HomeViewModelTests {
 
             await vm.SelectRepositoryAsync("/repo/a");
             await Assert.That(vm.SelectedVendor).IsEqualTo("codex");
+        });
+    }
+
+    static AgentStatusDto Agent(string id, string? repoPath) => new(
+        id, "agent", "claude", repoPath, "Running",
+        FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null,
+        RequesterDisplay: null);
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_repository_list_merges_remembered_repos_and_agent_repos() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+
+            await vm.SelectRepositoryAsync("/repo/a");
+            await vm.ChooseHarnessAsync("codex");
+            daemon.Agents.AddOrUpdate(Agent("x", "/repo/b"));
+
+            var repos = await vm.ListRepositoriesAsync();
+
+            var a = repos.Single(r => r.RepoPath == "/repo/a");
+            var b = repos.Single(r => r.RepoPath == "/repo/b");
+            await Assert.That(a.Vendor).IsEqualTo("codex");
+            await Assert.That(b.Vendor).IsEqualTo(HomeViewModel.DefaultVendor);
+            await Assert.That(a.Selected).IsTrue();
+            await Assert.That(b.Selected).IsFalse();
+        });
+    }
+
+    /// Same platform-follows-filesystem rule as the harness-memory test above: a daemon-supplied
+    /// path and a remembered key differing only in case are one repository on Windows/macOS and
+    /// two on Linux. This merge is exactly the case that motivated PathComparer.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_repository_list_dedups_the_way_the_filesystem_does() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+
+            await vm.SelectRepositoryAsync("/repo/Alpha");
+            await vm.ChooseHarnessAsync("codex");
+            daemon.Agents.AddOrUpdate(Agent("x", "/repo/alpha"));
+
+            var repos = (await vm.ListRepositoriesAsync()).Where(r => r.RepoPath.Length > 0).ToList();
+
+            var expected = OperatingSystem.IsLinux() ? 2 : 1;
+            await Assert.That(repos.Count).IsEqualTo(expected);
+            // The remembered key is the one the user picked, so its casing is the one displayed.
+            await Assert.That(repos.Any(r => r.RepoPath == "/repo/Alpha")).IsTrue();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_scratch_target_is_always_the_last_repository_entry() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+
+            await vm.SelectRepositoryAsync(HomeViewModel.ScratchRepoPath);
+            await vm.ChooseHarnessAsync("pi");
+            daemon.Agents.AddOrUpdate(Agent("x", "/repo/b"));
+
+            var repos = await vm.ListRepositoriesAsync();
+
+            await Assert.That(repos[^1].RepoPath).IsEqualTo(HomeViewModel.ScratchRepoPath);
+            await Assert.That(repos[^1].Vendor).IsEqualTo("pi");
+            await Assert.That(repos[^1].Selected).IsTrue();
+            await Assert.That(repos.Count(r => r.RepoPath.Length == 0)).IsEqualTo(1);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_agent_without_a_repository_contributes_no_entry() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+
+            daemon.Agents.AddOrUpdate(Agent("x", null));
+
+            var repos = await vm.ListRepositoriesAsync();
+
+            await Assert.That(repos.Count).IsEqualTo(1);
+            await Assert.That(repos[0].RepoPath).IsEqualTo(HomeViewModel.ScratchRepoPath);
+        });
+    }
+
+    /// A repository picked through the folder dialog but not yet remembered (and with no agent in
+    /// it) must still appear — otherwise closing and reopening the menu would lose it.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_current_selection_appears_even_when_unsaved_and_agentless() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+
+            vm.RememberHarness = false;
+            await vm.SelectRepositoryAsync("/repo/fresh");
+
+            var repos = await vm.ListRepositoriesAsync();
+
+            var fresh = repos.Single(r => r.RepoPath == "/repo/fresh");
+            await Assert.That(fresh.Vendor).IsEqualTo(HomeViewModel.DefaultVendor);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Repositories_are_ordered_by_leaf_name() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+
+            daemon.Agents.AddOrUpdate(Agent("x", "/x/bravo"));
+            daemon.Agents.AddOrUpdate(Agent("y", "/y/alpha"));
+
+            var repos = await vm.ListRepositoriesAsync();
+
+            await Assert.That(repos[0].RepoPath).IsEqualTo("/y/alpha");
+            await Assert.That(repos[1].RepoPath).IsEqualTo("/x/bravo");
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -21,10 +21,14 @@ public class HomeViewModelTests {
         }
     }
 
+    /// Scripted stand-in for RepoPathStore.GetSortedPathsAsync — the real store reads the
+    /// developer's own ~/.config/kcap/repos.json, which no test may touch.
+    static Func<Task<string[]>> Known(params string[] paths) => () => Task.FromResult(paths);
+
     static HomeViewModel Build(out RecordingLaunchClient launch, out AppStateStore store, string statePath) {
         launch = new RecordingLaunchClient();
         store = new AppStateStore(statePath);
-        return new HomeViewModel(new FakeDaemonClientService(), store, launch);
+        return new HomeViewModel(new FakeDaemonClientService(), store, launch, Known());
     }
 
     /// Repo keys compare the way the filesystem does — so the SAME repository reached under
@@ -187,7 +191,7 @@ public class HomeViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
             var daemon = new FakeDaemonClientService();
-            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
 
             await vm.SelectRepositoryAsync("/repo/a");
             await vm.ChooseHarnessAsync("codex");
@@ -213,7 +217,7 @@ public class HomeViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
             var daemon = new FakeDaemonClientService();
-            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
 
             await vm.SelectRepositoryAsync("/repo/Alpha");
             await vm.ChooseHarnessAsync("codex");
@@ -234,7 +238,7 @@ public class HomeViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
             var daemon = new FakeDaemonClientService();
-            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
 
             await vm.SelectRepositoryAsync(HomeViewModel.ScratchRepoPath);
             await vm.ChooseHarnessAsync("pi");
@@ -255,7 +259,7 @@ public class HomeViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
             var daemon = new FakeDaemonClientService();
-            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
 
             daemon.Agents.AddOrUpdate(Agent("x", null));
 
@@ -274,7 +278,7 @@ public class HomeViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
             var daemon = new FakeDaemonClientService();
-            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
 
             vm.RememberHarness = false;
             await vm.SelectRepositoryAsync("/repo/fresh");
@@ -292,7 +296,7 @@ public class HomeViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
             var daemon = new FakeDaemonClientService();
-            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
 
             daemon.Agents.AddOrUpdate(Agent("x", "/x/bravo"));
             daemon.Agents.AddOrUpdate(Agent("y", "/y/alpha"));
@@ -301,6 +305,49 @@ public class HomeViewModelTests {
 
             await Assert.That(repos[0].RepoPath).IsEqualTo("/y/alpha");
             await Assert.That(repos[1].RepoPath).IsEqualTo("/x/bravo");
+        });
+    }
+
+    /// The daemon's persisted known-repos store (repos.json — the same list DaemonConnect.RepoPaths
+    /// feeds the server's launch dialog) is a source of its own: a repo you once ran an agent in
+    /// must appear with no live agent and no locally remembered harness.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_repository_list_includes_the_daemons_persisted_known_repos() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            using var vm = new HomeViewModel(
+                new FakeDaemonClientService(), new AppStateStore(path), new RecordingLaunchClient(),
+                Known("/repo/recorded"));
+
+            var repos = await vm.ListRepositoriesAsync();
+
+            var known = repos.Single(r => r.RepoPath == "/repo/recorded");
+            await Assert.That(known.Vendor).IsEqualTo(HomeViewModel.DefaultVendor);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_known_repo_dedups_against_a_remembered_key_the_way_the_filesystem_does() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(
+                daemon, new AppStateStore(path), new RecordingLaunchClient(),
+                Known("/repo/alpha", "/repo/beta"));
+
+            await vm.SelectRepositoryAsync("/repo/Alpha");
+            await vm.ChooseHarnessAsync("codex");
+
+            var repos = (await vm.ListRepositoriesAsync()).Where(r => r.RepoPath.Length > 0).ToList();
+
+            // beta only exists in the store, so it proves the source is wired; alpha collides
+            // with the remembered key wherever the filesystem says they are one repository.
+            await Assert.That(repos.Any(r => r.RepoPath == "/repo/beta")).IsTrue();
+            var expected = OperatingSystem.IsLinux() ? 3 : 2;
+            await Assert.That(repos.Count).IsEqualTo(expected);
+            await Assert.That(repos.Any(r => r.RepoPath == "/repo/Alpha")).IsTrue();
         });
     }
 
@@ -314,7 +361,7 @@ public class HomeViewModelTests {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
             var daemon = new FakeDaemonClientService();
-            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient());
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
 
             // Before any snapshot: capability unknown, so everything is offered.
             var piBefore = vm.Harnesses.Single(h => h.Vendor == "pi").Available;

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -308,6 +308,25 @@ public class HomeViewModelTests {
         });
     }
 
+    /// A reviewer launched into a requester's worktree reports that worktree as its RepoPath —
+    /// the menu must offer the repository, never the agent's checkout (GH #655).
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_agents_worktree_path_is_listed_as_its_repository() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
+
+            daemon.Agents.AddOrUpdate(Agent("x", "/repo/a/.claude/worktrees/leafy"));
+
+            var repos = await vm.ListRepositoriesAsync();
+
+            await Assert.That(repos.Any(r => r.RepoPath == "/repo/a")).IsTrue();
+            await Assert.That(repos.Any(r => r.RepoPath.Contains("worktrees"))).IsFalse();
+        });
+    }
+
     /// The daemon's persisted known-repos store (repos.json — the same list DaemonConnect.RepoPaths
     /// feeds the server's launch dialog) is a source of its own: a repo you once ran an agent in
     /// must appear with no live agent and no locally remembered harness.

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -28,7 +28,7 @@ public class HomeViewSmokeTests {
         var tmp = TempDir.WithPathTo("app-state.json", out var path);
         var service = new FakeDaemonClientService();
         var launch = new RecordingLaunchClient();
-        var vm = new HomeViewModel(service, new AppStateStore(path), launch);
+        var vm = new HomeViewModel(service, new AppStateStore(path), launch, () => Task.FromResult(Array.Empty<string>()));
         return (new HomeView { DataContext = vm }, vm, service, launch, tmp);
     }
 

--- a/test/Capacitor.App.Tests.Unit/HostedHarnessCatalogTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HostedHarnessCatalogTests.cs
@@ -53,6 +53,15 @@ public class HostedHarnessCatalogTests {
     }
 
     [Test]
+    public async Task LabelFor_resolves_a_vendor_token_case_insensitively_and_falls_back_to_the_token() {
+        var options = HostedHarnessCatalog.Build(null);
+
+        await Assert.That(HostedHarnessCatalog.LabelFor(options, "CLAUDE"))
+            .IsEqualTo(options.Single(o => o.Vendor == "claude").Label);
+        await Assert.That(HostedHarnessCatalog.LabelFor(options, "neverheardof")).IsEqualTo("neverheardof");
+    }
+
+    [Test]
     public async Task Description_names_the_transport_and_the_surface() {
         var pty = HostedHarnessCatalog.Build(null).Single(o => o.Vendor == "claude");
         var acp = HostedHarnessCatalog.Build(null).Single(o => o.Vendor == "gemini");

--- a/test/Capacitor.Cli.Core.Tests.Unit/Config/RepoPathStoreTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Config/RepoPathStoreTests.cs
@@ -280,7 +280,9 @@ public class RepoPathStoreTests {
         var entries = await RepoPathStore.LoadAsync();
 
         await Assert.That(entries.Length).IsEqualTo(2);
-        var repo = entries.Single(e => e.Path == "/gone/repo");
+        // GetFullPath, like every assertion in this class: on Windows a rootless "/gone/repo"
+        // normalizes to "<drive>:\gone\repo".
+        var repo = entries.Single(e => e.Path == Path.GetFullPath("/gone/repo"));
         await Assert.That(repo.LastUsed).IsEqualTo(newer);
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Config/RepoPathStoreTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Config/RepoPathStoreTests.cs
@@ -241,4 +241,46 @@ public class RepoPathStoreTests {
         await Assert.That(paths.Length).IsEqualTo(1);
         await Assert.That(paths[0]).IsEqualTo(Path.GetFullPath("/tmp/project-x"));
     }
+
+    // ── Worktree resolution (GH #655) ─────────────────────────────────────────
+
+    /// Agent registrations persist the launch path, and review flows launch into the requester's
+    /// worktree — the store, not the caller, is where that collapses to the main repository, so
+    /// every consumer (server launch dialog, app menu, `kcap repos list`) inherits it.
+    [Test]
+    public async Task Add_resolves_a_linked_worktree_to_its_main_repository() {
+        using var tmp = new TempDir();
+        var main = tmp.CreateDir("main");
+        tmp.CreateDir("main", ".git", "worktrees", "wt1");
+        var wt = tmp.CreateDir("wt");
+        File.WriteAllText(Path.Combine(wt, ".git"), $"gitdir: {Path.Combine(main, ".git", "worktrees", "wt1")}\n");
+
+        await RepoPathStore.AddAsync(main);
+        await RepoPathStore.AddAsync(wt);
+
+        var entries = await RepoPathStore.LoadAsync();
+        await Assert.That(entries.Length).IsEqualTo(1);
+        await Assert.That(entries[0].Path).IsEqualTo(Path.GetFullPath(main));
+    }
+
+    /// Historical pollution: entries written before the resolution existed, whose worktree
+    /// directories are long gone. Read-side resolution collapses them without a migration,
+    /// keeping the newest last_used per surviving repository.
+    [Test]
+    public async Task Load_collapses_dead_worktree_entries_into_their_repository() {
+        var older = DateTimeOffset.UtcNow.AddDays(-2);
+        var newer = DateTimeOffset.UtcNow.AddDays(-1);
+        var polluted = new RepoEntry[] {
+            new() { Path = "/gone/repo", LastUsed = older },
+            new() { Path = "/gone/repo/.claude/worktrees/leaf", LastUsed = newer },
+            new() { Path = "/gone/other", LastUsed = older },
+        };
+        await File.WriteAllTextAsync(ReposJsonPath, System.Text.Json.JsonSerializer.Serialize(polluted));
+
+        var entries = await RepoPathStore.LoadAsync();
+
+        await Assert.That(entries.Length).IsEqualTo(2);
+        var repo = entries.Single(e => e.Path == "/gone/repo");
+        await Assert.That(repo.LastUsed).IsEqualTo(newer);
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/GitRepositoryTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/GitRepositoryTests.cs
@@ -48,4 +48,72 @@ public class GitRepositoryTests {
 
         await Assert.That(GitRepository.IsInsideRepo(tmp.Path)).IsTrue();
     }
+
+    // ── ResolveMainRepoRoot ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task Resolve_returns_the_main_repo_for_a_linked_worktree_with_an_absolute_gitdir() {
+        using var tmp = new TempDir();
+        var main = tmp.CreateDir("main");
+        tmp.CreateDir("main", ".git", "worktrees", "wt1");
+        var wt = tmp.CreateDir("wt");
+        File.WriteAllText(Path.Combine(wt, ".git"), $"gitdir: {Path.Combine(main, ".git", "worktrees", "wt1")}\n");
+
+        await Assert.That(GitRepository.ResolveMainRepoRoot(wt)).IsEqualTo(main);
+    }
+
+    [Test]
+    public async Task Resolve_returns_the_main_repo_for_a_linked_worktree_with_a_relative_gitdir() {
+        using var tmp = new TempDir();
+        var main = tmp.CreateDir("main");
+        tmp.CreateDir("main", ".git", "worktrees", "wt1");
+        var wt = tmp.CreateDir("main", ".claude", "worktrees", "wt1");
+        File.WriteAllText(Path.Combine(wt, ".git"), "gitdir: ../../../.git/worktrees/wt1\n");
+
+        await Assert.That(GitRepository.ResolveMainRepoRoot(wt)).IsEqualTo(main);
+    }
+
+    /// A submodule's .git is also a file, but pointing into .git/modules — a submodule is a real
+    /// repository of its own and must never collapse into the superproject.
+    [Test]
+    public async Task Resolve_leaves_a_submodule_checkout_alone() {
+        using var tmp = new TempDir();
+        tmp.CreateDir("super", ".git", "modules", "sub");
+        var sub = tmp.CreateDir("super", "sub");
+        File.WriteAllText(Path.Combine(sub, ".git"), "gitdir: ../.git/modules/sub\n");
+
+        await Assert.That(GitRepository.ResolveMainRepoRoot(sub)).IsEqualTo(sub);
+    }
+
+    [Test]
+    public async Task Resolve_leaves_a_normal_repository_alone() {
+        using var tmp = new TempDir();
+        tmp.CreateDir(".git");
+
+        await Assert.That(GitRepository.ResolveMainRepoRoot(tmp.Path)).IsEqualTo(tmp.Path);
+    }
+
+    /// A stored worktree path whose directory is gone (the worktree was removed) can no longer be
+    /// resolved through its .git file — the agent-infra path patterns are the fallback.
+    [Test]
+    public async Task Resolve_strips_the_agent_worktree_tail_from_a_path_that_no_longer_exists() {
+        await Assert.That(GitRepository.ResolveMainRepoRoot("/gone/repo/.claude/worktrees/snappy-leaf"))
+            .IsEqualTo("/gone/repo");
+        await Assert.That(GitRepository.ResolveMainRepoRoot("/gone/repo/.capacitor/worktrees/wt-1"))
+            .IsEqualTo("/gone/repo");
+    }
+
+    [Test]
+    public async Task Resolve_leaves_a_missing_path_without_a_worktree_pattern_alone() {
+        await Assert.That(GitRepository.ResolveMainRepoRoot("/gone/plain-repo"))
+            .IsEqualTo("/gone/plain-repo");
+    }
+
+    [Test]
+    public async Task Resolve_treats_an_unreadable_or_malformed_git_file_as_not_a_worktree() {
+        using var tmp = new TempDir();
+        tmp.CreateFile(".git", "this is not a gitdir line");
+
+        await Assert.That(GitRepository.ResolveMainRepoRoot(tmp.Path)).IsEqualTo(tmp.Path);
+    }
 }


### PR DESCRIPTION
Linear: AI-2200 (no GitHub issue — created directly in Linear as a follow-up gap of AI-2194). Also fixes the worktree leak in user-facing repo lists — Closes #655.

## What

AI-2194 shipped per-repository harness memory but only the folder picker to reach it — on every app start the sole route back to a known repository was re-navigating a native folder dialog. The repository chip now opens a menu:

- **Sources**: keys of `AppState.HarnessByRepo`, distinct `AgentStatusDto.RepoPath` values from the agent cache (the two AI-2194's plan named), the daemon's persisted known repos (`RepoPathStore` / `repos.json` — the same list `DaemonConnect.RepoPaths` feeds the server's launch dialog, so the two menus agree), and the current selection so a just-picked, not-yet-remembered repository survives menu reopens.
- **Dedup and selection marking** both go through the existing `HomeViewModel.PathComparer` (case-insensitive on Windows/macOS, sensitive on Linux) — no second comparison rule. Where two casings are one repository, the remembered key's casing wins the display.
- **Each entry shows its remembered harness** as a pill (leaf name over full path, per the settled design canvas), falling back to the default vendor label. Lookup extracted to `HostedHarnessCatalog.LabelFor`, now shared with the harness chip.
- **"No repository"** (scratch) stays a first-class entry, always last and separated.
- **"Add repository…"** keeps the folder picker for a repository not yet known.

The known-repos source is a required `HomeViewModel` constructor dependency (`RepoPathStore.GetSortedPathsAsync` in production) so a test can never silently read the developer's own `~/.config/kcap/repos.json`.

## Worktree resolution (#655)

Surfacing the store in the app exposed that agent registrations persist worktree launch paths (review flows launch into the requester's worktree), polluting every user-facing repo list — server launch dialog and web included — with `.claude/worktrees/*` entries (89 of 98 on one real machine). Regression of AI-134's rule that repo lists show actual repositories.

- `GitRepository.ResolveMainRepoRoot` follows a linked worktree's `gitdir:` to its main root (submodules stay themselves), with a `.claude`/`.capacitor` worktrees pattern fallback for entries whose directory is gone.
- `RepoPathStore` resolves on write and collapses on read (newest `last_used` per resolved repo wins) — historical pollution disappears from every consumer with no migration and **no server change**; the next write persists the cleaned list.
- The app menu's live-agent source runs through the same helper, so a reviewer running in a worktree doesn't resurface it as a launch target.

## Design

Bounded change; design record is the AI-2171 design-canvas comment (repository menu rows: name + path + remembered-harness pill, scratch last and separated). The list is assembled per menu open rather than kept as a live projection — the flyout is transient, so reading at click time is always fresh with no extra subscription machinery.

## Testing

Nine new `HomeViewModelTests` (merge, platform-aware dedup across remembered keys and the known-repos store, scratch placement, null-RepoPath agents, unsaved selection, ordering, known-repos inclusion, agent-worktree resolution), seven `GitRepositoryTests` for the resolver (absolute/relative gitdir, submodule, dead-path pattern fallback, malformed `.git` file), two `RepoPathStoreTests` (resolve-on-write, collapse-on-read), plus a `HostedHarnessCatalog.LabelFor` test; all red-green verified. App suite 1180/1180; Core suite green; full solution run shows only the machine-local pre-existing failures (session-start nudge set, installed-codex 0.149 vs 0.147 schema pin, and load-sensitive PTY flood timings that pass in isolation). AOT publish clean — no IL2026/IL3050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)