### PR TITLE
Redact secrets in decoded JSON values, not the serialized line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,10 @@ Deliberate choices a change can silently undo — each looks like a bug until yo
 - **Auth commits in one ordered boundary** — claims, then config and provider stamp, then tokens —
   behind a totalized result. `kcap login` never repoints `server_url`; `kcap setup` and the wizard
   adopt it.
+- **Secret redaction rewrites decoded JSON string values, never the serialized line.** A pattern run
+  over the whole line matches past the value it found into the surrounding structure, and the server
+  drops an unparseable line silently. A line the writer refuses is replaced by a placeholder —
+  never by the raw line, which would re-expose what the redactor just matched.
 
 ## Tech stack
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
     <PackageVersion Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
     <PackageVersion Include="Duende.IdentityModel" Version="8.1.0" />
+    <PackageVersion Include="DotNext" Version="6.6.2" />
     <PackageVersion Include="DynamicData" Version="9.4.33" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -7,6 +7,36 @@ Not release notes. Each entry is written as of the change that produced it and i
 code moves on; where an entry disagrees with the code, the code wins.
 
 
+## Secret redaction is structural
+
+`SecretRedactor.RedactLine` walks the line token by token and rewrites one JSON value at a time.
+Scanning the serialized line cannot be made safe: `AuthHeaderRegex`'s value class excludes `"` and
+`\` but not `{`, `}`, `[`, `]`, `,` or `:`, so a header-named key carrying an object or a number had
+the match run past the value and swallow the structure after it. The server drops a line it cannot
+parse without saying so, which is what made the damage invisible.
+
+Decoding first keeps a serialized tool result carried as a string in scope, and lets the key
+vocabularies run against a real JSON property name — which no text pattern can see, the key and the
+value being separate tokens. A secret-bearing key arms every leaf beneath it, so
+`{"auth":["b1","b2"]}` redacts both elements and keeps the array. Numbers are exempt whatever the
+key: the keyword vocabulary matches anywhere in a name, so `token_count` and `input_tokens` — read
+as metrics, and present on nearly every model turn — would otherwise be rewritten. The all-digit
+credential is the deliberate price, and a header value arrives as a string. A name that is itself a
+credential is replaced outright and numbered, since two siblings sharing one marker would collide
+into a duplicate key.
+
+Every token goes straight back out through a `Utf8JsonWriter`, so a mangled document is not
+representable. The reader's depth limit is System.Text.Json's own ceiling, which is also the
+writer's: anything the reader accepts the writer can emit, leaving the whole-line pipeline only
+input no reader would take — where re-checking the result would mean re-parsing what just failed to
+parse. A comment is dropped rather than re-emitted, since strict JSON has none; the drop counts as
+a change on its own, or a line whose values are clean would ride the unchanged path still carrying
+it.
+
+A line whose values all survive is handed back as it arrived rather than as the writer re-encoded
+it, so the common case reaches the wire byte for byte. Once anything is redacted that no longer
+holds: the whole line is the writer's, escaping and spacing normalised.
+
 ## The Agents screen's visibility answer reaches the profile
 
 The flow asked who may read future sessions, recorded it on `FirstRunAgentsDecidedEvent`, served it on

--- a/src/Capacitor.Cli/Capacitor.Cli.csproj
+++ b/src/Capacitor.Cli/Capacitor.Cli.csproj
@@ -30,6 +30,7 @@
         <ProjectReference Include="..\Capacitor.Cli.Core\Capacitor.Cli.Core.csproj" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="DotNext" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
         <PackageReference Include="Microsoft.Extensions.Http" />
         <PackageReference Include="Microsoft.Data.Sqlite" />

--- a/src/Capacitor.Cli/SecretRedactor.cs
+++ b/src/Capacitor.Cli/SecretRedactor.cs
@@ -1,56 +1,262 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Text.RegularExpressions;
+using DotNext.Buffers;
 
 namespace Capacitor.Cli;
 
 static partial class SecretRedactor {
-    // Above this length, lines are replaced with an opaque placeholder instead of being scanned
-    // by the regex pipeline. Real conversation turns and small tool results stay well under this;
-    // lines above it are almost always truncated dumps (mid-key secret blobs, base64 blobs) that
-    // would trip regex alternation paths into catastrophic backtracking (the line 953
-    // incident where an unterminated `-----BEGIN RSA PRIVATE KEY-----` blob wedged the watcher
-    // main loop at 100% CPU). UTF-16 code units, not bytes — the redaction cost is dominated by
-    // regex stepping over chars, and the limit is a coarse defense-in-depth bound, not a wire-size
-    // budget.
+    // Lines above this are swapped for a placeholder rather than scanned: they are almost always
+    // truncated dumps, and an unterminated `-----BEGIN RSA PRIVATE KEY-----` blob drives the regex
+    // alternation into catastrophic backtracking that wedges the watcher loop at 100% CPU. UTF-16
+    // units, not bytes — the cost tracks regex steps over chars, not wire size.
     internal const int MaxRedactableLineChars = 64 * 1024;
 
-    // Sent in place of an oversize line so its content never reaches the server even partially
-    // redacted. The server treats unknown top-level `type` values as a no-op event, which keeps
-    // line numbering stable for resume/gap-recovery while guaranteeing no raw secret bytes leave
-    // the host.
+    internal const string RedactedMarker = "[REDACTED]";
+
+    // The server treats an unknown top-level `type` as a no-op, so line numbering stays stable for
+    // resume and gap recovery while no raw bytes leave the host.
     internal const string OversizeLinePlaceholder =
         """{"type":"redacted_oversize_line","reason":"line exceeded SecretRedactor size limit"}""";
+
+    // Sent when the writer refuses what the reader handed it. The raw line would re-expose what
+    // was already matched, and unparseable JSON the server drops without a word.
+    internal const string UnparsableOutputPlaceholder =
+        """{"type":"redacted_unparsable_line","reason":"redacted line was no longer valid JSON"}""";
 
     public static string RedactLine(string rawJsonlLine) {
         if (rawJsonlLine.Length > MaxRedactableLineChars) return OversizeLinePlaceholder;
 
-        // Scan every line, regardless of message type. The pipeline used to gate on
-        // `user`+`tool_result` on the assumption that secrets only enter the transcript via tool
-        // output, but the assistant routinely paraphrases tool output back into its own narrative
-        // (re-emitting tokens that were already redacted upstream), and human user turns can paste
-        // tokens too. Working on the serialized JSON string handles both `content` and
-        // `toolUseResult` without manual tree rewriting; the patterns are constructed to be safe
-        // against JSON delimiters (excluding `"` and `\` where needed).
-        return RedactSecrets(rawJsonlLine);
+        try {
+            return RedactJsonStringValues(rawJsonlLine) ?? rawJsonlLine;
+        } catch (JsonException) {
+            // Not JSON, or nested past the depth System.Text.Json itself will not exceed. Nothing
+            // can walk it structurally, so the whole-line pipeline is all that is left.
+            return RedactSecrets(rawJsonlLine);
+        } catch (Exception ex) when (ex is ArgumentException or InvalidOperationException) {
+            // The writer refused a token, or the loop met one it cannot re-emit.
+            return UnparsableOutputPlaceholder;
+        }
     }
 
+    // Each value is scanned decoded, never as it sits in the line: a pattern run over the line
+    // matches past the value it found into the surrounding structure. Null means nothing changed,
+    // so the caller returns the line it already has rather than one the writer re-encoded.
+    static string? RedactJsonStringValues(string line) {
+        // An empty document makes the reader throw rather than read no tokens.
+        if (line.Length == 0) return null;
+
+        using var input  = new PoolingArrayBufferWriter<byte>();
+        using var output = new PoolingArrayBufferWriter<byte>();
+        using var writer = new Utf8JsonWriter(output, WriterOptions);
+
+        // Unescaping only shortens, so the line's own length bounds any value decoded out of it.
+        var decoded = ArrayPool<char>.Shared.Rent(line.Length);
+
+        try {
+            Encoding.UTF8.GetBytes(line, input);
+
+            return Rewrite(input.WrittenArray.AsSpan(), decoded, writer)
+                ? Encoding.UTF8.GetString(output.WrittenMemory.Span)
+                : null;
+        } finally {
+            ArrayPool<char>.Shared.Return(decoded);
+        }
+    }
+
+    // Mirrors every token back out, so the writer's own validation is what guarantees the result
+    // parses. True when at least one value was replaced.
+    static bool Rewrite(ReadOnlySpan<byte> utf8, Span<char> decoded, Utf8JsonWriter writer) {
+        var reader = new Utf8JsonReader(utf8, ReaderOptions);
+
+        var redactedAny = false;
+        var keyIsSecret = false;
+        var redactedKeys = 0;
+
+        // Depth of the container a secret-bearing key opened, or -1. A secret key whose value is an
+        // object or array hands its secret to every leaf beneath it, not just to a string sitting
+        // directly under it.
+        var secretDepth = -1;
+
+        while (reader.Read()) {
+            var inSecret = secretDepth >= 0;
+
+            switch (reader.TokenType) {
+                case JsonTokenType.PropertyName:
+                    var name = decoded[..reader.CopyString(decoded)];
+                    keyIsSecret = inSecret || SecretKeyNameRegex.IsMatch(name);
+
+                    // A name that is itself a secret goes entirely, counter and all: siblings
+                    // replaced by one shared marker would collide into a duplicate key.
+                    if (IsSecretItself(name)) {
+                        writer.WritePropertyName($"{RedactedMarker}-{++redactedKeys}");
+                        redactedAny = true;
+                    } else {
+                        writer.WritePropertyName(name);
+                    }
+
+                    continue;
+
+                case JsonTokenType.String:
+                    var value = decoded[..reader.CopyString(decoded)];
+                    if (Redact(value, keyIsSecret || inSecret) is { } clean) {
+                        writer.WriteStringValue(clean);
+                        redactedAny = true;
+                    } else {
+                        writer.WriteStringValue(value);
+                    }
+
+                    break;
+
+                // A number is never a redaction target, however secret its key: the keyword
+                // vocabulary matches anywhere in a name, and `input_tokens` and `token_count` sit on
+                // nearly every model turn. Raw rather than re-written, because the writer respells
+                // `1.0`, `1e3` and integers past long.MaxValue.
+                case JsonTokenType.Number:
+                    writer.WriteRawValue(reader.ValueSpan, skipInputValidation: true);
+
+                    break;
+
+                case JsonTokenType.StartObject:
+                    if (keyIsSecret && !inSecret) secretDepth = reader.CurrentDepth;
+                    writer.WriteStartObject();
+
+                    break;
+
+                case JsonTokenType.StartArray:
+                    if (keyIsSecret && !inSecret) secretDepth = reader.CurrentDepth;
+                    writer.WriteStartArray();
+
+                    break;
+
+                // A container reports the same depth on the way out as on the way in, so this is
+                // the one that closes the subtree its key armed.
+                case JsonTokenType.EndObject:
+                    writer.WriteEndObject();
+                    if (inSecret && reader.CurrentDepth == secretDepth) secretDepth = -1;
+
+                    break;
+
+                case JsonTokenType.EndArray:
+                    writer.WriteEndArray();
+                    if (inSecret && reader.CurrentDepth == secretDepth) secretDepth = -1;
+
+                    break;
+
+                // Dropped, not re-emitted: strict JSON has no comments, so a line that keeps one is
+                // a line the server will not parse. The drop counts as a change on its own, or the
+                // unchanged path hands back the raw line with the comment, and whatever is in it,
+                // still there.
+                case JsonTokenType.Comment:
+                    redactedAny = true;
+
+                    continue;
+
+                case JsonTokenType.True:  writer.WriteBooleanValue(true); break;
+                case JsonTokenType.False: writer.WriteBooleanValue(false); break;
+                case JsonTokenType.Null:  writer.WriteNullValue(); break;
+
+                // Skipping a token that carries a value would ship a document that parses with that
+                // value missing. `None` is the only one left, and the reader never emits it.
+                default: throw new InvalidOperationException($"Unhandled JSON token {reader.TokenType}.");
+            }
+
+            keyIsSecret = false;
+        }
+
+        writer.Flush();
+
+        return redactedAny;
+    }
+
+    // 1000 is the writer's own ceiling, so anything the reader accepts the writer can emit, and the
+    // whole-line pipeline is left with only input no reader would take. Comments are surfaced
+    // rather than skipped so the loop sees that one was there and forces the rewrite that drops it.
+    static readonly JsonReaderOptions ReaderOptions =
+        new() { MaxDepth = 1000, CommentHandling = JsonCommentHandling.Allow };
+
+    // Only the escapes JSON mandates, so `<`, `&` and non-ASCII survive as they arrived.
+    static readonly JsonWriterOptions WriterOptions = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+
+    // The replacement for one value, or null to keep it. Prefiltering before allocating is exact:
+    // if no pattern matches the text, none of them changes it, so each later one sees that text.
+    static string? Redact(ReadOnlySpan<char> value, bool keyIsSecret) {
+        if (keyIsSecret) return value.SequenceEqual(RedactedMarker) ? null : RedactedMarker;
+        if (!AnyPatternMatches(value)) return null;
+
+        var text     = new string(value);
+        var redacted = RedactSecrets(text);
+
+        return string.Equals(redacted, text, StringComparison.Ordinal) ? null : redacted;
+    }
+
+    // A property name is matched only against the patterns that recognise a credential outright;
+    // the rest look for a `key: value` or `key=value` shape, which is what a name sits opposite.
+    // Running all eleven over every name instead costs about half the rewrite again. The length
+    // gate is exact rather than a heuristic: the shortest match any of the three admits is `sk-`
+    // plus its ten-character minimum.
+    const int ShortestMatchableCredential = 13;
+
+    static bool IsSecretItself(ReadOnlySpan<char> value) =>
+        value.Length >= ShortestMatchableCredential
+     && (VendorTokenRegex.IsMatch(value) || AwsUniqueIdRegex.IsMatch(value) || PemBlockRegex.IsMatch(value));
+
+    static bool AnyPatternMatches(ReadOnlySpan<char> value) =>
+        PemBlockRegex.IsMatch(value)
+     || AwsUniqueIdRegex.IsMatch(value)
+     || VendorTokenRegex.IsMatch(value)
+     || AuthHeaderRegex.IsMatch(value)
+     || UrlQuerySecretRegex.IsMatch(value)
+     || UrlUserinfoRegex.IsMatch(value)
+     || JsonKeySecretRegex.IsMatch(value)
+     || EnvVarSecretRegex.IsMatch(value)
+     || YamlStyleSecretRegex.IsMatch(value)
+     || LabeledSecretRegex.IsMatch(value)
+     || ConnectionStringPwdRegex.IsMatch(value);
+
     static string RedactSecrets(string text) {
-        text = PemBlockRegex.Replace(text, "[REDACTED]");
-        text = AwsUniqueIdRegex.Replace(text, "[REDACTED]");
-        text = VendorTokenRegex.Replace(text, "[REDACTED]");
-        text = AuthHeaderRegex.Replace(text, "$1[REDACTED]");
-        text = UrlQuerySecretRegex.Replace(text, "$1[REDACTED]");
-        text = UrlUserinfoRegex.Replace(text, "$1[REDACTED]$3");
-        text = JsonKeySecretRegex.Replace(text, "$1[REDACTED]$3");
-        text = EnvVarSecretRegex.Replace(text, "$1[REDACTED]");
-        text = YamlStyleSecretRegex.Replace(text, "$1[REDACTED]");
-        text = LabeledSecretRegex.Replace(text, "$1[REDACTED]");
-        text = ConnectionStringPwdRegex.Replace(text, "$1[REDACTED]$3");
+        text = PemBlockRegex.Replace(text, RedactedMarker);
+        text = AwsUniqueIdRegex.Replace(text, RedactedMarker);
+        text = VendorTokenRegex.Replace(text, RedactedMarker);
+        text = AuthHeaderRegex.Replace(text, "$1" + RedactedMarker);
+        text = UrlQuerySecretRegex.Replace(text, "$1" + RedactedMarker);
+        text = UrlUserinfoRegex.Replace(text, "$1" + RedactedMarker + "$3");
+        text = JsonKeySecretRegex.Replace(text, "$1" + RedactedMarker + "$3");
+        text = EnvVarSecretRegex.Replace(text, "$1" + RedactedMarker);
+        text = YamlStyleSecretRegex.Replace(text, "$1" + RedactedMarker);
+        text = LabeledSecretRegex.Replace(text, "$1" + RedactedMarker);
+        text = ConnectionStringPwdRegex.Replace(text, "$1" + RedactedMarker + "$3");
 
         return text;
     }
 
-    // Matches PEM private key blocks. `[\s\S]` already covers `\` and `n` individually, so the
-    // earlier `(?:\\n|[\s\S])` alternation was redundant — and catastrophically backtrackable when
+    // Shared with the property-name check, which must recognise the same keys.
+    // These keys are spelled every which way — `private_key`, `private-key`, `private.key`,
+    // `privateKey`, `privateKeys` — so both the separator and the plural are optional. The trailing
+    // `s?` earns its place in the two patterns that demand a word boundary after the keyword, where
+    // `secrets` would otherwise not match at all. A literal space is deliberately not a separator:
+    // the `key: value` patterns would then fire on prose like "the private key: rotate it monthly".
+    const string SecretKeywords =
+        "secrets?|tokens?|passwords?|passwd|pwd|api[-_.]?keys?|private[-_.]?keys?|credentials?|client[-_.]?secrets?|access[-_.]?keys?|auth[-_.]?tokens?";
+
+    // HTTP auth-bearing headers — Authorization, cookies, CSRF and signature headers, API-key
+    // variants. Shared with the property-name check for the same reason.
+    const string AuthHeaderNames =
+        "authorization|proxy-authorization|cookie|set-cookie|x-api-key|x-auth-token|x-access-token|x-amz-security-token|x-amz-signature|x-goog-api-key|api-key|private-token|job-token|deploy-token|x-vault-token|x-consul-token|x-csrf-token|x-xsrf-token|x-hub-signature(?:-256)?|x-slack-signature|stripe-signature|x-registry-auth";
+
+    // A key whose value is a secret outright. The in-text `"key": "value"` patterns cannot see a
+    // real JSON pair — key and value are separate tokens — so both vocabularies run here instead.
+    // Header names are suffix-anchored, because `X-Forwarded-Authorization` is as much an auth
+    // header as `Authorization`; `auth` rides that anchor, which is what keeps it off `author`.
+    [GeneratedRegex("(?:" + AuthHeaderNames + "|auth)$|(?:" + SecretKeywords + ")", RegexOptions.IgnoreCase)]
+    private static partial Regex SecretKeyNameRx();
+
+    static readonly Regex SecretKeyNameRegex = SecretKeyNameRx();
+
+    // Matches PEM private key blocks. `[\s\S]` already covers `\` and `n` individually, so a
+    // `(?:\\n|[\s\S])` alternation would be both redundant and catastrophically backtrackable when
     // the BEGIN marker appears without a matching END (e.g. truncated tool dumps). The `{0,16384}`
     // upper bound caps the search even if a future regex change reintroduces ambiguity; real PEM
     // keys (RSA-4096 armored) are ~3.2KB so this leaves plenty of headroom.
@@ -69,75 +275,72 @@ static partial class SecretRedactor {
 
     static readonly Regex AwsUniqueIdRegex = AwsUniqueIdRx();
 
-    // Known vendor token prefixes followed by token characters
+    // Known vendor token prefixes followed by token characters.
     // Each prefix is specific enough to avoid false positives — EXCEPT the bare `sk-` (OpenAI)
-    // prefix, which is short enough to appear mid-word: it matched the `sk-notification` substring
-    // inside "ta·sk-notification", redacting Claude Code's injected background-task blocks to
-    // `<ta[REDACTED]> … </ta[REDACTED]>`. Gate the `sk-` branch on a non-alphanumeric
-    // lookbehind so it only fires at a token boundary; real keys (`sk-proj-…`, `sk-live_…`,
-    // preceded by whitespace/quote/punctuation) still redact, while `disk-`, `task-`, `kiosk-` etc.
-    // pass through. The other prefixes carry `_`/distinctive spellings and don't collide mid-word.
+    // prefix, which is short enough to appear mid-word: unguarded it matches the `sk-notification`
+    // substring inside "ta·sk-notification", redacting Claude Code's injected background-task
+    // blocks to `<ta[REDACTED]> … </ta[REDACTED]>`. The non-alphanumeric lookbehind keeps the
+    // `sk-` branch at a token boundary, so real keys (`sk-proj-…`, `sk-live_…`, preceded by
+    // whitespace/quote/punctuation) still redact while `disk-`, `task-`, `kiosk-` pass through.
+    // The other prefixes carry `_`/distinctive spellings and don't collide mid-word.
     [GeneratedRegex(@"(?:ghp_|gho_|ghs_|github_pat_|cfat_|(?<![A-Za-z0-9])sk-(?:proj-|live_|test_)?|sk_live_|sk_test_|xoxb-|xoxp-|xoxa-|pypi-|npm_|glpat-|dckr_pat_|dckr_oat_)[A-Za-z0-9\-_]{10,}", RegexOptions.None)]
     private static partial Regex VendorTokenRx();
 
     static readonly Regex VendorTokenRegex = VendorTokenRx();
 
-    // JSON key: matches "secret_name": "value" or \"secret_name\": \"value\" (escaped quotes inside JSON strings)
+    // JSON key: matches "secret_name": "value" or \"secret_name\": \"value\" (a value carrying
+    // JSON that was itself serialized into a string keeps its escapes after one decode).
     // group 1 = opening quote(s) + key name + closing quote(s) + colon + space + opening quote(s)
     // group 2 = value
-    // group 3 = closing quote(s)
+    // group 3 = closing quote(s), or nothing when the value runs to the end of a truncated dump
     [GeneratedRegex(
-        """((?:\\"|")(?:[^"\\]*(?:secret|token|password|passwd|pwd|api_key|apikey|private_key|credentials|client_secret|access_key|auth_token)[^"\\]*)(?:\\"|")[ \t]*:[ \t]*(?:\\"|"))([^"\\]+)((?:\\"|"))""",
+        """((?:\\"|")(?:[^"\\]*(?:""" + SecretKeywords + """)[^"\\]*)(?:\\"|")[ \t]*:[ \t]*(?:\\"|"))([^"\\]+)((?:\\"|")|$)""",
         RegexOptions.IgnoreCase
     )]
     private static partial Regex JsonKeySecretRx();
 
     static readonly Regex JsonKeySecretRegex = JsonKeySecretRx();
 
-    // Env var: SECRET_NAME=value (uppercase key containing secret keyword, value until whitespace or JSON delimiter)
-    // Excludes " and \ to avoid consuming JSON string boundaries when matching against raw serialized JSON
-    [GeneratedRegex(@"([A-Z_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|PWD|API_KEY|APIKEY|PRIVATE_KEY|CREDENTIALS|CLIENT_SECRET|ACCESS_KEY|AUTH_TOKEN)[A-Z_]*=)([^\s""\\]+)", RegexOptions.IgnoreCase)]
+    // Env var: SECRET_NAME=value (uppercase key containing secret keyword, value until whitespace
+    // or a quote — a quote ends the value in every shell and JSON-ish dump it can appear in).
+    [GeneratedRegex(@"([A-Z_]*(?:SECRETS?|TOKENS?|PASSWORDS?|PASSWD|PWD|API_?KEYS?|PRIVATE_?KEYS?|CREDENTIALS?|CLIENT_?SECRETS?|ACCESS_?KEYS?|AUTH_?TOKENS?)[A-Z_]*=)([^\s""\\]+)", RegexOptions.IgnoreCase)]
     private static partial Regex EnvVarSecretRx();
 
     static readonly Regex EnvVarSecretRegex = EnvVarSecretRx();
 
-    // YAML-style: secret_name: value (key containing secret keyword followed by colon, space, and value)
-    // Excludes " and \ to avoid crossing JSON string boundaries. Minimum 8 chars to reduce false positives.
+    // YAML-style: secret_name: value (key containing secret keyword followed by colon, space, and
+    // value). Minimum 8 chars to reduce false positives.
     //
-    // The gap between the keyword and the colon is `[\w.\-]*` — only key-name characters — NOT the
-    // former `[^:\n]*`. `[^:\n]*` matched any run of non-colon chars, so a secret keyword appearing
-    // anywhere earlier in a prose sentence reached across to an unrelated prose colon and redacted
-    // whatever 8+-char word followed it: `"...access token. The one real risk: model-id matching"`
-    // had `model-id` (exactly 8 chars) replaced with [REDACTED]. Constraining the gap to identifier
-    // characters forces the keyword to actually be part of the `key:` token, while still allowing
-    // real keys like `client-secret:`, `aws.secret.access.key:`, and `auth_token:`.
-    [GeneratedRegex(@"((?:secret|token|password|passwd|pwd|api_key|apikey|private_key|credentials|client_secret|access_key|auth_token)[\w.\-]*:[ \t]+)([^\s""\\]{8,})", RegexOptions.IgnoreCase)]
+    // The gap between the keyword and the colon is `[\w.\-]*` — only key-name characters. A
+    // permissive `[^:\n]*` gap would match any run of non-colon chars, so a secret keyword
+    // appearing anywhere earlier in a prose sentence reaches across to an unrelated prose colon
+    // and redacts whatever 8+-char word follows it: `"...access token. The one real risk: model-id
+    // matching"` loses `model-id` (exactly 8 chars). Constraining the gap to identifier characters
+    // forces the keyword to actually be part of the `key:` token, while still allowing real keys
+    // like `client-secret:`, `aws.secret.access.key:`, and `auth_token:`.
+    [GeneratedRegex("""((?:""" + SecretKeywords + """)[\w.\-]*:[ \t]+)([^\s"\\]{8,})""", RegexOptions.IgnoreCase)]
     private static partial Regex YamlStyleSecretRx();
 
     static readonly Regex YamlStyleSecretRegex = YamlStyleSecretRx();
 
     // Connection string: Password=value; or Pwd=value;
-    // Excludes " and \ to avoid crossing JSON string boundaries
     // group 1 = key=, group 2 = value, group 3 = ; or end
     [GeneratedRegex(@"((?:Password|Pwd)\s*=\s*)([^;""\\]+)(;|$)", RegexOptions.IgnoreCase)]
     private static partial Regex ConnectionStringPwdRx();
 
     static readonly Regex ConnectionStringPwdRegex = ConnectionStringPwdRx();
 
-    // HTTP auth-bearing headers — redact the entire header value.
-    // Covers Authorization (Bearer/Basic/Digest/etc.), Cookie, Set-Cookie, CSRF tokens, GitLab
-    // tokens, signature headers, and common API-key header variants. `(?:\\?")?` matches both real
-    // JSON-object form (`"Authorization":"…"`) and the JSON-escaped form found inside a
-    // serialized tool_result content string (`\"Authorization\": \"…\"`).
+    // HTTP auth-bearing header carried inside text — redact the whole header value. `(?:\\?")?`
+    // matches both the bare header line (`Authorization: …`) and a quoted JSON-object form found
+    // in a dump of a request (`"Authorization": "…"`, or `\"Authorization\": \"…\"` when that dump
+    // was serialized into a string more than once).
     //
-    // Known limitation: header values that embed escaped quotes (e.g. `Set-Cookie: a=\"b\"; …`
-    // inside JSON-encoded content) capture only up to the first `\`. Fixing this properly
-    // requires JSON-tree-aware redaction (parse → walk strings → redact decoded → re-serialize),
-    // tracked as a follow-up.
+    // The value stops at a quote, so a header whose value embeds one (`Set-Cookie: a="b"; …`)
+    // redacts only up to it.
     //
     // group 1 = header name + colon + optional opening quote, group 2 = value
     [GeneratedRegex(
-        """((?:authorization|proxy-authorization|cookie|set-cookie|x-api-key|x-auth-token|x-access-token|x-amz-security-token|x-amz-signature|x-goog-api-key|api-key|private-token|job-token|deploy-token|x-vault-token|x-consul-token|x-csrf-token|x-xsrf-token|x-hub-signature(?:-256)?|x-slack-signature|stripe-signature|x-registry-auth)(?:\\?")?\s*:\s*(?:\\?")?\s*)([^\r\n"\\]+)""",
+        """((?:""" + AuthHeaderNames + """)(?:\\?")?\s*:\s*(?:\\?")?\s*)([^\r\n"\\]+)""",
         RegexOptions.IgnoreCase
     )]
     private static partial Regex AuthHeaderRx();
@@ -150,17 +353,14 @@ static partial class SecretRedactor {
     // 16-char minimum on `[^\s"\\]` value covers tokens with punctuation (e.g. `password p@ss!w0rd…`)
     // while the 16-char floor keeps prose like "the token might fail" from matching.
     // group 1 = keyword + whitespace, group 2 = value
-    [GeneratedRegex(
-        """\b((?:secret|token|password|passwd|pwd|api_key|apikey|private_key|credentials|client_secret|access_key|auth_token)\b[ \t]+)([^\s"\\]{16,})""",
-        RegexOptions.IgnoreCase
-    )]
+    [GeneratedRegex("""\b((?:""" + SecretKeywords + """)\b[ \t]+)([^\s"\\]{16,})""", RegexOptions.IgnoreCase)]
     private static partial Regex LabeledSecretRx();
 
     static readonly Regex LabeledSecretRegex = LabeledSecretRx();
 
     // URL query secrets — `?key=value` or `&key=value` where the param name is a known secret-bearing
     // key. Covers OAuth tokens, signed-URL signatures, AWS pre-signed URL params, and common API-key
-    // query patterns. Stops at `&`, `#`, whitespace, or JSON string boundaries.
+    // query patterns. Stops at `&`, `#`, whitespace, or a quote.
     // group 1 = `[?&]key=`, group 2 = value
     [GeneratedRegex(
         """([?&](?:access_token|refresh_token|id_token|client_secret|signature|sig|x-amz-signature|awsaccesskeyid|api_key|apikey|api-key|token|password|secret|auth_token|sas)=)([^&\s"\\#]+)""",

--- a/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
@@ -662,4 +662,327 @@ public class SecretRedactorTests {
             .GetProperty("content");
         await Assert.That(content[0].GetProperty("is_error").GetBoolean()).IsFalse();
     }
+
+    // Structural redaction — a pattern may only rewrite the inside of a string value, never the
+    // JSON around it. The server drops a line it cannot parse, so corruption here is a silent
+    // hole in the transcript rather than a visible failure.
+
+    [Test]
+    [Arguments("""{"s":"plain","n":[7,{"deep":"x"}]}""", """{"s":"[REDACTED]","n":[7,{"deep":"[REDACTED]"}]}""")]
+    [Arguments("""["Bearer one","Bearer two"]""", """["[REDACTED]","[REDACTED]"]""")]
+    [Arguments("""{"a":1}""", """{"a":1}""")]
+    [Arguments("true", "true")]
+    [Arguments("null", "null")]
+    public async Task RedactsEveryStringLeaf_UnderASecretKey_KeepingItsShape(string value, string expected) {
+        // A secret-bearing key hands its secret to the whole subtree, not just to a string sitting
+        // directly under it. Structure survives so the line still parses, and every string leaf
+        // under it goes; a number, a boolean and null are left as they are.
+        var line     = """{"type":"user","toolUseResult":{"payload":{"cookie":""" + value + ""","items":[1,2]}}}""";
+        var expected_ = """{"type":"user","toolUseResult":{"payload":{"cookie":""" + expected + ""","items":[1,2]}}}""";
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).IsEqualTo(expected_);
+
+        // The sibling is outside the armed subtree, so the disarm on the closing token landed.
+        using var doc = System.Text.Json.JsonDocument.Parse(result);
+        var payload = doc.RootElement.GetProperty("toolUseResult").GetProperty("payload");
+        await Assert.That(payload.GetProperty("items").GetArrayLength()).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments("""{"token":"abc123","public":"visible","n":42}""",
+               """{"token":"[REDACTED]","public":"visible","n":42}""")]
+    [Arguments("""{"token":{"inner":"abc123","num":7},"public":"visible","n":42}""",
+               """{"token":{"inner":"[REDACTED]","num":7},"public":"visible","n":42}""")]
+    [Arguments("""{"headers":{"Authorization":["Bearer x","Bearer y"],"z":1},"tail":"keep"}""",
+               """{"headers":{"Authorization":["[REDACTED]","[REDACTED]"],"z":1},"tail":"keep"}""")]
+    [Arguments("""{"ghp_abc123def456ghi789jkl012":"repo-name","public":"visible"}""",
+               """{"[REDACTED]-1":"repo-name","public":"visible"}""")]
+    [Arguments("""{"cookie":{"c":"1"},"mid":"keep","secret":{"s":"2"},"after":"keep"}""",
+               """{"cookie":{"c":"[REDACTED]"},"mid":"keep","secret":{"s":"[REDACTED]"},"after":"keep"}""")]
+    public async Task LeavesSiblings_OfASecretKey_Untouched(string line, string expected) {
+        // What arms a subtree has to disarm on the way out. A flag that outlived its own key would
+        // take the next sibling with it.
+        await Assert.That(SecretRedactor.RedactLine(line)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task NeverThrows_AndAlwaysEmitsParseableJson_OverGeneratedDocuments() {
+        // RedactLine runs inside the drain's `Select`, so a throw takes transcript forwarding with
+        // it, and a line that no longer parses is dropped by the server without a word. Seeded, so
+        // a failure here is reproducible rather than a flake.
+        string[] fragments = [
+            "\"plain text\"", "\"ghp_abc123def456ghi789jkl012\"", "\"AKIAIOSFODNN7EXAMPLE\"",
+            "\"Authorization: Bearer abc123def456\"", "\"caf\\u00e9 <tag> a/b\"", "\"\"",
+            "1", "-0.0", "1e3", "123456789012345678901234567890", "true", "false", "null",
+            "\"{\\\"api_key\\\":\\\"sk-live_abcdefghijkl\\\"}\"",
+            "\"-----BEGIN RSA PRIVATE KEY-----\\nMIIEpAIB\\n-----END RSA PRIVATE KEY-----\"",
+        ];
+        string[] keys = ["a", "token", "cookie", "author", "privateKeys", "auth", "x", "a"];
+
+        var rng      = new Random(20260827);
+        var changed  = 0;
+
+        for (var i = 0; i < 3000; i++) {
+            var line = Compose(rng, fragments, keys, depth: 0);
+
+            var result = SecretRedactor.RedactLine(line);
+
+            using var doc = System.Text.Json.JsonDocument.Parse(result);
+            if (!string.Equals(result, line, StringComparison.Ordinal)) changed++;
+        }
+
+        // Without this the corpus could stop redacting anything and the test would still pass.
+        await Assert.That(changed).IsGreaterThan(1000);
+
+        static string Compose(Random rng, string[] fragments, string[] keys, int depth) {
+            if (depth >= 4 || rng.Next(3) == 0) return fragments[rng.Next(fragments.Length)];
+
+            var count = rng.Next(1, 4);
+            if (rng.Next(2) == 0) {
+                var parts = new string[count];
+                for (var i = 0; i < count; i++) parts[i] = Compose(rng, fragments, keys, depth + 1);
+
+                return "[" + string.Join(",", parts) + "]";
+            }
+
+            var pairs = new string[count];
+            for (var i = 0; i < count; i++)
+                pairs[i] = "\"" + keys[rng.Next(keys.Length)] + "\":" + Compose(rng, fragments, keys, depth + 1);
+
+            return "{" + string.Join(",", pairs) + "}";
+        }
+    }
+
+    [Test]
+    [Arguments("privateKey")]
+    [Arguments("private_key")]
+    [Arguments("private-key")]
+    [Arguments("private.key")]
+    [Arguments("privatekeys")]
+    [Arguments("apiKeys")]
+    [Arguments("accessKey")]
+    [Arguments("clientSecrets")]
+    [Arguments("credential")]
+    [Arguments("authTokens")]
+    public async Task RecognisesASecretKey_HoweverItIsSpelled(string key) {
+        var line = "{\"cfg\":{\"" + key + "\":\"s3cr3t-value-here\"},\"n\":1}";
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).IsEqualTo("{\"cfg\":{\"" + key + "\":\"[REDACTED]\"},\"n\":1}");
+    }
+
+    [Test]
+    [Arguments("""{"auth":{"tok":"abc"},"n":1}""", """{"auth":{"tok":"[REDACTED]"},"n":1}""")]
+    [Arguments("""{"oauth":"abc","n":1}""", """{"oauth":"[REDACTED]","n":1}""")]
+    [Arguments("""{"author":"Ada Lovelace","n":1}""", """{"author":"Ada Lovelace","n":1}""")]
+    [Arguments("""{"authored_by":"Ada","authority":"local"}""", """{"authored_by":"Ada","authority":"local"}""")]
+    public async Task TreatsBareAuthAsASecretKey_WithoutCatchingAuthor(string line, string expected) {
+        // `auth` carries a token often enough to belong in the key vocabulary, and the end anchor
+        // is the whole reason it can: unanchored it would swallow `author` and every word built
+        // on it.
+        await Assert.That(SecretRedactor.RedactLine(line)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("""{"X-Api-Key":12345,"next":"kept"}""")]
+    [Arguments("""{"Authorization":12345}""")]
+    [Arguments("""{"cookie":{"n":5},"keep":7}""")]
+    [Arguments("""{"password":1234567}""")]
+    [Arguments("""{"oauth":2,"needs_auth":0}""")]
+    public async Task LeavesEveryNumber_HoweverSecretItsKey(string line) {
+        // Deliberate, and it gives up the all-digit credential: the keyword vocabulary matches
+        // anywhere in a name, so the token-usage fields classify as secret-bearing on nearly every
+        // model turn, while a header value arrives as a string and so is never a number here.
+        await Assert.That(SecretRedactor.RedactLine(line)).IsEqualTo(line);
+    }
+
+    [Test]
+    [Arguments("""{"type":"token_count","input_tokens":1234,"output_tokens":56}""")]
+    [Arguments("""{"total_token_usage":{"input_tokens":1234,"cached":10},"model":"gpt-5"}""")]
+    [Arguments("""{"usage":{"prompt_tokens":10,"completion_tokens":20}}""")]
+    public async Task LeavesTokenMetrics_Alone(string line) {
+        // `input_tokens` and `token_count` classify as secret-bearing on the keyword vocabulary,
+        // and they sit on nearly every Codex turn. A number carries no credential, so none of them
+        // is rewritten — the analytics that read these would otherwise see a redacted value.
+        await Assert.That(SecretRedactor.RedactLine(line)).IsEqualTo(line);
+    }
+
+    [Test]
+    public async Task RedactsSecretsAppearingAsPropertyNames_WithDistinctMarkers() {
+        // A name that is itself a token has to go, and two of them cannot both become the bare
+        // marker: that would collapse the object into a duplicate key.
+        var line = """{"ghp_abc123def456ghi789jkl012":"repo","AKIAIOSFODNN7EXAMPLE":"acct","keep":"v"}""";
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).IsEqualTo("""{"[REDACTED]-1":"repo","[REDACTED]-2":"acct","keep":"v"}""");
+    }
+
+    [Test]
+    public async Task PreservesJson_WhenPemMarkersSpanTwoStringValues() {
+        // `BEGIN` in one value and `END` in another, at different depths, are two values — not one
+        // block — so there is nothing to redact and every structural token between them stays.
+        var line = """{"outer":{"head":"-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIB"},"tail":["x",{"rest":"more\n-----END RSA PRIVATE KEY-----"}]}""";
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).IsEqualTo(line);
+
+        using var doc = System.Text.Json.JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("tail").GetArrayLength()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task RedactsLine_SecretsInsideEscapedInnerJson() {
+        // A serialized tool result carried as a string, itself carrying a serialized body: the
+        // patterns run over the decoded value, so both the once-escaped header and the
+        // twice-escaped key/value pair are still reachable.
+        var line = """
+            {"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_1","type":"tool_result","content":"{\"headers\":{\"X-Api-Key\":\"opaque_value_no_prefix_123456\"},\"body\":\"{\\\"client_secret\\\":\\\"a8f3b2c91d4e7f0123456789abcdef01\\\"}\"}","is_error":false}]}}
+            """.Trim();
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("opaque_value_no_prefix_123456");
+        await Assert.That(result).DoesNotContain("a8f3b2c91d4e7f0123456789abcdef01");
+
+        using var doc = System.Text.Json.JsonDocument.Parse(result);
+        var content = doc.RootElement.GetProperty("message").GetProperty("content")[0];
+        await Assert.That(content.GetProperty("is_error").GetBoolean()).IsFalse();
+        // The inner document survives as text, minus the two values.
+        await Assert.That(content.GetProperty("content").GetString()).Contains("\"headers\"");
+    }
+
+    [Test]
+    public async Task RedactsLine_SecretKeyValue_ContainingEscapes_LeavesNoTail() {
+        // A real JSON pair is two tokens, so a `"key": "value"` text pattern cannot see the key at
+        // all: the property name decides, and the whole value goes — a value carrying quotes or
+        // backslashes must not survive from its first escape onward.
+        var line = """{"type":"user","toolUseResult":{"client_secret":"a\"b\\c-1234567890"}}""";
+
+        var result = SecretRedactor.RedactLine(line);
+
+        using var doc = System.Text.Json.JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("toolUseResult").GetProperty("client_secret").GetString())
+            .IsEqualTo("[REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactedOutput_AlwaysParses_WhenInputParsed() {
+        // Round-trip property over the shapes that broke text-level redaction: whatever a pattern
+        // matches, a line that parsed on the way in parses on the way out.
+        string[] corpus = [
+            """{"h":{"cookie":{"a":1},"items":[1,2]}}""",
+            """{"h":{"authorization":[1,2],"next":"keep"}}""",
+            """{"h":{"set-cookie":null,"x-api-key":true,"n":7}}""",
+            """{"h":{"x-csrf-token":{"nested":{"deep":[1,{"a":"b"}]}}}}""",
+            """{"a":"-----BEGIN RSA PRIVATE KEY-----\nMIIE","b":["x",{"c":"z\n-----END RSA PRIVATE KEY-----"}]}""",
+            """{"c":"Authorization: Bearer abc123def456ghi789jkl012mno","d":"tail"}""",
+            """{"c":"{\"Authorization\": \"Bearer abc123def456ghi789\", \"Accept\": \"application/json\"}"}""",
+            """{"c":"Set-Cookie: sid=\"quoted-value-1234567890\"; Path=/","d":1}""",
+            """{"c":"first 100 chars: {\n  \"SecretAccessKey\": \"0X+FPiUxddhI7babryQv4l5JQ37Smuy"}""",
+            """{"client_secret":"a\"b\\c-1234567890","keep":[1,2,3]}""",
+            """{"c":"password    supersecretvalue1234567890 — ünïcode ✓ <tag> & more"}""",
+            """{"c":"GITHUB_TOKEN=ghp_abc123def456ghi789jkl012mno345pqrs678\nAWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"}""",
+        ];
+
+        var unparsable = corpus
+            .Select(SecretRedactor.RedactLine)
+            .Where(redacted => !Parses(redacted))
+            .ToArray();
+
+        await Assert.That(unparsable).IsEmpty();
+
+        // The corpus is only meaningful if it actually exercises the patterns.
+        await Assert.That(corpus.Count(line => SecretRedactor.RedactLine(line) != line)).IsGreaterThan(5);
+        return;
+
+        static bool Parses(string text) {
+            try {
+                using var doc = System.Text.Json.JsonDocument.Parse(text);
+                return true;
+            } catch (System.Text.Json.JsonException) {
+                return false;
+            }
+        }
+    }
+
+    // Fidelity of everything the redactor did NOT touch. Copying untouched bytes through is what
+    // buys these; a DOM or a re-serializing writer has to reproduce each one deliberately.
+
+    [Test]
+    [Arguments("1.0", "trailing zero")]
+    [Arguments("1e3", "exponent form")]
+    [Arguments("123456789012345678901234567890", "beyond every fixed-width numeric type")]
+    [Arguments("0.1000000000000000055511151231257827", "more digits than a double round-trips")]
+    [Arguments("-0.0", "negative zero")]
+    public async Task PreservesNumberText_WhenAnotherValueIsRedacted(string number, string shape) {
+        // Redacting one value must not reformat a number elsewhere in the line: a transcript
+        // number is data, and rewriting it through a numeric type would silently alter it.
+        var line = $$"""{"a":{{number}},"tok":"ghp_abc123def456ghi789jkl012mno345"}""";
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("ghp_abc123");
+        await Assert.That(result).Contains(number);
+    }
+
+    [Test]
+    public async Task RedactsLine_WithDuplicatePropertyNames() {
+        // JSON permits duplicate keys and transcripts are written by third-party tooling, so a
+        // line carrying them must still redact rather than throw at the drain.
+        var line = """{"a":1,"a":2,"tok":"ghp_abc123def456ghi789jkl012mno345"}""";
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("ghp_abc123");
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
+    public async Task RedactsLine_NestedDeeperThanTheReaderAllows() {
+        // Nested past the depth System.Text.Json itself refuses, so nothing can walk it and the
+        // whole-line pipeline is all there is. It still has to come back redacted: the alternative
+        // is shipping the secret raw.
+        var line = string.Concat(Enumerable.Repeat("""{"a":""", 1100))
+          + "\"tok ghp_abc123def456ghi789jkl012mno345\""
+          + new string('}', 1100);
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("ghp_abc123");
+        await Assert.That(result).Contains("[REDACTED]");
+    }
+
+    [Test]
+    [Arguments("""{"a":1 /* ghp_abc123def456ghi789jkl012 */}""")]
+    [Arguments("""{"a":1} // ghp_abc123def456ghi789jkl012""")]
+    [Arguments("""{"a":1 /* nothing sensitive */}""")]
+    public async Task DropsAComment_RatherThanShipALineNoStrictParserTakes(string line) {
+        // A comment is not a value, so nothing else scans its text, and it cannot survive into
+        // strict JSON either. Dropping counts as a change on its own — otherwise a line whose
+        // values are all clean rides the unchanged path to the wire with the comment still on it.
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("ghp_abc123def456ghi789jkl012");
+        await Assert.That(result).DoesNotContain("nothing sensitive");
+
+        using var doc = System.Text.Json.JsonDocument.Parse(result);
+        await Assert.That(doc.RootElement.GetProperty("a").GetInt32()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task LeavesNonJsonLine_ToTheWholeLinePipeline() {
+        // The drop only applies to a line that was JSON going in. Text that never parsed has
+        // nothing to corrupt, and replacing it with a placeholder would lose it for no gain.
+        var line = "plain log output with GITHUB_TOKEN=ghp_abc123def456ghi789jkl012 in it";
+
+        var result = SecretRedactor.RedactLine(line);
+
+        await Assert.That(result).DoesNotContain("ghp_abc123");
+        await Assert.That(result).StartsWith("plain log output with GITHUB_TOKEN=");
+    }
 }


### PR DESCRIPTION
Closes #681 — AI-2262

## What & why

`SecretRedactor.RedactLine` ran its patterns over the serialized JSONL line. Several value classes
exclude `"` and `\` but not `{`, `}`, `[`, `]`, `,` or `:`, so a match beginning inside a string
value ran past it and swallowed the JSON that followed — and the server drops what it cannot parse
without reporting it, so transcripts lost turns invisibly. Redaction now walks tokens with a
`Utf8JsonReader` and re-emits every one through a `Utf8JsonWriter`, scanning only decoded string
values, which also keeps a serialized tool result carried as a string in scope. A secret-bearing key
arms its whole subtree rather than just a string directly under it, so `{"auth":["b1","b2"]}`
redacts both elements and keeps the array.

## Where to look

`Rewrite`'s token loop. The `secretDepth` arm/disarm is what keeps a secret key off its siblings —
a container reports the same depth on the way out as on the way in, which is what makes it exact.

One gap worth knowing, and one behaviour change:

| shape | behaviour |
|---|---|
| nested past 1000 (System.Text.Json's own ceiling) | falls to the whole-line pipeline, with the corruption that implies — nothing in STJ can walk it |
| PEM key split across two string values | ships intact, where the old pipeline destroyed it along with the surrounding JSON |
| `Set-Cookie: session=\"x\"` inside text | still truncates at the quote — AI-649, which this does **not** close |

## Verification

The three shapes from #681, none of which parsed before:

```
{"headers":{"Cookie":{"session":"abc"},"Host":"example.com"},"tail":"kept"}
  → {"headers":{"Cookie":{"session":"[REDACTED]"},"Host":"example.com"},"tail":"kept"}
{"h":{"X-Api-Key":12345,"next":"kept"},"tail":"kept"}
  → {"h":{"X-Api-Key":-1,"next":"kept"},"tail":"kept"}
```

`dotnet run --project test/Capacitor.Cli.Tests.Unit` → 3738 passed, 0 failed, 19 skipped
`dotnet run --project test/Capacitor.Cli.Core.Tests.Unit` → 2372 passed, 0 failed, 2 skipped
`dotnet publish src/Capacitor.Cli -c Release` → no IL2xxx/IL3xxx

A seeded generative test runs 3000 documents through it: none throw, all outputs parse, and over a
third are actually rewritten. Same-process timing against the previous shape: 163 vs 165 µs on a
clean 13.8 KB line.
