### PR TITLE
[AI-2335] Correct Antigravity MCP-server count in plugin help text

### DIFF
--- a/src/Capacitor.Cli.Core/Resources/help-plugin.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-plugin.txt
@@ -226,7 +226,7 @@ Notes:
 
   --antigravity installs the kcap plugin to ~/.gemini/config/plugins/kcap/ — a
   plugin.json manifest (which the GUI requires to load the dir) plus a hooks.json
-  kcap block (preserving any hook blocks you authored). It also registers the 4 kcap
+  kcap block (preserving any hook blocks you authored). It also registers the 6 kcap
   MCP servers in ~/.gemini/config/mcp_config.json (Antigravity's OWN MCP file, not the
   Gemini CLI's settings.json — see --skip-antigravity-mcp), installs a steering block
   into the shared ~/.gemini/GEMINI.md (see --skip-antigravity-instructions), and copies


### PR DESCRIPTION
AI-2335 — no GitHub issue; tracked in Linear only.

## What & why

`kcap plugin`'s help text described Antigravity as receiving "the 4 kcap MCP servers" while every other vendor said 6. Ground truth is `KcapMcpServers.All`, from which `HarnessMcpProjections` derives Antigravity's set: all six servers (review, sessions, memory, workitems, flows, analytics) register for every vendor, Antigravity included. Corrected the one stale count; the other seven vendor lines were already right.

## Verification

`grep -niE '(the|all) (four|4|six|6) .*kcap MCP' help-plugin.txt` now shows 6 on every vendor line, none saying 4. The only test reading this file (`AgentsSkillsInstallerTests`) pins the skills list, not MCP counts, so it is unaffected.