### PR TITLE
Bump SvcSystems.UI.Terminal to 1.1.2 and retire the caret workaround

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,11 +20,11 @@
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageVersion Include="Spectre.Console" Version="0.55.2" />
-    <PackageVersion Include="SvcSystems.UI.Terminal" Version="1.1.1" />
+    <PackageVersion Include="SvcSystems.UI.Terminal" Version="1.1.2" />
     <PackageVersion Include="Tomlyn" Version="2.4.0" />
     <PackageVersion Include="TUnit" Version="1.65.31" />
     <PackageVersion Include="TUnit.Core" Version="1.65.31" />
     <PackageVersion Include="WireMock.Net" Version="2.15.0" />
-    <PackageVersion Include="XTerm.NET" Version="1.0.16" />
+    <PackageVersion Include="XTerm.NET" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Capacitor.App/Services/ITerminalSurface.cs
+++ b/src/Capacitor.App/Services/ITerminalSurface.cs
@@ -20,14 +20,4 @@ public interface ITerminalSurface {
     /// correct the client's post-attach nudge (sent at RunAsync's phantom initial size, before the
     /// real pane size was ever known) to what the pane is actually showing.
     (int Cols, int Rows) CurrentSize { get; }
-
-    /// Re-shows the terminal caret after the snapshot replay. Claude/codex TUIs hide the hardware
-    /// cursor once at stream start and draw their own caret as an inverse-video cell — which the
-    /// pinned control (1.1.1) paints invisibly: default-color sentinels resolve by draw-call
-    /// position, so inverse-of-default is black-on-black. Fixed upstream in 1.1.2
-    /// (https://github.com/IvanJosipovic/SvcSystems.UI.Terminal/issues/69) — candidate for
-    /// retirement once a bump past 1.1.2 is verified visually. The engine's cursor position still
-    /// tracks the TUI's caret, so forcing it visible renders a correctly placed caret instead.
-    /// A TUI that hides the cursor again later is respected — this is a one-shot per attach.
-    void EnsureCaretVisible();
 }

--- a/src/Capacitor.App/Services/XtermTerminalSurface.cs
+++ b/src/Capacitor.App/Services/XtermTerminalSurface.cs
@@ -39,8 +39,6 @@ public sealed class XtermTerminalSurface : ITerminalSurface {
 
     public void Feed(string text) => Model.Feed(text);
 
-    public void EnsureCaretVisible() => Model.Terminal.Engine.CursorVisible = true;
-
     void OnUserInput(object? sender, TerminalUserInputEventArgs e) =>
         InputProduced?.Invoke(e.Data.ToArray());
 

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -355,8 +355,6 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         await Dispatcher.UIThread.InvokeAsync(() => {
             if (generation != _attemptGeneration) return;
             surface.Feed(text);
-            // AFTER the snapshot: the replay itself carries the TUI's own cursor-hide.
-            surface.EnsureCaretVisible();
             State = TerminalSessionState.Attached(reason);
         }, DispatcherPriority.Default, ct);
     }

--- a/test/Capacitor.App.Tests.Unit/FakeTerminalSurface.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeTerminalSurface.cs
@@ -2,9 +2,9 @@ using Capacitor.App.Services;
 
 namespace Capacitor.App.Tests.Unit;
 
-/// The shared ITerminalSurface fake: records what was fed and how often the caret was re-shown,
-/// and lets a test raise input/resize as if the control did. Suites that only need an inert
-/// surface use it as-is and ignore the recorders.
+/// The shared ITerminalSurface fake: records what was fed and lets a test raise input/resize as
+/// if the control did. Suites that only need an inert surface use it as-is and ignore the
+/// recorders.
 sealed class FakeTerminalSurface : ITerminalSurface {
     public List<string> Fed { get; } = [];
     public void Feed(string text) => Fed.Add(text);
@@ -13,6 +13,4 @@ sealed class FakeTerminalSurface : ITerminalSurface {
     public void RaiseInput(byte[] bytes) => InputProduced?.Invoke(bytes);
     public void RaiseResize(int cols, int rows) => Resized?.Invoke(cols, rows);
     public (int Cols, int Rows) CurrentSize { get; set; } = (80, 24);
-    public int CaretShown;
-    public void EnsureCaretVisible() => CaretShown++;
 }

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -171,22 +171,6 @@ public class TerminalTabViewModelTests {
         });
     }
 
-    /// Claude/codex TUIs hide the hardware cursor once at stream start and draw their own caret
-    /// as an inverse-video cell the control paints invisibly (upstream sentinel bug) — so the VM
-    /// re-shows the engine caret exactly once, AFTER the snapshot replay (which carries the hide).
-    [Test]
-    [NotInParallel("AvaloniaSession")]
-    public async Task Attach_re_shows_the_caret_after_the_snapshot_replay() {
-        await RunOnUiAsync(async () => {
-            var (_, _, _, vm, client) = await BuildConnectingAsync();
-
-            await client.TriggerAttached([], reason: null);
-
-            var surface = (FakeTerminalSurface)vm.Surface!;
-            await Assert.That(surface.CaretShown).IsEqualTo(1);
-        });
-    }
-
     /// I1 (final review, reworked): a post-attach resend fired from inside OnAttachedAsync is
     /// structurally defeated -- Core's own post-attach repaint nudge (AgentAttachClient.
     /// RunCoreAsync, right after a read-write Attached) writes at whatever size RunAsync started

--- a/test/Capacitor.App.Tests.Unit/TerminalTranscriptTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTranscriptTests.cs
@@ -6,8 +6,11 @@ namespace Capacitor.App.Tests.Unit;
 
 // API DISCOVERY (Task 8) — decompiled via ilspycmd against the NuGet cache copies of
 // SvcSystems.UI.Terminal 1.1.1 (net10.0 lib) and XTerm.NET 1.0.16 (net6.0 lib), cross-checked
-// against both packages' README.md. Recorded verbatim for Tasks 10–12 to build on; do not
-// rely on the README alone, it undersells a few things confirmed only in IL (marked below).
+// against both packages' README.md. The pins have since moved to 1.1.2 / 1.1.0 (upstream
+// caret-rendering fix, GH #662); the claims below are from the 1.1.1-era IL and stay proven on
+// the new pins by these tests exercising the real control — not by re-decompilation. Recorded
+// verbatim for Tasks 10–12 to build on; do not rely on the README alone, it undersells a few
+// things confirmed only in IL (marked below).
 //
 // ── SvcSystems.UI.Terminal.TerminalControlModel : Avalonia.AvaloniaObject ──────────────────
 //   ctor TerminalControlModel(TerminalOptions? options = null)


### PR DESCRIPTION
Closes #662. AI-2223.

SvcSystems.UI.Terminal 1.1.2 carries the upstream fix for [IvanJosipovic/SvcSystems.UI.Terminal#69](https://github.com/IvanJosipovic/SvcSystems.UI.Terminal/issues/69) (default-color sentinels resolved by draw position, painting inverse-of-default black-on-black), so the inverse-video caret Claude/codex TUIs draw now renders on its own. XTerm.NET moves to 1.1.0, the release's new dependency floor.

With the rendering fixed, the `EnsureCaretVisible` workaround is retired end to end: the `ITerminalSurface` member, the `XtermTerminalSurface` implementation, the `TerminalTabViewModel` post-replay call, the `Attach_re_shows_the_caret_after_the_snapshot_replay` test, and the `CaretShown` counter on the shared fake. Behavioral note: a TUI that deliberately hides its cursor is no longer overridden once per attach — the control now renders exactly what the TUI paints.

## Verification

- App unit suite green on the bumped packages (1163/1163).
- [x] Visual: attach to a live Claude session in the app — caret visible at the prompt without the force (verified by the owner on a live session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
