### PR TITLE
Fix parallel-load races in the LocalControlClient socket tests

### DIFF
--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/LocalControlClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/LocalControlClientTests.cs
@@ -12,7 +12,13 @@ namespace Capacitor.Cli.Core.Tests.Unit.LocalIpc;
 /// by generous polling deadlines rather than tight tolerances — see
 /// <see cref="Backoff_delay_advances_across_failures_and_resets_after_connected"/> for why a
 /// real clock was chosen there over a <c>FakeTimeProvider</c>).
+///
+/// <para>Runs exclusively (<see cref="NotInParallelAttribute"/>): every test drives a REAL Unix
+/// socket and a loopback-style handshake bounded by small real timeouts. Those bounds assume prompt
+/// connect and event-stream propagation, which the rest of the assembly's socket and thread-pool load
+/// can deny — so this class needs the host to itself.</para>
 /// </summary>
+[NotInParallel]
 public class LocalControlClientTests {
     /// One scripted connection behavior; the server runs them in accept order and repeats
     /// the last script for further connections.
@@ -177,6 +183,9 @@ public class LocalControlClientTests {
     }
     static bool HasConnectedLocked(object gate, List<LocalControlEvent> events) {
         lock (gate) return events.OfType<LocalControlEvent.Connected>().Any();
+    }
+    static int ConnectedCountLocked(object gate, List<LocalControlEvent> events) {
+        lock (gate) return events.OfType<LocalControlEvent.Connected>().Count();
     }
 
     [Test]
@@ -533,9 +542,10 @@ public class LocalControlClientTests {
             FirstSnapshotTimeout = TimeSpan.FromSeconds(10),
         };
         var events = new List<LocalControlEvent>();
+        var gate = new object();
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var run = Task.Run(async () => {
-            await foreach (var e in client.RunAsync(cts.Token)) events.Add(e);
+            await foreach (var e in client.RunAsync(cts.Token)) { lock (gate) events.Add(e); }
         });
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
@@ -551,6 +561,13 @@ public class LocalControlClientTests {
         var t2 = await WaitForServedAsync(4);             // cycle2's hello+subscribe, after the index1 (~2s) backoff
         await WaitForServedAsync(6);                      // cycle3's hello+subscribe — only reachable within the
                                                             // poll deadline if the schedule actually reset
+
+        // Served counts ACCEPTS, which run ahead of the client: the sixth accept lands before cycle3's
+        // hello/subscribe has been read and its Connected emitted. Wait for the client to surface both
+        // Connected events before cancelling, or the count assertion below races the very handshake it
+        // is meant to observe.
+        var connDeadline = DateTime.UtcNow.AddSeconds(10);
+        while (ConnectedCountLocked(gate, events) < 2 && DateTime.UtcNow < connDeadline) await Task.Delay(5);
 
         cts.Cancel();
         try { await run; } catch (OperationCanceledException) { }


### PR DESCRIPTION
AI-2243 — no separate GitHub issue (filed in Linear).

## What & why

Three `LocalControlClientTests` fail intermittently only in the **full** parallel `Capacitor.Cli.Core.Tests.Unit` run (they pass 22/22 in isolation). They drive a real Unix socket and a loopback-style handshake with small real timeouts, so under the rest of the assembly's socket + thread-pool load, connect latency and event-stream propagation beat those bounds — a slow connect is misclassified `daemon_unreachable`, a reconnect misses the 15 s window, a snapshot is read before the event lands. Fix: run the class exclusively (`[NotInParallel]`, matching the loopback-listener tests), so it runs last and alone.

The backoff test also had a genuine race independent of load: it synchronised on the server's *accept* counter, which increments before the response is even sent, then cancelled and asserted the client had emitted both `Connected` events. It now waits for the client's own events (lock-guarded) before cancelling.

## Where to look

The `Backoff…` change: `server.Served` counts accepts, which run ahead of the client — the added poll waits for the second client-side `Connected` so the count assertion no longer races the handshake it observes.

## Verification

Full parallel `Capacitor.Cli.Core.Tests.Unit`: **2240/2242**, all 22 `LocalControlClientTests` green. The 2 failures are `ProcessUrlPolicyTests` failing `NativeTestHost not built — build Capacitor.slnx first` (a missing solution build artifact under `--no-build`, untouched by this change), not a flake.
