### PR TITLE
[AI-2331] Fix Codex app-server reviewer sending the "default" model sentinel → 400

### DIFF
--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -401,7 +401,10 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
             ["approvalPolicy"]    = CodexAppServerPosture.RenderApprovalPolicy(_launch.Approval),
             ["approvalsReviewer"] = CodexAppServerPosture.ApprovalsReviewer,
         };
-        if (!string.IsNullOrEmpty(_launch.Model))
+        // Honor the "default" no-override sentinel exactly as the PTY path does (CodexLauncher.AddModelArg):
+        // sending model:"default" to Codex on a ChatGPT account is rejected (400) and fails the turn.
+        // Omitting it lets Codex resolve the model from ~/.codex/config.toml.
+        if (CodexLauncher.IsConcreteModel(_launch.Model))
             startParams["model"] = _launch.Model;
         if (isResume)
             startParams["threadId"] = _launch.ResumeSessionId; // resume-by-thread_id; response.thread.id == this id
@@ -440,8 +443,8 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
             ["approvalPolicy"]    = CodexAppServerPosture.RenderApprovalPolicy(_launch.Approval),
             ["approvalsReviewer"] = CodexAppServerPosture.ApprovalsReviewer,
         };
-        if (!string.IsNullOrEmpty(_launch.Model))  turnParams["model"]  = _launch.Model;
-        if (!string.IsNullOrEmpty(_launch.Effort)) turnParams["effort"] = MapEffort(_launch.Effort);
+        if (CodexLauncher.IsConcreteModel(_launch.Model)) turnParams["model"]  = _launch.Model; // omit the "default" sentinel (see thread/start)
+        if (!string.IsNullOrEmpty(_launch.Effort))        turnParams["effort"] = MapEffort(_launch.Effort);
 
         var result = await RequestAsync("turn/start", turnParams, ct).ConfigureAwait(false);
         var turn   = result.Obj("turn");

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexLauncher.cs
@@ -397,16 +397,23 @@ internal sealed partial class CodexLauncher(
         args.Add($"mcp_servers.{serverId}.default_tools_approval_mode=\"approve\"");
     }
 
-    /// Append `-m &lt;model&gt;` unless the model is empty or the "default" no-override sentinel.
-    /// "default" is the sentinel from the flow/agent dispatch; passing it as `-m default` is
-    /// rejected by Codex on a ChatGPT account ("The 'default' model is not supported when using
-    /// Codex with a ChatGPT account") and silently yields an empty turn. Omitting -m makes Codex
-    /// use the model from ~/.codex/config.toml (mirrors the effort=="auto" case). Shared by both
-    /// the default and review launch paths so the sentinel is honored in either.
+    /// True when <paramref name="model"/> is a concrete model slug to pass through to Codex, rather than
+    /// empty or the "default" no-override sentinel. "default" is the sentinel from the flow/agent
+    /// dispatch; passing it to Codex verbatim — as PTY `-m default`, or as the app-server
+    /// thread/turn `model` param — is rejected on a ChatGPT account ("The 'default' model is not
+    /// supported when using Codex with a ChatGPT account") and yields a failed/empty turn. Omitting it
+    /// makes Codex resolve the model from ~/.codex/config.toml (mirrors the effort=="auto" case). Shared
+    /// by the PTY launch args AND <c>CodexAppServerHostedAgentRuntime</c>'s thread/turn params so the
+    /// sentinel is honored on every Codex transport.
+    internal static bool IsConcreteModel(string? model) =>
+        !string.IsNullOrEmpty(model) && !string.Equals(model, "default", StringComparison.OrdinalIgnoreCase);
+
+    /// Append `-m &lt;model&gt;` unless the model is empty or the "default" no-override sentinel
+    /// (see <see cref="IsConcreteModel"/>).
     static void AddModelArg(List<string> args, string? model) {
-        if (!string.IsNullOrEmpty(model) && !string.Equals(model, "default", StringComparison.OrdinalIgnoreCase)) {
+        if (IsConcreteModel(model)) {
             args.Add("-m");
-            args.Add(model);
+            args.Add(model!);
         }
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -82,7 +82,7 @@ public class CodexAppServerHostedAgentRuntimeTests {
         await runtime.DisposeAsync();
     }
 
-    /// <summary>AI-2331: the "default" no-override sentinel must NOT be sent to Codex — on a ChatGPT
+    /// <summary>the "default" no-override sentinel must NOT be sent to Codex — on a ChatGPT
     /// account <c>model:"default"</c> is rejected with a 400 and fails the turn. thread/start AND
     /// turn/start must OMIT the model entirely (letting Codex resolve it from ~/.codex/config.toml),
     /// exactly as the PTY path (<c>CodexLauncher.AddModelArg</c>) does. Before the fix both carried
@@ -103,7 +103,7 @@ public class CodexAppServerHostedAgentRuntimeTests {
         await runtime.DisposeAsync();
     }
 
-    /// <summary>Control for AI-2331: a CONCRETE model is passed through verbatim on both thread/start and
+    /// <summary>Control: a CONCRETE model is passed through verbatim on both thread/start and
     /// turn/start (so the fix only strips the sentinel, never a real override).</summary>
     [Test]
     public async Task Concrete_model_is_passed_on_thread_start_and_turn_start() {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -82,29 +82,27 @@ public class CodexAppServerHostedAgentRuntimeTests {
         await runtime.DisposeAsync();
     }
 
-    /// <summary>the "default" no-override sentinel must NOT be sent to Codex — on a ChatGPT
-    /// account <c>model:"default"</c> is rejected with a 400 and fails the turn. thread/start AND
-    /// turn/start must OMIT the model entirely (letting Codex resolve it from ~/.codex/config.toml),
-    /// exactly as the PTY path (<c>CodexLauncher.AddModelArg</c>) does. Before the fix both carried
-    /// <c>model:"default"</c>.</summary>
+    /// <summary>The "default" no-override sentinel is omitted from both thread/start and turn/start,
+    /// so Codex resolves the model from ~/.codex/config.toml; sending <c>model:"default"</c> to a
+    /// ChatGPT-auth account is a 400.</summary>
     [Test]
     public async Task Default_model_sentinel_is_omitted_from_thread_start_and_turn_start() {
-        var fake = new FakeCodexAppServer { Model = "gpt-5.3-codex" }; // the model Codex resolves from config
+        var fake = new FakeCodexAppServer { Model = "gpt-5.3-codex" };
         var (runtime, _, _) = Build(_ => fake, Launch(model: "default"));
 
         await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
         await runtime.SendUserInputAsync("go").WaitAsync(HangGuard);
         await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
 
-        await Assert.That(fake.LastThreadStartHadModel).IsFalse(); // thread/start omitted the model
-        await Assert.That(fake.LastTurnStartHadModel).IsFalse();   // turn/start omitted the model
-        await Assert.That(runtime.ResolvedModel).IsEqualTo("gpt-5.3-codex"); // Codex's own resolution still surfaces
+        await Assert.That(fake.LastThreadStartHadModel).IsFalse();
+        await Assert.That(fake.LastTurnStartHadModel).IsFalse();
+        await Assert.That(runtime.ResolvedModel).IsEqualTo("gpt-5.3-codex");
 
         await runtime.DisposeAsync();
     }
 
-    /// <summary>Control: a CONCRETE model is passed through verbatim on both thread/start and
-    /// turn/start (so the fix only strips the sentinel, never a real override).</summary>
+    /// <summary>A concrete model is passed through verbatim on both thread/start and turn/start
+    /// (the sentinel handling strips only "default", never a real override).</summary>
     [Test]
     public async Task Concrete_model_is_passed_on_thread_start_and_turn_start() {
         var fake = new FakeCodexAppServer { Model = "gpt-5.3-codex" };

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerHostedAgentRuntimeTests.cs
@@ -82,6 +82,44 @@ public class CodexAppServerHostedAgentRuntimeTests {
         await runtime.DisposeAsync();
     }
 
+    /// <summary>AI-2331: the "default" no-override sentinel must NOT be sent to Codex — on a ChatGPT
+    /// account <c>model:"default"</c> is rejected with a 400 and fails the turn. thread/start AND
+    /// turn/start must OMIT the model entirely (letting Codex resolve it from ~/.codex/config.toml),
+    /// exactly as the PTY path (<c>CodexLauncher.AddModelArg</c>) does. Before the fix both carried
+    /// <c>model:"default"</c>.</summary>
+    [Test]
+    public async Task Default_model_sentinel_is_omitted_from_thread_start_and_turn_start() {
+        var fake = new FakeCodexAppServer { Model = "gpt-5.3-codex" }; // the model Codex resolves from config
+        var (runtime, _, _) = Build(_ => fake, Launch(model: "default"));
+
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await runtime.SendUserInputAsync("go").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(fake.LastThreadStartHadModel).IsFalse(); // thread/start omitted the model
+        await Assert.That(fake.LastTurnStartHadModel).IsFalse();   // turn/start omitted the model
+        await Assert.That(runtime.ResolvedModel).IsEqualTo("gpt-5.3-codex"); // Codex's own resolution still surfaces
+
+        await runtime.DisposeAsync();
+    }
+
+    /// <summary>Control for AI-2331: a CONCRETE model is passed through verbatim on both thread/start and
+    /// turn/start (so the fix only strips the sentinel, never a real override).</summary>
+    [Test]
+    public async Task Concrete_model_is_passed_on_thread_start_and_turn_start() {
+        var fake = new FakeCodexAppServer { Model = "gpt-5.3-codex" };
+        var (runtime, _, _) = Build(_ => fake, Launch(model: "gpt-5.3-codex"));
+
+        await runtime.StartAsync(CancellationToken.None).WaitAsync(HangGuard);
+        await runtime.SendUserInputAsync("go").WaitAsync(HangGuard);
+        await runtime.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        await Assert.That(fake.LastThreadStartModel).IsEqualTo("gpt-5.3-codex");
+        await Assert.That(fake.LastTurnStartModel).IsEqualTo("gpt-5.3-codex");
+
+        await runtime.DisposeAsync();
+    }
+
     [Test]
     public async Task Envelope_transcript_emits_a_token_usage_delta_through_the_forward_buffer() {
         // Gate ON: the real HandleNotification path feeds the mapper + forward buffer, so a turn's usage

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
@@ -47,9 +47,9 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
     public readonly List<string>       ReceivedMethods    = [];
     public readonly List<string>       InitializeOptOuts  = [];
     public string?                     LastThreadStartSandbox;
-    public bool                        LastThreadStartHadModel; // was the "model" key present on thread/start?
-    public string?                     LastThreadStartModel;    // its value when present (null when omitted)
-    public bool                        LastTurnStartHadModel;   // was the "model" key present on turn/start?
+    public bool                        LastThreadStartHadModel;
+    public string?                     LastThreadStartModel;
+    public bool                        LastTurnStartHadModel;
     public string?                     LastTurnStartModel;
     public string?                     LastResumeThreadId; // §2.7 B4: the threadId carried on thread/resume
     public string?                     LastTurnApprovalPolicy;
@@ -117,12 +117,10 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
                 break;
 
             case "thread/start":
-                if (@params.ValueKind == JsonValueKind.Object) {
-                    if (@params.TryGetProperty("sandbox", out var sb))
-                        LastThreadStartSandbox = sb.ValueKind == JsonValueKind.String ? sb.GetString() : null;
-                    LastThreadStartHadModel = @params.TryGetProperty("model", out var tsm);
-                    LastThreadStartModel    = LastThreadStartHadModel && tsm.ValueKind == JsonValueKind.String ? tsm.GetString() : null;
-                }
+                if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("sandbox", out var sb))
+                    LastThreadStartSandbox = sb.ValueKind == JsonValueKind.String ? sb.GetString() : null;
+                LastThreadStartHadModel = @params.Prop("model") is not null;
+                LastThreadStartModel    = @params.Str("model");
                 await RespondAsync(id, new JsonObject {
                     ["thread"]        = new JsonObject { ["id"] = ThreadId, ["sessionId"] = ThreadId, ["path"] = "/tmp/r.jsonl" },
                     ["model"]         = Model,
@@ -153,12 +151,8 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
                     LastTurnApprovalPolicy = ap.GetString();
                 if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("effort", out var ef))
                     LastTurnEffort = ef.GetString();
-                LastTurnStartHadModel = false;
-                LastTurnStartModel    = null;
-                if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("model", out var tm)) {
-                    LastTurnStartHadModel = true;
-                    LastTurnStartModel    = tm.ValueKind == JsonValueKind.String ? tm.GetString() : null;
-                }
+                LastTurnStartHadModel = @params.Prop("model") is not null;
+                LastTurnStartModel    = @params.Str("model");
 
                 var turnId = "turn-" + _turnStartCount;
                 _lastTurnId = turnId;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
@@ -47,9 +47,9 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
     public readonly List<string>       ReceivedMethods    = [];
     public readonly List<string>       InitializeOptOuts  = [];
     public string?                     LastThreadStartSandbox;
-    public bool                        LastThreadStartHadModel; // AI-2331: was the "model" key present on thread/start?
+    public bool                        LastThreadStartHadModel; // was the "model" key present on thread/start?
     public string?                     LastThreadStartModel;    // its value when present (null when omitted)
-    public bool                        LastTurnStartHadModel;   // AI-2331: was the "model" key present on turn/start?
+    public bool                        LastTurnStartHadModel;   // was the "model" key present on turn/start?
     public string?                     LastTurnStartModel;
     public string?                     LastResumeThreadId; // §2.7 B4: the threadId carried on thread/resume
     public string?                     LastTurnApprovalPolicy;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/FakeCodexAppServer.cs
@@ -47,6 +47,10 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
     public readonly List<string>       ReceivedMethods    = [];
     public readonly List<string>       InitializeOptOuts  = [];
     public string?                     LastThreadStartSandbox;
+    public bool                        LastThreadStartHadModel; // AI-2331: was the "model" key present on thread/start?
+    public string?                     LastThreadStartModel;    // its value when present (null when omitted)
+    public bool                        LastTurnStartHadModel;   // AI-2331: was the "model" key present on turn/start?
+    public string?                     LastTurnStartModel;
     public string?                     LastResumeThreadId; // §2.7 B4: the threadId carried on thread/resume
     public string?                     LastTurnApprovalPolicy;
     public string?                     LastTurnEffort;
@@ -113,8 +117,12 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
                 break;
 
             case "thread/start":
-                if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("sandbox", out var sb))
-                    LastThreadStartSandbox = sb.ValueKind == JsonValueKind.String ? sb.GetString() : null;
+                if (@params.ValueKind == JsonValueKind.Object) {
+                    if (@params.TryGetProperty("sandbox", out var sb))
+                        LastThreadStartSandbox = sb.ValueKind == JsonValueKind.String ? sb.GetString() : null;
+                    LastThreadStartHadModel = @params.TryGetProperty("model", out var tsm);
+                    LastThreadStartModel    = LastThreadStartHadModel && tsm.ValueKind == JsonValueKind.String ? tsm.GetString() : null;
+                }
                 await RespondAsync(id, new JsonObject {
                     ["thread"]        = new JsonObject { ["id"] = ThreadId, ["sessionId"] = ThreadId, ["path"] = "/tmp/r.jsonl" },
                     ["model"]         = Model,
@@ -145,6 +153,12 @@ sealed class FakeCodexAppServer : IAsyncDisposable {
                     LastTurnApprovalPolicy = ap.GetString();
                 if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("effort", out var ef))
                     LastTurnEffort = ef.GetString();
+                LastTurnStartHadModel = false;
+                LastTurnStartModel    = null;
+                if (@params.ValueKind == JsonValueKind.Object && @params.TryGetProperty("model", out var tm)) {
+                    LastTurnStartHadModel = true;
+                    LastTurnStartModel    = tm.ValueKind == JsonValueKind.String ? tm.GetString() : null;
+                }
 
                 var turnId = "turn-" + _turnStartCount;
                 _lastTurnId = turnId;


### PR DESCRIPTION
## What

A hosted **Codex app-server** reviewer launched **without an explicit model** failed its turn immediately. Codex's own rollout recorded:

```
400 invalid_request_error: "The 'default' model is not supported when using Codex with a ChatGPT account."
```

The flow/agent dispatch uses `"default"` as a no-override sentinel ("let Codex resolve the model from `~/.codex/config.toml`"). The **PTY** path honors it — `CodexLauncher.AddModelArg` omits `-m` for empty **or** `"default"`. The **app-server** path did not: `CodexAppServerHostedAgentRuntime` set `startParams["model"]` (thread/start) and `turnParams["model"]` (turn/start) whenever the model was merely non-empty, sending `model:"default"` to Codex, which a ChatGPT-auth account rejects.

## How

- Extract the sentinel logic into a shared `CodexLauncher.IsConcreteModel(model)` (non-empty **and not** the case-insensitive `"default"`), and refactor `AddModelArg` to use it.
- Use it for both app-server params, so `"default"` is omitted (Codex resolves from `config.toml`) exactly as PTY does.
- Test harness (`FakeCodexAppServer`) now captures the thread/start and turn/start `model` param; two runtime tests assert the sentinel is omitted from both, and a control asserts a concrete model is still passed through verbatim.

## Verification

Full daemon unit suite green. **Verified live** against kurrent (shipped `kcap` + `KCAP_CODEX_TRANSPORT=app-server`, dev daemon with this fix): the app-server reviewer's round-1 turn now completes and returns real findings ("`Add` subtracts... fix: `return a + b`"), then **parks** cleanly (arm-A `Parked resumable review-flow reviewer … thread kept alive for resume`).

## Found in passing (filed separately; NOT in this PR)

The same live E2E surfaced two issues that are **not** daemon-side and are out of scope here:

- **[AI-2332](https://linear.app/kurrent/issue/AI-2332)** — explicit-model app-server launch → `reviewer_model_resolution_timeout`. I initially hypothesized a daemon report-timing fix, built it, and re-ran live: it **still** times out, and `reviewer_model_resolution_timeout` is generated server-side (absent from kcap-cli). So it's a **kcap-server** issue; the daemon change was reverted from this PR.
- **[AI-2333](https://linear.app/kurrent/issue/AI-2333)** — resuming a cleanly-parked reviewer is blocked by `participant_unreachable` (the server never proves the parked agent gone). Also largely server-side, with a daemon contributor (Codex app-server ignores the graceful `/exit`, so every park teardown 15s-timeouts to SIGKILL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
