### PR TITLE
[AI-2256] Opt-in throttled background skills refresh at session start

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,11 @@ kcap skills sync              # fetch, write and prune this repo's skills
 kcap skills sync --dry-run    # print what would change without writing anything
 ```
 
+Opt into an automatic background refresh with `kcap config set skills.auto_sync true`: the Claude
+session-start hook then spawns a detached, self-throttling sync (at most one network round-trip
+per ~6 hours per repo), so centrally revoked or re-approved skills reach the machine without a
+manual sync. Off by default.
+
 
 ### Loading historical sessions
 

--- a/README.md
+++ b/README.md
@@ -650,6 +650,7 @@ working directory).
 ```bash
 kcap skills sync              # fetch, write and prune this repo's skills
 kcap skills sync --dry-run    # print what would change without writing anything
+kcap skills sync --auto       # hook-spawned form: silent, and skipped when synced recently
 ```
 
 Opt into an automatic background refresh with `kcap config set skills.auto_sync true`: the Claude

--- a/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/ProfileConfig.cs
@@ -146,6 +146,9 @@ public record Profile {
     [JsonPropertyName("flows")]
     public FlowsSettings? Flows { get; init; }
 
+    [JsonPropertyName("skills")]
+    public SkillsSettings? Skills { get; init; }
+
     /// <summary>
     /// Provider + canonical server identity learned at the last successful sign-in (Plan C's
     /// commit boundary). Additive and READ-only in Plan B — nothing writes it yet; only
@@ -170,6 +173,14 @@ public sealed record AuthProviderStamp(
 public record FlowsSettings {
     [JsonPropertyName("reviewer_vendor")]
     public string? ReviewerVendor { get; init; }
+}
+
+public record SkillsSettings {
+    /// <summary>when true, the Claude session-start hook spawns a detached, self-throttling
+    /// `kcap skills sync --auto` so centrally revoked or re-approved skills reach this machine
+    /// without a manual sync. Off by default.</summary>
+    [JsonPropertyName("auto_sync")]
+    public bool? AutoSync { get; init; }
 }
 
 /// <summary>Repo-level .kcap.json committed to VCS.</summary>

--- a/src/Capacitor.Cli/Commands/ConfigCommand.cs
+++ b/src/Capacitor.Cli/Commands/ConfigCommand.cs
@@ -183,6 +183,9 @@ public sealed class ConfigCommand(ConfigRoot config) {
                 profile with { Flows = (profile.Flows ?? new FlowsSettings()) with { ReviewerVendor = ReviewerVendors.Normalize(value) } },
             "flows.reviewer_vendor" => throw new ArgumentException(
                 "Invalid value for flows.reviewer_vendor: must not be empty. Use 'kcap config unset flows.reviewer_vendor' to remove it."),
+            "skills.auto_sync" when bool.TryParse(value, out var b) =>
+                profile with { Skills = (profile.Skills ?? new SkillsSettings()) with { AutoSync = b } },
+            "skills.auto_sync" => throw new ArgumentException($"Invalid value for skills.auto_sync: '{value}'. Must be true or false."),
             _ => throw new ArgumentException($"Unknown config key: {key}")
         };
 
@@ -193,6 +196,7 @@ public sealed class ConfigCommand(ConfigRoot config) {
     public static Profile ApplyUnset(Profile profile, string key) =>
         key switch {
             "flows.reviewer_vendor" => profile with { Flows = (profile.Flows ?? new FlowsSettings()) with { ReviewerVendor = null } },
+            "skills.auto_sync" => profile with { Skills = (profile.Skills ?? new SkillsSettings()) with { AutoSync = null } },
             _ => throw new ArgumentException($"Unknown or non-unsettable config key: {key}")
         };
 
@@ -214,6 +218,7 @@ public sealed class ConfigCommand(ConfigRoot config) {
         Console.Error.WriteLine("  use_provider_api_key        Keep ANTHROPIC_API_KEY/OPENAI_API_KEY in headless agent spawns (true/false)");
         Console.Error.WriteLine("  excluded_repos              Excluded repos, comma-separated (owner/repo,owner/repo)");
         Console.Error.WriteLine("  flows.reviewer_vendor       Preferred review-flow reviewer vendor (used only when the definition names none)");
+        Console.Error.WriteLine("  skills.auto_sync            Background skills refresh at Claude session start (true/false, default false)");
         Console.Error.WriteLine("  telemetry                   Anonymous CLI usage reporting, machine-wide (on/off)");
         Console.Error.WriteLine();
         Console.Error.WriteLine("Flags:");

--- a/src/Capacitor.Cli/Commands/ConfigCommand.cs
+++ b/src/Capacitor.Cli/Commands/ConfigCommand.cs
@@ -67,7 +67,7 @@ public sealed class ConfigCommand(ConfigRoot config) {
         var profileName = "default";
 
         await ConfigMutator.MutateAsync(config, c => {
-            profileName = c.ActiveProfile;
+            profileName = c.ActiveName;
             var profile = ApplySet(c.Profiles.GetValueOrDefault(profileName) ?? new Profile(), key, value);
 
             return c with { Profiles = new Dictionary<string, Profile>(c.Profiles) { [profileName] = profile } };
@@ -95,7 +95,7 @@ public sealed class ConfigCommand(ConfigRoot config) {
         var profileName = "default";
 
         await ConfigMutator.MutateAsync(config, c => {
-            profileName = c.ActiveProfile;
+            profileName = c.ActiveName;
             var profile = ApplyUnset(c.Profiles.GetValueOrDefault(profileName) ?? new Profile(), key);
 
             return c with { Profiles = new Dictionary<string, Profile>(c.Profiles) { [profileName] = profile } };

--- a/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
@@ -527,6 +527,11 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
                     agentId: null, cwd: sessionCwd, skipTitle: isResumeOrCompact);
             }
 
+            // Opt-in background skills refresh: detached and never awaited (the hook's latency
+            // budget must not pay for a sync); the child throttles itself off the manifest.
+            if (activeProfile?.Skills?.AutoSync == true && sessionCwd is not null)
+                SkillsAutoSync.SpawnDetached(sessionCwd);
+
             // Now that the watcher is running, await the deferred repo enrichment (a slow git/gh
             // probe could not have delayed capture start) and then inject default_visibility +
             // plan_content onto the enriched body before the POST.

--- a/src/Capacitor.Cli/Commands/SkillsAutoSync.cs
+++ b/src/Capacitor.Cli/Commands/SkillsAutoSync.cs
@@ -26,7 +26,15 @@ static class SkillsAutoSync {
             psi.ArgumentList.Add("skills");
             psi.ArgumentList.Add("sync");
             psi.ArgumentList.Add("--auto");
-            _ = ProcessStarterForTesting is { } fake ? fake(psi) : Process.Start(psi);
+            var child = ProcessStarterForTesting is { } fake ? fake(psi) : Process.Start(psi);
+            if (child is not null) {
+                // Redirected pipes must not wedge the child once their buffers fill: drain both
+                // to null while this process lives (the child itself also silences its streams
+                // in --auto, which covers the window after this hook exits).
+                child.StandardInput.Close();
+                _ = child.StandardOutput.BaseStream.CopyToAsync(Stream.Null);
+                _ = child.StandardError.BaseStream.CopyToAsync(Stream.Null);
+            }
         } catch {
             // best effort — never break a hook
         }

--- a/src/Capacitor.Cli/Commands/SkillsAutoSync.cs
+++ b/src/Capacitor.Cli/Commands/SkillsAutoSync.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// Spawns the detached, self-throttling background skills refresh (<c>kcap skills sync --auto</c>).
+/// Fire-and-forget by contract: the caller is a hook with a latency budget, so the child is never
+/// awaited and every failure is swallowed — a missed refresh costs staleness until the next
+/// session start, nothing more.
+/// </summary>
+static class SkillsAutoSync {
+    internal static Func<ProcessStartInfo, Process?>? ProcessStarterForTesting;
+
+    public static void SpawnDetached(string cwd) {
+        try {
+            var psi = new ProcessStartInfo(Environment.ProcessPath ?? "kcap") {
+                WorkingDirectory       = cwd,
+                UseShellExecute        = false,
+                CreateNoWindow         = true,
+                // The hook's stdout is a data channel (the context envelope) — the child must
+                // never inherit it. Its own output is quiet-mode small, so undrained pipes are safe.
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true,
+                RedirectStandardInput  = true,
+            };
+            psi.ArgumentList.Add("skills");
+            psi.ArgumentList.Add("sync");
+            psi.ArgumentList.Add("--auto");
+            _ = ProcessStarterForTesting is { } fake ? fake(psi) : Process.Start(psi);
+        } catch {
+            // best effort — never break a hook
+        }
+    }
+}

--- a/src/Capacitor.Cli/Commands/SkillsAutoSync.cs
+++ b/src/Capacitor.Cli/Commands/SkillsAutoSync.cs
@@ -26,6 +26,9 @@ static class SkillsAutoSync {
             psi.ArgumentList.Add("skills");
             psi.ArgumentList.Add("sync");
             psi.ArgumentList.Add("--auto");
+            // The child must not inherit the hook's ambient coding-agent pipe descriptors —
+            // an inherited data-channel fd would hold the agent open until the sync exits.
+            ProcessHelpers.PreventInheritedHandles();
             var child = ProcessStarterForTesting is { } fake ? fake(psi) : Process.Start(psi);
             if (child is not null) {
                 // Redirected pipes must not wedge the child once their buffers fill: drain both

--- a/src/Capacitor.Cli/Commands/SkillsCommand.cs
+++ b/src/Capacitor.Cli/Commands/SkillsCommand.cs
@@ -141,7 +141,10 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
     }
 
     internal static bool AutoThrottled(SkillsManifest? manifest, DateTimeOffset now) =>
-        manifest?.SyncedAt is { } syncedAt && now - syncedAt < AutoSyncInterval;
+        // A future stamp (clock correction, tampered file) must read as stale, not as an
+        // unbounded suppression of every revocation refresh until that future arrives.
+        manifest?.SyncedAt is { } syncedAt && now - syncedAt is { } age
+            && age >= TimeSpan.Zero && age < AutoSyncInterval;
 
     static SkillsManifest BuildManifest(string? etag, SkillSnapshotItem[] snapshot, string root) => new() {
         Etag = etag, SyncedAt = DateTimeOffset.UtcNow,

--- a/src/Capacitor.Cli/Commands/SkillsCommand.cs
+++ b/src/Capacitor.Cli/Commands/SkillsCommand.cs
@@ -17,7 +17,12 @@ namespace Capacitor.Cli.Commands;
 class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
     const string Vendor = "claude";
 
-    public async Task<int> HandleSync(bool dryRun) {
+    // The background refresh keys off the manifest's synced_at, so a burst of session starts
+    // costs one network round-trip per interval, not one per session.
+    static readonly TimeSpan AutoSyncInterval = TimeSpan.FromHours(6);
+
+    public async Task<int> HandleSync(bool dryRun, bool auto = false) {
+        void Info(string line) { if (!auto) Console.WriteLine(line); }
         var baseUrl = profiles.Resolution.ServerUrl!;
         var cwd = Environment.CurrentDirectory;
 
@@ -34,6 +39,7 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
 
         var manifestPath = config.Path("skills", hash, Vendor, "manifest.json");
         if (!TryLoadManifest(manifestPath, out var manifest)) return 1;
+        if (auto && AutoThrottled(manifest, DateTimeOffset.UtcNow)) return 0;
 
         // Metadata alone cannot prove a skill is served: a deleted or hand-edited SKILL.md must be
         // re-materialized, so local drift forfeits the conditional request — a 304 would otherwise
@@ -58,7 +64,7 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
 
         if (resp.StatusCode == HttpStatusCode.NotModified) {
             if (!dryRun) SaveManifest(manifestPath, manifest! with { SyncedAt = DateTimeOffset.UtcNow });
-            Console.WriteLine($"Skills up to date ({manifest?.Skills?.Length ?? 0} materialized).");
+            Info($"Skills up to date ({manifest?.Skills?.Length ?? 0} materialized).");
             return 0;
         }
         if (await HttpClientExtensions.HandleUnauthorizedAsync(resp)) return 1;
@@ -100,22 +106,25 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
 
         if (writes.Count == 0 && plan.Prunes.Count == 0) {
             if (!dryRun) SaveManifest(manifestPath, BuildManifest(dto.Etag, snapshot, root));
-            Console.WriteLine($"Skills up to date ({snapshot.Length} materialized).");
+            Info($"Skills up to date ({snapshot.Length} materialized).");
             return 0;
         }
 
         foreach (var w in writes)
-            Console.WriteLine($"{(dryRun ? "would write" : "write"),-12} {ClaudeSkillsMaterializer.SkillDirFor(root, w.Slug)} (v{w.Version})");
+            Info($"{(dryRun ? "would write" : "write"),-12} {ClaudeSkillsMaterializer.SkillDirFor(root, w.Slug)} (v{w.Version})");
         foreach (var p in plan.Prunes)
-            Console.WriteLine($"{(dryRun ? "would prune" : "prune"),-12} {p.Path}");
+            Info($"{(dryRun ? "would prune" : "prune"),-12} {p.Path}");
         if (dryRun) return 0;
 
         foreach (var w in writes) ClaudeSkillsMaterializer.Write(root, w);
         foreach (var p in plan.Prunes) ClaudeSkillsMaterializer.Prune(root, p);
         SaveManifest(manifestPath, BuildManifest(dto.Etag, snapshot, root));
-        Console.WriteLine($"Synced {writes.Count} skill(s), pruned {plan.Prunes.Count}; {snapshot.Length} materialized.");
+        Info($"Synced {writes.Count} skill(s), pruned {plan.Prunes.Count}; {snapshot.Length} materialized.");
         return 0;
     }
+
+    internal static bool AutoThrottled(SkillsManifest? manifest, DateTimeOffset now) =>
+        manifest?.SyncedAt is { } syncedAt && now - syncedAt < AutoSyncInterval;
 
     static SkillsManifest BuildManifest(string? etag, SkillSnapshotItem[] snapshot, string root) => new() {
         Etag = etag, SyncedAt = DateTimeOffset.UtcNow,

--- a/src/Capacitor.Cli/Commands/SkillsCommand.cs
+++ b/src/Capacitor.Cli/Commands/SkillsCommand.cs
@@ -37,7 +37,24 @@ class SkillsCommand(ConfigRoot config, ProfileContext profiles) {
         }
         var hash = RepoHashHelper.ComputeRepoHash(repo.Owner, repo.RepoName);
 
-        var manifestPath = config.Path("skills", hash, Vendor, "manifest.json");
+        var manifestName = Path.Combine("skills", hash, Vendor, "manifest.json");
+        var manifestPath = config.Path(manifestName);
+
+        // One sync per (repo, harness) at a time, machine-wide: a burst of session starts must
+        // collapse to ONE refresh — the throttle alone cannot do that, since every child of the
+        // burst reads the same stale synced_at before the winner stamps it. The manifest is
+        // re-read UNDER the lock, so waiters see the winner's stamp. In auto mode contention IS
+        // the answer (someone else is refreshing); a manual sync reports it instead.
+        IDisposable syncLock;
+        try {
+            syncLock = config.AcquireLock(manifestName, auto ? TimeSpan.FromMilliseconds(1) : null);
+        } catch (TimeoutException) {
+            if (auto) return 0;
+            await Console.Error.WriteLineAsync("Another kcap skills sync is already running for this repo.");
+            return 1;
+        }
+        using var heldSyncLock = syncLock;
+
         if (!TryLoadManifest(manifestPath, out var manifest)) return 1;
         if (auto && AutoThrottled(manifest, DateTimeOffset.UtcNow)) return 0;
 

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -454,10 +454,10 @@ switch (command) {
     }
     case "skills": {
         if (args.Length < 2 || args[1] != "sync") {
-            Console.Error.WriteLine("Usage: kcap skills sync [--dry-run]");
+            Console.Error.WriteLine("Usage: kcap skills sync [--dry-run] [--auto]");
             return 1;
         }
-        return await new SkillsCommand(config, profiles).HandleSync(args.Contains("--dry-run"));
+        return await new SkillsCommand(config, profiles).HandleSync(args.Contains("--dry-run"), args.Contains("--auto"));
     }
     case "curate": {
         if (args.Length < 2) {

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -457,7 +457,15 @@ switch (command) {
             Console.Error.WriteLine("Usage: kcap skills sync [--dry-run] [--auto]");
             return 1;
         }
-        return await new SkillsCommand(config, profiles).HandleSync(args.Contains("--dry-run"), args.Contains("--auto"));
+        var skillsAuto = args.Contains("--auto");
+        if (skillsAuto) {
+            // The auto spawn's parent (a hook) exits long before this process does, closing the
+            // pipe read ends — a later write would then throw on a dead fd. Null writers never
+            // touch an fd, so the background sync can outlive its parent safely.
+            Console.SetOut(TextWriter.Null);
+            Console.SetError(TextWriter.Null);
+        }
+        return await new SkillsCommand(config, profiles).HandleSync(args.Contains("--dry-run"), skillsAuto);
     }
     case "curate": {
         if (args.Length < 2) {

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeSkillsMaterializerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeSkillsMaterializerTests.cs
@@ -58,33 +58,3 @@ public class ClaudeSkillsMaterializerTests {
     }
 }
 
-public class SkillsAutoSyncTests {
-    [Test]
-    public async Task Throttle_skips_within_the_interval_and_runs_past_it() {
-        var now = new DateTimeOffset(2026, 8, 26, 12, 0, 0, TimeSpan.Zero);
-        static SkillsManifest M(DateTimeOffset t) => new() { SyncedAt = t };
-
-        await Assert.That(Cli.Commands.SkillsCommand.AutoThrottled(M(now.AddHours(-1)), now)).IsTrue();
-        await Assert.That(Cli.Commands.SkillsCommand.AutoThrottled(M(now.AddHours(-7)), now)).IsFalse();
-        await Assert.That(Cli.Commands.SkillsCommand.AutoThrottled(null, now)).IsFalse();               // no ledger ⇒ sync
-        await Assert.That(Cli.Commands.SkillsCommand.AutoThrottled(new() { SyncedAt = null }, now)).IsFalse();
-    }
-
-    [Test]
-    public async Task Spawn_is_detached_quiet_and_never_throws() {
-        System.Diagnostics.ProcessStartInfo? seen = null;
-        Cli.Commands.SkillsAutoSync.ProcessStarterForTesting = psi => { seen = psi; return null; };
-        try {
-            Cli.Commands.SkillsAutoSync.SpawnDetached("/some/repo");
-            await Assert.That(seen).IsNotNull();
-            await Assert.That(seen!.ArgumentList.ToArray()).IsEquivalentTo(new[] { "skills", "sync", "--auto" });
-            await Assert.That(seen.WorkingDirectory).IsEqualTo("/some/repo");
-            await Assert.That(seen.RedirectStandardOutput).IsTrue();   // the hook's stdout is a data channel
-
-            Cli.Commands.SkillsAutoSync.ProcessStarterForTesting = _ => throw new InvalidOperationException("boom");
-            Cli.Commands.SkillsAutoSync.SpawnDetached("/some/repo");       // swallowed — never breaks a hook
-        } finally {
-            Cli.Commands.SkillsAutoSync.ProcessStarterForTesting = null;
-        }
-    }
-}

--- a/test/Capacitor.Cli.Tests.Unit/ClaudeSkillsMaterializerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ClaudeSkillsMaterializerTests.cs
@@ -57,3 +57,34 @@ public class ClaudeSkillsMaterializerTests {
         }
     }
 }
+
+public class SkillsAutoSyncTests {
+    [Test]
+    public async Task Throttle_skips_within_the_interval_and_runs_past_it() {
+        var now = new DateTimeOffset(2026, 8, 26, 12, 0, 0, TimeSpan.Zero);
+        static SkillsManifest M(DateTimeOffset t) => new() { SyncedAt = t };
+
+        await Assert.That(Cli.Commands.SkillsCommand.AutoThrottled(M(now.AddHours(-1)), now)).IsTrue();
+        await Assert.That(Cli.Commands.SkillsCommand.AutoThrottled(M(now.AddHours(-7)), now)).IsFalse();
+        await Assert.That(Cli.Commands.SkillsCommand.AutoThrottled(null, now)).IsFalse();               // no ledger ⇒ sync
+        await Assert.That(Cli.Commands.SkillsCommand.AutoThrottled(new() { SyncedAt = null }, now)).IsFalse();
+    }
+
+    [Test]
+    public async Task Spawn_is_detached_quiet_and_never_throws() {
+        System.Diagnostics.ProcessStartInfo? seen = null;
+        Cli.Commands.SkillsAutoSync.ProcessStarterForTesting = psi => { seen = psi; return null; };
+        try {
+            Cli.Commands.SkillsAutoSync.SpawnDetached("/some/repo");
+            await Assert.That(seen).IsNotNull();
+            await Assert.That(seen!.ArgumentList.ToArray()).IsEquivalentTo(new[] { "skills", "sync", "--auto" });
+            await Assert.That(seen.WorkingDirectory).IsEqualTo("/some/repo");
+            await Assert.That(seen.RedirectStandardOutput).IsTrue();   // the hook's stdout is a data channel
+
+            Cli.Commands.SkillsAutoSync.ProcessStarterForTesting = _ => throw new InvalidOperationException("boom");
+            Cli.Commands.SkillsAutoSync.SpawnDetached("/some/repo");       // swallowed — never breaks a hook
+        } finally {
+            Cli.Commands.SkillsAutoSync.ProcessStarterForTesting = null;
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ConfigCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ConfigCommandTests.cs
@@ -216,6 +216,29 @@ public class ConfigCommandTests {
             .Throws<ArgumentException>();
     }
 
+    // ── skills.auto_sync ─────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ApplySet_SkillsAutoSync_ParsesBoolean() {
+        var updated = ConfigCommand.ApplySet(new Profile(), "skills.auto_sync", "true");
+        await Assert.That(updated.Skills!.AutoSync!.Value).IsTrue();
+        var off = ConfigCommand.ApplySet(updated, "skills.auto_sync", "false");
+        await Assert.That(off.Skills!.AutoSync!.Value).IsFalse();
+    }
+
+    [Test]
+    public async Task ApplySet_SkillsAutoSync_RejectsNonBoolean() {
+        await Assert.That(() => ConfigCommand.ApplySet(new Profile(), "skills.auto_sync", "yes"))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ApplyUnset_SkillsAutoSync_ClearsTheKey() {
+        var set = ConfigCommand.ApplySet(new Profile(), "skills.auto_sync", "true");
+        var cleared = ConfigCommand.ApplyUnset(set, "skills.auto_sync");
+        await Assert.That(cleared.Skills!.AutoSync).IsNull();
+    }
+
     // ── flows.reviewer_vendor ────────────────────────────────────────────────
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ConfigCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ConfigCommandTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli.Tests.Unit.Commands;
@@ -217,6 +218,27 @@ public class ConfigCommandTests {
     }
 
     // ── skills.auto_sync ─────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Set_WithBlankActiveProfile_WritesTheDefaultProfile() {
+        // Runtime profile resolution normalizes a blank active_profile to "default"; the write
+        // path must land on the SAME identity, or the set reports success while the effective
+        // profile never sees the value.
+        using var tmp  = new TempDir();
+        var root = new ConfigRoot(tmp.Path);
+        Directory.CreateDirectory(tmp.Path);
+        await File.WriteAllTextAsync(AppConfig.GetConfigPath(root), """{"active_profile":"","profiles":{}}""");
+
+        await new ConfigCommand(root).HandleAsync(["config", "set", "skills.auto_sync", "true"]);
+
+        var cfg = await AppConfig.LoadProfileConfig(root);
+        await Assert.That(cfg.Profiles.ContainsKey("")).IsFalse();
+        await Assert.That(cfg.Profiles["default"].Skills!.AutoSync!.Value).IsTrue();
+
+        await new ConfigCommand(root).HandleAsync(["config", "unset", "skills.auto_sync"]);
+        var after = await AppConfig.LoadProfileConfig(root);
+        await Assert.That(after.Profiles["default"].Skills!.AutoSync).IsNull();
+    }
 
     [Test]
     public async Task ApplySet_SkillsAutoSync_ParsesBoolean() {

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SkillsAutoSyncTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SkillsAutoSyncTests.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core.Skills;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+/// <summary>Mutates the process-wide <see cref="SkillsAutoSync.ProcessStarterForTesting"/> seam,
+/// so the class runs alone.</summary>
+[NotInParallel]
+public class SkillsAutoSyncTests {
+    [Test]
+    public async Task Throttle_skips_within_the_interval_and_runs_past_or_outside_it() {
+        var now = new DateTimeOffset(2026, 8, 26, 12, 0, 0, TimeSpan.Zero);
+        static SkillsManifest M(DateTimeOffset t) => new() { SyncedAt = t };
+
+        await Assert.That(SkillsCommand.AutoThrottled(M(now.AddHours(-1)), now)).IsTrue();
+        await Assert.That(SkillsCommand.AutoThrottled(M(now.AddHours(-7)), now)).IsFalse();
+        await Assert.That(SkillsCommand.AutoThrottled(null, now)).IsFalse();                    // no ledger ⇒ sync
+        await Assert.That(SkillsCommand.AutoThrottled(new() { SyncedAt = null }, now)).IsFalse();
+        // A future stamp (clock correction, tampered file) is stale, never an unbounded suppression.
+        await Assert.That(SkillsCommand.AutoThrottled(M(now.AddHours(2)), now)).IsFalse();
+    }
+
+    [Test]
+    public async Task Spawn_is_detached_quiet_and_never_throws() {
+        ProcessStartInfo? seen = null;
+        SkillsAutoSync.ProcessStarterForTesting = psi => { seen = psi; return null; };
+        try {
+            SkillsAutoSync.SpawnDetached("/some/repo");
+            await Assert.That(seen).IsNotNull();
+            await Assert.That(seen!.ArgumentList.ToArray()).IsEquivalentTo(new[] { "skills", "sync", "--auto" });
+            await Assert.That(seen.WorkingDirectory).IsEqualTo("/some/repo");
+            await Assert.That(seen.RedirectStandardOutput).IsTrue();   // the hook's stdout is a data channel
+
+            SkillsAutoSync.ProcessStarterForTesting = _ => throw new InvalidOperationException("boom");
+            SkillsAutoSync.SpawnDetached("/some/repo");                // swallowed — never breaks a hook
+        } finally {
+            SkillsAutoSync.ProcessStarterForTesting = null;
+        }
+    }
+}


### PR DESCRIPTION
AI-2256 (no imported GitHub issue — the Linear issue was not mirrored to this repo)

## What & why

v1 skills sync is manual, so a central revocation reaches a machine only when someone runs `kcap skills sync`. With `kcap config set skills.auto_sync true` (default off), the Claude session-start hook now spawns a detached `kcap skills sync --auto`: fire-and-forget — never awaited, every failure swallowed, the child's stdio redirected since the hook's stdout is a data channel — and self-throttling off the manifest's `synced_at`, so a burst of session starts costs at most one network round-trip per ~6-hour interval per repo. Flipping the default on is deliberately a later decision; this ships the mechanism opt-in.

## Where to look

The throttle reads the ownership manifest before any network call, and `--auto` changes cadence and verbosity only — drift repair, etag semantics and prune containment are untouched.

## Verification

Filtered suites, each with its own exit code: ConfigCommandTests 32/32 (three new `skills.auto_sync` pins), SkillsAutoSyncTests 2/2 (throttle boundaries incl. no-ledger and null `synced_at`; spawn args/cwd/redirection + the swallowed-failure contract via the process-starter seam), SessionStartPlatformStampTests 1/1, ClaudeSkillsMaterializerTests 2/2; Cli and Core build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)