### PR TITLE
Desktop shell: session workspace with terminal

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,9 +20,11 @@
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageVersion Include="Spectre.Console" Version="0.55.2" />
+    <PackageVersion Include="SvcSystems.UI.Terminal" Version="1.1.1" />
     <PackageVersion Include="Tomlyn" Version="2.4.0" />
     <PackageVersion Include="TUnit" Version="1.65.31" />
     <PackageVersion Include="TUnit.Core" Version="1.65.31" />
     <PackageVersion Include="WireMock.Net" Version="2.15.0" />
+    <PackageVersion Include="XTerm.NET" Version="1.0.16" />
   </ItemGroup>
 </Project>

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -138,6 +138,28 @@ daemon graph, no tray) and hands the outcome channel to the normal graph's consu
 permanently past the quiesce cap (decision 2/§6a). The §7 streaming `IProcessRunner` backs the
 Import step's live, bounded-tail log pane.
 
+## Session workspace terminal
+
+**AI-2195** (spec: `docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md`)
+attaches a live terminal to the session workspace. `TerminalTabViewModel` opens every workspace in
+`Resolving` and **never constructs an attach client until the session's first matching
+`AgentStatusDto` arrives**: attaching optimistically would race the has_terminal gate and show a
+spurious "no such agent" flash before a genuinely no-terminal session's note could render. `has_terminal`
+is authoritative when the daemon sends it; `HostedHarnessCatalog`'s vendor-transport map is only the
+fallback for an older daemon that sent null. `AgentAttachClient` linearizes every termination race
+through one atomic cause slot, and **detach intent is recorded, never itself a cause**: a terminal
+frame the pump already read wins even with a detach pending, so a daemon `Exited` racing a client
+`Detach` still resolves `Exited`, not `Detached`; only EOF with detach intent pending settles
+`Detached`. Teardown spends at most its first second on the (best-effort, unacknowledged) `Detach`
+write, then force-closes the socket regardless of whether that write landed — the tmux-style PTY
+dimension clamp is guaranteed to release by roughly that one-second mark on every exit path, not
+contingent on graceful pump completion. `WorkspaceTeardownTracker` seals atomically at the shutdown
+drain (registration and seal cannot race past the final snapshot); a post-seal `Track` is executed
+and observed rather than refused, so a workspace a coordinator builds between the two shutdown passes
+still cannot hold a socket open past the drain. The companion guard lives in `NavigationGate`: its
+first shutdown pass latches (which also bumps the generation), so `OpenSession` — card click or launch
+auto-open alike — rejects from then on in every window, current or later-built.
+
 ## Launch and stop command routing
 
 The receive pump no longer awaits launch/stop EXECUTION for either command format: arrival order is

--- a/docs/superpowers/plans/2026-08-24-ai2195-session-workspace-terminal.md
+++ b/docs/superpowers/plans/2026-08-24-ai2195-session-workspace-terminal.md
@@ -1,0 +1,1501 @@
+# Session Workspace with Terminal (AI-2195) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A workspace pane for one session — header, tab strip, Terminal tab attached to the live PTY over local-control IPC — opened by clicking a session card on Home.
+
+**Architecture:** One additive wire field (`has_terminal`) gives the app the authoritative Terminal gate; a new BCL-only Core client (`AgentAttachClient`) pumps the existing Attach/Stdout/Stdin/Resize frames with an atomic terminal-cause slot; app-side, a `WorkspaceViewModel` + `TerminalTabViewModel` pair owns the attach lifecycle behind a factory seam, `MainWindowViewModel` gains the first navigation seam (top-level surface swap), and a bounded teardown tracker guarantees socket close on every exit path.
+
+**Tech Stack:** .NET 10, Avalonia 12.1.1, ReactiveUI/DynamicData, TUnit; `SvcSystems.UI.Terminal` 1.1.1 + `XTerm.NET` 1.0.16 (direct pinned).
+
+**Spec:** `docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md` — the plan argues from the spec; read both. Where a task compresses a spec rule, the spec wins.
+
+## Global Constraints
+
+- Branch: `alexeyzimarev/ai-2195-desktop-shell-session-workspace-with-terminal` (already checked out in this worktree; spec committed).
+- TDD per repo convention: write the failing test, watch it fail, implement, watch it pass. TUnit filters use `--treenode-filter` glob syntax, never `--filter`.
+- Core `LocalIpc` surface is BCL-only, NativeAOT-safe: no Rx, no reflection-based JSON, no logging frameworks. Verify with `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` (must print nothing) after Core changes.
+- `FrameType` is append-only and untouched by this feature. `AgentStatusDto` fields are always emitted, additive, snake_case.
+- Test conventions: `TempDir` from Helpers (`tmp.PathTo/CreateDir/CreateFile`, `GetResolvedPath` for socket paths — macOS `/var`→`/private` symlink eats `sockaddr_un` budget); `EnvScope` for env vars; `[NotInParallel("AvaloniaSession")]` + `AvaloniaSession.WithImmediateRxScheduler` for app VM tests touching Rx-bound state.
+- Teardown durations (spec §3): Detach write bound **1 s**; per-teardown budget **3 s**; shutdown drain **5 s** total. All via injected `TimeProvider`.
+- Copy rules: non-PTY note is "This session has no terminal" (+ " — runs over ACP" only when the family is reliably known); never a vendor name, never a disabled tab.
+- No README change (desktop-app surface, not CLI).
+- Commits: small, per task, trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- `FakeTimeProvider`: the repo does not carry one. In the first task that needs it (Task 10), add `Microsoft.Extensions.TimeProvider.Testing` as a test-project `PackageVersion` + `PackageReference` (test projects only, never Core/App), or add a minimal manual-advance `TestTimeProvider` to `test/Capacitor.Tests.Helpers/` if the package pulls an unwanted dependency tree — check `dotnet list package --include-transitive` before choosing.
+
+---
+
+### Task 1: Wire — `has_terminal` on `AgentStatusDto`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs` (record `AgentStatusDto`, ~line 38)
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs`
+
+**Interfaces:**
+- Consumes: existing `AgentStatusDto`, `StatusIpcJsonContext`.
+- Produces: `AgentStatusDto.HasTerminal` — trailing `bool? HasTerminal = null`, serialized `has_terminal`, always emitted. Every later task reads this exact member name.
+
+- [ ] **Step 1: Write the failing tests** (append to `StatusIpcJsonTests`; mirror the file's existing serialize/deserialize helpers — read the top of the file first for its DTO-builder helpers and reuse them):
+
+```csharp
+[Test]
+public async Task Old_agent_json_without_has_terminal_deserializes_to_null() {
+    // Serialize a current DTO, strip the member, deserialize — the exact old-daemon shape.
+    var dto = new AgentStatusDto(
+        "a1", "agent", "claude", "/repo", "Running",
+        null, null, null, DateTime.UtcNow, null, null);
+    var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
+    var stripped = System.Text.RegularExpressions.Regex.Replace(json, ",\"has_terminal\":[^,}]+", "");
+
+    var back = JsonSerializer.Deserialize(stripped, StatusIpcJsonContext.Default.AgentStatusDto);
+
+    await Assert.That(back!.HasTerminal).IsNull();
+}
+
+[Test]
+[Arguments(true)]
+[Arguments(false)]
+public async Task Has_terminal_serializes_present_and_never_omitted(bool value) {
+    var dto = new AgentStatusDto(
+        "a1", "agent", "claude", "/repo", "Running",
+        null, null, null, DateTime.UtcNow, null, null, HasTerminal: value);
+
+    var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
+
+    await Assert.That(json).Contains($"\"has_terminal\":{value.ToString().ToLowerInvariant()}");
+}
+
+[Test]
+public async Task Null_has_terminal_still_emits_the_member() {
+    var dto = new AgentStatusDto(
+        "a1", "agent", "claude", "/repo", "Running",
+        null, null, null, DateTime.UtcNow, null, null);
+
+    var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
+
+    await Assert.That(json).Contains("\"has_terminal\":null");
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter '/*/*/StatusIpcJsonTests/*has_terminal*'`
+Expected: compile error `'AgentStatusDto' does not contain a definition for 'HasTerminal'` — then, after Step 3's record change but before serializer options are right, possibly an omitted-null failure. Iterate until the failures are the assertions, then proceed.
+
+- [ ] **Step 3: Implement**
+
+In `StatusIpc.cs`, add the trailing member with a why-comment:
+
+```csharp
+public sealed record AgentStatusDto(
+    string Id, string Kind, string Vendor, string? RepoPath, string Status,
+    string? FlowRunId, string? FlowRole, string? Requester, DateTime CreatedAt, string? Model,
+    string? RequesterDisplay,
+    // Whether the agent's runtime emits a PTY the app can attach to
+    // (IHostedAgentRuntime.EmitsTerminalOutput). Trailing + nullable so every
+    // existing positional construction stays valid; null = older daemon,
+    // unknown — the app falls back to its vendor heuristic. Always emitted:
+    // false is a real value, not an absence.
+    bool? HasTerminal = null);
+```
+
+If the context's `JsonSourceGenerationOptions` sets `DefaultIgnoreCondition`, the null-emission test will fail — this repo's StatusIpc context emits all members by default; do not add an ignore condition.
+
+- [ ] **Step 4: Run to verify pass** — same filter, expect all green, then run the whole Core suite: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj` (expect green; the `NativeTestHost` tests need `dotnet build Capacitor.slnx` first).
+
+- [ ] **Step 5: AOT check** — `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` prints nothing.
+
+- [ ] **Step 6: Commit** — `git add -A && git commit` message `Wire: additive has_terminal on AgentStatusDto`.
+
+---
+
+### Task 2: Daemon stamps `has_terminal`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs` (`SnapshotAgentsForStatus`, ~line 44)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/` — add to the file that already exercises `SnapshotAgentsForStatus`/status payloads; if none does, create `AgentStatusHasTerminalTests.cs` reusing the agent-registration harness from `AgentOrchestratorLocalAttachTests.cs` (that file shows how to build an orchestrator with a PTY runtime and how ACP-runtime agents are registered — copy its fixture setup verbatim, do not invent a new harness).
+
+**Interfaces:**
+- Consumes: `AgentStatusDto.HasTerminal` (Task 1); `IHostedAgentRuntime.EmitsTerminalOutput` (`src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs:53`).
+- Produces: every status payload carries `has_terminal` = the agent runtime's `EmitsTerminalOutput`.
+
+- [ ] **Step 1: Write the failing test.** Using the borrowed harness, register one agent whose runtime has `EmitsTerminalOutput == true` (the PTY fake the attach tests use) and one with `false` (the ACP fake). Assert on the **serialized** payload, not the DTO:
+
+```csharp
+[Test]
+public async Task Status_payload_carries_has_terminal_per_runtime() {
+    // fixture setup copied from AgentOrchestratorLocalAttachTests (same fakes, same registration calls)
+    var snapshot = orchestrator.SnapshotAgentsForStatus();
+    var json = JsonSerializer.Serialize(
+        snapshot.Single(a => a.Id == ptyAgentId), StatusIpcJsonContext.Default.AgentStatusDto);
+    var acpJson = JsonSerializer.Serialize(
+        snapshot.Single(a => a.Id == acpAgentId), StatusIpcJsonContext.Default.AgentStatusDto);
+
+    await Assert.That(json).Contains("\"has_terminal\":true");
+    await Assert.That(acpJson).Contains("\"has_terminal\":false");
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — `dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj -- --treenode-filter '/*/*/*/Status_payload_carries_has_terminal*'`. Expected: fails with `"has_terminal":null` in both payloads.
+
+- [ ] **Step 3: Implement** — in `SnapshotAgentsForStatus`, add the argument to the `AgentStatusDto` construction:
+
+```csharp
+.Select(a => new AgentStatusDto(
+    a.Id, KindText(a.Kind), a.Vendor, a.RepoPath, a.Status,
+    a.FlowRunId, a.FlowRole, a.RequesterUserId, a.CreatedAt,
+    /* existing model expression unchanged */,
+    a.RequesterDisplay,
+    HasTerminal: a.Runtime.EmitsTerminalOutput))
+```
+
+(Keep the existing model-expression lines exactly as they are; only append the named argument.)
+
+- [ ] **Step 4: Run to verify pass**, then the daemon suite: `dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj`. Known machine-local failures to ignore by name: `Installed_codex_schema_matches_the_vendored_pin`; PTY flood-timing tests if the machine is loaded (re-run filtered to confirm).
+
+- [ ] **Step 5: Commit** — `Daemon: stamp has_terminal from EmitsTerminalOutput`.
+
+---
+
+### Task 3: App gate projection — `HostedHarnessCatalog.FamilyFor` / `ShowsTerminal` / `EffectiveFamily`
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/HostedHarnessCatalog.cs`
+- Test: `test/Capacitor.App.Tests.Unit/HostedHarnessCatalogTests.cs`
+
+**Interfaces:**
+- Produces (all `public static` on `HostedHarnessCatalog`):
+  - `string FamilyFor(string vendor)` — `"pty" | "acp" | "rpc"`, case-insensitive, unmapped → `"rpc"` (the map itself stays private).
+  - `bool ShowsTerminal(bool? hasTerminal, string vendor)` — `hasTerminal ?? (FamilyFor(vendor) == "pty")`.
+  - `string EffectiveFamily(bool? hasTerminal, string vendor)` — `FamilyFor(vendor)`, except an authoritative `hasTerminal == false` with a conflicting `"pty"` guess returns `"rpc"` (generic chat). A non-PTY vendor family is preserved as-is.
+
+- [ ] **Step 1: Failing tests:**
+
+```csharp
+[Test]
+public async Task FamilyFor_maps_vendors_and_defaults_unknown_to_rpc() {
+    await Assert.That(HostedHarnessCatalog.FamilyFor("CLAUDE")).IsEqualTo("pty");
+    await Assert.That(HostedHarnessCatalog.FamilyFor("gemini")).IsEqualTo("acp");
+    await Assert.That(HostedHarnessCatalog.FamilyFor("neverheardof")).IsEqualTo("rpc");
+}
+
+[Test]
+public async Task ShowsTerminal_prefers_the_authoritative_flag_and_falls_back_to_family() {
+    await Assert.That(HostedHarnessCatalog.ShowsTerminal(true, "gemini")).IsTrue();
+    await Assert.That(HostedHarnessCatalog.ShowsTerminal(false, "claude")).IsFalse();
+    await Assert.That(HostedHarnessCatalog.ShowsTerminal(null, "claude")).IsTrue();
+    await Assert.That(HostedHarnessCatalog.ShowsTerminal(null, "gemini")).IsFalse();
+}
+
+[Test]
+public async Task EffectiveFamily_overrides_only_a_conflicting_pty_guess() {
+    // codex app-server: vendor map says pty, daemon says no terminal → generic chat family.
+    await Assert.That(HostedHarnessCatalog.EffectiveFamily(false, "codex")).IsEqualTo("rpc");
+    // an already-non-PTY family is preserved, not flattened:
+    await Assert.That(HostedHarnessCatalog.EffectiveFamily(false, "gemini")).IsEqualTo("acp");
+    await Assert.That(HostedHarnessCatalog.EffectiveFamily(null, "claude")).IsEqualTo("pty");
+    await Assert.That(HostedHarnessCatalog.EffectiveFamily(true, "claude")).IsEqualTo("pty");
+}
+```
+
+- [ ] **Step 2: Run to verify failure** (compile errors → add stubs returning `""`/`false` → assertion failures).
+
+- [ ] **Step 3: Implement:**
+
+```csharp
+/// Family for a vendor token, unmapped defaulting to "rpc" — the shared seam so
+/// the workspace never duplicates the private map.
+public static string FamilyFor(string vendor) =>
+    TransportFamilies.TryGetValue(vendor, out var family) ? family : "rpc";
+
+/// The Terminal-tab gate: the daemon's has_terminal when present, the vendor
+/// family guess when an older daemon sent null.
+public static bool ShowsTerminal(bool? hasTerminal, string vendor) =>
+    hasTerminal ?? FamilyFor(vendor) == "pty";
+
+/// Header family, corrected: has_terminal=false cannot distinguish acp/rpc/
+/// app-server, so only a CONFLICTING pty guess is overridden (to generic chat);
+/// an already-non-PTY family is preserved.
+public static string EffectiveFamily(bool? hasTerminal, string vendor) {
+    var family = FamilyFor(vendor);
+    return hasTerminal == false && family == "pty" ? "rpc" : family;
+}
+```
+
+- [ ] **Step 4: Run to verify pass** (catalog filter, then full app suite).
+- [ ] **Step 5: Commit** — `App: terminal gate projection on HostedHarnessCatalog`.
+
+---
+
+### Task 4: Core `AgentAttachClient` — types, scripted server harness, happy paths
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/LocalIpc/AttachOutcome.cs`
+- Create: `src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs`
+- Create: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/ScriptedAttachServer.cs`
+- Create: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs`
+
+**Interfaces:**
+- Consumes: `FrameCodec` (`WriteAsync`/`ReadAsync`, `Attached`, `AttachedReadOnly` helpers), `FrameType`, `LocalFrame` (all public in Core).
+- Produces (the full public API — later tasks fill in behavior, signatures never change):
+
+```csharp
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// Exactly one of these is RunAsync's result. Detached = locally initiated
+/// close; Exited = agent process exit; Failed = daemon Error / refusal /
+/// protocol failure / pre-attach failure; ConnectionLost = uninitiated
+/// transport loss after attach.
+public abstract record AttachOutcome {
+    public sealed record Detached : AttachOutcome;
+    public sealed record Exited(int Code) : AttachOutcome;
+    public sealed record Failed(string Message) : AttachOutcome;
+    public sealed record ConnectionLost : AttachOutcome;
+}
+
+public sealed class AgentAttachClient : IAsyncDisposable {
+    public AgentAttachClient(
+        string socketPath,
+        string agentId,                                   // full 32-hex, never a prefix
+        Func<byte[], string?, CancellationToken, Task> onAttachedAsync,  // (snapshot, readOnlyReason: null = read-write, internal token)
+        Func<byte[], CancellationToken, Task> onOutputAsync,             // (bytes, internal token)
+        Action<string, Exception>? diagnostics = null);   // MUST be fast and non-blocking (runs inline); exception-contained only
+
+    public Task<AttachOutcome> RunAsync(int initialCols, int initialRows, CancellationToken ct);
+    public Task SendInputAsync(byte[] bytes);
+    public Task ResizeAsync(int cols, int rows);
+    public Task DetachAsync();
+    public ValueTask DisposeAsync();
+}
+```
+
+- [ ] **Step 1: Write the scripted server.** A per-test in-proc Unix-socket server that records received frames and plays a script:
+
+```csharp
+namespace Capacitor.Cli.Core.Tests.Unit.LocalIpc;
+
+using System.Net.Sockets;
+using Capacitor.Cli.Core.LocalIpc;
+
+/// One accepted connection, scripted: records every inbound frame, sends the
+/// queued replies when told to. Socket path must come from
+/// tmp.GetResolvedPath(...) — sockaddr_un budget.
+sealed class ScriptedAttachServer : IAsyncDisposable {
+    readonly Socket _listener;
+    Socket? _conn;
+    NetworkStream? _stream;
+    public readonly List<LocalFrame> Received = [];
+    public readonly TaskCompletionSource<LocalFrame> FirstFrame = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public string Path { get; }
+
+    public ScriptedAttachServer(string socketPath) {
+        Path = socketPath;
+        _listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        _listener.Bind(new UnixDomainSocketEndPoint(socketPath));
+        _listener.Listen(1);
+    }
+
+    public async Task AcceptAndPumpInboundAsync(CancellationToken ct = default) {
+        _conn = await _listener.AcceptAsync(ct);
+        _stream = new NetworkStream(_conn, ownsSocket: false);
+        _ = Task.Run(async () => {
+            try {
+                while (await FrameCodec.ReadAsync(_stream, ct) is { } f) {
+                    lock (Received) Received.Add(f);
+                    FirstFrame.TrySetResult(f);
+                }
+            } catch { /* connection closed by client — fine for a script */ }
+        }, ct);
+    }
+
+    public Task SendAsync(LocalFrame frame) => FrameCodec.WriteAsync(_stream!, frame);
+    public Task SendAttachedAsync(string agentId, byte[] snapshot) => SendAsync(FrameCodec.Attached(agentId, snapshot));
+    public Task SendAttachedReadOnlyAsync(string agentId, string reason, byte[] snapshot) => SendAsync(FrameCodec.AttachedReadOnly(agentId, reason, snapshot));
+    public Task SendStdoutAsync(byte[] bytes) => SendAsync(LocalFrame.Stdout(bytes));
+    public Task SendExitedAsync(int code) => SendAsync(LocalFrame.Exited(code));
+    public Task SendErrorAsync(string text) => SendAsync(new LocalFrame(FrameType.Error) { Text = text });
+    public void CloseConnection() { _stream?.Dispose(); _conn?.Dispose(); }
+    /// For truncation tests: write raw bytes (a partial header/payload), then close.
+    public async Task SendRawThenCloseAsync(byte[] raw) { await _stream!.WriteAsync(raw); CloseConnection(); }
+
+    public async ValueTask DisposeAsync() { CloseConnection(); _listener.Dispose(); await Task.CompletedTask; }
+}
+```
+
+Check `FrameCodec`'s actual helper names/arities against `src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs:131-171` before finalizing — `Attached(string, byte[])` and `AttachedReadOnly(string, string, byte[])` exist; `LocalFrame.Stdout/Exited` factories at `LocalFrame.cs:15-20`; `Error` may or may not have a factory (construct with initializer as shown if not).
+
+- [ ] **Step 2: Write the failing happy-path tests:**
+
+```csharp
+public class AgentAttachClientTests {
+    static readonly string AgentId = new('a', 32);
+
+    static (ScriptedAttachServer Server, TempDir Tmp) NewServer() {
+        var tmp = new TempDir("sock");
+        var path = tmp.GetResolvedPath("s.sock");
+        return (new ScriptedAttachServer(path), tmp);
+    }
+
+    sealed class Recorder {
+        public readonly List<(byte[] Snapshot, string? Reason)> Attached = [];
+        public readonly List<byte[]> Output = [];
+        public Func<byte[], string?, CancellationToken, Task> OnAttached => (s, r, _) => { Attached.Add((s, r)); return Task.CompletedTask; };
+        public Func<byte[], CancellationToken, Task> OnOutput => (b, _) => { Output.Add(b); return Task.CompletedTask; };
+    }
+
+    [Test]
+    public async Task Read_write_attach_delivers_snapshot_then_output_then_exit_and_nudges_resize() {
+        var (server, tmp) = NewServer();
+        await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+
+        var run = client.RunAsync(120, 40, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        var first = await server.FirstFrame.Task;              // the opening Attach frame
+        await server.SendAttachedAsync(AgentId, [1, 2, 3]);
+        await server.SendStdoutAsync([4, 5]);
+        await server.SendExitedAsync(7);
+
+        var outcome = await run;
+
+        await Assert.That(first.Type).IsEqualTo(FrameType.Attach);
+        await Assert.That(first.Text).IsEqualTo(AgentId);
+        await Assert.That(outcome).IsEqualTo(new AttachOutcome.Exited(7));
+        await Assert.That(rec.Attached.Single().Snapshot).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(rec.Attached.Single().Reason).IsNull();
+        await Assert.That(rec.Output.Single()).IsEquivalentTo(new byte[] { 4, 5 });
+        // resize nudge at the initial size, after the read-write Attached:
+        var resize = server.Received.Single(f => f.Type == FrameType.Resize);
+        await Assert.That(resize.Cols).IsEqualTo((ushort)120);
+        await Assert.That(resize.Rows).IsEqualTo((ushort)40);
+    }
+
+    [Test]
+    public async Task Read_only_attach_carries_the_reason_and_sends_no_resize_nudge() {
+        var (server, tmp) = NewServer();
+        await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedReadOnlyAsync(AgentId, "flow participant", [9]);
+        await server.SendExitedAsync(0);
+        await run;
+
+        await Assert.That(rec.Attached.Single().Reason).IsEqualTo("flow participant");
+        await Assert.That(server.Received.Any(f => f.Type == FrameType.Resize)).IsFalse();
+    }
+
+    [Test]
+    public async Task Error_as_first_reply_settles_failed() {
+        var (server, tmp) = NewServer();
+        await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendErrorAsync("no such agent aaaa…");
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.Failed("no such agent aaaa…"));
+        await Assert.That(rec.Attached).IsEmpty();
+    }
+
+    /// Serial awaited delivery: the pump must not read frame N+1 until the
+    /// callback for frame N completed.
+    [Test]
+    public async Task Output_callbacks_are_awaited_serially() {
+        var (server, tmp) = NewServer();
+        await using var _s = server; using var _t = tmp;
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int concurrent = 0, maxConcurrent = 0, count = 0;
+        await using var client = new AgentAttachClient(server.Path, AgentId,
+            (_, _, _) => Task.CompletedTask,
+            async (_, _) => {
+                var c = Interlocked.Increment(ref concurrent);
+                maxConcurrent = Math.Max(maxConcurrent, c);
+                if (Interlocked.Increment(ref count) == 1) await gate.Task;
+                Interlocked.Decrement(ref concurrent);
+            });
+
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendStdoutAsync([1]);
+        await server.SendStdoutAsync([2]);   // must sit in the socket until the gate opens
+        await Task.Delay(100);
+        gate.SetResult();
+        await server.SendExitedAsync(0);
+        await run;
+
+        await Assert.That(maxConcurrent).IsEqualTo(1);
+        await Assert.That(count).IsEqualTo(2);
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify failure** — compile errors for the missing types; add the `AttachOutcome` file and an `AgentAttachClient` skeleton whose `RunAsync` returns `new AttachOutcome.ConnectionLost()` unconditionally; re-run; expect assertion failures.
+
+- [ ] **Step 4: Implement the client core.** Full skeleton with the cause slot from day one (later tasks only extend classification):
+
+```csharp
+namespace Capacitor.Cli.Core.LocalIpc;
+
+using System.Net.Sockets;
+
+public sealed class AgentAttachClient : IAsyncDisposable {
+    // The single linearization point: first CAS winner decides RunAsync's result.
+    // Values: AttachOutcome | Exception (callback fault) | _cancelledSentinel.
+    object? _cause;
+    static readonly object CancelledSentinel = new();
+
+    readonly string _socketPath;
+    readonly string _agentId;
+    readonly Func<byte[], string?, CancellationToken, Task> _onAttached;
+    readonly Func<byte[], CancellationToken, Task> _onOutput;
+    readonly Action<string, Exception>? _diagnostics;
+    readonly SemaphoreSlim _writeLock = new(1, 1);
+    readonly object _sinkLock = new();
+
+    Socket? _socket;
+    NetworkStream? _stream;
+    CancellationTokenSource? _lifetime;   // linked to the caller token; callbacks get this token
+    volatile bool _detachRequested;       // intent, never a cause
+    volatile bool _attachedReadWrite;     // true after a read-write Attached
+    volatile bool _attachedAny;           // true after either Attached reply
+    Task<AttachOutcome>? _run;
+
+    public AgentAttachClient(
+            string socketPath, string agentId,
+            Func<byte[], string?, CancellationToken, Task> onAttachedAsync,
+            Func<byte[], CancellationToken, Task> onOutputAsync,
+            Action<string, Exception>? diagnostics = null) {
+        _socketPath = socketPath;
+        _agentId = agentId;
+        _onAttached = onAttachedAsync;
+        _onOutput = onOutputAsync;
+        _diagnostics = diagnostics;
+    }
+
+    bool TryClaim(object cause) => Interlocked.CompareExchange(ref _cause, cause, null) is null;
+
+    // Losing exceptions go here exactly once; expected teardown artifacts are
+    // excluded by the callers. Serialized; a throwing sink is contained.
+    void Report(string context, Exception ex) {
+        if (_diagnostics is null) return;
+        lock (_sinkLock) {
+            try { _diagnostics(context, ex); } catch { /* contained by contract */ }
+        }
+    }
+
+    public Task<AttachOutcome> RunAsync(int initialCols, int initialRows, CancellationToken ct) {
+        // Dispose/Detach before Run: terminal immediately, no dialing.
+        if (_cause is AttachOutcome pre) return Task.FromResult(pre);
+        if (_detachRequested) { TryClaim(new AttachOutcome.Detached()); return Task.FromResult((AttachOutcome)_cause!); }
+        return _run = RunCoreAsync(initialCols, initialRows, ct);
+    }
+
+    async Task<AttachOutcome> RunCoreAsync(int cols, int rows, CancellationToken ct) {
+        _lifetime = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        using var reg = ct.Register(() => { if (TryClaim(CancelledSentinel)) _lifetime.Cancel(); });
+        try {
+            _socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            await _socket.ConnectAsync(new UnixDomainSocketEndPoint(_socketPath), ct).ConfigureAwait(false);
+            _stream = new NetworkStream(_socket, ownsSocket: false);
+            await FrameCodec.WriteAsync(_stream, new LocalFrame(FrameType.Attach) { Text = _agentId }).ConfigureAwait(false);
+
+            while (true) {
+                var frame = await FrameCodec.ReadAsync(_stream, CancellationToken.None).ConfigureAwait(false);
+                if (frame is null) {                                     // clean EOF
+                    TryClaim(_detachRequested ? new AttachOutcome.Detached() : new AttachOutcome.ConnectionLost());
+                    break;
+                }
+                switch (frame.Type) {
+                    case FrameType.Attached: {
+                        var (_, snapshot) = FrameCodec.Attached(frame);
+                        _attachedAny = true; _attachedReadWrite = true;
+                        await _onAttached(snapshot, null, _lifetime.Token).ConfigureAwait(false);
+                        await WriteLockedAsync(SizeFrame(cols, rows)).ConfigureAwait(false);  // repaint nudge
+                        break;
+                    }
+                    case FrameType.AttachedReadOnly: {
+                        var (_, reason, snapshot) = FrameCodec.AttachedReadOnly(frame);
+                        _attachedAny = true; _attachedReadWrite = false;
+                        await _onAttached(snapshot, reason, _lifetime.Token).ConfigureAwait(false);
+                        break;                                            // no nudge: never influence the clamp
+                    }
+                    case FrameType.Stdout:
+                        await _onOutput(frame.Bytes!, _lifetime.Token).ConfigureAwait(false);
+                        break;
+                    case FrameType.Exited:
+                        TryClaim(new AttachOutcome.Exited(frame.ExitCode!.Value));
+                        goto done;
+                    case FrameType.Error:
+                        TryClaim(new AttachOutcome.Failed(frame.Text ?? "daemon error"));
+                        goto done;
+                    default:
+                        TryClaim(new AttachOutcome.Failed($"protocol failure: unexpected frame {frame.Type}"));
+                        goto done;
+                }
+            }
+            done: ;
+        } catch (Exception ex) {
+            ClassifyPumpException(ex);      // Task 5 fills this in fully
+        } finally {
+            CloseTransport();
+        }
+        return Project();
+    }
+
+    // Task 5 completes classification; Task 4 needs only enough for its tests.
+    void ClassifyPumpException(Exception ex) {
+        if (_detachRequested || _cause is not null) { /* local close or already decided */ }
+        else if (!_attachedAny) TryClaim(new AttachOutcome.Failed(ex.Message));
+        else TryClaim(new AttachOutcome.ConnectionLost());
+        if (_cause is AttachOutcome && _cause is not AttachOutcome.Detached && ex is not OperationCanceledException)
+            Report("attach pump", ex);   // refine in Task 7 per loser rules
+    }
+
+    AttachOutcome Project() =>
+        _cause switch {
+            AttachOutcome o => o,
+            Exception fault => throw new AttachCallbackException(fault),   // Task 5 refines
+            _ when ReferenceEquals(_cause, CancelledSentinel) => throw new OperationCanceledException(),
+            _ => new AttachOutcome.ConnectionLost(),
+        };
+
+    static LocalFrame SizeFrame(int cols, int rows) => LocalFrame.Resize((ushort)cols, (ushort)rows);
+
+    async Task WriteLockedAsync(LocalFrame frame) {
+        await _writeLock.WaitAsync().ConfigureAwait(false);
+        try { await FrameCodec.WriteAsync(_stream!, frame).ConfigureAwait(false); }
+        finally { _writeLock.Release(); }
+    }
+
+    void CloseTransport() { try { _stream?.Dispose(); } catch { } try { _socket?.Dispose(); } catch { } }
+
+    // Tasks 5–7 implement these fully; Task 4 ships minimal versions that keep
+    // the signatures compiling.
+    public Task SendInputAsync(byte[] bytes) => throw new NotImplementedException("Task 6");
+    public Task ResizeAsync(int cols, int rows) => throw new NotImplementedException("Task 6");
+    public Task DetachAsync() => throw new NotImplementedException("Task 5");
+    public async ValueTask DisposeAsync() {
+        _detachRequested = true;
+        TryClaim(new AttachOutcome.Detached());
+        _lifetime?.Cancel();
+        CloseTransport();
+        if (_run is { } run) { try { await run.ConfigureAwait(false); } catch { /* Task 5 refines */ } }
+    }
+}
+
+/// Wraps a callback fault so RunAsync's fault is distinguishable from infrastructure exceptions.
+public sealed class AttachCallbackException(Exception inner) : Exception("attach callback failed", inner);
+```
+
+Adjust member access against the real `LocalFrame` (`Bytes`, `Text`, `Cols`, `Rows`, `ExitCode` — see `LocalFrame.cs:7-20`) and the tuple shapes of `FrameCodec.Attached/AttachedReadOnly` decode helpers.
+
+- [ ] **Step 5: Run to verify the four tests pass.**
+- [ ] **Step 6: AOT check** (Core changed): publish grep prints nothing.
+- [ ] **Step 7: Commit** — `Core: AgentAttachClient skeleton — handshake, streaming, outcome slot`.
+
+---
+
+### Task 5: Core client — termination semantics, cause slot completion, lifetime token, `DetachAsync`/`DisposeAsync`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs`
+
+**Interfaces:** unchanged from Task 4. Behavior contract delivered here (spec §2 "termination semantics", "exceptional paths", "cause slot", "lifetime token"):
+- `DetachAsync`: records intent (never claims the slot), sends the Detach frame under the write lock; idempotent; a `Detach` write failure resolves `Detached`.
+- EOF/close-induced read failure with intent pending → `Detached`; without → `ConnectionLost` (post-attach) / `Failed` (pre-attach, no intent).
+- Frame read after intent still wins (`Exited`/`Failed`).
+- `DisposeAsync`: claims `Detached` eagerly, cancels the internal token, closes the socket, awaits the pump; never rethrows cancellation, callback faults already reported, or expected close exceptions.
+- External cancellation: claims `CancelledSentinel` first, then cancels the internal token; `RunAsync` throws `OperationCanceledException` only when cancellation is the recorded cause.
+- Truncation (`EndOfStreamException`) post-attach without intent → `ConnectionLost`; malformed (`InvalidDataException`) → `Failed("protocol failure…")`; connect refusal → `Failed`.
+
+- [ ] **Step 1: Failing tests** (add to `AgentAttachClientTests`):
+
+```csharp
+[Test]
+public async Task Detach_intent_plus_eof_settles_detached() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+
+    await client.DetachAsync();
+    server.CloseConnection();                       // daemon closes; no ack
+
+    await Assert.That(await run).IsEqualTo(new AttachOutcome.Detached());
+    await Assert.That(server.Received.Any(f => f.Type == FrameType.Detach)).IsTrue();
+}
+
+[Test]
+public async Task A_terminal_frame_read_after_detach_intent_still_wins() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+
+    await client.DetachAsync();
+    await server.SendExitedAsync(3);                // daemon raced: exit after Detach
+
+    await Assert.That(await run).IsEqualTo(new AttachOutcome.Exited(3));
+}
+
+[Test]
+public async Task Uninitiated_eof_after_attach_is_connection_lost() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+    server.CloseConnection();
+
+    await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+}
+
+[Test]
+public async Task Mid_header_truncation_after_attach_is_connection_lost() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+    await server.SendRawThenCloseAsync([0x41, 0x00]);          // stdout type byte + half a length
+
+    await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+}
+
+[Test]
+public async Task Connect_refusal_without_intent_is_failed() {
+    using var tmp = new TempDir("sock");
+    var rec = new Recorder();
+    await using var client = new AgentAttachClient(tmp.GetResolvedPath("nobody.sock"), AgentId, rec.OnAttached, rec.OnOutput);
+
+    var outcome = await client.RunAsync(80, 24, CancellationToken.None);
+
+    await Assert.That(outcome).IsAssignableTo<AttachOutcome.Failed>();
+}
+
+[Test]
+public async Task Dispose_during_blocked_first_reply_settles_detached_without_fault() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.FirstFrame.Task;                   // Attach written, first reply pending
+
+    await client.DisposeAsync();                    // must not throw
+
+    await Assert.That(await run).IsEqualTo(new AttachOutcome.Detached());
+}
+
+[Test]
+public async Task Dispose_before_run_makes_a_later_run_return_detached_without_dialing() {
+    using var tmp = new TempDir("sock");
+    var rec = new Recorder();
+    var client = new AgentAttachClient(tmp.GetResolvedPath("nobody.sock"), AgentId, rec.OnAttached, rec.OnOutput);
+    await client.DisposeAsync();
+
+    var outcome = await client.RunAsync(80, 24, CancellationToken.None);   // path does not even exist
+
+    await Assert.That(outcome).IsEqualTo(new AttachOutcome.Detached());
+}
+
+[Test]
+public async Task Caller_cancellation_surfaces_as_oce_and_dispose_does_not_rethrow_it() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    using var cts = new CancellationTokenSource();
+    var run = client.RunAsync(80, 24, cts.Token);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+
+    cts.Cancel();
+
+    await Assert.ThrowsAsync<OperationCanceledException>(async () => await run);
+    await client.DisposeAsync();                    // must complete cleanly
+}
+
+[Test]
+public async Task Dispose_while_caller_token_uncancelled_exits_a_stuck_callback_via_internal_token() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    var client = new AgentAttachClient(server.Path, AgentId,
+        (_, _, _) => Task.CompletedTask,
+        async (_, ct) => { entered.SetResult(); await Task.Delay(Timeout.Infinite, ct); });
+    var run = client.RunAsync(80, 24, CancellationToken.None);   // external token: none, never cancelled
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+    await server.SendStdoutAsync([1]);
+    await entered.Task;                              // callback is now stuck on the internal token
+
+    await client.DisposeAsync();
+
+    await Assert.That(await run).IsEqualTo(new AttachOutcome.Detached());
+}
+```
+
+- [ ] **Step 2: Run to verify failures** (`DetachAsync` NotImplemented, classification gaps).
+- [ ] **Step 3: Implement.** Replace the Task-4 placeholders:
+
+```csharp
+public async Task DetachAsync() {
+    if (_detachRequested) return;                 // idempotent
+    _detachRequested = true;
+    if (_stream is null) { TryClaim(new AttachOutcome.Detached()); return; }
+    try { await WriteLockedAsync(LocalFrame.Detach()).ConfigureAwait(false); }
+    catch { TryClaim(new AttachOutcome.Detached()); CloseTransport(); }   // detach write failure = local close
+}
+
+public async ValueTask DisposeAsync() {
+    _detachRequested = true;
+    TryClaim(new AttachOutcome.Detached());       // the one eager local terminalizer
+    _lifetime?.Cancel();
+    CloseTransport();
+    if (_run is { } run) {
+        try { await run.ConfigureAwait(false); }
+        catch (OperationCanceledException) { }    // retired run's cancellation: never rethrown
+        catch (AttachCallbackException) { }       // already reported where it claimed / lost
+    }
+}
+```
+
+And complete `ClassifyPumpException`:
+
+```csharp
+void ClassifyPumpException(Exception ex) {
+    if (ex is OperationCanceledException && ReferenceEquals(_cause, CancelledSentinel)) return;
+    if (_detachRequested || _cause is AttachOutcome.Detached) {
+        TryClaim(new AttachOutcome.Detached());   // local close at any phase; expected — not a diagnostic
+        return;
+    }
+    if (ex is InvalidDataException) { TryClaim(new AttachOutcome.Failed($"protocol failure: {ex.Message}")); ReportIfLost("protocol", ex); return; }
+    if (!_attachedAny) { TryClaim(new AttachOutcome.Failed(ex.Message)); ReportIfLost("pre-attach", ex); return; }
+    TryClaim(new AttachOutcome.ConnectionLost());
+    ReportIfLost("transport", ex);
+}
+
+// An exception whose cause attempt LOST still gets observed exactly once (Task 7 tests pin this).
+void ReportIfLost(string context, Exception ex) {
+    if (_cause is AttachOutcome.Detached || ReferenceEquals(_cause, CancelledSentinel)) Report(context, ex);
+}
+```
+
+`Project()` gains the callback-fault path: when a callback throws, the pump catches it around the `await _onAttached/_onOutput` calls specifically, `TryClaim(ex)`, breaks the loop; `Project` rethrows via `AttachCallbackException` only when the claimed cause **is** that exception; a callback `OperationCanceledException` caused by the internal token is not a fault — it projects the recorded winner (guard: `catch (OperationCanceledException) when (_lifetime.IsCancellationRequested)` → fall through to `Project`).
+
+- [ ] **Step 4: Run all client tests to green.** Then whole Core suite. AOT grep.
+- [ ] **Step 5: Commit** — `Core: attach client termination semantics and cause slot`.
+
+---
+
+### Task 6: Core client — outbound methods, semantic invariants, dimension validation
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs`
+
+**Interfaces:** unchanged. Contract (spec §2 outbound): no input/resize before `Attached`; dropped silently after `AttachedReadOnly` and after any terminal cause; no input behind a queued detach; dims `1..=ushort.MaxValue` rejected locally (silently dropped, never sent, never thrown — the client owns invariants, callers are not policed with exceptions); input/resize transport-write failure claims `ConnectionLost`, closes the socket, initiating call does not rethrow.
+
+- [ ] **Step 1: Failing tests:**
+
+```csharp
+[Test]
+public async Task Input_and_resize_before_attached_are_dropped() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.FirstFrame.Task;
+
+    await client.SendInputAsync([1]);
+    await client.ResizeAsync(100, 30);
+    await server.SendAttachedAsync(AgentId, []);
+    await server.SendExitedAsync(0);
+    await run;
+
+    await Assert.That(server.Received.Count(f => f.Type == FrameType.Stdin)).IsEqualTo(0);
+    // the only Resize is the post-attach nudge at the run's initial size:
+    await Assert.That(server.Received.Count(f => f.Type == FrameType.Resize)).IsEqualTo(1);
+    await Assert.That(server.Received.Single(f => f.Type == FrameType.Resize).Cols).IsEqualTo((ushort)80);
+}
+
+[Test]
+public async Task Explicit_input_and_resize_after_read_only_attach_are_dropped() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedReadOnlyAsync(AgentId, "review", []);
+    await Task.Delay(50);
+
+    await client.SendInputAsync([1]);
+    await client.ResizeAsync(100, 30);
+    await server.SendExitedAsync(0);
+    await run;
+
+    await Assert.That(server.Received.Any(f => f.Type is FrameType.Stdin or FrameType.Resize)).IsFalse();
+}
+
+[Test]
+public async Task No_input_is_written_behind_a_queued_detach() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+    await Task.Delay(50);
+
+    await client.DetachAsync();
+    await client.SendInputAsync([9]);
+    server.CloseConnection();
+    await run;
+
+    var detachIndex = server.Received.FindIndex(f => f.Type == FrameType.Detach);
+    await Assert.That(detachIndex).IsGreaterThanOrEqualTo(0);
+    await Assert.That(server.Received.Skip(detachIndex + 1).Any(f => f.Type == FrameType.Stdin)).IsFalse();
+}
+
+[Test]
+[Arguments(0, 24)]
+[Arguments(-1, 24)]
+[Arguments(80, 0)]
+[Arguments(70000, 24)]
+public async Task Invalid_dimensions_are_rejected_locally(int cols, int rows) {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+    await Task.Delay(50);
+    var before = server.Received.Count(f => f.Type == FrameType.Resize);
+
+    await client.ResizeAsync(cols, rows);
+    await server.SendExitedAsync(0);
+    await run;
+
+    await Assert.That(server.Received.Count(f => f.Type == FrameType.Resize)).IsEqualTo(before);
+}
+
+/// Read side held open: the write failure alone must settle the run.
+[Test]
+public async Task Input_write_failure_settles_connection_lost_without_rethrow_or_hung_pump() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+    await Task.Delay(50);
+
+    server.CloseConnection();                                  // break the transport under the writer
+    await client.SendInputAsync([1, 2, 3]);                    // must not throw
+
+    await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+}
+```
+
+- [ ] **Step 2: Run to verify failures** (NotImplemented from Task 4 stubs).
+- [ ] **Step 3: Implement:**
+
+```csharp
+public async Task SendInputAsync(byte[] bytes) {
+    if (!_attachedReadWrite || _detachRequested || _cause is not null) return;
+    await WriteOutboundAsync(LocalFrame.Stdin(bytes)).ConfigureAwait(false);
+}
+
+public async Task ResizeAsync(int cols, int rows) {
+    if (!_attachedReadWrite || _detachRequested || _cause is not null) return;
+    if (cols is < 1 or > ushort.MaxValue || rows is < 1 or > ushort.MaxValue) return;
+    await WriteOutboundAsync(SizeFrame(cols, rows)).ConfigureAwait(false);
+}
+
+// Outbound writers claim the slot themselves on transport failure — the read
+// side may be blocked; closing the socket completes it and the pump projects.
+async Task WriteOutboundAsync(LocalFrame frame) {
+    try {
+        await _writeLock.WaitAsync().ConfigureAwait(false);
+        try {
+            if (_detachRequested || _cause is not null) return;   // re-check under the lock: nothing behind a queued detach
+            await FrameCodec.WriteAsync(_stream!, frame).ConfigureAwait(false);
+        } finally { _writeLock.Release(); }
+    } catch (Exception ex) {
+        if (TryClaim(new AttachOutcome.ConnectionLost())) Report("outbound write", ex);
+        else if (_cause is AttachOutcome.Detached || ReferenceEquals(_cause, CancelledSentinel)) Report("outbound write", ex);
+        CloseTransport();
+    }
+}
+```
+
+`DetachAsync` from Task 5 already uses `WriteLockedAsync`; change it to take the same under-lock `_cause` re-check style but note: a detach frame IS allowed while `_cause` is null and intent set (it sets intent first), so `DetachAsync` writes via `WriteLockedAsync` directly, not `WriteOutboundAsync`.
+
+- [ ] **Step 4: Run all client tests, Core suite, AOT grep.**
+- [ ] **Step 5: Commit** — `Core: attach client outbound invariants`.
+
+---
+
+### Task 7: Core client — diagnostic sink contract and loser matrix
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs` (refine `Report`/`ReportIfLost` call sites per the tests)
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs`
+
+**Interfaces:** unchanged. Contract (spec §2 sink + loser matrix): every actual losing exception hits the sink exactly once; cooperative-cancellation and local-close artifacts never reach it; a throwing sink is swallowed; concurrent losers are serialized; callback-fault-vs-Dispose both orderings; input-write-failure-vs-detach both orderings.
+
+- [ ] **Step 1: Failing tests:**
+
+```csharp
+sealed class RecordingSink {
+    public readonly List<(string Context, Exception Ex)> Entries = [];
+    readonly object _gate = new();
+    public int MaxConcurrent; int _current;
+    public Action<string, Exception> Callback => (c, e) => {
+        var now = Interlocked.Increment(ref _current);
+        MaxConcurrent = Math.Max(MaxConcurrent, now);
+        lock (_gate) Entries.Add((c, e));
+        Interlocked.Decrement(ref _current);
+    };
+}
+
+[Test]
+public async Task Routine_dispose_produces_zero_diagnostics() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var sink = new RecordingSink();
+    var rec = new Recorder();
+    var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput, sink.Callback);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+    await Task.Delay(50);
+
+    await client.DisposeAsync();
+    await run;
+
+    await Assert.That(sink.Entries).IsEmpty();
+}
+
+[Test]
+public async Task Callback_fault_losing_to_dispose_is_logged_once_and_run_settles_detached() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var sink = new RecordingSink();
+    var boom = new InvalidOperationException("render exploded");
+    var disposeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    AgentAttachClient client = null!;
+    client = new AgentAttachClient(server.Path, AgentId,
+        (_, _, _) => Task.CompletedTask,
+        async (_, _) => { await disposeStarted.Task; throw boom; },   // fault AFTER dispose claimed
+        sink.Callback);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+    await server.SendStdoutAsync([1]);
+    await Task.Delay(50);
+
+    var dispose = client.DisposeAsync();
+    disposeStarted.SetResult();
+    await dispose;                                             // completes normally, no rethrow
+
+    await Assert.That(await run).IsEqualTo(new AttachOutcome.Detached());
+    await Assert.That(sink.Entries.Count(e => ReferenceEquals(e.Ex, boom))).IsEqualTo(1);
+}
+
+[Test]
+public async Task Callback_fault_claiming_first_faults_run_and_dispose_does_not_rethrow() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var sink = new RecordingSink();
+    var boom = new InvalidOperationException("render exploded");
+    var client = new AgentAttachClient(server.Path, AgentId,
+        (_, _, _) => Task.CompletedTask,
+        (_, _) => throw boom,
+        sink.Callback);
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+    await server.SendStdoutAsync([1]);
+
+    var thrown = await Assert.ThrowsAsync<AttachCallbackException>(async () => await run);
+    await client.DisposeAsync();                               // completes normally
+
+    await Assert.That(thrown!.InnerException).IsSameReferenceAs(boom);
+    // the fault WON — it is the result, not a losing diagnostic:
+    await Assert.That(sink.Entries.Any(e => ReferenceEquals(e.Ex, boom))).IsFalse();
+}
+
+[Test]
+public async Task A_throwing_sink_is_swallowed_and_alters_nothing() {
+    var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+    var rec = new Recorder();
+    var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput,
+        (_, _) => throw new Exception("sink bug"));
+    var run = client.RunAsync(80, 24, CancellationToken.None);
+    await server.AcceptAndPumpInboundAsync();
+    await server.SendAttachedAsync(AgentId, []);
+    await Task.Delay(50);
+
+    server.CloseConnection();
+    await client.SendInputAsync([1]);                          // write failure → loser or winner, sink throws either way
+
+    await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+    await client.DisposeAsync();                               // still clean
+}
+```
+
+- [ ] **Step 2: Run to verify failures.** The Task-5 `ReportIfLost` skeleton likely over- or under-reports; the tests force the exact rule.
+- [ ] **Step 3: Implement** by refining the call sites until the matrix holds:
+  - `ClassifyPumpException`: local-close/cancellation artifacts (`_detachRequested` true, or the exception is the socket-close `IOException`/`ObjectDisposedException` following a claimed `Detached`) → **no** report. A genuine exception whose claim lost → one report.
+  - Callback catch: if `TryClaim(ex)` succeeded, the fault is the result — no report; if it lost (Dispose already claimed) → one report.
+  - Keep `Report` serialized under `_sinkLock`, wrapped in try/catch (already so from Task 4).
+- [ ] **Step 4: Run all client tests, full Core suite, AOT grep.**
+- [ ] **Step 5: Commit** — `Core: attach client diagnostic sink and loser matrix`.
+
+---
+
+### Task 8: Terminal packages, UTF-8 assembler, recorded-transcript test
+
+**Files:**
+- Modify: `Directory.Packages.props` (add `SvcSystems.UI.Terminal` 1.1.1, `XTerm.NET` 1.0.16 — both `PackageVersion` entries)
+- Modify: `src/Capacitor.App/Capacitor.App.csproj` (add **direct** `PackageReference` to BOTH — the repo has no transitive pinning, a `PackageVersion` line alone pins nothing)
+- Create: `src/Capacitor.App/Services/Utf8StreamDecoder.cs`
+- Test: `test/Capacitor.App.Tests.Unit/Utf8StreamDecoderTests.cs`, `test/Capacitor.App.Tests.Unit/TerminalTranscriptTests.cs`
+
+**Interfaces:**
+- Produces: `sealed class Utf8StreamDecoder` — `string Decode(ReadOnlySpan<byte> bytes)` (incremental, `Decoder`-backed), `string Flush()`. One instance spans snapshot + all frames of one attach attempt.
+
+- [ ] **Step 1: Failing decoder tests:**
+
+```csharp
+public class Utf8StreamDecoderTests {
+    [Test]
+    [Arguments("é")]      // 2-byte
+    [Arguments("€")]      // 3-byte
+    [Arguments("𝄞")]      // 4-byte
+    public async Task Multibyte_characters_split_at_every_boundary_reassemble(string ch) {
+        var bytes = System.Text.Encoding.UTF8.GetBytes($"a{ch}b");
+        for (var split = 1; split < bytes.Length; split++) {
+            var decoder = new Utf8StreamDecoder();
+            var text = decoder.Decode(bytes.AsSpan(0, split)) + decoder.Decode(bytes.AsSpan(split)) + decoder.Flush();
+            await Assert.That(text).IsEqualTo($"a{ch}b");
+        }
+    }
+
+    [Test]
+    public async Task The_snapshot_live_seam_is_one_stream() {
+        var bytes = System.Text.Encoding.UTF8.GetBytes("€");
+        var decoder = new Utf8StreamDecoder();
+        var snapshotPart = decoder.Decode(bytes.AsSpan(0, 1));   // snapshot ends mid-character
+        var livePart = decoder.Decode(bytes.AsSpan(1));          // first live frame completes it
+        await Assert.That(snapshotPart + livePart).IsEqualTo("€");
+    }
+
+    [Test]
+    public async Task Flush_emits_a_replacement_for_a_dangling_partial() {
+        var decoder = new Utf8StreamDecoder();
+        decoder.Decode(System.Text.Encoding.UTF8.GetBytes("€").AsSpan(0, 1));
+        await Assert.That(decoder.Flush()).IsEqualTo("�");
+    }
+}
+```
+
+- [ ] **Step 2: Verify failure, then implement:**
+
+```csharp
+namespace Capacitor.App.Services;
+
+using System.Text;
+
+/// One incremental UTF-8 stream per attach attempt: PTY frames split multibyte
+/// code points at arbitrary boundaries, and the terminal control's Feed does a
+/// fresh GetString per call — this is the single decoder spanning the snapshot
+/// and every live frame, flushed only at terminal completion.
+public sealed class Utf8StreamDecoder {
+    readonly Decoder _decoder = Encoding.UTF8.GetDecoder();
+
+    public string Decode(ReadOnlySpan<byte> bytes) {
+        if (bytes.IsEmpty) return "";
+        var chars = new char[Encoding.UTF8.GetMaxCharCount(bytes.Length)];
+        var n = _decoder.GetChars(bytes, chars, flush: false);
+        return new string(chars, 0, n);
+    }
+
+    public string Flush() {
+        var chars = new char[4];
+        var n = _decoder.GetChars(ReadOnlySpan<byte>.Empty, chars, flush: true);
+        return new string(chars, 0, n);
+    }
+}
+```
+
+- [ ] **Step 3: Add the packages.** `Directory.Packages.props`: `<PackageVersion Include="SvcSystems.UI.Terminal" Version="1.1.1" />` and `<PackageVersion Include="XTerm.NET" Version="1.0.16" />`; csproj: `<PackageReference Include="SvcSystems.UI.Terminal" />` and `<PackageReference Include="XTerm.NET" />`. Build the app project. **Then discover the actual control surface** — dump the API before writing the transcript test: `dotnet run` a scratch or use `ilspy`/completion to confirm: the control model type name (`TerminalControlModel`), its `Feed(string)`/`Feed(byte[])` members, the `TerminalOptions.ReflowOnResize` option, the user-input event (keyboard → bytes), and whether the engine's terminal-reply path (`Terminal.Engine.DataReceived` or equivalent) is reachable. Record findings as comments in `TerminalTranscriptTests.cs` — Task 10/11 consume them.
+- [ ] **Step 4: Recorded-transcript test** (headless — the model is engine state, not a rendered window):
+
+```csharp
+/// The acceptance gate for emulation fidelity: a captured ANSI/TUI stream
+/// (colors, cursor addressing, alternate screen) through the decode-and-feed
+/// path, ReflowOnResize=false per upstream's own TUI guidance.
+[NotInParallel("AvaloniaSession")]
+public class TerminalTranscriptTests {
+    [Test]
+    public async Task A_recorded_tui_transcript_feeds_without_faulting_and_lands_expected_cells() {
+        await AvaloniaSession.DispatchAsync(() => {
+            var model = /* construct the control model with ReflowOnResize = false, 80x24 */;
+            var decoder = new Utf8StreamDecoder();
+            // transcript: SGR color, cursor addressing, alt-screen enter/leave, text
+            var transcript = "\x1b[2J\x1b[H\x1b[1;31mRED\x1b[0m\x1b[10;5Hmid\x1b[?1049h alt \x1b[?1049l back"u8.ToArray();
+            foreach (var chunk in Chunk(transcript, 7))           // deliberately ugly boundaries
+                model.Feed(decoder.Decode(chunk));
+            model.Feed(decoder.Flush());
+            // assert on the engine buffer: "RED" at row 0, "mid" at row 9 col 4, "back" present post alt-screen
+            // (exact accessor per the API discovered in Step 3 — buffer/GetLine/Cells)
+            return true;
+        });
+    }
+    static IEnumerable<byte[]> Chunk(byte[] data, int size) {
+        for (var i = 0; i < data.Length; i += size) yield return data[i..Math.Min(i + size, data.Length)];
+    }
+}
+```
+
+Fill the two commented holes with the real API found in Step 3 — that discovery is part of this task's deliverable, not optional.
+
+- [ ] **Step 5: Run both test files to green; run the full app suite; commit** — `App: terminal packages (direct-pinned), UTF-8 assembler, transcript gate`. Include the license note in the commit body: SvcSystems.UI.Terminal MIT, XTerm.NET MIT, verify with `dotnet list src/Capacitor.App/Capacitor.App.csproj package --include-transitive` and record the resolved graph in the PR description later.
+
+---
+
+### Task 9: App seam — `ITerminalAttachClient`, factory, `TerminalSessionState`
+
+**Files:**
+- Create: `src/Capacitor.App/Services/TerminalAttach.cs`
+- Test: none of its own (types only, exercised from Task 10 onward) — but it must compile and the real adapter is trivial enough to include here.
+
+**Interfaces:**
+- Produces:
+
+```csharp
+namespace Capacitor.App.Services;
+
+using Capacitor.Cli.Core.LocalIpc;
+
+/// App-side seam over Core's AgentAttachClient so VM tests script attachment.
+public interface ITerminalAttachClient : IAsyncDisposable {
+    Task<AttachOutcome> RunAsync(int initialCols, int initialRows, CancellationToken ct);
+    Task SendInputAsync(byte[] bytes);
+    Task ResizeAsync(int cols, int rows);
+    Task DetachAsync();
+}
+
+/// One client per attach attempt — the factory is the unit tests' scripting seam.
+public delegate ITerminalAttachClient TerminalAttachClientFactory(
+    string agentId,
+    Func<byte[], string?, CancellationToken, Task> onAttached,
+    Func<byte[], CancellationToken, Task> onOutput);
+
+/// Production adapter: Core client, diagnostics to Console.Error (the app's
+/// teardown-diagnostic convention — never AppNotifier toasts).
+public sealed class CoreTerminalAttachClient(AgentAttachClient inner) : ITerminalAttachClient {
+    public static TerminalAttachClientFactory Factory(Func<string> socketPath) =>
+        (agentId, onAttached, onOutput) => new CoreTerminalAttachClient(new AgentAttachClient(
+            socketPath(), agentId, onAttached, onOutput,
+            (ctx, ex) => Console.Error.WriteLine($"kcap: terminal attach {ctx}: {ex.Message}")));
+    public Task<AttachOutcome> RunAsync(int c, int r, CancellationToken ct) => inner.RunAsync(c, r, ct);
+    public Task SendInputAsync(byte[] b) => inner.SendInputAsync(b);
+    public Task ResizeAsync(int c, int r) => inner.ResizeAsync(c, r);
+    public Task DetachAsync() => inner.DetachAsync();
+    public ValueTask DisposeAsync() => inner.DisposeAsync();
+}
+
+/// Deliberately NOT named *Attach*State — AttachStatus/AttachState already
+/// describe the daemon status subscription (spec naming note).
+public enum TerminalSessionPhase { Resolving, NoTerminal, NotFound, Connecting, Attached, Detached, Exited, Failed, SessionEnded }
+
+public sealed record TerminalSessionState(TerminalSessionPhase Phase, string? Detail = null, bool ReadOnly = false, int? ExitCode = null) {
+    public static readonly TerminalSessionState Resolving = new(TerminalSessionPhase.Resolving);
+    public static TerminalSessionState NoTerminal(string? familyNote) => new(TerminalSessionPhase.NoTerminal, familyNote);
+    public static readonly TerminalSessionState NotFound = new(TerminalSessionPhase.NotFound, "Session not found");
+    public static readonly TerminalSessionState Connecting = new(TerminalSessionPhase.Connecting);
+    public static TerminalSessionState Attached(string? readOnlyReason) => new(TerminalSessionPhase.Attached, readOnlyReason, ReadOnly: readOnlyReason is not null);
+    public static readonly TerminalSessionState DetachedState = new(TerminalSessionPhase.Detached);
+    public static TerminalSessionState Exited(int code) => new(TerminalSessionPhase.Exited, ExitCode: code);
+    public static TerminalSessionState Failed(string message) => new(TerminalSessionPhase.Failed, message);
+    public static readonly TerminalSessionState SessionEnded = new(TerminalSessionPhase.SessionEnded);
+}
+```
+
+- [ ] **Step 1: Write the file, build the app project, commit** — `App: terminal attach seam and session states`. (No standalone tests — every member is pinned by Tasks 10–12; a task reviewer verifies compilation only.)
+
+---
+
+### Task 10: `TerminalTabViewModel` — Resolving gate, attempt lifecycle, outcome mapping
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/TerminalTabViewModel.cs`
+- Test: `test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs`
+- Test helper: `test/Capacitor.App.Tests.Unit/FakeTerminalAttachClient.cs`
+
+**Interfaces:**
+- Consumes: `ITerminalAttachClient`/factory/`TerminalSessionState` (Task 9), `Utf8StreamDecoder` (Task 8), `IDaemonClientService.Agents`, `HostedHarnessCatalog.ShowsTerminal/EffectiveFamily` (Task 3), `RxSchedulers.MainThreadScheduler`, `TimeProvider`.
+- Produces:
+
+```csharp
+public sealed class TerminalTabViewModel : ReactiveObject {
+    public TerminalTabViewModel(
+        string agentId, IDaemonClientService daemon, TerminalAttachClientFactory factory,
+        Func<ITerminalSurface> surfaceFactory,     // fresh terminal model per attempt (Task 12 provides the real one)
+        TimeProvider time);
+
+    public TerminalSessionState State { get; }      // bound; mutated only on the UI scheduler
+    public ITerminalSurface? Surface { get; }       // the VM-owned model handle the view binds
+    public ReactiveCommand<Unit, Unit> ReattachCommand { get; }   // single-flight
+    public ReactiveCommand<Unit, Unit> DetachCommand { get; }
+    public ReactiveCommand<Unit, Unit> RetryResolveCommand { get; }
+    public Task TeardownAsync();                    // bounded per spec (1s detach / 3s budget) — Task 13's tracker calls this
+}
+
+/// Minimal surface the VM drives; the production implementation (Task 12) wraps
+/// the SvcSystems control model. Kept App-local so VM tests don't touch Avalonia.
+public interface ITerminalSurface {
+    void Feed(string text);
+    event Action<byte[]>? InputProduced;           // keyboard AND terminal-generated protocol replies
+    event Action<int, int>? Resized;
+}
+```
+
+Resolve budget: **10 s** via the injected `TimeProvider`.
+
+- [ ] **Step 1: Write `FakeTerminalAttachClient`** — scriptable: `TaskCompletionSource<AttachOutcome> Result`, recorded `SentInput`/`Resizes`/`DetachCalls`/`DisposeCalls`, exposed `TriggerAttached(snapshot, reason)` / `TriggerOutput(bytes)` that invoke the captured callbacks, `RunStarted` TCS. The factory fake records every created client.
+
+- [ ] **Step 2: Failing tests, first batch — the Resolving gate** (all `[NotInParallel("AvaloniaSession")]`, inside `AvaloniaSession.WithImmediateRxScheduler`, agents pushed through `FakeDaemonClientService.Agents` with the `Agent(...)` helper pattern from `HomeViewModelTests`, extended with a `hasTerminal` argument):
+
+```csharp
+[Test] public async Task Opens_resolving_and_no_client_exists_before_the_first_dto() { /* construct VM for an id absent from cache; assert State.Phase == Resolving && factory.Created.Count == 0 */ }
+[Test] public async Task Has_terminal_false_renders_the_note_with_zero_attempts() { /* push DTO hasTerminal:false vendor gemini; assert Phase == NoTerminal, Detail contains "runs over ACP" (from EffectiveFamily "acp"), factory.Created.Count == 0 */ }
+[Test] public async Task Has_terminal_true_and_null_pty_fallback_proceed_to_attach() { /* two cases: hasTerminal:true vendor gemini; hasTerminal:null vendor claude — both create exactly one client and enter Connecting */ }
+[Test] public async Task Resolve_timeout_is_not_found_and_a_late_dto_is_ignored_until_retry() { /* FakeTimeProvider advance 10s; Phase == NotFound; push DTO afterwards → still NotFound, zero clients; execute RetryResolveCommand → resolves against the now-present DTO */ }
+[Test] public async Task Removal_after_first_observation_is_session_ended_not_resolving() { /* push DTO, then remove from cache; Phase == SessionEnded */ }
+```
+
+- [ ] **Step 3: Failing tests, second batch — outcome mapping and attempt lifecycle:**
+
+```csharp
+[Test] public async Task Read_only_attach_shows_the_reason_and_suppresses_input_and_resize() { /* TriggerAttached(reason:"review"); raise surface.InputProduced + Resized; assert client.SentInput empty, client.Resizes empty, State.ReadOnly true */ }
+[Test] public async Task Exited_maps_to_exited_banner_and_connection_lost_maps_to_failed() { /* complete Result with Exited(3) → Phase Exited, ExitCode 3; new VM, complete with ConnectionLost → Phase Failed, Detail mentions lost connection */ }
+[Test] public async Task A_background_run_fault_renders_failed_with_reattach() { /* fail Result task with AttachCallbackException(new Exception("boom")) from a background thread; Phase Failed */ }
+[Test] public async Task Explicit_detach_stays_in_place_with_single_flight_reattach() { /* DetachCommand → client.DetachCalls == 1; complete Result Detached → Phase Detached (no navigation concept here); ReattachCommand twice quickly → factory.Created grows by exactly 1 */ }
+[Test] public async Task Reattach_swaps_in_a_fresh_surface_and_decoder_before_the_snapshot() { /* first attempt: TriggerOutput with "AB"; fail with ConnectionLost; Reattach; second client TriggerAttached(snapshot:"AB") — assert the NEW surface received "AB" exactly once and it is a different ITerminalSurface instance than the first */ }
+[Test] public async Task Exited_is_not_overwritten_by_session_ended() { /* complete Exited(0); then remove agent from cache; Phase stays Exited */ }
+[Test] public async Task A_retired_attempts_cancellation_mutates_nothing() { /* start attempt 1; begin Reattach (retires it: cancel+dispose); fail attempt 1's Result with OperationCanceledException afterwards; assert State reflects attempt 2 (Connecting), not Failed */ }
+[Test] public async Task Utf8_split_across_snapshot_and_frames_renders_whole_characters() { /* TriggerAttached(snapshot: first byte of "€"), TriggerOutput(remaining bytes); surface received "€" */ }
+[Test] public async Task Surface_swap_and_state_mutations_happen_on_the_ui_thread() { /* drive Reattach completion from Task.Run; record thread via surfaceFactory + State observer; assert UI-thread per the An_agent_arriving_off_the_UI_thread pattern in HomeViewSmokeTests (thread identity, not absence of throw) */ }
+[Test] public async Task Cancel_dispose_orderings_each_yield_one_recorded_state() { /* three cases with the fake client: cancel-before-dispose, dispose-before-cancel, simultaneous (start both from two Task.Run and Task.WhenAll) — each ends in exactly one terminal State transition on the VM, and a retired generation's late completion mutates nothing */ }
+[Test] public async Task A_never_completing_detach_write_is_force_closed_within_the_bound() { /* fake client whose DetachAsync never completes; TeardownAsync under FakeTimeProvider: advance 1s → DisposeAsync called (socket close); advance to 3s → TeardownAsync returns; the abandoned detach task later faulting is observed once (recording diagnostic), no further State mutation */ }
+[Test] public async Task A_never_completing_awaited_callback_is_released_by_run_token_cancellation() { /* fake client that captures the onOutput callback and invokes it with a token; block the callback on Task.Delay(Infinite, ct); TeardownAsync cancels the attempt → callback task completes cancelled; assert the VM's Surface reference is released (weak-reference goes dead after GC.Collect) or at minimum the callback task completed */ }
+```
+
+- [ ] **Step 4: Run to verify failures; implement the VM.** Key internals (write in full):
+  - Resolve: subscribe `daemon.Agents.Connect().ObserveOn(RxSchedulers.MainThreadScheduler)`, filter by id; an atomic `int _resolveState` (0 pending / 1 dto-won / 2 timeout-won / 3 disposed) compare-exchanged by the DTO handler, the `TimeProvider` timer callback, and `Dispose` — the loser no-ops. Timeout disposes the subscription.
+  - Attempt: `int _attemptGeneration`; each attempt captures its generation; every completion handler checks generation before mutating (`if (gen != _attemptGeneration) return;` — a cancelled retired attempt is silent). One `SemaphoreSlim(1,1)` single-flights attach/reattach; the previous client is `cts.Cancel()` + `await DisposeAsync()` before the next `factory(...)` call.
+  - Fresh per attempt: `surface = _surfaceFactory()` and `decoder = new Utf8StreamDecoder()` assigned on the UI scheduler **before** `RunAsync` is started; `OnAttached`/`OnOutput` decode then `await Dispatcher.UIThread.InvokeAsync(() => surface.Feed(text), DispatcherPriority.Default, ct)` — awaited with the callback's ct (the internal token), giving backpressure and cancellable dispatch.
+  - Input wiring: `surface.InputProduced += b => _ = client.SendInputAsync(b)` only when not read-only; `Resized` likewise (client also guards — belt and braces).
+  - `TeardownAsync()`: generation bump; detach with a 1 s bound (`Task.WhenAny(client.DetachAsync(), Task.Delay(1s, time))`), then `DisposeAsync` immediately, remainder of 3 s awaiting the run task; abandoned run gets `.ContinueWith` observer that writes to `Console.Error` on fault.
+- [ ] **Step 5: Green on the VM test file, then full app suite.**
+- [ ] **Step 6: Commit** — `App: TerminalTabViewModel — resolve gate, attempt lifecycle, outcome mapping`.
+
+---### Task 11: Terminal surface adapter + input/replies wiring (`ITerminalSurface` production impl)
+
+**Files:**
+- Create: `src/Capacitor.App/Services/XtermTerminalSurface.cs`
+- Test: extend `test/Capacitor.App.Tests.Unit/TerminalTranscriptTests.cs`
+
+**Interfaces:**
+- Consumes: the control-model API discovered in Task 8 Step 3; `ITerminalSurface` (Task 9).
+- Produces: `sealed class XtermTerminalSurface : ITerminalSurface` wrapping the SvcSystems control model with `ReflowOnResize = false`; `InputProduced` raised for BOTH keyboard input and terminal-generated protocol replies (the engine data-received path found in Task 8 — if the wrapper hides it, subscribe on the underlying XTerm.NET engine object; this reachability is a spec acceptance item and must not be silently skipped); `Resized` from the control's resize event.
+
+- [ ] **Step 1: Failing test — query/response through the surface:**
+
+```csharp
+[Test]
+[NotInParallel("AvaloniaSession")]
+public async Task A_device_status_query_produces_a_terminal_reply_through_InputProduced() {
+    await AvaloniaSession.DispatchAsync(() => {
+        var surface = new XtermTerminalSurface(cols: 80, rows: 24);
+        var replies = new List<byte[]>();
+        surface.InputProduced += replies.Add;
+
+        surface.Feed("\x1b[6n");                          // DSR: report cursor position
+
+        // the engine answers ESC[row;colR on its own:
+        return replies.Any(r => System.Text.Encoding.ASCII.GetString(r).Contains(";1R"));
+    }).ContinueWith(async t => await Assert.That(t.Result).IsTrue()).Unwrap();
+}
+```
+
+(Adapt the assertion plumbing to the file's existing `DispatchAsync` style; the substance is: feed DSR, observe the reply bytes.)
+
+- [ ] **Step 2: Verify failure, implement the adapter, verify pass.** The VM's read-only suppression from Task 10 already covers "suppressed in read-only mode" (InputProduced is not forwarded); add one VM-level test there if Task 10 didn't already assert replies specifically.
+- [ ] **Step 3: Full app suite; commit** — `App: xterm surface adapter with terminal-reply lane`.
+
+---
+
+### Task 12: `WorkspaceViewModel` + `WorkspaceView` (header, tabs)
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/WorkspaceViewModel.cs`
+- Create: `src/Capacitor.App/Views/WorkspaceView.axaml` + `.axaml.cs`
+- Test: `test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs`
+
+**Interfaces:**
+- Consumes: `TerminalTabViewModel` (Task 10), `AgentActionService` (`RequestStop(agentId, label, kind)` / `OpenInWeb(agentId)`), `RepoLabel.Leaf`, `HostedHarnessCatalog` (Task 3), `IDaemonClientService.Agents`.
+- Produces:
+
+```csharp
+public sealed class WorkspaceViewModel : ReactiveObject {
+    public WorkspaceViewModel(
+        string agentId, IDaemonClientService daemon, AgentActionService actions,
+        TerminalAttachClientFactory factory, Func<ITerminalSurface> surfaceFactory, TimeProvider time);
+    public string AgentId { get; }
+    public string Title { get; }            // "RepoLabel.Leaf(repo) · vendor", live from the cache
+    public string RepoLabelText { get; }    // repo leaf; NO branch this slice (spec)
+    public string VendorChip { get; }       // vendor + model
+    public string FamilyDot { get; }        // EffectiveFamily(hasTerminal, vendor): "pty"|"acp"|"rpc"
+    public bool ShowsTerminalTab { get; }   // ShowsTerminal(hasTerminal, vendor)
+    public string NoTerminalNote { get; }   // "This session has no terminal" (+ " — runs over ACP"/family when known); no vendor names
+    public TerminalTabViewModel Terminal { get; }
+    public ReactiveCommand<Unit, Unit> OpenInWebCommand { get; }
+    public ReactiveCommand<Unit, Unit> StopCommand { get; }
+    public bool SessionEnded { get; }
+    public Task TeardownAsync();            // delegates to Terminal.TeardownAsync()
+}
+```
+
+- [ ] **Step 1: Failing VM tests:** title/repo/chip projection from a pushed DTO; `ShowsTerminalTab` false + note text for `hasTerminal:false` vendor `gemini` (note says "runs over ACP", never "Gemini"); `SessionEnded` when the agent leaves the cache; Stop routes through `AgentActionService.RequestStop` with the DTO's kind (reuse the service's existing test fake pattern from `AgentActionServiceTests`).
+- [ ] **Step 2: Implement VM (OAPH projections over `daemon.Agents.Connect()` with `ObserveOn` before binding, per the codified rule).**
+- [ ] **Step 3: `WorkspaceView.axaml`** — canvas structure: 56px header row (title over repo label; spacer; vendor chip with family dot; icon buttons bound to `OpenInWebCommand`/`StopCommand`), 42px tab strip (`Terminal` tab when `ShowsTerminalTab`, else the muted note), content area hosting the terminal surface + the state banners (attach banner with Detach button; read-only reason; exited/failed/detached banners with Reattach). Named controls for smoke: `WorkspaceTitle`, `WorkspaceRepo`, `WorkspaceVendorChip`, `TerminalTabButton`, `NoTerminalNote`, `TerminalHost`, `DetachButton`, `ReattachButton`, `BackButton`. Use `KcapCanvasBrush`/`KcapSurfaceBrush`/`KcapBorderBrush`/`KcapMutedBrush`/`KcapTextBrush` resources; DataContext supplied externally per the app convention (header comment saying so).
+- [ ] **Step 4: Green, full suite, commit** — `App: WorkspaceViewModel and WorkspaceView`.
+
+---
+
+### Task 13: Workspace teardown tracker
+
+**Files:**
+- Create: `src/Capacitor.App/Services/WorkspaceTeardownTracker.cs`
+- Test: `test/Capacitor.App.Tests.Unit/WorkspaceTeardownTrackerTests.cs`
+
+**Interfaces:**
+- Produces:
+
+```csharp
+/// App-lifetime registry of asynchronous workspace teardowns — the piece the
+/// synchronous disposal pass cannot express. Sealed at shutdown drain.
+public sealed class WorkspaceTeardownTracker(TimeProvider time) {
+    /// Registers and starts observing a teardown. Post-seal: the teardown is
+    /// executed and observed immediately rather than refused (belt-and-braces —
+    /// a path that slips past the shutdown latch must still not hold a socket).
+    public void Track(Func<Task> teardown);
+    /// Seals atomically (no registration races past the snapshot), awaits all
+    /// pending teardowns bounded by 5 seconds total, then returns. Idempotent.
+    public Task DrainAsync();
+}
+```
+
+- [ ] **Step 1: Failing tests:** tracked teardown observed (fault logged once via an injected diagnostic callback — give the ctor an optional `Action<string, Exception>` like the Core sink, `Console.Error` in production); a teardown faulting does not poison the drain (drain still completes; other teardowns run); drain bounded at 5 s under `FakeTimeProvider` with a never-completing teardown (drain returns; the straggler task still gets its observer — complete it later, assert its fault is consumed exactly once and nothing throws); seal atomicity (a `Track` racing `DrainAsync` either joins the drained set or executes immediately post-seal — assert by tracking from another thread in a loop while draining and verifying every teardown ran exactly once); idempotent double-drain.
+- [ ] **Step 2: Implement** (lock + `List<Task>` + sealed flag; post-seal `Track` runs the func and attaches the same observer; `DrainAsync` = `Task.WhenAny(Task.WhenAll(snapshot), Delay(5s, time))`).
+- [ ] **Step 3: Green, commit** — `App: workspace teardown tracker`.
+
+---
+
+### Task 14: Navigation — `MainWindowViewModel` surface swap, entry points, shutdown latch, exit paths
+
+**Files:**
+- Modify: `src/Capacitor.App/ViewModels/MainWindowViewModel.cs`
+- Modify: `src/Capacitor.App/Views/MainWindow.axaml` + `.axaml.cs`
+- Modify: `src/Capacitor.App/ViewModels/HomeViewModel.cs` + `src/Capacitor.App/Views/HomeView.axaml` + `.axaml.cs` (card click)
+- Modify: `src/Capacitor.App/Services/MainWindowCoordinator.cs` (close paths start tracked teardown)
+- Modify: `src/Capacitor.App/App.axaml.cs` (composition: factory wiring, tracker, shutdown first pass, launch consumer)
+- Test: `test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs` (extend), `test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs` (new)
+
+**Interfaces:**
+- Produces on `MainWindowViewModel`:
+
+```csharp
+public WorkspaceViewModel? CurrentWorkspace { get; }        // null = tabbed shell
+public int NavigationGeneration { get; }                    // bumped by every navigation, close-to-hide, disposal; latched by shutdown
+public void OpenSession(string agentId);                    // rejects when shutdown-latched; bumps generation
+public void OpenSessionIfCurrent(string agentId, int generation);  // launch auto-open: no-ops on stale generation
+public void CloseWorkspace();                               // starts tracked teardown, swaps to shell
+public void LatchShutdown();                                // first shutdown pass: unhook workspace, register teardown, reject future opens
+```
+
+- On `HomeViewModel`: ctor gains `Action<string>? openSession = null` (invoked on card click) and the Start path calls the injected `Func<int>? navigationGeneration` + `Action<string, int>? openSessionIfCurrent` — concretely: capture `gen = navigationGeneration()` before `StartAsync`'s launch call; on `outcome.Started` with a well-formed 32-hex `AgentId`, call `openSessionIfCurrent(id, gen)`; a `Started` outcome with null/malformed id sets `StartError = "Launched, but the session id was unusable — open it from the session list."` and opens nothing.
+- On `SessionCardViewModel`: add `Id`-based click plumbing in `HomeView.axaml` — wrap the card `Border` in a `Button` (transparent style) with `Click` handler in code-behind calling `vm.OpenSessionRequested(card.Id)`.
+- Coordinator: `OnWindowClosing` additionally invokes an injected `Action` (`onCloseToHide`) that the composition root wires to `vm.CloseWorkspace()`; real close path (`QuitInProgress` or discard) triggers the same teardown before discarding.
+
+- [ ] **Step 1: Failing tests** (in `WorkspaceNavigationTests`, `AvaloniaSession` cohort, using fakes for daemon/factory/tracker):
+
+```csharp
+[Test] public async Task Open_session_swaps_to_a_workspace_and_close_returns_to_shell() { }
+[Test] public async Task Opening_another_session_tears_down_the_previous_workspace_tracked() { /* tracker fake records exactly one teardown; previous workspace's client got DetachAsync+DisposeAsync */ }
+[Test] public async Task Intercepted_close_to_hide_tears_down_and_resets_navigation() { /* drive MainWindowCoordinator.OnWindowClosing() itself (construct the coordinator with the wiring, not a direct CloseWorkspace call); assert Detach frame path via the fake client and CurrentWorkspace == null */ }
+[Test] public async Task A_stale_generation_launch_success_opens_nothing() { /* capture gen; bump via CloseWorkspace or OpenSession of another id; OpenSessionIfCurrent(staleGen) → CurrentWorkspace unchanged */ }
+[Test] public async Task Launch_success_after_close_to_hide_opens_nothing() { }
+[Test] public async Task Open_session_after_shutdown_latch_creates_nothing() { /* LatchShutdown(); OpenSession → CurrentWorkspace null, factory.Created empty */ }
+[Test] public async Task Shutdown_first_pass_registers_the_live_workspace_before_drain() { /* open workspace; LatchShutdown(); assert tracker received its teardown; DrainAsync completes with client disposed */ }
+[Test] public async Task A_window_built_after_shutdown_began_cannot_open_a_workspace() { /* new MainWindowViewModel constructed with the latched shared state → OpenSession no-ops */ }
+[Test] public async Task Malformed_launch_agent_id_surfaces_an_error_and_opens_nothing() { /* HomeViewModel path: Started with AgentId null → StartError set, callback not invoked */ }
+```
+
+The shutdown latch must be shared state (the tracker or a small `NavigationGate` class owned by the composition root and passed to each `MainWindowViewModel`) so a rebuilt window sees it — implement `NavigationGate` (`int Generation`, `bool ShutdownLatched`, `int Bump()`, `void Latch()`, thread-safe) in `src/Capacitor.App/Services/NavigationGate.cs` as part of this task, with the generation/latch tests above exercising it through the VM.
+
+- [ ] **Step 2: Implement** across the files listed; `MainWindow.axaml` top-level becomes:
+
+```xml
+<Panel>
+    <ContentControl IsVisible="{Binding CurrentWorkspace, Converter={x:Static ObjectConverters.IsNull}}"> <!-- existing TabControl moves inside --> </ContentControl>
+    <views:WorkspaceView DataContext="{Binding CurrentWorkspace}"
+                         IsVisible="{Binding CurrentWorkspace, Converter={x:Static ObjectConverters.IsNotNull}}" />
+</Panel>
+```
+
+(The Back button in `WorkspaceView` raises an event the window code-behind routes to `vm.CloseWorkspace()` — or bind a command injected by `MainWindowViewModel`; prefer the command.) App shutdown sequence in `App.axaml.cs`: at the point where `QuitInProgress` is set (the first pass), call `mainVm?.LatchShutdown()` then `await tracker.DrainAsync()` before the async service disposal continues.
+
+- [ ] **Step 3: Green on the navigation tests, then the FULL app suite** (regressions in MainWindow/Home tests are likely — every existing `MainWindowViewModel` construction gains the new ctor parameters; update the test fixtures by giving the parameters defaults or updating call sites, whichever the existing style prefers — look at how `home:` was added as nullable-with-default and follow it).
+- [ ] **Step 4: Commit** — `App: workspace navigation, entry points, shutdown latch`.
+
+---
+
+### Task 15: Smoke tests, suite-wide verification, manual QA
+
+**Files:**
+- Create: `test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs`
+- Modify: none expected
+
+- [ ] **Step 1: Smoke test** per `HomeViewSmokeTests` conventions: host `WorkspaceView` in a `Window` with a scripted `WorkspaceViewModel` (fake factory), resolve every named control from Task 12 (`WorkspaceTitle`, `WorkspaceRepo`, `WorkspaceVendorChip`, `TerminalTabButton`, `NoTerminalNote`, `TerminalHost`, `DetachButton`, `ReattachButton`, `BackButton`); assert the tab/note visibility flip on `ShowsTerminalTab`; assert the detached-banner presentation appears when the state is `Detached`.
+- [ ] **Step 2: Full verification battery:**
+  - `dotnet build Capacitor.slnx` — 0 errors/warnings.
+  - `dotnet test --solution Capacitor.slnx` — only the documented machine-local failures (session-start nudge set; codex schema pin; load-flaky PTY floods, re-run filtered).
+  - `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` — nothing.
+  - `dotnet list src/Capacitor.App/Capacitor.App.csproj package --include-transitive` — record the resolved terminal-package graph for the PR body; verify licenses (MIT expected throughout the SvcSystems/XTerm.NET subtree).
+- [ ] **Step 3: Manual QA on this machine (macOS — no CI leg):** `dotnet run --project src/Capacitor.App/Capacitor.App.csproj`; launch a claude session from Home; click its card; verify: terminal renders live output, typing reaches the agent, resize follows the window, Detach/Reattach round-trips with scrollback restored, an ACP session (e.g. gemini) shows the no-terminal note, Back returns Home, close-to-hide then daemon-side `kcap agent ls` shows the agent still running.
+- [ ] **Step 4: Commit** — `App: workspace smoke tests`; then push the branch and open the PR (reference AI-2195; spec + plan ride the PR; include the dependency-graph/license note and the manual-QA checklist results in the body).
+
+---
+
+## Self-review notes (kept for executors)
+
+- Spec §2's cause-slot enumeration maps to Tasks 4–7; §3's Resolving/attempt/precedence to Task 10; ownership/exit paths to Tasks 13–14; every §4 test bullet has a home in a task's test list — if you find one missing while executing, add it to the nearest task rather than skipping it.
+- Names locked across tasks: `AttachOutcome{.Detached/.Exited/.Failed/.ConnectionLost}`, `AgentAttachClient`, `AttachCallbackException`, `ITerminalAttachClient`, `TerminalAttachClientFactory`, `TerminalSessionState`/`TerminalSessionPhase`, `Utf8StreamDecoder`, `ITerminalSurface`, `XtermTerminalSurface`, `WorkspaceViewModel`, `TerminalTabViewModel`, `WorkspaceTeardownTracker`, `NavigationGate`, `HostedHarnessCatalog.FamilyFor/ShowsTerminal/EffectiveFamily`, `AgentStatusDto.HasTerminal`.
+- Task 8 Step 3's API discovery is load-bearing for Tasks 10–12: if the real control API differs from the assumed `Feed(string)`/model shape, adjust `ITerminalSurface`'s production adapter (Task 11), not the VM contract.

--- a/docs/superpowers/plans/2026-08-24-ai2195-session-workspace-terminal.md
+++ b/docs/superpowers/plans/2026-08-24-ai2195-session-workspace-terminal.md
@@ -1315,7 +1315,9 @@ Resolve budget: **10 s** via the injected `TimeProvider`.
 - [ ] **Step 5: Green on the VM test file, then full app suite.**
 - [ ] **Step 6: Commit** — `App: TerminalTabViewModel — resolve gate, attempt lifecycle, outcome mapping`.
 
----### Task 11: Terminal surface adapter + input/replies wiring (`ITerminalSurface` production impl)
+---
+
+### Task 11: Terminal surface adapter + input/replies wiring (`ITerminalSurface` production impl)
 
 **Files:**
 - Create: `src/Capacitor.App/Services/XtermTerminalSurface.cs`

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -183,9 +183,19 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   app's teardown tracker can never double-log the same exception. The rule is
   scoped precisely: **every actual losing *exception* is observed through the
   sink exactly once** — a losing cause *attempt* with no exception (e.g.
-  callback-fault-first followed by Dispose) logs nothing. The app wires the
-  sink to its logger; tests assert against a recording sink, not stderr
-  capture.
+  callback-fault-first followed by Dispose) logs nothing. **Expected
+  teardown artifacts are excluded**: a cooperative callback
+  `OperationCanceledException` and local-close-induced exceptions are the
+  normal mechanics of every Dispose, not diagnostics — they never reach the
+  sink. The sink has its own contract: invoked **outside all state/write
+  locks**, serialized by the client (callers may pass a non-thread-safe sink),
+  and wrapped — a throwing sink is swallowed and can never alter the winning
+  cause, escape a client method, or wedge `RunAsync`/outbound calls/teardown
+  past their bounds. App wiring is concrete: these diagnostics go to
+  **`Console.Error` only** (the app's existing teardown-diagnostic convention;
+  it has no logging module) — deliberately never `AppNotifier` toasts, which
+  would surface internal race noise as user notifications. Tests assert
+  against a recording sink, not stderr capture.
 - **Losers are observed exactly once and never become a second result:**
   - *callback fault vs `DisposeAsync`* — Dispose claims first: the callback
     exception is consumed and logged once, `RunAsync` settles `Detached`,
@@ -474,8 +484,11 @@ TDD throughout (red-green per test):
   BOTH orderings: the actual `AttachOutcome`/fault, the outbound call and
   `DisposeAsync` completing without rethrow of the losing exception, and every
   actual losing exception observed through the recording diagnostic sink
-  exactly once (a losing cause attempt with no exception logs nothing), never
-  a second result; **the lifetime-token contract** — `DisposeAsync` while the
+  exactly once (a losing cause attempt with no exception logs nothing;
+  cooperative-cancellation and local-close artifacts never reach the sink),
+  never a second result; a **throwing sink** — swallowed, winning cause and
+  method results unchanged; **concurrent losers** — two producers failing
+  together are serialized into the sink; **the lifetime-token contract** — `DisposeAsync` while the
   caller token stays uncancelled (awaited callback exits via the internal
   token, `RunAsync` returns `Detached`, the external token is untouched),
   caller-cancel while inside a callback (`OperationCanceledException`), and

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -79,17 +79,22 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   `AttachedReadOnly(reason, snapshot)`, or `Error(text)`; then `Stdout` frames
   stream until `Exited(code)`, `Error`, or EOF (whose meaning depends on who
   initiated it — see termination semantics below).
-- Surface: `RunAsync(initialCols, initialRows, CancellationToken)` — the initial
-  surface size is a run argument, because the client itself owes the daemon the
-  post-attach repaint nudge and has no other source for it. Events are **awaited
-  async callbacks** (`OnAttachedAsync(snapshot, readOnlyReason)`,
-  `OnOutputAsync(bytes)`, `OnExitedAsync(code)`, `OnErrorAsync(text)`): the pump
-  awaits each before reading the next frame, so delivery is serial and ordered
-  (snapshot strictly before any output), and the daemon's slow-client overflow
-  protection stays meaningful — a slow UI backs the socket up rather than
-  ballooning an unbounded dispatcher queue. A callback exception faults the run
-  (surfaces out of `RunAsync`); no callback is ever invoked after a terminal
-  result or dispose.
+- Surface: `Task<AttachOutcome> RunAsync(initialCols, initialRows,
+  CancellationToken)` — the initial surface size is a run argument, because the
+  client itself owes the daemon the post-attach repaint nudge and has no other
+  source for it. **Termination is the result, not a callback**:
+  `AttachOutcome` is exactly one of `Detached`, `Exited(code)`,
+  `Failed(message)` (daemon `Error`, refusal included), or `ConnectionLost`
+  (uninitiated EOF) — observable identically by a Core caller and the VM.
+  Caller cancellation surfaces as the standard `OperationCanceledException`.
+  Streaming events are two **awaited async callbacks** only —
+  `OnAttachedAsync(snapshot, readOnlyReason)` and `OnOutputAsync(bytes)` — the
+  pump awaits each before reading the next frame, so delivery is serial and
+  ordered (snapshot strictly before any output), and the daemon's slow-client
+  overflow protection stays meaningful: a slow UI backs the socket up rather
+  than ballooning an unbounded dispatcher queue. A callback exception faults the
+  run (surfaces out of `RunAsync`). With termination folded into the result,
+  "no events after termination" is structural, not a rule to police.
 - Outbound methods: `SendInputAsync(bytes)`, `ResizeAsync(cols, rows)`,
   `DetachAsync()`. All writes serialize behind one lock (input and resize share
   the stream — same reason the CLI holds a write semaphore), and **the client —
@@ -102,13 +107,18 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
 - After a read-write `Attached`, the client sends one `Resize` at the initial
   size to nudge a clean repaint (CLI parity). After `AttachedReadOnly` it sends
   nothing: a read-only viewer must not influence the PTY clamp.
-- Termination semantics: `DetachAsync` yields exactly one clean `Detached`
-  completion and **suppresses the EOF that follows it** — the daemon sends no
-  detach acknowledgement; it just closes the connection, so a detach-initiated
-  EOF is expected, not an error (the CLI models this with its `detached` flag).
-  Caller cancellation tears down silently. Only an EOF the client did not
-  initiate is "lost connection to the daemon". A detach racing `Exited` or a
-  daemon `Error` resolves to whichever terminal event the pump saw first, once.
+- Termination semantics, linearized in one place (the pump): `DetachAsync`
+  records detach intent and sends the frame — it does not itself produce the
+  outcome. The daemon sends no detach acknowledgement; it just closes the
+  connection, and it can still emit `Exited` after receiving a `Detach` when the
+  runtime exited concurrently. So the pump resolves the single `AttachOutcome`
+  as: the first terminal frame read (`Exited`/`Error`) wins even when detach
+  intent is pending; EOF with detach intent pending → `Detached`; EOF without it
+  → `ConnectionLost`. Exactly one outcome, assigned at exactly one point.
+- Disposal: the client is **`IAsyncDisposable`**. `DisposeAsync` records detach
+  intent, closes the socket, and awaits the pump's completion — so "dispose"
+  anywhere in this spec means an awaited async teardown, never a synchronous
+  best-effort.
 
 The CLI's `LocalAgentClient` stays untouched in this slice; folding it onto the
 new client is an optional follow-up, not part of this change.
@@ -172,10 +182,20 @@ Follows the settled canvas artboard:
 
 Owns the attach lifecycle behind an app-side factory seam: **the factory creates
 one client per attach attempt** (a client owns one socket and one run), the
-previous run is fully cancelled and disposed before the next starts, and
-reattach is single-flight. VM tests script the factory. States:
+previous run is fully cancelled and awaited-disposed before the next starts, and
+reattach is single-flight. **Each attempt also gets a fresh terminal model and a
+fresh incremental decoder, swapped in before its `Attached` snapshot is
+accepted** — the daemon replays the full scrollback on every connection
+(overflow recovery included), so feeding a replay into an emulator that already
+consumed the pre-error live stream would duplicate history and smear cursor /
+alternate-screen state; the view stays bound to the VM-owned property and just
+sees the replacement. VM tests script the factory. States:
 
 `Connecting → Attached (read-write | read-only with reason) → Detached / Exited(code) / Failed(error)`
+
+The terminal states map one-to-one from the client's `AttachOutcome`;
+`ConnectionLost` maps to `Failed` with a lost-connection message and the
+reattach affordance.
 
 - Output delivery: the VM awaits each `OnOutputAsync` by decoding through **one
   incremental `System.Text.Decoder` spanning the snapshot and every live
@@ -207,20 +227,41 @@ reattach is single-flight. VM tests script the factory. States:
 
 ### Workspace ownership (one owner, every path)
 
-`MainWindowViewModel` is the single owner of `CurrentWorkspace` and disposes the
-outgoing workspace (→ `DetachAsync`, socket teardown) on **every** exit path:
-Back, opening another session, **intercepted close-to-hide** (the coordinator
-cancels every non-quit close and only hides the window — the window and its VMs
-stay alive, so without this an invisible terminal would stay attached and keep
-clamping the PTY for every other viewer), real close, and app shutdown (app
-teardown today disposes `HomeViewModel` explicitly; the workspace joins that
-ownership). Intercepted close also resets navigation to the shell, so reopening
-from the tray lands on Home. Detach never stops the agent; reopening reattaches
-and the scrollback replay restores history. No app-side buffer persistence.
+Each `MainWindowViewModel` owns its `CurrentWorkspace`, and workspace teardown
+is **asynchronous by nature** (`DetachAsync` + socket close + pump completion),
+which the app's existing synchronous disposal pass cannot express. So the
+composition root gains one small app-lifetime piece: a **workspace teardown
+tracker** that every teardown registers with. Exit paths:
 
-Entry-point guard: `LaunchOutcome.AgentId` is nullable. A `Started` outcome
-without a well-formed 32-hex id does not open a workspace (and cannot call
-`OpenSession(null!)`); it surfaces as a launch-succeeded-but-unopenable error.
+- **Back / opening another session**: the VM starts the outgoing workspace's
+  async teardown (tracked) and swaps `CurrentWorkspace`.
+- **Intercepted close-to-hide**: the coordinator cancels every non-quit close
+  and only hides the window — the window and its VMs stay alive, so without
+  this an invisible terminal would stay attached and keep clamping the PTY for
+  every other viewer. The close handler *starts* the tracked teardown and
+  resets navigation to the shell; reopening from the tray lands on Home.
+- **Real close**: the coordinator discards the window and builds a fresh
+  window + VM on next show; the discarded VM's workspace teardown is started
+  (tracked) as part of that close, so a rebuilt window never inherits or leaks
+  an attach.
+- **App shutdown**: the teardown seam **awaits** the tracker's pending
+  teardowns (bounded — a few seconds) before the process exits, so a detach
+  frame is not abandoned mid-write.
+
+Detach never stops the agent; reopening reattaches and the scrollback replay
+restores history. No app-side buffer persistence.
+
+Entry-point guards:
+
+- `LaunchOutcome.AgentId` is nullable. A `Started` outcome without a
+  well-formed 32-hex id does not open a workspace (and cannot call
+  `OpenSession(null!)`); it surfaces as a launch-succeeded-but-unopenable error.
+- **Auto-open carries a navigation generation.** A launch captures the current
+  generation at Start; close-to-hide, workspace disposal, and every explicit
+  navigation bump it. A launch success arriving with a stale generation opens
+  nothing — otherwise a delayed completion would attach an invisible terminal
+  after close-to-hide (defeating the clamp mitigation) or silently replace a
+  session the user opened while the launch was in flight.
 
 Naming note: the app's existing `AttachStatus`/`AttachState` describe the
 *status subscription* to the daemon. New types avoid "attach" bare — they are
@@ -238,11 +279,12 @@ TDD throughout (red-green per test):
   dropped after `AttachedReadOnly`; no writes after a terminal result; no input
   behind a queued detach; idempotent `DetachAsync`); dimension validation
   (zero, negative, > ushort range rejected locally); resize nudge after
-  read-write attach and its absence after read-only; clean `Detached` with the
-  following EOF suppressed; detach racing `Exited`/`Error`; uninitiated EOF
-  surfaced as connection loss; calls made before the run and after termination;
-  no callbacks after terminal result or dispose; a throwing callback faults the
-  run.
+  read-write attach and its absence after read-only; **`AttachOutcome`
+  linearization** — detach intent + EOF → `Detached`; a terminal frame read
+  after detach intent wins (`Exited`/`Failed`, exactly one outcome); uninitiated
+  EOF → `ConnectionLost`; the outcome observable by an ordinary awaiting caller;
+  `DisposeAsync` awaits pump completion; calls made before the run and after
+  termination; a throwing callback faults the run.
 - **Wire**: `StatusIpcJsonTests` — old JSON without `has_terminal` → `null`;
   `true`/`false`/`null` all serialize with the member present; `false` never
   omitted.
@@ -254,10 +296,17 @@ TDD throughout (red-green per test):
   null/malformed `LaunchOutcome.AgentId` guard; UTF-8 assembly with 2-, 3- and
   4-byte characters split across every frame boundary including the
   snapshot/live seam; a terminal query/response sequence forwarded read-write
-  and suppressed read-only; navigation open/close on `MainWindowViewModel`
-  including the **coordinator's actual intercepted-close path proving a Detach
-  frame and socket teardown** (not just a direct `CloseWorkspace()` call);
-  card-click and launch-success entry paths.
+  and suppressed read-only; **reattach freshness** — consume output, receive
+  `Failed`, reattach with a snapshot containing that history, assert the final
+  buffer reflects the snapshot exactly once (no old-buffer-plus-replay);
+  navigation open/close on `MainWindowViewModel` including the **coordinator's
+  actual intercepted-close path proving a Detach frame and socket teardown**
+  (not just a direct `CloseWorkspace()` call), plus the **real-close /
+  rebuilt-window path** (a fresh window inherits no attach) and **shutdown
+  awaiting pending teardowns** via the tracker; **stale-generation launches** —
+  a delayed launch success after intercepted close, and after the user opened a
+  different session, opens/replaces nothing; card-click and launch-success
+  entry paths.
 - **Terminal rendering**: a headless recorded-transcript test feeding a captured
   ANSI/TUI byte stream (colors, cursor addressing, alternate screen) through the
   decode-and-feed path, with `ReflowOnResize = false` set per upstream's own TUI

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -120,12 +120,17 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   `InvalidDataException` on malformed frames; dial/read/write can throw
   `SocketException`/`IOException`; closing the socket locally completes a
   blocked read *by exception*, not by null):
-  - failures before a successful attach (dial refused, handshake error) →
-    `Failed(message)`;
-  - after attach, any **locally initiated** close — `DetachAsync` or
-    `DisposeAsync` closing the socket, whatever exception that surfaces in the
-    pending read — settles as `Detached`; `DisposeAsync` never rethrows the
-    exception its own expected close produced;
+  - **local-close intent takes precedence at every phase, not just after
+    attach**: once `DetachAsync`/`DisposeAsync` has recorded intent, any
+    close-induced exception — during dial, while writing the opening `Attach`,
+    awaiting the first reply, or streaming — settles as `Detached` (an
+    `Exited`/`Error` frame the pump had already read still wins). Expected
+    local teardown never faults `DisposeAsync` and never transiently publishes
+    `Failed`. `DetachAsync`/`DisposeAsync` **before** `RunAsync` puts the
+    client terminal immediately: a later `RunAsync` returns `Detached` without
+    dialing;
+  - failures before a successful attach **without local intent** (dial refused,
+    handshake error) → `Failed(message)`;
   - after attach, **uninitiated** transport failure or truncation →
     `ConnectionLost`;
   - a malformed or protocol-unexpected frame → `Failed` (protocol failure);
@@ -133,6 +138,15 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   - a throwing callback still faults the run (exception out of `RunAsync`), and
     the client transitions terminal first, so later writes are rejected rather
     than racing a faulted pump.
+- **Outbound write failures route to the pump, which stays the single
+  linearization point.** `SendInputAsync`/`ResizeAsync`/`DetachAsync` write from
+  caller tasks while the pump can be blocked in a read (the CLI being ported
+  has the same shape). A transport failure in an input/resize write atomically
+  terminalizes the client and closes the socket, so the blocked read completes
+  and `RunAsync` settles `ConnectionLost`; the initiating outbound call
+  **completes without rethrowing** — the failure is the run's to report, so
+  there is never a second result or a hung pump. A `Detach` write failure with
+  intent recorded resolves the same way every local close does: `Detached`.
 - Disposal: the client is **`IAsyncDisposable`**. `DisposeAsync` records detach
   intent, closes the socket, and awaits the pump's completion — so "dispose"
   anywhere in this spec means an awaited async teardown, never a synchronous
@@ -258,12 +272,19 @@ composition root gains one small app-lifetime piece: a **workspace teardown
 tracker** that every teardown registers with.
 
 **The teardown algorithm is bounded and always reaches the socket close.**
-`DetachAsync` is best-effort with a short bound — it can wait behind the write
-lock or a stalled socket and has no cancellation of its own — and a `finally`
-path closes the socket (`DisposeAsync`) regardless, within the bound. Releasing
-the PTY dimension clamp is guaranteed by the local socket close, never by the
-Detach frame arriving. The tracker isolates per-teardown exceptions: one failed
-teardown logs and completes, never poisoning the drain.
+The Detach write is best-effort with a **1-second** bound — it can wait behind
+the write lock or a stalled socket — and a `finally` path closes the socket
+(`DisposeAsync`) regardless; a whole teardown's budget is **3 seconds** before
+the socket is force-closed. Releasing the PTY dimension clamp is guaranteed by
+the local socket close, never by the Detach frame arriving. The shutdown drain
+has its own **separate 5-second total** deadline across all pending teardowns
+concurrently; on expiry the drain stops waiting and shutdown proceeds (the
+process exit closes any straggler socket at the OS level — the deadline governs
+how long we wait for *graceful* detach frames, not whether the clamp releases).
+All three durations flow through an injected `TimeProvider` so the
+never-completing-write tests are deterministic, not real-time. The tracker
+isolates per-teardown exceptions: one failed teardown logs and completes, never
+poisoning the drain.
 
 Exit paths:
 
@@ -283,12 +304,22 @@ Exit paths:
   never went through Back/close-to-hide would otherwise register its teardown
   after the drain, against already-disposed dependencies. Therefore the
   **first shutdown pass synchronously unhooks `CurrentWorkspace` from the
-  current VM and registers its teardown before draining**. The drain then
-  **seals** the tracker atomically: registration and seal cannot race past the
-  final snapshot, a post-seal registration is refused (its workspace is already
-  torn or tears down as an idempotent no-op), and the later real close of the
-  window is idempotent. The drain awaits pending teardowns (bounded — a few
-  seconds) before service disposal proceeds.
+  current VM (when a window exists — the coordinator can also build one after
+  shutdown began, see below) and registers its teardown before draining**. The
+  drain then **seals** the tracker atomically: registration and seal cannot
+  race past the final snapshot, and the later real close of the window is
+  idempotent. Sealing is belt-and-braces, not the guard itself:
+  - **the navigation seam closes with shutdown** — the first pass latches
+    shutdown into the navigation generation, and `OpenSession` (card click and
+    launch auto-open alike) rejects from then on, so no new workspace or attach
+    can be created while quiesce/disposal runs, including inside a window the
+    coordinator builds after shutdown began;
+  - **a post-seal `Track` is not silently refused** — it immediately performs
+    and observes the same bounded socket-close teardown, so even a path that
+    slips past the latch cannot hold a socket open.
+
+  The drain awaits pending teardowns (its own bounded deadline, above) before
+  service disposal proceeds.
 
 Detach never stops the agent; reopening reattaches and the scrollback replay
 restores history. No app-side buffer persistence.
@@ -327,10 +358,17 @@ TDD throughout (red-green per test):
   EOF → `ConnectionLost`; the outcome observable by an ordinary awaiting caller;
   `DisposeAsync` awaits pump completion; **exceptional-path classification** —
   connect refusal → `Failed`; mid-header and mid-payload stream loss →
-  `ConnectionLost`; an unexpected/malformed frame → `Failed`; a write failure;
-  `DisposeAsync` closing a blocked read settles `Detached` and rethrows
-  nothing; calls made before the run and after termination; a throwing callback
-  faults the run after the client turns terminal (subsequent writes rejected).
+  `ConnectionLost`; an unexpected/malformed frame → `Failed`; **disposal at
+  every pre-attach phase** — during a blocked connect, mid-opening-write, and
+  awaiting the first reply — settles `Detached`, faults nothing, and never
+  transiently publishes `Failed`; `DetachAsync`/`DisposeAsync` before `RunAsync`
+  → a later run returns `Detached` without dialing; **outbound write failure
+  with the read side held open** — the initiating call completes without
+  rethrow, the pump settles `ConnectionLost` (or `Detached` for a failed
+  Detach write), exactly one result, no hung pump; `DisposeAsync` closing a
+  blocked read settles `Detached` and rethrows nothing; calls made before the
+  run and after termination; a throwing callback faults the run after the
+  client turns terminal (subsequent writes rejected).
 - **Wire**: `StatusIpcJsonTests` — old JSON without `has_terminal` → `null`;
   `true`/`false`/`null` all serialize with the member present; `false` never
   omitted.
@@ -352,7 +390,10 @@ TDD throughout (red-green per test):
   a live workspace and no pre-existing tracked teardown** — the first pass
   registers it, the drain seals atomically, and its socket teardown completes
   before service disposal; a **never-completing Detach write on intercepted
-  close** — the socket is force-closed within the teardown bound; a
+  close** — the socket is force-closed within the teardown bound under a test
+  `TimeProvider`; an **explicit `OpenSession` after the first shutdown
+  pass/seal** and a **window constructed after shutdown began** — neither
+  creates a client or socket; a
   **scheduler assertion** driving retry/reattach completion from a background
   thread that fails on any off-UI-thread model construction or bound-state
   mutation; **stale-generation launches** — a delayed launch success after

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -37,18 +37,30 @@ Settled with the owner during brainstorming, 2026-08-24:
 
 `AgentStatusDto` (`src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs`) gains one field:
 
-- `HasTerminal` — `bool?`, serialized `has_terminal`, always emitted by a daemon
-  that knows it. The daemon stamps `agent.Runtime.EmitsTerminalOutput` when
-  building status payloads. `null` means "older daemon, unknown" and the app
-  falls back to `HostedHarnessCatalog.TransportFamilies` (vendor heuristic).
+- `HasTerminal` — declared as a **trailing `bool? HasTerminal = null`** member, so
+  every existing positional construction stays valid; serialized `has_terminal`,
+  always emitted (never conditionally omitted — `false` is a real value, not an
+  absence). The daemon stamps `agent.Runtime.EmitsTerminalOutput` in
+  `SnapshotAgentsForStatus`. `null` means "older daemon, unknown" and the app
+  falls back to the vendor heuristic.
+
+Serialization acceptance (extends `StatusIpcJsonTests`): old JSON without the
+member deserializes to `null`; `true`, `false`, and `null` all serialize with
+`has_terminal` present in the declared trailing order; `false` is never omitted.
+The daemon-side test asserts the final **serialized** status payload, not just an
+in-memory DTO.
 
 Deliberately a bool, not a transport token: `IHostedAgentRuntime.RuntimeTransport`
 defaults to `"pty"` even for ACP runtimes (only codex app-server overrides it), so
 it is the wrong source of truth for this gate. Nothing else on the wire changes;
 `FrameType` is untouched.
 
-The header's transport label derives from the vendor map, corrected to the "chat"
-family whenever `has_terminal` is authoritatively false.
+App-side projection: `HostedHarnessCatalog.TransportFamilies` is private, so the
+catalog gains one shared lookup (family-for-vendor) rather than the workspace
+duplicating the map. `has_terminal=false` cannot distinguish ACP / rpc /
+app-server, so the correction rule is: keep the vendor family when it is already
+non-PTY; only a *conflicting* PTY guess is overridden, to the generic "chat"
+family.
 
 ## 2. Core attach client
 
@@ -65,16 +77,38 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   prefixes on this path).
 - First reply is exactly one of `Attached(snapshot)`,
   `AttachedReadOnly(reason, snapshot)`, or `Error(text)`; then `Stdout` frames
-  stream until `Exited(code)`, `Error`, or EOF. EOF without `Exited`/`Error` is
-  "lost connection to the daemon", mirroring the CLI's interpretation.
-- Surface: a `RunAsync(CancellationToken)` pump with callbacks
-  (`OnAttached(snapshot, readOnlyReason)`, `OnOutput(bytes)`, `OnExited(code)`,
-  `OnError(text)`) plus `SendInputAsync(bytes)`, `ResizeAsync(cols, rows)`,
+  stream until `Exited(code)`, `Error`, or EOF (whose meaning depends on who
+  initiated it — see termination semantics below).
+- Surface: `RunAsync(initialCols, initialRows, CancellationToken)` — the initial
+  surface size is a run argument, because the client itself owes the daemon the
+  post-attach repaint nudge and has no other source for it. Events are **awaited
+  async callbacks** (`OnAttachedAsync(snapshot, readOnlyReason)`,
+  `OnOutputAsync(bytes)`, `OnExitedAsync(code)`, `OnErrorAsync(text)`): the pump
+  awaits each before reading the next frame, so delivery is serial and ordered
+  (snapshot strictly before any output), and the daemon's slow-client overflow
+  protection stays meaningful — a slow UI backs the socket up rather than
+  ballooning an unbounded dispatcher queue. A callback exception faults the run
+  (surfaces out of `RunAsync`); no callback is ever invoked after a terminal
+  result or dispose.
+- Outbound methods: `SendInputAsync(bytes)`, `ResizeAsync(cols, rows)`,
   `DetachAsync()`. All writes serialize behind one lock (input and resize share
-  the stream — same reason the CLI holds a write semaphore).
-- After a read-write `Attached`, the client sends one `Resize` at the current
-  surface size to nudge a clean repaint (CLI parity). After `AttachedReadOnly`
-  it sends nothing: a read-only viewer must not influence the PTY clamp.
+  the stream — same reason the CLI holds a write semaphore), and **the client —
+  not its caller — owns the semantic invariants**: no input/resize before
+  `Attached`; input/resize silently dropped after `AttachedReadOnly` (explicit
+  calls included, not just the missing nudge); no writes after a terminal
+  result; `DetachAsync` is idempotent and no input is written behind a queued
+  detach. Dimensions are validated to `1..=ushort.MaxValue` per axis; invalid
+  values are rejected locally, never sent.
+- After a read-write `Attached`, the client sends one `Resize` at the initial
+  size to nudge a clean repaint (CLI parity). After `AttachedReadOnly` it sends
+  nothing: a read-only viewer must not influence the PTY clamp.
+- Termination semantics: `DetachAsync` yields exactly one clean `Detached`
+  completion and **suppresses the EOF that follows it** — the daemon sends no
+  detach acknowledgement; it just closes the connection, so a detach-initiated
+  EOF is expected, not an error (the CLI models this with its `detached` flag).
+  Caller cancellation tears down silently. Only an EOF the client did not
+  initiate is "lost connection to the daemon". A detach racing `Exited` or a
+  daemon `Error` resolves to whichever terminal event the pump saw first, once.
 
 The CLI's `LocalAgentClient` stays untouched in this slice; folding it onto the
 new client is an optional follow-up, not part of this change.
@@ -113,42 +147,80 @@ Entry points:
 Follows the settled canvas artboard:
 
 - Header: session title (same `RepoLabel.Leaf(repo) · vendor` shape as the card),
-  repo/branch breadcrumb, vendor + model chip with transport-family dot, and the
-  two existing actions — Open in web and Stop — reused straight from
+  repo label, vendor + model chip with transport-family dot, and the two
+  existing actions — Open in web and Stop — reused straight from
   `AgentActionService` (one code path with tray/grid, force-stop confirmation
   included).
-- Branch: nothing carries it on the wire, so a best-effort local read of
-  `.git/HEAD` under the agent's `RepoPath` (worktree-aware — a `.git` *file* is
-  followed like `GitRepository.ResolveMainRepoRoot` does); empty on any failure.
+- **No branch in this slice.** The canvas breadcrumb shows repo/branch, but the
+  daemon runs owned launches in their own worktree on a `capacitor/agent-*`
+  branch, and the status wire carries only the *requested* `RepoPath` — reading
+  that checkout's `.git/HEAD` would show the user's branch, not the agent's.
+  Rather than display a confidently wrong branch, the breadcrumb shows the repo
+  alone; the execution worktree/branch arrives as an additive status field with
+  AI-2199 (whose rail needs worktree structure anyway).
 - Tab strip: this slice ships Terminal only. A PTY session (`has_terminal` true,
   or vendor-map fallback says pty) shows the Terminal tab; a non-PTY session
-  shows the design's muted note ("No terminal — Gemini runs over ACP") — never a
-  disabled tab. Chat's slot stays empty until AI-2196.
+  shows a muted note — "This session has no terminal", suffixed with the
+  transport family when it is reliably known (e.g. "— runs over ACP") — never a
+  disabled tab, and never a hard-coded vendor name. Chat's slot stays empty
+  until AI-2196.
 - The VM tracks its agent in `IDaemonClientService.Agents` (ObserveOn main-thread
   scheduler before touching bound state, the codified rule) so status/title stay
   live, and shows a "session ended" state when the agent leaves the cache.
 
 ### TerminalTabViewModel (attach lifecycle)
 
-Owns one `AgentAttachClient` behind an app-side interface seam
-(`IAgentAttachClient`-shaped factory) so VM tests script it. States:
+Owns the attach lifecycle behind an app-side factory seam: **the factory creates
+one client per attach attempt** (a client owns one socket and one run), the
+previous run is fully cancelled and disposed before the next starts, and
+reattach is single-flight. VM tests script the factory. States:
 
 `Connecting → Attached (read-write | read-only with reason) → Detached / Exited(code) / Failed(error)`
 
-- Feeds `OnAttached` snapshot then `OnOutput` bytes into the XTerm.NET terminal
-  the `SvcSystems.UI.Terminal` control renders; terminal buffer lives in the VM,
+- Output delivery: the VM awaits each `OnOutputAsync` by decoding through **one
+  incremental `System.Text.Decoder` spanning the snapshot and every live
+  frame** (PTY frames split multibyte UTF-8 at arbitrary byte boundaries, and
+  the terminal control's `Feed(byte[])` does a fresh `GetString` per call —
+  feeding raw frames would render replacement characters), flushed only at
+  terminal completion, then applies the decoded text to the terminal **awaiting
+  the UI thread** — no fire-and-forget dispatcher posts, so socket backpressure
+  reaches the daemon's overflow protection. Terminal buffer lives in the VM,
   never the view (window-rebuild premise).
-- Control input/resize events → `SendInputAsync`/`ResizeAsync`; suppressed
-  entirely in read-only mode, which also shows the daemon's reason banner
-  (canvas: attach banner with Detach button).
+- Input: control input events → `SendInputAsync`; resize → `ResizeAsync`.
+  **Terminal-generated protocol replies** (device-status and similar queries the
+  emulator answers on its own) go through the same ordered input lane in
+  read-write mode and are suppressed in read-only mode — the exact engine
+  surface (XTerm.NET's data-received path; the Avalonia wrapper does not expose
+  it directly) is verified at implementation and is an acceptance item. Read-only
+  mode suppresses all input/resize and shows the daemon's reason banner (canvas:
+  attach banner with Detach button).
 - Launch race: if attach fails with "no such agent" while the agent is not yet
   (or no longer) in the status cache, retry with backoff for up to 10 seconds
   before surfacing the error — this is the `LaunchOutcome.AgentId` path booting.
-- Navigating back or closing the window disposes the VM → `DetachAsync` and
-  socket teardown. Detach never stops the agent; reopening reattaches and the
-  scrollback replay restores history. No app-side buffer persistence.
+  The delay policy is injected (`TimeProvider`) so tests are deterministic.
+- Signal precedence: `Exited(code)` and daemon `Error` are more specific than
+  the agent leaving the status cache; the generic "session ended" state never
+  overwrites an already-terminal exited/failed state (the two signals arrive on
+  independent background pumps).
 - `Exited(code)` renders an exited banner in place; `Error` (including overflow
   force-detach) renders the daemon's message with a reattach affordance.
+
+### Workspace ownership (one owner, every path)
+
+`MainWindowViewModel` is the single owner of `CurrentWorkspace` and disposes the
+outgoing workspace (→ `DetachAsync`, socket teardown) on **every** exit path:
+Back, opening another session, **intercepted close-to-hide** (the coordinator
+cancels every non-quit close and only hides the window — the window and its VMs
+stay alive, so without this an invisible terminal would stay attached and keep
+clamping the PTY for every other viewer), real close, and app shutdown (app
+teardown today disposes `HomeViewModel` explicitly; the workspace joins that
+ownership). Intercepted close also resets navigation to the shell, so reopening
+from the tray lands on Home. Detach never stops the agent; reopening reattaches
+and the scrollback replay restores history. No app-side buffer persistence.
+
+Entry-point guard: `LaunchOutcome.AgentId` is nullable. A `Started` outcome
+without a well-formed 32-hex id does not open a workspace (and cannot call
+`OpenSession(null!)`); it surfaces as a launch-succeeded-but-unopenable error.
 
 Naming note: the app's existing `AttachStatus`/`AttachState` describe the
 *status subscription* to the daemon. New types avoid "attach" bare — they are
@@ -160,26 +232,56 @@ TDD throughout (red-green per test):
 
 - **Core `AgentAttachClient`**: against a scripted in-proc Unix-socket server in
   a `TempDir` (socket path budget: `GetResolvedPath` where needed). Pins: attach
-  handshake for all three first replies; snapshot-before-stream ordering; write
-  serialization; resize nudge after read-write attach and its absence after
-  read-only; detach frame on `DetachAsync`; EOF-without-`Exited` surfaced as
-  connection loss.
+  handshake for all three first replies; snapshot-before-stream ordering and
+  serial awaited callback delivery; write serialization AND semantic ordering
+  (no input/resize before `Attached`; explicit `SendInputAsync`/`ResizeAsync`
+  dropped after `AttachedReadOnly`; no writes after a terminal result; no input
+  behind a queued detach; idempotent `DetachAsync`); dimension validation
+  (zero, negative, > ushort range rejected locally); resize nudge after
+  read-write attach and its absence after read-only; clean `Detached` with the
+  following EOF suppressed; detach racing `Exited`/`Error`; uninitiated EOF
+  surfaced as connection loss; calls made before the run and after termination;
+  no callbacks after terminal result or dispose; a throwing callback faults the
+  run.
+- **Wire**: `StatusIpcJsonTests` — old JSON without `has_terminal` → `null`;
+  `true`/`false`/`null` all serialize with the member present; `false` never
+  omitted.
 - **Daemon**: `has_terminal` stamped true for a PTY runtime, false for ACP and
-  codex app-server runtimes, on the status payloads.
-- **App VMs**: scripted fake attach client — state transitions, read-only
-  suppression, retry-on-boot, session-ended tracking; navigation open/close on
-  `MainWindowViewModel`; card-click and launch-success entry paths.
+  codex app-server runtimes, asserted on the **serialized** status payload.
+- **App VMs**: scripted fake attach factory — state transitions, read-only
+  suppression, retry-on-boot under a test `TimeProvider`, one-client-per-attempt
+  and single-flight reattach, exited/error precedence over session-ended,
+  null/malformed `LaunchOutcome.AgentId` guard; UTF-8 assembly with 2-, 3- and
+  4-byte characters split across every frame boundary including the
+  snapshot/live seam; a terminal query/response sequence forwarded read-write
+  and suppressed read-only; navigation open/close on `MainWindowViewModel`
+  including the **coordinator's actual intercepted-close path proving a Detach
+  frame and socket teardown** (not just a direct `CloseWorkspace()` call);
+  card-click and launch-success entry paths.
+- **Terminal rendering**: a headless recorded-transcript test feeding a captured
+  ANSI/TUI byte stream (colors, cursor addressing, alternate screen) through the
+  decode-and-feed path, with `ReflowOnResize = false` set per upstream's own TUI
+  guidance — that setting is an acceptance criterion, not a suggestion.
 - **Smoke**: headless resolution of the new named controls, per
   `HomeViewSmokeTests` convention.
 
 ## Risks
 
-- **Supply chain**: `SvcSystems.UI.Terminal` + `XTerm.NET` are single-author,
-  small-audience MIT packages rendering untrusted PTY bytes. Pinned versions in
-  `Directory.Packages.props`; accepted by the owner.
-- **Emulation fidelity**: full-screen TUIs are the hard case; the package's own
-  samples cover them, but visual QA against a live claude/codex session is part
-  of acceptance.
+- **Supply chain**: `SvcSystems.UI.Terminal` (1.1.1) + `XTerm.NET` (1.0.16) are
+  single-author, small-audience MIT packages rendering untrusted PTY bytes.
+  Mitigation is concrete: this repo manages only *direct* references centrally
+  and does not enable transitive pinning, so `XTerm.NET` (and its Unicode/width
+  dependencies) get **direct pinned references** in `Directory.Packages.props` +
+  the app csproj — a `PackageVersion` line alone would not pin a transitive.
+  License/vulnerability audit of the full resolved graph is part of the PR.
+  Accepted by the owner.
+- **Emulation fidelity**: full-screen TUIs are the hard case. Gate: the headless
+  recorded-transcript test (§4) plus `ReflowOnResize = false`; visual QA against
+  a live claude/codex session on top, not instead.
+- **Platform coverage**: CI runs Ubuntu and Windows legs only — there is no
+  macOS leg — so CI smoke covers those two and macOS gets a manual QA pass
+  before merge (this machine).
 - **Dimension clamp**: an app viewer at a small window shrinks the PTY for all
   viewers (existing daemon semantics, tmux-style). Accepted; the read-only path
-  never contributes.
+  never contributes, and workspace disposal on every exit path (close-to-hide
+  included) guarantees a hidden window never keeps clamping.

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -189,9 +189,13 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   normal mechanics of every Dispose, not diagnostics — they never reach the
   sink. The sink has its own contract: invoked **outside all state/write
   locks**, serialized by the client (callers may pass a non-thread-safe sink),
-  and wrapped — a throwing sink is swallowed and can never alter the winning
-  cause, escape a client method, or wedge `RunAsync`/outbound calls/teardown
-  past their bounds. App wiring is concrete: these diagnostics go to
+  and wrapped — a throwing sink is swallowed and never alters the winning
+  cause or escapes a client method. The guarantee is deliberately narrowed to
+  **exception containment**: the delegate runs inline, so being fast and
+  non-blocking is a **caller obligation**, documented on the parameter — an
+  arbitrary blocking sink stalls its producer, and no queue machinery hides
+  that here, because the only real consumer is a `Console.Error` write, which
+  satisfies the obligation trivially. App wiring is concrete: these diagnostics go to
   **`Console.Error` only** (the app's existing teardown-diagnostic convention;
   it has no logging module) — deliberately never `AppNotifier` toasts, which
   would surface internal race noise as user notifications. Tests assert

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -1,0 +1,185 @@
+# Session workspace with terminal (AI-2195)
+
+Slice 2 of the desktop shell (parent AI-2171; design canvas "Hosted Agents Shell",
+Session artboard). The workspace pane for one session — header, tab strip, and a
+Terminal tab attached to the live PTY — opened by clicking a session card on Home.
+This is the half that makes Home's deliberately inert session cards mean something.
+
+Out of scope, by prior decomposition: the session rail (AI-2199), chat surfaces
+(AI-2196), structured turn frames (AI-2197), the work-context sidebar (AI-2198),
+and real search. `LaunchOutcome.AgentId` gains its first consumer here.
+
+## Decisions
+
+Settled with the owner during brainstorming, 2026-08-24:
+
+1. **Terminal rendering: `SvcSystems.UI.Terminal`** (MIT, XTerm.NET emulation,
+   Avalonia 12.1.1 / .NET 10 — exact match for this app). The renamed successor of
+   AvaloniaTerminal (Avalonia trademark), same author, actively maintained.
+   Trade-off accepted knowingly: a single-author, small-audience package renders
+   untrusted PTY bytes. Rejected: an in-house VT emulator (a project of its own,
+   not a slice — agents emit cursor addressing, alternate screen, SGR); a
+   WebView + xterm.js embed (webview runtime + packaging cost on three OSes).
+2. **Terminal-tab gate: additive `has_terminal` on `AgentStatusDto`, with vendor-map
+   fallback.** The daemon's `IHostedAgentRuntime.EmitsTerminalOutput` is the
+   authority and today never leaves the daemon; the app's vendor→family map guesses
+   wrong exactly where it matters (a codex agent on the app-server transport maps
+   "pty" but has no terminal). The issue's "no protocol change" is read as "no new
+   frame family": attach rides the existing frames untouched, and `AgentStatusDto`'s
+   own doc pins the additive-field compatibility rules this follows.
+3. **Navigation: top-level surface swap.** MainWindow gets its first navigation
+   seam — a `ContentControl` switching between the existing tabbed shell and the
+   workspace surface. Rejected: a fourth `TabItem` per open session (bakes in a
+   document-tabs model the canvas design does not have) and a window per session
+   (departs from the single-window design, multiplies tray/close-to-hide concerns).
+
+## 1. Wire change (additive only)
+
+`AgentStatusDto` (`src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs`) gains one field:
+
+- `HasTerminal` — `bool?`, serialized `has_terminal`, always emitted by a daemon
+  that knows it. The daemon stamps `agent.Runtime.EmitsTerminalOutput` when
+  building status payloads. `null` means "older daemon, unknown" and the app
+  falls back to `HostedHarnessCatalog.TransportFamilies` (vendor heuristic).
+
+Deliberately a bool, not a transport token: `IHostedAgentRuntime.RuntimeTransport`
+defaults to `"pty"` even for ACP runtimes (only codex app-server overrides it), so
+it is the wrong source of truth for this gate. Nothing else on the wire changes;
+`FrameType` is untouched.
+
+The header's transport label derives from the vendor map, corrected to the "chat"
+family whenever `has_terminal` is authoritatively false.
+
+## 2. Core attach client
+
+New `src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs` — a long-lived,
+bidirectional, per-agent client alongside the existing `LocalControlClient`
+(status subscribe) and `LocalControlOps` (one-shot request/reply). BCL-only, no
+Rx/JSON-reflection, per that surface's NativeAOT contract. It is a port of the
+CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
+
+- Dials `DaemonStore.SocketPath(daemonName)` — its own socket; the daemon routes
+  each connection on its opening frame, and the app already runs three socket
+  users, so a fourth is architecturally consistent.
+- Sends `Attach` with the **full 32-hex agent id** (the daemon does not resolve
+  prefixes on this path).
+- First reply is exactly one of `Attached(snapshot)`,
+  `AttachedReadOnly(reason, snapshot)`, or `Error(text)`; then `Stdout` frames
+  stream until `Exited(code)`, `Error`, or EOF. EOF without `Exited`/`Error` is
+  "lost connection to the daemon", mirroring the CLI's interpretation.
+- Surface: a `RunAsync(CancellationToken)` pump with callbacks
+  (`OnAttached(snapshot, readOnlyReason)`, `OnOutput(bytes)`, `OnExited(code)`,
+  `OnError(text)`) plus `SendInputAsync(bytes)`, `ResizeAsync(cols, rows)`,
+  `DetachAsync()`. All writes serialize behind one lock (input and resize share
+  the stream — same reason the CLI holds a write semaphore).
+- After a read-write `Attached`, the client sends one `Resize` at the current
+  surface size to nudge a clean repaint (CLI parity). After `AttachedReadOnly`
+  it sends nothing: a read-only viewer must not influence the PTY clamp.
+
+The CLI's `LocalAgentClient` stays untouched in this slice; folding it onto the
+new client is an optional follow-up, not part of this change.
+
+Daemon behaviors the client leans on (all existing, none modified): scrollback
+snapshot (2 MiB ring) delivered inside the attached frame, atomically consistent
+with the live stream; multiple concurrent attachers; read-only forced for
+non-`Default` launch kinds with the human reason on the frame; slow-client
+overflow force-detaches with an `Error`; tmux-style min-clamp of PTY dimensions
+across all viewers — the workspace participates like any attacher, which is
+accepted as-is.
+
+## 3. App workspace
+
+### Navigation
+
+`MainWindowViewModel` gains `OpenSession(string agentId)` / `CloseWorkspace()`
+and a `CurrentWorkspace` (`WorkspaceViewModel?`) the window binds through a
+top-level `ContentControl`: null → the existing `TabControl` shell, non-null →
+the workspace surface with a "← Home" affordance. Navigation state lives in the
+view-model layer, never the view — `MainWindowCoordinator` discards the window
+on real close on exactly that premise.
+
+Entry points:
+
+- **Session card click on Home** — the cards stop being inert. The card gains a
+  click affordance; `HomeViewModel` exposes the chosen agent id upward (callback
+  injected by the composition root, consistent with the app's plain-construction
+  style).
+- **Successful launch** — `LaunchOutcome.AgentId` finally gets its consumer:
+  Start opens the workspace for the new id. The agent may not be attachable for
+  a moment; the terminal state machine below absorbs that.
+
+### WorkspaceViewModel (header + tabs)
+
+Follows the settled canvas artboard:
+
+- Header: session title (same `RepoLabel.Leaf(repo) · vendor` shape as the card),
+  repo/branch breadcrumb, vendor + model chip with transport-family dot, and the
+  two existing actions — Open in web and Stop — reused straight from
+  `AgentActionService` (one code path with tray/grid, force-stop confirmation
+  included).
+- Branch: nothing carries it on the wire, so a best-effort local read of
+  `.git/HEAD` under the agent's `RepoPath` (worktree-aware — a `.git` *file* is
+  followed like `GitRepository.ResolveMainRepoRoot` does); empty on any failure.
+- Tab strip: this slice ships Terminal only. A PTY session (`has_terminal` true,
+  or vendor-map fallback says pty) shows the Terminal tab; a non-PTY session
+  shows the design's muted note ("No terminal — Gemini runs over ACP") — never a
+  disabled tab. Chat's slot stays empty until AI-2196.
+- The VM tracks its agent in `IDaemonClientService.Agents` (ObserveOn main-thread
+  scheduler before touching bound state, the codified rule) so status/title stay
+  live, and shows a "session ended" state when the agent leaves the cache.
+
+### TerminalTabViewModel (attach lifecycle)
+
+Owns one `AgentAttachClient` behind an app-side interface seam
+(`IAgentAttachClient`-shaped factory) so VM tests script it. States:
+
+`Connecting → Attached (read-write | read-only with reason) → Detached / Exited(code) / Failed(error)`
+
+- Feeds `OnAttached` snapshot then `OnOutput` bytes into the XTerm.NET terminal
+  the `SvcSystems.UI.Terminal` control renders; terminal buffer lives in the VM,
+  never the view (window-rebuild premise).
+- Control input/resize events → `SendInputAsync`/`ResizeAsync`; suppressed
+  entirely in read-only mode, which also shows the daemon's reason banner
+  (canvas: attach banner with Detach button).
+- Launch race: if attach fails with "no such agent" while the agent is not yet
+  (or no longer) in the status cache, retry with backoff for up to 10 seconds
+  before surfacing the error — this is the `LaunchOutcome.AgentId` path booting.
+- Navigating back or closing the window disposes the VM → `DetachAsync` and
+  socket teardown. Detach never stops the agent; reopening reattaches and the
+  scrollback replay restores history. No app-side buffer persistence.
+- `Exited(code)` renders an exited banner in place; `Error` (including overflow
+  force-detach) renders the daemon's message with a reattach affordance.
+
+Naming note: the app's existing `AttachStatus`/`AttachState` describe the
+*status subscription* to the daemon. New types avoid "attach" bare — they are
+`TerminalSessionState` etc. — so the two concepts cannot be confused.
+
+## 4. Testing
+
+TDD throughout (red-green per test):
+
+- **Core `AgentAttachClient`**: against a scripted in-proc Unix-socket server in
+  a `TempDir` (socket path budget: `GetResolvedPath` where needed). Pins: attach
+  handshake for all three first replies; snapshot-before-stream ordering; write
+  serialization; resize nudge after read-write attach and its absence after
+  read-only; detach frame on `DetachAsync`; EOF-without-`Exited` surfaced as
+  connection loss.
+- **Daemon**: `has_terminal` stamped true for a PTY runtime, false for ACP and
+  codex app-server runtimes, on the status payloads.
+- **App VMs**: scripted fake attach client — state transitions, read-only
+  suppression, retry-on-boot, session-ended tracking; navigation open/close on
+  `MainWindowViewModel`; card-click and launch-success entry paths.
+- **Smoke**: headless resolution of the new named controls, per
+  `HomeViewSmokeTests` convention.
+
+## Risks
+
+- **Supply chain**: `SvcSystems.UI.Terminal` + `XTerm.NET` are single-author,
+  small-audience MIT packages rendering untrusted PTY bytes. Pinned versions in
+  `Directory.Packages.props`; accepted by the owner.
+- **Emulation fidelity**: full-screen TUIs are the hard case; the package's own
+  samples cover them, but visual QA against a live claude/codex session is part
+  of acceptance.
+- **Dimension clamp**: an app viewer at a small window shrinks the PTY for all
+  viewers (existing daemon semantics, tmux-style). Accepted; the read-only path
+  never contributes.

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -139,13 +139,27 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   - a throwing callback still faults the run (exception out of `RunAsync`), and
     the client transitions terminal first, so later writes are rejected rather
     than racing a faulted pump.
-- **One atomic terminal-cause slot resolves every race.** Terminal frame read,
-  local-close intent, and observed cancellation all try to record themselves as
-  the run's terminal cause; the **first recorded cause wins** and alone decides
-  what `RunAsync` produces (`Exited`/`Failed` for a frame, `Detached` for local
-  close, `OperationCanceledException` for cancellation). The app retires an
-  attempt by cancelling *and* disposing, which makes both clauses applicable —
-  the slot, not scheduling, decides. `DisposeAsync` never rethrows the retired
+- **One atomic terminal-cause slot resolves every race — and detach intent is
+  not a cause.** `DetachAsync` only records *intent* and sends the frame; it
+  never claims the slot, which is what lets a subsequently read `Exited`/`Error`
+  frame still win after a detach (the daemon really does send `Exited` after
+  reading a `Detach`). The causes that do compete for the slot, each claiming
+  it exactly once by compare-exchange:
+  - a terminal frame read → `Exited`/`Failed`;
+  - EOF or close-induced read failure **with detach intent pending** →
+    `Detached`;
+  - uninitiated transport loss/truncation → `ConnectionLost`;
+  - protocol failure (malformed/unexpected frame) → `Failed`;
+  - an outbound input/resize write failure → `ConnectionLost`;
+  - a callback fault → the faulted run;
+  - observed cancellation → `OperationCanceledException`;
+  - `DisposeAsync` → claims `Detached` immediately, before force-closing the
+    socket (the one local action that terminalizes eagerly).
+
+  Compare-exchange guarantees exactly one winner; actual event ordering
+  determines *which* cause wins — the slot removes double-results, not
+  nondeterminism. The app retires an attempt by cancelling *and* disposing;
+  whichever claims first decides. `DisposeAsync` never rethrows the retired
   run's cancellation (or any expected-teardown exception).
 - **Outbound write failures route to the pump, which stays the single
   linearization point.** `SendInputAsync`/`ResizeAsync`/`DetachAsync` write from
@@ -280,6 +294,16 @@ state after its replacement begins.
   surfaces a not-found error. **Initial absence (`Resolving`) and
   "observed then left the cache" (session ended) are distinct states** — the
   second only exists after a first observation.
+- **Resolving has its own disposal/linearization contract**, because it owns an
+  asynchronous cache subscription plus a timer that race Back, replacement,
+  close-to-hide, and shutdown: the workspace holds a resolve
+  generation/cancellation, and **disposal wins permanently** — once navigation
+  has left, no later DTO or timer callback constructs a client or mutates
+  bound state. DTO-vs-timeout has one atomic winner (same compare-exchange
+  shape as the client's cause slot). **Timeout drops the cache subscription**:
+  a DTO arriving after timeout is ignored — the not-found state carries an
+  explicit retry affordance rather than auto-recovering, so the state a user
+  is looking at never changes underneath them without an action.
 - Signal precedence: `Exited(code)` and daemon `Error` are more specific than
   the agent leaving the status cache; the generic "session ended" state never
   overwrites an already-terminal exited/failed state (the two signals arrive on
@@ -303,11 +327,15 @@ the local socket is force-closed by roughly the 1-second mark on every path;
 the remainder of the **3-second** per-teardown budget is spent awaiting and
 observing pump completion. The shutdown drain has its own **separate 5-second
 total** across all pending teardowns concurrently; on expiry the drain stops
-waiting and shutdown proceeds. **Expiry can leave a straggler *task*
-(an unobserved pump), never a straggler *socket*** — every teardown closed its
-socket within its own first second, which is what the clamp-release guarantee
-in Risks rests on; the deadlines govern how long we wait for graceful detach
-frames and pump observation, not whether the clamp releases. All three
+waiting and shutdown proceeds. **Expiry can leave a straggler *task*, never a straggler *socket*** — every
+teardown closed its socket within its own first second, which is what the
+clamp-release guarantee in Risks rests on; the deadlines govern how long we
+wait for graceful detach frames and pump observation, not whether the clamp
+releases. **A timed-out pump is abandoned by the await, never left
+unobserved**: the wrapper attaches a continuation that consumes and logs its
+eventual completion or fault (the callback/rendering fault is a real
+possibility) without re-entering VM state — so a late fault cannot go
+unobserved, and cannot retain the disposed VM/model past its logging. All three
 durations flow through an injected `TimeProvider` so the
 never-completing-write tests are deterministic, not real-time. The tracker
 isolates per-teardown exceptions: one failed teardown logs and completes,
@@ -393,9 +421,11 @@ TDD throughout (red-green per test):
   with the read side held open** — the initiating call completes without
   rethrow, the pump settles `ConnectionLost` (or `Detached` for a failed
   Detach write), exactly one result, no hung pump; `DisposeAsync` closing a
-  blocked read settles `Detached` and rethrows nothing; calls made before the
-  run and after termination; a throwing callback faults the run after the
-  client turns terminal (subsequent writes rejected).
+  blocked read settles `Detached` and rethrows nothing; **cause-slot
+  cross-races** — an input-write failure racing `DetachAsync`, and a callback
+  fault racing `DisposeAsync`, each produce exactly one recorded cause; calls
+  made before the run and after termination; a throwing callback faults the
+  run after the client turns terminal (subsequent writes rejected).
 - **Wire**: `StatusIpcJsonTests` — old JSON without `has_terminal` → `null`;
   `true`/`false`/`null` all serialize with the member present; `false` never
   omitted.
@@ -407,6 +437,10 @@ TDD throughout (red-green per test):
   zero client/socket attempts; `true` and `null`+PTY-fallback proceed to
   attach; resolve timeout under a test `TimeProvider`; removal after first
   observation (session ended) is a different state than initial absence;
+  **Resolving disposal** — Back, replacement, intercepted close, and shutdown
+  while still Resolving each produce zero clients/sockets and no later
+  DTO/timer callback mutates state; DTO-vs-timeout has one atomic winner;
+  a DTO after timeout is ignored until the explicit retry;
   one-client-per-attempt and single-flight reattach; **cancellation vs
   local-close precedence**: cancel-before-dispose, dispose-before-cancel, and
   the simultaneous race each yield exactly one recorded cause, and a retired
@@ -427,9 +461,10 @@ TDD throughout (red-green per test):
   registers it, the drain seals atomically, and its socket teardown completes
   before service disposal; a **never-completing Detach write on intercepted
   close** — the socket is force-closed within the teardown bound under a test
-  `TimeProvider`; an **explicit `OpenSession` after the first shutdown
-  pass/seal** and a **window constructed after shutdown began** — neither
-  creates a client or socket; a
+  `TimeProvider`; a **pump faulting after the 3-second teardown budget** — the
+  fault is observed and logged exactly once with no late UI mutation; an
+  **explicit `OpenSession` after the first shutdown pass/seal** and a **window
+  constructed after shutdown began** — neither creates a client or socket; a
   **scheduler assertion** driving retry/reattach completion from a background
   thread that fails on any off-UI-thread model construction or bound-state
   mutation; **stale-generation launches** — a delayed launch success after

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -115,6 +115,24 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   as: the first terminal frame read (`Exited`/`Error`) wins even when detach
   intent is pending; EOF with detach intent pending → `Detached`; EOF without it
   → `ConnectionLost`. Exactly one outcome, assigned at exactly one point.
+- **Exceptional paths classify too** — the pump sees more than frames and clean
+  EOF (`FrameCodec.ReadAsync` throws `EndOfStreamException` on truncation and
+  `InvalidDataException` on malformed frames; dial/read/write can throw
+  `SocketException`/`IOException`; closing the socket locally completes a
+  blocked read *by exception*, not by null):
+  - failures before a successful attach (dial refused, handshake error) →
+    `Failed(message)`;
+  - after attach, any **locally initiated** close — `DetachAsync` or
+    `DisposeAsync` closing the socket, whatever exception that surfaces in the
+    pending read — settles as `Detached`; `DisposeAsync` never rethrows the
+    exception its own expected close produced;
+  - after attach, **uninitiated** transport failure or truncation →
+    `ConnectionLost`;
+  - a malformed or protocol-unexpected frame → `Failed` (protocol failure);
+  - caller cancellation remains `OperationCanceledException`;
+  - a throwing callback still faults the run (exception out of `RunAsync`), and
+    the client transitions terminal first, so later writes are rejected rather
+    than racing a faulted pump.
 - Disposal: the client is **`IAsyncDisposable`**. `DisposeAsync` records detach
   intent, closes the socket, and awaits the pump's completion — so "dispose"
   anywhere in this spec means an awaited async teardown, never a synchronous
@@ -189,7 +207,13 @@ accepted** — the daemon replays the full scrollback on every connection
 (overflow recovery included), so feeding a replay into an emulator that already
 consumed the pre-error live stream would duplicate history and smear cursor /
 alternate-screen state; the view stays bound to the VM-owned property and just
-sees the replacement. VM tests script the factory. States:
+sees the replacement. **Every UI-affine step runs awaited on the UI thread**,
+not just output application: the terminal control model is an `AvaloniaObject`
+(construction/use can acquire UI-thread affinity — the repo codifies this for
+brushes already), and retry/reattach completions arrive from background pumps —
+so model construction, event wiring, the bound-property swap, and every
+terminal-state/outcome mutation dispatch to `RxSchedulers.MainThreadScheduler`.
+VM tests script the factory. States:
 
 `Connecting → Attached (read-write | read-only with reason) → Detached / Exited(code) / Failed(error)`
 
@@ -231,7 +255,17 @@ Each `MainWindowViewModel` owns its `CurrentWorkspace`, and workspace teardown
 is **asynchronous by nature** (`DetachAsync` + socket close + pump completion),
 which the app's existing synchronous disposal pass cannot express. So the
 composition root gains one small app-lifetime piece: a **workspace teardown
-tracker** that every teardown registers with. Exit paths:
+tracker** that every teardown registers with.
+
+**The teardown algorithm is bounded and always reaches the socket close.**
+`DetachAsync` is best-effort with a short bound — it can wait behind the write
+lock or a stalled socket and has no cancellation of its own — and a `finally`
+path closes the socket (`DisposeAsync`) regardless, within the bound. Releasing
+the PTY dimension clamp is guaranteed by the local socket close, never by the
+Detach frame arriving. The tracker isolates per-teardown exceptions: one failed
+teardown logs and completes, never poisoning the drain.
+
+Exit paths:
 
 - **Back / opening another session**: the VM starts the outgoing workspace's
   async teardown (tracked) and swaps `CurrentWorkspace`.
@@ -244,9 +278,17 @@ tracker** that every teardown registers with. Exit paths:
   window + VM on next show; the discarded VM's workspace teardown is started
   (tracked) as part of that close, so a rebuilt window never inherits or leaks
   an attach.
-- **App shutdown**: the teardown seam **awaits** the tracker's pending
-  teardowns (bounded — a few seconds) before the process exits, so a detach
-  frame is not abandoned mid-write.
+- **App shutdown**: the shutdown sequence sets quit-in-progress first and only
+  closes the window *after* async service disposal — so a live workspace that
+  never went through Back/close-to-hide would otherwise register its teardown
+  after the drain, against already-disposed dependencies. Therefore the
+  **first shutdown pass synchronously unhooks `CurrentWorkspace` from the
+  current VM and registers its teardown before draining**. The drain then
+  **seals** the tracker atomically: registration and seal cannot race past the
+  final snapshot, a post-seal registration is refused (its workspace is already
+  torn or tears down as an idempotent no-op), and the later real close of the
+  window is idempotent. The drain awaits pending teardowns (bounded — a few
+  seconds) before service disposal proceeds.
 
 Detach never stops the agent; reopening reattaches and the scrollback replay
 restores history. No app-side buffer persistence.
@@ -283,8 +325,12 @@ TDD throughout (red-green per test):
   linearization** — detach intent + EOF → `Detached`; a terminal frame read
   after detach intent wins (`Exited`/`Failed`, exactly one outcome); uninitiated
   EOF → `ConnectionLost`; the outcome observable by an ordinary awaiting caller;
-  `DisposeAsync` awaits pump completion; calls made before the run and after
-  termination; a throwing callback faults the run.
+  `DisposeAsync` awaits pump completion; **exceptional-path classification** —
+  connect refusal → `Failed`; mid-header and mid-payload stream loss →
+  `ConnectionLost`; an unexpected/malformed frame → `Failed`; a write failure;
+  `DisposeAsync` closing a blocked read settles `Detached` and rethrows
+  nothing; calls made before the run and after termination; a throwing callback
+  faults the run after the client turns terminal (subsequent writes rejected).
 - **Wire**: `StatusIpcJsonTests` — old JSON without `has_terminal` → `null`;
   `true`/`false`/`null` all serialize with the member present; `false` never
   omitted.
@@ -302,11 +348,16 @@ TDD throughout (red-green per test):
   navigation open/close on `MainWindowViewModel` including the **coordinator's
   actual intercepted-close path proving a Detach frame and socket teardown**
   (not just a direct `CloseWorkspace()` call), plus the **real-close /
-  rebuilt-window path** (a fresh window inherits no attach) and **shutdown
-  awaiting pending teardowns** via the tracker; **stale-generation launches** —
-  a delayed launch success after intercepted close, and after the user opened a
-  different session, opens/replaces nothing; card-click and launch-success
-  entry paths.
+  rebuilt-window path** (a fresh window inherits no attach) and **shutdown with
+  a live workspace and no pre-existing tracked teardown** — the first pass
+  registers it, the drain seals atomically, and its socket teardown completes
+  before service disposal; a **never-completing Detach write on intercepted
+  close** — the socket is force-closed within the teardown bound; a
+  **scheduler assertion** driving retry/reattach completion from a background
+  thread that fails on any off-UI-thread model construction or bound-state
+  mutation; **stale-generation launches** — a delayed launch success after
+  intercepted close, and after the user opened a different session,
+  opens/replaces nothing; card-click and launch-success entry paths.
 - **Terminal rendering**: a headless recorded-transcript test feeding a captured
   ANSI/TUI byte stream (colors, cursor addressing, alternate screen) through the
   decode-and-feed path, with `ReflowOnResize = false` set per upstream's own TUI
@@ -332,5 +383,6 @@ TDD throughout (red-green per test):
   before merge (this machine).
 - **Dimension clamp**: an app viewer at a small window shrinks the PTY for all
   viewers (existing daemon semantics, tmux-style). Accepted; the read-only path
-  never contributes, and workspace disposal on every exit path (close-to-hide
-  included) guarantees a hidden window never keeps clamping.
+  never contributes, and on every exit path (close-to-hide included) clamp
+  release is guaranteed by the **local socket close** in the teardown's bounded
+  `finally` — the Detach frame is best-effort on top.

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -134,10 +134,19 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   - after attach, **uninitiated** transport failure or truncation →
     `ConnectionLost`;
   - a malformed or protocol-unexpected frame → `Failed` (protocol failure);
-  - caller cancellation remains `OperationCanceledException`;
+  - caller cancellation surfaces as `OperationCanceledException` — **when
+    cancellation is the recorded cause** (below);
   - a throwing callback still faults the run (exception out of `RunAsync`), and
     the client transitions terminal first, so later writes are rejected rather
     than racing a faulted pump.
+- **One atomic terminal-cause slot resolves every race.** Terminal frame read,
+  local-close intent, and observed cancellation all try to record themselves as
+  the run's terminal cause; the **first recorded cause wins** and alone decides
+  what `RunAsync` produces (`Exited`/`Failed` for a frame, `Detached` for local
+  close, `OperationCanceledException` for cancellation). The app retires an
+  attempt by cancelling *and* disposing, which makes both clauses applicable —
+  the slot, not scheduling, decides. `DisposeAsync` never rethrows the retired
+  run's cancellation (or any expected-teardown exception).
 - **Outbound write failures route to the pump, which stays the single
   linearization point.** `SendInputAsync`/`ResizeAsync`/`DetachAsync` write from
   caller tasks while the pump can be blocked in a read (the CLI being ported
@@ -231,9 +240,15 @@ VM tests script the factory. States:
 
 `Connecting → Attached (read-write | read-only with reason) → Detached / Exited(code) / Failed(error)`
 
-The terminal states map one-to-one from the client's `AttachOutcome`;
-`ConnectionLost` maps to `Failed` with a lost-connection message and the
-reattach affordance.
+The terminal states map from the client's **entire completion surface**, not
+just `AttachOutcome`: `ConnectionLost` maps to `Failed` with a lost-connection
+message and the reattach affordance; a **non-cancellation `RunAsync` fault**
+(the callbacks decode and feed a third-party engine untrusted PTY bytes — a
+real failure path) is caught and rendered as `Failed` (local rendering error)
+with the reattach affordance, applied on the UI scheduler; an
+`OperationCanceledException` from a retired or disposed attempt generation is
+swallowed silently and mutates nothing — a retired attempt never touches VM
+state after its replacement begins.
 
 - Output delivery: the VM awaits each `OnOutputAsync` by decoding through **one
   incremental `System.Text.Decoder` spanning the snapshot and every live
@@ -252,10 +267,19 @@ reattach affordance.
   it directly) is verified at implementation and is an acceptance item. Read-only
   mode suppresses all input/resize and shows the daemon's reason banner (canvas:
   attach banner with Detach button).
-- Launch race: if attach fails with "no such agent" while the agent is not yet
-  (or no longer) in the status cache, retry with backoff for up to 10 seconds
-  before surfacing the error — this is the `LaunchOutcome.AgentId` path booting.
-  The delay policy is injected (`TimeProvider`) so tests are deterministic.
+- **The workspace opens in a `Resolving` state and no attach client exists
+  until the session's first status DTO arrives.** `OpenSession` carries only an
+  agent id; `HasTerminal`/vendor arrive with the first matching
+  `AgentStatusDto` in the daemon cache. Attaching optimistically would race the
+  gate — a fresh ACP/app-server session would show "no such agent" then the
+  daemon's no-terminal refusal before the `has_terminal=false` note could
+  render. So: `Resolving` waits (up to 10 seconds, `TimeProvider`-injected) for
+  the first matching DTO, then applies the gate — `has_terminal=false` renders
+  the no-terminal note with **zero socket or client attempts ever made**;
+  `true`/`null`+PTY-fallback constructs the first attach client; timeout
+  surfaces a not-found error. **Initial absence (`Resolving`) and
+  "observed then left the cache" (session ended) are distinct states** — the
+  second only exists after a first observation.
 - Signal precedence: `Exited(code)` and daemon `Error` are more specific than
   the agent leaving the status cache; the generic "session ended" state never
   overwrites an already-terminal exited/failed state (the two signals arrive on
@@ -272,19 +296,22 @@ composition root gains one small app-lifetime piece: a **workspace teardown
 tracker** that every teardown registers with.
 
 **The teardown algorithm is bounded and always reaches the socket close.**
-The Detach write is best-effort with a **1-second** bound — it can wait behind
-the write lock or a stalled socket — and a `finally` path closes the socket
-(`DisposeAsync`) regardless; a whole teardown's budget is **3 seconds** before
-the socket is force-closed. Releasing the PTY dimension clamp is guaranteed by
-the local socket close, never by the Detach frame arriving. The shutdown drain
-has its own **separate 5-second total** deadline across all pending teardowns
-concurrently; on expiry the drain stops waiting and shutdown proceeds (the
-process exit closes any straggler socket at the OS level — the deadline governs
-how long we wait for *graceful* detach frames, not whether the clamp releases).
-All three durations flow through an injected `TimeProvider` so the
+The timeline, explicitly: wait at most **1 second** for the Detach write (it
+can wait behind the write lock or a stalled socket); then **close the socket
+immediately** — `DisposeAsync`'s contract closes before awaiting the pump, so
+the local socket is force-closed by roughly the 1-second mark on every path;
+the remainder of the **3-second** per-teardown budget is spent awaiting and
+observing pump completion. The shutdown drain has its own **separate 5-second
+total** across all pending teardowns concurrently; on expiry the drain stops
+waiting and shutdown proceeds. **Expiry can leave a straggler *task*
+(an unobserved pump), never a straggler *socket*** — every teardown closed its
+socket within its own first second, which is what the clamp-release guarantee
+in Risks rests on; the deadlines govern how long we wait for graceful detach
+frames and pump observation, not whether the clamp releases. All three
+durations flow through an injected `TimeProvider` so the
 never-completing-write tests are deterministic, not real-time. The tracker
-isolates per-teardown exceptions: one failed teardown logs and completes, never
-poisoning the drain.
+isolates per-teardown exceptions: one failed teardown logs and completes,
+never poisoning the drain.
 
 Exit paths:
 
@@ -375,9 +402,18 @@ TDD throughout (red-green per test):
 - **Daemon**: `has_terminal` stamped true for a PTY runtime, false for ACP and
   codex app-server runtimes, asserted on the **serialized** status payload.
 - **App VMs**: scripted fake attach factory — state transitions, read-only
-  suppression, retry-on-boot under a test `TimeProvider`, one-client-per-attempt
-  and single-flight reattach, exited/error precedence over session-ended,
-  null/malformed `LaunchOutcome.AgentId` guard; UTF-8 assembly with 2-, 3- and
+  suppression; **the `Resolving` gate**: launch success while the agent is
+  absent from the cache followed by `has_terminal=false` renders the note with
+  zero client/socket attempts; `true` and `null`+PTY-fallback proceed to
+  attach; resolve timeout under a test `TimeProvider`; removal after first
+  observation (session ended) is a different state than initial absence;
+  one-client-per-attempt and single-flight reattach; **cancellation vs
+  local-close precedence**: cancel-before-dispose, dispose-before-cancel, and
+  the simultaneous race each yield exactly one recorded cause, and a retired
+  attempt mutates no VM state after its replacement begins; **a throwing
+  output callback / background `RunAsync` fault** renders `Failed` with the
+  reattach affordance on the UI scheduler; exited/error precedence over
+  session-ended, null/malformed `LaunchOutcome.AgentId` guard; UTF-8 assembly with 2-, 3- and
   4-byte characters split across every frame boundary including the
   snapshot/live seam; a terminal query/response sequence forwarded read-write
   and suppressed read-only; **reattach freshness** — consume output, receive

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -92,13 +92,19 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   — the pump awaits each before reading the next frame, so delivery is serial
   and ordered (snapshot strictly before any output), and the daemon's
   slow-client overflow protection stays meaningful: a slow UI backs the socket
-  up rather than ballooning an unbounded dispatcher queue. **Callbacks receive
-  the run's cancellation token**, which disposal/retirement cancels — the app's
-  UI-thread dispatch awaits honor it — so a stuck callback releases rather than
-  retaining the disposed VM/model (see teardown). A callback exception faults
-  the run *when it claims the cause slot* (below). With termination folded into
-  the result, "no events after termination" is structural, not a rule to
-  police.
+  up rather than ballooning an unbounded dispatcher queue. **Callbacks receive an internal run-lifetime token, not the caller's.** The
+  client owns a run-lifetime `CancellationTokenSource` linked to the caller's
+  token — `DisposeAsync` cannot cancel a caller-owned token; only its source
+  can. External cancellation first tries to claim the `Cancellation` cause,
+  then cancels the internal token; `DisposeAsync` first claims `Detached`,
+  then cancels the internal token and closes the socket. The app's UI-thread
+  dispatch awaits honor the internal token, so a stuck callback releases
+  rather than retaining the disposed VM/model (see teardown). A callback
+  `OperationCanceledException` produced by either path **projects the
+  already-recorded winner** — it never becomes a callback-fault cause of its
+  own; a genuine callback exception faults the run *when it claims the cause
+  slot* (below). With termination folded into the result, "no events after
+  termination" is structural, not a rule to police.
 - Outbound methods: `SendInputAsync(bytes)`, `ResizeAsync(cols, rows)`,
   `DetachAsync()`. All writes serialize behind one lock (input and resize share
   the stream — same reason the CLI holds a write semaphore), and **the client —
@@ -169,6 +175,17 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   cancelling *and* disposing; whichever claims first decides. `DisposeAsync`
   never rethrows the retired run's cancellation (or any expected-teardown
   exception).
+- **Losing exceptions flow to an injected diagnostic sink — the client's one
+  observation seam.** Core is BCL-only and its LocalIpc convention returns
+  failures as data, never logs internally — so `AgentAttachClient` takes an
+  optional constructor delegate (`Action<string, Exception>`-shaped, default
+  no-op); the client alone invokes it, so `RunAsync`, `DisposeAsync`, and the
+  app's teardown tracker can never double-log the same exception. The rule is
+  scoped precisely: **every actual losing *exception* is observed through the
+  sink exactly once** — a losing cause *attempt* with no exception (e.g.
+  callback-fault-first followed by Dispose) logs nothing. The app wires the
+  sink to its logger; tests assert against a recording sink, not stderr
+  capture.
 - **Losers are observed exactly once and never become a second result:**
   - *callback fault vs `DisposeAsync`* — Dispose claims first: the callback
     exception is consumed and logged once, `RunAsync` settles `Detached`,
@@ -455,10 +472,16 @@ TDD throughout (red-green per test):
   cross-races with loser behavior pinned** — an input-write failure racing
   `DetachAsync`, and a callback fault racing `DisposeAsync`, each asserted in
   BOTH orderings: the actual `AttachOutcome`/fault, the outbound call and
-  `DisposeAsync` completing without rethrow of the losing exception, and the
-  loser logged exactly once, never a second result; calls made before the run
-  and after termination; a throwing callback faults the run after the client
-  turns terminal (subsequent writes rejected).
+  `DisposeAsync` completing without rethrow of the losing exception, and every
+  actual losing exception observed through the recording diagnostic sink
+  exactly once (a losing cause attempt with no exception logs nothing), never
+  a second result; **the lifetime-token contract** — `DisposeAsync` while the
+  caller token stays uncancelled (awaited callback exits via the internal
+  token, `RunAsync` returns `Detached`, the external token is untouched),
+  caller-cancel while inside a callback (`OperationCanceledException`), and
+  the two-way race; calls made before the run and after termination; a
+  throwing callback faults the run after the client turns terminal
+  (subsequent writes rejected).
 - **Wire**: `StatusIpcJsonTests` — old JSON without `has_terminal` → `null`;
   `true`/`false`/`null` all serialize with the member present; `false` never
   omitted.

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -88,13 +88,17 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
   (uninitiated EOF) — observable identically by a Core caller and the VM.
   Caller cancellation surfaces as the standard `OperationCanceledException`.
   Streaming events are two **awaited async callbacks** only —
-  `OnAttachedAsync(snapshot, readOnlyReason)` and `OnOutputAsync(bytes)` — the
-  pump awaits each before reading the next frame, so delivery is serial and
-  ordered (snapshot strictly before any output), and the daemon's slow-client
-  overflow protection stays meaningful: a slow UI backs the socket up rather
-  than ballooning an unbounded dispatcher queue. A callback exception faults the
-  run (surfaces out of `RunAsync`). With termination folded into the result,
-  "no events after termination" is structural, not a rule to police.
+  `OnAttachedAsync(snapshot, readOnlyReason, ct)` and `OnOutputAsync(bytes, ct)`
+  — the pump awaits each before reading the next frame, so delivery is serial
+  and ordered (snapshot strictly before any output), and the daemon's
+  slow-client overflow protection stays meaningful: a slow UI backs the socket
+  up rather than ballooning an unbounded dispatcher queue. **Callbacks receive
+  the run's cancellation token**, which disposal/retirement cancels — the app's
+  UI-thread dispatch awaits honor it — so a stuck callback releases rather than
+  retaining the disposed VM/model (see teardown). A callback exception faults
+  the run *when it claims the cause slot* (below). With termination folded into
+  the result, "no events after termination" is structural, not a rule to
+  police.
 - Outbound methods: `SendInputAsync(bytes)`, `ResizeAsync(cols, rows)`,
   `DetachAsync()`. All writes serialize behind one lock (input and resize share
   the stream — same reason the CLI holds a write semaphore), and **the client —
@@ -107,7 +111,7 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
 - After a read-write `Attached`, the client sends one `Resize` at the initial
   size to nudge a clean repaint (CLI parity). After `AttachedReadOnly` it sends
   nothing: a read-only viewer must not influence the PTY clamp.
-- Termination semantics, linearized in one place (the pump): `DetachAsync`
+- Termination semantics, linearized through the cause slot below: `DetachAsync`
   records detach intent and sends the frame — it does not itself produce the
   outcome. The daemon sends no detach acknowledgement; it just closes the
   connection, and it can still emit `Exited` after receiving a `Detach` when the
@@ -158,18 +162,33 @@ CLI's `LocalAgentClient.RunAsync` with the raw-tty plumbing removed:
 
   Compare-exchange guarantees exactly one winner; actual event ordering
   determines *which* cause wins — the slot removes double-results, not
-  nondeterminism. The app retires an attempt by cancelling *and* disposing;
-  whichever claims first decides. `DisposeAsync` never rethrows the retired
-  run's cancellation (or any expected-teardown exception).
-- **Outbound write failures route to the pump, which stays the single
-  linearization point.** `SendInputAsync`/`ResizeAsync`/`DetachAsync` write from
-  caller tasks while the pump can be blocked in a read (the CLI being ported
-  has the same shape). A transport failure in an input/resize write atomically
-  terminalizes the client and closes the socket, so the blocked read completes
-  and `RunAsync` settles `ConnectionLost`; the initiating outbound call
-  **completes without rethrowing** — the failure is the run's to report, so
-  there is never a second result or a hung pump. A `Detach` write failure with
-  intent recorded resolves the same way every local close does: `Detached`.
+  nondeterminism. **The slot is the linearization point** — the pump and the
+  outbound writers are all just producers, and the pump projects/completes the
+  winning cause into `RunAsync`'s result (earlier "linearized in the pump"
+  phrasing is superseded by this rule). The app retires an attempt by
+  cancelling *and* disposing; whichever claims first decides. `DisposeAsync`
+  never rethrows the retired run's cancellation (or any expected-teardown
+  exception).
+- **Losers are observed exactly once and never become a second result:**
+  - *callback fault vs `DisposeAsync`* — Dispose claims first: the callback
+    exception is consumed and logged once, `RunAsync` settles `Detached`,
+    `DisposeAsync` completes normally, no UI mutation. Callback fault claims
+    first: `RunAsync` faults with it; `DisposeAsync` still awaits the pump and
+    **does not rethrow the already-reported fault** — it completes normally.
+  - *input-write failure vs detach intent* — whichever cause claims first
+    decides the `AttachOutcome` (`ConnectionLost` for the write failure,
+    `Detached` for the intent-pending close); the initiating outbound call
+    completes without rethrow in both orderings, and the losing exception is
+    logged once.
+- **Outbound write failures claim the cause slot like any other producer.**
+  `SendInputAsync`/`ResizeAsync`/`DetachAsync` write from caller tasks while
+  the pump can be blocked in a read (the CLI being ported has the same shape).
+  A transport failure in an input/resize write claims `ConnectionLost` and
+  closes the socket, so the blocked read completes and the pump projects the
+  winner into `RunAsync`; the initiating outbound call **completes without
+  rethrowing** — the failure is the run's to report, so there is never a second
+  result or a hung pump. A `Detach` write failure with intent recorded resolves
+  the same way every local close does: `Detached`.
 - Disposal: the client is **`IAsyncDisposable`**. `DisposeAsync` records detach
   intent, closes the socket, and awaits the pump's completion — so "dispose"
   anywhere in this spec means an awaited async teardown, never a synchronous
@@ -310,6 +329,11 @@ state after its replacement begins.
   independent background pumps).
 - `Exited(code)` renders an exited banner in place; `Error` (including overflow
   force-detach) renders the daemon's message with a reattach affordance.
+- **An explicit Detach stays in place**: the `Detached` state renders an
+  in-place detached banner with a single-flight Reattach affordance — it does
+  not navigate Back. The socket is closed, the agent is never stopped, input is
+  gone until reattach; pinned in the VM tests and the smoke test alongside the
+  other terminal presentations.
 
 ### Workspace ownership (one owner, every path)
 
@@ -334,8 +358,14 @@ wait for graceful detach frames and pump observation, not whether the clamp
 releases. **A timed-out pump is abandoned by the await, never left
 unobserved**: the wrapper attaches a continuation that consumes and logs its
 eventual completion or fault (the callback/rendering fault is a real
-possibility) without re-entering VM state — so a late fault cannot go
-unobserved, and cannot retain the disposed VM/model past its logging. All three
+possibility) without re-entering VM state. A continuation alone cannot free a
+pump stuck *inside* an awaited callback, which is why the callbacks carry the
+run's cancellation token (§2): disposal/retirement cancels the token, the
+app's UI-dispatch awaits honor it, and the stuck callback completes — so the
+disposed VM/model is released rather than retained. The residual acceptance:
+a callback stuck in **synchronous** third-party code (inside the terminal
+engine's feed itself) cannot be cancelled cooperatively and is retained until
+it returns — documented, socket/clamp already released either way. All three
 durations flow through an injected `TimeProvider` so the
 never-completing-write tests are deterministic, not real-time. The tracker
 isolates per-teardown exceptions: one failed teardown logs and completes,
@@ -422,10 +452,13 @@ TDD throughout (red-green per test):
   rethrow, the pump settles `ConnectionLost` (or `Detached` for a failed
   Detach write), exactly one result, no hung pump; `DisposeAsync` closing a
   blocked read settles `Detached` and rethrows nothing; **cause-slot
-  cross-races** — an input-write failure racing `DetachAsync`, and a callback
-  fault racing `DisposeAsync`, each produce exactly one recorded cause; calls
-  made before the run and after termination; a throwing callback faults the
-  run after the client turns terminal (subsequent writes rejected).
+  cross-races with loser behavior pinned** — an input-write failure racing
+  `DetachAsync`, and a callback fault racing `DisposeAsync`, each asserted in
+  BOTH orderings: the actual `AttachOutcome`/fault, the outbound call and
+  `DisposeAsync` completing without rethrow of the losing exception, and the
+  loser logged exactly once, never a second result; calls made before the run
+  and after termination; a throwing callback faults the run after the client
+  turns terminal (subsequent writes rejected).
 - **Wire**: `StatusIpcJsonTests` — old JSON without `has_terminal` → `null`;
   `true`/`false`/`null` all serialize with the member present; `false` never
   omitted.
@@ -462,7 +495,11 @@ TDD throughout (red-green per test):
   before service disposal; a **never-completing Detach write on intercepted
   close** — the socket is force-closed within the teardown bound under a test
   `TimeProvider`; a **pump faulting after the 3-second teardown budget** — the
-  fault is observed and logged exactly once with no late UI mutation; an
+  fault is observed and logged exactly once with no late UI mutation; a
+  **never-completing awaited callback on teardown** (distinct from the
+  late-fault case) — run-token cancellation completes it and the VM/model is
+  released; an **explicit Detach** — in-place detached banner, single-flight
+  Reattach, socket closed, agent untouched; an
   **explicit `OpenSession` after the first shutdown pass/seal** and a **window
   constructed after shutdown began** — neither creates a client or socket; a
   **scheduler assertion** driving retry/reattach completion from a background

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -37,6 +37,15 @@ public partial class App : Application {
 
     // The app's one read of KCAP_DAEMONS_DIR.
     readonly DaemonStore _daemonStore = DaemonStore.FromEnvironment();
+
+    // Both are app-lifetime and BOTH exist before any graph does: OnShutdownRequested latches and
+    // drains them whether or not StartAsync ever got as far as building a window (spec §3). The gate
+    // is shared by every MainWindowViewModel the coordinator builds — including one built between
+    // the two shutdown passes, which is the case a per-window latch cannot cover.
+    readonly NavigationGate _navigation = new();
+    readonly WorkspaceTeardownTracker _workspaceTeardown = new(
+        TimeProvider.System,
+        (context, ex) => Console.Error.WriteLine($"kcap app: {context} failed: {ex}"));
     // Constructed FIRST (before any other graph object) in StartAsync and disposed LAST — every
     // daemon mutation in the app runs through it, so nothing that might still call RunAsync can outlive it.
     DaemonMutationLane? _lane;
@@ -164,10 +173,15 @@ public partial class App : Application {
             // when the failure hit, no tray will ever exist to bring it back, so hide-on-close
             // must not intercept anything from here on — every close on this path is a real one.
             if (_coordinator is not null) _coordinator.QuitInProgress = true;
+            // Also before any await, and the same reasoning as the shutdown path's: a workspace the
+            // user opened before the failure landed must release its attach here, not survive into
+            // the error window.
+            LatchNavigation();
             // No orphan wizard beside the error window: it is a dead shell once startup has failed,
             // and its own close path (the handoff) is exactly what did not run.
             if (_wizardWindow is { IsVisible: true } wizard) wizard.Close();
             Console.Error.WriteLine($"kcap app failed to start: {ex}");
+            await _workspaceTeardown.DrainAsync();
             await HandleStartupFailureAsync(
                 desktop, ex, _service, _shutdown, [_tray, _trayVm, _promptCoordinator, _consent, _activity, _home, _pause], _lifecycle, _lane);
             await DisposeLaunchClientAsync(); // after _home above — its only caller
@@ -281,8 +295,20 @@ public partial class App : Application {
         var launch = new ServerLaunchClient();
         _launch = launch;
 
+        // One attach client per attempt, dialed at the daemon's own control socket; 80x24 is a
+        // placeholder only — TerminalControl resizes its model to the real pane the moment it is
+        // attached to the visual tree (WorkspaceView's own header comment).
+        var attachFactory = CoreTerminalAttachClient.Factory(() => _daemonStore.SocketPath(service.DaemonName));
+        WorkspaceViewModel BuildWorkspace(string agentId) => new(
+            agentId, service, actions, attachFactory, () => new XtermTerminalSurface(80, 24), TimeProvider.System);
+
         _coordinator = new MainWindowCoordinator(
-            () => BuildAndShowMainWindow(service, actions, notifier, ticker, _shutdown.Token, activity, lifecycle.StartActionAsync, lifecycleStatus, launch));
+            () => BuildAndShowMainWindow(
+                service, actions, notifier, ticker, _shutdown.Token, activity, lifecycle.StartActionAsync,
+                lifecycleStatus, launch, _navigation, _workspaceTeardown.Track, BuildWorkspace),
+            // Both close paths release the workspace: hide-to-tray keeps the window (and its
+            // attach) alive, a real close discards the window the next Show() would rebuild.
+            releaseWorkspace: window => (window.DataContext as MainWindowViewModel)?.CloseWorkspace());
         // A shutdown that started before this continuation resumed already ran its first
         // pass against a null coordinator, so a window built now must never be
         // close-protected (BeginShutdownPass's rule 1 is the general defense; this is the
@@ -585,7 +611,9 @@ public partial class App : Application {
     internal static MainWindow BuildAndShowMainWindow(
             IDaemonClientService service, AgentActionService actions, IAppNotifier notifier, ITicker ticker,
             CancellationToken shutdownToken, ActivityViewModel activity, Func<CancellationToken, Task>? startAction = null,
-            IObservable<string?>? lifecycleStatus = null, ILaunchClient? launch = null) {
+            IObservable<string?>? lifecycleStatus = null, ILaunchClient? launch = null,
+            NavigationGate? navigation = null, Action<Func<Task>>? trackWorkspaceTeardown = null,
+            Func<string, WorkspaceViewModel>? workspaceFactory = null) {
         // Notifier is set on the WINDOW (spec §11 toast overlay), not the ViewModel — the toast
         // is a View-level concern (WindowNotificationManager lives on MainWindow) independent of
         // the VM's WhenActivated-scoped projections.
@@ -597,11 +625,23 @@ public partial class App : Application {
         // `new AppStateStore(PathHelpers.ConfigPath("app-state.json"))` already relies on. The
         // composition root passes its held client so teardown can dispose it; a caller that passes
         // none (a test) gets an unheld one, which owns nothing until a launch is actually made.
+        //
+        // Home's three navigation callbacks close over `vm`, which cannot exist yet (it takes Home
+        // itself) — a captured local, assigned right below, is what ties the knot without a
+        // settable hook on either ViewModel. Every callback runs on the UI thread, after both
+        // objects exist.
+        MainWindowViewModel? vm = null;
         var home = new HomeViewModel(
             service, new AppStateStore(PathHelpers.ConfigPath("app-state.json")),
-            launch ?? new ServerLaunchClient(), RepoPathStore.GetSortedPathsAsync, shutdownToken);
+            launch ?? new ServerLaunchClient(), RepoPathStore.GetSortedPathsAsync, shutdownToken,
+            openSession: agentId => vm?.OpenSession(agentId),
+            navigationGeneration: () => vm?.NavigationGeneration ?? 0,
+            openSessionIfCurrent: (agentId, generation) => vm?.OpenSessionIfCurrent(agentId, generation));
+        vm = new MainWindowViewModel(
+            service, actions, ticker, shutdownToken, activity, startAction, lifecycleStatus, home: home,
+            navigation: navigation, trackWorkspaceTeardown: trackWorkspaceTeardown, workspaceFactory: workspaceFactory);
         var window = new MainWindow {
-            DataContext = new MainWindowViewModel(service, actions, ticker, shutdownToken, activity, startAction, lifecycleStatus, home: home),
+            DataContext = vm,
             Notifier = notifier,
         };
         window.Show();
@@ -985,6 +1025,10 @@ public partial class App : Application {
     // Once that completes, TryShutdown() re-raises this same event; the SECOND pass is let
     // through. This never blocks the UI thread on the async disposal.
     void OnShutdownRequested(object? sender, ShutdownRequestedEventArgs e) {
+        // Navigation's twin of BeginShutdownPass rule 1, and for the same reason: applied on EVERY
+        // pass, before the confirmed-pass early return, so a window the coordinator builds BETWEEN
+        // the passes can neither open a workspace nor keep one attached.
+        LatchNavigation();
         if (!BeginShutdownPass(_coordinator, _shutdownConfirmed)) return;
 
         e.Cancel = true;
@@ -1014,7 +1058,25 @@ public partial class App : Application {
         return !shutdownConfirmed;
     }
 
+    // Synchronous, on the ShutdownRequested (UI) thread: the live workspace is unhooked and its
+    // teardown REGISTERED here, so the drain below can only ever seal a set that already contains
+    // it. The gate is latched even with no window ever built — a window built later still sees it.
+    void LatchNavigation() {
+        (_coordinator?.Window?.DataContext as MainWindowViewModel)?.LatchShutdown();
+        _navigation.Latch();
+    }
+
     async Task DisposeAndShutdownAsync() {
+        // FIRST, before quiesce (which can wait a full minute) and before any disposal: a live
+        // workspace holds a terminal attach on the daemon socket, and the clamp it implies must be
+        // released for every other viewer as early as possible. Bounded at 5s and never throws.
+        //
+        // Deliberately NOT ConfigureAwait(false), unlike its neighbours: this is the one await here
+        // that genuinely suspends on the quit-with-a-session-open path, and the UI disposables below
+        // must still be disposed ON the UI thread this was invoked from (see
+        // DisposeUiThenConfirmShutdownAsync's own comment) — a tray icon disposed off it throws.
+        await _workspaceTeardown.DrainAsync();
+
         // spec §3.6 + decision 2: an in-flight sign-in always settles, mutations get a bounded chance
         // to — both while the UI is still up, before teardown.
         if (_wizardAuth is not null || _wizardImport is not null || _lifecycle is not null || _lane is not null)

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -1072,9 +1072,9 @@ public partial class App : Application {
         // released for every other viewer as early as possible. Bounded at 5s and never throws.
         //
         // Deliberately NOT ConfigureAwait(false), unlike its neighbours: this is the one await here
-        // that genuinely suspends on the quit-with-a-session-open path, and the UI disposables below
-        // must still be disposed ON the UI thread this was invoked from (see
-        // DisposeUiThenConfirmShutdownAsync's own comment) — a tray icon disposed off it throws.
+        // that routinely suspends (a live workspace's teardown), and its continuation belongs back on
+        // the UI thread this was invoked from. That is all it buys — the quiesce below still resumes
+        // wherever ConfigureAwait(false) leaves it whenever IT suspends.
         await _workspaceTeardown.DrainAsync();
 
         // spec §3.6 + decision 2: an in-flight sign-in always settles, mutations get a bounded chance

--- a/src/Capacitor.App/Capacitor.App.csproj
+++ b/src/Capacitor.App/Capacitor.App.csproj
@@ -19,6 +19,8 @@
         <PackageReference Include="ReactiveUI.Avalonia" />
         <PackageReference Include="DynamicData" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+        <PackageReference Include="SvcSystems.UI.Terminal" />
+        <PackageReference Include="XTerm.NET" />
     </ItemGroup>
     <ItemGroup>
         <!-- .axaml files are auto-included as AvaloniaXaml by Avalonia's build props; plain

--- a/src/Capacitor.App/Services/HostedHarnessCatalog.cs
+++ b/src/Capacitor.App/Services/HostedHarnessCatalog.cs
@@ -64,4 +64,22 @@ public static class HostedHarnessCatalog {
         "acp" => "ACP · chat",
         _     => "chat",
     };
+
+    /// Family for a vendor token, unmapped defaulting to "rpc" — the shared seam so
+    /// the workspace never duplicates the private map.
+    public static string FamilyFor(string vendor) =>
+        TransportFamilies.TryGetValue(vendor, out var family) ? family : "rpc";
+
+    /// The Terminal-tab gate: the daemon's has_terminal when present, the vendor
+    /// family guess when an older daemon sent null.
+    public static bool ShowsTerminal(bool? hasTerminal, string vendor) =>
+        hasTerminal ?? FamilyFor(vendor) == "pty";
+
+    /// Header family, corrected: has_terminal=false cannot distinguish acp/rpc/
+    /// app-server, so only a CONFLICTING pty guess is overridden (to generic chat);
+    /// an already-non-PTY family is preserved.
+    public static string EffectiveFamily(bool? hasTerminal, string vendor) {
+        var family = FamilyFor(vendor);
+        return hasTerminal == false && family == "pty" ? "rpc" : family;
+    }
 }

--- a/src/Capacitor.App/Services/HostedHarnessCatalog.cs
+++ b/src/Capacitor.App/Services/HostedHarnessCatalog.cs
@@ -82,4 +82,14 @@ public static class HostedHarnessCatalog {
         var family = FamilyFor(vendor);
         return hasTerminal == false && family == "pty" ? "rpc" : family;
     }
+
+    /// The one source of the no-terminal wording (terminal tab and workspace tab strip alike).
+    /// Suffixed only when the family is reliably known: ACP is; the rpc/"chat" bucket also covers
+    /// claude/codex/any unmapped vendor whose has_terminal came back false for a reason this build
+    /// can't classify further, so it gets no family token at all rather than leaking "RPC" (an
+    /// internal transport name, not a user-facing concept).
+    public static string NoTerminalNote(bool? hasTerminal, string vendor) =>
+        EffectiveFamily(hasTerminal, vendor) == "acp"
+            ? "This session runs over ACP — no terminal to attach to."
+            : "This session has no terminal.";
 }

--- a/src/Capacitor.App/Services/ITerminalSurface.cs
+++ b/src/Capacitor.App/Services/ITerminalSurface.cs
@@ -15,4 +15,9 @@ public interface ITerminalSurface {
 
     /// User-driven resize (cols, rows) — the VM forwards this to ResizeAsync.
     event Action<int, int>? Resized;
+
+    /// The surface's own current dimensions — read once, right after a read-write Attached, to
+    /// correct the client's post-attach nudge (sent at RunAsync's phantom initial size, before the
+    /// real pane size was ever known) to what the pane is actually showing.
+    (int Cols, int Rows) CurrentSize { get; }
 }

--- a/src/Capacitor.App/Services/ITerminalSurface.cs
+++ b/src/Capacitor.App/Services/ITerminalSurface.cs
@@ -1,0 +1,18 @@
+namespace Capacitor.App.Services;
+
+/// Minimal surface the VM drives; the production implementation (Task 11/12) wraps the
+/// SvcSystems control model. Kept App-local (no Avalonia/SvcSystems types in the signature) so
+/// TerminalTabViewModel's own tests never need a real terminal control.
+public interface ITerminalSurface {
+    /// Renders already-decoded text — callers own UTF-8 decoding (Utf8StreamDecoder) since the
+    /// control's own byte-array Feed re-decodes fresh on every call and corrupts a code point
+    /// split across frames.
+    void Feed(string text);
+
+    /// Keyboard input AND terminal-generated protocol replies (e.g. a DSR/CPR answer) — both
+    /// need to reach the attached PTY, so the VM forwards this to SendInputAsync verbatim.
+    event Action<byte[]>? InputProduced;
+
+    /// User-driven resize (cols, rows) — the VM forwards this to ResizeAsync.
+    event Action<int, int>? Resized;
+}

--- a/src/Capacitor.App/Services/ITerminalSurface.cs
+++ b/src/Capacitor.App/Services/ITerminalSurface.cs
@@ -20,4 +20,12 @@ public interface ITerminalSurface {
     /// correct the client's post-attach nudge (sent at RunAsync's phantom initial size, before the
     /// real pane size was ever known) to what the pane is actually showing.
     (int Cols, int Rows) CurrentSize { get; }
+
+    /// Re-shows the terminal caret after the snapshot replay. Claude/codex TUIs hide the hardware
+    /// cursor once at stream start and draw their own caret as an inverse-video cell — which the
+    /// control currently paints invisibly (upstream: default-color sentinels resolve by draw-call
+    /// position, so inverse-of-default is black-on-black). The engine's cursor position still
+    /// tracks the TUI's caret, so forcing it visible renders a correctly placed caret instead.
+    /// A TUI that hides the cursor again later is respected — this is a one-shot per attach.
+    void EnsureCaretVisible();
 }

--- a/src/Capacitor.App/Services/ITerminalSurface.cs
+++ b/src/Capacitor.App/Services/ITerminalSurface.cs
@@ -23,8 +23,10 @@ public interface ITerminalSurface {
 
     /// Re-shows the terminal caret after the snapshot replay. Claude/codex TUIs hide the hardware
     /// cursor once at stream start and draw their own caret as an inverse-video cell — which the
-    /// control currently paints invisibly (upstream: default-color sentinels resolve by draw-call
-    /// position, so inverse-of-default is black-on-black). The engine's cursor position still
+    /// pinned control (1.1.1) paints invisibly: default-color sentinels resolve by draw-call
+    /// position, so inverse-of-default is black-on-black. Fixed upstream in 1.1.2
+    /// (https://github.com/IvanJosipovic/SvcSystems.UI.Terminal/issues/69) — candidate for
+    /// retirement once a bump past 1.1.2 is verified visually. The engine's cursor position still
     /// tracks the TUI's caret, so forcing it visible renders a correctly placed caret instead.
     /// A TUI that hides the cursor again later is respected — this is a one-shot per attach.
     void EnsureCaretVisible();

--- a/src/Capacitor.App/Services/MainWindowCoordinator.cs
+++ b/src/Capacitor.App/Services/MainWindowCoordinator.cs
@@ -8,7 +8,14 @@ namespace Capacitor.App.Services;
 /// ShowMainWindow then builds a fresh one from the factory: Avalonia refuses to Show() a closed
 /// window, and nothing is lost because no state lives in the view (everything displayed is
 /// projected from the live service).
-public sealed class MainWindowCoordinator(Func<MainWindow> windowFactory) {
+/// <param name="releaseWorkspace">
+/// Starts the tracked teardown of whatever session workspace the window still owns. Invoked on BOTH
+/// exits (spec §3): an intercepted close only hides the window, so its ViewModels stay alive and an
+/// invisible terminal would otherwise keep clamping the PTY for every other viewer; a real close
+/// discards the window, and the one the next ShowMainWindow builds must not inherit that attach.
+/// Idempotent by construction — a VM that already swapped back to the shell has nothing to release.
+/// </param>
+public sealed class MainWindowCoordinator(Func<MainWindow> windowFactory, Action<MainWindow>? releaseWorkspace = null) {
     MainWindow? _window;
 
     /// Set by App.OnShutdownRequested's FIRST (deferring) pass, so the second pass's real window
@@ -27,6 +34,9 @@ public sealed class MainWindowCoordinator(Func<MainWindow> windowFactory) {
             // the identity check keeps a late event from a superseded window from clearing a
             // newer one.
             window.Closed += (_, _) => {
+                // Released off the window that is actually closing, never off _window: a late event
+                // from a superseded window must not tear down the current one's workspace.
+                releaseWorkspace?.Invoke(window);
                 if (ReferenceEquals(_window, window)) _window = null;
             };
             _window = window;
@@ -39,7 +49,9 @@ public sealed class MainWindowCoordinator(Func<MainWindow> windowFactory) {
     /// Called from MainWindow.Closing. True → the close must be cancelled; the window is hidden
     /// here instead.
     public bool OnWindowClosing() {
-        if (QuitInProgress) return false;
+        if (QuitInProgress) return false; // a real close — the Closed handler above releases instead
+
+        if (_window is not null) releaseWorkspace?.Invoke(_window);
         _window?.Hide();
         return true;
     }

--- a/src/Capacitor.App/Services/NavigationGate.cs
+++ b/src/Capacitor.App/Services/NavigationGate.cs
@@ -1,0 +1,38 @@
+namespace Capacitor.App.Services;
+
+/// App-lifetime navigation state, owned by the composition root and shared by every
+/// MainWindowViewModel the coordinator builds — including one built BETWEEN the two shutdown
+/// passes, which is exactly why the latch cannot live on a single window's ViewModel (spec §3).
+///
+/// Generation is the launch auto-open's staleness token: a launch captures it before the call, and
+/// a success arriving at a different one opens nothing. Every navigation, every close-to-hide and
+/// the shutdown latch bump it, so an unchanged generation is the only thing that can mean "the user
+/// has not navigated since".
+public sealed class NavigationGate {
+    readonly Lock _lock = new();
+    int _generation;
+    bool _latched;
+
+    public int Generation {
+        get { lock (_lock) return _generation; }
+    }
+
+    /// Once true, never false again: shutdown has begun, so no new workspace — and therefore no new
+    /// attach — may be created, in this window or any later one.
+    public bool ShutdownLatched {
+        get { lock (_lock) return _latched; }
+    }
+
+    public int Bump() {
+        lock (_lock) return ++_generation;
+    }
+
+    /// Latching also bumps: a launch already in flight when shutdown began is then stale on its own
+    /// terms, not only because the latch happens to reject it.
+    public void Latch() {
+        lock (_lock) {
+            _latched = true;
+            _generation++;
+        }
+    }
+}

--- a/src/Capacitor.App/Services/TerminalAttach.cs
+++ b/src/Capacitor.App/Services/TerminalAttach.cs
@@ -1,0 +1,47 @@
+namespace Capacitor.App.Services;
+
+using Capacitor.Cli.Core.LocalIpc;
+
+/// App-side seam over Core's AgentAttachClient so VM tests script attachment.
+public interface ITerminalAttachClient : IAsyncDisposable {
+    Task<AttachOutcome> RunAsync(int initialCols, int initialRows, CancellationToken ct);
+    Task SendInputAsync(byte[] bytes);
+    Task ResizeAsync(int cols, int rows);
+    Task DetachAsync();
+}
+
+/// One client per attach attempt — the factory is the unit tests' scripting seam.
+public delegate ITerminalAttachClient TerminalAttachClientFactory(
+    string agentId,
+    Func<byte[], string?, CancellationToken, Task> onAttached,
+    Func<byte[], CancellationToken, Task> onOutput);
+
+/// Production adapter: Core client, diagnostics to Console.Error (the app's
+/// teardown-diagnostic convention — never AppNotifier toasts).
+public sealed class CoreTerminalAttachClient(AgentAttachClient inner) : ITerminalAttachClient {
+    public static TerminalAttachClientFactory Factory(Func<string> socketPath) =>
+        (agentId, onAttached, onOutput) => new CoreTerminalAttachClient(new AgentAttachClient(
+            socketPath(), agentId, onAttached, onOutput,
+            (ctx, ex) => Console.Error.WriteLine($"kcap: terminal attach {ctx}: {ex.Message}")));
+    public Task<AttachOutcome> RunAsync(int c, int r, CancellationToken ct) => inner.RunAsync(c, r, ct);
+    public Task SendInputAsync(byte[] b) => inner.SendInputAsync(b);
+    public Task ResizeAsync(int c, int r) => inner.ResizeAsync(c, r);
+    public Task DetachAsync() => inner.DetachAsync();
+    public ValueTask DisposeAsync() => inner.DisposeAsync();
+}
+
+/// Deliberately NOT named *Attach*State — AttachStatus/AttachState already
+/// describe the daemon status subscription (spec naming note).
+public enum TerminalSessionPhase { Resolving, NoTerminal, NotFound, Connecting, Attached, Detached, Exited, Failed, SessionEnded }
+
+public sealed record TerminalSessionState(TerminalSessionPhase Phase, string? Detail = null, bool ReadOnly = false, int? ExitCode = null) {
+    public static readonly TerminalSessionState Resolving = new(TerminalSessionPhase.Resolving);
+    public static TerminalSessionState NoTerminal(string? familyNote) => new(TerminalSessionPhase.NoTerminal, familyNote);
+    public static readonly TerminalSessionState NotFound = new(TerminalSessionPhase.NotFound, "Session not found");
+    public static readonly TerminalSessionState Connecting = new(TerminalSessionPhase.Connecting);
+    public static TerminalSessionState Attached(string? readOnlyReason) => new(TerminalSessionPhase.Attached, readOnlyReason, ReadOnly: readOnlyReason is not null);
+    public static readonly TerminalSessionState DetachedState = new(TerminalSessionPhase.Detached);
+    public static TerminalSessionState Exited(int code) => new(TerminalSessionPhase.Exited, ExitCode: code);
+    public static TerminalSessionState Failed(string message) => new(TerminalSessionPhase.Failed, message);
+    public static readonly TerminalSessionState SessionEnded = new(TerminalSessionPhase.SessionEnded);
+}

--- a/src/Capacitor.App/Services/Utf8StreamDecoder.cs
+++ b/src/Capacitor.App/Services/Utf8StreamDecoder.cs
@@ -1,0 +1,24 @@
+namespace Capacitor.App.Services;
+
+using System.Text;
+
+/// One incremental UTF-8 stream per attach attempt: PTY frames split multibyte
+/// code points at arbitrary boundaries, and the terminal control's Feed does a
+/// fresh GetString per call — this is the single decoder spanning the snapshot
+/// and every live frame, flushed only at terminal completion.
+public sealed class Utf8StreamDecoder {
+    readonly Decoder _decoder = Encoding.UTF8.GetDecoder();
+
+    public string Decode(ReadOnlySpan<byte> bytes) {
+        if (bytes.IsEmpty) return "";
+        var chars = new char[Encoding.UTF8.GetMaxCharCount(bytes.Length)];
+        var n = _decoder.GetChars(bytes, chars, flush: false);
+        return new string(chars, 0, n);
+    }
+
+    public string Flush() {
+        var chars = new char[4];
+        var n = _decoder.GetChars(ReadOnlySpan<byte>.Empty, chars, flush: true);
+        return new string(chars, 0, n);
+    }
+}

--- a/src/Capacitor.App/Services/Utf8StreamDecoder.cs
+++ b/src/Capacitor.App/Services/Utf8StreamDecoder.cs
@@ -8,12 +8,16 @@ using System.Text;
 /// and every live frame, flushed only at terminal completion.
 public sealed class Utf8StreamDecoder {
     readonly Decoder _decoder = Encoding.UTF8.GetDecoder();
+    // Grow-only scratch, safe because delivery is strictly sequential (one reader pump):
+    // without it every frame pays a second allocation beyond the result string.
+    char[] _scratch = new char[256];
 
     public string Decode(ReadOnlySpan<byte> bytes) {
         if (bytes.IsEmpty) return "";
-        var chars = new char[Encoding.UTF8.GetMaxCharCount(bytes.Length)];
-        var n = _decoder.GetChars(bytes, chars, flush: false);
-        return new string(chars, 0, n);
+        var need = Encoding.UTF8.GetMaxCharCount(bytes.Length);
+        if (_scratch.Length < need) _scratch = new char[need];
+        var n = _decoder.GetChars(bytes, _scratch, flush: false);
+        return new string(_scratch, 0, n);
     }
 
     public string Flush() {

--- a/src/Capacitor.App/Services/WorkspaceTeardownTracker.cs
+++ b/src/Capacitor.App/Services/WorkspaceTeardownTracker.cs
@@ -1,0 +1,59 @@
+namespace Capacitor.App.Services;
+
+/// App-lifetime registry of asynchronous workspace teardowns — the piece the synchronous
+/// disposal pass cannot express. Sealed at shutdown drain.
+public sealed class WorkspaceTeardownTracker(TimeProvider time, Action<string, Exception>? diagnostics = null) {
+    static readonly TimeSpan DrainBound = TimeSpan.FromSeconds(5);
+
+    readonly Lock _lock = new();
+    readonly Lock _diagnosticsLock = new();
+    readonly List<Task> _pending = [];
+    bool _sealed;
+    Task? _drain;
+
+    /// Registers and starts observing a teardown. Post-seal: the teardown is executed and
+    /// observed immediately rather than refused — belt-and-braces, a path that slips past the
+    /// shutdown latch must still not hold a socket. Pre- and post-seal run through the exact
+    /// same observed task, so there is one execution path, never two.
+    public void Track(Func<Task> teardown) {
+        var task = ObserveAsync(teardown);
+        lock (_lock) {
+            if (!_sealed) _pending.Add(task);
+        }
+    }
+
+    async Task ObserveAsync(Func<Task> teardown) {
+        try {
+            await teardown().ConfigureAwait(false);
+        } catch (Exception ex) {
+            Report("workspace teardown", ex);
+        }
+    }
+
+    // Losing/faulting teardowns land here exactly once; a throwing sink is contained so it
+    // can never poison the drain or a sibling teardown.
+    void Report(string context, Exception ex) {
+        if (diagnostics is null) return;
+        lock (_diagnosticsLock) {
+            try { diagnostics(context, ex); } catch { /* contained by contract */ }
+        }
+    }
+
+    /// Seals atomically (no registration races past the snapshot), awaits all pending
+    /// teardowns bounded by 5 seconds total, then returns. Idempotent.
+    public Task DrainAsync() {
+        lock (_lock) {
+            if (_drain is not null) return _drain;
+            _sealed = true;
+            var snapshot = _pending.ToArray();
+            return _drain = WaitBoundedAsync(snapshot);
+        }
+    }
+
+    // Every teardown already consumes and logs its own fault inside ObserveAsync, so
+    // Task.WhenAll here never faults — this only ever races the drain bound. A straggler left
+    // running past the bound keeps the same observer, so its eventual fault (or success) is
+    // still consumed exactly once, just later.
+    async Task WaitBoundedAsync(Task[] snapshot) =>
+        await Task.WhenAny(Task.WhenAll(snapshot), Task.Delay(DrainBound, time)).ConfigureAwait(false);
+}

--- a/src/Capacitor.App/Services/XtermTerminalSurface.cs
+++ b/src/Capacitor.App/Services/XtermTerminalSurface.cs
@@ -20,6 +20,11 @@ public sealed class XtermTerminalSurface : ITerminalSurface {
     public event Action<byte[]>? InputProduced;
     public event Action<int, int>? Resized;
 
+    // Terminal (the SvcSystems wrapper), not the model itself — the model has no direct Cols/Rows
+    // of its own (Task 8 discovery); Terminal.Cols/Rows are live, tracking every resize applied
+    // via Model.Terminal.Resize(cols, rows).
+    public (int Cols, int Rows) CurrentSize => (Model.Terminal.Cols, Model.Terminal.Rows);
+
     public XtermTerminalSurface(int cols, int rows) {
         Model = new TerminalControlModel(new TerminalOptions {
             Cols = cols,

--- a/src/Capacitor.App/Services/XtermTerminalSurface.cs
+++ b/src/Capacitor.App/Services/XtermTerminalSurface.cs
@@ -39,6 +39,8 @@ public sealed class XtermTerminalSurface : ITerminalSurface {
 
     public void Feed(string text) => Model.Feed(text);
 
+    public void EnsureCaretVisible() => Model.Terminal.Engine.CursorVisible = true;
+
     void OnUserInput(object? sender, TerminalUserInputEventArgs e) =>
         InputProduced?.Invoke(e.Data.ToArray());
 

--- a/src/Capacitor.App/Services/XtermTerminalSurface.cs
+++ b/src/Capacitor.App/Services/XtermTerminalSurface.cs
@@ -1,0 +1,48 @@
+namespace Capacitor.App.Services;
+
+using System.Text;
+using SvcSystems.UI.Terminal;
+
+/// Production ITerminalSurface wrapping SvcSystems.UI.Terminal's TerminalControlModel.
+///
+/// InputProduced fans in TWO distinct sources, both discovered in Task 8 and neither
+/// re-exposing the other: TerminalControlModel.UserInput (keyboard/mouse-originated bytes,
+/// ReadOnlyMemory&lt;byte&gt; already) and Terminal.Engine.DataReceived (terminal-originated
+/// protocol replies, e.g. a DSR/CPR answer — only reachable via the raw XTerm.NET engine
+/// object, which neither the SvcSystems Terminal wrapper nor the model re-expose; its payload
+/// is a string that must be UTF-8 encoded before it can join the same byte[] event). Both are
+/// needed for a correct PTY round trip: dropping either one silently breaks either keystrokes
+/// or terminal-side query/response protocols (cursor position reports, etc.).
+public sealed class XtermTerminalSurface : ITerminalSurface {
+    /// The VM-owned model handle the view binds (Task 12).
+    public TerminalControlModel Model { get; }
+
+    public event Action<byte[]>? InputProduced;
+    public event Action<int, int>? Resized;
+
+    public XtermTerminalSurface(int cols, int rows) {
+        Model = new TerminalControlModel(new TerminalOptions {
+            Cols = cols,
+            Rows = rows,
+            ReflowOnResize = false,
+        });
+
+        Model.UserInput += OnUserInput;
+        Model.SizeChanged += OnSizeChanged;
+        Model.Terminal.Engine.DataReceived += OnDataReceived;
+    }
+
+    public void Feed(string text) => Model.Feed(text);
+
+    void OnUserInput(object? sender, TerminalUserInputEventArgs e) =>
+        InputProduced?.Invoke(e.Data.ToArray());
+
+    // Terminal-originated protocol reply (DSR/CPR etc.) — the engine hands back a decoded
+    // string, not bytes; the PTY side needs bytes, so encode here rather than push the
+    // encoding concern onto every consumer of InputProduced.
+    void OnDataReceived(object? sender, XTerm.Events.TerminalEvents.DataEventArgs e) =>
+        InputProduced?.Invoke(Encoding.UTF8.GetBytes(e.Data));
+
+    void OnSizeChanged(object? sender, TerminalSizeChangedEventArgs e) =>
+        Resized?.Invoke(e.Cols, e.Rows);
+}

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -36,10 +36,18 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// a storage key only.
     public const string ScratchRepoPath = "";
 
+    /// A launch that started but handed back an id nothing can open. The session is real and running
+    /// — it just has to be reached from the session list, so this is a launch-succeeded wording, not
+    /// a failure one (spec §3, entry-point guards).
+    public const string UnusableIdMessage = "Launched, but the session id was unusable — open it from the session list.";
+
     readonly IDaemonClientService _daemon;
     readonly IAppStateStore _state;
     readonly ILaunchClient _launch;
     readonly Func<Task<string[]>> _knownRepos;
+    readonly Action<string>? _openSession;
+    readonly Func<int>? _navigationGeneration;
+    readonly Action<string, int>? _openSessionIfCurrent;
     readonly CompositeDisposable _disposables = new();
 
     string _selectedRepoPath = ScratchRepoPath;
@@ -94,14 +102,31 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// knownRepos is RepoPathStore.GetSortedPathsAsync in production — the same persisted list
     /// DaemonConnect.RepoPaths feeds the server's launch dialog. Required (no defaulted overload)
     /// so a test can never silently read the developer's own ~/.config/kcap/repos.json.
+    /// <param name="openSession">
+    /// A session card's click (MainWindowViewModel.OpenSession). Null leaves the cards inert — a
+    /// HomeViewModel with no window to navigate.
+    /// </param>
+    /// <param name="navigationGeneration">
+    /// Read BEFORE the launch call, never after: the captured value is what makes a success that
+    /// lands after the user navigated away open nothing (spec §3).
+    /// </param>
+    /// <param name="openSessionIfCurrent">
+    /// The launch auto-open (MainWindowViewModel.OpenSessionIfCurrent), carrying that captured
+    /// generation.
+    /// </param>
     public HomeViewModel(
             IDaemonClientService daemon, IAppStateStore state, ILaunchClient launch,
-            Func<Task<string[]>> knownRepos, CancellationToken shutdown = default) {
+            Func<Task<string[]>> knownRepos, CancellationToken shutdown = default,
+            Action<string>? openSession = null, Func<int>? navigationGeneration = null,
+            Action<string, int>? openSessionIfCurrent = null) {
         _daemon = daemon;
         _state = state;
         _launch = launch;
         _knownRepos = knownRepos;
         _shutdown = shutdown;
+        _openSession = openSession;
+        _navigationGeneration = navigationGeneration;
+        _openSessionIfCurrent = openSessionIfCurrent;
 
         // Never starts empty: a null SupportedVendors means "daemon
         // capability unknown", not "hosts nothing" — Build(null) offers everything until the first
@@ -193,16 +218,37 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         SelectedVendor = Lookup(saved.HarnessByRepo, repoPath) ?? DefaultVendor;
     }
 
+    /// A session card's click (HomeView routes it here). No generation is involved — the click IS
+    /// the current navigation, unlike the launch auto-open below.
+    public void OpenSessionRequested(string agentId) => _openSession?.Invoke(agentId);
+
     async Task StartAsync() {
         var request = new LaunchRequest(_daemon.DaemonName, SelectedRepoPath, SelectedVendor, Goal);
+        // Captured BEFORE the call, never after (spec §3): the whole point is to notice a navigation
+        // that happened WHILE the launch was in flight.
+        var generation = _navigationGeneration?.Invoke() ?? 0;
+
         var outcome = await _launch.StartAsync(request, _shutdown);
-        if (outcome.Started) {
-            StartError = null;
-            Goal = "";
-        } else {
+        if (!outcome.Started) {
             StartError = outcome.Error;
+            return;
         }
+
+        StartError = null;
+        Goal = ""; // the launch really did start — the goal is spent either way
+        if (!IsWellFormedAgentId(outcome.AgentId)) {
+            StartError = UnusableIdMessage;
+            return;
+        }
+
+        _openSessionIfCurrent?.Invoke(outcome.AgentId!, generation);
     }
+
+    /// The daemon mints agent ids as Guid("N") — 32 hex digits. Anything else cannot address a
+    /// session, so it never reaches OpenSession (which would otherwise build a workspace that can
+    /// only ever resolve to "session not found").
+    internal static bool IsWellFormedAgentId(string? agentId) =>
+        agentId is { Length: 32 } && agentId.All(Uri.IsHexDigit);
 
     /// Repo paths compare the way the filesystem underneath them does: case-insensitively on
     /// Windows and macOS, case-sensitively on Linux where two checkouts differing only in case are

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -236,19 +236,21 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
 
         StartError = null;
         Goal = ""; // the launch really did start — the goal is spent either way
-        if (!IsWellFormedAgentId(outcome.AgentId)) {
+        if (NormalizeAgentId(outcome.AgentId) is not { } agentId) {
             StartError = UnusableIdMessage;
             return;
         }
 
-        _openSessionIfCurrent?.Invoke(outcome.AgentId!, generation);
+        _openSessionIfCurrent?.Invoke(agentId, generation);
     }
 
-    /// The daemon mints agent ids as Guid("N") — 32 hex digits. Anything else cannot address a
-    /// session, so it never reaches OpenSession (which would otherwise build a workspace that can
-    /// only ever resolve to "session not found").
-    internal static bool IsWellFormedAgentId(string? agentId) =>
-        agentId is { Length: 32 } && agentId.All(Uri.IsHexDigit);
+    /// The daemon's status cache keys agents by Guid("N") — 32 hex digits — but the server hub
+    /// returns the launch id as a DASHED Guid, so the shapes must be normalized here or the
+    /// Resolving gate can never match the cache entry. Anything Guid.TryParse rejects cannot
+    /// address a session and never reaches OpenSession (which would otherwise build a workspace
+    /// that can only ever resolve to "session not found").
+    internal static string? NormalizeAgentId(string? agentId) =>
+        Guid.TryParse(agentId, out var parsed) ? parsed.ToString("N") : null;
 
     /// Repo paths compare the way the filesystem underneath them does: case-insensitively on
     /// Windows and macOS, case-sensitively on Linux where two checkouts differing only in case are

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -244,13 +244,16 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         _openSessionIfCurrent?.Invoke(agentId, generation);
     }
 
-    /// The daemon's status cache keys agents by Guid("N") — 32 hex digits — but the server hub
-    /// returns the launch id as a DASHED Guid, so the shapes must be normalized here or the
-    /// Resolving gate can never match the cache entry. Anything Guid.TryParse rejects cannot
-    /// address a session and never reaches OpenSession (which would otherwise build a workspace
-    /// that can only ever resolve to "session not found").
+    /// Id shapes differ across the stack and across daemon versions: the server hub has returned
+    /// DASHED Guids while a production daemon keys its status cache on SHORT (8-hex) ids — so a
+    /// Guid in any format is normalized to "N" (the Guid-keyed daemons' cache shape), and any
+    /// other non-empty id passes through VERBATIM to match whatever the daemon actually sent.
+    /// Only a null/blank id is unusable; an id that matches nothing degrades gracefully in the
+    /// workspace ("session not found" with retry), which beats a red error under a live card.
     internal static string? NormalizeAgentId(string? agentId) =>
-        Guid.TryParse(agentId, out var parsed) ? parsed.ToString("N") : null;
+        Guid.TryParse(agentId, out var parsed) ? parsed.ToString("N")
+        : string.IsNullOrWhiteSpace(agentId) ? null
+        : agentId;
 
     /// Repo paths compare the way the filesystem underneath them does: case-insensitively on
     /// Windows and macOS, case-sensitively on Linux where two checkouts differing only in case are

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -117,6 +117,27 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     /// tolerates a null DataContext, same as any other unbound view.
     public HomeViewModel? Home { get; }
 
+    readonly NavigationGate _navigation;
+    readonly Action<Func<Task>> _trackTeardown;
+    readonly Func<string, WorkspaceViewModel>? _workspaceFactory;
+
+    WorkspaceViewModel? _currentWorkspace;
+    /// null = the tabbed shell has the window; non-null = that session's workspace does. Exactly
+    /// one workspace at a time, and this VM owns it: every swap starts the outgoing one's tracked
+    /// teardown (spec §3).
+    public WorkspaceViewModel? CurrentWorkspace {
+        get => _currentWorkspace;
+        private set => this.RaiseAndSetIfChanged(ref _currentWorkspace, value);
+    }
+
+    /// The launch auto-open's staleness token — see NavigationGate. Read from the SHARED gate, not
+    /// a per-window counter, so a window built after shutdown began sees the latch too.
+    public int NavigationGeneration => _navigation.Generation;
+
+    /// Bound to WorkspaceView's Back button (the VM injects it into every workspace it builds), and
+    /// the same command the coordinator's close paths route through.
+    public ReactiveCommand<Unit, Unit> CloseWorkspaceCommand { get; }
+
     ObservableAsPropertyHelper<bool>? _gridEnabled;
     public bool GridEnabled => _gridEnabled?.Value ?? false;
 
@@ -162,15 +183,37 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     /// cleared by the identical Connected-transition rule below. Null (most existing tests, and
     /// any caller without a live lifecycle controller) means this lane never receives anything.
     /// </param>
+    /// <param name="navigation">
+    /// The composition root's app-lifetime NavigationGate (spec §3). Null builds a private one, so
+    /// a caller with no navigation of its own (most existing tests) still gets a working VM — but
+    /// only a SHARED gate makes the shutdown latch reach a window built after shutdown began.
+    /// </param>
+    /// <param name="trackWorkspaceTeardown">
+    /// WorkspaceTeardownTracker.Track, as a delegate: this VM only ever registers a teardown, never
+    /// drains, and the delegate keeps the drain (a composition-root concern) off its surface. Null
+    /// falls back to running the teardown untracked — never to skipping it, or a swap would strand
+    /// a live attach.
+    /// </param>
+    /// <param name="workspaceFactory">
+    /// Builds the workspace for an agent id (the production one wires the daemon socket's attach
+    /// client and the xterm surface). Null means this window cannot navigate to a workspace at all
+    /// — every existing caller that predates workspaces stays on the tabbed shell.
+    /// </param>
     public MainWindowViewModel(
             IDaemonClientService service, AgentActionService actions, ITicker ticker,
             CancellationToken shutdownToken, ActivityViewModel activity, Func<CancellationToken, Task>? startAction = null,
-            IObservable<string?>? lifecycleStatus = null, TimeProvider? time = null, HomeViewModel? home = null) {
+            IObservable<string?>? lifecycleStatus = null, TimeProvider? time = null, HomeViewModel? home = null,
+            NavigationGate? navigation = null, Action<Func<Task>>? trackWorkspaceTeardown = null,
+            Func<string, WorkspaceViewModel>? workspaceFactory = null) {
         _service = service;
         _time = time ?? TimeProvider.System;
         Agents = new ReadOnlyObservableCollection<AgentRowViewModel>(_agentsSource);
         Activity = activity;
         Home = home;
+        _navigation = navigation ?? new NavigationGate();
+        _trackTeardown = trackWorkspaceTeardown ?? RunUntracked;
+        _workspaceFactory = workspaceFactory;
+        CloseWorkspaceCommand = ReactiveCommand.Create(CloseWorkspace);
 
         // ReactiveCommand's own CanExecute observable already ANDs the supplied canExecute with
         // "not currently executing" (confirmed against the installed ReactiveUI 23.2.28 API
@@ -306,6 +349,62 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
                 .Subscribe()
                 .DisposeWith(disposables);
         });
+    }
+
+    /// Card click and Back's counterpart: swaps the window to this session's workspace, starting the
+    /// tracked teardown of whatever it replaces. Refused once shutdown has latched — a new workspace
+    /// is a new attach, and quiesce/disposal is already running (spec §3).
+    public void OpenSession(string agentId) {
+        if (_navigation.ShutdownLatched || _workspaceFactory is null) return;
+
+        var workspace = _workspaceFactory(agentId);
+        workspace.BackCommand = CloseWorkspaceCommand;
+        SwapTo(workspace);
+    }
+
+    /// The launch auto-open. `generation` is what the launch captured BEFORE its call: a success
+    /// arriving after any navigation (Back, another session, close-to-hide, the shutdown latch)
+    /// opens nothing, rather than attaching an invisible terminal or replacing what the user opened
+    /// while the launch was in flight.
+    public void OpenSessionIfCurrent(string agentId, int generation) {
+        if (generation != _navigation.Generation) return;
+        OpenSession(agentId);
+    }
+
+    /// Back, and the coordinator's close paths. Bumps unconditionally — a close-to-hide with no
+    /// workspace open must still retire an in-flight launch's captured generation.
+    public void CloseWorkspace() => SwapTo(null);
+
+    /// The first shutdown pass, synchronously: unhook the live workspace and register its teardown
+    /// BEFORE the drain seals the tracker, then latch the gate so no later window can open another
+    /// one. A workspace that never went through Back or close-to-hide would otherwise register its
+    /// teardown after the drain, against already-disposed dependencies (spec §3).
+    public void LatchShutdown() {
+        var live = CurrentWorkspace;
+        CurrentWorkspace = null;
+        _navigation.Latch();
+        if (live is not null) _trackTeardown(live.TeardownAsync);
+    }
+
+    void SwapTo(WorkspaceViewModel? next) {
+        var outgoing = CurrentWorkspace;
+        CurrentWorkspace = next;
+        _navigation.Bump();
+        if (outgoing is not null) _trackTeardown(outgoing.TeardownAsync);
+    }
+
+    // A VM built without a tracker (a test, or any caller predating workspaces) must still not
+    // strand a live attach: run the teardown and observe its fault exactly like the tracker's own
+    // wrapper does. The teardown is bounded by TerminalTabViewModel's own budget, so this cannot
+    // run away.
+    static void RunUntracked(Func<Task> teardown) {
+        try {
+            _ = teardown().ContinueWith(
+                t => Console.Error.WriteLine($"kcap app: untracked workspace teardown failed: {t.Exception}"),
+                CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap app: untracked workspace teardown failed: {ex}");
+        }
     }
 
     static string? ReasonText(AttachStatus status) => status.State switch {

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -301,9 +301,13 @@ public sealed class TerminalTabViewModel : ReactiveObject {
             // never call the factory for a retired attempt.
             if (Retired(generation)) return;
 
-            var client = _factory(
+            // Declared before assignment so OnAttachedAsync's closure below can capture it -- by
+            // the time that callback actually runs (after an Attach reply), the factory call
+            // this closure is an argument OF will already have returned and assigned it.
+            ITerminalAttachClient client = null!;
+            client = _factory(
                 _agentId,
-                (snapshot, reason, ct) => OnAttachedAsync(generation, surface, decoder, snapshot, reason, ct),
+                (snapshot, reason, ct) => OnAttachedAsync(generation, client, surface, decoder, snapshot, reason, ct),
                 (bytes, ct) => OnOutputAsync(generation, surface, decoder, bytes, ct));
 
             // One more check right before publishing: a retirement landing exactly between the
@@ -344,12 +348,24 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         };
     }
 
-    async Task OnAttachedAsync(int generation, ITerminalSurface surface, Utf8StreamDecoder decoder, byte[] snapshot, string? reason, CancellationToken ct) {
+    async Task OnAttachedAsync(int generation, ITerminalAttachClient client, ITerminalSurface surface, Utf8StreamDecoder decoder, byte[] snapshot, string? reason, CancellationToken ct) {
         var text = decoder.Decode(snapshot);
         await Dispatcher.UIThread.InvokeAsync(() => {
             if (generation != _attemptGeneration) return;
             surface.Feed(text);
             State = TerminalSessionState.Attached(reason);
+
+            // RunAsync's own initial cols/rows are the phantom DefaultCols/Rows constant -- the
+            // client's post-attach nudge (AgentAttachClient's own "repaint nudge") fires at that
+            // size because the real pane size is never known before RunAsync starts (the surface's
+            // Model-assignment resize fires before WireSurface even subscribes). Correct it here,
+            // once, at the surface's OWN current size -- read-only never influences the PTY's
+            // clamp, so no nudge for it (mirrors AgentAttachClient's own AttachedReadOnly case,
+            // which sends no nudge at all). Fire-and-forget: ResizeAsync never throws by contract
+            // (guarded internally, same as WireSurface's user-driven resize below), and the
+            // generation check above already retires a stale attempt's call -- a later retirement
+            // simply makes this a no-op, never a use of a stale VM field.
+            if (reason is null) _ = client.ResizeAsync(surface.CurrentSize.Cols, surface.CurrentSize.Rows);
         }, DispatcherPriority.Default, ct);
     }
 

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -221,24 +221,12 @@ public sealed class TerminalTabViewModel : ReactiveObject {
                 // Disposal wins permanently: never render a note for a tab TeardownAsync already
                 // tore down (a concurrent teardown could land while this hop is in flight).
                 if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
-                State = TerminalSessionState.NoTerminal(NoteFor(dto));
+                State = TerminalSessionState.NoTerminal(HostedHarnessCatalog.NoTerminalNote(dto.HasTerminal, dto.Vendor));
             });
             return;
         }
 
         await TryStartAttemptAsync().ConfigureAwait(false);
-    }
-
-    /// Suffixed only when the family is reliably known: ACP is ("This session runs over ACP");
-    /// the rpc/"chat" bucket also covers claude/codex/any unmapped vendor whose has_terminal came
-    /// back false for a reason this build can't classify further, so it gets no family token at
-    /// all rather than leaking "RPC" (an internal transport name, not a user-facing concept).
-    /// Internal (not private): WorkspaceViewModel's NoTerminalNote reuses this verbatim rather
-    /// than re-deriving the same wording from a second copy.
-    internal static string NoteFor(AgentStatusDto dto) {
-        const string bare = "This session has no terminal.";
-        var family = HostedHarnessCatalog.EffectiveFamily(dto.HasTerminal, dto.Vendor);
-        return family == "acp" ? "This session runs over ACP — no terminal to attach to." : bare;
     }
 
     /// Attach or reattach: retires whatever attempt is current (cancel + await-dispose its

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -1,0 +1,367 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using ReactiveUI;
+using System.Reactive;
+
+namespace Capacitor.App.ViewModels;
+
+/// One terminal tab: resolves the agent's terminal capability against the daemon's Agents cache,
+/// then drives the attach/reattach/detach lifecycle over ITerminalAttachClient. Constructed once
+/// per tab (like HomeViewModel/ActivityViewModel), not gated behind IActivatableViewModel — the
+/// resolve gate and the Agents-cache watch must be live from construction, and TeardownAsync
+/// (not Dispose/WhenActivated) is the one lifecycle exit a tab tracker calls when the tab closes.
+///
+/// State machine (TerminalSessionPhase): Resolving -> {NoTerminal | NotFound | Connecting} ->
+/// {Attached -> Detached/Exited/Failed/SessionEnded}. Two independent linearizations guard it:
+///
+/// * Resolve gate (_resolveState, CAS 0 pending/1 dto-won/2 timeout-won/3 disposed): the FIRST of
+///   {a DTO observed, the 10s TimeProvider timeout, TeardownAsync} wins; the loser no-ops. A
+///   timeout-win disposes the Agents subscription outright (a late DTO then has nothing to reach
+///   -- RetryResolveCommand is the only way back in). A dto-win leaves the subscription alive so a
+///   LATER removal can still render SessionEnded.
+/// * Attempt lifecycle (_attemptGeneration): every attach/reattach bumps it; a completion whose
+///   captured generation no longer matches the current one is a retired attempt and mutates
+///   nothing (silent, not an error). _attachLane (SemaphoreSlim(1,1), TRY-entered via Wait(0) --
+///   never awaited) single-flights the swap: two ReattachCommand.Execute() calls issued before the
+///   first has reached its own await point collapse to exactly one new client, because
+///   ReactiveCommand.Execute() invokes its Func&lt;Task&gt; eagerly and unconditionally (verified
+///   against the installed ReactiveUI 23.2.28 IL -- Execute() does NOT consult CanExecute/
+///   IsExecuting), so a queueing WaitAsync() here would let a double-click spawn two real clients.
+///   A call that loses the try-enter is a clean no-op, not a queued retry.
+///
+/// UI affinity: the resolve gate mutates State after ObserveOn(RxSchedulers.MainThreadScheduler)
+/// or RxSchedulers.MainThreadScheduler.Schedule(...) (the TimeProvider timer fires off-thread in
+/// production, synchronously on the CALLING thread under FakeTimeProvider.Advance -- Schedule onto
+/// MainThreadScheduler is what makes that synchronous under WithImmediateRxScheduler too). Every
+/// attempt-lifecycle mutation (the swap, OnAttached/OnOutput's Feed, the outcome mapping) goes
+/// through Dispatcher.UIThread.InvokeAsync awaited with the attempt's own token -- these arrive
+/// from the attach client's own async continuations, which carry no Rx scheduler affinity at all.
+public sealed class TerminalTabViewModel : ReactiveObject {
+    const int ResolvePending = 0, ResolveDtoWon = 1, ResolveTimeoutWon = 2, ResolveDisposed = 3;
+
+    static readonly TimeSpan ResolveBudget = TimeSpan.FromSeconds(10);
+    static readonly TimeSpan DetachBound   = TimeSpan.FromSeconds(1);
+    static readonly TimeSpan TeardownBudget = TimeSpan.FromSeconds(3);
+
+    const int DefaultCols = 80, DefaultRows = 24;
+
+    readonly string _agentId;
+    readonly IDaemonClientService _daemon;
+    readonly TerminalAttachClientFactory _factory;
+    readonly Func<ITerminalSurface> _surfaceFactory;
+    readonly TimeProvider _time;
+
+    // Try-entered only (Wait(0)/Release), never WaitAsync -- see the class doc comment.
+    readonly SemaphoreSlim _attachLane = new(1, 1);
+
+    int _resolveState;
+    IDisposable? _agentsSub;
+    ITimer? _resolveTimer;
+
+    int _attemptGeneration;
+    ITerminalAttachClient? _client;
+    CancellationTokenSource? _attemptCts;
+    Task? _runTask;
+
+    TerminalSessionState _state = TerminalSessionState.Resolving;
+    /// Bound; mutated only on the UI scheduler (see class doc comment).
+    public TerminalSessionState State {
+        get => _state;
+        private set => this.RaiseAndSetIfChanged(ref _state, value);
+    }
+
+    ITerminalSurface? _surface;
+    /// The VM-owned model handle the view binds -- a fresh instance per attempt, assigned on the
+    /// UI scheduler before the attempt's RunAsync starts.
+    public ITerminalSurface? Surface {
+        get => _surface;
+        private set => this.RaiseAndSetIfChanged(ref _surface, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> ReattachCommand { get; }
+    public ReactiveCommand<Unit, Unit> DetachCommand { get; }
+    public ReactiveCommand<Unit, Unit> RetryResolveCommand { get; }
+
+    /// Test-only seam: the in-flight resolve-triggered work (the has_terminal gate's Dispatcher
+    /// hop, or the first attach attempt's swap) so a test can await the exact completion the
+    /// Agents-cache push kicked off, instead of a fixed delay. Null once settled.
+    internal Task? PendingResolveWorkForTesting { get; private set; }
+
+    /// Test-only seam: the current attempt's RunAttemptAsync task (attach + pump + outcome
+    /// mapping) -- awaited after driving a fake client's Result/RunStarted from outside.
+    internal Task? CurrentRunForTesting => _runTask;
+
+    public TerminalTabViewModel(
+            string agentId, IDaemonClientService daemon, TerminalAttachClientFactory factory,
+            Func<ITerminalSurface> surfaceFactory, TimeProvider time) {
+        _agentId = agentId;
+        _daemon = daemon;
+        _factory = factory;
+        _surfaceFactory = surfaceFactory;
+        _time = time;
+
+        ReattachCommand = ReactiveCommand.CreateFromTask(TryStartAttemptAsync);
+        DetachCommand = ReactiveCommand.CreateFromTask(RunDetachAsync);
+        RetryResolveCommand = ReactiveCommand.CreateFromTask(RetryResolveAsync);
+
+        // Alive for the VM's whole lifetime UNLESS the timeout wins (disposed there) or
+        // TeardownAsync runs -- a dto-win leaves it live so a LATER removal renders SessionEnded.
+        _agentsSub = daemon.Agents.Connect()
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(OnAgentsChanged);
+
+        _resolveTimer = time.CreateTimer(_ => OnResolveTimeout(), null, ResolveBudget, Timeout.InfiniteTimeSpan);
+    }
+
+    void OnAgentsChanged(IChangeSet<AgentStatusDto, string> changes) {
+        foreach (var change in changes) {
+            if (change.Key != _agentId) continue;
+            switch (change.Reason) {
+                case ChangeReason.Add or ChangeReason.Update:
+                    HandleDtoObserved(change.Current);
+                    break;
+                case ChangeReason.Remove:
+                    HandleAgentRemoved();
+                    break;
+            }
+        }
+    }
+
+    void HandleDtoObserved(AgentStatusDto dto) {
+        // Only the FIRST observation is a resolve-gate event; a later update (status text, etc.)
+        // after the gate already decided is not re-run through it.
+        if (Interlocked.CompareExchange(ref _resolveState, ResolveDtoWon, ResolvePending) != ResolvePending) return;
+
+        _resolveTimer?.Dispose();
+        _resolveTimer = null;
+
+        PendingResolveWorkForTesting = ApplyResolvedDtoAsync(dto);
+    }
+
+    void HandleAgentRemoved() {
+        // Meaningful only once resolved via a DTO (not a pending or timed-out gate, which have
+        // their own terminal renderings already).
+        if (Volatile.Read(ref _resolveState) != ResolveDtoWon) return;
+        // Signal precedence: the run's own Exited/Failed verdict outranks a cache removal.
+        if (State.Phase is TerminalSessionPhase.Exited or TerminalSessionPhase.Failed) return;
+
+        State = TerminalSessionState.SessionEnded;
+    }
+
+    void OnResolveTimeout() {
+        if (Interlocked.CompareExchange(ref _resolveState, ResolveTimeoutWon, ResolvePending) != ResolvePending) return;
+
+        _agentsSub?.Dispose();
+        _agentsSub = null;
+
+        // The timer callback fires off-thread in production and synchronously on the CALLING
+        // thread under FakeTimeProvider.Advance -- Schedule (not a raw write) is what keeps this
+        // on the UI scheduler either way, and synchronous under WithImmediateRxScheduler's
+        // ImmediateScheduler so a test can assert right after Advance() returns.
+        RxSchedulers.MainThreadScheduler.Schedule(() => State = TerminalSessionState.NotFound);
+    }
+
+    async Task RetryResolveAsync() {
+        if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
+
+        var lookup = _daemon.Agents.Lookup(_agentId);
+        if (!lookup.HasValue) return;
+
+        Volatile.Write(ref _resolveState, ResolveDtoWon);
+        // A prior timeout disposed this; retrying re-arms live removal-watching too.
+        _agentsSub ??= _daemon.Agents.Connect()
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(OnAgentsChanged);
+
+        await ApplyResolvedDtoAsync(lookup.Value).ConfigureAwait(false);
+    }
+
+    async Task ApplyResolvedDtoAsync(AgentStatusDto dto) {
+        if (!HostedHarnessCatalog.ShowsTerminal(dto.HasTerminal, dto.Vendor)) {
+            await Dispatcher.UIThread.InvokeAsync(() => State = TerminalSessionState.NoTerminal(NoteFor(dto)));
+            return;
+        }
+
+        await TryStartAttemptAsync().ConfigureAwait(false);
+    }
+
+    static string NoteFor(AgentStatusDto dto) {
+        var family = HostedHarnessCatalog.EffectiveFamily(dto.HasTerminal, dto.Vendor).ToUpperInvariant();
+        return $"This session runs over {family} — no terminal to attach to.";
+    }
+
+    /// Attach or reattach: retires whatever attempt is current (cancel + await-dispose its
+    /// client), then swaps in a fresh surface/decoder and starts a new one. Try-entered only --
+    /// see the class doc comment for why a losing call is a silent no-op, not a queued retry.
+    async Task TryStartAttemptAsync() {
+        if (!_attachLane.Wait(0)) return;
+        try {
+            var prevClient = _client;
+            var prevCts = _attemptCts;
+            prevCts?.Cancel();
+            if (prevClient is not null) {
+                try { await prevClient.DisposeAsync().ConfigureAwait(false); }
+                catch { /* contained -- teardown diagnostic only, never VM state */ }
+            }
+
+            var generation = Interlocked.Increment(ref _attemptGeneration);
+            var cts = new CancellationTokenSource();
+            _attemptCts = cts;
+
+            // Construction happens INSIDE the dispatch, not just the property assignment: the
+            // surface factory wraps an Avalonia-affine control model (Task 11/12), so even
+            // building it off the UI thread would be unsafe -- not only assigning it.
+            var (surface, decoder) = await Dispatcher.UIThread.InvokeAsync(() => {
+                var s = _surfaceFactory();
+                var d = new Utf8StreamDecoder();
+                Surface = s;
+                State = TerminalSessionState.Connecting;
+                return (s, d);
+            }, DispatcherPriority.Default, cts.Token);
+
+            var client = _factory(
+                _agentId,
+                (snapshot, reason, ct) => OnAttachedAsync(generation, surface, decoder, snapshot, reason, ct),
+                (bytes, ct) => OnOutputAsync(generation, surface, decoder, bytes, ct));
+            _client = client;
+            WireSurface(surface, client, generation);
+
+            _runTask = RunAttemptAsync(generation, client, cts.Token);
+        } catch (OperationCanceledException) {
+            // Retired before the swap even finished (e.g. TeardownAsync raced this call) --
+            // expected, not an error.
+        } finally {
+            _attachLane.Release();
+        }
+    }
+
+    void WireSurface(ITerminalSurface surface, ITerminalAttachClient client, int generation) {
+        // Read-only is belt and braces: the client itself also guards SendInputAsync/ResizeAsync,
+        // but suppressing here means a read-only attach never even attempts the round trip.
+        surface.InputProduced += bytes => {
+            if (generation != _attemptGeneration || State.ReadOnly) return;
+            _ = client.SendInputAsync(bytes);
+        };
+        surface.Resized += (cols, rows) => {
+            if (generation != _attemptGeneration || State.ReadOnly) return;
+            _ = client.ResizeAsync(cols, rows);
+        };
+    }
+
+    async Task OnAttachedAsync(int generation, ITerminalSurface surface, Utf8StreamDecoder decoder, byte[] snapshot, string? reason, CancellationToken ct) {
+        var text = decoder.Decode(snapshot);
+        await Dispatcher.UIThread.InvokeAsync(() => {
+            if (generation != _attemptGeneration) return;
+            surface.Feed(text);
+            State = TerminalSessionState.Attached(reason);
+        }, DispatcherPriority.Default, ct);
+    }
+
+    async Task OnOutputAsync(int generation, ITerminalSurface surface, Utf8StreamDecoder decoder, byte[] bytes, CancellationToken ct) {
+        var text = decoder.Decode(bytes);
+        await Dispatcher.UIThread.InvokeAsync(() => {
+            if (generation != _attemptGeneration) return;
+            surface.Feed(text);
+        }, DispatcherPriority.Default, ct);
+    }
+
+    async Task RunAttemptAsync(int generation, ITerminalAttachClient client, CancellationToken ct) {
+        AttachOutcome outcome;
+        try {
+            outcome = await client.RunAsync(DefaultCols, DefaultRows, ct).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            return; // retired attempt's own cancellation -- silent, never an error
+        } catch (AttachCallbackException ex) {
+            await ApplyOutcomeStateAsync(generation, TerminalSessionState.Failed(Describe(ex))).ConfigureAwait(false);
+            return;
+        } catch (Exception ex) {
+            await ApplyOutcomeStateAsync(generation, TerminalSessionState.Failed(ex.Message)).ConfigureAwait(false);
+            return;
+        }
+
+        var mapped = outcome switch {
+            AttachOutcome.Detached          => TerminalSessionState.DetachedState,
+            AttachOutcome.Exited(var code)   => TerminalSessionState.Exited(code),
+            AttachOutcome.Failed(var msg)    => TerminalSessionState.Failed(msg),
+            AttachOutcome.ConnectionLost    => TerminalSessionState.Failed("the terminal lost connection to the daemon"),
+            _                                => TerminalSessionState.Failed("unknown attach outcome"),
+        };
+        await ApplyOutcomeStateAsync(generation, mapped).ConfigureAwait(false);
+    }
+
+    static string Describe(AttachCallbackException ex) => ex.InnerException?.Message ?? ex.Message;
+
+    // CancellationToken.None deliberately: a retired attempt's generation check (inside the
+    // dispatched action) already guards correctness, and the outcome must still apply when the
+    // attempt's own token is cancelled but the generation is still current (e.g. a graceful
+    // Detached racing TeardownAsync's early cts.Cancel()).
+    Task ApplyOutcomeStateAsync(int generation, TerminalSessionState state) =>
+        Dispatcher.UIThread.InvokeAsync(() => {
+            if (generation != _attemptGeneration) return;
+            State = state;
+        }, DispatcherPriority.Default, CancellationToken.None).GetTask();
+
+    async Task RunDetachAsync() {
+        var client = _client;
+        if (client is null) return;
+        try { await client.DetachAsync().ConfigureAwait(false); }
+        catch (Exception ex) { Console.Error.WriteLine($"kcap: terminal detach failed: {ex.Message}"); }
+    }
+
+    /// Bounded teardown (Task 13's tracker calls this when the tab closes): generation bump so any
+    /// still-in-flight completion becomes silently retired, detach bounded to 1s, DisposeAsync
+    /// immediately after regardless of whether the detach write landed, then the REMAINDER of a
+    /// 3s total budget awaiting the run task. Either bound abandons rather than blocks: an
+    /// abandoned task's later fault is observed once (Console.Error) and never re-enters VM state.
+    public async Task TeardownAsync() {
+        if (Interlocked.Exchange(ref _resolveState, ResolveDisposed) == ResolveDisposed) return; // idempotent
+
+        _agentsSub?.Dispose();
+        _agentsSub = null;
+        _resolveTimer?.Dispose();
+        _resolveTimer = null;
+
+        Interlocked.Increment(ref _attemptGeneration);
+
+        var client = _client;
+        var cts = _attemptCts;
+        var runTask = _runTask;
+        _client = null;
+        _attemptCts = null;
+
+        cts?.Cancel();
+
+        var start = _time.GetUtcNow();
+        if (client is not null) {
+            var detach = client.DetachAsync();
+            var detachWinner = await Task.WhenAny(detach, Task.Delay(DetachBound, _time)).ConfigureAwait(false);
+            if (!ReferenceEquals(detachWinner, detach)) ObserveAbandoned(detach, "detach");
+
+            try { await client.DisposeAsync().ConfigureAwait(false); }
+            catch { /* contained -- teardown diagnostic only */ }
+        }
+        cts?.Dispose();
+
+        if (runTask is not null) {
+            var elapsed = _time.GetUtcNow() - start;
+            var remaining = TeardownBudget - elapsed;
+            if (remaining < TimeSpan.Zero) remaining = TimeSpan.Zero;
+
+            var runWinner = await Task.WhenAny(runTask, Task.Delay(remaining, _time)).ConfigureAwait(false);
+            if (!ReferenceEquals(runWinner, runTask)) ObserveAbandoned(runTask, "run");
+        }
+        _runTask = null;
+
+        await Dispatcher.UIThread.InvokeAsync(() => { Surface = null; });
+    }
+
+    static void ObserveAbandoned(Task task, string label) =>
+        _ = task.ContinueWith(t => {
+            if (t.IsFaulted && t.Exception?.InnerException is { } ex and not OperationCanceledException)
+                Console.Error.WriteLine($"kcap: terminal attach teardown: abandoned {label} faulted: {ex.Message}");
+        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+}

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -28,9 +28,9 @@ namespace Capacitor.App.ViewModels;
 ///   nothing (silent, not an error). _attachLane (SemaphoreSlim(1,1), TRY-entered via Wait(0) --
 ///   never awaited) single-flights the swap: two ReattachCommand.Execute() calls issued before the
 ///   first has reached its own await point collapse to exactly one new client, because
-///   ReactiveCommand.Execute() invokes its Func&lt;Task&gt; eagerly and unconditionally (verified
-///   against the installed ReactiveUI 23.2.28 IL -- Execute() does NOT consult CanExecute/
-///   IsExecuting), so a queueing WaitAsync() here would let a double-click spawn two real clients.
+///   ReactiveCommand.Execute() invokes its Func&lt;Task&gt; eagerly, without consulting
+///   CanExecute/IsExecuting, so a queueing WaitAsync() here would let a double-click spawn two
+///   real clients.
 ///   A call that loses the try-enter is a clean no-op, not a queued retry.
 ///
 /// UI affinity: the resolve gate mutates State after ObserveOn(RxSchedulers.MainThreadScheduler)

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -233,7 +233,9 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     /// the rpc/"chat" bucket also covers claude/codex/any unmapped vendor whose has_terminal came
     /// back false for a reason this build can't classify further, so it gets no family token at
     /// all rather than leaking "RPC" (an internal transport name, not a user-facing concept).
-    static string NoteFor(AgentStatusDto dto) {
+    /// Internal (not private): WorkspaceViewModel's NoTerminalNote reuses this verbatim rather
+    /// than re-deriving the same wording from a second copy.
+    internal static string NoteFor(AgentStatusDto dto) {
         const string bare = "This session has no terminal.";
         var family = HostedHarnessCatalog.EffectiveFamily(dto.HasTerminal, dto.Vendor);
         return family == "acp" ? "This session runs over ACP — no terminal to attach to." : bare;

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -367,6 +367,8 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         await Dispatcher.UIThread.InvokeAsync(() => {
             if (generation != _attemptGeneration) return;
             surface.Feed(text);
+            // AFTER the snapshot: the replay itself carries the TUI's own cursor-hide.
+            surface.EnsureCaretVisible();
             State = TerminalSessionState.Attached(reason);
         }, DispatcherPriority.Default, ct);
     }

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -139,7 +139,28 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         _resolveTimer?.Dispose();
         _resolveTimer = null;
 
-        PendingResolveWorkForTesting = ApplyResolvedDtoAsync(dto);
+        PendingResolveWorkForTesting = RunResolveWorkAsync(dto);
+    }
+
+    /// Fault-observing wrapper around ApplyResolvedDtoAsync: this Task is fire-and-forget from
+    /// HandleDtoObserved in production (nothing else awaits it there), so an unhandled fault
+    /// (e.g. the surface factory throwing inside the swap) would otherwise be an unobserved task
+    /// exception AND leave the tab stuck in Resolving forever. A non-OCE fault renders as a local
+    /// Failed instead -- but only if nothing else has since moved the tab past Resolving (a
+    /// concurrent attempt that legitimately succeeded must never be clobbered by a stale fault).
+    async Task RunResolveWorkAsync(AgentStatusDto dto) {
+        try {
+            await ApplyResolvedDtoAsync(dto).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            // Retired/torn down mid-resolve -- expected, not an error.
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: terminal resolve failed: {ex.Message}");
+            await Dispatcher.UIThread.InvokeAsync(() => {
+                if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
+                if (State.Phase != TerminalSessionPhase.Resolving) return;
+                State = TerminalSessionState.Failed($"couldn't open the terminal: {ex.Message}");
+            });
+        }
     }
 
     void HandleAgentRemoved() {
@@ -165,41 +186,77 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         RxSchedulers.MainThreadScheduler.Schedule(() => State = TerminalSessionState.NotFound);
     }
 
+    /// CAS (not read-then-write): only a timed-out gate is eligible for retry, and only if
+    /// nothing else -- least of all a concurrent TeardownAsync -- has since claimed the slot. A
+    /// plain Volatile.Write here would resurrect a gate TeardownAsync already disposed (setting
+    /// it back to dto-won and re-arming a subscription teardown already tore down), and Retry is
+    /// also meaningless from an already-resolved (dto-won) gate -- it must never layer a second
+    /// attach attempt on top of one that already succeeded.
     async Task RetryResolveAsync() {
-        if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
+        if (Interlocked.CompareExchange(ref _resolveState, ResolveDtoWon, ResolveTimeoutWon) != ResolveTimeoutWon) return;
 
         var lookup = _daemon.Agents.Lookup(_agentId);
-        if (!lookup.HasValue) return;
+        if (!lookup.HasValue) {
+            // Nothing to resolve against yet -- restore timeout-won (CAS, so a concurrent
+            // TeardownAsync's Disposed still wins permanently over this restore) so a later
+            // retry can try again.
+            Interlocked.CompareExchange(ref _resolveState, ResolveTimeoutWon, ResolveDtoWon);
+            return;
+        }
 
-        Volatile.Write(ref _resolveState, ResolveDtoWon);
-        // A prior timeout disposed this; retrying re-arms live removal-watching too.
+        // Re-check right before touching the subscription: a concurrent TeardownAsync may have
+        // disposed it already (it always wins the CAS above too, since Disposed != TimeoutWon --
+        // this only guards a teardown landing in the tiny window between the CAS and here).
+        if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
         _agentsSub ??= _daemon.Agents.Connect()
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(OnAgentsChanged);
 
-        await ApplyResolvedDtoAsync(lookup.Value).ConfigureAwait(false);
+        await RunResolveWorkAsync(lookup.Value).ConfigureAwait(false);
     }
 
     async Task ApplyResolvedDtoAsync(AgentStatusDto dto) {
         if (!HostedHarnessCatalog.ShowsTerminal(dto.HasTerminal, dto.Vendor)) {
-            await Dispatcher.UIThread.InvokeAsync(() => State = TerminalSessionState.NoTerminal(NoteFor(dto)));
+            await Dispatcher.UIThread.InvokeAsync(() => {
+                // Disposal wins permanently: never render a note for a tab TeardownAsync already
+                // tore down (a concurrent teardown could land while this hop is in flight).
+                if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
+                State = TerminalSessionState.NoTerminal(NoteFor(dto));
+            });
             return;
         }
 
         await TryStartAttemptAsync().ConfigureAwait(false);
     }
 
+    /// Suffixed only when the family is reliably known: ACP is ("This session runs over ACP");
+    /// the rpc/"chat" bucket also covers claude/codex/any unmapped vendor whose has_terminal came
+    /// back false for a reason this build can't classify further, so it gets no family token at
+    /// all rather than leaking "RPC" (an internal transport name, not a user-facing concept).
     static string NoteFor(AgentStatusDto dto) {
-        var family = HostedHarnessCatalog.EffectiveFamily(dto.HasTerminal, dto.Vendor).ToUpperInvariant();
-        return $"This session runs over {family} — no terminal to attach to.";
+        const string bare = "This session has no terminal.";
+        var family = HostedHarnessCatalog.EffectiveFamily(dto.HasTerminal, dto.Vendor);
+        return family == "acp" ? "This session runs over ACP — no terminal to attach to." : bare;
     }
 
     /// Attach or reattach: retires whatever attempt is current (cancel + await-dispose its
     /// client), then swaps in a fresh surface/decoder and starts a new one. Try-entered only --
     /// see the class doc comment for why a losing call is a silent no-op, not a queued retry.
+    ///
+    /// Disposal wins permanently, which this method has TWO suspension points to prove against
+    /// (the previous client's await-dispose, and the UI swap): a TeardownAsync landing in either
+    /// window must neither leak a live, undisposed client (nothing would ever dispose it again --
+    /// TeardownAsync is idempotent) nor let this attempt publish over what teardown already tore
+    /// down. Every suspension point is followed by a re-check of BOTH `_resolveState ==
+    /// ResolveDisposed` (teardown ran, at any point, regardless of generation ordering) and
+    /// `generation != _attemptGeneration` (a DIFFERENT concurrent attempt retired this one, the
+    /// pre-existing non-teardown case) -- disposing anything this attempt already built before
+    /// bailing.
     async Task TryStartAttemptAsync() {
         if (!_attachLane.Wait(0)) return;
         try {
+            if (Retired(0)) return; // teardown may have already run before this call got the lane
+
             var prevClient = _client;
             var prevCts = _attemptCts;
             prevCts?.Cancel();
@@ -208,29 +265,56 @@ public sealed class TerminalTabViewModel : ReactiveObject {
                 catch { /* contained -- teardown diagnostic only, never VM state */ }
             }
 
+            // Suspension point 1: TeardownAsync may have landed while the previous client's
+            // dispose was in flight.
+            if (Retired(0)) return;
+
             var generation = Interlocked.Increment(ref _attemptGeneration);
             var cts = new CancellationTokenSource();
+            // Hoisted once: TeardownAsync never disposes an attempt's CTS (a disposed
+            // CancellationTokenSource's .Token getter, and Register on any token sourced from
+            // it, both throw ObjectDisposedException regardless of when the token was captured),
+            // so this single read stays valid for the rest of the attempt's life.
+            var token = cts.Token;
             _attemptCts = cts;
 
-            // Construction happens INSIDE the dispatch, not just the property assignment: the
-            // surface factory wraps an Avalonia-affine control model (Task 11/12), so even
-            // building it off the UI thread would be unsafe -- not only assigning it.
-            var (surface, decoder) = await Dispatcher.UIThread.InvokeAsync(() => {
-                var s = _surfaceFactory();
-                var d = new Utf8StreamDecoder();
-                Surface = s;
-                State = TerminalSessionState.Connecting;
-                return (s, d);
-            }, DispatcherPriority.Default, cts.Token);
+            ITerminalSurface surface;
+            Utf8StreamDecoder decoder;
+            try {
+                // Construction happens INSIDE the dispatch, not just the property assignment: the
+                // surface factory wraps an Avalonia-affine control model (Task 11/12), so even
+                // building it off the UI thread would be unsafe -- not only assigning it.
+                (surface, decoder) = await Dispatcher.UIThread.InvokeAsync(() => {
+                    var s = _surfaceFactory();
+                    var d = new Utf8StreamDecoder();
+                    Surface = s;
+                    State = TerminalSessionState.Connecting;
+                    return (s, d);
+                }, DispatcherPriority.Default, token);
+            } catch (OperationCanceledException) {
+                return; // retired before the swap even finished
+            }
+
+            // Suspension point 2 (the one most likely to straddle a concurrent TeardownAsync):
+            // never call the factory for a retired attempt.
+            if (Retired(generation)) return;
 
             var client = _factory(
                 _agentId,
                 (snapshot, reason, ct) => OnAttachedAsync(generation, surface, decoder, snapshot, reason, ct),
                 (bytes, ct) => OnOutputAsync(generation, surface, decoder, bytes, ct));
+
+            // One more check right before publishing: a retirement landing exactly between the
+            // (synchronous) factory call above and here must still not leak the client it built.
+            if (Retired(generation)) {
+                try { await client.DisposeAsync().ConfigureAwait(false); }
+                catch { /* contained */ }
+                return;
+            }
+
             _client = client;
             WireSurface(surface, client, generation);
-
-            _runTask = RunAttemptAsync(generation, client, cts.Token);
+            _runTask = RunAttemptAsync(generation, client, surface, decoder, token);
         } catch (OperationCanceledException) {
             // Retired before the swap even finished (e.g. TeardownAsync raced this call) --
             // expected, not an error.
@@ -238,6 +322,12 @@ public sealed class TerminalTabViewModel : ReactiveObject {
             _attachLane.Release();
         }
     }
+
+    /// True once TeardownAsync has run (permanently), or once a DIFFERENT concurrent attempt has
+    /// retired the one identified by `generation` (0 means "no attempt identity yet" -- only the
+    /// disposal half applies). See TryStartAttemptAsync's doc comment for why both are checked.
+    bool Retired(int generation) =>
+        Volatile.Read(ref _resolveState) == ResolveDisposed || (generation != 0 && generation != _attemptGeneration);
 
     void WireSurface(ITerminalSurface surface, ITerminalAttachClient client, int generation) {
         // Read-only is belt and braces: the client itself also guards SendInputAsync/ResizeAsync,
@@ -269,17 +359,17 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         }, DispatcherPriority.Default, ct);
     }
 
-    async Task RunAttemptAsync(int generation, ITerminalAttachClient client, CancellationToken ct) {
+    async Task RunAttemptAsync(int generation, ITerminalAttachClient client, ITerminalSurface surface, Utf8StreamDecoder decoder, CancellationToken ct) {
         AttachOutcome outcome;
         try {
             outcome = await client.RunAsync(DefaultCols, DefaultRows, ct).ConfigureAwait(false);
         } catch (OperationCanceledException) {
             return; // retired attempt's own cancellation -- silent, never an error
         } catch (AttachCallbackException ex) {
-            await ApplyOutcomeStateAsync(generation, TerminalSessionState.Failed(Describe(ex))).ConfigureAwait(false);
+            await FinishAttemptAsync(generation, surface, decoder, TerminalSessionState.Failed(Describe(ex))).ConfigureAwait(false);
             return;
         } catch (Exception ex) {
-            await ApplyOutcomeStateAsync(generation, TerminalSessionState.Failed(ex.Message)).ConfigureAwait(false);
+            await FinishAttemptAsync(generation, surface, decoder, TerminalSessionState.Failed(ex.Message)).ConfigureAwait(false);
             return;
         }
 
@@ -290,7 +380,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
             AttachOutcome.ConnectionLost    => TerminalSessionState.Failed("the terminal lost connection to the daemon"),
             _                                => TerminalSessionState.Failed("unknown attach outcome"),
         };
-        await ApplyOutcomeStateAsync(generation, mapped).ConfigureAwait(false);
+        await FinishAttemptAsync(generation, surface, decoder, mapped).ConfigureAwait(false);
     }
 
     static string Describe(AttachCallbackException ex) => ex.InnerException?.Message ?? ex.Message;
@@ -299,9 +389,18 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     // dispatched action) already guards correctness, and the outcome must still apply when the
     // attempt's own token is cancelled but the generation is still current (e.g. a graceful
     // Detached racing TeardownAsync's early cts.Cancel()).
-    Task ApplyOutcomeStateAsync(int generation, TerminalSessionState state) =>
+    //
+    // Flushes the decoder here too, not just on every live frame: a terminal completion (Exited,
+    // ConnectionLost, a mapped Failed) can land with a multibyte code point still buffered inside
+    // the decoder's own carry-over state (Utf8StreamDecoder.Decode never flushes on its own), and
+    // nothing else in this VM ever calls Flush -- without it, that trailing partial sequence is
+    // silently dropped instead of rendering (typically as U+FFFD, same as any other genuinely
+    // truncated stream).
+    Task FinishAttemptAsync(int generation, ITerminalSurface surface, Utf8StreamDecoder decoder, TerminalSessionState state) =>
         Dispatcher.UIThread.InvokeAsync(() => {
             if (generation != _attemptGeneration) return;
+            var remainder = decoder.Flush();
+            if (remainder.Length > 0) surface.Feed(remainder);
             State = state;
         }, DispatcherPriority.Default, CancellationToken.None).GetTask();
 
@@ -313,10 +412,20 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     }
 
     /// Bounded teardown (Task 13's tracker calls this when the tab closes): generation bump so any
-    /// still-in-flight completion becomes silently retired, detach bounded to 1s, DisposeAsync
-    /// immediately after regardless of whether the detach write landed, then the REMAINDER of a
-    /// 3s total budget awaiting the run task. Either bound abandons rather than blocks: an
-    /// abandoned task's later fault is observed once (Console.Error) and never re-enters VM state.
+    /// still-in-flight completion becomes silently retired, then detach/dispose/the run task each
+    /// draw from a SINGLE 3s-total budget in turn (detach itself additionally capped at 1s) --
+    /// every step abandons rather than blocks once its share is exhausted: an abandoned task's
+    /// later fault is observed once (Console.Error) and never re-enters VM state. DisposeAsync
+    /// specifically MUST share this budget, not run unbounded inside it -- the real client's
+    /// DisposeAsync awaits its own pump to fully unwind, which is exactly the thing the budget
+    /// exists to bound.
+    ///
+    /// Deliberately never disposes `cts`: TryStartAttemptAsync may still be straddling this same
+    /// attempt (reading its hoisted token) when teardown lands, and a disposed
+    /// CancellationTokenSource throws ObjectDisposedException from BOTH re-reading .Token and
+    /// registering a callback on any token sourced from it, regardless of when that token was
+    /// captured -- cancelling it is enough; a small leaked CTS (no timer, no WaitHandle ever
+    /// touched) is the acceptable trade against a straddling attempt crashing the app.
     public async Task TeardownAsync() {
         if (Interlocked.Exchange(ref _resolveState, ResolveDisposed) == ResolveDisposed) return; // idempotent
 
@@ -336,27 +445,40 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         cts?.Cancel();
 
         var start = _time.GetUtcNow();
+        TimeSpan Remaining() {
+            var left = TeardownBudget - (_time.GetUtcNow() - start);
+            return left < TimeSpan.Zero ? TimeSpan.Zero : left;
+        }
+
         if (client is not null) {
             var detach = client.DetachAsync();
             var detachWinner = await Task.WhenAny(detach, Task.Delay(DetachBound, _time)).ConfigureAwait(false);
             if (!ReferenceEquals(detachWinner, detach)) ObserveAbandoned(detach, "detach");
 
-            try { await client.DisposeAsync().ConfigureAwait(false); }
-            catch { /* contained -- teardown diagnostic only */ }
+            var dispose = client.DisposeAsync().AsTask();
+            var disposeWinner = await Task.WhenAny(dispose, Task.Delay(Remaining(), _time)).ConfigureAwait(false);
+            if (ReferenceEquals(disposeWinner, dispose)) {
+                // Completed within budget -- still observe (never re-throw) a fault the same way
+                // the old direct-await's containment did.
+                if (dispose.IsFaulted) _ = dispose.Exception;
+            } else {
+                ObserveAbandoned(dispose, "dispose");
+            }
         }
-        cts?.Dispose();
 
         if (runTask is not null) {
-            var elapsed = _time.GetUtcNow() - start;
-            var remaining = TeardownBudget - elapsed;
-            if (remaining < TimeSpan.Zero) remaining = TimeSpan.Zero;
-
-            var runWinner = await Task.WhenAny(runTask, Task.Delay(remaining, _time)).ConfigureAwait(false);
+            var runWinner = await Task.WhenAny(runTask, Task.Delay(Remaining(), _time)).ConfigureAwait(false);
             if (!ReferenceEquals(runWinner, runTask)) ObserveAbandoned(runTask, "run");
         }
         _runTask = null;
 
-        await Dispatcher.UIThread.InvokeAsync(() => { Surface = null; });
+        // Bounded, not fire-and-forget: a test proving the surface reference is released depends
+        // on this having actually landed by the time TeardownAsync returns, and an unbounded
+        // await here would defeat the whole point of a bounded teardown if the dispatcher were
+        // ever wedged. Not carved from the (possibly already-exhausted) 3s above -- this is a
+        // trivial property set, not something that should ever race the run/dispose budget.
+        var clear = Dispatcher.UIThread.InvokeAsync(() => { Surface = null; }).GetTask();
+        await Task.WhenAny(clear, Task.Delay(DetachBound, _time)).ConfigureAwait(false);
     }
 
     static void ObserveAbandoned(Task task, string label) =>

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -280,6 +280,13 @@ public sealed class TerminalTabViewModel : ReactiveObject {
             var token = cts.Token;
             _attemptCts = cts;
 
+            // Pre-swap fallback -- overwritten below once the real surface exists. Never actually
+            // observed as RunAsync's argument on the success path (the only way past the dispatch
+            // below without a real surface is the OperationCanceledException catch, which returns
+            // before cols/rows are ever read), but keeps the constant genuinely load-bearing rather
+            // than a stray literal.
+            var (cols, rows) = (DefaultCols, DefaultRows);
+
             ITerminalSurface surface;
             Utf8StreamDecoder decoder;
             try {
@@ -297,17 +304,24 @@ public sealed class TerminalTabViewModel : ReactiveObject {
                 return; // retired before the swap even finished
             }
 
+            // By now the dispatched swap above has run the view's Model binding AND the control's
+            // own synchronous Model-assignment resize (Task 11/12) -- CurrentSize is the real pane
+            // size, not the phantom default above. Read it BEFORE RunAsync starts (not resent
+            // after Attached, final review I1/I1-rework): AgentAttachClient's own post-attach nudge
+            // writes at whatever size RunAsync was given, and the pump's OWN follow-on write beat a
+            // same-callback resend in practice -- last write wins on the wire, so a resend from
+            // inside OnAttachedAsync is a structurally defeated no-op. A never-laid-out first open
+            // still reads the ctor's own 80x24 (App.axaml.cs's XtermTerminalSurface(80, 24)) here
+            // too; WireSurface's Resized lane self-heals that once the control is actually measured.
+            (cols, rows) = surface.CurrentSize;
+
             // Suspension point 2 (the one most likely to straddle a concurrent TeardownAsync):
             // never call the factory for a retired attempt.
             if (Retired(generation)) return;
 
-            // Declared before assignment so OnAttachedAsync's closure below can capture it -- by
-            // the time that callback actually runs (after an Attach reply), the factory call
-            // this closure is an argument OF will already have returned and assigned it.
-            ITerminalAttachClient client = null!;
-            client = _factory(
+            var client = _factory(
                 _agentId,
-                (snapshot, reason, ct) => OnAttachedAsync(generation, client, surface, decoder, snapshot, reason, ct),
+                (snapshot, reason, ct) => OnAttachedAsync(generation, surface, decoder, snapshot, reason, ct),
                 (bytes, ct) => OnOutputAsync(generation, surface, decoder, bytes, ct));
 
             // One more check right before publishing: a retirement landing exactly between the
@@ -320,7 +334,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
 
             _client = client;
             WireSurface(surface, client, generation);
-            _runTask = RunAttemptAsync(generation, client, surface, decoder, token);
+            _runTask = RunAttemptAsync(generation, client, surface, decoder, cols, rows, token);
         } catch (OperationCanceledException) {
             // Retired before the swap even finished (e.g. TeardownAsync raced this call) --
             // expected, not an error.
@@ -348,24 +362,12 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         };
     }
 
-    async Task OnAttachedAsync(int generation, ITerminalAttachClient client, ITerminalSurface surface, Utf8StreamDecoder decoder, byte[] snapshot, string? reason, CancellationToken ct) {
+    async Task OnAttachedAsync(int generation, ITerminalSurface surface, Utf8StreamDecoder decoder, byte[] snapshot, string? reason, CancellationToken ct) {
         var text = decoder.Decode(snapshot);
         await Dispatcher.UIThread.InvokeAsync(() => {
             if (generation != _attemptGeneration) return;
             surface.Feed(text);
             State = TerminalSessionState.Attached(reason);
-
-            // RunAsync's own initial cols/rows are the phantom DefaultCols/Rows constant -- the
-            // client's post-attach nudge (AgentAttachClient's own "repaint nudge") fires at that
-            // size because the real pane size is never known before RunAsync starts (the surface's
-            // Model-assignment resize fires before WireSurface even subscribes). Correct it here,
-            // once, at the surface's OWN current size -- read-only never influences the PTY's
-            // clamp, so no nudge for it (mirrors AgentAttachClient's own AttachedReadOnly case,
-            // which sends no nudge at all). Fire-and-forget: ResizeAsync never throws by contract
-            // (guarded internally, same as WireSurface's user-driven resize below), and the
-            // generation check above already retires a stale attempt's call -- a later retirement
-            // simply makes this a no-op, never a use of a stale VM field.
-            if (reason is null) _ = client.ResizeAsync(surface.CurrentSize.Cols, surface.CurrentSize.Rows);
         }, DispatcherPriority.Default, ct);
     }
 
@@ -377,10 +379,10 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         }, DispatcherPriority.Default, ct);
     }
 
-    async Task RunAttemptAsync(int generation, ITerminalAttachClient client, ITerminalSurface surface, Utf8StreamDecoder decoder, CancellationToken ct) {
+    async Task RunAttemptAsync(int generation, ITerminalAttachClient client, ITerminalSurface surface, Utf8StreamDecoder decoder, int cols, int rows, CancellationToken ct) {
         AttachOutcome outcome;
         try {
-            outcome = await client.RunAsync(DefaultCols, DefaultRows, ct).ConfigureAwait(false);
+            outcome = await client.RunAsync(cols, rows, ct).ConfigureAwait(false);
         } catch (OperationCanceledException) {
             return; // retired attempt's own cancellation -- silent, never an error
         } catch (AttachCallbackException ex) {

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -110,13 +110,10 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         _showsTerminalTab = presence.Select(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
             .ToProperty(this, x => x.ShowsTerminalTab, initialValue: false)
             .DisposeWith(_disposables);
-        // TerminalTabViewModel.NoteFor is the one source for this wording (bare for a non-ACP
-        // family, " — runs over ACP" suffix only when the family is reliably known to be ACP,
-        // never a vendor name) -- reused verbatim rather than re-derived here. Blank whenever
-        // ShowsTerminalTab is true (or the dto isn't resolved yet): the note replaces the Terminal
-        // tab button in the tab strip, so it must never render alongside it.
+        // Blank whenever ShowsTerminalTab is true (or the dto isn't resolved yet): the note
+        // replaces the Terminal tab button in the tab strip, so it must never render alongside it.
         _noTerminalNote = presence
-            .Select(p => p.Dto is null || HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor) ? "" : TerminalTabViewModel.NoteFor(p.Dto))
+            .Select(p => p.Dto is null || HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor) ? "" : HostedHarnessCatalog.NoTerminalNote(p.Dto.HasTerminal, p.Dto.Vendor))
             .ToProperty(this, x => x.NoTerminalNote, "")
             .DisposeWith(_disposables);
         _sessionEnded = presence.Select(p => p.SessionEnded)

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -65,8 +65,8 @@ public sealed class WorkspaceViewModel : ReactiveObject {
     public ReactiveCommand<Unit, Unit> OpenInWebCommand { get; }
     public ReactiveCommand<Unit, Unit> StopCommand { get; }
 
-    // Task 14 injects this once the window owns navigation between Home and a workspace; null
-    // (button hidden/disabled) until then, so THIS view never has to be re-touched to wire it.
+    // Null (button hidden/disabled) until the window wires navigation externally -- kept settable
+    // so this view never has to be re-touched to wire it.
     ReactiveCommand<Unit, Unit>? _backCommand;
     public ReactiveCommand<Unit, Unit>? BackCommand {
         get => _backCommand;
@@ -110,11 +110,11 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         _showsTerminalTab = presence.Select(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
             .ToProperty(this, x => x.ShowsTerminalTab, initialValue: false)
             .DisposeWith(_disposables);
-        // TerminalTabViewModel.NoteFor is the one source for this wording (post-review rule: bare
-        // for a non-ACP family, " — runs over ACP" suffix only when the family is reliably known
-        // to be ACP, never a vendor name) -- reused verbatim rather than re-derived here. Blank
-        // whenever ShowsTerminalTab is true (or the dto isn't resolved yet): the note replaces the
-        // Terminal tab button in the tab strip, so it must never render alongside it.
+        // TerminalTabViewModel.NoteFor is the one source for this wording (bare for a non-ACP
+        // family, " — runs over ACP" suffix only when the family is reliably known to be ACP,
+        // never a vendor name) -- reused verbatim rather than re-derived here. Blank whenever
+        // ShowsTerminalTab is true (or the dto isn't resolved yet): the note replaces the Terminal
+        // tab button in the tab strip, so it must never render alongside it.
         _noTerminalNote = presence
             .Select(p => p.Dto is null || HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor) ? "" : TerminalTabViewModel.NoteFor(p.Dto))
             .ToProperty(this, x => x.NoTerminalNote, "")

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -1,0 +1,165 @@
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
+using System.Reactive.Linq;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+/// The session workspace: header (title/repo/vendor chip) + one Terminal tab, for a single agent
+/// id. Constructed once per workspace, like TerminalTabViewModel/HomeViewModel -- ctor-scoped, not
+/// WhenActivated -- since the header projections and the Terminal tab must be live from
+/// construction, not deferred to a window's activation.
+///
+/// Every header projection below derives from ONE Scan-based aggregate over a single Filter'd view
+/// of daemon.Agents.Connect() (filtered to this agent id, ObserveOn the UI scheduler BEFORE
+/// anything touches bound state -- the same rule every other daemon.Agents/Snapshots consumer in
+/// this app follows), multicast via Replay(1)/RefCount so the several OAPHs below share ONE
+/// subscription to the daemon's cache rather than each opening (and independently re-deriving
+/// state from) their own. Replay(1) specifically -- not Publish -- because the 8 downstream
+/// subscribers below all attach within the SAME synchronous constructor call: a plain Publish
+/// would only deliver an already-fired synchronous replay (e.g. the agent already being in the
+/// cache when this VM is built) to whichever subscriber happened to attach first, leaving the rest
+/// with no initial value until the NEXT change -- which may never come. Scan's own output already
+/// IS the complete current state (dto + sticky-ended), so replaying just the latest one to a late
+/// subscriber is exactly correct, unlike replaying a raw changeset to a fresh DynamicData query
+/// aggregator would be.
+///
+/// A removed agent id freezes its LAST known dto rather than blanking the header back to
+/// placeholders -- SessionEnded flips (sticky, mirroring TerminalTabViewModel's own
+/// Exited/Failed stickiness) but Title/RepoLabelText/VendorChip/etc keep identifying the session
+/// that just ended instead of reverting to "— · —".
+public sealed class WorkspaceViewModel : ReactiveObject {
+    const string UnresolvedKind = "unresolved";
+
+    sealed record AgentPresence(AgentStatusDto? Dto, bool SessionEnded);
+
+    public string AgentId { get; }
+
+    readonly ObservableAsPropertyHelper<string> _title;
+    public string Title => _title.Value;
+
+    readonly ObservableAsPropertyHelper<string> _repoLabelText;
+    public string RepoLabelText => _repoLabelText.Value;
+
+    readonly ObservableAsPropertyHelper<string> _vendorChip;
+    public string VendorChip => _vendorChip.Value;
+
+    readonly ObservableAsPropertyHelper<string> _familyDot;
+    public string FamilyDot => _familyDot.Value;
+
+    readonly ObservableAsPropertyHelper<bool> _showsTerminalTab;
+    public bool ShowsTerminalTab => _showsTerminalTab.Value;
+
+    readonly ObservableAsPropertyHelper<string> _noTerminalNote;
+    public string NoTerminalNote => _noTerminalNote.Value;
+
+    readonly ObservableAsPropertyHelper<bool> _sessionEnded;
+    public bool SessionEnded => _sessionEnded.Value;
+
+    public TerminalTabViewModel Terminal { get; }
+
+    public ReactiveCommand<Unit, Unit> OpenInWebCommand { get; }
+    public ReactiveCommand<Unit, Unit> StopCommand { get; }
+
+    // Task 14 injects this once the window owns navigation between Home and a workspace; null
+    // (button hidden/disabled) until then, so THIS view never has to be re-touched to wire it.
+    ReactiveCommand<Unit, Unit>? _backCommand;
+    public ReactiveCommand<Unit, Unit>? BackCommand {
+        get => _backCommand;
+        set => this.RaiseAndSetIfChanged(ref _backCommand, value);
+    }
+
+    readonly CompositeDisposable _disposables = new();
+
+    // Read by StopCommand at click time -- the DTO's own Kind decides protected-ness
+    // (AgentActionService.IsProtectedKind), so Stop must see whatever the LATEST resolved dto
+    // says, not a value captured once at construction.
+    AgentStatusDto? _latestDto;
+
+    public WorkspaceViewModel(
+            string agentId, IDaemonClientService daemon, AgentActionService actions,
+            TerminalAttachClientFactory factory, Func<ITerminalSurface> surfaceFactory, TimeProvider time) {
+        AgentId = agentId;
+        Terminal = new TerminalTabViewModel(agentId, daemon, factory, surfaceFactory, time);
+
+        var presence = daemon.Agents.Connect()
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Filter(dto => dto.Id == agentId)
+            .Scan(new AgentPresence(null, false), Accumulate)
+            .Replay(1)
+            .RefCount();
+
+        presence.Select(p => p.Dto).Subscribe(dto => _latestDto = dto).DisposeWith(_disposables);
+
+        _title = presence.Select(p => TitleFor(p.Dto))
+            .ToProperty(this, x => x.Title, TitleFor(null))
+            .DisposeWith(_disposables);
+        _repoLabelText = presence.Select(p => RepoLabel.Leaf(p.Dto?.RepoPath))
+            .ToProperty(this, x => x.RepoLabelText, RepoLabel.Leaf(null))
+            .DisposeWith(_disposables);
+        _vendorChip = presence.Select(p => VendorChipFor(p.Dto))
+            .ToProperty(this, x => x.VendorChip, VendorChipFor(null))
+            .DisposeWith(_disposables);
+        _familyDot = presence.Select(p => p.Dto is null ? "" : HostedHarnessCatalog.EffectiveFamily(p.Dto.HasTerminal, p.Dto.Vendor))
+            .ToProperty(this, x => x.FamilyDot, "")
+            .DisposeWith(_disposables);
+        _showsTerminalTab = presence.Select(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
+            .ToProperty(this, x => x.ShowsTerminalTab, initialValue: false)
+            .DisposeWith(_disposables);
+        // TerminalTabViewModel.NoteFor is the one source for this wording (post-review rule: bare
+        // for a non-ACP family, " — runs over ACP" suffix only when the family is reliably known
+        // to be ACP, never a vendor name) -- reused verbatim rather than re-derived here. Blank
+        // whenever ShowsTerminalTab is true (or the dto isn't resolved yet): the note replaces the
+        // Terminal tab button in the tab strip, so it must never render alongside it.
+        _noTerminalNote = presence
+            .Select(p => p.Dto is null || HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor) ? "" : TerminalTabViewModel.NoteFor(p.Dto))
+            .ToProperty(this, x => x.NoTerminalNote, "")
+            .DisposeWith(_disposables);
+        _sessionEnded = presence.Select(p => p.SessionEnded)
+            .ToProperty(this, x => x.SessionEnded, initialValue: false)
+            .DisposeWith(_disposables);
+
+        OpenInWebCommand = ReactiveCommand.Create(() => actions.OpenInWeb(agentId));
+        _disposables.Add(OpenInWebCommand);
+
+        StopCommand = ReactiveCommand.Create(() => {
+            var dto = _latestDto;
+            // UnresolvedKind fails safe as protected (AgentActionService.IsProtectedKind treats
+            // anything other than exactly "agent" as protected) -- the edge case of a Stop click
+            // before the first dto ever arrives must never default to the ONE kind that skips
+            // the confirm-then-force seam.
+            var kind = dto?.Kind ?? UnresolvedKind;
+            var label = dto is null ? agentId : $"{dto.Kind} · {dto.Vendor} · {RepoLabel.Leaf(dto.RepoPath)}";
+            actions.RequestStop(agentId, label, kind);
+        });
+        _disposables.Add(StopCommand);
+    }
+
+    static AgentPresence Accumulate(AgentPresence state, IChangeSet<AgentStatusDto, string> changes) {
+        var dto = state.Dto;
+        var ended = state.SessionEnded;
+        foreach (var change in changes) {
+            if (change.Reason == ChangeReason.Remove) { ended = true; continue; } // dto stays frozen
+            dto = change.Current;
+        }
+        return new AgentPresence(dto, ended);
+    }
+
+    static string TitleFor(AgentStatusDto? dto) => $"{RepoLabel.Leaf(dto?.RepoPath)} · {dto?.Vendor ?? "—"}";
+
+    static string VendorChipFor(AgentStatusDto? dto) {
+        if (dto is null) return "—";
+        return dto.Model is null ? dto.Vendor : $"{dto.Vendor} ({dto.Model})";
+    }
+
+    /// Disposes this workspace's own daemon-cache projections, then delegates to
+    /// Terminal.TeardownAsync() -- Task 13's tracker calls this once, when the tab closes.
+    public Task TeardownAsync() {
+        _disposables.Dispose();
+        return Terminal.TeardownAsync();
+    }
+}

--- a/src/Capacitor.App/Views/HomeView.axaml
+++ b/src/Capacitor.App/Views/HomeView.axaml
@@ -5,6 +5,23 @@
              x:Class="Capacitor.App.Views.HomeView"
              x:DataType="vm:HomeViewModel"
              Background="{StaticResource KcapCanvasBrush}">
+    <UserControl.Styles>
+        <!-- A session card is a Button purely so the whole card is a click target; every piece of
+             chrome the theme would paint (its own background/border, and the hover and pressed
+             fills it puts on PART_ContentPresenter) is neutralized here, so the card renders exactly
+             as it did before it became clickable. Style setters outrank the control theme's. -->
+        <Style Selector="Button.sessionCard">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="Button.sessionCard /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+        </Style>
+    </UserControl.Styles>
+
     <ScrollViewer>
         <StackPanel Margin="28" Spacing="20" MaxWidth="960" HorizontalAlignment="Stretch">
             <!-- Greeting row: Search and New session are decorative placeholders here (spec's own
@@ -78,22 +95,24 @@
                 </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="vm:SessionCardViewModel">
-                        <Border Width="260" Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                                BorderThickness="1" CornerRadius="10" Padding="14">
-                            <StackPanel Spacing="8">
-                                <StackPanel Orientation="Horizontal" Spacing="7">
-                                    <Ellipse Width="8" Height="8" Fill="{Binding StatusDot}" VerticalAlignment="Center" />
-                                    <TextBlock Text="{Binding Title}" FontWeight="Bold" Foreground="{StaticResource KcapTextBrush}"
-                                               TextTrimming="CharacterEllipsis" />
+                        <Button Classes="sessionCard" Click="OnSessionCardClick" ToolTip.Tip="Open this session">
+                            <Border Width="260" Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                    BorderThickness="1" CornerRadius="10" Padding="14">
+                                <StackPanel Spacing="8">
+                                    <StackPanel Orientation="Horizontal" Spacing="7">
+                                        <Ellipse Width="8" Height="8" Fill="{Binding StatusDot}" VerticalAlignment="Center" />
+                                        <TextBlock Text="{Binding Title}" FontWeight="Bold" Foreground="{StaticResource KcapTextBrush}"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+                                    <TextBlock Text="{Binding RepoFull}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
+                                               ToolTip.Tip="{Binding RepoFull}" TextTrimming="CharacterEllipsis" />
+                                    <Grid ColumnDefinitions="*,Auto">
+                                        <TextBlock Text="{Binding StatusText}" FontSize="11" Foreground="{StaticResource KcapPurpleBrush}" />
+                                        <TextBlock Grid.Column="1" Text="{Binding Age}" FontSize="10" Foreground="{StaticResource KcapMutedBrush}" />
+                                    </Grid>
                                 </StackPanel>
-                                <TextBlock Text="{Binding RepoFull}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
-                                           ToolTip.Tip="{Binding RepoFull}" TextTrimming="CharacterEllipsis" />
-                                <Grid ColumnDefinitions="*,Auto">
-                                    <TextBlock Text="{Binding StatusText}" FontSize="11" Foreground="{StaticResource KcapPurpleBrush}" />
-                                    <TextBlock Grid.Column="1" Text="{Binding Age}" FontSize="10" Foreground="{StaticResource KcapMutedBrush}" />
-                                </Grid>
-                            </StackPanel>
-                        </Border>
+                            </Border>
+                        </Button>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>

--- a/src/Capacitor.App/Views/HomeView.axaml.cs
+++ b/src/Capacitor.App/Views/HomeView.axaml.cs
@@ -18,6 +18,13 @@ public partial class HomeView : UserControl {
 
     void OnNewSessionClick(object? sender, RoutedEventArgs e) => GoalInput.Focus();
 
+    // The card's own DataContext (the item), not this view's: the click has to carry WHICH session
+    // was clicked, and the button lives inside the ItemsControl's item template.
+    void OnSessionCardClick(object? sender, RoutedEventArgs e) {
+        if (DataContext is HomeViewModel vm && (sender as Control)?.DataContext is SessionCardViewModel card)
+            vm.OpenSessionRequested(card.Id);
+    }
+
     // Repository picker: one flyout item per ListRepositoriesAsync entry — leaf name over full
     // path, remembered-harness pill on the right, per the settled design. The scratch entry and
     // the folder-picker affordance sit last, each behind a separator.

--- a/src/Capacitor.App/Views/MainWindow.axaml
+++ b/src/Capacitor.App/Views/MainWindow.axaml
@@ -9,147 +9,163 @@
                      Title="Kurrent Capacitor Desktop"
                      Icon="avares://Kurrent Capacitor/Assets/kcap-icon.png"
                      Width="840" Height="480">
-    <Grid Margin="20" RowDefinitions="Auto,*">
-        <StackPanel Grid.Row="0" Spacing="20">
-            <StackPanel Spacing="8">
-                <StackPanel Orientation="Horizontal" Spacing="6">
-                    <TextBlock x:Name="DaemonIdentityText" Text="{Binding DaemonName}" FontWeight="Bold" />
-                    <TextBlock Text="·" />
-                    <TextBlock x:Name="DaemonVersionText" Text="{Binding VersionDisplay}" ToolTip.Tip="{Binding DaemonVersion}" />
-                </StackPanel>
-
-                <TextBlock x:Name="ServerUrlText" Text="{Binding ServerUrl}" Opacity="0.7" />
-
-                <StackPanel Orientation="Horizontal" Spacing="6">
-                    <Ellipse Width="8" Height="8" Fill="{Binding StatusDotBrush}" VerticalAlignment="Center" />
-                    <TextBlock x:Name="ConnectionText" Text="{Binding ConnectionDisplay}" VerticalAlignment="Center" />
-                    <TextBlock x:Name="AgentCountText" Text="{Binding AgentCountText, StringFormat='· {0}'}"
-                               IsVisible="{Binding GridEnabled}" VerticalAlignment="Center" />
-                </StackPanel>
-            </StackPanel>
-
-            <StackPanel Spacing="8">
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Button x:Name="StartButton" Content="Start daemon" Command="{Binding StartDaemonCommand}" IsVisible="{Binding StartVisible}" />
-                    <Button x:Name="RetryButton" Content="Retry" Command="{Binding RetryCommand}" IsVisible="{Binding RetryVisible}" />
-                </StackPanel>
-
-                <TextBlock x:Name="StartMessageText" Text="{Binding StartMessage}"
-                           IsVisible="{Binding StartMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                <TextBlock x:Name="ReasonText" Text="{Binding Reason}"
-                           IsVisible="{Binding Reason, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-            </StackPanel>
-        </StackPanel>
-
-        <!-- Tabs (spec §7): Home | Agents | Activity. Home is the default selection.
-             SelectionChanged is wired in code-behind (MainWindow.axaml.cs) so the Activity tab's
-             refresh cadence tracks both tab selection and the window's own on-screen state. -->
-        <TabControl Grid.Row="1" x:Name="MainTabs" Margin="0,8,0,0" SelectionChanged="OnTabSelectionChanged">
-            <TabItem x:Name="HomeTabItem" Header="Home">
-                <views:HomeView DataContext="{Binding Home}" />
-            </TabItem>
-
-            <TabItem Header="Agents">
-                <!-- The ENTIRE pre-existing agents block, unchanged: control names preserved so
-                     the existing smoke tests keep finding them in the window's name scope. -->
-                <Grid RowDefinitions="Auto,*">
-                    <StackPanel Grid.Row="0" Spacing="8">
-                        <Border Height="1" Background="{DynamicResource SystemControlForegroundBaseHighBrush}" Opacity="0.7" />
-                        <TextBlock Text="Agents" FontSize="14" FontWeight="Bold" />
-
-                        <TextBlock x:Name="EmptyStateText" Text="No agents running">
-                            <TextBlock.IsVisible>
-                                <MultiBinding Converter="{x:Static views:EmptyStateVisibleConverter.Instance}">
-                                    <Binding Path="GridEnabled" />
-                                    <Binding Path="Agents.Count" />
-                                </MultiBinding>
-                            </TextBlock.IsVisible>
-                        </TextBlock>
+    <!-- Two surfaces, one window (spec §3): the tabbed shell while CurrentWorkspace is null, that
+         session's workspace while it is not. The workspace side is a ContentControl over a template
+         rather than an always-present WorkspaceView, so the terminal control is CONSTRUCTED only
+         once a session is opened instead of sitting hidden in every window that never opens one. -->
+    <Panel>
+        <Grid Margin="20" RowDefinitions="Auto,*"
+              IsVisible="{Binding CurrentWorkspace, Converter={x:Static ObjectConverters.IsNull}}">
+            <StackPanel Grid.Row="0" Spacing="20">
+                <StackPanel Spacing="8">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <TextBlock x:Name="DaemonIdentityText" Text="{Binding DaemonName}" FontWeight="Bold" />
+                        <TextBlock Text="·" />
+                        <TextBlock x:Name="DaemonVersionText" Text="{Binding VersionDisplay}" ToolTip.Tip="{Binding DaemonVersion}" />
                     </StackPanel>
 
-                    <!-- Row "*" (bounded height, unlike a StackPanel child which Avalonia always
-                         measures with infinite height) is what lets this ScrollViewer's
-                         VerticalScrollBarVisibility actually engage. Fixed column widths total
-                         ~770px — wider than the default window's content area — so both
-                         scrollbars are Auto: horizontal reaches the Actions column when the
-                         window is narrower than the grid, vertical reaches every row when there
-                         are more than fit the window's height. -->
-                    <ScrollViewer Grid.Row="1" Margin="0,8,0,0"
-                                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
-                        <StackPanel x:Name="AgentsGrid" Opacity="{Binding GridEnabled, Converter={x:Static views:GridEnabledOpacityConverter.Instance}}">
-                            <Grid x:Name="AgentsGridHeader" ColumnDefinitions="80,140,140,100,90,70,150" Margin="0,0,0,4"
-                                  IsVisible="{Binding Agents.Count, Converter={x:Static views:HeaderRowVisibleConverter.Instance}}">
-                                <TextBlock Grid.Column="0" Text="Kind" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="1" Text="Vendor" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="2" Text="Repo" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="3" Text="Requester" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="4" Text="Status" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="5" Text="Uptime" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="6" Text="Actions" FontWeight="Bold" Opacity="0.7" />
-                            </Grid>
+                    <TextBlock x:Name="ServerUrlText" Text="{Binding ServerUrl}" Opacity="0.7" />
 
-                            <ItemsControl x:Name="AgentsItems" ItemsSource="{Binding Agents}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate x:DataType="vm:AgentRowViewModel">
-                                        <Grid ColumnDefinitions="80,140,140,100,90,70,150" Margin="0,2">
-                                            <TextBlock Grid.Column="0" Text="{Binding Kind}" TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Grid.Column="1" Text="{Binding VendorDisplay}" TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Grid.Column="2" Text="{Binding RepoLeaf}" ToolTip.Tip="{Binding RepoFull}" TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Grid.Column="3" Text="{Binding Requester}" TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Grid.Column="4" Text="{Binding StatusText}" TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Grid.Column="5" Text="{Binding Uptime}" TextTrimming="CharacterEllipsis" />
-                                            <StackPanel Grid.Column="6" Orientation="Horizontal" Spacing="4">
-                                                <Button Content="Stop" Command="{Binding StopCommand}" IsEnabled="{Binding ActionsEnabled}" Padding="8,2" FontSize="12" />
-                                                <Button Content="Open in web" Command="{Binding OpenInWebCommand}" IsEnabled="{Binding ActionsEnabled}" Padding="8,2" FontSize="12" />
-                                            </StackPanel>
-                                        </Grid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <Ellipse Width="8" Height="8" Fill="{Binding StatusDotBrush}" VerticalAlignment="Center" />
+                        <TextBlock x:Name="ConnectionText" Text="{Binding ConnectionDisplay}" VerticalAlignment="Center" />
+                        <TextBlock x:Name="AgentCountText" Text="{Binding AgentCountText, StringFormat='· {0}'}"
+                                   IsVisible="{Binding GridEnabled}" VerticalAlignment="Center" />
+                    </StackPanel>
+                </StackPanel>
+
+                <StackPanel Spacing="8">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Button x:Name="StartButton" Content="Start daemon" Command="{Binding StartDaemonCommand}" IsVisible="{Binding StartVisible}" />
+                        <Button x:Name="RetryButton" Content="Retry" Command="{Binding RetryCommand}" IsVisible="{Binding RetryVisible}" />
+                    </StackPanel>
+
+                    <TextBlock x:Name="StartMessageText" Text="{Binding StartMessage}"
+                               IsVisible="{Binding StartMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                    <TextBlock x:Name="ReasonText" Text="{Binding Reason}"
+                               IsVisible="{Binding Reason, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                </StackPanel>
+            </StackPanel>
+
+            <!-- Tabs (spec §7): Home | Agents | Activity. Home is the default selection.
+                 SelectionChanged is wired in code-behind (MainWindow.axaml.cs) so the Activity tab's
+                 refresh cadence tracks both tab selection and the window's own on-screen state. -->
+            <TabControl Grid.Row="1" x:Name="MainTabs" Margin="0,8,0,0" SelectionChanged="OnTabSelectionChanged">
+                <TabItem x:Name="HomeTabItem" Header="Home">
+                    <views:HomeView DataContext="{Binding Home}" />
+                </TabItem>
+
+                <TabItem Header="Agents">
+                    <!-- The ENTIRE pre-existing agents block, unchanged: control names preserved so
+                         the existing smoke tests keep finding them in the window's name scope. -->
+                    <Grid RowDefinitions="Auto,*">
+                        <StackPanel Grid.Row="0" Spacing="8">
+                            <Border Height="1" Background="{DynamicResource SystemControlForegroundBaseHighBrush}" Opacity="0.7" />
+                            <TextBlock Text="Agents" FontSize="14" FontWeight="Bold" />
+
+                            <TextBlock x:Name="EmptyStateText" Text="No agents running">
+                                <TextBlock.IsVisible>
+                                    <MultiBinding Converter="{x:Static views:EmptyStateVisibleConverter.Instance}">
+                                        <Binding Path="GridEnabled" />
+                                        <Binding Path="Agents.Count" />
+                                    </MultiBinding>
+                                </TextBlock.IsVisible>
+                            </TextBlock>
                         </StackPanel>
-                    </ScrollViewer>
-                </Grid>
-            </TabItem>
 
-            <TabItem x:Name="ActivityTabItem" Header="Activity">
-                <Grid RowDefinitions="Auto,*">
-                    <TextBlock x:Name="ActivityEmptyText" Text="No decisions yet"
-                               IsVisible="{Binding Activity.IsEmpty}" HorizontalAlignment="Center" Margin="0,24,0,0" />
+                        <!-- Row "*" (bounded height, unlike a StackPanel child which Avalonia always
+                             measures with infinite height) is what lets this ScrollViewer's
+                             VerticalScrollBarVisibility actually engage. Fixed column widths total
+                             ~770px — wider than the default window's content area — so both
+                             scrollbars are Auto: horizontal reaches the Actions column when the
+                             window is narrower than the grid, vertical reaches every row when there
+                             are more than fit the window's height. -->
+                        <ScrollViewer Grid.Row="1" Margin="0,8,0,0"
+                                      VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                            <StackPanel x:Name="AgentsGrid" Opacity="{Binding GridEnabled, Converter={x:Static views:GridEnabledOpacityConverter.Instance}}">
+                                <Grid x:Name="AgentsGridHeader" ColumnDefinitions="80,140,140,100,90,70,150" Margin="0,0,0,4"
+                                      IsVisible="{Binding Agents.Count, Converter={x:Static views:HeaderRowVisibleConverter.Instance}}">
+                                    <TextBlock Grid.Column="0" Text="Kind" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="1" Text="Vendor" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="2" Text="Repo" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="3" Text="Requester" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="4" Text="Status" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="5" Text="Uptime" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="6" Text="Actions" FontWeight="Bold" Opacity="0.7" />
+                                </Grid>
 
-                    <ScrollViewer Grid.Row="1" Margin="0,8,0,0"
-                                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
-                        <StackPanel>
-                            <Grid x:Name="ActivityHeader" ColumnDefinitions="150,70,120,90,140,90,110" Margin="0,0,0,4"
-                                  IsVisible="{Binding !Activity.IsEmpty}">
-                                <TextBlock Grid.Column="0" Text="Time" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="1" Text="Outcome" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="2" Text="Requester" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="3" Text="Kind" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="4" Text="Repo" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="5" Text="Vendor" FontWeight="Bold" Opacity="0.7" />
-                                <TextBlock Grid.Column="6" Text="Source" FontWeight="Bold" Opacity="0.7" />
-                            </Grid>
+                                <ItemsControl x:Name="AgentsItems" ItemsSource="{Binding Agents}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="vm:AgentRowViewModel">
+                                            <Grid ColumnDefinitions="80,140,140,100,90,70,150" Margin="0,2">
+                                                <TextBlock Grid.Column="0" Text="{Binding Kind}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="1" Text="{Binding VendorDisplay}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="2" Text="{Binding RepoLeaf}" ToolTip.Tip="{Binding RepoFull}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="3" Text="{Binding Requester}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="4" Text="{Binding StatusText}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="5" Text="{Binding Uptime}" TextTrimming="CharacterEllipsis" />
+                                                <StackPanel Grid.Column="6" Orientation="Horizontal" Spacing="4">
+                                                    <Button Content="Stop" Command="{Binding StopCommand}" IsEnabled="{Binding ActionsEnabled}" Padding="8,2" FontSize="12" />
+                                                    <Button Content="Open in web" Command="{Binding OpenInWebCommand}" IsEnabled="{Binding ActionsEnabled}" Padding="8,2" FontSize="12" />
+                                                </StackPanel>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Grid>
+                </TabItem>
 
-                            <ItemsControl x:Name="ActivityItems" ItemsSource="{Binding Activity.Rows}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate x:DataType="vm:ActivityRow">
-                                        <Grid ColumnDefinitions="150,70,120,90,140,90,110" Margin="0,2">
-                                            <TextBlock Grid.Column="0" Text="{Binding Time}" TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Grid.Column="1" Text="{Binding Outcome}" TextTrimming="CharacterEllipsis"
-                                                       Foreground="{Binding IsAllowed, Converter={x:Static views:OutcomeBrushConverter.Instance}}" />
-                                            <TextBlock Grid.Column="2" Text="{Binding Requester}" TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Grid.Column="3" Text="{Binding KindLabel}" TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Grid.Column="4" Text="{Binding RepoLeaf}" ToolTip.Tip="{Binding RepoFull}" TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Grid.Column="5" Text="{Binding Vendor}" TextTrimming="CharacterEllipsis" />
-                                            <TextBlock Grid.Column="6" Text="{Binding SourceLabel}" TextTrimming="CharacterEllipsis" />
-                                        </Grid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </StackPanel>
-                    </ScrollViewer>
-                </Grid>
-            </TabItem>
-        </TabControl>
-    </Grid>
+                <TabItem x:Name="ActivityTabItem" Header="Activity">
+                    <Grid RowDefinitions="Auto,*">
+                        <TextBlock x:Name="ActivityEmptyText" Text="No decisions yet"
+                                   IsVisible="{Binding Activity.IsEmpty}" HorizontalAlignment="Center" Margin="0,24,0,0" />
+
+                        <ScrollViewer Grid.Row="1" Margin="0,8,0,0"
+                                      VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                            <StackPanel>
+                                <Grid x:Name="ActivityHeader" ColumnDefinitions="150,70,120,90,140,90,110" Margin="0,0,0,4"
+                                      IsVisible="{Binding !Activity.IsEmpty}">
+                                    <TextBlock Grid.Column="0" Text="Time" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="1" Text="Outcome" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="2" Text="Requester" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="3" Text="Kind" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="4" Text="Repo" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="5" Text="Vendor" FontWeight="Bold" Opacity="0.7" />
+                                    <TextBlock Grid.Column="6" Text="Source" FontWeight="Bold" Opacity="0.7" />
+                                </Grid>
+
+                                <ItemsControl x:Name="ActivityItems" ItemsSource="{Binding Activity.Rows}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="vm:ActivityRow">
+                                            <Grid ColumnDefinitions="150,70,120,90,140,90,110" Margin="0,2">
+                                                <TextBlock Grid.Column="0" Text="{Binding Time}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="1" Text="{Binding Outcome}" TextTrimming="CharacterEllipsis"
+                                                           Foreground="{Binding IsAllowed, Converter={x:Static views:OutcomeBrushConverter.Instance}}" />
+                                                <TextBlock Grid.Column="2" Text="{Binding Requester}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="3" Text="{Binding KindLabel}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="4" Text="{Binding RepoLeaf}" ToolTip.Tip="{Binding RepoFull}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="5" Text="{Binding Vendor}" TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="6" Text="{Binding SourceLabel}" TextTrimming="CharacterEllipsis" />
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Grid>
+                </TabItem>
+            </TabControl>
+        </Grid>
+
+        <ContentControl x:Name="WorkspaceHost" Content="{Binding CurrentWorkspace}"
+                        IsVisible="{Binding CurrentWorkspace, Converter={x:Static ObjectConverters.IsNotNull}}">
+            <ContentControl.ContentTemplate>
+                <DataTemplate x:DataType="vm:WorkspaceViewModel">
+                    <views:WorkspaceView />
+                </DataTemplate>
+            </ContentControl.ContentTemplate>
+        </ContentControl>
+    </Panel>
 </rxui:ReactiveWindow>

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -66,12 +66,15 @@
                 <TextBlock Text="Connecting…" Foreground="{StaticResource KcapMutedBrush}" />
             </Border>
 
-            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalReadOnlyBannerVisibleConverter.Instance}}"
-                    Background="{StaticResource KcapWarningDimBrush}" BorderBrush="{StaticResource KcapWarningBrush}" BorderThickness="1"
-                    CornerRadius="8" Padding="12,7" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
+            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Attached}"
+                    Background="{Binding Terminal.State, Converter={x:Static views:TerminalAttachBannerBackgroundBrushConverter.Instance}}"
+                    BorderBrush="{Binding Terminal.State, Converter={x:Static views:TerminalAttachBannerBorderBrushConverter.Instance}}"
+                    BorderThickness="1" CornerRadius="8" Padding="12,7" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
                 <StackPanel Orientation="Horizontal" Spacing="10">
-                    <TextBlock Text="{Binding Terminal.State.Detail, StringFormat='Read-only: {0}'}"
-                               Foreground="{StaticResource KcapWarningBrush}" VerticalAlignment="Center" />
+                    <TextBlock x:Name="AttachBannerText"
+                               Text="{Binding Terminal.State, Converter={x:Static views:TerminalAttachBannerTextConverter.Instance}}"
+                               Foreground="{Binding Terminal.State, Converter={x:Static views:TerminalAttachBannerForegroundBrushConverter.Instance}}"
+                               VerticalAlignment="Center" />
                     <Button x:Name="DetachButton" Content="Detach" Command="{Binding Terminal.DetachCommand}" Padding="10,3" FontSize="12" />
                 </StackPanel>
             </Border>

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -60,8 +60,12 @@
             <!-- FontFamily MUST be set: the control's default is "Cascadia Mono", which only
                  exists on Windows — elsewhere it silently falls back to ESTIMATED cell metrics
                  while drawing with a real typeface, smearing every styled run off its column. -->
+            <!-- CaretBrush: without it the unfocused caret is a hairline in the default brush,
+                 invisible on this palette. Focus itself is wired in code-behind on Model
+                 assignment — the control only draws the filled caret while focused. -->
             <terminal:TerminalControl x:Name="TerminalHost" IsVisible="{Binding ShowsTerminalTab}"
                                        FontFamily="Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace"
+                                       CaretBrush="{StaticResource KcapAccentBrush}"
                                        Model="{Binding Terminal.Surface, Converter={x:Static views:TerminalSurfaceModelConverter.Instance}}" />
 
             <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Connecting}"

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -57,7 +57,11 @@
              see WorkspaceView.axaml.cs header comment) plus one state banner at a time, layered
              over it. -->
         <Grid Grid.Row="2">
+            <!-- FontFamily MUST be set: the control's default is "Cascadia Mono", which only
+                 exists on Windows — elsewhere it silently falls back to ESTIMATED cell metrics
+                 while drawing with a real typeface, smearing every styled run off its column. -->
             <terminal:TerminalControl x:Name="TerminalHost" IsVisible="{Binding ShowsTerminalTab}"
+                                       FontFamily="Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace"
                                        Model="{Binding Terminal.Surface, Converter={x:Static views:TerminalSurfaceModelConverter.Instance}}" />
 
             <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Connecting}"
@@ -66,15 +70,17 @@
                 <TextBlock Text="Connecting…" Foreground="{StaticResource KcapMutedBrush}" />
             </Border>
 
-            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Attached}"
-                    Background="{Binding Terminal.State, Converter={x:Static views:TerminalAttachBannerBackgroundBrushConverter.Instance}}"
-                    BorderBrush="{Binding Terminal.State, Converter={x:Static views:TerminalAttachBannerBorderBrushConverter.Instance}}"
+            <!-- Owner decision (post-QA): the attach banner overlays the terminal, so a normal
+                 read-write session shows NO banner — explicit detach returns when a use case
+                 earns it. Read-only keeps the banner: it is the only explanation for dead
+                 keystrokes, and Detach is the only action such a session has. -->
+            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalReadOnlyBannerVisibleConverter.Instance}}"
+                    Background="{StaticResource KcapWarningDimBrush}" BorderBrush="{StaticResource KcapWarningBrush}"
                     BorderThickness="1" CornerRadius="8" Padding="12,7" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
                 <StackPanel Orientation="Horizontal" Spacing="10">
                     <TextBlock x:Name="AttachBannerText"
-                               Text="{Binding Terminal.State, Converter={x:Static views:TerminalAttachBannerTextConverter.Instance}}"
-                               Foreground="{Binding Terminal.State, Converter={x:Static views:TerminalAttachBannerForegroundBrushConverter.Instance}}"
-                               VerticalAlignment="Center" />
+                               Text="{Binding Terminal.State.Detail, StringFormat='Read-only: {0}'}"
+                               Foreground="{StaticResource KcapWarningBrush}" VerticalAlignment="Center" />
                     <Button x:Name="DetachButton" Content="Detach" Command="{Binding Terminal.DetachCommand}" Padding="10,3" FontSize="12" />
                 </StackPanel>
             </Border>

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -1,0 +1,114 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Capacitor.App.ViewModels"
+             xmlns:views="clr-namespace:Capacitor.App.Views"
+             xmlns:terminal="clr-namespace:SvcSystems.UI.Terminal;assembly=SvcSystems.UI.Terminal"
+             x:Class="Capacitor.App.Views.WorkspaceView"
+             x:DataType="vm:WorkspaceViewModel"
+             Background="{StaticResource KcapCanvasBrush}">
+    <Grid RowDefinitions="56,42,*">
+        <!-- Header: Back (Task 14 injects BackCommand later — hidden until then) · title over
+             repo leaf · spacer · vendor chip with its family badge · Open-in-web/Stop. -->
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,*,Auto,Auto,Auto" Margin="16,0" VerticalAlignment="Center">
+            <Button x:Name="BackButton" Grid.Column="0" Content="← Back" Command="{Binding BackCommand}"
+                    IsVisible="{Binding BackCommand, Converter={x:Static ObjectConverters.IsNotNull}}"
+                    Background="Transparent" BorderThickness="0" Foreground="{StaticResource KcapTextBrush}"
+                    Padding="0,0,12,0" />
+
+            <StackPanel Grid.Column="1" Spacing="1" VerticalAlignment="Center">
+                <TextBlock x:Name="WorkspaceTitle" Text="{Binding Title}" FontWeight="Bold" FontSize="15"
+                           Foreground="{StaticResource KcapTextBrush}" TextTrimming="CharacterEllipsis" />
+                <TextBlock x:Name="WorkspaceRepo" Text="{Binding RepoLabelText}" FontSize="11"
+                           Foreground="{StaticResource KcapMutedBrush}" TextTrimming="CharacterEllipsis" />
+            </StackPanel>
+
+            <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center" Margin="0,0,12,0">
+                <Border Background="{StaticResource KcapSurfaceRaisedBrush}" CornerRadius="999" Padding="6,1"
+                        IsVisible="{Binding FamilyDot, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                    <TextBlock Text="{Binding FamilyDot}" FontSize="9" Foreground="{StaticResource KcapMutedBrush}" />
+                </Border>
+                <TextBlock x:Name="WorkspaceVendorChip" Text="{Binding VendorChip}" FontSize="12"
+                           Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
+            </StackPanel>
+
+            <Button Grid.Column="4" Content="Open in web" Command="{Binding OpenInWebCommand}"
+                    Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                    Foreground="{StaticResource KcapTextBrush}" Padding="10,4" FontSize="12" Margin="0,0,6,0" />
+            <Button Grid.Column="5" Content="Stop" Command="{Binding StopCommand}"
+                    Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                    Foreground="{StaticResource KcapDangerBrush}" Padding="10,4" FontSize="12" />
+        </Grid>
+
+        <!-- Tab strip: one Terminal tab when the daemon reports this session has one; the muted
+             family-aware note in its place otherwise (spec: never names a vendor). -->
+        <Border Grid.Row="1" Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                BorderThickness="0,1,0,1">
+            <Grid>
+                <Button x:Name="TerminalTabButton" Content="Terminal" IsVisible="{Binding ShowsTerminalTab}"
+                        HorizontalAlignment="Left" HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                        Background="Transparent" BorderBrush="{StaticResource KcapAccentBrush}" BorderThickness="0,0,0,2"
+                        CornerRadius="0" Foreground="{StaticResource KcapTextBrush}" Padding="16,0" Height="41" />
+                <TextBlock x:Name="NoTerminalNote" Text="{Binding NoTerminalNote}" IsVisible="{Binding !ShowsTerminalTab}"
+                           Foreground="{StaticResource KcapMutedBrush}" FontSize="12" Margin="16,0" VerticalAlignment="Center" />
+            </Grid>
+        </Border>
+
+        <!-- Content: the terminal control (real resize wiring lives inside TerminalControl itself,
+             see WorkspaceView.axaml.cs header comment) plus one state banner at a time, layered
+             over it. -->
+        <Grid Grid.Row="2">
+            <terminal:TerminalControl x:Name="TerminalHost" IsVisible="{Binding ShowsTerminalTab}"
+                                       Model="{Binding Terminal.Surface, Converter={x:Static views:TerminalSurfaceModelConverter.Instance}}" />
+
+            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Connecting}"
+                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                    CornerRadius="8" Padding="14,8" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
+                <TextBlock Text="Connecting…" Foreground="{StaticResource KcapMutedBrush}" />
+            </Border>
+
+            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalReadOnlyBannerVisibleConverter.Instance}}"
+                    Background="{StaticResource KcapWarningDimBrush}" BorderBrush="{StaticResource KcapWarningBrush}" BorderThickness="1"
+                    CornerRadius="8" Padding="12,7" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <TextBlock Text="{Binding Terminal.State.Detail, StringFormat='Read-only: {0}'}"
+                               Foreground="{StaticResource KcapWarningBrush}" VerticalAlignment="Center" />
+                    <Button x:Name="DetachButton" Content="Detach" Command="{Binding Terminal.DetachCommand}" Padding="10,3" FontSize="12" />
+                </StackPanel>
+            </Border>
+
+            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalDetachedOrFailedVisibleConverter.Instance}}"
+                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                    CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <StackPanel Spacing="10" HorizontalAlignment="Center">
+                    <TextBlock Text="{Binding Terminal.State, Converter={x:Static views:TerminalDetachedOrFailedMessageConverter.Instance}}"
+                               Foreground="{StaticResource KcapTextBrush}" HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="380" />
+                    <Button x:Name="ReattachButton" Content="Reattach" Command="{Binding Terminal.ReattachCommand}"
+                            HorizontalAlignment="Center" Background="{StaticResource KcapAccentBrush}" Foreground="#07120E"
+                            FontWeight="SemiBold" Padding="16,5" />
+                </StackPanel>
+            </Border>
+
+            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Exited}"
+                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                    CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding Terminal.State.ExitCode, StringFormat='Session exited (code {0})'}"
+                           Foreground="{StaticResource KcapTextBrush}" />
+            </Border>
+
+            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=NotFound}"
+                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                    CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <StackPanel Spacing="10" HorizontalAlignment="Center">
+                    <TextBlock Text="{Binding Terminal.State.Detail}" Foreground="{StaticResource KcapTextBrush}" />
+                    <Button Content="Retry" Command="{Binding Terminal.RetryResolveCommand}" HorizontalAlignment="Center" Padding="14,4" />
+                </StackPanel>
+            </Border>
+
+            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=SessionEnded}"
+                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                    CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="This session has ended." Foreground="{StaticResource KcapMutedBrush}" />
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Capacitor.App/Views/WorkspaceView.axaml.cs
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml.cs
@@ -19,7 +19,16 @@ namespace Capacitor.App.Views;
 /// Resize with worse (font-metric-unaware) width/height than TerminalControl's own
 /// _consoleTextSize-based computation.
 public partial class WorkspaceView : UserControl {
-    public WorkspaceView() => InitializeComponent();
+    public WorkspaceView() {
+        InitializeComponent();
+        // Keyboard focus is a view concern: the control draws its filled caret (and receives
+        // keystrokes) only while focused, and nothing else focuses it when a session opens or
+        // reattaches — Model assignment is exactly the "terminal became live" moment.
+        TerminalHost.PropertyChanged += (_, e) => {
+            if (e.Property == SvcSystems.UI.Terminal.TerminalControl.ModelProperty && TerminalHost.Model is not null)
+                TerminalHost.Focus();
+        };
+    }
 }
 
 /// ITerminalSurface -&gt; TerminalControlModel? bridge for TerminalHost's Model binding.

--- a/src/Capacitor.App/Views/WorkspaceView.axaml.cs
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data.Converters;
 using Capacitor.App.Services;
@@ -54,57 +53,14 @@ public sealed class TerminalPhaseIsConverter : IValueConverter {
         throw new NotSupportedException();
 }
 
-/// The attach banner's message: the daemon's read-only reason when ReadOnly, a fixed
-/// reassurance line for a normal read-write attach -- one banner (and its DetachButton) is
-/// visible for BOTH modes (design canvas), not just the read-only one.
-public sealed class TerminalAttachBannerTextConverter : IValueConverter {
-    public static readonly TerminalAttachBannerTextConverter Instance = new();
+/// The read-only warning banner: visible only for a read-only Attached session — the one case
+/// where the banner explains otherwise-dead keystrokes. A read-write attach shows no banner
+/// (owner decision after QA: it overlaid the terminal).
+public sealed class TerminalReadOnlyBannerVisibleConverter : IValueConverter {
+    public static readonly TerminalReadOnlyBannerVisibleConverter Instance = new();
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is TerminalSessionState { ReadOnly: true } state
-            ? $"Read-only: {state.Detail}"
-            : "Attached to the live PTY — keystrokes go straight to the process.";
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotSupportedException();
-}
-
-/// Attach banner background: the warning-dim skin for read-only, the plain surface skin for a
-/// normal read-write attach. Application-level resources (App.axaml) are a single fixed
-/// palette, so a static FindResource lookup here needs no per-frame re-resolution.
-public sealed class TerminalAttachBannerBackgroundBrushConverter : IValueConverter {
-    public static readonly TerminalAttachBannerBackgroundBrushConverter Instance = new();
-
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        Application.Current!.FindResource(
-            value is TerminalSessionState { ReadOnly: true } ? "KcapWarningDimBrush" : "KcapSurfaceBrush");
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotSupportedException();
-}
-
-/// Attach banner border: warning brush for read-only, the plain border brush for read-write --
-/// paired with TerminalAttachBannerBackgroundBrushConverter above.
-public sealed class TerminalAttachBannerBorderBrushConverter : IValueConverter {
-    public static readonly TerminalAttachBannerBorderBrushConverter Instance = new();
-
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        Application.Current!.FindResource(
-            value is TerminalSessionState { ReadOnly: true } ? "KcapWarningBrush" : "KcapBorderBrush");
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotSupportedException();
-}
-
-/// Attach banner text color: warning brush for read-only (matches the border), muted text for
-/// read-write -- a separate brush from the border since the neutral skin's text is muted, not
-/// KcapBorderBrush.
-public sealed class TerminalAttachBannerForegroundBrushConverter : IValueConverter {
-    public static readonly TerminalAttachBannerForegroundBrushConverter Instance = new();
-
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        Application.Current!.FindResource(
-            value is TerminalSessionState { ReadOnly: true } ? "KcapWarningBrush" : "KcapMutedBrush");
+        value is TerminalSessionState { Phase: TerminalSessionPhase.Attached, ReadOnly: true };
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.App/Views/WorkspaceView.axaml.cs
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml.cs
@@ -1,0 +1,93 @@
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Data.Converters;
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Views;
+
+/// The session workspace: DataContext is supplied externally (a plainly-constructed
+/// WorkspaceViewModel) -- same contract as HomeView/MainWindow, this view never builds its own VM.
+///
+/// TerminalHost hosts SvcSystems.UI.Terminal's own TerminalControl directly (no custom host/
+/// wrapper needed) -- decompile-verified (Task 12 discovery) that TerminalControl already calls
+/// its Model's Resize(width, height, textWidth, textHeight) itself, from BOTH its ModelProperty
+/// change handler (a reattach's fresh Model gets sized to the control's CURRENT bounds
+/// immediately) and its inner surface's own OnSizeChanged (an actual window/pane resize). Task
+/// 11's "the view must call Model.Resize(...) from its bounds-changed handling" obligation is
+/// therefore satisfied by USING the real vendor control rather than by re-implementing what it
+/// already does -- a hand-rolled bounds-changed handler here would only risk double-invoking
+/// Resize with worse (font-metric-unaware) width/height than TerminalControl's own
+/// _consoleTextSize-based computation.
+public partial class WorkspaceView : UserControl {
+    public WorkspaceView() => InitializeComponent();
+}
+
+/// ITerminalSurface -&gt; TerminalControlModel? bridge for TerminalHost's Model binding.
+/// ITerminalSurface (the VM-facing seam, deliberately Avalonia/SvcSystems-free per its own doc
+/// comment) has no Model member, so a plain property-path binding can't reach it -- this converter
+/// downcasts to the production XtermTerminalSurface and returns null for anything else (no
+/// surface yet, or a test's FakeTerminalSurface), which TerminalControl already renders as an
+/// empty pane (its own Render short-circuits on a null Model).
+public sealed class TerminalSurfaceModelConverter : IValueConverter {
+    public static readonly TerminalSurfaceModelConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        (value as XtermTerminalSurface)?.Model;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// Single-tab-strip banner visibility: true when TerminalTabViewModel.State.Phase equals the
+/// phase named by ConverterParameter (e.g. "Connecting", "Exited") -- one converter reused across
+/// every single-phase banner instead of a dedicated bool-returning class per phase.
+public sealed class TerminalPhaseIsConverter : IValueConverter {
+    public static readonly TerminalPhaseIsConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is TerminalSessionState state && parameter is string phaseName
+        && Enum.TryParse<TerminalSessionPhase>(phaseName, ignoreCase: true, out var phase)
+        && state.Phase == phase;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// The read-only banner's compound condition (Attached AND ReadOnly) -- kept separate from
+/// TerminalPhaseIsConverter since it is not a single-phase check.
+public sealed class TerminalReadOnlyBannerVisibleConverter : IValueConverter {
+    public static readonly TerminalReadOnlyBannerVisibleConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is TerminalSessionState { Phase: TerminalSessionPhase.Attached, ReadOnly: true };
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// Detached and Failed share one "not attached, offer Reattach" banner (same affordance, same
+/// recovery action) rather than two near-identical banners each carrying their own Reattach
+/// button -- also the reason there is exactly one x:Name="ReattachButton" in the view.
+public sealed class TerminalDetachedOrFailedVisibleConverter : IValueConverter {
+    public static readonly TerminalDetachedOrFailedVisibleConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is TerminalSessionState { Phase: TerminalSessionPhase.Detached or TerminalSessionPhase.Failed };
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// The combined banner's message: the failure detail when Failed, a fixed line for a plain
+/// (non-error) Detached.
+public sealed class TerminalDetachedOrFailedMessageConverter : IValueConverter {
+    public static readonly TerminalDetachedOrFailedMessageConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is TerminalSessionState state
+            ? state.Phase == TerminalSessionPhase.Failed ? state.Detail ?? "The terminal failed." : "Detached from the terminal."
+            : "";
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/src/Capacitor.App/Views/WorkspaceView.axaml.cs
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data.Converters;
 using Capacitor.App.Services;
@@ -53,13 +54,57 @@ public sealed class TerminalPhaseIsConverter : IValueConverter {
         throw new NotSupportedException();
 }
 
-/// The read-only banner's compound condition (Attached AND ReadOnly) -- kept separate from
-/// TerminalPhaseIsConverter since it is not a single-phase check.
-public sealed class TerminalReadOnlyBannerVisibleConverter : IValueConverter {
-    public static readonly TerminalReadOnlyBannerVisibleConverter Instance = new();
+/// The attach banner's message: the daemon's read-only reason when ReadOnly, a fixed
+/// reassurance line for a normal read-write attach -- one banner (and its DetachButton) is
+/// visible for BOTH modes (design canvas), not just the read-only one.
+public sealed class TerminalAttachBannerTextConverter : IValueConverter {
+    public static readonly TerminalAttachBannerTextConverter Instance = new();
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is TerminalSessionState { Phase: TerminalSessionPhase.Attached, ReadOnly: true };
+        value is TerminalSessionState { ReadOnly: true } state
+            ? $"Read-only: {state.Detail}"
+            : "Attached to the live PTY — keystrokes go straight to the process.";
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// Attach banner background: the warning-dim skin for read-only, the plain surface skin for a
+/// normal read-write attach. Application-level resources (App.axaml) are a single fixed
+/// palette, so a static FindResource lookup here needs no per-frame re-resolution.
+public sealed class TerminalAttachBannerBackgroundBrushConverter : IValueConverter {
+    public static readonly TerminalAttachBannerBackgroundBrushConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        Application.Current!.FindResource(
+            value is TerminalSessionState { ReadOnly: true } ? "KcapWarningDimBrush" : "KcapSurfaceBrush");
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// Attach banner border: warning brush for read-only, the plain border brush for read-write --
+/// paired with TerminalAttachBannerBackgroundBrushConverter above.
+public sealed class TerminalAttachBannerBorderBrushConverter : IValueConverter {
+    public static readonly TerminalAttachBannerBorderBrushConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        Application.Current!.FindResource(
+            value is TerminalSessionState { ReadOnly: true } ? "KcapWarningBrush" : "KcapBorderBrush");
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// Attach banner text color: warning brush for read-only (matches the border), muted text for
+/// read-write -- a separate brush from the border since the neutral skin's text is muted, not
+/// KcapBorderBrush.
+public sealed class TerminalAttachBannerForegroundBrushConverter : IValueConverter {
+    public static readonly TerminalAttachBannerForegroundBrushConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        Application.Current!.FindResource(
+            value is TerminalSessionState { ReadOnly: true } ? "KcapWarningBrush" : "KcapMutedBrush");
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
@@ -24,6 +24,7 @@ public sealed class AgentAttachClient : IAsyncDisposable {
     CancellationTokenSource? _lifetime;
     volatile bool _detachRequested;       // intent, never a cause
     volatile bool _attachedAny;           // true after either Attached reply
+    volatile bool _attachedReadWrite;     // true only after a read-write Attached (not AttachedReadOnly)
     int _disposed;                        // guards DisposeAsync re-entrancy
     Task<AttachOutcome>? _run;
 
@@ -79,6 +80,7 @@ public sealed class AgentAttachClient : IAsyncDisposable {
                     case FrameType.Attached: {
                         var (_, snapshot) = FrameCodec.Attached(frame);
                         _attachedAny = true;
+                        _attachedReadWrite = true;
                         if (!await InvokeCallbackAsync(() => _onAttached(snapshot, null, _lifetime.Token))) goto done;
                         await WriteLockedAsync(SizeFrame(cols, rows)).ConfigureAwait(false);  // repaint nudge
                         break;
@@ -86,6 +88,7 @@ public sealed class AgentAttachClient : IAsyncDisposable {
                     case FrameType.AttachedReadOnly: {
                         var (_, reason, snapshot) = FrameCodec.AttachedReadOnly(frame);
                         _attachedAny = true;
+                        _attachedReadWrite = false;
                         if (!await InvokeCallbackAsync(() => _onAttached(snapshot, reason, _lifetime.Token))) goto done;
                         break;                                            // no nudge: never influence the clamp
                     }
@@ -158,10 +161,32 @@ public sealed class AgentAttachClient : IAsyncDisposable {
 
     void CloseTransport() { try { _stream?.Dispose(); } catch { } try { _socket?.Dispose(); } catch { } }
 
-    // Task 6 implements these fully; Task 4 ships minimal versions that keep
-    // the signatures compiling.
-    public Task SendInputAsync(byte[] bytes) => throw new NotImplementedException("Task 6");
-    public Task ResizeAsync(int cols, int rows) => throw new NotImplementedException("Task 6");
+    public async Task SendInputAsync(byte[] bytes) {
+        if (!_attachedReadWrite || _detachRequested || _cause is not null) return;
+        await WriteOutboundAsync(LocalFrame.Stdin(bytes)).ConfigureAwait(false);
+    }
+
+    public async Task ResizeAsync(int cols, int rows) {
+        if (!_attachedReadWrite || _detachRequested || _cause is not null) return;
+        if (cols is < 1 or > ushort.MaxValue || rows is < 1 or > ushort.MaxValue) return;
+        await WriteOutboundAsync(SizeFrame(cols, rows)).ConfigureAwait(false);
+    }
+
+    // Outbound writers claim the slot themselves on transport failure — the read
+    // side may be blocked; closing the socket completes it and the pump projects.
+    async Task WriteOutboundAsync(LocalFrame frame) {
+        try {
+            await _writeLock.WaitAsync().ConfigureAwait(false);
+            try {
+                if (_detachRequested || _cause is not null) return;   // re-check under the lock: nothing behind a queued detach
+                await FrameCodec.WriteAsync(_stream!, frame, CancellationToken.None).ConfigureAwait(false);
+            } finally { _writeLock.Release(); }
+        } catch (Exception ex) {
+            if (TryClaim(new AttachOutcome.ConnectionLost())) Report("outbound write", ex);
+            else if (_cause is AttachOutcome.Detached || ReferenceEquals(_cause, CancelledSentinel)) Report("outbound write", ex);
+            CloseTransport();
+        }
+    }
 
     /// Records intent and sends the Detach frame; never itself claims the cause slot
     /// except when there is no stream, or the write fails — both mean the connection is

--- a/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
@@ -100,7 +100,7 @@ public sealed class AgentAttachClient : IAsyncDisposable {
                         break;                                            // no nudge: never influence the clamp
                     }
                     case FrameType.Stdout:
-                        if (!await InvokeCallbackAsync(() => _onOutput(frame.Bytes, _lifetime.Token))) goto done;
+                        if (!await InvokeOutputAsync(frame.Bytes)) goto done;
                         break;
                     case FrameType.Exited:
                         TryClaim(new AttachOutcome.Exited(frame.ExitCode));
@@ -133,6 +133,17 @@ public sealed class AgentAttachClient : IAsyncDisposable {
         catch (Exception ex) {
             // A won claim IS the run's result (Project rethrows it) — not a diagnostic;
             // only a loss (Dispose or another producer already claimed) is reported.
+            if (!TryClaim(ex)) ReportIfLost("callback", ex);
+            return false;
+        }
+    }
+
+    // Stdout's own lane: identical containment to InvokeCallbackAsync, but taking the
+    // bytes directly — a closure per frame is a heap allocation on the hottest path.
+    async Task<bool> InvokeOutputAsync(byte[] bytes) {
+        try { await _onOutput(bytes, _lifetime!.Token).ConfigureAwait(false); return true; }
+        catch (OperationCanceledException) when (_lifetime!.IsCancellationRequested) { throw; }
+        catch (Exception ex) {
             if (!TryClaim(ex)) ReportIfLost("callback", ex);
             return false;
         }

--- a/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
@@ -18,9 +18,13 @@ public sealed class AgentAttachClient : IAsyncDisposable {
 
     Socket? _socket;
     NetworkStream? _stream;
-    CancellationTokenSource? _lifetime;   // linked to the caller token; callbacks get this token
+    // Deliberately unlinked: the sole propagation path from the caller token is the
+    // `reg` callback in RunCoreAsync, which claims the cause before cancelling this —
+    // claim-before-cancel is then structural, not an artifact of CTS callback ordering.
+    CancellationTokenSource? _lifetime;
     volatile bool _detachRequested;       // intent, never a cause
     volatile bool _attachedAny;           // true after either Attached reply
+    int _disposed;                        // guards DisposeAsync re-entrancy
     Task<AttachOutcome>? _run;
 
     public AgentAttachClient(
@@ -54,7 +58,7 @@ public sealed class AgentAttachClient : IAsyncDisposable {
     }
 
     async Task<AttachOutcome> RunCoreAsync(int cols, int rows, CancellationToken ct) {
-        _lifetime = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _lifetime = new CancellationTokenSource();
         using var reg = ct.Register(() => { if (TryClaim(CancelledSentinel)) _lifetime.Cancel(); });
         try {
             _socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
@@ -172,6 +176,7 @@ public sealed class AgentAttachClient : IAsyncDisposable {
     }
 
     public async ValueTask DisposeAsync() {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;   // a second call is a safe no-op
         _detachRequested = true;
         TryClaim(new AttachOutcome.Detached());       // the one eager local terminalizer
         _lifetime?.Cancel();
@@ -181,6 +186,11 @@ public sealed class AgentAttachClient : IAsyncDisposable {
             catch (OperationCanceledException) { }    // retired run's cancellation: never rethrown
             catch (AttachCallbackException) { }        // already reported where it claimed / lost
         }
+        // Deferred until the pump (which reads _lifetime.Token throughout RunCoreAsync)
+        // has fully stopped — disposing earlier would race a live Token access into
+        // ObjectDisposedException instead of the OperationCanceledException it expects.
+        _lifetime?.Dispose();
+        _writeLock.Dispose();
     }
 }
 

--- a/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
@@ -59,13 +59,20 @@ public sealed class AgentAttachClient : IAsyncDisposable {
     }
 
     async Task<AttachOutcome> RunCoreAsync(int cols, int rows, CancellationToken ct) {
+        // A ushort nudge must carry something sane rather than silently wrap -- ResizeAsync
+        // already validates its own inputs; RunAsync's caller-supplied initial size does not.
+        cols = Math.Clamp(cols, 1, ushort.MaxValue);
+        rows = Math.Clamp(rows, 1, ushort.MaxValue);
         _lifetime = new CancellationTokenSource();
         using var reg = ct.Register(() => { if (TryClaim(CancelledSentinel)) _lifetime.Cancel(); });
         try {
             _socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
-            await _socket.ConnectAsync(new UnixDomainSocketEndPoint(_socketPath), ct).ConfigureAwait(false);
+            // The internal token, not the caller's: DetachAsync's no-stream-yet path cancels
+            // _lifetime to abort an in-flight dial, and the ct.Register above already routes
+            // external cancellation through _lifetime too -- one token aborts the connect either way.
+            await _socket.ConnectAsync(new UnixDomainSocketEndPoint(_socketPath), _lifetime.Token).ConfigureAwait(false);
             _stream = new NetworkStream(_socket, ownsSocket: false);
-            await FrameCodec.WriteAsync(_stream, new LocalFrame(FrameType.Attach) { Text = _agentId }, ct).ConfigureAwait(false);
+            if (!await TryWriteAttachAsync().ConfigureAwait(false)) return Project();
 
             while (true) {
                 // The internal token, not the caller's: a caller cancellation and an
@@ -182,6 +189,20 @@ public sealed class AgentAttachClient : IAsyncDisposable {
         finally { _writeLock.Release(); }
     }
 
+    // The opening write: routed through _writeLock like every other outbound frame, so it can
+    // never interleave on the wire with a concurrently written Detach frame, and re-checked under
+    // that same lock so a detach intent recorded before this runs takes priority outright -- the
+    // daemon must never see an Attach the caller already detached from. False means the run
+    // settles as Detached without ever entering the read loop.
+    async Task<bool> TryWriteAttachAsync() {
+        await _writeLock.WaitAsync().ConfigureAwait(false);
+        try {
+            if (_detachRequested) { TryClaim(new AttachOutcome.Detached()); return false; }
+            await FrameCodec.WriteAsync(_stream!, new LocalFrame(FrameType.Attach) { Text = _agentId }, CancellationToken.None).ConfigureAwait(false);
+            return true;
+        } finally { _writeLock.Release(); }
+    }
+
     void CloseTransport() { try { _stream?.Dispose(); } catch { } try { _socket?.Dispose(); } catch { } }
 
     public async Task SendInputAsync(byte[] bytes) {
@@ -218,10 +239,13 @@ public sealed class AgentAttachClient : IAsyncDisposable {
     /// except when there is no stream, or the write fails — both mean the connection is
     /// already effectively gone locally, so that IS a local close. Idempotent. A terminal
     /// frame the pump reads after this still wins the race (Exited/Failed beat Detached).
+    /// No-stream-yet also cancels _lifetime, aborting a dial still in flight — belt-and-
+    /// suspenders with TryWriteAttachAsync's own re-check, which is what actually holds when
+    /// the dial wins that race anyway (a completed connect isn't undone by cancelling after).
     public async Task DetachAsync() {
         if (_detachRequested) return;
         _detachRequested = true;
-        if (_stream is null) { TryClaim(new AttachOutcome.Detached()); return; }
+        if (_stream is null) { TryClaim(new AttachOutcome.Detached()); _lifetime?.Cancel(); return; }
         try { await WriteLockedAsync(LocalFrame.Detach()).ConfigureAwait(false); }
         catch { TryClaim(new AttachOutcome.Detached()); CloseTransport(); }   // detach write failure = local close
     }

--- a/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
@@ -147,7 +147,13 @@ public sealed class AgentAttachClient : IAsyncDisposable {
             if (!TryClaim(new AttachOutcome.Failed(ex.Message))) ReportIfLost("pre-attach", ex);
             return;
         }
-        if (!TryClaim(new AttachOutcome.ConnectionLost())) ReportIfLost("transport", ex);
+        // ConnectionLost carries no detail, so winners and losers of a transport
+        // failure both report once — the sink is the only place the exception ever
+        // surfaces (mirrors WriteOutboundAsync's writer-side transport failure).
+        // Without this, the most common real failure — the daemon dying, detected
+        // by the reader here — would yield no errno anywhere.
+        if (TryClaim(new AttachOutcome.ConnectionLost())) Report("transport", ex);
+        else ReportIfLost("transport", ex);
     }
 
     // Called only once the caller already knows this attempt LOST the cause-slot
@@ -199,8 +205,9 @@ public sealed class AgentAttachClient : IAsyncDisposable {
                 await FrameCodec.WriteAsync(_stream!, frame, CancellationToken.None).ConfigureAwait(false);
             } finally { _writeLock.Release(); }
         } catch (Exception ex) {
-            // ConnectionLost carries no detail, so a won claim is reported too — unlike a
-            // callback fault, the sink is the only place this exception ever surfaces.
+            // ConnectionLost carries no detail, so winners and losers of a transport
+            // failure both report once — the sink is the only place the exception ever
+            // surfaces (unlike a callback fault, which the caller observes directly).
             if (TryClaim(new AttachOutcome.ConnectionLost())) Report("outbound write", ex);
             else ReportIfLost("outbound write", ex);
             CloseTransport();

--- a/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
@@ -63,7 +63,10 @@ public sealed class AgentAttachClient : IAsyncDisposable {
             await FrameCodec.WriteAsync(_stream, new LocalFrame(FrameType.Attach) { Text = _agentId }, ct).ConfigureAwait(false);
 
             while (true) {
-                var frame = await FrameCodec.ReadAsync(_stream, CancellationToken.None).ConfigureAwait(false);
+                // The internal token, not the caller's: a caller cancellation and an
+                // internal Dispose both route through here, so one mechanism unblocks
+                // a pending read either way — no socket teardown required to cancel.
+                var frame = await FrameCodec.ReadAsync(_stream, _lifetime.Token).ConfigureAwait(false);
                 if (frame is null) {                                     // clean EOF
                     TryClaim(_detachRequested ? new AttachOutcome.Detached() : new AttachOutcome.ConnectionLost());
                     break;
@@ -72,18 +75,18 @@ public sealed class AgentAttachClient : IAsyncDisposable {
                     case FrameType.Attached: {
                         var (_, snapshot) = FrameCodec.Attached(frame);
                         _attachedAny = true;
-                        await _onAttached(snapshot, null, _lifetime.Token).ConfigureAwait(false);
+                        if (!await InvokeCallbackAsync(() => _onAttached(snapshot, null, _lifetime.Token))) goto done;
                         await WriteLockedAsync(SizeFrame(cols, rows)).ConfigureAwait(false);  // repaint nudge
                         break;
                     }
                     case FrameType.AttachedReadOnly: {
                         var (_, reason, snapshot) = FrameCodec.AttachedReadOnly(frame);
                         _attachedAny = true;
-                        await _onAttached(snapshot, reason, _lifetime.Token).ConfigureAwait(false);
+                        if (!await InvokeCallbackAsync(() => _onAttached(snapshot, reason, _lifetime.Token))) goto done;
                         break;                                            // no nudge: never influence the clamp
                     }
                     case FrameType.Stdout:
-                        await _onOutput(frame.Bytes, _lifetime.Token).ConfigureAwait(false);
+                        if (!await InvokeCallbackAsync(() => _onOutput(frame.Bytes, _lifetime.Token))) goto done;
                         break;
                     case FrameType.Exited:
                         TryClaim(new AttachOutcome.Exited(frame.ExitCode));
@@ -98,26 +101,45 @@ public sealed class AgentAttachClient : IAsyncDisposable {
             }
             done: ;
         } catch (Exception ex) {
-            ClassifyPumpException(ex);      // Task 5 fills this in fully
+            ClassifyPumpException(ex);
         } finally {
             CloseTransport();
         }
         return Project();
     }
 
-    // Task 5 completes classification; Task 4 needs only enough for its tests.
+    // A callback exception claims the cause with the raw exception itself (Project
+    // wraps it as AttachCallbackException). An OperationCanceledException while the
+    // internal token is cancelled is expected teardown, not a callback bug: rethrown
+    // so the outer catch classifies it the same way any other close-induced exception
+    // is classified (Detached / CancelledSentinel / ConnectionLost).
+    async Task<bool> InvokeCallbackAsync(Func<Task> callback) {
+        try { await callback().ConfigureAwait(false); return true; }
+        catch (OperationCanceledException) when (_lifetime!.IsCancellationRequested) { throw; }
+        catch (Exception ex) { TryClaim(ex); return false; }
+    }
+
     void ClassifyPumpException(Exception ex) {
-        if (_detachRequested || _cause is not null) { /* local close or already decided */ }
-        else if (!_attachedAny) TryClaim(new AttachOutcome.Failed(ex.Message));
-        else TryClaim(new AttachOutcome.ConnectionLost());
-        if (_cause is AttachOutcome && _cause is not AttachOutcome.Detached && ex is not OperationCanceledException)
-            Report("attach pump", ex);   // refine in Task 7 per loser rules
+        if (ex is OperationCanceledException && ReferenceEquals(_cause, CancelledSentinel)) return;
+        if (_detachRequested || _cause is AttachOutcome.Detached) {
+            TryClaim(new AttachOutcome.Detached());   // local close at any phase; expected — not a diagnostic
+            return;
+        }
+        if (ex is InvalidDataException) { TryClaim(new AttachOutcome.Failed($"protocol failure: {ex.Message}")); ReportIfLost("protocol", ex); return; }
+        if (!_attachedAny) { TryClaim(new AttachOutcome.Failed(ex.Message)); ReportIfLost("pre-attach", ex); return; }
+        TryClaim(new AttachOutcome.ConnectionLost());
+        ReportIfLost("transport", ex);
+    }
+
+    // An exception whose cause attempt LOST still gets observed exactly once (Task 7 tests pin this).
+    void ReportIfLost(string context, Exception ex) {
+        if (_cause is AttachOutcome.Detached || ReferenceEquals(_cause, CancelledSentinel)) Report(context, ex);
     }
 
     AttachOutcome Project() =>
         _cause switch {
             AttachOutcome o => o,
-            Exception fault => throw new AttachCallbackException(fault),   // Task 5 refines
+            Exception fault => throw new AttachCallbackException(fault),
             _ when ReferenceEquals(_cause, CancelledSentinel) => throw new OperationCanceledException(),
             _ => new AttachOutcome.ConnectionLost(),
         };
@@ -132,17 +154,33 @@ public sealed class AgentAttachClient : IAsyncDisposable {
 
     void CloseTransport() { try { _stream?.Dispose(); } catch { } try { _socket?.Dispose(); } catch { } }
 
-    // Tasks 5-7 implement these fully; Task 4 ships minimal versions that keep
+    // Task 6 implements these fully; Task 4 ships minimal versions that keep
     // the signatures compiling.
     public Task SendInputAsync(byte[] bytes) => throw new NotImplementedException("Task 6");
     public Task ResizeAsync(int cols, int rows) => throw new NotImplementedException("Task 6");
-    public Task DetachAsync() => throw new NotImplementedException("Task 5");
+
+    /// Records intent and sends the Detach frame; never itself claims the cause slot
+    /// except when there is no stream, or the write fails — both mean the connection is
+    /// already effectively gone locally, so that IS a local close. Idempotent. A terminal
+    /// frame the pump reads after this still wins the race (Exited/Failed beat Detached).
+    public async Task DetachAsync() {
+        if (_detachRequested) return;
+        _detachRequested = true;
+        if (_stream is null) { TryClaim(new AttachOutcome.Detached()); return; }
+        try { await WriteLockedAsync(LocalFrame.Detach()).ConfigureAwait(false); }
+        catch { TryClaim(new AttachOutcome.Detached()); CloseTransport(); }   // detach write failure = local close
+    }
+
     public async ValueTask DisposeAsync() {
         _detachRequested = true;
-        TryClaim(new AttachOutcome.Detached());
+        TryClaim(new AttachOutcome.Detached());       // the one eager local terminalizer
         _lifetime?.Cancel();
         CloseTransport();
-        if (_run is { } run) { try { await run.ConfigureAwait(false); } catch { /* Task 5 refines */ } }
+        if (_run is { } run) {
+            try { await run.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }    // retired run's cancellation: never rethrown
+            catch (AttachCallbackException) { }        // already reported where it claimed / lost
+        }
     }
 }
 

--- a/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
@@ -1,0 +1,150 @@
+namespace Capacitor.Cli.Core.LocalIpc;
+
+using System.Net.Sockets;
+
+public sealed class AgentAttachClient : IAsyncDisposable {
+    // The single linearization point: first CAS winner decides RunAsync's result.
+    // Values: AttachOutcome | Exception (callback fault) | _cancelledSentinel.
+    object? _cause;
+    static readonly object CancelledSentinel = new();
+
+    readonly string _socketPath;
+    readonly string _agentId;
+    readonly Func<byte[], string?, CancellationToken, Task> _onAttached;
+    readonly Func<byte[], CancellationToken, Task> _onOutput;
+    readonly Action<string, Exception>? _diagnostics;
+    readonly SemaphoreSlim _writeLock = new(1, 1);
+    readonly object _sinkLock = new();
+
+    Socket? _socket;
+    NetworkStream? _stream;
+    CancellationTokenSource? _lifetime;   // linked to the caller token; callbacks get this token
+    volatile bool _detachRequested;       // intent, never a cause
+    volatile bool _attachedAny;           // true after either Attached reply
+    Task<AttachOutcome>? _run;
+
+    public AgentAttachClient(
+            string socketPath, string agentId,
+            Func<byte[], string?, CancellationToken, Task> onAttachedAsync,
+            Func<byte[], CancellationToken, Task> onOutputAsync,
+            Action<string, Exception>? diagnostics = null) {
+        _socketPath = socketPath;
+        _agentId = agentId;
+        _onAttached = onAttachedAsync;
+        _onOutput = onOutputAsync;
+        _diagnostics = diagnostics;
+    }
+
+    bool TryClaim(object cause) => Interlocked.CompareExchange(ref _cause, cause, null) is null;
+
+    // Losing exceptions go here exactly once; expected teardown artifacts are
+    // excluded by the callers. Serialized; a throwing sink is contained.
+    void Report(string context, Exception ex) {
+        if (_diagnostics is null) return;
+        lock (_sinkLock) {
+            try { _diagnostics(context, ex); } catch { /* contained by contract */ }
+        }
+    }
+
+    public Task<AttachOutcome> RunAsync(int initialCols, int initialRows, CancellationToken ct) {
+        // Dispose/Detach before Run: terminal immediately, no dialing.
+        if (_cause is AttachOutcome pre) return Task.FromResult(pre);
+        if (_detachRequested) { TryClaim(new AttachOutcome.Detached()); return Task.FromResult((AttachOutcome)_cause!); }
+        return _run = RunCoreAsync(initialCols, initialRows, ct);
+    }
+
+    async Task<AttachOutcome> RunCoreAsync(int cols, int rows, CancellationToken ct) {
+        _lifetime = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        using var reg = ct.Register(() => { if (TryClaim(CancelledSentinel)) _lifetime.Cancel(); });
+        try {
+            _socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            await _socket.ConnectAsync(new UnixDomainSocketEndPoint(_socketPath), ct).ConfigureAwait(false);
+            _stream = new NetworkStream(_socket, ownsSocket: false);
+            await FrameCodec.WriteAsync(_stream, new LocalFrame(FrameType.Attach) { Text = _agentId }, ct).ConfigureAwait(false);
+
+            while (true) {
+                var frame = await FrameCodec.ReadAsync(_stream, CancellationToken.None).ConfigureAwait(false);
+                if (frame is null) {                                     // clean EOF
+                    TryClaim(_detachRequested ? new AttachOutcome.Detached() : new AttachOutcome.ConnectionLost());
+                    break;
+                }
+                switch (frame.Type) {
+                    case FrameType.Attached: {
+                        var (_, snapshot) = FrameCodec.Attached(frame);
+                        _attachedAny = true;
+                        await _onAttached(snapshot, null, _lifetime.Token).ConfigureAwait(false);
+                        await WriteLockedAsync(SizeFrame(cols, rows)).ConfigureAwait(false);  // repaint nudge
+                        break;
+                    }
+                    case FrameType.AttachedReadOnly: {
+                        var (_, reason, snapshot) = FrameCodec.AttachedReadOnly(frame);
+                        _attachedAny = true;
+                        await _onAttached(snapshot, reason, _lifetime.Token).ConfigureAwait(false);
+                        break;                                            // no nudge: never influence the clamp
+                    }
+                    case FrameType.Stdout:
+                        await _onOutput(frame.Bytes, _lifetime.Token).ConfigureAwait(false);
+                        break;
+                    case FrameType.Exited:
+                        TryClaim(new AttachOutcome.Exited(frame.ExitCode));
+                        goto done;
+                    case FrameType.Error:
+                        TryClaim(new AttachOutcome.Failed(frame.Text));
+                        goto done;
+                    default:
+                        TryClaim(new AttachOutcome.Failed($"protocol failure: unexpected frame {frame.Type}"));
+                        goto done;
+                }
+            }
+            done: ;
+        } catch (Exception ex) {
+            ClassifyPumpException(ex);      // Task 5 fills this in fully
+        } finally {
+            CloseTransport();
+        }
+        return Project();
+    }
+
+    // Task 5 completes classification; Task 4 needs only enough for its tests.
+    void ClassifyPumpException(Exception ex) {
+        if (_detachRequested || _cause is not null) { /* local close or already decided */ }
+        else if (!_attachedAny) TryClaim(new AttachOutcome.Failed(ex.Message));
+        else TryClaim(new AttachOutcome.ConnectionLost());
+        if (_cause is AttachOutcome && _cause is not AttachOutcome.Detached && ex is not OperationCanceledException)
+            Report("attach pump", ex);   // refine in Task 7 per loser rules
+    }
+
+    AttachOutcome Project() =>
+        _cause switch {
+            AttachOutcome o => o,
+            Exception fault => throw new AttachCallbackException(fault),   // Task 5 refines
+            _ when ReferenceEquals(_cause, CancelledSentinel) => throw new OperationCanceledException(),
+            _ => new AttachOutcome.ConnectionLost(),
+        };
+
+    static LocalFrame SizeFrame(int cols, int rows) => LocalFrame.Resize((ushort)cols, (ushort)rows);
+
+    async Task WriteLockedAsync(LocalFrame frame) {
+        await _writeLock.WaitAsync().ConfigureAwait(false);
+        try { await FrameCodec.WriteAsync(_stream!, frame, CancellationToken.None).ConfigureAwait(false); }
+        finally { _writeLock.Release(); }
+    }
+
+    void CloseTransport() { try { _stream?.Dispose(); } catch { } try { _socket?.Dispose(); } catch { } }
+
+    // Tasks 5-7 implement these fully; Task 4 ships minimal versions that keep
+    // the signatures compiling.
+    public Task SendInputAsync(byte[] bytes) => throw new NotImplementedException("Task 6");
+    public Task ResizeAsync(int cols, int rows) => throw new NotImplementedException("Task 6");
+    public Task DetachAsync() => throw new NotImplementedException("Task 5");
+    public async ValueTask DisposeAsync() {
+        _detachRequested = true;
+        TryClaim(new AttachOutcome.Detached());
+        _lifetime?.Cancel();
+        CloseTransport();
+        if (_run is { } run) { try { await run.ConfigureAwait(false); } catch { /* Task 5 refines */ } }
+    }
+}
+
+/// Wraps a callback fault so RunAsync's fault is distinguishable from infrastructure exceptions.
+public sealed class AttachCallbackException(Exception inner) : Exception("attach callback failed", inner);

--- a/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/AgentAttachClient.cs
@@ -123,7 +123,12 @@ public sealed class AgentAttachClient : IAsyncDisposable {
     async Task<bool> InvokeCallbackAsync(Func<Task> callback) {
         try { await callback().ConfigureAwait(false); return true; }
         catch (OperationCanceledException) when (_lifetime!.IsCancellationRequested) { throw; }
-        catch (Exception ex) { TryClaim(ex); return false; }
+        catch (Exception ex) {
+            // A won claim IS the run's result (Project rethrows it) — not a diagnostic;
+            // only a loss (Dispose or another producer already claimed) is reported.
+            if (!TryClaim(ex)) ReportIfLost("callback", ex);
+            return false;
+        }
     }
 
     void ClassifyPumpException(Exception ex) {
@@ -132,15 +137,27 @@ public sealed class AgentAttachClient : IAsyncDisposable {
             TryClaim(new AttachOutcome.Detached());   // local close at any phase; expected — not a diagnostic
             return;
         }
-        if (ex is InvalidDataException) { TryClaim(new AttachOutcome.Failed($"protocol failure: {ex.Message}")); ReportIfLost("protocol", ex); return; }
-        if (!_attachedAny) { TryClaim(new AttachOutcome.Failed(ex.Message)); ReportIfLost("pre-attach", ex); return; }
-        TryClaim(new AttachOutcome.ConnectionLost());
-        ReportIfLost("transport", ex);
+        // A won claim carries its own detail in the outcome (Failed's message), so
+        // reporting only fires on a genuine loss — never duplicate the winning result.
+        if (ex is InvalidDataException) {
+            if (!TryClaim(new AttachOutcome.Failed($"protocol failure: {ex.Message}"))) ReportIfLost("protocol", ex);
+            return;
+        }
+        if (!_attachedAny) {
+            if (!TryClaim(new AttachOutcome.Failed(ex.Message))) ReportIfLost("pre-attach", ex);
+            return;
+        }
+        if (!TryClaim(new AttachOutcome.ConnectionLost())) ReportIfLost("transport", ex);
     }
 
-    // An exception whose cause attempt LOST still gets observed exactly once (Task 7 tests pin this).
+    // Called only once the caller already knows this attempt LOST the cause-slot
+    // race (a failed TryClaim) — every actual losing exception is observed exactly
+    // once, regardless of which cause won. The one exclusion: a socket-close
+    // IOException/ObjectDisposedException that lost to a Detached claim is the
+    // normal knock-on of CloseTransport(), not a genuine failure to diagnose.
     void ReportIfLost(string context, Exception ex) {
-        if (_cause is AttachOutcome.Detached || ReferenceEquals(_cause, CancelledSentinel)) Report(context, ex);
+        if (ex is IOException or ObjectDisposedException && _cause is AttachOutcome.Detached) return;
+        Report(context, ex);
     }
 
     AttachOutcome Project() =>
@@ -182,8 +199,10 @@ public sealed class AgentAttachClient : IAsyncDisposable {
                 await FrameCodec.WriteAsync(_stream!, frame, CancellationToken.None).ConfigureAwait(false);
             } finally { _writeLock.Release(); }
         } catch (Exception ex) {
+            // ConnectionLost carries no detail, so a won claim is reported too — unlike a
+            // callback fault, the sink is the only place this exception ever surfaces.
             if (TryClaim(new AttachOutcome.ConnectionLost())) Report("outbound write", ex);
-            else if (_cause is AttachOutcome.Detached || ReferenceEquals(_cause, CancelledSentinel)) Report("outbound write", ex);
+            else ReportIfLost("outbound write", ex);
             CloseTransport();
         }
     }

--- a/src/Capacitor.Cli.Core/LocalIpc/AttachOutcome.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/AttachOutcome.cs
@@ -1,0 +1,12 @@
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// Exactly one of these is RunAsync's result. Detached = locally initiated
+/// close; Exited = agent process exit; Failed = daemon Error / refusal /
+/// protocol failure / pre-attach failure; ConnectionLost = uninitiated
+/// transport loss after attach.
+public abstract record AttachOutcome {
+    public sealed record Detached : AttachOutcome;
+    public sealed record Exited(int Code) : AttachOutcome;
+    public sealed record Failed(string Message) : AttachOutcome;
+    public sealed record ConnectionLost : AttachOutcome;
+}

--- a/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
@@ -38,7 +38,13 @@ public sealed record DaemonInfoDto(
 public sealed record AgentStatusDto(
     string Id, string Kind, string Vendor, string? RepoPath, string Status,
     string? FlowRunId, string? FlowRole, string? Requester, DateTime CreatedAt, string? Model,
-    string? RequesterDisplay);
+    string? RequesterDisplay,
+    // Whether the agent's runtime emits a PTY the app can attach to
+    // (IHostedAgentRuntime.EmitsTerminalOutput). Trailing + nullable so every
+    // existing positional construction stays valid; null = older daemon,
+    // unknown — the app falls back to its vendor heuristic. Always emitted:
+    // false is a real value, not an absence.
+    bool? HasTerminal = null);
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(DaemonStatusDto))]

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -53,7 +53,8 @@ internal partial class AgentOrchestrator {
                 // (ModelSelectionLaunchPolicy.Evaluate treats blank as Honor, i.e. pass-through
                 // unchanged) — but the wire contract pins absent = null. Normalize here, at the
                 // wire boundary, rather than changing what AgentInstance stores.
-                string.IsNullOrWhiteSpace(a.Model) ? null : a.Model, a.RequesterDisplay))];
+                string.IsNullOrWhiteSpace(a.Model) ? null : a.Model, a.RequesterDisplay,
+                HasTerminal: a.Runtime.EmitsTerminalOutput))];
 
     /// <summary>
     /// Serves the legacy <c>Stop</c> frame from older clients that predate --force. That frame

--- a/test/Capacitor.App.Tests.Unit/AvaloniaSession.cs
+++ b/test/Capacitor.App.Tests.Unit/AvaloniaSession.cs
@@ -73,4 +73,16 @@ internal static class AvaloniaSession {
         RxSchedulers.MainThreadScheduler = ImmediateScheduler.Instance;
         try { await body(); } finally { RxSchedulers.MainThreadScheduler = prior; }
     }
+
+    /// The standard wrapper for tests that need BOTH pieces at once: WithImmediateRxScheduler
+    /// nested INSIDE DispatchAsync. ObserveOn(RxSchedulers.MainThreadScheduler) projections need
+    /// the immediate scheduler to apply synchronously, while any Dispatcher.UIThread.InvokeAsync
+    /// hop needs the live pumped dispatcher loop DispatchAsync provides -- outside a Dispatch
+    /// frame the headless session's worker thread is blocked and a queued InvokeAsync never runs
+    /// (see TerminalTabViewModelTests' header comment for the full account).
+    public static Task RunOnUiAsync(Func<Task> body) =>
+        DispatchAsync(async () => {
+            await WithImmediateRxScheduler(body);
+            return true;
+        });
 }

--- a/test/Capacitor.App.Tests.Unit/FakeTerminalAttachClient.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeTerminalAttachClient.cs
@@ -51,6 +51,12 @@ sealed class FakeTerminalAttachClient : ITerminalAttachClient {
     public readonly TaskCompletionSource DetachGate =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+    /// When set, DisposeAsync awaits this gate before RETURNING -- letting a test hold "dispose in
+    /// flight" open deterministically, the same way a real client's DisposeAsync awaits its own
+    /// pump. Null (default) means DisposeAsync returns immediately once this class's own cleanup
+    /// runs, preserving every test written before this existed.
+    public TaskCompletionSource? DisposeGate { get; set; }
+
     public FakeTerminalAttachClient(
             Func<byte[], string?, CancellationToken, Task> onAttached,
             Func<byte[], CancellationToken, Task> onOutput) {
@@ -100,12 +106,16 @@ sealed class FakeTerminalAttachClient : ITerminalAttachClient {
         if (HangDetachForever) await DetachGate.Task.ConfigureAwait(false);
     }
 
-    public ValueTask DisposeAsync() {
+    public async ValueTask DisposeAsync() {
         DisposeCalls++;
         _lifetime?.Cancel();
         _onAttached = null;
         _onOutput = null;
-        return ValueTask.CompletedTask;
+        // Mirrors AgentAttachClient.DisposeAsync's "one eager local terminalizer" (TryClaim a
+        // Detached outcome) -- a TRY, so it's a silent no-op if the test (or an earlier caller)
+        // already completed Result with something else.
+        Result.TrySetResult(new AttachOutcome.Detached());
+        if (DisposeGate is not null) await DisposeGate.Task.ConfigureAwait(false);
     }
 }
 

--- a/test/Capacitor.App.Tests.Unit/FakeTerminalAttachClient.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeTerminalAttachClient.cs
@@ -1,0 +1,128 @@
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Scriptable ITerminalAttachClient: one instance per attach attempt, mirroring
+/// AgentAttachClient's own "one client = one run, never re-run after termination" contract.
+/// RunAsync blocks on <see cref="Result"/> until the test completes it (an outcome or a fault);
+/// TriggerAttached/TriggerOutput invoke the callbacks the factory captured, exactly like the
+/// production client's own read-loop would.
+sealed class FakeTerminalAttachClient : ITerminalAttachClient {
+    // NOT readonly: DisposeAsync clears these -- a real client's callbacks close over the
+    // attempt's surface/decoder, and this client is the only thing still referencing them once
+    // the VM has nulled its own Surface/_client fields, so a test proving the surface is released
+    // (weak-reference goes dead after GC.Collect) needs this hold broken too, exactly like the
+    // production client dropping its own captured state on Dispose.
+    Func<byte[], string?, CancellationToken, Task>? _onAttached;
+    Func<byte[], CancellationToken, Task>? _onOutput;
+
+    /// Cancelled by DisposeAsync (mirrors AgentAttachClient's internal `_lifetime`) and linked
+    /// from RunAsync's own ct -- so either the caller's token OR a Dispose releases anything
+    /// awaiting it, same as the production client.
+    CancellationTokenSource? _lifetime;
+
+    public readonly TaskCompletionSource<AttachOutcome> Result =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public readonly TaskCompletionSource RunStarted =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public List<byte[]> SentInput { get; } = [];
+    public List<(int Cols, int Rows)> Resizes { get; } = [];
+    public int DetachCalls { get; private set; }
+    public int DisposeCalls { get; private set; }
+    public int Cols { get; private set; }
+    public int Rows { get; private set; }
+
+    /// When true, RunAsync blocks on an internal never-completing await (standing in for a pump
+    /// that's awaiting a callback that never returns) released only by _lifetime -- i.e. only by
+    /// DisposeAsync or the run's own token, exactly like a real socket-read pump.
+    public bool HangOnOutputForever { get; set; }
+
+    /// The Task RunAsync is blocked on when HangOnOutputForever is set -- exposed so a test can
+    /// assert it completed (cancelled) after teardown, independent of any GC-based assertion.
+    public Task? CallbackTask { get; private set; }
+
+    /// When true, DetachAsync blocks until the test completes DetachGate (an outcome or a fault)
+    /// -- deliberately NOT tied to _lifetime, so TeardownAsync's 1s bound is what has to force it,
+    /// not an incidental Dispose-driven unblock.
+    public bool HangDetachForever { get; set; }
+    public readonly TaskCompletionSource DetachGate =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public FakeTerminalAttachClient(
+            Func<byte[], string?, CancellationToken, Task> onAttached,
+            Func<byte[], CancellationToken, Task> onOutput) {
+        _onAttached = onAttached;
+        _onOutput = onOutput;
+    }
+
+    public async Task<AttachOutcome> RunAsync(int initialCols, int initialRows, CancellationToken ct) {
+        Cols = initialCols;
+        Rows = initialRows;
+        _lifetime = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        RunStarted.TrySetResult();
+
+        if (HangOnOutputForever) {
+            CallbackTask = Task.Delay(Timeout.InfiniteTimeSpan, _lifetime.Token);
+            await CallbackTask.ConfigureAwait(false); // throws OperationCanceledException once released
+        }
+
+        return await Result.Task.ConfigureAwait(false);
+    }
+
+    /// Invokes the captured onAttached callback with the run's own token, exactly like the
+    /// production client's read loop does.
+    public Task TriggerAttached(byte[] snapshot, string? reason = null) =>
+        _onAttached is null
+            ? throw new ObjectDisposedException(nameof(FakeTerminalAttachClient))
+            : _onAttached(snapshot, reason, _lifetime?.Token ?? CancellationToken.None);
+
+    /// Invokes the captured onOutput callback with the run's own token.
+    public Task TriggerOutput(byte[] bytes) =>
+        _onOutput is null
+            ? throw new ObjectDisposedException(nameof(FakeTerminalAttachClient))
+            : _onOutput(bytes, _lifetime?.Token ?? CancellationToken.None);
+
+    public Task SendInputAsync(byte[] bytes) {
+        SentInput.Add(bytes);
+        return Task.CompletedTask;
+    }
+
+    public Task ResizeAsync(int cols, int rows) {
+        Resizes.Add((cols, rows));
+        return Task.CompletedTask;
+    }
+
+    public async Task DetachAsync() {
+        DetachCalls++;
+        if (HangDetachForever) await DetachGate.Task.ConfigureAwait(false);
+    }
+
+    public ValueTask DisposeAsync() {
+        DisposeCalls++;
+        _lifetime?.Cancel();
+        _onAttached = null;
+        _onOutput = null;
+        return ValueTask.CompletedTask;
+    }
+}
+
+/// Records every client it creates, and the callbacks the VM handed it -- the seam tests use to
+/// drive attach attempts from outside (TriggerAttached/TriggerOutput/Result) without a real daemon.
+sealed class FakeTerminalAttachClientFactory {
+    public List<FakeTerminalAttachClient> Created { get; } = [];
+
+    /// Configures the NEXT client this factory creates (consumed once) -- lets a test arrange
+    /// HangOnOutputForever/HangDetachForever before the VM triggers the attach that creates it.
+    public Action<FakeTerminalAttachClient>? ConfigureNext { get; set; }
+
+    public TerminalAttachClientFactory Factory => (agentId, onAttached, onOutput) => {
+        var client = new FakeTerminalAttachClient(onAttached, onOutput);
+        ConfigureNext?.Invoke(client);
+        ConfigureNext = null;
+        Created.Add(client);
+        return client;
+    };
+}

--- a/test/Capacitor.App.Tests.Unit/FakeTerminalSurface.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeTerminalSurface.cs
@@ -1,0 +1,18 @@
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The shared ITerminalSurface fake: records what was fed and how often the caret was re-shown,
+/// and lets a test raise input/resize as if the control did. Suites that only need an inert
+/// surface use it as-is and ignore the recorders.
+sealed class FakeTerminalSurface : ITerminalSurface {
+    public List<string> Fed { get; } = [];
+    public void Feed(string text) => Fed.Add(text);
+    public event Action<byte[]>? InputProduced;
+    public event Action<int, int>? Resized;
+    public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
+    public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
+    public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
+    public int CaretShown;
+    public void EnsureCaretVisible() => CaretShown++;
+}

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -11,9 +11,15 @@ namespace Capacitor.App.Tests.Unit;
 /// here runs inside AvaloniaSession.WithImmediateRxScheduler and carries
 /// [NotInParallel("AvaloniaSession")] — see MainWindowViewModelTests' identical header comment.
 public class HomeViewModelTests {
+    /// The daemon mints agent ids as Guid("N") — 32 hex digits — and a Started outcome carrying
+    /// anything else is the "launched but unopenable" case (spec §3), so every launch fixture here
+    /// uses real-shaped ids.
+    const string LaunchedId = "0123456789abcdef0123456789abcdef";
+    const string SecondLaunchedId = "fedcba9876543210fedcba9876543210";
+
     sealed class RecordingLaunchClient : ILaunchClient {
         public LaunchRequest? Last;
-        public LaunchOutcome Next = new(true, "agent-1", null);
+        public LaunchOutcome Next = new(true, LaunchedId, null);
 
         public Task<LaunchOutcome> StartAsync(LaunchRequest request, CancellationToken ct) {
             Last = request;
@@ -403,7 +409,7 @@ public class HomeViewModelTests {
             await vm.SelectRepositoryAsync("/repo/a");
             await vm.StartCommand.Execute();
 
-            launch.Next = new LaunchOutcome(true, "agent-2", null);
+            launch.Next = new LaunchOutcome(true, SecondLaunchedId, null);
             vm.Goal = "next thing";
             await vm.StartCommand.Execute();
 

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.Reactive.Linq;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Capacitor.App.Services;
@@ -17,8 +18,13 @@ namespace Capacitor.App.Tests.Unit;
 /// headless something to Show(); session setup and control lookup otherwise copy
 /// MainWindowSmokeTests exactly (see that file's own header comment).
 public class HomeViewSmokeTests {
+    /// Real-shaped agent ids (Guid("N"), 32 hex digits): a Started outcome carrying anything else
+    /// is HomeViewModel's "launched but unopenable" error, which would keep StartErrorText visible.
+    const string LaunchedId = "0123456789abcdef0123456789abcdef";
+    const string SecondLaunchedId = "fedcba9876543210fedcba9876543210";
+
     sealed class RecordingLaunchClient : ILaunchClient {
-        public LaunchOutcome Next = new(true, "agent-1", null);
+        public LaunchOutcome Next = new(true, LaunchedId, null);
 
         public Task<LaunchOutcome> StartAsync(LaunchRequest request, CancellationToken ct) =>
             Task.FromResult(Next);
@@ -114,7 +120,7 @@ public class HomeViewSmokeTests {
             var afterFailure = errorText.IsVisible;
             var message = errorText.Text;
 
-            launch.Next = new LaunchOutcome(true, "agent-2", null);
+            launch.Next = new LaunchOutcome(true, SecondLaunchedId, null);
             await vm.StartCommand.Execute();
             Dispatcher.UIThread.RunJobs();
             var afterSuccess = errorText.IsVisible;
@@ -178,6 +184,39 @@ public class HomeViewSmokeTests {
         await Assert.That(failure).IsNull();
         await Assert.That(mutatedOnUiThread).IsTrue();
         await Assert.That(realizedCount).IsEqualTo(1);
+    }
+
+    /// The card's click plumbing (spec §3, entry points): the whole card is a Button whose Click
+    /// carries the card's OWN id to the window. Realized-visual-dependent by necessity — the
+    /// handler lives in the item template, so only a rendered card can raise it.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Clicking_a_session_card_asks_to_open_that_session() {
+        var requested = await AvaloniaSession.DispatchAsync(() => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var service = new FakeDaemonClientService();
+            var opened = new List<string>();
+            var vm = new HomeViewModel(
+                service, new AppStateStore(path), new RecordingLaunchClient(),
+                () => Task.FromResult(Array.Empty<string>()), openSession: opened.Add);
+            var window = new Window { Content = new HomeView { DataContext = vm } };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            service.Agents.AddOrUpdate(new AgentStatusDto(
+                SecondLaunchedId, "agent", "claude", "/repos/kcap-cli", "Running", null, null, null, DateTime.UtcNow, null, null));
+            Dispatcher.UIThread.RunJobs();
+
+            var card = window.GetVisualDescendants().OfType<Button>().First(b => b.Classes.Contains("sessionCard"));
+            card.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            vm.Dispose();
+            return opened.ToList();
+        });
+
+        await Assert.That(requested).IsEquivalentTo([SecondLaunchedId]);
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/HostedHarnessCatalogTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HostedHarnessCatalogTests.cs
@@ -69,4 +69,29 @@ public class HostedHarnessCatalogTests {
         await Assert.That(HostedHarnessCatalog.DescriptionFor(pty)).IsEqualTo("PTY · terminal + chat");
         await Assert.That(HostedHarnessCatalog.DescriptionFor(acp)).IsEqualTo("ACP · chat");
     }
+
+    [Test]
+    public async Task FamilyFor_maps_vendors_and_defaults_unknown_to_rpc() {
+        await Assert.That(HostedHarnessCatalog.FamilyFor("CLAUDE")).IsEqualTo("pty");
+        await Assert.That(HostedHarnessCatalog.FamilyFor("gemini")).IsEqualTo("acp");
+        await Assert.That(HostedHarnessCatalog.FamilyFor("neverheardof")).IsEqualTo("rpc");
+    }
+
+    [Test]
+    public async Task ShowsTerminal_prefers_the_authoritative_flag_and_falls_back_to_family() {
+        await Assert.That(HostedHarnessCatalog.ShowsTerminal(true, "gemini")).IsTrue();
+        await Assert.That(HostedHarnessCatalog.ShowsTerminal(false, "claude")).IsFalse();
+        await Assert.That(HostedHarnessCatalog.ShowsTerminal(null, "claude")).IsTrue();
+        await Assert.That(HostedHarnessCatalog.ShowsTerminal(null, "gemini")).IsFalse();
+    }
+
+    [Test]
+    public async Task EffectiveFamily_overrides_only_a_conflicting_pty_guess() {
+        // codex app-server: vendor map says pty, daemon says no terminal → generic chat family.
+        await Assert.That(HostedHarnessCatalog.EffectiveFamily(false, "codex")).IsEqualTo("rpc");
+        // an already-non-PTY family is preserved, not flattened:
+        await Assert.That(HostedHarnessCatalog.EffectiveFamily(false, "gemini")).IsEqualTo("acp");
+        await Assert.That(HostedHarnessCatalog.EffectiveFamily(null, "claude")).IsEqualTo("pty");
+        await Assert.That(HostedHarnessCatalog.EffectiveFamily(true, "claude")).IsEqualTo("pty");
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -460,5 +460,6 @@ public class MainWindowSmokeTests {
         public event Action<int, int>? Resized;
         public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
         public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
+        public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
     }
 }

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -7,6 +7,7 @@ using Capacitor.App.ViewModels;
 using Capacitor.App.Views;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
+using Microsoft.Extensions.Time.Testing;
 using static Capacitor.App.Tests.Unit.FakeDaemonClientService;
 
 namespace Capacitor.App.Tests.Unit;
@@ -394,5 +395,70 @@ public class MainWindowSmokeTests {
         await Assert.That(afterActivity).IsEqualTo(1); // selecting Activity: one immediate read
         await Assert.That(afterHide).IsEqualTo(1); // hiding is a FALSE transition — no read
         await Assert.That(afterReshow).IsEqualTo(2); // re-showing: another TRUE transition
+    }
+
+    /// The surface swap itself (spec §3) — the XAML side of what WorkspaceNavigationTests pins on
+    /// the ViewModel. WorkspaceView is materialized from a template rather than always present, so
+    /// this also proves the terminal control is CONSTRUCTED only once a workspace exists.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Opening_a_session_swaps_the_window_from_the_tabbed_shell_to_the_workspace() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var swap = await AvaloniaSession.DispatchAsync(() => {
+                var service = new FakeDaemonClientService();
+                var (actions, _) = NewActions(service);
+                var attach = new FakeTerminalAttachClientFactory();
+                var vm = new MainWindowViewModel(
+                    service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New(),
+                    workspaceFactory: agentId => new WorkspaceViewModel(
+                        agentId, service, actions, attach.Factory, () => new SilentTerminalSurface(), new FakeTimeProvider()));
+                var window = new MainWindow { DataContext = vm };
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                // IsEffectivelyVisible, not IsVisible: the swap hides the tab strip's whole ANCESTOR
+                // (the shell Grid), and a control's own IsVisible says nothing about that.
+                var tabs = window.GetVisualDescendants().OfType<TabControl>().First(t => t.Name == "MainTabs");
+                var shellVisible = tabs.IsEffectivelyVisible;
+                var workspacesBefore = window.GetVisualDescendants().OfType<WorkspaceView>().Count();
+
+                vm.OpenSession("0123456789abcdef0123456789abcdef");
+                Dispatcher.UIThread.RunJobs();
+                var shellHidden = tabs.IsEffectivelyVisible;
+                var opened = window.GetVisualDescendants().OfType<WorkspaceView>().ToList();
+                // Read NOW, not in the return tuple: closing below detaches the view and clears the
+                // very DataContext this is asserting on.
+                var boundToWorkspace = opened.FirstOrDefault()?.DataContext is WorkspaceViewModel;
+
+                vm.CloseWorkspace();
+                Dispatcher.UIThread.RunJobs();
+                var shellBack = tabs.IsEffectivelyVisible;
+                var workspacesAfter = window.GetVisualDescendants().OfType<WorkspaceView>().Count();
+
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+
+                return (shellVisible, workspacesBefore, shellHidden, OpenedCount: opened.Count,
+                    boundToWorkspace, shellBack, workspacesAfter);
+            });
+
+            await Assert.That(swap.shellVisible).IsTrue();
+            await Assert.That(swap.workspacesBefore).IsEqualTo(0); // nothing terminal-shaped until a session is opened
+            await Assert.That(swap.shellHidden).IsFalse();
+            await Assert.That(swap.OpenedCount).IsEqualTo(1);
+            await Assert.That(swap.boundToWorkspace).IsTrue();
+            await Assert.That(swap.shellBack).IsTrue();
+            await Assert.That(swap.workspacesAfter).IsEqualTo(0);
+        });
+    }
+
+    /// Feeds nowhere and raises nothing: this suite is about the window's surfaces, not the
+    /// terminal's own behavior (TerminalTabViewModelTests owns that).
+    sealed class SilentTerminalSurface : ITerminalSurface {
+        public void Feed(string text) { }
+        public event Action<byte[]>? InputProduced;
+        public event Action<int, int>? Resized;
+        public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
+        public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
     }
 }

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -461,5 +461,7 @@ public class MainWindowSmokeTests {
         public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
         public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
         public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
+        public int CaretShown;
+        public void EnsureCaretVisible() => CaretShown++;
     }
 }

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -411,7 +411,7 @@ public class MainWindowSmokeTests {
                 var vm = new MainWindowViewModel(
                     service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New(),
                     workspaceFactory: agentId => new WorkspaceViewModel(
-                        agentId, service, actions, attach.Factory, () => new SilentTerminalSurface(), new FakeTimeProvider()));
+                        agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider()));
                 var window = new MainWindow { DataContext = vm };
                 window.Show();
                 Dispatcher.UIThread.RunJobs();
@@ -450,18 +450,5 @@ public class MainWindowSmokeTests {
             await Assert.That(swap.shellBack).IsTrue();
             await Assert.That(swap.workspacesAfter).IsEqualTo(0);
         });
-    }
-
-    /// Feeds nowhere and raises nothing: this suite is about the window's surfaces, not the
-    /// terminal's own behavior (TerminalTabViewModelTests owns that).
-    sealed class SilentTerminalSurface : ITerminalSurface {
-        public void Feed(string text) { }
-        public event Action<byte[]>? InputProduced;
-        public event Action<int, int>? Resized;
-        public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
-        public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
-        public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
-        public int CaretShown;
-        public void EnsureCaretVisible() => CaretShown++;
     }
 }

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -322,6 +322,53 @@ public class MainWindowViewModelTests {
         });
     }
 
+    // ---- Navigation (spec §3). The full surface-swap/teardown matrix lives in
+    // WorkspaceNavigationTests; these two pin what the VM's own nullable-default seams promise. ----
+
+    /// Every caller that predates workspaces passes no factory — and must keep landing on the
+    /// tabbed shell rather than a half-built workspace or a throw.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Without_a_workspace_factory_the_window_stays_on_the_tabbed_shell() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var (actions, _) = NewActions(service);
+            var vm = new MainWindowViewModel(service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New());
+
+            vm.OpenSession("0123456789abcdef0123456789abcdef");
+            vm.OpenSessionIfCurrent("0123456789abcdef0123456789abcdef", vm.NavigationGeneration);
+
+            await Assert.That(vm.CurrentWorkspace).IsNull();
+        });
+    }
+
+    /// The gate is app-lifetime, not per-window: MainWindowCoordinator can build a second window
+    /// over the same composition, and a launch captured in the first must read as stale in the
+    /// second — which only holds while both read ONE generation.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_navigation_gate_is_shared_across_the_windows_built_over_it() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var (actions, _) = NewActions(service);
+            var gate = new NavigationGate();
+            MainWindowViewModel Build() => new(
+                service, actions, new FakeTicker(), CancellationToken.None, TestActivity.New(), navigation: gate);
+
+            var first = Build();
+            var second = Build();
+            var captured = first.NavigationGeneration;
+
+            first.CloseWorkspace(); // close-to-hide in the first window
+
+            await Assert.That(second.NavigationGeneration).IsEqualTo(first.NavigationGeneration);
+            await Assert.That(second.NavigationGeneration).IsNotEqualTo(captured);
+
+            first.LatchShutdown();
+            await Assert.That(gate.ShutdownLatched).IsTrue();
+        });
+    }
+
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Deactivation_disposes_subscriptions() {

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -31,6 +31,7 @@ public class TerminalTabViewModelTests {
         public event Action<int, int>? Resized;
         public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
         public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
+        public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
     }
 
     static AgentStatusDto Agent(string id, string vendor, bool? hasTerminal, string? repoPath = null) => new(
@@ -66,11 +67,12 @@ public class TerminalTabViewModelTests {
         });
 
     static async Task<(FakeDaemonClientService Daemon, FakeTerminalAttachClientFactory Factory, FakeTimeProvider Time, TerminalTabViewModel Vm, FakeTerminalAttachClient Client)>
-            BuildConnectingAsync(string vendor = "claude", bool? hasTerminal = true, string agentId = "a1", Action<FakeTerminalAttachClient>? configureNext = null) {
+            BuildConnectingAsync(string vendor = "claude", bool? hasTerminal = true, string agentId = "a1",
+                Action<FakeTerminalAttachClient>? configureNext = null, Func<ITerminalSurface>? surfaceFactory = null) {
         var daemon = new FakeDaemonClientService();
         var factory = new FakeTerminalAttachClientFactory { ConfigureNext = configureNext };
         var time = new FakeTimeProvider();
-        var vm = Build(daemon, factory, time, agentId);
+        var vm = Build(daemon, factory, time, agentId, surfaceFactory);
 
         daemon.Agents.AddOrUpdate(Agent(agentId, vendor, hasTerminal));
         await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
@@ -201,6 +203,33 @@ public class TerminalTabViewModelTests {
 
             await Assert.That(client.SentInput).IsEmpty();
             await Assert.That(client.Resizes).IsEmpty();
+        });
+    }
+
+    /// I1 (final review): RunAsync's initial cols/rows are the phantom DefaultCols/Rows constant
+    /// (80x24), sent before the surface's real pane size is ever known -- a read-write Attached
+    /// must resend the surface's OWN current size to correct that nudge. A read-only attach gets
+    /// no nudge at all (belt-and-braces with WireSurface's own ReadOnly guard on user-driven
+    /// resizes -- this is the SEPARATE post-attach nudge fired once from OnAttachedAsync itself).
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Read_write_attach_resends_the_surfaces_real_size_and_read_only_sends_none() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, vm, client) = await BuildConnectingAsync(
+                surfaceFactory: () => new FakeTerminalSurface { CurrentSize = (137, 41) });
+
+            await client.TriggerAttached([]);
+
+            await Assert.That(vm.State.ReadOnly).IsFalse();
+            await Assert.That(client.Resizes.Single()).IsEqualTo((137, 41));
+
+            var (_, _, _, vm2, client2) = await BuildConnectingAsync(
+                agentId: "a2", surfaceFactory: () => new FakeTerminalSurface { CurrentSize = (137, 41) });
+
+            await client2.TriggerAttached([], reason: "review");
+
+            await Assert.That(vm2.State.ReadOnly).IsTrue();
+            await Assert.That(client2.Resizes).IsEmpty();
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -1,0 +1,467 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// TerminalTabViewModel's resolve gate, attempt lifecycle and outcome mapping. Every test here
+/// (except the scheduler-assertion test) runs through RunOnUiAsync and carries
+/// [NotInParallel("AvaloniaSession")]. Two DISTINCT things are needed together, not either alone:
+/// the resolve gate's Agents-cache projection ObserveOn(RxSchedulers.MainThreadScheduler) needs
+/// WithImmediateRxScheduler (same reason as HomeViewModelTests' identical header comment) to apply
+/// synchronously; but the attempt lifecycle's Dispatcher.UIThread.InvokeAsync hops (the swap,
+/// OnAttached/OnOutput, outcome mapping) need a LIVE dispatcher loop to ever be serviced at all --
+/// HeadlessUnitTestSession's own doc comment: "All UI tests are supposed to be executed from one
+/// of the Dispatch(...) methods to keep execution flow on the UI thread" -- outside an active
+/// Dispatch(...) frame its worker thread is simply blocked waiting for the next one, so an
+/// InvokeAsync queued from a bare WithImmediateRxScheduler body (no Dispatch involved) NEVER runs
+/// and the awaiting call hangs forever (confirmed empirically). ActivityViewModelTests' own header
+/// comment documents the identical fix for its Dispatcher.UIThread.InvokeAsync hop. RunOnUiAsync
+/// nests WithImmediateRxScheduler INSIDE DispatchAsync so both are satisfied at once.
+public class TerminalTabViewModelTests {
+    sealed class FakeTerminalSurface : ITerminalSurface {
+        public List<string> Fed { get; } = [];
+        public void Feed(string text) => Fed.Add(text);
+        public event Action<byte[]>? InputProduced;
+        public event Action<int, int>? Resized;
+        public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
+        public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
+    }
+
+    static AgentStatusDto Agent(string id, string vendor, bool? hasTerminal, string? repoPath = null) => new(
+        id, "agent", vendor, repoPath, "Running",
+        FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null,
+        RequesterDisplay: null, HasTerminal: hasTerminal);
+
+    static TerminalTabViewModel Build(
+            FakeDaemonClientService daemon, FakeTerminalAttachClientFactory factory, FakeTimeProvider time,
+            string agentId = "a1", Func<ITerminalSurface>? surfaceFactory = null) =>
+        new(agentId, daemon, factory.Factory, surfaceFactory ?? (() => new FakeTerminalSurface()), time);
+
+    // Real-time poll for a condition an async continuation settles OUTSIDE the test's own await
+    // chain (e.g. a Task.ContinueWith observer attached to an abandoned task) -- never used to
+    // gate FakeTimeProvider-driven logic itself, only to let its already-fired continuations
+    // flush. Same idiom as ConsentServiceTests/PauseControllerTests etc.
+    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    // See the class doc comment: WithImmediateRxScheduler alone never pumps Dispatcher.UIThread,
+    // so a test that reaches TryStartAttemptAsync/OnAttached/OnOutput (any Dispatcher.UIThread.
+    // InvokeAsync hop) needs the real, live dispatcher loop DispatchAsync provides. Nested rather
+    // than either alone.
+    static Task RunOnUiAsync(Func<Task> body) =>
+        AvaloniaSession.DispatchAsync(async () => {
+            await AvaloniaSession.WithImmediateRxScheduler(body);
+            return true;
+        });
+
+    static async Task<(FakeDaemonClientService Daemon, FakeTerminalAttachClientFactory Factory, FakeTimeProvider Time, TerminalTabViewModel Vm, FakeTerminalAttachClient Client)>
+            BuildConnectingAsync(string vendor = "claude", bool? hasTerminal = true, string agentId = "a1", Action<FakeTerminalAttachClient>? configureNext = null) {
+        var daemon = new FakeDaemonClientService();
+        var factory = new FakeTerminalAttachClientFactory { ConfigureNext = configureNext };
+        var time = new FakeTimeProvider();
+        var vm = Build(daemon, factory, time, agentId);
+
+        daemon.Agents.AddOrUpdate(Agent(agentId, vendor, hasTerminal));
+        await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+        return (daemon, factory, time, vm, factory.Created.Single());
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Opens_resolving_and_no_client_exists_before_the_first_dto() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var time = new FakeTimeProvider();
+            var vm = Build(daemon, factory, time, agentId: "missing");
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Resolving);
+            await Assert.That(factory.Created.Count).IsEqualTo(0);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Has_terminal_false_renders_the_note_with_zero_attempts() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var time = new FakeTimeProvider();
+            var vm = Build(daemon, factory, time, agentId: "a1");
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: false));
+            await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.NoTerminal);
+            await Assert.That(vm.State.Detail).Contains("runs over ACP");
+            await Assert.That(factory.Created.Count).IsEqualTo(0);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Has_terminal_true_and_null_pty_fallback_proceed_to_attach() {
+        await RunOnUiAsync(async () => {
+            // Case 1: explicit hasTerminal:true, vendor gemini (whose vendor family is acp).
+            var daemon1 = new FakeDaemonClientService();
+            var factory1 = new FakeTerminalAttachClientFactory();
+            var vm1 = Build(daemon1, factory1, new FakeTimeProvider(), agentId: "a1");
+
+            daemon1.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: true));
+            await (vm1.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+            await Assert.That(factory1.Created.Count).IsEqualTo(1);
+            await Assert.That(vm1.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
+
+            // Case 2: hasTerminal:null (older daemon), vendor claude falls back to its pty family.
+            var daemon2 = new FakeDaemonClientService();
+            var factory2 = new FakeTerminalAttachClientFactory();
+            var vm2 = Build(daemon2, factory2, new FakeTimeProvider(), agentId: "a2");
+
+            daemon2.Agents.AddOrUpdate(Agent("a2", "claude", hasTerminal: null));
+            await (vm2.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+            await Assert.That(factory2.Created.Count).IsEqualTo(1);
+            await Assert.That(vm2.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Resolve_timeout_is_not_found_and_a_late_dto_is_ignored_until_retry() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var time = new FakeTimeProvider();
+            var vm = Build(daemon, factory, time, agentId: "a1");
+
+            time.Advance(TimeSpan.FromSeconds(10));
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.NotFound);
+
+            // A late DTO reaches nothing -- the timeout disposed the Agents subscription.
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.NotFound);
+            await Assert.That(factory.Created.Count).IsEqualTo(0);
+
+            // RetryResolveCommand resolves against the now-present DTO.
+            await vm.RetryResolveCommand.Execute();
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
+            await Assert.That(factory.Created.Count).IsEqualTo(1);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Removal_after_first_observation_is_session_ended_not_resolving() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var time = new FakeTimeProvider();
+            var vm = Build(daemon, factory, time, agentId: "a1");
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+            await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
+
+            daemon.Agents.Remove("a1");
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.SessionEnded);
+        });
+    }
+
+    // ---- outcome mapping and attempt lifecycle ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Read_only_attach_shows_the_reason_and_suppresses_input_and_resize() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, vm, client) = await BuildConnectingAsync();
+
+            await client.TriggerAttached([], reason: "review");
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Attached);
+            await Assert.That(vm.State.ReadOnly).IsTrue();
+
+            var surface = (FakeTerminalSurface)vm.Surface!;
+            surface.RaiseInput([1, 2, 3]);
+            surface.RaiseResize(100, 40);
+
+            await Assert.That(client.SentInput).IsEmpty();
+            await Assert.That(client.Resizes).IsEmpty();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Exited_maps_to_exited_banner_and_connection_lost_maps_to_failed() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, vm1, client1) = await BuildConnectingAsync(agentId: "a1");
+            client1.Result.SetResult(new AttachOutcome.Exited(3));
+            await vm1.CurrentRunForTesting!;
+
+            await Assert.That(vm1.State.Phase).IsEqualTo(TerminalSessionPhase.Exited);
+            await Assert.That(vm1.State.ExitCode).IsEqualTo(3);
+
+            var (_, _, _, vm2, client2) = await BuildConnectingAsync(agentId: "a2");
+            client2.Result.SetResult(new AttachOutcome.ConnectionLost());
+            await vm2.CurrentRunForTesting!;
+
+            await Assert.That(vm2.State.Phase).IsEqualTo(TerminalSessionPhase.Failed);
+            await Assert.That(vm2.State.Detail).Contains("lost connection");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_background_run_fault_renders_failed_with_reattach() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, vm, client) = await BuildConnectingAsync();
+
+            await Task.Run(() => client.Result.SetException(new AttachCallbackException(new InvalidOperationException("boom"))));
+            await vm.CurrentRunForTesting!;
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Failed);
+            await Assert.That(vm.State.Detail).IsEqualTo("boom");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Explicit_detach_stays_in_place_with_single_flight_reattach() {
+        await RunOnUiAsync(async () => {
+            var (_, factory, _, vm, client) = await BuildConnectingAsync();
+
+            await vm.DetachCommand.Execute();
+            await Assert.That(client.DetachCalls).IsEqualTo(1);
+
+            client.Result.SetResult(new AttachOutcome.Detached());
+            await vm.CurrentRunForTesting!;
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Detached);
+
+            var before = factory.Created.Count;
+            // Issued back-to-back with no await between them: ReactiveCommand.Execute() invokes
+            // its Func<Task> eagerly and unconditionally (IL-verified, see the VM's class doc
+            // comment), so both calls genuinely race the try-entered _attachLane.
+            var t1 = vm.ReattachCommand.Execute().ToTask();
+            var t2 = vm.ReattachCommand.Execute().ToTask();
+            await Task.WhenAll(t1, t2);
+
+            await Assert.That(factory.Created.Count).IsEqualTo(before + 1);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Reattach_swaps_in_a_fresh_surface_and_decoder_before_the_snapshot() {
+        await RunOnUiAsync(async () => {
+            var (_, factory, _, vm, client1) = await BuildConnectingAsync();
+            var surface1 = vm.Surface;
+
+            await client1.TriggerOutput("AB"u8.ToArray());
+            client1.Result.SetResult(new AttachOutcome.ConnectionLost());
+            await vm.CurrentRunForTesting!;
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Failed);
+
+            await vm.ReattachCommand.Execute();
+            var client2 = factory.Created[^1];
+            await Assert.That(client2).IsNotSameReferenceAs(client1);
+
+            await client2.TriggerAttached("AB"u8.ToArray());
+
+            await Assert.That(vm.Surface).IsNotSameReferenceAs(surface1);
+            var surface2 = (FakeTerminalSurface)vm.Surface!;
+            await Assert.That(surface2.Fed.Count(t => t == "AB")).IsEqualTo(1);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Exited_is_not_overwritten_by_session_ended() {
+        await RunOnUiAsync(async () => {
+            var (daemon, _, _, vm, client) = await BuildConnectingAsync();
+
+            client.Result.SetResult(new AttachOutcome.Exited(0));
+            await vm.CurrentRunForTesting!;
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Exited);
+
+            daemon.Agents.Remove("a1");
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Exited);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_retired_attempts_cancellation_mutates_nothing() {
+        await RunOnUiAsync(async () => {
+            var (_, factory, _, vm, client1) = await BuildConnectingAsync();
+            var run1 = vm.CurrentRunForTesting!;
+
+            await vm.ReattachCommand.Execute(); // retires attempt 1: cancels + await-disposes client1
+
+            client1.Result.SetException(new OperationCanceledException());
+            await run1; // attempt 1's own run settles silently
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
+            await Assert.That(factory.Created.Count).IsEqualTo(2);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Utf8_split_across_snapshot_and_frames_renders_whole_characters() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, vm, client) = await BuildConnectingAsync();
+            var euro = "€"u8.ToArray(); // E2 82 AC
+
+            await client.TriggerAttached(euro[..1]);
+            await client.TriggerOutput(euro[1..]);
+
+            var surface = (FakeTerminalSurface)vm.Surface!;
+            await Assert.That(string.Concat(surface.Fed)).IsEqualTo("€");
+        });
+    }
+
+    /// Deliberately NOT wrapped in WithImmediateRxScheduler -- this test's whole point is thread
+    /// IDENTITY (HomeViewSmokeTests' An_agent_arriving_off_the_UI_thread idiom), which Immediate
+    /// would make a no-op by collapsing every hop onto the calling thread.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Surface_swap_and_state_mutations_happen_on_the_ui_thread() {
+        var (surfaceCreatedOnUi, stateChangedOnUi, failure) = await AvaloniaSession.DispatchAsync(async () => {
+            var (daemon, factory, time, vm, _) = await BuildConnectingAsync();
+            Dispatcher.UIThread.RunJobs();
+
+            bool? surfaceOnUi = null;
+            bool? stateOnUi = null;
+            var vm2 = new TerminalTabViewModel(
+                "a2", daemon, factory.Factory,
+                () => { surfaceOnUi ??= Dispatcher.UIThread.CheckAccess(); return new FakeTerminalSurface(); },
+                time);
+            vm2.PropertyChanged += (_, e) => {
+                if (e.PropertyName == nameof(TerminalTabViewModel.State))
+                    stateOnUi ??= Dispatcher.UIThread.CheckAccess();
+            };
+
+            Exception? thrown = null;
+            try {
+                // Off-thread, exactly like the resolve gate itself is fed in production: the
+                // Agents cache is mutated on the daemon client's own background pump.
+                await Task.Run(() => daemon.Agents.AddOrUpdate(new AgentStatusDto(
+                    "a2", "agent", "claude", null, "Running", null, null, null, DateTime.UtcNow, null, null)));
+
+                var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+                while (vm2.State.Phase != TerminalSessionPhase.Connecting && DateTime.UtcNow < deadline) {
+                    Dispatcher.UIThread.RunJobs();
+                    await Task.Delay(10);
+                }
+            } catch (Exception ex) {
+                thrown = ex;
+            }
+
+            Dispatcher.UIThread.RunJobs();
+            return (surfaceOnUi, stateOnUi, thrown?.ToString());
+        });
+
+        await Assert.That(failure).IsNull();
+        await Assert.That(surfaceCreatedOnUi).IsTrue();
+        await Assert.That(stateChangedOnUi).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Cancel_dispose_orderings_each_yield_one_recorded_state() {
+        await RunOnUiAsync(async () => {
+            // Three interleavings of "the retired attempt's own outcome" racing "reattach's
+            // retire step" (immediate completion, yielded completion, and a bare TrySetResult
+            // fired from its own background Task) -- regardless of ordering, the VM settles on
+            // exactly one coherent State (attempt 2's Connecting; the generation check makes
+            // attempt 1's outcome a no-op whichever side of the retiring increment it lands on)
+            // and the client is disposed exactly once.
+            for (var i = 0; i < 3; i++) {
+                var (_, factory, _, vm, client1) = await BuildConnectingAsync(agentId: $"race{i}");
+                var run1 = vm.CurrentRunForTesting!;
+
+                var reattach = Task.Run(() => vm.ReattachCommand.Execute().ToTask());
+                var raceOther = i switch {
+                    0 => Task.Run(() => client1.Result.TrySetResult(new AttachOutcome.Exited(1))),
+                    1 => Task.Run(async () => {
+                        await Task.Yield();
+                        client1.Result.TrySetResult(new AttachOutcome.Exited(1));
+                    }),
+                    _ => Task.Run(() => client1.Result.TrySetResult(new AttachOutcome.Exited(1))),
+                };
+                await Task.WhenAll(reattach, raceOther, run1);
+
+                await Assert.That(client1.DisposeCalls).IsEqualTo(1);
+                await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
+                await Assert.That(factory.Created.Count).IsEqualTo(2);
+            }
+        });
+    }
+
+    /// ConsoleOutput capture is process-global (its own doc comment), so this carries a BARE
+    /// [NotInParallel] instead of the keyed AvaloniaSession one -- bare is the strictly stronger
+    /// exclusion and still keeps this test out of every AvaloniaSession-tagged test's way.
+    [Test]
+    [NotInParallel]
+    public async Task A_never_completing_detach_write_is_force_closed_within_the_bound() {
+        await RunOnUiAsync(async () => {
+            var (_, _, time, vm, client) = await BuildConnectingAsync(configureNext: c => c.HangDetachForever = true);
+
+            using var stderr = ConsoleOutput.StartErrorCapture();
+
+            var teardown = vm.TeardownAsync();
+
+            time.Advance(TimeSpan.FromSeconds(1));
+            await WaitUntilAsync(() => client.DisposeCalls == 1, what: "DisposeAsync called at the 1s detach bound");
+
+            time.Advance(TimeSpan.FromSeconds(2)); // total 3s -- forces the run-task budget too
+            await teardown;
+
+            await Assert.That(client.DetachCalls).IsEqualTo(1);
+            await Assert.That(client.DisposeCalls).IsEqualTo(1);
+
+            var stateBefore = vm.State;
+            client.DetachGate.SetException(new InvalidOperationException("boom"));
+            await WaitUntilAsync(() => stderr.GetCapturedError().Length > 0, what: "abandoned detach diagnostic");
+
+            await Assert.That(stderr.GetCapturedError()).Contains("boom");
+            await Assert.That(vm.State).IsEqualTo(stateBefore);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_never_completing_awaited_callback_is_released_by_run_token_cancellation() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, vm, client) = await BuildConnectingAsync(configureNext: c => c.HangOnOutputForever = true);
+            await client.RunStarted.Task;
+
+            var surfaceRef = new WeakReference(vm.Surface);
+
+            await vm.TeardownAsync();
+
+            await Assert.That(client.CallbackTask!.IsCanceled).IsTrue();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            await Assert.That(surfaceRef.IsAlive).IsFalse();
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -32,6 +32,8 @@ public class TerminalTabViewModelTests {
         public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
         public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
         public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
+        public int CaretShown;
+        public void EnsureCaretVisible() => CaretShown++;
     }
 
     static AgentStatusDto Agent(string id, string vendor, bool? hasTerminal, string? repoPath = null) => new(
@@ -203,6 +205,22 @@ public class TerminalTabViewModelTests {
 
             await Assert.That(client.SentInput).IsEmpty();
             await Assert.That(client.Resizes).IsEmpty();
+        });
+    }
+
+    /// Claude/codex TUIs hide the hardware cursor once at stream start and draw their own caret
+    /// as an inverse-video cell the control paints invisibly (upstream sentinel bug) — so the VM
+    /// re-shows the engine caret exactly once, AFTER the snapshot replay (which carries the hide).
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Attach_re_shows_the_caret_after_the_snapshot_replay() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, vm, client) = await BuildConnectingAsync();
+
+            await client.TriggerAttached([], reason: null);
+
+            var surface = (FakeTerminalSurface)vm.Surface!;
+            await Assert.That(surface.CaretShown).IsEqualTo(1);
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -312,7 +312,10 @@ public class TerminalTabViewModelTests {
 
             await vm.ReattachCommand.Execute(); // retires attempt 1: cancels + await-disposes client1
 
-            client1.Result.SetException(new OperationCanceledException());
+            // TrySetException, not SetException: DisposeAsync's own Result.TrySetResult(Detached)
+            // (I4's fake-fidelity fix) may already have claimed Result as part of that retire --
+            // this call's outcome doesn't matter either way, only that attempt 1 settles silently.
+            client1.Result.TrySetException(new OperationCanceledException());
             await run1; // attempt 1's own run settles silently
 
             await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
@@ -429,7 +432,10 @@ public class TerminalTabViewModelTests {
             time.Advance(TimeSpan.FromSeconds(1));
             await WaitUntilAsync(() => client.DisposeCalls == 1, what: "DisposeAsync called at the 1s detach bound");
 
-            time.Advance(TimeSpan.FromSeconds(2)); // total 3s -- forces the run-task budget too
+            // A safety margin, not strictly required any more: DisposeAsync's own
+            // Result.TrySetResult(Detached) (I4) settles the run step through ordinary Task
+            // scheduling once DisposeCalls confirms it ran, but this covers a slow CI box too.
+            time.Advance(TimeSpan.FromSeconds(2));
             await teardown;
 
             await Assert.That(client.DetachCalls).IsEqualTo(1);
@@ -462,6 +468,165 @@ public class TerminalTabViewModelTests {
             GC.Collect();
 
             await Assert.That(surfaceRef.IsAlive).IsFalse();
+        });
+    }
+
+    // ---- review fixes: C1/I1-I6 ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Reattach_after_teardown_creates_no_client() {
+        await RunOnUiAsync(async () => {
+            var (_, factory, _, vm, _) = await BuildConnectingAsync();
+
+            await vm.TeardownAsync();
+
+            var before = factory.Created.Count;
+            await vm.ReattachCommand.Execute();
+
+            // Disposal wins permanently: a post-teardown Reattach must build nothing -- the
+            // straggler client C1 reproduced (nothing would ever dispose it; TeardownAsync is
+            // idempotent) never gets created at all.
+            await Assert.That(factory.Created.Count).IsEqualTo(before);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Teardown_racing_a_straddling_reattach_neither_throws_nor_leaks_a_client() {
+        await RunOnUiAsync(async () => {
+            var (_, factory, _, vm, client1) = await BuildConnectingAsync();
+
+            // Gate client1's DisposeAsync open so Reattach's retire step is still suspended
+            // (straddling the swap) when TeardownAsync lands -- the class of race C1 reproduced:
+            // a resumed cts.Token read/Register throwing ObjectDisposedException, and a second
+            // live client nothing could ever dispose.
+            client1.DisposeGate = new TaskCompletionSource();
+
+            var reattach = Task.Run(() => vm.ReattachCommand.Execute().ToTask());
+            await WaitUntilAsync(() => client1.DisposeCalls > 0, what: "reattach to start retiring client1");
+
+            // Called directly, NOT via Task.Run: an async method's synchronous prefix always runs
+            // on the calling thread up to its own first suspension point, so by the time this
+            // call RETURNS (a pending Task), TeardownAsync has already set _resolveState =
+            // Disposed and cancelled the attempt's cts -- deterministically, before the gate
+            // below is released (both TeardownAsync's own client-handling and Reattach's retire
+            // step independently captured the same `_client` = client1 before either nulled it,
+            // so both may end up awaiting this same gate too; either way the ordering that
+            // matters -- Disposed set before Reattach's re-check ever runs -- is guaranteed).
+            var teardownTask = vm.TeardownAsync();
+
+            client1.DisposeGate.SetResult();
+
+            Exception? thrown = null;
+            try { await teardownTask; } catch (Exception ex) { thrown = ex; }
+            await reattach;
+
+            await Assert.That(thrown).IsNull();
+            // TeardownAsync's own resolveState re-check caught the race before Reattach ever
+            // reached the factory call -- no second client. client1 was disposed (never left
+            // live) -- possibly by both racing callers, since the real client's DisposeAsync is
+            // itself idempotent for exactly that.
+            await Assert.That(factory.Created.Count).IsEqualTo(1);
+            await Assert.That(client1.DisposeCalls).IsGreaterThanOrEqualTo(1);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Retry_is_a_no_op_unless_the_gate_is_timed_out() {
+        await RunOnUiAsync(async () => {
+            var (_, factory, _, vm, _) = await BuildConnectingAsync(); // resolves normally -> dto-won, Connecting
+
+            await vm.RetryResolveCommand.Execute();
+
+            // The CAS only accepts a transition FROM timeout-won: a gate already resolved via a
+            // normal DTO must never layer a second attach attempt on top of one that succeeded
+            // (the old read-then-write let this through).
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
+            await Assert.That(factory.Created.Count).IsEqualTo(1);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_never_completing_dispose_is_abandoned_within_the_teardown_budget() {
+        await RunOnUiAsync(async () => {
+            var (_, _, time, vm, client) = await BuildConnectingAsync(configureNext: c => c.DisposeGate = new TaskCompletionSource());
+
+            var teardown = vm.TeardownAsync();
+            await WaitUntilAsync(() => client.DisposeCalls == 1, what: "DisposeAsync entered");
+
+            // DisposeAsync itself never completes on its own (the gate is never released) --
+            // mirrors the real client, whose DisposeAsync awaits its own pump to fully unwind.
+            // The remainder of the 3s budget must still force TeardownAsync to return.
+            time.Advance(TimeSpan.FromSeconds(3));
+            await teardown;
+
+            await Assert.That(client.DisposeCalls).IsEqualTo(1);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_throwing_surface_factory_renders_failed_instead_of_hanging_in_resolving() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var vm = new TerminalTabViewModel(
+                "a1", daemon, factory.Factory,
+                () => throw new InvalidOperationException("boom"),
+                new FakeTimeProvider());
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+            await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+            // A throw inside the swap must not leave the tab stuck in Resolving with an
+            // unobserved task fault -- it renders as a local Failed instead.
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Failed);
+            await Assert.That(factory.Created.Count).IsEqualTo(0);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_trailing_partial_code_point_is_flushed_to_the_surface_on_exit() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, vm, client) = await BuildConnectingAsync();
+            var euro = "€"u8.ToArray(); // E2 82 AC
+
+            await client.TriggerAttached([]);
+            await client.TriggerOutput(euro[..2]); // genuinely incomplete at exit -- missing the last byte
+
+            client.Result.SetResult(new AttachOutcome.Exited(0));
+            await vm.CurrentRunForTesting!;
+
+            var surface = (FakeTerminalSurface)vm.Surface!;
+            // The decoder's own carry-over state buffered the incomplete sequence; Flush() at
+            // terminal completion must still surface SOMETHING for it -- a genuinely truncated
+            // stream can't recover the missing byte, so this proves Flush ran (U+FFFD), not that
+            // the byte was magically recovered.
+            await Assert.That(string.Concat(surface.Fed)).Contains("�");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Has_terminal_false_over_rpc_renders_a_bare_note_with_no_family_token() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var vm = Build(daemon, factory, new FakeTimeProvider(), agentId: "a1");
+
+            // "pi" is mapped to rpc; hasTerminal:false leaves EffectiveFamily at "rpc" unchanged
+            // (no pty guess to correct), so this must render bare -- never "runs over RPC", an
+            // internal transport token, not a user-facing concept.
+            daemon.Agents.AddOrUpdate(Agent("a1", "pi", hasTerminal: false));
+            await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.NoTerminal);
+            await Assert.That(vm.State.Detail).IsEqualTo("This session has no terminal.");
+            await Assert.That(factory.Created.Count).IsEqualTo(0);
         });
     }
 }

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -206,30 +206,28 @@ public class TerminalTabViewModelTests {
         });
     }
 
-    /// I1 (final review): RunAsync's initial cols/rows are the phantom DefaultCols/Rows constant
-    /// (80x24), sent before the surface's real pane size is ever known -- a read-write Attached
-    /// must resend the surface's OWN current size to correct that nudge. A read-only attach gets
-    /// no nudge at all (belt-and-braces with WireSurface's own ReadOnly guard on user-driven
-    /// resizes -- this is the SEPARATE post-attach nudge fired once from OnAttachedAsync itself).
+    /// I1 (final review, reworked): a post-attach resend fired from inside OnAttachedAsync is
+    /// structurally defeated -- Core's own post-attach repaint nudge (AgentAttachClient.
+    /// RunCoreAsync, right after a read-write Attached) writes at whatever size RunAsync started
+    /// with and follows immediately after any same-callback resend on the wire; the daemon applies
+    /// resizes in stream order with last-write-wins, so the resend never survives. The fix instead
+    /// starts the run itself at the surface's real size (TryStartAttemptAsync reads CurrentSize
+    /// right after the UI swap dispatch, before calling RunAsync) -- committed before any Attach
+    /// reply, so it holds regardless of whether the attach turns out read-write or read-only.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Read_write_attach_resends_the_surfaces_real_size_and_read_only_sends_none() {
+    public async Task Attach_starts_the_run_at_the_surfaces_real_current_size() {
         await RunOnUiAsync(async () => {
-            var (_, _, _, vm, client) = await BuildConnectingAsync(
+            var (_, _, _, _, client) = await BuildConnectingAsync(
                 surfaceFactory: () => new FakeTerminalSurface { CurrentSize = (137, 41) });
 
-            await client.TriggerAttached([]);
+            await Assert.That((client.Cols, client.Rows)).IsEqualTo((137, 41));
 
-            await Assert.That(vm.State.ReadOnly).IsFalse();
-            await Assert.That(client.Resizes.Single()).IsEqualTo((137, 41));
-
-            var (_, _, _, vm2, client2) = await BuildConnectingAsync(
+            var (_, _, _, _, client2) = await BuildConnectingAsync(
                 agentId: "a2", surfaceFactory: () => new FakeTerminalSurface { CurrentSize = (137, 41) });
+            await client2.TriggerAttached([], reason: "review");   // read-only: same RunAsync argument either way
 
-            await client2.TriggerAttached([], reason: "review");
-
-            await Assert.That(vm2.State.ReadOnly).IsTrue();
-            await Assert.That(client2.Resizes).IsEmpty();
+            await Assert.That((client2.Cols, client2.Rows)).IsEqualTo((137, 41));
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -6,6 +6,8 @@ using Capacitor.App.ViewModels;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
 using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -24,49 +26,10 @@ namespace Capacitor.App.Tests.Unit;
 /// comment documents the identical fix for its Dispatcher.UIThread.InvokeAsync hop. RunOnUiAsync
 /// nests WithImmediateRxScheduler INSIDE DispatchAsync so both are satisfied at once.
 public class TerminalTabViewModelTests {
-    sealed class FakeTerminalSurface : ITerminalSurface {
-        public List<string> Fed { get; } = [];
-        public void Feed(string text) => Fed.Add(text);
-        public event Action<byte[]>? InputProduced;
-        public event Action<int, int>? Resized;
-        public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
-        public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
-        public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
-        public int CaretShown;
-        public void EnsureCaretVisible() => CaretShown++;
-    }
-
-    static AgentStatusDto Agent(string id, string vendor, bool? hasTerminal, string? repoPath = null) => new(
-        id, "agent", vendor, repoPath, "Running",
-        FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null,
-        RequesterDisplay: null, HasTerminal: hasTerminal);
-
     static TerminalTabViewModel Build(
             FakeDaemonClientService daemon, FakeTerminalAttachClientFactory factory, FakeTimeProvider time,
             string agentId = "a1", Func<ITerminalSurface>? surfaceFactory = null) =>
         new(agentId, daemon, factory.Factory, surfaceFactory ?? (() => new FakeTerminalSurface()), time);
-
-    // Real-time poll for a condition an async continuation settles OUTSIDE the test's own await
-    // chain (e.g. a Task.ContinueWith observer attached to an abandoned task) -- never used to
-    // gate FakeTimeProvider-driven logic itself, only to let its already-fired continuations
-    // flush. Same idiom as ConsentServiceTests/PauseControllerTests etc.
-    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
-        while (!condition()) {
-            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
-            await Task.Delay(10);
-        }
-    }
-
-    // See the class doc comment: WithImmediateRxScheduler alone never pumps Dispatcher.UIThread,
-    // so a test that reaches TryStartAttemptAsync/OnAttached/OnOutput (any Dispatcher.UIThread.
-    // InvokeAsync hop) needs the real, live dispatcher loop DispatchAsync provides. Nested rather
-    // than either alone.
-    static Task RunOnUiAsync(Func<Task> body) =>
-        AvaloniaSession.DispatchAsync(async () => {
-            await AvaloniaSession.WithImmediateRxScheduler(body);
-            return true;
-        });
 
     static async Task<(FakeDaemonClientService Daemon, FakeTerminalAttachClientFactory Factory, FakeTimeProvider Time, TerminalTabViewModel Vm, FakeTerminalAttachClient Client)>
             BuildConnectingAsync(string vendor = "claude", bool? hasTerminal = true, string agentId = "a1",

--- a/test/Capacitor.App.Tests.Unit/TerminalTranscriptTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTranscriptTests.cs
@@ -291,4 +291,58 @@ public class TerminalTranscriptTests {
     static IEnumerable<byte[]> Chunk(byte[] data, int size) {
         for (var i = 0; i < data.Length; i += size) yield return data[i..Math.Min(i + size, data.Length)];
     }
+
+    // ── Task 11: XtermTerminalSurface wiring ─────────────────────────────────────────────────
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_device_status_query_produces_a_terminal_reply_through_InputProduced() {
+        // The engine answers a DSR (Device Status Report / cursor-position query) on its own,
+        // via Terminal.Engine.DataReceived -- reachable only through XtermTerminalSurface
+        // subscribing on the raw engine object (Task 8 discovery), not the wrapper or model.
+        var replyContainsCursorPositionReport = await AvaloniaSession.DispatchAsync(() => {
+            var surface = new XtermTerminalSurface(cols: 80, rows: 24);
+            var replies = new List<byte[]>();
+            surface.InputProduced += replies.Add;
+
+            surface.Feed("\x1b[6n"); // DSR: report cursor position
+
+            return replies.Any(r => System.Text.Encoding.ASCII.GetString(r).Contains(";1R"));
+        });
+
+        await Assert.That(replyContainsCursorPositionReport).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Programmatic_input_on_the_model_raises_InputProduced() {
+        // TerminalControlModel has no headless-testable keyboard event of its own (TerminalControl,
+        // the Avalonia visual that turns real keypresses into Send(...) calls via
+        // GenerateKeyInput/GenerateCharInput, is explicitly excluded from headless tests per Task 8
+        // discovery). Model.Send(...) is the same UserInput event a real keypress handler raises,
+        // so it's the correct headless-testable proxy for "keyboard input reaches InputProduced".
+        var sawTypedByte = await AvaloniaSession.DispatchAsync(() => {
+            var surface = new XtermTerminalSurface(cols: 80, rows: 24);
+            var replies = new List<byte[]>();
+            surface.InputProduced += replies.Add;
+
+            surface.Model.Send("a");
+
+            return replies.Any(r => System.Text.Encoding.UTF8.GetString(r) == "a");
+        });
+
+        await Assert.That(sawTypedByte).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Feed_renders_text_into_the_model() {
+        var line0 = await AvaloniaSession.DispatchAsync(() => {
+            var surface = new XtermTerminalSurface(cols: 80, rows: 24);
+            surface.Feed("hello");
+            return surface.Model.Terminal.Engine.GetLine(0);
+        });
+
+        await Assert.That(line0).IsEqualTo("hello");
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/TerminalTranscriptTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTranscriptTests.cs
@@ -197,6 +197,35 @@ namespace Capacitor.App.Tests.Unit;
 // Package/license: both packages are net-standard MIT-licensed (SvcSystems.UI.Terminal per its
 // GitHub repo's codecov badge and MIT LICENSE; XTerm.NET's README states "License: MIT"
 // explicitly). See task-8-report.md for the full `dotnet list ... --include-transitive` graph.
+//
+// ── WHAT THE ALT-SCREEN ASSERTIONS DO AND DON'T PROVE (fixed after review; read before reusing
+//    this transcript pattern in Tasks 11/12) ────────────────────────────────────────────────
+//   The transcript is fed in two pieces specifically so alt-screen ENTRY can be pinned, not
+//   just exit: `alternateActiveDuringAltScreen` is read immediately after the \x1b[?1049h
+//   prefix, before any suffix bytes are fed. The FIRST version of this test only asserted
+//   `IsAlternateBufferActive == false` at the very end and `mainBufferText.Contains("back")`
+//   — both of those hold identically whether \x1b[?1049h/l are interpreted OR silently
+//   no-op'd (proven empirically: stripping the 1049 codes still ends with
+//   IsAlternateBufferActive == false and "back" present, because "back" is fed unconditionally
+//   after where \x1b[?1049l would have been). That version was NOT exercising alt-screen
+//   support at all — it would have passed against a build with the alt-buffer switch
+//   completely deleted. Proven now:
+//     1. Entry:     alternateActiveDuringAltScreen is asserted TRUE right after \x1b[?1049h.
+//     2. Exit:      isAlternateBufferActiveAfter is asserted FALSE after \x1b[?1049l.
+//     3. Isolation: mainBufferText.DoesNotContain("alt") — the alt-buffer's own text must NOT
+//        leak into the main buffer once switched back (with the codes stripped, "alt" DOES
+//        appear in mainBufferText, since everything then lands in the one buffer:
+//        "    mid alt  back"). This is what actually confirms the model is using two distinct
+//        buffer objects, not just flipping a flag.
+//   Still NOT proven by this test: alt-buffer content itself (what "mid" writes to the alt
+//   screen render as, its own cursor/attribute state, or that re-entering alt-screen a second
+//   time clears it) — only that alt-buffer writes don't bleed into the main buffer and that the
+//   flag flips correctly around one enter/leave cycle. A future test touching alt-buffer
+//   *content* (not just isolation) should read `engine.Buffer` while `IsAlternateBufferActive`
+//   is still true (i.e. mid-transcript, the same way `alternateActiveDuringAltScreen` is
+//   captured here), since `Terminal.Engine.Buffer`/`GetLine` always reflect whichever buffer is
+//   CURRENTLY active — there is no separate always-addressable "the alt buffer" accessor once
+//   you've switched back.
 
 /// The acceptance gate for emulation fidelity: a captured ANSI/TUI stream
 /// (colors, cursor addressing, alternate screen) through the decode-and-feed
@@ -205,7 +234,8 @@ namespace Capacitor.App.Tests.Unit;
 public class TerminalTranscriptTests {
     [Test]
     public async Task A_recorded_tui_transcript_feeds_without_faulting_and_lands_expected_cells() {
-        var (row0Text, row0Bold, row0FgColor, midCells, isAlternateBufferActive, mainBufferText) =
+        var (row0Text, row0Bold, row0FgColor, midCells, alternateActiveDuringAltScreen,
+                isAlternateBufferActiveAfter, mainBufferText) =
             await AvaloniaSession.DispatchAsync(() => {
                 var model = new TerminalControlModel(new TerminalOptions {
                     Cols = 80,
@@ -213,14 +243,21 @@ public class TerminalTranscriptTests {
                     ReflowOnResize = false,
                 });
                 var decoder = new Utf8StreamDecoder();
+                var engine = model.Terminal.Engine;
 
-                // transcript: SGR color, cursor addressing, alt-screen enter/leave, text
-                var transcript = "\x1b[2J\x1b[H\x1b[1;31mRED\x1b[0m\x1b[10;5Hmid\x1b[?1049h alt \x1b[?1049l back"u8.ToArray();
-                foreach (var chunk in Chunk(transcript, 7)) // deliberately ugly boundaries
+                // transcript, split at the alt-screen boundary so ENTRY can be pinned (not just
+                // exit): prefix ends with \x1b[?1049h; suffix carries the alt-only text, the
+                // \x1b[?1049l exit, and the post-exit text.
+                var prefix = "\x1b[2J\x1b[H\x1b[1;31mRED\x1b[0m\x1b[10;5Hmid\x1b[?1049h"u8.ToArray();
+                var suffix = " alt \x1b[?1049l back"u8.ToArray();
+
+                foreach (var chunk in Chunk(prefix, 7)) // deliberately ugly boundaries
+                    model.Feed(decoder.Decode(chunk));
+                var alternateActiveDuringAltScreen = engine.IsAlternateBufferActive;
+
+                foreach (var chunk in Chunk(suffix, 7)) // deliberately ugly boundaries
                     model.Feed(decoder.Decode(chunk));
                 model.Feed(decoder.Flush());
-
-                var engine = model.Terminal.Engine;
 
                 var row0 = engine.Buffer.Lines[0]!;
                 var row9 = engine.Buffer.Lines[9]!;
@@ -233,7 +270,8 @@ public class TerminalTranscriptTests {
                     row0Bold: row0[0].Attributes.IsBold(),
                     row0FgColor: row0[0].Attributes.GetFgColor(),
                     midCells: mid,
-                    isAlternateBufferActive: engine.IsAlternateBufferActive,
+                    alternateActiveDuringAltScreen,
+                    isAlternateBufferActiveAfter: engine.IsAlternateBufferActive,
                     mainBufferText: mainText);
             });
 
@@ -241,8 +279,13 @@ public class TerminalTranscriptTests {
         await Assert.That(row0Bold).IsTrue();
         await Assert.That(row0FgColor).IsEqualTo(1); // SGR 31 -> legacy palette index 1 (red)
         await Assert.That(midCells).IsEquivalentTo(["m", "i", "d"], CollectionOrdering.Matching);
-        await Assert.That(isAlternateBufferActive).IsFalse();
+        await Assert.That(alternateActiveDuringAltScreen).IsTrue();  // alt-screen ENTRY pinned
+        await Assert.That(isAlternateBufferActiveAfter).IsFalse();   // alt-screen EXIT pinned
         await Assert.That(mainBufferText).Contains("back");
+        // The alt-buffer's own text must NOT leak into the main buffer once we've switched
+        // back — this is the isolation check the original version of this test was missing
+        // (it passed identically whether \x1b[?1049h/l were interpreted or silently no-op'd).
+        await Assert.That(mainBufferText).DoesNotContain("alt");
     }
 
     static IEnumerable<byte[]> Chunk(byte[] data, int size) {

--- a/test/Capacitor.App.Tests.Unit/TerminalTranscriptTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTranscriptTests.cs
@@ -1,0 +1,251 @@
+using Capacitor.App.Services;
+using SvcSystems.UI.Terminal;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.App.Tests.Unit;
+
+// API DISCOVERY (Task 8) — decompiled via ilspycmd against the NuGet cache copies of
+// SvcSystems.UI.Terminal 1.1.1 (net10.0 lib) and XTerm.NET 1.0.16 (net6.0 lib), cross-checked
+// against both packages' README.md. Recorded verbatim for Tasks 10–12 to build on; do not
+// rely on the README alone, it undersells a few things confirmed only in IL (marked below).
+//
+// ── SvcSystems.UI.Terminal.TerminalControlModel : Avalonia.AvaloniaObject ──────────────────
+//   ctor TerminalControlModel(TerminalOptions? options = null)
+//   Feed(string text)                          — the encode/decode-safe entrypoint. Internally
+//                                                 does Encoding.UTF8.GetBytes(text) then calls
+//                                                 the byte[] overload below (round-trips through
+//                                                 UTF-8 once more; lossless for already-decoded
+//                                                 text, just wasted work).
+//   Feed(byte[] text, int length = -1)         — ⚠ NOT incremental: SvcSystems.UI.Terminal.
+//                                                 Terminal.Feed(byte[],int) does a FRESH
+//                                                 Encoding.UTF8.GetString(data, 0, len) on every
+//                                                 call. A multibyte code point split across two
+//                                                 Feed(byte[]) calls corrupts silently (each half
+//                                                 becomes U+FFFD independently). This is exactly
+//                                                 why Utf8StreamDecoder exists — decode PTY bytes
+//                                                 externally with ONE Decoder spanning the whole
+//                                                 attach attempt, then call Feed(string).
+//   Send(string text) / Send(byte[] data)      — programmatic input; raises UserInput directly
+//                                                 (after EnsureCaretIsVisible()).
+//   event EventHandler<TerminalUserInputEventArgs> UserInput
+//                                               — the keyboard/programmatic-input → bytes path.
+//                                                 TerminalUserInputEventArgs.Data is a
+//                                                 ReadOnlyMemory<byte> (ctor takes it directly,
+//                                                 no encoding step — Send(string) UTF8-encodes
+//                                                 before raising). This is what a consumer wires
+//                                                 to a PTY's stdin.
+//   event EventHandler<TerminalSizeChangedEventArgs> SizeChanged
+//                                               — raised from Resize(...) below; args carry
+//                                                 Cols, Rows, Width, Height (the last two are the
+//                                                 pixel dimensions passed in, not derived).
+//   Resize(double width, double height, double textWidth, double textHeight)
+//                                               — pixel-based; model computes cols/rows itself
+//                                                 (Math.Max(width/textWidth, 1) etc.) and calls
+//                                                 Terminal.Resize(cols, rows) internally. There is
+//                                                 NO Resize(int cols, int rows) on the model —
+//                                                 for a direct cols/rows resize call
+//                                                 model.Terminal.Resize(cols, rows) instead.
+//   Terminal Terminal { get; }                 — the SvcSystems wrapper (see below); Avalonia
+//                                                 DirectProperty-backed.
+//   SearchService SearchService { get; }
+//   Title, SelectedText, HasSelection, LastSearchText, SearchResultCount,
+//   CurrentSearchResultIndex                    — Avalonia DirectProperty-backed.
+//   ScrollOffset, MaxScrollback, ScrollPosition, ScrollThumbsize, CanScroll,
+//   CaretColumn, CaretRow, IsCaretVisible, IsMouseModeActive, OptionAsMetaKey
+//   ScrollLines(int) / PageUp() / PageDown() / ScrollToYDisp(int) / ScrollToPosition(double) /
+//   EnsureCaretIsVisible()
+//   StartSelection(row, col) / StartSelectionFromSoftStart() / SetSoftSelectionStart(row, col) /
+//   DragExtendSelection(row, col) / ShiftExtendSelection(row, col) /
+//   SelectWordOrExpression(row, col) / SelectRow(row) / SelectAll() / ClearSelection()
+//   Search(string) / SelectNextSearchResult() / SelectPreviousSearchResult()
+//
+// ── SvcSystems.UI.Terminal.TerminalOptions (sealed class) ──────────────────────────────────
+//   Cols = 80, Rows = 24, Scrollback = 1000, TabStopWidth = 8, TermName = "xterm",
+//   ConvertEol = false, ReflowOnResize = true   — all settable init-style properties with the
+//                                                 defaults shown; ReflowOnResize=false is what
+//                                                 upstream's own sample shell sets to avoid
+//                                                 corrupting full-screen TUIs (e.g. `mc`) on
+//                                                 resize (README, "Sample shell notes").
+//
+// ── SvcSystems.UI.Terminal.Terminal (sealed wrapper class; model.Terminal) ─────────────────
+//   ctor Terminal(TerminalOptions? options = null) — clamps Cols>=2, Rows>=1, Scrollback>=0,
+//                                                 TabStopWidth>=1 before constructing the engine.
+//   Feed(string text)                           — engine.Write(text) directly, no re-decode.
+//   Feed(byte[] data, int len = -1)             — ⚠ see the model's Feed(byte[]) note above;
+//                                                 same fresh-GetString-per-call behavior lives
+//                                                 here (the model's byte[] overload just forwards
+//                                                 to this one).
+//   Resize(int cols, int rows)                  — clamps to >=1 each; use this for a direct
+//                                                 cols/rows resize (not on the model).
+//   SwitchToAltBuffer() / SwitchToNormalBuffer()
+//   event EventHandler<TitleChangedEventArgs> TitleChanged
+//   Engine  -> XTerm.Terminal                   — the underlying XTerm.NET engine object; this
+//                                                 is where DataReceived and every other XTerm.NET
+//                                                 event lives (NOT re-exposed by this wrapper or
+//                                                 by TerminalControlModel).
+//   Buffer  -> XTerm.Buffer.TerminalBuffer       — same instance as Engine.Buffer.
+//   Selection -> XTerm.Selection.SelectionManager
+//   IsAlternateBufferActive : bool
+//   Options -> TerminalOptions (a fresh snapshot object, not the one passed to the ctor)
+//   Cols, Rows, Title
+//
+// ── SvcSystems.UI.Terminal.TerminalUserInputEventArgs(ReadOnlyMemory<byte> data) : EventArgs
+//   Data : ReadOnlyMemory<byte>
+// ── SvcSystems.UI.Terminal.TerminalSizeChangedEventArgs(int cols, int rows, double width,
+//    double height) : EventArgs  — Cols, Rows, Width, Height
+//
+// ── XTerm.Terminal (the "engine", reached ONLY via model.Terminal.Engine) ──────────────────
+//   Buffer -> XTerm.Buffer.TerminalBuffer (== SvcSystems Terminal.Buffer, same object)
+//   Cols, Rows, Title, ActiveBuffer (XTerm.Common.BufferType), IsAlternateBufferActive
+//   Many terminal-mode flags as bool props: InsertMode, ApplicationCursorKeys,
+//   ApplicationKeypad, BracketedPasteMode, OriginMode, CursorVisible, ReverseWraparound,
+//   ReverseVideo, SendFocusEvents, Win32InputMode, EightBitInput, MetaSendsEscape,
+//   AltSendsEscape
+//   CurrentDirectory, CurrentHyperlink, HyperlinkId, MouseTrackingMode, MouseEncoding
+//   Selection -> XTerm.Selection.SelectionManager
+//   ★ THE TERMINAL-REPLY PATH: event EventHandler<TerminalEvents.DataEventArgs> DataReceived
+//     — raised when the terminal itself needs to talk back to the host process (e.g. a Device
+//     Status Report / Cursor Position Report reply to a DSR/CPR query the remote app sent).
+//     TerminalEvents.DataEventArgs.Data is a `string` (not bytes) — a consumer forwarding this
+//     to a PTY must UTF8-encode it. This is reachable ONLY through Engine — neither the
+//     SvcSystems.UI.Terminal.Terminal wrapper nor TerminalControlModel re-expose it, and it is
+//     NOT the same as TerminalControlModel.UserInput (that one is for user-originated
+//     keyboard/mouse input; DataReceived is for terminal-originated protocol replies). A full
+//     wiring needs BOTH: UserInput for keystrokes, Engine.DataReceived for terminal replies.
+//   Other events: CursorStyleChanged, TitleChanged, BellRang, Resized, Scrolled, LineFed,
+//   DirectoryChanged, HyperlinkChanged, WindowMoved, WindowResized, WindowMinimized,
+//   WindowMaximized, WindowRestored, WindowRaised, WindowLowered, WindowRefreshed,
+//   WindowFullscreened, WindowInfoRequested, BufferChanged
+//   Write(string data) / WriteLine(string data)  — raw feed entrypoints (wrapper's Feed calls
+//                                                 Write under the hood).
+//   Resize(int cols, int rows), Reset(), Clear()
+//   ScrollLines(int), ScrollToTop(), ScrollToBottom()
+//   GetLine(int line) -> string                  — `_buffer.Lines[line]?.TranslateToString
+//                                                 (trimRight: true) ?? ""`. ⚠ `line` indexes
+//                                                 buffer.Lines ABSOLUTELY, not the viewport — it
+//                                                 only equals the on-screen row when YDisp == 0
+//                                                 (no scrollback in play), which holds for this
+//                                                 transcript test.
+//   GetVisibleLines() -> string[]                 — Rows entries, GetLine(Buffer.YDisp + i).
+//   GenerateKeyInput(Key, KeyModifiers = None) -> string
+//   GenerateCharInput(char, KeyModifiers = None) -> string
+//   GenerateMouseEvent(MouseButton, x, y, MouseEventType, KeyModifiers = None) -> string
+//   GenerateFocusEvent(bool focused) -> string     — these four are the engine-side keyboard/
+//                                                 mouse → escape-sequence generators; a host
+//                                                 (e.g. TerminalControl's key handler) calls one
+//                                                 of these to turn a keypress into bytes, then
+//                                                 raises TerminalControlModel.UserInput/Send(...)
+//                                                 with the result — the engine itself has no
+//                                                 "user input" event of its own.
+//   SetCursorStyle(CursorStyle, bool blink), SwitchToAltBuffer()/SwitchToNormalBuffer(), Dispose()
+//
+// ── XTerm.Buffer.TerminalBuffer (engine.Buffer) ─────────────────────────────────────────────
+//   ViewportY, BaseY, Length, IsAtBottom, Cols, Rows, YDisp, YBase, Y, X, ScrollTop,
+//   ScrollBottom, Lines -> CircularList<BufferLine>, SavedCursorState (nested SavedCursor:
+//   X, Y, Attr, Charset), event Action<int> Trimmed
+//   GetLine(int y) -> BufferLine?                 — buffer-local, distinct from Terminal.
+//                                                 GetLine(int), which returns a string.
+//   GetBlankLine, ScrollUp/ScrollDown/ScrollDisp/ScrollToLine/ScrollToBottom/ScrollToTop/
+//   ClearScrollback/ScrollLines/SetScrollRegion/ResetScrollRegion/GetAbsoluteY/Resize/
+//   SetCursor/SetCursorRaw, PrintViewport() -> string
+//
+// ── XTerm.Buffer.CircularList<T> (Lines) ────────────────────────────────────────────────────
+//   this[int index] -> T?  (⚠ nullable — null-check or null-forgive before indexing further)
+//   Length, MaxLength, Push/Pop/Splice/TrimStart/ShiftElements/Recycle/Clear/Resize/GetItems()
+//
+// ── XTerm.Buffer.BufferLine : IEnumerable<BufferCell> ───────────────────────────────────────
+//   Length, IsWrapped, LineAttribute, IsDoubleWidth, Cache
+//   this[int index] -> BufferCell                 — the per-cell accessor (non-nullable struct).
+//   SetCell, GetCodePoint(int), Resize, Fill, CopyCellsFrom
+//   TranslateToString(bool trimRight = false, int startCol = 0, int endCol = -1) -> string
+//   GetTrimmedLength(), Clone(), CopyFrom(), GetEnumerator()
+//
+// ── XTerm.Buffer.BufferCell (struct) ────────────────────────────────────────────────────────
+//   Content: string, Width: int, Attributes: AttributeData, CodePoint: int
+//   static Empty, static Space; ctors (), (string content, int width, AttributeData attrs),
+//   (int codePoint, int width, AttributeData attrs); IsEmpty(), IsSpace(), equality members.
+//   Wide characters: first cell has Width == 2 and the glyph; the second cell has Width == 0 as
+//   a placeholder (skip it when rendering, per XTerm.NET's own README).
+//
+// ── XTerm.Buffer.AttributeData (struct) ─────────────────────────────────────────────────────
+//   Fg: int, Bg: int, Extended: int
+//   ⚠ EXACT BIT LAYOUT (decompiled — the README's "0/1/2 mode" story is real but easy to
+//   misapply; verified live with a scratch probe against `\x1b[1;31mR`, see below):
+//     - Default (no color set) sentinel: Fg = 256, Bg = 257, Extended = 0 (static Default /
+//       parameterless ctor both set this). This is NOT "mode 0" — it's a magic index value.
+//     - GetFgColor()/GetBgColor()  = Fg/Bg & 0x1FFFFFF        (low 25 bits: the color index)
+//     - GetFgColorMode()/GetBgColorMode() = Fg/Bg >> 25       (high bits: 0 = legacy/16-color
+//       index, 1 = 256-color palette, 2 = true-color RGB — this axis is ONLY about how to
+//       interpret a non-default index, not whether a color is set at all)
+//     - SetFgColor(color, mode=0)/SetBgColor(color, mode=0) = (mode << 25) | (color & 0x1FFFFFF)
+//     - Basic ANSI SGR colors (30–37 fg / 40–47 bg) land as GetFgColorMode() == 0 (legacy) with
+//       GetFgColor() == the 0–7 index (SGR 31 "red" → GetFgColor() == 1). ⚠ So "was a color set"
+//       must be tested as `GetFgColor() != 256` (or Bg != 257), NOT `GetFgColorMode() != 0` —
+//       mode 0 is both the legacy-index case AND indistinguishable-by-mode-alone from unset.
+//       Verified live: feeding "\x1b[1;31mR" then reading cell(0,0).Attributes gives
+//       Fg=1, Bg=257, Extended=1, IsBold()=True, GetFgColor()=1, GetFgColorMode()=0.
+//   IsBold()/IsDim()/IsItalic()/IsUnderline()/IsBlink()/IsInverse()/IsInvisible()/
+//   IsStrikethrough()/IsOverline() read bits 0,1,2,3,4,5,6,7,8 of Extended respectively
+//   (+ matching Set*(bool) mutators bit-flagging the same field).
+//
+// ── SvcSystems.UI.Terminal.TerminalControl (Avalonia visual; NOT used by this headless test)
+//   Model, SelectedText, HasSelection, RightClickAction, IsMouseModeActive, FontFamily,
+//   FontSize, CaretBrush, SelectionBrush, SelectAll(), CopySelection(), CopySelectionAsync(),
+//   Paste(string), PasteFromClipboardAsync(), Search(string), SelectNextSearchResult(),
+//   SelectPreviousSearchResult(), event ContextRequested
+//
+// Package/license: both packages are net-standard MIT-licensed (SvcSystems.UI.Terminal per its
+// GitHub repo's codecov badge and MIT LICENSE; XTerm.NET's README states "License: MIT"
+// explicitly). See task-8-report.md for the full `dotnet list ... --include-transitive` graph.
+
+/// The acceptance gate for emulation fidelity: a captured ANSI/TUI stream
+/// (colors, cursor addressing, alternate screen) through the decode-and-feed
+/// path, ReflowOnResize=false per upstream's own TUI guidance.
+[NotInParallel("AvaloniaSession")]
+public class TerminalTranscriptTests {
+    [Test]
+    public async Task A_recorded_tui_transcript_feeds_without_faulting_and_lands_expected_cells() {
+        var (row0Text, row0Bold, row0FgColor, midCells, isAlternateBufferActive, mainBufferText) =
+            await AvaloniaSession.DispatchAsync(() => {
+                var model = new TerminalControlModel(new TerminalOptions {
+                    Cols = 80,
+                    Rows = 24,
+                    ReflowOnResize = false,
+                });
+                var decoder = new Utf8StreamDecoder();
+
+                // transcript: SGR color, cursor addressing, alt-screen enter/leave, text
+                var transcript = "\x1b[2J\x1b[H\x1b[1;31mRED\x1b[0m\x1b[10;5Hmid\x1b[?1049h alt \x1b[?1049l back"u8.ToArray();
+                foreach (var chunk in Chunk(transcript, 7)) // deliberately ugly boundaries
+                    model.Feed(decoder.Decode(chunk));
+                model.Feed(decoder.Flush());
+
+                var engine = model.Terminal.Engine;
+
+                var row0 = engine.Buffer.Lines[0]!;
+                var row9 = engine.Buffer.Lines[9]!;
+                var mid = new[] { row9[4].Content, row9[5].Content, row9[6].Content };
+
+                var mainText = string.Join('\n', Enumerable.Range(0, engine.Rows).Select(engine.GetLine));
+
+                return (
+                    row0Text: engine.GetLine(0),
+                    row0Bold: row0[0].Attributes.IsBold(),
+                    row0FgColor: row0[0].Attributes.GetFgColor(),
+                    midCells: mid,
+                    isAlternateBufferActive: engine.IsAlternateBufferActive,
+                    mainBufferText: mainText);
+            });
+
+        await Assert.That(row0Text).IsEqualTo("RED");
+        await Assert.That(row0Bold).IsTrue();
+        await Assert.That(row0FgColor).IsEqualTo(1); // SGR 31 -> legacy palette index 1 (red)
+        await Assert.That(midCells).IsEquivalentTo(["m", "i", "d"], CollectionOrdering.Matching);
+        await Assert.That(isAlternateBufferActive).IsFalse();
+        await Assert.That(mainBufferText).Contains("back");
+    }
+
+    static IEnumerable<byte[]> Chunk(byte[] data, int size) {
+        for (var i = 0; i < data.Length; i += size) yield return data[i..Math.Min(i + size, data.Length)];
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/Utf8StreamDecoderTests.cs
+++ b/test/Capacitor.App.Tests.Unit/Utf8StreamDecoderTests.cs
@@ -1,0 +1,34 @@
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class Utf8StreamDecoderTests {
+    [Test]
+    [Arguments("é")]      // 2-byte
+    [Arguments("€")]      // 3-byte
+    [Arguments("𝄞")]      // 4-byte
+    public async Task Multibyte_characters_split_at_every_boundary_reassemble(string ch) {
+        var bytes = System.Text.Encoding.UTF8.GetBytes($"a{ch}b");
+        for (var split = 1; split < bytes.Length; split++) {
+            var decoder = new Utf8StreamDecoder();
+            var text = decoder.Decode(bytes.AsSpan(0, split)) + decoder.Decode(bytes.AsSpan(split)) + decoder.Flush();
+            await Assert.That(text).IsEqualTo($"a{ch}b");
+        }
+    }
+
+    [Test]
+    public async Task The_snapshot_live_seam_is_one_stream() {
+        var bytes = System.Text.Encoding.UTF8.GetBytes("€");
+        var decoder = new Utf8StreamDecoder();
+        var snapshotPart = decoder.Decode(bytes.AsSpan(0, 1));   // snapshot ends mid-character
+        var livePart = decoder.Decode(bytes.AsSpan(1));          // first live frame completes it
+        await Assert.That(snapshotPart + livePart).IsEqualTo("€");
+    }
+
+    [Test]
+    public async Task Flush_emits_a_replacement_for_a_dangling_partial() {
+        var decoder = new Utf8StreamDecoder();
+        decoder.Decode(System.Text.Encoding.UTF8.GetBytes("€").AsSpan(0, 1));
+        await Assert.That(decoder.Flush()).IsEqualTo("�");
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WorkspaceFixtures.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceFixtures.cs
@@ -1,0 +1,37 @@
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Shared workspace-suite fixture pieces, imported via `using static` so call sites read the
+/// same as the private copies they replaced.
+static class WorkspaceFixtures {
+    /// The canonical AgentStatusDto construction: one home for the positional tail, so the DTO
+    /// gaining a field means one edit here, not one drifting copy per suite. Suites with their
+    /// own defaults (fixed repo path, hasTerminal) keep a thin local wrapper delegating here.
+    public static AgentStatusDto Agent(
+            string id, string vendor, bool? hasTerminal, string? repoPath = null,
+            string kind = "agent", string? model = null) => new(
+        id, kind, vendor, repoPath, "Running",
+        FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: model,
+        RequesterDisplay: null, HasTerminal: hasTerminal);
+
+    /// An AgentActionService over the scripted/recording deps, for suites that never assert on
+    /// those deps individually.
+    public static AgentActionService NewActions() =>
+        new(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener(),
+            new ReplaySubject<DaemonStatusDto>(1), CancellationToken.None, NeverConfirm.Confirm);
+
+    /// Real-time poll for a condition an async continuation settles OUTSIDE the test's own await
+    /// chain (e.g. a Task.ContinueWith observer attached to an abandoned task) -- never used to
+    /// gate FakeTimeProvider-driven logic itself, only to let its already-fired continuations
+    /// flush. Same idiom as ConsentServiceTests/PauseControllerTests etc.
+    public static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
 using Avalonia.Threading;
 using Capacitor.App.Services;
@@ -8,6 +7,8 @@ using Capacitor.App.Views;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
 using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -26,17 +27,6 @@ public class WorkspaceNavigationTests {
     const string Id1 = "0123456789abcdef0123456789abcdef";
     const string Id2 = "fedcba9876543210fedcba9876543210";
     const string UnusableId = "Launched, but the session id was unusable — open it from the session list.";
-
-    sealed class FakeTerminalSurface : ITerminalSurface {
-        public void Feed(string text) { }
-        public event Action<byte[]>? InputProduced;
-        public event Action<int, int>? Resized;
-        public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
-        public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
-        public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
-        public int CaretShown;
-        public void EnsureCaretVisible() => CaretShown++;
-    }
 
     /// The tracker as the VM sees it (Action&lt;Func&lt;Task&gt;&gt;): records every registration and
     /// starts it immediately, exactly like WorkspaceTeardownTracker.Track — so a test can count
@@ -65,14 +55,8 @@ public class WorkspaceNavigationTests {
         public Task<LaunchOutcome> StartAsync(LaunchRequest request, CancellationToken ct) => Gate.Task;
     }
 
-    static AgentStatusDto Agent(string id, bool? hasTerminal = true, string vendor = "claude") => new(
-        id, "agent", vendor, "/repo/myproj", "Running",
-        FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null,
-        RequesterDisplay: null, HasTerminal: hasTerminal);
-
-    static AgentActionService NewActions() =>
-        new(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener(),
-            new ReplaySubject<DaemonStatusDto>(1), CancellationToken.None, NeverConfirm.Confirm);
+    static AgentStatusDto Agent(string id, bool? hasTerminal = true, string vendor = "claude") =>
+        WorkspaceFixtures.Agent(id, vendor, hasTerminal, "/repo/myproj");
 
     /// The composition root's shape with its three navigation seams faked: a SHARED navigation gate
     /// (a window the coordinator rebuilds gets the same one), the tracker as a delegate, and a
@@ -124,14 +108,6 @@ public class WorkspaceNavigationTests {
             openSession: nav.Vm.OpenSession,
             navigationGeneration: () => nav.Vm.NavigationGeneration,
             openSessionIfCurrent: nav.Vm.OpenSessionIfCurrent);
-
-    // See the class doc comment: WithImmediateRxScheduler alone never pumps Dispatcher.UIThread,
-    // which every workspace open and every teardown reaches.
-    static Task RunOnUiAsync(Func<Task> body) =>
-        AvaloniaSession.DispatchAsync(async () => {
-            await AvaloniaSession.WithImmediateRxScheduler(body);
-            return true;
-        });
 
     [Test]
     [NotInParallel("AvaloniaSession")]

--- a/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
@@ -211,6 +211,43 @@ public class WorkspaceNavigationTests {
         });
     }
 
+    /// The OTHER close (spec §3, real close): nothing intercepts it, the coordinator DISCARDS the
+    /// window, and the next ShowMainWindow builds a fresh one — so the discarded VM's workspace
+    /// teardown has to start as part of this close, or the attach outlives the window that owned it.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_real_close_releases_the_discarded_windows_workspace() {
+        await RunOnUiAsync(async () => {
+            var nav = NewNav();
+            var coordinator = new MainWindowCoordinator(
+                () => {
+                    var window = new MainWindow { DataContext = nav.Vm };
+                    window.Show();
+                    return window;
+                },
+                releaseWorkspace: window => (window.DataContext as MainWindowViewModel)?.CloseWorkspace());
+
+            coordinator.ShowMainWindow();
+            Dispatcher.UIThread.RunJobs();
+
+            var client = await OpenAttachedAsync(nav, Id1);
+            Dispatcher.UIThread.RunJobs();
+
+            // QuitInProgress is what a quit sets, and it is exactly what makes the close REAL: the
+            // interceptor stands down, Closing is not cancelled, and Closed fires.
+            coordinator.QuitInProgress = true;
+            coordinator.Window!.Close();
+            Dispatcher.UIThread.RunJobs();
+            await nav.Tracker.StartedTeardowns();
+
+            await Assert.That(coordinator.Window).IsNull(); // discarded; the next Show builds afresh
+            await Assert.That(nav.Vm.CurrentWorkspace).IsNull();
+            await Assert.That(nav.Tracker.Registered.Count).IsEqualTo(1);
+            await Assert.That(client.DetachCalls).IsEqualTo(1);
+            await Assert.That(client.DisposeCalls).IsGreaterThanOrEqualTo(1);
+        });
+    }
+
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task A_stale_generation_launch_success_opens_nothing() {

--- a/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
@@ -33,6 +33,7 @@ public class WorkspaceNavigationTests {
         public event Action<int, int>? Resized;
         public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
         public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
+        public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
     }
 
     /// The tracker as the VM sees it (Action&lt;Func&lt;Task&gt;&gt;): records every registration and

--- a/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
@@ -372,6 +372,30 @@ public class WorkspaceNavigationTests {
         });
     }
 
+    /// The server hub hands back the agent id as a DASHED Guid ("D"), while the daemon's status
+    /// cache keys on the 32-hex "N" form — the launch path must normalize, or every real launch
+    /// reads as unusable (found in manual QA: red error over a perfectly healthy session card).
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    [Arguments("01234567-89ab-cdef-0123-456789abcdef")]     // "D" — what the server actually sends
+    [Arguments("{01234567-89ab-cdef-0123-456789abcdef}")]   // "B" — tolerate any Guid shape
+    [Arguments("0123456789abcdef0123456789abcdef")]         // "N" — already canonical
+    public async Task A_launch_id_in_any_guid_shape_normalizes_and_opens(string agentId) {
+        await RunOnUiAsync(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var nav = NewNav();
+            var launch = new FixedLaunchClient { Next = new LaunchOutcome(true, agentId, null) };
+            using var home = NewHome(nav, launch, path);
+
+            await home.SelectRepositoryAsync("/repo/myproj");
+            home.Goal = "do the thing";
+            await home.StartCommand.Execute();
+
+            await Assert.That(home.StartError).IsNull();
+            await Assert.That(nav.Opened).IsEquivalentTo(new[] { "0123456789abcdef0123456789abcdef" });
+        });
+    }
+
     /// The card click's own entry point (HomeView routes a click to this), distinct from the launch
     /// auto-open above: no generation is involved, the click IS the current navigation.
     [Test]

--- a/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
@@ -1,0 +1,352 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.App.Views;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Navigation between the tabbed shell and a session workspace: the surface swap, the two entry
+/// points (card click and launch auto-open), every exit path (Back, open-another, intercepted
+/// close-to-hide, shutdown), and the generation/latch guards that keep a late launch success from
+/// attaching an invisible terminal (spec §3, "Workspace ownership" / "Entry-point guards").
+///
+/// Opening a workspace builds a REAL WorkspaceViewModel (over the fake daemon and the scripted
+/// attach factory), whose TerminalTabViewModel reaches Dispatcher.UIThread.InvokeAsync on every
+/// dto push and again in its teardown — so every test runs through RunOnUiAsync (DispatchAsync for
+/// a live pumped dispatcher, WithImmediateRxScheduler so ObserveOn(RxSchedulers.MainThreadScheduler)
+/// applies synchronously) and carries [NotInParallel("AvaloniaSession")], exactly like
+/// WorkspaceViewModelTests/TerminalTabViewModelTests.
+public class WorkspaceNavigationTests {
+    const string Id1 = "0123456789abcdef0123456789abcdef";
+    const string Id2 = "fedcba9876543210fedcba9876543210";
+    const string UnusableId = "Launched, but the session id was unusable — open it from the session list.";
+
+    sealed class FakeTerminalSurface : ITerminalSurface {
+        public void Feed(string text) { }
+        public event Action<byte[]>? InputProduced;
+        public event Action<int, int>? Resized;
+        public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
+        public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
+    }
+
+    /// The tracker as the VM sees it (Action&lt;Func&lt;Task&gt;&gt;): records every registration and
+    /// starts it immediately, exactly like WorkspaceTeardownTracker.Track — so a test can count
+    /// registrations AND await the teardown that registration started.
+    sealed class RecordingTeardownTracker {
+        readonly List<Task> _started = [];
+        public List<Func<Task>> Registered { get; } = [];
+
+        public void Track(Func<Task> teardown) {
+            Registered.Add(teardown);
+            _started.Add(teardown());
+        }
+
+        public Task StartedTeardowns() => Task.WhenAll(_started.ToArray());
+    }
+
+    sealed class FixedLaunchClient : ILaunchClient {
+        public LaunchOutcome Next = new(true, Id1, null);
+        public Task<LaunchOutcome> StartAsync(LaunchRequest request, CancellationToken ct) => Task.FromResult(Next);
+    }
+
+    /// Holds a launch open so a test can navigate (close-to-hide, open another) WHILE the launch is
+    /// in flight — the exact window a stale generation has to close.
+    sealed class GatedLaunchClient : ILaunchClient {
+        public readonly TaskCompletionSource<LaunchOutcome> Gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Task<LaunchOutcome> StartAsync(LaunchRequest request, CancellationToken ct) => Gate.Task;
+    }
+
+    static AgentStatusDto Agent(string id, bool? hasTerminal = true, string vendor = "claude") => new(
+        id, "agent", vendor, "/repo/myproj", "Running",
+        FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null,
+        RequesterDisplay: null, HasTerminal: hasTerminal);
+
+    static AgentActionService NewActions() =>
+        new(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener(),
+            new ReplaySubject<DaemonStatusDto>(1), CancellationToken.None, NeverConfirm.Confirm);
+
+    /// The composition root's shape with its three navigation seams faked: a SHARED navigation gate
+    /// (a window the coordinator rebuilds gets the same one), the tracker as a delegate, and a
+    /// workspace factory that records what it was asked to open.
+    sealed class Nav {
+        public required FakeDaemonClientService Daemon { get; init; }
+        public required FakeTerminalAttachClientFactory Attach { get; init; }
+        public required RecordingTeardownTracker Tracker { get; init; }
+        public required List<string> Opened { get; init; }
+        public required NavigationGate Gate { get; init; }
+        public required MainWindowViewModel Vm { get; init; }
+    }
+
+    static Nav NewNav(NavigationGate? gate = null, Action<Func<Task>>? track = null) {
+        var daemon = new FakeDaemonClientService();
+        var attach = new FakeTerminalAttachClientFactory();
+        var time = new FakeTimeProvider();
+        var tracker = new RecordingTeardownTracker();
+        var opened = new List<string>();
+        var actions = NewActions();
+        gate ??= new NavigationGate();
+
+        var vm = new MainWindowViewModel(
+            daemon, actions, new FakeTicker(), CancellationToken.None, TestActivity.New(),
+            navigation: gate,
+            trackWorkspaceTeardown: track ?? tracker.Track,
+            workspaceFactory: agentId => {
+                opened.Add(agentId);
+                return new WorkspaceViewModel(
+                    agentId, daemon, actions, attach.Factory, () => new FakeTerminalSurface(), time);
+            });
+
+        return new Nav {
+            Daemon = daemon, Attach = attach, Tracker = tracker, Opened = opened, Gate = gate, Vm = vm,
+        };
+    }
+
+    /// Opens a workspace whose terminal has actually attached — the only state in which a teardown
+    /// can be proven by DetachAsync/DisposeAsync on the scripted client.
+    static async Task<FakeTerminalAttachClient> OpenAttachedAsync(Nav nav, string agentId) {
+        nav.Daemon.Agents.AddOrUpdate(Agent(agentId));
+        nav.Vm.OpenSession(agentId);
+        await (nav.Vm.CurrentWorkspace!.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+        return nav.Attach.Created[^1];
+    }
+
+    static HomeViewModel NewHome(Nav nav, ILaunchClient launch, string statePath) =>
+        new(nav.Daemon, new AppStateStore(statePath), launch, () => Task.FromResult(Array.Empty<string>()),
+            openSession: nav.Vm.OpenSession,
+            navigationGeneration: () => nav.Vm.NavigationGeneration,
+            openSessionIfCurrent: nav.Vm.OpenSessionIfCurrent);
+
+    // See the class doc comment: WithImmediateRxScheduler alone never pumps Dispatcher.UIThread,
+    // which every workspace open and every teardown reaches.
+    static Task RunOnUiAsync(Func<Task> body) =>
+        AvaloniaSession.DispatchAsync(async () => {
+            await AvaloniaSession.WithImmediateRxScheduler(body);
+            return true;
+        });
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Open_session_swaps_to_a_workspace_and_close_returns_to_shell() {
+        await RunOnUiAsync(async () => {
+            var nav = NewNav();
+
+            nav.Vm.OpenSession(Id1);
+
+            await Assert.That(nav.Vm.CurrentWorkspace).IsNotNull();
+            await Assert.That(nav.Vm.CurrentWorkspace!.AgentId).IsEqualTo(Id1);
+            // The window binds Back to the VM's own close command — never left null on a workspace
+            // the VM itself built (WorkspaceView hides the button while it is).
+            await Assert.That(nav.Vm.CurrentWorkspace!.BackCommand).IsNotNull();
+
+            await nav.Vm.CurrentWorkspace!.BackCommand!.Execute();
+
+            await Assert.That(nav.Vm.CurrentWorkspace).IsNull();
+            await Assert.That(nav.Tracker.Registered.Count).IsEqualTo(1);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Opening_another_session_tears_down_the_previous_workspace_tracked() {
+        await RunOnUiAsync(async () => {
+            var nav = NewNav();
+            var first = await OpenAttachedAsync(nav, Id1);
+
+            nav.Daemon.Agents.AddOrUpdate(Agent(Id2));
+            nav.Vm.OpenSession(Id2);
+            await nav.Tracker.StartedTeardowns();
+
+            await Assert.That(nav.Vm.CurrentWorkspace!.AgentId).IsEqualTo(Id2);
+            await Assert.That(nav.Opened).IsEquivalentTo([Id1, Id2]);
+            // Exactly one registration: the OUTGOING workspace's, never the incoming one's.
+            await Assert.That(nav.Tracker.Registered.Count).IsEqualTo(1);
+            await Assert.That(first.DetachCalls).IsEqualTo(1);
+            await Assert.That(first.DisposeCalls).IsGreaterThanOrEqualTo(1);
+        });
+    }
+
+    /// Drives MainWindowCoordinator.OnWindowClosing itself — the ACTUAL intercepted-close path,
+    /// wired the way the composition root wires it — rather than calling CloseWorkspace directly:
+    /// the window stays alive on a hide, so nothing but this wiring stops an invisible terminal
+    /// from staying attached and clamping the PTY for every other viewer (spec §3).
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Intercepted_close_to_hide_tears_down_and_resets_navigation() {
+        await RunOnUiAsync(async () => {
+            var nav = NewNav();
+            var coordinator = new MainWindowCoordinator(
+                () => {
+                    var window = new MainWindow { DataContext = nav.Vm };
+                    window.Show(); // the production factory (App.BuildAndShowMainWindow) shows too
+                    return window;
+                },
+                releaseWorkspace: window => (window.DataContext as MainWindowViewModel)?.CloseWorkspace());
+
+            coordinator.ShowMainWindow();
+            Dispatcher.UIThread.RunJobs();
+
+            var client = await OpenAttachedAsync(nav, Id1);
+            Dispatcher.UIThread.RunJobs();
+            var generationBefore = nav.Vm.NavigationGeneration;
+
+            var intercepted = coordinator.OnWindowClosing();
+            await nav.Tracker.StartedTeardowns();
+
+            await Assert.That(intercepted).IsTrue();                  // hidden, not closed
+            await Assert.That(coordinator.Window!.IsVisible).IsFalse();
+            await Assert.That(nav.Vm.CurrentWorkspace).IsNull();      // reopening lands on the shell
+            await Assert.That(nav.Vm.NavigationGeneration).IsGreaterThan(generationBefore);
+            await Assert.That(client.DetachCalls).IsEqualTo(1);
+            await Assert.That(client.DisposeCalls).IsGreaterThanOrEqualTo(1);
+
+            coordinator.QuitInProgress = true; // let the window really close, as a quit would
+            coordinator.Window!.Close();
+            Dispatcher.UIThread.RunJobs();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_stale_generation_launch_success_opens_nothing() {
+        await RunOnUiAsync(async () => {
+            var nav = NewNav();
+            nav.Vm.OpenSession(Id1);
+            var captured = nav.Vm.NavigationGeneration;
+
+            nav.Vm.CloseWorkspace(); // any explicit navigation retires the captured generation
+
+            nav.Vm.OpenSessionIfCurrent(Id2, captured);
+
+            await Assert.That(nav.Vm.CurrentWorkspace).IsNull();
+            await Assert.That(nav.Opened).IsEquivalentTo([Id1]);
+
+            // The same call at the CURRENT generation is the control: the guard is the generation,
+            // not a blanket refusal.
+            nav.Vm.OpenSessionIfCurrent(Id2, nav.Vm.NavigationGeneration);
+            await Assert.That(nav.Vm.CurrentWorkspace!.AgentId).IsEqualTo(Id2);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Launch_success_after_close_to_hide_opens_nothing() {
+        await RunOnUiAsync(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var nav = NewNav();
+            var launch = new GatedLaunchClient();
+            using var home = NewHome(nav, launch, path);
+
+            await home.SelectRepositoryAsync("/repo/myproj");
+            var start = home.StartCommand.Execute().ToTask(); // generation captured before the launch
+
+            nav.Vm.CloseWorkspace(); // stands in for the coordinator's close-to-hide: bumps
+            launch.Gate.SetResult(new LaunchOutcome(true, Id1, null));
+            await start;
+
+            await Assert.That(nav.Vm.CurrentWorkspace).IsNull();
+            await Assert.That(nav.Opened).IsEmpty();
+            await Assert.That(home.StartError).IsNull(); // the launch itself succeeded
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Open_session_after_shutdown_latch_creates_nothing() {
+        await RunOnUiAsync(async () => {
+            var nav = NewNav();
+
+            nav.Vm.LatchShutdown();
+            nav.Vm.OpenSession(Id1);
+            nav.Vm.OpenSessionIfCurrent(Id1, nav.Vm.NavigationGeneration);
+
+            await Assert.That(nav.Vm.CurrentWorkspace).IsNull();
+            await Assert.That(nav.Opened).IsEmpty();
+            await Assert.That(nav.Attach.Created).IsEmpty(); // no client, therefore no socket
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Shutdown_first_pass_registers_the_live_workspace_before_drain() {
+        await RunOnUiAsync(async () => {
+            // The REAL tracker here: the point is that the registration lands before the drain
+            // seals it, which only the real seal-and-drain can show.
+            var tracker = new WorkspaceTeardownTracker(new FakeTimeProvider());
+            var nav = NewNav(track: tracker.Track);
+            var client = await OpenAttachedAsync(nav, Id1);
+
+            nav.Vm.LatchShutdown();
+            await Assert.That(nav.Vm.CurrentWorkspace).IsNull(); // unhooked synchronously
+
+            await tracker.DrainAsync();
+
+            await Assert.That(client.DetachCalls).IsEqualTo(1);
+            await Assert.That(client.DisposeCalls).IsGreaterThanOrEqualTo(1);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_window_built_after_shutdown_began_cannot_open_a_workspace() {
+        await RunOnUiAsync(async () => {
+            var gate = new NavigationGate();
+            var first = NewNav(gate);
+            first.Vm.LatchShutdown();
+
+            // MainWindowCoordinator can build a window between the two shutdown passes — it shares
+            // the composition root's gate, so the latch reaches it by construction.
+            var rebuilt = NewNav(gate);
+            rebuilt.Vm.OpenSession(Id1);
+
+            await Assert.That(rebuilt.Vm.CurrentWorkspace).IsNull();
+            await Assert.That(rebuilt.Opened).IsEmpty();
+            await Assert.That(rebuilt.Attach.Created).IsEmpty();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("agent-2")]                                  // not hex
+    [Arguments("0123456789abcdef0123456789abcde")]          // 31 chars
+    public async Task Malformed_launch_agent_id_surfaces_an_error_and_opens_nothing(string? agentId) {
+        await RunOnUiAsync(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var nav = NewNav();
+            var launch = new FixedLaunchClient { Next = new LaunchOutcome(true, agentId, null) };
+            using var home = NewHome(nav, launch, path);
+
+            await home.SelectRepositoryAsync("/repo/myproj");
+            home.Goal = "do the thing";
+            await home.StartCommand.Execute();
+
+            await Assert.That(home.StartError).IsEqualTo(UnusableId);
+            await Assert.That(nav.Vm.CurrentWorkspace).IsNull();
+            await Assert.That(nav.Opened).IsEmpty();
+            await Assert.That(home.Goal).IsEqualTo(""); // the launch DID start — the goal is spent
+        });
+    }
+
+    /// The card click's own entry point (HomeView routes a click to this), distinct from the launch
+    /// auto-open above: no generation is involved, the click IS the current navigation.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_session_card_click_opens_that_sessions_workspace() {
+        await RunOnUiAsync(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var nav = NewNav();
+            using var home = NewHome(nav, new FixedLaunchClient(), path);
+
+            home.OpenSessionRequested(Id2);
+
+            await Assert.That(nav.Vm.CurrentWorkspace!.AgentId).IsEqualTo(Id2);
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
@@ -34,6 +34,8 @@ public class WorkspaceNavigationTests {
         public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
         public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
         public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
+        public int CaretShown;
+        public void EnsureCaretVisible() => CaretShown++;
     }
 
     /// The tracker as the VM sees it (Action&lt;Func&lt;Task&gt;&gt;): records every registration and
@@ -348,12 +350,14 @@ public class WorkspaceNavigationTests {
         });
     }
 
+    /// Only a null/blank id is unusable. Anything else passes through verbatim (see
+    /// NormalizeAgentId: a production daemon keys its cache on SHORT 8-hex ids, so shape
+    /// validation beyond emptiness rejects real launches).
     [Test]
     [NotInParallel("AvaloniaSession")]
     [Arguments(null)]
     [Arguments("")]
-    [Arguments("agent-2")]                                  // not hex
-    [Arguments("0123456789abcdef0123456789abcde")]          // 31 chars
+    [Arguments("   ")]
     public async Task Malformed_launch_agent_id_surfaces_an_error_and_opens_nothing(string? agentId) {
         await RunOnUiAsync(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
@@ -372,15 +376,18 @@ public class WorkspaceNavigationTests {
         });
     }
 
-    /// The server hub hands back the agent id as a DASHED Guid ("D"), while the daemon's status
-    /// cache keys on the 32-hex "N" form — the launch path must normalize, or every real launch
-    /// reads as unusable (found in manual QA: red error over a perfectly healthy session card).
+    /// Id shapes vary across the stack (found in manual QA, twice): the server hub has returned
+    /// DASHED Guids, and a production daemon keys its status cache on SHORT 8-hex ids. Guids in
+    /// any format normalize to "N"; every other non-blank id passes through VERBATIM so it can
+    /// match whatever the daemon actually sent.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    [Arguments("01234567-89ab-cdef-0123-456789abcdef")]     // "D" — what the server actually sends
-    [Arguments("{01234567-89ab-cdef-0123-456789abcdef}")]   // "B" — tolerate any Guid shape
-    [Arguments("0123456789abcdef0123456789abcdef")]         // "N" — already canonical
-    public async Task A_launch_id_in_any_guid_shape_normalizes_and_opens(string agentId) {
+    [Arguments("01234567-89ab-cdef-0123-456789abcdef", "0123456789abcdef0123456789abcdef")]  // "D" → "N"
+    [Arguments("{01234567-89ab-cdef-0123-456789abcdef}", "0123456789abcdef0123456789abcdef")] // "B" → "N"
+    [Arguments("0123456789abcdef0123456789abcdef", "0123456789abcdef0123456789abcdef")]       // "N" → "N"
+    [Arguments("3d53f34d", "3d53f34d")]                     // short daemon id → verbatim
+    [Arguments("agent-2", "agent-2")]                       // unknown shape → verbatim
+    public async Task A_launch_id_in_any_guid_shape_normalizes_and_opens(string agentId, string expected) {
         await RunOnUiAsync(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
             var nav = NewNav();
@@ -392,7 +399,7 @@ public class WorkspaceNavigationTests {
             await home.StartCommand.Execute();
 
             await Assert.That(home.StartError).IsNull();
-            await Assert.That(nav.Opened).IsEquivalentTo(new[] { "0123456789abcdef0123456789abcdef" });
+            await Assert.That(nav.Opened).IsEquivalentTo(new[] { expected });
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/WorkspaceTeardownTrackerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceTeardownTrackerTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Capacitor.App.Services;
 using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -10,14 +11,6 @@ namespace Capacitor.App.Tests.Unit;
 /// first would leave the timer scheduled into a future that already passed.
 public class WorkspaceTeardownTrackerTests {
     static readonly DateTimeOffset T0 = new(2026, 8, 8, 10, 0, 0, TimeSpan.Zero);
-
-    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
-        while (!condition()) {
-            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
-            await Task.Delay(10);
-        }
-    }
 
     [Test]
     public async Task Track_runs_and_observes_a_normal_teardown() {

--- a/test/Capacitor.App.Tests.Unit/WorkspaceTeardownTrackerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceTeardownTrackerTests.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+using Capacitor.App.Services;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Plain async tests — the tracker has no UI/Avalonia affinity, so no AvaloniaSession is needed.
+/// The 5s-bound test uses TimerCountingTimeProvider (shared from ConsentServiceTests.cs) to know
+/// the drain's Task.Delay is armed before advancing the underlying FakeTimeProvider — advancing
+/// first would leave the timer scheduled into a future that already passed.
+public class WorkspaceTeardownTrackerTests {
+    static readonly DateTimeOffset T0 = new(2026, 8, 8, 10, 0, 0, TimeSpan.Zero);
+
+    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    [Test]
+    public async Task Track_runs_and_observes_a_normal_teardown() {
+        var tracker = new WorkspaceTeardownTracker(new FakeTimeProvider(T0));
+        var ran = false;
+
+        tracker.Track(() => { ran = true; return Task.CompletedTask; });
+        await tracker.DrainAsync();
+
+        await Assert.That(ran).IsTrue();
+    }
+
+    [Test]
+    public async Task Faulting_teardown_is_logged_exactly_once_via_diagnostics() {
+        var diagnostics = new List<(string Context, Exception Ex)>();
+        var tracker = new WorkspaceTeardownTracker(new FakeTimeProvider(T0), (ctx, ex) => diagnostics.Add((ctx, ex)));
+        var boom = new InvalidOperationException("boom");
+
+        tracker.Track(() => throw boom);
+        await tracker.DrainAsync();
+
+        await Assert.That(diagnostics.Count).IsEqualTo(1);
+        await Assert.That(diagnostics[0].Ex).IsSameReferenceAs(boom);
+    }
+
+    [Test]
+    public async Task Faulting_teardown_does_not_poison_the_drain_or_other_teardowns() {
+        var diagnostics = new List<(string Context, Exception Ex)>();
+        var tracker = new WorkspaceTeardownTracker(new FakeTimeProvider(T0), (ctx, ex) => diagnostics.Add((ctx, ex)));
+        var otherRan = false;
+
+        tracker.Track(() => throw new InvalidOperationException("boom"));
+        tracker.Track(() => { otherRan = true; return Task.CompletedTask; });
+        await tracker.DrainAsync();
+
+        await Assert.That(diagnostics.Count).IsEqualTo(1);
+        await Assert.That(otherRan).IsTrue();
+    }
+
+    [Test]
+    public async Task Faulting_teardown_without_a_diagnostics_callback_does_not_throw() {
+        var tracker = new WorkspaceTeardownTracker(new FakeTimeProvider(T0));
+
+        tracker.Track(() => throw new InvalidOperationException("boom"));
+
+        await tracker.DrainAsync(); // must not throw
+    }
+
+    [Test]
+    public async Task DrainAsync_is_bounded_at_5_seconds_and_the_straggler_keeps_its_observer() {
+        var innerTime = new FakeTimeProvider(T0);
+        var countingTime = new TimerCountingTimeProvider(innerTime);
+        var diagnostics = new List<(string Context, Exception Ex)>();
+        var tracker = new WorkspaceTeardownTracker(countingTime, (ctx, ex) => diagnostics.Add((ctx, ex)));
+
+        var gate = new TaskCompletionSource();
+        tracker.Track(() => gate.Task); // never completes on its own
+
+        var drainTask = tracker.DrainAsync();
+        await WaitUntilAsync(() => countingTime.TimersCreated >= 1, what: "the 5s drain bound to be armed");
+        innerTime.Advance(TimeSpan.FromSeconds(5));
+
+        await drainTask; // returns without waiting for the straggler
+
+        var straggler = new InvalidOperationException("late");
+        gate.SetException(straggler);
+        await WaitUntilAsync(() => diagnostics.Count == 1, what: "the straggler's fault to be logged");
+
+        await Assert.That(diagnostics[0].Ex).IsSameReferenceAs(straggler);
+    }
+
+    [Test]
+    public async Task DrainAsync_is_idempotent() {
+        var tracker = new WorkspaceTeardownTracker(new FakeTimeProvider(T0));
+        var runs = 0;
+        tracker.Track(() => { runs++; return Task.CompletedTask; });
+
+        var first = tracker.DrainAsync();
+        await first;
+        var second = tracker.DrainAsync(); // idempotent: must not throw, must not re-drain
+        await second;
+
+        await Assert.That(runs).IsEqualTo(1);
+        await Assert.That(second).IsSameReferenceAs(first);
+    }
+
+    [Test]
+    public async Task Track_racing_DrainAsync_runs_every_teardown_exactly_once() {
+        var tracker = new WorkspaceTeardownTracker(new FakeTimeProvider(T0));
+        var counts = new ConcurrentDictionary<int, int>();
+        const int total = 2000;
+
+        var producer = Task.Run(() => {
+            for (var i = 0; i < total; i++) {
+                var idx = i;
+                tracker.Track(() => {
+                    counts.AddOrUpdate(idx, 1, (_, c) => c + 1);
+                    return Task.CompletedTask;
+                });
+            }
+        });
+
+        var drainTask = tracker.DrainAsync(); // races the producer loop above
+        await Task.WhenAll(producer, drainTask);
+
+        await Assert.That(counts.Count).IsEqualTo(total);
+        await Assert.That(counts.Values.All(c => c == 1)).IsTrue();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -6,6 +6,8 @@ using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
 using Microsoft.Extensions.Time.Testing;
 using TUnit.Assertions.Enums;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -19,24 +21,6 @@ namespace Capacitor.App.Tests.Unit;
 /// so ObserveOn(RxSchedulers.MainThreadScheduler) applies synchronously) and carries
 /// [NotInParallel("AvaloniaSession")] -- see that class's identical header comment.
 public class WorkspaceViewModelTests {
-    sealed class FakeTerminalSurface : ITerminalSurface {
-        public void Feed(string text) { }
-        public event Action<byte[]>? InputProduced;
-        public event Action<int, int>? Resized;
-        public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
-        public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
-        public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
-        public int CaretShown;
-        public void EnsureCaretVisible() => CaretShown++;
-    }
-
-    static AgentStatusDto Agent(
-            string id, string vendor, bool? hasTerminal, string? repoPath = null,
-            string kind = "agent", string? model = null) => new(
-        id, kind, vendor, repoPath, "Running",
-        FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: model,
-        RequesterDisplay: null, HasTerminal: hasTerminal);
-
     static WorkspaceViewModel Build(
             FakeDaemonClientService daemon, AgentActionService actions, FakeTerminalAttachClientFactory factory,
             FakeTimeProvider time, string agentId = "a1") =>
@@ -47,22 +31,6 @@ public class WorkspaceViewModelTests {
             Func<string, Task<bool>>? confirmForceStop = null) =>
         new(ops, notifier, opener, new ReplaySubject<DaemonStatusDto>(1), CancellationToken.None,
             confirmForceStop ?? NeverConfirm.Confirm);
-
-    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
-        while (!condition()) {
-            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
-            await Task.Delay(10);
-        }
-    }
-
-    // See the class doc comment: WithImmediateRxScheduler alone never pumps Dispatcher.UIThread,
-    // which the internal TerminalTabViewModel's resolve gate reaches on every dto push.
-    static Task RunOnUiAsync(Func<Task> body) =>
-        AvaloniaSession.DispatchAsync(async () => {
-            await AvaloniaSession.WithImmediateRxScheduler(body);
-            return true;
-        });
 
     [Test]
     [NotInParallel("AvaloniaSession")]

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -1,0 +1,172 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// WorkspaceViewModel's header projections (Title/RepoLabelText/VendorChip/FamilyDot/
+/// ShowsTerminalTab/NoTerminalNote), SessionEnded, and Stop routing. WorkspaceViewModel always
+/// builds a real TerminalTabViewModel internally, so pushing a matching AgentStatusDto into the
+/// shared daemon.Agents cache also drives Terminal's OWN resolve gate -- which reaches
+/// Dispatcher.UIThread.InvokeAsync regardless of hasTerminal (both the NoTerminal and the attach
+/// branches dispatch). Every test therefore runs through the same RunOnUiAsync nesting
+/// TerminalTabViewModelTests uses (DispatchAsync for a live pumped dispatcher, WithImmediateRxScheduler
+/// so ObserveOn(RxSchedulers.MainThreadScheduler) applies synchronously) and carries
+/// [NotInParallel("AvaloniaSession")] -- see that class's identical header comment.
+public class WorkspaceViewModelTests {
+    sealed class FakeTerminalSurface : ITerminalSurface {
+        public void Feed(string text) { }
+        public event Action<byte[]>? InputProduced;
+        public event Action<int, int>? Resized;
+        public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
+        public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
+    }
+
+    static AgentStatusDto Agent(
+            string id, string vendor, bool? hasTerminal, string? repoPath = null,
+            string kind = "agent", string? model = null) => new(
+        id, kind, vendor, repoPath, "Running",
+        FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: model,
+        RequesterDisplay: null, HasTerminal: hasTerminal);
+
+    static WorkspaceViewModel Build(
+            FakeDaemonClientService daemon, AgentActionService actions, FakeTerminalAttachClientFactory factory,
+            FakeTimeProvider time, string agentId = "a1") =>
+        new(agentId, daemon, actions, factory.Factory, () => new FakeTerminalSurface(), time);
+
+    static AgentActionService NewActions(
+            ScriptedLocalControlOps ops, RecordingNotifier notifier, RecordingOpener opener,
+            Func<string, Task<bool>>? confirmForceStop = null) =>
+        new(ops, notifier, opener, new ReplaySubject<DaemonStatusDto>(1), CancellationToken.None,
+            confirmForceStop ?? NeverConfirm.Confirm);
+
+    static async Task WaitUntilAsync(Func<bool> condition, TimeSpan? timeout = null, string what = "condition") {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    // See the class doc comment: WithImmediateRxScheduler alone never pumps Dispatcher.UIThread,
+    // which the internal TerminalTabViewModel's resolve gate reaches on every dto push.
+    static Task RunOnUiAsync(Func<Task> body) =>
+        AvaloniaSession.DispatchAsync(async () => {
+            await AvaloniaSession.WithImmediateRxScheduler(body);
+            return true;
+        });
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Title_repo_and_vendor_chip_project_from_the_pushed_dto() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var actions = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
+            var factory = new FakeTerminalAttachClientFactory();
+            var vm = Build(daemon, actions, factory, new FakeTimeProvider(), agentId: "a1");
+
+            // Before any dto: placeholders, never a crash on the null-dto default path.
+            await Assert.That(vm.RepoLabelText).IsEqualTo("—");
+            await Assert.That(vm.ShowsTerminalTab).IsFalse();
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo/myproj", model: "sonnet"));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+            await Assert.That(vm.Title).IsEqualTo("myproj · claude");
+            await Assert.That(vm.RepoLabelText).IsEqualTo("myproj");
+            await Assert.That(vm.VendorChip).IsEqualTo("claude (sonnet)");
+            await Assert.That(vm.FamilyDot).IsEqualTo("pty");
+            await Assert.That(vm.ShowsTerminalTab).IsTrue();
+            await Assert.That(vm.NoTerminalNote).IsEqualTo("");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Has_terminal_false_hides_the_tab_and_sets_the_family_aware_note() {
+        await RunOnUiAsync(async () => {
+            // Case 1: an ACP vendor (gemini) -- note says "runs over ACP", never the vendor name.
+            var daemon1 = new FakeDaemonClientService();
+            var actions1 = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
+            var factory1 = new FakeTerminalAttachClientFactory();
+            var vm1 = Build(daemon1, actions1, factory1, new FakeTimeProvider(), agentId: "a1");
+
+            daemon1.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: false));
+            await (vm1.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+            await Assert.That(vm1.ShowsTerminalTab).IsFalse();
+            await Assert.That(vm1.NoTerminalNote).Contains("runs over ACP");
+            await Assert.That(vm1.NoTerminalNote).DoesNotContain("Gemini");
+
+            // Case 2: a non-ACP vendor (pi maps to rpc) -- bare note, no family token leaked.
+            var daemon2 = new FakeDaemonClientService();
+            var actions2 = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
+            var factory2 = new FakeTerminalAttachClientFactory();
+            var vm2 = Build(daemon2, actions2, factory2, new FakeTimeProvider(), agentId: "a2");
+
+            daemon2.Agents.AddOrUpdate(Agent("a2", "pi", hasTerminal: false));
+            await (vm2.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+            await Assert.That(vm2.ShowsTerminalTab).IsFalse();
+            await Assert.That(vm2.NoTerminalNote).IsEqualTo("This session has no terminal.");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task SessionEnded_flips_on_cache_removal_and_the_header_stays_frozen() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var actions = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
+            var factory = new FakeTerminalAttachClientFactory();
+            var vm = Build(daemon, actions, factory, new FakeTimeProvider(), agentId: "a1");
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo/myproj"));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(vm.SessionEnded).IsFalse();
+
+            daemon.Agents.Remove("a1");
+
+            await Assert.That(vm.SessionEnded).IsTrue();
+            // The header keeps identifying the session that just ended rather than reverting to
+            // "— · —" -- a frozen last-known snapshot, not a blanked one.
+            await Assert.That(vm.Title).IsEqualTo("myproj · claude");
+            await Assert.That(vm.ShowsTerminalTab).IsTrue();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Stop_routes_through_agent_action_service_with_the_dtos_kind() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var ops = new ScriptedLocalControlOps();
+            var notifier = new RecordingNotifier();
+            var confirmer = new RecordingConfirmer();
+            var actions = NewActions(ops, notifier, new RecordingOpener(), confirmForceStop: confirmer.Confirm);
+            var factory = new FakeTerminalAttachClientFactory();
+            var vm = Build(daemon, actions, factory, new FakeTimeProvider(), agentId: "a1");
+
+            // "review" is a PROTECTED kind (AgentActionService.IsProtectedKind: anything but
+            // exactly "agent"). Only reaching the confirm-then-force seam proves StopCommand read
+            // the DTO's OWN kind rather than some fixed default -- StopPayloads alone can't show
+            // this, since the wire call never carries kind, only the force bool the confirm
+            // decision produces.
+            daemon.Agents.AddOrUpdate(Agent("a1", "codex", hasTerminal: true, kind: "review"));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+            confirmer.Queue(true);
+            ops.QueueStop(new StopAgentResult(true, "stopped", null));
+            await vm.StopCommand.Execute();
+
+            await WaitUntilAsync(() => ops.StopCalls >= 1, what: "stop issued after confirm");
+            await Assert.That(confirmer.Prompted.Count).IsEqualTo(1);
+            await Assert.That(ops.StopPayloads).IsEquivalentTo([("a1", true)], CollectionOrdering.Matching);
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -26,6 +26,8 @@ public class WorkspaceViewModelTests {
         public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
         public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
         public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
+        public int CaretShown;
+        public void EnsureCaretVisible() => CaretShown++;
     }
 
     static AgentStatusDto Agent(

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -25,6 +25,7 @@ public class WorkspaceViewModelTests {
         public event Action<int, int>? Resized;
         public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
         public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
+        public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
     }
 
     static AgentStatusDto Agent(

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -37,6 +37,8 @@ public class WorkspaceViewSmokeTests {
         public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
         public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
         public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
+        public int CaretShown;
+        public void EnsureCaretVisible() => CaretShown++;
     }
 
     static AgentStatusDto Agent(string id, bool? hasTerminal, string vendor = "claude") => new(

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -183,4 +183,76 @@ public class WorkspaceViewSmokeTests {
             await vm.TeardownAsync();
         });
     }
+
+    /// Run-and-observe: a NORMAL read-write attach (TriggerAttached with no reason) must still
+    /// show the attach banner and its DetachButton -- the design canvas's whole point is that
+    /// Detach is reachable from the primary (read-write) flow, not only the read-only one. Before
+    /// the fix, the banner's Border bound to TerminalReadOnlyBannerVisibleConverter, which is
+    /// false here (ReadOnly stays false), so DetachButton was IsEffectivelyVisible: false and
+    /// this test failed against the pre-fix view.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Read_write_attached_state_shows_the_attach_banner_and_detach_button() {
+        await RunOnUiAsync(async () => {
+            var (view, vm, daemon, attach) = Build();
+            var window = new Window { Content = view };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var detachButton = Find<Control>(window, "DetachButton")!;
+            var bannerText = Find<TextBlock>(window, "AttachBannerText")!;
+
+            daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: true));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+
+            var client = attach.Created[^1];
+            await client.TriggerAttached([], reason: null);
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(vm.Terminal.State.Phase).IsEqualTo(TerminalSessionPhase.Attached);
+            await Assert.That(vm.Terminal.State.ReadOnly).IsFalse();
+            await Assert.That(detachButton.IsEffectivelyVisible).IsTrue();
+            await Assert.That(bannerText.Text)
+                .IsEqualTo("Attached to the live PTY — keystrokes go straight to the process.");
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    /// Companion to the read-write test above: a read-only attach (TriggerAttached with a reason)
+    /// still shows the same banner/DetachButton, now with the warning copy and the reason baked
+    /// into the text -- both modes share one banner per the design canvas.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Read_only_attached_state_shows_the_warning_banner_and_detach_button() {
+        await RunOnUiAsync(async () => {
+            var (view, vm, daemon, attach) = Build();
+            var window = new Window { Content = view };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var detachButton = Find<Control>(window, "DetachButton")!;
+            var bannerText = Find<TextBlock>(window, "AttachBannerText")!;
+
+            daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: true));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+
+            var client = attach.Created[^1];
+            await client.TriggerAttached([], reason: "review");
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(vm.Terminal.State.Phase).IsEqualTo(TerminalSessionPhase.Attached);
+            await Assert.That(vm.Terminal.State.ReadOnly).IsTrue();
+            await Assert.That(detachButton.IsEffectivelyVisible).IsTrue();
+            await Assert.That(bannerText.Text).IsEqualTo("Read-only: review");
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -184,15 +184,12 @@ public class WorkspaceViewSmokeTests {
         });
     }
 
-    /// Run-and-observe: a NORMAL read-write attach (TriggerAttached with no reason) must still
-    /// show the attach banner and its DetachButton -- the design canvas's whole point is that
-    /// Detach is reachable from the primary (read-write) flow, not only the read-only one. Before
-    /// the fix, the banner's Border bound to TerminalReadOnlyBannerVisibleConverter, which is
-    /// false here (ReadOnly stays false), so DetachButton was IsEffectivelyVisible: false and
-    /// this test failed against the pre-fix view.
+    /// Owner decision after manual QA: a NORMAL read-write attach shows NO banner — it overlaid
+    /// the terminal content. Explicit detach returns when a use case earns it; read-only keeps
+    /// the banner because it is the only explanation for dead keystrokes.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Read_write_attached_state_shows_the_attach_banner_and_detach_button() {
+    public async Task Read_write_attached_state_shows_no_banner() {
         await RunOnUiAsync(async () => {
             var (view, vm, daemon, attach) = Build();
             var window = new Window { Content = view };
@@ -212,9 +209,8 @@ public class WorkspaceViewSmokeTests {
 
             await Assert.That(vm.Terminal.State.Phase).IsEqualTo(TerminalSessionPhase.Attached);
             await Assert.That(vm.Terminal.State.ReadOnly).IsFalse();
-            await Assert.That(detachButton.IsEffectivelyVisible).IsTrue();
-            await Assert.That(bannerText.Text)
-                .IsEqualTo("Attached to the live PTY — keystrokes go straight to the process.");
+            await Assert.That(detachButton.IsEffectivelyVisible).IsFalse();
+            await Assert.That(bannerText.IsEffectivelyVisible).IsFalse();
 
             window.Close();
             Dispatcher.UIThread.RunJobs();
@@ -223,8 +219,8 @@ public class WorkspaceViewSmokeTests {
     }
 
     /// Companion to the read-write test above: a read-only attach (TriggerAttached with a reason)
-    /// still shows the same banner/DetachButton, now with the warning copy and the reason baked
-    /// into the text -- both modes share one banner per the design canvas.
+    /// is the ONE mode that shows the banner — warning copy with the daemon's reason, plus the
+    /// Detach button (the only action a read-only session has).
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Read_only_attached_state_shows_the_warning_banner_and_detach_button() {

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -1,0 +1,185 @@
+using System.Reactive.Subjects;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.App.Views;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Headless rendering acceptance for the session workspace: WorkspaceView is a UserControl (like
+/// HomeView), so each test hosts it inside a plain Window purely to give headless something to
+/// Show() -- see HomeViewSmokeTests' identical header comment. Unlike HomeView, this VIEW is
+/// normally handed its DataContext through MainWindow's ContentControl/DataTemplate swap
+/// (WorkspaceNavigationTests exercises that path); a smoke test instead sets DataContext directly,
+/// bypassing the template so the view under test is exactly WorkspaceView, not MainWindow's swap
+/// machinery.
+///
+/// WorkspaceViewModel always builds a real TerminalTabViewModel internally, which reaches
+/// Dispatcher.UIThread.InvokeAsync on every daemon-cache dto push regardless of has_terminal (both
+/// the NoTerminal and the attach branches dispatch) -- so every test here runs through the same
+/// RunOnUiAsync nesting WorkspaceViewModelTests/WorkspaceNavigationTests use (DispatchAsync for a
+/// live pumped dispatcher, WithImmediateRxScheduler so ObserveOn(RxSchedulers.MainThreadScheduler)
+/// applies synchronously) and carries [NotInParallel("AvaloniaSession")]. Fixture pieces (the fake
+/// terminal surface, FakeTerminalAttachClientFactory, the AgentActionService scripted deps) are
+/// copied from WorkspaceNavigationTests/WorkspaceViewModelTests rather than re-derived.
+public class WorkspaceViewSmokeTests {
+    const string AgentId = "0123456789abcdef0123456789abcdef";
+
+    sealed class FakeTerminalSurface : ITerminalSurface {
+        public void Feed(string text) { }
+        public event Action<byte[]>? InputProduced;
+        public event Action<int, int>? Resized;
+        public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
+        public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
+    }
+
+    static AgentStatusDto Agent(string id, bool? hasTerminal, string vendor = "claude") => new(
+        id, "agent", vendor, "/repo/myproj", "Running",
+        FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null,
+        RequesterDisplay: null, HasTerminal: hasTerminal);
+
+    static AgentActionService NewActions() =>
+        new(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener(),
+            new ReplaySubject<DaemonStatusDto>(1), CancellationToken.None, NeverConfirm.Confirm);
+
+    static (WorkspaceView View, WorkspaceViewModel Vm, FakeDaemonClientService Daemon, FakeTerminalAttachClientFactory Attach) Build(
+            string agentId = AgentId) {
+        var daemon = new FakeDaemonClientService();
+        var attach = new FakeTerminalAttachClientFactory();
+        var vm = new WorkspaceViewModel(
+            agentId, daemon, NewActions(), attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider());
+        return (new WorkspaceView { DataContext = vm }, vm, daemon, attach);
+    }
+
+    static T? Find<T>(Window window, string name) where T : Control =>
+        window.GetVisualDescendants().OfType<T>().FirstOrDefault(c => c.Name == name);
+
+    // See the class doc comment: WithImmediateRxScheduler alone never pumps Dispatcher.UIThread,
+    // which the internal TerminalTabViewModel's resolve gate and attempt lifecycle both reach.
+    static Task RunOnUiAsync(Func<Task> body) =>
+        AvaloniaSession.DispatchAsync(async () => {
+            await AvaloniaSession.WithImmediateRxScheduler(body);
+            return true;
+        });
+
+    /// Run-and-observe: hosts the view with a plainly-Resolving VM (no dto ever pushed) and looks
+    /// every named control up by x:Name. Every control is statically declared in the XAML (no
+    /// DataTemplate/ItemsControl realization involved, unlike HomeView's session cards), so this
+    /// is not red-verifiable the way a missing-feature test would be -- the view already exists and
+    /// already carries all nine names; there is no "before" state in which the assertion could
+    /// fail short of a typo. TerminalTabButton is a plain Button in the XAML with no Command bound
+    /// (non-interactive today), so it is resolved as a bare Control like every other name here
+    /// rather than assumed clickable.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task WorkspaceView_resolves_all_nine_named_controls() {
+        await RunOnUiAsync(async () => {
+            var (view, vm, _, _) = Build();
+            var window = new Window { Content = view };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var names = new[] {
+                "WorkspaceTitle", "WorkspaceRepo", "WorkspaceVendorChip", "TerminalTabButton",
+                "NoTerminalNote", "TerminalHost", "DetachButton", "ReattachButton", "BackButton",
+            };
+            foreach (var name in names)
+                await Assert.That(Find<Control>(window, name)).IsNotNull().Because($"{name} should resolve");
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    /// Run-and-observe: drives ONE workspace through both has_terminal values for the same agent id
+    /// and asserts the tab/note pair actually flips, not just that one arrangement renders
+    /// correctly. TerminalTabButton and NoTerminalNote both bind IsVisible directly to
+    /// WorkspaceViewModel.ShowsTerminalTab (never negated the same way twice, see the XAML's `!`
+    /// prefix on the note), so a bare `.IsVisible` read is enough -- neither sits behind an
+    /// invisible ancestor.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Tab_and_note_visibility_flip_with_ShowsTerminalTab() {
+        await RunOnUiAsync(async () => {
+            var (view, vm, daemon, _) = Build();
+            var window = new Window { Content = view };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var tabButton = Find<Control>(window, "TerminalTabButton")!;
+            var note = Find<Control>(window, "NoTerminalNote")!;
+            var terminalHost = Find<Control>(window, "TerminalHost")!;
+
+            daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: false));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(vm.ShowsTerminalTab).IsFalse();
+            await Assert.That(tabButton.IsVisible).IsFalse();
+            await Assert.That(note.IsVisible).IsTrue();
+            await Assert.That(terminalHost.IsVisible).IsFalse();
+            await Assert.That(vm.NoTerminalNote).IsNotEmpty();
+
+            // Same agent id, has_terminal flips to true: WorkspaceViewModel's ShowsTerminalTab/
+            // NoTerminalNote are plain Rx projections off the daemon cache (not gated by
+            // TerminalTabViewModel's own one-shot resolve CAS), so a later update still moves them.
+            daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: true));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(vm.ShowsTerminalTab).IsTrue();
+            await Assert.That(tabButton.IsVisible).IsTrue();
+            await Assert.That(note.IsVisible).IsFalse();
+            await Assert.That(terminalHost.IsVisible).IsTrue();
+            await Assert.That(vm.NoTerminalNote).IsEmpty();
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    /// Run-and-observe: drives the fake attach client's Result straight to AttachOutcome.Detached
+    /// (TerminalTabViewModelTests' own idiom) and checks the view actually renders the combined
+    /// Detached/Failed banner -- ReattachButton sits inside a Border whose OWN IsVisible is bound
+    /// to the phase, so IsEffectivelyVisible (not IsVisible) is required to see the ancestor's
+    /// collapse, same as MainWindowSmokeTests' shell-vs-workspace check.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Detached_state_shows_the_reattach_banner() {
+        await RunOnUiAsync(async () => {
+            var (view, vm, daemon, attach) = Build();
+            var window = new Window { Content = view };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var reattachButton = Find<Control>(window, "ReattachButton")!;
+            var detachButton = Find<Control>(window, "DetachButton")!;
+
+            daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: true));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(reattachButton.IsEffectivelyVisible).IsFalse();
+
+            var client = attach.Created[^1];
+            client.Result.SetResult(new AttachOutcome.Detached());
+            await vm.Terminal.CurrentRunForTesting!;
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(vm.Terminal.State.Phase).IsEqualTo(TerminalSessionPhase.Detached);
+            await Assert.That(reattachButton.IsEffectivelyVisible).IsTrue();
+            await Assert.That(detachButton.IsEffectivelyVisible).IsFalse();
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -1,4 +1,3 @@
-using System.Reactive.Subjects;
 using Avalonia.Controls;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -8,6 +7,8 @@ using Capacitor.App.Views;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
 using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -24,31 +25,12 @@ namespace Capacitor.App.Tests.Unit;
 /// the NoTerminal and the attach branches dispatch) -- so every test here runs through the same
 /// RunOnUiAsync nesting WorkspaceViewModelTests/WorkspaceNavigationTests use (DispatchAsync for a
 /// live pumped dispatcher, WithImmediateRxScheduler so ObserveOn(RxSchedulers.MainThreadScheduler)
-/// applies synchronously) and carries [NotInParallel("AvaloniaSession")]. Fixture pieces (the fake
-/// terminal surface, FakeTerminalAttachClientFactory, the AgentActionService scripted deps) are
-/// copied from WorkspaceNavigationTests/WorkspaceViewModelTests rather than re-derived.
+/// applies synchronously) and carries [NotInParallel("AvaloniaSession")].
 public class WorkspaceViewSmokeTests {
     const string AgentId = "0123456789abcdef0123456789abcdef";
 
-    sealed class FakeTerminalSurface : ITerminalSurface {
-        public void Feed(string text) { }
-        public event Action<byte[]>? InputProduced;
-        public event Action<int, int>? Resized;
-        public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
-        public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
-        public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
-        public int CaretShown;
-        public void EnsureCaretVisible() => CaretShown++;
-    }
-
-    static AgentStatusDto Agent(string id, bool? hasTerminal, string vendor = "claude") => new(
-        id, "agent", vendor, "/repo/myproj", "Running",
-        FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: null,
-        RequesterDisplay: null, HasTerminal: hasTerminal);
-
-    static AgentActionService NewActions() =>
-        new(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener(),
-            new ReplaySubject<DaemonStatusDto>(1), CancellationToken.None, NeverConfirm.Confirm);
+    static AgentStatusDto Agent(string id, bool? hasTerminal, string vendor = "claude") =>
+        WorkspaceFixtures.Agent(id, vendor, hasTerminal, "/repo/myproj");
 
     static (WorkspaceView View, WorkspaceViewModel Vm, FakeDaemonClientService Daemon, FakeTerminalAttachClientFactory Attach) Build(
             string agentId = AgentId) {
@@ -61,14 +43,6 @@ public class WorkspaceViewSmokeTests {
 
     static T? Find<T>(Window window, string name) where T : Control =>
         window.GetVisualDescendants().OfType<T>().FirstOrDefault(c => c.Name == name);
-
-    // See the class doc comment: WithImmediateRxScheduler alone never pumps Dispatcher.UIThread,
-    // which the internal TerminalTabViewModel's resolve gate and attempt lifecycle both reach.
-    static Task RunOnUiAsync(Func<Task> body) =>
-        AvaloniaSession.DispatchAsync(async () => {
-            await AvaloniaSession.WithImmediateRxScheduler(body);
-            return true;
-        });
 
     /// Run-and-observe: hosts the view with a plainly-Resolving VM (no dto ever pushed) and looks
     /// every named control up by x:Name. Every control is statically declared in the XAML (no

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -36,6 +36,7 @@ public class WorkspaceViewSmokeTests {
         public event Action<int, int>? Resized;
         public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
         public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
+        public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
     }
 
     static AgentStatusDto Agent(string id, bool? hasTerminal, string vendor = "claude") => new(

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -336,6 +336,66 @@ public class AgentAttachClientTests {
     }
 
     [Test]
+    public async Task Out_of_range_initial_size_is_clamped_not_dropped_from_the_opening_nudge() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+
+        var run = client.RunAsync(70000, -5, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendExitedAsync(0);
+        await run;
+
+        await server.WaitForReceivedAsync(FrameType.Resize);
+        var resize = server.SnapshotReceived().Single(f => f.Type == FrameType.Resize);
+        await Assert.That(resize.Cols).IsEqualTo((ushort)65535);
+        await Assert.That(resize.Rows).IsEqualTo((ushort)1);
+    }
+
+    /// The dial itself never blocks a local Unix socket connect on every platform this suite
+    /// runs on -- it resolves (success or refusal) within microseconds. So "detach before the
+    /// server accepts" is forced by scheduling asymmetry, not by an OS-level pending connect:
+    /// RunAsync is queued onto the pool (a real dial + _writeLock acquisition, real work), while
+    /// DetachAsync fires immediately after on the calling thread (a flag write, no I/O) -- it
+    /// reliably records intent before TryWriteAttachAsync's under-lock re-check runs, whether or
+    /// not the dial itself ever gets cancelled. Repeated because it is still a genuine race, not
+    /// a guaranteed ordering; the vacuous-test guard below proves it actually lands.
+    [Test]
+    public async Task Detach_racing_the_dial_prevents_the_daemon_from_ever_seeing_an_attach() {
+        const int attempts = 20;
+        var sawNoAttach = false;
+        for (var attempt = 0; attempt < attempts; attempt++) {
+            var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+            var rec = new Recorder();
+            await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+
+            var runTask = Task.Run(() => client.RunAsync(80, 24, CancellationToken.None));
+            await client.DetachAsync();
+
+            var outcome = await runTask.WaitAsync(TimeSpan.FromSeconds(5));   // must settle promptly, never hang
+
+            // Best-effort: when the dial itself got aborted before completing, nothing ever
+            // reached the listener's backlog, so an unbounded Accept() would hang forever waiting
+            // for a connection that will never arrive -- bound it and treat a timeout as "no
+            // attach possible", which is exactly the outcome under test.
+            using var acceptCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+            try {
+                await server.AcceptAndPumpInboundAsync(acceptCts.Token);
+                await server.WaitForReceivedAsync(FrameType.Attach, acceptCts.Token);
+            } catch (OperationCanceledException) { }
+            var receivedAttach = server.SnapshotReceived().Any(f => f.Type == FrameType.Attach);
+
+            if (!receivedAttach) {
+                sawNoAttach = true;
+                await Assert.That(outcome).IsEqualTo(new AttachOutcome.Detached());
+            }
+        }
+
+        await Assert.That(sawNoAttach).IsTrue();   // otherwise this race never actually landed -- test would be vacuous
+    }
+
+    [Test]
     [Arguments(0, 24)]
     [Arguments(-1, 24)]
     [Arguments(80, 0)]

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -108,4 +108,133 @@ public class AgentAttachClientTests {
         await Assert.That(maxConcurrent).IsEqualTo(1);
         await Assert.That(count).IsEqualTo(2);
     }
+
+    [Test]
+    public async Task Detach_intent_plus_eof_settles_detached() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+
+        await client.DetachAsync();
+        await server.WaitForReceivedAsync(FrameType.Detach);   // deterministic: pump has drained it
+        server.CloseConnection();                       // daemon closes; no ack
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.Detached());
+        await Assert.That(server.Received.Any(f => f.Type == FrameType.Detach)).IsTrue();
+    }
+
+    [Test]
+    public async Task A_terminal_frame_read_after_detach_intent_still_wins() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+
+        await client.DetachAsync();
+        await server.SendExitedAsync(3);                // daemon raced: exit after Detach
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.Exited(3));
+    }
+
+    [Test]
+    public async Task Uninitiated_eof_after_attach_is_connection_lost() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        server.CloseConnection();
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+    }
+
+    [Test]
+    public async Task Mid_header_truncation_after_attach_is_connection_lost() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendRawThenCloseAsync([0x41, 0x00]);          // stdout type byte + half a length
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+    }
+
+    [Test]
+    public async Task Connect_refusal_without_intent_is_failed() {
+        using var tmp = new TempDir("sock");
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(tmp.GetResolvedPath("nobody.sock"), AgentId, rec.OnAttached, rec.OnOutput);
+
+        var outcome = await client.RunAsync(80, 24, CancellationToken.None);
+
+        await Assert.That(outcome).IsAssignableTo<AttachOutcome.Failed>();
+    }
+
+    [Test]
+    public async Task Dispose_during_blocked_first_reply_settles_detached_without_fault() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.FirstFrame.Task;                   // Attach written, first reply pending
+
+        await client.DisposeAsync();                    // must not throw
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.Detached());
+    }
+
+    [Test]
+    public async Task Dispose_before_run_makes_a_later_run_return_detached_without_dialing() {
+        using var tmp = new TempDir("sock");
+        var rec = new Recorder();
+        var client = new AgentAttachClient(tmp.GetResolvedPath("nobody.sock"), AgentId, rec.OnAttached, rec.OnOutput);
+        await client.DisposeAsync();
+
+        var outcome = await client.RunAsync(80, 24, CancellationToken.None);   // path does not even exist
+
+        await Assert.That(outcome).IsEqualTo(new AttachOutcome.Detached());
+    }
+
+    [Test]
+    public async Task Caller_cancellation_surfaces_as_oce_and_dispose_does_not_rethrow_it() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        using var cts = new CancellationTokenSource();
+        var run = client.RunAsync(80, 24, cts.Token);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await run);
+        await client.DisposeAsync();                    // must complete cleanly
+    }
+
+    [Test]
+    public async Task Dispose_while_caller_token_uncancelled_exits_a_stuck_callback_via_internal_token() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new AgentAttachClient(server.Path, AgentId,
+            (_, _, _) => Task.CompletedTask,
+            async (_, ct) => { entered.SetResult(); await Task.Delay(Timeout.Infinite, ct); });
+        var run = client.RunAsync(80, 24, CancellationToken.None);   // external token: none, never cancelled
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendStdoutAsync([1]);
+        await entered.Task;                              // callback is now stuck on the internal token
+
+        await client.DisposeAsync();
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.Detached());
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -237,4 +237,19 @@ public class AgentAttachClientTests {
 
         await Assert.That(await run).IsEqualTo(new AttachOutcome.Detached());
     }
+
+    [Test]
+    public async Task Double_dispose_and_dispose_after_a_completed_run_are_both_safe() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendExitedAsync(0);
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.Exited(0));   // run already completed, unforced
+
+        await client.DisposeAsync();                    // dispose after a completed run: must not throw
+        await client.DisposeAsync();                    // second dispose: must not throw
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -1,0 +1,111 @@
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Core.Tests.Unit.LocalIpc;
+
+public class AgentAttachClientTests {
+    static readonly string AgentId = new('a', 32);
+
+    static (ScriptedAttachServer Server, TempDir Tmp) NewServer() {
+        var tmp = new TempDir("sock");
+        var path = tmp.GetResolvedPath("s.sock");
+        return (new ScriptedAttachServer(path), tmp);
+    }
+
+    sealed class Recorder {
+        public readonly List<(byte[] Snapshot, string? Reason)> Attached = [];
+        public readonly List<byte[]> Output = [];
+        public Func<byte[], string?, CancellationToken, Task> OnAttached => (s, r, _) => { Attached.Add((s, r)); return Task.CompletedTask; };
+        public Func<byte[], CancellationToken, Task> OnOutput => (b, _) => { Output.Add(b); return Task.CompletedTask; };
+    }
+
+    [Test]
+    public async Task Read_write_attach_delivers_snapshot_then_output_then_exit_and_nudges_resize() {
+        var (server, tmp) = NewServer();
+        await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+
+        var run = client.RunAsync(120, 40, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        var first = await server.FirstFrame.Task;              // the opening Attach frame
+        await server.SendAttachedAsync(AgentId, [1, 2, 3]);
+        await server.SendStdoutAsync([4, 5]);
+        await server.SendExitedAsync(7);
+
+        var outcome = await run;
+
+        await Assert.That(first.Type).IsEqualTo(FrameType.Attach);
+        await Assert.That(first.Text).IsEqualTo(AgentId);
+        await Assert.That(outcome).IsEqualTo(new AttachOutcome.Exited(7));
+        await Assert.That(rec.Attached.Single().Snapshot).IsEquivalentTo(new byte[] { 1, 2, 3 });
+        await Assert.That(rec.Attached.Single().Reason).IsNull();
+        await Assert.That(rec.Output.Single()).IsEquivalentTo(new byte[] { 4, 5 });
+        // resize nudge at the initial size, after the read-write Attached:
+        var resize = server.Received.Single(f => f.Type == FrameType.Resize);
+        await Assert.That(resize.Cols).IsEqualTo((ushort)120);
+        await Assert.That(resize.Rows).IsEqualTo((ushort)40);
+    }
+
+    [Test]
+    public async Task Read_only_attach_carries_the_reason_and_sends_no_resize_nudge() {
+        var (server, tmp) = NewServer();
+        await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedReadOnlyAsync(AgentId, "flow participant", [9]);
+        await server.SendExitedAsync(0);
+        await run;
+
+        await Assert.That(rec.Attached.Single().Reason).IsEqualTo("flow participant");
+        await Assert.That(server.Received.Any(f => f.Type == FrameType.Resize)).IsFalse();
+    }
+
+    [Test]
+    public async Task Error_as_first_reply_settles_failed() {
+        var (server, tmp) = NewServer();
+        await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendErrorAsync("no such agent aaaa…");
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.Failed("no such agent aaaa…"));
+        await Assert.That(rec.Attached).IsEmpty();
+    }
+
+    /// Serial awaited delivery: the pump must not read frame N+1 until the
+    /// callback for frame N completed.
+    [Test]
+    public async Task Output_callbacks_are_awaited_serially() {
+        var (server, tmp) = NewServer();
+        await using var _s = server; using var _t = tmp;
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int concurrent = 0, maxConcurrent = 0, count = 0;
+        await using var client = new AgentAttachClient(server.Path, AgentId,
+            (_, _, _) => Task.CompletedTask,
+            async (_, _) => {
+                var c = Interlocked.Increment(ref concurrent);
+                maxConcurrent = Math.Max(maxConcurrent, c);
+                if (Interlocked.Increment(ref count) == 1) await gate.Task;
+                Interlocked.Decrement(ref concurrent);
+            });
+
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendStdoutAsync([1]);
+        await server.SendStdoutAsync([2]);   // must sit in the socket until the gate opens
+        await Task.Delay(100);
+        gate.SetResult();
+        await server.SendExitedAsync(0);
+        await run;
+
+        await Assert.That(maxConcurrent).IsEqualTo(1);
+        await Assert.That(count).IsEqualTo(2);
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -18,6 +18,18 @@ public class AgentAttachClientTests {
         public Func<byte[], CancellationToken, Task> OnOutput => (b, _) => { Output.Add(b); return Task.CompletedTask; };
     }
 
+    sealed class RecordingSink {
+        public readonly List<(string Context, Exception Ex)> Entries = [];
+        readonly object _gate = new();
+        public int MaxConcurrent; int _current;
+        public Action<string, Exception> Callback => (c, e) => {
+            var now = Interlocked.Increment(ref _current);
+            MaxConcurrent = Math.Max(MaxConcurrent, now);
+            lock (_gate) Entries.Add((c, e));
+            Interlocked.Decrement(ref _current);
+        };
+    }
+
     [Test]
     public async Task Read_write_attach_delivers_snapshot_then_output_then_exit_and_nudges_resize() {
         var (server, tmp) = NewServer();
@@ -350,5 +362,163 @@ public class AgentAttachClientTests {
         await client.SendInputAsync([1, 2, 3]);                    // must not throw
 
         await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+    }
+
+    [Test]
+    public async Task Routine_dispose_produces_zero_diagnostics() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var sink = new RecordingSink();
+        var rec = new Recorder();
+        var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput, sink.Callback);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await Task.Delay(50);
+
+        await client.DisposeAsync();
+        await run;
+
+        await Assert.That(sink.Entries).IsEmpty();
+    }
+
+    [Test]
+    public async Task Callback_fault_losing_to_dispose_is_logged_once_and_run_settles_detached() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var sink = new RecordingSink();
+        var boom = new InvalidOperationException("render exploded");
+        var disposeStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        AgentAttachClient client = null!;
+        client = new AgentAttachClient(server.Path, AgentId,
+            (_, _, _) => Task.CompletedTask,
+            async (_, _) => { await disposeStarted.Task; throw boom; },   // fault AFTER dispose claimed
+            sink.Callback);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendStdoutAsync([1]);
+        await Task.Delay(50);
+
+        var dispose = client.DisposeAsync();
+        disposeStarted.SetResult();
+        await dispose;                                             // completes normally, no rethrow
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.Detached());
+        await Assert.That(sink.Entries.Count(e => ReferenceEquals(e.Ex, boom))).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Callback_fault_claiming_first_faults_run_and_dispose_does_not_rethrow() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var sink = new RecordingSink();
+        var boom = new InvalidOperationException("render exploded");
+        var client = new AgentAttachClient(server.Path, AgentId,
+            (_, _, _) => Task.CompletedTask,
+            (_, _) => throw boom,
+            sink.Callback);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendStdoutAsync([1]);
+
+        var thrown = await Assert.ThrowsAsync<AttachCallbackException>(async () => await run);
+        await client.DisposeAsync();                               // completes normally
+
+        await Assert.That(thrown!.InnerException).IsSameReferenceAs(boom);
+        // the fault WON — it is the result, not a losing diagnostic:
+        await Assert.That(sink.Entries.Any(e => ReferenceEquals(e.Ex, boom))).IsFalse();
+    }
+
+    [Test]
+    public async Task A_throwing_sink_is_swallowed_and_alters_nothing() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput,
+            (_, _) => throw new InvalidOperationException("sink bug"));
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await Task.Delay(50);
+
+        server.CloseConnection();
+        await client.SendInputAsync([1]);                          // write failure → loser or winner, sink throws either way
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+        await client.DisposeAsync();                               // still clean
+    }
+
+    /// A second, independent throwing-sink drive: unlike the sink above, this one
+    /// counts its own invocations, so the test can assert it was actually called
+    /// (not merely that nothing escaped) while pinning the same "no rethrow, no
+    /// altered outcome" contract on a fresh write-failure path.
+    [Test]
+    public async Task Throwing_sink_is_invoked_and_swallowed_without_altering_the_outcome() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        var sinkCalls = 0;
+        var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput,
+            (_, _) => { Interlocked.Increment(ref sinkCalls); throw new InvalidOperationException("sink bug"); });
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await Task.Delay(50);
+
+        server.CloseConnection();
+        await client.SendInputAsync([1, 2, 3]);                    // must not throw despite the sink throwing
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+        await Assert.That(sinkCalls).IsGreaterThanOrEqualTo(1);    // the throwing sink was actually invoked
+        await client.DisposeAsync();                               // still clean
+        await client.DisposeAsync();                               // idempotent even after a throwing sink
+    }
+
+    /// Two real producers fail around the same moment — an input-write failure and
+    /// an output-callback fault — and race for the one cause slot. Whichever wins
+    /// decides `RunAsync`'s result; the loser rule then pins exactly which
+    /// exception(s) reach the sink, and `MaxConcurrent == 1` proves `_sinkLock`
+    /// actually serializes the two producers rather than merely happening not to
+    /// overlap.
+    [Test]
+    public async Task Concurrent_losers_are_serialized_into_the_sink() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var sink = new RecordingSink();
+        var boom = new InvalidOperationException("callback exploded");
+        var proceed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new AgentAttachClient(server.Path, AgentId,
+            (_, _, _) => Task.CompletedTask,
+            async (_, _) => { await proceed.Task; throw boom; },    // stdout callback: armed, not yet fired
+            sink.Callback);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendStdoutAsync([1]);
+        await Task.Delay(50);                                      // pump is now blocked inside the callback
+
+        server.CloseConnection();                                  // break the transport under the writer
+        var write = client.SendInputAsync([9]);                    // races the callback fault for the cause slot
+        proceed.SetResult();                                       // let the callback fault fire concurrently
+
+        await write;                                               // must not throw either way
+
+        AttachOutcome? outcome = null;
+        AttachCallbackException? thrown = null;
+        try { outcome = await run; }
+        catch (AttachCallbackException ex) { thrown = ex; }
+        await client.DisposeAsync();
+
+        await Assert.That(sink.MaxConcurrent).IsEqualTo(1);        // serialized despite the race
+
+        if (thrown is not null) {
+            // the callback fault won the slot: it IS the run's result, not a diagnostic;
+            // the write failure lost and is observed exactly once.
+            await Assert.That(thrown.InnerException).IsSameReferenceAs(boom);
+            await Assert.That(sink.Entries.Any(e => ReferenceEquals(e.Ex, boom))).IsFalse();
+            await Assert.That(sink.Entries.Count(e => e.Context == "outbound write")).IsEqualTo(1);
+        } else {
+            // the write failure won the slot: ConnectionLost carries no detail, so it is
+            // reported even as the winner; the callback fault lost and is observed once.
+            await Assert.That(outcome).IsEqualTo(new AttachOutcome.ConnectionLost());
+            await Assert.That(sink.Entries.Count(e => e.Context == "outbound write")).IsEqualTo(1);
+            await Assert.That(sink.Entries.Count(e => ReferenceEquals(e.Ex, boom))).IsEqualTo(1);
+        }
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -446,79 +446,205 @@ public class AgentAttachClientTests {
         await client.DisposeAsync();                               // still clean
     }
 
-    /// A second, independent throwing-sink drive: unlike the sink above, this one
-    /// counts its own invocations, so the test can assert it was actually called
-    /// (not merely that nothing escaped) while pinning the same "no rethrow, no
-    /// altered outcome" contract on a fresh write-failure path.
+    /// A second, independent throwing-sink drive. The output callback parks on the
+    /// internal token (`Task.Delay(Timeout.Infinite, ct)`), so `DisposeAsync`
+    /// unblocks it cleanly via cooperative cancellation and, crucially, the pump
+    /// can never independently race the write for the cause slot — the write is
+    /// the ONLY producer that can possibly reach the sink here, so the call count
+    /// and context are asserted exactly, not just "at least one call".
     [Test]
     public async Task Throwing_sink_is_invoked_and_swallowed_without_altering_the_outcome() {
         var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
-        var rec = new Recorder();
         var sinkCalls = 0;
-        var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput,
-            (_, _) => { Interlocked.Increment(ref sinkCalls); throw new InvalidOperationException("sink bug"); });
+        var contexts = new List<string>();
+        var client = new AgentAttachClient(server.Path, AgentId,
+            (_, _, _) => Task.CompletedTask,
+            async (_, ct) => await Task.Delay(Timeout.Infinite, ct),   // parks the pump; only Dispose unblocks it
+            (c, _) => { Interlocked.Increment(ref sinkCalls); lock (contexts) contexts.Add(c); throw new InvalidOperationException("sink bug"); });
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
-        await Task.Delay(50);
+        await server.SendStdoutAsync([1]);
+        await Task.Delay(50);                                       // pump is now parked inside the callback
 
         server.CloseConnection();
-        await client.SendInputAsync([1, 2, 3]);                    // must not throw despite the sink throwing
+        await client.SendInputAsync([1, 2, 3]);                     // the only producer that can possibly fail right now
 
-        await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
-        await Assert.That(sinkCalls).IsGreaterThanOrEqualTo(1);    // the throwing sink was actually invoked
-        await client.DisposeAsync();                               // still clean
-        await client.DisposeAsync();                               // idempotent even after a throwing sink
+        await client.DisposeAsync();                                 // unblocks the parked callback via the internal token
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());  // the already-claimed cause wins
+
+        await Assert.That(sinkCalls).IsEqualTo(1);
+        await Assert.That(contexts).IsEquivalentTo(["outbound write"]);
+        await client.DisposeAsync();                                 // idempotent even after a throwing sink
     }
 
-    /// Two real producers fail around the same moment — an input-write failure and
-    /// an output-callback fault — and race for the one cause slot. Whichever wins
-    /// decides `RunAsync`'s result; the loser rule then pins exactly which
-    /// exception(s) reach the sink, and `MaxConcurrent == 1` proves `_sinkLock`
-    /// actually serializes the two producers rather than merely happening not to
-    /// overlap.
+    /// A deterministic pump-side LOSS (review finding C1): the pump is parked
+    /// inside `onOutput` (armed, not yet released), so nothing on the read side
+    /// can claim anything while an input-write failure independently claims
+    /// `ConnectionLost` and tears down the local transport. Releasing the
+    /// callback then lets the pump's own next read hit the now-disposed stream —
+    /// its exception LOSES the already-claimed slot, and since it lost to
+    /// `ConnectionLost` (not `Detached`), the socket-close exclusion does not
+    /// apply: it must be observed through the sink exactly once, alongside the
+    /// writer's own report.
     [Test]
-    public async Task Concurrent_losers_are_serialized_into_the_sink() {
+    public async Task Pump_exception_losing_to_writer_connection_lost_is_reported_once() {
         var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
         var sink = new RecordingSink();
-        var boom = new InvalidOperationException("callback exploded");
-        var proceed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new AgentAttachClient(server.Path, AgentId,
             (_, _, _) => Task.CompletedTask,
-            async (_, _) => { await proceed.Task; throw boom; },    // stdout callback: armed, not yet fired
+            async (_, _) => { await gate.Task; },        // blocks the pump, then returns normally (no fault)
             sink.Callback);
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
         await server.SendStdoutAsync([1]);
-        await Task.Delay(50);                                      // pump is now blocked inside the callback
+        await Task.Delay(50);                             // pump is now blocked inside the callback, gate not yet open
 
-        server.CloseConnection();                                  // break the transport under the writer
-        var write = client.SendInputAsync([9]);                    // races the callback fault for the cause slot
-        proceed.SetResult();                                       // let the callback fault fire concurrently
+        server.CloseConnection();
+        await client.SendInputAsync([9]);                 // the writer claims ConnectionLost, closes the local transport
 
-        await write;                                               // must not throw either way
+        gate.SetResult();                                  // release the pump: its next read hits the disposed stream
 
-        AttachOutcome? outcome = null;
-        AttachCallbackException? thrown = null;
-        try { outcome = await run; }
-        catch (AttachCallbackException ex) { thrown = ex; }
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
         await client.DisposeAsync();
 
-        await Assert.That(sink.MaxConcurrent).IsEqualTo(1);        // serialized despite the race
+        await Assert.That(sink.Entries.Count(e => e.Context == "transport")).IsEqualTo(1);
+        await Assert.That(sink.Entries.Count(e => e.Context == "outbound write")).IsEqualTo(1);
+        await Assert.That(sink.Entries.Count).IsEqualTo(2);
+    }
 
-        if (thrown is not null) {
-            // the callback fault won the slot: it IS the run's result, not a diagnostic;
-            // the write failure lost and is observed exactly once.
-            await Assert.That(thrown.InnerException).IsSameReferenceAs(boom);
-            await Assert.That(sink.Entries.Any(e => ReferenceEquals(e.Ex, boom))).IsFalse();
-            await Assert.That(sink.Entries.Count(e => e.Context == "outbound write")).IsEqualTo(1);
-        } else {
-            // the write failure won the slot: ConnectionLost carries no detail, so it is
-            // reported even as the winner; the callback fault lost and is observed once.
-            await Assert.That(outcome).IsEqualTo(new AttachOutcome.ConnectionLost());
-            await Assert.That(sink.Entries.Count(e => e.Context == "outbound write")).IsEqualTo(1);
-            await Assert.That(sink.Entries.Count(e => ReferenceEquals(e.Ex, boom))).IsEqualTo(1);
+    /// A deterministic pump-side WIN (review finding C4): nothing else races this
+    /// exception — the pump's own truncated-frame read is the first and only
+    /// cause-slot claim. Per the ruling, a winning transport exception is now
+    /// ALSO reported: `ConnectionLost` carries no detail, so the sink is the only
+    /// place it ever surfaces — the most common real failure (the daemon dying,
+    /// detected by the reader) must yield an errno somewhere, not silence.
+    [Test]
+    public async Task Pump_exception_winning_the_slot_is_reported_once() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var sink = new RecordingSink();
+        var rec = new Recorder();
+        var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput, sink.Callback);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendRawThenCloseAsync([0x41, 0x00]);   // stdout type byte + half a length: mid-header truncation
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+        await client.DisposeAsync();
+
+        await Assert.That(sink.Entries.Count).IsEqualTo(1);
+        await Assert.That(sink.Entries.Single().Context).IsEqualTo("transport");
+    }
+
+    /// The other half of the input-write-failure-vs-detach-intent ordering (review
+    /// finding I2 — the brief's "both orderings" requirement's second half): here
+    /// `DisposeAsync`'s `Detached` claim wins first, and an outbound write —
+    /// already past its own guard check and genuinely in flight — faults when
+    /// `DisposeAsync`'s teardown lands underneath it. `ReportIfLost`'s
+    /// socket-close exclusion must swallow that fault: the sink stays empty. This
+    /// is a genuine, unforced race (see the loop comment below for why and how it
+    /// is repeated rather than hit in one shot) — not a claim of proven
+    /// concurrency, only of repeated, honest attempts at it.
+    [Test]
+    public async Task Write_losing_to_an_already_claimed_detach_is_excluded_from_the_sink() {
+        // No test-side hook exists into the write's actual I/O (frozen API), so the
+        // desired interleaving — a write already past its guard check and genuinely
+        // in flight (either still inside FrameCodec.WriteAsync, or in its own
+        // finally releasing _writeLock) when DisposeAsync's Detached claim and
+        // teardown land — cannot be forced deterministically in one shot. Confirmed
+        // empirically: a single attempt hits it about half the time (observed both
+        // an IOException from the disposed stream and an ObjectDisposedException
+        // from _writeLock.Release() racing _writeLock.Dispose()). So this forces
+        // the ordering across repeats instead of a single race hoped to land: every
+        // attempt must stay silent regardless of whether that specific interleaving
+        // landed on it, and 25 attempts make it near-certain at least one did.
+        // Verified by mutation: deleting ReportIfLost's exclusion turns this red.
+        for (var attempt = 0; attempt < 25; attempt++) {
+            var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+            var sink = new RecordingSink();
+            var rec = new Recorder();
+            var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput, sink.Callback);
+            var run = client.RunAsync(80, 24, CancellationToken.None);
+            await server.AcceptAndPumpInboundAsync();
+            await server.SendAttachedAsync(AgentId, []);
+            await Task.Delay(10);
+
+            var huge = new byte[8 * 1024 * 1024 - 64];      // near FrameCodec's payload cap: real in-flight time on write
+            var writeTask = Task.Run(() => client.SendInputAsync(huge));
+            await Task.Yield();                              // give the write a chance past its guard, into real I/O
+            await client.DisposeAsync();                     // claims Detached first, then tears down the local transport
+            await writeTask;                                 // must not throw regardless of the race's outcome
+
+            await Assert.That(await run).IsEqualTo(new AttachOutcome.Detached());
+            await Assert.That(sink.Entries).IsEmpty();
         }
+    }
+
+    /// Two real producers race for the one cause slot and for `_sinkLock`: an
+    /// input write failure and an output-callback fault. The write's own sink
+    /// call is made to PARK — holding `_sinkLock` — until the test has
+    /// independently confirmed the callback fault is genuinely in flight and
+    /// blocked trying to acquire that same lock (a real 50ms window, not a race
+    /// hoped to land). This forces the write to claim the slot first (the
+    /// callback is gated until after the write's report call has already
+    /// parked), so the loser rule is pinned deterministically under PROVEN
+    /// contention rather than a coincidental absence of overlap: `MaxConcurrent
+    /// == 1` is evidence, not a tautology, because the second producer had a
+    /// real, confirmed opportunity to run concurrently and was made to wait for
+    /// the lock instead.
+    [Test]
+    public async Task Concurrent_losers_are_serialized_into_the_sink() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var boom = new InvalidOperationException("callback exploded");
+        var proceed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var entries = new List<(string Context, Exception Ex)>();
+        var entriesGate = new object();
+        var current = 0;
+        var maxConcurrent = 0;
+        var sinkCallCount = 0;
+        var firstInSink = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void Sink(string c, Exception e) {
+            var now = Interlocked.Increment(ref current);
+            maxConcurrent = Math.Max(maxConcurrent, now);
+            if (Interlocked.Increment(ref sinkCallCount) == 1) {
+                firstInSink.TrySetResult();                    // tell the test: parked inside Report, holding _sinkLock
+                releaseFirst.Task.GetAwaiter().GetResult();     // block synchronously until the test says go
+            }
+            lock (entriesGate) entries.Add((c, e));
+            Interlocked.Decrement(ref current);
+        }
+
+        var client = new AgentAttachClient(server.Path, AgentId,
+            (_, _, _) => Task.CompletedTask,
+            async (_, _) => { await proceed.Task; throw boom; },    // stdout callback: armed, not yet fired
+            Sink);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendStdoutAsync([1]);
+        await Task.Delay(50);                                      // pump is blocked inside the callback, gated on `proceed`
+
+        server.CloseConnection();                                  // break the transport under the writer
+        var writeTask = Task.Run(async () => await client.SendInputAsync([9]).ConfigureAwait(false));
+
+        await firstInSink.Task;             // the write's own report has entered the sink and parked, holding _sinkLock
+        proceed.SetResult();                // now let the callback fault fire — it must lose the already-claimed slot
+        await Task.Delay(50);               // real wall-clock time for it to reach Report and block on the held lock
+        releaseFirst.SetResult();           // release the write's parked call; the blocked callback call can now proceed
+
+        await writeTask;                    // must not throw
+        var outcome = await run;            // the write already won the slot: no callback fault is ever thrown here
+        await client.DisposeAsync();
+
+        await Assert.That(maxConcurrent).IsEqualTo(1);                          // serialized under proven contention
+        await Assert.That(outcome).IsEqualTo(new AttachOutcome.ConnectionLost());
+        await Assert.That(entries.Count(e => e.Context == "outbound write")).IsEqualTo(1);
+        await Assert.That(entries.Count(e => ReferenceEquals(e.Ex, boom))).IsEqualTo(1);
+        await Assert.That(entries.Count).IsEqualTo(2);
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -46,6 +46,11 @@ public class AgentAttachClientTests {
 
         var outcome = await run;
 
+        // The Received pump is a background drain (ScriptedAttachServer's own doc comment);
+        // waiting for the frame we actually assert on makes the read deterministic instead of
+        // racing that pump.
+        await server.WaitForReceivedAsync(FrameType.Resize);
+
         await Assert.That(first.Type).IsEqualTo(FrameType.Attach);
         await Assert.That(first.Text).IsEqualTo(AgentId);
         await Assert.That(outcome).IsEqualTo(new AttachOutcome.Exited(7));
@@ -53,7 +58,7 @@ public class AgentAttachClientTests {
         await Assert.That(rec.Attached.Single().Reason).IsNull();
         await Assert.That(rec.Output.Single()).IsEquivalentTo(new byte[] { 4, 5 });
         // resize nudge at the initial size, after the read-write Attached:
-        var resize = server.Received.Single(f => f.Type == FrameType.Resize);
+        var resize = server.SnapshotReceived().Single(f => f.Type == FrameType.Resize);
         await Assert.That(resize.Cols).IsEqualTo((ushort)120);
         await Assert.That(resize.Rows).IsEqualTo((ushort)40);
     }
@@ -280,10 +285,15 @@ public class AgentAttachClientTests {
         await server.SendExitedAsync(0);
         await run;
 
-        await Assert.That(server.Received.Count(f => f.Type == FrameType.Stdin)).IsEqualTo(0);
+        // Deterministic: the stream is ordered, so observing the post-attach Resize nudge proves
+        // any erroneous pre-attach Stdin (which would have arrived first) is already recorded too.
+        await server.WaitForReceivedAsync(FrameType.Resize);
+
+        var received = server.SnapshotReceived();
+        await Assert.That(received.Count(f => f.Type == FrameType.Stdin)).IsEqualTo(0);
         // the only Resize is the post-attach nudge at the run's initial size:
-        await Assert.That(server.Received.Count(f => f.Type == FrameType.Resize)).IsEqualTo(1);
-        await Assert.That(server.Received.Single(f => f.Type == FrameType.Resize).Cols).IsEqualTo((ushort)80);
+        await Assert.That(received.Count(f => f.Type == FrameType.Resize)).IsEqualTo(1);
+        await Assert.That(received.Single(f => f.Type == FrameType.Resize).Cols).IsEqualTo((ushort)80);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -252,4 +252,103 @@ public class AgentAttachClientTests {
         await client.DisposeAsync();                    // dispose after a completed run: must not throw
         await client.DisposeAsync();                    // second dispose: must not throw
     }
+
+    [Test]
+    public async Task Input_and_resize_before_attached_are_dropped() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.FirstFrame.Task;
+
+        await client.SendInputAsync([1]);
+        await client.ResizeAsync(100, 30);
+        await server.SendAttachedAsync(AgentId, []);
+        await server.SendExitedAsync(0);
+        await run;
+
+        await Assert.That(server.Received.Count(f => f.Type == FrameType.Stdin)).IsEqualTo(0);
+        // the only Resize is the post-attach nudge at the run's initial size:
+        await Assert.That(server.Received.Count(f => f.Type == FrameType.Resize)).IsEqualTo(1);
+        await Assert.That(server.Received.Single(f => f.Type == FrameType.Resize).Cols).IsEqualTo((ushort)80);
+    }
+
+    [Test]
+    public async Task Explicit_input_and_resize_after_read_only_attach_are_dropped() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedReadOnlyAsync(AgentId, "review", []);
+        await Task.Delay(50);
+
+        await client.SendInputAsync([1]);
+        await client.ResizeAsync(100, 30);
+        await server.SendExitedAsync(0);
+        await run;
+
+        await Assert.That(server.Received.Any(f => f.Type is FrameType.Stdin or FrameType.Resize)).IsFalse();
+    }
+
+    [Test]
+    public async Task No_input_is_written_behind_a_queued_detach() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await Task.Delay(50);
+
+        await client.DetachAsync();
+        await server.WaitForReceivedAsync(FrameType.Detach);   // deterministic: pump has drained it
+        await client.SendInputAsync([9]);
+        server.CloseConnection();
+        await run;
+
+        var detachIndex = server.Received.FindIndex(f => f.Type == FrameType.Detach);
+        await Assert.That(detachIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(server.Received.Skip(detachIndex + 1).Any(f => f.Type == FrameType.Stdin)).IsFalse();
+    }
+
+    [Test]
+    [Arguments(0, 24)]
+    [Arguments(-1, 24)]
+    [Arguments(80, 0)]
+    [Arguments(70000, 24)]
+    public async Task Invalid_dimensions_are_rejected_locally(int cols, int rows) {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await Task.Delay(50);
+        var before = server.Received.Count(f => f.Type == FrameType.Resize);
+
+        await client.ResizeAsync(cols, rows);
+        await server.SendExitedAsync(0);
+        await run;
+
+        await Assert.That(server.Received.Count(f => f.Type == FrameType.Resize)).IsEqualTo(before);
+    }
+
+    /// Read side held open: the write failure alone must settle the run.
+    [Test]
+    public async Task Input_write_failure_settles_connection_lost_without_rethrow_or_hung_pump() {
+        var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
+        var rec = new Recorder();
+        await using var client = new AgentAttachClient(server.Path, AgentId, rec.OnAttached, rec.OnOutput);
+        var run = client.RunAsync(80, 24, CancellationToken.None);
+        await server.AcceptAndPumpInboundAsync();
+        await server.SendAttachedAsync(AgentId, []);
+        await Task.Delay(50);
+
+        server.CloseConnection();                                  // break the transport under the writer
+        await client.SendInputAsync([1, 2, 3]);                    // must not throw
+
+        await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -14,7 +14,11 @@ public class AgentAttachClientTests {
     sealed class Recorder {
         public readonly List<(byte[] Snapshot, string? Reason)> Attached = [];
         public readonly List<byte[]> Output = [];
-        public Func<byte[], string?, CancellationToken, Task> OnAttached => (s, r, _) => { Attached.Add((s, r)); return Task.CompletedTask; };
+        // Completed inside OnAttached so a test can await having actually observed the
+        // Attached frame before severing the connection — see the barrier comment at its
+        // first use below.
+        public readonly TaskCompletionSource AttachedObserved = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Func<byte[], string?, CancellationToken, Task> OnAttached => (s, r, _) => { Attached.Add((s, r)); AttachedObserved.TrySetResult(); return Task.CompletedTask; };
         public Func<byte[], CancellationToken, Task> OnOutput => (b, _) => { Output.Add(b); return Task.CompletedTask; };
     }
 
@@ -166,6 +170,12 @@ public class AgentAttachClientTests {
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
+        // Windows: an abortive close (socket dispose without a graceful shutdown) sends RST,
+        // and RST discards whatever the peer hasn't read yet — unlike Unix's FIN, which is
+        // only delivered after buffered data. Without this wait, CloseConnection() can beat
+        // the client's read of Attached, so it never observes attach and the run settles
+        // Failed instead of ConnectionLost.
+        await rec.AttachedObserved.Task;
         server.CloseConnection();
 
         await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
@@ -179,6 +189,7 @@ public class AgentAttachClientTests {
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
+        await rec.AttachedObserved.Task;              // Windows RST guard — see comment above
         await server.SendRawThenCloseAsync([0x41, 0x00]);          // stdout type byte + half a length
 
         await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
@@ -426,7 +437,7 @@ public class AgentAttachClientTests {
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
-        await Task.Delay(50);
+        await rec.AttachedObserved.Task;              // Windows RST guard — see comment above
 
         server.CloseConnection();                                  // break the transport under the writer
         await client.SendInputAsync([1, 2, 3]);                    // must not throw
@@ -507,7 +518,7 @@ public class AgentAttachClientTests {
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
-        await Task.Delay(50);
+        await rec.AttachedObserved.Task;              // Windows RST guard — see comment above
 
         server.CloseConnection();
         await client.SendInputAsync([1]);                          // write failure → loser or winner, sink throws either way
@@ -527,13 +538,15 @@ public class AgentAttachClientTests {
         var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
         var sinkCalls = 0;
         var contexts = new List<string>();
+        var attachedObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new AgentAttachClient(server.Path, AgentId,
-            (_, _, _) => Task.CompletedTask,
+            (_, _, _) => { attachedObserved.TrySetResult(); return Task.CompletedTask; },
             async (_, ct) => await Task.Delay(Timeout.Infinite, ct),   // parks the pump; only Dispose unblocks it
             (c, _) => { Interlocked.Increment(ref sinkCalls); lock (contexts) contexts.Add(c); throw new InvalidOperationException("sink bug"); });
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
+        await attachedObserved.Task;                  // Windows RST guard — see comment above
         await server.SendStdoutAsync([1]);
         await Task.Delay(50);                                       // pump is now parked inside the callback
 
@@ -562,13 +575,15 @@ public class AgentAttachClientTests {
         var (server, tmp) = NewServer(); await using var _s = server; using var _t = tmp;
         var sink = new RecordingSink();
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachedObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new AgentAttachClient(server.Path, AgentId,
-            (_, _, _) => Task.CompletedTask,
+            (_, _, _) => { attachedObserved.TrySetResult(); return Task.CompletedTask; },
             async (_, _) => { await gate.Task; },        // blocks the pump, then returns normally (no fault)
             sink.Callback);
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
+        await attachedObserved.Task;                      // Windows RST guard — see comment above
         await server.SendStdoutAsync([1]);
         await Task.Delay(50);                             // pump is now blocked inside the callback, gate not yet open
 
@@ -600,6 +615,7 @@ public class AgentAttachClientTests {
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
+        await rec.AttachedObserved.Task;              // Windows RST guard — see comment above
         await server.SendRawThenCloseAsync([0x41, 0x00]);   // stdout type byte + half a length: mid-header truncation
 
         await Assert.That(await run).IsEqualTo(new AttachOutcome.ConnectionLost());
@@ -678,6 +694,7 @@ public class AgentAttachClientTests {
         var sinkCallCount = 0;
         var firstInSink = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attachedObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         void Sink(string c, Exception e) {
             var now = Interlocked.Increment(ref current);
             maxConcurrent = Math.Max(maxConcurrent, now);
@@ -690,12 +707,13 @@ public class AgentAttachClientTests {
         }
 
         var client = new AgentAttachClient(server.Path, AgentId,
-            (_, _, _) => Task.CompletedTask,
+            (_, _, _) => { attachedObserved.TrySetResult(); return Task.CompletedTask; },
             async (_, _) => { await proceed.Task; throw boom; },    // stdout callback: armed, not yet fired
             Sink);
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
+        await attachedObserved.Task;                               // Windows RST guard — see comment above
         await server.SendStdoutAsync([1]);
         await Task.Delay(50);                                      // pump is blocked inside the callback, gated on `proceed`
 

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/ScriptedAttachServer.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/ScriptedAttachServer.cs
@@ -34,6 +34,16 @@ sealed class ScriptedAttachServer : IAsyncDisposable {
         }, ct);
     }
 
+    /// Polls until a frame of the given type has been recorded. Bytes already handed to the
+    /// kernel are observable here only once the background pump task above is actually
+    /// scheduled to drain them — a client-side write completing does not guarantee that.
+    public async Task WaitForReceivedAsync(FrameType type, CancellationToken ct = default) {
+        while (true) {
+            lock (Received) { if (Received.Any(f => f.Type == type)) return; }
+            await Task.Delay(5, ct).ConfigureAwait(false);
+        }
+    }
+
     public Task SendAsync(LocalFrame frame) => FrameCodec.WriteAsync(_stream!, frame, CancellationToken.None);
     public Task SendAttachedAsync(string agentId, byte[] snapshot) => SendAsync(FrameCodec.Attached(agentId, snapshot));
     public Task SendAttachedReadOnlyAsync(string agentId, string reason, byte[] snapshot) => SendAsync(FrameCodec.AttachedReadOnly(agentId, reason, snapshot));

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/ScriptedAttachServer.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/ScriptedAttachServer.cs
@@ -1,0 +1,48 @@
+using System.Net.Sockets;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Core.Tests.Unit.LocalIpc;
+
+/// One accepted connection, scripted: records every inbound frame, sends the
+/// queued replies when told to. Socket path must come from
+/// tmp.GetResolvedPath(...) — sockaddr_un budget.
+sealed class ScriptedAttachServer : IAsyncDisposable {
+    readonly Socket _listener;
+    Socket? _conn;
+    NetworkStream? _stream;
+    public readonly List<LocalFrame> Received = [];
+    public readonly TaskCompletionSource<LocalFrame> FirstFrame = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public string Path { get; }
+
+    public ScriptedAttachServer(string socketPath) {
+        Path = socketPath;
+        _listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+        _listener.Bind(new UnixDomainSocketEndPoint(socketPath));
+        _listener.Listen(1);
+    }
+
+    public async Task AcceptAndPumpInboundAsync(CancellationToken ct = default) {
+        _conn = await _listener.AcceptAsync(ct);
+        _stream = new NetworkStream(_conn, ownsSocket: false);
+        _ = Task.Run(async () => {
+            try {
+                while (await FrameCodec.ReadAsync(_stream, ct) is { } f) {
+                    lock (Received) Received.Add(f);
+                    FirstFrame.TrySetResult(f);
+                }
+            } catch { /* connection closed by client — fine for a script */ }
+        }, ct);
+    }
+
+    public Task SendAsync(LocalFrame frame) => FrameCodec.WriteAsync(_stream!, frame, CancellationToken.None);
+    public Task SendAttachedAsync(string agentId, byte[] snapshot) => SendAsync(FrameCodec.Attached(agentId, snapshot));
+    public Task SendAttachedReadOnlyAsync(string agentId, string reason, byte[] snapshot) => SendAsync(FrameCodec.AttachedReadOnly(agentId, reason, snapshot));
+    public Task SendStdoutAsync(byte[] bytes) => SendAsync(LocalFrame.Stdout(bytes));
+    public Task SendExitedAsync(int code) => SendAsync(LocalFrame.Exited(code));
+    public Task SendErrorAsync(string text) => SendAsync(new LocalFrame(FrameType.Error) { Text = text });
+    public void CloseConnection() { _stream?.Dispose(); _conn?.Dispose(); }
+    /// For truncation tests: write raw bytes (a partial header/payload), then close.
+    public async Task SendRawThenCloseAsync(byte[] raw) { await _stream!.WriteAsync(raw); CloseConnection(); }
+
+    public async ValueTask DisposeAsync() { CloseConnection(); _listener.Dispose(); await Task.CompletedTask; }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/ScriptedAttachServer.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/ScriptedAttachServer.cs
@@ -37,12 +37,22 @@ sealed class ScriptedAttachServer : IAsyncDisposable {
     /// Polls until a frame of the given type has been recorded. Bytes already handed to the
     /// kernel are observable here only once the background pump task above is actually
     /// scheduled to drain them — a client-side write completing does not guarantee that.
+    /// Bounded so a regression that stops the pump delivering the frame FAILS the test with a
+    /// named timeout instead of hanging the run indefinitely.
     public async Task WaitForReceivedAsync(FrameType type, CancellationToken ct = default) {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
         while (true) {
             lock (Received) { if (Received.Any(f => f.Type == type)) return; }
+            if (DateTime.UtcNow > deadline)
+                throw new TimeoutException($"ScriptedAttachServer.WaitForReceivedAsync: no {type} frame recorded within 10s.");
             await Task.Delay(5, ct).ConfigureAwait(false);
         }
     }
+
+    /// A locked copy for a test that needs to enumerate Received directly (Single/Count/etc.) —
+    /// the field itself is mutated by the background pump under the same lock, so an unlocked
+    /// enumeration races it.
+    public List<LocalFrame> SnapshotReceived() { lock (Received) return Received.ToList(); }
 
     public Task SendAsync(LocalFrame frame) => FrameCodec.WriteAsync(_stream!, frame, CancellationToken.None);
     public Task SendAttachedAsync(string agentId, byte[] snapshot) => SendAsync(FrameCodec.Attached(agentId, snapshot));

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs
@@ -29,7 +29,7 @@ public class StatusIpcJsonTests {
         var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.DaemonStatusDto);
 
         await Assert.That(json).IsEqualTo(
-            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1,"pid":4242,"instance_id":"inst-abc","supported_vendors":null},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex","requester_display":"Ada Lovelace"},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null,"requester_display":null}]}""");
+            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1,"pid":4242,"instance_id":"inst-abc","supported_vendors":null},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex","requester_display":"Ada Lovelace","has_terminal":null},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null,"requester_display":null,"has_terminal":null}]}""");
     }
 
     [Test]
@@ -43,5 +43,43 @@ public class StatusIpcJsonTests {
         await Assert.That(dto!.Daemon.Name).IsEqualTo("m");
         await Assert.That(dto.Agents[0].Id).IsEqualTo("a");
         await Assert.That(dto.Agents[0].Status).IsEqualTo("Live");
+    }
+
+    [Test]
+    public async Task Old_agent_json_without_has_terminal_deserializes_to_null() {
+        // Serialize a current DTO, strip the member, deserialize — the exact old-daemon shape.
+        var dto = new AgentStatusDto(
+            "a1", "agent", "claude", "/repo", "Running",
+            null, null, null, DateTime.UtcNow, null, null);
+        var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
+        var stripped = System.Text.RegularExpressions.Regex.Replace(json, ",\"has_terminal\":[^,}]+", "");
+
+        var back = JsonSerializer.Deserialize(stripped, StatusIpcJsonContext.Default.AgentStatusDto);
+
+        await Assert.That(back!.HasTerminal).IsNull();
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task Has_terminal_serializes_present_and_never_omitted(bool value) {
+        var dto = new AgentStatusDto(
+            "a1", "agent", "claude", "/repo", "Running",
+            null, null, null, DateTime.UtcNow, null, null, HasTerminal: value);
+
+        var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
+
+        await Assert.That(json).Contains($"\"has_terminal\":{value.ToString().ToLowerInvariant()}");
+    }
+
+    [Test]
+    public async Task Null_has_terminal_still_emits_the_member() {
+        var dto = new AgentStatusDto(
+            "a1", "agent", "claude", "/repo", "Running",
+            null, null, null, DateTime.UtcNow, null, null);
+
+        var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
+
+        await Assert.That(json).Contains("\"has_terminal\":null");
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Pty;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Hosting;
@@ -143,6 +145,36 @@ public class AgentStatusSnapshotTests {
 
             await Assert.That(byId["blank-model"].Model).IsNull();
             await Assert.That(byId["real-model"].Model).IsEqualTo("gpt-5-codex");
+        } finally {
+            await fixture.CleanupAsync();
+        }
+    }
+
+    /// <summary>
+    /// Pins <see cref="AgentOrchestrator.SnapshotAgentsForStatus"/>'s stamping of
+    /// <c>HasTerminal</c> from the agent's own runtime — a PTY runtime (<c>SeedAgentForTest</c>'s
+    /// default, mirroring <see cref="PtyHostedAgentRuntime"/>) reports true, a non-PTY/ACP runtime
+    /// (<see cref="FakeAcpRuntime"/>, seeded via <see cref="AgentOrchestratorHarness.SeedAcpAgent"/>
+    /// since <c>SeedAgentForTest</c> only builds PTY runtimes) reports false. Asserted on the
+    /// SERIALIZED wire payload, not the DTO field, so a naming-policy regression on the
+    /// snake_case <c>has_terminal</c> member would fail this too.
+    /// </summary>
+    [Test]
+    public async Task Status_payload_carries_has_terminal_per_runtime() {
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
+        try {
+            orch.SeedAgentForTest("pty-1");
+            AgentOrchestratorHarness.SeedAcpAgent(orch, "acp-1", new FakeAcpRuntime());
+
+            var snapshot = orch.SnapshotAgentsForStatus();
+            var ptyJson  = JsonSerializer.Serialize(
+                snapshot.Single(a => a.Id == "pty-1"), StatusIpcJsonContext.Default.AgentStatusDto);
+            var acpJson = JsonSerializer.Serialize(
+                snapshot.Single(a => a.Id == "acp-1"), StatusIpcJsonContext.Default.AgentStatusDto);
+
+            await Assert.That(ptyJson).Contains("\"has_terminal\":true");
+            await Assert.That(acpJson).Contains("\"has_terminal\":false");
         } finally {
             await fixture.CleanupAsync();
         }


### PR DESCRIPTION
Linear: AI-2195 (no GitHub issue — created directly in Linear as part of the AI-2171 decomposition). The spec (`docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md`, review-clean after an 11-round Codex spec-review flow) and the implementation plan ride this PR; `docs/CHANGES.md` carries the invariant reasoning.

## What

The workspace pane for one session — header (title, repo, vendor+model chip with transport dot), tab strip, and a Terminal tab attached to the live PTY — opened by clicking a session card on Home. Home's cards stop being inert, and `LaunchOutcome.AgentId` gains its consumer (successful launch auto-opens the workspace, generation-guarded).

- **Wire (additive only):** `AgentStatusDto.HasTerminal` (`bool?`, trailing, always emitted) stamped from the daemon runtime's `EmitsTerminalOutput` — the authoritative Terminal-tab gate, with the vendor-map heuristic as the older-daemon fallback. `FrameType` untouched.
- **Core `AgentAttachClient`:** long-lived attach client over the existing Attach/Stdout/Stdin/Resize frames. Termination is the `RunAsync` result, linearized through one atomic cause slot (detach intent is deliberately *not* a cause — a terminal frame read after a detach still wins, matching the daemon's real race); full exceptional-path classification; internal run-lifetime CTS with structural claim-before-cancel; loser-exception diagnostics through an injected sink; `IAsyncDisposable`. BCL-only, AOT-clean.
- **App workspace:** `Resolving` gate (no socket is ever dialed before the session's first status DTO settles the gate); one client + fresh terminal model + fresh incremental UTF-8 decoder per attach attempt; awaited UI application for backpressure; read-only attaches surface the daemon's reason and suppress input; explicit Detach stays in place with single-flight Reattach; `SvcSystems.UI.Terminal`/XTerm.NET render, `ReflowOnResize=false`, terminal protocol replies (DSR/CPR) forwarded through the input lane.
- **Ownership:** bounded teardown (1 s detach write → immediate socket close → 3 s pump observation → 5 s shutdown drain; clamp release is guaranteed by the local socket close, the Detach frame is best-effort); every exit path tracked — Back, open-another, close-to-hide, real close, shutdown (latch on every pass, sealed tracker, post-seal teardowns execute rather than refuse). A hidden window can never keep clamping the PTY.

## Verification

33 feature commits + a 2-item final fix wave, each task gated by an adversarial per-task review (four tasks took fix rounds, all closed with mutation-level proof; the final whole-branch review's cross-task finding — the initial PTY size seam — is fixed by feeding the surface's real size into the run). Suites: Core 2040/2040, App 1249/1249, solution build 0 warnings, AOT publish grep clean. Machine-local flakes observed during full-suite runs are all pre-existing and documented (session-start nudge set, codex 0.149-vs-0.147 schema pin, load-sensitive PTY timing tests — each passes filtered).

Dependencies (direct-pinned; the repo has no transitive pinning): `SvcSystems.UI.Terminal` 1.1.1 (MIT), `XTerm.NET` 1.0.16 (MIT), transitives `Unicode.net` 2.0.0 (MIT), `Wcwidth` 3.0.0 (MIT). Test-only: `Microsoft.Extensions.TimeProvider.Testing`.

## Manual QA (macOS — no CI leg; owner)

- [ ] Launch the app, start a claude session from Home, click its card
- [ ] Terminal renders live output; typing reaches the agent
- [ ] Resize follows the window (PTY size, not just the view)
- [ ] Detach → in-place banner; Reattach restores with scrollback
- [ ] An ACP session (e.g. gemini) shows the no-terminal note, no tab
- [ ] Back returns Home; reopening the card reattaches
- [ ] Close-to-hide: `kcap agent ls` shows the agent still running; reopening from tray lands on Home

## Known follow-ups (deliberately not in this PR)

- Unguarded factory throws in `OpenSession`/`ReattachCommand` land in ReactiveUI `ThrownExceptions` (app-crash class if a third-party ctor ever throws) — one guard covers both; scheduled promptly.
- `RunAsync` after a faulted run can `InvalidCastException` (unreachable via the app's one-client-per-attempt discipline); `RunDetachAsync` unbounded (stuck Detach button on a hung write); Failed-guard widening to `Resolving or Connecting`; `[Timeout]` on two sink tests; a WeakReference assert to relax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)