### PR TITLE
Desktop shell: chat for PTY harnesses

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
     <PackageVersion Include="Duende.IdentityModel" Version="8.1.0" />
     <PackageVersion Include="DynamicData" Version="9.4.33" />
+    <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -160,6 +160,29 @@ still cannot hold a socket open past the drain. The companion guard lives in `Na
 first shutdown pass latches (which also bumps the generation), so `OpenSession` — card click or launch
 auto-open alike — rejects from then on in every window, current or later-built.
 
+## Session chat
+
+**AI-2196** (spec: `docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md`)
+renders a Claude or interactive Codex session's own transcript as the workspace's Chat tab and sends
+composer text to the PTY. **The daemon, not the app, knows where the transcript is**: every PTY launch
+runs the same transcript discovery the server-driven path used, and the link-resolved path rides
+`AgentStatusDto.transcript_path` — link-resolved because the per-worktree Claude project dir is a
+symlink the launcher deletes at cleanup. Discovery runs until the *path* is known and pulses the
+status notifier before any server report. Every transcript open shares read/write/delete; the tail
+promises only length-regression reset. **Composer sends are accepted, never acknowledged**, and one
+at a time: bracketed paste, a 150 ms wait past Codex's post-paste Enter suppression, then one CR —
+only if the terminal's opening token is unchanged. The token advances only through `BeginAttempt`
+(after the attach lane is won) and `Invalidate` (detach, teardown, removal, every terminal outcome);
+an attempt's own `Connecting`/`Attached` publishes never advance it, and a stale token discards a
+late `Attached`, so a queued attach callback cannot reopen a terminal the daemon already dropped.
+`TerminalHost` stays laid out under the Chat tab (faded, disabled, reported offscreen) so the PTY
+clamp sees the real pane size; everything else collapses with `IsVisible`. Links open only through
+`LinkPolicy` (absolute http/https) via one tab-level command. **Markdown never emits a `LineBreak`
+inline or a newline inside a `Run`**: Avalonia 12's line breaker never finishes laying one out under a
+height-unconstrained parent (any `StackPanel` or `ScrollViewer`), so a soft break is a space and a
+hard break splits the paragraph into stacked text blocks; the pipeline carries precise source
+locations only so an unmapped inline can degrade to its own source text rather than a type name.
+
 ## Launch and stop command routing
 
 The receive pump no longer awaits launch/stop EXECUTION for either command format: arrival order is

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -159,12 +159,15 @@ and observed rather than refused, so a workspace a coordinator builds between th
 still cannot hold a socket open past the drain. The companion guard lives in `NavigationGate`: its
 first shutdown pass latches (which also bumps the generation), so `OpenSession` — card click or launch
 auto-open alike — rejects from then on in every window, current or later-built.
-The feed into the embedded emulator is rewritten first (`TerminalFeedSanitizer`): XTerm.NET has no
-arm for the underline-colour selectors 58/59, so their arguments are read as attribute codes — a `4`
-among them underlines every later cell, and agent renderers close styles one at a time and never send
-the full reset that would clear it — and it drops any parameter with colon sub-parameters, losing
-`4:0` and the colon truecolour form. `KCAP_APP_PTY_DUMP=<file>` appends every fed frame as received,
-the only record of what the emulator was given.
+The feed into the embedded emulator is rewritten first (`TerminalFeedSanitizer`): XTerm.NET
+dispatches a CSI on its final byte alone, so xterm's modifyOtherKeys set — `CSI > 4 ; 2 m`, which
+Claude Code sends on every return to raw mode — reaches the SGR handler as "underline on, dim on",
+and agent renderers close styles one at a time and never send the full reset that would clear it;
+every private-parameter sequence ending in `m` is dropped. The same handler has no arm for the
+underline-colour selectors 58/59, whose arguments are read as attribute codes, and drops any
+parameter with colon sub-parameters, losing `4:0` and the colon truecolour form.
+`KCAP_APP_PTY_DUMP=<file>` appends every fed frame as received, the only record of what the
+emulator was given.
 
 ## Session chat
 

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -159,6 +159,12 @@ and observed rather than refused, so a workspace a coordinator builds between th
 still cannot hold a socket open past the drain. The companion guard lives in `NavigationGate`: its
 first shutdown pass latches (which also bumps the generation), so `OpenSession` — card click or launch
 auto-open alike — rejects from then on in every window, current or later-built.
+The feed into the embedded emulator is rewritten first (`TerminalFeedSanitizer`): XTerm.NET has no
+arm for the underline-colour selectors 58/59, so their arguments are read as attribute codes — a `4`
+among them underlines every later cell, and agent renderers close styles one at a time and never send
+the full reset that would clear it — and it drops any parameter with colon sub-parameters, losing
+`4:0` and the colon truecolour form. `KCAP_APP_PTY_DUMP=<file>` appends every fed frame as received,
+the only record of what the emulator was given.
 
 ## Session chat
 

--- a/docs/superpowers/plans/2026-08-26-ai2196-chat-for-pty-harnesses.md
+++ b/docs/superpowers/plans/2026-08-26-ai2196-chat-for-pty-harnesses.md
@@ -1,0 +1,3982 @@
+# Chat for PTY harnesses Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give a Claude or interactive Codex session in the desktop app a Chat tab rendered from the vendor's own transcript file, with a composer that sends to the PTY, without any new local-IPC frame.
+
+**Architecture:** The daemon already locates each PTY agent's transcript; it now stamps the link-resolved path onto the existing `AgentStatusDto` as a trailing nullable member. Core gains a total, sharing-safe `JsonlTail` and two public per-vendor line→`AcpEventEnvelope` projections behind one `ITranscriptProjection` seam. The app's `WorkspaceViewModel` grows a `ChatTabViewModel` (poll → project → `AvaloniaList.AddRange`), a Markdig-backed `MarkdownView`, and a composer that delivers text through the sibling `TerminalTabViewModel` behind an opening-token send gate.
+
+**Tech Stack:** .NET 10, Avalonia 12.1.1 + ReactiveUI.Avalonia + DynamicData, TUnit on MTP, `Microsoft.Extensions.TimeProvider.Testing`, Markdig 1.3.2 (app only), System.Text.Json (Core, AOT-safe).
+
+**Spec:** `docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md` — read it first; every task below cites the section it implements.
+
+## Global Constraints
+
+- Core (`src/Capacitor.Cli.Core`) is `IsAotCompatible`/`IsTrimmable` and compiles into two NativeAOT binaries: BCL + `System.Text.Json` only, `Utf8JsonWriter` for anything built rather than copied, `[GeneratedRegex]` for any regex, never reflection-based serialization. Final acceptance runs `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` and expects no output.
+- Every JSON read in Core goes through `JsonElementExtensions` (`Str/Num/Bool/Obj/Arr/Prop`), never raw `GetProperty`/`ValueKind` checks.
+- Every open of an agent-owned transcript is `new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete)`. Never `File.ReadAllText`/`File.ReadLines` on a transcript.
+- `AgentStatusDto` members are trailing, nullable, always emitted (JSON null, never omitted). The context must never gain a `DefaultIgnoreCondition`.
+- Daemon status mutations: mutate first, `_statusNotifier.Pulse()` second, never a pulse behind an awaited server call.
+- App: every daemon-fed observable goes through `ObserveOn(RxSchedulers.MainThreadScheduler)` before touching bound state; pool-thread completions hop through `Dispatcher.UIThread.InvokeAsync`; VMs are ctor-scoped with `TeardownAsync` as the one exit; no state lives in views.
+- Tests: `[TempDir] public required TempDir Tmp { get; init; }` or `using var tmp = new TempDir();`; build paths with `tmp.PathTo(…)`, `tmp.CreateFile(…)`, `tmp.CreateDir(…)`. UI tests carry `[NotInParallel("AvaloniaSession")]` and run inside `RunOnUiAsync`. Never assert an env var is absent from a `ProcessStartInfo`.
+- Comments: scarce; never design/ticket coordinates, review artifacts, or change narration. State the constraint that would otherwise be undone.
+- Commit subjects: one imperative clause, ≤ 80 chars, no issue reference (none is known), body ≤ 5 lines, end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Composer delivery constants (verbatim from the spec): bracketed paste `ESC[200~` … `ESC[201~`, then `\r` after **150 ms**; poll interval **500 ms**; tool-result cap **4096** UTF-16 units including the `…` marker; tool detail cut at **80** characters.
+
+## File structure
+
+**Core (`src/Capacitor.Cli.Core`)**
+- `LocalIpc/StatusIpc.cs` — modify: `AgentStatusDto.TranscriptPath`.
+- `JsonElementExtensions.cs` — modify: `Prop(name)`.
+- `JsonlTail.cs` — create: `JsonlTail`, `TailRead`, `TailStatus`.
+- `TranscriptProjection.cs` — create: `ITranscriptProjection`, `TranscriptProjection.For`, internal `TranscriptProjectionText` (cap, join, object wrapping).
+- `Harness/Claude/ClaudeTranscriptEvents.cs` — create.
+- `Harness/Codex/CodexRolloutEvents.cs` — create.
+
+**Daemon (`src/Capacitor.Cli.Daemon`)**
+- `Harness/Claude/SessionTranscriptLocator.cs` — modify: `TryLocateWinner`, link resolution.
+- `Services/TranscriptDiscovery.cs` — create: the `TimeProvider`-driven poll.
+- `Services/AgentOrchestrator.cs` — modify: `AgentInstance.TranscriptPath`, discovery wiring, test seams.
+- `Services/AgentOrchestrator.LocalIpc.cs` — modify: local spawn starts discovery; snapshot stamps the path.
+
+**App (`src/Capacitor.App`)**
+- `Directory.Packages.props`, `Capacitor.App.csproj` — modify: Markdig.
+- `Services/TerminalInputEncoder.cs`, `Services/LinkPolicy.cs` — create.
+- `ViewModels/ToolDetail.cs`, `ViewModels/ChatItems.cs`, `ViewModels/ChatTabViewModel.cs` — create.
+- `ViewModels/TerminalTabViewModel.cs` — modify: send gate.
+- `ViewModels/WorkspaceViewModel.cs` — modify: `Chat`, `ActiveTab`.
+- `Views/MarkdownBlocks.cs`, `Views/MarkdownView.cs`, `Views/ChatTabView.axaml(.cs)` — create.
+- `Views/WorkspaceView.axaml(.cs)`, `Views/Converters.cs` — modify.
+- `App.axaml.cs` — modify: workspace factory passes the opener.
+- `docs/CHANGES.md` — modify.
+
+**Tests** mirror the prod directories: `test/Capacitor.Cli.Core.Tests.Unit/{JsonlTailTests,TranscriptProjectionTests,JsonElementExtensionsTests}.cs`, `test/Capacitor.Cli.Core.Tests.Unit/Harness/{Claude/ClaudeTranscriptEventsTests,Codex/CodexRolloutEventsTests}.cs`, `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs`; `test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/SessionTranscriptLocatorTests.cs`, `.../Services/{TranscriptDiscoveryTests,AgentStatusSnapshotTests,AgentOrchestratorLocalAttachTests}.cs`; `test/Capacitor.App.Tests.Unit/{TerminalInputEncoderTests,LinkPolicyTests,ToolDetailTests,TerminalSendGateTests,ChatTabViewModelTests,ChatComposerTests,MarkdownBlocksTests,WorkspaceViewModelTests,WorkspaceViewSmokeTests,ChatTabViewSmokeTests}.cs`.
+
+**Running one suite while iterating** (faster than the solution run):
+
+```bash
+dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/JsonlTailTests/*"
+```
+
+The filter is `/<assembly>/<namespace>/<class>/<test>` with globs; `--filter` is NOT supported.
+
+---
+
+### Task 1: `transcript_path` on the status wire
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs`
+
+**Interfaces:**
+- Produces: `AgentStatusDto(..., bool? HasTerminal = null, string? Title = null, string? TranscriptPath = null)`; serialized member `transcript_path`, last.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `StatusIpcJsonTests`:
+
+```csharp
+    [Test]
+    public async Task Transcript_path_serializes_last_and_null_is_emitted() {
+        var withPath = new AgentStatusDto(
+            "a1", "agent", "claude", "/repo", "Running",
+            null, null, null, new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc), null, null,
+            HasTerminal: true, Title: "t", TranscriptPath: "/home/u/.claude/projects/-repo/abc.jsonl");
+        var without = withPath with { TranscriptPath = null };
+
+        var json = JsonSerializer.Serialize(withPath, StatusIpcJsonContext.Default.AgentStatusDto);
+        var jsonNull = JsonSerializer.Serialize(without, StatusIpcJsonContext.Default.AgentStatusDto);
+
+        await Assert.That(json).EndsWith(""","has_terminal":true,"title":"t","transcript_path":"/home/u/.claude/projects/-repo/abc.jsonl"}""");
+        await Assert.That(jsonNull).EndsWith(""","has_terminal":true,"title":"t","transcript_path":null}""");
+    }
+
+    [Test]
+    public async Task Old_agent_json_without_transcript_path_deserializes_to_null() {
+        var dto = new AgentStatusDto(
+            "a1", "agent", "claude", "/repo", "Running",
+            null, null, null, DateTime.UtcNow, null, null, TranscriptPath: "/x.jsonl");
+        var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
+        var stripped = System.Text.RegularExpressions.Regex.Replace(json, ",\"transcript_path\":[^,}]+", "");
+
+        var back = JsonSerializer.Deserialize(stripped, StatusIpcJsonContext.Default.AgentStatusDto);
+
+        await Assert.That(back!.TranscriptPath).IsNull();
+    }
+```
+
+Also extend the exact-JSON pin `DaemonStatus_serializes_exactly_with_nulls_present_and_pinned_field_order`: append `,"transcript_path":null` after `"title":"Fix the flaky test"` and after `"title":null` in the expected string.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/StatusIpcJsonTests/*"`
+Expected: build error — `TranscriptPath` is not a member of `AgentStatusDto`.
+
+- [ ] **Step 3: Add the member**
+
+In `StatusIpc.cs`, after `string? Title = null` inside `AgentStatusDto`:
+
+```csharp
+    string? Title = null,
+    // Where the daemon found the agent's own transcript (Claude's project .jsonl, Codex's
+    // rollout), link-resolved. Trailing + nullable: null is "older daemon", "not found yet",
+    // "no transcript for this runtime", or "found nothing before the agent exited" alike —
+    // a client waits, it never distinguishes them.
+    string? TranscriptPath = null);
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run the same command. Expected: all `StatusIpcJsonTests` PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs
+git commit -m "Carry the agent's transcript path on the status wire
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `JsonElementExtensions.Prop`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/JsonElementExtensions.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/JsonElementExtensionsTests.cs` (create)
+
+**Interfaces:**
+- Produces: `JsonElement? Prop(string property)` — the named property of any kind (arrays, scalars, JSON null included) as an element; null when the receiver is not an object or the property is absent.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class JsonElementExtensionsTests {
+    static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Test]
+    public async Task Prop_returns_any_kind_and_null_when_absent_or_not_an_object() {
+        var el = Parse("""{"arr":[1,2],"num":3,"nil":null,"str":"s"}""");
+
+        await Assert.That(el.Prop("arr")!.Value.ValueKind).IsEqualTo(JsonValueKind.Array);
+        await Assert.That(el.Prop("num")!.Value.GetInt32()).IsEqualTo(3);
+        await Assert.That(el.Prop("nil")!.Value.ValueKind).IsEqualTo(JsonValueKind.Null);
+        await Assert.That(el.Prop("str")!.Value.GetString()).IsEqualTo("s");
+        await Assert.That(el.Prop("absent")).IsNull();
+        await Assert.That(Parse("[1]").Prop("x")).IsNull();
+        await Assert.That(Parse("\"scalar\"").Prop("x")).IsNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/JsonElementExtensionsTests/*"`
+Expected: build error — no `Prop` member.
+
+- [ ] **Step 3: Add the accessor**
+
+Inside the `extension(JsonElement el)` block, after `Arr`:
+
+```csharp
+        // The property as-is, whatever its kind — for the one caller that has to copy a value
+        // verbatim (a non-object tool input wrapped into an object). Every other read wants a
+        // typed accessor above; this one deliberately answers "present" for JSON null too.
+        public JsonElement? Prop(string property) => el.IsObject && el.TryGetProperty(property, out var v) ? v : null;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Same command. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/JsonElementExtensions.cs test/Capacitor.Cli.Core.Tests.Unit/JsonElementExtensionsTests.cs
+git commit -m "Add an any-kind property accessor to JsonElementExtensions
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `JsonlTail`
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/JsonlTail.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/JsonlTailTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `public enum TailStatus { Ok, Reset, Missing, Failed }`
+  - `public sealed record TailRead(IReadOnlyList<string> Lines, TailStatus Status, string? Failure = null)`
+  - `public sealed class JsonlTail(string path)` with `string Path`, `long Cursor`, `TailRead ReadAppended()` (never throws), `static List<string> SplitCompleteLines(ReadOnlySpan<byte> bytes, out int consumed)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using System.Text;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class JsonlTailTests {
+    [TempDir] public required TempDir Tmp { get; init; }
+
+    [Test]
+    public async Task Complete_lines_are_delivered_once_and_a_partial_final_line_is_held() {
+        var path = Tmp.CreateFile("t.jsonl", "{\"a\":1}\n{\"b\":2}\n{\"c\":");
+        var tail = new JsonlTail(path);
+
+        var first = tail.ReadAppended();
+        await Assert.That(first.Status).IsEqualTo(TailStatus.Ok);
+        await Assert.That(first.Lines).IsEquivalentTo(new[] { "{\"a\":1}", "{\"b\":2}" });
+
+        var second = tail.ReadAppended();
+        await Assert.That(second.Lines).IsEmpty();
+
+        File.AppendAllText(path, "3}\n");
+        var third = tail.ReadAppended();
+        await Assert.That(third.Lines).IsEquivalentTo(new[] { "{\"c\":3}" });
+    }
+
+    [Test]
+    public async Task Crlf_is_stripped_and_blank_lines_are_skipped() {
+        var path = Tmp.CreateFile("t.jsonl", "{\"a\":1}\r\n\n   \n{\"b\":2}\r\n");
+        var read = new JsonlTail(path).ReadAppended();
+
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"a\":1}", "{\"b\":2}" });
+    }
+
+    [Test]
+    public async Task Length_regression_resets_and_rereads_from_zero() {
+        var path = Tmp.CreateFile("t.jsonl", "{\"a\":1}\n{\"b\":2}\n");
+        var tail = new JsonlTail(path);
+        tail.ReadAppended();
+
+        File.WriteAllText(path, "{\"z\":9}\n");
+        var read = tail.ReadAppended();
+
+        await Assert.That(read.Status).IsEqualTo(TailStatus.Reset);
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"z\":9}" });
+        await Assert.That(tail.Cursor).IsEqualTo(8);
+    }
+
+    [Test]
+    public async Task Missing_file_is_reported_then_read_once_it_appears() {
+        var path = Tmp.PathTo("later.jsonl");
+        var tail = new JsonlTail(path);
+
+        await Assert.That(tail.ReadAppended().Status).IsEqualTo(TailStatus.Missing);
+
+        File.WriteAllText(path, "{\"a\":1}\n");
+        var read = tail.ReadAppended();
+        await Assert.That(read.Status).IsEqualTo(TailStatus.Ok);
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"a\":1}" });
+    }
+
+    [Test]
+    public async Task A_transient_failure_keeps_the_cursor_and_the_next_read_succeeds() {
+        var path = Tmp.CreateFile("t.jsonl", "{\"a\":1}\n");
+        var tail = new JsonlTail(path);
+        tail.ReadAppended();
+
+        // A directory in the file's place is the one failure every OS reports as neither
+        // FileNotFound nor DirectoryNotFound when opened for read.
+        File.Delete(path);
+        Directory.CreateDirectory(path);
+        var failed = tail.ReadAppended();
+        await Assert.That(failed.Status).IsEqualTo(TailStatus.Failed);
+        await Assert.That(failed.Failure).IsNotNull();
+        await Assert.That(tail.Cursor).IsEqualTo(8);
+
+        Directory.Delete(path);
+        File.WriteAllText(path, "{\"a\":1}\n{\"b\":2}\n");
+        var read = tail.ReadAppended();
+        await Assert.That(read.Status).IsEqualTo(TailStatus.Ok);
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"b\":2}" });
+    }
+
+    [Test]
+    public async Task Reads_a_file_another_handle_holds_open_for_writing() {
+        var path = Tmp.PathTo("live.jsonl");
+        using var writer = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
+        writer.Write(Encoding.UTF8.GetBytes("{\"a\":1}\n"));
+        writer.Flush();
+
+        var read = new JsonlTail(path).ReadAppended();
+
+        await Assert.That(read.Status).IsEqualTo(TailStatus.Ok);
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"a\":1}" });
+    }
+
+    [Test]
+    public async Task Split_consumes_only_through_the_last_newline() {
+        var bytes = Encoding.UTF8.GetBytes("x\ny\nzz");
+        var lines = JsonlTail.SplitCompleteLines(bytes, out var consumed);
+
+        await Assert.That(lines).IsEquivalentTo(new[] { "x", "y" });
+        await Assert.That(consumed).IsEqualTo(4);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/JsonlTailTests/*"`
+Expected: build error — `JsonlTail` does not exist.
+
+- [ ] **Step 3: Implement `JsonlTail`**
+
+```csharp
+using System.Text;
+
+namespace Capacitor.Cli.Core;
+
+public enum TailStatus { Ok, Reset, Missing, Failed }
+
+public sealed record TailRead(IReadOnlyList<string> Lines, TailStatus Status, string? Failure = null);
+
+/// Appended-lines reader over a JSONL file another process is writing. Every open shares
+/// read/write/delete: a FileShare.Read open would deny the agent its own write handle on
+/// Windows. Only a length regression resets the cursor — a replacement by a same-or-longer
+/// file is read from the old cursor, which both vendors' append-only transcripts never produce.
+public sealed class JsonlTail(string path) {
+    long _cursor;
+
+    public string Path { get; } = path;
+    public long Cursor => _cursor;
+
+    public TailRead ReadAppended() {
+        try {
+            using var stream = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var status = TailStatus.Ok;
+            var length = stream.Length;
+            if (length < _cursor) {
+                _cursor = 0;
+                status = TailStatus.Reset;
+            }
+            if (length == _cursor) return new TailRead([], status);
+
+            stream.Position = _cursor;
+            var buffer = new byte[length - _cursor];
+            var read = 0;
+            while (read < buffer.Length) {
+                var n = stream.Read(buffer, read, buffer.Length - read);
+                if (n == 0) break;
+                read += n;
+            }
+
+            var lines = SplitCompleteLines(buffer.AsSpan(0, read), out var consumed);
+            _cursor += consumed;
+            return new TailRead(lines, status);
+        } catch (FileNotFoundException) {
+            return new TailRead([], TailStatus.Missing);
+        } catch (DirectoryNotFoundException) {
+            return new TailRead([], TailStatus.Missing);
+        } catch (Exception ex) {
+            return new TailRead([], TailStatus.Failed, ex.Message);
+        }
+    }
+
+    /// Complete lines only; `consumed` stops after the last '\n' so an unterminated tail is
+    /// re-read whole once its newline lands.
+    public static List<string> SplitCompleteLines(ReadOnlySpan<byte> bytes, out int consumed) {
+        var lines = new List<string>();
+        consumed = 0;
+        var start = 0;
+        for (var i = 0; i < bytes.Length; i++) {
+            if (bytes[i] != (byte)'\n') continue;
+            var line = bytes[start..i];
+            if (line.Length > 0 && line[^1] == (byte)'\r') line = line[..^1];
+            if (!IsBlank(line)) lines.Add(Encoding.UTF8.GetString(line));
+            start = i + 1;
+            consumed = start;
+        }
+        return lines;
+    }
+
+    static bool IsBlank(ReadOnlySpan<byte> line) {
+        foreach (var b in line) {
+            if (b is not ((byte)' ' or (byte)'\t' or (byte)'\r')) return false;
+        }
+        return true;
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Same command. Expected: 7 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/JsonlTail.cs test/Capacitor.Cli.Core.Tests.Unit/JsonlTailTests.cs
+git commit -m "Add a sharing-safe appended-lines reader for agent transcripts
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Projection seam and the Claude transcript projection
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/TranscriptProjection.cs`
+- Create: `src/Capacitor.Cli.Core/Harness/Claude/ClaudeTranscriptEvents.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/TranscriptProjectionTests.cs`, `test/Capacitor.Cli.Core.Tests.Unit/Harness/Claude/ClaudeTranscriptEventsTests.cs`
+
+**Interfaces:**
+- Consumes: `AcpEventEnvelope`, `AcpEventKind` (`Capacitor.Cli.Core`, `Models.cs`), `JsonElementExtensions` (Task 2).
+- Produces:
+  - `public interface ITranscriptProjection { IReadOnlyList<AcpEventEnvelope> Project(string line); }`
+  - `public static class TranscriptProjection { public static ITranscriptProjection? For(string vendor); }` (Task 5 registers Codex; this task registers Claude only)
+  - `internal static class TranscriptProjectionText` with `const int ToolResultCap = 4096`, `string Cap(string)`, `string JoinTextBlocks(JsonElement array, string blockType, string textProperty = "text")`, `string WrapAsObject(string property, JsonElement value)`, `string WrapAsObject(string property, string value)`.
+  - `public sealed class ClaudeTranscriptEvents : ITranscriptProjection { public static readonly ClaudeTranscriptEvents Instance; }` with `internal static string StripWrappers(string)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`TranscriptProjectionTests.cs`:
+
+```csharp
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class TranscriptProjectionTests {
+    [Test]
+    public async Task For_is_case_insensitive_and_null_for_an_unknown_vendor() {
+        await Assert.That(TranscriptProjection.For("claude")).IsNotNull();
+        await Assert.That(TranscriptProjection.For("Claude")).IsSameReferenceAs(TranscriptProjection.For("claude")!);
+        await Assert.That(TranscriptProjection.For("gemini")).IsNull();
+    }
+
+    [Test]
+    public async Task Cap_keeps_at_most_4096_units_including_the_marker_and_never_splits_a_pair() {
+        var plain = new string('a', 5000);
+        var capped = TranscriptProjectionText.Cap(plain);
+        await Assert.That(capped.Length).IsEqualTo(4096);
+        await Assert.That(capped[^1]).IsEqualTo('…');
+
+        // 4094 units, then an astral pair straddling the cut position 4095.
+        var astral = new string('a', 4094) + "😀" + new string('b', 100);
+        var cappedAstral = TranscriptProjectionText.Cap(astral);
+        await Assert.That(cappedAstral.Length).IsEqualTo(4095);
+        await Assert.That(char.IsHighSurrogate(cappedAstral[^2])).IsFalse();
+        await Assert.That(cappedAstral[^1]).IsEqualTo('…');
+
+        await Assert.That(TranscriptProjectionText.Cap("short")).IsEqualTo("short");
+        await Assert.That(TranscriptProjectionText.Cap(new string('a', 4096)).Length).IsEqualTo(4096);
+    }
+
+    [Test]
+    public async Task WrapAsObject_builds_a_json_object_around_any_value() {
+        using var doc = System.Text.Json.JsonDocument.Parse("""[1,"x",null]""");
+        await Assert.That(TranscriptProjectionText.WrapAsObject("input", doc.RootElement)).IsEqualTo("""{"input":[1,"x",null]}""");
+        await Assert.That(TranscriptProjectionText.WrapAsObject("arguments", "raw \"q\"")).IsEqualTo("""{"arguments":"raw "q""}""");
+    }
+}
+```
+
+`Harness/Claude/ClaudeTranscriptEventsTests.cs`:
+
+```csharp
+using System.Text.Json;
+using Capacitor.Cli.Core.Harness.Claude;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Harness.Claude;
+
+public class ClaudeTranscriptEventsTests {
+    static IReadOnlyList<AcpEventEnvelope> P(string line) => ClaudeTranscriptEvents.Instance.Project(line);
+
+    [Test]
+    public async Task String_user_content_is_one_user_message_with_its_timestamp() {
+        var e = P("""{"type":"user","message":{"role":"user","content":"hello"},"timestamp":"2026-08-26T12:00:00Z"}""");
+        await Assert.That(e).HasCount().EqualTo(1);
+        await Assert.That(e[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(e[0].Text).IsEqualTo("hello");
+        await Assert.That(e[0].TimestampIso).IsEqualTo("2026-08-26T12:00:00Z");
+    }
+
+    [Test]
+    public async Task Meta_and_sidechain_records_project_to_nothing() {
+        await Assert.That(P("""{"type":"user","isMeta":true,"message":{"content":"x"}}""")).IsEmpty();
+        await Assert.That(P("""{"type":"user","isSidechain":true,"message":{"content":"x"}}""")).IsEmpty();
+        await Assert.That(P("""{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"x"}]}}""")).IsEmpty();
+    }
+
+    [Test]
+    public async Task Wrappers_are_stripped_and_a_blank_remainder_is_not_emitted() {
+        var stripped = P("""{"type":"user","message":{"content":[{"type":"text","text":"<system-reminder>\nnoise\n</system-reminder>real"}]}}""");
+        await Assert.That(stripped).HasCount().EqualTo(1);
+        await Assert.That(stripped[0].Text).IsEqualTo("real");
+
+        var onlyWrappers = P("""{"type":"user","message":{"content":[{"type":"text","text":"<command-name>/clear</command-name><local-command-stdout>ok</local-command-stdout>"}]}}""");
+        await Assert.That(onlyWrappers).IsEmpty();
+    }
+
+    [Test]
+    public async Task Tool_results_carry_string_or_block_content_capped_and_flag_errors() {
+        var str = P("""{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"done","is_error":true}]}}""");
+        await Assert.That(str[0].Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(str[0].ToolCallId).IsEqualTo("t1");
+        await Assert.That(str[0].ToolResult).IsEqualTo("done");
+        await Assert.That(str[0].ToolIsError).IsTrue();
+
+        var blocks = P("""{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t2","content":[{"type":"text","text":"a"},{"type":"text","text":"b"}]}]}}""");
+        await Assert.That(blocks[0].ToolResult).IsEqualTo("a\nb");
+        await Assert.That(blocks[0].ToolIsError).IsFalse();
+
+        var big = new string('x', 5000);
+        var capped = P($$"""{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t3","content":"{{big}}"}]}}""");
+        await Assert.That(capped[0].ToolResult!.Length).IsEqualTo(4096);
+    }
+
+    [Test]
+    public async Task Assistant_blocks_map_to_text_thinking_and_tool_call() {
+        var line = """{"type":"assistant","timestamp":"2026-08-26T12:00:01Z","message":{"model":"claude-fable-5","content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"Hi"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}]}}""";
+        var e = P(line);
+
+        await Assert.That(e).HasCount().EqualTo(3);
+        await Assert.That(e[0].Kind).IsEqualTo(AcpEventKind.AssistantThinking);
+        await Assert.That(e[0].Text).IsEqualTo("hmm");
+        await Assert.That(e[1].Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(e[1].Text).IsEqualTo("Hi");
+        await Assert.That(e[1].Model).IsEqualTo("claude-fable-5");
+        await Assert.That(e[2].Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(e[2].ToolCallId).IsEqualTo("toolu_1");
+        await Assert.That(e[2].ToolName).IsEqualTo("Bash");
+        await Assert.That(e[2].ToolInputJson).IsEqualTo("""{"command":"ls"}""");
+        await Assert.That(e[2].TimestampIso).IsEqualTo("2026-08-26T12:00:01Z");
+    }
+
+    [Test]
+    public async Task Encrypted_thinking_and_non_object_inputs_are_normalized() {
+        var enc = P("""{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"","signature":"abc"}]}}""");
+        await Assert.That(enc[0].ThinkingEncrypted).IsTrue();
+
+        foreach (var (input, expected) in new[] {
+            ("[1,2]", """{"input":[1,2]}"""),
+            ("\"s\"", """{"input":"s"}"""),
+            ("null", """{"input":null}"""),
+        }) {
+            var e = P($$"""{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t","name":"X","input":{{input}}}]}}""");
+            await Assert.That(e[0].ToolInputJson).IsEqualTo(expected);
+            using var doc = JsonDocument.Parse(e[0].ToolInputJson!);
+            await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+        }
+    }
+
+    [Test]
+    public async Task Every_other_record_type_and_malformed_input_project_to_nothing() {
+        foreach (var type in new[] { "attachment", "summary", "system", "file-history-snapshot", "file-history-delta", "mode", "permission-mode", "last-prompt", "ai-title", "atis-latch", "worktree-state", "queue-operation", "progress", "unknown-future" })
+            await Assert.That(P($$"""{"type":"{{type}}","message":{"content":"x"}}""")).IsEmpty().Because(type);
+
+        await Assert.That(P("not json")).IsEmpty();
+        await Assert.That(P("[1,2]")).IsEmpty();
+        await Assert.That(P("""{"type":"user","message":{"content":42}}""")).IsEmpty();
+        await Assert.That(P("""{"type":"assistant","message":{"content":[{"type":"text","text":7}]}}""")).IsEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/*Transcript*/*"`
+Expected: build errors — the types do not exist.
+
+- [ ] **Step 3: Implement the seam and shared text helpers**
+
+`src/Capacitor.Cli.Core/TranscriptProjection.cs`:
+
+```csharp
+using System.Text;
+using System.Text.Json;
+using Capacitor.Cli.Core.Harness.Claude;
+
+namespace Capacitor.Cli.Core;
+
+/// One transcript line in, zero or more canonical chat events out. Stateless: the consumer
+/// orders by arrival and pairs tool calls to results by id itself.
+public interface ITranscriptProjection {
+    IReadOnlyList<AcpEventEnvelope> Project(string line);
+}
+
+/// The one registration site: a vendor's transcript projection lives under Harness/<Vendor>/
+/// and is named here, nowhere else.
+public static class TranscriptProjection {
+    public static ITranscriptProjection? For(string vendor) => vendor.ToLowerInvariant() switch {
+        "claude" => ClaudeTranscriptEvents.Instance,
+        _        => null,
+    };
+}
+
+/// Output rules both projections share, so an envelope reads the same whichever vendor wrote it.
+internal static class TranscriptProjectionText {
+    public const int ToolResultCap = 4096;
+    const string CapMarker = "…";
+
+    /// At most ToolResultCap units including the marker; a cut that would split a surrogate
+    /// pair drops the high half too, so the result can be one unit short of the cap.
+    public static string Cap(string text) {
+        if (text.Length <= ToolResultCap) return text;
+        var cut = ToolResultCap - CapMarker.Length;
+        if (char.IsHighSurrogate(text[cut - 1])) cut--;
+        return string.Concat(text.AsSpan(0, cut), CapMarker);
+    }
+
+    public static string JoinTextBlocks(JsonElement array, string blockType, string textProperty = "text") {
+        var sb = new StringBuilder();
+        foreach (var block in array.EnumerateArray()) {
+            if (block.Str("type") != blockType || block.Str(textProperty) is not { } text) continue;
+            if (sb.Length > 0) sb.Append('\n');
+            sb.Append(text);
+        }
+        return sb.ToString();
+    }
+
+    public static string WrapAsObject(string property, JsonElement value) {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer)) {
+            writer.WriteStartObject();
+            writer.WritePropertyName(property);
+            value.WriteTo(writer);
+            writer.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    public static string WrapAsObject(string property, string value) {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer)) {
+            writer.WriteStartObject();
+            writer.WriteString(property, value);
+            writer.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+}
+```
+
+`src/Capacitor.Cli.Core/Harness/Claude/ClaudeTranscriptEvents.cs`:
+
+```csharp
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using static Capacitor.Cli.Core.TranscriptProjectionText;
+
+namespace Capacitor.Cli.Core.Harness.Claude;
+
+/// Claude Code's project transcript (`~/.claude/projects/<slug>/<session>.jsonl`): one JSON
+/// record per line, `type` at the root, the API message under `message`.
+public sealed partial class ClaudeTranscriptEvents : ITranscriptProjection {
+    public static readonly ClaudeTranscriptEvents Instance = new();
+
+    ClaudeTranscriptEvents() { }
+
+    public IReadOnlyList<AcpEventEnvelope> Project(string line) {
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(line); } catch (JsonException) { return []; }
+
+        using (doc) {
+            var root = doc.RootElement;
+            if (!root.IsObject || root.Bool("isSidechain") == true) return [];
+            var ts = root.Str("timestamp");
+            return root.Str("type") switch {
+                "user"      => root.Bool("isMeta") == true ? [] : ProjectUser(root, ts),
+                "assistant" => ProjectAssistant(root, ts),
+                _           => [],
+            };
+        }
+    }
+
+    static List<AcpEventEnvelope> ProjectUser(JsonElement root, string? ts) {
+        var result = new List<AcpEventEnvelope>();
+        if (root.Obj("message") is not { } message) return result;
+
+        if (message.Str("content") is { } text) {
+            AddUserText(result, text, ts);
+            return result;
+        }
+        if (message.Arr("content") is not { } blocks) return result;
+
+        foreach (var block in blocks.EnumerateArray()) {
+            switch (block.Str("type")) {
+                case "text":
+                    if (block.Str("text") is { } t) AddUserText(result, t, ts);
+                    break;
+                case "tool_result":
+                    result.Add(new AcpEventEnvelope(
+                        Kind: AcpEventKind.ToolResult,
+                        ToolCallId: block.Str("tool_use_id"),
+                        ToolResult: Cap(ToolResultText(block)),
+                        ToolIsError: block.Bool("is_error") == true,
+                        TimestampIso: ts));
+                    break;
+            }
+        }
+        return result;
+    }
+
+    static string ToolResultText(JsonElement block) =>
+        block.Str("content") ?? (block.Arr("content") is { } blocks ? JoinTextBlocks(blocks, "text") : "");
+
+    static void AddUserText(List<AcpEventEnvelope> result, string raw, string? ts) {
+        var text = StripWrappers(raw);
+        if (text.Length == 0) return;
+        result.Add(new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: text, TimestampIso: ts));
+    }
+
+    static List<AcpEventEnvelope> ProjectAssistant(JsonElement root, string? ts) {
+        var result = new List<AcpEventEnvelope>();
+        if (root.Obj("message") is not { } message || message.Arr("content") is not { } blocks) return result;
+        var model = message.Str("model");
+
+        foreach (var block in blocks.EnumerateArray()) {
+            switch (block.Str("type")) {
+                case "text":
+                    if (block.Str("text") is { Length: > 0 } text)
+                        result.Add(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: text, Model: model, TimestampIso: ts));
+                    break;
+                case "thinking": {
+                    var thinking = block.Str("thinking");
+                    result.Add(new AcpEventEnvelope(
+                        Kind: AcpEventKind.AssistantThinking,
+                        Text: string.IsNullOrEmpty(thinking) ? null : thinking,
+                        ThinkingEncrypted: string.IsNullOrEmpty(thinking),
+                        Model: model, TimestampIso: ts));
+                    break;
+                }
+                case "tool_use":
+                    result.Add(new AcpEventEnvelope(
+                        Kind: AcpEventKind.ToolCall,
+                        ToolCallId: block.Str("id"),
+                        ToolName: block.Str("name"),
+                        ToolInputJson: InputJson(block),
+                        Model: model, TimestampIso: ts));
+                    break;
+            }
+        }
+        return result;
+    }
+
+    // ToolInputJson must always be a JSON object string: a non-object input is wrapped
+    // rather than copied, and an absent one becomes the empty object.
+    static string InputJson(JsonElement block) =>
+        block.Obj("input") is { } obj ? obj.GetRawText()
+        : block.Prop("input") is { } value ? WrapAsObject("input", value)
+        : "{}";
+
+    /// Removes the blocks Claude Code injects around a user turn — reminders and slash-command
+    /// echoes — so only what the user typed remains.
+    internal static string StripWrappers(string text) => Wrappers().Replace(text, "").Trim();
+
+    [GeneratedRegex(@"<(system-reminder|command-name|command-message|command-args|local-command-stdout|local-command-caveat)>.*?</\1>", RegexOptions.Singleline)]
+    private static partial Regex Wrappers();
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Same command. Expected: all tests in both classes PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/TranscriptProjection.cs src/Capacitor.Cli.Core/Harness/Claude/ClaudeTranscriptEvents.cs test/Capacitor.Cli.Core.Tests.Unit/TranscriptProjectionTests.cs test/Capacitor.Cli.Core.Tests.Unit/Harness/Claude/ClaudeTranscriptEventsTests.cs
+git commit -m "Project Claude transcript lines to chat envelopes
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Codex rollout projection, registry, AOT check
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/Harness/Codex/CodexRolloutEvents.cs`
+- Modify: `src/Capacitor.Cli.Core/TranscriptProjection.cs` (register `"codex"`)
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexRolloutEventsTests.cs`, extend `TranscriptProjectionTests`
+
+**Interfaces:**
+- Produces: `public sealed class CodexRolloutEvents : ITranscriptProjection { public static readonly CodexRolloutEvents Instance; }`; `TranscriptProjection.For("codex")` returns it.
+
+- [ ] **Step 1: Write the failing tests**
+
+`Harness/Codex/CodexRolloutEventsTests.cs`:
+
+```csharp
+using System.Text.Json;
+using Capacitor.Cli.Core.Harness.Codex;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Harness.Codex;
+
+public class CodexRolloutEventsTests {
+    static IReadOnlyList<AcpEventEnvelope> P(string line) => CodexRolloutEvents.Instance.Project(line);
+
+    static string Item(string payload, string ts = "2026-08-25T00:00:00Z") =>
+        $$"""{"timestamp":"{{ts}}","ordinal":1,"type":"response_item","payload":{{payload}}}""";
+
+    [Test]
+    public async Task User_and_assistant_messages_join_their_text_blocks() {
+        var user = P(Item("""{"type":"message","role":"user","content":[{"type":"input_text","text":"a"},{"type":"input_text","text":"b"}]}"""));
+        await Assert.That(user[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(user[0].Text).IsEqualTo("a\nb");
+        await Assert.That(user[0].TimestampIso).IsEqualTo("2026-08-25T00:00:00Z");
+
+        var assistant = P(Item("""{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hi"}]}"""));
+        await Assert.That(assistant[0].Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(assistant[0].Text).IsEqualTo("Hi");
+    }
+
+    [Test]
+    public async Task Injected_preludes_developer_and_system_roles_are_skipped() {
+        foreach (var prelude in new[] { "<environment_context>", "# AGENTS.md instructions", "<turn_aborted>", "<user_instructions>", "<permissions instructions>" })
+            await Assert.That(P(Item($$"""{"type":"message","role":"user","content":[{"type":"input_text","text":"{{prelude}}\nstuff"}]}"""))).IsEmpty().Because(prelude);
+
+        await Assert.That(P(Item("""{"type":"message","role":"developer","content":[{"type":"input_text","text":"x"}]}"""))).IsEmpty();
+        await Assert.That(P(Item("""{"type":"message","role":"system","content":[{"type":"input_text","text":"x"}]}"""))).IsEmpty();
+    }
+
+    [Test]
+    public async Task Tool_calls_always_carry_a_json_object_input() {
+        var fn = P(Item("""{"type":"function_call","name":"spawn_agent","call_id":"c1","arguments":"{\"task\":\"t\"}"}"""));
+        await Assert.That(fn[0].Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(fn[0].ToolCallId).IsEqualTo("c1");
+        await Assert.That(fn[0].ToolName).IsEqualTo("spawn_agent");
+        await Assert.That(fn[0].ToolInputJson).IsEqualTo("""{"task":"t"}""");
+
+        var nonObject = P(Item("""{"type":"function_call","name":"f","call_id":"c2","arguments":"not json"}"""));
+        await Assert.That(nonObject[0].ToolInputJson).IsEqualTo("""{"arguments":"not json"}""");
+
+        var custom = P(Item("""{"type":"custom_tool_call","name":"exec","call_id":"c3","input":"const r = 1;"}"""));
+        await Assert.That(custom[0].ToolName).IsEqualTo("exec");
+        await Assert.That(custom[0].ToolInputJson).IsEqualTo("""{"input":"const r = 1;"}""");
+
+        foreach (var e in new[] { fn[0], nonObject[0], custom[0] }) {
+            using var doc = JsonDocument.Parse(e.ToolInputJson!);
+            await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+        }
+    }
+
+    [Test]
+    public async Task Tool_outputs_carry_string_or_block_output_capped() {
+        var str = P(Item("""{"type":"function_call_output","call_id":"c1","output":"{\"ok\":true}"}"""));
+        await Assert.That(str[0].Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(str[0].ToolCallId).IsEqualTo("c1");
+        await Assert.That(str[0].ToolResult).IsEqualTo("""{"ok":true}""");
+
+        var blocks = P(Item("""{"type":"custom_tool_call_output","call_id":"c3","output":[{"type":"input_text","text":"Script completed"},{"type":"input_text","text":"Output:"}]}"""));
+        await Assert.That(blocks[0].ToolResult).IsEqualTo("Script completed\nOutput:");
+
+        var big = new string('x', 5000);
+        var capped = P(Item($$"""{"type":"function_call_output","call_id":"c4","output":"{{big}}"}"""));
+        await Assert.That(capped[0].ToolResult!.Length).IsEqualTo(4096);
+    }
+
+    [Test]
+    public async Task Reasoning_joins_summaries_and_flags_encrypted_only_content() {
+        var summarized = P(Item("""{"type":"reasoning","summary":[{"type":"summary_text","text":"plan"},{"type":"summary_text","text":"more"}],"encrypted_content":"zzz"}"""));
+        await Assert.That(summarized[0].Kind).IsEqualTo(AcpEventKind.AssistantThinking);
+        await Assert.That(summarized[0].Text).IsEqualTo("plan\nmore");
+        await Assert.That(summarized[0].ThinkingEncrypted).IsFalse();
+
+        var encrypted = P(Item("""{"type":"reasoning","summary":[],"encrypted_content":"zzz"}"""));
+        await Assert.That(encrypted[0].Text).IsNull();
+        await Assert.That(encrypted[0].ThinkingEncrypted).IsTrue();
+    }
+
+    [Test]
+    public async Task Every_other_envelope_and_payload_type_projects_to_nothing() {
+        foreach (var type in new[] { "event_msg", "turn_context", "session_meta", "world_state", "compacted", "inter_agent_communication_metadata" })
+            await Assert.That(P($$"""{"type":"{{type}}","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"x"}]}}""")).IsEmpty().Because(type);
+
+        await Assert.That(P(Item("""{"type":"agent_message","content":[{"type":"input_text","text":"x"}]}"""))).IsEmpty();
+        await Assert.That(P("garbage")).IsEmpty();
+        await Assert.That(P(Item("""{"type":"message","role":"user","content":"not-an-array"}"""))).IsEmpty();
+    }
+}
+```
+
+Append to `TranscriptProjectionTests`:
+
+```csharp
+    [Test]
+    public async Task For_registers_codex() {
+        await Assert.That(TranscriptProjection.For("CODEX")).IsSameReferenceAs(Capacitor.Cli.Core.Harness.Codex.CodexRolloutEvents.Instance);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/*Codex*/*"`
+Expected: build error — `CodexRolloutEvents` does not exist.
+
+- [ ] **Step 3: Implement the Codex projection and register it**
+
+`src/Capacitor.Cli.Core/Harness/Codex/CodexRolloutEvents.cs`:
+
+```csharp
+using System.Text.Json;
+using static Capacitor.Cli.Core.TranscriptProjectionText;
+
+namespace Capacitor.Cli.Core.Harness.Codex;
+
+/// Codex's rollout (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`): an envelope per line with
+/// `type` and `payload`; only `response_item` payloads are conversation, the rest is telemetry.
+public sealed class CodexRolloutEvents : ITranscriptProjection {
+    public static readonly CodexRolloutEvents Instance = new();
+
+    static readonly string[] InjectedPreludes = [
+        "<environment_context>", "# AGENTS.md instructions", "<turn_aborted>", "<user_instructions>", "<permissions instructions>",
+    ];
+
+    CodexRolloutEvents() { }
+
+    public IReadOnlyList<AcpEventEnvelope> Project(string line) {
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(line); } catch (JsonException) { return []; }
+
+        using (doc) {
+            var root = doc.RootElement;
+            if (!root.IsObject || root.Str("type") != "response_item" || root.Obj("payload") is not { } payload) return [];
+            var ts = root.Str("timestamp");
+
+            return payload.Str("type") switch {
+                "message"          => ProjectMessage(payload, ts),
+                "function_call"    => [new AcpEventEnvelope(Kind: AcpEventKind.ToolCall, ToolCallId: payload.Str("call_id"), ToolName: payload.Str("name"), ToolInputJson: ArgumentsJson(payload.Str("arguments")), TimestampIso: ts)],
+                "custom_tool_call" => [new AcpEventEnvelope(Kind: AcpEventKind.ToolCall, ToolCallId: payload.Str("call_id"), ToolName: payload.Str("name"), ToolInputJson: WrapAsObject("input", payload.Str("input") ?? ""), TimestampIso: ts)],
+                "function_call_output" or "custom_tool_call_output"
+                                   => [new AcpEventEnvelope(Kind: AcpEventKind.ToolResult, ToolCallId: payload.Str("call_id"), ToolResult: Cap(OutputText(payload)), TimestampIso: ts)],
+                "reasoning"        => [Reasoning(payload, ts)],
+                _                  => [],
+            };
+        }
+    }
+
+    static List<AcpEventEnvelope> ProjectMessage(JsonElement payload, string? ts) {
+        if (payload.Arr("content") is not { } blocks) return [];
+        switch (payload.Str("role")) {
+            case "user": {
+                var text = JoinTextBlocks(blocks, "input_text");
+                if (text.Length == 0 || IsInjectedPrelude(text)) return [];
+                return [new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: text, TimestampIso: ts)];
+            }
+            case "assistant": {
+                var text = JoinTextBlocks(blocks, "output_text");
+                return text.Length == 0 ? [] : [new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: text, TimestampIso: ts)];
+            }
+            default:
+                return [];
+        }
+    }
+
+    static bool IsInjectedPrelude(string text) {
+        var trimmed = text.TrimStart();
+        foreach (var prelude in InjectedPreludes) {
+            if (trimmed.StartsWith(prelude, StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+
+    static string ArgumentsJson(string? arguments) {
+        if (arguments is not null) {
+            try {
+                using var doc = JsonDocument.Parse(arguments);
+                if (doc.RootElement.IsObject) return doc.RootElement.GetRawText();
+            } catch (JsonException) { }
+        }
+        return WrapAsObject("arguments", arguments ?? "");
+    }
+
+    static string OutputText(JsonElement payload) =>
+        payload.Str("output") ?? (payload.Arr("output") is { } blocks ? JoinTextBlocks(blocks, "input_text") : "");
+
+    static AcpEventEnvelope Reasoning(JsonElement payload, string? ts) {
+        var summary = payload.Arr("summary") is { } blocks ? JoinTextBlocks(blocks, "summary_text") : "";
+        return new AcpEventEnvelope(
+            Kind: AcpEventKind.AssistantThinking,
+            Text: summary.Length == 0 ? null : summary,
+            ThinkingEncrypted: summary.Length == 0 && payload.Str("encrypted_content") is not null,
+            TimestampIso: ts);
+    }
+}
+```
+
+In `TranscriptProjection.cs` add `using Capacitor.Cli.Core.Harness.Codex;` and the switch arm `"codex" => CodexRolloutEvents.Instance,`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/*Transcript*/*"` and the Codex filter above. Expected: all PASS.
+
+- [ ] **Step 5: AOT check**
+
+Run: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'`
+Expected: no output (no IL2026/IL3050 warnings). If a warning names `ClaudeTranscriptEvents`/`CodexRolloutEvents`/`TranscriptProjectionText`, the offending call is reflection-based and must be replaced (only `JsonDocument`, `Utf8JsonWriter`, `GeneratedRegex` are allowed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/Harness/Codex/CodexRolloutEvents.cs src/Capacitor.Cli.Core/TranscriptProjection.cs test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexRolloutEventsTests.cs test/Capacitor.Cli.Core.Tests.Unit/TranscriptProjectionTests.cs
+git commit -m "Project Codex rollout lines to chat envelopes
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Claude locator returns a link-resolved winner
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Harness/Claude/SessionTranscriptLocator.cs`
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/SessionTranscriptLocatorTests.cs`
+
+**Interfaces:**
+- Produces: `internal static (string SessionId, string Path)? TryLocateWinner(string projectDir, string worktreePath, DateTime spawnedAtUtc, ISet<string>? ruledOut = null)`; `TryLocate` keeps its signature and delegates. `internal static string ResolveDirectory(string projectDir)` (final link target, or the input).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `SessionTranscriptLocatorTests`:
+
+```csharp
+    // ── TryLocateWinner: the matched file, link-resolved ────────────────
+
+    static string TranscriptLine(string cwd) => $$"""{"type":"user","cwd":"{{cwd}}","sessionId":"abc","message":{"content":"hi"}}""";
+
+    [Test]
+    public async Task TryLocateWinner_returns_id_and_the_matched_path() {
+        using var tmp = new TempDir();
+        var projectDir = tmp.CreateDir("projects", "-repo").Path;
+        var worktree = tmp.PathTo("wt");
+        var file = tmp.CreateFile(["projects", "-repo", "0123456789abcdef0123456789abcdef.jsonl"], TranscriptLine(worktree) + "\n");
+
+        var winner = SessionTranscriptLocator.TryLocateWinner(projectDir, worktree, DateTime.UtcNow.AddMinutes(-1));
+
+        await Assert.That(winner?.SessionId).IsEqualTo("0123456789abcdef0123456789abcdef");
+        await Assert.That(winner?.Path).IsEqualTo(file);
+    }
+
+    [Test]
+    public async Task Winner_through_a_symlinked_project_dir_survives_the_symlink_going_away() {
+        using var tmp = new TempDir();
+        var real = tmp.CreateDir("projects", "-source").Path;
+        var link = tmp.PathTo("projects", "-worktree");
+        Directory.CreateSymbolicLink(link, real);
+        var worktree = tmp.PathTo("wt");
+        tmp.CreateFile(["projects", "-source", "0123456789abcdef0123456789abcdef.jsonl"], TranscriptLine(worktree) + "\n");
+
+        var winner = SessionTranscriptLocator.TryLocateWinner(link, worktree, DateTime.UtcNow.AddMinutes(-1));
+
+        await Assert.That(winner?.Path).IsEqualTo(Path.Combine(real, "0123456789abcdef0123456789abcdef.jsonl"));
+
+        Directory.Delete(link);
+        File.AppendAllText(winner!.Value.Path, TranscriptLine(worktree) + "\n");
+        await Assert.That(File.ReadLines(winner.Value.Path).Count()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task A_freshly_appended_transcript_with_a_foreign_cwd_is_never_a_winner() {
+        // The boundary a Claude --resume into a new worktree hits: the resumed transcript's
+        // early records keep their original cwd, and no amount of fresh writes changes that.
+        using var tmp = new TempDir();
+        var projectDir = tmp.CreateDir("projects", "-repo").Path;
+        tmp.CreateFile(["projects", "-repo", "0123456789abcdef0123456789abcdef.jsonl"], TranscriptLine(tmp.PathTo("original-cwd")) + "\n");
+        var ruledOut = new HashSet<string>();
+
+        var winner = SessionTranscriptLocator.TryLocateWinner(projectDir, tmp.PathTo("new-worktree"), DateTime.UtcNow.AddMinutes(-1), ruledOut);
+
+        await Assert.That(winner).IsNull();
+        await Assert.That(ruledOut).HasCount().EqualTo(1);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj -- --treenode-filter "/*/*/SessionTranscriptLocatorTests/*"`
+Expected: build error — `TryLocateWinner` does not exist.
+
+- [ ] **Step 3: Implement the winner and link resolution**
+
+Replace `TryLocate` in `SessionTranscriptLocator.cs` with:
+
+```csharp
+    public static string? TryLocate(string projectDir, string worktreePath, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) =>
+        TryLocateWinner(projectDir, worktreePath, spawnedAtUtc, ruledOut)?.SessionId;
+
+    /// The matched transcript's id AND its path, link-resolved: the per-worktree project dir is
+    /// a symlink the launcher deletes at cleanup, and a path through it would die with the
+    /// process while the file lives on in the source repo's project dir.
+    internal static (string SessionId, string Path)? TryLocateWinner(string projectDir, string worktreePath, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) {
+        if (!Directory.Exists(projectDir)) return null;
+
+        foreach (var file in Directory.EnumerateFiles(projectDir, "*.jsonl")) {
+            if (ruledOut?.Contains(file) == true) continue;
+
+            try {
+                if (SessionIdFromFileName(file) is not { } sessionId) {
+                    ruledOut?.Add(file);
+                    continue;
+                }
+
+                if (!IsNewEnough(File.GetCreationTimeUtc(file), File.GetLastWriteTimeUtc(file), spawnedAtUtc)) continue;
+
+                switch (MatchTranscript(ReadFirstLines(file), worktreePath, DefaultPathComparison)) {
+                    case CwdMatch.Yes: return (sessionId, Path.Combine(ResolveDirectory(projectDir), Path.GetFileName(file)));
+                    case CwdMatch.No:  ruledOut?.Add(file); break;
+                }
+            } catch {
+                // Candidate vanished mid-scan, is locked, or is otherwise unreadable — the
+                // caller polls, so it is retried next tick.
+            }
+        }
+
+        return null;
+    }
+
+    /// The directory a symlinked project dir points at (final target), or the directory itself.
+    internal static string ResolveDirectory(string projectDir) {
+        try {
+            return new DirectoryInfo(projectDir).ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? projectDir;
+        } catch (IOException) {
+            return projectDir;
+        }
+    }
+```
+
+Keep the existing doc comment on `TryLocate`'s `ruledOut` parameter; move it onto `TryLocateWinner`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Same command. Expected: every `SessionTranscriptLocatorTests` PASS (the pre-existing ones included).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Harness/Claude/SessionTranscriptLocator.cs test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/SessionTranscriptLocatorTests.cs
+git commit -m "Return the link-resolved transcript path from the Claude locator
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: `TranscriptDiscovery`
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/TranscriptDiscovery.cs`
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptDiscoveryTests.cs`
+
+**Interfaces:**
+- Produces: `internal sealed class TranscriptDiscovery(TimeProvider time, TimeSpan interval, TimeSpan timeout)` with `Task<bool> RunAsync(Func<ISet<string>, (string SessionId, string Path)?> locate, Func<(string SessionId, string Path), Task> onFound, CancellationToken ct)` — true when a winner was handed to `onFound`; false on deadline or cancellation; never throws.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class TranscriptDiscoveryTests {
+    static readonly TimeSpan Interval = TimeSpan.FromSeconds(2);
+    static readonly TimeSpan Timeout = TimeSpan.FromMinutes(3);
+
+    [Test]
+    public async Task A_winner_on_a_later_tick_is_handed_over_once() {
+        var time = new FakeTimeProvider();
+        var discovery = new TranscriptDiscovery(time, Interval, Timeout);
+        var calls = 0;
+        var found = new List<(string, string)>();
+
+        var run = discovery.RunAsync(
+            _ => ++calls >= 3 ? ("sid", "/t.jsonl") : null,
+            w => { found.Add(w); return Task.CompletedTask; },
+            CancellationToken.None);
+
+        time.Advance(Interval);
+        time.Advance(Interval);
+        await Assert.That(await run).IsTrue();
+        await Assert.That(found).IsEquivalentTo(new[] { ("sid", "/t.jsonl") });
+        await Assert.That(calls).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task The_ruled_out_set_persists_across_ticks() {
+        var time = new FakeTimeProvider();
+        var discovery = new TranscriptDiscovery(time, Interval, Timeout);
+        ISet<string>? first = null, second = null;
+
+        var run = discovery.RunAsync(
+            set => { if (first is null) { first = set; set.Add("x"); return null; } second = set; return ("sid", "/p"); },
+            _ => Task.CompletedTask, CancellationToken.None);
+
+        time.Advance(Interval);
+        await run;
+        await Assert.That(second).IsSameReferenceAs(first!);
+        await Assert.That(second!.Contains("x")).IsTrue();
+    }
+
+    [Test]
+    public async Task The_deadline_ends_the_poll_without_a_handover() {
+        var time = new FakeTimeProvider();
+        var discovery = new TranscriptDiscovery(time, Interval, Timeout);
+        var handed = false;
+
+        var run = discovery.RunAsync(_ => null, _ => { handed = true; return Task.CompletedTask; }, CancellationToken.None);
+        for (var elapsed = TimeSpan.Zero; elapsed <= Timeout; elapsed += Interval) time.Advance(Interval);
+
+        await Assert.That(await run).IsFalse();
+        await Assert.That(handed).IsFalse();
+    }
+
+    [Test]
+    public async Task Cancellation_ends_the_poll_cleanly_without_a_final_locate() {
+        var time = new FakeTimeProvider();
+        var discovery = new TranscriptDiscovery(time, Interval, Timeout);
+        using var cts = new CancellationTokenSource();
+        var calls = 0;
+
+        var run = discovery.RunAsync(_ => { calls++; return null; }, _ => Task.CompletedTask, cts.Token);
+        cts.Cancel();
+
+        await Assert.That(await run).IsFalse();
+        await Assert.That(calls).IsEqualTo(1);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj -- --treenode-filter "/*/*/TranscriptDiscoveryTests/*"`
+Expected: build error — `TranscriptDiscovery` does not exist.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+namespace Capacitor.Cli.Daemon.Services;
+
+/// Polls a vendor's session tree for a freshly spawned agent's transcript until the file is
+/// known, the deadline passes, or the agent goes away. Runs until the PATH is known — a
+/// session id learned some other way is not a reason to stop, since the path is what the
+/// desktop app reads.
+internal sealed class TranscriptDiscovery(TimeProvider time, TimeSpan interval, TimeSpan timeout) {
+    public async Task<bool> RunAsync(
+            Func<ISet<string>, (string SessionId, string Path)?> locate,
+            Func<(string SessionId, string Path), Task> onFound,
+            CancellationToken ct) {
+        var deadline = time.GetUtcNow() + timeout;
+        var ruledOut = new HashSet<string>();
+
+        try {
+            while (time.GetUtcNow() < deadline) {
+                if (ct.IsCancellationRequested) return false;
+                if (locate(ruledOut) is { } winner) {
+                    await onFound(winner).ConfigureAwait(false);
+                    return true;
+                }
+                await Task.Delay(interval, time, ct).ConfigureAwait(false);
+            }
+        } catch (OperationCanceledException) {
+            // The agent exited or the daemon is shutting down — nothing left to find.
+        }
+        return false;
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Same command. Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/TranscriptDiscovery.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptDiscoveryTests.cs
+git commit -m "Extract transcript discovery into a clock-driven poll
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Orchestrator wiring — path on the agent, every PTY launch, the snapshot
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (`AgentInstance.CodexRolloutPath` → `TranscriptPath`; `DetectSessionIdAsync`/`PollForSessionIdAsync` → discovery; test seams)
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs` (`HandleLocalSpawnAsync`, `SnapshotAgentsForStatus`)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs`, `test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs`
+
+**Interfaces:**
+- Consumes: `TranscriptDiscovery` (Task 7), `SessionTranscriptLocator.TryLocateWinner` (Task 6), `CodexSessionRolloutLocator.TryLocateWinner` (existing).
+- Produces: `AgentInstance.TranscriptPath` (`string?`, set once discovery wins); `AgentStatusDto.TranscriptPath` stamped in `SnapshotAgentsForStatus`; test seams `internal Task RunDiscoveryForTest(AgentInstance agent, Func<ISet<string>, (string SessionId, string Path)?> locate)` and `internal int DiscoveryStartsForTest`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `AgentStatusSnapshotTests` (inside the class; it already has the `Build()` fixture with a notifier):
+
+```csharp
+    [Test]
+    public async Task Status_payload_carries_transcript_path_null_before_discovery_and_the_value_after() {
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
+        try {
+            var agent = orch.SeedAgentForTest("pty-1");
+
+            var before = System.Text.Json.JsonSerializer.Serialize(orch.SnapshotAgentsForStatus()[0], StatusIpcJsonContext.Default.AgentStatusDto);
+            await Assert.That(before).Contains("\"transcript_path\":null");
+
+            var versionBefore = fixture.Notifier.Version;
+            await orch.RunDiscoveryForTest(agent, _ => ("0123456789abcdef0123456789abcdef", "/home/u/.claude/projects/-repo/t.jsonl"));
+
+            var after = System.Text.Json.JsonSerializer.Serialize(orch.SnapshotAgentsForStatus()[0], StatusIpcJsonContext.Default.AgentStatusDto);
+            await Assert.That(after).Contains("\"transcript_path\":\"/home/u/.claude/projects/-repo/t.jsonl\"");
+            await Assert.That(agent.SessionId).IsEqualTo("0123456789abcdef0123456789abcdef");
+            await Assert.That(fixture.Notifier.Version).IsGreaterThan(versionBefore);
+        } finally {
+            await fixture.CleanupAsync();
+        }
+    }
+
+    /// A session id learned elsewhere must not stop discovery: the path is the obligation.
+    [Test]
+    public async Task Discovery_sets_the_path_even_when_the_session_id_is_already_known() {
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
+        try {
+            var agent = orch.SeedAgentForTest("pty-2");
+            agent.SessionId = "pre-known";
+
+            await orch.RunDiscoveryForTest(agent, _ => ("other", "/t.jsonl"));
+
+            await Assert.That(agent.SessionId).IsEqualTo("pre-known");
+            await Assert.That(agent.TranscriptPath).IsEqualTo("/t.jsonl");
+        } finally {
+            await fixture.CleanupAsync();
+        }
+    }
+
+    /// A private agent gets the path and the pulse with no server call in the way.
+    [Test]
+    public async Task A_private_agent_gets_its_path_and_pulse_without_server_reports() {
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
+        try {
+            var agent = orch.SeedAgentForTest("priv-1", isPrivate: true);
+            var versionBefore = fixture.Notifier.Version;
+
+            await orch.RunDiscoveryForTest(agent, _ => ("sid", "/p.jsonl"));
+
+            await Assert.That(agent.TranscriptPath).IsEqualTo("/p.jsonl");
+            await Assert.That(fixture.Notifier.Version).IsGreaterThan(versionBefore);
+        } finally {
+            await fixture.CleanupAsync();
+        }
+    }
+```
+
+Append to `AgentOrchestratorLocalAttachTests`:
+
+```csharp
+    [Test]
+    public async Task Local_spawns_start_transcript_discovery_private_included() {
+        using var tmp = new TempDir();
+        var server    = new TripwireServerConnection();
+        var pty       = new EnvCapturingPtyFactory();
+        var launchers = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = new SpyHostedAgentLauncher("claude", "spy-claude") };
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, pty, launchers);
+
+        foreach (var isPrivate in new[] { false, true }) {
+            var readBuf = new MemoryStream();
+            await FrameCodec.WriteAsync(readBuf, LocalFrame.Detach(), default);
+            readBuf.Position = 0;
+            using var client = new DuplexTestStream(readBuf, new MemoryStream());
+
+            var spawn = FrameCodec.Spawn("claude", WorkLocation.BorrowedCwd, isPrivate, tmp.Path, [], 80, 24);
+            await orch.HandleLocalSpawnAsync(spawn, client, default);
+        }
+
+        await Assert.That(orch.DiscoveryStartsForTest).IsEqualTo(2);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj -- --treenode-filter "/*/*/AgentStatusSnapshotTests/*"`
+Expected: build errors — `RunDiscoveryForTest`, `TranscriptPath`, `DiscoveryStartsForTest` do not exist.
+
+- [ ] **Step 3: Rename the cached path and rewire discovery**
+
+In `AgentOrchestrator.cs`:
+
+1. On `AgentInstance`, replace `CodexRolloutPath` with:
+
+```csharp
+    /// The agent's own transcript — Claude's project .jsonl or Codex's rollout — resolved once
+    /// by discovery and cached: the status payload and the Codex send-path probe both read it,
+    /// and neither may scan a directory to do so. Null until discovery lands, and forever for a
+    /// runtime that writes nothing the daemon locates.
+    public string? TranscriptPath { get; set; }
+```
+
+   and update both Codex probe reads (`if (agent.CodexRolloutPath is { } rolloutPath)` and `if (agent.CodexRolloutPath is not { } rolloutPath …)`) to `agent.TranscriptPath`. Fix the `Title` doc comment's mention of `CodexRolloutPath` to `TranscriptPath`.
+
+2. Add the seam counter beside the other `*ForTest` members:
+
+```csharp
+    int _discoveryStarts;
+    internal int DiscoveryStartsForTest => Volatile.Read(ref _discoveryStarts);
+```
+
+3. Replace `DetectSessionIdAsync` and `PollForSessionIdAsync` (keep the two timing constants) with:
+
+```csharp
+    /// Locates the transcript a freshly spawned PTY agent writes — Claude's per-worktree
+    /// project dir (a symlink onto the source repo's, shared with the user's own sessions,
+    /// so the locator disambiguates by cwd), Codex's rollout tree (disambiguated by cwd and
+    /// spawn time). A vendor without a locator is a no-op. Best-effort background work,
+    /// cancelled with the agent; it never blocks a launch.
+    Task DetectSessionIdAsync(AgentInstance agent, string vendor, DateTime spawnedAtUtc) {
+        Func<ISet<string>, (string SessionId, string Path)?>? locate = vendor.ToLowerInvariant() switch {
+            "claude" => ruledOut => SessionTranscriptLocator.TryLocateWinner(
+                ClaudePaths.ProjectDir(agent.Worktree.Path), agent.Worktree.Path, spawnedAtUtc, ruledOut),
+            "codex"  => ruledOut => CodexSessionRolloutLocator.TryLocateWinner(
+                CodexPaths.Sessions, agent.Worktree.Path, spawnedAtUtc, ruledOut),
+            _        => null,
+        };
+        if (locate is null) return Task.CompletedTask;
+
+        Interlocked.Increment(ref _discoveryStarts);
+        return RunDiscoveryAsync(agent, locate);
+    }
+
+    internal Task RunDiscoveryForTest(AgentInstance agent, Func<ISet<string>, (string SessionId, string Path)?> locate) =>
+        RunDiscoveryAsync(agent, locate);
+
+    async Task RunDiscoveryAsync(AgentInstance agent, Func<ISet<string>, (string SessionId, string Path)?> locate) {
+        try {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
+            var discovery = new TranscriptDiscovery(TimeProvider.System, SessionIdPollInterval, SessionIdPollTimeout);
+
+            var found = await discovery.RunAsync(locate, async winner => {
+                // Mutation first, pulse second — and the pulse before any server call, which can
+                // stall on a reconnect and must never hold the app's status push hostage.
+                agent.SessionId ??= winner.SessionId;
+                agent.TranscriptPath = winner.Path;
+                _statusNotifier.Pulse();
+                LogSessionIdDetected(agent.Id, winner.SessionId);
+
+                if (agent.IsPrivate) return;
+                await _server.AppendAgentRunEventAsync(agent.Id, new AgentRunHeartbeat(winner.SessionId));
+                await _server.AgentStatusChangedAsync(agent.Id, agent.Status, winner.SessionId);
+            }, cts.Token);
+
+            if (!found && !agent.ReadCts.IsCancellationRequested) LogSessionIdNotDetected(agent.Id, SessionIdPollTimeout.TotalSeconds);
+        } catch (Exception ex) {
+            LogSessionIdDetectFailed(ex, agent.Id);
+        }
+    }
+```
+
+   Check the two `Log*` method names still match the existing `[LoggerMessage]` declarations; keep them unchanged.
+
+4. In `AgentOrchestrator.LocalIpc.cs`, `HandleLocalSpawnAsync`: capture `var spawnedAtUtc = DateTime.UtcNow;` immediately before `var pty = _ptyFactory.Spawn(...)`, and after `_ = ReadAgentOutputAsync(agent);` add `_ = DetectSessionIdAsync(agent, vendor, spawnedAtUtc);`.
+
+5. In `SnapshotAgentsForStatus`, extend the DTO construction: `HasTerminal: a.Runtime.EmitsTerminalOutput, Title: a.Title, TranscriptPath: a.TranscriptPath))];`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run both filters (`AgentStatusSnapshotTests`, `AgentOrchestratorLocalAttachTests`), then the whole daemon suite: `dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj`. Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
+git commit -m "Discover every PTY agent's transcript and stamp it on the status wire
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: App pure helpers — Markdig reference, input encoder, link policy, tool detail
+
+**Files:**
+- Modify: `Directory.Packages.props`, `src/Capacitor.App/Capacitor.App.csproj`
+- Create: `src/Capacitor.App/Services/TerminalInputEncoder.cs`, `src/Capacitor.App/Services/LinkPolicy.cs`, `src/Capacitor.App/ViewModels/ToolDetail.cs`
+- Test: `test/Capacitor.App.Tests.Unit/TerminalInputEncoderTests.cs`, `LinkPolicyTests.cs`, `ToolDetailTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `public static class TerminalInputEncoder { public static readonly byte[] Submit; public static byte[] Paste(string text); }`
+  - `public static class LinkPolicy { public static bool IsOpenable(string? url); }`
+  - `public static class ToolDetail { public static string From(string? inputJson); }`
+
+- [ ] **Step 1: Add the package**
+
+In `Directory.Packages.props` add `<PackageVersion Include="Markdig" Version="1.3.2" />` (alphabetical, after `DynamicData`). In `Capacitor.App.csproj` add `<PackageReference Include="Markdig" />` after `DynamicData`. Run `dotnet build src/Capacitor.App/Capacitor.App.csproj` — expected: success.
+
+- [ ] **Step 2: Write the failing tests**
+
+`TerminalInputEncoderTests.cs`:
+
+```csharp
+using System.Text;
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class TerminalInputEncoderTests {
+    [Test]
+    public async Task Paste_wraps_in_bracketed_paste_normalizes_crlf_and_drops_one_trailing_newline() {
+        await Assert.That(Encoding.UTF8.GetString(TerminalInputEncoder.Paste("hi"))).IsEqualTo("\x1b[200~hi\x1b[201~");
+        await Assert.That(Encoding.UTF8.GetString(TerminalInputEncoder.Paste("a\r\nb\n"))).IsEqualTo("\x1b[200~a\nb\x1b[201~");
+        await Assert.That(Encoding.UTF8.GetString(TerminalInputEncoder.Paste("a\n\n"))).IsEqualTo("\x1b[200~a\n\x1b[201~");
+        await Assert.That(TerminalInputEncoder.Submit).IsEquivalentTo("\r"u8.ToArray());
+    }
+}
+```
+
+`LinkPolicyTests.cs`:
+
+```csharp
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class LinkPolicyTests {
+    [Test]
+    public async Task Only_absolute_http_and_https_open() {
+        await Assert.That(LinkPolicy.IsOpenable("https://example.com/x?y=1")).IsTrue();
+        await Assert.That(LinkPolicy.IsOpenable("http://example.com")).IsTrue();
+        foreach (var refused in new[] { "file:///etc/passwd", "javascript:alert(1)", "kcap://open", "docs/readme.md", "not a url", "", null })
+            await Assert.That(LinkPolicy.IsOpenable(refused)).IsFalse().Because(refused ?? "null");
+    }
+}
+```
+
+`ToolDetailTests.cs`:
+
+```csharp
+using Capacitor.App.ViewModels;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ToolDetailTests {
+    [Test]
+    public async Task Picks_the_first_present_key_in_priority_order() {
+        await Assert.That(ToolDetail.From("""{"command":"ls","description":"List files"}""")).IsEqualTo("List files");
+        await Assert.That(ToolDetail.From("""{"file_path":"/a/b.cs","command":"x"}""")).IsEqualTo("x");
+        await Assert.That(ToolDetail.From("""{"pattern":"*.cs"}""")).IsEqualTo("*.cs");
+        await Assert.That(ToolDetail.From("""{"input":"const r = 1;"}""")).IsEqualTo("const r = 1;");
+    }
+
+    [Test]
+    public async Task Keeps_the_first_line_and_cuts_at_80_characters() {
+        await Assert.That(ToolDetail.From("""{"command":"first line\nsecond"}""")).IsEqualTo("first line");
+        var longLine = new string('x', 100);
+        var detail = ToolDetail.From($$"""{"command":"{{longLine}}"}""");
+        await Assert.That(detail.Length).IsEqualTo(80);
+        await Assert.That(detail[^1]).IsEqualTo('…');
+    }
+
+    [Test]
+    public async Task Empty_when_nothing_applies() {
+        await Assert.That(ToolDetail.From("""{"other":"x"}""")).IsEqualTo("");
+        await Assert.That(ToolDetail.From("""{"command":"   "}""")).IsEqualTo("");
+        await Assert.That(ToolDetail.From("not json")).IsEqualTo("");
+        await Assert.That(ToolDetail.From(null)).IsEqualTo("");
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/{TerminalInputEncoderTests,LinkPolicyTests,ToolDetailTests}/*"`
+Expected: build errors — types missing.
+
+- [ ] **Step 4: Implement**
+
+`Services/TerminalInputEncoder.cs`:
+
+```csharp
+using System.Text;
+
+namespace Capacitor.App.Services;
+
+/// The composer's bytes, in the shape the daemon's own PTY input path uses: one bracketed
+/// paste so the TUI takes the text as a block, and a separate carriage return to submit it.
+public static class TerminalInputEncoder {
+    public static readonly byte[] Submit = "\r"u8.ToArray();
+
+    public static byte[] Paste(string text) {
+        var normalized = text.Replace("\r\n", "\n");
+        if (normalized.EndsWith('\n')) normalized = normalized[..^1];
+        return Encoding.UTF8.GetBytes("\x1b[200~" + normalized + "\x1b[201~");
+    }
+}
+```
+
+`Services/LinkPolicy.cs`:
+
+```csharp
+namespace Capacitor.App.Services;
+
+/// The trust boundary for agent-authored links: the shell opener launches whatever it is
+/// handed, so only absolute web URLs ever reach it.
+public static class LinkPolicy {
+    public static bool IsOpenable(string? url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri)
+        && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+}
+```
+
+`ViewModels/ToolDetail.cs`:
+
+```csharp
+using System.Text.Json;
+
+namespace Capacitor.App.ViewModels;
+
+/// The one-line detail a tool row shows beside its name, read from the call's input object.
+public static class ToolDetail {
+    const int MaxLength = 80;
+
+    static readonly string[] Keys = [
+        "description", "command", "cmd", "file_path", "path", "pattern", "query", "url", "skill", "prompt", "input",
+    ];
+
+    public static string From(string? inputJson) {
+        if (string.IsNullOrEmpty(inputJson)) return "";
+        try {
+            using var doc = JsonDocument.Parse(inputJson);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return "";
+            foreach (var key in Keys) {
+                if (doc.RootElement.TryGetProperty(key, out var value)
+                    && value.ValueKind == JsonValueKind.String
+                    && value.GetString() is { } s && s.Trim().Length > 0)
+                    return FirstLine(s);
+            }
+        } catch (JsonException) { }
+        return "";
+    }
+
+    static string FirstLine(string text) {
+        var line = text.Trim();
+        var newline = line.IndexOfAny(['\r', '\n']);
+        if (newline >= 0) line = line[..newline].TrimEnd();
+        return line.Length <= MaxLength ? line : string.Concat(line.AsSpan(0, MaxLength - 1), "…");
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Same command. Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Directory.Packages.props src/Capacitor.App/Capacitor.App.csproj src/Capacitor.App/Services/TerminalInputEncoder.cs src/Capacitor.App/Services/LinkPolicy.cs src/Capacitor.App/ViewModels/ToolDetail.cs test/Capacitor.App.Tests.Unit/TerminalInputEncoderTests.cs test/Capacitor.App.Tests.Unit/LinkPolicyTests.cs test/Capacitor.App.Tests.Unit/ToolDetailTests.cs
+git commit -m "Add the composer's input encoder, link policy and tool detail
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: The terminal's send gate
+
+**Files:**
+- Modify: `src/Capacitor.App/ViewModels/TerminalTabViewModel.cs`
+- Modify: `src/Capacitor.App/Services/TerminalAttach.cs` (add `SendAvailability`)
+- Test: `test/Capacitor.App.Tests.Unit/TerminalSendGateTests.cs` (create), `test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs` (extend the back-to-back reattach test)
+
+**Interfaces:**
+- Consumes: `TerminalInputEncoder` (Task 9), `FakeTerminalAttachClient` (`SentInput`, `DisposeGate`, `HangDetachForever`, `DetachGate`, `Result`, `TriggerAttached`).
+- Produces on `TerminalTabViewModel`: `bool TrySendText(string text)`, `bool CanAcceptText`, `bool SendInFlight`, `SendAvailability SendAvailability`, `internal int OpeningTokenForTesting`, `internal bool SendGateOpenForTesting`, `internal Task? PendingDeliveryForTesting`. In `TerminalAttach.cs`: `public enum SendAvailability { Ready, Sending, Transitioning, ReadOnly, Connecting, Reattach, Ended, NoTerminal }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`TerminalSendGateTests.cs`:
+
+```csharp
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The composer's send gate on TerminalTabViewModel: acceptance, the two-write delivery, and
+/// every window in which a send must be refused or a pending CR dropped. Same RunOnUiAsync +
+/// [NotInParallel("AvaloniaSession")] discipline as TerminalTabViewModelTests.
+public class TerminalSendGateTests {
+    static readonly byte[] Paste = TerminalInputEncoder.Paste("hello");
+    static readonly TimeSpan Delay = TimeSpan.FromMilliseconds(150);
+
+    static async Task<(FakeDaemonClientService Daemon, FakeTerminalAttachClientFactory Factory, FakeTimeProvider Time, TerminalTabViewModel Vm, FakeTerminalAttachClient Client)>
+            BuildAttachedAsync(string? readOnlyReason = null, Action<FakeTerminalAttachClient>? configureNext = null) {
+        var daemon = new FakeDaemonClientService();
+        var factory = new FakeTerminalAttachClientFactory { ConfigureNext = configureNext };
+        var time = new FakeTimeProvider();
+        var vm = new TerminalTabViewModel("a1", daemon, factory.Factory, () => new FakeTerminalSurface(), time);
+        daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+        await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
+        var client = factory.Created.Single();
+        await client.TriggerAttached([], readOnlyReason);
+        return (daemon, factory, time, vm, client);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Accepted_send_writes_the_paste_then_the_cr_after_the_delay_on_the_same_client() {
+        await RunOnUiAsync(async () => {
+            var (_, _, time, vm, client) = await BuildAttachedAsync();
+            await Assert.That(vm.CanAcceptText).IsTrue();
+            await Assert.That(vm.SendAvailability).IsEqualTo(SendAvailability.Ready);
+
+            await Assert.That(vm.TrySendText("hello")).IsTrue();
+            await Assert.That(vm.SendInFlight).IsTrue();
+            await Assert.That(vm.SendAvailability).IsEqualTo(SendAvailability.Sending);
+            await WaitUntilAsync(() => client.SentInput.Count == 1, what: "paste written");
+            await Assert.That(client.SentInput[0]).IsEquivalentTo(Paste);
+
+            time.Advance(Delay);
+            await vm.PendingDeliveryForTesting!;
+            await Assert.That(client.SentInput).HasCount().EqualTo(2);
+            await Assert.That(client.SentInput[1]).IsEquivalentTo(TerminalInputEncoder.Submit);
+            await Assert.That(vm.SendInFlight).IsFalse();
+            await Assert.That(vm.CanAcceptText).IsTrue();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_second_send_is_refused_while_one_is_in_flight_then_goes_through() {
+        await RunOnUiAsync(async () => {
+            var (_, _, time, vm, client) = await BuildAttachedAsync();
+
+            await Assert.That(vm.TrySendText("A")).IsTrue();
+            await Assert.That(vm.TrySendText("B")).IsFalse();
+            await Assert.That(vm.CanAcceptText).IsFalse();
+
+            time.Advance(Delay);
+            await vm.PendingDeliveryForTesting!;
+            await Assert.That(vm.TrySendText("B")).IsTrue();
+            time.Advance(Delay);
+            await vm.PendingDeliveryForTesting!;
+
+            await Assert.That(client.SentInput.Select(b => System.Text.Encoding.UTF8.GetString(b))).IsEquivalentTo(
+                new[] { "\x1b[200~A\x1b[201~", "\r", "\x1b[200~B\x1b[201~", "\r" }, TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Refused_unless_attached_read_write() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, ro, _) = await BuildAttachedAsync(readOnlyReason: "review");
+            await Assert.That(ro.TrySendText("x")).IsFalse();
+            await Assert.That(ro.SendAvailability).IsEqualTo(SendAvailability.ReadOnly);
+
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var connecting = new TerminalTabViewModel("a2", daemon, factory.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider());
+            daemon.Agents.AddOrUpdate(Agent("a2", "claude", hasTerminal: true));
+            await (connecting.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(connecting.TrySendText("x")).IsFalse();
+            await Assert.That(connecting.SendAvailability).IsEqualTo(SendAvailability.Connecting);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_send_during_a_reattach_disposal_or_a_detach_write_is_refused_while_state_still_reads_attached() {
+        await RunOnUiAsync(async () => {
+            // Reattach: the old client's disposal is held open, State still Attached.
+            var gate = new TaskCompletionSource();
+            var (_, factory, _, vm, client) = await BuildAttachedAsync(configureNext: c => c.DisposeGate = gate);
+            var reattach = vm.ReattachCommand.Execute().ToTask();
+            await WaitUntilAsync(() => client.DisposeCalls == 1, what: "old client disposing");
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Attached);
+            await Assert.That(vm.CanAcceptText).IsFalse();
+            await Assert.That(vm.SendAvailability).IsEqualTo(SendAvailability.Transitioning);
+            await Assert.That(vm.TrySendText("x")).IsFalse();
+
+            gate.SetResult();
+            await reattach;
+            var client2 = factory.Created[^1];
+            await Assert.That(vm.CanAcceptText).IsFalse(); // Connecting: still closed
+            await client2.TriggerAttached([]);
+            await Assert.That(vm.CanAcceptText).IsTrue();
+
+            // Detach: the detach write is held open, State still Attached.
+            var (_, _, _, vm2, client3) = await BuildAttachedAsync(configureNext: c => c.HangDetachForever = true);
+            var detach = vm2.DetachCommand.Execute().ToTask();
+            await WaitUntilAsync(() => client3.DetachCalls == 1, what: "detach in flight");
+            await Assert.That(vm2.State.Phase).IsEqualTo(TerminalSessionPhase.Attached);
+            await Assert.That(vm2.TrySendText("x")).IsFalse();
+            await Assert.That(vm2.SendAvailability).IsEqualTo(SendAvailability.Transitioning);
+            client3.DetachGate.SetResult();
+            await detach;
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Invalidation_during_the_delay_drops_the_cr_and_clears_in_flight() {
+        await RunOnUiAsync(async () => {
+            foreach (var invalidate in new Func<TerminalTabViewModel, FakeTerminalAttachClient, FakeDaemonClientService, Task>[] {
+                async (vm, _, _) => { await vm.DetachCommand.Execute(); },
+                async (vm, client, _) => { client.Result.SetResult(new AttachOutcome.Exited(0)); await vm.CurrentRunForTesting!; },
+                async (vm, client, _) => { client.Result.SetResult(new AttachOutcome.ConnectionLost()); await vm.CurrentRunForTesting!; },
+                (_, _, daemon) => { daemon.Agents.Remove("a1"); return Task.CompletedTask; },
+                async (vm, _, _) => { await vm.TeardownAsync(); },
+            }) {
+                var (daemon, _, time, vm, client) = await BuildAttachedAsync();
+                await Assert.That(vm.TrySendText("hello")).IsTrue();
+                await WaitUntilAsync(() => client.SentInput.Count == 1, what: "paste written");
+
+                await invalidate(vm, client, daemon);
+                await Assert.That(vm.SendInFlight).IsFalse();
+                await Assert.That(vm.CanAcceptText).IsFalse();
+                await Assert.That(vm.TrySendText("again")).IsFalse();
+
+                time.Advance(Delay);
+                await (vm.PendingDeliveryForTesting ?? Task.CompletedTask);
+                await Assert.That(client.SentInput).HasCount().EqualTo(1);
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_late_attached_publish_cannot_reopen_after_a_removal_or_detach() {
+        await RunOnUiAsync(async () => {
+            // (b) removal while Connecting: the attach callback's publish is queued, then the agent goes.
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var vm = new TerminalTabViewModel("a1", daemon, factory.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider());
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+            await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            var client = factory.Created.Single();
+            var tokenWhileConnecting = vm.OpeningTokenForTesting;
+
+            var attached = client.TriggerAttached([]);   // queued for the UI dispatch, not yet run
+            daemon.Agents.Remove("a1");                  // lands first: SessionEnded, ownership advanced
+            await attached;
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.SessionEnded);
+            await Assert.That(vm.OpeningTokenForTesting).IsNotEqualTo(tokenWhileConnecting);
+            await Assert.That(vm.CanAcceptText).IsFalse();
+            await Assert.That(vm.TrySendText("x")).IsFalse();
+
+            // (c) removal during a reattach's pre-Connecting disposal aborts that attempt.
+            var gate = new TaskCompletionSource();
+            var (daemon2, factory2, _, vm2, client2) = await BuildAttachedAsync(configureNext: c => c.DisposeGate = gate);
+            var reattach = vm2.ReattachCommand.Execute().ToTask();
+            await WaitUntilAsync(() => client2.DisposeCalls == 1, what: "old client disposing");
+            daemon2.Agents.Remove("a1");
+            gate.SetResult();
+            await reattach;
+
+            await Assert.That(vm2.State.Phase).IsEqualTo(TerminalSessionPhase.SessionEnded);
+            await Assert.That(factory2.Created.Count).IsEqualTo(1); // no second client was ever created
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_write_fault_clears_in_flight_and_leaves_state_alone() {
+        await RunOnUiAsync(async () => {
+            var (_, _, time, vm, client) = await BuildAttachedAsync();
+            client.ThrowOnSendInput = new IOException("pipe closed");
+
+            await Assert.That(vm.TrySendText("hello")).IsTrue();
+            await vm.PendingDeliveryForTesting!;
+
+            await Assert.That(vm.SendInFlight).IsFalse();
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Attached);
+            await Assert.That(vm.CanAcceptText).IsTrue();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Teardown_during_the_delay_queues_no_dispatcher_work_afterwards() {
+        await RunOnUiAsync(async () => {
+            var (_, _, time, vm, client) = await BuildAttachedAsync();
+            await Assert.That(vm.TrySendText("hello")).IsTrue();
+            await WaitUntilAsync(() => client.SentInput.Count == 1, what: "paste written");
+            var delivery = vm.PendingDeliveryForTesting!;
+
+            await vm.TeardownAsync();
+            var changes = 0;
+            vm.PropertyChanged += (_, _) => changes++;
+            time.Advance(Delay);
+            await delivery;
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(changes).IsEqualTo(0);
+            await Assert.That(client.SentInput).HasCount().EqualTo(1);
+        });
+    }
+}
+```
+
+Add to `FakeTerminalAttachClient` a `public Exception? ThrowOnSendInput;` field and make `SendInputAsync` throw it when set:
+
+```csharp
+    public Task SendInputAsync(byte[] bytes) {
+        if (ThrowOnSendInput is { } ex) return Task.FromException(ex);
+        SentInput.Add(bytes);
+        return Task.CompletedTask;
+    }
+```
+
+Extend `Explicit_detach_stays_in_place_with_single_flight_reattach` in `TerminalTabViewModelTests` (case (d)) — after `await Task.WhenAll(t1, t2);` add:
+
+```csharp
+            // The losing call changed neither the token nor the gate; the winner opens on Attached.
+            var winner = factory.Created[^1];
+            var token = vm.OpeningTokenForTesting;
+            await Assert.That(vm.SendGateOpenForTesting).IsFalse();
+            await winner.TriggerAttached([]);
+            await Assert.That(vm.OpeningTokenForTesting).IsEqualTo(token);
+            await Assert.That(vm.CanAcceptText).IsTrue();
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/TerminalSendGateTests/*"`
+Expected: build errors — `TrySendText`, `CanAcceptText`, `SendAvailability` missing.
+
+- [ ] **Step 3: Implement the gate**
+
+In `TerminalAttach.cs`, after `TerminalSessionPhase`:
+
+```csharp
+/// What the composer can do right now, folding the send gate into the terminal state so a hint
+/// built from it is true in every window — including the ones where State still reads Attached
+/// while a reattach or detach is under way.
+public enum SendAvailability { Ready, Sending, Transitioning, ReadOnly, Connecting, Reattach, Ended, NoTerminal }
+```
+
+In `TerminalTabViewModel.cs`:
+
+1. Add fields and the bound projections (near `State`):
+
+```csharp
+    static readonly TimeSpan SubmitDelay = TimeSpan.FromMilliseconds(150);
+
+    // The send gate. Only BeginAttempt and Invalidate advance the token; an attempt carries the
+    // token its BeginAttempt produced and may open the gate only while that token is current.
+    int _openingToken;
+    bool _gateOpen;
+    bool _sendInFlight;
+    Task? _delivery;
+
+    public bool SendInFlight {
+        get => _sendInFlight;
+        private set {
+            if (_sendInFlight == value) return;
+            _sendInFlight = value;
+            this.RaisePropertyChanged();
+            RaiseSendProjections();
+        }
+    }
+
+    public bool CanAcceptText => _gateOpen && !_sendInFlight;
+
+    public SendAvailability SendAvailability {
+        get {
+            if (_sendInFlight) return SendAvailability.Sending;
+            if (State is { Phase: TerminalSessionPhase.Attached, ReadOnly: false })
+                return _gateOpen ? SendAvailability.Ready : SendAvailability.Transitioning;
+            return State.Phase switch {
+                TerminalSessionPhase.Attached => SendAvailability.ReadOnly,
+                TerminalSessionPhase.Resolving or TerminalSessionPhase.Connecting => SendAvailability.Connecting,
+                TerminalSessionPhase.Detached or TerminalSessionPhase.Failed => SendAvailability.Reattach,
+                TerminalSessionPhase.Exited or TerminalSessionPhase.SessionEnded => SendAvailability.Ended,
+                _ => SendAvailability.NoTerminal,
+            };
+        }
+    }
+
+    internal int OpeningTokenForTesting => Volatile.Read(ref _openingToken);
+    internal bool SendGateOpenForTesting => _gateOpen;
+    internal Task? PendingDeliveryForTesting => _delivery;
+
+    void RaiseSendProjections() {
+        this.RaisePropertyChanged(nameof(CanAcceptText));
+        this.RaisePropertyChanged(nameof(SendAvailability));
+    }
+
+    int BeginAttempt() {
+        _gateOpen = false;
+        SendInFlight = false;
+        var token = Interlocked.Increment(ref _openingToken);
+        RaiseSendProjections();
+        return token;
+    }
+
+    void Invalidate() {
+        _gateOpen = false;
+        SendInFlight = false;
+        Interlocked.Increment(ref _openingToken);
+        RaiseSendProjections();
+    }
+
+    /// The one place State is assigned. An attempt-owned publish (Connecting, Attached) carries
+    /// its token and is discarded when that token is stale; every other state is an invalidation.
+    void Publish(TerminalSessionState state, int? ownerToken) {
+        if (state.Phase is TerminalSessionPhase.Connecting or TerminalSessionPhase.Attached) {
+            if (ownerToken != Volatile.Read(ref _openingToken)) return;
+            State = state;
+            if (state is { Phase: TerminalSessionPhase.Attached, ReadOnly: false }) _gateOpen = true;
+            RaiseSendProjections();
+            return;
+        }
+        Invalidate();
+        State = state;
+        RaiseSendProjections();
+    }
+```
+
+   Make `State`'s setter `private` stay as is; every former `State = …` assignment below becomes a `Publish(...)` call.
+
+2. `TrySendText` and the delivery:
+
+```csharp
+    /// Synchronous acceptance on the UI thread: true means the text is on its way through the
+    /// current client and the composer may clear; false means nothing was written.
+    public bool TrySendText(string text) {
+        if (!CanAcceptText || _client is not { } client) return false;
+        var token = Volatile.Read(ref _openingToken);
+        SendInFlight = true;
+        _delivery = DeliverAsync(client, token, TerminalInputEncoder.Paste(text));
+        return true;
+    }
+
+    // Paste, wait out the TUI's post-paste Enter suppression, then one CR — only if nothing
+    // advanced the token meanwhile. A fault ends the delivery and never touches State: the
+    // attach outcome is the transport's own channel.
+    async Task DeliverAsync(ITerminalAttachClient client, int token, byte[] paste) {
+        try {
+            await client.SendInputAsync(paste).ConfigureAwait(false);
+            await Task.Delay(SubmitDelay, _time).ConfigureAwait(false);
+            if (Volatile.Read(ref _openingToken) != token) return;
+            await client.SendInputAsync(TerminalInputEncoder.Submit).ConfigureAwait(false);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: composer send failed: {ex.Message}");
+        } finally {
+            if (Volatile.Read(ref _resolveState) != ResolveDisposed && Volatile.Read(ref _openingToken) == token) {
+                await Dispatcher.UIThread.InvokeAsync(() => {
+                    if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
+                    if (Volatile.Read(ref _openingToken) != token) return;
+                    SendInFlight = false;
+                });
+            }
+        }
+    }
+```
+
+3. Wire the existing lifecycle to the gate:
+
+- `HandleAgentRemoved`: replace `State = TerminalSessionState.SessionEnded;` with `Publish(TerminalSessionState.SessionEnded, null);`.
+- `OnResolveTimeout`: `RxSchedulers.MainThreadScheduler.Schedule(() => Publish(TerminalSessionState.NotFound, null));`.
+- `RunResolveWorkAsync`'s catch: `Publish(TerminalSessionState.Failed($"couldn't open the terminal: {ex.Message}"), null);`.
+- `ApplyResolvedDtoAsync`'s NoTerminal branch: `Publish(TerminalSessionState.NoTerminal(...), null);`.
+- `TryStartAttemptAsync`: after `if (Retired(0)) return;` (the first guard inside the try) insert `var token = BeginAttempt();`. After the previous client's disposal await and its `if (Retired(0)) return;`, add `if (Volatile.Read(ref _openingToken) != token) return;`. Inside the UI swap dispatch replace `State = TerminalSessionState.Connecting;` with `Publish(TerminalSessionState.Connecting, token);`. Thread `token` into `OnAttachedAsync` (new parameter after `generation`) and into the factory lambda that captures it.
+- `OnAttachedAsync(int generation, int token, ...)`: replace `State = TerminalSessionState.Attached(reason);` with `Publish(TerminalSessionState.Attached(reason), token);`.
+- `FinishAttemptAsync`: replace `State = state;` with `Publish(state, null);`.
+- `RunDetachAsync`: first statement `Invalidate();`.
+- `TeardownAsync`: right after the idempotent `Interlocked.Exchange`, `Invalidate();`.
+- Add `_delivery = null;` nowhere — the field is a test seam; `TeardownAsync` leaves it for the test to await.
+
+4. Keep every existing `State.Phase`-based check (`Retired`, the Exited/Failed precedence in `HandleAgentRemoved`) unchanged.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run `TerminalSendGateTests` and `TerminalTabViewModelTests`, then the whole app suite: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj`. Expected: green. If `Removal_after_first_observation_is_session_ended_not_resolving` or `Exited_is_not_overwritten_by_session_ended` regress, the precedence check in `HandleAgentRemoved` was lost — restore it before `Publish`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/TerminalTabViewModel.cs src/Capacitor.App/Services/TerminalAttach.cs test/Capacitor.App.Tests.Unit/TerminalSendGateTests.cs test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs test/Capacitor.App.Tests.Unit/FakeTerminalAttachClient.cs
+git commit -m "Gate composer sends on the terminal's attach ownership
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Chat items and the tail-driven `ChatTabViewModel`
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/ChatItems.cs`, `src/Capacitor.App/ViewModels/ChatTabViewModel.cs`
+- Test: `test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs`
+
+**Interfaces:**
+- Consumes: `JsonlTail`/`TailRead`/`TailStatus` (Task 3), `ITranscriptProjection` (Task 4), `ToolDetail` (Task 9), `TerminalTabViewModel` (Task 10), `IUrlOpener`, `IDaemonClientService`.
+- Produces:
+  - `public abstract class ChatItemViewModel : ReactiveObject`; `UserTurnItem(string Text)`, `AssistantTextItem(string Text)`, `ToolCallItem(string Name, string Detail)` with `ToolOutcome Outcome` (bound), `string OutcomeGlyph`, `bool IsError`; `public enum ToolOutcome { Running, Done, Error }`.
+  - `public enum ChatTabPhase { Waiting, Reading, Missing, Unavailable }`.
+  - `public sealed class ChatTabViewModel(string agentId, IDaemonClientService daemon, TerminalTabViewModel terminal, ITranscriptProjection? projection, IUrlOpener opener, TimeProvider time)` with `IAvaloniaReadOnlyList<ChatItemViewModel> Items`, `ChatTabPhase Phase`, `string PhaseNote`, `Task TeardownAsync()`, `internal Task? PendingReadForTesting`, `internal static readonly TimeSpan PollInterval` (500 ms). Composer/footer/link members come in Task 12.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using System.Reactive.Linq;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using TUnit.Assertions.Enums;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// ChatTabViewModel's tail: phases, the poll, item projection and pairing, path switches and
+/// teardown. Every test runs under RunOnUiAsync (the apply hops through Dispatcher.UIThread) and
+/// carries [NotInParallel("AvaloniaSession")], like every other VM suite touching the dispatcher.
+public class ChatTabViewModelTests {
+    [TempDir] public required TempDir Tmp { get; init; }
+
+    const string UserLine = """{"type":"user","message":{"role":"user","content":"hello"}}""";
+    const string AssistantLine = """{"type":"assistant","message":{"content":[{"type":"text","text":"Hi there"}]}}""";
+    const string ToolCallLine = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls -la"}}]}}""";
+    const string ToolResultLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}}""";
+    const string ToolErrorLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"boom","is_error":true}]}}""";
+
+    static AgentStatusDto Dto(string? transcriptPath, string vendor = "claude") =>
+        Agent("a1", vendor, hasTerminal: true, repoPath: "/repo/x") with { TranscriptPath = transcriptPath };
+
+    sealed class Harness {
+        public FakeDaemonClientService Daemon { get; } = new();
+        public FakeTerminalAttachClientFactory Factory { get; } = new();
+        public FakeTimeProvider Time { get; } = new();
+        public RecordingOpener Opener { get; } = new();
+        public TerminalTabViewModel Terminal { get; }
+        public ChatTabViewModel Chat { get; }
+
+        public Harness(ITranscriptProjection? projection) {
+            Terminal = new TerminalTabViewModel("a1", Daemon, Factory.Factory, () => new FakeTerminalSurface(), Time);
+            Chat = new ChatTabViewModel("a1", Daemon, Terminal, projection, Opener, Time);
+        }
+
+        public async Task PushAsync(AgentStatusDto dto) {
+            Daemon.Agents.AddOrUpdate(dto);
+            await (Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+        }
+
+        public async Task TickAsync() {
+            Time.Advance(ChatTabViewModel.PollInterval);
+            await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+        }
+
+        public async Task TeardownAsync() {
+            await Chat.TeardownAsync();
+            await Terminal.TeardownAsync();
+        }
+    }
+
+    static Harness Claude() => new(TranscriptProjection.For("claude"));
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Waits_until_a_path_then_renders_the_initial_load_in_file_order() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Waiting);
+            await Assert.That(h.Chat.PhaseNote).IsEqualTo("Waiting for the transcript…");
+
+            await h.PushAsync(Dto(transcriptPath: null));
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Waiting);
+
+            var path = Tmp.CreateFile("t.jsonl", [UserLine, AssistantLine, ToolCallLine]);
+            await h.PushAsync(Dto(path));
+
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(
+                new[] { nameof(UserTurnItem), nameof(AssistantTextItem), nameof(ToolCallItem) }, CollectionOrdering.Matching);
+            await Assert.That(((UserTurnItem)h.Chat.Items[0]).Text).IsEqualTo("hello");
+            await Assert.That(((ToolCallItem)h.Chat.Items[2]).Detail).IsEqualTo("ls -la");
+            await Assert.That(((ToolCallItem)h.Chat.Items[2]).Outcome).IsEqualTo(ToolOutcome.Running);
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Appended_lines_render_after_a_tick_and_a_partial_line_waits_for_its_newline() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine]);
+            await h.PushAsync(Dto(path));
+            await Assert.That(h.Chat.Items).HasCount().EqualTo(1);
+
+            File.AppendAllText(path, AssistantLine + "\n" + ToolCallLine[..20]);
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).HasCount().EqualTo(2);
+
+            File.AppendAllText(path, ToolCallLine[20..] + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).HasCount().EqualTo(3);
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Tool_results_flip_their_call_in_place_and_unmatched_results_are_ignored() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ToolResultLine]);
+            await h.PushAsync(Dto(path));
+            var call = (ToolCallItem)h.Chat.Items.Single();
+            await Assert.That(call.Outcome).IsEqualTo(ToolOutcome.Done);
+            await Assert.That(call.OutcomeGlyph).IsEqualTo("✓");
+
+            File.AppendAllText(path, ToolCallLine + "\n" + ToolErrorLine + "\n" + ToolErrorLine.Replace("t1", "unknown") + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).HasCount().EqualTo(2);
+            await Assert.That(((ToolCallItem)h.Chat.Items[1]).Outcome).IsEqualTo(ToolOutcome.Error);
+            await Assert.That(((ToolCallItem)h.Chat.Items[1]).IsError).IsTrue();
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Length_regression_resets_items_missing_recovers_and_failed_keeps_items() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.PathTo("t.jsonl");
+            await h.PushAsync(Dto(path));
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Missing);
+            await Assert.That(h.Chat.PhaseNote).IsEqualTo("The transcript file is missing");
+
+            File.WriteAllLines(path, [UserLine, AssistantLine]);
+            await h.TickAsync();
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
+            await Assert.That(h.Chat.Items).HasCount().EqualTo(2);
+
+            File.WriteAllLines(path, [ToolCallLine]);
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).HasCount().EqualTo(1);
+            await Assert.That(h.Chat.Items[0]).IsTypeOf<ToolCallItem>();
+
+            File.Delete(path);
+            Directory.CreateDirectory(path);
+            await h.TickAsync();
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
+            await Assert.That(h.Chat.Items).HasCount().EqualTo(1);
+            Directory.Delete(path);
+            await h.TeardownAsync();
+        });
+    }
+
+    sealed class GatedProjection(ITranscriptProjection inner, string blockOn, TaskCompletionSource gate) : ITranscriptProjection {
+        public IReadOnlyList<AcpEventEnvelope> Project(string line) {
+            if (line.Contains(blockOn, StringComparison.Ordinal)) gate.Task.GetAwaiter().GetResult();
+            return inner.Project(line);
+        }
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_path_switch_discards_a_read_still_in_flight_for_the_old_file() {
+        await RunOnUiAsync(async () => {
+            var gate = new TaskCompletionSource();
+            var h = new Harness(new GatedProjection(TranscriptProjection.For("claude")!, "OLD", gate));
+            var oldPath = Tmp.CreateFile("old.jsonl", [UserLine.Replace("hello", "OLD"), ToolCallLine]);
+            var newPath = Tmp.CreateFile("new.jsonl", [AssistantLine]);
+
+            h.Daemon.Agents.AddOrUpdate(Dto(oldPath));
+            await (h.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            var oldRead = h.Chat.PendingReadForTesting!;
+
+            h.Daemon.Agents.AddOrUpdate(Dto(newPath));
+            gate.SetResult();
+            await oldRead;
+            await (h.Chat.PendingReadForTesting ?? Task.CompletedTask);
+            await h.TickAsync();
+
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(new[] { nameof(AssistantTextItem) });
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Unavailable_for_a_vendor_without_a_projection_and_no_ticks_after_teardown() {
+        await RunOnUiAsync(async () => {
+            var unavailable = new Harness(projection: null);
+            await Assert.That(unavailable.Chat.Phase).IsEqualTo(ChatTabPhase.Unavailable);
+            await Assert.That(unavailable.Chat.PhaseNote).IsEqualTo("No chat view for this harness");
+            await unavailable.TeardownAsync();
+
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine]);
+            await h.PushAsync(Dto(path));
+            await h.TeardownAsync();
+            File.AppendAllText(path, AssistantLine + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).HasCount().EqualTo(1);
+
+            // A removed agent keeps its items.
+            var kept = Claude();
+            var keptPath = Tmp.CreateFile("kept.jsonl", [UserLine]);
+            await kept.PushAsync(Dto(keptPath));
+            kept.Daemon.Agents.Remove("a1");
+            await Assert.That(kept.Chat.Items).HasCount().EqualTo(1);
+            await kept.TeardownAsync();
+        });
+    }
+
+    /// Thread identity, so deliberately not under WithImmediateRxScheduler.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_dto_pushed_from_a_pool_thread_lands_on_the_ui_thread() {
+        var onUi = await DispatchAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine]);
+            bool? phaseChangedOnUi = null;
+            h.Chat.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(ChatTabViewModel.Phase)) phaseChangedOnUi = Dispatcher.UIThread.CheckAccess(); };
+
+            await Task.Run(() => h.Daemon.Agents.AddOrUpdate(Dto(path)));
+            await WaitUntilAsync(() => h.Chat.Phase == ChatTabPhase.Reading, what: "reading");
+            await h.TeardownAsync();
+            return phaseChangedOnUi;
+        });
+        await Assert.That(onUi).IsEqualTo(true);
+    }
+}
+```
+
+`WaitUntilAsync` inside a `DispatchAsync` body: it uses `await Task.Delay(10)`, which posts back onto the pumped dispatcher frame — the same idiom `WorkspaceFixtures` documents.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/ChatTabViewModelTests/*"`
+Expected: build errors — the types do not exist.
+
+- [ ] **Step 3: Implement the items**
+
+`ViewModels/ChatItems.cs`:
+
+```csharp
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+/// One row of the Chat tab. Three shapes, matched by DataTemplates on the concrete type.
+public abstract class ChatItemViewModel : ReactiveObject { }
+
+public sealed class UserTurnItem(string text) : ChatItemViewModel {
+    public string Text { get; } = text;
+}
+
+public sealed class AssistantTextItem(string text) : ChatItemViewModel {
+    public string Text { get; } = text;
+}
+
+public enum ToolOutcome { Running, Done, Error }
+
+public sealed class ToolCallItem(string name, string detail) : ChatItemViewModel {
+    public string Name { get; } = name;
+    public string Detail { get; } = detail;
+
+    ToolOutcome _outcome;
+    /// Flipped in place when the matching tool_result arrives; never rebuilt.
+    public ToolOutcome Outcome {
+        get => _outcome;
+        set {
+            if (_outcome == value) return;
+            _outcome = value;
+            this.RaisePropertyChanged();
+            this.RaisePropertyChanged(nameof(OutcomeGlyph));
+            this.RaisePropertyChanged(nameof(IsError));
+        }
+    }
+
+    public string OutcomeGlyph => _outcome switch { ToolOutcome.Done => "✓", ToolOutcome.Error => "✕", _ => "" };
+    public bool IsError => _outcome == ToolOutcome.Error;
+}
+```
+
+- [ ] **Step 4: Implement the view model's tail**
+
+`ViewModels/ChatTabViewModel.cs` (the composer, footer and link members are added in Task 12; leave the marked region for them):
+
+```csharp
+using System.Collections.Concurrent;
+using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
+using System.Reactive.Linq;
+using Avalonia.Collections;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+public enum ChatTabPhase { Waiting, Reading, Missing, Unavailable }
+
+/// The Chat tab: the session's transcript, tailed and projected into chat rows, plus the composer
+/// that sends through the sibling terminal. Ctor-scoped; TeardownAsync is the one exit.
+///
+/// Path identity is part of the read generation: a distinct transcript_path clears the rows and
+/// installs a fresh tail in one UI-thread step, and any read still in flight for the old file
+/// completes under a stale generation and is discarded.
+public sealed class ChatTabViewModel : ReactiveObject {
+    internal static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
+
+    readonly string _agentId;
+    readonly TerminalTabViewModel _terminal;
+    readonly ITranscriptProjection? _projection;
+    readonly IUrlOpener _opener;
+    readonly TimeProvider _time;
+    readonly CompositeDisposable _disposables = new();
+    readonly AvaloniaList<ChatItemViewModel> _items = new();
+    readonly Dictionary<string, ToolCallItem> _pendingTools = new(StringComparer.Ordinal);
+    readonly ConcurrentDictionary<string, byte> _loggedFailures = new(StringComparer.Ordinal);
+
+    int _generation;
+    int _readInFlight;
+    string? _path;
+    JsonlTail? _tail;
+    ITimer? _timer;
+    Task? _pendingRead;
+
+    public IAvaloniaReadOnlyList<ChatItemViewModel> Items => _items;
+
+    ChatTabPhase _phase;
+    public ChatTabPhase Phase {
+        get => _phase;
+        private set {
+            this.RaiseAndSetIfChanged(ref _phase, value);
+            this.RaisePropertyChanged(nameof(PhaseNote));
+        }
+    }
+
+    public string PhaseNote => Phase switch {
+        ChatTabPhase.Waiting     => "Waiting for the transcript…",
+        ChatTabPhase.Missing     => "The transcript file is missing",
+        ChatTabPhase.Unavailable => "No chat view for this harness",
+        _                        => "",
+    };
+
+    internal Task? PendingReadForTesting => _pendingRead;
+
+    public ChatTabViewModel(
+            string agentId, IDaemonClientService daemon, TerminalTabViewModel terminal,
+            ITranscriptProjection? projection, IUrlOpener opener, TimeProvider time) {
+        _agentId = agentId;
+        _terminal = terminal;
+        _projection = projection;
+        _opener = opener;
+        _time = time;
+        _phase = projection is null ? ChatTabPhase.Unavailable : ChatTabPhase.Waiting;
+
+        daemon.Agents.Connect()
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(OnAgentsChanged)
+            .DisposeWith(_disposables);
+
+        if (projection is not null)
+            _timer = time.CreateTimer(_ => OnTick(), null, PollInterval, PollInterval);
+
+        // Task 12: composer, footer and link members are constructed here.
+    }
+
+    void OnAgentsChanged(IChangeSet<AgentStatusDto, string> changes) {
+        foreach (var change in changes) {
+            if (change.Key != _agentId || change.Reason is not (ChangeReason.Add or ChangeReason.Update)) continue;
+            OnDto(change.Current);
+        }
+    }
+
+    void OnDto(AgentStatusDto dto) {
+        if (_projection is not null && dto.TranscriptPath is { } path && path != _path) SwitchPath(path);
+    }
+
+    void SwitchPath(string path) {
+        Interlocked.Increment(ref _generation);
+        _items.Clear();
+        _pendingTools.Clear();
+        _path = path;
+        Volatile.Write(ref _tail, new JsonlTail(path));
+        Phase = ChatTabPhase.Waiting;
+        OnTick();
+    }
+
+    void OnTick() {
+        if (Volatile.Read(ref _tail) is not { } tail || _projection is not { } projection) return;
+        if (Interlocked.CompareExchange(ref _readInFlight, 1, 0) != 0) return;
+        _pendingRead = ReadAndApplyAsync(tail, projection, Volatile.Read(ref _generation));
+    }
+
+    async Task ReadAndApplyAsync(JsonlTail tail, ITranscriptProjection projection, int generation) {
+        try {
+            var (read, envelopes) = await Task.Run(() => {
+                var result = tail.ReadAppended();
+                var list = new List<AcpEventEnvelope>();
+                foreach (var line in result.Lines) {
+                    try { list.AddRange(projection.Project(line)); }
+                    catch (Exception ex) { LogOnce($"projection: {ex.Message}"); }
+                }
+                return (result, list);
+            }).ConfigureAwait(false);
+
+            await Dispatcher.UIThread.InvokeAsync(() => Apply(generation, read, envelopes));
+        } catch (Exception ex) {
+            LogOnce($"read: {ex.Message}");
+        } finally {
+            Volatile.Write(ref _readInFlight, 0);
+        }
+    }
+
+    void Apply(int generation, TailRead read, List<AcpEventEnvelope> envelopes) {
+        if (generation != Volatile.Read(ref _generation)) return;
+
+        switch (read.Status) {
+            case TailStatus.Missing:
+                Phase = ChatTabPhase.Missing;
+                return;
+            case TailStatus.Failed:
+                LogOnce(read.Failure ?? "read failed");
+                return;
+            case TailStatus.Reset:
+                _items.Clear();
+                _pendingTools.Clear();
+                break;
+        }
+
+        Phase = ChatTabPhase.Reading;
+        if (envelopes.Count == 0) return;
+
+        var fresh = new List<ChatItemViewModel>();
+        foreach (var e in envelopes) {
+            switch (e.Kind) {
+                case AcpEventKind.UserMessage:
+                    fresh.Add(new UserTurnItem(e.Text ?? ""));
+                    break;
+                case AcpEventKind.AssistantText:
+                    fresh.Add(new AssistantTextItem(e.Text ?? ""));
+                    break;
+                case AcpEventKind.ToolCall: {
+                    var item = new ToolCallItem(e.ToolName ?? "tool", ToolDetail.From(e.ToolInputJson));
+                    if (e.ToolCallId is { } id) _pendingTools[id] = item;
+                    fresh.Add(item);
+                    break;
+                }
+                case AcpEventKind.ToolResult:
+                    if (e.ToolCallId is { } resultId && _pendingTools.Remove(resultId, out var call))
+                        call.Outcome = e.ToolIsError ? ToolOutcome.Error : ToolOutcome.Done;
+                    break;
+            }
+        }
+        if (fresh.Count > 0) _items.AddRange(fresh);
+    }
+
+    void LogOnce(string reason) {
+        if (_loggedFailures.TryAdd(reason, 0)) Console.Error.WriteLine($"kcap: chat transcript: {reason}");
+    }
+
+    public Task TeardownAsync() {
+        Interlocked.Increment(ref _generation);
+        _timer?.Dispose();
+        _timer = null;
+        _disposables.Dispose();
+        return Task.CompletedTask;
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Same command. Expected: 7 PASS. If `A_path_switch_discards_a_read_still_in_flight_for_the_old_file` sees the OLD user row, the generation captured by `OnTick` is being read after the switch — it must be captured before `ReadAndApplyAsync` starts, as written.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/ChatItems.cs src/Capacitor.App/ViewModels/ChatTabViewModel.cs test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+git commit -m "Tail the session transcript into chat rows
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: Composer, footer and link command on `ChatTabViewModel`
+
+**Files:**
+- Modify: `src/Capacitor.App/ViewModels/ChatTabViewModel.cs`
+- Test: `test/Capacitor.App.Tests.Unit/ChatComposerTests.cs`
+
+**Interfaces:**
+- Consumes: `TerminalTabViewModel.TrySendText/CanAcceptText/SendAvailability/State` (Task 10), `LinkPolicy` (Task 9), `HostedHarnessCatalog.Build/LabelFor/ModelLabelFor`, `SessionStatusDots.For`.
+- Produces on `ChatTabViewModel`: `string ComposerText` (bound, settable), `ReactiveCommand<Unit, Unit> SendCommand`, `ReactiveCommand<string, Unit> OpenLinkCommand`, `string ComposerHint`, `string VendorLabel`, `string ModelLabel`, `string StatusText`, `IBrush StatusDot`; `internal static string HintFor(SendAvailability, TerminalSessionState, string vendorLabel)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ChatComposerTests {
+    static async Task<(FakeDaemonClientService Daemon, FakeTimeProvider Time, TerminalTabViewModel Terminal, ChatTabViewModel Chat, FakeTerminalAttachClient Client, RecordingOpener Opener)>
+            BuildAttachedAsync() {
+        var daemon = new FakeDaemonClientService();
+        var factory = new FakeTerminalAttachClientFactory();
+        var time = new FakeTimeProvider();
+        var opener = new RecordingOpener();
+        var terminal = new TerminalTabViewModel("a1", daemon, factory.Factory, () => new FakeTerminalSurface(), time);
+        var chat = new ChatTabViewModel("a1", daemon, terminal, TranscriptProjection.For("claude"), opener, time);
+        daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(supportedVendors: ["claude", "codex"]));
+        daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo", model: "claude-opus-5") with { Status = "Running" });
+        await (terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+        var client = factory.Created.Single();
+        await client.TriggerAttached([]);
+        return (daemon, time, terminal, chat, client, opener);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Send_clears_the_text_on_acceptance_and_keeps_it_on_refusal() {
+        await RunOnUiAsync(async () => {
+            var (_, time, terminal, chat, client, _) = await BuildAttachedAsync();
+            await Assert.That(await chat.SendCommand.CanExecute.FirstAsync()).IsFalse();
+
+            chat.ComposerText = "hello";
+            await Assert.That(await chat.SendCommand.CanExecute.FirstAsync()).IsTrue();
+            await chat.SendCommand.Execute();
+            await Assert.That(chat.ComposerText).IsEqualTo("");
+            await Assert.That(chat.ComposerHint).IsEqualTo("Sending…");
+
+            chat.ComposerText = "second";
+            await Assert.That(await chat.SendCommand.CanExecute.FirstAsync()).IsFalse();
+            time.Advance(TimeSpan.FromMilliseconds(150));
+            await terminal.PendingDeliveryForTesting!;
+            await Assert.That(chat.ComposerText).IsEqualTo("second");
+            await Assert.That(await chat.SendCommand.CanExecute.FirstAsync()).IsTrue();
+            await Assert.That(client.SentInput).HasCount().EqualTo(2);
+            await chat.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Hint_follows_send_availability_and_the_vendor_label() {
+        await RunOnUiAsync(async () => {
+            var (daemon, _, terminal, chat, client, _) = await BuildAttachedAsync();
+            await Assert.That(chat.VendorLabel).IsEqualTo("Claude Code");
+            await Assert.That(chat.ComposerHint).IsEqualTo("Reply to Claude Code · Enter sends · Shift+Enter for a new line");
+
+            client.Result.SetResult(new AttachOutcome.Detached());
+            await terminal.CurrentRunForTesting!;
+            await Assert.That(chat.ComposerHint).IsEqualTo("Reattach the terminal to send");
+
+            daemon.Agents.Remove("a1");
+            await Assert.That(chat.ComposerHint).IsEqualTo("Reattach the terminal to send"); // Detached outranks removal
+
+            var attached = TerminalSessionState.Attached(null);
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Transitioning, attached, "Claude Code")).IsEqualTo("Updating the terminal connection…");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.ReadOnly, TerminalSessionState.Attached("review"), "x")).IsEqualTo("Read-only: review");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Connecting, TerminalSessionState.Connecting, "x")).IsEqualTo("Connecting to the terminal…");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Ended, TerminalSessionState.SessionEnded, "x")).IsEqualTo("This session has ended");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.NoTerminal, TerminalSessionState.NotFound, "x")).IsEqualTo("No terminal to send to");
+            await chat.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Footer_reflects_the_dto() {
+        await RunOnUiAsync(async () => {
+            var (daemon, _, _, chat, _, _) = await BuildAttachedAsync();
+            await Assert.That(chat.ModelLabel).IsEqualTo("Claude Opus 5");
+            await Assert.That(chat.StatusText).IsEqualTo("Running");
+            await Assert.That(chat.StatusDot).IsSameReferenceAs(SessionStatusDots.For("Running"));
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo") with { Status = "Failed" });
+            await Assert.That(chat.StatusText).IsEqualTo("Failed");
+            await Assert.That(chat.ModelLabel).IsEqualTo("default");
+            await chat.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Links_open_only_through_the_policy_and_an_opener_fault_is_contained() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, chat, _, opener) = await BuildAttachedAsync();
+
+            await chat.OpenLinkCommand.Execute("https://example.com/a");
+            await chat.OpenLinkCommand.Execute("file:///etc/passwd");
+            await chat.OpenLinkCommand.Execute("javascript:alert(1)");
+            await Assert.That(opener.Opened).IsEquivalentTo(new[] { "https://example.com/a" });
+
+            opener.ThrowOnOpen = new InvalidOperationException("no browser");
+            await chat.OpenLinkCommand.Execute("https://example.com/b");
+            await Assert.That(opener.Opened).HasCount().EqualTo(2);
+            await chat.TeardownAsync();
+        });
+    }
+
+    /// Thread identity: the hint's own change lands on the UI thread even when the terminal's
+    /// state flips from a pool thread.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_pool_thread_state_flip_updates_the_hint_on_the_ui_thread() {
+        var onUi = await DispatchAsync(async () => {
+            var (_, _, terminal, chat, client, _) = await BuildAttachedAsync();
+            bool? hintChangedOnUi = null;
+            chat.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(ChatTabViewModel.ComposerHint)) hintChangedOnUi = Dispatcher.UIThread.CheckAccess(); };
+
+            await Task.Run(() => client.Result.SetResult(new AttachOutcome.Exited(0)));
+            await terminal.CurrentRunForTesting!;
+            await WaitUntilAsync(() => chat.ComposerHint == "This session has ended", what: "hint");
+            await chat.TeardownAsync();
+            return hintChangedOnUi;
+        });
+        await Assert.That(onUi).IsEqualTo(true);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/ChatComposerTests/*"`
+Expected: build errors — `ComposerText`, `SendCommand`, `HintFor` missing.
+
+- [ ] **Step 3: Add the composer, footer and link members**
+
+In `ChatTabViewModel.cs` add the usings `using System.Reactive;` and `using Avalonia.Media;`, these members, and the constructor block at the marked spot:
+
+```csharp
+    string _composerText = "";
+    public string ComposerText {
+        get => _composerText;
+        set => this.RaiseAndSetIfChanged(ref _composerText, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> SendCommand { get; }
+    public ReactiveCommand<string, Unit> OpenLinkCommand { get; }
+
+    readonly ObservableAsPropertyHelper<string> _composerHint;
+    public string ComposerHint => _composerHint.Value;
+
+    string _vendor = "";
+    IReadOnlyList<HarnessOption> _options = HostedHarnessCatalog.Build(null);
+
+    string _vendorLabel = "";
+    public string VendorLabel { get => _vendorLabel; private set => this.RaiseAndSetIfChanged(ref _vendorLabel, value); }
+
+    string _modelLabel = "default";
+    public string ModelLabel { get => _modelLabel; private set => this.RaiseAndSetIfChanged(ref _modelLabel, value); }
+
+    string _statusText = "";
+    public string StatusText { get => _statusText; private set => this.RaiseAndSetIfChanged(ref _statusText, value); }
+
+    IBrush _statusDot = SessionStatusDots.For("");
+    public IBrush StatusDot { get => _statusDot; private set => this.RaiseAndSetIfChanged(ref _statusDot, value); }
+
+    /// The hint is built from the terminal's own availability, so it is true in the windows
+    /// where State alone would lie (a reattach or detach under way while State reads Attached).
+    internal static string HintFor(SendAvailability availability, TerminalSessionState state, string vendorLabel) => availability switch {
+        SendAvailability.Ready         => $"Reply to {vendorLabel} · Enter sends · Shift+Enter for a new line",
+        SendAvailability.Sending       => "Sending…",
+        SendAvailability.Transitioning => "Updating the terminal connection…",
+        SendAvailability.ReadOnly      => $"Read-only: {state.Detail}",
+        SendAvailability.Connecting    => "Connecting to the terminal…",
+        SendAvailability.Reattach      => "Reattach the terminal to send",
+        SendAvailability.Ended         => "This session has ended",
+        _                              => "No terminal to send to",
+    };
+```
+
+Constructor additions (replace the `// Task 12` comment):
+
+```csharp
+        daemon.Snapshots
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(snapshot => {
+                _options = HostedHarnessCatalog.Build(snapshot.Daemon.SupportedVendors);
+                VendorLabel = HostedHarnessCatalog.LabelFor(_options, _vendor);
+            })
+            .DisposeWith(_disposables);
+
+        _composerHint = Observable.CombineLatest(
+                terminal.WhenAnyValue(t => t.SendAvailability, t => t.State, (availability, state) => (availability, state)),
+                this.WhenAnyValue(x => x.VendorLabel),
+                (t, label) => HintFor(t.availability, t.state, label))
+            .ToProperty(this, x => x.ComposerHint, HintFor(terminal.SendAvailability, terminal.State, ""))
+            .DisposeWith(_disposables);
+
+        var canSend = Observable.CombineLatest(
+            this.WhenAnyValue(x => x.ComposerText),
+            terminal.WhenAnyValue(t => t.CanAcceptText),
+            (text, can) => can && !string.IsNullOrWhiteSpace(text));
+        SendCommand = ReactiveCommand.Create(() => {
+            if (_terminal.TrySendText(ComposerText)) ComposerText = "";
+        }, canSend);
+        _disposables.Add(SendCommand);
+
+        OpenLinkCommand = ReactiveCommand.Create<string>(url => {
+            if (!LinkPolicy.IsOpenable(url)) return;
+            try { _opener.Open(url); }
+            catch (Exception ex) { Console.Error.WriteLine($"kcap: open link failed: {ex.Message}"); }
+        });
+        _disposables.Add(OpenLinkCommand);
+```
+
+Extend `OnDto` so the footer follows every dto:
+
+```csharp
+    void OnDto(AgentStatusDto dto) {
+        _vendor = dto.Vendor;
+        VendorLabel = HostedHarnessCatalog.LabelFor(_options, dto.Vendor);
+        ModelLabel = HostedHarnessCatalog.ModelLabelFor(dto.Vendor, dto.Model ?? "");
+        StatusText = dto.Status;
+        StatusDot = SessionStatusDots.For(dto.Status);
+        if (_projection is not null && dto.TranscriptPath is { } path && path != _path) SwitchPath(path);
+    }
+```
+
+`FakeDaemonClientService.Agent` fixtures are records, so `with { Status = "Failed" }` and `with { TranscriptPath = … }` work as the tests use them.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Same command, then `ChatTabViewModelTests` again. Expected: all PASS. `VendorLabel` "Claude Code" comes from `HarnessCatalog.All`'s label for `claude` — if the catalog spells it differently, use the catalog's actual label in the assertion, never a literal that drifts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/ChatTabViewModel.cs test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
+git commit -m "Add the chat composer, footer and link command
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Markdown rendering
+
+**Files:**
+- Create: `src/Capacitor.App/Views/MarkdownBlocks.cs`, `src/Capacitor.App/Views/MarkdownView.cs`
+- Test: `test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs`
+
+**Interfaces:**
+- Consumes: Markdig (`Markdown.Parse`, block/inline AST), `LinkPolicy` (Task 9).
+- Produces: `public static class MarkdownBlocks { public static Control Build(string markdown, ICommand? openLink); }`; `public sealed class MarkdownView : ContentControl` with styled `string? Text` and `ICommand? OpenLink`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using System.Reactive;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.Views;
+using ReactiveUI;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class MarkdownBlocksTests {
+    static (Window Window, Control Root, List<string> Opened) Show(string markdown) {
+        var opened = new List<string>();
+        ICommand open = ReactiveCommand.Create<string>(opened.Add);
+        var view = new MarkdownView { Text = markdown, OpenLink = open, Width = 400 };
+        var window = new Window { Content = view, Width = 500, Height = 400 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, view, opened);
+    }
+
+    static IEnumerable<T> All<T>(Control root) where T : Visual => root.GetVisualDescendants().OfType<T>();
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Paragraph_inlines_code_blocks_lists_and_quotes_render() {
+        await RunOnUiAsync(async () => {
+            var (window, root, _) = Show("Some **bold** and *em* and `code`.\n\n```\nvar x = 1;\n```\n\n- one\n- two\n\n> quoted\n\n---\n");
+
+            var paragraph = All<SelectableTextBlock>(root).First();
+            await Assert.That(paragraph.Inlines!.OfType<Bold>().Count()).IsEqualTo(1);
+            await Assert.That(paragraph.Inlines!.OfType<Italic>().Count()).IsEqualTo(1);
+            await Assert.That(paragraph.Inlines!.OfType<Run>().Any(r => r.Text == "code")).IsTrue();
+            await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Text == "var x = 1;")).IsTrue();
+            await Assert.That(All<TextBlock>(root).Count(t => t.Text == "•")).IsEqualTo(2);
+            await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Inlines!.Any(i => i is Run { Text: "quoted" }))).IsTrue();
+            window.Close();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_allowed_link_is_a_button_that_opens_once_by_pointer_and_once_by_keyboard() {
+        await RunOnUiAsync(async () => {
+            var (window, root, opened) = Show("See [docs](https://example.com/docs) now.");
+            var button = All<HyperlinkButton>(root).Single();
+            await Assert.That(button.NavigateUri).IsNull();
+            await Assert.That(button.CommandParameter).IsEqualTo("https://example.com/docs");
+
+            var origin = button.TranslatePoint(new Avalonia.Point(2, 2), window)!.Value;
+            window.MouseDown(origin, MouseButton.Left);
+            window.MouseUp(origin, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(opened).IsEquivalentTo(new[] { "https://example.com/docs" });
+
+            button.Focus();
+            window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(opened).HasCount().EqualTo(2);
+            window.Close();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_disallowed_link_and_unknown_constructs_render_as_plain_text() {
+        await RunOnUiAsync(async () => {
+            var (window, root, opened) = Show("Bad [link](javascript:alert(1)) and <b>html</b>\n\n| a | b |\n|---|---|\n| 1 | 2 |\n");
+            await Assert.That(All<HyperlinkButton>(root)).IsEmpty();
+            await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Inlines!.Any(i => i is Run { Text: "link" }))).IsTrue();
+            await Assert.That(All<SelectableTextBlock>(root).Any(t => (t.Text ?? "").Contains("| a | b |"))).IsTrue();
+            await Assert.That(opened).IsEmpty();
+            await Assert.That(root.GetVisualDescendants().OfType<Control>().Any(c => c.Focusable && c is not SelectableTextBlock)).IsFalse();
+            window.Close();
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/MarkdownBlocksTests/*"`
+Expected: build errors — `MarkdownView`/`MarkdownBlocks` missing.
+
+- [ ] **Step 3: Implement the renderer**
+
+`Views/MarkdownBlocks.cs`:
+
+```csharp
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Capacitor.App.Services;
+using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace Capacitor.App.Views;
+
+/// Maps the markdown constructs agents actually emit to Avalonia controls. Anything else
+/// renders as its literal source text — degraded, never dropped.
+public static class MarkdownBlocks {
+    static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder().UseAutoLinks().Build();
+    static readonly FontFamily Mono = new("Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace");
+
+    static IBrush Brush(string key) => Application.Current?.FindResource(key) as IBrush ?? Brushes.Gray;
+
+    public static Control Build(string markdown, ICommand? openLink) {
+        var document = Markdown.Parse(markdown, Pipeline);
+        var panel = new StackPanel { Spacing = 8 };
+        foreach (var block in document) panel.Children.Add(BuildBlock(markdown, block, openLink));
+        return panel;
+    }
+
+    static Control BuildBlock(string source, Block block, ICommand? openLink) => block switch {
+        ParagraphBlock p     => InlineText(p.Inline, openLink, 13.5, bold: false),
+        HeadingBlock h       => InlineText(h.Inline, openLink, h.Level switch { 1 => 18, 2 => 16, _ => 14.5 }, bold: true),
+        FencedCodeBlock f    => CodeBlock(f),
+        CodeBlock c          => CodeBlock(c),
+        ListBlock list       => List(source, list, openLink),
+        QuoteBlock quote     => Quote(source, quote, openLink),
+        ThematicBreakBlock   => new Border { Height = 1, Background = Brush("KcapBorderBrush"), Margin = new Thickness(0, 4) },
+        _                    => Literal(source, block),
+    };
+
+    static SelectableTextBlock InlineText(ContainerInline? inlines, ICommand? openLink, double fontSize, bool bold) {
+        var text = new SelectableTextBlock {
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = fontSize,
+            FontWeight = bold ? FontWeight.SemiBold : FontWeight.Normal,
+            LineHeight = fontSize * 1.6,
+            Foreground = Brush("KcapTextBrush"),
+        };
+        AddInlines(text.Inlines!, inlines, openLink);
+        return text;
+    }
+
+    static void AddInlines(InlineCollection target, ContainerInline? container, ICommand? openLink) {
+        if (container is null) return;
+        foreach (var inline in container) {
+            switch (inline) {
+                case LiteralInline literal:
+                    target.Add(new Run(literal.Content.ToString()));
+                    break;
+                case EmphasisInline emphasis: {
+                    Span span = emphasis.DelimiterCount >= 2 ? new Bold() : new Italic();
+                    AddInlines(span.Inlines, emphasis, openLink);
+                    target.Add(span);
+                    break;
+                }
+                case CodeInline code:
+                    target.Add(new Run(code.Content) { FontFamily = Mono });
+                    break;
+                case LineBreakInline:
+                    target.Add(new LineBreak());
+                    break;
+                case LinkInline link when !link.IsImage && LinkPolicy.IsOpenable(link.Url):
+                    target.Add(new InlineUIContainer { Child = LinkButton(PlainText(link), link.Url!, openLink) });
+                    break;
+                case LinkInline link:
+                    AddInlines(target, link, openLink);
+                    break;
+                case AutolinkInline auto when LinkPolicy.IsOpenable(auto.Url):
+                    target.Add(new InlineUIContainer { Child = LinkButton(auto.Url, auto.Url, openLink) });
+                    break;
+                case AutolinkInline auto:
+                    target.Add(new Run(auto.Url));
+                    break;
+                case HtmlInline html:
+                    target.Add(new Run(html.Tag));
+                    break;
+                case ContainerInline nested:
+                    AddInlines(target, nested, openLink);
+                    break;
+                default:
+                    target.Add(new Run(inline.ToString() ?? ""));
+                    break;
+            }
+        }
+    }
+
+    // NavigateUri stays unset on purpose: set, the control opens the URI itself and the policy
+    // in the command would never run.
+    static HyperlinkButton LinkButton(string label, string url, ICommand? openLink) => new() {
+        Content = label,
+        Command = openLink,
+        CommandParameter = url,
+        Padding = new Thickness(0),
+        Cursor = new Cursor(StandardCursorType.Hand),
+        Foreground = Brush("KcapAccentBrush"),
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    static string PlainText(ContainerInline container) =>
+        string.Concat(container.Select(i => i is LiteralInline l ? l.Content.ToString() : i is ContainerInline c ? PlainText(c) : ""));
+
+    static Control CodeBlock(LeafBlock code) => new Border {
+        Background = Brush("KcapSurfaceBrush"),
+        BorderBrush = Brush("KcapBorderBrush"),
+        BorderThickness = new Thickness(1),
+        CornerRadius = new CornerRadius(8),
+        Padding = new Thickness(12, 8),
+        Child = new SelectableTextBlock {
+            Text = code.Lines.ToString().TrimEnd('\n', '\r'),
+            FontFamily = Mono,
+            FontSize = 12.5,
+            TextWrapping = TextWrapping.NoWrap,
+            Foreground = Brush("KcapTextBrush"),
+        },
+    };
+
+    static Control List(string source, ListBlock list, ICommand? openLink) {
+        var panel = new StackPanel { Spacing = 4 };
+        var index = list.IsOrdered && int.TryParse(list.OrderedStart, out var start) ? start : 1;
+        foreach (var item in list.OfType<ListItemBlock>()) {
+            var row = new Grid { ColumnDefinitions = new ColumnDefinitions("22,*") };
+            var marker = new TextBlock {
+                Text = list.IsOrdered ? $"{index++}." : "•",
+                Foreground = Brush("KcapMutedBrush"),
+                FontSize = 13.5,
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+            var content = new StackPanel { Spacing = 4 };
+            foreach (var child in item) content.Children.Add(BuildBlock(source, child, openLink));
+            Grid.SetColumn(content, 1);
+            row.Children.Add(marker);
+            row.Children.Add(content);
+            panel.Children.Add(row);
+        }
+        return panel;
+    }
+
+    static Control Quote(string source, QuoteBlock quote, ICommand? openLink) {
+        var content = new StackPanel { Spacing = 6 };
+        foreach (var child in quote) content.Children.Add(BuildBlock(source, child, openLink));
+        return new Border {
+            BorderBrush = Brush("KcapBorderBrush"),
+            BorderThickness = new Thickness(3, 0, 0, 0),
+            Padding = new Thickness(12, 0, 0, 0),
+            Child = content,
+        };
+    }
+
+    static Control Literal(string source, Block block) {
+        var span = block.Span;
+        var text = span.Start >= 0 && span.End < source.Length && span.End >= span.Start
+            ? source.Substring(span.Start, span.Length)
+            : block.ToString() ?? "";
+        return new SelectableTextBlock {
+            Text = text,
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 13.5,
+            Foreground = Brush("KcapTextBrush"),
+        };
+    }
+}
+```
+
+`Views/MarkdownView.cs`:
+
+```csharp
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+
+namespace Capacitor.App.Views;
+
+/// Assistant prose: a ContentControl whose content is rebuilt from the markdown on every change.
+public sealed class MarkdownView : ContentControl {
+    public static readonly StyledProperty<string?> TextProperty =
+        AvaloniaProperty.Register<MarkdownView, string?>(nameof(Text));
+
+    public static readonly StyledProperty<ICommand?> OpenLinkProperty =
+        AvaloniaProperty.Register<MarkdownView, ICommand?>(nameof(OpenLink));
+
+    static MarkdownView() {
+        TextProperty.Changed.AddClassHandler<MarkdownView>((view, _) => view.Rebuild());
+        OpenLinkProperty.Changed.AddClassHandler<MarkdownView>((view, _) => view.Rebuild());
+    }
+
+    public string? Text {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public ICommand? OpenLink {
+        get => GetValue(OpenLinkProperty);
+        set => SetValue(OpenLinkProperty, value);
+    }
+
+    void Rebuild() => Content = MarkdownBlocks.Build(Text ?? "", OpenLink);
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Same command. Expected: 3 PASS. If the pipe-table assertion fails because Markdig's default pipeline parses the table rows as a paragraph, the literal text still contains `| a | b |` — keep the assertion on `Contains`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/Views/MarkdownBlocks.cs src/Capacitor.App/Views/MarkdownView.cs test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
+git commit -m "Render assistant markdown with Markdig behind a link policy
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: `WorkspaceViewModel` — the Chat tab and the tab switch
+
+**Files:**
+- Modify: `src/Capacitor.App/ViewModels/WorkspaceViewModel.cs`
+- Modify: `src/Capacitor.App/App.axaml.cs` (`BuildWorkspace`), every `new WorkspaceViewModel(` in tests (`grep -rn "new WorkspaceViewModel(" src test`)
+- Test: `test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs`
+
+**Interfaces:**
+- Consumes: `ChatTabViewModel` (Tasks 11–12), `TranscriptProjection.For`.
+- Produces on `WorkspaceViewModel`: constructor gains a trailing `IUrlOpener opener` parameter; `ChatTabViewModel? Chat` (bound); `WorkspaceTab ActiveTab` (default `Chat`); `bool IsChatActive`, `bool IsTerminalActive`; `ReactiveCommand<Unit, Unit> ShowChatCommand`, `ShowTerminalCommand`; `public enum WorkspaceTab { Chat, Terminal }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `WorkspaceViewModelTests` (its `Build` helper gains `new RecordingOpener()` as the last constructor argument; update it):
+
+```csharp
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Chat_is_the_default_tab_and_the_switch_commands_flip_it() {
+        await RunOnUiAsync(async () => {
+            var vm = Build(new FakeDaemonClientService(), NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider());
+
+            await Assert.That(vm.ActiveTab).IsEqualTo(WorkspaceTab.Chat);
+            await Assert.That(vm.IsChatActive).IsTrue();
+            await Assert.That(vm.IsTerminalActive).IsFalse();
+
+            await vm.ShowTerminalCommand.Execute();
+            await Assert.That(vm.IsTerminalActive).IsTrue();
+            await vm.ShowChatCommand.Execute();
+            await Assert.That(vm.IsChatActive).IsTrue();
+            await vm.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Chat_is_built_for_a_pty_dto_only_and_torn_down_with_the_workspace() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var vm = Build(daemon, NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider());
+            await Assert.That(vm.Chat).IsNull();
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: false));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(vm.Chat).IsNull();
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: true));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(vm.Chat).IsNotNull();
+            await Assert.That(vm.Chat!.Phase).IsEqualTo(ChatTabPhase.Unavailable); // gemini has no transcript projection
+
+            var chat = vm.Chat;
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+            await Assert.That(vm.Chat).IsSameReferenceAs(chat); // built once
+
+            await vm.TeardownAsync();
+            await Assert.That(chat.PendingReadForTesting).IsNull();
+        });
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/WorkspaceViewModelTests/*"`
+Expected: build errors — `ActiveTab`, `Chat` missing.
+
+- [ ] **Step 3: Implement**
+
+In `WorkspaceViewModel.cs`:
+
+```csharp
+public enum WorkspaceTab { Chat, Terminal }
+```
+
+Add members:
+
+```csharp
+    ChatTabViewModel? _chat;
+    /// Built once, on the first dto that passes the PTY gate — the projection is chosen by the
+    /// dto's vendor. Null for a non-PTY session.
+    public ChatTabViewModel? Chat {
+        get => _chat;
+        private set => this.RaiseAndSetIfChanged(ref _chat, value);
+    }
+
+    WorkspaceTab _activeTab = WorkspaceTab.Chat;
+    public WorkspaceTab ActiveTab {
+        get => _activeTab;
+        private set {
+            this.RaiseAndSetIfChanged(ref _activeTab, value);
+            this.RaisePropertyChanged(nameof(IsChatActive));
+            this.RaisePropertyChanged(nameof(IsTerminalActive));
+        }
+    }
+    public bool IsChatActive => ActiveTab == WorkspaceTab.Chat;
+    public bool IsTerminalActive => ActiveTab == WorkspaceTab.Terminal;
+
+    public ReactiveCommand<Unit, Unit> ShowChatCommand { get; }
+    public ReactiveCommand<Unit, Unit> ShowTerminalCommand { get; }
+```
+
+Constructor: add the trailing parameter `IUrlOpener opener`, and after the existing `_sessionEnded` projection:
+
+```csharp
+        presence
+            .Where(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
+            .Take(1)
+            .Subscribe(p => Chat = new ChatTabViewModel(
+                agentId, daemon, Terminal, TranscriptProjection.For(p.Dto!.Vendor), opener, time))
+            .DisposeWith(_disposables);
+
+        ShowChatCommand = ReactiveCommand.Create(() => { ActiveTab = WorkspaceTab.Chat; });
+        ShowTerminalCommand = ReactiveCommand.Create(() => { ActiveTab = WorkspaceTab.Terminal; });
+        _disposables.Add(ShowChatCommand);
+        _disposables.Add(ShowTerminalCommand);
+```
+
+`TeardownAsync`:
+
+```csharp
+    public async Task TeardownAsync() {
+        _disposables.Dispose();
+        if (Chat is { } chat) await chat.TeardownAsync();
+        await Terminal.TeardownAsync();
+    }
+```
+
+Add `using Capacitor.Cli.Core;` for `TranscriptProjection`.
+
+Composition root (`App.axaml.cs`, `BuildWorkspace`): append `new ShellUrlOpener()` — reuse the instance already built for `AgentActionService` by hoisting it into a local `var opener = new ShellUrlOpener();` used by both. Update every test constructing `WorkspaceViewModel` (grep) to pass `new RecordingOpener()`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run `WorkspaceViewModelTests`, then the whole app suite. Expected: green (the smoke and navigation suites compile against the new parameter).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/WorkspaceViewModel.cs src/Capacitor.App/App.axaml.cs test/Capacitor.App.Tests.Unit
+git commit -m "Give the workspace a Chat tab and make it the default
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 15: The views — `ChatTabView`, the tab strip, focus, follow-tail
+
+**Files:**
+- Create: `src/Capacitor.App/Views/ChatTabView.axaml`, `src/Capacitor.App/Views/ChatTabView.axaml.cs`
+- Modify: `src/Capacitor.App/Views/WorkspaceView.axaml`, `src/Capacitor.App/Views/WorkspaceView.axaml.cs`, `src/Capacitor.App/Views/Converters.cs`
+- Test: `test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs` (extend), `test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs` (create)
+
+**Interfaces:**
+- Consumes: `WorkspaceViewModel.Chat/ActiveTab/IsChatActive/IsTerminalActive/ShowChatCommand/ShowTerminalCommand` (Task 14), `ChatTabViewModel` members (Tasks 11–12), `MarkdownView` (Task 13).
+- Produces: named controls `ChatTabButton`, `ChatHost`, `ChatItems`, `ChatPhaseNote`, `ComposerInput`, `SendButton`, `TerminalBanners`; `ChatTabView.FocusComposer()`; converters `BoolToOpacityConverter`, `OffscreenWhenInactiveConverter`, `ToolOutcomeBrushConverter`.
+
+- [ ] **Step 1: Write the failing smoke tests**
+
+Extend `WorkspaceViewSmokeTests`: change `Build` to pass `new RecordingOpener()` and to accept an optional `Func<ITerminalSurface>? surface`; add the names to `WorkspaceView_resolves_all_eight_named_controls` (rename it to `..._named_controls`), and append:
+
+```csharp
+    static async Task<(Window Window, WorkspaceViewModel Vm, FakeDaemonClientService Daemon, FakeTerminalAttachClientFactory Attach)> ShowPtyAsync(Func<ITerminalSurface>? surface = null) {
+        var (view, vm, daemon, attach) = Build(surface: surface);
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: true));
+        await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        return (window, vm, daemon, attach);
+    }
+
+    static bool IsOffscreen(Control control) =>
+        Avalonia.Automation.Peers.ControlAutomationPeer.CreatePeerForElement(control).IsOffscreen();
+
+    static IEnumerable<IInputElement> TabRing(IInputElement start) {
+        var seen = new HashSet<IInputElement>();
+        var current = start;
+        while (current is not null && seen.Add(current)) {
+            yield return current;
+            current = KeyboardNavigationHandler.GetNext(current, NavigationDirection.Next);
+        }
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Chat_opens_first_and_the_tabs_swap_the_surfaces_while_the_terminal_stays_in_the_tree() {
+        await RunOnUiAsync(async () => {
+            var (window, vm, _, _) = await ShowPtyAsync();
+            var chatHost = Find<Control>(window, "ChatHost")!;
+            var banners = Find<Control>(window, "TerminalBanners")!;
+            var terminalHost = Find<Control>(window, "TerminalHost")!;
+
+            await Assert.That(vm.IsChatActive).IsTrue();
+            await Assert.That(chatHost.IsEffectivelyVisible).IsTrue();
+            await Assert.That(banners.IsEffectivelyVisible).IsFalse();
+            await Assert.That(IsOffscreen(banners)).IsTrue();
+            await Assert.That(terminalHost.IsEnabled).IsFalse();
+            await Assert.That(terminalHost.IsHitTestVisible).IsFalse();
+            await Assert.That(terminalHost.IsVisible).IsTrue();
+            await Assert.That(IsOffscreen(terminalHost)).IsTrue();
+
+            await vm.ShowTerminalCommand.Execute();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(chatHost.IsEffectivelyVisible).IsFalse();
+            await Assert.That(IsOffscreen(chatHost)).IsTrue();
+            await Assert.That(terminalHost.IsEnabled).IsTrue();
+            await Assert.That(IsOffscreen(terminalHost)).IsFalse();
+            await Assert.That(Find<Control>(window, "TerminalHost")).IsNotNull();
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_workspace_opened_on_chat_still_reports_the_laid_out_pane_size() {
+        await RunOnUiAsync(async () => {
+            var (window, vm, _, attach) = await ShowPtyAsync(surface: () => new XtermTerminalSurface(80, 24));
+            var client = attach.Created[^1];
+
+            await Assert.That((client.Cols, client.Rows)).IsNotEqualTo((80, 24));
+            await Assert.That(client.Cols).IsGreaterThan(80);
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Focus_follows_the_tab_and_survives_a_late_model_assignment() {
+        await RunOnUiAsync(async () => {
+            var (window, vm, _, attach) = await ShowPtyAsync();
+            var composer = Find<TextBox>(window, "ComposerInput")!;
+            var terminalHost = Find<Control>(window, "TerminalHost")!;
+            await Assert.That(composer.IsFocused).IsTrue();
+
+            await attach.Created[^1].TriggerAttached([]);
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(composer.IsFocused).IsTrue();
+
+            await vm.ShowTerminalCommand.Execute();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(terminalHost.IsFocused).IsTrue();
+
+            await vm.ShowChatCommand.Execute();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(composer.IsFocused).IsTrue();
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Tab_traversal_never_reaches_the_inactive_surface() {
+        await RunOnUiAsync(async () => {
+            var (window, vm, _, attach) = await ShowPtyAsync();
+            attach.Created[^1].Result.SetResult(new AttachOutcome.Detached());
+            await vm.Terminal.CurrentRunForTesting!;
+            Dispatcher.UIThread.RunJobs();
+
+            var composer = Find<TextBox>(window, "ComposerInput")!;
+            var detach = Find<Control>(window, "DetachButton")!;
+            var reattach = Find<Control>(window, "ReattachButton")!;
+            var send = Find<Control>(window, "SendButton")!;
+            var terminalHost = Find<Control>(window, "TerminalHost")!;
+
+            var ringFromComposer = TabRing(composer).ToList();
+            await Assert.That(ringFromComposer).DoesNotContain(detach);
+            await Assert.That(ringFromComposer).DoesNotContain(reattach);
+
+            await vm.ShowTerminalCommand.Execute();
+            Dispatcher.UIThread.RunJobs();
+            var ringFromTerminal = TabRing(terminalHost).ToList();
+            await Assert.That(ringFromTerminal).DoesNotContain(composer);
+            await Assert.That(ringFromTerminal).DoesNotContain(send);
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+```
+
+`ChatTabViewSmokeTests.cs` (batching and follow-tail; the view is hosted directly with a `ChatTabViewModel` DataContext):
+
+```csharp
+using System.Collections.Specialized;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.ViewModels;
+using Capacitor.App.Views;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ChatTabViewSmokeTests {
+    [TempDir] public required TempDir Tmp { get; init; }
+
+    const string UserLine = """{"type":"user","message":{"role":"user","content":"hello"}}""";
+
+    sealed class Host {
+        public FakeDaemonClientService Daemon { get; } = new();
+        public FakeTimeProvider Time { get; } = new();
+        public TerminalTabViewModel Terminal { get; }
+        public ChatTabViewModel Chat { get; }
+        public ChatTabView View { get; }
+        public Window Window { get; }
+        public ScrollViewer Scroll => View.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+        public Host() {
+            Terminal = new TerminalTabViewModel("a1", Daemon, new FakeTerminalAttachClientFactory().Factory, () => new FakeTerminalSurface(), Time);
+            Chat = new ChatTabViewModel("a1", Daemon, Terminal, TranscriptProjection.For("claude"), new RecordingOpener(), Time);
+            View = new ChatTabView { DataContext = Chat };
+            Window = new Window { Content = View, Width = 800, Height = 600 };
+            Window.Show();
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        public async Task LoadAsync(string path) {
+            Daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true) with { TranscriptPath = path });
+            await (Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+            Window.UpdateLayout();
+        }
+
+        public async Task AppendAndTickAsync(string path, int lines) {
+            File.AppendAllLines(path, Enumerable.Repeat(UserLine, lines));
+            Time.Advance(ChatTabViewModel.PollInterval);
+            await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+        }
+
+        public bool AtBottom() => Scroll.Offset.Y + Scroll.Viewport.Height >= Scroll.Extent.Height - 1;
+
+        public async Task CloseAsync() {
+            Window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await Chat.TeardownAsync();
+            await Terminal.TeardownAsync();
+        }
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_large_initial_load_is_one_notification_into_a_bounded_number_of_containers() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var path = Tmp.CreateFile("big.jsonl", Enumerable.Repeat(UserLine, 5000).ToArray());
+            var notifications = 0;
+            ((INotifyCollectionChanged)host.Chat.Items).CollectionChanged += (_, _) => notifications++;
+
+            await host.LoadAsync(path);
+
+            await Assert.That(host.Chat.Items).HasCount().EqualTo(5000);
+            await Assert.That(notifications).IsEqualTo(1);
+            var items = host.View.FindControl<ItemsControl>("ChatItems")!;
+            await Assert.That(items.GetRealizedContainers().Count()).IsLessThan(200);
+            await host.CloseAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Follow_tail_tracks_the_bottom_and_leaves_a_scrolled_up_reader_alone() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var path = Tmp.CreateFile("t.jsonl", Enumerable.Repeat(UserLine, 60).ToArray());
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            await host.AppendAndTickAsync(path, 20);
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            host.Scroll.Offset = new Vector(0, 0);
+            host.Window.UpdateLayout();
+            await host.AppendAndTickAsync(path, 20);
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
+
+            // At the bottom, append, then scroll up before the layout pass completes.
+            host.Scroll.ScrollToEnd();
+            host.Window.UpdateLayout();
+            await host.AppendAndTickAsync(path, 20);
+            host.Scroll.Offset = new Vector(0, 0);
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
+            await host.CloseAsync();
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/*Smoke*/*"`
+Expected: build errors (`ChatTabView`, converters) and, once compiling, failing name lookups.
+
+- [ ] **Step 3: Converters**
+
+Append to `Views/Converters.cs`:
+
+```csharp
+/// Opacity for the off-tab terminal: it must stay measured (so the PTY gets the real pane size),
+/// so it is faded rather than collapsed.
+public sealed class BoolToOpacityConverter : IValueConverter {
+    public static readonly BoolToOpacityConverter Instance = new();
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => value is true ? 1.0 : 0.0;
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotSupportedException();
+}
+
+/// A visible-but-faded control is still announced as onscreen by default; the inactive terminal
+/// must be reported offscreen instead.
+public sealed class OffscreenWhenInactiveConverter : IValueConverter {
+    public static readonly OffscreenWhenInactiveConverter Instance = new();
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is true ? Avalonia.Automation.IsOffscreenBehavior.Default : Avalonia.Automation.IsOffscreenBehavior.Offscreen;
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotSupportedException();
+}
+
+public sealed class ToolOutcomeBrushConverter : IValueConverter {
+    public static readonly ToolOutcomeBrushConverter Instance = new();
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        Avalonia.Application.Current?.FindResource(value is true ? "KcapDangerBrush" : "KcapAccentBrush");
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotSupportedException();
+}
+```
+
+- [ ] **Step 4: `ChatTabView.axaml`**
+
+```xml
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Capacitor.App.ViewModels"
+             xmlns:views="clr-namespace:Capacitor.App.Views"
+             x:Class="Capacitor.App.Views.ChatTabView"
+             x:DataType="vm:ChatTabViewModel">
+    <Grid RowDefinitions="*,Auto">
+        <!-- The template owns the ScrollViewer: that is the shape Avalonia virtualizes. An
+             ItemsControl inside an external ScrollViewer is measured at infinite height. -->
+        <ItemsControl x:Name="ChatItems" Grid.Row="0" ItemsSource="{Binding Items}">
+            <ItemsControl.Template>
+                <ControlTemplate>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <ItemsPresenter Name="PART_ItemsPresenter" Margin="22,26,22,8" />
+                    </ScrollViewer>
+                </ControlTemplate>
+            </ItemsControl.Template>
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.DataTemplates>
+                <DataTemplate x:DataType="vm:UserTurnItem">
+                    <Border HorizontalAlignment="Right" MaxWidth="520" Margin="0,0,0,20" Padding="14,11" CornerRadius="10"
+                            Background="{StaticResource KcapSurfaceRaisedBrush}">
+                        <SelectableTextBlock Text="{Binding Text}" TextWrapping="Wrap" FontSize="13.5" LineHeight="20"
+                                             Foreground="{StaticResource KcapTextBrush}" />
+                    </Border>
+                </DataTemplate>
+                <DataTemplate x:DataType="vm:AssistantTextItem">
+                    <views:MarkdownView Text="{Binding Text}" MaxWidth="660" HorizontalAlignment="Left" Margin="0,0,0,20"
+                                        OpenLink="{Binding $parent[ItemsControl].((vm:ChatTabViewModel)DataContext).OpenLinkCommand}" />
+                </DataTemplate>
+                <DataTemplate x:DataType="vm:ToolCallItem">
+                    <StackPanel Orientation="Horizontal" Spacing="9" Margin="0,0,0,20">
+                        <TextBlock Text="›" FontSize="13" Foreground="{StaticResource KcapFaintBrush}" VerticalAlignment="Center" />
+                        <TextBlock Text="{Binding Name}" FontSize="11.5" Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
+                        <TextBlock Text="{Binding Detail}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
+                                   TextTrimming="CharacterEllipsis" MaxWidth="480" VerticalAlignment="Center" />
+                        <TextBlock Text="{Binding OutcomeGlyph}" FontSize="11" VerticalAlignment="Center"
+                                   Foreground="{Binding IsError, Converter={x:Static views:ToolOutcomeBrushConverter.Instance}}" />
+                    </StackPanel>
+                </DataTemplate>
+            </ItemsControl.DataTemplates>
+        </ItemsControl>
+
+        <TextBlock x:Name="ChatPhaseNote" Grid.Row="0" Text="{Binding PhaseNote}"
+                   IsVisible="{Binding PhaseNote, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                   Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5"
+                   HorizontalAlignment="Center" VerticalAlignment="Center" />
+
+        <Border Grid.Row="1" Margin="22,8,22,18" MaxWidth="660" HorizontalAlignment="Left"
+                Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                BorderThickness="1" CornerRadius="10" Padding="13,12">
+            <StackPanel Spacing="6">
+                <TextBox x:Name="ComposerInput" Text="{Binding ComposerText}" AcceptsReturn="True" TextWrapping="Wrap"
+                         MinHeight="38" MaxHeight="160" Background="Transparent" BorderThickness="0"
+                         Watermark="Write a message" KeyDown="OnComposerKeyDown" />
+                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto">
+                    <TextBlock Text="{Binding ComposerHint}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
+                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                    <TextBlock Grid.Column="1" Text="{Binding ModelLabel}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
+                               VerticalAlignment="Center" Margin="12,0,0,0" />
+                    <Ellipse Grid.Column="2" Width="7" Height="7" Fill="{Binding StatusDot}" VerticalAlignment="Center" Margin="12,0,6,0" />
+                    <TextBlock Grid.Column="3" Text="{Binding StatusText}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
+                               VerticalAlignment="Center" />
+                    <Button x:Name="SendButton" Grid.Column="4" Content="Send" Command="{Binding SendCommand}" Margin="12,0,0,0"
+                            Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
+                            Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" />
+                </Grid>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>
+```
+
+- [ ] **Step 5: `ChatTabView.axaml.cs`**
+
+```csharp
+using System.Collections.Specialized;
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using Capacitor.App.ViewModels;
+
+namespace Capacitor.App.Views;
+
+/// Follow-tail lives here, stateless across events: "was at end" is decided at the collection
+/// change from the OLD extent (the new rows are not measured yet), and the scroll is applied
+/// after the layout pass that establishes the new extent — only if the reader has not moved.
+public partial class ChatTabView : UserControl {
+    INotifyCollectionChanged? _observed;
+
+    public ChatTabView() {
+        InitializeComponent();
+        DataContextChanged += (_, _) => Observe((DataContext as ChatTabViewModel)?.Items as INotifyCollectionChanged);
+    }
+
+    void Observe(INotifyCollectionChanged? items) {
+        if (_observed is not null) _observed.CollectionChanged -= OnItemsChanged;
+        _observed = items;
+        if (_observed is not null) _observed.CollectionChanged += OnItemsChanged;
+    }
+
+    ScrollViewer? Scroll => ChatItems.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+
+    void OnItemsChanged(object? sender, NotifyCollectionChangedEventArgs e) {
+        if (e.Action != NotifyCollectionChangedAction.Add || Scroll is not { } scroll) return;
+        var wasAtEnd = scroll.Offset.Y + scroll.Viewport.Height >= scroll.Extent.Height - 1;
+        if (!wasAtEnd) return;
+
+        var captured = scroll.Offset;
+        void OnLayoutUpdated(object? _, EventArgs __) {
+            scroll.LayoutUpdated -= OnLayoutUpdated;
+            if (scroll.Offset == captured) scroll.ScrollToEnd();
+        }
+        scroll.LayoutUpdated += OnLayoutUpdated;
+    }
+
+    // Enter sends, Shift+Enter is the TextBox's own newline.
+    void OnComposerKeyDown(object? sender, KeyEventArgs e) {
+        if (e.Key != Key.Enter || e.KeyModifiers.HasFlag(KeyModifiers.Shift)) return;
+        e.Handled = true;
+        if (DataContext is ChatTabViewModel vm && ((ICommand)vm.SendCommand).CanExecute(null))
+            vm.SendCommand.Execute().Subscribe();
+    }
+
+    public void FocusComposer() => ComposerInput.Focus();
+}
+```
+
+- [ ] **Step 6: `WorkspaceView.axaml` changes**
+
+Replace the tab-strip `Grid` content with:
+
+```xml
+            <Grid Margin="20,0">
+                <StackPanel Orientation="Horizontal" Spacing="6" IsVisible="{Binding ShowsTerminalTab}" HorizontalAlignment="Left" VerticalAlignment="Center">
+                    <Button x:Name="ChatTabButton" Content="Chat" Classes="tab" Classes.active="{Binding IsChatActive}" Command="{Binding ShowChatCommand}" />
+                    <Button x:Name="TerminalTabButton" Content="Terminal" Classes="tab" Classes.active="{Binding IsTerminalActive}" Command="{Binding ShowTerminalCommand}" />
+                </StackPanel>
+                <TextBlock x:Name="NoTerminalNote" Text="{Binding NoTerminalNote}" IsVisible="{Binding !ShowsTerminalTab}"
+                           Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5" VerticalAlignment="Center" />
+            </Grid>
+```
+
+Add to the UserControl a `<UserControl.Styles>` block:
+
+```xml
+    <UserControl.Styles>
+        <Style Selector="Button.tab">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="CornerRadius" Value="7" />
+            <Setter Property="Foreground" Value="{StaticResource KcapMutedBrush}" />
+            <Setter Property="FontSize" Value="12.5" />
+            <Setter Property="Padding" Value="12,5" />
+        </Style>
+        <Style Selector="Button.tab.active">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+    </UserControl.Styles>
+```
+
+In the content `Grid` (row 2): give `TerminalHost` the inactive-tab treatment and wrap the banners:
+
+```xml
+            <terminal:TerminalControl x:Name="TerminalHost" IsVisible="{Binding ShowsTerminalTab}"
+                                       IsEnabled="{Binding IsTerminalActive}"
+                                       IsHitTestVisible="{Binding IsTerminalActive}"
+                                       Opacity="{Binding IsTerminalActive, Converter={x:Static views:BoolToOpacityConverter.Instance}}"
+                                       AutomationProperties.IsOffscreenBehavior="{Binding IsTerminalActive, Converter={x:Static views:OffscreenWhenInactiveConverter.Instance}}"
+                                       FontFamily="Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace"
+                                       CaretBrush="{StaticResource KcapAccentBrush}"
+                                       Model="{Binding Terminal.Surface, Converter={x:Static views:TerminalSurfaceModelConverter.Instance}}" />
+
+            <Panel x:Name="TerminalBanners" IsVisible="{Binding IsTerminalActive}">
+                <!-- the five existing banner Borders, unchanged, move inside this Panel -->
+            </Panel>
+
+            <Panel IsVisible="{Binding IsChatActive}">
+                <views:ChatTabView x:Name="ChatHost" DataContext="{Binding Chat}" />
+            </Panel>
+```
+
+Keep the existing comments about `FontFamily`/`CaretBrush`; drop the "the strip gains Chat beside it" comment.
+
+- [ ] **Step 7: `WorkspaceView.axaml.cs` focus wiring**
+
+Replace the constructor body:
+
+```csharp
+    IDisposable? _tabFocus;
+
+    public WorkspaceView() {
+        InitializeComponent();
+        // The control draws its caret and takes keystrokes only while focused; a Model assignment
+        // is the "terminal became live" moment — but only the Terminal tab may take focus, or a
+        // reattach under the Chat tab would steal it from the composer.
+        TerminalHost.PropertyChanged += (_, e) => {
+            if (e.Property == SvcSystems.UI.Terminal.TerminalControl.ModelProperty && TerminalHost.Model is not null
+                && DataContext is WorkspaceViewModel { IsTerminalActive: true })
+                TerminalHost.Focus();
+        };
+        DataContextChanged += (_, _) => {
+            _tabFocus?.Dispose();
+            _tabFocus = (DataContext as WorkspaceViewModel)?
+                .WhenAnyValue(vm => vm.ActiveTab)
+                .Subscribe(tab => Dispatcher.UIThread.Post(() => {
+                    if (tab == WorkspaceTab.Chat) ChatHost.FocusComposer();
+                    else TerminalHost.Focus();
+                }, DispatcherPriority.Loaded));
+        };
+    }
+```
+
+Add `using Avalonia.Threading;`, `using Capacitor.App.ViewModels;`, `using ReactiveUI;`.
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run the smoke filter, then the whole app suite. Expected: green. Known sharp edges: if `ChatTabButton` is not found, the `StackPanel` wrapper hides it before a dto arrives — the names test pushes no dto and the buttons are still instantiated (`IsVisible=false` keeps them in the tree), so `Find` must still resolve them; if `IsOffscreen(terminalHost)` reads false while faded, the converter binding is not applied — `AutomationProperties.IsOffscreenBehavior` is an attached property and must be set exactly as written.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Capacitor.App/Views test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+git commit -m "Render the Chat tab beside the terminal with focus and follow-tail
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 16: CHANGES entry, full acceptance, PR
+
+**Files:**
+- Modify: `docs/CHANGES.md`
+- No new tests; this task runs the whole acceptance set.
+
+- [ ] **Step 1: `docs/CHANGES.md`**
+
+Insert before `## Launch and stop command routing`:
+
+```markdown
+## Session chat
+
+**AI-2196** (spec: `docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md`)
+renders a Claude or interactive Codex session's own transcript as the workspace's Chat tab and sends
+composer text to the PTY. **The daemon, not the app, knows where the transcript is**: every PTY launch
+runs the same transcript discovery the server-driven path used, and the link-resolved path rides
+`AgentStatusDto.transcript_path` — link-resolved because the per-worktree Claude project dir is a
+symlink the launcher deletes at cleanup. Discovery runs until the *path* is known and pulses the
+status notifier before any server report. Every transcript open shares read/write/delete; the tail
+promises only length-regression reset. **Composer sends are accepted, never acknowledged**, and one
+at a time: bracketed paste, a 150 ms wait past Codex's post-paste Enter suppression, then one CR —
+only if the terminal's opening token is unchanged. The token advances only through `BeginAttempt`
+(after the attach lane is won) and `Invalidate` (detach, teardown, removal, every terminal outcome);
+an attempt's own `Connecting`/`Attached` publishes never advance it, and a stale token discards a
+late `Attached`, so a queued attach callback cannot reopen a terminal the daemon already dropped.
+`TerminalHost` stays laid out under the Chat tab (faded, disabled, reported offscreen) so the PTY
+clamp sees the real pane size; everything else collapses with `IsVisible`. Links open only through
+`LinkPolicy` (absolute http/https) via one tab-level command.
+```
+
+- [ ] **Step 2: Full acceptance**
+
+```bash
+dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj
+dotnet test --solution Capacitor.slnx
+dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+Expected: build clean; every suite green except the pre-existing local nudge failures noted in memory (7 unit + 1 integration `session-start` tests) — verify by name that nothing else fails; the publish grep prints nothing.
+
+- [ ] **Step 3: Manual QA (one live session)**
+
+`dotnet run --project src/Capacitor.App/Capacitor.App.csproj` against a running daemon; start a Claude session from the launcher; confirm: Chat opens first and shows "Waiting for the transcript…" for a few seconds, then the rows; the Terminal tab still works and reports a real size (`stty size` inside the session is not 80 24); typing in the composer and pressing Enter reaches the agent (the reply appears in Chat within a second of the transcript write); a markdown reply renders lists/code/links; a link click opens the browser; Shift+Enter adds a line.
+
+- [ ] **Step 4: Commit and open the PR**
+
+```bash
+git add docs/CHANGES.md
+git commit -m "Record the session chat design constraints
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin alexeyzimarev/ai-2196-desktop-shell-chat-for-pty-harnesses-rendered-from-the
+```
+
+Open the PR with title `Desktop shell: chat for PTY harnesses` and a description written from `.github/PULL_REQUEST_TEMPLATE.md`'s comment block; the reference line carries `AI-2196` and the GitHub issue with a closing keyword if one exists (ask the owner for the number — never invent one).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §1 → Tasks 1, 6, 7, 8; §2 → Tasks 2–5; §3 `ChatTabViewModel` → Tasks 11–12; Markdown → Task 13; tab strip and focus → Tasks 14–15; composer and send gate → Tasks 10, 12, 15; §4 tests → each task's Step 1 plus Task 16's acceptance; Risks → CHANGES entry.
+- **Type consistency:** `TranscriptPath` (DTO and `AgentInstance`), `ITranscriptProjection.Project`, `TailRead(Lines, Status, Failure)`, `TrySendText`/`CanAcceptText`/`SendAvailability`, `ChatTabViewModel(agentId, daemon, terminal, projection, opener, time)`, `WorkspaceViewModel(..., time, opener)`, `ToolDetail.From(inputJson)` are used with the same shapes in every task that names them.
+- **Deliberate deviations from the spec's test list, and why:** the resume boundaries are pinned at the locator level (a foreign-cwd Claude transcript is never a winner; the Codex older-stamp rule already has its own test) plus an orchestrator test that local spawns start discovery — the same guarantee without a real worktree or an env pin; `ToolDetail.From` takes only the input JSON, since the name contributed nothing to the detail.

--- a/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
+++ b/docs/superpowers/specs/2026-08-24-ai2195-session-workspace-terminal-design.md
@@ -261,8 +261,9 @@ Entry points:
 
 Follows the settled canvas artboard:
 
-- Header: session title (same `RepoLabel.Leaf(repo) · vendor` shape as the card),
-  repo label, vendor + model chip with transport-family dot, and the two
+- Header: the session's title when the daemon reports one, else the
+  `RepoLabel.Leaf(repo) · vendor` shape the card had; the repository label, read
+  through a worktree to the repository, vendor + model chip with transport-family dot, and the two
   existing actions — Open in web and Stop — reused straight from
   `AgentActionService` (one code path with tray/grid, force-stop confirmation
   included).

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -294,10 +294,13 @@ transcript yields), and `Reset` is one `Clear`. Three shapes:
 - `ToolCallItem(Name, Detail, Outcome)`: the muted `›` row. `Outcome` is a
   bound property ∈ Running | Done | Error, flipped in place when the matching
   `tool_result` arrives (indexed by `ToolCallId`; an unmatched result is
-  ignored). `Detail` is `ToolDetail.From(name, inputJson)`: the first present
-  of `description`, `command`, `cmd`, `file_path`, `path`, `pattern`, `query`,
-  `url`, `skill`, `prompt`, `input`; its first line, trimmed to 80 characters
-  with an ellipsis; empty when none applies.
+  ignored). `Detail` is `ToolDetail.From(inputJson, repoPath)`: the first
+  present of `description`, `command`, `cmd`, `file_path`, `path`,
+  `notebook_path`, `pattern`, `query`, `url`, `skill`, `prompt`, `input`; its
+  first line, trimmed to 80 characters with an ellipsis; empty when none
+  applies. A path key under the session's repository reads relative to it —
+  or to the daemon's per-agent worktree beneath it when the path is in one —
+  as the web UI shows it, so the file name survives the cut.
 
 `assistant_thinking` and unmatched `tool_result` envelopes create no item;
 `Reset` clears the items and the pairing index.

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -324,7 +324,8 @@ already scrolled up keeps their offset untouched.
 `MarkdownView` — a `ContentControl` with a styled `Text` property and an
 `OpenLink` command property — rebuilds its `Content` (a vertical panel of
 block controls) from a Markdig AST (default CommonMark pipeline plus
-auto-links) on every `Text` change. `MarkdownBlocks` maps: paragraphs and
+auto-links, with precise source locations so an unmapped inline can print its
+own source text — no other extension) on every `Text` change. `MarkdownBlocks` maps: paragraphs and
 headings → `SelectableTextBlock` with inlines (`Bold`, `Italic`, monospace
 `Run` for code spans); a soft line break is a space, as CommonMark renders it,
 and a paragraph with a top-level hard break is a vertical stack of one

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -393,21 +393,26 @@ Chat — focuses `ComposerInput`.
 Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
 
 - `ComposerText`; `SendCommand` (`ReactiveCommand.Create`, synchronous),
-  executable iff the terminal is `Attached`, not read-only, **no send is in
-  flight** (`Terminal.SendInFlight`, below), and the text is not blank. It
-  calls `Terminal.TrySendText(text)` and clears the text iff that returns
-  true — one synchronous step on the UI thread, no await, so acceptance and
-  the clear cannot be separated by a state change. The send is
+  executable iff **`Terminal.CanAcceptText`** (the terminal-owned projection
+  below — the one authority `TrySendText` itself consults, so can-execute and
+  acceptance can never disagree) and the text is not blank. It calls
+  `Terminal.TrySendText(text)` and clears the text iff that returns true —
+  one synchronous step on the UI thread, no await, so acceptance and the
+  clear cannot be separated by a state change. The send is
   **accepted**, not acknowledged: the attach seam's `SendInputAsync` returns
   nothing and Core's client no-ops when it is no longer writable and folds a
   transport failure into the attach outcome — so no send can learn whether
   its bytes landed. A refused send leaves the text in place and the hint
   already says why. A transport loss surfaces the way it always does — the
   attach outcome flips `Terminal.State`, and the hint follows.
-- `ComposerHint` follows `Terminal.State`: attached read-write → "Reply to
-  {vendor label} · Enter sends · Shift+Enter for a new line"; attached read-only
-  → "Read-only: {reason}"; `Resolving`/`Connecting` → "Connecting to the
-  terminal…"; `Detached`/`Failed` → "Reattach the terminal to send";
+- `ComposerHint` follows `Terminal.SendAvailability` (below), which folds
+  the gate into the state so the hint is truthful in every window: `Ready` →
+  "Reply to {vendor label} · Enter sends · Shift+Enter for a new line";
+  `Sending` → "Sending…"; `Transitioning` (the gate is closed while `State`
+  still reads Attached — a reattach or detach in progress) → "Reconnecting
+  the terminal…"; otherwise by `State`: attached read-only → "Read-only:
+  {reason}"; `Resolving`/`Connecting` → "Connecting to the terminal…";
+  `Detached`/`Failed` → "Reattach the terminal to send";
   `Exited`/`SessionEnded` → "This session has ended"; `NoTerminal`/`NotFound` →
   "No terminal to send to". The vendor label comes from
   `HostedHarnessCatalog.LabelFor` over the daemon's advertised options.
@@ -421,33 +426,48 @@ Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
 thread. The terminal owns a **send gate** with three pieces of state, all
 mutated only on the UI thread:
 
-- `SendGate` ∈ Open | Closed. **Closed synchronously, before any await, at
-  the start of** `TryStartAttemptAsync` (reattach), `RunDetachAsync` and
-  `TeardownAsync`; **reopened only when a later attempt lands `Attached`
-  read-write** (the `OnAttachedAsync` dispatch that sets that state). Neither
-  `State` nor `_client` can serve as the gate: a reattach leaves both
-  `Attached` and live while it awaits the old client's disposal, and a detach
-  leaves both unchanged while it awaits the detach write — a send started in
-  either window would otherwise be accepted against a client on its way out.
-- The **send epoch**, a counter bumped at the same three points, which a
-  running delivery re-checks before its CR.
+- `SendGate` ∈ Open | Closed. **Open exactly while the terminal is in
+  writable `Attached`, as the gate sees it.** It closes in two kinds of
+  place: synchronously, before any await, at the start of the transitions
+  that *begin* while `State` still reads Attached — `TryStartAttemptAsync`
+  (reattach), `RunDetachAsync`, `TeardownAsync` — and inside **every**
+  UI-thread publish of a `State` other than writable Attached (the natural
+  outcomes `FinishAttemptAsync` maps — Detached, Exited, Failed,
+  ConnectionLost — the agent removal that lands `SessionEnded`, `NotFound`,
+  `NoTerminal`), in the same dispatch and before the new state is published.
+  It reopens only inside the publish of a read-write `Attached`. To make
+  that unforgettable, `State` has one publish point that applies the gate
+  rule; nothing assigns it directly. Neither `State` nor `_client` can serve
+  as the gate on its own: a reattach leaves both `Attached` and live while it
+  awaits the old client's disposal, and a detach leaves both unchanged while
+  it awaits the detach write — a send started in either window would
+  otherwise be accepted against a client on its way out.
+- The **send epoch**, a counter bumped by every closure, which a running
+  delivery re-checks before its CR.
 - `SendInFlight` (bound), true from acceptance until the delivery ends.
 
-`TrySendText` refuses (false, nothing written) unless `SendGate` is Open and
-`SendInFlight` is false; otherwise it captures the client and the epoch, sets
-`SendInFlight`, starts the fault-contained background delivery, and returns
-true. One transaction at a time is the point: two accepted sends inside the
-150 ms window would interleave as paste A, paste B, CR, CR — Core's client
-serializes single frames, not multi-frame messages — and the TUI would submit
-both as one prompt and spend the second Enter on whatever is up next.
-Refusing keeps the second text in the composer for the user to send again a
-moment later.
+Two bound projections fold these together for the composer:
+`CanAcceptText` = gate Open ∧ ¬`SendInFlight`, and `SendAvailability` ∈
+`Ready | Sending | Transitioning | <by State>` — `Transitioning` being the
+gate Closed while `State` still reads Attached. Both raise change
+notifications on every gate, in-flight and state change.
+
+`TrySendText` refuses (false, nothing written) unless `CanAcceptText`;
+otherwise it captures the client and the epoch, sets `SendInFlight`, starts
+the fault-contained background delivery, and returns true. One transaction
+at a time is the point: two accepted sends inside the 150 ms window would
+interleave as paste A, paste B, CR, CR — Core's client serializes single
+frames, not multi-frame messages — and the TUI would submit both as one
+prompt and spend the second Enter on whatever is up next. Refusing keeps the
+second text in the composer for the user to send again a moment later.
 
 Ownership of `SendInFlight` is one rule: **the closer retires the send.**
-Closing the gate (reattach, detach, teardown) synchronously bumps the epoch
-and clears `SendInFlight`; the delivery's own completion — success or fault —
-clears it through a UI-thread dispatch that mutates nothing unless the epoch
-it captured is still current and the VM has not been torn down, so a late
+Every closure — an entry-point closure or a state publish — synchronously
+bumps the epoch and clears `SendInFlight`, so a natural exit or an agent
+removal landing during the 150 ms delay kills the pending CR the same way a
+reattach does; the delivery's own completion — success or fault — clears it
+through a UI-thread dispatch that mutates nothing unless the epoch it
+captured is still current and the VM has not been torn down, so a late
 completion can neither clear a newer send nor touch a torn-down VM.
 
 The delivery is the daemon's own `PtyHostedAgentRuntime.SendUserInputAsync`
@@ -544,16 +564,22 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
   goes through — the only order ever observed is paste A, CR, paste B, CR;
   a send started while a reattach is awaiting the old client's disposal
   (`DisposeGate`) or a detach is awaiting its write (`HangDetachForever`) is
-  refused — `State` still reads `Attached` in both windows — and the gate
-  reopens only once the new attempt lands `Attached`; a reattach whose
-  old-client disposal is held open past 150 ms, a detach, or a teardown started
-  during the delay sends no CR to any client and clears `SendInFlight`
-  synchronously; a faulting write clears `SendInFlight` and leaves `State`
+  refused — `State` still reads `Attached` in both windows, `SendCommand`'s
+  `CanExecute` is false and the hint reads "Reconnecting the terminal…" — and
+  the gate reopens only once the new attempt lands read-write `Attached` (a
+  read-only Attached leaves it closed); a reattach whose old-client disposal
+  is held open past 150 ms, a detach, or a teardown started during the delay
+  sends no CR to any client and clears `SendInFlight` synchronously; an
+  `AttachOutcome` (`Exited` and `ConnectionLost` at least) and an agent
+  removal landing during the delay each close acceptance synchronously,
+  clear `SendInFlight`, suppress the CR, and a direct `TrySendText` right
+  after is refused; a faulting write clears `SendInFlight` and leaves `State`
   untouched; a retired delivery's completion cannot clear a newer send's
   `SendInFlight`; after `TeardownAsync` returns, no bound state changes and no
   dispatcher work is queued by a still-running delivery; the text clears on
-  acceptance and stays on refusal; every hint string; a pool-thread state
-  flip updates the hint on the UI thread.
+  acceptance and stays on refusal; every hint string including "Sending…"
+  and "Reconnecting the terminal…"; a pool-thread state flip updates the
+  hint on the UI thread.
 - `TerminalInputEncoderTests`, `ToolDetailTests` (key priority, first line,
   80-character cut), `LinkPolicyTests` (https/http open, `file:`,
   `javascript:`, custom schemes, relative and malformed text refused).

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -326,7 +326,14 @@ already scrolled up keeps their offset untouched.
 block controls) from a Markdig AST (default CommonMark pipeline plus
 auto-links) on every `Text` change. `MarkdownBlocks` maps: paragraphs and
 headings → `SelectableTextBlock` with inlines (`Bold`, `Italic`, monospace
-`Run` for code spans, `LineBreak`); fenced and indented code → a `Border`
+`Run` for code spans); a soft line break is a space, as CommonMark renders it,
+and a paragraph with a top-level hard break is a vertical stack of one
+`SelectableTextBlock` per hard-break-delimited segment — never a `LineBreak`
+inline or a `\n` inside a `Run`, which Avalonia 12's line breaker never
+finishes laying out under a height-unconstrained parent (any `StackPanel` or
+`ScrollViewer`) — so selection stops at a segment boundary, and a hard break
+nested inside emphasis or a link label degrades to a space; fenced and
+indented code → a `Border`
 around a monospace `SelectableTextBlock`; bullet and ordered lists → marker +
 nested content rows; block quotes → a left rule beside the content; thematic
 breaks → a hairline. A link is an `InlineUIContainer` hosting a link-styled

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -67,7 +67,7 @@ trailing member after `Title`:
   `SnapshotAgentsForStatus`. `null` means any of: an older daemon; not resolved
   yet; the 3-minute poll gave up; a runtime with nothing to read (app-server
   Codex, every ACP vendor); a local passthrough launch that resumes an existing
-  Codex session (below); or an agent that exited before discovery found its
+  session the locator cannot claim (below); or an agent that exited before discovery found its
   file or before the status push carrying the path was delivered — a 250 ms
   debounce sits between a pulse and its snapshot, and cleanup and removal can
   land inside it. The app never distinguishes these; it waits.
@@ -103,13 +103,20 @@ Daemon side (`src/Capacitor.Cli.Daemon`):
   against the exit path. The path resolves within a few seconds of launch for
   both vendors (Claude writes its first record, with `cwd`, before its first
   prompt renders).
-- **A resumed Codex session is outside discovery.** `kcap agent start codex --
-  resume …` passes through, and Codex then appends to the rollout it resumes
-  — a file stamped before this spawn. The Codex locator accepts only rollouts
-  stamped at or after spawn; that rule is what keeps a user's older session in
-  the same cwd from being claimed, and it is not weakened here. Such a launch
-  leaves `transcript_path` null and Chat in `Waiting`. Claude `--resume` is
-  discoverable by construction: its locator also accepts a fresh last write.
+- **A resumed session is outside discovery unless the locator's own rules
+  happen to admit it.** Passthrough args reach the vendor verbatim, so
+  `kcap agent start codex -- resume …` and `… claude -- --resume …` are in the
+  launch surface. Codex appends to the rollout it resumes — a file stamped
+  before this spawn — and the Codex locator accepts only rollouts stamped at
+  or after spawn; that rule is what keeps a user's older session in the same
+  cwd from being claimed, and it is not weakened here. Claude's locator
+  matches the `cwd` in a transcript's first fifty records against the agent's
+  worktree and permanently rules out a file whose cwd differs, so a Claude
+  resume is discoverable only when it resumes in the very checkout it was
+  recorded in (a borrowed-cwd launch) — an owned-worktree resume has a new cwd
+  and is never claimed. Every such launch leaves `transcript_path` null and
+  Chat in `Waiting`; supporting resume means resolving the resumed id from
+  the arguments, which this slice leaves alone.
 
 The path is the daemon's view of the filesystem (its `CLAUDE_CONFIG_DIR` /
 `CODEX_HOME`), which is the correct one: it launched the process. Nothing else
@@ -185,9 +192,10 @@ Output invariants shared by both mappers:
 - *Joining*: when several text blocks feed one envelope they are joined with
   `"\n"`.
 - *Capping*: `ToolResult` longer than 4096 UTF-16 code units is cut so that
-  the result **including** its trailing `…` marker is exactly 4096 long, and
-  the cut never lands between the halves of a surrogate pair (the high
-  surrogate goes too). Nothing else is capped.
+  the result **including** its trailing `…` marker is at most 4096 long, and
+  the cut never lands between the halves of a surrogate pair — when the cut
+  would, the high surrogate goes too and the result is 4095 long. The same
+  rule the daemon's `TitleFromPrompt` applies at 80. Nothing else is capped.
 - *`ToolInputJson` is always a JSON object string*, as `AcpEventEnvelope`
   documents. Anything that has to be built rather than copied is written with
   `Utf8JsonWriter` — never reflection-based serialization, because Core is
@@ -300,8 +308,13 @@ the shape Avalonia virtualizes; an `ItemsControl` dropped inside an external
 `ScrollViewer` is measured at infinite height and realizes every item. Item
 templates are per item type (`DataTemplates` keyed on the three shapes).
 
-Follow-tail is a view concern: the `ScrollViewer` scrolls to the end on an add
-only when it was already at the end, so a user reading history is not yanked.
+Follow-tail is a view concern, stateless across events: on each collection
+change the view decides *was at end* right then, from the `ScrollViewer`'s
+current offset, viewport and **old** extent (the new items have not been
+measured yet), and if so schedules one scroll-to-end after the next layout
+pass (`DispatcherPriority.Loaded`), when the virtualized presenter has
+established the new extent — an immediate `ScrollToEnd` would clamp against
+the old one. A user who has scrolled up keeps their offset untouched.
 
 ### Markdown
 
@@ -323,12 +336,16 @@ any other node render their literal source text — degraded, never dropped.
 User bubbles do not go through it: what the user typed is shown as typed.
 
 Links are agent-authored and untrusted, and `ShellUrlOpener` hands any string
-to the OS shell. The trust boundary is the item's `OpenLinkCommand` on
-`AssistantTextItem`, backed by a pure `LinkPolicy.IsOpenable(url)`: only an
-absolute `http` or `https` URI opens; anything else (`file:`, `javascript:`,
-custom schemes, relative or malformed text) renders as plain text with no
-link affordance at all. An opener exception is caught and logged to
-`Console.Error` — a bad link never escapes a UI event.
+to the OS shell. The trust boundary is **one** ctor-scoped
+`ChatTabViewModel.OpenLinkCommand` — the items carry no command; every
+markdown template binds to the tab's through the ancestor `DataContext`, so
+policy, error containment and disposal live in one place rather than in
+thousands of transcript items. It is backed by a pure
+`LinkPolicy.IsOpenable(url)`: only an absolute `http` or `https` URI opens;
+anything else (`file:`, `javascript:`, custom schemes, relative or malformed
+text) renders as plain text with no link affordance at all. An opener
+exception is caught and logged to `Console.Error` — a bad link never escapes
+a UI event.
 
 `Markdig` is added to `Directory.Packages.props` and the app csproj. The app
 is not NativeAOT, so trimming is not a concern for it.
@@ -346,34 +363,36 @@ is not NativeAOT, so trimming is not a concern for it.
 - `ShowsChatTab` is `ShowsTerminalTab` — one gate, exposed once.
 
 `WorkspaceView`: `ChatTabButton` precedes `TerminalTabButton`; a `ChatTabView`
-(`ChatHost`) and the existing terminal grid share the content cell. **The
-terminal control stays laid out on both tabs** — hidden by opacity and
-hit-test visibility, not `IsVisible` — so the pane size it reports to the PTY
-is the real pane size whichever tab is up. An `IsVisible=false` control is never
-measured: a workspace opened on Chat would then keep the constructor's 80×24
-and, through the daemon's min-clamp across viewers, shrink the agent's terminal
-for every other attacher.
+(`ChatHost`) and the existing terminal grid share the content cell. Only one
+control needs to exist off-tab: **`TerminalHost` stays laid out on both tabs**,
+so the pane size it reports to the PTY is the real pane size whichever tab is
+up. An `IsVisible=false` control is never measured: a workspace opened on Chat
+would then keep the constructor's 80×24 and, through the daemon's min-clamp
+across viewers, shrink the agent's terminal for every other attacher.
 
-Focus follows the tab, and the view enforces it rather than assuming it. The
-**inactive surface's root** — the whole terminal grid (control, banners,
-Detach/Reattach buttons) or the whole chat surface (list, composer, Send) — is
-disabled (`IsEnabled=false`), non-hit-testable and transparent, so nothing in
-it can hold focus, be tabbed into, or be activated; a disabled control is
-still measured and arranged, which is what keeps the terminal's pane size
-real. The existing focus-on-Model-assignment handler runs only while the
-Terminal tab is active (a reattach while Chat is up must not steal the
-composer's focus); switching to Terminal focuses the terminal, switching to
-Chat — and the first open on Chat — focuses `ComposerInput`.
+Everything else simply is not there when its tab is inactive: the chat
+surface (list, composer, Send) and the terminal's banners and Detach/Reattach
+buttons are `IsVisible=false` — unmeasured, unfocusable, out of the
+automation tree. `TerminalHost` alone, when Chat is active, is disabled,
+non-hit-testable, transparent, and marked
+`AutomationProperties.IsOffscreenBehavior=Offscreen` — the default derives
+"offscreen" from `IsVisible`, so a visible-but-transparent control would
+otherwise be announced beside the chat. Focus follows the tab: the existing
+focus-on-Model-assignment handler runs only while the Terminal tab is active
+(a reattach while Chat is up must not steal the composer's focus); switching
+to Terminal focuses the terminal, switching to Chat — and the first open on
+Chat — focuses `ComposerInput`.
 
 ### Composer
 
 Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
 
 - `ComposerText`; `SendCommand` (`ReactiveCommand.Create`, synchronous),
-  executable iff the terminal is `Attached`, not read-only, and the text is not
-  blank. It calls `Terminal.TrySendText(text)` and clears the text iff that
-  returns true — one synchronous step on the UI thread, no await, so
-  acceptance and the clear cannot be separated by a state change. The send is
+  executable iff the terminal is `Attached`, not read-only, **no send is in
+  flight** (`Terminal.SendInFlight`, below), and the text is not blank. It
+  calls `Terminal.TrySendText(text)` and clears the text iff that returns
+  true — one synchronous step on the UI thread, no await, so acceptance and
+  the clear cannot be separated by a state change. The send is
   **accepted**, not acknowledged: the attach seam's `SendInputAsync` returns
   nothing and Core's client no-ops when it is no longer writable and folds a
   transport failure into the attach outcome — so no send can learn whether
@@ -395,9 +414,16 @@ Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
 
 `TerminalTabViewModel.TrySendText(string text)` → `bool`, synchronous, UI
 thread. It refuses (false, nothing written) unless `State` is `Attached`
-read-write and a client is live; otherwise it captures the client and the
-current **send epoch** and starts a fault-contained background delivery, then
-returns true. The send epoch is a counter the VM bumps **synchronously, before
+read-write, a client is live, **and no delivery is in flight**; otherwise it
+captures the client and the current **send epoch**, sets `SendInFlight`
+(bound; cleared on the UI thread when the delivery ends, however it ends),
+starts a fault-contained background delivery, and returns true. One
+transaction at a time is the point: two accepted sends inside the 150 ms
+window would interleave as paste A, paste B, CR, CR — Core's client
+serializes single frames, not multi-frame messages — and the TUI would submit
+both as one prompt and spend the second Enter on whatever is up next.
+Refusing keeps the second text in the composer for the user to send again
+a moment later. The send epoch is a counter the VM bumps **synchronously, before
 any await, at the start of** `TryStartAttemptAsync` (reattach), `RunDetachAsync`
 and `TeardownAsync` — the attempt generation cannot serve, because reattach
 bumps it only after awaiting the old client's disposal, and detach never bumps
@@ -436,8 +462,9 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
   per shape in §2 — including a string `tool_result.content` and a block-array
   one, a non-object `input`, non-object `arguments`, the skip lists, wrapper
   stripping, prelude skipping, the joining separator, the cap (final
-  `string.Length` exactly 4096 with the marker, and an astral character at the
-  boundary kept whole or dropped whole), wrong-typed fields reading as absent,
+  `string.Length` 4096 with the marker in the plain case, 4095 when an astral
+  character straddles the boundary and its high surrogate is dropped, never a
+  lone surrogate), wrong-typed fields reading as absent,
   and a malformed line → empty. Every `ToolInputJson` in every fixture parses
   as a JSON object; the wrapper fixtures cover an array, a scalar and a null
   `input`. `TranscriptProjection.For`: case-insensitive, unknown → null.
@@ -460,9 +487,11 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
   mutation; cancellation (agent exit) ends it cleanly.
 - `AgentOrchestrator`: `HandleLocalSpawnAsync` starts discovery for a local
   (and a `--private`) PTY launch — over a fake PTY factory and launcher, no
-  real process. A `codex -- resume <id>` passthrough launch against a sessions
-  tree holding only the resumed, older-stamped rollout leaves `transcript_path`
-  null — the boundary pinned, so weakening it is a deliberate change.
+  real process. Two resume launches pin the boundary so weakening it is a
+  deliberate change: `codex -- resume <id>` against a sessions tree holding
+  only the resumed, older-stamped rollout, and an owned-worktree
+  `claude -- --resume <id>` against a project dir holding only the resumed
+  transcript with its original cwd — both leave `transcript_path` null.
 - `AgentStatusSnapshotTests`: `transcript_path` null before detection, the
   value after — on the serialized payload.
 
@@ -481,10 +510,16 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
 - Batching: a 5,000-record initial transcript raises exactly one collection
   notification, and — in a headless window at a fixed size — the
   `ItemsControl` realizes a bounded number of containers.
+- Follow-tail (headless, laid out): the initial load ends at the bottom; an
+  append while at the bottom ends at the **new** bottom after the layout
+  pass; an append while scrolled up leaves the offset where it was.
 - Composer: `SendCommand` enablement across every terminal phase and the
   read-only case; the exact two writes via `FakeTerminalAttachClient.SentInput`
   — the bracketed paste, then `\r` only once the `FakeTimeProvider` advances
-  past the delay, on the same client; a detach or reattach that has *begun*
+  past the delay, on the same client; a second send accepted before the
+  first's CR is refused with its text intact, and once the first completes it
+  goes through — the only order ever observed is paste A, CR, paste B, CR;
+  a detach or reattach that has *begun*
   before the send refuses it (text stays, nothing written); a reattach whose
   old-client disposal is held open past 150 ms (`DisposeGate`), a detach, or a
   teardown started during the delay sends no CR to any client; a faulting
@@ -504,13 +539,16 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
   `ChatItems`, `ComposerInput`, `SendButton`); switching tabs flips which
   surface is visible while `TerminalHost` stays in the tree on both; a
   workspace opened on Chat with a **real** `XtermTerminalSurface` reports the
-  laid-out pane size to the attach client, not 80×24, while the terminal
-  surface is disabled and non-hit-testable; focus lands on `ComposerInput` on
-  open, stays there through a late Model assignment, moves to the terminal on
-  the Terminal switch and back on the Chat switch; tab traversal from the
-  composer never reaches `DetachButton`/`ReattachButton` while Chat is active
-  (terminal driven to Detached/Failed first), and from the terminal never
-  reaches `ComposerInput`/`SendButton` while Terminal is active.
+  laid-out pane size to the attach client, not 80×24, while `TerminalHost` is
+  disabled and non-hit-testable and its automation peer reports offscreen;
+  with Terminal active the chat surface is not in the visual tree, and with
+  Chat active the terminal's banners and buttons are not; focus lands on
+  `ComposerInput` on open, stays there through a late Model assignment, moves
+  to the terminal on the Terminal switch and back on the Chat switch; tab
+  traversal from the composer never reaches `DetachButton`/`ReattachButton`
+  while Chat is active (terminal driven to Detached/Failed first), and from
+  the terminal never reaches `ComposerInput`/`SendButton` while Terminal is
+  active.
 
 README: the desktop app has no section yet and this slice adds no CLI surface,
 so it is unchanged. `docs/CHANGES.md` gains a "Session chat" entry.
@@ -545,10 +583,11 @@ so it is unchanged. `docs/CHANGES.md` gains a "Session chat" entry.
   Such a session's Chat stays in `Waiting` — its Terminal tab still has the
   scrollback. Coordinating discovery with the exit path was judged not worth
   its coupling for a session that ran for seconds.
-- **Codex resume is not discoverable.** A local passthrough `resume` appends
-  to an older-stamped rollout the locator will never accept; Chat stays in
-  `Waiting`. Supporting it means reading the resumed id out of the arguments,
-  which this slice leaves alone.
+- **Resume is mostly not discoverable.** A Codex `resume` appends to an
+  older-stamped rollout the locator will never accept, and a Claude `--resume`
+  into a fresh owned worktree carries its original cwd, which the locator
+  rules out permanently; Chat stays in `Waiting`. Supporting resume means
+  reading the resumed id out of the arguments, which this slice leaves alone.
 - **Rendering granularity is the transcript's.** Both vendors write complete
   blocks, not tokens, so assistant text appears per block, a few hundred
   milliseconds after the vendor writes it. That is what "rendered from the

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -10,7 +10,7 @@ Out of scope, by prior decomposition and by the canvas annotations: structured
 turn frames, the "NEEDS YOU" approval card, permission-mode control and the "+"
 attachment affordance (AI-2197); chat for ACP / app-server sessions, which have
 no PTY and no transcript file the daemon locates (AI-2197); the work-context
-sidebar (AI-2198). Deferred within this slice: markdown tables and images,
+sidebar (AI-2198). Deferred within this slice: markdown images,
 syntax highlighting in code blocks, and rendering thinking or tool-result bodies.
 
 ## Decisions
@@ -324,7 +324,7 @@ already scrolled up keeps their offset untouched.
 `MarkdownView` — a `ContentControl` with a styled `Text` property and an
 `OpenLink` command property — rebuilds its `Content` (a vertical panel of
 block controls) from a Markdig AST (default CommonMark pipeline plus
-auto-links, with precise source locations so an unmapped inline can print its
+auto-links and pipe tables, with precise source locations so an unmapped inline can print its
 own source text — no other extension) on every `Text` change. `MarkdownBlocks` maps: paragraphs and
 headings → `SelectableTextBlock` with inlines (`Bold`, `Italic`, monospace
 `Run` for code spans); a soft line break is a space, as CommonMark renders it,
@@ -337,13 +337,17 @@ nested inside emphasis or a link label degrades to a space; fenced and
 indented code → a `Border`
 around a monospace `SelectableTextBlock`; bullet and ordered lists → marker +
 nested content rows; block quotes → a left rule beside the content; thematic
-breaks → a hairline. A link is an `InlineUIContainer` hosting a link-styled
+breaks → a hairline; a pipe table → a framed `Grid` with one row per source
+row, a semibold header row, cells rendered through the same inline mapper with
+the alignment the separator row declares, the widest column taking the
+remaining width while the others size to content up to a cap, so a prose
+column wraps inside the pane. A link is an `InlineUIContainer` hosting a link-styled
 `HyperlinkButton` (accent, underlined, hand cursor) with **`NavigateUri` left
 unset** — set, the control opens the URI itself and would bypass the policy
 below — and `Command` bound to `OpenLink` with the URL as its parameter; a
 button brings keyboard activation (Enter/Space), focus, and automation
-semantics, which a bare inline `Run` has none of. HTML, tables, images and
-any other node render their literal source text — degraded, never dropped.
+semantics, which a bare inline `Run` has none of. HTML, images and any
+other node render their literal source text — degraded, never dropped.
 User bubbles do not go through it: what the user typed is shown as typed.
 
 Links are agent-authored and untrusted, and `ShellUrlOpener` hands any string
@@ -697,8 +701,8 @@ so it is unchanged. `docs/CHANGES.md` gains a "Session chat" entry.
   blocks, not tokens, so assistant text appears per block, a few hundred
   milliseconds after the vendor writes it. That is what "rendered from the
   transcript" means; token streaming is AI-2197's frames.
-- **Markdown subset.** Unknown constructs degrade to literal text. Tables and
-  images are the likeliest gaps and are deferred knowingly.
+- **Markdown subset.** Unknown constructs degrade to literal text. Images are
+  the likeliest gap and are deferred knowingly.
 - **A never-resolving path** (older daemon, or the poll gave up) leaves Chat in
   `Waiting` with the Terminal tab one click away; the note says what it is
   waiting for.

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -64,9 +64,13 @@ trailing member after `Title`:
 - `TranscriptPath` — `string? TranscriptPath = null`, serialized
   `transcript_path`, always emitted (null, never omitted — the context's own
   rule). The daemon stamps `AgentInstance.TranscriptPath` in
-  `SnapshotAgentsForStatus`. `null` means any of: an older daemon, not resolved
-  yet, the 3-minute poll gave up, or a runtime with nothing to read (app-server
-  Codex, every ACP vendor). The app never distinguishes these; it waits.
+  `SnapshotAgentsForStatus`. `null` means any of: an older daemon; not resolved
+  yet; the 3-minute poll gave up; a runtime with nothing to read (app-server
+  Codex, every ACP vendor); a local passthrough launch that resumes an existing
+  Codex session (below); or an agent that exited before discovery found its
+  file or before the status push carrying the path was delivered — a 250 ms
+  debounce sits between a pulse and its snapshot, and cleanup and removal can
+  land inside it. The app never distinguishes these; it waits.
 
 Daemon side (`src/Capacitor.Cli.Daemon`):
 
@@ -93,9 +97,19 @@ Daemon side (`src/Capacitor.Cli.Daemon`):
   sets `SessionId` and `TranscriptPath` on the agent and pulses
   `_statusNotifier` **before** either awaited server report — mutation first,
   pulse second, the notifier's own contract, and the pulse must not wait behind
-  a SignalR call that can stall on a reconnect. The path resolves within a few
-  seconds of launch for both vendors (Claude writes its first record, with
-  `cwd`, before its first prompt renders).
+  a SignalR call that can stall on a reconnect. Cancellation (the agent's read
+  loop ending) ends the poll without a final locate — an agent that exits
+  between two scans keeps a null path, accepted rather than coordinated
+  against the exit path. The path resolves within a few seconds of launch for
+  both vendors (Claude writes its first record, with `cwd`, before its first
+  prompt renders).
+- **A resumed Codex session is outside discovery.** `kcap agent start codex --
+  resume …` passes through, and Codex then appends to the rollout it resumes
+  — a file stamped before this spawn. The Codex locator accepts only rollouts
+  stamped at or after spawn; that rule is what keeps a user's older session in
+  the same cwd from being claimed, and it is not weakened here. Such a launch
+  leaves `transcript_path` null and Chat in `Waiting`. Claude `--resume` is
+  discoverable by construction: its locator also accepts a fresh last write.
 
 The path is the daemon's view of the filesystem (its `CLAUDE_CONFIG_DIR` /
 `CODEX_HOME`), which is the correct one: it launched the process. Nothing else
@@ -161,14 +175,19 @@ the one registration site, so adding a vendor's transcript means a new
 `TimestampIso` when the record has a timestamp; `Seq` stays 0 — arrival order
 is the order. Every JSON read goes through `JsonElementExtensions`, so a
 wrong-typed field reads as absent rather than throwing; a line that is not a
-JSON object projects to nothing.
+JSON object projects to nothing. The extension gains one internal accessor,
+`Prop(name) → JsonElement?` — the property of any kind, null when absent — for
+the one place the typed accessors cannot serve: copying a non-object `input`
+verbatim into its wrapper. No public surface changes.
 
 Output invariants shared by both mappers:
 
 - *Joining*: when several text blocks feed one envelope they are joined with
   `"\n"`.
-- *Capping*: `ToolResult` is cut at 4096 UTF-16 characters and marked with a
-  trailing `…`; nothing else is capped.
+- *Capping*: `ToolResult` longer than 4096 UTF-16 code units is cut so that
+  the result **including** its trailing `…` marker is exactly 4096 long, and
+  the cut never lands between the halves of a surrogate pair (the high
+  surrogate goes too). Nothing else is capped.
 - *`ToolInputJson` is always a JSON object string*, as `AcpEventEnvelope`
   documents. Anything that has to be built rather than copied is written with
   `Utf8JsonWriter` — never reflection-based serialization, because Core is
@@ -242,15 +261,20 @@ before touching bound state — the client's pump is a background thread. Two
 subscriptions: `daemon.Agents.Connect()` filtered to the agent id (the path
 watch, and the footer's model/status), and `daemon.Snapshots` (the advertised
 vendor options behind the composer hint's vendor label). The first non-null
-`TranscriptPath` starts the tail; a later, different path restarts from zero
-(a re-resolution after a daemon restart).
+`TranscriptPath` starts the tail. **Path identity is part of the read
+generation**: every distinct path, on the UI thread and in one step, bumps the
+generation, clears the items and the pairing index, and installs a fresh
+`JsonlTail`; a read or projection still in flight for the old path completes
+under a stale generation and is discarded. A fresh tail starts at cursor zero
+with `Ok`, which is why the reset belongs to the switch, not to the tail.
 
 Poll: a `TimeProvider` timer every 500 ms (a tuning constant, not a contract).
 A tick with a read still in flight is skipped. The read and the projection run
 on the thread pool and never throw past the tick (the tail is total; a
 projection fault is caught, logged once, and drops that line); the apply hops
-to the UI thread through `Dispatcher.UIThread.InvokeAsync`, guarded by a
-generation `TeardownAsync` bumps so a late completion mutates nothing.
+to the UI thread through `Dispatcher.UIThread.InvokeAsync` and mutates nothing
+unless the generation it captured is still current — `TeardownAsync` and every
+path switch bump it.
 
 Items — an `AvaloniaList<ChatItemViewModel>` exposed read-only and mutated on
 the UI thread. A read's items are applied with one `AddRange` (one collection
@@ -281,19 +305,22 @@ only when it was already at the end, so a user reading history is not yanked.
 
 ### Markdown
 
-`MarkdownView` — a `Control` with a styled `Text` property and an
-`OpenLink` command property — rebuilds its content from a Markdig AST (default
-CommonMark pipeline plus auto-links) on every change. `MarkdownBlocks` maps:
-paragraphs and headings → `SelectableTextBlock` with inlines (`Bold`, `Italic`,
-monospace `Run` for code spans, `LineBreak`); fenced and indented code → a
-`Border` around a monospace `SelectableTextBlock`; bullet and ordered lists →
-marker + nested content rows; block quotes → a left rule beside the content;
-thematic breaks → a hairline. A link is an `InlineUIContainer` hosting a
-link-styled `TextBlock` (accent, underlined, hand cursor) — an inline `Run`
-takes no pointer input of its own — whose pointer-release executes `OpenLink`
-with the URL. HTML, tables, images and any other node render their literal
-source text — degraded, never dropped. User bubbles do not go through it: what
-the user typed is shown as typed.
+`MarkdownView` — a `ContentControl` with a styled `Text` property and an
+`OpenLink` command property — rebuilds its `Content` (a vertical panel of
+block controls) from a Markdig AST (default CommonMark pipeline plus
+auto-links) on every `Text` change. `MarkdownBlocks` maps: paragraphs and
+headings → `SelectableTextBlock` with inlines (`Bold`, `Italic`, monospace
+`Run` for code spans, `LineBreak`); fenced and indented code → a `Border`
+around a monospace `SelectableTextBlock`; bullet and ordered lists → marker +
+nested content rows; block quotes → a left rule beside the content; thematic
+breaks → a hairline. A link is an `InlineUIContainer` hosting a link-styled
+`HyperlinkButton` (accent, underlined, hand cursor) with **`NavigateUri` left
+unset** — set, the control opens the URI itself and would bypass the policy
+below — and `Command` bound to `OpenLink` with the URL as its parameter; a
+button brings keyboard activation (Enter/Space), focus, and automation
+semantics, which a bare inline `Run` has none of. HTML, tables, images and
+any other node render their literal source text — degraded, never dropped.
+User bubbles do not go through it: what the user typed is shown as typed.
 
 Links are agent-authored and untrusted, and `ShellUrlOpener` hands any string
 to the OS shell. The trust boundary is the item's `OpenLinkCommand` on
@@ -327,28 +354,32 @@ measured: a workspace opened on Chat would then keep the constructor's 80×24
 and, through the daemon's min-clamp across viewers, shrink the agent's terminal
 for every other attacher.
 
-Focus follows the tab, and the view enforces it rather than assuming it:
-`TerminalHost.Focusable` and `IsTabStop` are bound to `IsTerminalActive`, so a
-hidden terminal can neither hold keyboard focus nor be tabbed into; the
-existing focus-on-Model-assignment handler runs only while the Terminal tab is
-active (a reattach while Chat is up must not steal the composer's focus);
-switching to Terminal focuses the terminal, switching to Chat — and the first
-open on Chat — focuses `ComposerInput`.
+Focus follows the tab, and the view enforces it rather than assuming it. The
+**inactive surface's root** — the whole terminal grid (control, banners,
+Detach/Reattach buttons) or the whole chat surface (list, composer, Send) — is
+disabled (`IsEnabled=false`), non-hit-testable and transparent, so nothing in
+it can hold focus, be tabbed into, or be activated; a disabled control is
+still measured and arranged, which is what keeps the terminal's pane size
+real. The existing focus-on-Model-assignment handler runs only while the
+Terminal tab is active (a reattach while Chat is up must not steal the
+composer's focus); switching to Terminal focuses the terminal, switching to
+Chat — and the first open on Chat — focuses `ComposerInput`.
 
 ### Composer
 
 Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
 
-- `ComposerText`; `SendCommand` (`CreateFromTask`), executable iff the terminal
-  is `Attached`, not read-only, and the text is not blank. The send is
+- `ComposerText`; `SendCommand` (`ReactiveCommand.Create`, synchronous),
+  executable iff the terminal is `Attached`, not read-only, and the text is not
+  blank. It calls `Terminal.TrySendText(text)` and clears the text iff that
+  returns true — one synchronous step on the UI thread, no await, so
+  acceptance and the clear cannot be separated by a state change. The send is
   **accepted**, not acknowledged: the attach seam's `SendInputAsync` returns
   nothing and Core's client no-ops when it is no longer writable and folds a
   transport failure into the attach outcome — so no send can learn whether
-  its bytes landed. Acceptance (a live read-write attach at the moment of the
-  call) clears the text synchronously on the UI thread, before any await; a
-  refused send leaves the text in place and the hint already says why. A
-  transport loss surfaces the way it always does — the attach outcome flips
-  `Terminal.State`, and the hint follows.
+  its bytes landed. A refused send leaves the text in place and the hint
+  already says why. A transport loss surfaces the way it always does — the
+  attach outcome flips `Terminal.State`, and the hint follows.
 - `ComposerHint` follows `Terminal.State`: attached read-write → "Reply to
   {vendor label} · Enter sends · Shift+Enter for a new line"; attached read-only
   → "Read-only: {reason}"; `Resolving`/`Connecting` → "Connecting to the
@@ -362,25 +393,34 @@ Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
   reading or switching the mode is AI-2197's, and the transcript does not
   carry the live prompt state anyway.
 
-`TerminalTabViewModel.SendTextAsync(string text)` → `Task<bool>` — true when
-accepted. It delivers the text the way the daemon's own
-`PtyHostedAgentRuntime.SendUserInputAsync` does, and captures the client and
-attempt generation once, at acceptance: one write of
-`TerminalInputEncoder.Paste(text)` — `\r\n` normalized to `\n`, one trailing
-newline dropped, wrapped in bracketed paste (`ESC[200~` … `ESC[201~`) so the TUI
-takes it as one block — then, after a 150 ms `TimeProvider` delay, one write of
-`\r` **to the same captured client, only if the generation is still current**
-and teardown has not run. A retirement during the delay (reattach, detach,
-teardown) drops the CR: the paste already went to the old client, and the
-replacement must never receive a stray Enter. The delay is measured against
-Codex's TUI, which suppresses Enter-as-submit for 120 ms after ingesting a
-paste and turns a CR inside that window into a newline. A single CR, never a
-retry spray: an interactive launch keeps its permission prompts (Claude
-prompts unless it is an owned review-flow launch; Codex follows its posture),
-and the transcript cannot show a prompt that is up on the PTY, so every extra
-Enter is a chance to answer one. Every message takes this one path,
-single-line or not. Enter sends and Shift+Enter inserts a newline — a
-view-level key handler on the composer's `TextBox`.
+`TerminalTabViewModel.TrySendText(string text)` → `bool`, synchronous, UI
+thread. It refuses (false, nothing written) unless `State` is `Attached`
+read-write and a client is live; otherwise it captures the client and the
+current **send epoch** and starts a fault-contained background delivery, then
+returns true. The send epoch is a counter the VM bumps **synchronously, before
+any await, at the start of** `TryStartAttemptAsync` (reattach), `RunDetachAsync`
+and `TeardownAsync` — the attempt generation cannot serve, because reattach
+bumps it only after awaiting the old client's disposal, and detach never bumps
+it at all; a delayed CR must be dead the instant a detach or reattach begins,
+not when it finishes.
+
+The delivery is the daemon's own `PtyHostedAgentRuntime.SendUserInputAsync`
+shape: one write of `TerminalInputEncoder.Paste(text)` — `\r\n` normalized to
+`\n`, one trailing newline dropped, wrapped in bracketed paste (`ESC[200~` …
+`ESC[201~`) so the TUI takes it as one block — then, after a 150 ms
+`TimeProvider` delay, one write of `\r` **to the same captured client, only if
+the send epoch is unchanged**. A stale epoch drops the CR: the paste already
+went to the old client, and a replacement must never receive a stray Enter.
+A fault in either write is observed and logged once to `Console.Error`; it
+never touches VM state (the attach outcome is the transport's own reporting
+channel). The delay is measured against Codex's TUI, which suppresses
+Enter-as-submit for 120 ms after ingesting a paste and turns a CR inside that
+window into a newline. A single CR, never a retry spray: an interactive launch
+keeps its permission prompts (Claude prompts unless it is an owned review-flow
+launch; Codex follows its posture), and the transcript cannot show a prompt
+that is up on the PTY, so every extra Enter is a chance to answer one. Every
+message takes this one path, single-line or not. Enter sends and Shift+Enter
+inserts a newline — a view-level key handler on the composer's `TextBox`.
 
 ## 4. Testing
 
@@ -395,10 +435,14 @@ view-level key handler on the composer's `TextBox`.
 - `ClaudeTranscriptEventsTests` / `CodexRolloutEventsTests`: one fixture line
   per shape in §2 — including a string `tool_result.content` and a block-array
   one, a non-object `input`, non-object `arguments`, the skip lists, wrapper
-  stripping, prelude skipping, the joining separator, the 4096-character cap
-  and its marker, wrong-typed fields reading as absent, and a malformed line →
-  empty. Every `ToolInputJson` in every fixture parses as a JSON object.
-  `TranscriptProjection.For`: case-insensitive, unknown → null.
+  stripping, prelude skipping, the joining separator, the cap (final
+  `string.Length` exactly 4096 with the marker, and an astral character at the
+  boundary kept whole or dropped whole), wrong-typed fields reading as absent,
+  and a malformed line → empty. Every `ToolInputJson` in every fixture parses
+  as a JSON object; the wrapper fixtures cover an array, a scalar and a null
+  `input`. `TranscriptProjection.For`: case-insensitive, unknown → null.
+- `JsonElementExtensionsTests`: `Prop` returns an array, a scalar and a null
+  property as elements, and null for an absent one or a non-object receiver.
 - `StatusIpcJsonTests`: `transcript_path` round trip, trailing order, old JSON
   → null.
 - AOT: the Release publish of the CLI stays free of `IL2026`/`IL3050`
@@ -416,7 +460,9 @@ view-level key handler on the composer's `TextBox`.
   mutation; cancellation (agent exit) ends it cleanly.
 - `AgentOrchestrator`: `HandleLocalSpawnAsync` starts discovery for a local
   (and a `--private`) PTY launch — over a fake PTY factory and launcher, no
-  real process.
+  real process. A `codex -- resume <id>` passthrough launch against a sessions
+  tree holding only the resumed, older-stamped rollout leaves `transcript_path`
+  null — the boundary pinned, so weakening it is a deliberate change.
 - `AgentStatusSnapshotTests`: `transcript_path` null before detection, the
   value after — on the serialized payload.
 
@@ -426,37 +472,45 @@ view-level key handler on the composer's `TextBox`.
   the initial load renders items in file order; lines appended after a tick
   render; a held partial line does not render until complete; tool outcome
   pairing (Done, Error); `Reset` on length regression; `Missing` then
-  recovery; a `Failed` read keeps items and phase; a different path restarts;
-  ticks stop after teardown; a projection-less vendor → `Unavailable`; a
-  removed agent keeps its items; a dto or snapshot pushed from a pool thread
-  lands on bound state without a thread-affinity fault; both subscriptions
-  end at teardown.
+  recovery; a `Failed` read keeps items and phase; a path switch with a read
+  of the old file deliberately blocked mid-flight — switch, release, and only
+  the new file's items remain, with an empty pairing index; ticks stop after
+  teardown; a projection-less vendor → `Unavailable`; a removed agent keeps
+  its items; a dto or snapshot pushed from a pool thread lands on bound state
+  without a thread-affinity fault; both subscriptions end at teardown.
 - Batching: a 5,000-record initial transcript raises exactly one collection
   notification, and — in a headless window at a fixed size — the
   `ItemsControl` realizes a bounded number of containers.
 - Composer: `SendCommand` enablement across every terminal phase and the
   read-only case; the exact two writes via `FakeTerminalAttachClient.SentInput`
   — the bracketed paste, then `\r` only once the `FakeTimeProvider` advances
-  past the delay, on the same client; a reattach, detach or teardown during
-  the delay sends no CR to any client; the text clears on acceptance and
-  stays on refusal; every hint string; a pool-thread state flip updates the
-  hint on the UI thread.
+  past the delay, on the same client; a detach or reattach that has *begun*
+  before the send refuses it (text stays, nothing written); a reattach whose
+  old-client disposal is held open past 150 ms (`DisposeGate`), a detach, or a
+  teardown started during the delay sends no CR to any client; a faulting
+  write leaves VM state untouched; the text clears on acceptance and stays on
+  refusal; every hint string; a pool-thread state flip updates the hint on
+  the UI thread.
 - `TerminalInputEncoderTests`, `ToolDetailTests` (key priority, first line,
   80-character cut), `LinkPolicyTests` (https/http open, `file:`,
   `javascript:`, custom schemes, relative and malformed text refused).
 - `MarkdownBlocksTests` (headless): paragraph inlines, a fenced block, list
-  items, a link that executes `OpenLink` once, a disallowed link rendered as
-  plain text, and an unsupported construct degrading to literal text.
+  items, a link that executes `OpenLink` exactly once from a pointer click and
+  once from keyboard activation, a disallowed link rendered as plain text that
+  is not focusable, and an unsupported construct degrading to literal text.
 - `WorkspaceViewModelTests`: Chat is the default tab; the switch commands; `Chat`
   is built for a PTY dto only; teardown disposes it.
 - `WorkspaceViewSmokeTests`: the new names resolve (`ChatTabButton`, `ChatHost`,
   `ChatItems`, `ComposerInput`, `SendButton`); switching tabs flips which
   surface is visible while `TerminalHost` stays in the tree on both; a
   workspace opened on Chat with a **real** `XtermTerminalSurface` reports the
-  laid-out pane size to the attach client, not 80×24, while `TerminalHost` is
-  neither focusable nor hit-testable; focus lands on `ComposerInput` on open,
-  stays there through a late Model assignment, moves to the terminal on the
-  Terminal switch and back on the Chat switch.
+  laid-out pane size to the attach client, not 80×24, while the terminal
+  surface is disabled and non-hit-testable; focus lands on `ComposerInput` on
+  open, stays there through a late Model assignment, moves to the terminal on
+  the Terminal switch and back on the Chat switch; tab traversal from the
+  composer never reaches `DetachButton`/`ReattachButton` while Chat is active
+  (terminal driven to Detached/Failed first), and from the terminal never
+  reaches `ComposerInput`/`SendButton` while Terminal is active.
 
 README: the desktop app has no section yet and this slice adds no CLI surface,
 so it is unchanged. `docs/CHANGES.md` gains a "Session chat" entry.
@@ -485,6 +539,16 @@ so it is unchanged. `docs/CHANGES.md` gains a "Session chat" entry.
   cwd and spawn time; a user's own session started in the same checkout within
   the skew tolerance could win. Display-only, and the same exposure the
   daemon's session-id link already carries.
+- **A short-lived session may never get its path.** Discovery scans every
+  2 s and stops at agent exit without a final locate; and a path that lands
+  at exit still has to cross the status debounce before cleanup and removal.
+  Such a session's Chat stays in `Waiting` — its Terminal tab still has the
+  scrollback. Coordinating discovery with the exit path was judged not worth
+  its coupling for a session that ran for seconds.
+- **Codex resume is not discoverable.** A local passthrough `resume` appends
+  to an older-stamped rollout the locator will never accept; Chat stays in
+  `Waiting`. Supporting it means reading the resumed id out of the arguments,
+  which this slice leaves alone.
 - **Rendering granularity is the transcript's.** Both vendors write complete
   blocks, not tokens, so assistant text appears per block, a few hundred
   milliseconds after the vendor writes it. That is what "rendered from the

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -409,8 +409,8 @@ Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
   the gate into the state so the hint is truthful in every window: `Ready` →
   "Reply to {vendor label} · Enter sends · Shift+Enter for a new line";
   `Sending` → "Sending…"; `Transitioning` (the gate is closed while `State`
-  still reads Attached — a reattach or detach in progress) → "Reconnecting
-  the terminal…"; otherwise by `State`: attached read-only → "Read-only:
+  still reads Attached — a reattach or detach in progress) → "Updating the
+  terminal connection…"; otherwise by `State`: attached read-only → "Read-only:
   {reason}"; `Resolving`/`Connecting` → "Connecting to the terminal…";
   `Detached`/`Failed` → "Reattach the terminal to send";
   `Exited`/`SessionEnded` → "This session has ended"; `NoTerminal`/`NotFound` →
@@ -435,9 +435,18 @@ mutated only on the UI thread:
   outcomes `FinishAttemptAsync` maps — Detached, Exited, Failed,
   ConnectionLost — the agent removal that lands `SessionEnded`, `NotFound`,
   `NoTerminal`), in the same dispatch and before the new state is published.
-  It reopens only inside the publish of a read-write `Attached`. To make
-  that unforgettable, `State` has one publish point that applies the gate
-  rule; nothing assigns it directly. Neither `State` nor `_client` can serve
+  It reopens only inside the publish of a read-write `Attached`, **and only
+  for the attempt that owns the current closure**: an attempt records the
+  epoch value its own opening closure produced, and `OnAttachedAsync`'s
+  publish is discarded unless both its attempt generation and that epoch are
+  still current. The attempt generation alone cannot decide this — a cache
+  removal (`SessionEnded`) and an explicit detach retire nothing today, so a
+  callback still queued for its UI dispatch when either lands would publish
+  a writable `Attached` on top of the closure and reopen a terminal the
+  daemon has already dropped. Only an explicitly started later attempt, with
+  its own epoch, can reopen. To make all of this unforgettable, `State` has
+  one publish point that applies the gate rule; nothing assigns it directly.
+  Neither `State` nor `_client` can serve
   as the gate on its own: a reattach leaves both `Attached` and live while it
   awaits the old client's disposal, and a detach leaves both unchanged while
   it awaits the detach write — a send started in either window would
@@ -565,9 +574,15 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
   a send started while a reattach is awaiting the old client's disposal
   (`DisposeGate`) or a detach is awaiting its write (`HangDetachForever`) is
   refused — `State` still reads `Attached` in both windows, `SendCommand`'s
-  `CanExecute` is false and the hint reads "Reconnecting the terminal…" — and
-  the gate reopens only once the new attempt lands read-write `Attached` (a
-  read-only Attached leaves it closed); a reattach whose old-client disposal
+  `CanExecute` is false and the hint reads "Updating the terminal
+  connection…" — and the gate reopens only once the new attempt lands
+  read-write `Attached` (a read-only Attached leaves it closed); an attach
+  callback whose UI publish is still queued when the agent is removed (and,
+  separately, when an explicit detach begins) does not reopen: after the
+  queue drains, `State` is still `SessionEnded` (respectively not Attached),
+  `CanAcceptText` is false and a direct `TrySendText` is refused, while a
+  later explicitly started attempt's own Attached does reopen; a reattach
+  whose old-client disposal
   is held open past 150 ms, a detach, or a teardown started during the delay
   sends no CR to any client and clears `SendInFlight` synchronously; an
   `AttachOutcome` (`Exited` and `ConnectionLost` at least) and an agent
@@ -578,8 +593,8 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
   `SendInFlight`; after `TeardownAsync` returns, no bound state changes and no
   dispatcher work is queued by a still-running delivery; the text clears on
   acceptance and stays on refusal; every hint string including "Sending…"
-  and "Reconnecting the terminal…"; a pool-thread state flip updates the
-  hint on the UI thread.
+  and "Updating the terminal connection…"; a pool-thread state flip updates
+  the hint on the UI thread.
 - `TerminalInputEncoderTests`, `ToolDetailTests` (key priority, first line,
   80-character cut), `LinkPolicyTests` (https/http open, `file:`,
   `javascript:`, custom schemes, relative and malformed text refused).

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -429,9 +429,15 @@ mutated only on the UI thread:
 - `SendGate` ∈ Open | Closed, and the **opening token** — a counter whose
   current value names who may open the gate. Two operations, and only two,
   advance it, both synchronous on the UI thread:
-  - `BeginAttempt()` — the first thing `TryStartAttemptAsync` does, before
-    any await: closes the gate, allocates a fresh token and hands it to the
-    attempt, which carries it for its whole life.
+  - `BeginAttempt()` — `TryStartAttemptAsync`'s first **state-mutating**
+    action, after it has try-entered `_attachLane` and passed the
+    disposed/retired guard, and still before any await: closes the gate,
+    allocates a fresh token and hands it to the attempt, which carries it
+    for its whole life. A call that loses the lane (a double-click —
+    `ReactiveCommand.Execute` runs the handler even while one is active) or
+    finds the VM torn down allocates no token and touches no send state; it
+    is the complete no-op it is today, so the winning attempt's token stays
+    current.
   - `Invalidate()` — closes the gate (an already-closed gate still counts:
     ownership must advance even mid-`Connecting`), allocates a fresh token
     that no attempt holds, and clears `SendInFlight`. Called at the start of
@@ -597,7 +603,11 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
   (c) a removal or detach landing during a reattach's pre-`Connecting`
   old-client disposal (`DisposeGate`) aborts that attempt — it never
   publishes `Connecting` or `Attached` — while a subsequently, explicitly
-  begun attempt holds a fresh token and does open; a reattach
+  begun attempt holds a fresh token and does open; (d) the existing
+  back-to-back reattach test grows a token assertion: with the winning
+  attempt held in its first await, the losing call changes neither the
+  token nor the gate, and once the winner publishes `Connecting` and
+  `Attached`, `CanAcceptText` is true; a reattach
   whose old-client disposal
   is held open past 150 ms, a detach, or a teardown started during the delay
   sends no CR to any client and clears `SendInFlight` synchronously; an

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -1,0 +1,352 @@
+# Chat for PTY harnesses, rendered from the transcript (AI-2196)
+
+Slice of the desktop shell (parent AI-2171; design canvas "Hosted Agents Shell",
+Session artboard — the Chat tab and the composer). A Claude or interactive Codex
+session gets a **Chat** tab beside its Terminal tab, rendered from the transcript
+file the vendor itself writes; input still goes to the PTY. The same session, read
+two ways.
+
+Out of scope, by prior decomposition and by the canvas annotations: structured
+turn frames, the "NEEDS YOU" approval card, permission-mode control and the "+"
+attachment affordance (AI-2197); chat for ACP / app-server sessions, which have
+no PTY and no transcript file the daemon locates (AI-2197); the work-context
+sidebar (AI-2198). Deferred within this slice: markdown tables and images,
+syntax highlighting in code blocks, and rendering thinking or tool-result bodies.
+
+## Decisions
+
+Settled with the owner during brainstorming, 2026-08-26:
+
+1. **The daemon tells the app where the transcript is: additive `transcript_path`
+   on `AgentStatusDto`.** The daemon already resolves every PTY agent's vendor
+   session id by scanning the vendor's session tree (a 2 s poll for up to 3 min)
+   and caches the Codex rollout path for its own turn diagnostic; the agent's
+   worktree — `<repo>/.capacitor/worktrees/agent-<guid>` — never reaches the app
+   and cannot be reconstructed from `RepoPath`. Rejected: shipping session id plus
+   worktree path and porting both locators into Core (duplicates work the daemon
+   does anyway); a client-side scan of the repo's Claude project dir (ambiguous
+   with two agents on one repo, and no Codex equivalent without the session id).
+   "No protocol change" is read as AI-2195 read it: no new frame family; trailing
+   nullable DTO members are the sanctioned path.
+2. **The transcript → chat projection lives in Core, public, and emits
+   `AcpEventEnvelope`.** `AcpEventKind` is the vocabulary the daemon's ACP and
+   app-server runtimes already emit live and the one AI-2197's frames would carry,
+   so the Chat tab's renderer is written once. Core has the internal
+   `JsonElementExtensions` the repo mandates for JSON access; BCL plus
+   `JsonDocument` keeps it AOT-clean. Rejected: app-local mappers behind an
+   `InternalsVisibleTo` on a production assembly; daemon-side projection pushed
+   over a new frame (that *is* AI-2197).
+3. **The composer sits on the Chat tab only.** The canvas draws it under both
+   tabs, but the Terminal tab is its own input surface — a second one beneath it
+   would be two ways to type into one process. Recorded as a deliberate
+   deviation from the artboard.
+4. **Markdown: Markdig plus an in-house renderer.** `Avalonia.Controls.Markdown`
+   is AvaloniaUI's commercial Accelerate control (license key in the csproj — not
+   for a public repository); `Markdown.Avalonia` is an Avalonia-12 alpha with no
+   cut since April 2026 and a single author; `LiveMarkdown.Avalonia` brings
+   TextMateSharp and its grammar bundle. Markdig (BSD-2, 74M downloads, no
+   dependencies) parses; a small renderer maps the constructs agents actually
+   emit to Avalonia inlines and blocks, and anything it does not know renders as
+   its literal text rather than vanishing.
+5. **Chat is the default tab for a PTY session** (the canvas selects it on every
+   rail click). The Terminal stays attached while Chat is up — the composer needs
+   the live PTY link, and a reattach would only replay scrollback anyway.
+6. **Thinking and tool-result bodies are not rendered.** The canvas timeline is
+   user bubbles, assistant prose and one muted row per tool call; a tool row
+   carries a one-line detail from its input and an outcome mark that its result
+   flips. Thinking is projected (the vocabulary has it) and dropped by the tab.
+
+## 1. Wire change (additive only)
+
+`AgentStatusDto` (`src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs`) gains one
+trailing member after `Title`:
+
+- `TranscriptPath` — `string? TranscriptPath = null`, serialized
+  `transcript_path`, always emitted (null, never omitted — the context's own
+  rule). The daemon stamps `AgentInstance.TranscriptPath` in
+  `SnapshotAgentsForStatus`. `null` means any of: an older daemon, not resolved
+  yet, the 3-minute poll gave up, or a runtime with nothing to read (app-server
+  Codex, every ACP vendor). The app never distinguishes these; it waits.
+
+Daemon side (`src/Capacitor.Cli.Daemon`):
+
+- `AgentInstance.CodexRolloutPath` becomes `TranscriptPath`, populated for both
+  PTY vendors; the Codex turn diagnostic reads the renamed property unchanged.
+- `SessionTranscriptLocator` (`Harness/Claude/`) gains
+  `TryLocateWinner(projectDir, worktreePath, spawnedAtUtc, ruledOut)` returning
+  `(SessionId, Path)?`, mirroring `CodexSessionRolloutLocator.TryLocateWinner`;
+  `TryLocate` delegates to it. The path is the matched file under the
+  per-worktree project dir — a symlink onto the source repo's dir, which the app
+  opens as-is.
+- `DetectSessionIdAsync`'s Claude and Codex branches set `agent.TranscriptPath`
+  from the winner, and `PollForSessionIdAsync` pulses `_statusNotifier` after
+  the match lands on the agent — mutation first, pulse second, the notifier's
+  own contract. The path resolves within a few seconds of launch for both
+  vendors (Claude writes its first record, with `cwd`, before its first prompt
+  renders).
+
+The path is the daemon's view of the filesystem (its `CLAUDE_CONFIG_DIR` /
+`CODEX_HOME`), which is the correct one: it launched the process. Nothing else
+on the wire changes; `FrameType` and the capability list are untouched.
+
+Serialization acceptance (extends `StatusIpcJsonTests`): old JSON without the
+member deserializes to `null`; a value and `null` both serialize with
+`transcript_path` present, last, in the declared trailing order. The daemon
+snapshot test (`AgentStatusSnapshotTests`) asserts the serialized payload
+carries `null` before detection and the path after.
+
+## 2. Core: tail and projection
+
+### `JsonlTail` (`src/Capacitor.Cli.Core/JsonlTail.cs`)
+
+Vendor-neutral, BCL-only, one instance per file, holding a byte cursor.
+`ReadAppended()` returns `TailRead(IReadOnlyList<string> Lines, bool Reset, bool Missing)`:
+
+- Opens `new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete)`
+  per call and closes it after. The trap named on the issue: `File.ReadAllText`,
+  `File.ReadLines` and friends open `FileShare.Read`, which on Windows denies the
+  agent the write handle to its own transcript — worst during its shutdown
+  drain. Invisible on macOS/Linux; only the Windows CI leg catches a violation.
+- A missing file is `Missing = true` with no lines and no cursor change.
+- `Length < cursor` is a truncation or replacement: the cursor resets to zero
+  and the read reports `Reset = true` so the consumer clears what it rendered.
+- Reads `[cursor, Length)`, splits on `\n` (a trailing `\r` is stripped), skips
+  blank lines, and **holds back an unterminated final chunk**: the cursor
+  advances only past the last `\n`, so the chunk is re-read whole once its
+  newline lands. This is `WatchCommand`'s `Hold` policy, as a pure function
+  (`SplitCompleteLines(ReadOnlySpan<byte>, out int consumed)`) the tail wraps.
+  UTF-8 decoding is per complete line — a multibyte sequence cannot straddle a
+  newline, so no decoder state carries over.
+
+### Projection
+
+Two public, stateless line mappers, each `Project(string line) →
+IReadOnlyList<AcpEventEnvelope>` (empty for anything unparseable or
+uninteresting), plus a registry `TranscriptProjection.For(vendor)` beside them
+in Core returning the mapper or null — the one registration site, so adding a
+vendor's transcript means a new `Harness/<Vendor>/` file and one line here.
+Every envelope carries `TimestampIso` when the record has a timestamp; `Seq`
+stays 0 — arrival order is the order.
+
+`ClaudeTranscriptEvents` (`Harness/Claude/`), keyed on the record's root `type`:
+
+- `user`, not `isMeta`, not `isSidechain`: a string `message.content` is one
+  `user_message`; an array yields one `user_message` per `text` block and one
+  `tool_result` per `tool_result` block (`ToolCallId` = `tool_use_id`,
+  `ToolIsError` = `is_error`, `ToolResult` = the block's text, capped at 4 KiB).
+  Before emitting user text, `<system-reminder>…</system-reminder>` blocks and
+  the local-command wrappers (`<command-name>`, `<command-message>`,
+  `<command-args>`, `<local-command-stdout>`, `<local-command-caveat>`) are
+  stripped; text that is blank afterwards is not emitted.
+- `assistant`, not `isSidechain`: per content block — `text` → `assistant_text`;
+  `thinking` → `assistant_thinking` (`ThinkingEncrypted` when the block carries
+  no text); `tool_use` → `tool_call` (`ToolCallId` = `id`, `ToolName` = `name`,
+  `ToolInputJson` = the raw `input` object). `Model` = `message.model`.
+- Everything else is skipped: `attachment`, `summary`, `system`,
+  `file-history-snapshot`, `file-history-delta`, `mode`, `permission-mode`,
+  `last-prompt`, `ai-title`, `atis-latch`, `worktree-state`,
+  `queue-operation`, `progress`, and any type this build has never heard of.
+
+`CodexRolloutEvents` (`Harness/Codex/`), keyed on `type == "response_item"` and
+then `payload.type`; every other envelope type (`event_msg`, `turn_context`,
+`session_meta`, `world_state`, `compacted`,
+`inter_agent_communication_metadata`) is skipped:
+
+- `message` with role `user`: the `input_text` blocks joined → `user_message`,
+  unless the text opens with an injected prelude (`<environment_context>`,
+  `# AGENTS.md instructions`, `<turn_aborted>`, `<user_instructions>`,
+  `<permissions instructions>`); role `assistant`: the `output_text` blocks →
+  `assistant_text`; roles `developer` and `system` are skipped.
+- `function_call` → `tool_call` (`ToolCallId` = `call_id`, `ToolName` = `name`,
+  `ToolInputJson` = `arguments`); `custom_tool_call` → `tool_call`
+  (`ToolInputJson` = a JSON object `{"input": …}` wrapping the raw input string);
+  `function_call_output` and `custom_tool_call_output` → `tool_result`
+  (`call_id`; the output string, or its text blocks joined, capped at 4 KiB).
+- `reasoning` → `assistant_thinking` (summary texts joined;
+  `ThinkingEncrypted` when only `encrypted_content` is present).
+- `agent_message` (inter-agent traffic) is skipped.
+
+## 3. App: the Chat tab
+
+### `ChatTabViewModel`
+
+Constructed by `WorkspaceViewModel` for a PTY session only — the same gate as
+the Terminal tab (`HostedHarnessCatalog.ShowsTerminal`) — once the first dto
+resolves, because the projector is chosen by the dto's vendor. Ctor-scoped like
+its siblings; `TeardownAsync` is its one exit. Inputs: agent id,
+`IDaemonClientService`, the sibling `TerminalTabViewModel`, the projector from
+`TranscriptProjection.For(vendor)` (null → the `Unavailable` phase), and a
+`TimeProvider`.
+
+Phases (`ChatTabPhase`): `Waiting` (no `transcript_path` yet — muted "Waiting
+for the transcript…"), `Reading`, `Missing` (a path that does not exist on
+disk — "The transcript is not readable from here"), `Unavailable` (a PTY vendor
+with no projector — "No chat view for this harness"). A session that ends keeps
+its items and keeps polling until teardown: the file outlives the process and
+may still receive its final records.
+
+Path watch: `daemon.Agents.Connect().ObserveOn(RxSchedulers.MainThreadScheduler)`
+filtered to the agent id; the first non-null `TranscriptPath` starts the tail; a
+later, different path restarts from zero (a re-resolution after a daemon restart).
+
+Poll: a `TimeProvider` timer every 500 ms (a tuning constant, not a contract).
+A tick with a read still in flight is skipped. The read and the projection run
+on the thread pool; the apply hops to the UI thread through
+`Dispatcher.UIThread.InvokeAsync`, guarded by a generation `TeardownAsync`
+bumps so a late completion mutates nothing. The first read of a long transcript
+produces one batch, applied under one dispatch.
+
+Items — a `ReadOnlyObservableCollection<ChatItemViewModel>` mutated on the UI
+thread — in three shapes:
+
+- `UserTurnItem(Text)`: the canvas's right-aligned bubble, plain text.
+- `AssistantTextItem(Text)`: markdown-rendered prose, one item per envelope.
+- `ToolCallItem(Name, Detail, Outcome)`: the muted `›` row. `Outcome` is a
+  bound property ∈ Running | Done | Error, flipped in place when the matching
+  `tool_result` arrives (indexed by `ToolCallId`; an unmatched result is
+  ignored). `Detail` is `ToolDetail.From(name, inputJson)`: the first present
+  of `description`, `command`, `cmd`, `file_path`, `path`, `pattern`, `query`,
+  `url`, `skill`, `prompt`, `input`; its first line, trimmed to 80 characters
+  with an ellipsis; empty when none applies.
+
+`assistant_thinking` and unmatched `tool_result` envelopes create no item;
+`Reset` clears the items and the pairing index.
+
+Follow-tail is a view concern: the `ScrollViewer` scrolls to the end on an add
+only when it was already at the end, so a user reading history is not yanked.
+
+### Markdown
+
+`MarkdownView` — a `Control` with a styled `Text` property — rebuilds its
+content from a Markdig AST (default CommonMark pipeline plus auto-links) on
+every change. `MarkdownBlocks` maps: paragraphs and headings →
+`SelectableTextBlock` with inlines (`Bold`, `Italic`, monospace `Run` for code
+spans, `LineBreak`); fenced and indented code → a `Border` around a monospace
+`SelectableTextBlock`; bullet and ordered lists → marker + nested content rows;
+block quotes → a left rule beside the content; thematic breaks → a hairline;
+links → an accent-coloured underlined run opened through `UrlOpener` on click.
+HTML, tables, images and any other node render their literal source text —
+degraded, never dropped. User bubbles do not go through it: what the user typed
+is shown as typed.
+
+`Markdig` is added to `Directory.Packages.props` and the app csproj. The app
+is not NativeAOT, so trimming is not a concern for it.
+
+### Tab strip and workspace
+
+`WorkspaceViewModel`:
+
+- `Chat` (`ChatTabViewModel?`): created from the presence stream on the first
+  dto that passes the PTY gate, disposed by `TeardownAsync`. Null for a
+  non-PTY session, whose tab strip keeps today's muted note.
+- `ActiveTab` (`WorkspaceTab.Chat | Terminal`), default Chat;
+  `ShowChatCommand` / `ShowTerminalCommand`; `IsChatActive` / `IsTerminalActive`
+  drive the pill styling. A new workspace (any `OpenSession`) opens on Chat.
+- `ShowsChatTab` is `ShowsTerminalTab` — one gate, exposed once.
+
+`WorkspaceView`: `ChatTabButton` precedes `TerminalTabButton`; a `ChatTabView`
+(`ChatHost`) and the existing terminal grid share the content cell. **The
+terminal control stays laid out on both tabs** — hidden by opacity and
+hit-test visibility, not `IsVisible` — so the pane size it reports to the PTY
+is the real pane size whichever tab is up. An `IsVisible=false` control is never
+measured: a workspace opened on Chat would then keep the constructor's 80×24
+and, through the daemon's min-clamp across viewers, shrink the agent's terminal
+for every other attacher. Focus follows the tab: the terminal takes keyboard
+focus only while its tab is active; the composer takes it on Chat.
+
+### Composer
+
+Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
+
+- `ComposerText`; `SendCommand` (`CreateFromTask`), executable iff the terminal
+  is `Attached`, not read-only, and the text is not blank. Success clears the
+  text; a failed send keeps it and surfaces the reason on the hint line.
+- `ComposerHint` follows `Terminal.State`: attached read-write → "Reply to
+  {vendor label} · Enter sends · Shift+Enter for a new line"; attached read-only
+  → "Read-only: {reason}"; `Resolving`/`Connecting` → "Connecting to the
+  terminal…"; `Detached`/`Failed` → "Reattach the terminal to send";
+  `Exited`/`SessionEnded` → "This session has ended"; `NoTerminal`/`NotFound` →
+  "No terminal to send to". The vendor label comes from
+  `HostedHarnessCatalog.LabelFor` over the daemon's advertised options.
+- Footer: model label (`HostedHarnessCatalog.ModelLabelFor`, "default" for
+  none), the session's status dot (`SessionStatusDots.For`) and status word
+  (the dto's `Status`, verbatim, like the Home cards). No permission-mode chip:
+  a hosted launch always runs `bypassPermissions`, and switching modes is
+  AI-2197's.
+
+`TerminalTabViewModel.SendTextAsync(string text)` → `Task<bool>`: false without
+a live read-write attach; otherwise writes `TerminalInputEncoder.Encode(text)`
+through the current client under the same generation check as keyboard input.
+`Encode` normalizes `\r\n` to `\n` and drops one trailing newline; a single line
+becomes UTF-8 text plus `\r`; a multi-line text is wrapped in bracketed paste
+(`ESC[200~` … `ESC[201~`) followed by `\r`, which both Claude Code and the Codex
+TUI honour as one submitted message. Enter sends and Shift+Enter inserts a
+newline — a view-level key handler on the composer's `TextBox`.
+
+## 4. Testing
+
+`test/Capacitor.Cli.Core.Tests.Unit`:
+- `JsonlTailTests`: complete lines delivered once; an unterminated final line
+  held, then delivered whole after its newline; CRLF; blank lines skipped;
+  truncation → `Reset` and a re-read from zero; missing file → `Missing`;
+  a file held open for writing by another handle is still readable (the
+  sharing-mode pin — asserted through a write handle opened first).
+- `ClaudeTranscriptEventsTests` / `CodexRolloutEventsTests`: one fixture line
+  per shape in §2, the skip lists, wrapper stripping, prelude skipping,
+  result capping, and a malformed line → empty.
+- `StatusIpcJsonTests`: `transcript_path` round trip, trailing order, old JSON
+  → null.
+
+`test/Capacitor.Cli.Daemon.Tests.Unit`:
+- `SessionTranscriptLocatorTests`: the winner carries the matched file's path.
+- `AgentStatusSnapshotTests`: `transcript_path` null before detection, the
+  value after — on the serialized payload.
+- The notifier pulse on a detected session id, pinned wherever the existing
+  detection tests already drive the poll.
+
+`test/Capacitor.App.Tests.Unit` (over `FakeDaemonClientService`,
+`FakeTerminalAttachClient`, `FakeTimeProvider`, a `TempDir` transcript):
+- `ChatTabViewModelTests`: `Waiting` until a path; the path starts reading and
+  the initial load renders items in file order; lines appended after a tick
+  render; a held partial line does not render until complete; tool outcome
+  pairing (Done, Error); `Reset` on truncation; a different path restarts;
+  ticks stop after teardown; a projector-less vendor → `Unavailable`; a removed
+  agent keeps its items.
+- Composer: `SendCommand` enablement across every terminal phase and the
+  read-only case; exact bytes for single-line (`text\r`) and multi-line
+  (bracketed) sends via `FakeTerminalAttachClient.SentInput`; the text clears on
+  success and survives a failure; every hint string.
+- `TerminalInputEncoderTests`, `ToolDetailTests` (key priority, first line,
+  80-character cut).
+- `MarkdownBlocksTests` (headless): paragraph inlines, a fenced block, list
+  items, a link, and an unsupported construct degrading to literal text.
+- `WorkspaceViewModelTests`: Chat is the default tab; the switch commands; `Chat`
+  is built for a PTY dto only; teardown disposes it.
+- `WorkspaceViewSmokeTests`: the new names resolve (`ChatTabButton`, `ChatHost`,
+  `ChatItems`, `ComposerInput`, `SendButton`); switching tabs flips which
+  surface is visible while `TerminalHost` stays in the tree on both.
+
+README: the desktop app has no section yet and this slice adds no CLI surface,
+so it is unchanged. `docs/CHANGES.md` gains a "Session chat" entry.
+
+## Risks
+
+- **Transcript size.** The whole file is parsed at open. A multi-megabyte
+  transcript costs one pool-thread pass and one batched UI apply into a
+  virtualized list; accepted for now, and a tail-only initial load is the
+  obvious upgrade if it ever hurts.
+- **Agent-owned files.** Every open is `FileShare.ReadWrite | Delete`; a
+  regression is invisible locally and reddens only the Windows CI leg. The
+  sharing test in `JsonlTailTests` is the local guard.
+- **Composer bytes are raw PTY input.** The agent's TUI decides what they mean;
+  bracketed paste assumes the TUI enabled it (both do). Text landing during a
+  redraw may echo oddly in the Terminal tab; the transcript is unaffected.
+- **Rendering granularity is the transcript's.** Both vendors write complete
+  blocks, not tokens, so assistant text appears per block, a few hundred
+  milliseconds after the vendor writes it. That is what "rendered from the
+  transcript" means; token streaming is AI-2197's frames.
+- **Markdown subset.** Unknown constructs degrade to literal text. Tables and
+  images are the likeliest gaps and are deferred knowingly.
+- **A never-resolving path** (older daemon, or the poll gave up) leaves Chat in
+  `Waiting` with the Terminal tab one click away; the note says what it is
+  waiting for.

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -426,34 +426,44 @@ Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
 thread. The terminal owns a **send gate** with three pieces of state, all
 mutated only on the UI thread:
 
-- `SendGate` ∈ Open | Closed. **Open exactly while the terminal is in
-  writable `Attached`, as the gate sees it.** It closes in two kinds of
-  place: synchronously, before any await, at the start of the transitions
-  that *begin* while `State` still reads Attached — `TryStartAttemptAsync`
-  (reattach), `RunDetachAsync`, `TeardownAsync` — and inside **every**
-  UI-thread publish of a `State` other than writable Attached (the natural
-  outcomes `FinishAttemptAsync` maps — Detached, Exited, Failed,
-  ConnectionLost — the agent removal that lands `SessionEnded`, `NotFound`,
-  `NoTerminal`), in the same dispatch and before the new state is published.
-  It reopens only inside the publish of a read-write `Attached`, **and only
-  for the attempt that owns the current closure**: an attempt records the
-  epoch value its own opening closure produced, and `OnAttachedAsync`'s
-  publish is discarded unless both its attempt generation and that epoch are
-  still current. The attempt generation alone cannot decide this — a cache
-  removal (`SessionEnded`) and an explicit detach retire nothing today, so a
-  callback still queued for its UI dispatch when either lands would publish
-  a writable `Attached` on top of the closure and reopen a terminal the
-  daemon has already dropped. Only an explicitly started later attempt, with
-  its own epoch, can reopen. To make all of this unforgettable, `State` has
-  one publish point that applies the gate rule; nothing assigns it directly.
-  Neither `State` nor `_client` can serve
+- `SendGate` ∈ Open | Closed, and the **opening token** — a counter whose
+  current value names who may open the gate. Two operations, and only two,
+  advance it, both synchronous on the UI thread:
+  - `BeginAttempt()` — the first thing `TryStartAttemptAsync` does, before
+    any await: closes the gate, allocates a fresh token and hands it to the
+    attempt, which carries it for its whole life.
+  - `Invalidate()` — closes the gate (an already-closed gate still counts:
+    ownership must advance even mid-`Connecting`), allocates a fresh token
+    that no attempt holds, and clears `SendInFlight`. Called at the start of
+    `RunDetachAsync` and `TeardownAsync`, before any await; by the agent
+    removal that lands `SessionEnded`; by the resolve timeout (`NotFound`)
+    and the no-terminal note; and by every terminal outcome
+    `FinishAttemptAsync` publishes (Detached, Exited, Failed, ConnectionLost).
+
+  An attempt's **own** publishes never advance the token: its `Connecting`
+  publish preserves it, and its read-write `Attached` publish **opens the
+  gate iff the token it carries is still current** (a read-only Attached
+  leaves it closed, token untouched). A carried token that is no longer
+  current means an invalidation landed since — a cache removal or an explicit
+  detach retires no attempt generation today, so a callback still queued for
+  its UI dispatch when either lands would otherwise publish a writable
+  `Attached` on top of the closure and reopen a terminal the daemon has
+  already dropped. Only a later, explicitly begun attempt holds a fresh
+  token and can open.
+
+  The pre-`Connecting` window closes the same way: after `TryStartAttemptAsync`
+  awaits the old client's disposal, it re-checks that the token
+  `BeginAttempt` handed it is still current and aborts the attempt otherwise
+  — an invalidation that landed during that await (a removal, a detach) must
+  not be overridden by an attempt that never reached `Connecting`. `State`
+  has one publish point that takes the publisher's token and applies these
+  rules; nothing assigns it directly. Neither `State` nor `_client` can serve
   as the gate on its own: a reattach leaves both `Attached` and live while it
   awaits the old client's disposal, and a detach leaves both unchanged while
   it awaits the detach write — a send started in either window would
   otherwise be accepted against a client on its way out.
-- The **send epoch**, a counter bumped by every closure, which a running
-  delivery re-checks before its CR.
-- `SendInFlight` (bound), true from acceptance until the delivery ends.
+- `SendInFlight` (bound), true from acceptance until the delivery ends. A
+  delivery captures the token at acceptance and re-checks it before its CR.
 
 Two bound projections fold these together for the composer:
 `CanAcceptText` = gate Open ∧ ¬`SendInFlight`, and `SendAvailability` ∈
@@ -462,7 +472,7 @@ gate Closed while `State` still reads Attached. Both raise change
 notifications on every gate, in-flight and state change.
 
 `TrySendText` refuses (false, nothing written) unless `CanAcceptText`;
-otherwise it captures the client and the epoch, sets `SendInFlight`, starts
+otherwise it captures the client and the token, sets `SendInFlight`, starts
 the fault-contained background delivery, and returns true. One transaction
 at a time is the point: two accepted sends inside the 150 ms window would
 interleave as paste A, paste B, CR, CR — Core's client serializes single
@@ -470,21 +480,22 @@ frames, not multi-frame messages — and the TUI would submit both as one
 prompt and spend the second Enter on whatever is up next. Refusing keeps the
 second text in the composer for the user to send again a moment later.
 
-Ownership of `SendInFlight` is one rule: **the closer retires the send.**
-Every closure — an entry-point closure or a state publish — synchronously
-bumps the epoch and clears `SendInFlight`, so a natural exit or an agent
-removal landing during the 150 ms delay kills the pending CR the same way a
-reattach does; the delivery's own completion — success or fault — clears it
-through a UI-thread dispatch that mutates nothing unless the epoch it
-captured is still current and the VM has not been torn down, so a late
-completion can neither clear a newer send nor touch a torn-down VM.
+Ownership of `SendInFlight` is one rule: **whoever advances the token
+retires the send.** `BeginAttempt` and `Invalidate` both clear it
+synchronously as they allocate, so a natural exit, an agent removal or a
+reattach landing during the 150 ms delay kills the pending CR the same way
+(its captured token is no longer current); the delivery's own completion —
+success or fault — clears it through a UI-thread dispatch that mutates
+nothing unless the token it captured is still current and the VM has not
+been torn down, so a late completion can neither clear a newer send nor
+touch a torn-down VM.
 
 The delivery is the daemon's own `PtyHostedAgentRuntime.SendUserInputAsync`
 shape: one write of `TerminalInputEncoder.Paste(text)` — `\r\n` normalized to
 `\n`, one trailing newline dropped, wrapped in bracketed paste (`ESC[200~` …
 `ESC[201~`) so the TUI takes it as one block — then, after a 150 ms
 `TimeProvider` delay, one write of `\r` **to the same captured client, only if
-the send epoch is unchanged**. A stale epoch drops the CR: the paste already
+the token is unchanged**. A stale token drops the CR: the paste already
 went to the old client, and a replacement must never receive a stray Enter.
 A fault in either write is observed and logged once to `Console.Error` and
 ends the delivery (clearing `SendInFlight` under the rule above); it never
@@ -576,12 +587,17 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
   refused — `State` still reads `Attached` in both windows, `SendCommand`'s
   `CanExecute` is false and the hint reads "Updating the terminal
   connection…" — and the gate reopens only once the new attempt lands
-  read-write `Attached` (a read-only Attached leaves it closed); an attach
-  callback whose UI publish is still queued when the agent is removed (and,
-  separately, when an explicit detach begins) does not reopen: after the
-  queue drains, `State` is still `SessionEnded` (respectively not Attached),
-  `CanAcceptText` is false and a direct `TrySendText` is refused, while a
-  later explicitly started attempt's own Attached does reopen; a reattach
+  read-write `Attached` (a read-only Attached leaves it closed); the token
+  protocol in its three cases — (a) a normal attempt keeps its token across
+  its own `Connecting` publish and opens on `Attached`; (b) a removal, and
+  separately an explicit detach, landing while the attempt is `Connecting`
+  (its attach callback's UI publish still queued) advances ownership, so
+  after the queue drains `State` is `SessionEnded` (respectively not
+  Attached), `CanAcceptText` is false and a direct `TrySendText` is refused;
+  (c) a removal or detach landing during a reattach's pre-`Connecting`
+  old-client disposal (`DisposeGate`) aborts that attempt — it never
+  publishes `Connecting` or `Attached` — while a subsequently, explicitly
+  begun attempt holds a fresh token and does open; a reattach
   whose old-client disposal
   is held open past 150 ms, a detach, or a teardown started during the delay
   sends no CR to any client and clears `SendInFlight` synchronously; an

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -308,16 +308,21 @@ the shape Avalonia virtualizes; an `ItemsControl` dropped inside an external
 `ScrollViewer` is measured at infinite height and realizes every item. Item
 templates are per item type (`DataTemplates` keyed on the three shapes).
 
-Follow-tail is a view concern, stateless across events: on each collection
-change the view decides *was at end* right then, from the `ScrollViewer`'s
-current offset, viewport and **old** extent (the new items have not been
-measured yet), and if so arms a one-shot `LayoutUpdated` hook — the explicit
-layout-completion seam, when the virtualized presenter has established the
-new extent; an immediate `ScrollToEnd` would clamp against the old one. The
-hook re-checks before scrolling that the offset is still the one captured at
-decision time and does nothing otherwise, so a user who scrolls up in the
-window between the event and the layout pass is not yanked; a user who has
-already scrolled up keeps their offset untouched.
+Follow-tail is a view concern that sticks to the bottom: on every
+`ScrollViewer.ScrollChanged` whose extent or viewport moved, the view decides
+*was at the bottom before this change* from the event's deltas and, if so,
+scrolls to the new end. It is not a once-per-append scroll because the
+virtualizing panel reports the extent as an estimate that a tall row corrects
+only once it is realized — a single scroll to the estimated end lands short,
+and the next append then reads "not at the bottom" and stops following;
+re-evaluating on each change converges instead. A reader scrolling up moves
+the offset down, in the same change or an earlier one, and a change whose
+offset delta is negative is never followed — only the panel's own anchoring
+moves the offset up while the extent grows — so a user who has scrolled up
+keeps their offset untouched until they return to the bottom. The hook is
+attached when the list's template is applied, which for a surface built
+before its first layout is later than its first rows, so the initial load
+lands at the bottom through the same rule.
 
 ### Markdown
 

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -75,15 +75,27 @@ Daemon side (`src/Capacitor.Cli.Daemon`):
 - `SessionTranscriptLocator` (`Harness/Claude/`) gains
   `TryLocateWinner(projectDir, worktreePath, spawnedAtUtc, ruledOut)` returning
   `(SessionId, Path)?`, mirroring `CodexSessionRolloutLocator.TryLocateWinner`;
-  `TryLocate` delegates to it. The path is the matched file under the
-  per-worktree project dir — a symlink onto the source repo's dir, which the app
-  opens as-is.
-- `DetectSessionIdAsync`'s Claude and Codex branches set `agent.TranscriptPath`
-  from the winner, and `PollForSessionIdAsync` pulses `_statusNotifier` after
-  the match lands on the agent — mutation first, pulse second, the notifier's
-  own contract. The path resolves within a few seconds of launch for both
-  vendors (Claude writes its first record, with `cwd`, before its first prompt
-  renders).
+  `TryLocate` delegates to it. **The returned path is link-resolved**: the
+  per-worktree project dir is a symlink onto the source repo's dir that
+  `ClaudeLauncher.Cleanup` deletes when the agent exits, so a path through the
+  link would die with the process while the file lives on. The winner is
+  `Path.Combine(<link target of projectDir, final>, <matched file name>)`; a
+  project dir that is a real directory (a borrowed checkout, or no symlink
+  because the source project dir did not exist at launch) resolves to itself.
+- **Every PTY launch runs the locator**, not only server-driven ones:
+  `HandleLocalSpawnAsync` (a `kcap agent start`, `--private` included) captures
+  the spawn time before `Spawn` and starts the same detection. A `--private`
+  agent skips the server reports as today; the path is local state.
+- The poll is extracted into an internal `TranscriptDiscovery` unit over a
+  `TimeProvider` (interval, deadline, cancellation, the vendor's locate
+  function, and the two callbacks it drives) so it is tested directly. It runs
+  **until the path is known**, not until a session id exists; on a winner it
+  sets `SessionId` and `TranscriptPath` on the agent and pulses
+  `_statusNotifier` **before** either awaited server report — mutation first,
+  pulse second, the notifier's own contract, and the pulse must not wait behind
+  a SignalR call that can stall on a reconnect. The path resolves within a few
+  seconds of launch for both vendors (Claude writes its first record, with
+  `cwd`, before its first prompt renders).
 
 The path is the daemon's view of the filesystem (its `CLAUDE_CONFIG_DIR` /
 `CODEX_HOME`), which is the correct one: it launched the process. Nothing else
@@ -100,16 +112,27 @@ carries `null` before detection and the path after.
 ### `JsonlTail` (`src/Capacitor.Cli.Core/JsonlTail.cs`)
 
 Vendor-neutral, BCL-only, one instance per file, holding a byte cursor.
-`ReadAppended()` returns `TailRead(IReadOnlyList<string> Lines, bool Reset, bool Missing)`:
+`ReadAppended()` is total — it never throws — and returns
+`TailRead(IReadOnlyList<string> Lines, TailStatus Status, string? Failure)`
+with `TailStatus` ∈ `Ok | Reset | Missing | Failed`:
 
 - Opens `new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete)`
   per call and closes it after. The trap named on the issue: `File.ReadAllText`,
   `File.ReadLines` and friends open `FileShare.Read`, which on Windows denies the
   agent the write handle to its own transcript — worst during its shutdown
   drain. Invisible on macOS/Linux; only the Windows CI leg catches a violation.
-- A missing file is `Missing = true` with no lines and no cursor change.
-- `Length < cursor` is a truncation or replacement: the cursor resets to zero
-  and the read reports `Reset = true` so the consumer clears what it rendered.
+- `FileNotFoundException` / `DirectoryNotFoundException` → `Missing`, no
+  lines, cursor unchanged. Any other exception (a sharing violation, an
+  `UnauthorizedAccessException`, any `IOException`) → `Failed` with the
+  message, no lines, cursor unchanged. Both are transient by contract: the
+  next call retries from the same cursor, so a file that appears or becomes
+  readable later is picked up without any consumer action.
+- `Length < cursor` is a length regression — a truncation, or a replacement by
+  a shorter file: the cursor resets to zero and the read reports `Reset` so
+  the consumer clears what it rendered. **A replacement by a file of equal or
+  greater length is not detected** and would be read from the old cursor; the
+  tail promises no more than length regression. Both vendors append only, so
+  this is a stated limitation rather than a handled case.
 - Reads `[cursor, Length)`, splits on `\n` (a trailing `\r` is stripped), skips
   blank lines, and **holds back an unterminated final chunk**: the cursor
   advances only past the last `\n`, so the chunk is re-read whole once its
@@ -120,35 +143,60 @@ Vendor-neutral, BCL-only, one instance per file, holding a byte cursor.
 
 ### Projection
 
-Two public, stateless line mappers, each `Project(string line) →
-IReadOnlyList<AcpEventEnvelope>` (empty for anything unparseable or
-uninteresting), plus a registry `TranscriptProjection.For(vendor)` beside them
-in Core returning the mapper or null — the one registration site, so adding a
-vendor's transcript means a new `Harness/<Vendor>/` file and one line here.
-Every envelope carries `TimestampIso` when the record has a timestamp; `Seq`
-stays 0 — arrival order is the order.
+One public seam:
 
-`ClaudeTranscriptEvents` (`Harness/Claude/`), keyed on the record's root `type`:
+```csharp
+public interface ITranscriptProjection {
+    IReadOnlyList<AcpEventEnvelope> Project(string line);   // stateless; empty for anything unparseable or uninteresting
+}
+public static class TranscriptProjection {
+    public static ITranscriptProjection? For(string vendor); // ordinal-ignore-case; null for an unknown vendor
+}
+```
+
+`ClaudeTranscriptEvents` (`Harness/Claude/`) and `CodexRolloutEvents`
+(`Harness/Codex/`) implement it as singletons; `TranscriptProjection.For` is
+the one registration site, so adding a vendor's transcript means a new
+`Harness/<Vendor>/` file and one line there. Every envelope carries
+`TimestampIso` when the record has a timestamp; `Seq` stays 0 — arrival order
+is the order. Every JSON read goes through `JsonElementExtensions`, so a
+wrong-typed field reads as absent rather than throwing; a line that is not a
+JSON object projects to nothing.
+
+Output invariants shared by both mappers:
+
+- *Joining*: when several text blocks feed one envelope they are joined with
+  `"\n"`.
+- *Capping*: `ToolResult` is cut at 4096 UTF-16 characters and marked with a
+  trailing `…`; nothing else is capped.
+- *`ToolInputJson` is always a JSON object string*, as `AcpEventEnvelope`
+  documents. Anything that has to be built rather than copied is written with
+  `Utf8JsonWriter` — never reflection-based serialization, because Core is
+  `IsAotCompatible` and ships inside two AOT binaries.
+
+`ClaudeTranscriptEvents`, keyed on the record's root `type`:
 
 - `user`, not `isMeta`, not `isSidechain`: a string `message.content` is one
   `user_message`; an array yields one `user_message` per `text` block and one
   `tool_result` per `tool_result` block (`ToolCallId` = `tool_use_id`,
-  `ToolIsError` = `is_error`, `ToolResult` = the block's text, capped at 4 KiB).
-  Before emitting user text, `<system-reminder>…</system-reminder>` blocks and
-  the local-command wrappers (`<command-name>`, `<command-message>`,
-  `<command-args>`, `<local-command-stdout>`, `<local-command-caveat>`) are
-  stripped; text that is blank afterwards is not emitted.
+  `ToolIsError` = `is_error`, `ToolResult` = the block's `content` when it is
+  a string, else its `text` blocks joined). Before emitting user text,
+  `<system-reminder>…</system-reminder>` blocks and the local-command wrappers
+  (`<command-name>`, `<command-message>`, `<command-args>`,
+  `<local-command-stdout>`, `<local-command-caveat>`) are stripped; text that
+  is blank afterwards is not emitted.
 - `assistant`, not `isSidechain`: per content block — `text` → `assistant_text`;
   `thinking` → `assistant_thinking` (`ThinkingEncrypted` when the block carries
   no text); `tool_use` → `tool_call` (`ToolCallId` = `id`, `ToolName` = `name`,
-  `ToolInputJson` = the raw `input` object). `Model` = `message.model`.
+  `ToolInputJson` = the `input` object's raw text; an `input` that is not an
+  object becomes `{"input": <raw value>}`). `Model` = `message.model`.
 - Everything else is skipped: `attachment`, `summary`, `system`,
   `file-history-snapshot`, `file-history-delta`, `mode`, `permission-mode`,
   `last-prompt`, `ai-title`, `atis-latch`, `worktree-state`,
   `queue-operation`, `progress`, and any type this build has never heard of.
 
-`CodexRolloutEvents` (`Harness/Codex/`), keyed on `type == "response_item"` and
-then `payload.type`; every other envelope type (`event_msg`, `turn_context`,
+`CodexRolloutEvents`, keyed on `type == "response_item"` and then
+`payload.type`; every other envelope type (`event_msg`, `turn_context`,
 `session_meta`, `world_state`, `compacted`,
 `inter_agent_communication_metadata`) is skipped:
 
@@ -158,10 +206,11 @@ then `payload.type`; every other envelope type (`event_msg`, `turn_context`,
   `<permissions instructions>`); role `assistant`: the `output_text` blocks →
   `assistant_text`; roles `developer` and `system` are skipped.
 - `function_call` → `tool_call` (`ToolCallId` = `call_id`, `ToolName` = `name`,
-  `ToolInputJson` = `arguments`); `custom_tool_call` → `tool_call`
-  (`ToolInputJson` = a JSON object `{"input": …}` wrapping the raw input string);
+  `ToolInputJson` = `arguments` when it parses as a JSON object, else
+  `{"arguments": <the string>}`); `custom_tool_call` → `tool_call`
+  (`ToolInputJson` = `{"input": <the raw input string>}`);
   `function_call_output` and `custom_tool_call_output` → `tool_result`
-  (`call_id`; the output string, or its text blocks joined, capped at 4 KiB).
+  (`call_id`; the `output` string, or its text blocks joined).
 - `reasoning` → `assistant_thinking` (summary texts joined;
   `ThinkingEncrypted` when only `encrypted_content` is present).
 - `agent_message` (inter-agent traffic) is skipped.
@@ -172,32 +221,41 @@ then `payload.type`; every other envelope type (`event_msg`, `turn_context`,
 
 Constructed by `WorkspaceViewModel` for a PTY session only — the same gate as
 the Terminal tab (`HostedHarnessCatalog.ShowsTerminal`) — once the first dto
-resolves, because the projector is chosen by the dto's vendor. Ctor-scoped like
-its siblings; `TeardownAsync` is its one exit. Inputs: agent id,
-`IDaemonClientService`, the sibling `TerminalTabViewModel`, the projector from
-`TranscriptProjection.For(vendor)` (null → the `Unavailable` phase), and a
-`TimeProvider`.
+resolves, because the projection is chosen by the dto's vendor. Ctor-scoped
+like its siblings; `TeardownAsync` is its one exit and disposes every
+subscription below. Inputs: agent id, `IDaemonClientService`, the sibling
+`TerminalTabViewModel`, the `ITranscriptProjection?` from
+`TranscriptProjection.For(vendor)` (null → the `Unavailable` phase), an
+`IUrlOpener`, and a `TimeProvider`.
 
 Phases (`ChatTabPhase`): `Waiting` (no `transcript_path` yet — muted "Waiting
-for the transcript…"), `Reading`, `Missing` (a path that does not exist on
-disk — "The transcript is not readable from here"), `Unavailable` (a PTY vendor
-with no projector — "No chat view for this harness"). A session that ends keeps
-its items and keeps polling until teardown: the file outlives the process and
-may still receive its final records.
+for the transcript…"), `Reading`, `Missing` (the path exists on the wire but
+not on disk — "The transcript file is missing"), `Unavailable` (a PTY vendor
+with no projection — "No chat view for this harness"). A `Failed` tail read
+keeps the current phase and items and logs its reason once per distinct
+message to `Console.Error` (the app's diagnostic convention); the next tick
+retries. A session that ends keeps its items and keeps polling until teardown:
+the file outlives the process and may still receive its final records.
 
-Path watch: `daemon.Agents.Connect().ObserveOn(RxSchedulers.MainThreadScheduler)`
-filtered to the agent id; the first non-null `TranscriptPath` starts the tail; a
-later, different path restarts from zero (a re-resolution after a daemon restart).
+Every daemon-fed input goes through `ObserveOn(RxSchedulers.MainThreadScheduler)`
+before touching bound state — the client's pump is a background thread. Two
+subscriptions: `daemon.Agents.Connect()` filtered to the agent id (the path
+watch, and the footer's model/status), and `daemon.Snapshots` (the advertised
+vendor options behind the composer hint's vendor label). The first non-null
+`TranscriptPath` starts the tail; a later, different path restarts from zero
+(a re-resolution after a daemon restart).
 
 Poll: a `TimeProvider` timer every 500 ms (a tuning constant, not a contract).
 A tick with a read still in flight is skipped. The read and the projection run
-on the thread pool; the apply hops to the UI thread through
-`Dispatcher.UIThread.InvokeAsync`, guarded by a generation `TeardownAsync`
-bumps so a late completion mutates nothing. The first read of a long transcript
-produces one batch, applied under one dispatch.
+on the thread pool and never throw past the tick (the tail is total; a
+projection fault is caught, logged once, and drops that line); the apply hops
+to the UI thread through `Dispatcher.UIThread.InvokeAsync`, guarded by a
+generation `TeardownAsync` bumps so a late completion mutates nothing.
 
-Items — a `ReadOnlyObservableCollection<ChatItemViewModel>` mutated on the UI
-thread — in three shapes:
+Items — an `AvaloniaList<ChatItemViewModel>` exposed read-only and mutated on
+the UI thread. A read's items are applied with one `AddRange` (one collection
+notification per read, however many records the first read of a long
+transcript yields), and `Reset` is one `Clear`. Three shapes:
 
 - `UserTurnItem(Text)`: the canvas's right-aligned bubble, plain text.
 - `AssistantTextItem(Text)`: markdown-rendered prose, one item per envelope.
@@ -212,22 +270,38 @@ thread — in three shapes:
 `assistant_thinking` and unmatched `tool_result` envelopes create no item;
 `Reset` clears the items and the pairing index.
 
+The list is an `ItemsControl` whose control template is a `ScrollViewer`
+around the `ItemsPresenter`, with a `VirtualizingStackPanel` items panel —
+the shape Avalonia virtualizes; an `ItemsControl` dropped inside an external
+`ScrollViewer` is measured at infinite height and realizes every item. Item
+templates are per item type (`DataTemplates` keyed on the three shapes).
+
 Follow-tail is a view concern: the `ScrollViewer` scrolls to the end on an add
 only when it was already at the end, so a user reading history is not yanked.
 
 ### Markdown
 
-`MarkdownView` — a `Control` with a styled `Text` property — rebuilds its
-content from a Markdig AST (default CommonMark pipeline plus auto-links) on
-every change. `MarkdownBlocks` maps: paragraphs and headings →
-`SelectableTextBlock` with inlines (`Bold`, `Italic`, monospace `Run` for code
-spans, `LineBreak`); fenced and indented code → a `Border` around a monospace
-`SelectableTextBlock`; bullet and ordered lists → marker + nested content rows;
-block quotes → a left rule beside the content; thematic breaks → a hairline;
-links → an accent-coloured underlined run opened through `UrlOpener` on click.
-HTML, tables, images and any other node render their literal source text —
-degraded, never dropped. User bubbles do not go through it: what the user typed
-is shown as typed.
+`MarkdownView` — a `Control` with a styled `Text` property and an
+`OpenLink` command property — rebuilds its content from a Markdig AST (default
+CommonMark pipeline plus auto-links) on every change. `MarkdownBlocks` maps:
+paragraphs and headings → `SelectableTextBlock` with inlines (`Bold`, `Italic`,
+monospace `Run` for code spans, `LineBreak`); fenced and indented code → a
+`Border` around a monospace `SelectableTextBlock`; bullet and ordered lists →
+marker + nested content rows; block quotes → a left rule beside the content;
+thematic breaks → a hairline. A link is an `InlineUIContainer` hosting a
+link-styled `TextBlock` (accent, underlined, hand cursor) — an inline `Run`
+takes no pointer input of its own — whose pointer-release executes `OpenLink`
+with the URL. HTML, tables, images and any other node render their literal
+source text — degraded, never dropped. User bubbles do not go through it: what
+the user typed is shown as typed.
+
+Links are agent-authored and untrusted, and `ShellUrlOpener` hands any string
+to the OS shell. The trust boundary is the item's `OpenLinkCommand` on
+`AssistantTextItem`, backed by a pure `LinkPolicy.IsOpenable(url)`: only an
+absolute `http` or `https` URI opens; anything else (`file:`, `javascript:`,
+custom schemes, relative or malformed text) renders as plain text with no
+link affordance at all. An opener exception is caught and logged to
+`Console.Error` — a bad link never escapes a UI event.
 
 `Markdig` is added to `Directory.Packages.props` and the app csproj. The app
 is not NativeAOT, so trimming is not a concern for it.
@@ -251,16 +325,30 @@ hit-test visibility, not `IsVisible` — so the pane size it reports to the PTY
 is the real pane size whichever tab is up. An `IsVisible=false` control is never
 measured: a workspace opened on Chat would then keep the constructor's 80×24
 and, through the daemon's min-clamp across viewers, shrink the agent's terminal
-for every other attacher. Focus follows the tab: the terminal takes keyboard
-focus only while its tab is active; the composer takes it on Chat.
+for every other attacher.
+
+Focus follows the tab, and the view enforces it rather than assuming it:
+`TerminalHost.Focusable` and `IsTabStop` are bound to `IsTerminalActive`, so a
+hidden terminal can neither hold keyboard focus nor be tabbed into; the
+existing focus-on-Model-assignment handler runs only while the Terminal tab is
+active (a reattach while Chat is up must not steal the composer's focus);
+switching to Terminal focuses the terminal, switching to Chat — and the first
+open on Chat — focuses `ComposerInput`.
 
 ### Composer
 
 Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
 
 - `ComposerText`; `SendCommand` (`CreateFromTask`), executable iff the terminal
-  is `Attached`, not read-only, and the text is not blank. Success clears the
-  text; a failed send keeps it and surfaces the reason on the hint line.
+  is `Attached`, not read-only, and the text is not blank. The send is
+  **accepted**, not acknowledged: the attach seam's `SendInputAsync` returns
+  nothing and Core's client no-ops when it is no longer writable and folds a
+  transport failure into the attach outcome — so no send can learn whether
+  its bytes landed. Acceptance (a live read-write attach at the moment of the
+  call) clears the text synchronously on the UI thread, before any await; a
+  refused send leaves the text in place and the hint already says why. A
+  transport loss surfaces the way it always does — the attach outcome flips
+  `Terminal.State`, and the hint follows.
 - `ComposerHint` follows `Terminal.State`: attached read-write → "Reply to
   {vendor label} · Enter sends · Shift+Enter for a new line"; attached read-only
   → "Read-only: {reason}"; `Resolving`/`Connecting` → "Connecting to the
@@ -271,60 +359,104 @@ Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
 - Footer: model label (`HostedHarnessCatalog.ModelLabelFor`, "default" for
   none), the session's status dot (`SessionStatusDots.For`) and status word
   (the dto's `Status`, verbatim, like the Home cards). No permission-mode chip:
-  a hosted launch always runs `bypassPermissions`, and switching modes is
-  AI-2197's.
+  reading or switching the mode is AI-2197's, and the transcript does not
+  carry the live prompt state anyway.
 
-`TerminalTabViewModel.SendTextAsync(string text)` → `Task<bool>`: false without
-a live read-write attach; otherwise writes `TerminalInputEncoder.Encode(text)`
-through the current client under the same generation check as keyboard input.
-`Encode` normalizes `\r\n` to `\n` and drops one trailing newline; a single line
-becomes UTF-8 text plus `\r`; a multi-line text is wrapped in bracketed paste
-(`ESC[200~` … `ESC[201~`) followed by `\r`, which both Claude Code and the Codex
-TUI honour as one submitted message. Enter sends and Shift+Enter inserts a
-newline — a view-level key handler on the composer's `TextBox`.
+`TerminalTabViewModel.SendTextAsync(string text)` → `Task<bool>` — true when
+accepted. It delivers the text the way the daemon's own
+`PtyHostedAgentRuntime.SendUserInputAsync` does, and captures the client and
+attempt generation once, at acceptance: one write of
+`TerminalInputEncoder.Paste(text)` — `\r\n` normalized to `\n`, one trailing
+newline dropped, wrapped in bracketed paste (`ESC[200~` … `ESC[201~`) so the TUI
+takes it as one block — then, after a 150 ms `TimeProvider` delay, one write of
+`\r` **to the same captured client, only if the generation is still current**
+and teardown has not run. A retirement during the delay (reattach, detach,
+teardown) drops the CR: the paste already went to the old client, and the
+replacement must never receive a stray Enter. The delay is measured against
+Codex's TUI, which suppresses Enter-as-submit for 120 ms after ingesting a
+paste and turns a CR inside that window into a newline. A single CR, never a
+retry spray: an interactive launch keeps its permission prompts (Claude
+prompts unless it is an owned review-flow launch; Codex follows its posture),
+and the transcript cannot show a prompt that is up on the PTY, so every extra
+Enter is a chance to answer one. Every message takes this one path,
+single-line or not. Enter sends and Shift+Enter inserts a newline — a
+view-level key handler on the composer's `TextBox`.
 
 ## 4. Testing
 
 `test/Capacitor.Cli.Core.Tests.Unit`:
 - `JsonlTailTests`: complete lines delivered once; an unterminated final line
   held, then delivered whole after its newline; CRLF; blank lines skipped;
-  truncation → `Reset` and a re-read from zero; missing file → `Missing`;
-  a file held open for writing by another handle is still readable (the
-  sharing-mode pin — asserted through a write handle opened first).
+  length regression → `Reset` and a re-read from zero; missing → `Missing`,
+  then the same tail reads the file once it appears; a transient failure →
+  `Failed` with the cursor intact, then the next read succeeds; a file held
+  open for writing by another handle (sharing read/write/delete, opened first)
+  is still readable — the Windows sharing pin.
 - `ClaudeTranscriptEventsTests` / `CodexRolloutEventsTests`: one fixture line
-  per shape in §2, the skip lists, wrapper stripping, prelude skipping,
-  result capping, and a malformed line → empty.
+  per shape in §2 — including a string `tool_result.content` and a block-array
+  one, a non-object `input`, non-object `arguments`, the skip lists, wrapper
+  stripping, prelude skipping, the joining separator, the 4096-character cap
+  and its marker, wrong-typed fields reading as absent, and a malformed line →
+  empty. Every `ToolInputJson` in every fixture parses as a JSON object.
+  `TranscriptProjection.For`: case-insensitive, unknown → null.
 - `StatusIpcJsonTests`: `transcript_path` round trip, trailing order, old JSON
   → null.
+- AOT: the Release publish of the CLI stays free of `IL2026`/`IL3050`
+  warnings (`dotnet publish -c Release … | grep -E 'IL[23][01][0-9]{2}'`), run
+  as part of the slice's acceptance, not left to CI.
 
 `test/Capacitor.Cli.Daemon.Tests.Unit`:
-- `SessionTranscriptLocatorTests`: the winner carries the matched file's path.
+- `SessionTranscriptLocatorTests`: the winner carries the matched file's
+  path; a winner located through a project-dir symlink reports the
+  link-resolved path, and after the symlink is deleted (what `Cleanup` does)
+  that path still reads, final append included.
+- `TranscriptDiscoveryTests` (over `FakeTimeProvider`): a winner sets both id
+  and path and pulses before the reports; a pre-populated session id with no
+  path keeps polling until the path lands; the deadline ends the poll with no
+  mutation; cancellation (agent exit) ends it cleanly.
+- `AgentOrchestrator`: `HandleLocalSpawnAsync` starts discovery for a local
+  (and a `--private`) PTY launch — over a fake PTY factory and launcher, no
+  real process.
 - `AgentStatusSnapshotTests`: `transcript_path` null before detection, the
   value after — on the serialized payload.
-- The notifier pulse on a detected session id, pinned wherever the existing
-  detection tests already drive the poll.
 
 `test/Capacitor.App.Tests.Unit` (over `FakeDaemonClientService`,
 `FakeTerminalAttachClient`, `FakeTimeProvider`, a `TempDir` transcript):
 - `ChatTabViewModelTests`: `Waiting` until a path; the path starts reading and
   the initial load renders items in file order; lines appended after a tick
   render; a held partial line does not render until complete; tool outcome
-  pairing (Done, Error); `Reset` on truncation; a different path restarts;
-  ticks stop after teardown; a projector-less vendor → `Unavailable`; a removed
-  agent keeps its items.
+  pairing (Done, Error); `Reset` on length regression; `Missing` then
+  recovery; a `Failed` read keeps items and phase; a different path restarts;
+  ticks stop after teardown; a projection-less vendor → `Unavailable`; a
+  removed agent keeps its items; a dto or snapshot pushed from a pool thread
+  lands on bound state without a thread-affinity fault; both subscriptions
+  end at teardown.
+- Batching: a 5,000-record initial transcript raises exactly one collection
+  notification, and — in a headless window at a fixed size — the
+  `ItemsControl` realizes a bounded number of containers.
 - Composer: `SendCommand` enablement across every terminal phase and the
-  read-only case; exact bytes for single-line (`text\r`) and multi-line
-  (bracketed) sends via `FakeTerminalAttachClient.SentInput`; the text clears on
-  success and survives a failure; every hint string.
+  read-only case; the exact two writes via `FakeTerminalAttachClient.SentInput`
+  — the bracketed paste, then `\r` only once the `FakeTimeProvider` advances
+  past the delay, on the same client; a reattach, detach or teardown during
+  the delay sends no CR to any client; the text clears on acceptance and
+  stays on refusal; every hint string; a pool-thread state flip updates the
+  hint on the UI thread.
 - `TerminalInputEncoderTests`, `ToolDetailTests` (key priority, first line,
-  80-character cut).
+  80-character cut), `LinkPolicyTests` (https/http open, `file:`,
+  `javascript:`, custom schemes, relative and malformed text refused).
 - `MarkdownBlocksTests` (headless): paragraph inlines, a fenced block, list
-  items, a link, and an unsupported construct degrading to literal text.
+  items, a link that executes `OpenLink` once, a disallowed link rendered as
+  plain text, and an unsupported construct degrading to literal text.
 - `WorkspaceViewModelTests`: Chat is the default tab; the switch commands; `Chat`
   is built for a PTY dto only; teardown disposes it.
 - `WorkspaceViewSmokeTests`: the new names resolve (`ChatTabButton`, `ChatHost`,
   `ChatItems`, `ComposerInput`, `SendButton`); switching tabs flips which
-  surface is visible while `TerminalHost` stays in the tree on both.
+  surface is visible while `TerminalHost` stays in the tree on both; a
+  workspace opened on Chat with a **real** `XtermTerminalSurface` reports the
+  laid-out pane size to the attach client, not 80×24, while `TerminalHost` is
+  neither focusable nor hit-testable; focus lands on `ComposerInput` on open,
+  stays there through a late Model assignment, moves to the terminal on the
+  Terminal switch and back on the Chat switch.
 
 README: the desktop app has no section yet and this slice adds no CLI surface,
 so it is unchanged. `docs/CHANGES.md` gains a "Session chat" entry.
@@ -332,15 +464,27 @@ so it is unchanged. `docs/CHANGES.md` gains a "Session chat" entry.
 ## Risks
 
 - **Transcript size.** The whole file is parsed at open. A multi-megabyte
-  transcript costs one pool-thread pass and one batched UI apply into a
-  virtualized list; accepted for now, and a tail-only initial load is the
-  obvious upgrade if it ever hurts.
+  transcript costs one pool-thread pass and one `AddRange` into a virtualizing
+  `ItemsControl`; accepted for now, and a tail-only initial load is the obvious
+  upgrade if it ever hurts.
 - **Agent-owned files.** Every open is `FileShare.ReadWrite | Delete`; a
   regression is invisible locally and reddens only the Windows CI leg. The
   sharing test in `JsonlTailTests` is the local guard.
-- **Composer bytes are raw PTY input.** The agent's TUI decides what they mean;
-  bracketed paste assumes the TUI enabled it (both do). Text landing during a
-  redraw may echo oddly in the Terminal tab; the transcript is unaffected.
+- **Replacement is not detected.** The tail promises length regression only;
+  a same-or-longer replacement reads from the old cursor. Both vendors append
+  in place, so this is a documented limitation, not a handled case.
+- **A send can answer a prompt.** Composer bytes are raw PTY input, and an
+  interactive launch keeps its permission prompts, which the transcript never
+  shows. The single delayed CR limits the exposure to one keypress, and the
+  Terminal tab is where a live prompt is visible; only AI-2197's frames can
+  close the gap. Bracketed paste assumes the TUI enabled it (both do), and
+  the 150 ms paste-to-CR gap is calibrated to today's Codex suppression window
+  — a TUI that widens it would turn a send into a newline, which the Terminal
+  tab makes visible.
+- **A borrowed-cwd local launch can mislink.** The locator disambiguates by
+  cwd and spawn time; a user's own session started in the same checkout within
+  the skew tolerance could win. Display-only, and the same exposure the
+  daemon's session-id link already carries.
 - **Rendering granularity is the transcript's.** Both vendors write complete
   blocks, not tokens, so assistant text appears per block, a few hundred
   milliseconds after the vendor writes it. That is what "rendered from the

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -311,10 +311,13 @@ templates are per item type (`DataTemplates` keyed on the three shapes).
 Follow-tail is a view concern, stateless across events: on each collection
 change the view decides *was at end* right then, from the `ScrollViewer`'s
 current offset, viewport and **old** extent (the new items have not been
-measured yet), and if so schedules one scroll-to-end after the next layout
-pass (`DispatcherPriority.Loaded`), when the virtualized presenter has
-established the new extent — an immediate `ScrollToEnd` would clamp against
-the old one. A user who has scrolled up keeps their offset untouched.
+measured yet), and if so arms a one-shot `LayoutUpdated` hook — the explicit
+layout-completion seam, when the virtualized presenter has established the
+new extent; an immediate `ScrollToEnd` would clamp against the old one. The
+hook re-checks before scrolling that the offset is still the one captured at
+decision time and does nothing otherwise, so a user who scrolls up in the
+window between the event and the layout pass is not yanked; a user who has
+already scrolled up keeps their offset untouched.
 
 ### Markdown
 
@@ -370,14 +373,16 @@ up. An `IsVisible=false` control is never measured: a workspace opened on Chat
 would then keep the constructor's 80×24 and, through the daemon's min-clamp
 across viewers, shrink the agent's terminal for every other attacher.
 
-Everything else simply is not there when its tab is inactive: the chat
-surface (list, composer, Send) and the terminal's banners and Detach/Reattach
-buttons are `IsVisible=false` — unmeasured, unfocusable, out of the
-automation tree. `TerminalHost` alone, when Chat is active, is disabled,
-non-hit-testable, transparent, and marked
-`AutomationProperties.IsOffscreenBehavior=Offscreen` — the default derives
-"offscreen" from `IsVisible`, so a visible-but-transparent control would
-otherwise be announced beside the chat. Focus follows the tab: the existing
+Everything else is collapsed when its tab is inactive: the chat surface
+(list, composer, Send) and the terminal's banners and Detach/Reattach buttons
+are `IsVisible=false` — still instantiated in the tree, but unmeasured, not
+effectively visible, unfocusable, out of tab navigation, and reported
+offscreen by their automation peers (the default derives that from
+`IsVisible`). `TerminalHost` alone, when Chat is active, stays visible so it
+is measured — disabled, non-hit-testable, transparent, and marked
+`AutomationProperties.IsOffscreenBehavior=Offscreen`, since a
+visible-but-transparent control would otherwise be announced beside the chat.
+Focus follows the tab: the existing
 focus-on-Model-assignment handler runs only while the Terminal tab is active
 (a reattach while Chat is up must not steal the composer's focus); switching
 to Terminal focuses the terminal, switching to Chat — and the first open on
@@ -413,22 +418,37 @@ Lives on `ChatTabViewModel`, sends through the sibling Terminal tab:
   carry the live prompt state anyway.
 
 `TerminalTabViewModel.TrySendText(string text)` → `bool`, synchronous, UI
-thread. It refuses (false, nothing written) unless `State` is `Attached`
-read-write, a client is live, **and no delivery is in flight**; otherwise it
-captures the client and the current **send epoch**, sets `SendInFlight`
-(bound; cleared on the UI thread when the delivery ends, however it ends),
-starts a fault-contained background delivery, and returns true. One
-transaction at a time is the point: two accepted sends inside the 150 ms
-window would interleave as paste A, paste B, CR, CR — Core's client
+thread. The terminal owns a **send gate** with three pieces of state, all
+mutated only on the UI thread:
+
+- `SendGate` ∈ Open | Closed. **Closed synchronously, before any await, at
+  the start of** `TryStartAttemptAsync` (reattach), `RunDetachAsync` and
+  `TeardownAsync`; **reopened only when a later attempt lands `Attached`
+  read-write** (the `OnAttachedAsync` dispatch that sets that state). Neither
+  `State` nor `_client` can serve as the gate: a reattach leaves both
+  `Attached` and live while it awaits the old client's disposal, and a detach
+  leaves both unchanged while it awaits the detach write — a send started in
+  either window would otherwise be accepted against a client on its way out.
+- The **send epoch**, a counter bumped at the same three points, which a
+  running delivery re-checks before its CR.
+- `SendInFlight` (bound), true from acceptance until the delivery ends.
+
+`TrySendText` refuses (false, nothing written) unless `SendGate` is Open and
+`SendInFlight` is false; otherwise it captures the client and the epoch, sets
+`SendInFlight`, starts the fault-contained background delivery, and returns
+true. One transaction at a time is the point: two accepted sends inside the
+150 ms window would interleave as paste A, paste B, CR, CR — Core's client
 serializes single frames, not multi-frame messages — and the TUI would submit
 both as one prompt and spend the second Enter on whatever is up next.
-Refusing keeps the second text in the composer for the user to send again
-a moment later. The send epoch is a counter the VM bumps **synchronously, before
-any await, at the start of** `TryStartAttemptAsync` (reattach), `RunDetachAsync`
-and `TeardownAsync` — the attempt generation cannot serve, because reattach
-bumps it only after awaiting the old client's disposal, and detach never bumps
-it at all; a delayed CR must be dead the instant a detach or reattach begins,
-not when it finishes.
+Refusing keeps the second text in the composer for the user to send again a
+moment later.
+
+Ownership of `SendInFlight` is one rule: **the closer retires the send.**
+Closing the gate (reattach, detach, teardown) synchronously bumps the epoch
+and clears `SendInFlight`; the delivery's own completion — success or fault —
+clears it through a UI-thread dispatch that mutates nothing unless the epoch
+it captured is still current and the VM has not been torn down, so a late
+completion can neither clear a newer send nor touch a torn-down VM.
 
 The delivery is the daemon's own `PtyHostedAgentRuntime.SendUserInputAsync`
 shape: one write of `TerminalInputEncoder.Paste(text)` — `\r\n` normalized to
@@ -437,9 +457,10 @@ shape: one write of `TerminalInputEncoder.Paste(text)` — `\r\n` normalized to
 `TimeProvider` delay, one write of `\r` **to the same captured client, only if
 the send epoch is unchanged**. A stale epoch drops the CR: the paste already
 went to the old client, and a replacement must never receive a stray Enter.
-A fault in either write is observed and logged once to `Console.Error`; it
-never touches VM state (the attach outcome is the transport's own reporting
-channel). The delay is measured against Codex's TUI, which suppresses
+A fault in either write is observed and logged once to `Console.Error` and
+ends the delivery (clearing `SendInFlight` under the rule above); it never
+touches `State` — the attach outcome is the transport's own reporting
+channel. The delay is measured against Codex's TUI, which suppresses
 Enter-as-submit for 120 ms after ingesting a paste and turns a CR inside that
 window into a newline. A single CR, never a retry spray: an interactive launch
 keeps its permission prompts (Claude prompts unless it is an owned review-flow
@@ -512,20 +533,27 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
   `ItemsControl` realizes a bounded number of containers.
 - Follow-tail (headless, laid out): the initial load ends at the bottom; an
   append while at the bottom ends at the **new** bottom after the layout
-  pass; an append while scrolled up leaves the offset where it was.
+  pass; an append while scrolled up leaves the offset where it was; an append
+  at the bottom followed by a scroll up before the layout pass completes
+  leaves the offset up.
 - Composer: `SendCommand` enablement across every terminal phase and the
   read-only case; the exact two writes via `FakeTerminalAttachClient.SentInput`
   — the bracketed paste, then `\r` only once the `FakeTimeProvider` advances
   past the delay, on the same client; a second send accepted before the
   first's CR is refused with its text intact, and once the first completes it
   goes through — the only order ever observed is paste A, CR, paste B, CR;
-  a detach or reattach that has *begun*
-  before the send refuses it (text stays, nothing written); a reattach whose
-  old-client disposal is held open past 150 ms (`DisposeGate`), a detach, or a
-  teardown started during the delay sends no CR to any client; a faulting
-  write leaves VM state untouched; the text clears on acceptance and stays on
-  refusal; every hint string; a pool-thread state flip updates the hint on
-  the UI thread.
+  a send started while a reattach is awaiting the old client's disposal
+  (`DisposeGate`) or a detach is awaiting its write (`HangDetachForever`) is
+  refused — `State` still reads `Attached` in both windows — and the gate
+  reopens only once the new attempt lands `Attached`; a reattach whose
+  old-client disposal is held open past 150 ms, a detach, or a teardown started
+  during the delay sends no CR to any client and clears `SendInFlight`
+  synchronously; a faulting write clears `SendInFlight` and leaves `State`
+  untouched; a retired delivery's completion cannot clear a newer send's
+  `SendInFlight`; after `TeardownAsync` returns, no bound state changes and no
+  dispatcher work is queued by a still-running delivery; the text clears on
+  acceptance and stays on refusal; every hint string; a pool-thread state
+  flip updates the hint on the UI thread.
 - `TerminalInputEncoderTests`, `ToolDetailTests` (key priority, first line,
   80-character cut), `LinkPolicyTests` (https/http open, `file:`,
   `javascript:`, custom schemes, relative and malformed text refused).
@@ -541,8 +569,10 @@ inserts a newline — a view-level key handler on the composer's `TextBox`.
   workspace opened on Chat with a **real** `XtermTerminalSurface` reports the
   laid-out pane size to the attach client, not 80×24, while `TerminalHost` is
   disabled and non-hit-testable and its automation peer reports offscreen;
-  with Terminal active the chat surface is not in the visual tree, and with
-  Chat active the terminal's banners and buttons are not; focus lands on
+  with Terminal active the chat surface is not effectively visible
+  (`IsEffectivelyVisible == false`, the existing smoke tests' own probe) and
+  its peer reports offscreen, and with Chat active the same holds for the
+  terminal's banners and buttons; focus lands on
   `ComposerInput` on open, stays there through a late Model assignment, moves
   to the terminal on the Terminal switch and back on the Chat switch; tab
   traversal from the composer never reaches `DetachButton`/`ReattachButton`

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -203,6 +203,9 @@ Output invariants shared by both mappers:
 
 `ClaudeTranscriptEvents`, keyed on the record's root `type`:
 
+- `user` whose `origin.kind` is `task-notification` — a finished background task
+  Claude Code injects as if the user had spoken: one `system_note` whose text is
+  the `<summary>` in bold and the `<result>` as markdown, never a user message.
 - `user`, not `isMeta`, not `isSidechain`: a string `message.content` is one
   `user_message`; an array yields one `user_message` per `text` block and one
   `tool_result` per `tool_result` block (`ToolCallId` = `tool_use_id`,
@@ -287,10 +290,13 @@ path switch bump it.
 Items — an `AvaloniaList<ChatItemViewModel>` exposed read-only and mutated on
 the UI thread. A read's items are applied with one `AddRange` (one collection
 notification per read, however many records the first read of a long
-transcript yields), and `Reset` is one `Clear`. Three shapes:
+transcript yields), and `Reset` is one `Clear`. Four shapes:
 
 - `UserTurnItem(Text)`: the canvas's right-aligned bubble, plain text.
 - `AssistantTextItem(Text)`: markdown-rendered prose, one item per envelope.
+- `SystemNoteItem(Text)`: a `system_note` — markdown in a muted card, left-aligned
+  like assistant prose but framed, so a task notification reads as the
+  system's word, not the user's.
 - `ToolCallItem(Name, Detail, Outcome)`: the muted `›` row. `Outcome` is a
   bound property ∈ Running | Done | Error, flipped in place when the matching
   `tool_result` arrives (indexed by `ToolCallId`; an unmatched result is

--- a/src/Capacitor.App/App.axaml
+++ b/src/Capacitor.App/App.axaml
@@ -33,5 +33,11 @@
             <Setter Property="CornerRadius" Value="12" />
             <Setter Property="Padding" Value="0" />
         </Style>
+        <!-- A TextBox inside one of our cards: the card is its boundary, so the theme's focused
+             ring and fill would read as a second box. -->
+        <Style Selector="TextBox.kcapEmbedded:focus /template/ Border#PART_BorderElement, TextBox.kcapEmbedded:pointerover /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+        </Style>
     </Application.Styles>
 </Application>

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -42,6 +42,10 @@ public partial class App : Application {
     // And its one read of KCAP_CONFIG_DIR.
     readonly ConfigRoot _config = ConfigRoot.FromEnvironment();
 
+    // And its one read of KCAP_APP_PTY_DUMP: a file every terminal feed frame is appended to as
+    // received, for seeing what the emulator was given.
+    static readonly string? PtyDumpPath = Environment.GetEnvironmentVariable("KCAP_APP_PTY_DUMP");
+
     // Both are app-lifetime and BOTH exist before any graph does: OnShutdownRequested latches and
     // drains them whether or not StartAsync ever got as far as building a window (spec §3). The gate
     // is shared by every MainWindowViewModel the coordinator builds — including one built between
@@ -313,7 +317,7 @@ public partial class App : Application {
         // attached to the visual tree (WorkspaceView's own header comment).
         var attachFactory = CoreTerminalAttachClient.Factory(() => _daemonStore.SocketPath(service.DaemonName));
         WorkspaceViewModel BuildWorkspace(string agentId) => new(
-            agentId, service, actions, attachFactory, () => new XtermTerminalSurface(80, 24), TimeProvider.System, opener);
+            agentId, service, actions, attachFactory, () => new XtermTerminalSurface(80, 24, PtyDumpPath), TimeProvider.System, opener);
 
         _coordinator = new MainWindowCoordinator(
             () => BuildAndShowMainWindow(

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -280,7 +280,8 @@ public partial class App : Application {
         // ConfirmForceStopAsync reads _coordinator at INVOCATION time (a captured field, not
         // a captured value) — safe even though _coordinator is still null right here, because
         // nothing can trigger a protected-kind stop before ShowMainWindow below assigns it.
-        var actions = new AgentActionService(ops, notifier, new ShellUrlOpener(), service.Snapshots, _shutdown.Token, ConfirmForceStopAsync);
+        var opener = new ShellUrlOpener();
+        var actions = new AgentActionService(ops, notifier, opener, service.Snapshots, _shutdown.Token, ConfirmForceStopAsync);
 
         // Constructed once here, like the ticker and consent service (spec §7): the prompt
         // window factory below and MainWindowViewModel both need the SAME instance — the
@@ -312,7 +313,7 @@ public partial class App : Application {
         // attached to the visual tree (WorkspaceView's own header comment).
         var attachFactory = CoreTerminalAttachClient.Factory(() => _daemonStore.SocketPath(service.DaemonName));
         WorkspaceViewModel BuildWorkspace(string agentId) => new(
-            agentId, service, actions, attachFactory, () => new XtermTerminalSurface(80, 24), TimeProvider.System);
+            agentId, service, actions, attachFactory, () => new XtermTerminalSurface(80, 24), TimeProvider.System, opener);
 
         _coordinator = new MainWindowCoordinator(
             () => BuildAndShowMainWindow(

--- a/src/Capacitor.App/Capacitor.App.csproj
+++ b/src/Capacitor.App/Capacitor.App.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Avalonia.Themes.Fluent" />
         <PackageReference Include="ReactiveUI.Avalonia" />
         <PackageReference Include="DynamicData" />
+        <PackageReference Include="Markdig" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
         <PackageReference Include="SvcSystems.UI.Terminal" />
         <PackageReference Include="XTerm.NET" />

--- a/src/Capacitor.App/Services/LinkPolicy.cs
+++ b/src/Capacitor.App/Services/LinkPolicy.cs
@@ -1,0 +1,9 @@
+namespace Capacitor.App.Services;
+
+/// The trust boundary for agent-authored links: the shell opener launches whatever it is
+/// handed, so only absolute web URLs ever reach it.
+public static class LinkPolicy {
+    public static bool IsOpenable(string? url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var uri)
+        && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+}

--- a/src/Capacitor.App/Services/TerminalAttach.cs
+++ b/src/Capacitor.App/Services/TerminalAttach.cs
@@ -34,6 +34,11 @@ public sealed class CoreTerminalAttachClient(AgentAttachClient inner) : ITermina
 /// describe the daemon status subscription (spec naming note).
 public enum TerminalSessionPhase { Resolving, NoTerminal, NotFound, Connecting, Attached, Detached, Exited, Failed, SessionEnded }
 
+/// What the composer can do right now, folding the send gate into the terminal state so a hint
+/// built from it is true in every window — including the ones where State still reads Attached
+/// while a reattach or detach is under way.
+public enum SendAvailability { Ready, Sending, Transitioning, ReadOnly, Connecting, Reattach, Ended, NoTerminal }
+
 public sealed record TerminalSessionState(TerminalSessionPhase Phase, string? Detail = null, bool ReadOnly = false, int? ExitCode = null) {
     public static readonly TerminalSessionState Resolving = new(TerminalSessionPhase.Resolving);
     public static TerminalSessionState NoTerminal(string? familyNote) => new(TerminalSessionPhase.NoTerminal, familyNote);

--- a/src/Capacitor.App/Services/TerminalFeedSanitizer.cs
+++ b/src/Capacitor.App/Services/TerminalFeedSanitizer.cs
@@ -16,13 +16,14 @@ public sealed class TerminalFeedSanitizer {
     const int HoldCap = 64;
 
     readonly StringBuilder _held = new();
+    readonly StringBuilder _output = new();
 
     public string Sanitize(string text) {
         if (_held.Length == 0 && text.IndexOf(Esc) < 0) return text;
 
         var input = _held.Length == 0 ? text : _held.Append(text).ToString();
         _held.Clear();
-        var output = new StringBuilder(input.Length);
+        var output = _output.Clear();
         var i = 0;
         while (i < input.Length) {
             if (input[i] != Esc) { output.Append(input[i]); i++; continue; }
@@ -39,10 +40,22 @@ public sealed class TerminalFeedSanitizer {
 
             var parameters = input.AsSpan(i + 2, j - i - 2);
             if (input[j] != 'm') output.Append(input, i, j - i + 1);
-            else if (parameters.IsEmpty || parameters[0] is >= '0' and <= '9' or ';' or ':') output.Append(RewriteSgr(parameters));
+            else if (parameters.IsEmpty || parameters[0] is >= '0' and <= '9' or ';' or ':') {
+                if (NeedsRewrite(parameters)) output.Append(RewriteSgr(parameters));
+                else output.Append(input, i, j - i + 1);
+            }
             i = j + 1;
         }
         return output.ToString();
+    }
+
+    static bool NeedsRewrite(ReadOnlySpan<char> parameters) {
+        if (parameters.IndexOf(':') >= 0) return true;
+        foreach (var range in parameters.Split(';')) {
+            var group = parameters[range];
+            if (group.SequenceEqual("58") || group.SequenceEqual("59")) return true;
+        }
+        return false;
     }
 
     static string RewriteSgr(ReadOnlySpan<char> parameters) {

--- a/src/Capacitor.App/Services/TerminalFeedSanitizer.cs
+++ b/src/Capacitor.App/Services/TerminalFeedSanitizer.cs
@@ -1,0 +1,87 @@
+namespace Capacitor.App.Services;
+
+using System.Text;
+
+/// Rewrites the SGR forms the embedded emulator mis-parses before they reach it. XTerm.NET has
+/// no arm for the underline-colour selectors 58 and 59, so their numeric arguments are read as
+/// attribute codes — a 4 among them underlines every later cell, and the renderers agents use
+/// close styles one at a time and never send the full reset that would clear it — and it drops
+/// any parameter carrying colon sub-parameters, losing 4:0 (underline off) and the colon
+/// truecolour form. One instance per stream: a sequence cut by a frame boundary is held until
+/// its final byte arrives.
+public sealed class TerminalFeedSanitizer {
+    const char Esc = (char)27;
+    const int HoldCap = 64;
+
+    readonly StringBuilder _held = new();
+
+    public string Sanitize(string text) {
+        if (_held.Length == 0 && text.IndexOf(Esc) < 0) return text;
+
+        var input = _held.Length == 0 ? text : _held.Append(text).ToString();
+        _held.Clear();
+        var output = new StringBuilder(input.Length);
+        var i = 0;
+        while (i < input.Length) {
+            if (input[i] != Esc) { output.Append(input[i]); i++; continue; }
+            if (i + 1 == input.Length) { _held.Append(Esc); break; }
+            if (input[i + 1] != '[') { output.Append(Esc); i++; continue; }
+
+            var j = i + 2;
+            while (j < input.Length && input[j] is >= (char)0x20 and <= (char)0x3F) j++;
+            if (j == input.Length) {
+                if (input.Length - i <= HoldCap) _held.Append(input, i, input.Length - i);
+                else output.Append(input, i, input.Length - i);
+                break;
+            }
+
+            var parameters = input.AsSpan(i + 2, j - i - 2);
+            var isSgr = input[j] == 'm' && (parameters.IsEmpty || parameters[0] is >= '0' and <= '9' or ';' or ':');
+            if (isSgr) output.Append(RewriteSgr(parameters));
+            else output.Append(input, i, j - i + 1);
+            i = j + 1;
+        }
+        return output.ToString();
+    }
+
+    static string RewriteSgr(ReadOnlySpan<char> parameters) {
+        if (parameters.IsEmpty) return Esc + "[m";
+        var groups = parameters.ToString().Split(';');
+        var kept = new List<string>(groups.Length);
+        for (var k = 0; k < groups.Length; k++) {
+            var group = groups[k];
+            var colon = group.IndexOf(':');
+            var head = colon < 0 ? group : group[..colon];
+            switch (head) {
+                case "58":
+                    if (colon < 0) k += ArgumentCount(k + 1 < groups.Length ? groups[k + 1] : "");
+                    continue;
+                case "59":
+                    continue;
+            }
+            if (colon < 0) { kept.Add(group); continue; }
+
+            var subs = group[(colon + 1)..].Split(':');
+            switch (head) {
+                case "4":
+                    kept.Add(subs[0] == "0" ? "24" : "4");
+                    break;
+                case "38" or "48" when subs[0] == "2" && subs.Length >= 4:
+                    // 38:2::r:g:b carries a colour-space id (empty in practice); 38:2:r:g:b omits it.
+                    var rgb = subs.Length >= 5 ? subs[2..5] : subs[1..4];
+                    kept.Add($"{head};2;{rgb[0]};{rgb[1]};{rgb[2]}");
+                    break;
+                case "38" or "48" when subs[0] == "5" && subs.Length >= 2:
+                    kept.Add($"{head};5;{subs[1]}");
+                    break;
+                default:
+                    kept.Add(head);
+                    break;
+            }
+        }
+        return kept.Count == 0 ? "" : Esc + "[" + string.Join(';', kept) + "m";
+    }
+
+    // The semicolon form's argument count: 58;2;r;g;b or 58;5;n.
+    static int ArgumentCount(string kind) => kind switch { "2" => 4, "5" => 2, _ => 0 };
+}

--- a/src/Capacitor.App/Services/TerminalFeedSanitizer.cs
+++ b/src/Capacitor.App/Services/TerminalFeedSanitizer.cs
@@ -2,13 +2,15 @@ namespace Capacitor.App.Services;
 
 using System.Text;
 
-/// Rewrites the SGR forms the embedded emulator mis-parses before they reach it. XTerm.NET has
-/// no arm for the underline-colour selectors 58 and 59, so their numeric arguments are read as
-/// attribute codes — a 4 among them underlines every later cell, and the renderers agents use
-/// close styles one at a time and never send the full reset that would clear it — and it drops
-/// any parameter carrying colon sub-parameters, losing 4:0 (underline off) and the colon
-/// truecolour form. One instance per stream: a sequence cut by a frame boundary is held until
-/// its final byte arrives.
+/// Rewrites what the embedded emulator mis-parses before it reaches it. XTerm.NET dispatches a
+/// CSI on its final byte alone, so xterm's modifyOtherKeys set — `CSI > 4 ; 2 m`, which Claude
+/// Code sends on every return to raw mode — lands in the SGR handler as "underline on, dim on",
+/// and the renderers agents use close styles one at a time and never send the full reset that
+/// would clear it; every private-parameter sequence ending in `m` is dropped, the emulator
+/// implementing none of them. The SGR handler also has no arm for the underline-colour selectors
+/// 58 and 59, whose arguments are read as attribute codes, and drops any parameter carrying colon
+/// sub-parameters, losing 4:0 (underline off) and the colon truecolour form. One instance per
+/// stream: a sequence cut by a frame boundary is held until its final byte arrives.
 public sealed class TerminalFeedSanitizer {
     const char Esc = (char)27;
     const int HoldCap = 64;
@@ -36,9 +38,8 @@ public sealed class TerminalFeedSanitizer {
             }
 
             var parameters = input.AsSpan(i + 2, j - i - 2);
-            var isSgr = input[j] == 'm' && (parameters.IsEmpty || parameters[0] is >= '0' and <= '9' or ';' or ':');
-            if (isSgr) output.Append(RewriteSgr(parameters));
-            else output.Append(input, i, j - i + 1);
+            if (input[j] != 'm') output.Append(input, i, j - i + 1);
+            else if (parameters.IsEmpty || parameters[0] is >= '0' and <= '9' or ';' or ':') output.Append(RewriteSgr(parameters));
             i = j + 1;
         }
         return output.ToString();

--- a/src/Capacitor.App/Services/TerminalInputEncoder.cs
+++ b/src/Capacitor.App/Services/TerminalInputEncoder.cs
@@ -1,0 +1,15 @@
+using System.Text;
+
+namespace Capacitor.App.Services;
+
+/// The composer's bytes, in the shape the daemon's own PTY input path uses: one bracketed
+/// paste so the TUI takes the text as a block, and a separate carriage return to submit it.
+public static class TerminalInputEncoder {
+    public static readonly byte[] Submit = "\r"u8.ToArray();
+
+    public static byte[] Paste(string text) {
+        var normalized = text.Replace("\r\n", "\n");
+        if (normalized.EndsWith('\n')) normalized = normalized[..^1];
+        return Encoding.UTF8.GetBytes("\x1b[200~" + normalized + "\x1b[201~");
+    }
+}

--- a/src/Capacitor.App/Services/XtermTerminalSurface.cs
+++ b/src/Capacitor.App/Services/XtermTerminalSurface.cs
@@ -25,7 +25,13 @@ public sealed class XtermTerminalSurface : ITerminalSurface {
     // via Model.Terminal.Resize(cols, rows).
     public (int Cols, int Rows) CurrentSize => (Model.Terminal.Cols, Model.Terminal.Rows);
 
-    public XtermTerminalSurface(int cols, int rows) {
+    readonly TerminalFeedSanitizer _sanitizer = new();
+    readonly string? _dumpPath;
+
+    /// <paramref name="dumpPath"/>: a file every fed frame is appended to as received, before
+    /// any rewriting — the only record of what the emulator was given.
+    public XtermTerminalSurface(int cols, int rows, string? dumpPath = null) {
+        _dumpPath = dumpPath;
         Model = new TerminalControlModel(new TerminalOptions {
             Cols = cols,
             Rows = rows,
@@ -37,7 +43,10 @@ public sealed class XtermTerminalSurface : ITerminalSurface {
         Model.Terminal.Engine.DataReceived += OnDataReceived;
     }
 
-    public void Feed(string text) => Model.Feed(text);
+    public void Feed(string text) {
+        if (_dumpPath is not null) File.AppendAllText(_dumpPath, text);
+        Model.Feed(_sanitizer.Sanitize(text));
+    }
 
     void OnUserInput(object? sender, TerminalUserInputEventArgs e) =>
         InputProduced?.Invoke(e.Data.ToArray());

--- a/src/Capacitor.App/ViewModels/ChatItems.cs
+++ b/src/Capacitor.App/ViewModels/ChatItems.cs
@@ -2,7 +2,7 @@ using ReactiveUI;
 
 namespace Capacitor.App.ViewModels;
 
-/// One row of the Chat tab. Three shapes, matched by DataTemplates on the concrete type.
+/// One row of the Chat tab. Four shapes, matched by DataTemplates on the concrete type.
 public abstract class ChatItemViewModel : ReactiveObject { }
 
 public sealed class UserTurnItem(string text) : ChatItemViewModel {
@@ -10,6 +10,11 @@ public sealed class UserTurnItem(string text) : ChatItemViewModel {
 }
 
 public sealed class AssistantTextItem(string text) : ChatItemViewModel {
+    public string Text { get; } = text;
+}
+
+/// System-attributed text — a finished background task, a reconnect note — never anyone's speech.
+public sealed class SystemNoteItem(string text) : ChatItemViewModel {
     public string Text { get; } = text;
 }
 

--- a/src/Capacitor.App/ViewModels/ChatItems.cs
+++ b/src/Capacitor.App/ViewModels/ChatItems.cs
@@ -1,0 +1,37 @@
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+/// One row of the Chat tab. Three shapes, matched by DataTemplates on the concrete type.
+public abstract class ChatItemViewModel : ReactiveObject { }
+
+public sealed class UserTurnItem(string text) : ChatItemViewModel {
+    public string Text { get; } = text;
+}
+
+public sealed class AssistantTextItem(string text) : ChatItemViewModel {
+    public string Text { get; } = text;
+}
+
+public enum ToolOutcome { Running, Done, Error }
+
+public sealed class ToolCallItem(string name, string detail) : ChatItemViewModel {
+    public string Name { get; } = name;
+    public string Detail { get; } = detail;
+
+    ToolOutcome _outcome;
+    /// Flipped in place when the matching tool_result arrives; never rebuilt.
+    public ToolOutcome Outcome {
+        get => _outcome;
+        set {
+            if (_outcome == value) return;
+            _outcome = value;
+            this.RaisePropertyChanged();
+            this.RaisePropertyChanged(nameof(OutcomeGlyph));
+            this.RaisePropertyChanged(nameof(IsError));
+        }
+    }
+
+    public string OutcomeGlyph => _outcome switch { ToolOutcome.Done => "✓", ToolOutcome.Error => "✕", _ => "" };
+    public bool IsError => _outcome == ToolOutcome.Error;
+}

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -43,6 +43,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
     int _generation;
     int _readInFlight;
     string? _path;
+    string? _root;
     volatile TailLease? _lease;
     ITimer? _timer;
     volatile Task? _pendingRead;
@@ -170,6 +171,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
 
     void OnDto(AgentStatusDto dto) {
         _vendor = dto.Vendor;
+        _root = dto.RepoPath;
         VendorLabel = HostedHarnessCatalog.LabelFor(_options, dto.Vendor);
         ModelLabel = HostedHarnessCatalog.ModelLabelFor(dto.Vendor, dto.Model ?? "");
         StatusText = dto.Status;
@@ -245,7 +247,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
                     fresh.Add(new AssistantTextItem(e.Text ?? ""));
                     break;
                 case AcpEventKind.ToolCall: {
-                    var item = new ToolCallItem(e.ToolName ?? "tool", ToolDetail.From(e.ToolInputJson));
+                    var item = new ToolCallItem(e.ToolName ?? "tool", ToolDetail.From(e.ToolInputJson, _root));
                     if (e.ToolCallId is { } id) _pendingTools[id] = item;
                     fresh.Add(item);
                     break;

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -246,6 +246,9 @@ public sealed class ChatTabViewModel : ReactiveObject {
                 case AcpEventKind.AssistantText:
                     fresh.Add(new AssistantTextItem(e.Text ?? ""));
                     break;
+                case AcpEventKind.SystemNote:
+                    fresh.Add(new SystemNoteItem(e.Text ?? ""));
+                    break;
                 case AcpEventKind.ToolCall: {
                     var item = new ToolCallItem(e.ToolName ?? "tool", ToolDetail.From(e.ToolInputJson, _root));
                     if (e.ToolCallId is { } id) _pendingTools[id] = item;

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -1,0 +1,185 @@
+using System.Collections.Concurrent;
+using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
+using System.Reactive.Linq;
+using Avalonia.Collections;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+public enum ChatTabPhase { Waiting, Reading, Missing, Unavailable }
+
+/// The Chat tab: the session's transcript, tailed and projected into chat rows, plus the composer
+/// that sends through the sibling terminal. Ctor-scoped; TeardownAsync is the one exit.
+///
+/// Path identity is part of the read generation: a distinct transcript_path clears the rows and
+/// installs a fresh tail in one UI-thread step, and any read still in flight for the old file
+/// completes under a stale generation and is discarded.
+public sealed class ChatTabViewModel : ReactiveObject {
+    internal static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
+
+    readonly string _agentId;
+    readonly TerminalTabViewModel _terminal;
+    readonly ITranscriptProjection? _projection;
+    readonly IUrlOpener _opener;
+    readonly TimeProvider _time;
+    readonly CompositeDisposable _disposables = new();
+    readonly AvaloniaList<ChatItemViewModel> _items = new();
+    readonly Dictionary<string, ToolCallItem> _pendingTools = new(StringComparer.Ordinal);
+    readonly ConcurrentDictionary<string, byte> _loggedFailures = new(StringComparer.Ordinal);
+
+    int _generation;
+    int _readInFlight;
+    string? _path;
+    JsonlTail? _tail;
+    ITimer? _timer;
+    Task? _pendingRead;
+
+    public IAvaloniaReadOnlyList<ChatItemViewModel> Items => _items;
+
+    ChatTabPhase _phase;
+    public ChatTabPhase Phase {
+        get => _phase;
+        private set {
+            this.RaiseAndSetIfChanged(ref _phase, value);
+            this.RaisePropertyChanged(nameof(PhaseNote));
+        }
+    }
+
+    public string PhaseNote => Phase switch {
+        ChatTabPhase.Waiting     => "Waiting for the transcript…",
+        ChatTabPhase.Missing     => "The transcript file is missing",
+        ChatTabPhase.Unavailable => "No chat view for this harness",
+        _                        => "",
+    };
+
+    internal Task? PendingReadForTesting => _pendingRead;
+
+    public ChatTabViewModel(
+            string agentId, IDaemonClientService daemon, TerminalTabViewModel terminal,
+            ITranscriptProjection? projection, IUrlOpener opener, TimeProvider time) {
+        _agentId = agentId;
+        _terminal = terminal;
+        _projection = projection;
+        _opener = opener;
+        _time = time;
+        _phase = projection is null ? ChatTabPhase.Unavailable : ChatTabPhase.Waiting;
+
+        daemon.Agents.Connect()
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(OnAgentsChanged)
+            .DisposeWith(_disposables);
+
+        if (projection is not null)
+            _timer = time.CreateTimer(_ => OnTick(), null, PollInterval, PollInterval);
+
+        // Task 12: composer, footer and link members are constructed here.
+    }
+
+    void OnAgentsChanged(IChangeSet<AgentStatusDto, string> changes) {
+        foreach (var change in changes) {
+            if (change.Key != _agentId || change.Reason is not (ChangeReason.Add or ChangeReason.Update)) continue;
+            OnDto(change.Current);
+        }
+    }
+
+    void OnDto(AgentStatusDto dto) {
+        if (_projection is not null && dto.TranscriptPath is { } path && path != _path) SwitchPath(path);
+    }
+
+    void SwitchPath(string path) {
+        Interlocked.Increment(ref _generation);
+        _items.Clear();
+        _pendingTools.Clear();
+        _path = path;
+        Volatile.Write(ref _tail, new JsonlTail(path));
+        Phase = ChatTabPhase.Waiting;
+        OnTick();
+    }
+
+    void OnTick() {
+        if (Volatile.Read(ref _tail) is not { } tail || _projection is not { } projection) return;
+        if (Interlocked.CompareExchange(ref _readInFlight, 1, 0) != 0) return;
+        _pendingRead = ReadAndApplyAsync(tail, projection, Volatile.Read(ref _generation));
+    }
+
+    async Task ReadAndApplyAsync(JsonlTail tail, ITranscriptProjection projection, int generation) {
+        try {
+            var (read, envelopes) = await Task.Run(() => {
+                var result = tail.ReadAppended();
+                var list = new List<AcpEventEnvelope>();
+                foreach (var line in result.Lines) {
+                    try { list.AddRange(projection.Project(line)); }
+                    catch (Exception ex) { LogOnce($"projection: {ex.Message}"); }
+                }
+                return (result, list);
+            }).ConfigureAwait(false);
+
+            await Dispatcher.UIThread.InvokeAsync(() => Apply(generation, read, envelopes));
+        } catch (Exception ex) {
+            LogOnce($"read: {ex.Message}");
+        } finally {
+            Volatile.Write(ref _readInFlight, 0);
+        }
+    }
+
+    void Apply(int generation, TailRead read, List<AcpEventEnvelope> envelopes) {
+        if (generation != Volatile.Read(ref _generation)) return;
+
+        switch (read.Status) {
+            case TailStatus.Missing:
+                Phase = ChatTabPhase.Missing;
+                return;
+            case TailStatus.Failed:
+                LogOnce(read.Failure ?? "read failed");
+                return;
+            case TailStatus.Reset:
+                _items.Clear();
+                _pendingTools.Clear();
+                break;
+        }
+
+        Phase = ChatTabPhase.Reading;
+        if (envelopes.Count == 0) return;
+
+        var fresh = new List<ChatItemViewModel>();
+        foreach (var e in envelopes) {
+            switch (e.Kind) {
+                case AcpEventKind.UserMessage:
+                    fresh.Add(new UserTurnItem(e.Text ?? ""));
+                    break;
+                case AcpEventKind.AssistantText:
+                    fresh.Add(new AssistantTextItem(e.Text ?? ""));
+                    break;
+                case AcpEventKind.ToolCall: {
+                    var item = new ToolCallItem(e.ToolName ?? "tool", ToolDetail.From(e.ToolInputJson));
+                    if (e.ToolCallId is { } id) _pendingTools[id] = item;
+                    fresh.Add(item);
+                    break;
+                }
+                case AcpEventKind.ToolResult:
+                    if (e.ToolCallId is { } resultId && _pendingTools.Remove(resultId, out var call))
+                        call.Outcome = e.ToolIsError ? ToolOutcome.Error : ToolOutcome.Done;
+                    break;
+            }
+        }
+        if (fresh.Count > 0) _items.AddRange(fresh);
+    }
+
+    void LogOnce(string reason) {
+        if (_loggedFailures.TryAdd(reason, 0)) Console.Error.WriteLine($"kcap: chat transcript: {reason}");
+    }
+
+    public Task TeardownAsync() {
+        Interlocked.Increment(ref _generation);
+        _timer?.Dispose();
+        _timer = null;
+        _disposables.Dispose();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -33,12 +33,17 @@ public sealed class ChatTabViewModel : ReactiveObject {
     readonly Dictionary<string, ToolCallItem> _pendingTools = new(StringComparer.Ordinal);
     readonly ConcurrentDictionary<string, byte> _loggedFailures = new(StringComparer.Ordinal);
 
+    /// The tail and the generation it belongs to, taken as one reference: reading the two
+    /// separately lets a switch land between them and tag a read of the old file with the new
+    /// generation, which Apply's guard would then wave through onto the freshly cleared list.
+    sealed record TailLease(JsonlTail Tail, int Generation);
+
     int _generation;
     int _readInFlight;
     string? _path;
-    JsonlTail? _tail;
+    volatile TailLease? _lease;
     ITimer? _timer;
-    Task? _pendingRead;
+    volatile Task? _pendingRead;
 
     public IAvaloniaReadOnlyList<ChatItemViewModel> Items => _items;
 
@@ -46,6 +51,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
     public ChatTabPhase Phase {
         get => _phase;
         private set {
+            if (_phase == value) return;
             this.RaiseAndSetIfChanged(ref _phase, value);
             this.RaisePropertyChanged(nameof(PhaseNote));
         }
@@ -58,6 +64,9 @@ public sealed class ChatTabViewModel : ReactiveObject {
         _                        => "",
     };
 
+    /// Test-only seam: the read in flight, or the last one started. A switch that loses the
+    /// in-flight CAS starts no read of its own, so this still points at the previous file's read —
+    /// await that, advance one tick, then await again to see the new path's first rows.
     internal Task? PendingReadForTesting => _pendingRead;
 
     public ChatTabViewModel(
@@ -93,19 +102,21 @@ public sealed class ChatTabViewModel : ReactiveObject {
     }
 
     void SwitchPath(string path) {
-        Interlocked.Increment(ref _generation);
         _items.Clear();
         _pendingTools.Clear();
         _path = path;
-        Volatile.Write(ref _tail, new JsonlTail(path));
+        _lease = new TailLease(new JsonlTail(path), Interlocked.Increment(ref _generation));
         Phase = ChatTabPhase.Waiting;
+        // A switch re-announces the note even when it lands on the phase already showing: the rows
+        // are gone, so the view has to re-read what stands in for them.
+        this.RaisePropertyChanged(nameof(PhaseNote));
         OnTick();
     }
 
     void OnTick() {
-        if (Volatile.Read(ref _tail) is not { } tail || _projection is not { } projection) return;
+        if (_lease is not { } lease || _projection is not { } projection) return;
         if (Interlocked.CompareExchange(ref _readInFlight, 1, 0) != 0) return;
-        _pendingRead = ReadAndApplyAsync(tail, projection, Volatile.Read(ref _generation));
+        _pendingRead = ReadAndApplyAsync(lease.Tail, projection, lease.Generation);
     }
 
     async Task ReadAndApplyAsync(JsonlTail tail, ITranscriptProjection projection, int generation) {
@@ -177,6 +188,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
 
     public Task TeardownAsync() {
         Interlocked.Increment(ref _generation);
+        _lease = null;
         _timer?.Dispose();
         _timer = null;
         _disposables.Dispose();

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -1,8 +1,10 @@
 using System.Collections.Concurrent;
+using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using Avalonia.Collections;
+using Avalonia.Media;
 using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core;
@@ -64,6 +66,46 @@ public sealed class ChatTabViewModel : ReactiveObject {
         _                        => "",
     };
 
+    string _composerText = "";
+    public string ComposerText {
+        get => _composerText;
+        set => this.RaiseAndSetIfChanged(ref _composerText, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> SendCommand { get; }
+    public ReactiveCommand<string, Unit> OpenLinkCommand { get; }
+
+    readonly ObservableAsPropertyHelper<string> _composerHint;
+    public string ComposerHint => _composerHint.Value;
+
+    string _vendor = "";
+    IReadOnlyList<HarnessOption> _options = HostedHarnessCatalog.Build(null);
+
+    string _vendorLabel = "";
+    public string VendorLabel { get => _vendorLabel; private set => this.RaiseAndSetIfChanged(ref _vendorLabel, value); }
+
+    string _modelLabel = "default";
+    public string ModelLabel { get => _modelLabel; private set => this.RaiseAndSetIfChanged(ref _modelLabel, value); }
+
+    string _statusText = "";
+    public string StatusText { get => _statusText; private set => this.RaiseAndSetIfChanged(ref _statusText, value); }
+
+    IBrush _statusDot = SessionStatusDots.For("");
+    public IBrush StatusDot { get => _statusDot; private set => this.RaiseAndSetIfChanged(ref _statusDot, value); }
+
+    /// The hint is built from the terminal's own availability, so it is true in the windows
+    /// where State alone would lie (a reattach or detach under way while State reads Attached).
+    internal static string HintFor(SendAvailability availability, TerminalSessionState state, string vendorLabel) => availability switch {
+        SendAvailability.Ready         => $"Reply to {vendorLabel} · Enter sends · Shift+Enter for a new line",
+        SendAvailability.Sending       => "Sending…",
+        SendAvailability.Transitioning => "Updating the terminal connection…",
+        SendAvailability.ReadOnly      => $"Read-only: {state.Detail}",
+        SendAvailability.Connecting    => "Connecting to the terminal…",
+        SendAvailability.Reattach      => "Reattach the terminal to send",
+        SendAvailability.Ended         => "This session has ended",
+        _                              => "No terminal to send to",
+    };
+
     /// Test-only seam: the read in flight, or the last one started. A switch that loses the
     /// in-flight CAS starts no read of its own, so this still points at the previous file's read —
     /// await that, advance one tick, then await again to see the new path's first rows.
@@ -87,7 +129,36 @@ public sealed class ChatTabViewModel : ReactiveObject {
         if (projection is not null)
             _timer = time.CreateTimer(_ => OnTick(), null, PollInterval, PollInterval);
 
-        // Task 12: composer, footer and link members are constructed here.
+        daemon.Snapshots
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(snapshot => {
+                _options = HostedHarnessCatalog.Build(snapshot.Daemon.SupportedVendors);
+                VendorLabel = HostedHarnessCatalog.LabelFor(_options, _vendor);
+            })
+            .DisposeWith(_disposables);
+
+        _composerHint = Observable.CombineLatest(
+                terminal.WhenAnyValue(t => t.SendAvailability, t => t.State, (availability, state) => (availability, state)),
+                this.WhenAnyValue(x => x.VendorLabel),
+                (t, label) => HintFor(t.availability, t.state, label))
+            .ToProperty(this, x => x.ComposerHint, HintFor(terminal.SendAvailability, terminal.State, ""))
+            .DisposeWith(_disposables);
+
+        var canSend = Observable.CombineLatest(
+            this.WhenAnyValue(x => x.ComposerText),
+            terminal.WhenAnyValue(t => t.CanAcceptText),
+            (text, can) => can && !string.IsNullOrWhiteSpace(text));
+        SendCommand = ReactiveCommand.Create(() => {
+            if (_terminal.TrySendText(ComposerText)) ComposerText = "";
+        }, canSend);
+        _disposables.Add(SendCommand);
+
+        OpenLinkCommand = ReactiveCommand.Create<string>(url => {
+            if (!LinkPolicy.IsOpenable(url)) return;
+            try { _opener.Open(url); }
+            catch (Exception ex) { Console.Error.WriteLine($"kcap: open link failed: {ex.Message}"); }
+        });
+        _disposables.Add(OpenLinkCommand);
     }
 
     void OnAgentsChanged(IChangeSet<AgentStatusDto, string> changes) {
@@ -98,6 +169,11 @@ public sealed class ChatTabViewModel : ReactiveObject {
     }
 
     void OnDto(AgentStatusDto dto) {
+        _vendor = dto.Vendor;
+        VendorLabel = HostedHarnessCatalog.LabelFor(_options, dto.Vendor);
+        ModelLabel = HostedHarnessCatalog.ModelLabelFor(dto.Vendor, dto.Model ?? "");
+        StatusText = dto.Status;
+        StatusDot = SessionStatusDots.For(dto.Status);
         if (_projection is not null && dto.TranscriptPath is { } path && path != _path) SwitchPath(path);
     }
 
@@ -106,10 +182,11 @@ public sealed class ChatTabViewModel : ReactiveObject {
         _pendingTools.Clear();
         _path = path;
         _lease = new TailLease(new JsonlTail(path), Interlocked.Increment(ref _generation));
+        var wasWaiting = _phase == ChatTabPhase.Waiting;
         Phase = ChatTabPhase.Waiting;
-        // A switch re-announces the note even when it lands on the phase already showing: the rows
-        // are gone, so the view has to re-read what stands in for them.
-        this.RaisePropertyChanged(nameof(PhaseNote));
+        // The rows are gone, so the view has to re-read what stands in for them even when the phase
+        // is unchanged — and only then, since the setter itself raises the note on a real change.
+        if (wasWaiting) this.RaisePropertyChanged(nameof(PhaseNote));
         OnTick();
     }
 

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -161,9 +161,10 @@ public sealed class TerminalTabViewModel : ReactiveObject {
             RaiseSendProjections();
             return;
         }
-        Invalidate();
+        // State first: Invalidate raises the projections, and they must not be read against the
+        // state this publish is replacing.
         State = state;
-        RaiseSendProjections();
+        Invalidate();
     }
 
     /// Synchronous acceptance on the UI thread: true means the text is on its way through the

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -32,6 +32,10 @@ namespace Capacitor.App.ViewModels;
 ///   CanExecute/IsExecuting, so a queueing WaitAsync() here would let a double-click spawn two
 ///   real clients.
 ///   A call that loses the try-enter is a clean no-op, not a queued retry.
+/// * Send gate (_openingToken): who may accept composer text. BeginAttempt and Invalidate are its
+///   only advances; an attempt may open the gate only while the token it carries is still current,
+///   and every publish that is not an attempt's own Connecting/Attached invalidates. State has one
+///   assignment site, Publish, which applies both rules.
 ///
 /// UI affinity: the resolve gate mutates State after ObserveOn(RxSchedulers.MainThreadScheduler)
 /// or RxSchedulers.MainThreadScheduler.Schedule(...) (the TimeProvider timer fires off-thread in
@@ -46,6 +50,10 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     static readonly TimeSpan ResolveBudget = TimeSpan.FromSeconds(10);
     static readonly TimeSpan DetachBound   = TimeSpan.FromSeconds(1);
     static readonly TimeSpan TeardownBudget = TimeSpan.FromSeconds(3);
+
+    // Codex's TUI suppresses Enter-as-submit for 120ms after ingesting a paste and turns a CR
+    // inside that window into a newline.
+    static readonly TimeSpan SubmitDelay = TimeSpan.FromMilliseconds(150);
 
     const int DefaultCols = 80, DefaultRows = 24;
 
@@ -68,10 +76,127 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     Task? _runTask;
 
     TerminalSessionState _state = TerminalSessionState.Resolving;
-    /// Bound; mutated only on the UI scheduler (see class doc comment).
+    /// Bound; mutated only on the UI scheduler (see class doc comment), and only from Publish.
     public TerminalSessionState State {
         get => _state;
         private set => this.RaiseAndSetIfChanged(ref _state, value);
+    }
+
+    // The send gate. Only BeginAttempt and Invalidate advance the token; an attempt carries the
+    // token its BeginAttempt produced and may open the gate only while that token is current.
+    // Neither State nor _client can serve as the gate alone: a reattach leaves both Attached and
+    // live while it awaits the old client's disposal, and a detach leaves both unchanged while it
+    // awaits the detach write.
+    int _openingToken;
+    bool _gateOpen;
+    bool _sendInFlight;
+    Task? _delivery;
+
+    /// Bound; true from a send's acceptance until its delivery ends.
+    public bool SendInFlight {
+        get => _sendInFlight;
+        private set {
+            if (_sendInFlight == value) return;
+            _sendInFlight = value;
+            this.RaisePropertyChanged();
+            RaiseSendProjections();
+        }
+    }
+
+    /// Bound; the one authority TrySendText itself consults, so can-execute and acceptance can
+    /// never disagree.
+    public bool CanAcceptText => _gateOpen && !_sendInFlight;
+
+    /// Bound; the gate folded into the state, so a hint built from it is true in every window.
+    public SendAvailability SendAvailability {
+        get {
+            if (_sendInFlight) return SendAvailability.Sending;
+            if (State is { Phase: TerminalSessionPhase.Attached, ReadOnly: false })
+                return _gateOpen ? SendAvailability.Ready : SendAvailability.Transitioning;
+            return State.Phase switch {
+                TerminalSessionPhase.Attached => SendAvailability.ReadOnly,
+                TerminalSessionPhase.Resolving or TerminalSessionPhase.Connecting => SendAvailability.Connecting,
+                TerminalSessionPhase.Detached or TerminalSessionPhase.Failed => SendAvailability.Reattach,
+                TerminalSessionPhase.Exited or TerminalSessionPhase.SessionEnded => SendAvailability.Ended,
+                _ => SendAvailability.NoTerminal,
+            };
+        }
+    }
+
+    internal int OpeningTokenForTesting => Volatile.Read(ref _openingToken);
+    internal bool SendGateOpenForTesting => _gateOpen;
+    internal Task? PendingDeliveryForTesting => _delivery;
+
+    void RaiseSendProjections() {
+        this.RaisePropertyChanged(nameof(CanAcceptText));
+        this.RaisePropertyChanged(nameof(SendAvailability));
+    }
+
+    /// Closes the gate and hands the caller a fresh token, which that attempt carries for its
+    /// whole life.
+    int BeginAttempt() {
+        _gateOpen = false;
+        SendInFlight = false;
+        var token = Interlocked.Increment(ref _openingToken);
+        RaiseSendProjections();
+        return token;
+    }
+
+    /// Advances ownership past every attempt alive: an already-closed gate still allocates, since
+    /// a callback queued mid-Connecting must lose its right to open.
+    void Invalidate() {
+        _gateOpen = false;
+        SendInFlight = false;
+        Interlocked.Increment(ref _openingToken);
+        RaiseSendProjections();
+    }
+
+    /// The one place State is assigned. An attempt-owned publish (Connecting, Attached) carries
+    /// its token and is discarded when that token is stale; every other state is an invalidation.
+    void Publish(TerminalSessionState state, int? ownerToken) {
+        if (state.Phase is TerminalSessionPhase.Connecting or TerminalSessionPhase.Attached) {
+            if (ownerToken != Volatile.Read(ref _openingToken)) return;
+            State = state;
+            if (state is { Phase: TerminalSessionPhase.Attached, ReadOnly: false }) _gateOpen = true;
+            RaiseSendProjections();
+            return;
+        }
+        Invalidate();
+        State = state;
+        RaiseSendProjections();
+    }
+
+    /// Synchronous acceptance on the UI thread: true means the text is on its way through the
+    /// current client and the composer may clear; false means nothing was written.
+    public bool TrySendText(string text) {
+        if (!CanAcceptText || _client is not { } client) return false;
+        var token = Volatile.Read(ref _openingToken);
+        SendInFlight = true;
+        _delivery = DeliverAsync(client, token, TerminalInputEncoder.Paste(text));
+        return true;
+    }
+
+    // Paste, wait out the TUI's post-paste Enter suppression, then one CR -- only if nothing
+    // advanced the token meanwhile, since the paste already went to a client a replacement must
+    // never follow with a stray Enter. A fault ends the delivery and never touches State: the
+    // attach outcome is the transport's own channel.
+    async Task DeliverAsync(ITerminalAttachClient client, int token, byte[] paste) {
+        try {
+            await client.SendInputAsync(paste).ConfigureAwait(false);
+            await Task.Delay(SubmitDelay, _time).ConfigureAwait(false);
+            if (Volatile.Read(ref _openingToken) != token) return;
+            await client.SendInputAsync(TerminalInputEncoder.Submit).ConfigureAwait(false);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: composer send failed: {ex.Message}");
+        } finally {
+            if (Volatile.Read(ref _resolveState) != ResolveDisposed && Volatile.Read(ref _openingToken) == token) {
+                await Dispatcher.UIThread.InvokeAsync(() => {
+                    if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
+                    if (Volatile.Read(ref _openingToken) != token) return;
+                    SendInFlight = false;
+                });
+            }
+        }
     }
 
     ITerminalSurface? _surface;
@@ -158,7 +283,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
             await Dispatcher.UIThread.InvokeAsync(() => {
                 if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
                 if (State.Phase != TerminalSessionPhase.Resolving) return;
-                State = TerminalSessionState.Failed($"couldn't open the terminal: {ex.Message}");
+                Publish(TerminalSessionState.Failed($"couldn't open the terminal: {ex.Message}"), null);
             });
         }
     }
@@ -170,7 +295,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         // Signal precedence: the run's own Exited/Failed verdict outranks a cache removal.
         if (State.Phase is TerminalSessionPhase.Exited or TerminalSessionPhase.Failed) return;
 
-        State = TerminalSessionState.SessionEnded;
+        Publish(TerminalSessionState.SessionEnded, null);
     }
 
     void OnResolveTimeout() {
@@ -183,7 +308,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         // thread under FakeTimeProvider.Advance -- Schedule (not a raw write) is what keeps this
         // on the UI scheduler either way, and synchronous under WithImmediateRxScheduler's
         // ImmediateScheduler so a test can assert right after Advance() returns.
-        RxSchedulers.MainThreadScheduler.Schedule(() => State = TerminalSessionState.NotFound);
+        RxSchedulers.MainThreadScheduler.Schedule(() => Publish(TerminalSessionState.NotFound, null));
     }
 
     /// CAS (not read-then-write): only a timed-out gate is eligible for retry, and only if
@@ -221,7 +346,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
                 // Disposal wins permanently: never render a note for a tab TeardownAsync already
                 // tore down (a concurrent teardown could land while this hop is in flight).
                 if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
-                State = TerminalSessionState.NoTerminal(HostedHarnessCatalog.NoTerminalNote(dto.HasTerminal, dto.Vendor));
+                Publish(TerminalSessionState.NoTerminal(HostedHarnessCatalog.NoTerminalNote(dto.HasTerminal, dto.Vendor)), null);
             });
             return;
         }
@@ -247,6 +372,8 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         try {
             if (Retired(0)) return; // teardown may have already run before this call got the lane
 
+            var openingToken = BeginAttempt();
+
             var prevClient = _client;
             var prevCts = _attemptCts;
             prevCts?.Cancel();
@@ -258,6 +385,10 @@ public sealed class TerminalTabViewModel : ReactiveObject {
             // Suspension point 1: TeardownAsync may have landed while the previous client's
             // dispose was in flight.
             if (Retired(0)) return;
+            // A removal or an explicit detach landing in that same window retires no attempt
+            // generation, so only the opening token catches it -- and an attempt that never
+            // reached Connecting must not publish over what that invalidation already rendered.
+            if (Volatile.Read(ref _openingToken) != openingToken) return;
 
             var generation = Interlocked.Increment(ref _attemptGeneration);
             var cts = new CancellationTokenSource();
@@ -285,7 +416,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
                     var s = _surfaceFactory();
                     var d = new Utf8StreamDecoder();
                     Surface = s;
-                    State = TerminalSessionState.Connecting;
+                    Publish(TerminalSessionState.Connecting, openingToken);
                     return (s, d);
                 }, DispatcherPriority.Default, token);
             } catch (OperationCanceledException) {
@@ -309,7 +440,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
 
             var client = _factory(
                 _agentId,
-                (snapshot, reason, ct) => OnAttachedAsync(generation, surface, decoder, snapshot, reason, ct),
+                (snapshot, reason, ct) => OnAttachedAsync(generation, openingToken, surface, decoder, snapshot, reason, ct),
                 (bytes, ct) => OnOutputAsync(generation, surface, decoder, bytes, ct));
 
             // One more check right before publishing: a retirement landing exactly between the
@@ -350,12 +481,12 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         };
     }
 
-    async Task OnAttachedAsync(int generation, ITerminalSurface surface, Utf8StreamDecoder decoder, byte[] snapshot, string? reason, CancellationToken ct) {
+    async Task OnAttachedAsync(int generation, int openingToken, ITerminalSurface surface, Utf8StreamDecoder decoder, byte[] snapshot, string? reason, CancellationToken ct) {
         var text = decoder.Decode(snapshot);
         await Dispatcher.UIThread.InvokeAsync(() => {
             if (generation != _attemptGeneration) return;
             surface.Feed(text);
-            State = TerminalSessionState.Attached(reason);
+            Publish(TerminalSessionState.Attached(reason), openingToken);
         }, DispatcherPriority.Default, ct);
     }
 
@@ -409,10 +540,11 @@ public sealed class TerminalTabViewModel : ReactiveObject {
             if (generation != _attemptGeneration) return;
             var remainder = decoder.Flush();
             if (remainder.Length > 0) surface.Feed(remainder);
-            State = state;
+            Publish(state, null);
         }, DispatcherPriority.Default, CancellationToken.None).GetTask();
 
     async Task RunDetachAsync() {
+        Invalidate();
         var client = _client;
         if (client is null) return;
         try { await client.DetachAsync().ConfigureAwait(false); }
@@ -436,6 +568,8 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     /// touched) is the acceptable trade against a straddling attempt crashing the app.
     public async Task TeardownAsync() {
         if (Interlocked.Exchange(ref _resolveState, ResolveDisposed) == ResolveDisposed) return; // idempotent
+
+        Invalidate();
 
         _agentsSub?.Dispose();
         _agentsSub = null;

--- a/src/Capacitor.App/ViewModels/ToolDetail.cs
+++ b/src/Capacitor.App/ViewModels/ToolDetail.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Capacitor.Cli.Core;
 
 namespace Capacitor.App.ViewModels;
 
@@ -18,11 +19,9 @@ public static class ToolDetail {
         if (string.IsNullOrEmpty(inputJson)) return "";
         try {
             using var doc = JsonDocument.Parse(inputJson);
-            if (doc.RootElement.ValueKind != JsonValueKind.Object) return "";
+            if (!doc.RootElement.IsObject) return "";
             foreach (var key in Keys) {
-                if (doc.RootElement.TryGetProperty(key, out var value)
-                    && value.ValueKind == JsonValueKind.String
-                    && value.GetString() is { } s && s.Trim().Length > 0)
+                if (doc.RootElement.Str(key) is { } s && s.Trim().Length > 0)
                     return FirstLine(PathKeys.Contains(key) ? Relative(s.Trim(), root) : s);
             }
         } catch (JsonException) { }

--- a/src/Capacitor.App/ViewModels/ToolDetail.cs
+++ b/src/Capacitor.App/ViewModels/ToolDetail.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+
+namespace Capacitor.App.ViewModels;
+
+/// The one-line detail a tool row shows beside its name, read from the call's input object.
+public static class ToolDetail {
+    const int MaxLength = 80;
+
+    static readonly string[] Keys = [
+        "description", "command", "cmd", "file_path", "path", "pattern", "query", "url", "skill", "prompt", "input",
+    ];
+
+    public static string From(string? inputJson) {
+        if (string.IsNullOrEmpty(inputJson)) return "";
+        try {
+            using var doc = JsonDocument.Parse(inputJson);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return "";
+            foreach (var key in Keys) {
+                if (doc.RootElement.TryGetProperty(key, out var value)
+                    && value.ValueKind == JsonValueKind.String
+                    && value.GetString() is { } s && s.Trim().Length > 0)
+                    return FirstLine(s);
+            }
+        } catch (JsonException) { }
+        return "";
+    }
+
+    static string FirstLine(string text) {
+        var line = text.Trim();
+        var newline = line.IndexOfAny(['\r', '\n']);
+        if (newline >= 0) line = line[..newline].TrimEnd();
+        return line.Length <= MaxLength ? line : string.Concat(line.AsSpan(0, MaxLength - 1), "…");
+    }
+}

--- a/src/Capacitor.App/ViewModels/ToolDetail.cs
+++ b/src/Capacitor.App/ViewModels/ToolDetail.cs
@@ -2,15 +2,19 @@ using System.Text.Json;
 
 namespace Capacitor.App.ViewModels;
 
-/// The one-line detail a tool row shows beside its name, read from the call's input object.
+/// The one-line detail a tool row shows beside its name, read from the call's input object. A
+/// path under the session's root reads relative to it, the way the web UI shows it: the root is
+/// the repository, or the daemon's per-agent worktree beneath it when the path is in one.
 public static class ToolDetail {
     const int MaxLength = 80;
+    const string WorktreesSegment = "/.capacitor/worktrees/";
 
     static readonly string[] Keys = [
-        "description", "command", "cmd", "file_path", "path", "pattern", "query", "url", "skill", "prompt", "input",
+        "description", "command", "cmd", "file_path", "path", "notebook_path", "pattern", "query", "url", "skill", "prompt", "input",
     ];
+    static readonly string[] PathKeys = ["file_path", "path", "notebook_path"];
 
-    public static string From(string? inputJson) {
+    public static string From(string? inputJson, string? root = null) {
         if (string.IsNullOrEmpty(inputJson)) return "";
         try {
             using var doc = JsonDocument.Parse(inputJson);
@@ -19,10 +23,22 @@ public static class ToolDetail {
                 if (doc.RootElement.TryGetProperty(key, out var value)
                     && value.ValueKind == JsonValueKind.String
                     && value.GetString() is { } s && s.Trim().Length > 0)
-                    return FirstLine(s);
+                    return FirstLine(PathKeys.Contains(key) ? Relative(s.Trim(), root) : s);
             }
         } catch (JsonException) { }
         return "";
+    }
+
+    static string Relative(string path, string? root) {
+        if (string.IsNullOrEmpty(root)) return path;
+        var prefix = root.TrimEnd('/') + "/";
+        if (!path.StartsWith(prefix, StringComparison.Ordinal)) return path;
+        var rest = path[prefix.Length..];
+        if (rest.StartsWith(WorktreesSegment[1..], StringComparison.Ordinal)) {
+            var afterWorktree = rest.IndexOf('/', WorktreesSegment.Length - 1);
+            if (afterWorktree >= 0) rest = rest[(afterWorktree + 1)..];
+        }
+        return rest.Length == 0 ? path : rest;
     }
 
     static string FirstLine(string text) {

--- a/src/Capacitor.App/ViewModels/ToolDetail.cs
+++ b/src/Capacitor.App/ViewModels/ToolDetail.cs
@@ -29,6 +29,9 @@ public static class ToolDetail {
         var line = text.Trim();
         var newline = line.IndexOfAny(['\r', '\n']);
         if (newline >= 0) line = line[..newline].TrimEnd();
-        return line.Length <= MaxLength ? line : string.Concat(line.AsSpan(0, MaxLength - 1), "…");
+        if (line.Length <= MaxLength) return line;
+        var cut = MaxLength - 1;
+        if (char.IsHighSurrogate(line[cut - 1])) cut--;
+        return string.Concat(line.AsSpan(0, cut), "…");
     }
 }

--- a/src/Capacitor.App/ViewModels/TrayModels.cs
+++ b/src/Capacitor.App/ViewModels/TrayModels.cs
@@ -13,7 +13,9 @@ public static class RepoLabel {
         if (repoPath is null) return "—";
 
         var segments = repoPath.Replace('\\', '/').TrimEnd('/').Split('/');
-        if (segments.Length >= 4 && segments[^3] == ".claude" && segments[^2] == "worktrees" && segments[^4].Length > 0)
+        // A worktree an agent runs in — Claude's own or the daemon's — sits two levels under its
+        // repository, which is the name worth showing.
+        if (segments.Length >= 4 && segments[^3] is ".claude" or ".capacitor" && segments[^2] == "worktrees" && segments[^4].Length > 0)
             return segments[^4];
 
         return PlatformPaths.Leaf(repoPath);

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -3,11 +3,14 @@ using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using Capacitor.App.Services;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
 using ReactiveUI;
 
 namespace Capacitor.App.ViewModels;
+
+public enum WorkspaceTab { Chat, Terminal }
 
 /// The session workspace: header (title/repo/vendor chip) + one Terminal tab, for a single agent
 /// id. Constructed once per workspace, like TerminalTabViewModel/HomeViewModel -- ctor-scoped, not
@@ -62,6 +65,29 @@ public sealed class WorkspaceViewModel : ReactiveObject {
 
     public TerminalTabViewModel Terminal { get; }
 
+    ChatTabViewModel? _chat;
+    /// Built once, on the first dto that passes the PTY gate -- the projection is chosen by the
+    /// dto's vendor. Null for a non-PTY session.
+    public ChatTabViewModel? Chat {
+        get => _chat;
+        private set => this.RaiseAndSetIfChanged(ref _chat, value);
+    }
+
+    WorkspaceTab _activeTab = WorkspaceTab.Chat;
+    public WorkspaceTab ActiveTab {
+        get => _activeTab;
+        private set {
+            this.RaiseAndSetIfChanged(ref _activeTab, value);
+            this.RaisePropertyChanged(nameof(IsChatActive));
+            this.RaisePropertyChanged(nameof(IsTerminalActive));
+        }
+    }
+    public bool IsChatActive => ActiveTab == WorkspaceTab.Chat;
+    public bool IsTerminalActive => ActiveTab == WorkspaceTab.Terminal;
+
+    public ReactiveCommand<Unit, Unit> ShowChatCommand { get; }
+    public ReactiveCommand<Unit, Unit> ShowTerminalCommand { get; }
+
     public ReactiveCommand<Unit, Unit> OpenInWebCommand { get; }
     public ReactiveCommand<Unit, Unit> StopCommand { get; }
 
@@ -74,7 +100,8 @@ public sealed class WorkspaceViewModel : ReactiveObject {
 
     public WorkspaceViewModel(
             string agentId, IDaemonClientService daemon, AgentActionService actions,
-            TerminalAttachClientFactory factory, Func<ITerminalSurface> surfaceFactory, TimeProvider time) {
+            TerminalAttachClientFactory factory, Func<ITerminalSurface> surfaceFactory, TimeProvider time,
+            IUrlOpener opener) {
         AgentId = agentId;
         Terminal = new TerminalTabViewModel(agentId, daemon, factory, surfaceFactory, time);
 
@@ -112,6 +139,18 @@ public sealed class WorkspaceViewModel : ReactiveObject {
             .ToProperty(this, x => x.SessionEnded, initialValue: false)
             .DisposeWith(_disposables);
 
+        presence
+            .Where(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
+            .Take(1)
+            .Subscribe(p => Chat = new ChatTabViewModel(
+                agentId, daemon, Terminal, TranscriptProjection.For(p.Dto!.Vendor), opener, time))
+            .DisposeWith(_disposables);
+
+        ShowChatCommand = ReactiveCommand.Create(() => { ActiveTab = WorkspaceTab.Chat; });
+        ShowTerminalCommand = ReactiveCommand.Create(() => { ActiveTab = WorkspaceTab.Terminal; });
+        _disposables.Add(ShowChatCommand);
+        _disposables.Add(ShowTerminalCommand);
+
         OpenInWebCommand = ReactiveCommand.Create(() => actions.OpenInWeb(agentId));
         _disposables.Add(OpenInWebCommand);
 
@@ -145,10 +184,11 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         return dto.Model is null ? dto.Vendor : $"{dto.Vendor} ({dto.Model})";
     }
 
-    /// Disposes this workspace's own daemon-cache projections, then delegates to
-    /// Terminal.TeardownAsync() -- Task 13's tracker calls this once, when the tab closes.
-    public Task TeardownAsync() {
+    /// Disposes this workspace's own daemon-cache projections, then tears down Chat (if built)
+    /// before Terminal -- the caller that closes a workspace tab calls this once.
+    public async Task TeardownAsync() {
         _disposables.Dispose();
-        return Terminal.TeardownAsync();
+        if (Chat is { } chat) await chat.TeardownAsync();
+        await Terminal.TeardownAsync();
     }
 }

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -12,7 +12,7 @@ namespace Capacitor.App.ViewModels;
 
 public enum WorkspaceTab { Chat, Terminal }
 
-/// The session workspace: header (title/repo/vendor chip) + one Terminal tab, for a single agent
+/// The session workspace: header (title/repo/vendor chip) + Chat and Terminal tabs, for one agent
 /// id. Constructed once per workspace, like TerminalTabViewModel/HomeViewModel -- ctor-scoped, not
 /// WhenActivated -- since the header projections and the Terminal tab must be live from
 /// construction, not deferred to a window's activation.

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -177,7 +177,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         return new AgentPresence(dto, ended);
     }
 
-    static string TitleFor(AgentStatusDto? dto) => $"{RepoLabel.Leaf(dto?.RepoPath)} · {dto?.Vendor ?? "—"}";
+    static string TitleFor(AgentStatusDto? dto) => dto?.Title ?? $"{RepoLabel.Leaf(dto?.RepoPath)} · {dto?.Vendor ?? "—"}";
 
     static string VendorChipFor(AgentStatusDto? dto) {
         if (dto is null) return "—";

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -1,0 +1,78 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Capacitor.App.ViewModels"
+             xmlns:views="clr-namespace:Capacitor.App.Views"
+             x:Class="Capacitor.App.Views.ChatTabView"
+             x:DataType="vm:ChatTabViewModel">
+    <Grid RowDefinitions="*,Auto">
+        <!-- The template owns the ScrollViewer: that is the shape Avalonia virtualizes. An
+             ItemsControl inside an external ScrollViewer is measured at infinite height. -->
+        <ItemsControl x:Name="ChatItems" Grid.Row="0" ItemsSource="{Binding Items}">
+            <ItemsControl.Template>
+                <ControlTemplate>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <!-- ItemsPanel does not reach the presenter on its own: without this
+                             template binding it falls back to its own default StackPanel and
+                             every row is realized. -->
+                        <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" Margin="22,26,22,8" />
+                    </ScrollViewer>
+                </ControlTemplate>
+            </ItemsControl.Template>
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.DataTemplates>
+                <DataTemplate x:DataType="vm:UserTurnItem">
+                    <Border HorizontalAlignment="Right" MaxWidth="520" Margin="0,0,0,20" Padding="14,11" CornerRadius="10"
+                            Background="{StaticResource KcapSurfaceRaisedBrush}">
+                        <SelectableTextBlock Text="{Binding Text}" TextWrapping="Wrap" FontSize="13.5" LineHeight="20"
+                                             Foreground="{StaticResource KcapTextBrush}" />
+                    </Border>
+                </DataTemplate>
+                <DataTemplate x:DataType="vm:AssistantTextItem">
+                    <views:MarkdownView Text="{Binding Text}" MaxWidth="660" HorizontalAlignment="Left" Margin="0,0,0,20"
+                                        OpenLink="{Binding $parent[ItemsControl].((vm:ChatTabViewModel)DataContext).OpenLinkCommand}" />
+                </DataTemplate>
+                <DataTemplate x:DataType="vm:ToolCallItem">
+                    <StackPanel Orientation="Horizontal" Spacing="9" Margin="0,0,0,20">
+                        <TextBlock Text="›" FontSize="13" Foreground="{StaticResource KcapFaintBrush}" VerticalAlignment="Center" />
+                        <TextBlock Text="{Binding Name}" FontSize="11.5" Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
+                        <TextBlock Text="{Binding Detail}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
+                                   TextTrimming="CharacterEllipsis" MaxWidth="480" VerticalAlignment="Center" />
+                        <TextBlock Text="{Binding OutcomeGlyph}" FontSize="11" VerticalAlignment="Center"
+                                   Foreground="{Binding IsError, Converter={x:Static views:ToolOutcomeBrushConverter.Instance}}" />
+                    </StackPanel>
+                </DataTemplate>
+            </ItemsControl.DataTemplates>
+        </ItemsControl>
+
+        <TextBlock x:Name="ChatPhaseNote" Grid.Row="0" Text="{Binding PhaseNote}"
+                   IsVisible="{Binding PhaseNote, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                   Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5"
+                   HorizontalAlignment="Center" VerticalAlignment="Center" />
+
+        <Border Grid.Row="1" Margin="22,8,22,18" MaxWidth="660" HorizontalAlignment="Left"
+                Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                BorderThickness="1" CornerRadius="10" Padding="13,12">
+            <StackPanel Spacing="6">
+                <TextBox x:Name="ComposerInput" Text="{Binding ComposerText}" AcceptsReturn="True" TextWrapping="Wrap"
+                         MinHeight="38" MaxHeight="160" Background="Transparent" BorderThickness="0"
+                         PlaceholderText="Write a message" KeyDown="OnComposerKeyDown" />
+                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto">
+                    <TextBlock Text="{Binding ComposerHint}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
+                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                    <TextBlock Grid.Column="1" Text="{Binding ModelLabel}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
+                               VerticalAlignment="Center" Margin="12,0,0,0" />
+                    <Ellipse Grid.Column="2" Width="7" Height="7" Fill="{Binding StatusDot}" VerticalAlignment="Center" Margin="12,0,6,0" />
+                    <TextBlock Grid.Column="3" Text="{Binding StatusText}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
+                               VerticalAlignment="Center" />
+                    <Button x:Name="SendButton" Grid.Column="4" Content="Send" Command="{Binding SendCommand}" Margin="12,0,0,0"
+                            Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
+                            Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" />
+                </Grid>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -4,6 +4,18 @@
              xmlns:views="clr-namespace:Capacitor.App.Views"
              x:Class="Capacitor.App.Views.ChatTabView"
              x:DataType="vm:ChatTabViewModel">
+    <UserControl.Styles>
+        <!-- The card is the composer's boundary: the theme's focused ring and fill inside it would
+             read as a second box. -->
+        <Style Selector="TextBox#ComposerInput:focus /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+        </Style>
+        <Style Selector="TextBox#ComposerInput:pointerover /template/ Border#PART_BorderElement">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+        </Style>
+    </UserControl.Styles>
     <Grid RowDefinitions="*,Auto">
         <!-- The template owns the ScrollViewer: that is the shape Avalonia virtualizes. An
              ItemsControl inside an external ScrollViewer is measured at infinite height. -->
@@ -53,7 +65,7 @@
                    Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5"
                    HorizontalAlignment="Center" VerticalAlignment="Center" />
 
-        <Border Grid.Row="1" Margin="22,8,22,18" MaxWidth="660" HorizontalAlignment="Left"
+        <Border Grid.Row="1" Margin="22,8,22,18"
                 Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
                 BorderThickness="1" CornerRadius="10" Padding="13,12">
             <StackPanel Spacing="6">

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -4,18 +4,6 @@
              xmlns:views="clr-namespace:Capacitor.App.Views"
              x:Class="Capacitor.App.Views.ChatTabView"
              x:DataType="vm:ChatTabViewModel">
-    <UserControl.Styles>
-        <!-- The card is the composer's boundary: the theme's focused ring and fill inside it would
-             read as a second box. -->
-        <Style Selector="TextBox#ComposerInput:focus /template/ Border#PART_BorderElement">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-        </Style>
-        <Style Selector="TextBox#ComposerInput:pointerover /template/ Border#PART_BorderElement">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-        </Style>
-    </UserControl.Styles>
     <Grid RowDefinitions="*,Auto">
         <!-- The template owns the ScrollViewer: that is the shape Avalonia virtualizes. An
              ItemsControl inside an external ScrollViewer is measured at infinite height. -->
@@ -69,7 +57,7 @@
                 Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
                 BorderThickness="1" CornerRadius="10" Padding="13,12">
             <StackPanel Spacing="6">
-                <TextBox x:Name="ComposerInput" Text="{Binding ComposerText}" AcceptsReturn="True" TextWrapping="Wrap"
+                <TextBox x:Name="ComposerInput" Classes="kcapEmbedded" Text="{Binding ComposerText}" AcceptsReturn="True" TextWrapping="Wrap"
                          MinHeight="38" MaxHeight="160" Background="Transparent" BorderThickness="0"
                          PlaceholderText="Write a message" />
                 <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto">

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -26,7 +26,7 @@
                         <!-- ItemsPanel does not reach the presenter on its own: without this
                              template binding it falls back to its own default StackPanel and
                              every row is realized. -->
-                        <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" Margin="22,26,22,8" />
+                        <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" Margin="22,18,22,8" />
                     </ScrollViewer>
                 </ControlTemplate>
             </ItemsControl.Template>
@@ -37,18 +37,18 @@
             </ItemsControl.ItemsPanel>
             <ItemsControl.DataTemplates>
                 <DataTemplate x:DataType="vm:UserTurnItem">
-                    <Border HorizontalAlignment="Right" MaxWidth="520" Margin="0,0,0,20" Padding="14,11" CornerRadius="10"
+                    <Border HorizontalAlignment="Right" MaxWidth="520" Margin="0,8,0,12" Padding="14,11" CornerRadius="10"
                             Background="{StaticResource KcapSurfaceRaisedBrush}">
                         <SelectableTextBlock Text="{Binding Text}" TextWrapping="Wrap" FontSize="13.5" LineHeight="20"
                                              Foreground="{StaticResource KcapTextBrush}" />
                     </Border>
                 </DataTemplate>
                 <DataTemplate x:DataType="vm:AssistantTextItem">
-                    <views:MarkdownView Text="{Binding Text}" MaxWidth="660" HorizontalAlignment="Left" Margin="0,0,0,20"
+                    <views:MarkdownView Text="{Binding Text}" MaxWidth="660" HorizontalAlignment="Left" Margin="0,8,0,12"
                                         OpenLink="{Binding $parent[ItemsControl].((vm:ChatTabViewModel)DataContext).OpenLinkCommand}" />
                 </DataTemplate>
                 <DataTemplate x:DataType="vm:ToolCallItem">
-                    <StackPanel Orientation="Horizontal" Spacing="9" Margin="0,0,0,20">
+                    <StackPanel Orientation="Horizontal" Spacing="9" Margin="0,0,0,6">
                         <TextBlock Text="›" FontSize="13" Foreground="{StaticResource KcapFaintBrush}" VerticalAlignment="Center" />
                         <TextBlock Text="{Binding Name}" FontSize="11.5" Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
                         <TextBlock Text="{Binding Detail}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -59,7 +59,7 @@
             <StackPanel Spacing="6">
                 <TextBox x:Name="ComposerInput" Text="{Binding ComposerText}" AcceptsReturn="True" TextWrapping="Wrap"
                          MinHeight="38" MaxHeight="160" Background="Transparent" BorderThickness="0"
-                         PlaceholderText="Write a message" KeyDown="OnComposerKeyDown" />
+                         PlaceholderText="Write a message" />
                 <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto">
                     <TextBlock Text="{Binding ComposerHint}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
                                VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -35,6 +35,13 @@
                     <views:MarkdownView Text="{Binding Text}" MaxWidth="660" HorizontalAlignment="Left" Margin="0,8,0,12"
                                         OpenLink="{Binding $parent[ItemsControl].((vm:ChatTabViewModel)DataContext).OpenLinkCommand}" />
                 </DataTemplate>
+                <DataTemplate x:DataType="vm:SystemNoteItem">
+                    <Border Classes="systemNote" MaxWidth="660" HorizontalAlignment="Left" Margin="0,8,0,12" Padding="14,10" CornerRadius="10"
+                            Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1">
+                        <views:MarkdownView Text="{Binding Text}"
+                                            OpenLink="{Binding $parent[ItemsControl].((vm:ChatTabViewModel)DataContext).OpenLinkCommand}" />
+                    </Border>
+                </DataTemplate>
                 <DataTemplate x:DataType="vm:ToolCallItem">
                     <StackPanel Orientation="Horizontal" Spacing="9" Margin="0,0,0,6">
                         <TextBlock Text="›" FontSize="13" Foreground="{StaticResource KcapFaintBrush}" VerticalAlignment="Center" />

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -1,0 +1,51 @@
+using System.Collections.Specialized;
+using System.Windows.Input;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using Capacitor.App.ViewModels;
+
+namespace Capacitor.App.Views;
+
+/// Follow-tail lives here, stateless across events: "was at end" is decided at the collection
+/// change from the OLD extent (the new rows are not measured yet), and the scroll is applied
+/// after the layout pass that establishes the new extent — only if the reader has not moved.
+public partial class ChatTabView : UserControl {
+    INotifyCollectionChanged? _observed;
+
+    public ChatTabView() {
+        InitializeComponent();
+        DataContextChanged += (_, _) => Observe((DataContext as ChatTabViewModel)?.Items as INotifyCollectionChanged);
+    }
+
+    void Observe(INotifyCollectionChanged? items) {
+        if (_observed is not null) _observed.CollectionChanged -= OnItemsChanged;
+        _observed = items;
+        if (_observed is not null) _observed.CollectionChanged += OnItemsChanged;
+    }
+
+    ScrollViewer? Scroll => ChatItems.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+
+    void OnItemsChanged(object? sender, NotifyCollectionChangedEventArgs e) {
+        if (e.Action != NotifyCollectionChangedAction.Add || Scroll is not { } scroll) return;
+        var wasAtEnd = scroll.Offset.Y + scroll.Viewport.Height >= scroll.Extent.Height - 1;
+        if (!wasAtEnd) return;
+
+        var captured = scroll.Offset;
+        void OnLayoutUpdated(object? _, EventArgs __) {
+            scroll.LayoutUpdated -= OnLayoutUpdated;
+            if (scroll.Offset == captured) scroll.ScrollToEnd();
+        }
+        scroll.LayoutUpdated += OnLayoutUpdated;
+    }
+
+    // Enter sends, Shift+Enter is the TextBox's own newline.
+    void OnComposerKeyDown(object? sender, KeyEventArgs e) {
+        if (e.Key != Key.Enter || e.KeyModifiers.HasFlag(KeyModifiers.Shift)) return;
+        e.Handled = true;
+        if (DataContext is ChatTabViewModel vm && ((ICommand)vm.SendCommand).CanExecute(null))
+            vm.SendCommand.Execute().Subscribe();
+    }
+
+    public void FocusComposer() => ComposerInput.Focus();
+}

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -1,4 +1,3 @@
-using System.Collections.Specialized;
 using System.Windows.Input;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -8,64 +7,40 @@ using Capacitor.App.ViewModels;
 
 namespace Capacitor.App.Views;
 
-/// Follow-tail lives here: "was at end" is decided at the collection change from the OLD extent
-/// (the new rows are not measured yet), and the scroll is applied after the layout pass that
-/// establishes the new extent — only if the reader has not moved. One one-shot at a time: a
-/// layout pass that resolves the ScrollViewer retires it, so a stretch without one — the surface
-/// collapsed behind the other tab — would otherwise accumulate a handler per append, at the
-/// transcript's poll rate.
+/// Follow-tail sticks to the bottom: on every extent or viewport change, a reader who was at the
+/// bottom before the change lands at the new bottom. The virtualizing panel reports the extent
+/// as an estimate that a tall row corrects only once it is realized, so following re-evaluates
+/// on each change rather than scrolling once per append. A reader scrolling up moves the offset
+/// down in the same change or an earlier one — either way the change is not followed, and only
+/// the panel's own adjustments move the offset up while growing the extent.
 public partial class ChatTabView : UserControl {
-    INotifyCollectionChanged? _observed;
-    bool _followPending;
+    const double BottomTolerance = 2;
+
+    ScrollViewer? _scroll;
 
     public ChatTabView() {
         InitializeComponent();
         // Tunnel, not bubble: TextBox's own class handler runs first on the bubbling route, where
         // it inserts the newline and marks Enter handled before any instance handler sees it.
         ComposerInput.AddHandler(KeyDownEvent, OnComposerKeyDown, RoutingStrategies.Tunnel);
-        DataContextChanged += (_, _) => Observe((DataContext as ChatTabViewModel)?.Items as INotifyCollectionChanged);
+        // The ScrollViewer is the list template's; it exists only once the list is first measured,
+        // which for a surface built before its first layout is later than the first rows.
+        ChatItems.TemplateApplied += (_, _) => Follow(ChatItems.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault());
     }
 
-    void Observe(INotifyCollectionChanged? items) {
-        if (_observed is not null) _observed.CollectionChanged -= OnItemsChanged;
-        _observed = items;
-        if (_observed is not null) _observed.CollectionChanged += OnItemsChanged;
+    void Follow(ScrollViewer? scroll) {
+        if (_scroll is not null) _scroll.ScrollChanged -= OnScrollChanged;
+        _scroll = scroll;
+        if (_scroll is not null) _scroll.ScrollChanged += OnScrollChanged;
     }
 
-    ScrollViewer? Scroll => ChatItems.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
-
-    void OnItemsChanged(object? sender, NotifyCollectionChangedEventArgs e) {
-        if (e.Action != NotifyCollectionChangedAction.Add || _followPending) return;
-        if (Scroll is not { } scroll) {
-            FollowOnFirstLayout();
-            return;
-        }
-        var wasAtEnd = scroll.Offset.Y + scroll.Viewport.Height >= scroll.Extent.Height - 1;
-        if (!wasAtEnd) return;
-
-        _followPending = true;
-        var captured = scroll.Offset;
-        void OnLayoutUpdated(object? _, EventArgs __) {
-            scroll.LayoutUpdated -= OnLayoutUpdated;
-            _followPending = false;
-            if (scroll.Offset == captured) scroll.ScrollToEnd();
-        }
-        scroll.LayoutUpdated += OnLayoutUpdated;
-    }
-
-    /// Rows can land before the view has ever been laid out — the tab is built and its first read
-    /// started before the workspace view exists — leaving no extent to decide "was at end" from.
-    /// This one-shot waits on the view's own layout and retires only once a ScrollViewer exists,
-    /// so a pass that builds none (the surface still collapsed) leaves it armed.
-    void FollowOnFirstLayout() {
-        _followPending = true;
-        void OnLayoutUpdated(object? _, EventArgs __) {
-            if (Scroll is not { } scroll) return;
-            LayoutUpdated -= OnLayoutUpdated;
-            _followPending = false;
-            if (scroll.Offset.Y == 0) scroll.ScrollToEnd();
-        }
-        LayoutUpdated += OnLayoutUpdated;
+    static void OnScrollChanged(object? sender, ScrollChangedEventArgs e) {
+        if (sender is not ScrollViewer scroll || (e.ExtentDelta.Y == 0 && e.ViewportDelta.Y == 0)) return;
+        var offsetBefore   = scroll.Offset.Y - e.OffsetDelta.Y;
+        var viewportBefore = scroll.Viewport.Height - e.ViewportDelta.Y;
+        var extentBefore   = scroll.Extent.Height - e.ExtentDelta.Y;
+        var stayed = e.OffsetDelta.Y >= 0;
+        if (stayed && offsetBefore + viewportBefore >= extentBefore - BottomTolerance) scroll.ScrollToEnd();
     }
 
     /// A bare Enter is always consumed — it sends when the composer can send, and otherwise does

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -2,19 +2,26 @@ using System.Collections.Specialized;
 using System.Windows.Input;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using Capacitor.App.ViewModels;
 
 namespace Capacitor.App.Views;
 
-/// Follow-tail lives here, stateless across events: "was at end" is decided at the collection
-/// change from the OLD extent (the new rows are not measured yet), and the scroll is applied
-/// after the layout pass that establishes the new extent — only if the reader has not moved.
+/// Follow-tail lives here: "was at end" is decided at the collection change from the OLD extent
+/// (the new rows are not measured yet), and the scroll is applied after the layout pass that
+/// establishes the new extent — only if the reader has not moved. One one-shot at a time: only a
+/// layout pass retires one, so a stretch without one — the surface collapsed behind the other
+/// tab — would otherwise accumulate a handler per append, at the transcript's poll rate.
 public partial class ChatTabView : UserControl {
     INotifyCollectionChanged? _observed;
+    bool _followPending;
 
     public ChatTabView() {
         InitializeComponent();
+        // Tunnel, not bubble: TextBox's own class handler runs first on the bubbling route, where
+        // it inserts the newline and marks Enter handled before any instance handler sees it.
+        ComposerInput.AddHandler(KeyDownEvent, OnComposerKeyDown, RoutingStrategies.Tunnel);
         DataContextChanged += (_, _) => Observe((DataContext as ChatTabViewModel)?.Items as INotifyCollectionChanged);
     }
 
@@ -27,19 +34,23 @@ public partial class ChatTabView : UserControl {
     ScrollViewer? Scroll => ChatItems.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
 
     void OnItemsChanged(object? sender, NotifyCollectionChangedEventArgs e) {
-        if (e.Action != NotifyCollectionChangedAction.Add || Scroll is not { } scroll) return;
+        if (e.Action != NotifyCollectionChangedAction.Add || _followPending || Scroll is not { } scroll) return;
         var wasAtEnd = scroll.Offset.Y + scroll.Viewport.Height >= scroll.Extent.Height - 1;
         if (!wasAtEnd) return;
 
+        _followPending = true;
         var captured = scroll.Offset;
         void OnLayoutUpdated(object? _, EventArgs __) {
             scroll.LayoutUpdated -= OnLayoutUpdated;
+            _followPending = false;
             if (scroll.Offset == captured) scroll.ScrollToEnd();
         }
         scroll.LayoutUpdated += OnLayoutUpdated;
     }
 
-    // Enter sends, Shift+Enter is the TextBox's own newline.
+    /// A bare Enter is always consumed — it sends when the composer can send, and otherwise does
+    /// nothing, leaving the text and the hint that says why. Shift+Enter falls through to the
+    /// TextBox's own newline.
     void OnComposerKeyDown(object? sender, KeyEventArgs e) {
         if (e.Key != Key.Enter || e.KeyModifiers.HasFlag(KeyModifiers.Shift)) return;
         e.Handled = true;

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -25,13 +25,11 @@ public partial class ChatTabView : UserControl {
         ComposerInput.AddHandler(KeyDownEvent, OnComposerKeyDown, RoutingStrategies.Tunnel);
         // The ScrollViewer is the list template's; it exists only once the list is first measured,
         // which for a surface built before its first layout is later than the first rows.
-        ChatItems.TemplateApplied += (_, _) => Follow(ChatItems.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault());
-    }
-
-    void Follow(ScrollViewer? scroll) {
-        if (_scroll is not null) _scroll.ScrollChanged -= OnScrollChanged;
-        _scroll = scroll;
-        if (_scroll is not null) _scroll.ScrollChanged += OnScrollChanged;
+        ChatItems.TemplateApplied += (_, _) => {
+            if (_scroll is not null) _scroll.ScrollChanged -= OnScrollChanged;
+            _scroll = ChatItems.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+            if (_scroll is not null) _scroll.ScrollChanged += OnScrollChanged;
+        };
     }
 
     static void OnScrollChanged(object? sender, ScrollChangedEventArgs e) {

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -10,9 +10,10 @@ namespace Capacitor.App.Views;
 
 /// Follow-tail lives here: "was at end" is decided at the collection change from the OLD extent
 /// (the new rows are not measured yet), and the scroll is applied after the layout pass that
-/// establishes the new extent — only if the reader has not moved. One one-shot at a time: only a
-/// layout pass retires one, so a stretch without one — the surface collapsed behind the other
-/// tab — would otherwise accumulate a handler per append, at the transcript's poll rate.
+/// establishes the new extent — only if the reader has not moved. One one-shot at a time: a
+/// layout pass that resolves the ScrollViewer retires it, so a stretch without one — the surface
+/// collapsed behind the other tab — would otherwise accumulate a handler per append, at the
+/// transcript's poll rate.
 public partial class ChatTabView : UserControl {
     INotifyCollectionChanged? _observed;
     bool _followPending;
@@ -34,7 +35,11 @@ public partial class ChatTabView : UserControl {
     ScrollViewer? Scroll => ChatItems.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
 
     void OnItemsChanged(object? sender, NotifyCollectionChangedEventArgs e) {
-        if (e.Action != NotifyCollectionChangedAction.Add || _followPending || Scroll is not { } scroll) return;
+        if (e.Action != NotifyCollectionChangedAction.Add || _followPending) return;
+        if (Scroll is not { } scroll) {
+            FollowOnFirstLayout();
+            return;
+        }
         var wasAtEnd = scroll.Offset.Y + scroll.Viewport.Height >= scroll.Extent.Height - 1;
         if (!wasAtEnd) return;
 
@@ -46,6 +51,21 @@ public partial class ChatTabView : UserControl {
             if (scroll.Offset == captured) scroll.ScrollToEnd();
         }
         scroll.LayoutUpdated += OnLayoutUpdated;
+    }
+
+    /// Rows can land before the view has ever been laid out — the tab is built and its first read
+    /// started before the workspace view exists — leaving no extent to decide "was at end" from.
+    /// This one-shot waits on the view's own layout and retires only once a ScrollViewer exists,
+    /// so a pass that builds none (the surface still collapsed) leaves it armed.
+    void FollowOnFirstLayout() {
+        _followPending = true;
+        void OnLayoutUpdated(object? _, EventArgs __) {
+            if (Scroll is not { } scroll) return;
+            LayoutUpdated -= OnLayoutUpdated;
+            _followPending = false;
+            if (scroll.Offset.Y == 0) scroll.ScrollToEnd();
+        }
+        LayoutUpdated += OnLayoutUpdated;
     }
 
     /// A bare Enter is always consumed — it sends when the composer can send, and otherwise does

--- a/src/Capacitor.App/Views/Converters.cs
+++ b/src/Capacitor.App/Views/Converters.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Avalonia.Controls;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
 
@@ -25,6 +26,42 @@ public sealed class OutcomeBrushConverter : IValueConverter {
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         new SolidColorBrush(Color.Parse(value is true ? "#2E7D32" : "#D32F2F"));
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// Opacity for the off-tab terminal: it must stay measured (so the PTY gets the real pane size),
+/// so it is faded rather than collapsed.
+public sealed class BoolToOpacityConverter : IValueConverter {
+    public static readonly BoolToOpacityConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is true ? 1.0 : 0.0;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// A visible-but-faded control is still announced as onscreen by default; the inactive terminal
+/// must be reported offscreen instead.
+public sealed class OffscreenWhenInactiveConverter : IValueConverter {
+    public static readonly OffscreenWhenInactiveConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is true ? Avalonia.Automation.IsOffscreenBehavior.Default : Avalonia.Automation.IsOffscreenBehavior.Offscreen;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// The tool-call outcome glyph's colour, resolved off the app palette at bind time for the same
+/// UI-thread-affinity reason OutcomeBrushConverter documents.
+public sealed class ToolOutcomeBrushConverter : IValueConverter {
+    public static readonly ToolOutcomeBrushConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        Avalonia.Application.Current?.FindResource(value is true ? "KcapDangerBrush" : "KcapAccentBrush");
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml
@@ -16,7 +16,7 @@
         <Border Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
                 BorderThickness="1" CornerRadius="12" Padding="14">
             <StackPanel Spacing="12">
-                <TextBox x:Name="GoalInput" Text="{Binding Goal}"
+                <TextBox x:Name="GoalInput" Classes="kcapEmbedded" Text="{Binding Goal}"
                          PlaceholderText="What should we build? Type a goal or paste an issue, PR, or work-item URL…"
                          Background="Transparent" Foreground="{StaticResource KcapTextBrush}"
                          BorderThickness="0" MinHeight="72" TextWrapping="Wrap" FontSize="14"

--- a/src/Capacitor.App/Views/MarkdownBlocks.cs
+++ b/src/Capacitor.App/Views/MarkdownBlocks.cs
@@ -2,7 +2,6 @@ using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
-using Avalonia.Controls.Presenters;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -33,6 +32,11 @@ public static class MarkdownBlocks {
     public static Control Build(string markdown, ICommand? openLink) {
         var document = Markdown.Parse(markdown, Pipeline);
         var panel = new StackPanel { Spacing = 8 };
+        // A link's glyph descenders hang below its button, so the text part inside a link must not
+        // clip; the part is created after the button's template, so only a style reaches it.
+        panel.Styles.Add(new Style(x => x.OfType<HyperlinkButton>().Descendant().Is<TextBlock>()) {
+            Setters = { new Setter(Visual.ClipToBoundsProperty, false) },
+        });
         foreach (var block in document) panel.Children.Add(BuildBlock(markdown, block, openLink));
         return panel;
     }
@@ -73,7 +77,7 @@ public static class MarkdownBlocks {
             LineHeight = fontSize * LineSpacing,
             Foreground = Brush("KcapTextBrush"),
         };
-        foreach (var inline in inlines) AddInline(source, text.Inlines!, inline, openLink, (fontSize, text.FontWeight));
+        foreach (var inline in inlines) AddInline(source, text.Inlines!, inline, openLink, fontSize, text.FontWeight);
         return text;
     }
 
@@ -88,19 +92,19 @@ public static class MarkdownBlocks {
             ? source.Substring(span.Start, span.Length)
             : "";
 
-    static void AddInlines(string source, InlineCollection target, ContainerInline? container, ICommand? openLink, (double Size, FontWeight Weight) font) {
+    static void AddInlines(string source, InlineCollection target, ContainerInline? container, ICommand? openLink, double fontSize, FontWeight weight) {
         if (container is null) return;
-        foreach (var inline in container) AddInline(source, target, inline, openLink, font);
+        foreach (var inline in container) AddInline(source, target, inline, openLink, fontSize, weight);
     }
 
-    static void AddInline(string source, InlineCollection target, MdInline inline, ICommand? openLink, (double Size, FontWeight Weight) font) {
+    static void AddInline(string source, InlineCollection target, MdInline inline, ICommand? openLink, double fontSize, FontWeight weight) {
         switch (inline) {
             case LiteralInline literal:
                 target.Add(new Run(Flat(literal.Content.ToString())));
                 break;
             case EmphasisInline emphasis: {
                 Span span = emphasis.DelimiterCount >= 2 ? new Bold() : new Italic();
-                AddInlines(source, span.Inlines, emphasis, openLink, font);
+                AddInlines(source, span.Inlines, emphasis, openLink, fontSize, weight);
                 target.Add(span);
                 break;
             }
@@ -117,13 +121,13 @@ public static class MarkdownBlocks {
                 target.Add(new Run(Flat(SpanText(source, image.Span))));
                 break;
             case LinkInline link when LinkPolicy.IsOpenable(link.Url):
-                target.Add(Link(LinkButton(Flat(PlainText(source, link)), link.Url!, openLink, font)));
+                target.Add(Link(LinkButton(Flat(PlainText(source, link)), link.Url!, openLink, fontSize, weight)));
                 break;
             case LinkInline link:
-                AddInlines(source, target, link, openLink, font);
+                AddInlines(source, target, link, openLink, fontSize, weight);
                 break;
             case AutolinkInline auto when LinkPolicy.IsOpenable(auto.Url):
-                target.Add(Link(LinkButton(auto.Url, auto.Url, openLink, font)));
+                target.Add(Link(LinkButton(auto.Url, auto.Url, openLink, fontSize, weight)));
                 break;
             case AutolinkInline auto:
                 target.Add(new Run(Flat(auto.Url)));
@@ -132,7 +136,7 @@ public static class MarkdownBlocks {
                 target.Add(new Run(Flat(html.Tag)));
                 break;
             case ContainerInline nested:
-                AddInlines(source, target, nested, openLink, font);
+                AddInlines(source, target, nested, openLink, fontSize, weight);
                 break;
             default:
                 target.Add(new Run(Flat(SpanText(source, inline.Span))));
@@ -142,7 +146,7 @@ public static class MarkdownBlocks {
 
     // NavigateUri stays unset on purpose: set, the control opens the URI itself and the policy
     // in the command would never run.
-    static HyperlinkButton LinkButton(string label, string url, ICommand? openLink, (double Size, FontWeight Weight) font) => new() {
+    static HyperlinkButton LinkButton(string label, string url, ICommand? openLink, double fontSize, FontWeight weight) => new() {
         Content = label,
         Command = openLink,
         CommandParameter = url,
@@ -150,8 +154,8 @@ public static class MarkdownBlocks {
         BorderThickness = new Thickness(0),
         MinHeight = 0,
         MinWidth = 0,
-        FontSize = font.Size,
-        FontWeight = font.Weight,
+        FontSize = fontSize,
+        FontWeight = weight,
         Cursor = new Cursor(StandardCursorType.Hand),
         Foreground = Brush("KcapAccentBrush"),
         VerticalAlignment = VerticalAlignment.Center,
@@ -161,22 +165,29 @@ public static class MarkdownBlocks {
     // baseline: a button as tall as the line drags the whole line's text down to its bottom. The
     // button is therefore laid out at the font's natural line height and sized to its ascent,
     // so its bottom is a baseline no taller than the text's own, its glyphs sit on that line, and
-    // their descenders overflow it — which every template part must be allowed to draw.
+    // their descenders overflow it, which the block's style lets every part draw.
     static InlineUIContainer Link(HyperlinkButton button) {
         button.VerticalContentAlignment = VerticalAlignment.Top;
         button.ClipToBounds = false;
         button.UseLayoutRounding = false;
         button.SetValue(TextBlock.LineHeightProperty, double.NaN);
-        // The presenter creates its text part after TemplateApplied, so a one-off pass would miss
-        // it; a style reaches every part whenever it appears.
-        button.Styles.Add(new Style(x => x.Is<TextBlock>()) { Setters = { new Setter(Visual.ClipToBoundsProperty, false) } });
-        button.Styles.Add(new Style(x => x.Is<ContentPresenter>()) { Setters = { new Setter(Visual.ClipToBoundsProperty, false) } });
-        button.AttachedToVisualTree += (_, _) => button.Height = AscentOf(button.FontFamily, button.FontWeight, button.FontSize);
+        button.AttachedToVisualTree += OnLinkAttached;
         return new() { Child = button };
     }
 
-    static double AscentOf(FontFamily family, FontWeight weight, double fontSize) =>
-        new TextLayout("x", new Typeface(family, FontStyle.Normal, weight), fontSize, Brushes.Black).TextLines[0].Baseline;
+    // Sized once the inherited font is known.
+    static void OnLinkAttached(object? sender, VisualTreeAttachmentEventArgs e) {
+        if (sender is HyperlinkButton button) button.Height = Ascent(button.FontFamily, button.FontWeight, button.FontSize);
+    }
+
+    static readonly Dictionary<(string Family, FontWeight Weight, double Size), double> Ascents = [];
+
+    static double Ascent(FontFamily family, FontWeight weight, double fontSize) {
+        var key = (family.Name, weight, fontSize);
+        if (!Ascents.TryGetValue(key, out var ascent))
+            Ascents[key] = ascent = new TextLayout("x", new Typeface(family, FontStyle.Normal, weight), fontSize, Brushes.Black).TextLines[0].Baseline;
+        return ascent;
+    }
 
     static string PlainText(string source, ContainerInline container) =>
         string.Concat(container.Select(inline => inline switch {
@@ -237,7 +248,7 @@ public static class MarkdownBlocks {
         var weight = new int[columns];
         foreach (var row in rows)
             foreach (var (cell, column) in row.OfType<TableCell>().Select((c, i) => (c, i)))
-                if (column < columns) weight[column] += SpanText(source, cell.Span).Length;
+                if (column < columns) weight[column] += cell.Span.Length;
         var widest = Array.IndexOf(weight, weight.Max());
         for (var c = 0; c < columns; c++)
             grid.ColumnDefinitions.Add(c == widest

--- a/src/Capacitor.App/Views/MarkdownBlocks.cs
+++ b/src/Capacitor.App/Views/MarkdownBlocks.cs
@@ -2,11 +2,12 @@ using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
+using Avalonia.Controls.Presenters;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
-using Avalonia.VisualTree;
+using Avalonia.Styling;
 using Capacitor.App.Services;
 using Markdig;
 using Markdig.Extensions.Tables;
@@ -166,7 +167,10 @@ public static class MarkdownBlocks {
         button.ClipToBounds = false;
         button.UseLayoutRounding = false;
         button.SetValue(TextBlock.LineHeightProperty, double.NaN);
-        button.TemplateApplied += (_, _) => { foreach (var part in button.GetVisualDescendants()) part.ClipToBounds = false; };
+        // The presenter creates its text part after TemplateApplied, so a one-off pass would miss
+        // it; a style reaches every part whenever it appears.
+        button.Styles.Add(new Style(x => x.Is<TextBlock>()) { Setters = { new Setter(Visual.ClipToBoundsProperty, false) } });
+        button.Styles.Add(new Style(x => x.Is<ContentPresenter>()) { Setters = { new Setter(Visual.ClipToBoundsProperty, false) } });
         button.AttachedToVisualTree += (_, _) => button.Height = AscentOf(button.FontFamily, button.FontWeight, button.FontSize);
         return new() { Child = button };
     }

--- a/src/Capacitor.App/Views/MarkdownBlocks.cs
+++ b/src/Capacitor.App/Views/MarkdownBlocks.cs
@@ -5,6 +5,8 @@ using Avalonia.Controls.Documents;
 using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using Avalonia.VisualTree;
 using Capacitor.App.Services;
 using Markdig;
 using Markdig.Extensions.Tables;
@@ -23,6 +25,7 @@ public static class MarkdownBlocks {
     static readonly MarkdownPipeline Pipeline =
         new MarkdownPipelineBuilder().UseAutoLinks().UsePipeTables().UsePreciseSourceLocation().Build();
     static readonly FontFamily Mono = new("Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace");
+    const double LineSpacing = 1.6;
 
     static IBrush Brush(string key) => Application.Current?.FindResource(key) as IBrush ?? Brushes.Gray;
 
@@ -66,7 +69,7 @@ public static class MarkdownBlocks {
             TextWrapping = TextWrapping.Wrap,
             FontSize = fontSize,
             FontWeight = bold ? FontWeight.SemiBold : FontWeight.Normal,
-            LineHeight = fontSize * 1.6,
+            LineHeight = fontSize * LineSpacing,
             Foreground = Brush("KcapTextBrush"),
         };
         foreach (var inline in inlines) AddInline(source, text.Inlines!, inline, openLink, (fontSize, text.FontWeight));
@@ -153,9 +156,23 @@ public static class MarkdownBlocks {
         VerticalAlignment = VerticalAlignment.Center,
     };
 
-    // A control's baseline is its bottom edge, so aligning it to the text baseline lifts the
-    // whole button above the line; centring keeps its glyphs on the neighbours' line.
-    static InlineUIContainer Link(HyperlinkButton button) => new() { Child = button, BaselineAlignment = BaselineAlignment.Center };
+    // A hosted control's baseline is its bottom edge, and the line adopts the largest run
+    // baseline: a button as tall as the line drags the whole line's text down to its bottom. The
+    // button is therefore laid out at the font's natural line height and sized to its ascent,
+    // so its bottom is a baseline no taller than the text's own, its glyphs sit on that line, and
+    // their descenders overflow it — which every template part must be allowed to draw.
+    static InlineUIContainer Link(HyperlinkButton button) {
+        button.VerticalContentAlignment = VerticalAlignment.Top;
+        button.ClipToBounds = false;
+        button.UseLayoutRounding = false;
+        button.SetValue(TextBlock.LineHeightProperty, double.NaN);
+        button.TemplateApplied += (_, _) => { foreach (var part in button.GetVisualDescendants()) part.ClipToBounds = false; };
+        button.AttachedToVisualTree += (_, _) => button.Height = AscentOf(button.FontFamily, button.FontWeight, button.FontSize);
+        return new() { Child = button };
+    }
+
+    static double AscentOf(FontFamily family, FontWeight weight, double fontSize) =>
+        new TextLayout("x", new Typeface(family, FontStyle.Normal, weight), fontSize, Brushes.Black).TextLines[0].Baseline;
 
     static string PlainText(string source, ContainerInline container) =>
         string.Concat(container.Select(inline => inline switch {

--- a/src/Capacitor.App/Views/MarkdownBlocks.cs
+++ b/src/Capacitor.App/Views/MarkdownBlocks.cs
@@ -69,7 +69,7 @@ public static class MarkdownBlocks {
             LineHeight = fontSize * 1.6,
             Foreground = Brush("KcapTextBrush"),
         };
-        foreach (var inline in inlines) AddInline(source, text.Inlines!, inline, openLink);
+        foreach (var inline in inlines) AddInline(source, text.Inlines!, inline, openLink, (fontSize, text.FontWeight));
         return text;
     }
 
@@ -84,19 +84,19 @@ public static class MarkdownBlocks {
             ? source.Substring(span.Start, span.Length)
             : "";
 
-    static void AddInlines(string source, InlineCollection target, ContainerInline? container, ICommand? openLink) {
+    static void AddInlines(string source, InlineCollection target, ContainerInline? container, ICommand? openLink, (double Size, FontWeight Weight) font) {
         if (container is null) return;
-        foreach (var inline in container) AddInline(source, target, inline, openLink);
+        foreach (var inline in container) AddInline(source, target, inline, openLink, font);
     }
 
-    static void AddInline(string source, InlineCollection target, MdInline inline, ICommand? openLink) {
+    static void AddInline(string source, InlineCollection target, MdInline inline, ICommand? openLink, (double Size, FontWeight Weight) font) {
         switch (inline) {
             case LiteralInline literal:
                 target.Add(new Run(Flat(literal.Content.ToString())));
                 break;
             case EmphasisInline emphasis: {
                 Span span = emphasis.DelimiterCount >= 2 ? new Bold() : new Italic();
-                AddInlines(source, span.Inlines, emphasis, openLink);
+                AddInlines(source, span.Inlines, emphasis, openLink, font);
                 target.Add(span);
                 break;
             }
@@ -113,13 +113,13 @@ public static class MarkdownBlocks {
                 target.Add(new Run(Flat(SpanText(source, image.Span))));
                 break;
             case LinkInline link when LinkPolicy.IsOpenable(link.Url):
-                target.Add(new InlineUIContainer { Child = LinkButton(Flat(PlainText(source, link)), link.Url!, openLink) });
+                target.Add(Link(LinkButton(Flat(PlainText(source, link)), link.Url!, openLink, font)));
                 break;
             case LinkInline link:
-                AddInlines(source, target, link, openLink);
+                AddInlines(source, target, link, openLink, font);
                 break;
             case AutolinkInline auto when LinkPolicy.IsOpenable(auto.Url):
-                target.Add(new InlineUIContainer { Child = LinkButton(auto.Url, auto.Url, openLink) });
+                target.Add(Link(LinkButton(auto.Url, auto.Url, openLink, font)));
                 break;
             case AutolinkInline auto:
                 target.Add(new Run(Flat(auto.Url)));
@@ -128,7 +128,7 @@ public static class MarkdownBlocks {
                 target.Add(new Run(Flat(html.Tag)));
                 break;
             case ContainerInline nested:
-                AddInlines(source, target, nested, openLink);
+                AddInlines(source, target, nested, openLink, font);
                 break;
             default:
                 target.Add(new Run(Flat(SpanText(source, inline.Span))));
@@ -138,15 +138,24 @@ public static class MarkdownBlocks {
 
     // NavigateUri stays unset on purpose: set, the control opens the URI itself and the policy
     // in the command would never run.
-    static HyperlinkButton LinkButton(string label, string url, ICommand? openLink) => new() {
+    static HyperlinkButton LinkButton(string label, string url, ICommand? openLink, (double Size, FontWeight Weight) font) => new() {
         Content = label,
         Command = openLink,
         CommandParameter = url,
         Padding = new Thickness(0),
+        BorderThickness = new Thickness(0),
+        MinHeight = 0,
+        MinWidth = 0,
+        FontSize = font.Size,
+        FontWeight = font.Weight,
         Cursor = new Cursor(StandardCursorType.Hand),
         Foreground = Brush("KcapAccentBrush"),
         VerticalAlignment = VerticalAlignment.Center,
     };
+
+    // A control's baseline is its bottom edge, so aligning it to the text baseline lifts the
+    // whole button above the line; centring keeps its glyphs on the neighbours' line.
+    static InlineUIContainer Link(HyperlinkButton button) => new() { Child = button, BaselineAlignment = BaselineAlignment.Center };
 
     static string PlainText(string source, ContainerInline container) =>
         string.Concat(container.Select(inline => inline switch {

--- a/src/Capacitor.App/Views/MarkdownBlocks.cs
+++ b/src/Capacitor.App/Views/MarkdownBlocks.cs
@@ -1,0 +1,177 @@
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Capacitor.App.Services;
+using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace Capacitor.App.Views;
+
+/// Maps the markdown constructs agents actually emit to Avalonia controls. Anything else
+/// renders as its literal source text — degraded, never dropped.
+public static class MarkdownBlocks {
+    static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder().UseAutoLinks().Build();
+    static readonly FontFamily Mono = new("Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace");
+
+    static IBrush Brush(string key) => Application.Current?.FindResource(key) as IBrush ?? Brushes.Gray;
+
+    public static Control Build(string markdown, ICommand? openLink) {
+        var document = Markdown.Parse(markdown, Pipeline);
+        var panel = new StackPanel { Spacing = 8 };
+        foreach (var block in document) panel.Children.Add(BuildBlock(markdown, block, openLink));
+        return panel;
+    }
+
+    static Control BuildBlock(string source, Block block, ICommand? openLink) => block switch {
+        ParagraphBlock p     => InlineText(p.Inline, openLink, 13.5, bold: false),
+        HeadingBlock h       => InlineText(h.Inline, openLink, h.Level switch { 1 => 18, 2 => 16, _ => 14.5 }, bold: true),
+        FencedCodeBlock f    => CodeBlock(f),
+        CodeBlock c          => CodeBlock(c),
+        ListBlock list       => List(source, list, openLink),
+        QuoteBlock quote     => Quote(source, quote, openLink),
+        ThematicBreakBlock   => new Border { Height = 1, Background = Brush("KcapBorderBrush"), Margin = new Thickness(0, 4) },
+        _                    => Literal(source, block),
+    };
+
+    static SelectableTextBlock InlineText(ContainerInline? inlines, ICommand? openLink, double fontSize, bool bold) {
+        var text = new SelectableTextBlock {
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = fontSize,
+            FontWeight = bold ? FontWeight.SemiBold : FontWeight.Normal,
+            LineHeight = fontSize * 1.6,
+            Foreground = Brush("KcapTextBrush"),
+        };
+        AddInlines(text.Inlines!, inlines, openLink);
+        return text;
+    }
+
+    // A newline reaching a text block's inlines makes Avalonia's line breaker spin forever
+    // whenever the block's height is unconstrained (every scrolled list). Inline content is
+    // therefore always single-line — a break inside a paragraph becomes a space, which is also
+    // how CommonMark's soft break renders. Multi-line source belongs on Text, which is safe.
+    static string Flat(string text) => text.ReplaceLineEndings(" ");
+
+    static void AddInlines(InlineCollection target, ContainerInline? container, ICommand? openLink) {
+        if (container is null) return;
+        foreach (var inline in container) {
+            switch (inline) {
+                case LiteralInline literal:
+                    target.Add(new Run(Flat(literal.Content.ToString())));
+                    break;
+                case EmphasisInline emphasis: {
+                    Span span = emphasis.DelimiterCount >= 2 ? new Bold() : new Italic();
+                    AddInlines(span.Inlines, emphasis, openLink);
+                    target.Add(span);
+                    break;
+                }
+                case CodeInline code:
+                    target.Add(new Run(Flat(code.Content)) { FontFamily = Mono });
+                    break;
+                case LineBreakInline:
+                    target.Add(new Run(" "));
+                    break;
+                case LinkInline link when !link.IsImage && LinkPolicy.IsOpenable(link.Url):
+                    target.Add(new InlineUIContainer { Child = LinkButton(PlainText(link), link.Url!, openLink) });
+                    break;
+                case LinkInline link:
+                    AddInlines(target, link, openLink);
+                    break;
+                case AutolinkInline auto when LinkPolicy.IsOpenable(auto.Url):
+                    target.Add(new InlineUIContainer { Child = LinkButton(auto.Url, auto.Url, openLink) });
+                    break;
+                case AutolinkInline auto:
+                    target.Add(new Run(Flat(auto.Url)));
+                    break;
+                case HtmlInline html:
+                    target.Add(new Run(Flat(html.Tag)));
+                    break;
+                case ContainerInline nested:
+                    AddInlines(target, nested, openLink);
+                    break;
+                default:
+                    target.Add(new Run(Flat(inline.ToString() ?? "")));
+                    break;
+            }
+        }
+    }
+
+    // NavigateUri stays unset on purpose: set, the control opens the URI itself and the policy
+    // in the command would never run.
+    static HyperlinkButton LinkButton(string label, string url, ICommand? openLink) => new() {
+        Content = label,
+        Command = openLink,
+        CommandParameter = url,
+        Padding = new Thickness(0),
+        Cursor = new Cursor(StandardCursorType.Hand),
+        Foreground = Brush("KcapAccentBrush"),
+        VerticalAlignment = VerticalAlignment.Center,
+    };
+
+    static string PlainText(ContainerInline container) =>
+        string.Concat(container.Select(i => i is LiteralInline l ? l.Content.ToString() : i is ContainerInline c ? PlainText(c) : ""));
+
+    static Control CodeBlock(LeafBlock code) => new Border {
+        Background = Brush("KcapSurfaceBrush"),
+        BorderBrush = Brush("KcapBorderBrush"),
+        BorderThickness = new Thickness(1),
+        CornerRadius = new CornerRadius(8),
+        Padding = new Thickness(12, 8),
+        Child = new SelectableTextBlock {
+            Text = code.Lines.ToString().TrimEnd('\n', '\r'),
+            FontFamily = Mono,
+            FontSize = 12.5,
+            TextWrapping = TextWrapping.NoWrap,
+            Foreground = Brush("KcapTextBrush"),
+        },
+    };
+
+    static Control List(string source, ListBlock list, ICommand? openLink) {
+        var panel = new StackPanel { Spacing = 4 };
+        var index = list.IsOrdered && int.TryParse(list.OrderedStart, out var start) ? start : 1;
+        foreach (var item in list.OfType<ListItemBlock>()) {
+            var row = new Grid { ColumnDefinitions = new ColumnDefinitions("22,*") };
+            var marker = new TextBlock {
+                Text = list.IsOrdered ? $"{index++}." : "•",
+                Foreground = Brush("KcapMutedBrush"),
+                FontSize = 13.5,
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+            var content = new StackPanel { Spacing = 4 };
+            foreach (var child in item) content.Children.Add(BuildBlock(source, child, openLink));
+            Grid.SetColumn(content, 1);
+            row.Children.Add(marker);
+            row.Children.Add(content);
+            panel.Children.Add(row);
+        }
+        return panel;
+    }
+
+    static Control Quote(string source, QuoteBlock quote, ICommand? openLink) {
+        var content = new StackPanel { Spacing = 6 };
+        foreach (var child in quote) content.Children.Add(BuildBlock(source, child, openLink));
+        return new Border {
+            BorderBrush = Brush("KcapBorderBrush"),
+            BorderThickness = new Thickness(3, 0, 0, 0),
+            Padding = new Thickness(12, 0, 0, 0),
+            Child = content,
+        };
+    }
+
+    static Control Literal(string source, Block block) {
+        var span = block.Span;
+        var text = span.Start >= 0 && span.End < source.Length && span.End >= span.Start
+            ? source.Substring(span.Start, span.Length)
+            : block.ToString() ?? "";
+        return new SelectableTextBlock {
+            Text = text,
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 13.5,
+            Foreground = Brush("KcapTextBrush"),
+        };
+    }
+}

--- a/src/Capacitor.App/Views/MarkdownBlocks.cs
+++ b/src/Capacitor.App/Views/MarkdownBlocks.cs
@@ -7,6 +7,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Capacitor.App.Services;
 using Markdig;
+using Markdig.Extensions.Tables;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using MdInline = Markdig.Syntax.Inlines.Inline;
@@ -20,7 +21,7 @@ public static class MarkdownBlocks {
     // without them every inline span is empty and that fallback prints the document's first
     // character. They change recorded positions only, never which constructs parse.
     static readonly MarkdownPipeline Pipeline =
-        new MarkdownPipelineBuilder().UseAutoLinks().UsePreciseSourceLocation().Build();
+        new MarkdownPipelineBuilder().UseAutoLinks().UsePipeTables().UsePreciseSourceLocation().Build();
     static readonly FontFamily Mono = new("Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace");
 
     static IBrush Brush(string key) => Application.Current?.FindResource(key) as IBrush ?? Brushes.Gray;
@@ -39,6 +40,7 @@ public static class MarkdownBlocks {
         CodeBlock c          => CodeBlock(c),
         ListBlock list       => List(source, list, openLink),
         QuoteBlock quote     => Quote(source, quote, openLink),
+        Table table          => Table(source, table, openLink),
         ThematicBreakBlock   => new Border { Height = 1, Background = Brush("KcapBorderBrush"), Margin = new Thickness(0, 4) },
         _                    => Literal(source, block),
     };
@@ -190,6 +192,63 @@ public static class MarkdownBlocks {
             panel.Children.Add(row);
         }
         return panel;
+    }
+
+    // Auto columns wrap only once capped; the widest column takes what is left so a prose column
+    // wraps inside the pane instead of pushing the table past it.
+    const double AutoColumnCap = 240;
+
+    static Control Table(string source, Table table, ICommand? openLink) {
+        var rows = table.OfType<TableRow>().ToList();
+        var columns = Math.Max(table.ColumnDefinitions.Count, rows.Count == 0 ? 0 : rows.Max(r => r.Count));
+        var grid = new Grid { Name = "MarkdownTable" };
+        if (columns == 0) return grid;
+
+        var weight = new int[columns];
+        foreach (var row in rows)
+            foreach (var (cell, column) in row.OfType<TableCell>().Select((c, i) => (c, i)))
+                if (column < columns) weight[column] += SpanText(source, cell.Span).Length;
+        var widest = Array.IndexOf(weight, weight.Max());
+        for (var c = 0; c < columns; c++)
+            grid.ColumnDefinitions.Add(c == widest
+                ? new ColumnDefinition(1, GridUnitType.Star)
+                : new ColumnDefinition(GridLength.Auto) { MaxWidth = AutoColumnCap });
+
+        for (var r = 0; r < rows.Count; r++) {
+            grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+            foreach (var (cell, c) in rows[r].OfType<TableCell>().Select((cell, i) => (cell, i))) {
+                if (c >= columns) break;
+                var align = table.ColumnDefinitions.ElementAtOrDefault(c)?.Alignment switch {
+                    TableColumnAlign.Right  => TextAlignment.Right,
+                    TableColumnAlign.Center => TextAlignment.Center,
+                    _                       => TextAlignment.Left,
+                };
+                var content = InlineText(source, (cell.FirstOrDefault() as ParagraphBlock)?.Inline, openLink, 13, bold: rows[r].IsHeader);
+                Align(content, align);
+                var border = new Border {
+                    Padding = new Thickness(8, 5),
+                    BorderBrush = Brush("KcapBorderBrush"),
+                    BorderThickness = new Thickness(0, 0, 0, r == rows.Count - 1 ? 0 : 1),
+                    Child = content,
+                };
+                Grid.SetRow(border, r);
+                Grid.SetColumn(border, c);
+                grid.Children.Add(border);
+            }
+        }
+        return new Border {
+            BorderBrush = Brush("KcapBorderBrush"),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(8),
+            Child = grid,
+        };
+    }
+
+    static void Align(Control control, TextAlignment alignment) {
+        switch (control) {
+            case SelectableTextBlock text: text.TextAlignment = alignment; break;
+            case Panel panel: foreach (var child in panel.Children) Align(child, alignment); break;
+        }
     }
 
     static Control Quote(string source, QuoteBlock quote, ICommand? openLink) {

--- a/src/Capacitor.App/Views/MarkdownBlocks.cs
+++ b/src/Capacitor.App/Views/MarkdownBlocks.cs
@@ -9,13 +9,18 @@ using Capacitor.App.Services;
 using Markdig;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
+using MdInline = Markdig.Syntax.Inlines.Inline;
 
 namespace Capacitor.App.Views;
 
 /// Maps the markdown constructs agents actually emit to Avalonia controls. Anything else
 /// renders as its literal source text — degraded, never dropped.
 public static class MarkdownBlocks {
-    static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder().UseAutoLinks().Build();
+    // Precise source locations are what let an unmapped inline fall back to its own source text:
+    // without them every inline span is empty and that fallback prints the document's first
+    // character. They change recorded positions only, never which constructs parse.
+    static readonly MarkdownPipeline Pipeline =
+        new MarkdownPipelineBuilder().UseAutoLinks().UsePreciseSourceLocation().Build();
     static readonly FontFamily Mono = new("Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace");
 
     static IBrush Brush(string key) => Application.Current?.FindResource(key) as IBrush ?? Brushes.Gray;
@@ -28,8 +33,8 @@ public static class MarkdownBlocks {
     }
 
     static Control BuildBlock(string source, Block block, ICommand? openLink) => block switch {
-        ParagraphBlock p     => InlineText(p.Inline, openLink, 13.5, bold: false),
-        HeadingBlock h       => InlineText(h.Inline, openLink, h.Level switch { 1 => 18, 2 => 16, _ => 14.5 }, bold: true),
+        ParagraphBlock p     => InlineText(source, p.Inline, openLink, 13.5, bold: false),
+        HeadingBlock h       => InlineText(source, h.Inline, openLink, h.Level switch { 1 => 18, 2 => 16, _ => 14.5 }, bold: true),
         FencedCodeBlock f    => CodeBlock(f),
         CodeBlock c          => CodeBlock(c),
         ListBlock list       => List(source, list, openLink),
@@ -38,7 +43,23 @@ public static class MarkdownBlocks {
         _                    => Literal(source, block),
     };
 
-    static SelectableTextBlock InlineText(ContainerInline? inlines, ICommand? openLink, double fontSize, bool bold) {
+    static Control InlineText(string source, ContainerInline? inlines, ICommand? openLink, double fontSize, bool bold) {
+        // A hard break is a segment boundary rather than an inline, for the reason on Flat.
+        var segments = new List<List<MdInline>> { new() };
+        if (inlines is not null)
+            foreach (var inline in inlines) {
+                if (inline is LineBreakInline { IsHard: true }) segments.Add([]);
+                else segments[^1].Add(inline);
+            }
+
+        if (segments.Count == 1) return Segment(source, segments[0], openLink, fontSize, bold);
+        var panel = new StackPanel();
+        foreach (var segment in segments) panel.Children.Add(Segment(source, segment, openLink, fontSize, bold));
+        return panel;
+    }
+
+    static SelectableTextBlock Segment(
+            string source, List<MdInline> inlines, ICommand? openLink, double fontSize, bool bold) {
         var text = new SelectableTextBlock {
             TextWrapping = TextWrapping.Wrap,
             FontSize = fontSize,
@@ -46,57 +67,70 @@ public static class MarkdownBlocks {
             LineHeight = fontSize * 1.6,
             Foreground = Brush("KcapTextBrush"),
         };
-        AddInlines(text.Inlines!, inlines, openLink);
+        foreach (var inline in inlines) AddInline(source, text.Inlines!, inline, openLink);
         return text;
     }
 
-    // A newline reaching a text block's inlines makes Avalonia's line breaker spin forever
-    // whenever the block's height is unconstrained (every scrolled list). Inline content is
-    // therefore always single-line — a break inside a paragraph becomes a space, which is also
-    // how CommonMark's soft break renders. Multi-line source belongs on Text, which is safe.
+    // Avalonia 12's line breaker never finishes laying out a text block whose inlines carry a
+    // newline while the parent leaves height unconstrained — every StackPanel and ScrollViewer.
+    // Inline content is single-line: a soft break is a space, as CommonMark renders it. Multi-line
+    // source belongs on Text, which lays out fine.
     static string Flat(string text) => text.ReplaceLineEndings(" ");
 
-    static void AddInlines(InlineCollection target, ContainerInline? container, ICommand? openLink) {
+    static string SpanText(string source, SourceSpan span) =>
+        span.Start >= 0 && span.End >= span.Start && span.End < source.Length
+            ? source.Substring(span.Start, span.Length)
+            : "";
+
+    static void AddInlines(string source, InlineCollection target, ContainerInline? container, ICommand? openLink) {
         if (container is null) return;
-        foreach (var inline in container) {
-            switch (inline) {
-                case LiteralInline literal:
-                    target.Add(new Run(Flat(literal.Content.ToString())));
-                    break;
-                case EmphasisInline emphasis: {
-                    Span span = emphasis.DelimiterCount >= 2 ? new Bold() : new Italic();
-                    AddInlines(span.Inlines, emphasis, openLink);
-                    target.Add(span);
-                    break;
-                }
-                case CodeInline code:
-                    target.Add(new Run(Flat(code.Content)) { FontFamily = Mono });
-                    break;
-                case LineBreakInline:
-                    target.Add(new Run(" "));
-                    break;
-                case LinkInline link when !link.IsImage && LinkPolicy.IsOpenable(link.Url):
-                    target.Add(new InlineUIContainer { Child = LinkButton(PlainText(link), link.Url!, openLink) });
-                    break;
-                case LinkInline link:
-                    AddInlines(target, link, openLink);
-                    break;
-                case AutolinkInline auto when LinkPolicy.IsOpenable(auto.Url):
-                    target.Add(new InlineUIContainer { Child = LinkButton(auto.Url, auto.Url, openLink) });
-                    break;
-                case AutolinkInline auto:
-                    target.Add(new Run(Flat(auto.Url)));
-                    break;
-                case HtmlInline html:
-                    target.Add(new Run(Flat(html.Tag)));
-                    break;
-                case ContainerInline nested:
-                    AddInlines(target, nested, openLink);
-                    break;
-                default:
-                    target.Add(new Run(Flat(inline.ToString() ?? "")));
-                    break;
+        foreach (var inline in container) AddInline(source, target, inline, openLink);
+    }
+
+    static void AddInline(string source, InlineCollection target, MdInline inline, ICommand? openLink) {
+        switch (inline) {
+            case LiteralInline literal:
+                target.Add(new Run(Flat(literal.Content.ToString())));
+                break;
+            case EmphasisInline emphasis: {
+                Span span = emphasis.DelimiterCount >= 2 ? new Bold() : new Italic();
+                AddInlines(source, span.Inlines, emphasis, openLink);
+                target.Add(span);
+                break;
             }
+            case CodeInline code:
+                target.Add(new Run(Flat(code.Content)) { FontFamily = Mono });
+                break;
+            case HtmlEntityInline entity:
+                target.Add(new Run(Flat(entity.Transcoded.ToString())));
+                break;
+            case LineBreakInline:
+                target.Add(new Run(" "));
+                break;
+            case LinkInline { IsImage: true } image:
+                target.Add(new Run(Flat(SpanText(source, image.Span))));
+                break;
+            case LinkInline link when LinkPolicy.IsOpenable(link.Url):
+                target.Add(new InlineUIContainer { Child = LinkButton(Flat(PlainText(source, link)), link.Url!, openLink) });
+                break;
+            case LinkInline link:
+                AddInlines(source, target, link, openLink);
+                break;
+            case AutolinkInline auto when LinkPolicy.IsOpenable(auto.Url):
+                target.Add(new InlineUIContainer { Child = LinkButton(auto.Url, auto.Url, openLink) });
+                break;
+            case AutolinkInline auto:
+                target.Add(new Run(Flat(auto.Url)));
+                break;
+            case HtmlInline html:
+                target.Add(new Run(Flat(html.Tag)));
+                break;
+            case ContainerInline nested:
+                AddInlines(source, target, nested, openLink);
+                break;
+            default:
+                target.Add(new Run(Flat(SpanText(source, inline.Span))));
+                break;
         }
     }
 
@@ -112,8 +146,15 @@ public static class MarkdownBlocks {
         VerticalAlignment = VerticalAlignment.Center,
     };
 
-    static string PlainText(ContainerInline container) =>
-        string.Concat(container.Select(i => i is LiteralInline l ? l.Content.ToString() : i is ContainerInline c ? PlainText(c) : ""));
+    static string PlainText(string source, ContainerInline container) =>
+        string.Concat(container.Select(inline => inline switch {
+            LiteralInline literal    => literal.Content.ToString(),
+            CodeInline code          => code.Content,
+            HtmlEntityInline entity  => entity.Transcoded.ToString(),
+            LineBreakInline          => " ",
+            ContainerInline nested   => PlainText(source, nested),
+            _                        => SpanText(source, inline.Span),
+        }));
 
     static Control CodeBlock(LeafBlock code) => new Border {
         Background = Brush("KcapSurfaceBrush"),
@@ -162,16 +203,10 @@ public static class MarkdownBlocks {
         };
     }
 
-    static Control Literal(string source, Block block) {
-        var span = block.Span;
-        var text = span.Start >= 0 && span.End < source.Length && span.End >= span.Start
-            ? source.Substring(span.Start, span.Length)
-            : block.ToString() ?? "";
-        return new SelectableTextBlock {
-            Text = text,
-            TextWrapping = TextWrapping.Wrap,
-            FontSize = 13.5,
-            Foreground = Brush("KcapTextBrush"),
-        };
-    }
+    static Control Literal(string source, Block block) => new SelectableTextBlock {
+        Text = SpanText(source, block.Span),
+        TextWrapping = TextWrapping.Wrap,
+        FontSize = 13.5,
+        Foreground = Brush("KcapTextBrush"),
+    };
 }

--- a/src/Capacitor.App/Views/MarkdownView.cs
+++ b/src/Capacitor.App/Views/MarkdownView.cs
@@ -1,0 +1,31 @@
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+
+namespace Capacitor.App.Views;
+
+/// Assistant prose: a ContentControl whose content is rebuilt from the markdown on every change.
+public sealed class MarkdownView : ContentControl {
+    public static readonly StyledProperty<string?> TextProperty =
+        AvaloniaProperty.Register<MarkdownView, string?>(nameof(Text));
+
+    public static readonly StyledProperty<ICommand?> OpenLinkProperty =
+        AvaloniaProperty.Register<MarkdownView, ICommand?>(nameof(OpenLink));
+
+    static MarkdownView() {
+        TextProperty.Changed.AddClassHandler<MarkdownView>((view, _) => view.Rebuild());
+        OpenLinkProperty.Changed.AddClassHandler<MarkdownView>((view, _) => view.Rebuild());
+    }
+
+    public string? Text {
+        get => GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    public ICommand? OpenLink {
+        get => GetValue(OpenLinkProperty);
+        set => SetValue(OpenLinkProperty, value);
+    }
+
+    void Rebuild() => Content = MarkdownBlocks.Build(Text ?? "", OpenLink);
+}

--- a/src/Capacitor.App/Views/MarkdownView.cs
+++ b/src/Capacitor.App/Views/MarkdownView.cs
@@ -4,7 +4,6 @@ using Avalonia.Controls;
 
 namespace Capacitor.App.Views;
 
-/// Assistant prose: a ContentControl whose content is rebuilt from the markdown on every change.
 public sealed class MarkdownView : ContentControl {
     public static readonly StyledProperty<string?> TextProperty =
         AvaloniaProperty.Register<MarkdownView, string?>(nameof(Text));

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -91,17 +91,26 @@
                                        CaretBrush="{StaticResource KcapAccentBrush}"
                                        Model="{Binding Terminal.Surface, Converter={x:Static views:TerminalSurfaceModelConverter.Instance}}" />
 
-            <Panel x:Name="TerminalBanners" IsVisible="{Binding IsTerminalActive}">
+            <!-- A session with no tabs at all has no Terminal tab to activate, and these banners
+                 are the only content its cell ever gets — so they stay up whenever the strip is
+                 showing the muted note instead of the tabs. -->
+            <Panel x:Name="TerminalBanners">
+                <Panel.IsVisible>
+                    <MultiBinding Converter="{x:Static BoolConverters.Or}">
+                        <Binding Path="IsTerminalActive" />
+                        <Binding Path="!ShowsTerminalTab" />
+                    </MultiBinding>
+                </Panel.IsVisible>
+
                 <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Connecting}"
                         Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
                         CornerRadius="8" Padding="14,8" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
                     <TextBlock Text="Connecting…" Foreground="{StaticResource KcapMutedBrush}" />
                 </Border>
 
-                <!-- Owner decision (post-QA): the attach banner overlays the terminal, so a normal
-                     read-write session shows NO banner — explicit detach returns when a use case
-                     earns it. Read-only keeps the banner: it is the only explanation for dead
-                     keystrokes, and Detach is the only action such a session has. -->
+                <!-- The attach banner overlays the terminal, so a read-write session shows none.
+                     Read-only keeps it: it is the only explanation for dead keystrokes, and
+                     Detach is the only action such a session has. -->
                 <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalReadOnlyBannerVisibleConverter.Instance}}"
                         Background="{StaticResource KcapWarningDimBrush}" BorderBrush="{StaticResource KcapWarningBrush}"
                         BorderThickness="1" CornerRadius="8" Padding="12,7" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
@@ -144,15 +153,23 @@
                 <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=SessionEnded}"
                         Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
                         CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
-                    <TextBlock Text="This session has ended." Foreground="{StaticResource KcapMutedBrush}" />
+                    <TextBlock x:Name="SessionEndedNote" Text="This session has ended." Foreground="{StaticResource KcapMutedBrush}" />
                 </Border>
             </Panel>
 
-            <!-- The automation peer reports offscreen from the control's OWN IsVisible, so hiding
-                 an ancestor instead would leave the inactive chat announced as onscreen. The flag
-                 lives on the workspace VM, which is not this control's DataContext. -->
-            <views:ChatTabView x:Name="ChatHost" DataContext="{Binding Chat}"
-                               IsVisible="{Binding $parent[views:WorkspaceView].((vm:WorkspaceViewModel)DataContext).IsChatActive}" />
+            <!-- The chat surface exists only where the tab strip does, so a session with no PTY
+                 renders none of it. The automation peer reports offscreen from the control's OWN
+                 IsVisible, so hiding an ancestor instead would leave the inactive chat announced
+                 as onscreen — and both flags live on the workspace VM, which is not this
+                 control's DataContext. -->
+            <views:ChatTabView x:Name="ChatHost" DataContext="{Binding Chat}">
+                <views:ChatTabView.IsVisible>
+                    <MultiBinding Converter="{x:Static BoolConverters.And}">
+                        <Binding Path="$parent[views:WorkspaceView].((vm:WorkspaceViewModel)DataContext).ShowsTerminalTab" />
+                        <Binding Path="$parent[views:WorkspaceView].((vm:WorkspaceViewModel)DataContext).IsChatActive" />
+                    </MultiBinding>
+                </views:ChatTabView.IsVisible>
+            </views:ChatTabView>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -6,6 +6,22 @@
              x:Class="Capacitor.App.Views.WorkspaceView"
              x:DataType="vm:WorkspaceViewModel"
              Background="{StaticResource KcapCanvasBrush}">
+    <UserControl.Styles>
+        <Style Selector="Button.tab">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="CornerRadius" Value="7" />
+            <Setter Property="Foreground" Value="{StaticResource KcapMutedBrush}" />
+            <Setter Property="FontSize" Value="12.5" />
+            <Setter Property="Padding" Value="12,5" />
+        </Style>
+        <Style Selector="Button.tab.active">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+    </UserControl.Styles>
+
     <Grid RowDefinitions="56,42,*">
         <!-- Header: title over repo leaf · spacer · vendor chip with its family badge ·
              Open-in-web/Stop. Leaving the workspace is the rail's job, not a Back button's. -->
@@ -40,16 +56,17 @@
                     Foreground="{StaticResource KcapDangerBrush}" Padding="10,5" FontSize="12.5" />
         </Grid>
 
-        <!-- Tab strip: one Terminal tab when the daemon reports this session has one; the muted
-             family-aware note in its place otherwise (spec: never names a vendor). -->
+        <!-- Tab strip: Chat and Terminal when the daemon reports this session has a PTY; the muted
+             family-aware note in their place otherwise (it never names a vendor). -->
         <Border Grid.Row="1" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="0,1,0,1">
             <Grid Margin="20,0">
-                <!-- Pill tab, active (design canvas): the strip gains Chat beside it with AI-2196. -->
-                <Button x:Name="TerminalTabButton" Content="Terminal" IsVisible="{Binding ShowsTerminalTab}"
-                        HorizontalAlignment="Left" VerticalAlignment="Center"
-                        Background="{StaticResource KcapSurfaceRaisedBrush}" BorderThickness="0"
-                        CornerRadius="7" Foreground="{StaticResource KcapTextBrush}" FontWeight="SemiBold"
-                        FontSize="12.5" Padding="12,5" />
+                <StackPanel Orientation="Horizontal" Spacing="6" IsVisible="{Binding ShowsTerminalTab}"
+                            HorizontalAlignment="Left" VerticalAlignment="Center">
+                    <Button x:Name="ChatTabButton" Content="Chat" Classes="tab" Classes.active="{Binding IsChatActive}"
+                            Command="{Binding ShowChatCommand}" />
+                    <Button x:Name="TerminalTabButton" Content="Terminal" Classes="tab" Classes.active="{Binding IsTerminalActive}"
+                            Command="{Binding ShowTerminalCommand}" />
+                </StackPanel>
                 <TextBlock x:Name="NoTerminalNote" Text="{Binding NoTerminalNote}" IsVisible="{Binding !ShowsTerminalTab}"
                            Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5" VerticalAlignment="Center" />
             </Grid>
@@ -66,64 +83,76 @@
                  invisible on this palette. Focus itself is wired in code-behind on Model
                  assignment — the control only draws the filled caret while focused. -->
             <terminal:TerminalControl x:Name="TerminalHost" IsVisible="{Binding ShowsTerminalTab}"
+                                       IsEnabled="{Binding IsTerminalActive}"
+                                       IsHitTestVisible="{Binding IsTerminalActive}"
+                                       Opacity="{Binding IsTerminalActive, Converter={x:Static views:BoolToOpacityConverter.Instance}}"
+                                       AutomationProperties.IsOffscreenBehavior="{Binding IsTerminalActive, Converter={x:Static views:OffscreenWhenInactiveConverter.Instance}}"
                                        FontFamily="Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace"
                                        CaretBrush="{StaticResource KcapAccentBrush}"
                                        Model="{Binding Terminal.Surface, Converter={x:Static views:TerminalSurfaceModelConverter.Instance}}" />
 
-            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Connecting}"
-                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
-                    CornerRadius="8" Padding="14,8" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
-                <TextBlock Text="Connecting…" Foreground="{StaticResource KcapMutedBrush}" />
-            </Border>
+            <Panel x:Name="TerminalBanners" IsVisible="{Binding IsTerminalActive}">
+                <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Connecting}"
+                        Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                        CornerRadius="8" Padding="14,8" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
+                    <TextBlock Text="Connecting…" Foreground="{StaticResource KcapMutedBrush}" />
+                </Border>
 
-            <!-- Owner decision (post-QA): the attach banner overlays the terminal, so a normal
-                 read-write session shows NO banner — explicit detach returns when a use case
-                 earns it. Read-only keeps the banner: it is the only explanation for dead
-                 keystrokes, and Detach is the only action such a session has. -->
-            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalReadOnlyBannerVisibleConverter.Instance}}"
-                    Background="{StaticResource KcapWarningDimBrush}" BorderBrush="{StaticResource KcapWarningBrush}"
-                    BorderThickness="1" CornerRadius="8" Padding="12,7" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
-                <StackPanel Orientation="Horizontal" Spacing="10">
-                    <TextBlock x:Name="AttachBannerText"
-                               Text="{Binding Terminal.State.Detail, StringFormat='Read-only: {0}'}"
-                               Foreground="{StaticResource KcapWarningBrush}" VerticalAlignment="Center" />
-                    <Button x:Name="DetachButton" Content="Detach" Command="{Binding Terminal.DetachCommand}" Padding="10,3" FontSize="12" />
-                </StackPanel>
-            </Border>
+                <!-- Owner decision (post-QA): the attach banner overlays the terminal, so a normal
+                     read-write session shows NO banner — explicit detach returns when a use case
+                     earns it. Read-only keeps the banner: it is the only explanation for dead
+                     keystrokes, and Detach is the only action such a session has. -->
+                <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalReadOnlyBannerVisibleConverter.Instance}}"
+                        Background="{StaticResource KcapWarningDimBrush}" BorderBrush="{StaticResource KcapWarningBrush}"
+                        BorderThickness="1" CornerRadius="8" Padding="12,7" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,14,0,0">
+                    <StackPanel Orientation="Horizontal" Spacing="10">
+                        <TextBlock x:Name="AttachBannerText"
+                                   Text="{Binding Terminal.State.Detail, StringFormat='Read-only: {0}'}"
+                                   Foreground="{StaticResource KcapWarningBrush}" VerticalAlignment="Center" />
+                        <Button x:Name="DetachButton" Content="Detach" Command="{Binding Terminal.DetachCommand}" Padding="10,3" FontSize="12" />
+                    </StackPanel>
+                </Border>
 
-            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalDetachedOrFailedVisibleConverter.Instance}}"
-                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
-                    CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <StackPanel Spacing="10" HorizontalAlignment="Center">
-                    <TextBlock Text="{Binding Terminal.State, Converter={x:Static views:TerminalDetachedOrFailedMessageConverter.Instance}}"
-                               Foreground="{StaticResource KcapTextBrush}" HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="380" />
-                    <Button x:Name="ReattachButton" Content="Reattach" Command="{Binding Terminal.ReattachCommand}"
-                            HorizontalAlignment="Center" Background="{StaticResource KcapAccentBrush}" Foreground="#07120E"
-                            FontWeight="SemiBold" Padding="16,5" />
-                </StackPanel>
-            </Border>
+                <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalDetachedOrFailedVisibleConverter.Instance}}"
+                        Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                        CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <StackPanel Spacing="10" HorizontalAlignment="Center">
+                        <TextBlock Text="{Binding Terminal.State, Converter={x:Static views:TerminalDetachedOrFailedMessageConverter.Instance}}"
+                                   Foreground="{StaticResource KcapTextBrush}" HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="380" />
+                        <Button x:Name="ReattachButton" Content="Reattach" Command="{Binding Terminal.ReattachCommand}"
+                                HorizontalAlignment="Center" Background="{StaticResource KcapAccentBrush}" Foreground="#07120E"
+                                FontWeight="SemiBold" Padding="16,5" />
+                    </StackPanel>
+                </Border>
 
-            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Exited}"
-                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
-                    CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="{Binding Terminal.State.ExitCode, StringFormat='Session exited (code {0})'}"
-                           Foreground="{StaticResource KcapTextBrush}" />
-            </Border>
+                <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Exited}"
+                        Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                        CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding Terminal.State.ExitCode, StringFormat='Session exited (code {0})'}"
+                               Foreground="{StaticResource KcapTextBrush}" />
+                </Border>
 
-            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=NotFound}"
-                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
-                    CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <StackPanel Spacing="10" HorizontalAlignment="Center">
-                    <TextBlock Text="{Binding Terminal.State.Detail}" Foreground="{StaticResource KcapTextBrush}" />
-                    <Button Content="Retry" Command="{Binding Terminal.RetryResolveCommand}" HorizontalAlignment="Center" Padding="14,4" />
-                </StackPanel>
-            </Border>
+                <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=NotFound}"
+                        Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                        CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <StackPanel Spacing="10" HorizontalAlignment="Center">
+                        <TextBlock Text="{Binding Terminal.State.Detail}" Foreground="{StaticResource KcapTextBrush}" />
+                        <Button Content="Retry" Command="{Binding Terminal.RetryResolveCommand}" HorizontalAlignment="Center" Padding="14,4" />
+                    </StackPanel>
+                </Border>
 
-            <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=SessionEnded}"
-                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
-                    CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="This session has ended." Foreground="{StaticResource KcapMutedBrush}" />
-            </Border>
+                <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=SessionEnded}"
+                        Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                        CornerRadius="8" Padding="16,12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <TextBlock Text="This session has ended." Foreground="{StaticResource KcapMutedBrush}" />
+                </Border>
+            </Panel>
+
+            <!-- The automation peer reports offscreen from the control's OWN IsVisible, so hiding
+                 an ancestor instead would leave the inactive chat announced as onscreen. The flag
+                 lives on the workspace VM, which is not this control's DataContext. -->
+            <views:ChatTabView x:Name="ChatHost" DataContext="{Binding Chat}"
+                               IsVisible="{Binding $parent[views:WorkspaceView].((vm:WorkspaceViewModel)DataContext).IsChatActive}" />
         </Grid>
     </Grid>
 </UserControl>

--- a/src/Capacitor.App/Views/WorkspaceView.axaml.cs
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.Data.Converters;
 using Avalonia.Threading;
@@ -35,12 +36,16 @@ public partial class WorkspaceView : UserControl {
                 && DataContext is WorkspaceViewModel { IsTerminalActive: true })
                 TerminalHost.Focus();
         };
+        // A session with no PTY has neither surface to focus, so nothing is posted until the chat
+        // tab exists — which is also the moment a workspace opened on Chat gets its composer
+        // focused, since the tab is already active by then.
         DataContextChanged += (_, _) => {
             _tabFocus?.Dispose();
             _tabFocus = (DataContext as WorkspaceViewModel)?
-                .WhenAnyValue(vm => vm.ActiveTab)
-                .Subscribe(tab => Dispatcher.UIThread.Post(() => {
-                    if (tab == WorkspaceTab.Chat) ChatHost.FocusComposer();
+                .WhenAnyValue(vm => vm.ActiveTab, vm => vm.Chat)
+                .Where(pair => pair.Item2 is not null)
+                .Subscribe(pair => Dispatcher.UIThread.Post(() => {
+                    if (pair.Item1 == WorkspaceTab.Chat) ChatHost.FocusComposer();
                     else TerminalHost.Focus();
                 }, DispatcherPriority.Loaded));
         };
@@ -79,8 +84,8 @@ public sealed class TerminalPhaseIsConverter : IValueConverter {
 }
 
 /// The read-only warning banner: visible only for a read-only Attached session — the one case
-/// where the banner explains otherwise-dead keystrokes. A read-write attach shows no banner
-/// (owner decision after QA: it overlaid the terminal).
+/// where the banner explains otherwise-dead keystrokes. A read-write attach shows none: the
+/// banner would overlay the terminal it sits on.
 public sealed class TerminalReadOnlyBannerVisibleConverter : IValueConverter {
     public static readonly TerminalReadOnlyBannerVisibleConverter Instance = new();
 

--- a/src/Capacitor.App/Views/WorkspaceView.axaml.cs
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml.cs
@@ -1,24 +1,25 @@
 using System.Globalization;
 using Avalonia.Controls;
 using Avalonia.Data.Converters;
+using Avalonia.Threading;
 using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using ReactiveUI;
 
 namespace Capacitor.App.Views;
 
 /// The session workspace: DataContext is supplied externally (a plainly-constructed
 /// WorkspaceViewModel) -- same contract as HomeView/MainWindow, this view never builds its own VM.
 ///
-/// TerminalHost hosts SvcSystems.UI.Terminal's own TerminalControl directly (no custom host/
-/// wrapper needed) -- decompile-verified (Task 12 discovery) that TerminalControl already calls
-/// its Model's Resize(width, height, textWidth, textHeight) itself, from BOTH its ModelProperty
-/// change handler (a reattach's fresh Model gets sized to the control's CURRENT bounds
-/// immediately) and its inner surface's own OnSizeChanged (an actual window/pane resize). Task
-/// 11's "the view must call Model.Resize(...) from its bounds-changed handling" obligation is
-/// therefore satisfied by USING the real vendor control rather than by re-implementing what it
-/// already does -- a hand-rolled bounds-changed handler here would only risk double-invoking
-/// Resize with worse (font-metric-unaware) width/height than TerminalControl's own
-/// _consoleTextSize-based computation.
+/// TerminalHost is SvcSystems.UI.Terminal's own TerminalControl, unwrapped: it already calls its
+/// Model's Resize(width, height, textWidth, textHeight) itself, from BOTH its ModelProperty change
+/// handler (a reattach's fresh Model gets sized to the control's CURRENT bounds immediately) and
+/// its inner surface's own OnSizeChanged (an actual window/pane resize). A bounds-changed handler
+/// here would only double-invoke Resize with worse (font-metric-unaware) width/height than the
+/// control's own _consoleTextSize-based computation.
 public partial class WorkspaceView : UserControl {
+    IDisposable? _tabFocus;
+
     // The workspace header doubles as the draggable chrome on its side of the split — see
     // WindowChrome.
     void OnHeaderPointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e) =>
@@ -26,12 +27,22 @@ public partial class WorkspaceView : UserControl {
 
     public WorkspaceView() {
         InitializeComponent();
-        // Keyboard focus is a view concern: the control draws its filled caret (and receives
-        // keystrokes) only while focused, and nothing else focuses it when a session opens or
-        // reattaches — Model assignment is exactly the "terminal became live" moment.
+        // The control draws its caret and takes keystrokes only while focused; a Model assignment
+        // is the "terminal became live" moment — but only the Terminal tab may take focus, or a
+        // reattach under the Chat tab would steal it from the composer.
         TerminalHost.PropertyChanged += (_, e) => {
-            if (e.Property == SvcSystems.UI.Terminal.TerminalControl.ModelProperty && TerminalHost.Model is not null)
+            if (e.Property == SvcSystems.UI.Terminal.TerminalControl.ModelProperty && TerminalHost.Model is not null
+                && DataContext is WorkspaceViewModel { IsTerminalActive: true })
                 TerminalHost.Focus();
+        };
+        DataContextChanged += (_, _) => {
+            _tabFocus?.Dispose();
+            _tabFocus = (DataContext as WorkspaceViewModel)?
+                .WhenAnyValue(vm => vm.ActiveTab)
+                .Subscribe(tab => Dispatcher.UIThread.Post(() => {
+                    if (tab == WorkspaceTab.Chat) ChatHost.FocusComposer();
+                    else TerminalHost.Focus();
+                }, DispatcherPriority.Loaded));
         };
     }
 }

--- a/src/Capacitor.Cli.Core/Harness/Claude/ClaudeTranscriptEvents.cs
+++ b/src/Capacitor.Cli.Core/Harness/Claude/ClaudeTranscriptEvents.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using static Capacitor.Cli.Core.TranscriptProjectionText;
+
+namespace Capacitor.Cli.Core.Harness.Claude;
+
+/// Claude Code's project transcript (`~/.claude/projects/&lt;slug&gt;/&lt;session&gt;.jsonl`): one JSON
+/// record per line, `type` at the root, the API message under `message`.
+public sealed partial class ClaudeTranscriptEvents : ITranscriptProjection {
+    public static readonly ClaudeTranscriptEvents Instance = new();
+
+    ClaudeTranscriptEvents() { }
+
+    public IReadOnlyList<AcpEventEnvelope> Project(string line) {
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(line); } catch (JsonException) { return []; }
+
+        using (doc) {
+            var root = doc.RootElement;
+            if (!root.IsObject || root.Bool("isSidechain") == true) return [];
+            var ts = root.Str("timestamp");
+            return root.Str("type") switch {
+                "user"      => root.Bool("isMeta") == true ? [] : ProjectUser(root, ts),
+                "assistant" => ProjectAssistant(root, ts),
+                _           => [],
+            };
+        }
+    }
+
+    static List<AcpEventEnvelope> ProjectUser(JsonElement root, string? ts) {
+        var result = new List<AcpEventEnvelope>();
+        if (root.Obj("message") is not { } message) return result;
+
+        if (message.Str("content") is { } text) {
+            AddUserText(result, text, ts);
+            return result;
+        }
+        if (message.Arr("content") is not { } blocks) return result;
+
+        foreach (var block in blocks.EnumerateArray()) {
+            switch (block.Str("type")) {
+                case "text":
+                    if (block.Str("text") is { } t) AddUserText(result, t, ts);
+                    break;
+                case "tool_result":
+                    result.Add(new AcpEventEnvelope(
+                        Kind: AcpEventKind.ToolResult,
+                        ToolCallId: block.Str("tool_use_id"),
+                        ToolResult: Cap(ToolResultText(block)),
+                        ToolIsError: block.Bool("is_error") == true,
+                        TimestampIso: ts));
+                    break;
+            }
+        }
+        return result;
+    }
+
+    static string ToolResultText(JsonElement block) =>
+        block.Str("content") ?? (block.Arr("content") is { } blocks ? JoinTextBlocks(blocks, "text") : "");
+
+    static void AddUserText(List<AcpEventEnvelope> result, string raw, string? ts) {
+        var text = StripWrappers(raw);
+        if (text.Length == 0) return;
+        result.Add(new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: text, TimestampIso: ts));
+    }
+
+    static List<AcpEventEnvelope> ProjectAssistant(JsonElement root, string? ts) {
+        var result = new List<AcpEventEnvelope>();
+        if (root.Obj("message") is not { } message || message.Arr("content") is not { } blocks) return result;
+        var model = message.Str("model");
+
+        foreach (var block in blocks.EnumerateArray()) {
+            switch (block.Str("type")) {
+                case "text":
+                    if (block.Str("text") is { Length: > 0 } text)
+                        result.Add(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: text, Model: model, TimestampIso: ts));
+                    break;
+                case "thinking": {
+                    var thinking = block.Str("thinking");
+                    result.Add(new AcpEventEnvelope(
+                        Kind: AcpEventKind.AssistantThinking,
+                        Text: string.IsNullOrEmpty(thinking) ? null : thinking,
+                        ThinkingEncrypted: string.IsNullOrEmpty(thinking),
+                        Model: model, TimestampIso: ts));
+                    break;
+                }
+                case "tool_use":
+                    result.Add(new AcpEventEnvelope(
+                        Kind: AcpEventKind.ToolCall,
+                        ToolCallId: block.Str("id"),
+                        ToolName: block.Str("name"),
+                        ToolInputJson: InputJson(block),
+                        Model: model, TimestampIso: ts));
+                    break;
+            }
+        }
+        return result;
+    }
+
+    // ToolInputJson must always be a JSON object string: a non-object input is wrapped
+    // rather than copied, and an absent one becomes the empty object.
+    static string InputJson(JsonElement block) =>
+        block.Obj("input") is { } obj ? obj.GetRawText()
+        : block.Prop("input") is { } value ? WrapAsObject("input", value)
+        : "{}";
+
+    /// Removes the blocks Claude Code injects around a user turn — reminders and slash-command
+    /// echoes — so only what the user typed remains.
+    internal static string StripWrappers(string text) => Wrappers().Replace(text, "").Trim();
+
+    [GeneratedRegex(@"<(system-reminder|command-name|command-message|command-args|local-command-stdout|local-command-caveat)>.*?</\1>", RegexOptions.Singleline)]
+    private static partial Regex Wrappers();
+}

--- a/src/Capacitor.Cli.Core/Harness/Claude/ClaudeTranscriptEvents.cs
+++ b/src/Capacitor.Cli.Core/Harness/Claude/ClaudeTranscriptEvents.cs
@@ -20,7 +20,9 @@ public sealed partial class ClaudeTranscriptEvents : ITranscriptProjection {
             if (!root.IsObject || root.Bool("isSidechain") == true) return [];
             var ts = root.Str("timestamp");
             return root.Str("type") switch {
-                "user"      => root.Bool("isMeta") == true ? [] : ProjectUser(root, ts),
+                "user"      => root.Bool("isMeta") == true ? []
+                             : root.Obj("origin")?.Str("kind") == "task-notification" ? ProjectTaskNotification(root, ts)
+                             : ProjectUser(root, ts),
                 "assistant" => ProjectAssistant(root, ts),
                 _           => [],
             };
@@ -57,6 +59,30 @@ public sealed partial class ClaudeTranscriptEvents : ITranscriptProjection {
 
     static string ToolResultText(JsonElement block) =>
         block.Str("content") ?? (block.Arr("content") is { } blocks ? JoinTextBlocks(blocks, "text") : "");
+
+    // A finished background task lands in the transcript as a user record Claude Code marks by
+    // its origin: system-attributed, and its summary and result are what a reader wants.
+    static List<AcpEventEnvelope> ProjectTaskNotification(JsonElement root, string? ts) {
+        var raw = root.Obj("message") is { } message
+            ? message.Str("content") ?? (message.Arr("content") is { } blocks ? JoinTextBlocks(blocks, "text") : "")
+            : "";
+        var summary = TaskSummary().Match(raw) is { Success: true } s ? s.Groups[1].Value.Trim() : "";
+        var body    = TaskResult().Match(raw) is { Success: true } r ? r.Groups[1].Value.Trim() : "";
+        var parts = new List<string>(2);
+        if (summary.Length > 0) parts.Add($"**{summary}**");
+        if (body.Length > 0) parts.Add(body);
+        var text = parts.Count > 0 ? string.Join("\n\n", parts) : TaskWrapper().Replace(raw, "").Trim();
+        return text.Length == 0 ? [] : [new AcpEventEnvelope(Kind: AcpEventKind.SystemNote, Text: text, TimestampIso: ts)];
+    }
+
+    [GeneratedRegex(@"<summary>(.*?)</summary>", RegexOptions.Singleline)]
+    private static partial Regex TaskSummary();
+
+    [GeneratedRegex(@"<result>(.*?)</result>", RegexOptions.Singleline)]
+    private static partial Regex TaskResult();
+
+    [GeneratedRegex(@"</?task-notification>")]
+    private static partial Regex TaskWrapper();
 
     static void AddUserText(List<AcpEventEnvelope> result, string raw, string? ts) {
         var text = StripWrappers(raw);

--- a/src/Capacitor.Cli.Core/Harness/Codex/CodexRolloutEvents.cs
+++ b/src/Capacitor.Cli.Core/Harness/Codex/CodexRolloutEvents.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using static Capacitor.Cli.Core.TranscriptProjectionText;
+
+namespace Capacitor.Cli.Core.Harness.Codex;
+
+/// Codex's rollout (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`): an envelope per line with
+/// `type` and `payload`; only `response_item` payloads are conversation, the rest is telemetry.
+public sealed class CodexRolloutEvents : ITranscriptProjection {
+    public static readonly CodexRolloutEvents Instance = new();
+
+    static readonly string[] InjectedPreludes = [
+        "<environment_context>", "# AGENTS.md instructions", "<turn_aborted>", "<user_instructions>", "<permissions instructions>",
+    ];
+
+    CodexRolloutEvents() { }
+
+    public IReadOnlyList<AcpEventEnvelope> Project(string line) {
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(line); } catch (JsonException) { return []; }
+
+        using (doc) {
+            var root = doc.RootElement;
+            if (!root.IsObject || root.Str("type") != "response_item" || root.Obj("payload") is not { } payload) return [];
+            var ts = root.Str("timestamp");
+
+            return payload.Str("type") switch {
+                "message"          => ProjectMessage(payload, ts),
+                "function_call"    => [new AcpEventEnvelope(Kind: AcpEventKind.ToolCall, ToolCallId: payload.Str("call_id"), ToolName: payload.Str("name"), ToolInputJson: ArgumentsJson(payload.Str("arguments")), TimestampIso: ts)],
+                "custom_tool_call" => [new AcpEventEnvelope(Kind: AcpEventKind.ToolCall, ToolCallId: payload.Str("call_id"), ToolName: payload.Str("name"), ToolInputJson: WrapAsObject("input", payload.Str("input") ?? ""), TimestampIso: ts)],
+                "function_call_output" or "custom_tool_call_output"
+                                   => [new AcpEventEnvelope(Kind: AcpEventKind.ToolResult, ToolCallId: payload.Str("call_id"), ToolResult: Cap(OutputText(payload)), TimestampIso: ts)],
+                "reasoning"        => [Reasoning(payload, ts)],
+                _                  => [],
+            };
+        }
+    }
+
+    static List<AcpEventEnvelope> ProjectMessage(JsonElement payload, string? ts) {
+        if (payload.Arr("content") is not { } blocks) return [];
+        switch (payload.Str("role")) {
+            case "user": {
+                var text = JoinTextBlocks(blocks, "input_text");
+                if (text.Length == 0 || IsInjectedPrelude(text)) return [];
+                return [new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: text, TimestampIso: ts)];
+            }
+            case "assistant": {
+                var text = JoinTextBlocks(blocks, "output_text");
+                return text.Length == 0 ? [] : [new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: text, TimestampIso: ts)];
+            }
+            default:
+                return [];
+        }
+    }
+
+    static bool IsInjectedPrelude(string text) {
+        var trimmed = text.TrimStart();
+        foreach (var prelude in InjectedPreludes) {
+            if (trimmed.StartsWith(prelude, StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+
+    static string ArgumentsJson(string? arguments) {
+        if (arguments is not null) {
+            try {
+                using var doc = JsonDocument.Parse(arguments);
+                if (doc.RootElement.IsObject) return doc.RootElement.GetRawText();
+            } catch (JsonException) { }
+        }
+        return WrapAsObject("arguments", arguments ?? "");
+    }
+
+    static string OutputText(JsonElement payload) =>
+        payload.Str("output") ?? (payload.Arr("output") is { } blocks ? JoinTextBlocks(blocks, "input_text") : "");
+
+    static AcpEventEnvelope Reasoning(JsonElement payload, string? ts) {
+        var summary = payload.Arr("summary") is { } blocks ? JoinTextBlocks(blocks, "summary_text") : "";
+        return new AcpEventEnvelope(
+            Kind: AcpEventKind.AssistantThinking,
+            Text: summary.Length == 0 ? null : summary,
+            ThinkingEncrypted: summary.Length == 0 && payload.Str("encrypted_content") is not null,
+            TimestampIso: ts);
+    }
+}

--- a/src/Capacitor.Cli.Core/JsonElementExtensions.cs
+++ b/src/Capacitor.Cli.Core/JsonElementExtensions.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 namespace Capacitor.Cli.Core;
 
-static class JsonElementExtensions {
+public static class JsonElementExtensions {
     extension(JsonElement el) {
         // The one primitive the property accessors below cannot express: whether the element ITSELF
         // is an object. They all answer about a named property, so a caller guarding a document root

--- a/src/Capacitor.Cli.Core/JsonElementExtensions.cs
+++ b/src/Capacitor.Cli.Core/JsonElementExtensions.cs
@@ -35,5 +35,10 @@ static class JsonElementExtensions {
         public JsonElement? Obj(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.IsObject ? v : null;
 
         public JsonElement? Arr(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.Array ? v : null;
+
+        // The property as-is, whatever its kind — for the one caller that has to copy a value
+        // verbatim (a non-object tool input wrapped into an object). Every other read wants a
+        // typed accessor above; this one deliberately answers "present" for JSON null too.
+        public JsonElement? Prop(string property) => el.IsObject && el.TryGetProperty(property, out var v) ? v : null;
     }
 }

--- a/src/Capacitor.Cli.Core/JsonlTail.cs
+++ b/src/Capacitor.Cli.Core/JsonlTail.cs
@@ -19,16 +19,20 @@ public sealed class JsonlTail(string path) {
     public TailRead ReadAppended() {
         try {
             using var stream = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            var status = TailStatus.Ok;
             var length = stream.Length;
-            if (length < _cursor) {
-                _cursor = 0;
-                status = TailStatus.Reset;
+            var regressed = length < _cursor;
+            // The origin stays local until the read succeeds: assigning the reset cursor up front
+            // would let a fault mid-read return Failed with the regression already spent, and the
+            // next Ok read would then deliver the whole file on top of what it had reported.
+            var origin = regressed ? 0 : _cursor;
+            var status = regressed ? TailStatus.Reset : TailStatus.Ok;
+            if (length == origin) {
+                _cursor = origin;
+                return new TailRead([], status);
             }
-            if (length == _cursor) return new TailRead([], status);
 
-            stream.Position = _cursor;
-            var buffer = new byte[length - _cursor];
+            stream.Position = origin;
+            var buffer = new byte[length - origin];
             var read = 0;
             while (read < buffer.Length) {
                 var n = stream.Read(buffer, read, buffer.Length - read);
@@ -37,7 +41,7 @@ public sealed class JsonlTail(string path) {
             }
 
             var lines = SplitCompleteLines(buffer.AsSpan(0, read), out var consumed);
-            _cursor += consumed;
+            _cursor = origin + consumed;
             return new TailRead(lines, status);
         } catch (FileNotFoundException) {
             return new TailRead([], TailStatus.Missing);

--- a/src/Capacitor.Cli.Core/JsonlTail.cs
+++ b/src/Capacitor.Cli.Core/JsonlTail.cs
@@ -1,0 +1,74 @@
+using System.Text;
+
+namespace Capacitor.Cli.Core;
+
+public enum TailStatus { Ok, Reset, Missing, Failed }
+
+public sealed record TailRead(IReadOnlyList<string> Lines, TailStatus Status, string? Failure = null);
+
+/// Appended-lines reader over a JSONL file another process is writing. Every open shares
+/// read/write/delete: a FileShare.Read open would deny the agent its own write handle on
+/// Windows. Only a length regression resets the cursor — a replacement by a same-or-longer
+/// file is read from the old cursor, which both vendors' append-only transcripts never produce.
+public sealed class JsonlTail(string path) {
+    long _cursor;
+
+    public string Path { get; } = path;
+    public long Cursor => _cursor;
+
+    public TailRead ReadAppended() {
+        try {
+            using var stream = new FileStream(Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var status = TailStatus.Ok;
+            var length = stream.Length;
+            if (length < _cursor) {
+                _cursor = 0;
+                status = TailStatus.Reset;
+            }
+            if (length == _cursor) return new TailRead([], status);
+
+            stream.Position = _cursor;
+            var buffer = new byte[length - _cursor];
+            var read = 0;
+            while (read < buffer.Length) {
+                var n = stream.Read(buffer, read, buffer.Length - read);
+                if (n == 0) break;
+                read += n;
+            }
+
+            var lines = SplitCompleteLines(buffer.AsSpan(0, read), out var consumed);
+            _cursor += consumed;
+            return new TailRead(lines, status);
+        } catch (FileNotFoundException) {
+            return new TailRead([], TailStatus.Missing);
+        } catch (DirectoryNotFoundException) {
+            return new TailRead([], TailStatus.Missing);
+        } catch (Exception ex) {
+            return new TailRead([], TailStatus.Failed, ex.Message);
+        }
+    }
+
+    /// Complete lines only; `consumed` stops after the last '\n' so an unterminated tail is
+    /// re-read whole once its newline lands.
+    public static List<string> SplitCompleteLines(ReadOnlySpan<byte> bytes, out int consumed) {
+        var lines = new List<string>();
+        consumed = 0;
+        var start = 0;
+        for (var i = 0; i < bytes.Length; i++) {
+            if (bytes[i] != (byte)'\n') continue;
+            var line = bytes[start..i];
+            if (line.Length > 0 && line[^1] == (byte)'\r') line = line[..^1];
+            if (!IsBlank(line)) lines.Add(Encoding.UTF8.GetString(line));
+            start = i + 1;
+            consumed = start;
+        }
+        return lines;
+    }
+
+    static bool IsBlank(ReadOnlySpan<byte> line) {
+        foreach (var b in line) {
+            if (b is not ((byte)' ' or (byte)'\t' or (byte)'\r')) return false;
+        }
+        return true;
+    }
+}

--- a/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
@@ -47,7 +47,12 @@ public sealed record AgentStatusDto(
     bool? HasTerminal = null,
     // The launch prompt's first non-blank line, truncated by the daemon (TitleFromPrompt) —
     // display text for session rows. Trailing + nullable: null = older daemon or no goal text.
-    string? Title = null);
+    string? Title = null,
+    // Where the daemon found the agent's own transcript (Claude's project .jsonl, Codex's
+    // rollout), link-resolved. Trailing + nullable: null is "older daemon", "not found yet",
+    // "no transcript for this runtime", or "found nothing before the agent exited" alike —
+    // a client waits, it never distinguishes them.
+    string? TranscriptPath = null);
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(DaemonStatusDto))]

--- a/src/Capacitor.Cli.Core/TranscriptProjection.cs
+++ b/src/Capacitor.Cli.Core/TranscriptProjection.cs
@@ -54,8 +54,13 @@ internal static class TranscriptProjectionText {
         return Encoding.UTF8.GetString(buffer.ToArray());
     }
 
-    // Embeds value verbatim between quotes rather than JSON-escaping it: the caller supplies
-    // text already safe to sit inside a JSON string (e.g. a vendor's own quoted field).
-    public static string WrapAsObject(string property, string value) =>
-        $$"""{"{{property}}":"{{value}}"}""";
+    public static string WrapAsObject(string property, string value) {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer)) {
+            writer.WriteStartObject();
+            writer.WriteString(property, value);
+            writer.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
 }

--- a/src/Capacitor.Cli.Core/TranscriptProjection.cs
+++ b/src/Capacitor.Cli.Core/TranscriptProjection.cs
@@ -1,0 +1,61 @@
+using System.Text;
+using System.Text.Json;
+using Capacitor.Cli.Core.Harness.Claude;
+
+namespace Capacitor.Cli.Core;
+
+/// One transcript line in, zero or more canonical chat events out. Stateless: the consumer
+/// orders by arrival and pairs tool calls to results by id itself.
+public interface ITranscriptProjection {
+    IReadOnlyList<AcpEventEnvelope> Project(string line);
+}
+
+/// The one registration site: a vendor's transcript projection lives under Harness/&lt;Vendor&gt;/
+/// and is named here, nowhere else.
+public static class TranscriptProjection {
+    public static ITranscriptProjection? For(string vendor) => vendor.ToLowerInvariant() switch {
+        "claude" => ClaudeTranscriptEvents.Instance,
+        _        => null,
+    };
+}
+
+/// Output rules both projections share, so an envelope reads the same whichever vendor wrote it.
+internal static class TranscriptProjectionText {
+    public const int ToolResultCap = 4096;
+    const string CapMarker = "…";
+
+    /// At most ToolResultCap units including the marker; a cut that would split a surrogate
+    /// pair drops the high half too, so the result can be one unit short of the cap.
+    public static string Cap(string text) {
+        if (text.Length <= ToolResultCap) return text;
+        var cut = ToolResultCap - CapMarker.Length;
+        if (char.IsHighSurrogate(text[cut - 1])) cut--;
+        return string.Concat(text.AsSpan(0, cut), CapMarker);
+    }
+
+    public static string JoinTextBlocks(JsonElement array, string blockType, string textProperty = "text") {
+        var sb = new StringBuilder();
+        foreach (var block in array.EnumerateArray()) {
+            if (block.Str("type") != blockType || block.Str(textProperty) is not { } text) continue;
+            if (sb.Length > 0) sb.Append('\n');
+            sb.Append(text);
+        }
+        return sb.ToString();
+    }
+
+    public static string WrapAsObject(string property, JsonElement value) {
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer)) {
+            writer.WriteStartObject();
+            writer.WritePropertyName(property);
+            value.WriteTo(writer);
+            writer.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    // Embeds value verbatim between quotes rather than JSON-escaping it: the caller supplies
+    // text already safe to sit inside a JSON string (e.g. a vendor's own quoted field).
+    public static string WrapAsObject(string property, string value) =>
+        $$"""{"{{property}}":"{{value}}"}""";
+}

--- a/src/Capacitor.Cli.Core/TranscriptProjection.cs
+++ b/src/Capacitor.Cli.Core/TranscriptProjection.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Core.Harness.Claude;
+using Capacitor.Cli.Core.Harness.Codex;
 
 namespace Capacitor.Cli.Core;
 
@@ -15,6 +16,7 @@ public interface ITranscriptProjection {
 public static class TranscriptProjection {
     public static ITranscriptProjection? For(string vendor) => vendor.ToLowerInvariant() switch {
         "claude" => ClaudeTranscriptEvents.Instance,
+        "codex"  => CodexRolloutEvents.Instance,
         _        => null,
     };
 }

--- a/src/Capacitor.Cli.Daemon/Harness/Claude/SessionTranscriptLocator.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Claude/SessionTranscriptLocator.cs
@@ -43,15 +43,21 @@ internal static class SessionTranscriptLocator {
     static readonly TimeSpan FileTimeSkewTolerance = TimeSpan.FromSeconds(5);
 
     /// <summary>
-    /// Scans <paramref name="projectDir"/> for a transcript written at/after
-    /// <paramref name="spawnedAtUtc"/> whose early lines report <c>cwd</c> equal to
-    /// <paramref name="worktreePath"/>. Returns the normalized (dashless, lowercase)
-    /// session id, or null when no candidate matches yet. Best-effort: unreadable or
-    /// malformed candidates are skipped, never thrown.
+    /// The normalized (dashless, lowercase) session id of the transcript
+    /// <see cref="TryLocateWinner"/> picks, or null when no candidate matches yet.
     /// </summary>
     public static string? TryLocate(string projectDir, string worktreePath, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) =>
         TryLocateWinner(projectDir, worktreePath, spawnedAtUtc, ruledOut)?.SessionId;
 
+    /// <summary>
+    /// Scans <paramref name="projectDir"/> for a transcript written at/after
+    /// <paramref name="spawnedAtUtc"/> whose early lines report <c>cwd</c> equal to
+    /// <paramref name="worktreePath"/>, and returns its normalized (dashless, lowercase) session
+    /// id together with its path — link-resolved, because the per-worktree project dir is a
+    /// symlink the launcher deletes at cleanup and a path through it would die with the process
+    /// while the file lives on in the source repo's project dir. Null when no candidate matches
+    /// yet. Best-effort: unreadable or malformed candidates are skipped, never thrown.
+    /// </summary>
     /// <param name="ruledOut">
     /// Optional set of file paths already confirmed to belong to another session (or to not be a
     /// transcript at all). Since the caller polls every few seconds over a shared project dir,
@@ -61,9 +67,6 @@ internal static class SessionTranscriptLocator {
     /// Files with no <c>cwd</c> yet (still being written) are left out so the agent's own
     /// freshly-created transcript is always re-checked.
     /// </param>
-    /// The matched transcript's id AND its path, link-resolved: the per-worktree project dir is
-    /// a symlink the launcher deletes at cleanup, and a path through it would die with the
-    /// process while the file lives on in the source repo's project dir.
     internal static (string SessionId, string Path)? TryLocateWinner(string projectDir, string worktreePath, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) {
         if (!Directory.Exists(projectDir)) return null;
 

--- a/src/Capacitor.Cli.Daemon/Harness/Claude/SessionTranscriptLocator.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Claude/SessionTranscriptLocator.cs
@@ -49,6 +49,9 @@ internal static class SessionTranscriptLocator {
     /// session id, or null when no candidate matches yet. Best-effort: unreadable or
     /// malformed candidates are skipped, never thrown.
     /// </summary>
+    public static string? TryLocate(string projectDir, string worktreePath, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) =>
+        TryLocateWinner(projectDir, worktreePath, spawnedAtUtc, ruledOut)?.SessionId;
+
     /// <param name="ruledOut">
     /// Optional set of file paths already confirmed to belong to another session (or to not be a
     /// transcript at all). Since the caller polls every few seconds over a shared project dir,
@@ -58,7 +61,10 @@ internal static class SessionTranscriptLocator {
     /// Files with no <c>cwd</c> yet (still being written) are left out so the agent's own
     /// freshly-created transcript is always re-checked.
     /// </param>
-    public static string? TryLocate(string projectDir, string worktreePath, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) {
+    /// The matched transcript's id AND its path, link-resolved: the per-worktree project dir is
+    /// a symlink the launcher deletes at cleanup, and a path through it would die with the
+    /// process while the file lives on in the source repo's project dir.
+    internal static (string SessionId, string Path)? TryLocateWinner(string projectDir, string worktreePath, DateTime spawnedAtUtc, ISet<string>? ruledOut = null) {
         if (!Directory.Exists(projectDir)) return null;
 
         foreach (var file in Directory.EnumerateFiles(projectDir, "*.jsonl")) {
@@ -73,7 +79,7 @@ internal static class SessionTranscriptLocator {
                 if (!IsNewEnough(File.GetCreationTimeUtc(file), File.GetLastWriteTimeUtc(file), spawnedAtUtc)) continue;
 
                 switch (MatchTranscript(ReadFirstLines(file), worktreePath, DefaultPathComparison)) {
-                    case CwdMatch.Yes: return sessionId;
+                    case CwdMatch.Yes: return (sessionId, Path.Combine(ResolveDirectory(projectDir), Path.GetFileName(file)));
                     case CwdMatch.No:  ruledOut?.Add(file); break; // another session's transcript — cwd is fixed
                     // CwdMatch.Unknown: no cwd yet (file still being written) — leave uncached, re-check next tick.
                 }
@@ -84,6 +90,15 @@ internal static class SessionTranscriptLocator {
         }
 
         return null;
+    }
+
+    /// <summary>The directory a symlinked project dir points at (final target), or the directory itself.</summary>
+    internal static string ResolveDirectory(string projectDir) {
+        try {
+            return new DirectoryInfo(projectDir).ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? projectDir;
+        } catch (IOException) {
+            return projectDir;
+        }
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Harness/Claude/SessionTranscriptLocator.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Claude/SessionTranscriptLocator.cs
@@ -3,28 +3,21 @@ using System.Text.Json.Nodes;
 namespace Capacitor.Cli.Daemon.Harness.Claude;
 
 /// <summary>
-/// Discovers the session id of a freshly spawned hosted Claude agent by scanning the
-/// Claude Code project directory for the transcript file the agent writes.
+/// Locates the transcript a freshly spawned hosted Claude agent writes — and with it the agent's
+/// session id — by scanning the Claude Code project directory. The daemon reports the id over its
+/// own authenticated connection, so the server's link to the session does not depend on the
+/// agent's session-start hook reaching it.
 ///
-/// Why this exists: the web chat can only attach to a hosted agent once the server's
-/// registry entry has a SessionId, and until now the ONLY source of that link was the
-/// spawned Claude's session-start hook POSTing to <c>/hooks/session-start</c>. When that
-/// hook fails (e.g. an expired kcap token → 401), the link is never made and the agent
-/// page shows "Waiting for session to start..." forever even though the terminal works.
-/// The daemon itself can make the link instead: Claude Code writes its transcript to
-/// <c>{ClaudePaths.Projects}/{project-dir-hash}/{session-id}.jsonl</c>, so polling that
-/// directory and reporting the discovered id over the daemon's own (authenticated)
-/// SignalR connection is a hook-independent fallback.
+/// Disambiguation: the daemon symlinks the worktree's project dir to the SOURCE repo's project
+/// dir (see <c>ClaudeLauncher.SymlinkClaudeProjectDir</c>), which is shared with the user's own
+/// sessions in that repo — so a new <c>.jsonl</c> there is not necessarily this agent's.
+/// Candidates are verified by reading the first lines of the file and requiring the JSON
+/// <c>"cwd"</c> field to equal the agent's worktree path (the worktree is created per-agent, so a
+/// cwd match is definitive).
 ///
-/// Disambiguation: the daemon symlinks the worktree's project dir to the SOURCE repo's
-/// project dir (see <c>ClaudeLauncher.SymlinkClaudeProjectDir</c>), which is shared with
-/// the user's own sessions in that repo — so a new <c>.jsonl</c> there is not necessarily
-/// this agent's. Candidates are verified by reading the first lines of the file and
-/// requiring the JSON <c>"cwd"</c> field to equal the agent's worktree path (the worktree
-/// is created per-agent, so a cwd match is definitive).
-///
-/// The decision logic (cwd matching, filename → session id parsing, timestamp filtering)
-/// is pure and unit-tested without a filesystem; only <see cref="TryLocate"/> touches disk.
+/// The decision logic (cwd matching, filename → session id parsing, timestamp filtering) is pure
+/// and unit-tested without a filesystem; only <see cref="TryLocateWinner"/> — and
+/// <see cref="TryLocate"/> through it — touches disk.
 /// </summary>
 internal static class SessionTranscriptLocator {
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -54,7 +54,7 @@ internal partial class AgentOrchestrator {
                 // unchanged) — but the wire contract pins absent = null. Normalize here, at the
                 // wire boundary, rather than changing what AgentInstance stores.
                 string.IsNullOrWhiteSpace(a.Model) ? null : a.Model, a.RequesterDisplay,
-                HasTerminal: a.Runtime.EmitsTerminalOutput, Title: a.Title))];
+                HasTerminal: a.Runtime.EmitsTerminalOutput, Title: a.Title, TranscriptPath: a.TranscriptPath))];
 
     /// <summary>
     /// Serves the legacy <c>Stop</c> frame from older clients that predate --force. That frame
@@ -158,6 +158,7 @@ internal partial class AgentOrchestrator {
 
         var           agentId       = Guid.NewGuid().ToString("N");
         AgentInstance agent;
+        DateTime      spawnedAtUtc;
         WorktreeInfo? ownedWorktree = null; // tracked so a failure after creation cleans it up
 
         try {
@@ -192,6 +193,7 @@ internal partial class AgentOrchestrator {
                 if (_permissionBridge.BaseUrl is { } bridgeUrl) env["KCAP_DAEMON_URL"] = bridgeUrl;
             }
 
+            spawnedAtUtc = DateTime.UtcNow;
             var pty     = _ptyFactory.Spawn(launcher.CliPath, built.Args, worktree.Path, env, cols, rows);
             var runtime = new PtyHostedAgentRuntime(vendor, pty);
 
@@ -226,6 +228,7 @@ internal partial class AgentOrchestrator {
         catch (Exception ex) { LogLocalRegisterFailed(ex, agentId); }
 
         _ = ReadAgentOutputAsync(agent);
+        _ = DetectSessionIdAsync(agent, vendor, spawnedAtUtc);
         await AttachClientLoopAsync(agent, stream, ct);
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -4443,7 +4443,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 await _server.AgentStatusChangedAsync(agent.Id, agent.Status, winner.SessionId);
             }, cts.Token);
 
-            if (!found && !agent.ReadCts.IsCancellationRequested) LogSessionIdNotDetected(agent.Id, SessionIdPollTimeout.TotalSeconds);
+            if (!found && !cts.IsCancellationRequested) LogSessionIdNotDetected(agent.Id, SessionIdPollTimeout.TotalSeconds);
         } catch (Exception ex) {
             LogSessionIdDetectFailed(ex, agent.Id);
         }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -41,16 +41,17 @@ internal record AgentInstance(
     public bool                 HasReceivedOutput { get; set; }
     public TerminalOutputBuffer OutputBuffer      { get; } = new();
 
-    /// <summary>Codex turn diagnostic: the reviewer's own rollout JSONL path, resolved ONCE by the
-    /// session-id detector and cached so the send path can sample its length with a single stat
-    /// (never a directory scan). Null until detection resolves it, and for non-Codex agents.</summary>
-    public string? CodexRolloutPath { get; set; }
+    /// The agent's own transcript — Claude's project .jsonl or Codex's rollout — resolved once
+    /// by discovery and cached: the status payload and the Codex send-path probe both read it,
+    /// and neither may scan a directory to do so. Null until discovery lands, and forever for a
+    /// runtime that writes nothing the daemon locates.
+    public string? TranscriptPath { get; set; }
 
     bool _titleComputed;
     string? _title;
     /// <summary>The status payload's display title, computed ONCE from the immutable Prompt
     /// (SnapshotAgentsForStatus re-runs for every agent on every status pulse — re-parsing an
-    /// invariant there is pure waste, same reasoning as CodexRolloutPath's cache).</summary>
+    /// invariant there is pure waste, same reasoning as TranscriptPath's cache).</summary>
     public string? Title {
         get {
             if (!_titleComputed) { _title = TitleFromPrompt(Prompt); _titleComputed = true; }
@@ -395,6 +396,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// wiring test can pin that the registered singleton — not a private fallback nobody
     /// subscribes to — is the one every agent mutation reaches (see DaemonStatusWiringTests).</summary>
     internal DaemonStatusNotifier StatusNotifierForTest => _statusNotifier;
+
+    int _discoveryStarts;
+    internal int DiscoveryStartsForTest => Volatile.Read(ref _discoveryStarts);
 
     // Phase B (D4): durable PID records + this daemon's logical identity/epoch for
     // crash-survivor reaping. Initialized in the ctor from config.
@@ -3508,7 +3512,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // is handled in ArmCodexTurnProbe.
             if (isCodex) {
                 codexGen = Interlocked.Increment(ref agent.CodexTurnProbeGen);
-                if (agent.CodexRolloutPath is { } rolloutPath) codexBaseline = TryFileLength(rolloutPath);
+                if (agent.TranscriptPath is { } rolloutPath) codexBaseline = TryFileLength(rolloutPath);
             }
 
             // PTY runtimes use bracketed paste; ACP runtimes send a structured prompt.
@@ -3564,7 +3568,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// already invalidated.</para>
     /// </summary>
     void ArmCodexTurnProbe(AgentInstance agent, long? baseline, long gen) {
-        if (agent.CodexRolloutPath is not { } rolloutPath || baseline is not { } b) {
+        if (agent.TranscriptPath is not { } rolloutPath || baseline is not { } b) {
             LogCodexTurnRolloutUnresolved(agent.Id);
             return;
         }
@@ -4399,94 +4403,48 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     static readonly TimeSpan CodexTurnObserveInterval = TimeSpan.FromSeconds(2);
     static readonly TimeSpan CodexTurnObserveTimeout  = TimeSpan.FromMinutes(2);
 
-    /// <summary>
-    /// Vendor-dispatched, best-effort background fallback that discovers a spawned agent's
-    /// session id from the transcript/rollout its harness writes and reports it to the server,
-    /// for when the session-start hook (the primary source of the agent↔session link) fails or
-    /// doesn't land in time — e.g. an expired kcap token 401s every /hooks POST, or an
-    /// unattended/borrowed reviewer completes before the hook correlates. The server no longer
-    /// gates incarnation completion on this id (it converges on daemon liveness), so this only
-    /// resolves the id lazily for correlation/display and never blocks a launch.
-    ///
-    /// Claude reads its per-worktree Claude project dir (symlinked to the SOURCE repo's, shared
-    /// with the user's own sessions — <see cref="SessionTranscriptLocator"/> disambiguates by
-    /// cwd). Codex reads its <c>~/.codex/sessions</c> rollout tree (shared across all the user's
-    /// Codex sessions — <see cref="CodexSessionRolloutLocator"/> disambiguates by
-    /// <c>payload.cwd</c> + spawn time). A vendor with no daemon-side locator is a no-op: the
-    /// hook stays its only session-id source.
-    /// </summary>
-    async Task DetectSessionIdAsync(AgentInstance agent, string vendor, DateTime spawnedAtUtc) {
-        // The locator scans a shared dir, so a foreign-session file is cached in ruledOut and
-        // never re-opened. A cwd is fixed, so a definitive non-match is permanent; a file with
-        // no cwd yet (still being written) is NOT cached, so the agent's own freshly-created
-        // transcript/rollout is always re-checked.
-        Func<ISet<string>, string?>? locate = vendor.ToLowerInvariant() switch {
-            "claude" => ruledOut => SessionTranscriptLocator.TryLocate(
+    /// Locates the transcript a freshly spawned PTY agent writes — Claude's per-worktree
+    /// project dir (a symlink onto the source repo's, shared with the user's own sessions,
+    /// so the locator disambiguates by cwd), Codex's rollout tree (disambiguated by cwd and
+    /// spawn time). A vendor without a locator is a no-op. Best-effort background work,
+    /// cancelled with the agent; it never blocks a launch.
+    Task DetectSessionIdAsync(AgentInstance agent, string vendor, DateTime spawnedAtUtc) {
+        Func<ISet<string>, (string SessionId, string Path)?>? locate = vendor.ToLowerInvariant() switch {
+            "claude" => ruledOut => SessionTranscriptLocator.TryLocateWinner(
                 ClaudePaths.ProjectDir(agent.Worktree.Path), agent.Worktree.Path, spawnedAtUtc, ruledOut),
-            // Codex turn diagnostic: resolve id AND path together and cache the path on the agent,
-            // so the send-path probe needs only a single stat later — no directory scan on the
-            // daemon command loop. The path is stable for a session's lifetime.
-            "codex" => ruledOut => {
-                if (CodexSessionRolloutLocator.TryLocateWinner(
-                        CodexPaths.Sessions, agent.Worktree.Path, spawnedAtUtc, ruledOut) is not { } winner)
-                    return null;
-                agent.CodexRolloutPath = winner.Path;
-                return winner.SessionId;
-            },
-            _ => null,
+            "codex"  => ruledOut => CodexSessionRolloutLocator.TryLocateWinner(
+                CodexPaths.Sessions, agent.Worktree.Path, spawnedAtUtc, ruledOut),
+            _        => null,
         };
+        if (locate is null) return Task.CompletedTask;
 
-        if (locate is null) return;
-
-        await PollForSessionIdAsync(agent, locate);
+        Interlocked.Increment(ref _discoveryStarts);
+        return RunDiscoveryAsync(agent, locate);
     }
 
-    /// <summary>
-    /// Shared poll loop for <see cref="DetectSessionIdAsync"/>. Polls <paramref name="locate"/>
-    /// until it resolves a session id, the id is set by other means (hook succeeded), the agent
-    /// exits (ReadCts), the daemon shuts down, or the timeout elapses. On a match it sets
-    /// <see cref="AgentInstance.SessionId"/> and best-effort reports via AgentStatusChanged (live
-    /// registry link) AND an <see cref="AgentRunHeartbeat"/> (so the server's restart-recovery
-    /// FindAgentSessionIdAsync path works too). Once SessionId is set, the 30 s heartbeat loop and
-    /// reconnect re-registration keep re-sending it, so a transient report failure self-heals.
-    /// Never breaks the launch.
-    /// </summary>
-    async Task PollForSessionIdAsync(AgentInstance agent, Func<ISet<string>, string?> locate) {
+    internal Task RunDiscoveryForTest(AgentInstance agent, Func<ISet<string>, (string SessionId, string Path)?> locate) =>
+        RunDiscoveryAsync(agent, locate);
+
+    async Task RunDiscoveryAsync(AgentInstance agent, Func<ISet<string>, (string SessionId, string Path)?> locate) {
         try {
-            var deadline = DateTime.UtcNow + SessionIdPollTimeout;
-            var ruledOut = new HashSet<string>();
-
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
+            var discovery = new TranscriptDiscovery(TimeProvider.System, SessionIdPollInterval, SessionIdPollTimeout);
 
-            while (DateTime.UtcNow < deadline) {
-                if (agent.SessionId is not null) return; // linked by other means (hook succeeded)
+            var found = await discovery.RunAsync(locate, async winner => {
+                // Mutation first, pulse second — and the pulse before any server call, which can
+                // stall on a reconnect and must never hold the app's status push hostage.
+                agent.SessionId ??= winner.SessionId;
+                agent.TranscriptPath = winner.Path;
+                _statusNotifier.Pulse();
+                LogSessionIdDetected(agent.Id, winner.SessionId);
 
-                if (locate(ruledOut) is { } sessionId) {
-                    agent.SessionId ??= sessionId;
+                if (agent.IsPrivate) return;
+                await _server.AppendAgentRunEventAsync(agent.Id, new AgentRunHeartbeat(winner.SessionId));
+                await _server.AgentStatusChangedAsync(agent.Id, agent.Status, winner.SessionId);
+            }, cts.Token);
 
-                    LogSessionIdDetected(agent.Id, sessionId);
-
-                    if (!agent.IsPrivate) {
-                        // Enqueue the run-event first: it's a non-throwing local enqueue, whereas
-                        // the SignalR status update can throw during a reconnect. Ordering it first
-                        // ensures a transient connection hiccup can't skip the durable report — the
-                        // status update then re-sends via the heartbeat loop regardless.
-                        await _server.AppendAgentRunEventAsync(agent.Id, new AgentRunHeartbeat(sessionId));
-                        await _server.AgentStatusChangedAsync(agent.Id, agent.Status, sessionId);
-                    }
-
-                    return;
-                }
-
-                await Task.Delay(SessionIdPollInterval, cts.Token);
-            }
-
-            LogSessionIdNotDetected(agent.Id, SessionIdPollTimeout.TotalSeconds);
-        } catch (OperationCanceledException) {
-            // Agent stopped or daemon shutting down — nothing to report.
+            if (!found && !agent.ReadCts.IsCancellationRequested) LogSessionIdNotDetected(agent.Id, SessionIdPollTimeout.TotalSeconds);
         } catch (Exception ex) {
-            // Best-effort by design: if the immediate report failed after SessionId was set,
-            // the heartbeat loop / reconnect re-registration will re-send it.
             LogSessionIdDetectFailed(ex, agent.Id);
         }
     }

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptDiscovery.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptDiscovery.cs
@@ -1,0 +1,29 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+/// Polls a vendor's session tree for a freshly spawned agent's transcript until the file is
+/// known, the deadline passes, or the agent goes away. Runs until the PATH is known — a
+/// session id learned some other way is not a reason to stop, since the path is what the
+/// desktop app reads.
+internal sealed class TranscriptDiscovery(TimeProvider time, TimeSpan interval, TimeSpan timeout) {
+    public async Task<bool> RunAsync(
+            Func<ISet<string>, (string SessionId, string Path)?> locate,
+            Func<(string SessionId, string Path), Task> onFound,
+            CancellationToken ct) {
+        var deadline = time.GetUtcNow() + timeout;
+        var ruledOut = new HashSet<string>();
+
+        try {
+            while (time.GetUtcNow() < deadline) {
+                if (ct.IsCancellationRequested) return false;
+                if (locate(ruledOut) is { } winner) {
+                    await onFound(winner).ConfigureAwait(false);
+                    return true;
+                }
+                await Task.Delay(interval, time, ct).ConfigureAwait(false);
+            }
+        } catch (OperationCanceledException) {
+            // The agent exited or the daemon is shutting down — nothing left to find.
+        }
+        return false;
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptDiscovery.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptDiscovery.cs
@@ -3,7 +3,8 @@ namespace Capacitor.Cli.Daemon.Services;
 /// Polls a vendor's session tree for a freshly spawned agent's transcript until the file is
 /// known, the deadline passes, or the agent goes away. Runs until the PATH is known — a
 /// session id learned some other way is not a reason to stop, since the path is what the
-/// desktop app reads.
+/// desktop app reads. Returns false on deadline or on cancellation of `ct`, true once `onFound`
+/// has run; a fault from `locate` or `onFound` propagates to the caller.
 internal sealed class TranscriptDiscovery(TimeProvider time, TimeSpan interval, TimeSpan timeout) {
     public async Task<bool> RunAsync(
             Func<ISet<string>, (string SessionId, string Path)?> locate,
@@ -11,19 +12,21 @@ internal sealed class TranscriptDiscovery(TimeProvider time, TimeSpan interval, 
             CancellationToken ct) {
         var deadline = time.GetUtcNow() + timeout;
         var ruledOut = new HashSet<string>();
+        (string SessionId, string Path)? winner = null;
 
         try {
-            while (time.GetUtcNow() < deadline) {
+            while (winner is null && time.GetUtcNow() < deadline) {
                 if (ct.IsCancellationRequested) return false;
-                if (locate(ruledOut) is { } winner) {
-                    await onFound(winner).ConfigureAwait(false);
-                    return true;
-                }
-                await Task.Delay(interval, time, ct).ConfigureAwait(false);
+                winner = locate(ruledOut);
+                if (winner is null) await Task.Delay(interval, time, ct).ConfigureAwait(false);
             }
         } catch (OperationCanceledException) {
             // The agent exited or the daemon is shutting down — nothing left to find.
+            return false;
         }
-        return false;
+
+        if (winner is null) return false;
+        await onFound(winner.Value).ConfigureAwait(false);
+        return true;
     }
 }

--- a/test/Capacitor.App.Tests.Unit/Ansi.cs
+++ b/test/Capacitor.App.Tests.Unit/Ansi.cs
@@ -1,0 +1,5 @@
+namespace Capacitor.App.Tests.Unit;
+
+public static class Ansi {
+    public static readonly string Esc = ((char)27).ToString();
+}

--- a/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
@@ -1,0 +1,134 @@
+using System.Reactive.Linq;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ChatComposerTests {
+    static async Task<(FakeDaemonClientService Daemon, FakeTimeProvider Time, TerminalTabViewModel Terminal, ChatTabViewModel Chat, FakeTerminalAttachClient Client, RecordingOpener Opener)>
+            BuildAttachedAsync() {
+        var daemon = new FakeDaemonClientService();
+        var factory = new FakeTerminalAttachClientFactory();
+        var time = new FakeTimeProvider();
+        var opener = new RecordingOpener();
+        var terminal = new TerminalTabViewModel("a1", daemon, factory.Factory, () => new FakeTerminalSurface(), time);
+        var chat = new ChatTabViewModel("a1", daemon, terminal, TranscriptProjection.For("claude"), opener, time);
+        daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(supportedVendors: ["claude", "codex"]));
+        daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo", model: "claude-opus-5") with { Status = "Running" });
+        await (terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+        var client = factory.Created.Single();
+        await client.TriggerAttached([]);
+        return (daemon, time, terminal, chat, client, opener);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Send_clears_the_text_on_acceptance_and_keeps_it_on_refusal() {
+        await RunOnUiAsync(async () => {
+            var (_, time, terminal, chat, client, _) = await BuildAttachedAsync();
+            await Assert.That(await chat.SendCommand.CanExecute.FirstAsync()).IsFalse();
+
+            chat.ComposerText = "hello";
+            await Assert.That(await chat.SendCommand.CanExecute.FirstAsync()).IsTrue();
+            await chat.SendCommand.Execute();
+            await Assert.That(chat.ComposerText).IsEqualTo("");
+            await Assert.That(chat.ComposerHint).IsEqualTo("Sending…");
+
+            chat.ComposerText = "second";
+            await Assert.That(await chat.SendCommand.CanExecute.FirstAsync()).IsFalse();
+            time.Advance(TimeSpan.FromMilliseconds(150));
+            await terminal.PendingDeliveryForTesting!;
+            await Assert.That(chat.ComposerText).IsEqualTo("second");
+            await Assert.That(await chat.SendCommand.CanExecute.FirstAsync()).IsTrue();
+            await Assert.That(client.SentInput).Count().IsEqualTo(2);
+            await chat.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Hint_follows_send_availability_and_the_vendor_label() {
+        await RunOnUiAsync(async () => {
+            var (daemon, _, terminal, chat, client, _) = await BuildAttachedAsync();
+            await Assert.That(chat.VendorLabel).IsEqualTo("Claude Code");
+            await Assert.That(chat.ComposerHint).IsEqualTo("Reply to Claude Code · Enter sends · Shift+Enter for a new line");
+
+            client.Result.SetResult(new AttachOutcome.Detached());
+            await terminal.CurrentRunForTesting!;
+            await Assert.That(chat.ComposerHint).IsEqualTo("Reattach the terminal to send");
+
+            // Only the run's own Exited/Failed verdict outranks a cache removal, so a removal after
+            // a detach lands SessionEnded — and the hint follows the terminal there too.
+            daemon.Agents.Remove("a1");
+            await Assert.That(chat.ComposerHint).IsEqualTo("This session has ended");
+
+            var attached = TerminalSessionState.Attached(null);
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Transitioning, attached, "Claude Code")).IsEqualTo("Updating the terminal connection…");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.ReadOnly, TerminalSessionState.Attached("review"), "x")).IsEqualTo("Read-only: review");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Connecting, TerminalSessionState.Connecting, "x")).IsEqualTo("Connecting to the terminal…");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Ended, TerminalSessionState.SessionEnded, "x")).IsEqualTo("This session has ended");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.NoTerminal, TerminalSessionState.NotFound, "x")).IsEqualTo("No terminal to send to");
+            await chat.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Footer_reflects_the_dto() {
+        await RunOnUiAsync(async () => {
+            var (daemon, _, _, chat, _, _) = await BuildAttachedAsync();
+            await Assert.That(chat.ModelLabel).IsEqualTo("Claude Opus 5");
+            await Assert.That(chat.StatusText).IsEqualTo("Running");
+            await Assert.That(chat.StatusDot).IsSameReferenceAs(SessionStatusDots.For("Running"));
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo") with { Status = "Failed" });
+            await Assert.That(chat.StatusText).IsEqualTo("Failed");
+            await Assert.That(chat.ModelLabel).IsEqualTo("default");
+            await chat.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Links_open_only_through_the_policy_and_an_opener_fault_is_contained() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, chat, _, opener) = await BuildAttachedAsync();
+
+            await chat.OpenLinkCommand.Execute("https://example.com/a");
+            await chat.OpenLinkCommand.Execute("file:///etc/passwd");
+            await chat.OpenLinkCommand.Execute("javascript:alert(1)");
+            await Assert.That(opener.Opened).IsEquivalentTo(new[] { "https://example.com/a" });
+
+            opener.ThrowOnOpen = new InvalidOperationException("no browser");
+            await chat.OpenLinkCommand.Execute("https://example.com/b");
+            await Assert.That(opener.Opened).Count().IsEqualTo(2);
+            await chat.TeardownAsync();
+        });
+    }
+
+    /// Thread identity: the hint's own change lands on the UI thread even when the terminal's
+    /// state flips from a pool thread.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_pool_thread_state_flip_updates_the_hint_on_the_ui_thread() {
+        var onUi = await DispatchAsync(async () => {
+            var (_, _, terminal, chat, client, _) = await BuildAttachedAsync();
+            bool? hintChangedOnUi = null;
+            chat.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(ChatTabViewModel.ComposerHint)) hintChangedOnUi = Dispatcher.UIThread.CheckAccess(); };
+
+            await Task.Run(() => client.Result.SetResult(new AttachOutcome.Exited(0)));
+            await terminal.CurrentRunForTesting!;
+            await WaitUntilAsync(() => chat.ComposerHint == "This session has ended", what: "hint");
+            await chat.TeardownAsync();
+            return hintChangedOnUi;
+        });
+        await Assert.That(onUi).IsTrue();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -210,7 +210,10 @@ public class ChatTabViewModelTests {
         });
     }
 
-    /// Thread identity, so deliberately not under WithImmediateRxScheduler.
+    /// Thread identity, so deliberately not under WithImmediateRxScheduler. PhaseNote and the FIRST
+    /// notification are what make it discriminating: that one is raised by the path switch, on
+    /// whichever thread delivered the dto, while every later one comes from the apply, which hops
+    /// to the UI thread on its own and would pass with no ObserveOn at all.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task A_dto_pushed_from_a_pool_thread_lands_on_the_ui_thread() {
@@ -218,7 +221,10 @@ public class ChatTabViewModelTests {
             var h = Claude();
             var path = Tmp.CreateFile("t.jsonl", [UserLine]);
             bool? phaseChangedOnUi = null;
-            h.Chat.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(ChatTabViewModel.Phase)) phaseChangedOnUi = Dispatcher.UIThread.CheckAccess(); };
+            h.Chat.PropertyChanged += (_, e) => {
+                if (e.PropertyName == nameof(ChatTabViewModel.PhaseNote))
+                    phaseChangedOnUi ??= Dispatcher.UIThread.CheckAccess();
+            };
 
             await Task.Run(() => h.Daemon.Agents.AddOrUpdate(Dto(path)));
             await WaitUntilAsync(() => h.Chat.Phase == ChatTabPhase.Reading, what: "reading");

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -233,4 +233,22 @@ public class ChatTabViewModelTests {
         });
         await Assert.That(onUi).IsTrue();
     }
+
+    /// Pins the system-note row: a task notification the vendor injects into the transcript
+    /// renders as a system note carrying its summary and result, never as a user bubble.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_task_notification_renders_as_a_system_note() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [
+                """{"type":"user","origin":{"kind":"task-notification"},"message":{"content":"<task-notification>\n<summary>Agent finished</summary>\n<result>\nAll good.\n</result>\n</task-notification>"}}""",
+            ]);
+            await h.PushAsync(Dto(path));
+
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(new[] { nameof(SystemNoteItem) });
+            await Assert.That(((SystemNoteItem)h.Chat.Items[0]).Text).IsEqualTo("**Agent finished**\n\nAll good.");
+            await h.TeardownAsync();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -1,0 +1,230 @@
+using System.Reactive.Linq;
+using Avalonia.Threading;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using TUnit.Assertions.Enums;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// ChatTabViewModel's tail: phases, the poll, item projection and pairing, path switches and
+/// teardown. Every test runs under RunOnUiAsync (the apply hops through Dispatcher.UIThread) and
+/// carries [NotInParallel("AvaloniaSession")], like every other VM suite touching the dispatcher.
+public class ChatTabViewModelTests {
+    [TempDir] public required TempDir Tmp { get; init; }
+
+    const string UserLine = """{"type":"user","message":{"role":"user","content":"hello"}}""";
+    const string AssistantLine = """{"type":"assistant","message":{"content":[{"type":"text","text":"Hi there"}]}}""";
+    const string ToolCallLine = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls -la"}}]}}""";
+    const string ToolResultLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}}""";
+    const string ToolErrorLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"boom","is_error":true}]}}""";
+
+    static AgentStatusDto Dto(string? transcriptPath, string vendor = "claude") =>
+        Agent("a1", vendor, hasTerminal: true, repoPath: "/repo/x") with { TranscriptPath = transcriptPath };
+
+    sealed class Harness {
+        public FakeDaemonClientService Daemon { get; } = new();
+        public FakeTerminalAttachClientFactory Factory { get; } = new();
+        public FakeTimeProvider Time { get; } = new();
+        public RecordingOpener Opener { get; } = new();
+        public TerminalTabViewModel Terminal { get; }
+        public ChatTabViewModel Chat { get; }
+
+        public Harness(ITranscriptProjection? projection) {
+            Terminal = new TerminalTabViewModel("a1", Daemon, Factory.Factory, () => new FakeTerminalSurface(), Time);
+            Chat = new ChatTabViewModel("a1", Daemon, Terminal, projection, Opener, Time);
+        }
+
+        public async Task PushAsync(AgentStatusDto dto) {
+            Daemon.Agents.AddOrUpdate(dto);
+            await (Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+        }
+
+        public async Task TickAsync() {
+            Time.Advance(ChatTabViewModel.PollInterval);
+            await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+        }
+
+        public async Task TeardownAsync() {
+            await Chat.TeardownAsync();
+            await Terminal.TeardownAsync();
+        }
+    }
+
+    static Harness Claude() => new(TranscriptProjection.For("claude"));
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Waits_until_a_path_then_renders_the_initial_load_in_file_order() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Waiting);
+            await Assert.That(h.Chat.PhaseNote).IsEqualTo("Waiting for the transcript…");
+
+            await h.PushAsync(Dto(transcriptPath: null));
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Waiting);
+
+            var path = Tmp.CreateFile("t.jsonl", [UserLine, AssistantLine, ToolCallLine]);
+            await h.PushAsync(Dto(path));
+
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(
+                new[] { nameof(UserTurnItem), nameof(AssistantTextItem), nameof(ToolCallItem) }, CollectionOrdering.Matching);
+            await Assert.That(((UserTurnItem)h.Chat.Items[0]).Text).IsEqualTo("hello");
+            await Assert.That(((ToolCallItem)h.Chat.Items[2]).Detail).IsEqualTo("ls -la");
+            await Assert.That(((ToolCallItem)h.Chat.Items[2]).Outcome).IsEqualTo(ToolOutcome.Running);
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Appended_lines_render_after_a_tick_and_a_partial_line_waits_for_its_newline() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine]);
+            await h.PushAsync(Dto(path));
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+
+            File.AppendAllText(path, AssistantLine + "\n" + ToolCallLine[..20]);
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(2);
+
+            File.AppendAllText(path, ToolCallLine[20..] + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(3);
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Tool_results_flip_their_call_in_place_and_unmatched_results_are_ignored() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ToolResultLine]);
+            await h.PushAsync(Dto(path));
+            var call = (ToolCallItem)h.Chat.Items.Single();
+            await Assert.That(call.Outcome).IsEqualTo(ToolOutcome.Done);
+            await Assert.That(call.OutcomeGlyph).IsEqualTo("✓");
+
+            File.AppendAllText(path, ToolCallLine + "\n" + ToolErrorLine + "\n" + ToolErrorLine.Replace("t1", "unknown") + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(2);
+            await Assert.That(((ToolCallItem)h.Chat.Items[1]).Outcome).IsEqualTo(ToolOutcome.Error);
+            await Assert.That(((ToolCallItem)h.Chat.Items[1]).IsError).IsTrue();
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Length_regression_resets_items_missing_recovers_and_failed_keeps_items() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.PathTo("t.jsonl");
+            await h.PushAsync(Dto(path));
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Missing);
+            await Assert.That(h.Chat.PhaseNote).IsEqualTo("The transcript file is missing");
+
+            File.WriteAllLines(path, [UserLine, AssistantLine]);
+            await h.TickAsync();
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(2);
+
+            File.WriteAllLines(path, [ToolCallLine]);
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(h.Chat.Items[0]).IsTypeOf<ToolCallItem>();
+
+            File.Delete(path);
+            Directory.CreateDirectory(path);
+            await h.TickAsync();
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            Directory.Delete(path);
+            await h.TeardownAsync();
+        });
+    }
+
+    sealed class GatedProjection(ITranscriptProjection inner, string blockOn, TaskCompletionSource gate) : ITranscriptProjection {
+        public IReadOnlyList<AcpEventEnvelope> Project(string line) {
+            if (line.Contains(blockOn, StringComparison.Ordinal)) gate.Task.GetAwaiter().GetResult();
+            return inner.Project(line);
+        }
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_path_switch_discards_a_read_still_in_flight_for_the_old_file() {
+        await RunOnUiAsync(async () => {
+            var gate = new TaskCompletionSource();
+            var h = new Harness(new GatedProjection(TranscriptProjection.For("claude")!, "OLD", gate));
+            var oldPath = Tmp.CreateFile("old.jsonl", [UserLine.Replace("hello", "OLD"), ToolCallLine]);
+            var newPath = Tmp.CreateFile("new.jsonl", [AssistantLine]);
+
+            h.Daemon.Agents.AddOrUpdate(Dto(oldPath));
+            await (h.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            var oldRead = h.Chat.PendingReadForTesting!;
+
+            h.Daemon.Agents.AddOrUpdate(Dto(newPath));
+            gate.SetResult();
+            await oldRead;
+            await (h.Chat.PendingReadForTesting ?? Task.CompletedTask);
+            await h.TickAsync();
+
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(new[] { nameof(AssistantTextItem) });
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Unavailable_for_a_vendor_without_a_projection_and_no_ticks_after_teardown() {
+        await RunOnUiAsync(async () => {
+            var unavailable = new Harness(projection: null);
+            await Assert.That(unavailable.Chat.Phase).IsEqualTo(ChatTabPhase.Unavailable);
+            await Assert.That(unavailable.Chat.PhaseNote).IsEqualTo("No chat view for this harness");
+            await unavailable.TeardownAsync();
+
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine]);
+            await h.PushAsync(Dto(path));
+            await h.TeardownAsync();
+            File.AppendAllText(path, AssistantLine + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+
+            // A removed agent keeps its items.
+            var kept = Claude();
+            var keptPath = Tmp.CreateFile("kept.jsonl", [UserLine]);
+            await kept.PushAsync(Dto(keptPath));
+            kept.Daemon.Agents.Remove("a1");
+            await Assert.That(kept.Chat.Items).Count().IsEqualTo(1);
+            await kept.TeardownAsync();
+        });
+    }
+
+    /// Thread identity, so deliberately not under WithImmediateRxScheduler.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_dto_pushed_from_a_pool_thread_lands_on_the_ui_thread() {
+        var onUi = await DispatchAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine]);
+            bool? phaseChangedOnUi = null;
+            h.Chat.PropertyChanged += (_, e) => { if (e.PropertyName == nameof(ChatTabViewModel.Phase)) phaseChangedOnUi = Dispatcher.UIThread.CheckAccess(); };
+
+            await Task.Run(() => h.Daemon.Agents.AddOrUpdate(Dto(path)));
+            await WaitUntilAsync(() => h.Chat.Phase == ChatTabPhase.Reading, what: "reading");
+            await h.TeardownAsync();
+            return phaseChangedOnUi;
+        });
+        await Assert.That(onUi).IsTrue();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -1,0 +1,130 @@
+using System.Collections.Specialized;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.ViewModels;
+using Capacitor.App.Views;
+using Capacitor.Cli.Core;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Headless rendering acceptance for the Chat tab on its own: the view is hosted directly with a
+/// ChatTabViewModel DataContext, so what is under test is exactly ChatTabView's list virtualization
+/// and follow-tail, not WorkspaceView's tab swap. Same session rules as every UI suite here —
+/// RunOnUiAsync plus [NotInParallel("AvaloniaSession")].
+public class ChatTabViewSmokeTests {
+    [TempDir] public required TempDir Tmp { get; init; }
+
+    const string UserLine = """{"type":"user","message":{"role":"user","content":"hello"}}""";
+
+    sealed class Host {
+        public FakeDaemonClientService Daemon { get; } = new();
+        public FakeTimeProvider Time { get; } = new();
+        public TerminalTabViewModel Terminal { get; }
+        public ChatTabViewModel Chat { get; }
+        public ChatTabView View { get; }
+        public Window Window { get; }
+        public ScrollViewer Scroll => View.GetVisualDescendants().OfType<ScrollViewer>().First();
+
+        public Host() {
+            Terminal = new TerminalTabViewModel("a1", Daemon, new FakeTerminalAttachClientFactory().Factory, () => new FakeTerminalSurface(), Time);
+            Chat = new ChatTabViewModel("a1", Daemon, Terminal, TranscriptProjection.For("claude"), new RecordingOpener(), Time);
+            View = new ChatTabView { DataContext = Chat };
+            Window = new Window { Content = View, Width = 800, Height = 600 };
+            Window.Show();
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        public async Task LoadAsync(string path) {
+            Daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true) with { TranscriptPath = path });
+            await (Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+            Window.UpdateLayout();
+        }
+
+        public async Task AppendAndTickAsync(string path, int lines) {
+            File.AppendAllLines(path, Enumerable.Repeat(UserLine, lines));
+            Time.Advance(ChatTabViewModel.PollInterval);
+            await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+        }
+
+        public bool AtBottom() => Scroll.Offset.Y + Scroll.Viewport.Height >= Scroll.Extent.Height - 1;
+
+        public async Task CloseAsync() {
+            Window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await Chat.TeardownAsync();
+            await Terminal.TeardownAsync();
+        }
+    }
+
+    /// Pins the two costs a long transcript could impose on the UI thread: one collection
+    /// notification for the whole initial load, and containers for the viewport only.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_large_initial_load_is_one_notification_into_a_bounded_number_of_containers() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var path = Tmp.CreateFile("big.jsonl", Enumerable.Repeat(UserLine, 5000).ToArray());
+            var notifications = 0;
+            ((INotifyCollectionChanged)host.Chat.Items).CollectionChanged += (_, _) => notifications++;
+
+            await host.LoadAsync(path);
+
+            await Assert.That(host.Chat.Items).Count().IsEqualTo(5000);
+            await Assert.That(notifications).IsEqualTo(1);
+            var items = host.View.FindControl<ItemsControl>("ChatItems")!;
+            await Assert.That(items.GetRealizedContainers().Count()).IsLessThan(200);
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins follow-tail's whole contract: it tracks the bottom, leaves a scrolled-up reader where
+    /// they are, and abandons a scroll it had already decided on if the reader moves first.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Follow_tail_tracks_the_bottom_and_leaves_a_scrolled_up_reader_alone() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var path = Tmp.CreateFile("t.jsonl", Enumerable.Repeat(UserLine, 60).ToArray());
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            await host.AppendAndTickAsync(path, 20);
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            host.Scroll.Offset = new Vector(0, 0);
+            host.Window.UpdateLayout();
+            await host.AppendAndTickAsync(path, 20);
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
+
+            // At the bottom, append, then scroll up before the layout pass completes. The view
+            // subscribes first, so this handler runs after it has decided to follow and captured
+            // the offset — the one ordering that reaches the abandon path.
+            host.Scroll.ScrollToEnd();
+            host.Window.UpdateLayout();
+            await Assert.That(host.AtBottom()).IsTrue();
+            void ScrollUp(object? sender, NotifyCollectionChangedEventArgs e) => host.Scroll.Offset = new Vector(0, 0);
+            ((INotifyCollectionChanged)host.Chat.Items).CollectionChanged += ScrollUp;
+            await host.AppendAndTickAsync(path, 20);
+            ((INotifyCollectionChanged)host.Chat.Items).CollectionChanged -= ScrollUp;
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
+            await host.CloseAsync();
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -1,9 +1,11 @@
 using System.Collections.Specialized;
+using System.Globalization;
 using System.Text;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
+using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Capacitor.App.Services;
@@ -26,25 +28,48 @@ public class ChatTabViewSmokeTests {
     [TempDir] public required TempDir Tmp { get; init; }
 
     const string UserLine = """{"type":"user","message":{"role":"user","content":"hello"}}""";
+    const string AssistantLinkLine = """{"type":"assistant","message":{"content":[{"type":"text","text":"See [docs](https://example.com/docs) now."}]}}""";
+    const string ToolCallLine = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls -la"}}]}}""";
+    const string ToolResultLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}}""";
+    const string ToolErrorLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"boom","is_error":true}]}}""";
     static readonly TimeSpan CrDelay = TimeSpan.FromMilliseconds(150);
 
     sealed class Host {
+        bool _shown;
+
         public FakeDaemonClientService Daemon { get; } = new();
         public FakeTimeProvider Time { get; } = new();
         public FakeTerminalAttachClientFactory Attach { get; } = new();
+        public RecordingOpener Opener { get; } = new();
         public TerminalTabViewModel Terminal { get; }
         public ChatTabViewModel Chat { get; }
         public ChatTabView View { get; }
         public Window Window { get; }
         public ScrollViewer Scroll => View.GetVisualDescendants().OfType<ScrollViewer>().First();
+        public bool HasScroll => View.GetVisualDescendants().OfType<ScrollViewer>().Any();
         public TextBox Composer => View.FindControl<TextBox>("ComposerInput")!;
 
-        public Host() {
+        /// `show: false` leaves the window unshown, so the view has no template and no
+        /// ScrollViewer until Show() is called — the order production takes, where the tab's
+        /// first read starts before the workspace view exists.
+        public Host(bool show = true) {
             Terminal = new TerminalTabViewModel("a1", Daemon, Attach.Factory, () => new FakeTerminalSurface(), Time);
-            Chat = new ChatTabViewModel("a1", Daemon, Terminal, TranscriptProjection.For("claude"), new RecordingOpener(), Time);
+            Chat = new ChatTabViewModel("a1", Daemon, Terminal, TranscriptProjection.For("claude"), Opener, Time);
             View = new ChatTabView { DataContext = Chat };
             Window = new Window { Content = View, Width = 800, Height = 600 };
+            if (!show) return;
+            Show();
+        }
+
+        public void Show() {
             Window.Show();
+            _shown = true;
+            Settle();
+        }
+
+        public void Settle() {
+            Dispatcher.UIThread.RunJobs();
+            if (_shown) Window.UpdateLayout();
             Dispatcher.UIThread.RunJobs();
         }
 
@@ -76,8 +101,7 @@ public class ChatTabViewSmokeTests {
             Daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true) with { TranscriptPath = path });
             await (Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
             await (Chat.PendingReadForTesting ?? Task.CompletedTask);
-            Dispatcher.UIThread.RunJobs();
-            Window.UpdateLayout();
+            Settle();
         }
 
         public async Task AppendAndTickAsync(string path, int lines) {
@@ -160,6 +184,37 @@ public class ChatTabViewSmokeTests {
         });
     }
 
+    /// Pins that the initial load lands the reader at the bottom even when it completes before the
+    /// view's first layout pass — an unshown window, and a tab collapsed from the start — so there
+    /// is no ScrollViewer to read "was at end" from when the rows arrive.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_initial_load_before_the_first_layout_still_lands_the_reader_at_the_bottom() {
+        await RunOnUiAsync(async () => {
+            var unshown = new Host(show: false);
+            await unshown.LoadAsync(Tmp.CreateFile("unshown.jsonl", Enumerable.Repeat(UserLine, 60).ToArray()));
+            await Assert.That(unshown.Chat.Items).Count().IsEqualTo(60);
+            await Assert.That(unshown.HasScroll).IsFalse();
+
+            unshown.Show();
+
+            await Assert.That(unshown.AtBottom()).IsTrue();
+            await unshown.CloseAsync();
+
+            var collapsed = new Host(show: false);
+            collapsed.View.IsVisible = false;
+            collapsed.Show();
+            await collapsed.LoadAsync(Tmp.CreateFile("hidden.jsonl", Enumerable.Repeat(UserLine, 60).ToArray()));
+            await Assert.That(collapsed.HasScroll).IsFalse();
+
+            collapsed.View.IsVisible = true;
+            collapsed.Settle();
+
+            await Assert.That(collapsed.AtBottom()).IsTrue();
+            await collapsed.CloseAsync();
+        });
+    }
+
     /// Pins that appends arriving while the surface is collapsed still leave the reader at the
     /// bottom once it is laid out again — the shape a Chat tab sitting behind the Terminal tab is
     /// in, where the view arms at most one pending scroll however many appends land.
@@ -190,6 +245,53 @@ public class ChatTabViewSmokeTests {
             await host.CloseAsync();
         });
     }
+
+    /// Pins the assistant template's one silent binding: a link rendered inside a chat row opens
+    /// through the tab's own command, reached across the item boundary, and opens exactly once.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_link_in_an_assistant_row_opens_through_the_tabs_command() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("link.jsonl", [AssistantLinkLine]));
+
+            await Assert.That(host.Chat.Items).Count().IsEqualTo(1);
+
+            var link = host.View.GetVisualDescendants().OfType<HyperlinkButton>().Single();
+            var origin = link.TranslatePoint(new Point(2, 2), host.Window)!.Value;
+            host.Window.MouseDown(origin, MouseButton.Left);
+            host.Window.MouseUp(origin, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(host.Opener.Opened).IsEquivalentTo(new[] { "https://example.com/docs" });
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins the tool row's outcome colour: the glyph takes the brush ToolOutcomeBrushConverter
+    /// maps for the paired result, danger for an error and accent for a success.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_paired_tool_row_paints_its_glyph_with_the_outcome_brush() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("tools.jsonl",
+                [ToolCallLine, ToolResultLine, ToolCallLine.Replace("t1", "t2"), ToolErrorLine.Replace("t1", "t2")]));
+
+            await Assert.That(host.Chat.Items.Cast<ToolCallItem>().Select(i => i.Outcome))
+                .IsEquivalentTo([ToolOutcome.Done, ToolOutcome.Error], CollectionOrdering.Matching);
+            var glyphs = host.View.GetVisualDescendants().OfType<TextBlock>()
+                .Where(t => t.Text is "✓" or "✕").ToList();
+
+            await Assert.That(glyphs.Select(g => g.Text!)).IsEquivalentTo(["✓", "✕"], CollectionOrdering.Matching);
+            await Assert.That(glyphs[0].Foreground).IsSameReferenceAs(Brush(isError: false));
+            await Assert.That(glyphs[1].Foreground).IsSameReferenceAs(Brush(isError: true));
+            await host.CloseAsync();
+        });
+    }
+
+    static object? Brush(bool isError) =>
+        ToolOutcomeBrushConverter.Instance.Convert(isError, typeof(IBrush), null, CultureInfo.InvariantCulture);
 
     /// Pins that Enter reaches the send: the composer consumes it, the typed text leaves as one
     /// bracketed paste followed by the CR, and no newline is left behind in the box.

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -332,7 +332,7 @@ public class ChatTabViewSmokeTests {
 
             host.PressEnter(RawInputModifiers.Shift);
 
-            await Assert.That(host.Composer.Text).IsEqualTo("hi\n");
+            await Assert.That(host.Composer.Text).IsEqualTo("hi" + Environment.NewLine);
             await Assert.That(client.SentInput).IsEmpty();
             await host.CloseAsync();
         });

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -435,4 +435,22 @@ public class ChatTabViewSmokeTests {
             await host.CloseAsync();
         });
     }
+
+    /// Pins the system note's surface: a muted card carrying the note as markdown, distinct from
+    /// the user bubble and the assistant prose around it.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_system_note_renders_as_a_muted_markdown_card() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("note.jsonl", [
+                """{"type":"user","origin":{"kind":"task-notification"},"message":{"content":"<task-notification>\n<summary>Agent finished</summary>\n<result>\nAll **good**.\n</result>\n</task-notification>"}}""",
+            ]));
+
+            var card = host.View.GetVisualDescendants().OfType<Border>().Single(b => b.Classes.Contains("systemNote"));
+            var text = card.GetVisualDescendants().OfType<SelectableTextBlock>().ToList();
+            await Assert.That(text.Select(t => t.Inlines?.Text ?? t.Text ?? "")).IsEquivalentTo(new[] { "Agent finished", "All good." }, CollectionOrdering.Matching);
+            await host.CloseAsync();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
+using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -385,6 +386,29 @@ public class ChatTabViewSmokeTests {
             await Assert.That(host.Composer.IsFocused).IsTrue();
             await Assert.That(ring.BorderThickness).IsEqualTo(new Thickness(0));
             await Assert.That(ring.Background is null || ring.Background is ISolidColorBrush { Color.A: 0 }).IsTrue();
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins the timeline's rhythm: consecutive tool rows sit close together, and a run of them
+    /// keeps a clear gap before the assistant text that follows.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Tool_rows_stack_densely_and_keep_their_distance_from_text() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("rows.jsonl",
+                [ToolCallLine, ToolResultLine, ToolCallLine.Replace("t1", "t2"), ToolResultLine.Replace("t1", "t2"), AssistantLinkLine]));
+
+            var rows = host.View.GetVisualDescendants().OfType<StackPanel>()
+                .Where(p => p.Orientation == Orientation.Horizontal && p.DataContext is ToolCallItem).ToList();
+            var text = host.View.GetVisualDescendants().OfType<MarkdownView>().Single();
+            double Top(Control c) => c.TranslatePoint(new Point(0, 0), host.View)!.Value.Y;
+            double Bottom(Control c) => Top(c) + c.Bounds.Height;
+
+            await Assert.That(rows).Count().IsEqualTo(2);
+            await Assert.That(Top(rows[1]) - Bottom(rows[0])).IsLessThan(10);
+            await Assert.That(Top(text) - Bottom(rows[1])).IsGreaterThanOrEqualTo(12);
             await host.CloseAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -355,4 +355,37 @@ public class ChatTabViewSmokeTests {
             await host.CloseAsync();
         });
     }
+
+    /// Pins the composer's width: it spans the pane like the Home goal box rather than capping
+    /// at the assistant column's width on the left.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_composer_spans_the_pane() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            host.Window.UpdateLayout();
+
+            await Assert.That(host.Composer.Bounds.Width).IsGreaterThan(host.View.Bounds.Width - 100);
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins that focusing the composer draws no ring of its own: the card is the input's
+    /// boundary, so the theme's focused border and fill stay off.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_focused_composer_draws_no_ring_inside_its_card() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            host.Composer.Focus();
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+
+            var ring = host.Composer.GetVisualDescendants().OfType<Border>().Single(b => b.Name == "PART_BorderElement");
+            await Assert.That(host.Composer.IsFocused).IsTrue();
+            await Assert.That(ring.BorderThickness).IsEqualTo(new Thickness(0));
+            await Assert.That(ring.Background is null || ring.Background is ISolidColorBrush { Color.A: 0 }).IsTrue();
+            await host.CloseAsync();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -1,13 +1,18 @@
 using System.Collections.Specialized;
+using System.Text;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
 using Capacitor.App.Views;
 using Capacitor.Cli.Core;
 using DynamicData;
 using Microsoft.Extensions.Time.Testing;
+using TUnit.Assertions.Enums;
 using static Capacitor.App.Tests.Unit.AvaloniaSession;
 using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
@@ -21,22 +26,49 @@ public class ChatTabViewSmokeTests {
     [TempDir] public required TempDir Tmp { get; init; }
 
     const string UserLine = """{"type":"user","message":{"role":"user","content":"hello"}}""";
+    static readonly TimeSpan CrDelay = TimeSpan.FromMilliseconds(150);
 
     sealed class Host {
         public FakeDaemonClientService Daemon { get; } = new();
         public FakeTimeProvider Time { get; } = new();
+        public FakeTerminalAttachClientFactory Attach { get; } = new();
         public TerminalTabViewModel Terminal { get; }
         public ChatTabViewModel Chat { get; }
         public ChatTabView View { get; }
         public Window Window { get; }
         public ScrollViewer Scroll => View.GetVisualDescendants().OfType<ScrollViewer>().First();
+        public TextBox Composer => View.FindControl<TextBox>("ComposerInput")!;
 
         public Host() {
-            Terminal = new TerminalTabViewModel("a1", Daemon, new FakeTerminalAttachClientFactory().Factory, () => new FakeTerminalSurface(), Time);
+            Terminal = new TerminalTabViewModel("a1", Daemon, Attach.Factory, () => new FakeTerminalSurface(), Time);
             Chat = new ChatTabViewModel("a1", Daemon, Terminal, TranscriptProjection.For("claude"), new RecordingOpener(), Time);
             View = new ChatTabView { DataContext = Chat };
             Window = new Window { Content = View, Width = 800, Height = 600 };
             Window.Show();
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        /// A loaded transcript over a read-write attached terminal — the one state in which the
+        /// composer's send is accepted.
+        public async Task<FakeTerminalAttachClient> AttachAsync(string path) {
+            await LoadAsync(path);
+            var client = Attach.Created[^1];
+            await client.TriggerAttached([]);
+            Dispatcher.UIThread.RunJobs();
+            return client;
+        }
+
+        /// Real key events into the focused composer: the TextBox's own key handling is exactly
+        /// what these tests are about, so the text cannot be poked into the view model instead.
+        public void Type(string text) {
+            Composer.Focus();
+            Dispatcher.UIThread.RunJobs();
+            Window.KeyTextInput(text);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        public void PressEnter(RawInputModifiers modifiers) {
+            Window.KeyPressQwerty(PhysicalKey.Enter, modifiers);
             Dispatcher.UIThread.RunJobs();
         }
 
@@ -124,6 +156,100 @@ public class ChatTabViewSmokeTests {
             host.Window.UpdateLayout();
             Dispatcher.UIThread.RunJobs();
             await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins that appends arriving while the surface is collapsed still leave the reader at the
+    /// bottom once it is laid out again — the shape a Chat tab sitting behind the Terminal tab is
+    /// in, where the view arms at most one pending scroll however many appends land.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Appends_while_the_surface_is_collapsed_still_land_the_reader_at_the_bottom() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var path = Tmp.CreateFile("collapsed.jsonl", Enumerable.Repeat(UserLine, 60).ToArray());
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            host.View.IsVisible = false;
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+
+            await host.AppendAndTickAsync(path, 20);
+            await host.AppendAndTickAsync(path, 20);
+            await Assert.That(host.Chat.Items).Count().IsEqualTo(100);
+
+            host.View.IsVisible = true;
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+
+            await Assert.That(host.AtBottom()).IsTrue();
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins that Enter reaches the send: the composer consumes it, the typed text leaves as one
+    /// bracketed paste followed by the CR, and no newline is left behind in the box.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Enter_sends_the_typed_text_and_leaves_no_newline_behind() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var client = await host.AttachAsync(Tmp.CreateFile("send.jsonl", UserLine));
+            host.Type("hi");
+            await Assert.That(host.Composer.Text).IsEqualTo("hi");
+
+            host.PressEnter(RawInputModifiers.None);
+
+            await Assert.That(host.Composer.Text ?? "").IsEqualTo("");
+            await Assert.That(host.Chat.ComposerText).IsEqualTo("");
+            await WaitUntilAsync(() => client.SentInput.Count == 1, what: "paste written");
+            await Assert.That(client.SentInput[0]).IsEquivalentTo(TerminalInputEncoder.Paste("hi"));
+
+            host.Time.Advance(CrDelay);
+            await host.Terminal.PendingDeliveryForTesting!;
+            await Assert.That(client.SentInput.Select(Encoding.UTF8.GetString))
+                .IsEquivalentTo(["\x1b[200~hi\x1b[201~", "\r"], CollectionOrdering.Matching);
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins the other half of the key contract: Shift+Enter stays the TextBox's own newline and
+    /// sends nothing.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Shift_enter_inserts_a_newline_and_sends_nothing() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var client = await host.AttachAsync(Tmp.CreateFile("newline.jsonl", UserLine));
+            host.Type("hi");
+
+            host.PressEnter(RawInputModifiers.Shift);
+
+            await Assert.That(host.Composer.Text).IsEqualTo("hi\n");
+            await Assert.That(client.SentInput).IsEmpty();
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins that a refused send still consumes Enter: nothing goes out and the text survives
+    /// intact, so the user can send it again once the hint's reason clears.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Enter_on_a_refused_send_neither_sends_nor_inserts_a_newline() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            host.Type("hi");
+            await Assert.That(host.Terminal.CanAcceptText).IsFalse();
+
+            host.PressEnter(RawInputModifiers.None);
+
+            await Assert.That(host.Composer.Text).IsEqualTo("hi");
+            await Assert.That(host.Chat.ComposerText).IsEqualTo("hi");
+            await Assert.That(host.Attach.Created).IsEmpty();
             await host.CloseAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -412,4 +412,27 @@ public class ChatTabViewSmokeTests {
             await host.CloseAsync();
         });
     }
+
+    /// Pins follow-tail against virtualization's estimate: an appended row far taller than the
+    /// rows around it still leaves the reader at the real bottom once it is measured.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Follow_tail_lands_at_the_bottom_when_the_appended_row_is_taller_than_the_estimate() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var path = Tmp.CreateFile("tall.jsonl", Enumerable.Repeat(UserLine, 60).ToArray());
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            var reply = string.Join("\\n\\n", Enumerable.Range(1, 25).Select(i => $"Paragraph {i} of a long reply."));
+            File.AppendAllLines(path, ["{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"" + reply + "\"}]}}"]);
+            host.Time.Advance(ChatTabViewModel.PollInterval);
+            await (host.Chat.PendingReadForTesting ?? Task.CompletedTask);
+            host.Settle();
+
+            await Assert.That(host.Chat.Items.Count).IsEqualTo(61);
+            await Assert.That(host.AtBottom()).IsTrue();
+            await host.CloseAsync();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/FakeTerminalAttachClient.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeTerminalAttachClient.cs
@@ -91,7 +91,12 @@ sealed class FakeTerminalAttachClient : ITerminalAttachClient {
             ? throw new ObjectDisposedException(nameof(FakeTerminalAttachClient))
             : _onOutput(bytes, _lifetime?.Token ?? CancellationToken.None);
 
+    /// When set, SendInputAsync faults instead of recording -- the transport-loss shape a
+    /// composer delivery has to contain without touching VM state.
+    public Exception? ThrowOnSendInput;
+
     public Task SendInputAsync(byte[] bytes) {
+        if (ThrowOnSendInput is { } ex) return Task.FromException(ex);
         SentInput.Add(bytes);
         return Task.CompletedTask;
     }

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -251,4 +251,31 @@ public class HomeViewSmokeTests {
         await Assert.That(countAfterOne).IsEqualTo(1);
         await Assert.That(countAfterTwo).IsEqualTo(2);
     }
+
+    /// Pins that the goal box draws no ring of its own on focus: the card is its boundary, so
+    /// the theme's focused border and fill stay off.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_focused_goal_box_draws_no_ring_inside_its_card() {
+        var (thickness, transparent) = await AvaloniaSession.DispatchAsync(() => {
+            var (_, vm, _, _, tmp) = Build();
+            using var _tmp = tmp;
+            var window = new Window { Content = new LauncherPaneView { DataContext = vm }, Width = 800, Height = 600 };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            var goal = Find<TextBox>(window, "GoalInput")!;
+            goal.Focus();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            var ring = goal.GetVisualDescendants().OfType<Border>().Single(b => b.Name == "PART_BorderElement");
+            var result = (ring.BorderThickness, ring.Background is null || ring.Background is Avalonia.Media.ISolidColorBrush { Color.A: 0 });
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            vm.Dispose();
+            return result;
+        });
+
+        await Assert.That(thickness).IsEqualTo(new Avalonia.Thickness(0));
+        await Assert.That(transparent).IsTrue();
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/LinkPolicyTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LinkPolicyTests.cs
@@ -1,0 +1,13 @@
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class LinkPolicyTests {
+    [Test]
+    public async Task Only_absolute_http_and_https_open() {
+        await Assert.That(LinkPolicy.IsOpenable("https://example.com/x?y=1")).IsTrue();
+        await Assert.That(LinkPolicy.IsOpenable("http://example.com")).IsTrue();
+        foreach (var refused in new[] { "file:///etc/passwd", "javascript:alert(1)", "kcap://open", "docs/readme.md", "not a url", "", null })
+            await Assert.That(LinkPolicy.IsOpenable(refused)).IsFalse().Because(refused ?? "null");
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -32,7 +32,7 @@ public class MainWindowSmokeTests {
     /// pieces MainWindowViewModelTests wires, over the actions this file's NewActions built.
     static WorkspaceViewModel NewWorkspace(FakeDaemonClientService service, AgentActionService actions, string agentId) =>
         new(agentId, service, actions, new FakeTerminalAttachClientFactory().Factory,
-            () => new FakeTerminalSurface(), new FakeTimeProvider());
+            () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener());
 
     [Test]
     [NotInParallel("AvaloniaSession")]
@@ -291,7 +291,7 @@ public class MainWindowSmokeTests {
             var vm = new MainWindowViewModel(
                 service, CancellationToken.None, activity,
                 workspaceFactory: agentId => new WorkspaceViewModel(
-                    agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider()));
+                    agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener()));
             var window = new MainWindow { DataContext = vm };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -378,7 +378,7 @@ public class MainWindowSmokeTests {
                 var vm = new MainWindowViewModel(
                     service, CancellationToken.None, TestActivity.New(),
                     workspaceFactory: agentId => new WorkspaceViewModel(
-                        agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider()));
+                        agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener()));
                 var window = new MainWindow { DataContext = vm };
                 window.Show();
                 Dispatcher.UIThread.RunJobs();

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -42,7 +42,7 @@ public class MainWindowViewModelTests {
         var (actions, _) = NewActions(service);
         var attach = new FakeTerminalAttachClientFactory();
         return new WorkspaceViewModel(
-            agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider());
+            agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener());
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
@@ -179,6 +179,10 @@ public class MarkdownBlocksTests {
                 var lineBaseline = linkedText.TextLayout.TextLines[0].Baseline;
                 await Assert.That(Math.Abs(lineBaseline - plainText.TextLayout.TextLines[0].Baseline)).IsLessThanOrEqualTo(0.5);
                 await Assert.That(Math.Abs(innerBaseline - lineBaseline)).IsLessThanOrEqualTo(1);
+
+                // The glyphs' descenders hang below the button, so nothing in it may clip.
+                await Assert.That(button.ClipToBounds).IsFalse();
+                await Assert.That(button.GetVisualDescendants().OfType<Visual>().Any(v => v.ClipToBounds)).IsFalse();
             } finally { linked.Close(); plain.Close(); }
         });
     }

--- a/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
@@ -8,6 +8,7 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Capacitor.App.Views;
 using ReactiveUI;
+using TUnit.Assertions.Enums;
 using static Capacitor.App.Tests.Unit.AvaloniaSession;
 
 namespace Capacitor.App.Tests.Unit;
@@ -29,57 +30,102 @@ public class MarkdownBlocksTests {
     /// inline collection, so a "what does this block read as" assertion has to consult both.
     static string Reads(TextBlock block) => block.Text ?? block.Inlines?.Text ?? "";
 
+    /// Pins the block map: emphasis and code spans as inlines, fenced code, bullets and a quote.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Paragraph_inlines_code_blocks_lists_and_quotes_render() {
         await RunOnUiAsync(async () => {
             var (window, root, _) = Show("Some **bold** and *em* and `code`.\n\n```\nvar x = 1;\n```\n\n- one\n- two\n\n> quoted\n\n---\n");
-
-            var paragraph = All<SelectableTextBlock>(root).First();
-            await Assert.That(paragraph.Inlines!.OfType<Bold>().Count()).IsEqualTo(1);
-            await Assert.That(paragraph.Inlines!.OfType<Italic>().Count()).IsEqualTo(1);
-            await Assert.That(paragraph.Inlines!.OfType<Run>().Any(r => r.Text == "code")).IsTrue();
-            await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Text == "var x = 1;")).IsTrue();
-            await Assert.That(All<TextBlock>(root).Count(t => t.Text == "•")).IsEqualTo(2);
-            await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Inlines!.Any(i => i is Run { Text: "quoted" }))).IsTrue();
-            window.Close();
+            try {
+                var paragraph = All<SelectableTextBlock>(root).First();
+                await Assert.That(paragraph.Inlines!.OfType<Bold>().Count()).IsEqualTo(1);
+                await Assert.That(paragraph.Inlines!.OfType<Italic>().Count()).IsEqualTo(1);
+                await Assert.That(paragraph.Inlines!.OfType<Run>().Any(r => r.Text == "code")).IsTrue();
+                await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Text == "var x = 1;")).IsTrue();
+                await Assert.That(All<TextBlock>(root).Count(t => t.Text == "•")).IsEqualTo(2);
+                await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Inlines!.Any(i => i is Run { Text: "quoted" }))).IsTrue();
+            } finally { window.Close(); }
         });
     }
 
+    /// Pins the link affordance: a policy-approved link opens through the command, never itself,
+    /// and answers to both a pointer and the keyboard.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task An_allowed_link_is_a_button_that_opens_once_by_pointer_and_once_by_keyboard() {
         await RunOnUiAsync(async () => {
             var (window, root, opened) = Show("See [docs](https://example.com/docs) now.");
-            var button = All<HyperlinkButton>(root).Single();
-            await Assert.That(button.NavigateUri).IsNull();
-            await Assert.That(button.CommandParameter).IsEqualTo("https://example.com/docs");
+            try {
+                var button = All<HyperlinkButton>(root).Single();
+                await Assert.That(button.NavigateUri).IsNull();
+                await Assert.That(button.CommandParameter).IsEqualTo("https://example.com/docs");
 
-            var origin = button.TranslatePoint(new Avalonia.Point(2, 2), window)!.Value;
-            window.MouseDown(origin, MouseButton.Left);
-            window.MouseUp(origin, MouseButton.Left);
-            Dispatcher.UIThread.RunJobs();
-            await Assert.That(opened).IsEquivalentTo(new[] { "https://example.com/docs" });
+                var origin = button.TranslatePoint(new Point(2, 2), window)!.Value;
+                window.MouseDown(origin, MouseButton.Left);
+                window.MouseUp(origin, MouseButton.Left);
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(opened).IsEquivalentTo(new[] { "https://example.com/docs" });
 
-            button.Focus();
-            window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
-            Dispatcher.UIThread.RunJobs();
-            await Assert.That(opened).Count().IsEqualTo(2);
-            window.Close();
+                button.Focus();
+                window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(opened).Count().IsEqualTo(2);
+            } finally { window.Close(); }
         });
     }
 
+    /// Pins the trust boundary and the degrade rule: a refused scheme leaves no clickable
+    /// affordance behind, and constructs with no mapping keep their source text.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task A_disallowed_link_and_unknown_constructs_render_as_plain_text() {
         await RunOnUiAsync(async () => {
             var (window, root, opened) = Show("Bad [link](javascript:alert(1)) and <b>html</b>\n\n| a | b |\n|---|---|\n| 1 | 2 |\n");
-            await Assert.That(All<HyperlinkButton>(root)).IsEmpty();
-            await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Inlines!.Any(i => i is Run { Text: "link" }))).IsTrue();
-            await Assert.That(All<SelectableTextBlock>(root).Any(t => Reads(t).Contains("| a | b |"))).IsTrue();
-            await Assert.That(opened).IsEmpty();
-            await Assert.That(root.GetVisualDescendants().OfType<Control>().Any(c => c.Focusable && c is not SelectableTextBlock)).IsFalse();
-            window.Close();
+            try {
+                await Assert.That(All<HyperlinkButton>(root)).IsEmpty();
+                await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Inlines!.Any(i => i is Run { Text: "link" }))).IsTrue();
+                await Assert.That(All<SelectableTextBlock>(root).Any(t => Reads(t).Contains("| a | b |"))).IsTrue();
+                await Assert.That(opened).IsEmpty();
+                await Assert.That(root.GetVisualDescendants().OfType<Control>().Any(c => c.Focusable && c is not SelectableTextBlock)).IsFalse();
+            } finally { window.Close(); }
+        });
+    }
+
+    /// Pins what a newline may become: a hard break splits the paragraph into stacked blocks, a
+    /// soft break is a space, and an entity reaches the block decoded — no newline in any inline.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Hard_breaks_stack_soft_breaks_are_spaces_and_entities_decode() {
+        await RunOnUiAsync(async () => {
+            var (hard, hardRoot, _) = Show("a  \nb");
+            try {
+                await Assert.That(All<SelectableTextBlock>(hardRoot).Select(Reads))
+                    .IsEquivalentTo(["a", "b"], CollectionOrdering.Matching);
+            } finally { hard.Close(); }
+
+            var (soft, softRoot, _) = Show("a\nb");
+            try {
+                await Assert.That(All<SelectableTextBlock>(softRoot).Select(Reads)).IsEquivalentTo(["a b"]);
+            } finally { soft.Close(); }
+
+            var (entity, entityRoot, _) = Show("a &amp; b");
+            try {
+                await Assert.That(All<SelectableTextBlock>(entityRoot).Select(Reads)).IsEquivalentTo(["a & b"]);
+            } finally { entity.Close(); }
+        });
+    }
+
+    /// Pins the image and label rules: an image keeps its source text whatever its scheme, and a
+    /// label's code span survives into the button's content.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Images_keep_their_source_text_and_link_labels_keep_their_code_spans() {
+        await RunOnUiAsync(async () => {
+            var (window, root, _) = Show("![](https://example.com/y.png) and [see `code` here](https://example.com/d)");
+            try {
+                await Assert.That(All<SelectableTextBlock>(root).Single().Inlines!.OfType<Run>().Any(r => r.Text == "![](https://example.com/y.png)")).IsTrue();
+                await Assert.That(All<HyperlinkButton>(root).Single().Content).IsEqualTo("see code here");
+            } finally { window.Close(); }
         });
     }
 }

--- a/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
@@ -172,6 +172,13 @@ public class MarkdownBlocksTests {
                 await Assert.That(button.FontSize).IsEqualTo(linkedText.FontSize);
                 await Assert.That(button.FontWeight).IsEqualTo(linkedText.FontWeight);
                 await Assert.That(button.Bounds.Height).IsLessThanOrEqualTo(linkedText.Bounds.Height);
+
+                // The line keeps the text's own baseline, and the button's glyphs sit on it.
+                var inner = All<TextBlock>(button).Single();
+                var innerBaseline = ((Visual)inner).TranslatePoint(new Point(0, inner.TextLayout.TextLines[0].Baseline), linkedText)!.Value.Y;
+                var lineBaseline = linkedText.TextLayout.TextLines[0].Baseline;
+                await Assert.That(Math.Abs(lineBaseline - plainText.TextLayout.TextLines[0].Baseline)).IsLessThanOrEqualTo(0.5);
+                await Assert.That(Math.Abs(innerBaseline - lineBaseline)).IsLessThanOrEqualTo(1);
             } finally { linked.Close(); plain.Close(); }
         });
     }

--- a/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
@@ -1,0 +1,85 @@
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.Views;
+using ReactiveUI;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class MarkdownBlocksTests {
+    static (Window Window, Control Root, List<string> Opened) Show(string markdown) {
+        var opened = new List<string>();
+        ICommand open = ReactiveCommand.Create<string>(opened.Add);
+        var view = new MarkdownView { Text = markdown, OpenLink = open, Width = 400 };
+        var window = new Window { Content = view, Width = 500, Height = 400 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, view, opened);
+    }
+
+    static IEnumerable<T> All<T>(Control root) where T : Visual => root.GetVisualDescendants().OfType<T>();
+
+    /// A text block built from inlines leaves Text null and carries its characters on the
+    /// inline collection, so a "what does this block read as" assertion has to consult both.
+    static string Reads(TextBlock block) => block.Text ?? block.Inlines?.Text ?? "";
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Paragraph_inlines_code_blocks_lists_and_quotes_render() {
+        await RunOnUiAsync(async () => {
+            var (window, root, _) = Show("Some **bold** and *em* and `code`.\n\n```\nvar x = 1;\n```\n\n- one\n- two\n\n> quoted\n\n---\n");
+
+            var paragraph = All<SelectableTextBlock>(root).First();
+            await Assert.That(paragraph.Inlines!.OfType<Bold>().Count()).IsEqualTo(1);
+            await Assert.That(paragraph.Inlines!.OfType<Italic>().Count()).IsEqualTo(1);
+            await Assert.That(paragraph.Inlines!.OfType<Run>().Any(r => r.Text == "code")).IsTrue();
+            await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Text == "var x = 1;")).IsTrue();
+            await Assert.That(All<TextBlock>(root).Count(t => t.Text == "•")).IsEqualTo(2);
+            await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Inlines!.Any(i => i is Run { Text: "quoted" }))).IsTrue();
+            window.Close();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_allowed_link_is_a_button_that_opens_once_by_pointer_and_once_by_keyboard() {
+        await RunOnUiAsync(async () => {
+            var (window, root, opened) = Show("See [docs](https://example.com/docs) now.");
+            var button = All<HyperlinkButton>(root).Single();
+            await Assert.That(button.NavigateUri).IsNull();
+            await Assert.That(button.CommandParameter).IsEqualTo("https://example.com/docs");
+
+            var origin = button.TranslatePoint(new Avalonia.Point(2, 2), window)!.Value;
+            window.MouseDown(origin, MouseButton.Left);
+            window.MouseUp(origin, MouseButton.Left);
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(opened).IsEquivalentTo(new[] { "https://example.com/docs" });
+
+            button.Focus();
+            window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(opened).Count().IsEqualTo(2);
+            window.Close();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_disallowed_link_and_unknown_constructs_render_as_plain_text() {
+        await RunOnUiAsync(async () => {
+            var (window, root, opened) = Show("Bad [link](javascript:alert(1)) and <b>html</b>\n\n| a | b |\n|---|---|\n| 1 | 2 |\n");
+            await Assert.That(All<HyperlinkButton>(root)).IsEmpty();
+            await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Inlines!.Any(i => i is Run { Text: "link" }))).IsTrue();
+            await Assert.That(All<SelectableTextBlock>(root).Any(t => Reads(t).Contains("| a | b |"))).IsTrue();
+            await Assert.That(opened).IsEmpty();
+            await Assert.That(root.GetVisualDescendants().OfType<Control>().Any(c => c.Focusable && c is not SelectableTextBlock)).IsFalse();
+            window.Close();
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
@@ -152,4 +152,27 @@ public class MarkdownBlocksTests {
             } finally { window.Close(); }
         });
     }
+
+    /// Pins the link's place in the line: a paragraph with a link is no taller than the same
+    /// paragraph without one, and the button reads in the paragraph's own size and weight.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_link_sits_in_the_line_without_changing_its_height() {
+        await RunOnUiAsync(async () => {
+            var (linked, linkedRoot, _) = Show("PR opened: [pull/588](https://example.com/pull/588) and done.");
+            var (plain, plainRoot, _) = Show("PR opened: pull/588 and done.");
+            try {
+                linked.UpdateLayout();
+                plain.UpdateLayout();
+                var linkedText = All<SelectableTextBlock>(linkedRoot).Single();
+                var plainText = All<SelectableTextBlock>(plainRoot).Single();
+                var button = All<HyperlinkButton>(linkedRoot).Single();
+
+                await Assert.That(Math.Abs(linkedText.Bounds.Height - plainText.Bounds.Height)).IsLessThanOrEqualTo(1);
+                await Assert.That(button.FontSize).IsEqualTo(linkedText.FontSize);
+                await Assert.That(button.FontWeight).IsEqualTo(linkedText.FontWeight);
+                await Assert.That(button.Bounds.Height).IsLessThanOrEqualTo(linkedText.Bounds.Height);
+            } finally { linked.Close(); plain.Close(); }
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Headless;
 using Avalonia.Input;
+using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Capacitor.App.Views;
@@ -80,11 +81,11 @@ public class MarkdownBlocksTests {
     [NotInParallel("AvaloniaSession")]
     public async Task A_disallowed_link_and_unknown_constructs_render_as_plain_text() {
         await RunOnUiAsync(async () => {
-            var (window, root, opened) = Show("Bad [link](javascript:alert(1)) and <b>html</b>\n\n| a | b |\n|---|---|\n| 1 | 2 |\n");
+            var (window, root, opened) = Show("Bad [link](javascript:alert(1)) and <b>html</b>\n\n<div>raw</div>\n");
             try {
                 await Assert.That(All<HyperlinkButton>(root)).IsEmpty();
                 await Assert.That(All<SelectableTextBlock>(root).Any(t => t.Inlines!.Any(i => i is Run { Text: "link" }))).IsTrue();
-                await Assert.That(All<SelectableTextBlock>(root).Any(t => Reads(t).Contains("| a | b |"))).IsTrue();
+                await Assert.That(All<SelectableTextBlock>(root).Any(t => Reads(t).Contains("<div>raw</div>"))).IsTrue();
                 await Assert.That(opened).IsEmpty();
                 await Assert.That(root.GetVisualDescendants().OfType<Control>().Any(c => c.Focusable && c is not SelectableTextBlock)).IsFalse();
             } finally { window.Close(); }
@@ -125,6 +126,29 @@ public class MarkdownBlocksTests {
             try {
                 await Assert.That(All<SelectableTextBlock>(root).Single().Inlines!.OfType<Run>().Any(r => r.Text == "![](https://example.com/y.png)")).IsTrue();
                 await Assert.That(All<HyperlinkButton>(root).Single().Content).IsEqualTo("see code here");
+            } finally { window.Close(); }
+        });
+    }
+
+    /// Pins table rendering: a pipe table is a grid with one row per source row, a semibold header,
+    /// inline-rendered cells, and the column alignment the separator row declares.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_pipe_table_renders_as_a_grid_with_a_header_and_aligned_cells() {
+        await RunOnUiAsync(async () => {
+            var (window, root, _) = Show("| Issue | Count |\n|---|--:|\n| `x` first | 2 |\n| second | 10 |");
+            try {
+                var table = All<Grid>(root).Single(g => g.Name == "MarkdownTable");
+                await Assert.That(table.RowDefinitions.Count).IsEqualTo(3);
+                await Assert.That(table.ColumnDefinitions.Count).IsEqualTo(2);
+
+                var cells = All<SelectableTextBlock>(table).ToList();
+                await Assert.That(cells.Select(Reads)).IsEquivalentTo(["Issue", "Count", "x first", "2", "second", "10"], CollectionOrdering.Matching);
+                await Assert.That(cells[0].FontWeight).IsEqualTo(FontWeight.SemiBold);
+                await Assert.That(cells[2].FontWeight).IsEqualTo(FontWeight.Normal);
+                await Assert.That(cells[2].Inlines!.OfType<Run>().First().FontFamily.Name).IsNotEqualTo(cells[4].FontFamily.Name);
+                await Assert.That(cells[3].TextAlignment).IsEqualTo(TextAlignment.Right);
+                await Assert.That(cells[2].TextAlignment).IsEqualTo(TextAlignment.Left);
             } finally { window.Close(); }
         });
     }

--- a/test/Capacitor.App.Tests.Unit/RepoLabelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/RepoLabelTests.cs
@@ -1,0 +1,17 @@
+using Capacitor.App.ViewModels;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class RepoLabelTests {
+    /// Pins the repository leaf behind both worktree layouts an agent can run in — Claude's
+    /// `.claude/worktrees/…` and the daemon's `.capacitor/worktrees/agent-…` — and the
+    /// plain cases around them.
+    [Test]
+    public async Task The_leaf_is_the_repository_behind_either_worktree_layout() {
+        await Assert.That(RepoLabel.Leaf("/repo/myproj/.claude/worktrees/feature")).IsEqualTo("myproj");
+        await Assert.That(RepoLabel.Leaf("/repo/myproj/.capacitor/worktrees/agent-6da2")).IsEqualTo("myproj");
+        await Assert.That(RepoLabel.Leaf("/repo/myproj")).IsEqualTo("myproj");
+        await Assert.That(RepoLabel.Leaf("/repo/myproj/")).IsEqualTo("myproj");
+        await Assert.That(RepoLabel.Leaf(null)).IsEqualTo("—");
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/TerminalFeedSanitizerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalFeedSanitizerTests.cs
@@ -1,9 +1,9 @@
 using Capacitor.App.Services;
+using static Capacitor.App.Tests.Unit.Ansi;
 
 namespace Capacitor.App.Tests.Unit;
 
 public class TerminalFeedSanitizerTests {
-    static readonly string Esc = ((char)27).ToString();
     static string Csi(string parameters) => Esc + "[" + parameters + "m";
 
     /// Pins the underline-colour rule: 58 with its arguments, and 59, leave the feed entirely,

--- a/test/Capacitor.App.Tests.Unit/TerminalFeedSanitizerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalFeedSanitizerTests.cs
@@ -58,4 +58,14 @@ public class TerminalFeedSanitizerTests {
         var input = Esc + "[" + new string('1', 80);
         await Assert.That(s.Sanitize(input)).IsEqualTo(input);
     }
+
+    /// Pins the private-parameter rule: a sequence such as xterm's modifyOtherKeys set, which
+    /// only shares SGR's final byte, leaves the feed rather than reaching the SGR handler.
+    [Test]
+    public async Task Private_parameter_sequences_ending_in_m_are_dropped() {
+        var s = new TerminalFeedSanitizer();
+        await Assert.That(s.Sanitize(Esc + "[>4;2ma")).IsEqualTo("a");
+        await Assert.That(s.Sanitize(Esc + "[?4mb")).IsEqualTo("b");
+        await Assert.That(s.Sanitize(Esc + "[>5u" + Esc + "[<u")).IsEqualTo(Esc + "[>5u" + Esc + "[<u");
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/TerminalFeedSanitizerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalFeedSanitizerTests.cs
@@ -1,0 +1,61 @@
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class TerminalFeedSanitizerTests {
+    static readonly string Esc = ((char)27).ToString();
+    static string Csi(string parameters) => Esc + "[" + parameters + "m";
+
+    /// Pins the underline-colour rule: 58 with its arguments, and 59, leave the feed entirely,
+    /// in every form they are written.
+    [Test]
+    public async Task Underline_colour_selectors_are_dropped_with_their_arguments() {
+        var s = new TerminalFeedSanitizer();
+        await Assert.That(s.Sanitize(Csi("58;2;255;4;4") + "a")).IsEqualTo("a");
+        await Assert.That(s.Sanitize(Csi("1;58;5;4;31"))).IsEqualTo(Csi("1;31"));
+        await Assert.That(s.Sanitize(Csi("59"))).IsEqualTo("");
+        await Assert.That(s.Sanitize(Csi("4;58:2::1:2:3"))).IsEqualTo(Csi("4"));
+    }
+
+    /// Pins the sub-parameter rule: a colon form becomes the semicolon form the emulator reads,
+    /// and an underline style of 0 is the underline-off code.
+    [Test]
+    public async Task Colon_sub_parameters_are_normalised_to_semicolon_forms() {
+        var s = new TerminalFeedSanitizer();
+        await Assert.That(s.Sanitize(Csi("4:0"))).IsEqualTo(Csi("24"));
+        await Assert.That(s.Sanitize(Csi("4:3"))).IsEqualTo(Csi("4"));
+        await Assert.That(s.Sanitize(Csi("38:2::10:20:30"))).IsEqualTo(Csi("38;2;10;20;30"));
+        await Assert.That(s.Sanitize(Csi("48:2:10:20:30"))).IsEqualTo(Csi("48;2;10;20;30"));
+        await Assert.That(s.Sanitize(Csi("48:5:7"))).IsEqualTo(Csi("48;5;7"));
+    }
+
+    /// Pins chunk safety: a sequence cut anywhere by a frame boundary is held and rewritten
+    /// whole, including a lone escape at the end of a frame.
+    [Test]
+    public async Task A_sequence_cut_by_a_frame_boundary_is_rewritten_whole() {
+        var whole = Csi("58;2;1;2;3") + "a" + Esc + "[24mb";
+        for (var split = 1; split < whole.Length; split++) {
+            var s = new TerminalFeedSanitizer();
+            var text = s.Sanitize(whole[..split]) + s.Sanitize(whole[split..]);
+            await Assert.That(text).IsEqualTo("a" + Csi("24") + "b");
+        }
+    }
+
+    /// Pins the pass-through: text, other control sequences and well-formed SGR are untouched,
+    /// and an empty SGR stays the reset it is.
+    [Test]
+    public async Task Everything_else_passes_through_untouched() {
+        var s = new TerminalFeedSanitizer();
+        var input = "plain " + Esc + "[2J" + Esc + "]0;title\a" + Csi("38;2;1;2;3") + Csi("") + Csi("0;1;4;24") + Esc + "M";
+        await Assert.That(s.Sanitize(input)).IsEqualTo(input);
+    }
+
+    /// Pins the hold cap: parameter bytes that never end are not a sequence and flow through,
+    /// so a stream of garbage cannot pin the sanitiser's buffer.
+    [Test]
+    public async Task An_over_long_partial_sequence_flows_through() {
+        var s = new TerminalFeedSanitizer();
+        var input = Esc + "[" + new string('1', 80);
+        await Assert.That(s.Sanitize(input)).IsEqualTo(input);
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/TerminalInputEncoderTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalInputEncoderTests.cs
@@ -1,0 +1,14 @@
+using System.Text;
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class TerminalInputEncoderTests {
+    [Test]
+    public async Task Paste_wraps_in_bracketed_paste_normalizes_crlf_and_drops_one_trailing_newline() {
+        await Assert.That(Encoding.UTF8.GetString(TerminalInputEncoder.Paste("hi"))).IsEqualTo("\x1b[200~hi\x1b[201~");
+        await Assert.That(Encoding.UTF8.GetString(TerminalInputEncoder.Paste("a\r\nb\n"))).IsEqualTo("\x1b[200~a\nb\x1b[201~");
+        await Assert.That(Encoding.UTF8.GetString(TerminalInputEncoder.Paste("a\n\n"))).IsEqualTo("\x1b[200~a\n\x1b[201~");
+        await Assert.That(TerminalInputEncoder.Submit).IsEquivalentTo("\r"u8.ToArray());
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/TerminalSendGateTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalSendGateTests.cs
@@ -1,0 +1,235 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using TUnit.Assertions.Enums;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The composer's send gate on TerminalTabViewModel: acceptance, the two-write delivery, and
+/// every window in which a send must be refused or a pending CR dropped. Same RunOnUiAsync +
+/// [NotInParallel("AvaloniaSession")] discipline as TerminalTabViewModelTests.
+public class TerminalSendGateTests {
+    static readonly byte[] Paste = TerminalInputEncoder.Paste("hello");
+    static readonly TimeSpan Delay = TimeSpan.FromMilliseconds(150);
+
+    static async Task<(FakeDaemonClientService Daemon, FakeTerminalAttachClientFactory Factory, FakeTimeProvider Time, TerminalTabViewModel Vm, FakeTerminalAttachClient Client)>
+            BuildAttachedAsync(string? readOnlyReason = null, Action<FakeTerminalAttachClient>? configureNext = null) {
+        var daemon = new FakeDaemonClientService();
+        var factory = new FakeTerminalAttachClientFactory { ConfigureNext = configureNext };
+        var time = new FakeTimeProvider();
+        var vm = new TerminalTabViewModel("a1", daemon, factory.Factory, () => new FakeTerminalSurface(), time);
+        daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+        await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
+        var client = factory.Created.Single();
+        await client.TriggerAttached([], readOnlyReason);
+        return (daemon, factory, time, vm, client);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Accepted_send_writes_the_paste_then_the_cr_after_the_delay_on_the_same_client() {
+        await RunOnUiAsync(async () => {
+            var (_, _, time, vm, client) = await BuildAttachedAsync();
+            await Assert.That(vm.CanAcceptText).IsTrue();
+            await Assert.That(vm.SendAvailability).IsEqualTo(SendAvailability.Ready);
+
+            await Assert.That(vm.TrySendText("hello")).IsTrue();
+            await Assert.That(vm.SendInFlight).IsTrue();
+            await Assert.That(vm.SendAvailability).IsEqualTo(SendAvailability.Sending);
+            await WaitUntilAsync(() => client.SentInput.Count == 1, what: "paste written");
+            await Assert.That(client.SentInput[0]).IsEquivalentTo(Paste);
+
+            time.Advance(Delay);
+            await vm.PendingDeliveryForTesting!;
+            await Assert.That(client.SentInput).Count().IsEqualTo(2);
+            await Assert.That(client.SentInput[1]).IsEquivalentTo(TerminalInputEncoder.Submit);
+            await Assert.That(vm.SendInFlight).IsFalse();
+            await Assert.That(vm.CanAcceptText).IsTrue();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_second_send_is_refused_while_one_is_in_flight_then_goes_through() {
+        await RunOnUiAsync(async () => {
+            var (_, _, time, vm, client) = await BuildAttachedAsync();
+
+            await Assert.That(vm.TrySendText("A")).IsTrue();
+            await Assert.That(vm.TrySendText("B")).IsFalse();
+            await Assert.That(vm.CanAcceptText).IsFalse();
+
+            time.Advance(Delay);
+            await vm.PendingDeliveryForTesting!;
+            await Assert.That(vm.TrySendText("B")).IsTrue();
+            time.Advance(Delay);
+            await vm.PendingDeliveryForTesting!;
+
+            await Assert.That(client.SentInput.Select(Encoding.UTF8.GetString)).IsEquivalentTo(
+                ["\x1b[200~A\x1b[201~", "\r", "\x1b[200~B\x1b[201~", "\r"], CollectionOrdering.Matching);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Refused_unless_attached_read_write() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, ro, _) = await BuildAttachedAsync(readOnlyReason: "review");
+            await Assert.That(ro.TrySendText("x")).IsFalse();
+            await Assert.That(ro.SendAvailability).IsEqualTo(SendAvailability.ReadOnly);
+
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var connecting = new TerminalTabViewModel("a2", daemon, factory.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider());
+            daemon.Agents.AddOrUpdate(Agent("a2", "claude", hasTerminal: true));
+            await (connecting.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(connecting.TrySendText("x")).IsFalse();
+            await Assert.That(connecting.SendAvailability).IsEqualTo(SendAvailability.Connecting);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_send_during_a_reattach_disposal_or_a_detach_write_is_refused_while_state_still_reads_attached() {
+        await RunOnUiAsync(async () => {
+            // Reattach: the old client's disposal is held open, State still Attached.
+            var gate = new TaskCompletionSource();
+            var (_, factory, _, vm, client) = await BuildAttachedAsync(configureNext: c => c.DisposeGate = gate);
+            var reattach = vm.ReattachCommand.Execute().ToTask();
+            await WaitUntilAsync(() => client.DisposeCalls == 1, what: "old client disposing");
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Attached);
+            await Assert.That(vm.CanAcceptText).IsFalse();
+            await Assert.That(vm.SendAvailability).IsEqualTo(SendAvailability.Transitioning);
+            await Assert.That(vm.TrySendText("x")).IsFalse();
+
+            gate.SetResult();
+            await reattach;
+            var client2 = factory.Created[^1];
+            await Assert.That(vm.CanAcceptText).IsFalse(); // Connecting: still closed
+            await client2.TriggerAttached([]);
+            await Assert.That(vm.CanAcceptText).IsTrue();
+
+            // Detach: the detach write is held open, State still Attached.
+            var (_, _, _, vm2, client3) = await BuildAttachedAsync(configureNext: c => c.HangDetachForever = true);
+            var detach = vm2.DetachCommand.Execute().ToTask();
+            await WaitUntilAsync(() => client3.DetachCalls == 1, what: "detach in flight");
+            await Assert.That(vm2.State.Phase).IsEqualTo(TerminalSessionPhase.Attached);
+            await Assert.That(vm2.TrySendText("x")).IsFalse();
+            await Assert.That(vm2.SendAvailability).IsEqualTo(SendAvailability.Transitioning);
+            client3.DetachGate.SetResult();
+            await detach;
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Invalidation_during_the_delay_drops_the_cr_and_clears_in_flight() {
+        await RunOnUiAsync(async () => {
+            foreach (var invalidate in new Func<TerminalTabViewModel, FakeTerminalAttachClient, FakeDaemonClientService, Task>[] {
+                async (vm, _, _) => { await vm.DetachCommand.Execute(); },
+                async (vm, client, _) => { client.Result.SetResult(new AttachOutcome.Exited(0)); await vm.CurrentRunForTesting!; },
+                async (vm, client, _) => { client.Result.SetResult(new AttachOutcome.ConnectionLost()); await vm.CurrentRunForTesting!; },
+                (_, _, daemon) => { daemon.Agents.Remove("a1"); return Task.CompletedTask; },
+                async (vm, _, _) => { await vm.TeardownAsync(); },
+            }) {
+                var (daemon, _, time, vm, client) = await BuildAttachedAsync();
+                await Assert.That(vm.TrySendText("hello")).IsTrue();
+                await WaitUntilAsync(() => client.SentInput.Count == 1, what: "paste written");
+
+                await invalidate(vm, client, daemon);
+                await Assert.That(vm.SendInFlight).IsFalse();
+                await Assert.That(vm.CanAcceptText).IsFalse();
+                await Assert.That(vm.TrySendText("again")).IsFalse();
+
+                time.Advance(Delay);
+                await (vm.PendingDeliveryForTesting ?? Task.CompletedTask);
+                await Assert.That(client.SentInput).Count().IsEqualTo(1);
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_late_attached_publish_cannot_reopen_after_a_removal_or_detach() {
+        await RunOnUiAsync(async () => {
+            // (b) removal while Connecting: the attach callback's publish is queued, then the agent goes.
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var vm = new TerminalTabViewModel("a1", daemon, factory.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider());
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+            await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            var client = factory.Created.Single();
+            var tokenWhileConnecting = vm.OpeningTokenForTesting;
+
+            var attached = client.TriggerAttached([]);   // queued for the UI dispatch, not yet run
+            daemon.Agents.Remove("a1");                  // lands first: SessionEnded, ownership advanced
+            await attached;
+
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.SessionEnded);
+            await Assert.That(vm.OpeningTokenForTesting).IsNotEqualTo(tokenWhileConnecting);
+            await Assert.That(vm.CanAcceptText).IsFalse();
+            await Assert.That(vm.TrySendText("x")).IsFalse();
+
+            // (c) removal during a reattach's pre-Connecting disposal aborts that attempt.
+            var gate = new TaskCompletionSource();
+            var (daemon2, factory2, _, vm2, client2) = await BuildAttachedAsync(configureNext: c => c.DisposeGate = gate);
+            var reattach = vm2.ReattachCommand.Execute().ToTask();
+            await WaitUntilAsync(() => client2.DisposeCalls == 1, what: "old client disposing");
+            // The fake's DisposeAsync terminalizes the run it retires (Detached), exactly as the
+            // real client does; draining that outcome first is what makes the removal below the
+            // LAST publish, rather than racing the retired attempt's own.
+            await vm2.CurrentRunForTesting!;
+            daemon2.Agents.Remove("a1");
+            gate.SetResult();
+            await reattach;
+
+            await Assert.That(vm2.State.Phase).IsEqualTo(TerminalSessionPhase.SessionEnded);
+            await Assert.That(factory2.Created.Count).IsEqualTo(1); // no second client was ever created
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_write_fault_clears_in_flight_and_leaves_state_alone() {
+        await RunOnUiAsync(async () => {
+            var (_, _, _, vm, client) = await BuildAttachedAsync();
+            client.ThrowOnSendInput = new IOException("pipe closed");
+
+            await Assert.That(vm.TrySendText("hello")).IsTrue();
+            await vm.PendingDeliveryForTesting!;
+
+            await Assert.That(vm.SendInFlight).IsFalse();
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Attached);
+            await Assert.That(vm.CanAcceptText).IsTrue();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Teardown_during_the_delay_queues_no_dispatcher_work_afterwards() {
+        await RunOnUiAsync(async () => {
+            var (_, _, time, vm, client) = await BuildAttachedAsync();
+            await Assert.That(vm.TrySendText("hello")).IsTrue();
+            await WaitUntilAsync(() => client.SentInput.Count == 1, what: "paste written");
+            var delivery = vm.PendingDeliveryForTesting!;
+
+            await vm.TeardownAsync();
+            var changes = 0;
+            vm.PropertyChanged += (_, _) => changes++;
+            time.Advance(Delay);
+            await delivery;
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(changes).IsEqualTo(0);
+            await Assert.That(client.SentInput).Count().IsEqualTo(1);
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/TerminalSendGateTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalSendGateTests.cs
@@ -110,8 +110,15 @@ public class TerminalSendGateTests {
             await Assert.That(vm.SendAvailability).IsEqualTo(SendAvailability.Transitioning);
             await Assert.That(vm.TrySendText("x")).IsFalse();
 
+            // The fake terminalizes the run it retires (Detached) where the real client cancels
+            // it, so draining that outcome here is what fixes the order the held-open reattach
+            // resumes into, rather than letting the UI pump race the resumption.
+            await vm.CurrentRunForTesting!;
             gate.SetResult();
             await reattach;
+            await Assert.That(factory.Created.Count).IsEqualTo(1); // the drained outcome retired the attempt
+
+            await vm.ReattachCommand.Execute();
             var client2 = factory.Created[^1];
             await Assert.That(vm.CanAcceptText).IsFalse(); // Connecting: still closed
             await client2.TriggerAttached([]);
@@ -160,7 +167,7 @@ public class TerminalSendGateTests {
     [NotInParallel("AvaloniaSession")]
     public async Task A_late_attached_publish_cannot_reopen_after_a_removal_or_detach() {
         await RunOnUiAsync(async () => {
-            // (b) removal while Connecting: the attach callback's publish is queued, then the agent goes.
+            // Removal while Connecting: the attach callback's publish is queued, then the agent goes.
             var daemon = new FakeDaemonClientService();
             var factory = new FakeTerminalAttachClientFactory();
             var vm = new TerminalTabViewModel("a1", daemon, factory.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider());
@@ -178,14 +185,16 @@ public class TerminalSendGateTests {
             await Assert.That(vm.CanAcceptText).IsFalse();
             await Assert.That(vm.TrySendText("x")).IsFalse();
 
-            // (c) removal during a reattach's pre-Connecting disposal aborts that attempt.
+            // An invalidation landing during a reattach's pre-Connecting disposal aborts that
+            // attempt: no Connecting, no second client.
             var gate = new TaskCompletionSource();
             var (daemon2, factory2, _, vm2, client2) = await BuildAttachedAsync(configureNext: c => c.DisposeGate = gate);
             var reattach = vm2.ReattachCommand.Execute().ToTask();
             await WaitUntilAsync(() => client2.DisposeCalls == 1, what: "old client disposing");
-            // The fake's DisposeAsync terminalizes the run it retires (Detached), exactly as the
-            // real client does; draining that outcome first is what makes the removal below the
-            // LAST publish, rather than racing the retired attempt's own.
+            // The fake terminalizes the run it retires (Detached) where the real client cancels it
+            // -- the retiring Cancel claims the run and its outcome is swallowed as a retired
+            // attempt's own cancellation. Draining that outcome here makes the removal below the
+            // last publish, so what the abort leaves behind is asserted, not raced.
             await vm2.CurrentRunForTesting!;
             daemon2.Agents.Remove("a1");
             gate.SetResult();
@@ -193,6 +202,24 @@ public class TerminalSendGateTests {
 
             await Assert.That(vm2.State.Phase).IsEqualTo(TerminalSessionPhase.SessionEnded);
             await Assert.That(factory2.Created.Count).IsEqualTo(1); // no second client was ever created
+
+            // A detach landing while the attach callback's publish is still queued: the late
+            // Attached is discarded on its stale token, so the gate never opens.
+            var daemon3 = new FakeDaemonClientService();
+            var factory3 = new FakeTerminalAttachClientFactory();
+            var vm3 = new TerminalTabViewModel("a3", daemon3, factory3.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider());
+            daemon3.Agents.AddOrUpdate(Agent("a3", "claude", hasTerminal: true));
+            await (vm3.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            var client3 = factory3.Created.Single();
+
+            var attached3 = client3.TriggerAttached([]);
+            await vm3.DetachCommand.Execute();
+            await attached3;
+
+            await Assert.That(client3.DetachCalls).IsEqualTo(1);
+            await Assert.That(vm3.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
+            await Assert.That(vm3.CanAcceptText).IsFalse();
+            await Assert.That(vm3.TrySendText("x")).IsFalse();
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -252,6 +252,14 @@ public class TerminalTabViewModelTests {
             await Task.WhenAll(t1, t2);
 
             await Assert.That(factory.Created.Count).IsEqualTo(before + 1);
+
+            // The losing call changed neither the token nor the gate; the winner opens on Attached.
+            var winner = factory.Created[^1];
+            var token = vm.OpeningTokenForTesting;
+            await Assert.That(vm.SendGateOpenForTesting).IsFalse();
+            await winner.TriggerAttached([]);
+            await Assert.That(vm.OpeningTokenForTesting).IsEqualTo(token);
+            await Assert.That(vm.CanAcceptText).IsTrue();
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/ToolDetailTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ToolDetailTests.cs
@@ -1,0 +1,30 @@
+using Capacitor.App.ViewModels;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ToolDetailTests {
+    [Test]
+    public async Task Picks_the_first_present_key_in_priority_order() {
+        await Assert.That(ToolDetail.From("""{"command":"ls","description":"List files"}""")).IsEqualTo("List files");
+        await Assert.That(ToolDetail.From("""{"file_path":"/a/b.cs","command":"x"}""")).IsEqualTo("x");
+        await Assert.That(ToolDetail.From("""{"pattern":"*.cs"}""")).IsEqualTo("*.cs");
+        await Assert.That(ToolDetail.From("""{"input":"const r = 1;"}""")).IsEqualTo("const r = 1;");
+    }
+
+    [Test]
+    public async Task Keeps_the_first_line_and_cuts_at_80_characters() {
+        await Assert.That(ToolDetail.From("""{"command":"first line\nsecond"}""")).IsEqualTo("first line");
+        var longLine = new string('x', 100);
+        var detail = ToolDetail.From($$"""{"command":"{{longLine}}"}""");
+        await Assert.That(detail.Length).IsEqualTo(80);
+        await Assert.That(detail[^1]).IsEqualTo('…');
+    }
+
+    [Test]
+    public async Task Empty_when_nothing_applies() {
+        await Assert.That(ToolDetail.From("""{"other":"x"}""")).IsEqualTo("");
+        await Assert.That(ToolDetail.From("""{"command":"   "}""")).IsEqualTo("");
+        await Assert.That(ToolDetail.From("not json")).IsEqualTo("");
+        await Assert.That(ToolDetail.From(null)).IsEqualTo("");
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ToolDetailTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ToolDetailTests.cs
@@ -36,4 +36,19 @@ public class ToolDetailTests {
         await Assert.That(ToolDetail.From("not json")).IsEqualTo("");
         await Assert.That(ToolDetail.From(null)).IsEqualTo("");
     }
+
+    /// Pins path display: a path under the session's root reads relative to it — the daemon's
+    /// per-agent worktree under the repository counts as the root — while other keys and paths
+    /// elsewhere are left alone.
+    [Test]
+    public async Task File_paths_read_relative_to_the_sessions_root() {
+        const string repo = "/Users/me/dev/repo";
+        await Assert.That(ToolDetail.From("""{"file_path":"/Users/me/dev/repo/.capacitor/worktrees/agent-1/src/Foo.cs"}""", repo)).IsEqualTo("src/Foo.cs");
+        await Assert.That(ToolDetail.From("""{"file_path":"/Users/me/dev/repo/src/Foo.cs"}""", repo)).IsEqualTo("src/Foo.cs");
+        await Assert.That(ToolDetail.From("""{"path":"/Users/me/dev/repo/.capacitor/worktrees/agent-1/docs"}""", repo)).IsEqualTo("docs");
+        await Assert.That(ToolDetail.From("""{"notebook_path":"/Users/me/dev/repo/n.ipynb"}""", repo)).IsEqualTo("n.ipynb");
+        await Assert.That(ToolDetail.From("""{"file_path":"/elsewhere/x.cs"}""", repo)).IsEqualTo("/elsewhere/x.cs");
+        await Assert.That(ToolDetail.From("""{"command":"cat /Users/me/dev/repo/x"}""", repo)).IsEqualTo("cat /Users/me/dev/repo/x");
+        await Assert.That(ToolDetail.From("""{"file_path":"/Users/me/dev/repo/src/Foo.cs"}""", null)).IsEqualTo("/Users/me/dev/repo/src/Foo.cs");
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/ToolDetailTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ToolDetailTests.cs
@@ -21,6 +21,15 @@ public class ToolDetailTests {
     }
 
     [Test]
+    public async Task Never_splits_a_surrogate_pair_at_the_cut() {
+        var line = new string('x', 78) + "😀" + new string('y', 20);
+        var detail = ToolDetail.From($$"""{"command":"{{line}}"}""");
+        await Assert.That(detail.Length).IsEqualTo(79);
+        await Assert.That(detail[^1]).IsEqualTo('…');
+        await Assert.That(char.IsHighSurrogate(detail[^2])).IsFalse();
+    }
+
+    [Test]
     public async Task Empty_when_nothing_applies() {
         await Assert.That(ToolDetail.From("""{"other":"x"}""")).IsEqualTo("");
         await Assert.That(ToolDetail.From("""{"command":"   "}""")).IsEqualTo("");

--- a/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
@@ -86,7 +86,7 @@ public class WorkspaceNavigationTests {
             workspaceFactory: agentId => {
                 opened.Add(agentId);
                 return new WorkspaceViewModel(
-                    agentId, daemon, actions, attach.Factory, () => new FakeTerminalSurface(), time);
+                    agentId, daemon, actions, attach.Factory, () => new FakeTerminalSurface(), time, new RecordingOpener());
             });
 
         return new Nav {

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -24,7 +24,7 @@ public class WorkspaceViewModelTests {
     static WorkspaceViewModel Build(
             FakeDaemonClientService daemon, AgentActionService actions, FakeTerminalAttachClientFactory factory,
             FakeTimeProvider time, string agentId = "a1") =>
-        new(agentId, daemon, actions, factory.Factory, () => new FakeTerminalSurface(), time);
+        new(agentId, daemon, actions, factory.Factory, () => new FakeTerminalSurface(), time, new RecordingOpener());
 
     static AgentActionService NewActions(
             ScriptedLocalControlOps ops, RecordingNotifier notifier, RecordingOpener opener,
@@ -138,6 +138,50 @@ public class WorkspaceViewModelTests {
             await WaitUntilAsync(() => ops.StopCalls >= 1, what: "stop issued after confirm");
             await Assert.That(confirmer.Prompted.Count).IsEqualTo(1);
             await Assert.That(ops.StopPayloads).IsEquivalentTo([("a1", true)], CollectionOrdering.Matching);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Chat_is_the_default_tab_and_the_switch_commands_flip_it() {
+        await RunOnUiAsync(async () => {
+            var vm = Build(new FakeDaemonClientService(), NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider());
+
+            await Assert.That(vm.ActiveTab).IsEqualTo(WorkspaceTab.Chat);
+            await Assert.That(vm.IsChatActive).IsTrue();
+            await Assert.That(vm.IsTerminalActive).IsFalse();
+
+            await vm.ShowTerminalCommand.Execute();
+            await Assert.That(vm.IsTerminalActive).IsTrue();
+            await vm.ShowChatCommand.Execute();
+            await Assert.That(vm.IsChatActive).IsTrue();
+            await vm.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Chat_is_built_for_a_pty_dto_only_and_torn_down_with_the_workspace() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var vm = Build(daemon, NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider());
+            await Assert.That(vm.Chat).IsNull();
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: false));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(vm.Chat).IsNull();
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: true));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(vm.Chat).IsNotNull();
+            await Assert.That(vm.Chat!.Phase).IsEqualTo(ChatTabPhase.Unavailable); // gemini has no transcript projection
+
+            var chat = vm.Chat;
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+            await Assert.That(vm.Chat).IsSameReferenceAs(chat); // built once
+
+            await vm.TeardownAsync();
+            await Assert.That(chat.PendingReadForTesting!).IsNull();
         });
     }
 }

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -184,4 +184,25 @@ public class WorkspaceViewModelTests {
             await Assert.That(chat.PendingReadForTesting!).IsNull();
         });
     }
+
+    /// Pins the header for a titled session on a borrowed checkout: the title line is the
+    /// session's own title, and the repository line reads through the worktree to the repository.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_header_shows_the_session_title_over_the_repository_behind_a_borrowed_worktree() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var actions = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
+            var vm = Build(daemon, actions, new FakeTerminalAttachClientFactory(), new FakeTimeProvider(), agentId: "r1");
+
+            daemon.Agents.AddOrUpdate(
+                Agent("r1", "codex", hasTerminal: true, repoPath: "/repo/myproj/.capacitor/worktrees/agent-6da2", kind: "review-flow")
+                    with { Title = "Review this PR" });
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+
+            await Assert.That(vm.Title).IsEqualTo("Review this PR");
+            await Assert.That(vm.RepoLabelText).IsEqualTo("myproj");
+            await vm.TeardownAsync();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -64,6 +64,11 @@ public class WorkspaceViewSmokeTests {
         return (window, vm, daemon, attach);
     }
 
+    /// Effectively visible under this window. A name that never gets realized into the visual
+    /// tree — the collapsed chat surface's own controls — reads as not visible, which is exactly
+    /// what the gate promises.
+    static bool Visible(Window window, string name) => Find<Control>(window, name) is { IsEffectivelyVisible: true };
+
     static bool IsOffscreen(Control control) =>
         Avalonia.Automation.Peers.ControlAutomationPeer.CreatePeerForElement(control).IsOffscreen();
 
@@ -84,7 +89,9 @@ public class WorkspaceViewSmokeTests {
 
     /// Pins that every x:Name the view's code-behind and the suite reach for resolves before any
     /// dto arrives — the tab strip included, which is collapsed in this state and must still be
-    /// in the tree for the code-behind to find.
+    /// in the tree for the code-behind to find. The chat surface is collapsed too, and a
+    /// collapsed UserControl is never measured, so its own names resolve through its name scope
+    /// rather than the window's visual tree.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task WorkspaceView_resolves_all_named_controls() {
@@ -97,11 +104,14 @@ public class WorkspaceViewSmokeTests {
             var names = new[] {
                 "WorkspaceTitle", "WorkspaceRepo", "WorkspaceVendorChip", "ChatTabButton",
                 "TerminalTabButton", "NoTerminalNote", "TerminalHost", "TerminalBanners",
-                "DetachButton", "ReattachButton", "ChatHost", "ChatItems", "ChatPhaseNote",
-                "ComposerInput", "SendButton",
+                "DetachButton", "ReattachButton", "SessionEndedNote", "ChatHost",
             };
             foreach (var name in names)
                 await Assert.That(Find<Control>(window, name)).IsNotNull().Because($"{name} should resolve");
+
+            var chatHost = Find<ChatTabView>(window, "ChatHost")!;
+            foreach (var name in new[] { "ChatItems", "ChatPhaseNote", "ComposerInput", "SendButton" })
+                await Assert.That(chatHost.FindControl<Control>(name)).IsNotNull().Because($"{name} should resolve");
 
             window.Close();
             Dispatcher.UIThread.RunJobs();
@@ -194,9 +204,9 @@ public class WorkspaceViewSmokeTests {
         });
     }
 
-    /// Owner decision after manual QA: a NORMAL read-write attach shows NO banner — it overlaid
-    /// the terminal content. Explicit detach returns when a use case earns it; read-only keeps
-    /// the banner because it is the only explanation for dead keystrokes.
+    /// Pins that a normal read-write attach shows NO banner — one would overlay the terminal
+    /// content. Read-only keeps its banner because it is the only explanation for dead
+    /// keystrokes.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Read_write_attached_state_shows_no_banner() {
@@ -293,6 +303,44 @@ public class WorkspaceViewSmokeTests {
             await Assert.That(terminalHost.Opacity).IsEqualTo(1.0);
             await Assert.That(IsOffscreen(terminalHost)).IsFalse();
             await Assert.That(Find<Control>(window, "TerminalHost")).IsNotNull();
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    /// Pins the one gate the chat surface hangs off: a session with no PTY renders no chat at
+    /// all — not the host, not the composer, not Send — and keeps the banner layer it has no
+    /// Terminal tab to reach, so its end is still announced.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_session_without_a_terminal_shows_no_chat_surface_and_still_banners_its_end() {
+        await RunOnUiAsync(async () => {
+            var (view, vm, daemon, _) = Build();
+            var window = new Window { Content = view, Width = 900, Height = 600 };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: false));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            var chatHost = Find<ChatTabView>(window, "ChatHost")!;
+            await Assert.That(vm.IsChatActive).IsTrue();
+            await Assert.That(chatHost.IsEffectivelyVisible).IsFalse();
+            await Assert.That(Visible(window, "ComposerInput")).IsFalse();
+            await Assert.That(Visible(window, "SendButton")).IsFalse();
+            await Assert.That(chatHost.FindControl<TextBox>("ComposerInput")!.IsFocused).IsFalse();
+            await Assert.That(Find<Control>(window, "NoTerminalNote")!.IsVisible).IsTrue();
+
+            daemon.Agents.Remove(AgentId);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            await Assert.That(vm.Terminal.State.Phase).IsEqualTo(TerminalSessionPhase.SessionEnded);
+            await Assert.That(Find<Control>(window, "SessionEndedNote")!.IsEffectivelyVisible).IsTrue();
 
             window.Close();
             Dispatcher.UIThread.RunJobs();

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -1,4 +1,7 @@
+using System.Reactive.Linq;
 using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Capacitor.App.Services;
@@ -7,6 +10,7 @@ using Capacitor.App.Views;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
 using Microsoft.Extensions.Time.Testing;
+using SvcSystems.UI.Terminal;
 using static Capacitor.App.Tests.Unit.AvaloniaSession;
 using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
@@ -33,28 +37,57 @@ public class WorkspaceViewSmokeTests {
         WorkspaceFixtures.Agent(id, vendor, hasTerminal, "/repo/myproj");
 
     static (WorkspaceView View, WorkspaceViewModel Vm, FakeDaemonClientService Daemon, FakeTerminalAttachClientFactory Attach) Build(
-            string agentId = AgentId) {
+            string agentId = AgentId, Func<ITerminalSurface>? surface = null) {
         var daemon = new FakeDaemonClientService();
         var attach = new FakeTerminalAttachClientFactory();
         var vm = new WorkspaceViewModel(
-            agentId, daemon, NewActions(), attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener());
+            agentId, daemon, NewActions(), attach.Factory, surface ?? (() => new FakeTerminalSurface()),
+            new FakeTimeProvider(), new RecordingOpener());
         return (new WorkspaceView { DataContext = vm }, vm, daemon, attach);
     }
 
     static T? Find<T>(Window window, string name) where T : Control =>
         window.GetVisualDescendants().OfType<T>().FirstOrDefault(c => c.Name == name);
 
-    /// Run-and-observe: hosts the view with a plainly-Resolving VM (no dto ever pushed) and looks
-    /// every named control up by x:Name. Every control is statically declared in the XAML (no
-    /// DataTemplate/ItemsControl realization involved, unlike HomeView's session cards), so this
-    /// is not red-verifiable the way a missing-feature test would be -- the view already exists and
-    /// already carries all eight names; there is no "before" state in which the assertion could
-    /// fail short of a typo. TerminalTabButton is a plain Button in the XAML with no Command bound
-    /// (non-interactive today), so it is resolved as a bare Control like every other name here
-    /// rather than assumed clickable.
+    /// A shown workspace on a PTY session, laid out at a real pane size — the shape every
+    /// tab/focus test below starts from.
+    static async Task<(Window Window, WorkspaceViewModel Vm, FakeDaemonClientService Daemon, FakeTerminalAttachClientFactory Attach)> ShowPtyAsync(
+            Func<ITerminalSurface>? surface = null) {
+        var (view, vm, daemon, attach) = Build(surface: surface);
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: true));
+        await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        return (window, vm, daemon, attach);
+    }
+
+    static bool IsOffscreen(Control control) =>
+        Avalonia.Automation.Peers.ControlAutomationPeer.CreatePeerForElement(control).IsOffscreen();
+
+    /// Everything a real Tab from `start` reaches, in order, until it comes back round. Avalonia's
+    /// own navigation handler is internal, so the ring is walked by pressing the key.
+    static List<IInputElement> TabRing(Window window, Control start) {
+        start.Focus();
+        Dispatcher.UIThread.RunJobs();
+        var ring = new List<IInputElement>();
+        var seen = new HashSet<IInputElement>();
+        while (window.FocusManager?.GetFocusedElement() is { } current && seen.Add(current)) {
+            ring.Add(current);
+            window.KeyPressQwerty(PhysicalKey.Tab, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+        }
+        return ring;
+    }
+
+    /// Pins that every x:Name the view's code-behind and the suite reach for resolves before any
+    /// dto arrives — the tab strip included, which is collapsed in this state and must still be
+    /// in the tree for the code-behind to find.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task WorkspaceView_resolves_all_eight_named_controls() {
+    public async Task WorkspaceView_resolves_all_named_controls() {
         await RunOnUiAsync(async () => {
             var (view, vm, _, _) = Build();
             var window = new Window { Content = view };
@@ -62,8 +95,10 @@ public class WorkspaceViewSmokeTests {
             Dispatcher.UIThread.RunJobs();
 
             var names = new[] {
-                "WorkspaceTitle", "WorkspaceRepo", "WorkspaceVendorChip", "TerminalTabButton",
-                "NoTerminalNote", "TerminalHost", "DetachButton", "ReattachButton",
+                "WorkspaceTitle", "WorkspaceRepo", "WorkspaceVendorChip", "ChatTabButton",
+                "TerminalTabButton", "NoTerminalNote", "TerminalHost", "TerminalBanners",
+                "DetachButton", "ReattachButton", "ChatHost", "ChatItems", "ChatPhaseNote",
+                "ComposerInput", "SendButton",
             };
             foreach (var name in names)
                 await Assert.That(Find<Control>(window, name)).IsNotNull().Because($"{name} should resolve");
@@ -76,10 +111,8 @@ public class WorkspaceViewSmokeTests {
 
     /// Run-and-observe: drives ONE workspace through both has_terminal values for the same agent id
     /// and asserts the tab/note pair actually flips, not just that one arrangement renders
-    /// correctly. TerminalTabButton and NoTerminalNote both bind IsVisible directly to
-    /// WorkspaceViewModel.ShowsTerminalTab (never negated the same way twice, see the XAML's `!`
-    /// prefix on the note), so a bare `.IsVisible` read is enough -- neither sits behind an
-    /// invisible ancestor.
+    /// correctly. The tab buttons share one IsVisible-bound strip, so the button is read through
+    /// IsEffectivelyVisible while the note, which binds the negation itself, is read directly.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Tab_and_note_visibility_flip_with_ShowsTerminalTab() {
@@ -98,7 +131,7 @@ public class WorkspaceViewSmokeTests {
             Dispatcher.UIThread.RunJobs();
 
             await Assert.That(vm.ShowsTerminalTab).IsFalse();
-            await Assert.That(tabButton.IsVisible).IsFalse();
+            await Assert.That(tabButton.IsEffectivelyVisible).IsFalse();
             await Assert.That(note.IsVisible).IsTrue();
             await Assert.That(terminalHost.IsVisible).IsFalse();
             await Assert.That(vm.NoTerminalNote).IsNotEmpty();
@@ -111,7 +144,7 @@ public class WorkspaceViewSmokeTests {
             Dispatcher.UIThread.RunJobs();
 
             await Assert.That(vm.ShowsTerminalTab).IsTrue();
-            await Assert.That(tabButton.IsVisible).IsTrue();
+            await Assert.That(tabButton.IsEffectivelyVisible).IsTrue();
             await Assert.That(note.IsVisible).IsFalse();
             await Assert.That(terminalHost.IsVisible).IsTrue();
             await Assert.That(vm.NoTerminalNote).IsEmpty();
@@ -141,6 +174,7 @@ public class WorkspaceViewSmokeTests {
 
             daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: true));
             await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await vm.ShowTerminalCommand.Execute();
             Dispatcher.UIThread.RunJobs();
 
             await Assert.That(reattachButton.IsEffectivelyVisible).IsFalse();
@@ -177,6 +211,7 @@ public class WorkspaceViewSmokeTests {
 
             daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: true));
             await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await vm.ShowTerminalCommand.Execute();
             Dispatcher.UIThread.RunJobs();
 
             var client = attach.Created[^1];
@@ -211,6 +246,7 @@ public class WorkspaceViewSmokeTests {
 
             daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: true));
             await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await vm.ShowTerminalCommand.Execute();
             Dispatcher.UIThread.RunJobs();
 
             var client = attach.Created[^1];
@@ -221,6 +257,127 @@ public class WorkspaceViewSmokeTests {
             await Assert.That(vm.Terminal.State.ReadOnly).IsTrue();
             await Assert.That(detachButton.IsEffectivelyVisible).IsTrue();
             await Assert.That(bannerText.Text).IsEqualTo("Read-only: review");
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    /// Pins the tab swap: Chat is the surface a PTY session opens on, and the terminal stays in
+    /// the tree behind it — inert and reported offscreen, never unloaded.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Chat_opens_first_and_the_tabs_swap_the_surfaces_while_the_terminal_stays_in_the_tree() {
+        await RunOnUiAsync(async () => {
+            var (window, vm, _, _) = await ShowPtyAsync();
+            var chatHost = Find<Control>(window, "ChatHost")!;
+            var banners = Find<Control>(window, "TerminalBanners")!;
+            var terminalHost = Find<Control>(window, "TerminalHost")!;
+
+            await Assert.That(vm.IsChatActive).IsTrue();
+            await Assert.That(chatHost.IsEffectivelyVisible).IsTrue();
+            await Assert.That(banners.IsEffectivelyVisible).IsFalse();
+            await Assert.That(IsOffscreen(banners)).IsTrue();
+            await Assert.That(terminalHost.IsEnabled).IsFalse();
+            await Assert.That(terminalHost.IsHitTestVisible).IsFalse();
+            await Assert.That(terminalHost.IsVisible).IsTrue();
+            await Assert.That(terminalHost.Opacity).IsEqualTo(0.0);
+            await Assert.That(IsOffscreen(terminalHost)).IsTrue();
+
+            await vm.ShowTerminalCommand.Execute();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(chatHost.IsEffectivelyVisible).IsFalse();
+            await Assert.That(IsOffscreen(chatHost)).IsTrue();
+            await Assert.That(terminalHost.IsEnabled).IsTrue();
+            await Assert.That(terminalHost.Opacity).IsEqualTo(1.0);
+            await Assert.That(IsOffscreen(terminalHost)).IsFalse();
+            await Assert.That(Find<Control>(window, "TerminalHost")).IsNotNull();
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    /// Pins why the off-tab terminal is faded rather than collapsed: the PTY is sized from the
+    /// laid-out pane, so opening on Chat must not hand the daemon the surface's ctor default.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_workspace_opened_on_chat_still_reports_the_laid_out_pane_size() {
+        await RunOnUiAsync(async () => {
+            XtermTerminalSurface? surface = null;
+            var (window, vm, _, attach) = await ShowPtyAsync(surface: () => surface = new XtermTerminalSurface(80, 24));
+            var client = attach.Created[^1];
+
+            await Assert.That((client.Cols, client.Rows)).IsNotEqualTo((80, 24));
+            await Assert.That((client.Cols, client.Rows)).IsEqualTo(surface!.CurrentSize);
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    /// Pins that focus follows the active tab, and that a terminal going live under the Chat tab
+    /// does not steal the composer's focus. A Model assignment is that "went live" moment, so the
+    /// test performs one rather than waiting for a reattach to produce it.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Focus_follows_the_tab_and_survives_a_late_model_assignment() {
+        await RunOnUiAsync(async () => {
+            var (window, vm, _, _) = await ShowPtyAsync();
+            var composer = Find<TextBox>(window, "ComposerInput")!;
+            var terminalHost = Find<TerminalControl>(window, "TerminalHost")!;
+            await Assert.That(composer.IsFocused).IsTrue();
+
+            terminalHost.Model = new XtermTerminalSurface(80, 24).Model;
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(terminalHost.IsFocused).IsFalse();
+            await Assert.That(composer.IsFocused).IsTrue();
+
+            await vm.ShowTerminalCommand.Execute();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(terminalHost.IsFocused).IsTrue();
+
+            await vm.ShowChatCommand.Execute();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(composer.IsFocused).IsTrue();
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await vm.TeardownAsync();
+        });
+    }
+
+    /// Pins that the inactive surface is out of the keyboard's reach in both directions — a Tab
+    /// from either tab's own controls never lands on the other's.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Tab_traversal_never_reaches_the_inactive_surface() {
+        await RunOnUiAsync(async () => {
+            var (window, vm, _, attach) = await ShowPtyAsync();
+            attach.Created[^1].Result.SetResult(new AttachOutcome.Detached());
+            await vm.Terminal.CurrentRunForTesting!;
+            Dispatcher.UIThread.RunJobs();
+
+            var composer = Find<TextBox>(window, "ComposerInput")!;
+            var detach = Find<Control>(window, "DetachButton")!;
+            var reattach = Find<Control>(window, "ReattachButton")!;
+            var send = Find<Control>(window, "SendButton")!;
+            var terminalHost = Find<Control>(window, "TerminalHost")!;
+
+            var ringFromComposer = TabRing(window, composer);
+            await Assert.That(ringFromComposer).Contains(composer);
+            await Assert.That(ringFromComposer).DoesNotContain(detach);
+            await Assert.That(ringFromComposer).DoesNotContain(reattach);
+
+            await vm.ShowTerminalCommand.Execute();
+            Dispatcher.UIThread.RunJobs();
+            var ringFromTerminal = TabRing(window, terminalHost);
+            await Assert.That(ringFromTerminal).Contains(terminalHost);
+            await Assert.That(ringFromTerminal).DoesNotContain(composer);
+            await Assert.That(ringFromTerminal).DoesNotContain(send);
 
             window.Close();
             Dispatcher.UIThread.RunJobs();

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -37,7 +37,7 @@ public class WorkspaceViewSmokeTests {
         var daemon = new FakeDaemonClientService();
         var attach = new FakeTerminalAttachClientFactory();
         var vm = new WorkspaceViewModel(
-            agentId, daemon, NewActions(), attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider());
+            agentId, daemon, NewActions(), attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener());
         return (new WorkspaceView { DataContext = vm }, vm, daemon, attach);
     }
 

--- a/test/Capacitor.App.Tests.Unit/XtermTerminalSurfaceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/XtermTerminalSurfaceTests.cs
@@ -40,4 +40,17 @@ public class XtermTerminalSurfaceTests {
             await Assert.That(File.ReadAllText(dump)).IsEqualTo("ab" + Esc + "[59mc");
         });
     }
+
+    /// Pins the keyboard-mode guard end to end: the modifyOtherKeys set Claude Code sends on
+    /// every return to raw mode underlines nothing.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_keyboard_mode_set_in_the_feed_does_not_underline_later_cells() {
+        await RunOnUiAsync(async () => {
+            var surface = new XtermTerminalSurface(40, 4);
+            surface.Feed(Esc + "[<u" + Esc + "[>5u" + Esc + "[>4;2ma");
+
+            await Assert.That(Underlined(surface, 0)).IsFalse();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/XtermTerminalSurfaceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/XtermTerminalSurfaceTests.cs
@@ -1,0 +1,43 @@
+using Capacitor.App.Services;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class XtermTerminalSurfaceTests {
+    [TempDir] public required TempDir Tmp { get; init; }
+
+    static readonly string Esc = ((char)27).ToString();
+
+    static bool Underlined(XtermTerminalSurface surface, int x) =>
+        surface.Model.Terminal.Engine.Buffer.GetLine(0)![x].Attributes.IsUnderline();
+
+    /// Pins the end-to-end guard: an underline-colour selector in the feed reaches the emulator
+    /// rewritten, so it underlines nothing, while a real underline still does.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_underline_colour_in_the_feed_does_not_underline_later_cells() {
+        await RunOnUiAsync(async () => {
+            var surface = new XtermTerminalSurface(40, 4);
+            surface.Feed(Esc + "[58;2;255;4;4ma" + Esc + "[39mb" + Esc + "[4mc");
+
+            await Assert.That(Underlined(surface, 0)).IsFalse();
+            await Assert.That(Underlined(surface, 1)).IsFalse();
+            await Assert.That(Underlined(surface, 2)).IsTrue();
+        });
+    }
+
+    /// Pins the diagnostic tap: with a dump path, every fed frame is appended to that file as
+    /// the bytes the emulator saw, before any rewriting.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_dump_path_receives_every_fed_frame_before_rewriting() {
+        await RunOnUiAsync(async () => {
+            var dump = Tmp.PathTo("feed.bin");
+            var surface = new XtermTerminalSurface(40, 4, dump);
+            surface.Feed("ab" + Esc + "[59m");
+            surface.Feed("c");
+
+            await Assert.That(File.ReadAllText(dump)).IsEqualTo("ab" + Esc + "[59mc");
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/XtermTerminalSurfaceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/XtermTerminalSurfaceTests.cs
@@ -1,12 +1,11 @@
 using Capacitor.App.Services;
+using static Capacitor.App.Tests.Unit.Ansi;
 using static Capacitor.App.Tests.Unit.AvaloniaSession;
 
 namespace Capacitor.App.Tests.Unit;
 
 public class XtermTerminalSurfaceTests {
     [TempDir] public required TempDir Tmp { get; init; }
-
-    static readonly string Esc = ((char)27).ToString();
 
     static bool Underlined(XtermTerminalSurface surface, int x) =>
         surface.Model.Terminal.Engine.Buffer.GetLine(0)![x].Attributes.IsUnderline();

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Claude/ClaudeTranscriptEventsTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Claude/ClaudeTranscriptEventsTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using Capacitor.Cli.Core.Harness.Claude;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Harness.Claude;
+
+public class ClaudeTranscriptEventsTests {
+    static IReadOnlyList<AcpEventEnvelope> P(string line) => ClaudeTranscriptEvents.Instance.Project(line);
+
+    [Test]
+    public async Task String_user_content_is_one_user_message_with_its_timestamp() {
+        var e = P("""{"type":"user","message":{"role":"user","content":"hello"},"timestamp":"2026-08-26T12:00:00Z"}""");
+        await Assert.That(e).Count().IsEqualTo(1);
+        await Assert.That(e[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(e[0].Text).IsEqualTo("hello");
+        await Assert.That(e[0].TimestampIso).IsEqualTo("2026-08-26T12:00:00Z");
+    }
+
+    [Test]
+    public async Task Meta_and_sidechain_records_project_to_nothing() {
+        await Assert.That(P("""{"type":"user","isMeta":true,"message":{"content":"x"}}""")).IsEmpty();
+        await Assert.That(P("""{"type":"user","isSidechain":true,"message":{"content":"x"}}""")).IsEmpty();
+        await Assert.That(P("""{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"x"}]}}""")).IsEmpty();
+    }
+
+    [Test]
+    public async Task Wrappers_are_stripped_and_a_blank_remainder_is_not_emitted() {
+        var stripped = P("""{"type":"user","message":{"content":[{"type":"text","text":"<system-reminder>\nnoise\n</system-reminder>real"}]}}""");
+        await Assert.That(stripped).Count().IsEqualTo(1);
+        await Assert.That(stripped[0].Text).IsEqualTo("real");
+
+        var onlyWrappers = P("""{"type":"user","message":{"content":[{"type":"text","text":"<command-name>/clear</command-name><local-command-stdout>ok</local-command-stdout>"}]}}""");
+        await Assert.That(onlyWrappers).IsEmpty();
+    }
+
+    [Test]
+    public async Task Tool_results_carry_string_or_block_content_capped_and_flag_errors() {
+        var str = P("""{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"done","is_error":true}]}}""");
+        await Assert.That(str[0].Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(str[0].ToolCallId).IsEqualTo("t1");
+        await Assert.That(str[0].ToolResult).IsEqualTo("done");
+        await Assert.That(str[0].ToolIsError).IsTrue();
+
+        var blocks = P("""{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t2","content":[{"type":"text","text":"a"},{"type":"text","text":"b"}]}]}}""");
+        await Assert.That(blocks[0].ToolResult).IsEqualTo("a\nb");
+        await Assert.That(blocks[0].ToolIsError).IsFalse();
+
+        var big = new string('x', 5000);
+        var capped = P($$$"""{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t3","content":"{{{big}}}"}]}}""");
+        await Assert.That(capped[0].ToolResult!.Length).IsEqualTo(4096);
+    }
+
+    [Test]
+    public async Task Assistant_blocks_map_to_text_thinking_and_tool_call() {
+        var line = """{"type":"assistant","timestamp":"2026-08-26T12:00:01Z","message":{"model":"claude-fable-5","content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"Hi"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}]}}""";
+        var e = P(line);
+
+        await Assert.That(e).Count().IsEqualTo(3);
+        await Assert.That(e[0].Kind).IsEqualTo(AcpEventKind.AssistantThinking);
+        await Assert.That(e[0].Text).IsEqualTo("hmm");
+        await Assert.That(e[1].Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(e[1].Text).IsEqualTo("Hi");
+        await Assert.That(e[1].Model).IsEqualTo("claude-fable-5");
+        await Assert.That(e[2].Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(e[2].ToolCallId).IsEqualTo("toolu_1");
+        await Assert.That(e[2].ToolName).IsEqualTo("Bash");
+        await Assert.That(e[2].ToolInputJson).IsEqualTo("""{"command":"ls"}""");
+        await Assert.That(e[2].TimestampIso).IsEqualTo("2026-08-26T12:00:01Z");
+    }
+
+    [Test]
+    public async Task Encrypted_thinking_and_non_object_inputs_are_normalized() {
+        var enc = P("""{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"","signature":"abc"}]}}""");
+        await Assert.That(enc[0].ThinkingEncrypted).IsTrue();
+
+        foreach (var (input, expected) in new[] {
+            ("[1,2]", """{"input":[1,2]}"""),
+            ("\"s\"", """{"input":"s"}"""),
+            ("null", """{"input":null}"""),
+        }) {
+            var e = P($$$"""{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t","name":"X","input":{{{input}}}}]}}""");
+            await Assert.That(e[0].ToolInputJson).IsEqualTo(expected);
+            using var doc = JsonDocument.Parse(e[0].ToolInputJson!);
+            await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+        }
+    }
+
+    [Test]
+    public async Task Every_other_record_type_and_malformed_input_project_to_nothing() {
+        foreach (var type in new[] { "attachment", "summary", "system", "file-history-snapshot", "file-history-delta", "mode", "permission-mode", "last-prompt", "ai-title", "atis-latch", "worktree-state", "queue-operation", "progress", "unknown-future" })
+            await Assert.That(P($$$"""{"type":"{{{type}}}","message":{"content":"x"}}""")).IsEmpty().Because(type);
+
+        await Assert.That(P("not json")).IsEmpty();
+        await Assert.That(P("[1,2]")).IsEmpty();
+        await Assert.That(P("""{"type":"user","message":{"content":42}}""")).IsEmpty();
+        await Assert.That(P("""{"type":"assistant","message":{"content":[{"type":"text","text":7}]}}""")).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Claude/ClaudeTranscriptEventsTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Claude/ClaudeTranscriptEventsTests.cs
@@ -94,4 +94,22 @@ public class ClaudeTranscriptEventsTests {
         await Assert.That(P("""{"type":"user","message":{"content":42}}""")).IsEmpty();
         await Assert.That(P("""{"type":"assistant","message":{"content":[{"type":"text","text":7}]}}""")).IsEmpty();
     }
+
+    /// Pins the task-notification rule: a record Claude Code injects for a finished background
+    /// task is system-attributed, never the user's words — its summary leads in bold and its result
+    /// follows as markdown; a notification with no result is the summary alone.
+    [Test]
+    public async Task A_task_notification_projects_to_a_system_note_of_summary_and_result() {
+        var line = """{"type":"user","origin":{"kind":"task-notification"},"promptSource":"system","message":{"role":"user","content":"<task-notification>\n<task-id>k1</task-id>\n<status>completed</status>\n<summary>Agent \"Review Task 15\" finished</summary>\n<result>\n## Findings\n\nNone.\n</result>\n</task-notification>"}}""";
+        var note = P(line);
+        await Assert.That(note).Count().IsEqualTo(1);
+        await Assert.That(note[0].Kind).IsEqualTo(AcpEventKind.SystemNote);
+        await Assert.That(note[0].Text).IsEqualTo("**Agent \"Review Task 15\" finished**\n\n## Findings\n\nNone.");
+
+        var bare = P("""{"type":"user","origin":{"kind":"task-notification"},"message":{"content":"<task-notification>\n<summary>MCP task done.</summary>\n</task-notification>"}}""");
+        await Assert.That(bare[0].Text).IsEqualTo("**MCP task done.**");
+
+        var human = P("""{"type":"user","origin":{"kind":"human"},"promptSource":"typed","message":{"content":"hello"}}""");
+        await Assert.That(human[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexRolloutEventsTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexRolloutEventsTests.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using Capacitor.Cli.Core.Harness.Codex;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Harness.Codex;
+
+public class CodexRolloutEventsTests {
+    static IReadOnlyList<AcpEventEnvelope> P(string line) => CodexRolloutEvents.Instance.Project(line);
+
+    static string Item(string payload, string ts = "2026-08-25T00:00:00Z") =>
+        $$$"""{"timestamp":"{{{ts}}}","ordinal":1,"type":"response_item","payload":{{{payload}}}}""";
+
+    [Test]
+    public async Task User_and_assistant_messages_join_their_text_blocks() {
+        var user = P(Item("""{"type":"message","role":"user","content":[{"type":"input_text","text":"a"},{"type":"input_text","text":"b"}]}"""));
+        await Assert.That(user[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(user[0].Text).IsEqualTo("a\nb");
+        await Assert.That(user[0].TimestampIso).IsEqualTo("2026-08-25T00:00:00Z");
+
+        var assistant = P(Item("""{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hi"}]}"""));
+        await Assert.That(assistant[0].Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(assistant[0].Text).IsEqualTo("Hi");
+    }
+
+    [Test]
+    public async Task Injected_preludes_developer_and_system_roles_are_skipped() {
+        foreach (var prelude in new[] { "<environment_context>", "# AGENTS.md instructions", "<turn_aborted>", "<user_instructions>", "<permissions instructions>" })
+            await Assert.That(P(Item($$"""{"type":"message","role":"user","content":[{"type":"input_text","text":"{{prelude}}\nstuff"}]}"""))).IsEmpty().Because(prelude);
+
+        await Assert.That(P(Item("""{"type":"message","role":"developer","content":[{"type":"input_text","text":"x"}]}"""))).IsEmpty();
+        await Assert.That(P(Item("""{"type":"message","role":"system","content":[{"type":"input_text","text":"x"}]}"""))).IsEmpty();
+    }
+
+    [Test]
+    public async Task Tool_calls_always_carry_a_json_object_input() {
+        var fn = P(Item("""{"type":"function_call","name":"spawn_agent","call_id":"c1","arguments":"{\"task\":\"t\"}"}"""));
+        await Assert.That(fn[0].Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(fn[0].ToolCallId).IsEqualTo("c1");
+        await Assert.That(fn[0].ToolName).IsEqualTo("spawn_agent");
+        await Assert.That(fn[0].ToolInputJson).IsEqualTo("""{"task":"t"}""");
+
+        var nonObject = P(Item("""{"type":"function_call","name":"f","call_id":"c2","arguments":"not json"}"""));
+        await Assert.That(nonObject[0].ToolInputJson).IsEqualTo("""{"arguments":"not json"}""");
+
+        var custom = P(Item("""{"type":"custom_tool_call","name":"exec","call_id":"c3","input":"const r = 1;"}"""));
+        await Assert.That(custom[0].ToolName).IsEqualTo("exec");
+        await Assert.That(custom[0].ToolInputJson).IsEqualTo("""{"input":"const r = 1;"}""");
+
+        foreach (var e in new[] { fn[0], nonObject[0], custom[0] }) {
+            using var doc = JsonDocument.Parse(e.ToolInputJson!);
+            await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+        }
+    }
+
+    [Test]
+    public async Task Tool_outputs_carry_string_or_block_output_capped() {
+        var str = P(Item("""{"type":"function_call_output","call_id":"c1","output":"{\"ok\":true}"}"""));
+        await Assert.That(str[0].Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(str[0].ToolCallId).IsEqualTo("c1");
+        await Assert.That(str[0].ToolResult).IsEqualTo("""{"ok":true}""");
+
+        var blocks = P(Item("""{"type":"custom_tool_call_output","call_id":"c3","output":[{"type":"input_text","text":"Script completed"},{"type":"input_text","text":"Output:"}]}"""));
+        await Assert.That(blocks[0].ToolResult).IsEqualTo("Script completed\nOutput:");
+
+        var big = new string('x', 5000);
+        var capped = P(Item($$"""{"type":"function_call_output","call_id":"c4","output":"{{big}}"}"""));
+        await Assert.That(capped[0].ToolResult!.Length).IsEqualTo(4096);
+    }
+
+    [Test]
+    public async Task Reasoning_joins_summaries_and_flags_encrypted_only_content() {
+        var summarized = P(Item("""{"type":"reasoning","summary":[{"type":"summary_text","text":"plan"},{"type":"summary_text","text":"more"}],"encrypted_content":"zzz"}"""));
+        await Assert.That(summarized[0].Kind).IsEqualTo(AcpEventKind.AssistantThinking);
+        await Assert.That(summarized[0].Text).IsEqualTo("plan\nmore");
+        await Assert.That(summarized[0].ThinkingEncrypted).IsFalse();
+
+        var encrypted = P(Item("""{"type":"reasoning","summary":[],"encrypted_content":"zzz"}"""));
+        await Assert.That(encrypted[0].Text).IsNull();
+        await Assert.That(encrypted[0].ThinkingEncrypted).IsTrue();
+    }
+
+    [Test]
+    public async Task Every_other_envelope_and_payload_type_projects_to_nothing() {
+        foreach (var type in new[] { "event_msg", "turn_context", "session_meta", "world_state", "compacted", "inter_agent_communication_metadata" })
+            await Assert.That(P($$$"""{"type":"{{{type}}}","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"x"}]}}""")).IsEmpty().Because(type);
+
+        await Assert.That(P(Item("""{"type":"agent_message","content":[{"type":"input_text","text":"x"}]}"""))).IsEmpty();
+        await Assert.That(P("garbage")).IsEmpty();
+        await Assert.That(P(Item("""{"type":"message","role":"user","content":"not-an-array"}"""))).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/JsonElementExtensionsTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/JsonElementExtensionsTests.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class JsonElementExtensionsTests {
+    static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Test]
+    public async Task Prop_returns_any_kind_and_null_when_absent_or_not_an_object() {
+        var el = Parse("""{"arr":[1,2],"num":3,"nil":null,"str":"s"}""");
+
+        await Assert.That(el.Prop("arr")!.Value.ValueKind).IsEqualTo(JsonValueKind.Array);
+        await Assert.That(el.Prop("num")!.Value.GetInt32()).IsEqualTo(3);
+        await Assert.That(el.Prop("nil")!.Value.ValueKind).IsEqualTo(JsonValueKind.Null);
+        await Assert.That(el.Prop("str")!.Value.GetString()).IsEqualTo("s");
+        await Assert.That(el.Prop("absent")).IsNull();
+        await Assert.That(Parse("[1]").Prop("x")).IsNull();
+        await Assert.That(Parse("\"scalar\"").Prop("x")).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/JsonlTailTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/JsonlTailTests.cs
@@ -1,7 +1,4 @@
-#pragma warning disable IDE0005 // Suppress false positive on necessary usings
 using System.Text;
-using Capacitor.Cli.Core;
-#pragma warning restore IDE0005
 
 namespace Capacitor.Cli.Core.Tests.Unit;
 

--- a/test/Capacitor.Cli.Core.Tests.Unit/JsonlTailTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/JsonlTailTests.cs
@@ -79,6 +79,30 @@ public class JsonlTailTests {
         await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"b\":2}" });
     }
 
+    /// Pins that a failure never spends a truncation: a Failed read leaves the cursor exactly
+    /// where it started, so the shorter file is still a regression to the next successful read,
+    /// which reports Reset and delivers the new content once rather than appending it.
+    [Test]
+    public async Task A_failure_between_a_truncation_and_its_reset_still_reports_the_reset() {
+        var path = Tmp.CreateFile("t.jsonl", "{\"a\":1}\n{\"b\":2}\n");
+        var tail = new JsonlTail(path);
+        tail.ReadAppended();
+        await Assert.That(tail.Cursor).IsEqualTo(16);
+
+        File.Delete(path);
+        Directory.CreateDirectory(path);
+        await Assert.That(tail.ReadAppended().Status).IsEqualTo(TailStatus.Failed);
+        await Assert.That(tail.Cursor).IsEqualTo(16);
+
+        Directory.Delete(path);
+        File.WriteAllText(path, "{\"z\":9}\n");
+        var read = tail.ReadAppended();
+
+        await Assert.That(read.Status).IsEqualTo(TailStatus.Reset);
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"z\":9}" });
+        await Assert.That(tail.Cursor).IsEqualTo(8);
+    }
+
     [Test]
     public async Task Reads_a_file_another_handle_holds_open_for_writing() {
         var path = Tmp.PathTo("live.jsonl");

--- a/test/Capacitor.Cli.Core.Tests.Unit/JsonlTailTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/JsonlTailTests.cs
@@ -1,0 +1,106 @@
+#pragma warning disable IDE0005 // Suppress false positive on necessary usings
+using System.Text;
+using Capacitor.Cli.Core;
+#pragma warning restore IDE0005
+
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class JsonlTailTests {
+    [TempDir] public required TempDir Tmp { get; init; }
+
+    [Test]
+    public async Task Complete_lines_are_delivered_once_and_a_partial_final_line_is_held() {
+        var path = Tmp.CreateFile("t.jsonl", "{\"a\":1}\n{\"b\":2}\n{\"c\":");
+        var tail = new JsonlTail(path);
+
+        var first = tail.ReadAppended();
+        await Assert.That(first.Status).IsEqualTo(TailStatus.Ok);
+        await Assert.That(first.Lines).IsEquivalentTo(new[] { "{\"a\":1}", "{\"b\":2}" });
+
+        var second = tail.ReadAppended();
+        await Assert.That(second.Lines).IsEmpty();
+
+        File.AppendAllText(path, "3}\n");
+        var third = tail.ReadAppended();
+        await Assert.That(third.Lines).IsEquivalentTo(new[] { "{\"c\":3}" });
+    }
+
+    [Test]
+    public async Task Crlf_is_stripped_and_blank_lines_are_skipped() {
+        var path = Tmp.CreateFile("t.jsonl", "{\"a\":1}\r\n\n   \n{\"b\":2}\r\n");
+        var read = new JsonlTail(path).ReadAppended();
+
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"a\":1}", "{\"b\":2}" });
+    }
+
+    [Test]
+    public async Task Length_regression_resets_and_rereads_from_zero() {
+        var path = Tmp.CreateFile("t.jsonl", "{\"a\":1}\n{\"b\":2}\n");
+        var tail = new JsonlTail(path);
+        tail.ReadAppended();
+
+        File.WriteAllText(path, "{\"z\":9}\n");
+        var read = tail.ReadAppended();
+
+        await Assert.That(read.Status).IsEqualTo(TailStatus.Reset);
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"z\":9}" });
+        await Assert.That(tail.Cursor).IsEqualTo(8);
+    }
+
+    [Test]
+    public async Task Missing_file_is_reported_then_read_once_it_appears() {
+        var path = Tmp.PathTo("later.jsonl");
+        var tail = new JsonlTail(path);
+
+        await Assert.That(tail.ReadAppended().Status).IsEqualTo(TailStatus.Missing);
+
+        File.WriteAllText(path, "{\"a\":1}\n");
+        var read = tail.ReadAppended();
+        await Assert.That(read.Status).IsEqualTo(TailStatus.Ok);
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"a\":1}" });
+    }
+
+    [Test]
+    public async Task A_transient_failure_keeps_the_cursor_and_the_next_read_succeeds() {
+        var path = Tmp.CreateFile("t.jsonl", "{\"a\":1}\n");
+        var tail = new JsonlTail(path);
+        tail.ReadAppended();
+
+        // A directory in the file's place is the one failure every OS reports as neither
+        // FileNotFound nor DirectoryNotFound when opened for read.
+        File.Delete(path);
+        Directory.CreateDirectory(path);
+        var failed = tail.ReadAppended();
+        await Assert.That(failed.Status).IsEqualTo(TailStatus.Failed);
+        await Assert.That(failed.Failure).IsNotNull();
+        await Assert.That(tail.Cursor).IsEqualTo(8);
+
+        Directory.Delete(path);
+        File.WriteAllText(path, "{\"a\":1}\n{\"b\":2}\n");
+        var read = tail.ReadAppended();
+        await Assert.That(read.Status).IsEqualTo(TailStatus.Ok);
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"b\":2}" });
+    }
+
+    [Test]
+    public async Task Reads_a_file_another_handle_holds_open_for_writing() {
+        var path = Tmp.PathTo("live.jsonl");
+        using var writer = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
+        writer.Write(Encoding.UTF8.GetBytes("{\"a\":1}\n"));
+        writer.Flush();
+
+        var read = new JsonlTail(path).ReadAppended();
+
+        await Assert.That(read.Status).IsEqualTo(TailStatus.Ok);
+        await Assert.That(read.Lines).IsEquivalentTo(new[] { "{\"a\":1}" });
+    }
+
+    [Test]
+    public async Task Split_consumes_only_through_the_last_newline() {
+        var bytes = Encoding.UTF8.GetBytes("x\ny\nzz");
+        var lines = JsonlTail.SplitCompleteLines(bytes, out var consumed);
+
+        await Assert.That(lines).IsEquivalentTo(new[] { "x", "y" });
+        await Assert.That(consumed).IsEqualTo(4);
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs
@@ -29,7 +29,7 @@ public class StatusIpcJsonTests {
         var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.DaemonStatusDto);
 
         await Assert.That(json).IsEqualTo(
-            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1,"pid":4242,"instance_id":"inst-abc","supported_vendors":null},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex","requester_display":"Ada Lovelace","has_terminal":null,"title":"Fix the flaky test"},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null,"requester_display":null,"has_terminal":null,"title":null}]}""");
+            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1,"pid":4242,"instance_id":"inst-abc","supported_vendors":null},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex","requester_display":"Ada Lovelace","has_terminal":null,"title":"Fix the flaky test","transcript_path":null},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null,"requester_display":null,"has_terminal":null,"title":null,"transcript_path":null}]}""");
     }
 
     [Test]
@@ -94,5 +94,33 @@ public class StatusIpcJsonTests {
         var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
 
         await Assert.That(json).Contains("\"has_terminal\":null");
+    }
+
+    [Test]
+    public async Task Transcript_path_serializes_last_and_null_is_emitted() {
+        var withPath = new AgentStatusDto(
+            "a1", "agent", "claude", "/repo", "Running",
+            null, null, null, new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc), null, null,
+            HasTerminal: true, Title: "t", TranscriptPath: "/home/u/.claude/projects/-repo/abc.jsonl");
+        var without = withPath with { TranscriptPath = null };
+
+        var json = JsonSerializer.Serialize(withPath, StatusIpcJsonContext.Default.AgentStatusDto);
+        var jsonNull = JsonSerializer.Serialize(without, StatusIpcJsonContext.Default.AgentStatusDto);
+
+        await Assert.That(json).EndsWith(""","has_terminal":true,"title":"t","transcript_path":"/home/u/.claude/projects/-repo/abc.jsonl"}""");
+        await Assert.That(jsonNull).EndsWith(""","has_terminal":true,"title":"t","transcript_path":null}""");
+    }
+
+    [Test]
+    public async Task Old_agent_json_without_transcript_path_deserializes_to_null() {
+        var dto = new AgentStatusDto(
+            "a1", "agent", "claude", "/repo", "Running",
+            null, null, null, DateTime.UtcNow, null, null, TranscriptPath: "/x.jsonl");
+        var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
+        var stripped = System.Text.RegularExpressions.Regex.Replace(json, ",\"transcript_path\":[^,}]+", "");
+
+        var back = JsonSerializer.Deserialize(stripped, StatusIpcJsonContext.Default.AgentStatusDto);
+
+        await Assert.That(back!.TranscriptPath).IsNull();
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/TranscriptProjectionTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/TranscriptProjectionTests.cs
@@ -29,7 +29,13 @@ public class TranscriptProjectionTests {
     [Test]
     public async Task WrapAsObject_builds_a_json_object_around_any_value() {
         using var doc = System.Text.Json.JsonDocument.Parse("""[1,"x",null]""");
-        await Assert.That(TranscriptProjectionText.WrapAsObject("input", doc.RootElement)).IsEqualTo("""{"input":[1,"x",null]}""");
-        await Assert.That(TranscriptProjectionText.WrapAsObject("arguments", "raw \"q\"")).IsEqualTo("""{"arguments":"raw "q""}""");
+        var fromElement = TranscriptProjectionText.WrapAsObject("input", doc.RootElement);
+        await Assert.That(fromElement).IsEqualTo("""{"input":[1,"x",null]}""");
+        await Assert.That(System.Text.Json.JsonDocument.Parse(fromElement).RootElement.ValueKind).IsEqualTo(System.Text.Json.JsonValueKind.Object);
+
+        var fromString = TranscriptProjectionText.WrapAsObject("arguments", "raw \"q\"");
+        // Utf8JsonWriter's default encoder escapes a quote as \u0022, not \".
+        await Assert.That(fromString).IsEqualTo("""{"arguments":"raw \u0022q\u0022"}""");
+        await Assert.That(System.Text.Json.JsonDocument.Parse(fromString).RootElement.ValueKind).IsEqualTo(System.Text.Json.JsonValueKind.Object);
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/TranscriptProjectionTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/TranscriptProjectionTests.cs
@@ -38,4 +38,9 @@ public class TranscriptProjectionTests {
         await Assert.That(fromString).IsEqualTo("""{"arguments":"raw \u0022q\u0022"}""");
         await Assert.That(System.Text.Json.JsonDocument.Parse(fromString).RootElement.ValueKind).IsEqualTo(System.Text.Json.JsonValueKind.Object);
     }
+
+    [Test]
+    public async Task For_registers_codex() {
+        await Assert.That(TranscriptProjection.For("CODEX")).IsSameReferenceAs(Capacitor.Cli.Core.Harness.Codex.CodexRolloutEvents.Instance);
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/TranscriptProjectionTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/TranscriptProjectionTests.cs
@@ -1,0 +1,35 @@
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class TranscriptProjectionTests {
+    [Test]
+    public async Task For_is_case_insensitive_and_null_for_an_unknown_vendor() {
+        await Assert.That(TranscriptProjection.For("claude")).IsNotNull();
+        await Assert.That(TranscriptProjection.For("Claude")).IsSameReferenceAs(TranscriptProjection.For("claude")!);
+        await Assert.That(TranscriptProjection.For("gemini")).IsNull();
+    }
+
+    [Test]
+    public async Task Cap_keeps_at_most_4096_units_including_the_marker_and_never_splits_a_pair() {
+        var plain = new string('a', 5000);
+        var capped = TranscriptProjectionText.Cap(plain);
+        await Assert.That(capped.Length).IsEqualTo(4096);
+        await Assert.That(capped[^1]).IsEqualTo('…');
+
+        // 4094 units, then an astral pair straddling the cut position 4095.
+        var astral = new string('a', 4094) + "😀" + new string('b', 100);
+        var cappedAstral = TranscriptProjectionText.Cap(astral);
+        await Assert.That(cappedAstral.Length).IsEqualTo(4095);
+        await Assert.That(char.IsHighSurrogate(cappedAstral[^2])).IsFalse();
+        await Assert.That(cappedAstral[^1]).IsEqualTo('…');
+
+        await Assert.That(TranscriptProjectionText.Cap("short")).IsEqualTo("short");
+        await Assert.That(TranscriptProjectionText.Cap(new string('a', 4096)).Length).IsEqualTo(4096);
+    }
+
+    [Test]
+    public async Task WrapAsObject_builds_a_json_object_around_any_value() {
+        using var doc = System.Text.Json.JsonDocument.Parse("""[1,"x",null]""");
+        await Assert.That(TranscriptProjectionText.WrapAsObject("input", doc.RootElement)).IsEqualTo("""{"input":[1,"x",null]}""");
+        await Assert.That(TranscriptProjectionText.WrapAsObject("arguments", "raw \"q\"")).IsEqualTo("""{"arguments":"raw "q""}""");
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/SessionTranscriptLocatorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/SessionTranscriptLocatorTests.cs
@@ -250,4 +250,54 @@ public class SessionTranscriptLocatorTests {
 
         await Assert.That(SessionTranscriptLocator.IsNewEnough(tooOld, tooOld, SpawnedAt)).IsFalse();
     }
+
+    // ── TryLocateWinner: the matched file, link-resolved ────────────────
+
+    static string TranscriptLine(string cwd) => $$$"""{"type":"user","cwd":"{{{cwd}}}","sessionId":"abc","message":{"content":"hi"}}""";
+
+    [Test]
+    public async Task TryLocateWinner_returns_id_and_the_matched_path() {
+        using var tmp = new TempDir();
+        var projectDir = tmp.CreateDir("projects", "-repo").Path;
+        var worktree = tmp.PathTo("wt");
+        var file = tmp.CreateFile(["projects", "-repo", "0123456789abcdef0123456789abcdef.jsonl"], TranscriptLine(worktree) + "\n");
+
+        var winner = SessionTranscriptLocator.TryLocateWinner(projectDir, worktree, DateTime.UtcNow.AddMinutes(-1));
+
+        await Assert.That(winner?.SessionId).IsEqualTo("0123456789abcdef0123456789abcdef");
+        await Assert.That(winner?.Path).IsEqualTo(file);
+    }
+
+    [Test]
+    public async Task Winner_through_a_symlinked_project_dir_survives_the_symlink_going_away() {
+        using var tmp = new TempDir();
+        var real = tmp.CreateDir("projects", "-source").Path;
+        var link = tmp.PathTo("projects", "-worktree");
+        Directory.CreateSymbolicLink(link, real);
+        var worktree = tmp.PathTo("wt");
+        tmp.CreateFile(["projects", "-source", "0123456789abcdef0123456789abcdef.jsonl"], TranscriptLine(worktree) + "\n");
+
+        var winner = SessionTranscriptLocator.TryLocateWinner(link, worktree, DateTime.UtcNow.AddMinutes(-1));
+
+        await Assert.That(winner?.Path).IsEqualTo(Path.Combine(real, "0123456789abcdef0123456789abcdef.jsonl"));
+
+        Directory.Delete(link);
+        File.AppendAllText(winner!.Value.Path, TranscriptLine(worktree) + "\n");
+        await Assert.That(File.ReadLines(winner.Value.Path).Count()).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task A_freshly_appended_transcript_with_a_foreign_cwd_is_never_a_winner() {
+        // The boundary a Claude --resume into a new worktree hits: the resumed transcript's
+        // early records keep their original cwd, and no amount of fresh writes changes that.
+        using var tmp = new TempDir();
+        var projectDir = tmp.CreateDir("projects", "-repo").Path;
+        tmp.CreateFile(["projects", "-repo", "0123456789abcdef0123456789abcdef.jsonl"], TranscriptLine(tmp.PathTo("original-cwd")) + "\n");
+        var ruledOut = new HashSet<string>();
+
+        var winner = SessionTranscriptLocator.TryLocateWinner(projectDir, tmp.PathTo("new-worktree"), DateTime.UtcNow.AddMinutes(-1), ruledOut);
+
+        await Assert.That(winner).IsNull();
+        await Assert.That(ruledOut).Count().IsEqualTo(1);
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/SessionTranscriptLocatorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/SessionTranscriptLocatorTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Capacitor.Cli.Daemon.Harness.Claude;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Claude;
@@ -253,7 +254,8 @@ public class SessionTranscriptLocatorTests {
 
     // ── TryLocateWinner: the matched file, link-resolved ────────────────
 
-    static string TranscriptLine(string cwd) => $$$"""{"type":"user","cwd":"{{{cwd}}}","sessionId":"abc","message":{"content":"hi"}}""";
+    // Encoded, not interpolated: a Windows path's backslashes are JSON escapes.
+    static string TranscriptLine(string cwd) => $$$"""{"type":"user","cwd":"{{{JsonEncodedText.Encode(cwd)}}}","sessionId":"abc","message":{"content":"hi"}}""";
 
     [Test]
     public async Task TryLocateWinner_returns_id_and_the_matched_path() {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
@@ -182,6 +182,32 @@ public class AgentOrchestratorLocalAttachTests {
     }
 
     [Test]
+    public async Task Discovery_reports_to_the_server_for_a_public_agent_only() {
+        var privServer = new TripwireServerConnection();
+        await using var privOrch = AgentOrchestratorHarness.BuildOrchestrator(privServer, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var privAgent = new AgentInstance("priv-1", null, "", null, "/r", "claude",
+            new PtyHostedAgentRuntime("claude", new StubPtyProcess()), new WorktreeInfo("/r", "", "/r"), new CancellationTokenSource()) { IsPrivate = true };
+        privOrch.RegisterAgentForTest(privAgent);
+
+        await privOrch.RunDiscoveryForTest(privAgent, _ => ("sid", "/p.jsonl"));
+
+        await Assert.That(privAgent.TranscriptPath).IsEqualTo("/p.jsonl");
+        await Assert.That(privServer.Calls.Count).IsEqualTo(0);
+
+        var pubServer = new TripwireServerConnection();
+        await using var pubOrch = AgentOrchestratorHarness.BuildOrchestrator(pubServer, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var pubAgent = new AgentInstance("pub-1", null, "", null, "/r", "claude",
+            new PtyHostedAgentRuntime("claude", new StubPtyProcess()), new WorktreeInfo("/r", "", "/r"), new CancellationTokenSource()) { IsPrivate = false };
+        pubOrch.RegisterAgentForTest(pubAgent);
+
+        await pubOrch.RunDiscoveryForTest(pubAgent, _ => ("sid2", "/q.jsonl"));
+
+        await Assert.That(pubAgent.TranscriptPath).IsEqualTo("/q.jsonl");
+        await Assert.That(pubServer.Calls).Contains(nameof(ServerConnection.AgentStatusChangedAsync));
+        await Assert.That(pubServer.Calls).Contains(nameof(ServerConnection.AppendAgentRunEventAsync));
+    }
+
+    [Test]
     public async Task RegisterAgentAsync_registers_public_agent_and_skips_private() {
         var server = new TripwireServerConnection();
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
@@ -161,6 +161,27 @@ public class AgentOrchestratorLocalAttachTests {
     }
 
     [Test]
+    public async Task Local_spawns_start_transcript_discovery_private_included() {
+        using var tmp = new TempDir();
+        var server    = new TripwireServerConnection();
+        var pty       = new EnvCapturingPtyFactory();
+        var launchers = new Dictionary<string, IHostedAgentLauncher> { ["claude"] = new SpyHostedAgentLauncher("claude", "spy-claude") };
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, pty, launchers);
+
+        foreach (var isPrivate in new[] { false, true }) {
+            var readBuf = new MemoryStream();
+            await FrameCodec.WriteAsync(readBuf, LocalFrame.Detach(), default);
+            readBuf.Position = 0;
+            using var client = new DuplexTestStream(readBuf, new MemoryStream());
+
+            var spawn = FrameCodec.Spawn("claude", WorkLocation.BorrowedCwd, isPrivate, tmp.Path, [], 80, 24);
+            await orch.HandleLocalSpawnAsync(spawn, client, default);
+        }
+
+        await Assert.That(orch.DiscoveryStartsForTest).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task RegisterAgentAsync_registers_public_agent_and_skips_private() {
         var server = new TripwireServerConnection();
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs
@@ -273,9 +273,9 @@ public class AgentStatusSnapshotTests {
         }
     }
 
-    /// A private agent gets the path and the pulse with no server call in the way.
+    /// A private agent gets the path and the pulse too.
     [Test]
-    public async Task A_private_agent_gets_its_path_and_pulse_without_server_reports() {
+    public async Task A_private_agent_gets_its_path_and_pulse() {
         var fixture = Build();
         var orch    = fixture.Orchestrator;
         try {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs
@@ -232,4 +232,62 @@ public class AgentStatusSnapshotTests {
             await fixture.CleanupAsync();
         }
     }
+
+    [Test]
+    public async Task Status_payload_carries_transcript_path_null_before_discovery_and_the_value_after() {
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
+        try {
+            var agent = orch.SeedAgentForTest("pty-1");
+
+            var before = System.Text.Json.JsonSerializer.Serialize(orch.SnapshotAgentsForStatus()[0], StatusIpcJsonContext.Default.AgentStatusDto);
+            await Assert.That(before).Contains("\"transcript_path\":null");
+
+            var versionBefore = fixture.Notifier.Version;
+            await orch.RunDiscoveryForTest(agent, _ => ("0123456789abcdef0123456789abcdef", "/home/u/.claude/projects/-repo/t.jsonl"));
+
+            var after = System.Text.Json.JsonSerializer.Serialize(orch.SnapshotAgentsForStatus()[0], StatusIpcJsonContext.Default.AgentStatusDto);
+            await Assert.That(after).Contains("\"transcript_path\":\"/home/u/.claude/projects/-repo/t.jsonl\"");
+            await Assert.That(agent.SessionId).IsEqualTo("0123456789abcdef0123456789abcdef");
+            await Assert.That(fixture.Notifier.Version).IsGreaterThan(versionBefore);
+        } finally {
+            await fixture.CleanupAsync();
+        }
+    }
+
+    /// A session id learned elsewhere must not stop discovery: the path is the obligation.
+    [Test]
+    public async Task Discovery_sets_the_path_even_when_the_session_id_is_already_known() {
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
+        try {
+            var agent = orch.SeedAgentForTest("pty-2");
+            agent.SessionId = "pre-known";
+
+            await orch.RunDiscoveryForTest(agent, _ => ("other", "/t.jsonl"));
+
+            await Assert.That(agent.SessionId).IsEqualTo("pre-known");
+            await Assert.That(agent.TranscriptPath).IsEqualTo("/t.jsonl");
+        } finally {
+            await fixture.CleanupAsync();
+        }
+    }
+
+    /// A private agent gets the path and the pulse with no server call in the way.
+    [Test]
+    public async Task A_private_agent_gets_its_path_and_pulse_without_server_reports() {
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
+        try {
+            var agent = orch.SeedAgentForTest("priv-1", isPrivate: true);
+            var versionBefore = fixture.Notifier.Version;
+
+            await orch.RunDiscoveryForTest(agent, _ => ("sid", "/p.jsonl"));
+
+            await Assert.That(agent.TranscriptPath).IsEqualTo("/p.jsonl");
+            await Assert.That(fixture.Notifier.Version).IsGreaterThan(versionBefore);
+        } finally {
+            await fixture.CleanupAsync();
+        }
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptDiscoveryTests.cs
@@ -68,4 +68,17 @@ public class TranscriptDiscoveryTests {
         await Assert.That(await run).IsFalse();
         await Assert.That(calls).IsEqualTo(1);
     }
+
+    [Test]
+    public async Task A_fault_in_onFound_propagates_and_is_not_reported_as_not_found() {
+        var time = new FakeTimeProvider();
+        var discovery = new TranscriptDiscovery(time, Interval, Timeout);
+
+        var run = discovery.RunAsync(
+            _ => ("sid", "/t.jsonl"),
+            _ => throw new InvalidOperationException("report failed"),
+            CancellationToken.None);
+
+        await Assert.That(async () => await run).Throws<InvalidOperationException>();
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptDiscoveryTests.cs
@@ -1,0 +1,71 @@
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class TranscriptDiscoveryTests {
+    static readonly TimeSpan Interval = TimeSpan.FromSeconds(2);
+    static readonly TimeSpan Timeout = TimeSpan.FromMinutes(3);
+
+    [Test]
+    public async Task A_winner_on_a_later_tick_is_handed_over_once() {
+        var time = new FakeTimeProvider();
+        var discovery = new TranscriptDiscovery(time, Interval, Timeout);
+        var calls = 0;
+        var found = new List<(string, string)>();
+
+        var run = discovery.RunAsync(
+            _ => ++calls >= 3 ? ("sid", "/t.jsonl") : null,
+            w => { found.Add(w); return Task.CompletedTask; },
+            CancellationToken.None);
+
+        time.Advance(Interval);
+        time.Advance(Interval);
+        await Assert.That(await run).IsTrue();
+        await Assert.That(found).IsEquivalentTo(new[] { ("sid", "/t.jsonl") });
+        await Assert.That(calls).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task The_ruled_out_set_persists_across_ticks() {
+        var time = new FakeTimeProvider();
+        var discovery = new TranscriptDiscovery(time, Interval, Timeout);
+        ISet<string>? first = null, second = null;
+
+        var run = discovery.RunAsync(
+            set => { if (first is null) { first = set; set.Add("x"); return null; } second = set; return ("sid", "/p"); },
+            _ => Task.CompletedTask, CancellationToken.None);
+
+        time.Advance(Interval);
+        await run;
+        await Assert.That(second).IsSameReferenceAs(first!);
+        await Assert.That(second!.Contains("x")).IsTrue();
+    }
+
+    [Test]
+    public async Task The_deadline_ends_the_poll_without_a_handover() {
+        var time = new FakeTimeProvider();
+        var discovery = new TranscriptDiscovery(time, Interval, Timeout);
+        var handed = false;
+
+        var run = discovery.RunAsync(_ => null, _ => { handed = true; return Task.CompletedTask; }, CancellationToken.None);
+        for (var elapsed = TimeSpan.Zero; elapsed <= Timeout; elapsed += Interval) time.Advance(Interval);
+
+        await Assert.That(await run).IsFalse();
+        await Assert.That(handed).IsFalse();
+    }
+
+    [Test]
+    public async Task Cancellation_ends_the_poll_cleanly_without_a_final_locate() {
+        var time = new FakeTimeProvider();
+        var discovery = new TranscriptDiscovery(time, Interval, Timeout);
+        using var cts = new CancellationTokenSource();
+        var calls = 0;
+
+        var run = discovery.RunAsync(_ => { calls++; return null; }, _ => Task.CompletedTask, cts.Token);
+        cts.Cancel();
+
+        await Assert.That(await run).IsFalse();
+        await Assert.That(calls).IsEqualTo(1);
+    }
+}


### PR DESCRIPTION
AI-2196 — no GitHub issue exists for this slice, so the reference line carries the Linear id alone.

## What & why

A Claude or interactive Codex session in the desktop app gets a Chat tab beside its Terminal tab, rendered from the transcript file the vendor itself writes; composer input still goes to the PTY. The daemon, not the app, knows where that file is: every PTY launch runs the same transcript discovery the server-driven path already used, and the link-resolved path rides a trailing nullable `transcript_path` on the status DTO — no new frame family. The transcript → chat projection lives in Core and emits the ACP event vocabulary the daemon's live runtimes already speak, so the renderer is written once.

## Where to look

Composer sends are accepted, never acknowledged: bracketed paste, a 150 ms wait past Codex's post-paste Enter suppression, then one CR — and only if the terminal's opening token is unchanged, so a queued attach callback cannot reopen a terminal the daemon already dropped. `TerminalHost` stays laid out under the Chat tab (faded, disabled, reported offscreen) because an unmeasured control would report 80×24 and shrink the PTY for every attacher. Enter is handled on the tunnelling route: `TextBox`'s own class handler consumes a bubbling Enter first.

## Verification

- `dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj` — 0 warnings, 0 errors
- `dotnet test --solution Capacitor.slnx` — 10,292 tests: 10,218 passed, 59 skipped, 15 failed, every failure a known machine-local one in a suite this branch does not touch (Cursor/Gemini session-start nudge tests, the codex schema pin, CLI/daemon timing tests that pass filtered); `Capacitor.App.Tests.Unit` 1,208/1,208 and `Capacitor.Cli.Core.Tests.Unit` fully green
- `dotnet publish -c Release … | grep -E 'IL[23][01][0-9]{2}'` — no output
