### PR TITLE
Report the import outcome to the first-run flow

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -7,6 +7,52 @@ Not release notes. Each entry is written as of the change that produced it and i
 code moves on; where an entry disagrees with the code, the code wins.
 
 
+## The import outcome reaches the first-run flow
+
+The flow's `import-outcome` route folded a report into `FirstRunFlowState.ImportOutcome` and had no
+caller, so the Done screen's counts caption was unreachable — and since the outcome is also the signal
+that the run finished, the screen could not tell a working import from a stalled one.
+
+`FinalCounts` already carried the route's three counts, so nothing is re-derived. Two things it did not
+carry: a session the `--private` preflight held back never reaches the upload and so appears in none of
+the three, and folds into `failed` (re-running retries exactly it); and a pass that threw leaves its
+sessions unaccounted, which **three counts cannot express**, so nothing at all is reported for that run.
+Sending the surviving pass's figures would state a clean import over a run that lost one.
+
+**Null is not `(0,0,0)`.** Three zeroes are also a clean run over an already-loaded history, so a refusal
+carries a coded token — `no_readable_agents`, or `decision_unreadable` — and the server rejects a token
+on an outcome that moved something.
+
+**An empty answer has two causes and only one is a decline.** `Choices` is empty both when the user asked
+for nothing and when every level in the decision was unreadable here; `IsDecline` already drew that line,
+and reporting the second as a clean zero would tell the screen "you chose not to" about a user who chose
+otherwise. Relatedly, `HandleImport` had three "found nothing" exits that returned 0 without reaching
+`onFinished`, so a clean run over an out-of-scope selection looked like a lost pass and reported nothing —
+they now report a measured zero, the rule the discovery report in the same file already followed.
+
+The retry is **not** credited against the poll budget, unlike the scan and the import. It runs on every
+tick for as long as the report is refused, so crediting it would let a server that never accepts it
+stretch the flow's own 30-minute backstop into hours.
+
+That second token had no producer, and the branch that should raise it was worse than silent: a decision
+naming a window this build cannot map returned early **without stamping the cursor**, re-evaluating the
+same answer on every tick for the life of the flow. Polling cannot make a newer server's vocabulary
+readable, so it is reported and the cursor moves.
+
+`decided_at` cannot be wrong inside the lane — the answer is built from the view's own stamp, so they are
+one value. The reachable hazard is the retry: the report is held across ticks, and `DeliverOutcomeAsync`
+takes no view, so it cannot re-stamp a held report with whatever is standing.
+
+**Retrying a retryable status is opt-in.** `SendWithRetryAsync` retried transport faults but returned any
+completed response, so one 503 cost a session with no second attempt while an unreachable server got
+thirty seconds of trying — which is what made `failed` too weak to show. It is now retried like a
+transport fault (408, 429, 5xx; `Retry-After` honoured, capped by the remaining budget) but only where the
+call site asks. Every hook, watch, daemon and MCP path shares that helper and their budgets assume one
+attempt; changing it for all of them in service of one caption is not the trade. An exhausted budget
+returns the status rather than throwing — the call sites catch `HttpRequestException` only, so a throw
+would turn a 503 into a crash mid-import.
+
+
 ## The Agents screen's visibility answer reaches the profile
 
 The flow asked who may read future sessions, recorded it on `FirstRunAgentsDecidedEvent`, served it on

--- a/docs/superpowers/specs/2026-08-27-ai2307-import-outcome-report-design.md
+++ b/docs/superpowers/specs/2026-08-27-ai2307-import-outcome-report-design.md
@@ -1,0 +1,159 @@
+# AI-2307 — Report the import outcome to the first-run flow
+
+## Problem
+
+The flow's `POST /api/first-run/flows/{id}/import-outcome` route takes `{imported, skipped, failed,
+reason, decided_at}`, folds into `FirstRunFlowState.ImportOutcome`, and **had no caller**. So the Done
+screen's `N imported · N skipped · N failed` caption was unreachable, and — because the outcome is also
+the signal that the run *finished* — the screen could not tell a working import from a stalled one.
+
+Note the route ships with AI-2038, which is **still open** as kcap-server#1671. The ticket described it
+as shipped; it is not. This half is written against the contract on that branch, and the CLI degrades on
+a 404 the way it does for every other route a newer server introduced.
+
+## Where the counts come from
+
+`ImportCommand.FinalCounts` already exposes exactly the route's three, and they are not re-derived here:
+`Imported` folds loaded and resumed (a resume is an import that finished, not a third thing), `Skipped`
+folds already-loaded, too-short and excluded, and `Failed` folds probe errors and upload errors.
+
+**Two things the run has that the three counts did not.**
+
+*A session held back by the visibility preflight.* AI-2222 made `--private` fail closed: a session whose
+privatisation write is lost is dropped from the upload rather than uploaded shared. Those sessions land
+in none of `FinalCounts`' three — not loaded, not skipped, not errored — so a report built from it alone
+silently understates the total. They fold into `failed`, which matches that field's own definition:
+should have landed and did not, and re-running retries exactly these.
+
+*A pass that produced no accounting.* `--private` is per invocation, so a decision spanning both levels
+runs two imports and the report has to sum them. A pass that threw, or returned without reaching its Done
+grid, leaves its sessions unaccounted — and **three counts cannot express "some unknown number failed"**.
+So the lane returns null for that run and nothing is reported at all: sending the surviving pass's figures
+would state a clean import over a run that lost one. The screen's existing "cannot tell" is honest about
+that; a wrong number is not. This is the same argument the ticket makes for retrying a lost status before
+counting it.
+
+## Null is not (0,0,0)
+
+The distinction is load-bearing in two places, and in both the wrong choice reads as success:
+
+| Situation | Reported |
+| --- | --- |
+| ran, moved nothing, nothing to move | `(0,0,0)`, no reason |
+| ran, lost a pass | nothing |
+| repositories chosen, no vendor readable | `(0,0,0)` + `no_readable_agents` |
+| decision this build cannot map | `(0,0,0)` + `decision_unreadable` |
+
+Three zeroes are also what a clean run over an already-loaded history looks like, which is the whole
+reason the reason token exists. The server enforces the other half: it rejects a token on an outcome that
+moved something, so a refusal is three zeroes or it is nothing.
+
+**An empty answer has two causes and only one is a decline.** `Choices` is also empty when every
+repository in the decision named a level this build cannot map, and reporting *that* as a clean zero tells
+the screen "you chose not to import" about a user who chose otherwise. `FirstRunImportAnswer.IsDecline`
+already draws the line (`Choices == 0 && Unreadable == 0`) and is what the branch tests, so the
+all-unreadable case reports `decision_unreadable` alongside the other two unreadable shapes.
+
+The partial case — some levels readable, some not — runs and reports its counts, with the dropped
+repositories not represented. That is a limitation rather than a choice: the wire has one reason field and
+the server rejects a reason on counts that moved something, so there is nowhere to say "and two more were
+dropped". The terminal summary does say it.
+
+**A deliberate empty exit reports its zero.** `HandleImport` returns 0 without reaching `onFinished` on
+three "found nothing" paths — no sessions in scope, no transcript files, no agents installed. Read
+through the null contract above, a clean run over an out-of-scope selection therefore looked like a lost
+pass and reported nothing at all, which loses the finished signal this change exists to send. Those exits
+now report a measured zero, which is the rule the discovery report in the same file already follows:
+zero is an answer, and silence is indistinguishable from having died.
+
+## The spin this fixes
+
+`FirstRunFlowOutcomes.Import` returns null when the decision names a window or titles value this build
+cannot map. `ActOnImportDecisionAsync` returned early **without stamping the cursor**, so it re-evaluated
+that same unreadable decision on every poll tick for the life of the flow, reporting nothing.
+
+Polling again cannot make a newer server's vocabulary readable, so this is reported rather than retried:
+the cursor moves and `decision_unreadable` goes to the screen. The server had defined the token and
+nothing could produce it.
+
+Scope note: this was found while adding the report, not filed separately, because the fix is one stamp
+inside the branch the report is being added to. Leaving a known infinite loop in place to keep a diff
+tidy is not a trade worth making.
+
+## Correlation is structural, not asserted
+
+`decided_at` identifies the answer that ran, and the server records nothing for a superseded one. It
+cannot be wrong inside the lane: `Import(view)` builds `answer.DecidedAt` *from* `view.ImportDecidedAt`,
+so the two are one value. A mutation swapping them is an equivalent mutant and no test can separate them
+— worth stating rather than covering.
+
+Where it *can* go wrong is the retry. The report is held in `ImportLaneState.Outcome` across ticks, so a
+decision may change while one is still owed. `DeliverOutcomeAsync` takes no view and therefore cannot
+re-stamp, which is the guarantee; the test pins the observable half — a held report keeps its own stamp
+while a later decision reports its own.
+
+The flush matters for the same reason. The poll returns on a finished flow, so the tick that reports is
+the last one that exists, and an outcome refused once would otherwise never be sent.
+
+**The retry is deliberately uncredited against the poll budget.** The loop extends its own 30-minute
+backstop by time spent on work — a disk scan, an upload — on the reasoning that those are the flow
+progressing rather than a terminal nobody is sitting at. The owed-outcome retry is neither: it runs on
+every tick for as long as the report is refused, so crediting it back would let a server that never
+accepts the report stretch the backstop from thirty minutes into hours. Only the run itself is credited.
+A first draft credited every exit, which is exactly that bug.
+
+## Retrying a status, opt-in
+
+`SendWithRetryAsync` retried transport faults with backoff to a budget but **returned** any completed
+response, so the caller read `.StatusCode` and counted the session failed. One 503 during a deploy cost a
+session with no second attempt, while an unreachable server got thirty seconds of trying. That asymmetry
+is what made `failed` too weak to show — a number mixing one unlucky response with a persistently stuck
+server is not actionable either way.
+
+**Opt-in per call site rather than a change to the shared helper.** Every hook, watch, daemon and MCP path
+goes through it, and their budgets are shaped around a single attempt; the hook path already keeps
+`PostOnceAsync` for exactly that reason. Turning it on for all of them at once would be a timing change
+across the CLI in service of one screen's caption. It is set on the three transcript uploads and the
+visibility PUT — the calls whose loss is counted and shown to someone.
+
+Retryable is 408, 429 and 5xx: a timeout, a rate limit, and anything the server calls its own fault. A
+4xx is a refusal the server meant, and re-sending a body it will refuse identically just spends the
+budget.
+
+Two details that are not incidental:
+
+- **An exhausted budget returns the status, never a throw.** The call sites catch `HttpRequestException`
+  only, so throwing would turn a 503 into an unhandled crash mid-import — and it would report a transport
+  failure about a server that answered every time. The last refusal is held for that, handed over by
+  nulling the field so the `finally` disposes only what nobody received, and dropped otherwise so it
+  cannot leak a connection. **A refusal in hand outranks a late transport fault** on the same reasoning:
+  the server did answer, and a connection reset on the final attempt must not erase what it said.
+- **`Retry-After` wins when longer than the backoff**, in either header form, and is still capped by the
+  remaining budget so a server asking for an hour cannot stretch an import by an hour.
+
+## Tests
+
+The lane's summing and folding are pinned directly: totals across both passes, a resume counting as
+imported, a probe error as failed rather than skipped, a held-back visibility write as failed, and both
+null paths (a throw, and a pass with no grid) reporting nothing — plus a clean run *not* collapsing into
+null, since that is the case the narrow null exists to stay out of.
+
+The loop's four report shapes each have a test, and the spin has one that would have failed before this
+change: three identical unreadable polls produce exactly one report and no import.
+
+The wire round-trip goes through the source-generated context against WireMock, asserting the JSON names
+and that a reason token crosses verbatim. Nothing else covered it — every other test in that file builds
+the request object directly, so a naming or AOT-binding slip would have left the screen waiting for ever
+with the suite green.
+
+Sixteen mutations, fifteen killed and one shown to be equivalent (the correlation swap above). The retry
+predicate is pinned from both sides: retrying a 4xx kills six tests, not retrying a 429 kills two, and
+defaulting the flag to on kills the opt-in test.
+
+Four of those pin defects external review found here, and each has a test that fails without its fix:
+treating every empty answer as a decline, the nothing-in-scope exit reporting nothing, crediting the
+stalled report back to the deadline, and a late transport fault outranking the refusal in hand. Two of
+them initially survived mutation against branches the tests did not reach — the deadline one exits through
+the cursor-match arm rather than the not-settled one, and the transport one needs the fault to land
+*after* the budget to reach the unguarded catch. Both were mutation-aim errors rather than coverage gaps,
+and both die once aimed correctly.

--- a/docs/superpowers/specs/2026-08-27-ai2307-import-outcome-report-design.md
+++ b/docs/superpowers/specs/2026-08-27-ai2307-import-outcome-report-design.md
@@ -100,7 +100,6 @@ backstop by time spent on work — a disk scan, an upload — on the reasoning t
 progressing rather than a terminal nobody is sitting at. The owed-outcome retry is neither: it runs on
 every tick for as long as the report is refused, so crediting it back would let a server that never
 accepts the report stretch the backstop from thirty minutes into hours. Only the run itself is credited.
-A first draft credited every exit, which is exactly that bug.
 
 ## Retrying a status, opt-in
 
@@ -146,14 +145,12 @@ and that a reason token crosses verbatim. Nothing else covered it — every othe
 the request object directly, so a naming or AOT-binding slip would have left the screen waiting for ever
 with the suite green.
 
-Sixteen mutations, fifteen killed and one shown to be equivalent (the correlation swap above). The retry
-predicate is pinned from both sides: retrying a 4xx kills six tests, not retrying a 429 kills two, and
-defaulting the flag to on kills the opt-in test.
+The retry predicate is pinned from both sides, since either half alone would pass a one-sided test:
+retrying a 4xx breaks six rows, and not retrying a 429 breaks two.
 
-Four of those pin defects external review found here, and each has a test that fails without its fix:
-treating every empty answer as a decline, the nothing-in-scope exit reporting nothing, crediting the
-stalled report back to the deadline, and a late transport fault outranking the refusal in hand. Two of
-them initially survived mutation against branches the tests did not reach — the deadline one exits through
-the cursor-match arm rather than the not-settled one, and the transport one needs the fault to land
-*after* the budget to reach the unguarded catch. Both were mutation-aim errors rather than coverage gaps,
-and both die once aimed correctly.
+Four rules carry a test that fails without them and are easy to reintroduce, so they are worth naming:
+an empty answer treated as a decline, the nothing-in-scope exit reporting nothing, the stalled report
+credited back to the deadline, and a late transport fault outranking the refusal in hand. The last two
+are only reachable down one arm each — the deadline through the cursor-match exit rather than the
+not-settled one, and the transport fault only once it lands *after* the budget, which is what reaches the
+unguarded catch. A check aimed at the other arm passes while the rule is broken.

--- a/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
@@ -185,10 +185,10 @@ public sealed class BrowserFirstRunFlow(
                     // nobody is sitting at, and letting it eat the backstop would abandon a flow that
                     // is progressing.
                     deadline += await RunImportLaneAsync(serverUrl, flowId, last!, report, import, ct);
-                    deadline += await ActOnImportDecisionAsync(last!, import, ct);
+                    deadline += await ActOnImportDecisionAsync(serverUrl, flowId, last!, import, ct);
 
                     if (FirstRunFlowOutcomes.IsFinished(last!)) {
-                        await FlushReportsAsync(serverUrl, flowId, performed, reported, ct);
+                        await FlushReportsAsync(serverUrl, flowId, performed, reported, import, ct);
 
                         return new FirstRunFlowResult.Finished(last!);
                     }
@@ -285,30 +285,75 @@ public sealed class BrowserFirstRunFlow(
     /// </summary>
     /// <returns>How long this took, for the caller to add back to the budget.</returns>
     async Task<TimeSpan> ActOnImportDecisionAsync(
-            FirstRunFlowResponse view, ImportLaneState state, CancellationToken ct) {
+            string serverUrl, string flowId, FirstRunFlowResponse view, ImportLaneState state,
+            CancellationToken ct) {
         if (importing is null) return TimeSpan.Zero;
+
+        // First, so a report that did not land last tick is retried without waiting for the decision to
+        // change — which it never will, once it has been acted on.
+        //
+        // Deliberately uncredited, unlike the import below: this runs on every tick for as long as an
+        // outcome is owed, so crediting a stalled POST back to the poll budget would let a server that
+        // never accepts the report stretch the flow's own backstop from minutes into hours. A refused
+        // report is a blip; only the run is progress.
+        await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
+
         if (!FirstRunFlowOutcomes.IsSettled(view, FirstRunFlowStep.Import)) return TimeSpan.Zero;
-        if (FirstRunFlowOutcomes.Import(view) is not { } answer) return TimeSpan.Zero;
+
+        // A decision this build cannot read is REPORTED, not re-read: polling again cannot make a newer
+        // server's window or titles vocabulary readable, so the cursor moves and the screen is told why
+        // rather than left waiting on a machine that has silently given up.
+        if (FirstRunFlowOutcomes.Import(view) is not { } answer) {
+            if (view.ImportDecidedAt is { } unreadable && state.ImportedThrough != unreadable) {
+                state.ImportedThrough = unreadable;
+                state.Outcome        = Refusal(unreadable, FirstRunImportOutcomeReasons.DecisionUnreadable);
+
+                await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
+            }
+
+            return TimeSpan.Zero;
+        }
+
         if (state.ImportedThrough == answer.DecidedAt) return TimeSpan.Zero;
 
         // Stamped before the run, not after: a throw must not leave the same answer to be run again on
         // the next tick, which would repeat an upload rather than retry a failed one.
         state.ImportedThrough = answer.DecidedAt;
 
-        // "Import nothing" is an answer, and there is nothing to run for it — but it is still answered,
-        // so the cursor above has moved and the screen is not left waiting on this machine.
-        if (answer.Choices.Count == 0) return TimeSpan.Zero;
+        // "Import nothing" is an answer, and there is nothing to run for it — but the screen waits on
+        // this machine to say the run is over, so a clean zero is still owed.
+        //
+        // Only when it really is a decline: an answer left empty because every level in it was
+        // unreadable asked for imports and got none, and reporting that as a clean zero states the one
+        // thing the screen must not — "you chose not to" — about a user who chose otherwise.
+        if (answer.Choices.Count == 0) {
+            state.Outcome = answer.IsDecline
+                ? Outcome(answer.DecidedAt, default, null)
+                : Refusal(answer.DecidedAt, FirstRunImportOutcomeReasons.DecisionUnreadable);
 
-        // Nothing to scan, so nothing to run: the caller says why instead of announcing an import of
-        // history that could not move.
-        if (answer.NoReadableVendors) return TimeSpan.Zero;
+            await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
+
+            return TimeSpan.Zero;
+        }
+
+        // Nothing to scan, so nothing to run. Reported as a refusal rather than as three zeroes, which
+        // is what a clean import over an already-loaded history also looks like.
+        if (answer.NoReadableVendors) {
+            state.Outcome = Refusal(answer.DecidedAt, FirstRunImportOutcomeReasons.NoReadableAgents);
+
+            await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
+
+            return TimeSpan.Zero;
+        }
 
         var began = _clock.GetUtcNow();
 
         progress.Importing(answer.Choices.Count, SessionsInScope(state.Discovered, answer));
 
+        FirstRunImportTotals? moved = null;
+
         try {
-            await importing.ImportAsync(answer, state.WindowsAsOf(_clock), ct);
+            moved = await importing.ImportAsync(answer, state.WindowsAsOf(_clock), ct);
         } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
             throw;
         } catch (Exception) {
@@ -318,7 +363,41 @@ public sealed class BrowserFirstRunFlow(
             progress.ImportEnded();
         }
 
+        // Nothing is sent for a run that lost a pass. Its sessions are unaccounted, and three counts
+        // cannot say so — the surviving pass's figures alone would report a clean import.
+        if (moved is { } totals) {
+            state.Outcome = Outcome(answer.DecidedAt, totals, null);
+
+            await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
+        }
+
         return _clock.GetUtcNow() - began;
+    }
+
+    /// <summary>The outcome as the route takes it.</summary>
+    static ReportFirstRunImportOutcomeRequest Outcome(
+            DateTimeOffset decidedAt, FirstRunImportTotals totals, string? reason) =>
+        new() {
+            DecidedAt = decidedAt,
+            Imported  = totals.Imported,
+            Skipped   = totals.Skipped,
+            Failed    = totals.Failed,
+            Reason    = reason
+        };
+
+    /// <summary>A refusal: three zeroes and a token. The server rejects the report outright if a reason
+    /// arrives on counts that moved something, so the zeroes are part of the contract rather than a
+    /// convenience.</summary>
+    static ReportFirstRunImportOutcomeRequest Refusal(DateTimeOffset decidedAt, string reason) =>
+        Outcome(decidedAt, default, reason);
+
+    /// <summary>Hands over the owed outcome, keeping it for a later tick unless the server took it.</summary>
+    async Task DeliverOutcomeAsync(
+            string serverUrl, string flowId, ImportLaneState state, CancellationToken ct) {
+        if (state.Outcome is not { } owed) return;
+
+        if ((await channel.ReportImportOutcomeAsync(serverUrl, flowId, owed, ct)).Recorded)
+            state.Outcome = null;
     }
 
     /// <summary>The import lane's state across polls, in one object because an async method cannot
@@ -333,6 +412,10 @@ public sealed class BrowserFirstRunFlow(
 
         /// <summary>The report reached the server. Until it does, every tick tries again.</summary>
         public bool Delivered { get; set; }
+
+        /// <summary>The outcome still owed to the server, or null when there is none left to send.
+        /// Retried every tick like the discovery report, and cleared only once taken.</summary>
+        public ReportFirstRunImportOutcomeRequest? Outcome { get; set; }
 
         /// <summary>The answer already run, as a cursor rather than a flag. The server advances the
         /// stamp only when the answer CHANGES, so going Back and widening the window runs the wider
@@ -448,11 +531,13 @@ public sealed class BrowserFirstRunFlow(
     async Task FlushReportsAsync(
             string serverUrl, string flowId,
             Dictionary<FirstRunMachineActionRequest, FirstRunMachineActionResult> performed,
-            HashSet<FirstRunMachineActionRequest> reported, CancellationToken ct) {
+            HashSet<FirstRunMachineActionRequest> reported, ImportLaneState import, CancellationToken ct) {
         for (var retry = 0; retry < FlushRetries; retry++) {
             var outstanding = performed.Where(p => !reported.Contains(p.Key)).ToList();
 
-            if (outstanding.Count == 0) return;
+            // The import outcome flushes here too: the poll returns on a finished flow, so this is the
+            // last tick that exists and an outcome left owed would never be sent at all.
+            if (outstanding.Count == 0 && import.Outcome is null) return;
 
             // Always gapped, including the first: this runs immediately after the tick's own attempt
             // failed, and an instant re-POST at the same server answers the same way.
@@ -460,6 +545,8 @@ public sealed class BrowserFirstRunFlow(
 
             foreach (var (request, result) in outstanding)
                 await ReportAsync(serverUrl, flowId, request, result, reported, ct);
+
+            await DeliverOutcomeAsync(serverUrl, flowId, import, ct);
         }
     }
 

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowClient.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowClient.cs
@@ -21,8 +21,9 @@ public sealed record FirstRunActionReportOutcome(int StatusCode) {
     public bool Recorded => StatusCode is >= 200 and < 300;
 }
 
-/// <summary>One report of what this machine found on disk. A non-2xx is retried on a later tick;
-/// there is nothing to undo, because the server takes the first report and ignores the rest.</summary>
+/// <summary>One report about the import — what was found on disk, or how the run ended. A non-2xx is
+/// retried on a later tick; there is nothing to undo, because the server takes the first report for a
+/// given decision and ignores the rest.</summary>
 public sealed record FirstRunImportReportOutcome(int StatusCode) {
     public bool Recorded => StatusCode is >= 200 and < 300;
 }
@@ -47,6 +48,11 @@ public interface IFirstRunFlowChannel {
     /// lands, so a machine with no history still has to report — an empty repo list is an answer.</summary>
     Task<FirstRunImportReportOutcome> ReportImportAsync(
         string serverUrl, string flowId, ReportFirstRunImportRequest report, CancellationToken ct);
+
+    /// <summary>Reports how the import ended, against the decision that ran. Also how the screen learns
+    /// the run is over, so a refusal and an empty choice are both reported rather than left silent.</summary>
+    Task<FirstRunImportReportOutcome> ReportImportOutcomeAsync(
+        string serverUrl, string flowId, ReportFirstRunImportOutcomeRequest report, CancellationToken ct);
 }
 
 /// <summary>
@@ -137,6 +143,27 @@ public sealed class FirstRunFlowClient(HttpClient http) : IFirstRunFlowChannel {
             using var req = new HttpRequestMessage(
                     HttpMethod.Post,
                     $"{Base(serverUrl)}/api/first-run/flows/{Uri.EscapeDataString(flowId)}/import") {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json")
+            };
+
+            using var resp = await http.SendAsync(req, ct);
+
+            return new((int)resp.StatusCode);
+        } catch (Exception e) when (IsTransient(e, ct)) {
+            return new(0);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<FirstRunImportReportOutcome> ReportImportOutcomeAsync(
+            string serverUrl, string flowId, ReportFirstRunImportOutcomeRequest report, CancellationToken ct) {
+        var payload = JsonSerializer.Serialize(
+            report, CapacitorJsonContext.Default.ReportFirstRunImportOutcomeRequest);
+
+        try {
+            using var req = new HttpRequestMessage(
+                    HttpMethod.Post,
+                    $"{Base(serverUrl)}/api/first-run/flows/{Uri.EscapeDataString(flowId)}/import-outcome") {
                 Content = new StringContent(payload, Encoding.UTF8, "application/json")
             };
 

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowModels.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowModels.cs
@@ -94,6 +94,31 @@ public sealed record ReportFirstRunMachineActionRequest {
     [JsonPropertyName("reason")]       public          string?        Reason      { get; init; }
 }
 
+/// <summary>
+/// POST /api/first-run/flows/{id}/import-outcome — how the import ended, once its passes are done.
+///
+/// <para><b>Also the signal that it finished.</b> Without it the screen cannot tell a run still working
+/// from one that stopped, so an outcome that moved nothing is still worth sending.</para>
+/// </summary>
+/// <remarks>
+/// Bound rather than loose, unlike the discovery report: three counts are the whole record, so the
+/// server refuses a request missing one instead of defaulting it to a figure nobody measured.
+/// </remarks>
+public sealed record ReportFirstRunImportOutcomeRequest {
+    /// <summary>The decision this answers, echoed from the poll's <c>import_decided_at</c>. <b>The
+    /// report's identity</b>: the server records nothing for a decision the user has since replaced, so
+    /// this is the stamp of the answer that actually ran and never the standing one.</summary>
+    [JsonPropertyName("decided_at")] public required DateTimeOffset DecidedAt { get; init; }
+
+    [JsonPropertyName("imported")] public required int Imported { get; init; }
+    [JsonPropertyName("skipped")]  public required int Skipped  { get; init; }
+    [JsonPropertyName("failed")]   public required int Failed   { get; init; }
+
+    /// <summary>A <see cref="FirstRunImportOutcomeReasons"/> token, and only on a run that moved
+    /// nothing — the server rejects the whole report otherwise.</summary>
+    [JsonPropertyName("reason")] public string? Reason { get; init; }
+}
+
 /// <summary>One repository discovery found, as the report carries it.</summary>
 /// <remarks><c>sessions</c> is keyed by window rather than positional: an array aligned by index goes
 /// wrong silently. An absent key reads as "not counted", never as zero.</remarks>

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunImportOutcome.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunImportOutcome.cs
@@ -1,0 +1,44 @@
+namespace Capacitor.Cli.Core.FirstRun;
+
+/// <summary>
+/// Why an import moved nothing, as a coded token. Three zeroes are also what a clean run over an
+/// already-loaded history looks like, so this is what separates a refusal from a no-op.
+///
+/// <para><b>The server's closed set, spelled once.</b> It rejects a token it does not know and rejects
+/// any token at all on an outcome that moved something, so a second spelling here is a silent wire
+/// break rather than a rejected field.</para>
+/// </summary>
+public static class FirstRunImportOutcomeReasons {
+    /// <summary>Repositories were chosen and no vendor on this machine could be read for them. The one
+    /// otherwise-silent failure: the counts alone would claim a clean import of history that never
+    /// moved.</summary>
+    public const string NoReadableAgents = "no_readable_agents";
+
+    /// <summary>The decision named a window or a titles answer this build cannot map, so none of it was
+    /// acted on. Reported rather than retried: a newer server's vocabulary does not become readable by
+    /// polling again.</summary>
+    public const string DecisionUnreadable = "decision_unreadable";
+
+    public static readonly IReadOnlyList<string> All = [NoReadableAgents, DecisionUnreadable];
+
+    public static bool IsKnown(string? reason) =>
+        reason is not null && All.Contains(reason, StringComparer.Ordinal);
+}
+
+/// <summary>
+/// What one import run moved, summed across its passes.
+///
+/// <para><b>The three counts the flow's route takes</b>, and nothing derived: the screen's own figures
+/// come from a read of the sessions themselves, so these say what the machine attempted rather than
+/// what is searchable yet.</para>
+/// </summary>
+/// <param name="Imported">Uploaded — loaded or resumed, which is one outcome and not two.</param>
+/// <param name="Skipped">Deliberately left: already here, too short, or an excluded repository. Not a
+/// shortfall, and the copy downstream must not read as one.</param>
+/// <param name="Failed">Should have landed and did not, so re-running retries exactly these.
+/// <b>Includes a session held back because it could not be made private</b> — the visibility preflight
+/// drops those before the upload, and they are otherwise in none of the three.</param>
+public readonly record struct FirstRunImportTotals(int Imported, int Skipped, int Failed) {
+    public static FirstRunImportTotals operator +(FirstRunImportTotals a, FirstRunImportTotals b) =>
+        new(a.Imported + b.Imported, a.Skipped + b.Skipped, a.Failed + b.Failed);
+}

--- a/src/Capacitor.Cli.Core/FirstRun/IFirstRunImportLane.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/IFirstRunImportLane.cs
@@ -33,5 +33,14 @@ public interface IFirstRunImportLane {
     /// report's counts were built from</b>, not today's — a user who reads the screen across UTC
     /// midnight would otherwise be shown a figure for one boundary and given an import against the
     /// next, silently missing the day between.</param>
-    Task ImportAsync(FirstRunImportAnswer answer, DateOnly today, CancellationToken ct);
+    /// <returns>
+    /// What the passes moved, or <b>null when a pass produced no accounting at all</b> — it threw, or
+    /// finished without reaching its own summary.
+    ///
+    /// <para>Null is not <c>(0,0,0)</c>, and the difference is the point: the sessions that pass was
+    /// uploading are unaccounted, and there is no way to say "some unknown number failed" in three
+    /// counts. Reporting the surviving pass's figures alone would state a clean import over a run that
+    /// lost one, so the caller sends nothing and the screen keeps saying it cannot tell.</para>
+    /// </returns>
+    Task<FirstRunImportTotals?> ImportAsync(FirstRunImportAnswer answer, DateOnly today, CancellationToken ct);
 }

--- a/src/Capacitor.Cli.Core/HttpClientExtensions.cs
+++ b/src/Capacitor.Cli.Core/HttpClientExtensions.cs
@@ -306,7 +306,7 @@ public static class HttpClientExtensions {
     static readonly TimeSpan MaxDelay       = TimeSpan.FromSeconds(4);
 
     /// <summary>
-    /// Per-attempt cap on a single HTTP call inside <see cref="SendWithRetryAsync(Func{CancellationToken, Task{HttpResponseMessage}}, TimeSpan, CancellationToken)"/>.
+    /// Per-attempt cap on a single HTTP call inside <see cref="SendWithRetryAsync(Func{CancellationToken, Task{HttpResponseMessage}}, TimeSpan, CancellationToken, bool)"/>.
     /// Enforced via a linked <see cref="CancellationTokenSource"/> so the wall-clock cap
     /// is observable on the token we pass to <see cref="HttpClient"/> — not on the
     /// client's own <see cref="HttpClient.Timeout"/> (default 100s), which would
@@ -352,14 +352,18 @@ public static class HttpClientExtensions {
     }
 
     extension(HttpClient client) {
+        /// <param name="retryStatuses">Retry a retryable status as a transport fault is retried — see
+        /// <see cref="IsRetryableStatus"/>. Off by default, and set only where a lost call is counted and
+        /// shown to someone.</param>
         public Task<HttpResponseMessage> PostWithRetryAsync(
                 string            url,
                 HttpContent       content,
-                TimeSpan?         timeout = null,
-                CancellationToken ct      = default
+                TimeSpan?         timeout       = null,
+                CancellationToken ct            = default,
+                bool              retryStatuses = false
             ) {
             EnsureAbsolute(url);
-            return SendWithRetryAsync(token => client.PostAsync(url, content, token), timeout ?? DefaultTimeout, ct);
+            return SendWithRetryAsync(token => client.PostAsync(url, content, token), timeout ?? DefaultTimeout, ct, retryStatuses);
         }
 
         public Task<HttpResponseMessage> GetWithRetryAsync(string url, TimeSpan? timeout = null, CancellationToken ct = default) {
@@ -367,14 +371,18 @@ public static class HttpClientExtensions {
             return SendWithRetryAsync(token => client.GetAsync(url, token), timeout ?? DefaultTimeout, ct);
         }
 
+        /// <param name="retryStatuses">Retry a retryable status as a transport fault is retried — see
+        /// <see cref="IsRetryableStatus"/>. Off by default, and set only where a lost call is counted and
+        /// shown to someone.</param>
         public Task<HttpResponseMessage> PutWithRetryAsync(
                 string            url,
                 HttpContent       content,
-                TimeSpan?         timeout = null,
-                CancellationToken ct      = default
+                TimeSpan?         timeout       = null,
+                CancellationToken ct            = default,
+                bool              retryStatuses = false
             ) {
             EnsureAbsolute(url);
-            return SendWithRetryAsync(token => client.PutAsync(url, content, token), timeout ?? DefaultTimeout, ct);
+            return SendWithRetryAsync(token => client.PutAsync(url, content, token), timeout ?? DefaultTimeout, ct, retryStatuses);
         }
 
         public Task<HttpResponseMessage> DeleteWithRetryAsync(string url, TimeSpan? timeout = null, CancellationToken ct = default) {
@@ -469,72 +477,140 @@ public static class HttpClientExtensions {
         return true;
     }
 
+    /// <summary>
+    /// Statuses worth a second attempt: a request timeout, a rate limit, and anything the server calls
+    /// its own fault.
+    ///
+    /// <para><b>Opt-in per call site, never the default.</b> Every hook, watch, daemon and MCP path
+    /// shares this helper, and retrying a 5xx for all of them at once would change the timing of paths
+    /// whose budgets are shaped around a single attempt.</para>
+    /// </summary>
+    internal static bool IsRetryableStatus(HttpStatusCode status) =>
+        status is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests || (int)status >= 500;
+
+    /// <summary>How long the server asked us to wait, in either header form — a proxy may rewrite
+    /// delta-seconds as an HTTP date, and reading only the delta would treat that as no header at all. A
+    /// date is measured against the response's own Date header so clock skew cannot invert the wait.</summary>
+    static TimeSpan? RetryAfterOf(HttpResponseMessage resp) => resp.Headers.RetryAfter switch {
+        { Delta: { } delta } => delta,
+        { Date:  { } date  } => date - (resp.Headers.Date ?? DateTimeOffset.UtcNow) is { Ticks: > 0 } wait
+                                    ? wait
+                                    : TimeSpan.Zero,
+        _                    => null
+    };
+
     internal static Task<HttpResponseMessage> SendWithRetryAsync(
             Func<CancellationToken, Task<HttpResponseMessage>> send,
             TimeSpan                                           totalTimeout,
-            CancellationToken                                  ct
-        ) => SendWithRetryAsync(send, totalTimeout, PerAttemptTimeout, ct);
+            CancellationToken                                  ct,
+            bool                                               retryStatuses = false
+        ) => SendWithRetryAsync(send, totalTimeout, PerAttemptTimeout, ct, retryStatuses);
 
     internal static async Task<HttpResponseMessage> SendWithRetryAsync(
             Func<CancellationToken, Task<HttpResponseMessage>> send,
             TimeSpan                                           totalTimeout,
             TimeSpan                                           perAttemptTimeout,
-            CancellationToken                                  ct
+            CancellationToken                                  ct,
+            bool                                               retryStatuses = false
         ) {
         var        sw        = Stopwatch.StartNew();
         var        delayMs   = 250;
         Exception? lastError = null;
 
-        while (true) {
-            // Hard wall-clock guard: never start a new attempt (or sleep) past totalTimeout,
-            // even when perAttemptTimeout would otherwise allow it. Without this, a default
-            // call (total=30s, per-attempt=60s) against a hung server still blocks for ~60s.
-            var remaining = totalTimeout - sw.Elapsed;
+        // The last retryable response, held so that running out of budget returns the status the server
+        // actually sent. Throwing instead would report a transport failure about a server that answered
+        // every time, and the call sites catch only HttpRequestException.
+        //
+        // Nulled when handed to the caller, so the finally disposes only what nobody received.
+        HttpResponseMessage? refused   = null;
+        TimeSpan?            honourFor = null;
 
-            if (remaining <= TimeSpan.Zero)
-                throw BudgetExhausted(totalTimeout, perAttemptTimeout, lastError);
+        try {
+            while (true) {
+                // Hard wall-clock guard: never start a new attempt (or sleep) past totalTimeout,
+                // even when perAttemptTimeout would otherwise allow it. Without this, a default
+                // call (total=30s, per-attempt=60s) against a hung server still blocks for ~60s.
+                var remaining = totalTimeout - sw.Elapsed;
 
-            var attemptCap = remaining < perAttemptTimeout ? remaining : perAttemptTimeout;
+                if (remaining <= TimeSpan.Zero)
+                    return Answered() ?? throw BudgetExhausted(totalTimeout, perAttemptTimeout, lastError);
 
-            using var attemptCts = new CancellationTokenSource(attemptCap);
-            using var linkedCts  = CancellationTokenSource.CreateLinkedTokenSource(ct, attemptCts.Token);
+                var attemptCap = remaining < perAttemptTimeout ? remaining : perAttemptTimeout;
 
-            try {
-                return await send(linkedCts.Token);
-            } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
-                // Caller cancelled — surface as cancellation, never retry.
-                throw;
-            } catch (HttpRequestException ex) when (sw.Elapsed < totalTimeout) {
-                // Transient transport error within retry budget — back off and try again.
-                lastError = ex;
-            } catch (OperationCanceledException ex) when (sw.Elapsed < totalTimeout) {
-                // Per-attempt timeout fired (linked CTS, not caller's ct) and retry budget
-                // remains — back off and try again. Without this branch the same condition
-                // would surface as an unhandled TaskCanceledException at every call site
-                // that only catches HttpRequestException (import probes, transcript POSTs,
-                // session-start hooks, ...).
-                lastError = ex;
-            } catch (HttpRequestException ex) {
-                // Budget exhausted on transport error — surface as HttpRequestException so
-                // existing `catch (HttpRequestException)` handlers degrade gracefully.
-                throw new HttpRequestException(
-                    $"Request failed after exhausting the {totalTimeout.TotalSeconds:F0}s retry budget.",
-                    ex
-                );
-            } catch (OperationCanceledException ex) {
-                throw BudgetExhausted(totalTimeout, perAttemptTimeout, ex);
+                using var attemptCts = new CancellationTokenSource(attemptCap);
+                using var linkedCts  = CancellationTokenSource.CreateLinkedTokenSource(ct, attemptCts.Token);
+
+                try {
+                    var resp = await send(linkedCts.Token);
+
+                    if (!retryStatuses || !IsRetryableStatus(resp.StatusCode)) return resp;
+
+                    // Replaces rather than accumulates: only the newest refusal is worth returning, and
+                    // the one it replaces holds a connection until it is dropped.
+                    refused?.Dispose();
+                    refused   = resp;
+                    honourFor = RetryAfterOf(resp);
+                    lastError = null;
+                } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+                    // Caller cancelled — surface as cancellation, never retry.
+                    throw;
+                } catch (HttpRequestException ex) when (sw.Elapsed < totalTimeout) {
+                    // Transient transport error within retry budget — back off and try again.
+                    lastError = ex;
+                } catch (OperationCanceledException ex) when (sw.Elapsed < totalTimeout) {
+                    // Per-attempt timeout fired (linked CTS, not caller's ct) and retry budget
+                    // remains — back off and try again. Without this branch the same condition
+                    // would surface as an unhandled TaskCanceledException at every call site
+                    // that only catches HttpRequestException (import probes, transcript POSTs,
+                    // session-start hooks, ...).
+                    lastError = ex;
+                } catch (HttpRequestException ex) {
+                    // A refusal already in hand outranks a late transport fault: the server did answer,
+                    // and that answer is what the caller counts on.
+                    if (Answered() is { } answer) return answer;
+
+                    // Budget exhausted on transport error — surface as HttpRequestException so
+                    // existing `catch (HttpRequestException)` handlers degrade gracefully.
+                    throw new HttpRequestException(
+                        $"Request failed after exhausting the {totalTimeout.TotalSeconds:F0}s retry budget.",
+                        ex
+                    );
+                } catch (OperationCanceledException ex) {
+                    if (Answered() is { } answer) return answer;
+
+                    throw BudgetExhausted(totalTimeout, perAttemptTimeout, ex);
+                }
+
+                // Cap the backoff sleep to the remaining budget so a retry delay can never push
+                // us past totalTimeout. If nothing's left, jump back to the loop top so the
+                // hard-guard above throws with lastError preserved as the inner exception.
+                var remainingAfter = totalTimeout - sw.Elapsed;
+
+                if (remainingAfter <= TimeSpan.Zero) continue;
+
+                // The server's own figure wins when it is longer: it is the one party that knows when it
+                // will be ready, and backing off less than it asked is what earns the next refusal.
+                var wantMs = honourFor is { } asked
+                    ? Math.Max(delayMs, asked.TotalMilliseconds)
+                    : delayMs;
+
+                honourFor = null;
+
+                var actualDelayMs = (int)Math.Min(wantMs, remainingAfter.TotalMilliseconds);
+                await Task.Delay(actualDelayMs, ct);
+                delayMs = Math.Min(delayMs * 2, (int)MaxDelay.TotalMilliseconds);
             }
+        } finally {
+            refused?.Dispose();
+        }
 
-            // Cap the backoff sleep to the remaining budget so a retry delay can never push
-            // us past totalTimeout. If nothing's left, jump back to the loop top so the
-            // hard-guard above throws with lastError preserved as the inner exception.
-            var remainingAfter = totalTimeout - sw.Elapsed;
+        // Hands the held refusal over, so the finally above stops owning it.
+        HttpResponseMessage? Answered() {
+            var answer = refused;
 
-            if (remainingAfter <= TimeSpan.Zero) continue;
+            refused = null;
 
-            var actualDelayMs = (int)Math.Min(delayMs, remainingAfter.TotalMilliseconds);
-            await Task.Delay(actualDelayMs, ct);
-            delayMs = Math.Min(delayMs * 2, (int)MaxDelay.TotalMilliseconds);
+            return answer;
         }
 
         static HttpRequestException BudgetExhausted(TimeSpan totalTimeout, TimeSpan perAttemptTimeout, Exception? inner) =>

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -976,6 +976,7 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(FirstRun.FirstRunFlowResponse))]
 [JsonSerializable(typeof(FirstRun.ReportFirstRunMachineActionRequest))]
 [JsonSerializable(typeof(FirstRun.ReportFirstRunImportRequest))]
+[JsonSerializable(typeof(FirstRun.ReportFirstRunImportOutcomeRequest))]
 [JsonSerializable(typeof(LaunchAgentCommand))]
 // Task 8: reviewer-model launch block + preflight RPC + resolved report wire DTOs.
 [JsonSerializable(typeof(ExplicitReviewerModelLaunch))]

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -978,7 +978,6 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(FirstRun.ReportFirstRunImportRequest))]
 [JsonSerializable(typeof(FirstRun.ReportFirstRunImportOutcomeRequest))]
 [JsonSerializable(typeof(LaunchAgentCommand))]
-// Task 8: reviewer-model launch block + preflight RPC + resolved report wire DTOs.
 [JsonSerializable(typeof(ExplicitReviewerModelLaunch))]
 [JsonSerializable(typeof(ReviewerModelResolveRequestV1))]
 [JsonSerializable(typeof(ReviewerModelResolveResponseV1))]

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -607,6 +607,14 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles) {
     /// failed — import is best-effort and the Done grid is where that is reported — so a caller
     /// deriving success from the exit code calls a partial or total failure a success.
     /// </remarks>
+    /// <summary>Reports a run that deliberately moved nothing: it reached a decision, and the decision
+    /// was that there was nothing to do.</summary>
+    static void ReportNothing(Action<ImportRunOutcome>? onFinished) =>
+        onFinished?.Invoke(new ImportRunOutcome(
+            new FinalCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, RanBackground: false,
+                            RequestedSummaries: false),
+            VisibilityFailures: 0));
+
     internal sealed record ImportRunOutcome(FinalCounts Counts, int VisibilityFailures) {
         /// <summary>Anything the user asked for that did not happen.</summary>
         internal bool AnythingFailed => Counts.Failed > 0 || VisibilityFailures > 0;
@@ -743,6 +751,10 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles) {
 
             display.Line("No coding-agent sessions found. Install Claude, Codex, or Cursor and try again.");
 
+            // Zero is an answer, and a caller that hears nothing cannot tell it from a run that died
+            // before it got here — the same rule the discovery report already follows.
+            ReportNothing(onFinished);
+
             return 0;
         }
 
@@ -794,6 +806,10 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles) {
             if (discoverOnly) return WriteEmptyDiscoveryReport(discoverySink, ScannedVendors(sources), windowsAsOf);
 
             display.Line("No transcript files found.");
+
+            // Zero is an answer, and a caller that hears nothing cannot tell it from a run that died
+            // before it got here — the same rule the discovery report already follows.
+            ReportNothing(onFinished);
 
             return 0;
         }
@@ -1015,6 +1031,10 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles) {
 
         if (totalAfterScope == 0) {
             display.Line("No sessions match the selected scope.");
+
+            // Zero is an answer, and a caller that hears nothing cannot tell it from a run that died
+            // before it got here — the same rule the discovery report already follows.
+            ReportNothing(onFinished);
 
             return 0;
         }
@@ -2966,7 +2986,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles) {
                 if (resumeLastTs is not null) resumeEndHook["ended_at"] = resumeLastTs.Value.ToString("O");
 
                 using var endContent = new StringContent(resumeEndHook.ToJsonString(), Encoding.UTF8, "application/json");
-                using var endResp    = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/session-end/{session.Vendor}", endContent, ct: ct);
+                using var endResp    = await httpClient.PostWithRetryAsync(
+                    $"{baseUrl}/hooks/session-end/{session.Vendor}", endContent, ct: ct, retryStatuses: true);
 
                 if (!endResp.IsSuccessStatusCode) {
                     events.OnSessionErrored(slot, session.SessionId, $"resume session-end failed: HTTP {(int)endResp.StatusCode}");
@@ -3076,7 +3097,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles) {
         // claude even though the transcript was a codex rollout.
         try {
             using var startContent = new StringContent(startHook.ToJsonString(), Encoding.UTF8, "application/json");
-            using var startResp    = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/session-start/{session.Vendor}", startContent, ct: ct);
+            using var startResp    = await httpClient.PostWithRetryAsync(
+                $"{baseUrl}/hooks/session-start/{session.Vendor}", startContent, ct: ct, retryStatuses: true);
 
             if (!startResp.IsSuccessStatusCode) {
                 events.OnSessionErrored(slot, session.SessionId, $"session-start failed: HTTP {(int)startResp.StatusCode}");
@@ -3128,7 +3150,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles) {
         // session-start comment above) — symmetric route, same default of claude.
         try {
             using var endContent = new StringContent(endHook.ToJsonString(), Encoding.UTF8, "application/json");
-            using var endResp    = await httpClient.PostWithRetryAsync($"{baseUrl}/hooks/session-end/{session.Vendor}", endContent, ct: ct);
+            using var endResp    = await httpClient.PostWithRetryAsync(
+                    $"{baseUrl}/hooks/session-end/{session.Vendor}", endContent, ct: ct, retryStatuses: true);
 
             if (endResp.IsSuccessStatusCode) {
                 try {
@@ -3225,7 +3248,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles) {
             try {
                 using var resp = await httpClient.PutWithRetryAsync(
                     $"{baseUrl}/api/sessions/{sessionId}/visibility",
-                    content
+                    content,
+                    retryStatuses: true
                 );
 
                 if (!resp.IsSuccessStatusCode) {

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -224,8 +224,11 @@ sealed class SetupImportLane(
         return outcome;
     }
 
-    public async Task ImportAsync(FirstRunImportAnswer answer, DateOnly today, CancellationToken ct) {
-        var since = answer.Since(today);
+    public async Task<FirstRunImportTotals?> ImportAsync(
+            FirstRunImportAnswer answer, DateOnly today, CancellationToken ct) {
+        var since   = answer.Since(today);
+        var totals  = new FirstRunImportTotals(0, 0, 0);
+        var counted = true;
 
         // One pass per level, because --private is per invocation. Ordered narrowest first so a run
         // interrupted between them has uploaded the private history rather than the shared.
@@ -244,7 +247,8 @@ sealed class SetupImportLane(
 
                 throw;
             } catch (Exception ex) {
-                Failed = true;
+                Failed  = true;
+                counted = false;
 
                 AnsiConsole.MarkupLine(
                     $"  [yellow]![/] That history did not import: {Markup.Escape(ex.Message)}. "
@@ -262,7 +266,22 @@ sealed class SetupImportLane(
                 AnsiConsole.MarkupLine(
                     "  [yellow]![/] Some of that history did not import. Run [cyan]kcap import[/] to retry it.");
             }
+
+            if (outcome is null) {
+                counted = false;
+
+                continue;
+            }
+
+            // A session the visibility preflight held back never reached the upload, so it is in none of
+            // the run's three counts — and re-running retries it, which is what `failed` means here.
+            totals += new FirstRunImportTotals(
+                outcome.Counts.Imported,
+                outcome.Counts.Skipped,
+                outcome.Counts.Failed + outcome.VisibilityFailures);
         }
+
+        return counted ? totals : null;
     }
 }
 

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
@@ -88,6 +88,25 @@ public class BrowserFirstRunFlowTests {
             return Task.FromResult(new FirstRunImportReportOutcome(
                 ImportReportStatuses.Count > 0 ? ImportReportStatuses.Dequeue() : 200));
         }
+
+        public List<ReportFirstRunImportOutcomeRequest> OutcomeReports { get; } = [];
+
+        /// <summary>Status per outcome report in turn; the last repeats. A non-2xx drives the retry.</summary>
+        public Queue<int> OutcomeStatuses { get; } = new();
+
+        /// <summary>Run on each outcome report, to model one that takes real time on the wire.</summary>
+        public Action? OnOutcomeReport { get; set; }
+
+        public Task<FirstRunImportReportOutcome> ReportImportOutcomeAsync(
+                string serverUrl, string flowId, ReportFirstRunImportOutcomeRequest report,
+                CancellationToken ct) {
+            log.Add("outcome-report");
+            OnOutcomeReport?.Invoke();
+            OutcomeReports.Add(report);
+
+            return Task.FromResult(new FirstRunImportReportOutcome(
+                OutcomeStatuses.Count > 0 ? OutcomeStatuses.Dequeue() : 200));
+        }
     }
 
     sealed class RecordingProgress(Log log) : IFirstRunFlowProgress {
@@ -163,7 +182,12 @@ public class BrowserFirstRunFlowTests {
 
         public List<DateOnly> Dates { get; } = [];
 
-        public Task ImportAsync(FirstRunImportAnswer answer, DateOnly today, CancellationToken ct) {
+        /// <summary>What the run reports. Null models a run that lost a pass, which must be reported as
+        /// nothing rather than as a clean zero.</summary>
+        public FirstRunImportTotals? Moved { get; set; } = new(3, 1, 0);
+
+        public Task<FirstRunImportTotals?> ImportAsync(
+                FirstRunImportAnswer answer, DateOnly today, CancellationToken ct) {
             log.Add("import");
             Advance?.Invoke();
             Imports.Add(answer);
@@ -171,7 +195,7 @@ public class BrowserFirstRunFlowTests {
 
             if (ImportThrows is { } boom) throw boom;
 
-            return Task.CompletedTask;
+            return Task.FromResult(Moved);
         }
 
         public static ReportFirstRunImportRequest Report(int sessions = 12) => new() {
@@ -1180,6 +1204,198 @@ public class BrowserFirstRunFlowTests {
 
         await Assert.That(h.Importing!.Imports).IsEmpty();
         await Assert.That(h.Progress.Imports).IsEmpty();
+    }
+
+    [Test]
+    public async Task Reports_what_the_run_moved_against_the_decision_that_ran() {
+        var h = Build(importing: true);
+        h.Importing!.Moved = new FirstRunImportTotals(7, 2, 1);
+        h.Channel.Polls.Enqueue(new(200, ImportAnswered()));
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        await Run(h);
+
+        var sent = h.Channel.OutcomeReports.Single();
+
+        await Assert.That((sent.Imported, sent.Skipped, sent.Failed)).IsEqualTo((7, 2, 1));
+        await Assert.That(sent.Reason).IsNull();
+        await Assert.That(sent.DecidedAt).IsEqualTo(Decided)
+                    .Because("the answer that ran, not whichever is standing when the run ends");
+    }
+
+    [Test]
+    public async Task An_undelivered_outcome_keeps_its_own_stamp_when_the_decision_moves_under_it() {
+        // The report is held across ticks, so this is the one place the stamp CAN go wrong: re-stamping
+        // the retry with whatever is standing would attach the first run's counts to an answer it never
+        // ran, and the server would then discard both — the earlier one as superseded, the later one as
+        // already answered.
+        var h     = Build(importing: true);
+        var later = Decided.AddMinutes(3);
+
+        h.Channel.OutcomeStatuses.Enqueue(503);   // the first run's report is refused...
+        h.Channel.OutcomeStatuses.Enqueue(200);   // ...and taken on the next tick, still as its own
+        h.Channel.Polls.Enqueue(new(200, ImportAnswered(FirstRunImportWindows.Last30)));
+        h.Channel.Polls.Enqueue(new(200, ImportAnswered(FirstRunImportWindows.Everything, decidedAt: later)));
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        await Run(h);
+
+        await Assert.That(h.Channel.OutcomeReports.Select(r => r.DecidedAt))
+                    .IsEquivalentTo([Decided, Decided, later]);
+    }
+
+    [Test]
+    public async Task Reports_a_decision_it_cannot_read_as_a_refusal_rather_than_polling_it_forever() {
+        // A window this build cannot map never becomes readable by asking again, so the cursor moves and
+        // the screen is told why. Without the stamp this re-evaluated the same answer on every tick and
+        // reported nothing at all.
+        var h    = Build(importing: true);
+        var view = ImportAnswered();
+        var stuck = view with { Import = view.Import! with { Window = "since_the_dawn_of_time" } };
+
+        h.Channel.Polls.Enqueue(new(200, stuck));
+        h.Channel.Polls.Enqueue(new(200, stuck));
+        h.Channel.Polls.Enqueue(new(200, stuck));
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        await Run(h);
+
+        var sent = h.Channel.OutcomeReports.Single();
+
+        await Assert.That(sent.Reason).IsEqualTo(FirstRunImportOutcomeReasons.DecisionUnreadable);
+        await Assert.That((sent.Imported, sent.Skipped, sent.Failed)).IsEqualTo((0, 0, 0));
+        await Assert.That(sent.DecidedAt).IsEqualTo(Decided);
+        await Assert.That(h.Importing!.Imports).IsEmpty();
+    }
+
+    [Test]
+    public async Task Reports_no_readable_vendor_as_a_refusal_and_not_as_three_zeroes() {
+        // Three zeroes are also a clean run over an already-loaded history. The token is what stops the
+        // screen calling "nothing could be read" a successful import.
+        var h    = Build(importing: true);
+        var view = ImportAnswered();
+
+        h.Channel.Polls.Enqueue(new(200, view with { Import = view.Import! with { Vendors = ["telepathy"] } }));
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        await Run(h);
+
+        await Assert.That(h.Channel.OutcomeReports.Single().Reason)
+                    .IsEqualTo(FirstRunImportOutcomeReasons.NoReadableAgents);
+    }
+
+    [Test]
+    public async Task Reports_a_clean_zero_when_the_user_chose_to_import_nothing() {
+        // Answered, with nothing to do — but the outcome is also how the screen learns the machine has
+        // finished, so silence here leaves it unable to tell this from a stalled run.
+        var h = Build(importing: true);
+        h.Channel.Polls.Enqueue(new(200, ImportAnswered(noRepos: true)));
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        await Run(h);
+
+        var sent = h.Channel.OutcomeReports.Single();
+
+        await Assert.That((sent.Imported, sent.Skipped, sent.Failed)).IsEqualTo((0, 0, 0));
+        await Assert.That(sent.Reason).IsNull().Because("nothing was refused; nothing was asked for");
+    }
+
+    [Test]
+    public async Task Reports_nothing_for_a_run_that_lost_a_pass() {
+        // Its sessions are unaccounted and three counts cannot say so. Reporting the surviving figures
+        // would state a clean import over a run that dropped one.
+        var h = Build(importing: true);
+        h.Importing!.Moved = null;
+        h.Channel.Polls.Enqueue(new(200, ImportAnswered()));
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        await Run(h);
+
+        await Assert.That(h.Importing.Imports).HasSingleItem().Because("the run still happened");
+        await Assert.That(h.Channel.OutcomeReports).IsEmpty();
+    }
+
+    [Test]
+    public async Task Retries_the_outcome_until_it_lands_without_importing_again() {
+        var h = Build(importing: true);
+        h.Channel.OutcomeStatuses.Enqueue(500);
+        h.Channel.OutcomeStatuses.Enqueue(500);
+        h.Channel.OutcomeStatuses.Enqueue(200);
+        h.Channel.Polls.Enqueue(new(200, ImportAnswered()));
+        h.Channel.Polls.Enqueue(new(200, ImportAnswered()));
+        h.Channel.Polls.Enqueue(new(200, ImportAnswered()));
+        h.Channel.Polls.Enqueue(new(200, ImportAnswered()));
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        await Run(h);
+
+        await Assert.That(h.Importing!.Imports).HasSingleItem();
+        await Assert.That(h.Channel.OutcomeReports.Count).IsEqualTo(3)
+                    .Because("retried until taken, then never again");
+    }
+
+    [Test]
+    public async Task Flushes_an_owed_outcome_when_the_flow_finishes_in_the_same_tick() {
+        // The poll returns on a finished flow, so the tick that reports is also the last one that
+        // exists. Without the flush an outcome refused once would never be sent at all.
+        var h = Build(importing: true);
+        h.Channel.OutcomeStatuses.Enqueue(503);
+        h.Channel.OutcomeStatuses.Enqueue(200);
+        h.Channel.Polls.Enqueue(new(200, ImportAnswered() with {
+            Steps = new() {
+                ["SignIn"] = "Completed", ["Agents"] = "Completed",
+                ["Import"] = "Completed", ["Done"] = "Completed"
+            }
+        }));
+
+        await Run(h);
+
+        await Assert.That(h.Channel.OutcomeReports.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task An_answer_left_empty_because_its_levels_were_unreadable_is_not_a_decline() {
+        // Choices.Count == 0 has two causes and only one of them is "the user chose nothing". A newer
+        // server's level empties the list too, and reporting THAT as a clean zero tells the screen the
+        // user declined an import they actually asked for.
+        var h    = Build(importing: true);
+        var view = ImportAnswered();
+
+        h.Channel.Polls.Enqueue(new(200, view with {
+            Import = view.Import! with {
+                Repos = [new FirstRunImportRepoChoiceResponse {
+                    Owner = "kurrent-io", Name = "kcap-server", Level = "EveryoneOnTheInternet"
+                }]
+            }
+        }));
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        await Run(h);
+
+        var sent = h.Channel.OutcomeReports.Single();
+
+        await Assert.That(sent.Reason).IsEqualTo(FirstRunImportOutcomeReasons.DecisionUnreadable);
+        await Assert.That((sent.Imported, sent.Skipped, sent.Failed)).IsEqualTo((0, 0, 0));
+        await Assert.That(h.Importing!.Imports).IsEmpty();
+    }
+
+    [Test]
+    public async Task A_stalled_outcome_report_does_not_extend_the_flows_own_backstop() {
+        // The report is retried on every tick for as long as it is owed, so crediting its time back to
+        // the poll budget — the way the import and the scan are credited — would let a server that never
+        // accepts it stretch a 30-minute backstop into hours. A refused report is a blip, not progress.
+        var h = Build(importing: true);
+
+        h.Channel.Tail            = new(200, ImportAnswered());
+        h.Channel.OnOutcomeReport = () => h.Clock.Advance(TimeSpan.FromSeconds(15));
+
+        // Never taken, so it stays owed for the life of the flow.
+        for (var i = 0; i < 5_000; i++) h.Channel.OutcomeStatuses.Enqueue(503);
+
+        var result = await Run(h);
+
+        await Assert.That(result).IsTypeOf<FirstRunFlowResult.Abandoned>();
+        await Assert.That(h.Clock.GetUtcNow() - ClockBase).IsLessThanOrEqualTo(TimeSpan.FromMinutes(31));
     }
 
     [Test]

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunFlowClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunFlowClientTests.cs
@@ -596,7 +596,7 @@ public class FirstRunFlowClientTests {
         await Assert.That(sent.GetProperty("decided_at").GetDateTimeOffset())
                     .IsEqualTo(new DateTimeOffset(2026, 8, 27, 9, 30, 0, TimeSpan.Zero));
         await Assert.That(sent.TryGetProperty("reason", out var reason)).IsTrue();
-        await Assert.That(reason.ValueKind).IsEqualTo(System.Text.Json.JsonValueKind.Null);
+        await Assert.That(reason.IsNull).IsTrue();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunFlowClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunFlowClientTests.cs
@@ -559,4 +559,93 @@ public class FirstRunFlowClientTests {
         await Assert.That(outcome.Body!.DefaultVisibility).IsNull();
         await Assert.That(FirstRunFlowOutcomes.Agents(outcome.Body)!.DefaultVisibility).IsNull();
     }
+
+    // ---- The import-outcome route. Every other test in this file builds the request object directly,
+    // so nothing else proves the source-generated names actually reach the wire — and a slip there
+    // leaves the screen waiting for ever with the whole suite green.
+
+    static string OutcomePath => $"{PollPath}/import-outcome";
+
+    [Test]
+    public async Task ReportImportOutcomeAsync_sends_the_counts_under_the_names_the_route_reads() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath(OutcomePath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithBody(StateBody("Completed")).WithHeader("Content-Type", "application/json"));
+
+        using var http = new HttpClient();
+
+        var outcome = await new FirstRunFlowClient(http).ReportImportOutcomeAsync(
+            server.Urls[0], FlowId,
+            new ReportFirstRunImportOutcomeRequest {
+                DecidedAt = new DateTimeOffset(2026, 8, 27, 9, 30, 0, TimeSpan.Zero),
+                Imported  = 7,
+                Skipped   = 2,
+                Failed    = 1
+            },
+            CancellationToken.None);
+
+        await Assert.That(outcome.Recorded).IsTrue();
+
+        var sent = System.Text.Json.JsonDocument.Parse(server.LogEntries.Single()
+            .RequestMessage.Body!).RootElement;
+
+        await Assert.That(sent.GetProperty("imported").GetInt32()).IsEqualTo(7);
+        await Assert.That(sent.GetProperty("skipped").GetInt32()).IsEqualTo(2);
+        await Assert.That(sent.GetProperty("failed").GetInt32()).IsEqualTo(1);
+        await Assert.That(sent.GetProperty("decided_at").GetDateTimeOffset())
+                    .IsEqualTo(new DateTimeOffset(2026, 8, 27, 9, 30, 0, TimeSpan.Zero));
+        await Assert.That(sent.TryGetProperty("reason", out var reason)).IsTrue();
+        await Assert.That(reason.ValueKind).IsEqualTo(System.Text.Json.JsonValueKind.Null);
+    }
+
+    [Test]
+    public async Task ReportImportOutcomeAsync_sends_a_refusal_token_verbatim() {
+        // The server validates against its own closed set and rejects the whole report on a token it
+        // does not know, so a second spelling here is a silent wire break rather than a dropped field.
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath(OutcomePath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithBody(StateBody("Completed")).WithHeader("Content-Type", "application/json"));
+
+        using var http = new HttpClient();
+
+        await new FirstRunFlowClient(http).ReportImportOutcomeAsync(
+            server.Urls[0], FlowId,
+            new ReportFirstRunImportOutcomeRequest {
+                DecidedAt = DateTimeOffset.UnixEpoch,
+                Imported  = 0,
+                Skipped   = 0,
+                Failed    = 0,
+                Reason    = FirstRunImportOutcomeReasons.NoReadableAgents
+            },
+            CancellationToken.None);
+
+        var sent = System.Text.Json.JsonDocument.Parse(server.LogEntries.Single()
+            .RequestMessage.Body!).RootElement;
+
+        await Assert.That(sent.GetProperty("reason").GetString()).IsEqualTo("no_readable_agents");
+    }
+
+    [Test]
+    [Arguments(400)]
+    [Arguments(410)]
+    [Arguments(500)]
+    public async Task ReportImportOutcomeAsync_reports_a_refusal_as_not_recorded(int status) {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath(OutcomePath).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(status));
+
+        using var http = new HttpClient();
+
+        var outcome = await new FirstRunFlowClient(http).ReportImportOutcomeAsync(
+            server.Urls[0], FlowId,
+            new ReportFirstRunImportOutcomeRequest {
+                DecidedAt = DateTimeOffset.UnixEpoch, Imported = 0, Skipped = 0, Failed = 0
+            },
+            CancellationToken.None);
+
+        await Assert.That(outcome.StatusCode).IsEqualTo(status);
+        await Assert.That(outcome.Recorded).IsFalse();
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/HttpClientExtensionsRetryTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/HttpClientExtensionsRetryTests.cs
@@ -131,4 +131,200 @@ public class HttpClientExtensionsRetryTests {
         await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.OK);
         await Assert.That(attempts).IsEqualTo(3);
     }
+
+    // ---- Retryable statuses. Opt-in: a lost transcript upload is counted and shown to someone, and a
+    // count that mixes one unlucky 503 with a persistently stuck server is not worth acting on.
+
+    [Test]
+    [Arguments(HttpStatusCode.RequestTimeout)]
+    [Arguments(HttpStatusCode.TooManyRequests)]
+    [Arguments(HttpStatusCode.InternalServerError)]
+    [Arguments(HttpStatusCode.BadGateway)]
+    [Arguments(HttpStatusCode.ServiceUnavailable)]
+    [Arguments(HttpStatusCode.GatewayTimeout)]
+    public async Task A_retryable_status_gets_a_second_attempt(HttpStatusCode first) {
+        var attempts = 0;
+
+        Task<HttpResponseMessage> Send(CancellationToken token) {
+            var attempt = Interlocked.Increment(ref attempts);
+
+            return Task.FromResult(new HttpResponseMessage(attempt == 1 ? first : HttpStatusCode.OK));
+        }
+
+        using var resp = await HttpClientExtensions.SendWithRetryAsync(
+            Send, TimeSpan.FromSeconds(5), CancellationToken.None, retryStatuses: true);
+
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments(HttpStatusCode.BadRequest)]
+    [Arguments(HttpStatusCode.Unauthorized)]
+    [Arguments(HttpStatusCode.Forbidden)]
+    [Arguments(HttpStatusCode.NotFound)]
+    [Arguments(HttpStatusCode.Conflict)]
+    [Arguments(HttpStatusCode.RequestEntityTooLarge)]
+    public async Task A_refusal_the_server_meant_is_not_retried(HttpStatusCode status) {
+        // Retrying a 4xx spends the budget re-asking a question already answered — and on a 413 or a
+        // 401 it would re-send a body the server will refuse identically every time.
+        var attempts = 0;
+
+        Task<HttpResponseMessage> Send(CancellationToken token) {
+            Interlocked.Increment(ref attempts);
+
+            return Task.FromResult(new HttpResponseMessage(status));
+        }
+
+        using var resp = await HttpClientExtensions.SendWithRetryAsync(
+            Send, TimeSpan.FromSeconds(5), CancellationToken.None, retryStatuses: true);
+
+        await Assert.That(resp.StatusCode).IsEqualTo(status);
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Status_retry_is_off_unless_asked_for() {
+        // The whole reason this is a flag: every hook, watch, daemon and MCP path shares this helper,
+        // and their budgets are shaped around a single attempt.
+        var attempts = 0;
+
+        Task<HttpResponseMessage> Send(CancellationToken token) {
+            Interlocked.Increment(ref attempts);
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        }
+
+        using var resp = await HttpClientExtensions.SendWithRetryAsync(
+            Send, TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
+        await Assert.That(attempts).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task An_exhausted_budget_returns_the_status_the_server_sent_rather_than_throwing() {
+        // The caller counts a session failed off the status. Throwing here would surface a transport
+        // error for a server that answered every time, and the call sites catch only
+        // HttpRequestException — so a 503 would become an unhandled crash mid-import.
+        var attempts = 0;
+
+        Task<HttpResponseMessage> Send(CancellationToken token) {
+            Interlocked.Increment(ref attempts);
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        }
+
+        using var resp = await HttpClientExtensions.SendWithRetryAsync(
+            Send, TimeSpan.FromMilliseconds(600), CancellationToken.None, retryStatuses: true);
+
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
+        await Assert.That(attempts).IsGreaterThan(1).Because("it did try again before giving up");
+    }
+
+    [Test]
+    public async Task A_retry_after_longer_than_the_backoff_is_honoured() {
+        // The server is the one party that knows when it will be ready; backing off less than it asked
+        // is what earns the next 429.
+        var attempts = 0;
+
+        Task<HttpResponseMessage> Send(CancellationToken token) {
+            var attempt = Interlocked.Increment(ref attempts);
+
+            if (attempt > 1) return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+
+            var refused = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+
+            refused.Headers.RetryAfter = new(TimeSpan.FromMilliseconds(900));
+
+            return Task.FromResult(refused);
+        }
+
+        var sw = Stopwatch.StartNew();
+
+        using var resp = await HttpClientExtensions.SendWithRetryAsync(
+            Send, TimeSpan.FromSeconds(10), CancellationToken.None, retryStatuses: true);
+
+        sw.Stop();
+
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(sw.ElapsedMilliseconds).IsGreaterThanOrEqualTo(800)
+                    .Because("the 250ms first backoff alone would have retried far sooner");
+    }
+
+    [Test]
+    public async Task A_retry_after_never_outlives_the_budget() {
+        // A server asking for an hour must not stretch an import by an hour. The wait is capped by what
+        // is left, and the refusal is then returned.
+        static Task<HttpResponseMessage> Send(CancellationToken token) {
+            var refused = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+
+            refused.Headers.RetryAfter = new(TimeSpan.FromHours(1));
+
+            return Task.FromResult(refused);
+        }
+
+        var sw = Stopwatch.StartNew();
+
+        using var resp = await HttpClientExtensions.SendWithRetryAsync(
+            Send, TimeSpan.FromMilliseconds(400), CancellationToken.None, retryStatuses: true);
+
+        sw.Stop();
+
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
+        await Assert.That(sw.ElapsedMilliseconds).IsLessThan(5_000);
+    }
+
+    [Test]
+    public async Task A_caller_cancel_during_status_retry_is_cancellation_and_not_a_refusal() {
+        using var cts      = new CancellationTokenSource();
+        var       attempts = 0;
+
+        Task<HttpResponseMessage> Send(CancellationToken token) {
+            if (Interlocked.Increment(ref attempts) == 1) cts.Cancel();
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        }
+
+        await Assert.That(async () => await HttpClientExtensions.SendWithRetryAsync(
+            Send, TimeSpan.FromSeconds(5), cts.Token, retryStatuses: true))
+            .Throws<OperationCanceledException>();
+    }
+
+    [Test]
+    public async Task A_refusal_in_hand_outranks_a_transport_fault_that_lands_after_the_budget() {
+        // The server DID answer. Surfacing a transport error instead would report "could not reach the
+        // server" about one that replied to every attempt but the last.
+        var attempts = 0;
+
+        async Task<HttpResponseMessage> Send(CancellationToken token) {
+            if (Interlocked.Increment(ref attempts) == 1)
+                return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+
+            // Deliberately past the budget and deliberately ignoring the token, so the throw lands in
+            // the UNGUARDED transport catch rather than the within-budget one that loops.
+            await Task.Delay(600, CancellationToken.None);
+
+            throw new HttpRequestException("connection reset");
+        }
+
+        using var resp = await HttpClientExtensions.SendWithRetryAsync(
+            Send, TimeSpan.FromMilliseconds(400), CancellationToken.None, retryStatuses: true);
+
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
+        await Assert.That(attempts).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task A_returned_refusal_is_not_disposed_on_the_way_out() {
+        // It is handed to the caller, who owns it — reading its status must not throw.
+        static Task<HttpResponseMessage> Send(CancellationToken token) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway));
+
+        using var resp = await HttpClientExtensions.SendWithRetryAsync(
+            Send, TimeSpan.FromMilliseconds(400), CancellationToken.None, retryStatuses: true);
+
+        await Assert.That(resp.StatusCode).IsEqualTo(HttpStatusCode.BadGateway);
+        await Assert.That(await resp.Content.ReadAsStringAsync()).IsEqualTo("");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportVisibilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportVisibilityTests.cs
@@ -526,6 +526,37 @@ public class ImportVisibilityTests : IDisposable {
     }
 
     [Test]
+    public async Task HandleImport_reports_a_measured_zero_when_nothing_matches_the_scope() {
+        // The exit that costs the first-run flow its finished signal: a scope matching nothing returns 0
+        // having decided there was nothing to do, and a caller told nothing at all cannot tell that from
+        // a run that died before it got there.
+        _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(404));
+        StubAllHookEndpoints();
+
+        var projectsDir = Path.Combine(_tempDir, "claude-projects-nothing-in-scope");
+        WriteClaudeSession(projectsDir, "vis-out-of-scope");
+
+        ImportCommand.ImportRunOutcome? outcome = null;
+
+        var exitCode = await new ImportCommand(Config.Root, Resolutions.At(_server.Url!, Config.Root)).HandleImport(
+            filterCwd: null,
+            minLines: 1,
+            sources: [new ClaudeImportSource(Config.Root, projectsDir)],
+            scope: new ImportScope.Repo([("kurrent-io", "nothing-here-by-that-name")]),
+            skipConfirmation: true,
+            onFinished: o => outcome = o
+        );
+
+        await Assert.That(exitCode).IsEqualTo(0);
+        await Assert.That(outcome).IsNotNull().Because("zero is an answer; silence is not");
+        await Assert.That(outcome!.Counts.Imported).IsEqualTo(0);
+        await Assert.That(outcome.Counts.Skipped).IsEqualTo(0);
+        await Assert.That(outcome.Counts.Failed).IsEqualTo(0);
+        await Assert.That(outcome.AnythingFailed).IsFalse();
+    }
+
+    [Test]
     public async Task HandleImport_reports_a_clean_run_as_nothing_failed() {
         _server.Given(Request.Create().WithPath("/api/sessions/*/last-line").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(404));

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportVisibilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportVisibilityTests.cs
@@ -534,7 +534,7 @@ public class ImportVisibilityTests : IDisposable {
             .RespondWith(Response.Create().WithStatusCode(404));
         StubAllHookEndpoints();
 
-        var projectsDir = Path.Combine(_tempDir, "claude-projects-nothing-in-scope");
+        var projectsDir = _tmp.PathTo("claude-projects-nothing-in-scope");
         WriteClaudeSession(projectsDir, "vis-out-of-scope");
 
         ImportCommand.ImportRunOutcome? outcome = null;

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupImportLaneTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupImportLaneTests.cs
@@ -291,4 +291,124 @@ public class SetupImportLaneTests {
         // collapsing it to "no filter" would import exactly what the user declined.
         await Assert.That(SetupCommand.BuildImportSources(Config.Root, [])).IsEmpty();
     }
+
+    // ---- What the run reports back to the flow.
+
+    static ImportCommand.FinalCounts Moved(
+            int loaded = 0, int resumed = 0, int alreadyLoaded = 0, int tooShort = 0, int excluded = 0,
+            int probeError = 0, int errored = 0) =>
+        new(loaded, resumed, alreadyLoaded, tooShort, excluded, probeError, errored,
+            TitlesGenerated: 0, TitlesSkipped: 0, TitlesFailed: 0,
+            SummariesGenerated: 0, SummariesFailed: 0, RanBackground: false, RequestedSummaries: false);
+
+    [Test]
+    public async Task Sums_the_totals_across_both_passes() {
+        // One report goes to the flow but --private forces two invocations, so a lane returning either
+        // pass alone would halve the figures the screen shows.
+        var queue = new Queue<ImportCommand.ImportRunOutcome?>([
+            new(Moved(loaded: 3, alreadyLoaded: 1), 0),
+            new(Moved(loaded: 4, resumed: 2, tooShort: 5, errored: 1), 0)
+        ]);
+
+        var totals = await Lane(_ => Task.FromResult(queue.Dequeue())).ImportAsync(
+            Answer(repos: [("mine", FirstRunImportLevel.OnlyMe), ("ours", FirstRunImportLevel.Shared)]),
+            new DateOnly(2026, 6, 15), CancellationToken.None);
+
+        await Assert.That(totals).IsNotNull();
+        await Assert.That((totals!.Value.Imported, totals.Value.Skipped, totals.Value.Failed))
+                    .IsEqualTo((9, 6, 1));
+    }
+
+    [Test]
+    public async Task A_resume_counts_as_imported_and_not_as_a_third_thing() {
+        var totals = await Lane(_ => Task.FromResult<ImportCommand.ImportRunOutcome?>(
+                new(Moved(resumed: 4), 0))).ImportAsync(
+            Answer(repos: ("ours", FirstRunImportLevel.Shared)), new DateOnly(2026, 6, 15),
+            CancellationToken.None);
+
+        await Assert.That(totals!.Value.Imported).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task A_probe_error_is_reported_as_failed_and_not_as_skipped() {
+        // Re-running retries it, which is what failed means here — unlike too-short or already-loaded.
+        var totals = await Lane(_ => Task.FromResult<ImportCommand.ImportRunOutcome?>(
+                new(Moved(probeError: 2), 0))).ImportAsync(
+            Answer(repos: ("ours", FirstRunImportLevel.Shared)), new DateOnly(2026, 6, 15),
+            CancellationToken.None);
+
+        await Assert.That((totals!.Value.Skipped, totals.Value.Failed)).IsEqualTo((0, 2));
+    }
+
+    [Test]
+    public async Task A_session_held_back_by_a_lost_visibility_write_is_reported_as_failed() {
+        // The preflight drops it before the upload, so it is in none of the run's own three counts —
+        // and re-running retries exactly it. Left out, the total would silently understate.
+        var totals = await Lane(_ => Task.FromResult<ImportCommand.ImportRunOutcome?>(
+                new(Moved(loaded: 2), 3))).ImportAsync(
+            Answer(repos: ("ours", FirstRunImportLevel.Shared)), new DateOnly(2026, 6, 15),
+            CancellationToken.None);
+
+        await Assert.That((totals!.Value.Imported, totals.Value.Failed)).IsEqualTo((2, 3));
+    }
+
+    [Test]
+    public async Task A_pass_that_threw_reports_nothing_at_all() {
+        // Its sessions are unaccounted, and the surviving pass's figures alone would state a clean
+        // import over a run that lost one.
+        var first = true;
+
+        Task<ImportCommand.ImportRunOutcome?> Run(SetupImportLane.Pass pass) {
+            if (first) {
+                first = false;
+
+                throw new InvalidOperationException("disk went away");
+            }
+
+            return Task.FromResult<ImportCommand.ImportRunOutcome?>(new(Moved(loaded: 5), 0));
+        }
+
+        var lane   = Lane(Run);
+        var totals = await lane.ImportAsync(
+            Answer(repos: [("mine", FirstRunImportLevel.OnlyMe), ("ours", FirstRunImportLevel.Shared)]),
+            new DateOnly(2026, 6, 15), CancellationToken.None);
+
+        await Assert.That(totals).IsNull();
+        await Assert.That(lane.Failed).IsTrue();
+    }
+
+    [Test]
+    public async Task A_pass_that_reported_no_grid_reports_nothing_at_all() {
+        var totals = await Lane(_ => Task.FromResult<ImportCommand.ImportRunOutcome?>(null)).ImportAsync(
+            Answer(repos: ("ours", FirstRunImportLevel.Shared)), new DateOnly(2026, 6, 15),
+            CancellationToken.None);
+
+        await Assert.That(totals).IsNull();
+    }
+
+    [Test]
+    public async Task A_run_that_measured_zero_reports_zero_rather_than_nothing() {
+        // A pass that reached its grid and found nothing in scope is the "(0,0,0), no reason" row, not a
+        // lost pass. Collapsing it into null would leave the screen unable to say the import finished.
+        var totals = await Lane(_ => Task.FromResult<ImportCommand.ImportRunOutcome?>(
+                new(Moved(), 0))).ImportAsync(
+            Answer(repos: ("ours", FirstRunImportLevel.Shared)), new DateOnly(2026, 6, 15),
+            CancellationToken.None);
+
+        await Assert.That(totals).IsNotNull();
+        await Assert.That((totals!.Value.Imported, totals.Value.Skipped, totals.Value.Failed))
+                    .IsEqualTo((0, 0, 0));
+    }
+
+    [Test]
+    public async Task A_clean_run_reports_totals_rather_than_null() {
+        // The null case has to stay narrow: it is how the caller decides to send nothing, so a clean
+        // run collapsing into it would leave the screen unable to say the import finished.
+        var totals = await Lane(_ => Task.FromResult<ImportCommand.ImportRunOutcome?>(
+                new(Moved(loaded: 1), 0))).ImportAsync(
+            Answer(repos: ("ours", FirstRunImportLevel.Shared)), new DateOnly(2026, 6, 15),
+            CancellationToken.None);
+
+        await Assert.That(totals).IsNotNull();
+    }
 }


### PR DESCRIPTION
AI-2307

## What & why

The flow's `import-outcome` route folded a report into `FirstRunFlowState.ImportOutcome` and had no
caller, so the Done screen's counts caption was unreachable — and since the outcome is also the signal
that the run finished, the screen cannot tell a working import from a stalled one. This is the caller.
The route itself is still open as kcap-server#1671, so this is written against the contract on that
branch and degrades on a 404 like any other newer-server route.

## Where to look

- **Null is not `(0,0,0)`.** A run that lost a pass reports *nothing* — its sessions are unaccounted and
  three counts cannot say so, while the surviving pass's figures alone would state a clean import. An
  empty `Choices` likewise has two causes, and `IsDecline` separates a real decline from a decision
  whose every level was unreadable here.
- **The held report's retry is deliberately uncredited against the poll budget**, unlike the scan and
  the import: it runs every tick for as long as the report is refused, so crediting it would let a
  server that never accepts it stretch the 30-minute backstop into hours.
- **Status retry is opt-in per call site** — every hook, watch, daemon and MCP path shares
  `SendWithRetryAsync` and their budgets assume one attempt. An exhausted budget returns the status
  rather than throwing, because those call sites catch `HttpRequestException` only.

## Verification

Core 2459, Cli 3727, App 1161 — all pass. `dotnet publish -c Release` clean, no IL2026/IL3050. The
daemon suite fails 12–29 in this container on both this branch and an untouched `origin/main` worktree
(three runs each, overlapping ranges): contention between subprocess-heavy classes, left to CI.

Sixteen mutations, fifteen killed and one shown equivalent — swapping `answer.DecidedAt` for
`view.ImportDecidedAt`, which are the same value by construction. The retry predicate is pinned from
both sides: retrying a 4xx kills six tests, not retrying a 429 kills two, defaulting the flag on kills
the opt-in test.

The wire shape is round-tripped through the source-generated context against WireMock, present and
absent. Nothing else covered it — every other test in that file builds the request object directly, so
a naming or AOT-binding slip would leave the screen waiting for ever with the suite green.
