### PR TITLE
[AI-1990] Session-start platform field and kcap skills sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ At a glance — each links to its section below:
 | [`kcap review`](#pr-review-with-full-context) | Launch a PR review with full transcript context |
 | [`kcap mcp <server>`](#sessions-mcp-server-for-agents) | Run an MCP server (sessions / flows / memory / …) for agents |
 | [`kcap curate apply`](#curate-guidelines) | Sync promoted guidelines into `CLAUDE.md` / `AGENTS.md` |
+| [`kcap skills sync`](#skills-sync) | Materialize the repo's approved skill docs into Claude's skills directory |
 | [`kcap daemon …`](#daemon) | Run and manage the agent daemon |
 | [`kcap agent`](#local-agents-kcap-agent) | Start, list, attach to, and stop daemon-hosted agents |
 | [`kcap repos`](#repository-paths) | Manage known repo paths for the launch dialog |
@@ -625,6 +626,21 @@ kcap curate apply             # preview changes and confirm interactively
 kcap curate apply --dry-run   # print what would change without writing anything
 kcap curate apply --yes       # apply without prompting (CI / scripted)
 kcap curate apply -y          # shorthand for --yes
+```
+
+### Skills sync
+
+Materialize the current repo's approved, skill-targeted guidance docs into Claude Code's
+user-level skills directory (`~/.claude/skills/kcap-<slug>/SKILL.md`). The server is the canonical
+source: each sync fetches the repo's versioned snapshot, writes new or re-approved skills, and
+prunes ones revoked centrally — a manifest under `~/.config/kcap/skills/` records exactly which
+directories kcap owns, and nothing outside it is ever touched. Skills are never written into the
+repository itself. Requires `kcap login` and a repo checkout (the repo is detected from the
+working directory).
+
+```bash
+kcap skills sync              # fetch, write and prune this repo's skills
+kcap skills sync --dry-run    # print what would change without writing anything
 ```
 
 

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1113,6 +1113,8 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(Capacitor.Cli.Core.Commands.RegisterMachineRequest))]
 [JsonSerializable(typeof(Capacitor.Cli.Core.Commands.RegisterMachineResponse))]
 [JsonSerializable(typeof(Capacitor.Cli.Core.Commands.MachineSummary[]))]
+[JsonSerializable(typeof(Capacitor.Cli.Core.Skills.SkillsSnapshotResponse))]
+[JsonSerializable(typeof(Capacitor.Cli.Core.Skills.SkillsManifest))]
 [JsonSerializable(typeof(Capacitor.Cli.Core.Commands.FeedbackSubmitRequest))]
 [JsonSerializable(typeof(Capacitor.Cli.Core.Commands.FeedbackSubmitContext))]
 [JsonSerializable(typeof(Capacitor.Cli.Core.Commands.FeedbackSubmitResponse))]

--- a/src/Capacitor.Cli.Core/Skills/SkillsSync.cs
+++ b/src/Capacitor.Cli.Core/Skills/SkillsSync.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.Skills;
+
+/// <summary>One row of the server's versioned skills snapshot.</summary>
+public sealed record SkillSnapshotItem {
+    [JsonPropertyName("doc_id")]       public required Guid   DocId       { get; init; }
+    [JsonPropertyName("slug")]         public required string Slug        { get; init; }
+    [JsonPropertyName("title")]        public required string Title       { get; init; }
+    [JsonPropertyName("description")]  public string?         Description { get; init; }
+    [JsonPropertyName("body")]         public required string Body        { get; init; }
+    [JsonPropertyName("version")]      public required int    Version     { get; init; }
+    [JsonPropertyName("content_hash")] public required string ContentHash { get; init; }
+}
+
+public sealed record SkillsSnapshotResponse {
+    [JsonPropertyName("etag")]   public string?              Etag   { get; init; }
+    [JsonPropertyName("skills")] public SkillSnapshotItem[]? Skills { get; init; }
+}
+
+/// <summary>The sync ledger for one (repo, harness): which harness paths kcap owns. Pruning walks
+/// THIS, never the skills root — user-authored skills and other plugins are untouchable.</summary>
+public sealed record SkillsManifest {
+    [JsonPropertyName("etag")]      public string?                Etag     { get; init; }
+    [JsonPropertyName("synced_at")] public DateTimeOffset?        SyncedAt { get; init; }
+    [JsonPropertyName("skills")]    public SkillsManifestEntry[]? Skills   { get; init; }
+}
+
+public sealed record SkillsManifestEntry {
+    [JsonPropertyName("doc_id")]       public required Guid   DocId       { get; init; }
+    [JsonPropertyName("slug")]         public required string Slug        { get; init; }
+    [JsonPropertyName("version")]      public required int    Version     { get; init; }
+    [JsonPropertyName("content_hash")] public required string ContentHash { get; init; }
+    [JsonPropertyName("path")]         public required string Path        { get; init; }
+}
+
+public sealed record SkillsSyncPlan(
+    IReadOnlyList<SkillSnapshotItem>   Writes,
+    IReadOnlyList<SkillsManifestEntry> Prunes,
+    IReadOnlyList<SkillSnapshotItem>   Unchanged);
+
+/// <summary>
+/// Pure reconciliation of the manifest against a fresh snapshot. Identity is <c>doc_id</c> — the
+/// server's stable manifest key — so a retitled doc (same id, new slug) is a rewrite at the new
+/// path plus a prune of the old one, never an orphaned directory.
+/// </summary>
+public static class SkillsSyncPlanner {
+    public static SkillsSyncPlan Plan(SkillsManifest? manifest, IReadOnlyList<SkillSnapshotItem> snapshot) {
+        var owned = (manifest?.Skills ?? []).ToDictionary(e => e.DocId);
+        var writes    = new List<SkillSnapshotItem>();
+        var unchanged = new List<SkillSnapshotItem>();
+        foreach (var item in snapshot) {
+            if (owned.TryGetValue(item.DocId, out var have)
+                    && have.Version == item.Version && have.ContentHash == item.ContentHash
+                    && have.Slug == item.Slug)
+                unchanged.Add(item);
+            else
+                writes.Add(item);
+        }
+        var live   = snapshot.Select(s => s.DocId).ToHashSet();
+        var prunes = (manifest?.Skills ?? [])
+            .Where(e => !live.Contains(e.DocId)
+                        || snapshot.First(s => s.DocId == e.DocId).Slug != e.Slug)
+            .ToList();
+        return new SkillsSyncPlan(writes, prunes, unchanged);
+    }
+
+    /// <summary>The materialized SKILL.md: YAML frontmatter (name + when-to-use description as a
+    /// double-quoted scalar) over the approved body.</summary>
+    public static string RenderSkillFile(SkillSnapshotItem item) {
+        var sb = new StringBuilder();
+        sb.Append("---\n");
+        sb.Append("name: ").Append(item.Slug).Append('\n');
+        var description = string.IsNullOrWhiteSpace(item.Description) ? item.Title : item.Description!;
+        sb.Append("description: ").Append(YamlQuote(description)).Append('\n');
+        sb.Append("---\n\n");
+        sb.Append(item.Body);
+        if (!item.Body.EndsWith('\n')) sb.Append('\n');
+        return sb.ToString();
+    }
+
+    static string YamlQuote(string value) {
+        var sb = new StringBuilder(value.Length + 2).Append('"');
+        foreach (var c in value)
+            sb.Append(c switch {
+                '\\' => "\\\\", '"' => "\\\"", '\n' => "\\n", '\r' => "\\r", '\t' => "\\t",
+                _ => c.ToString(),
+            });
+        return sb.Append('"').ToString();
+    }
+}

--- a/src/Capacitor.Cli.Core/Skills/SkillsSync.cs
+++ b/src/Capacitor.Cli.Core/Skills/SkillsSync.cs
@@ -33,6 +33,9 @@ public sealed record SkillsManifestEntry {
     [JsonPropertyName("version")]      public required int    Version     { get; init; }
     [JsonPropertyName("content_hash")] public required string ContentHash { get; init; }
     [JsonPropertyName("path")]         public required string Path        { get; init; }
+    // Hash of the rendered file as written, so a later sync can tell an edited or deleted
+    // materialization from a served one. Null (an older manifest) reads as drifted.
+    [JsonPropertyName("file_hash")]    public string?         FileHash    { get; init; }
 }
 
 public sealed record SkillsSyncPlan(

--- a/src/Capacitor.Cli.Core/Skills/SkillsSync.cs
+++ b/src/Capacitor.Cli.Core/Skills/SkillsSync.cs
@@ -80,6 +80,12 @@ public static class SkillsSyncPlanner {
         return sb.ToString();
     }
 
+    /// <summary>A slug usable as a single path segment: lowercase alphanumerics and dashes only —
+    /// exactly the server's slug alphabet. Anything else (separators, dots, empty) is refused
+    /// before it can reach a filesystem operation.</summary>
+    public static bool IsSafeSlug(string slug) =>
+        slug.Length is > 0 and <= 100 && slug.All(c => char.IsAsciiLetterLower(c) || char.IsAsciiDigit(c) || c == '-');
+
     static string YamlQuote(string value) {
         var sb = new StringBuilder(value.Length + 2).Append('"');
         foreach (var c in value)

--- a/src/Capacitor.Cli/Commands/SkillsCommand.cs
+++ b/src/Capacitor.Cli/Commands/SkillsCommand.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Skills;
+using Capacitor.Cli.Harness.Claude;
 
 namespace Capacitor.Cli.Commands;
 
@@ -34,11 +35,17 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
         var manifestPath = config.Path("skills", hash, Vendor, "manifest.json");
         if (!TryLoadManifest(manifestPath, out var manifest)) return 1;
 
+        // Metadata alone cannot prove a skill is served: a deleted or hand-edited SKILL.md must be
+        // re-materialized, so local drift forfeits the conditional request — a 304 would otherwise
+        // report "up to date" over a missing file forever.
+        var drifted = (manifest?.Skills ?? []).Where(ClaudeSkillsMaterializer.HasDrifted)
+            .Select(e => e.DocId).ToHashSet();
+
         using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(config, profiles, baseUrl);
         var url = $"{baseUrl}/api/repositories/{hash}/skills?vendor={Vendor}"
                 + (HostPlatform.Normalized is { } platform ? $"&platform={platform}" : "");
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        if (manifest?.Etag is { Length: > 0 } etag)
+        if (drifted.Count == 0 && manifest?.Etag is { Length: > 0 } etag)
             request.Headers.TryAddWithoutValidation("If-None-Match", $"\"{etag}\"");
 
         HttpResponseMessage resp;
@@ -87,54 +94,35 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
                 await Console.Error.WriteLineAsync($"Refusing snapshot: unsafe slug '{u.Slug}'.");
             return 1;
         }
-        var plan = SkillsSyncPlanner.Plan(manifest, snapshot);
-        var root = SkillsRoot();
+        var plan   = SkillsSyncPlanner.Plan(manifest, snapshot);
+        var root   = ClaudeSkillsMaterializer.SkillsRoot();
+        var writes = plan.Writes.Concat(plan.Unchanged.Where(u => drifted.Contains(u.DocId))).ToList();
 
-        if (plan.Writes.Count == 0 && plan.Prunes.Count == 0) {
+        if (writes.Count == 0 && plan.Prunes.Count == 0) {
             if (!dryRun) SaveManifest(manifestPath, BuildManifest(dto.Etag, snapshot, root));
             Console.WriteLine($"Skills up to date ({snapshot.Length} materialized).");
             return 0;
         }
 
-        foreach (var w in plan.Writes)
-            Console.WriteLine($"{(dryRun ? "would write" : "write"),-12} {SkillDirFor(root, w.Slug)} (v{w.Version})");
+        foreach (var w in writes)
+            Console.WriteLine($"{(dryRun ? "would write" : "write"),-12} {ClaudeSkillsMaterializer.SkillDirFor(root, w.Slug)} (v{w.Version})");
         foreach (var p in plan.Prunes)
             Console.WriteLine($"{(dryRun ? "would prune" : "prune"),-12} {p.Path}");
         if (dryRun) return 0;
 
-        foreach (var w in plan.Writes) {
-            var dir = SkillDirFor(root, w.Slug);
-            Directory.CreateDirectory(dir);
-            File.WriteAllText(Path.Combine(dir, "SKILL.md"), SkillsSyncPlanner.RenderSkillFile(w));
-        }
-        foreach (var p in plan.Prunes) {
-            // Only ever a manifest-recorded path, and only a DIRECT kcap-* child of the skills
-            // root — a manifest edited by hand must not aim the delete anywhere else (prefix
-            // checks admit siblings like skills-backup/ and nested user directories; parent
-            // EQUALITY does not).
-            var full = Path.GetFullPath(p.Path);
-            if (string.Equals(Path.GetDirectoryName(full), Path.GetFullPath(root), StringComparison.Ordinal)
-                    && Path.GetFileName(full).StartsWith("kcap-", StringComparison.Ordinal)
-                    && Directory.Exists(full))
-                Directory.Delete(full, recursive: true);
-        }
+        foreach (var w in writes) ClaudeSkillsMaterializer.Write(root, w);
+        foreach (var p in plan.Prunes) ClaudeSkillsMaterializer.Prune(root, p);
         SaveManifest(manifestPath, BuildManifest(dto.Etag, snapshot, root));
-        Console.WriteLine($"Synced {plan.Writes.Count} skill(s), pruned {plan.Prunes.Count}; {snapshot.Length} materialized.");
+        Console.WriteLine($"Synced {writes.Count} skill(s), pruned {plan.Prunes.Count}; {snapshot.Length} materialized.");
         return 0;
     }
-
-    static string SkillsRoot() =>
-        Path.Combine(PathHelpers.HomeDirectory, ".claude", "skills");
-
-    // The server's slug is already doc-id-anchored and unique; the kcap- prefix namespaces the
-    // materialized set inside the shared user-level skills root.
-    static string SkillDirFor(string root, string slug) => Path.Combine(root, "kcap-" + slug);
 
     static SkillsManifest BuildManifest(string? etag, SkillSnapshotItem[] snapshot, string root) => new() {
         Etag = etag, SyncedAt = DateTimeOffset.UtcNow,
         Skills = [.. snapshot.Select(s => new SkillsManifestEntry {
             DocId = s.DocId, Slug = s.Slug, Version = s.Version, ContentHash = s.ContentHash,
-            Path = SkillDirFor(root, s.Slug),
+            Path = ClaudeSkillsMaterializer.SkillDirFor(root, s.Slug),
+            FileHash = ClaudeSkillsMaterializer.FileHash(SkillsSyncPlanner.RenderSkillFile(s)),
         })],
     };
 

--- a/src/Capacitor.Cli/Commands/SkillsCommand.cs
+++ b/src/Capacitor.Cli/Commands/SkillsCommand.cs
@@ -32,7 +32,7 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
         var hash = RepoHashHelper.ComputeRepoHash(repo.Owner, repo.RepoName);
 
         var manifestPath = config.Path("skills", hash, Vendor, "manifest.json");
-        var manifest = LoadManifest(manifestPath);
+        if (!TryLoadManifest(manifestPath, out var manifest)) return 1;
 
         using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(config, profiles, baseUrl);
         var url = $"{baseUrl}/api/repositories/{hash}/skills?vendor={Vendor}"
@@ -78,8 +78,17 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
         }
 
         var snapshot = dto.Skills ?? [];
-        var plan     = SkillsSyncPlanner.Plan(manifest, snapshot);
-        var root     = SkillsRoot();
+        // Whole-snapshot validation BEFORE any filesystem mutation: acting on a partially-valid
+        // snapshot and recording its etag would prune real skills, write no replacements, and
+        // 304 forever after — refusing outright leaves everything intact and retried in full.
+        var unsafeSlugs = snapshot.Where(s => !SkillsSyncPlanner.IsSafeSlug(s.Slug)).ToList();
+        if (unsafeSlugs.Count > 0) {
+            foreach (var u in unsafeSlugs)
+                await Console.Error.WriteLineAsync($"Refusing snapshot: unsafe slug '{u.Slug}'.");
+            return 1;
+        }
+        var plan = SkillsSyncPlanner.Plan(manifest, snapshot);
+        var root = SkillsRoot();
 
         if (plan.Writes.Count == 0 && plan.Prunes.Count == 0) {
             if (!dryRun) SaveManifest(manifestPath, BuildManifest(dto.Etag, snapshot, root));
@@ -94,12 +103,6 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
         if (dryRun) return 0;
 
         foreach (var w in plan.Writes) {
-            // The slug becomes a path segment, so it must BE one — a server (or tampered response)
-            // handing out separators or dots must not reach a filesystem operation.
-            if (!SkillsSyncPlanner.IsSafeSlug(w.Slug)) {
-                await Console.Error.WriteLineAsync($"Skipping skill with unsafe slug: {w.Slug}");
-                continue;
-            }
             var dir = SkillDirFor(root, w.Slug);
             Directory.CreateDirectory(dir);
             File.WriteAllText(Path.Combine(dir, "SKILL.md"), SkillsSyncPlanner.RenderSkillFile(w));
@@ -129,23 +132,38 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
 
     static SkillsManifest BuildManifest(string? etag, SkillSnapshotItem[] snapshot, string root) => new() {
         Etag = etag, SyncedAt = DateTimeOffset.UtcNow,
-        // Unsafe-slug items are skipped by the write loop, so they must not be claimed here either.
-        Skills = [.. snapshot.Where(s => SkillsSyncPlanner.IsSafeSlug(s.Slug)).Select(s => new SkillsManifestEntry {
+        Skills = [.. snapshot.Select(s => new SkillsManifestEntry {
             DocId = s.DocId, Slug = s.Slug, Version = s.Version, ContentHash = s.ContentHash,
             Path = SkillDirFor(root, s.Slug),
         })],
     };
 
-    static SkillsManifest? LoadManifest(string path) {
-        if (!File.Exists(path)) return null;
+    // The manifest is the ownership ledger, and the two failure classes diverge: an unreadable
+    // file may be transient (sharing violation), so the sync ABORTS rather than reconciling
+    // ledger-less over a still-valid file; a corrupt file proceeds from scratch only once the
+    // evidence is genuinely preserved aside — a failed preserve also aborts.
+    static bool TryLoadManifest(string path, out SkillsManifest? manifest) {
+        manifest = null;
+        if (!File.Exists(path)) return true;
+        string text;
         try {
-            return JsonSerializer.Deserialize(File.ReadAllText(path), CapacitorJsonContext.Default.SkillsManifest);
-        } catch {
-            // The manifest is the ownership ledger — losing it silently would strand revoked
-            // directories forever. Keep the evidence aside; the next full sync rebuilds ownership.
-            try { File.Move(path, path + ".corrupt", overwrite: true); } catch { /* best effort */ }
+            text = File.ReadAllText(path);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Cannot read skills manifest ({ex.Message}); aborting sync.");
+            return false;
+        }
+        try {
+            manifest = JsonSerializer.Deserialize(text, CapacitorJsonContext.Default.SkillsManifest);
+            return true;
+        } catch (JsonException) {
+            try {
+                File.Move(path, path + ".corrupt", overwrite: true);
+            } catch (Exception ex) {
+                Console.Error.WriteLine($"Corrupt skills manifest could not be preserved ({ex.Message}); aborting sync.");
+                return false;
+            }
             Console.Error.WriteLine($"Warning: corrupt skills manifest moved aside ({path}.corrupt); re-syncing from scratch.");
-            return null;
+            return true;
         }
     }
 

--- a/src/Capacitor.Cli/Commands/SkillsCommand.cs
+++ b/src/Capacitor.Cli/Commands/SkillsCommand.cs
@@ -154,17 +154,22 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
         }
         try {
             manifest = JsonSerializer.Deserialize(text, CapacitorJsonContext.Default.SkillsManifest);
-            return true;
         } catch (JsonException) {
-            try {
-                File.Move(path, path + ".corrupt", overwrite: true);
-            } catch (Exception ex) {
-                Console.Error.WriteLine($"Corrupt skills manifest could not be preserved ({ex.Message}); aborting sync.");
-                return false;
-            }
-            Console.Error.WriteLine($"Warning: corrupt skills manifest moved aside ({path}.corrupt); re-syncing from scratch.");
-            return true;
+            manifest = null;
         }
+        // A parseable `null` or a missing skills collection is no ledger either — under a stored
+        // etag it would 304 forever with zero owned paths, stranding every prior directory. Same
+        // recovery route as unparseable content.
+        if (manifest?.Skills is not null) return true;
+        manifest = null;
+        try {
+            File.Move(path, path + ".corrupt", overwrite: true);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"Corrupt skills manifest could not be preserved ({ex.Message}); aborting sync.");
+            return false;
+        }
+        Console.Error.WriteLine($"Warning: corrupt skills manifest moved aside ({path}.corrupt); re-syncing from scratch.");
+        return true;
     }
 
     static void SaveManifest(string path, SkillsManifest manifest) {

--- a/src/Capacitor.Cli/Commands/SkillsCommand.cs
+++ b/src/Capacitor.Cli/Commands/SkillsCommand.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Skills;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// <c>kcap skills sync</c> — materializes the server's versioned skill-doc snapshot for this repo
+/// into the harness's user-level skills root (Claude, the one harness with a skills mechanism).
+/// Server-canonical and centrally revocable: files land under a kcap namespace, a manifest in the
+/// kcap config root records every path kcap owns, and pruning walks the manifest — never the
+/// skills root — so user-authored skills are untouchable. Nothing is ever written into a repo.
+/// </summary>
+class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
+    const string Vendor = "claude";
+
+    public async Task<int> HandleSync(bool dryRun) {
+        var baseUrl = profiles.Resolution.ServerUrl!;
+        var cwd = Environment.CurrentDirectory;
+
+        if (GitRepository.FindRoot(cwd) is null) {
+            await Console.Error.WriteLineAsync("Not inside a git repository — run `kcap skills sync` from a repo.");
+            return 1;
+        }
+        var repo = await RepositoryDetection.DetectRepositoryAsync(config, cwd);
+        if (repo?.Owner is null || repo.RepoName is null) {
+            await Console.Error.WriteLineAsync("Could not determine the repo's owner/name from its git remote.");
+            return 1;
+        }
+        var hash = RepoHashHelper.ComputeRepoHash(repo.Owner, repo.RepoName);
+
+        var manifestPath = config.Path("skills", hash, Vendor, "manifest.json");
+        var manifest = LoadManifest(manifestPath);
+
+        using var client = await HttpClientExtensions.CreateAuthenticatedClientAsync(config, profiles, baseUrl);
+        var url = $"{baseUrl}/api/repositories/{hash}/skills?vendor={Vendor}"
+                + (HostPlatform.Normalized is { } platform ? $"&platform={platform}" : "");
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        if (manifest?.Etag is { Length: > 0 } etag)
+            request.Headers.TryAddWithoutValidation("If-None-Match", $"\"{etag}\"");
+
+        HttpResponseMessage resp;
+        try {
+            resp = await client.SendAsync(request);
+        } catch (HttpRequestException ex) {
+            HttpClientExtensions.WriteUnreachableError(baseUrl, ex);
+            return 1;
+        }
+
+        if (resp.StatusCode == HttpStatusCode.NotModified) {
+            if (!dryRun) SaveManifest(manifestPath, manifest! with { SyncedAt = DateTimeOffset.UtcNow });
+            Console.WriteLine($"Skills up to date ({manifest?.Skills?.Length ?? 0} materialized).");
+            return 0;
+        }
+        if (await HttpClientExtensions.HandleUnauthorizedAsync(resp)) return 1;
+        if (resp.StatusCode == HttpStatusCode.NotFound) {
+            await Console.Error.WriteLineAsync(
+                "Repo not found or not visible for this profile. Check `kcap whoami` / your active profile.");
+            return 1;
+        }
+        if (!resp.IsSuccessStatusCode) {
+            await Console.Error.WriteLineAsync($"HTTP {(int)resp.StatusCode}");
+            return 1;
+        }
+
+        SkillsSnapshotResponse? dto;
+        try {
+            dto = JsonSerializer.Deserialize(
+                await resp.Content.ReadAsStringAsync(), CapacitorJsonContext.Default.SkillsSnapshotResponse);
+        } catch (JsonException) {
+            dto = null;
+        }
+        if (dto is null) {
+            await Console.Error.WriteLineAsync("Malformed response from server (could not parse skills snapshot).");
+            return 1;
+        }
+
+        var snapshot = dto.Skills ?? [];
+        var plan     = SkillsSyncPlanner.Plan(manifest, snapshot);
+        var root     = SkillsRoot();
+
+        if (plan.Writes.Count == 0 && plan.Prunes.Count == 0) {
+            if (!dryRun) SaveManifest(manifestPath, BuildManifest(dto.Etag, snapshot, root));
+            Console.WriteLine($"Skills up to date ({snapshot.Length} materialized).");
+            return 0;
+        }
+
+        foreach (var w in plan.Writes)
+            Console.WriteLine($"{(dryRun ? "would write" : "write"),-12} {SkillDirFor(root, w.Slug)} (v{w.Version})");
+        foreach (var p in plan.Prunes)
+            Console.WriteLine($"{(dryRun ? "would prune" : "prune"),-12} {p.Path}");
+        if (dryRun) return 0;
+
+        foreach (var w in plan.Writes) {
+            var dir = SkillDirFor(root, w.Slug);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "SKILL.md"), SkillsSyncPlanner.RenderSkillFile(w));
+        }
+        foreach (var p in plan.Prunes) {
+            // Only ever a manifest-recorded path, and only when it still sits inside the kcap
+            // namespace — a manifest edited by hand must not aim the delete anywhere else.
+            var full = Path.GetFullPath(p.Path);
+            if (full.StartsWith(Path.GetFullPath(root), StringComparison.Ordinal)
+                    && Path.GetFileName(full).StartsWith("kcap-", StringComparison.Ordinal)
+                    && Directory.Exists(full))
+                Directory.Delete(full, recursive: true);
+        }
+        SaveManifest(manifestPath, BuildManifest(dto.Etag, snapshot, root));
+        Console.WriteLine($"Synced {plan.Writes.Count} skill(s), pruned {plan.Prunes.Count}; {snapshot.Length} materialized.");
+        return 0;
+    }
+
+    static string SkillsRoot() =>
+        Path.Combine(PathHelpers.HomeDirectory, ".claude", "skills");
+
+    // The server's slug is already doc-id-anchored and unique; the kcap- prefix namespaces the
+    // materialized set inside the shared user-level skills root.
+    static string SkillDirFor(string root, string slug) => Path.Combine(root, "kcap-" + slug);
+
+    static SkillsManifest BuildManifest(string? etag, SkillSnapshotItem[] snapshot, string root) => new() {
+        Etag = etag, SyncedAt = DateTimeOffset.UtcNow,
+        Skills = [.. snapshot.Select(s => new SkillsManifestEntry {
+            DocId = s.DocId, Slug = s.Slug, Version = s.Version, ContentHash = s.ContentHash,
+            Path = SkillDirFor(root, s.Slug),
+        })],
+    };
+
+    static SkillsManifest? LoadManifest(string path) {
+        try {
+            if (!File.Exists(path)) return null;
+            return JsonSerializer.Deserialize(File.ReadAllText(path), CapacitorJsonContext.Default.SkillsManifest);
+        } catch {
+            return null;   // a corrupt manifest re-syncs from scratch; files reconcile by rewrite
+        }
+    }
+
+    static void SaveManifest(string path, SkillsManifest manifest) {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, JsonSerializer.Serialize(manifest, CapacitorJsonContext.Default.SkillsManifest));
+    }
+}

--- a/src/Capacitor.Cli/Commands/SkillsCommand.cs
+++ b/src/Capacitor.Cli/Commands/SkillsCommand.cs
@@ -94,15 +94,23 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
         if (dryRun) return 0;
 
         foreach (var w in plan.Writes) {
+            // The slug becomes a path segment, so it must BE one — a server (or tampered response)
+            // handing out separators or dots must not reach a filesystem operation.
+            if (!SkillsSyncPlanner.IsSafeSlug(w.Slug)) {
+                await Console.Error.WriteLineAsync($"Skipping skill with unsafe slug: {w.Slug}");
+                continue;
+            }
             var dir = SkillDirFor(root, w.Slug);
             Directory.CreateDirectory(dir);
             File.WriteAllText(Path.Combine(dir, "SKILL.md"), SkillsSyncPlanner.RenderSkillFile(w));
         }
         foreach (var p in plan.Prunes) {
-            // Only ever a manifest-recorded path, and only when it still sits inside the kcap
-            // namespace — a manifest edited by hand must not aim the delete anywhere else.
+            // Only ever a manifest-recorded path, and only a DIRECT kcap-* child of the skills
+            // root — a manifest edited by hand must not aim the delete anywhere else (prefix
+            // checks admit siblings like skills-backup/ and nested user directories; parent
+            // EQUALITY does not).
             var full = Path.GetFullPath(p.Path);
-            if (full.StartsWith(Path.GetFullPath(root), StringComparison.Ordinal)
+            if (string.Equals(Path.GetDirectoryName(full), Path.GetFullPath(root), StringComparison.Ordinal)
                     && Path.GetFileName(full).StartsWith("kcap-", StringComparison.Ordinal)
                     && Directory.Exists(full))
                 Directory.Delete(full, recursive: true);
@@ -121,23 +129,31 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
 
     static SkillsManifest BuildManifest(string? etag, SkillSnapshotItem[] snapshot, string root) => new() {
         Etag = etag, SyncedAt = DateTimeOffset.UtcNow,
-        Skills = [.. snapshot.Select(s => new SkillsManifestEntry {
+        // Unsafe-slug items are skipped by the write loop, so they must not be claimed here either.
+        Skills = [.. snapshot.Where(s => SkillsSyncPlanner.IsSafeSlug(s.Slug)).Select(s => new SkillsManifestEntry {
             DocId = s.DocId, Slug = s.Slug, Version = s.Version, ContentHash = s.ContentHash,
             Path = SkillDirFor(root, s.Slug),
         })],
     };
 
     static SkillsManifest? LoadManifest(string path) {
+        if (!File.Exists(path)) return null;
         try {
-            if (!File.Exists(path)) return null;
             return JsonSerializer.Deserialize(File.ReadAllText(path), CapacitorJsonContext.Default.SkillsManifest);
         } catch {
-            return null;   // a corrupt manifest re-syncs from scratch; files reconcile by rewrite
+            // The manifest is the ownership ledger — losing it silently would strand revoked
+            // directories forever. Keep the evidence aside; the next full sync rebuilds ownership.
+            try { File.Move(path, path + ".corrupt", overwrite: true); } catch { /* best effort */ }
+            Console.Error.WriteLine($"Warning: corrupt skills manifest moved aside ({path}.corrupt); re-syncing from scratch.");
+            return null;
         }
     }
 
     static void SaveManifest(string path, SkillsManifest manifest) {
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-        File.WriteAllText(path, JsonSerializer.Serialize(manifest, CapacitorJsonContext.Default.SkillsManifest));
+        // Atomic replace: a crash mid-write must never truncate the ownership ledger in place.
+        var tmp = path + ".tmp";
+        File.WriteAllText(tmp, JsonSerializer.Serialize(manifest, CapacitorJsonContext.Default.SkillsManifest));
+        File.Move(tmp, path, overwrite: true);
     }
 }

--- a/src/Capacitor.Cli/Harness/Claude/ClaudeSkillsMaterializer.cs
+++ b/src/Capacitor.Cli/Harness/Claude/ClaudeSkillsMaterializer.cs
@@ -1,0 +1,55 @@
+using System.Security.Cryptography;
+using System.Text;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Skills;
+
+namespace Capacitor.Cli.Harness.Claude;
+
+/// <summary>
+/// The Claude half of skills materialization: where skills live for this harness, how a slug maps
+/// to a directory, and the write/prune/drift file operations. The vendor-neutral snapshot models
+/// and reconciliation planner stay in <c>Cli.Core/Skills</c>.
+/// </summary>
+static class ClaudeSkillsMaterializer {
+    public static string SkillsRoot() =>
+        Path.Combine(PathHelpers.HomeDirectory, ".claude", "skills");
+
+    // The server's slug is already doc-id-anchored and unique; the kcap- prefix namespaces the
+    // materialized set inside the shared user-level skills root.
+    public static string SkillDirFor(string root, string slug) => Path.Combine(root, "kcap-" + slug);
+
+    public static string SkillFileFor(string dir) => Path.Combine(dir, "SKILL.md");
+
+    public static string FileHash(string rendered) =>
+        Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(rendered)));
+
+    /// <summary>A manifest entry whose materialized file is missing or edited. A drifted entry means
+    /// metadata alone cannot prove the skill is served — the snapshot must be re-applied.</summary>
+    public static bool HasDrifted(SkillsManifestEntry entry) {
+        var file = SkillFileFor(entry.Path);
+        if (entry.FileHash is null || !File.Exists(file)) return true;
+        try {
+            return FileHash(File.ReadAllText(file)) != entry.FileHash;
+        } catch {
+            return true;
+        }
+    }
+
+    public static void Write(string root, SkillSnapshotItem item) {
+        var dir = SkillDirFor(root, item.Slug);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(SkillFileFor(dir), SkillsSyncPlanner.RenderSkillFile(item));
+    }
+
+    /// <summary>Deletes one manifest-recorded directory — and only a DIRECT kcap-* child of the
+    /// skills root: a manifest edited by hand must not aim the delete anywhere else (prefix checks
+    /// admit siblings like <c>skills-backup/</c> and nested user directories; parent EQUALITY does
+    /// not).</summary>
+    public static void Prune(string root, SkillsManifestEntry entry) {
+        var full = Path.GetFullPath(entry.Path);
+        if (string.Equals(Path.GetDirectoryName(full), Path.GetFullPath(root), StringComparison.Ordinal)
+                && Path.GetFileName(full).StartsWith("kcap-", StringComparison.Ordinal)
+                && Directory.Exists(full))
+            Directory.Delete(full, recursive: true);
+    }
+}

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -452,6 +452,13 @@ switch (command) {
                 return 1;
         }
     }
+    case "skills": {
+        if (args.Length < 2 || args[1] != "sync") {
+            Console.Error.WriteLine("Usage: kcap skills sync [--dry-run]");
+            return 1;
+        }
+        return await new SkillsCommand(config, profiles).HandleSync(args.Contains("--dry-run"));
+    }
     case "curate": {
         if (args.Length < 2) {
             Console.Error.WriteLine("Usage: kcap curate apply [--dry-run] [--yes]");

--- a/src/Capacitor.Cli/SessionStartInventory.cs
+++ b/src/Capacitor.Cli/SessionStartInventory.cs
@@ -17,9 +17,14 @@ static class SessionStartInventory {
             var inv  = HarnessInventory.EvaluateCurrent(config);
             var json = JsonSerializer.Serialize(inv, CapacitorJsonContext.Default.HarnessInventory);
             body["harness_inventory"] = JsonNode.Parse(json);
-            // The CLI's own OS, feeding the server's live applicability gate. Deliberately no
-            // path/heuristic inference — omitted when unrecognized, and unknown EXCLUDES
-            // platform-restricted facts server-side, which beats a wrong guess admitting them.
+        } catch {
+            // best-effort metadata — never break a hook
+        }
+        // The CLI's own OS, feeding the server's live applicability gate. Independent of the
+        // inventory probe (its own best-effort boundary — an inventory failure must not cost the
+        // platform axis), and deliberately no path/heuristic inference: omitted when unrecognized,
+        // and unknown EXCLUDES platform-restricted facts server-side, which beats a wrong guess.
+        try {
             if (HostPlatform.Normalized is { } platform) body["platform"] = platform;
         } catch {
             // best-effort metadata — never break a hook

--- a/src/Capacitor.Cli/SessionStartInventory.cs
+++ b/src/Capacitor.Cli/SessionStartInventory.cs
@@ -6,10 +6,10 @@ using Capacitor.Cli.Core.Setup;
 namespace Capacitor.Cli;
 
 /// <summary>
-/// Surface 3 hook carrier: stamps this machine's harness inventory onto a SessionStart body, so a
-/// daemonless machine still reports it. Serialized through the same <see cref="CapacitorJsonContext"/>
-/// as the daemon's copy, so both carriers are byte-identical. Never throws — a probe failure just
-/// omits the field (must never break a hook).
+/// Surface 3 hook carrier: stamps this machine's harness inventory and platform onto a SessionStart
+/// body, so a daemonless machine still reports them. The inventory is serialized through the same
+/// <see cref="CapacitorJsonContext"/> as the daemon's copy, so both carriers are byte-identical.
+/// Never throws — a probe failure just omits the field (must never break a hook).
 /// </summary>
 static class SessionStartInventory {
     public static void Stamp(JsonObject body, ConfigRoot config) {
@@ -20,5 +20,18 @@ static class SessionStartInventory {
         } catch {
             // best-effort metadata — never break a hook
         }
+        // The CLI's own OS, feeding the server's live applicability gate. Deliberately no
+        // path/heuristic inference — omitted when unrecognized, and unknown EXCLUDES
+        // platform-restricted facts server-side, which beats a wrong guess admitting them.
+        if (HostPlatform.Normalized is { } platform) body["platform"] = platform;
     }
+}
+
+/// <summary>The applicability gate's platform vocabulary: macos / linux / windows.</summary>
+static class HostPlatform {
+    public static string? Normalized =>
+        OperatingSystem.IsMacOS()   ? "macos"
+      : OperatingSystem.IsLinux()   ? "linux"
+      : OperatingSystem.IsWindows() ? "windows"
+      : null;
 }

--- a/src/Capacitor.Cli/SessionStartInventory.cs
+++ b/src/Capacitor.Cli/SessionStartInventory.cs
@@ -17,13 +17,13 @@ static class SessionStartInventory {
             var inv  = HarnessInventory.EvaluateCurrent(config);
             var json = JsonSerializer.Serialize(inv, CapacitorJsonContext.Default.HarnessInventory);
             body["harness_inventory"] = JsonNode.Parse(json);
+            // The CLI's own OS, feeding the server's live applicability gate. Deliberately no
+            // path/heuristic inference — omitted when unrecognized, and unknown EXCLUDES
+            // platform-restricted facts server-side, which beats a wrong guess admitting them.
+            if (HostPlatform.Normalized is { } platform) body["platform"] = platform;
         } catch {
             // best-effort metadata — never break a hook
         }
-        // The CLI's own OS, feeding the server's live applicability gate. Deliberately no
-        // path/heuristic inference — omitted when unrecognized, and unknown EXCLUDES
-        // platform-restricted facts server-side, which beats a wrong guess admitting them.
-        if (HostPlatform.Normalized is { } platform) body["platform"] = platform;
     }
 }
 

--- a/src/Capacitor.Cli/SessionStartInventory.cs
+++ b/src/Capacitor.Cli/SessionStartInventory.cs
@@ -6,8 +6,8 @@ using Capacitor.Cli.Core.Setup;
 namespace Capacitor.Cli;
 
 /// <summary>
-/// Surface 3 hook carrier: stamps this machine's harness inventory and platform onto a SessionStart
-/// body, so a daemonless machine still reports them. The inventory is serialized through the same
+/// Stamps this machine's harness inventory and platform onto a SessionStart body, so a daemonless
+/// machine still reports them through the hook carrier. The inventory is serialized through the same
 /// <see cref="CapacitorJsonContext"/> as the daemon's copy, so both carriers are byte-identical.
 /// Never throws — a probe failure just omits the field (must never break a hook).
 /// </summary>

--- a/test/Capacitor.Cli.Core.Tests.Unit/Skills/SkillsSyncPlannerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Skills/SkillsSyncPlannerTests.cs
@@ -1,6 +1,6 @@
 using Capacitor.Cli.Core.Skills;
 
-namespace Capacitor.Cli.Core.Tests.Unit;
+namespace Capacitor.Cli.Core.Tests.Unit.Skills;
 
 public class SkillsSyncPlannerTests {
     static SkillSnapshotItem Item(Guid doc, string slug = "s-1", int version = 1, string hash = "h1") => new() {

--- a/test/Capacitor.Cli.Core.Tests.Unit/SkillsSyncPlannerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/SkillsSyncPlannerTests.cs
@@ -1,0 +1,71 @@
+using Capacitor.Cli.Core.Skills;
+
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class SkillsSyncPlannerTests {
+    static SkillSnapshotItem Item(Guid doc, string slug = "s-1", int version = 1, string hash = "h1") => new() {
+        DocId = doc, Slug = slug, Title = "T", Description = "When to use.", Body = "Body.",
+        Version = version, ContentHash = hash,
+    };
+
+    static SkillsManifestEntry Entry(SkillSnapshotItem i, string path = "/skills/kcap-s-1") => new() {
+        DocId = i.DocId, Slug = i.Slug, Version = i.Version, ContentHash = i.ContentHash, Path = path,
+    };
+
+    [Test]
+    public async Task A_new_doc_is_written_and_an_absent_one_pruned() {
+        var (keep, gone, fresh) = (Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid());
+        var manifest = new SkillsManifest { Skills = [
+            Entry(Item(keep, "keep")), Entry(Item(gone, "gone"), "/skills/kcap-gone"),
+        ] };
+        var plan = SkillsSyncPlanner.Plan(manifest, [Item(keep, "keep"), Item(fresh, "fresh")]);
+
+        await Assert.That(plan.Writes.Select(w => w.DocId)).IsEquivalentTo([fresh]);
+        await Assert.That(plan.Prunes.Select(p => p.DocId)).IsEquivalentTo([gone]);
+        await Assert.That(plan.Unchanged.Select(u => u.DocId)).IsEquivalentTo([keep]);
+    }
+
+    [Test]
+    public async Task A_reapproved_version_rewrites_in_place() {
+        var doc = Guid.NewGuid();
+        var manifest = new SkillsManifest { Skills = [Entry(Item(doc))] };
+        var plan = SkillsSyncPlanner.Plan(manifest, [Item(doc, version: 2, hash: "h2")]);
+
+        await Assert.That(plan.Writes.Select(w => w.DocId)).IsEquivalentTo([doc]);
+        await Assert.That(plan.Prunes).IsEmpty();   // same slug ⇒ same directory, overwritten
+    }
+
+    [Test]
+    public async Task A_retitle_prunes_the_old_slug_and_writes_the_new() {
+        // doc_id is the reconciliation identity (the server contract): a retitled doc keeps its id
+        // but changes slug, so the old directory must go and the new one appear — never both.
+        var doc = Guid.NewGuid();
+        var manifest = new SkillsManifest { Skills = [Entry(Item(doc, "old-name"), "/skills/kcap-old-name")] };
+        var plan = SkillsSyncPlanner.Plan(manifest, [Item(doc, "new-name")]);
+
+        await Assert.That(plan.Writes.Select(w => w.Slug)).IsEquivalentTo(["new-name"]);
+        await Assert.That(plan.Prunes.Select(p => p.Path)).IsEquivalentTo(["/skills/kcap-old-name"]);
+    }
+
+    [Test]
+    public async Task An_empty_snapshot_prunes_everything_the_manifest_owns() {
+        // Central revocation: the snapshot is the complete canonical set, so absence IS removal.
+        var manifest = new SkillsManifest { Skills = [
+            Entry(Item(Guid.NewGuid(), "a"), "/skills/kcap-a"),
+            Entry(Item(Guid.NewGuid(), "b"), "/skills/kcap-b"),
+        ] };
+        var plan = SkillsSyncPlanner.Plan(manifest, []);
+        await Assert.That(plan.Writes).IsEmpty();
+        await Assert.That(plan.Prunes.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Renders_frontmatter_with_a_quoted_description() {
+        var text = SkillsSyncPlanner.RenderSkillFile(Item(Guid.NewGuid(), "retry-rules") with {
+            Description = "Use when \"retrying\" appends:\nafter a conflict.",
+        });
+        await Assert.That(text.StartsWith("---\nname: retry-rules\n", StringComparison.Ordinal)).IsTrue();
+        await Assert.That(text).Contains("description: \"Use when \\\"retrying\\\" appends:\\nafter a conflict.\"");
+        await Assert.That(text.EndsWith("---\n\nBody.\n", StringComparison.Ordinal)).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/SkillsSyncPlannerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/SkillsSyncPlannerTests.cs
@@ -60,6 +60,19 @@ public class SkillsSyncPlannerTests {
     }
 
     [Test]
+    [Arguments("retry-rules-ab12cd34", true)]
+    [Arguments("a", true)]
+    [Arguments("", false)]
+    [Arguments("has/slash", false)]
+    [Arguments("has\\backslash", false)]
+    [Arguments("..", false)]
+    [Arguments("Upper-Case", false)]
+    [Arguments("dot.name", false)]
+    public async Task Slug_safety_admits_only_single_lowercase_segments(string slug, bool safe) {
+        await Assert.That(SkillsSyncPlanner.IsSafeSlug(slug)).IsEqualTo(safe);
+    }
+
+    [Test]
     public async Task Renders_frontmatter_with_a_quoted_description() {
         var text = SkillsSyncPlanner.RenderSkillFile(Item(Guid.NewGuid(), "retry-rules") with {
             Description = "Use when \"retrying\" appends:\nafter a conflict.",

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeSkillsMaterializerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeSkillsMaterializerTests.cs
@@ -1,0 +1,59 @@
+using Capacitor.Cli.Core.Skills;
+using Capacitor.Cli.Harness.Claude;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class ClaudeSkillsMaterializerTests {
+    static SkillSnapshotItem Item(string slug) => new() {
+        DocId = Guid.NewGuid(), Slug = slug, Title = "T", Description = "When.", Body = "Body.",
+        Version = 1, ContentHash = "h1",
+    };
+
+    [Test]
+    public async Task Drift_detection_covers_missing_edited_and_untracked_files() {
+        using var tmp = new TempDir();
+        var root = tmp.Path;
+        var item = Item("retry-rules");
+        ClaudeSkillsMaterializer.Write(root, item);
+        var dir      = ClaudeSkillsMaterializer.SkillDirFor(root, item.Slug);
+        var rendered = SkillsSyncPlanner.RenderSkillFile(item);
+        var entry = new SkillsManifestEntry {
+            DocId = item.DocId, Slug = item.Slug, Version = 1, ContentHash = "h1",
+            Path = dir, FileHash = ClaudeSkillsMaterializer.FileHash(rendered),
+        };
+
+        await Assert.That(ClaudeSkillsMaterializer.HasDrifted(entry)).IsFalse();          // served as written
+        File.AppendAllText(Path.Combine(dir, "SKILL.md"), "tampered");
+        await Assert.That(ClaudeSkillsMaterializer.HasDrifted(entry)).IsTrue();           // edited
+        Directory.Delete(dir, recursive: true);
+        await Assert.That(ClaudeSkillsMaterializer.HasDrifted(entry)).IsTrue();           // deleted
+        await Assert.That(ClaudeSkillsMaterializer.HasDrifted(entry with { FileHash = null })).IsTrue();   // pre-hash manifest
+    }
+
+    [Test]
+    public async Task Prune_deletes_only_direct_kcap_children_of_the_root() {
+        using var tmp = new TempDir();
+        var root = tmp.Path;
+        var owned = Path.Combine(root, "kcap-mine");
+        var nested = Path.Combine(root, "user-owned", "kcap-nested");
+        var sibling = root + "-backup";
+        var siblingChild = Path.Combine(sibling, "kcap-foo");
+        Directory.CreateDirectory(owned);
+        Directory.CreateDirectory(nested);
+        Directory.CreateDirectory(siblingChild);
+        try {
+            static SkillsManifestEntry E(string p) => new() {
+                DocId = Guid.NewGuid(), Slug = "s", Version = 1, ContentHash = "h", Path = p,
+            };
+            ClaudeSkillsMaterializer.Prune(root, E(owned));
+            ClaudeSkillsMaterializer.Prune(root, E(nested));
+            ClaudeSkillsMaterializer.Prune(root, E(siblingChild));
+
+            await Assert.That(Directory.Exists(owned)).IsFalse();
+            await Assert.That(Directory.Exists(nested)).IsTrue();        // nested user dir untouched
+            await Assert.That(Directory.Exists(siblingChild)).IsTrue();  // sibling root untouched
+        } finally {
+            Directory.Delete(sibling, recursive: true);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartPlatformStampTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartPlatformStampTests.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+public class SessionStartPlatformStampTests {
+    [Test]
+    public async Task Stamp_carries_the_normalized_platform() {
+        // The field feeds the server's live applicability gate; the vocabulary is closed
+        // (macos/linux/windows) and every CI host is one of them.
+        var body = new JsonObject();
+        var tmp  = Directory.CreateTempSubdirectory("kcap-stamp-test-");
+        try {
+            SessionStartInventory.Stamp(body, new ConfigRoot(tmp.FullName));
+        } finally {
+            tmp.Delete(recursive: true);
+        }
+
+        var platform = (string?)body["platform"];
+        await Assert.That(platform).IsEqualTo(HostPlatform.Normalized);
+        await Assert.That(new[] { "macos", "linux", "windows" }).Contains(platform!);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartPlatformStampTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartPlatformStampTests.cs
@@ -9,12 +9,8 @@ public class SessionStartPlatformStampTests {
         // The field feeds the server's live applicability gate; the vocabulary is closed
         // (macos/linux/windows) and every CI host is one of them.
         var body = new JsonObject();
-        var tmp  = Directory.CreateTempSubdirectory("kcap-stamp-test-");
-        try {
-            SessionStartInventory.Stamp(body, new ConfigRoot(tmp.FullName));
-        } finally {
-            tmp.Delete(recursive: true);
-        }
+        using var tmp = new TempDir();
+        SessionStartInventory.Stamp(body, new ConfigRoot(tmp.Path));
 
         var platform = (string?)body["platform"];
         await Assert.That(platform).IsEqualTo(HostPlatform.Normalized);


### PR DESCRIPTION
AI-1990 (no imported GitHub issue — the Linear issue was not mirrored to this repo)

## What & why

The kcap-cli halves of the durable-knowledge tranche, both server sides already live. The session-start hook payload gains an optional `platform` (`macos`/`linux`/`windows`, normalized from the running OS) feeding the server's live applicability gate — stamped on the one `SessionStartInventory.Stamp` seam every live session-start sender already funnels through, and deliberately omitted when unrecognized: unknown *excludes* platform-restricted facts server-side, which beats a wrong guess admitting them. `kcap skills sync` materializes the server's versioned skill-doc snapshot (`GET /api/repositories/{hash}/skills?vendor=claude&platform=…`) into `~/.claude/skills/kcap-<slug>/SKILL.md` with a manifest in the kcap config root — etag-conditional, refreshed on sync, and pruned on revocation via manifest diff, so a central revoke reaches the machine on its next sync. Never written into a repository.

## Where to look

Deletion safety: pruning iterates the manifest, never the skills root, and each delete re-checks the path is inside the root under the `kcap-` namespace — user-authored skills and the packaged installer's targets are structurally untouchable. `doc_id` (not the slug) is the reconciliation identity, so a retitle prunes the old directory instead of orphaning it.

## Verification

`SkillsSyncPlannerTests` 5/5 (new/prune, rewrite-in-place, retitle, empty-snapshot revocation, frontmatter quoting) and `SessionStartPlatformStampTests` 1/1, each run filtered with its own exit code; Cli, Core and Daemon projects build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)