### PR TITLE
[AI-2333] Graceful Codex app-server shutdown: close stdin so park teardown doesn't SIGKILL

### DIFF
--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerConnection.cs
@@ -402,6 +402,26 @@ internal sealed partial class CodexAppServerConnection : IAsyncDisposable {
         }
     }
 
+    /// <summary>Signal a clean shutdown to the peer by closing the WRITE side (its stdin) —
+    /// <c>codex app-server</c> exits 0 on stdin EOF. Serializes with an in-flight write via the write
+    /// gate (bounded, so a stuck write never delays the EOF that shuts the peer down), then disposes
+    /// ONLY the write stream — the read loop still observes the peer's own exit via stdout EOF. Idempotent
+    /// and best-effort: a prior/concurrent <see cref="DisposeAsync"/> or an already-broken stream is
+    /// swallowed, so the caller can fall through to a hard terminate. Does NOT dispose the connection.</summary>
+    public async Task CloseInputAsync() {
+        if (Volatile.Read(ref _disposed) != 0) return;
+
+        bool gated;
+        try { gated = await _writeGate.WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false); }
+        catch (ObjectDisposedException) { return; } // DisposeAsync won the race — stdin is already closed.
+
+        try {
+            await _writeStream.DisposeAsync().ConfigureAwait(false);
+        } finally {
+            if (gated) { try { _writeGate.Release(); } catch (ObjectDisposedException) { /* raced DisposeAsync */ } }
+        }
+    }
+
     public async ValueTask DisposeAsync() {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerConnection.cs
@@ -58,6 +58,7 @@ internal sealed partial class CodexAppServerConnection : IAsyncDisposable {
 
     long _nextId;
     int  _disposed;
+    bool IsDisposed => Volatile.Read(ref _disposed) != 0;
 
     /// <param name="debugFrames">
     /// <see cref="DaemonConfig.DebugFrames"/> (<c>KCAP_ACP_DEBUG_FRAMES</c>) — off by default. When
@@ -379,10 +380,16 @@ internal sealed partial class CodexAppServerConnection : IAsyncDisposable {
     }
 
     async Task WriteLineAsync(string json, CancellationToken ct) {
+        // IsDisposed checks (before AND after acquiring the gate) turn away a writer that raced
+        // DisposeAsync / CloseInputAsync — the second catches a writer that only won the gate once the
+        // write stream was already disposed. Cleaner than letting it write into a disposed stream, and
+        // it lets DisposeAsync leave _writeGate undisposed (see there) without a queued writer hanging.
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
         var bytes = Encoding.UTF8.GetBytes(json + "\n");
 
         await _writeGate.WaitAsync(ct).ConfigureAwait(false);
         try {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
             await _writeStream.WriteAsync(bytes, ct).ConfigureAwait(false);
             await _writeStream.FlushAsync(ct).ConfigureAwait(false);
 
@@ -409,16 +416,18 @@ internal sealed partial class CodexAppServerConnection : IAsyncDisposable {
     /// and best-effort: a prior/concurrent <see cref="DisposeAsync"/> or an already-broken stream is
     /// swallowed, so the caller can fall through to a hard terminate. Does NOT dispose the connection.</summary>
     public async Task CloseInputAsync() {
-        if (Volatile.Read(ref _disposed) != 0) return;
+        if (IsDisposed) return; // fully disposed → the write stream is already closed.
 
-        bool gated;
-        try { gated = await _writeGate.WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false); }
-        catch (ObjectDisposedException) { return; } // DisposeAsync won the race — stdin is already closed.
-
+        // Serialize with an in-flight write when possible, but never let a stuck write (a peer that
+        // stopped reading) delay the EOF that shuts it down — after a bounded wait, close regardless.
+        // _writeGate is left undisposed by DisposeAsync, so this timed wait always honors its timeout
+        // even if disposal races (a disposed SemaphoreSlim abandons a queued WaitAsync — it neither
+        // completes nor times out).
+        var gated = await _writeGate.WaitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
         try {
             await _writeStream.DisposeAsync().ConfigureAwait(false);
         } finally {
-            if (gated) { try { _writeGate.Release(); } catch (ObjectDisposedException) { /* raced DisposeAsync */ } }
+            if (gated) _writeGate.Release();
         }
     }
 
@@ -428,8 +437,12 @@ internal sealed partial class CodexAppServerConnection : IAsyncDisposable {
 
         FaultAllPending(new ObjectDisposedException(nameof(CodexAppServerConnection)));
 
-        _writeGate.Dispose();
-
+        // _writeGate is deliberately left UNDISPOSED. Disposing a SemaphoreSlim does not release an
+        // outstanding async waiter — a WriteLineAsync (or CloseInputAsync's bounded wait) already queued
+        // in WaitAsync when this ran would then hang forever, neither completing nor honoring its
+        // timeout. It holds no unmanaged state unless AvailableWaitHandle is touched (never here), so
+        // leaving it undisposed is accepted .NET practice; the IsDisposed checks in WriteLineAsync turn
+        // post-dispose writers away cleanly instead.
         await _writeStream.DisposeAsync().ConfigureAwait(false);
         await _readStream.DisposeAsync().ConfigureAwait(false);
     }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -609,13 +609,10 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
             }
         }
 
-        // Ask the app-server PROCESS to exit by closing its stdin (EOF) — `codex app-server`
-        // exits cleanly (code 0) on stdin EOF. Previously this method sent only `turn/interrupt`, and ONLY
-        // when a turn was in flight, so a between-rounds PARK (the reviewer is idle) made it a total no-op:
-        // the process never exited, the daemon waited out the full 15s graceful window and SIGKILLed
-        // (exit 137), delaying AgentUnregistered ~16s on every park. Closing stdin lands the exit inside
-        // the window. Best-effort: if the peer ignores EOF the caller still falls through to
-        // WaitForExitAsync → TerminateAsync, so this can only shorten teardown, never wedge it.
+        // Ask the app-server PROCESS to exit by closing its stdin (EOF) — `codex app-server` exits
+        // cleanly on stdin EOF. Runs unconditionally: a between-rounds park has no in-flight turn to
+        // interrupt, so this is the only step that ends the process. Best-effort — if the peer ignores
+        // EOF the caller still falls through to WaitForExitAsync → TerminateAsync (hard kill).
         try {
             await connection.CloseInputAsync().ConfigureAwait(false);
         } catch (Exception ex) {

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -591,19 +591,35 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
 
     public async Task RequestGracefulStopAsync() {
         var connection = _connection;
-        var threadId   = _threadId;
-        var turnId     = _dispatcher.CurrentTurnId;
-        if (connection is null || threadId is null || turnId is null)
+        if (connection is null)
             return;
 
+        // If a turn is in flight, interrupt it first so the app-server isn't mid-generation when we ask
+        // it to shut down. Best-effort; never let it block teardown.
+        var threadId = _threadId;
+        var turnId   = _dispatcher.CurrentTurnId;
+        if (threadId is not null && turnId is not null) {
+            try {
+                var interruptParams = ToElement(new JsonObject { ["threadId"] = threadId, ["turnId"] = turnId });
+                await connection.RequestAsync("turn/interrupt", interruptParams, _cts.Token).ConfigureAwait(false);
+                // Bounded wait for the interrupted turn to settle before we close stdin; never block teardown.
+                await WaitForTurnIdleAsync(_cts.Token).WaitAsync(TimeSpan.FromSeconds(5), _time).ConfigureAwait(false);
+            } catch (Exception ex) {
+                _logger.LogDebug(ex, "codex app-server: turn/interrupt during graceful stop failed; continuing to shutdown.");
+            }
+        }
+
+        // Ask the app-server PROCESS to exit by closing its stdin (EOF) — `codex app-server`
+        // exits cleanly (code 0) on stdin EOF. Previously this method sent only `turn/interrupt`, and ONLY
+        // when a turn was in flight, so a between-rounds PARK (the reviewer is idle) made it a total no-op:
+        // the process never exited, the daemon waited out the full 15s graceful window and SIGKILLed
+        // (exit 137), delaying AgentUnregistered ~16s on every park. Closing stdin lands the exit inside
+        // the window. Best-effort: if the peer ignores EOF the caller still falls through to
+        // WaitForExitAsync → TerminateAsync, so this can only shorten teardown, never wedge it.
         try {
-            var interruptParams = ToElement(new JsonObject { ["threadId"] = threadId, ["turnId"] = turnId });
-            await connection.RequestAsync("turn/interrupt", interruptParams, _cts.Token).ConfigureAwait(false);
-            // Bounded wait for the interrupted turn to settle before the caller falls through to
-            // terminate; never let this block teardown.
-            await WaitForTurnIdleAsync(_cts.Token).WaitAsync(TimeSpan.FromSeconds(5), _time).ConfigureAwait(false);
+            await connection.CloseInputAsync().ConfigureAwait(false);
         } catch (Exception ex) {
-            _logger.LogDebug(ex, "codex app-server: graceful stop (turn/interrupt) failed; falling through to terminate.");
+            _logger.LogDebug(ex, "codex app-server: closing stdin during graceful stop failed; falling through to terminate.");
         }
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerConnectionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerConnectionTests.cs
@@ -463,4 +463,17 @@ public class CodexAppServerConnectionTests {
         // Idempotent: a second CloseInputAsync (and the eventual DisposeAsync in the harness) must not throw.
         await harness.Connection.CloseInputAsync();
     }
+
+    /// <summary>After DisposeAsync, a write is turned away cleanly (ObjectDisposedException) and
+    /// CloseInputAsync is a prompt no-op — never a hang. DisposeAsync leaves the write gate UNDISPOSED
+    /// (disposing a SemaphoreSlim abandons a queued waiter — it neither completes nor honors its
+    /// timeout), so a bounded wait can always make progress; the IsDisposed guards do the turning-away.</summary>
+    [Test]
+    public async Task After_dispose_writes_are_turned_away_and_close_input_is_a_prompt_noop() {
+        var harness = new Harness();
+        await harness.DisposeAsync();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await harness.Connection.NotifyAsync("x", null));
+        await harness.Connection.CloseInputAsync().WaitAsync(HangGuard); // must return promptly, not hang
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerConnectionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexAppServerConnectionTests.cs
@@ -442,4 +442,25 @@ public class CodexAppServerConnectionTests {
             // expected shutdown path for this test's owned CTS
         }
     }
+
+    /// <summary>CloseInputAsync completes the WRITE side (the peer's stdin) so a real
+    /// `codex app-server` sees EOF and exits — the graceful-shutdown trigger the park teardown needs.
+    /// Here the peer read observes end-of-stream, the read side stays usable, and it is idempotent.</summary>
+    [Test]
+    public async Task CloseInputAsync_ends_the_write_side_so_the_peer_reads_eof() {
+        await using var harness = new Harness();
+
+        // Precondition — the write side is live: a notification reaches the peer.
+        await harness.Connection.NotifyAsync("session/ping", null);
+        var frame = await harness.ReadFrameFromConnectionAsync();
+        await Assert.That(frame).Contains("session/ping");
+
+        // Closing the input completes the write side; the peer's next read is end-of-stream (EOF).
+        await harness.Connection.CloseInputAsync();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(harness.ReadFrameFromConnectionAsync);
+        await Assert.That(ex!.Message).Contains("stream completed");
+
+        // Idempotent: a second CloseInputAsync (and the eventual DisposeAsync in the harness) must not throw.
+        await harness.Connection.CloseInputAsync();
+    }
 }


### PR DESCRIPTION
## What

The Codex **app-server** hosted reviewer never shut down gracefully on a park, so every park teardown 15s-timed-out to SIGKILL (exit 137) — delaying `AgentUnregistered` ~16s each time. This is the kcap-cli half of the §2.7 B6 park→resume issue (server-side tracked in kurrent-io/kcap-server#1715 / AI-2333).

## Root cause

`CodexAppServerHostedAgentRuntime.RequestGracefulStopAsync` sent `turn/interrupt` **and only when a turn was in flight**:

```csharp
var turnId = _dispatcher.CurrentTurnId;
if (connection is null || threadId is null || turnId is null) return;   // ← between-rounds park: no-op
```

At park time the reviewer is idle between rounds, so `CurrentTurnId` is null and the method returned immediately without touching the process. Even mid-turn, `turn/interrupt` only cancels the *turn* — it never asks the `codex app-server` process to exit. So `HasExited` never flipped, `WaitForExitAsync(15s)` always exhausted, and teardown fell through to `TerminateAsync`'s SIGKILL on every park.

## How

`codex app-server` exits cleanly (**code 0**) on stdin EOF — verified empirically against `codex-cli 0.147.0` (a bare `codex app-server < /dev/null` exits 0 with no handshake).

- Add `CodexAppServerConnection.CloseInputAsync()` — disposes **only** the write stream (the peer's stdin), leaving the read loop to observe the peer's own exit via stdout EOF. Serializes with an in-flight write via the write gate (bounded), idempotent, best-effort.
- `RequestGracefulStopAsync` now: (1) interrupts the in-flight turn **if** one exists (unchanged, best-effort), then (2) **unconditionally** closes stdin so the process exits inside the graceful window. If the peer ever ignored EOF, the caller still falls through to `WaitForExitAsync → TerminateAsync` — so this can only shorten teardown, never wedge it.

## Verification

- New unit test `CloseInputAsync_ends_the_write_side_so_the_peer_reads_eof` over the in-memory pipe harness — the peer reads EOF exactly as a real app-server's stdin would; read side stays usable; idempotent.
- Full Codex app-server harness suite green (**44/44**: `CodexAppServerConnectionTests` + `CodexAppServerHostedAgentRuntimeTests`).
- Linear-id lint passes (no ticket tokens in tracked C#).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
