### PR TITLE
Gate Antigravity nudges on the invocation counter

### DIFF
--- a/src/Capacitor.Cli/Commands/Harness/AntigravityHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/AntigravityHookCommand.cs
@@ -207,9 +207,14 @@ sealed class AntigravityHookCommand(ConfigRoot config, ProfileContext profiles, 
         // subtracts HookBudget.Safety — do NOT subtract it again. Written even when the watcher-spawn
         // gate below returns early — a withheld watcher must not suppress injection.
         var fragment = await SessionStartMemoryHookSupport.AwaitBounded(memoryTask, budget);
-        var workItemsNudge = HarnessNudgeEmitter.Combine(
-            WorkItemsNudgeEmitter.Resolve(HarnessId.Antigravity, sessionId, activeProfile?.DisableWorkItemsNudge is true, home),
-            HarnessNudgeEmitter.ResolveFragmentForHook(activeProfile?.DisableHarnessNudge is true, config, home));
+        // Nudges are unleased pure functions of the session id, so on this repeating callback they
+        // must be gated by the vendor's own per-conversation counter: without the gate every turn
+        // re-injects them as another persistent userMessage step.
+        var workItemsNudge = IsFirstInvocation(payload)
+            ? HarnessNudgeEmitter.Combine(
+                WorkItemsNudgeEmitter.Resolve(HarnessId.Antigravity, sessionId, activeProfile?.DisableWorkItemsNudge is true, home),
+                HarnessNudgeEmitter.ResolveFragmentForHook(activeProfile?.DisableHarnessNudge is true, config, home))
+            : null;
         WritePreInvocationOutput(stdout, fragment, workItemsNudge);
         await stdout.FlushAsync();
 
@@ -309,6 +314,17 @@ sealed class AntigravityHookCommand(ConfigRoot config, ProfileContext profiles, 
             return Task.FromResult<string?>(null);
         }
     }
+
+    /// <summary>
+    /// Whether this PreInvocation is the conversation's first, read from the vendor's own
+    /// <c>invocationNum</c> counter — the one payload field that varies between callbacks. An absent
+    /// or non-numeric value reads as first: a payload without the counter cannot distinguish
+    /// callbacks, and emitting once too often beats never emitting.
+    /// </summary>
+    internal static bool IsFirstInvocation(JsonObject payload) =>
+        payload["invocationNum"] is not JsonValue value
+     || !value.TryGetValue<long>(out var invocation)
+     || invocation <= 1;
 
     /// <summary>The event name — the first positional token after <c>--antigravity</c>.</summary>
     internal static string? EventArg(string[] args) {

--- a/test/Capacitor.Cli.Tests.Unit/Harness/Antigravity/AntigravitySessionStartMemoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Harness/Antigravity/AntigravitySessionStartMemoryTests.cs
@@ -244,4 +244,26 @@ public class AntigravitySessionStartMemoryTests {
         await Assert.That(sw.ToString()).IsEqualTo("");
         await Assert.That(consulted).IsTrue();
     }
+
+    // The nudges carry no lease, so on this repeating callback only the invocation counter keeps
+    // them from re-injecting a persistent userMessage step every turn.
+
+    [Test]
+    public async Task The_first_invocation_emits_nudges() {
+        await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("""{"invocationNum":1}"""))).IsTrue();
+    }
+
+    [Test]
+    public async Task A_later_invocation_suppresses_nudges() {
+        await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("""{"invocationNum":2}"""))).IsFalse();
+        await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("""{"invocationNum":97}"""))).IsFalse();
+    }
+
+    // Fail-open: a payload that cannot distinguish callbacks must still emit.
+    [Test]
+    public async Task A_missing_or_non_numeric_counter_reads_as_the_first_invocation() {
+        await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("{}"))).IsTrue();
+        await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("""{"invocationNum":"2"}"""))).IsTrue();
+        await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("""{"invocationNum":0}"""))).IsTrue();
+    }
 }


### PR DESCRIPTION
Closes #668 — Linear id omitted: the issue was filed minutes ago and has not been imported yet.

## What & why

Antigravity's `PreInvocation` is a per-turn callback (`CallbackMayRepeat: true`). The memory index is fenced against that by the once-per-conversation lease; the work-items and harness nudges are not — they are resolved at the output layer, after the lease is decided, as pure functions of the session id. Every turn therefore wrote another `injectSteps` `userMessage`, which Antigravity persists for the conversation. This gates both on `invocationNum`, the one payload field that separates the callbacks. An absent or non-numeric counter reads as first, so a payload change degrades to emitting rather than to silence.

## Where to look

The gate lives at the hook's output site, not inside the emitters, so the lease lanes keep their current acquire/complete/retry behaviour untouched.

Kiro, OpenCode and Pi also declare `CallbackMayRepeat: true` and resolve the nudge unconditionally. They are left alone here — each would need its own counter or marker — and #668 records that.

## Verification

Same conversation id, three invocations, before and after (stdout bytes):

| invocationNum | 0.11.33 | this branch |
| --- | --- | --- |
| 1 | 929 | 929 |
| 2 | 929 | 0 |
| 3 | 929 | 0 |

`AntigravitySessionStartMemoryTests`: 22/22 pass. Release publish is clean of IL2026/IL3050.
