### PR TITLE
[AI-2228] De-flake the attach detach/dial race test

### DIFF
--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -384,18 +384,29 @@ public class AgentAttachClientTests {
             var runTask = Task.Run(() => client.RunAsync(80, 24, CancellationToken.None));
             await client.DetachAsync();
 
-            var outcome = await runTask.WaitAsync(TimeSpan.FromSeconds(5));   // must settle promptly, never hang
-
-            // Best-effort: when the dial itself got aborted before completing, nothing ever
-            // reached the listener's backlog, so an unbounded Accept() would hang forever waiting
-            // for a connection that will never arrive -- bound it and treat a timeout as "no
-            // attach possible", which is exactly the outcome under test.
+            // Accepted CONCURRENTLY with the run, and never after it. When the DIAL wins this race
+            // the client has written a graceful Detach and is parked in its read loop waiting for the
+            // peer to answer -- which is correct: DetachAsync deliberately leaves the transport open
+            // so a terminal frame can still beat Detached. Accepting only once the run had finished
+            // therefore waited for a client that was waiting for us, and the attempt deadlocked
+            // against its own fixture until the timeout below fired. Rare on a fast machine, where
+            // the detach almost always wins; reliable enough under CI contention to redden the leg.
+            //
+            // Best-effort still: when the dial WAS aborted before completing, nothing ever reached
+            // the listener's backlog, so bound the accept and read a timeout as "no attach possible"
+            // -- which is the outcome under test.
             using var acceptCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
             try {
                 await server.AcceptAndPumpInboundAsync(acceptCts.Token);
                 await server.WaitForReceivedAsync(FrameType.Attach, acceptCts.Token);
             } catch (OperationCanceledException) { }
             var receivedAttach = server.SnapshotReceived().Any(f => f.Type == FrameType.Attach);
+
+            // EOF is what ends a graceful detach — the daemon closes once it holds the frame. Without
+            // it the dial-wins attempts have nothing to settle on.
+            server.CloseConnection();
+
+            var outcome = await runTask.WaitAsync(TimeSpan.FromSeconds(5));   // backstop, not the mechanism
 
             if (!receivedAttach) {
                 sawNoAttach = true;

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -384,17 +384,13 @@ public class AgentAttachClientTests {
             var runTask = Task.Run(() => client.RunAsync(80, 24, CancellationToken.None));
             await client.DetachAsync();
 
-            // Accepted CONCURRENTLY with the run, and never after it. When the DIAL wins this race
-            // the client has written a graceful Detach and is parked in its read loop waiting for the
-            // peer to answer -- which is correct: DetachAsync deliberately leaves the transport open
-            // so a terminal frame can still beat Detached. Accepting only once the run had finished
-            // therefore waited for a client that was waiting for us, and the attempt deadlocked
-            // against its own fixture until the timeout below fired. Rare on a fast machine, where
-            // the detach almost always wins; reliable enough under CI contention to redden the leg.
+            // Accept CONCURRENTLY with the run, never after it: when the dial wins this race the
+            // client has written a graceful Detach and is parked in its read loop awaiting the peer,
+            // because DetachAsync leaves the transport open so a terminal frame can still beat
+            // Detached. An accept that waits for the run waits for a client that is waiting for it.
             //
-            // Best-effort still: when the dial WAS aborted before completing, nothing ever reached
-            // the listener's backlog, so bound the accept and read a timeout as "no attach possible"
-            // -- which is the outcome under test.
+            // Bounded, because an aborted dial reaches no listener backlog: a timeout here means no
+            // attach was possible, which is the outcome under test.
             using var acceptCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
             try {
                 await server.AcceptAndPumpInboundAsync(acceptCts.Token);
@@ -402,11 +398,10 @@ public class AgentAttachClientTests {
             } catch (OperationCanceledException) { }
             var receivedAttach = server.SnapshotReceived().Any(f => f.Type == FrameType.Attach);
 
-            // EOF is what ends a graceful detach — the daemon closes once it holds the frame. Without
-            // it the dial-wins attempts have nothing to settle on.
+            // The EOF that settles a graceful detach: a daemon closes once it holds the frame.
             server.CloseConnection();
 
-            var outcome = await runTask.WaitAsync(TimeSpan.FromSeconds(5));   // backstop, not the mechanism
+            var outcome = await runTask.WaitAsync(TimeSpan.FromSeconds(5));
 
             if (!receivedAttach) {
                 sawNoAttach = true;

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -389,19 +389,25 @@ public class AgentAttachClientTests {
             // because DetachAsync leaves the transport open so a terminal frame can still beat
             // Detached. An accept that waits for the run waits for a client that is waiting for it.
             //
-            // Bounded, because an aborted dial reaches no listener backlog: a timeout here means no
-            // attach was possible, which is the outcome under test.
+            // Bounded, because an aborted dial reaches no listener backlog: a timeout here means the
+            // dial never landed, which is the outcome under test.
             using var acceptCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
-            try {
-                await server.AcceptAndPumpInboundAsync(acceptCts.Token);
-                await server.WaitForReceivedAsync(FrameType.Attach, acceptCts.Token);
-            } catch (OperationCanceledException) { }
-            var receivedAttach = server.SnapshotReceived().Any(f => f.Type == FrameType.Attach);
+            try { await server.AcceptAndPumpInboundAsync(acceptCts.Token); } catch (OperationCanceledException) { }
 
-            // The EOF that settles a graceful detach: a daemon closes once it holds the frame.
-            server.CloseConnection();
+            // Half-close, so the client sees EOF and settles on the outcome it chose. Closing outright
+            // would settle it too, but would also discard anything not yet drained — and what was
+            // drained is the whole question below.
+            server.ShutdownSend();
 
             var outcome = await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // The client writes nothing further once its run has settled, so closing it here ends the
+            // pump at EOF rather than at a deadline. Joining the pump is what makes "no Attach
+            // arrived" a fact about the wire instead of a snapshot taken before it caught up.
+            await client.DisposeAsync();
+            await server.InboundDrained;
+
+            var receivedAttach = server.SnapshotReceived().Any(f => f.Type == FrameType.Attach);
 
             if (!receivedAttach) {
                 sawNoAttach = true;

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/ScriptedAttachServer.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/ScriptedAttachServer.cs
@@ -10,6 +10,7 @@ sealed class ScriptedAttachServer : IAsyncDisposable {
     readonly Socket _listener;
     Socket? _conn;
     NetworkStream? _stream;
+    Task _pump = Task.CompletedTask;
     public readonly List<LocalFrame> Received = [];
     public readonly TaskCompletionSource<LocalFrame> FirstFrame = new(TaskCreationOptions.RunContinuationsAsynchronously);
     public string Path { get; }
@@ -21,17 +22,33 @@ sealed class ScriptedAttachServer : IAsyncDisposable {
         _listener.Listen(1);
     }
 
+    /// <paramref name="ct"/> bounds the ACCEPT only. The pump runs to EOF: a test that asserts a
+    /// frame did not arrive needs it to have read everything the client wrote, and a pump that stops
+    /// on a caller's deadline can leave one sitting in the socket unread.
     public async Task AcceptAndPumpInboundAsync(CancellationToken ct = default) {
         _conn = await _listener.AcceptAsync(ct);
         _stream = new NetworkStream(_conn, ownsSocket: false);
-        _ = Task.Run(async () => {
+        _pump = Task.Run(async () => {
             try {
-                while (await FrameCodec.ReadAsync(_stream, ct) is { } f) {
+                while (await FrameCodec.ReadAsync(_stream, CancellationToken.None) is { } f) {
                     lock (Received) Received.Add(f);
                     FirstFrame.TrySetResult(f);
                 }
             } catch { /* connection closed by client — fine for a script */ }
-        }, ct);
+        }, CancellationToken.None);
+    }
+
+    /// Completes once the inbound pump has stopped, which happens when the peer closes. <b>Await it
+    /// before concluding a frame never arrived</b> — the pump records under the same lock
+    /// <see cref="SnapshotReceived"/> takes, so a snapshot read while it is still running says only
+    /// what had been drained by then, not what the client sent.
+    public Task InboundDrained => _pump;
+
+    /// Half-close, so the peer sees EOF and settles on its own outcome while our receive side stays
+    /// open. <see cref="CloseConnection"/> discards anything not yet drained, which is exactly what a
+    /// negative assertion must not do.
+    public void ShutdownSend() {
+        try { _conn?.Shutdown(SocketShutdown.Send); } catch (SocketException) { } catch (ObjectDisposedException) { }
     }
 
     /// Polls until a frame of the given type has been recorded. Bytes already handed to the


### PR DESCRIPTION
AI-2228

## What & why

`Detach_racing_the_dial_prevents_the_daemon_from_ever_seeing_an_attach` deadlocks against its own fixture on one of the two interleavings it exercises, and times out at its 5s backstop.

When the detach wins, `_stream` is still null, `DetachAsync` claims `Detached`, and the run settles at once — the case the test is for. When the dial wins, `DetachAsync` takes its success path: it writes a graceful Detach and deliberately leaves the transport open so a terminal frame can still beat `Detached`, leaving `RunCoreAsync` parked in `FrameCodec.ReadAsync` awaiting the peer. The fixture accepted only after `await runTask`, so the client waited for a server that was waiting for the client.

`AgentAttachClient` is not at fault and is unchanged.

## Where to look

The accept moves to run concurrently with the dial, and the connection is closed once an Attach has been observed — the EOF a daemon produces once it holds the Detach frame. `AcceptAndPumpInboundAsync` only reads, so accepting alone would not settle the client.

Assertion semantics are untouched: attempts that delivered an Attach are still skipped, and `sawNoAttach` must still be set by a detach-wins attempt or the test fails as vacuous.

## Verification

Reproduced on the 6th full-assembly run of `Capacitor.Cli.Core.Tests.Unit` (2245 tests): `TimeoutException` at `AgentAttachClientTests.cs:387`. Six further runs after the change, all clean.

Six clean runs against a one-in-six flake is not decisive on its own — the argument is that the deadlock is structural for the dial-wins interleaving, and this removes it. The class in isolation never reproduces it; contention across the assembly is required.
