### PR TITLE
Tell the server when this machine stops listening

### DIFF
--- a/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
@@ -118,10 +118,57 @@ public sealed class BrowserFirstRunFlow(
         progress.Opening(setupUrl);
         launcher.TryOpen(setupUrl);
 
+        // Armed for the leg's whole duration, because an interrupt runs no finally: Ctrl+C, SIGTERM and
+        // SIGHUP all reach Environment.Exit from a handler, and this is the only thing between that and a
+        // browser left offering decisions nobody will act on.
+        using var armed = FirstRunInterruptRelinquish.Arm(
+            token => RelinquishAsync(serverUrl, flowId, FirstRunRelinquishReasons.Stopped, token));
+
+        FirstRunFlowResult result;
+
         try {
-            return await PollAsync(serverUrl, flowId, report, ct);
+            result = await PollAsync(serverUrl, flowId, report, ct);
         } finally {
             progress.WaitEnded();
+        }
+
+        // ONE call, keyed off the result type, so the closed tab and the failed leg are covered without a
+        // special case for the keypress.
+        //
+        // Finished must not relinquish, and that guard is the load-bearing one: the flow is over on its own
+        // terms and the browser is rendering the payoff. Expired needs nothing either — the server already
+        // refuses a flow past its lifetime, and the page says so.
+        if (ReasonFor(result) is { } reason) await RelinquishAsync(serverUrl, flowId, reason, ct);
+
+        return result;
+    }
+
+    /// <summary>
+    /// What to tell the browser about this ending, or null when there is nothing to tell it.
+    ///
+    /// <para><b>A dismissal is a handover and nothing else is.</b> It is the one exit where the terminal
+    /// carries on with everything the browser settled, so it is the one where the page must not send anyone
+    /// back to <c>kcap setup</c>. A backstop that elapsed and a leg that failed both leave nothing
+    /// running.</para>
+    /// </summary>
+    static string? ReasonFor(FirstRunFlowResult result) => result switch {
+        FirstRunFlowResult.Dismissed => FirstRunRelinquishReasons.Handover,
+        FirstRunFlowResult.Abandoned or FirstRunFlowResult.Failed => FirstRunRelinquishReasons.Stopped,
+        _ => null
+    };
+
+    /// <summary>Says the machine has gone. Swallows everything: this runs as the leg ends, and a setup that
+    /// otherwise worked must not report a failure because one best-effort POST did not land.</summary>
+    async Task RelinquishAsync(string serverUrl, string flowId, string reason, CancellationToken ct) {
+        try {
+            await channel.RelinquishAsync(serverUrl, flowId, reason, ct);
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            // Propagated, as every other await in this class does: a caller's cancel is not this method's
+            // to swallow, and the poll would already have thrown on one.
+            throw;
+        } catch (Exception) {
+            // The channel already degrades a transport failure to a status code, so reaching here means
+            // something unexpected — and there is still nothing useful to do about it.
         }
     }
 

--- a/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
@@ -124,46 +124,50 @@ public sealed class BrowserFirstRunFlow(
         progress.Opening(setupUrl);
         launcher.TryOpen(setupUrl);
 
-        FirstRunFlowResult result;
+        // ONE write decides the reason, and it is the poll's own assignment — so an interrupt either sees
+        // a leg still waiting (the machine is dying: `stopped`) or the reason its result names, never a
+        // half-decided state. Computing the reason into a second variable would reopen exactly that gap.
+        FirstRunFlowResult? settled = null;
 
-        // Scoped to the POLL, and that is load-bearing rather than tidiness. An interrupt runs no finally
-        // — Ctrl+C, SIGTERM, SIGHUP and the parent watchdog all reach Environment.Exit from a handler — so
-        // something has to be armed while the leg waits. But this callback can only ever say `stopped`, so
-        // leaving it armed past the poll would let it race the reason the result actually names: a
-        // dismissed leg would gamble `handover` against `stopped`, and a FINISHED one — which must never
-        // relinquish — could do so at all.
-        using (_interrupts.Arm(
-                   token => RelinquishAsync(serverUrl, flowId, FirstRunRelinquishReasons.Stopped, token))) {
-            try {
-                result = await PollAsync(serverUrl, flowId, report, ct);
-            } finally {
-                progress.WaitEnded();
-            }
+        using var notice = _interrupts.Arm(token =>
+            ReasonToSend(Volatile.Read(ref settled)) is { } reason
+                ? RelinquishAsync(serverUrl, flowId, reason, token)
+                : Task.CompletedTask);
+
+        try {
+            Volatile.Write(ref settled, await PollAsync(serverUrl, flowId, report, ct));
+        } finally {
+            progress.WaitEnded();
         }
 
-        // ONE call, keyed off the result type, so the closed tab and the failed leg are covered without a
-        // special case for the keypress.
-        //
-        // Finished must not relinquish, and that guard is the load-bearing one: the flow is over on its own
-        // terms and the browser is rendering the payoff. Expired needs nothing either — the server already
-        // refuses a flow past its lifetime, and the page says so.
-        if (ReasonFor(result) is { } reason) await RelinquishAsync(serverUrl, flowId, reason, ct);
+        // The same notice the interrupt handler would have sent, claimed once: whichever path gets there
+        // first is the only one that sends, so the browser cannot be told two opposite things.
+        await notice.SendAsync(ct);
 
-        return result;
+        return settled!;
     }
 
     /// <summary>
-    /// What to tell the browser about this ending, or null when there is nothing to tell it.
+    /// What to tell the browser, or null when there is nothing to tell it.
+    ///
+    /// <para><b>A leg still waiting reads as <c>stopped</c></b>, because the only way to observe that is
+    /// from an interrupt handler: the process is being killed, so nothing is carrying on whatever the
+    /// screen currently offers.</para>
     ///
     /// <para><b>A dismissal is a handover and nothing else is.</b> It is the one exit where the terminal
     /// carries on with everything the browser settled, so it is the one where the page must not send anyone
     /// back to <c>kcap setup</c>. A backstop that elapsed and a leg that failed both leave nothing
     /// running.</para>
+    ///
+    /// <para><b>Finished sends nothing, and that guard is the load-bearing one:</b> the flow is over on its
+    /// own terms and the browser is rendering the payoff. Expired needs nothing either — the server already
+    /// refuses a flow past its lifetime, and the page says so.</para>
     /// </summary>
-    static string? ReasonFor(FirstRunFlowResult result) => result switch {
-        FirstRunFlowResult.Dismissed => FirstRunRelinquishReasons.Handover,
+    static string? ReasonToSend(FirstRunFlowResult? settled) => settled switch {
+        null                                                     => FirstRunRelinquishReasons.Stopped,
+        FirstRunFlowResult.Dismissed                             => FirstRunRelinquishReasons.Handover,
         FirstRunFlowResult.Abandoned or FirstRunFlowResult.Failed => FirstRunRelinquishReasons.Stopped,
-        _ => null
+        _                                                        => null
     };
 
     /// <summary>Says the machine has gone. Swallows everything: this runs as the leg ends, and a setup that

--- a/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
@@ -11,6 +11,9 @@ namespace Capacitor.Cli.Core.FirstRun;
 /// and the screen goes on saying it is waiting.</param>
 /// <param name="importing">The Import step's scan and run. Null leaves the screen waiting on a report
 /// that never comes, so a host that renders the flow at all should supply one.</param>
+/// <param name="interrupts">Where to leave the "this machine has gone" callback for an interrupt handler
+/// to find. Defaults to the process-global one the CLI's signal handlers read; passing another keeps an
+/// ordinary run out of process state.</param>
 public sealed class BrowserFirstRunFlow(
         IFirstRunFlowChannel     channel,
         IFirstRunFlowProgress    progress,
@@ -18,9 +21,12 @@ public sealed class BrowserFirstRunFlow(
         TimeProvider?            clock     = null,
         IKeyWatcher?             keys      = null,
         IFirstRunMachineActions? actions   = null,
-        IFirstRunImportLane?     importing = null) {
+        IFirstRunImportLane?     importing = null,
+        IFirstRunInterrupts?     interrupts = null) {
     readonly TimeProvider _clock = clock ?? TimeProvider.System;
     readonly IKeyWatcher  _keys  = keys ?? ConsoleKeyWatcher.Instance;
+
+    readonly IFirstRunInterrupts _interrupts = interrupts ?? FirstRunInterruptRelinquish.Process;
 
     /// <summary>
     /// The backstop, not the way out. Nothing like the flow's own 12-hour TTL, which is sized for a
@@ -118,18 +124,21 @@ public sealed class BrowserFirstRunFlow(
         progress.Opening(setupUrl);
         launcher.TryOpen(setupUrl);
 
-        // Armed for the leg's whole duration, because an interrupt runs no finally: Ctrl+C, SIGTERM and
-        // SIGHUP all reach Environment.Exit from a handler, and this is the only thing between that and a
-        // browser left offering decisions nobody will act on.
-        using var armed = FirstRunInterruptRelinquish.Arm(
-            token => RelinquishAsync(serverUrl, flowId, FirstRunRelinquishReasons.Stopped, token));
-
         FirstRunFlowResult result;
 
-        try {
-            result = await PollAsync(serverUrl, flowId, report, ct);
-        } finally {
-            progress.WaitEnded();
+        // Scoped to the POLL, and that is load-bearing rather than tidiness. An interrupt runs no finally
+        // — Ctrl+C, SIGTERM, SIGHUP and the parent watchdog all reach Environment.Exit from a handler — so
+        // something has to be armed while the leg waits. But this callback can only ever say `stopped`, so
+        // leaving it armed past the poll would let it race the reason the result actually names: a
+        // dismissed leg would gamble `handover` against `stopped`, and a FINISHED one — which must never
+        // relinquish — could do so at all.
+        using (_interrupts.Arm(
+                   token => RelinquishAsync(serverUrl, flowId, FirstRunRelinquishReasons.Stopped, token))) {
+            try {
+                result = await PollAsync(serverUrl, flowId, report, ct);
+            } finally {
+                progress.WaitEnded();
+            }
         }
 
         // ONE call, keyed off the result type, so the closed tab and the failed leg are covered without a

--- a/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
@@ -124,15 +124,13 @@ public sealed class BrowserFirstRunFlow(
         progress.Opening(setupUrl);
         launcher.TryOpen(setupUrl);
 
-        // ONE write decides the reason, and it is the poll's own assignment — so an interrupt either sees
-        // a leg still waiting (the machine is dying: `stopped`) or the reason its result names, never a
-        // half-decided state. Computing the reason into a second variable would reopen exactly that gap.
+        // The poll's own assignment is the single write that publishes the result, so an interrupt sees
+        // either a leg still waiting or a settled one, never a half-decided state.
         FirstRunFlowResult? settled = null;
 
-        using var notice = _interrupts.Arm(token =>
-            ReasonToSend(Volatile.Read(ref settled)) is { } reason
-                ? RelinquishAsync(serverUrl, flowId, reason, token)
-                : Task.CompletedTask);
+        using var notice = _interrupts.Arm(
+            (reason, token) => RelinquishAsync(serverUrl, flowId, reason, token),
+            interruptReason: () => InterruptReason(Volatile.Read(ref settled)));
 
         try {
             Volatile.Write(ref settled, await PollAsync(serverUrl, flowId, report, ct));
@@ -140,19 +138,15 @@ public sealed class BrowserFirstRunFlow(
             progress.WaitEnded();
         }
 
-        // The same notice the interrupt handler would have sent, claimed once: whichever path gets there
-        // first is the only one that sends, so the browser cannot be told two opposite things.
-        await notice.SendAsync(ct);
+        // Claimed once, so whichever path gets there first is the only one that sends and the browser
+        // cannot be told two opposite things.
+        await notice.SendAsync(ReasonFor(settled!), ct);
 
         return settled!;
     }
 
     /// <summary>
-    /// What to tell the browser, or null when there is nothing to tell it.
-    ///
-    /// <para><b>A leg still waiting reads as <c>stopped</c></b>, because the only way to observe that is
-    /// from an interrupt handler: the process is being killed, so nothing is carrying on whatever the
-    /// screen currently offers.</para>
+    /// What the LEG tells the browser about its own ending, or null when there is nothing to tell it.
     ///
     /// <para><b>A dismissal is a handover and nothing else is.</b> It is the one exit where the terminal
     /// carries on with everything the browser settled, so it is the one where the page must not send anyone
@@ -163,12 +157,25 @@ public sealed class BrowserFirstRunFlow(
     /// own terms and the browser is rendering the payoff. Expired needs nothing either — the server already
     /// refuses a flow past its lifetime, and the page says so.</para>
     /// </summary>
-    static string? ReasonToSend(FirstRunFlowResult? settled) => settled switch {
-        null                                                     => FirstRunRelinquishReasons.Stopped,
-        FirstRunFlowResult.Dismissed                             => FirstRunRelinquishReasons.Handover,
-        FirstRunFlowResult.Abandoned or FirstRunFlowResult.Failed => FirstRunRelinquishReasons.Stopped,
-        _                                                        => null
+    static string? ReasonFor(FirstRunFlowResult settled) => settled switch {
+        FirstRunFlowResult.Dismissed                              => FirstRunRelinquishReasons.Handover,
+        FirstRunFlowResult.Abandoned or FirstRunFlowResult.Failed  => FirstRunRelinquishReasons.Stopped,
+        _                                                         => null
     };
+
+    /// <summary>
+    /// What an INTERRUPT tells the browser, given whatever the leg has published so far.
+    ///
+    /// <para><b>Never the leg's own reason.</b> An interrupt is the process being killed, so nothing is
+    /// carrying on however the poll ended — borrowing <see cref="ReasonFor"/> here would tell someone who
+    /// had chosen their terminal that it had taken over, as it died, leaving the one tail that states no
+    /// remedy at all.</para>
+    ///
+    /// <para><b>The published result decides only WHETHER there is anything to say.</b> A leg that would
+    /// send nothing stays silent under an interrupt too, so a flow that reached its payoff keeps it.</para>
+    /// </summary>
+    static string? InterruptReason(FirstRunFlowResult? settled) =>
+        settled is null || ReasonFor(settled) is not null ? FirstRunRelinquishReasons.Stopped : null;
 
     /// <summary>Says the machine has gone. Swallows everything: this runs as the leg ends, and a setup that
     /// otherwise worked must not report a failure because one best-effort POST did not land.</summary>

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowClient.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowClient.cs
@@ -29,8 +29,8 @@ public sealed record FirstRunImportReportOutcome(int StatusCode) {
 }
 
 /// <summary>One attempt at saying this machine has gone. Never retried: it is sent as the leg ends, so
-/// there is no later tick, and what a failure costs is the browser falling back to the behaviour it had
-/// before the route existed.</summary>
+/// there is no later tick, and what a failure costs is a browser left waiting until the flow's own
+/// lifetime ends it.</summary>
 public sealed record FirstRunRelinquishOutcome(int StatusCode) {
     public bool Recorded => StatusCode is >= 200 and < 300;
 }

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowClient.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowClient.cs
@@ -28,6 +28,13 @@ public sealed record FirstRunImportReportOutcome(int StatusCode) {
     public bool Recorded => StatusCode is >= 200 and < 300;
 }
 
+/// <summary>One attempt at saying this machine has gone. Never retried: it is sent as the leg ends, so
+/// there is no later tick, and what a failure costs is the browser falling back to the behaviour it had
+/// before the route existed.</summary>
+public sealed record FirstRunRelinquishOutcome(int StatusCode) {
+    public bool Recorded => StatusCode is >= 200 and < 300;
+}
+
 /// <summary>The flow routes, as a seam: the loop, the backoff and the guards around them are the
 /// part worth testing, and they should not need a socket to exercise.</summary>
 public interface IFirstRunFlowChannel {
@@ -53,6 +60,11 @@ public interface IFirstRunFlowChannel {
     /// the run is over, so a refusal and an empty choice are both reported rather than left silent.</summary>
     Task<FirstRunImportReportOutcome> ReportImportOutcomeAsync(
         string serverUrl, string flowId, ReportFirstRunImportOutcomeRequest report, CancellationToken ct);
+
+    /// <summary>Says this machine has stopped listening, so the browser stops offering decisions nothing
+    /// will act on. Best effort by design: it is the last thing the leg does.</summary>
+    Task<FirstRunRelinquishOutcome> RelinquishAsync(
+        string serverUrl, string flowId, string reason, CancellationToken ct);
 }
 
 /// <summary>
@@ -164,6 +176,28 @@ public sealed class FirstRunFlowClient(HttpClient http) : IFirstRunFlowChannel {
             using var req = new HttpRequestMessage(
                     HttpMethod.Post,
                     $"{Base(serverUrl)}/api/first-run/flows/{Uri.EscapeDataString(flowId)}/import-outcome") {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json")
+            };
+
+            using var resp = await http.SendAsync(req, ct);
+
+            return new((int)resp.StatusCode);
+        } catch (Exception e) when (IsTransient(e, ct)) {
+            return new(0);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<FirstRunRelinquishOutcome> RelinquishAsync(
+            string serverUrl, string flowId, string reason, CancellationToken ct) {
+        var payload = JsonSerializer.Serialize(
+            new RelinquishFirstRunFlowRequest { Reason = reason },
+            CapacitorJsonContext.Default.RelinquishFirstRunFlowRequest);
+
+        try {
+            using var req = new HttpRequestMessage(
+                    HttpMethod.Post,
+                    $"{Base(serverUrl)}/api/first-run/flows/{Uri.EscapeDataString(flowId)}/relinquish") {
                 Content = new StringContent(payload, Encoding.UTF8, "application/json")
             };
 

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowModels.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowModels.cs
@@ -119,6 +119,19 @@ public sealed record ReportFirstRunImportOutcomeRequest {
     [JsonPropertyName("reason")] public string? Reason { get; init; }
 }
 
+/// <summary>
+/// POST /api/first-run/flows/{id}/relinquish — this machine has stopped listening.
+///
+/// <para>One token and nothing else. What the browser does with it is take affordances away, so there is
+/// nothing for a detail field to improve: a page that cannot be written to has no use for an error
+/// string, and the terminal is where anything worth reading is already being printed.</para>
+/// </summary>
+public sealed record RelinquishFirstRunFlowRequest {
+    /// <summary>A <see cref="FirstRunRelinquishReasons"/> token. Required by the route — the two members
+    /// give opposite instructions, so there is no safe default for the server to pick.</summary>
+    [JsonPropertyName("reason")] public required string Reason { get; init; }
+}
+
 /// <summary>One repository discovery found, as the report carries it.</summary>
 /// <remarks><c>sessions</c> is keyed by window rather than positional: an array aligned by index goes
 /// wrong silently. An absent key reads as "not counted", never as zero.</remarks>

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunInterruptRelinquish.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunInterruptRelinquish.cs
@@ -1,0 +1,50 @@
+namespace Capacitor.Cli.Core.FirstRun;
+
+/// <summary>
+/// The one exit the browser leg cannot see: an interrupt handler calling <c>Environment.Exit</c>, which
+/// runs no <c>finally</c> anywhere. This lets the handler spend a moment saying the machine has gone
+/// before the process does.
+///
+/// <para><b>A static because the handlers are installed process-wide and take no arguments.</b> There is
+/// nothing command-scoped for them to reach through, so the leg leaves a callback here for its own
+/// duration and takes it back. A test touching this needs bare <c>[NotInParallel]</c> — it is
+/// process-global state.</para>
+///
+/// <para><b>Best effort, and bounded.</b> It usually lands. A SIGKILL, a lost network or a machine going
+/// to sleep sends nothing, and the browser then falls back to what it did before this existed: a screen
+/// that keeps waiting, bounded by the flow's own lifetime.</para>
+/// </summary>
+public static class FirstRunInterruptRelinquish {
+    static Func<CancellationToken, Task>? _pending;
+
+    /// <summary>Registers what to send if the process is interrupted. Dispose to take it back — a leg that
+    /// ended normally has already said its piece.</summary>
+    public static IDisposable Arm(Func<CancellationToken, Task> relinquish) {
+        Volatile.Write(ref _pending, relinquish);
+
+        return new Disarm(relinquish);
+    }
+
+    /// <summary>
+    /// Sends it, blocking for at most <paramref name="budget"/>. Called from a signal handler, so it
+    /// swallows everything: the next statement is an exit, and there is no state left for a failure to
+    /// change.
+    /// </summary>
+    public static void RunBeforeExit(TimeSpan budget) {
+        if (Volatile.Read(ref _pending) is not { } relinquish) return;
+
+        try {
+            using var cts = new CancellationTokenSource(budget);
+
+            relinquish(cts.Token).Wait(budget);
+        } catch {
+            // Best effort, by construction.
+        }
+    }
+
+    /// <summary>Compares before clearing, so a second leg's registration is not dropped by the first
+    /// leg's handle going out of scope.</summary>
+    sealed class Disarm(Func<CancellationToken, Task> armed) : IDisposable {
+        public void Dispose() => Interlocked.CompareExchange(ref _pending, null, armed);
+    }
+}

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunInterruptRelinquish.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunInterruptRelinquish.cs
@@ -1,24 +1,43 @@
 namespace Capacitor.Cli.Core.FirstRun;
 
 /// <summary>
+/// Where a leg leaves its "this machine has gone" callback for an interrupt handler to find.
+///
+/// <para><b>A seam because the real one is process-global.</b> Without it every ordinary run writes
+/// process state, which forces assembly-wide test exclusion on tests that have nothing to do with
+/// interrupts.</para>
+/// </summary>
+public interface IFirstRunInterrupts {
+    /// <summary>Registers what to send if the process is interrupted. Dispose to take it back.</summary>
+    IDisposable Arm(Func<CancellationToken, Task> relinquish);
+}
+
+/// <summary>
 /// The one exit the browser leg cannot see: an interrupt handler calling <c>Environment.Exit</c>, which
 /// runs no <c>finally</c> anywhere. This lets the handler spend a moment saying the machine has gone
 /// before the process does.
 ///
 /// <para><b>A static because the handlers are installed process-wide and take no arguments.</b> There is
 /// nothing command-scoped for them to reach through, so the leg leaves a callback here for its own
-/// duration and takes it back. A test touching this needs bare <c>[NotInParallel]</c> — it is
-/// process-global state.</para>
+/// duration and takes it back. A test touching THIS needs bare <c>[NotInParallel]</c>; a test of a leg
+/// passes its own <see cref="IFirstRunInterrupts"/> and needs none.</para>
 ///
 /// <para><b>Best effort, and bounded.</b> It usually lands. A SIGKILL, a lost network or a machine going
-/// to sleep sends nothing, and the browser then falls back to what it did before this existed: a screen
-/// that keeps waiting, bounded by the flow's own lifetime.</para>
+/// to sleep sends nothing, and the browser is then left waiting until the flow's own lifetime ends
+/// it.</para>
 /// </summary>
 public static class FirstRunInterruptRelinquish {
     static Func<CancellationToken, Task>? _pending;
 
-    /// <summary>Registers what to send if the process is interrupted. Dispose to take it back — a leg that
-    /// ended normally has already said its piece.</summary>
+    /// <summary>The process-global sink, which is what the CLI's signal handlers read.</summary>
+    public static IFirstRunInterrupts Process { get; } = new ProcessSink();
+
+    sealed class ProcessSink : IFirstRunInterrupts {
+        public IDisposable Arm(Func<CancellationToken, Task> relinquish) =>
+            FirstRunInterruptRelinquish.Arm(relinquish);
+    }
+
+    /// <inheritdoc cref="IFirstRunInterrupts.Arm"/>
     public static IDisposable Arm(Func<CancellationToken, Task> relinquish) {
         Volatile.Write(ref _pending, relinquish);
 

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunInterruptRelinquish.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunInterruptRelinquish.cs
@@ -1,69 +1,123 @@
 namespace Capacitor.Cli.Core.FirstRun;
 
 /// <summary>
-/// Where a leg leaves its "this machine has gone" callback for an interrupt handler to find.
+/// Where a leg leaves its "this machine has gone" notice for an interrupt handler to find.
 ///
 /// <para><b>A seam because the real one is process-global.</b> Without it every ordinary run writes
 /// process state, which forces assembly-wide test exclusion on tests that have nothing to do with
 /// interrupts.</para>
 /// </summary>
 public interface IFirstRunInterrupts {
-    /// <summary>Registers what to send if the process is interrupted. Dispose to take it back.</summary>
-    IDisposable Arm(Func<CancellationToken, Task> relinquish);
+    /// <summary>Registers the one notice this leg may send. Dispose to take it back.</summary>
+    IFirstRunNotice Arm(Func<CancellationToken, Task> send);
 }
 
 /// <summary>
-/// The one exit the browser leg cannot see: an interrupt handler calling <c>Environment.Exit</c>, which
-/// runs no <c>finally</c> anywhere. This lets the handler spend a moment saying the machine has gone
-/// before the process does.
+/// One send, claimed once, by whichever path gets there first.
 ///
-/// <para><b>A static because the handlers are installed process-wide and take no arguments.</b> There is
-/// nothing command-scoped for them to reach through, so the leg leaves a callback here for its own
-/// duration and takes it back. A test touching THIS needs bare <c>[NotInParallel]</c>; a test of a leg
-/// passes its own <see cref="IFirstRunInterrupts"/> and needs none.</para>
-///
-/// <para><b>Best effort, and bounded.</b> It usually lands. A SIGKILL, a lost network or a machine going
-/// to sleep sends nothing, and the browser is then left waiting until the flow's own lifetime ends
-/// it.</para>
+/// <para><b>Two paths race for it and they must not both win.</b> The leg sends the reason its result
+/// names; an interrupt handler sends whatever the reason is at that instant, because
+/// <c>Environment.Exit</c> runs no <c>finally</c> and there is nothing else between it and a browser left
+/// offering decisions nobody will act on. The two reasons give opposite remedies, so a second send is not
+/// a duplicate — it is a contradiction.</para>
 /// </summary>
-public static class FirstRunInterruptRelinquish {
-    static Func<CancellationToken, Task>? _pending;
+public interface IFirstRunNotice : IDisposable {
+    /// <summary>The leg's path: claims the send and performs it. A no-op when an interrupt already
+    /// claimed it — its reason is the one that stands, because the process is going away.</summary>
+    Task SendAsync(CancellationToken ct);
+}
 
-    /// <summary>The process-global sink, which is what the CLI's signal handlers read.</summary>
-    public static IFirstRunInterrupts Process { get; } = new ProcessSink();
+/// <summary>
+/// The single send, and the arbitration between the two paths that want to make it.
+///
+/// <para><b>Claim-then-send, never read-then-send.</b> Reading the callback and invoking it as separate
+/// steps leaves both paths able to proceed: the reader holds its reference while the other path disarms
+/// and sends its own reason, and the browser then shows whichever of two opposite remedies lands last.
+/// One <see cref="Interlocked"/> exchange decides it.</para>
+///
+/// <para><b>The loser waits rather than exiting through the winner.</b> An interrupt that lost the claim
+/// would otherwise call <c>Environment.Exit</c> mid-POST and lose the notice altogether.</para>
+/// </summary>
+public sealed class FirstRunNotice(
+        Func<CancellationToken, Task> send,
+        Action<FirstRunNotice>?       onDispose = null) : IFirstRunNotice {
+    readonly TaskCompletionSource _sent = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    sealed class ProcessSink : IFirstRunInterrupts {
-        public IDisposable Arm(Func<CancellationToken, Task> relinquish) =>
-            FirstRunInterruptRelinquish.Arm(relinquish);
-    }
+    int _claimed;
 
-    /// <inheritdoc cref="IFirstRunInterrupts.Arm"/>
-    public static IDisposable Arm(Func<CancellationToken, Task> relinquish) {
-        Volatile.Write(ref _pending, relinquish);
+    /// <inheritdoc/>
+    public async Task SendAsync(CancellationToken ct) {
+        if (!TryClaim()) return;
 
-        return new Disarm(relinquish);
+        await RunAsync(ct);
     }
 
     /// <summary>
-    /// Sends it, blocking for at most <paramref name="budget"/>. Called from a signal handler, so it
-    /// swallows everything: the next statement is an exit, and there is no state left for a failure to
-    /// change.
+    /// An interrupt handler's path, blocking for at most <paramref name="budget"/>. Swallows everything:
+    /// the next statement is an exit, and there is no state left for a failure to change.
     /// </summary>
-    public static void RunBeforeExit(TimeSpan budget) {
-        if (Volatile.Read(ref _pending) is not { } relinquish) return;
-
+    public void RunBeforeExit(TimeSpan budget) {
         try {
-            using var cts = new CancellationTokenSource(budget);
+            if (TryClaim()) {
+                using var cts = new CancellationTokenSource(budget);
 
-            relinquish(cts.Token).Wait(budget);
+                RunAsync(cts.Token).Wait(budget);
+            } else {
+                _sent.Task.Wait(budget);
+            }
         } catch {
             // Best effort, by construction.
         }
     }
 
-    /// <summary>Compares before clearing, so a second leg's registration is not dropped by the first
-    /// leg's handle going out of scope.</summary>
-    sealed class Disarm(Func<CancellationToken, Task> armed) : IDisposable {
-        public void Dispose() => Interlocked.CompareExchange(ref _pending, null, armed);
+    public void Dispose() {
+        onDispose?.Invoke(this);
+
+        // Releases an interrupt waiting on a send that is never coming.
+        _sent.TrySetResult();
+    }
+
+    bool TryClaim() => Interlocked.Exchange(ref _claimed, 1) == 0;
+
+    async Task RunAsync(CancellationToken ct) {
+        try {
+            await send(ct);
+        } finally {
+            _sent.TrySetResult();
+        }
+    }
+}
+
+/// <summary>
+/// The process-global sink the CLI's signal handlers read. Ctrl+C, SIGTERM, SIGHUP and the
+/// parent-liveness watchdog all reach <c>Environment.Exit</c>, which runs no <c>finally</c> anywhere, so
+/// the notice has to be reachable from a handler that takes no arguments.
+///
+/// <para><b>Best effort, and bounded.</b> It usually lands. A SIGKILL, a lost network or a machine going
+/// to sleep sends nothing, and the browser is then left waiting until the flow's own lifetime ends
+/// it.</para>
+///
+/// <para>A test touching THIS needs bare <c>[NotInParallel]</c>; a test of a leg passes its own
+/// <see cref="IFirstRunInterrupts"/> and needs none.</para>
+/// </summary>
+public static class FirstRunInterruptRelinquish {
+    static FirstRunNotice? _pending;
+
+    public static IFirstRunInterrupts Process { get; } = new ProcessSink();
+
+    /// <summary>Sends whatever is armed, or waits out a send already in flight.</summary>
+    public static void RunBeforeExit(TimeSpan budget) => Volatile.Read(ref _pending)?.RunBeforeExit(budget);
+
+    sealed class ProcessSink : IFirstRunInterrupts {
+        public IFirstRunNotice Arm(Func<CancellationToken, Task> send) {
+            // Compares before clearing, so a second leg's registration is not dropped by the first leg's
+            // handle going out of scope.
+            var notice = new FirstRunNotice(
+                send, onDispose: n => Interlocked.CompareExchange(ref _pending, null, n));
+
+            Volatile.Write(ref _pending, notice);
+
+            return notice;
+        }
     }
 }

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunInterruptRelinquish.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunInterruptRelinquish.cs
@@ -9,47 +9,51 @@ namespace Capacitor.Cli.Core.FirstRun;
 /// </summary>
 public interface IFirstRunInterrupts {
     /// <summary>Registers the one notice this leg may send. Dispose to take it back.</summary>
-    IFirstRunNotice Arm(Func<CancellationToken, Task> send);
+    /// <param name="send">Sends one reason. Called at most once, by whichever path claims it.</param>
+    /// <param name="interruptReason">What an INTERRUPT would say, evaluated at the moment it fires, or
+    /// null for nothing to say. Separate from the leg's own reason deliberately — see
+    /// <see cref="FirstRunNotice"/>.</param>
+    IFirstRunNotice Arm(Func<string, CancellationToken, Task> send, Func<string?> interruptReason);
 }
 
-/// <summary>
-/// One send, claimed once, by whichever path gets there first.
-///
-/// <para><b>Two paths race for it and they must not both win.</b> The leg sends the reason its result
-/// names; an interrupt handler sends whatever the reason is at that instant, because
-/// <c>Environment.Exit</c> runs no <c>finally</c> and there is nothing else between it and a browser left
-/// offering decisions nobody will act on. The two reasons give opposite remedies, so a second send is not
-/// a duplicate — it is a contradiction.</para>
-/// </summary>
+/// <summary>One send, claimed once, by whichever path gets there first.</summary>
 public interface IFirstRunNotice : IDisposable {
-    /// <summary>The leg's path: claims the send and performs it. A no-op when an interrupt already
-    /// claimed it — its reason is the one that stands, because the process is going away.</summary>
-    Task SendAsync(CancellationToken ct);
+    /// <summary>
+    /// The leg's path: claims the send and performs it. A null <paramref name="reason"/> claims without
+    /// sending, which is how a result that must not be relinquished also shuts the interrupt out. A no-op
+    /// when an interrupt already claimed it.
+    /// </summary>
+    Task SendAsync(string? reason, CancellationToken ct);
 }
 
 /// <summary>
 /// The single send, and the arbitration between the two paths that want to make it.
 ///
 /// <para><b>Claim-then-send, never read-then-send.</b> Reading the callback and invoking it as separate
-/// steps leaves both paths able to proceed: the reader holds its reference while the other path disarms
-/// and sends its own reason, and the browser then shows whichever of two opposite remedies lands last.
-/// One <see cref="Interlocked"/> exchange decides it.</para>
+/// steps leaves both paths able to proceed, and the browser then shows whichever of two opposite remedies
+/// landed last. One <see cref="Interlocked"/> exchange decides it.</para>
+///
+/// <para><b>Each claimant supplies its own reason, and neither may borrow the other's.</b> An interrupt
+/// means the process is being killed, so nothing is carrying on however the leg's own result turned out;
+/// an interrupt that sent the leg's reason could tell someone their terminal had taken over as that
+/// terminal died — the one tail that states no remedy at all.</para>
 ///
 /// <para><b>The loser waits rather than exiting through the winner.</b> An interrupt that lost the claim
 /// would otherwise call <c>Environment.Exit</c> mid-POST and lose the notice altogether.</para>
 /// </summary>
 public sealed class FirstRunNotice(
-        Func<CancellationToken, Task> send,
-        Action<FirstRunNotice>?       onDispose = null) : IFirstRunNotice {
+        Func<string, CancellationToken, Task> send,
+        Func<string?>                         interruptReason,
+        Action<FirstRunNotice>?               onDispose = null) : IFirstRunNotice {
     readonly TaskCompletionSource _sent = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     int _claimed;
 
     /// <inheritdoc/>
-    public async Task SendAsync(CancellationToken ct) {
+    public async Task SendAsync(string? reason, CancellationToken ct) {
         if (!TryClaim()) return;
 
-        await RunAsync(ct);
+        await RunAsync(reason, ct);
     }
 
     /// <summary>
@@ -61,7 +65,7 @@ public sealed class FirstRunNotice(
             if (TryClaim()) {
                 using var cts = new CancellationTokenSource(budget);
 
-                RunAsync(cts.Token).Wait(budget);
+                RunAsync(interruptReason(), cts.Token).Wait(budget);
             } else {
                 _sent.Task.Wait(budget);
             }
@@ -79,9 +83,9 @@ public sealed class FirstRunNotice(
 
     bool TryClaim() => Interlocked.Exchange(ref _claimed, 1) == 0;
 
-    async Task RunAsync(CancellationToken ct) {
+    async Task RunAsync(string? reason, CancellationToken ct) {
         try {
-            await send(ct);
+            if (reason is not null) await send(reason, ct);
         } finally {
             _sent.TrySetResult();
         }
@@ -109,11 +113,12 @@ public static class FirstRunInterruptRelinquish {
     public static void RunBeforeExit(TimeSpan budget) => Volatile.Read(ref _pending)?.RunBeforeExit(budget);
 
     sealed class ProcessSink : IFirstRunInterrupts {
-        public IFirstRunNotice Arm(Func<CancellationToken, Task> send) {
+        public IFirstRunNotice Arm(
+                Func<string, CancellationToken, Task> send, Func<string?> interruptReason) {
             // Compares before clearing, so a second leg's registration is not dropped by the first leg's
             // handle going out of scope.
             var notice = new FirstRunNotice(
-                send, onDispose: n => Interlocked.CompareExchange(ref _pending, null, n));
+                send, interruptReason, onDispose: n => Interlocked.CompareExchange(ref _pending, null, n));
 
             Volatile.Write(ref _pending, notice);
 

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunRelinquish.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunRelinquish.cs
@@ -1,0 +1,16 @@
+namespace Capacitor.Cli.Core.FirstRun;
+
+/// <summary>
+/// Why this machine has stopped listening, as the server's own vocabulary. The browser renders a
+/// different remedy per member and <b>the two are not interchangeable</b>: telling someone who chose to
+/// carry on here to run setup again would make them restart a run that is mid-flight.
+/// </summary>
+public static class FirstRunRelinquishReasons {
+    /// <summary>The user pressed a key to carry on in the terminal. Everything the browser settled comes
+    /// with us, so the page has nothing left to offer and nothing to warn about.</summary>
+    public const string Handover = "handover";
+
+    /// <summary>Anything else: the backstop elapsed, the leg failed, or the process was interrupted. The
+    /// remedy the browser states is <c>kcap setup</c> on this machine.</summary>
+    public const string Stopped = "stopped";
+}

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -976,6 +976,7 @@ public sealed record CurationApplyResponse {
 [JsonSerializable(typeof(FirstRun.FirstRunFlowResponse))]
 [JsonSerializable(typeof(FirstRun.ReportFirstRunMachineActionRequest))]
 [JsonSerializable(typeof(FirstRun.ReportFirstRunImportRequest))]
+[JsonSerializable(typeof(FirstRun.RelinquishFirstRunFlowRequest))]
 [JsonSerializable(typeof(FirstRun.ReportFirstRunImportOutcomeRequest))]
 [JsonSerializable(typeof(LaunchAgentCommand))]
 [JsonSerializable(typeof(ExplicitReviewerModelLaunch))]

--- a/src/Capacitor.Cli/InteractiveLifetime.cs
+++ b/src/Capacitor.Cli/InteractiveLifetime.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Capacitor.Cli.Core.FirstRun;
 
 namespace Capacitor.Cli;
 
@@ -33,6 +34,11 @@ static class InteractiveLifetime {
     // How often the parent-liveness watchdog polls. Short enough to reap a
     // stray promptly, long enough to be negligible overhead.
     static readonly TimeSpan ParentPollInterval = TimeSpan.FromSeconds(3);
+
+    // What an interrupt may spend telling a server the machine has gone. A whole second of an exit
+    // the user has already asked for is as much as this is worth: one small POST to a host we are
+    // mid-conversation with either lands well inside it or is not going to.
+    static readonly TimeSpan ExitNoticeBudget = TimeSpan.FromSeconds(1);
 
     // PosixSignalRegistration.Create returns an IDisposable that owns the
     // underlying handler slot; if it isn't rooted for the process lifetime the
@@ -70,7 +76,7 @@ static class InteractiveLifetime {
         try {
             Console.CancelKeyPress += static (_, e) => {
                 e.Cancel = true; // we own termination below
-                Environment.Exit(InterruptExitCode);
+                Interrupt();
             };
         } catch {
             // Some hosts don't support CancelKeyPress; the watchdog still covers us.
@@ -81,7 +87,7 @@ static class InteractiveLifetime {
         try {
             _sigterm = PosixSignalRegistration.Create(PosixSignal.SIGTERM, static ctx => {
                 ctx.Cancel = true;
-                Environment.Exit(InterruptExitCode);
+                Interrupt();
             });
         } catch {
             // best effort
@@ -90,7 +96,7 @@ static class InteractiveLifetime {
         try {
             _sighup = PosixSignalRegistration.Create(PosixSignal.SIGHUP, static ctx => {
                 ctx.Cancel = true;
-                Environment.Exit(InterruptExitCode);
+                Interrupt();
             });
         } catch {
             // best effort
@@ -108,6 +114,18 @@ static class InteractiveLifetime {
         }
     }
 
+    /// <summary>
+    /// The exit every interrupt path takes. <c>Environment.Exit</c> runs no <c>finally</c>, so anything a
+    /// command needs to say on its way out has to be said here — today that is the browser setup flow
+    /// telling the server this machine has stopped listening, which is what stops the page going on to
+    /// offer decisions nobody will act on.
+    /// </summary>
+    static void Interrupt() {
+        FirstRunInterruptRelinquish.RunBeforeExit(ExitNoticeBudget);
+
+        Environment.Exit(InterruptExitCode);
+    }
+
     static void StartParentWatchdog(int? parentPid) {
         // pid <= 1 means no real parent (init / detached) — nothing sane to
         // monitor, so skip rather than risk self-terminating immediately.
@@ -120,7 +138,7 @@ static class InteractiveLifetime {
                 Thread.Sleep(ParentPollInterval);
 
                 if (!ProcessHelpers.IsProcessAlive(ppid)) {
-                    Environment.Exit(InterruptExitCode);
+                    Interrupt();
                 }
             }
         }) {

--- a/src/Capacitor.Cli/InteractiveLifetime.cs
+++ b/src/Capacitor.Cli/InteractiveLifetime.cs
@@ -116,9 +116,9 @@ static class InteractiveLifetime {
 
     /// <summary>
     /// The exit every interrupt path takes. <c>Environment.Exit</c> runs no <c>finally</c>, so anything a
-    /// command needs to say on its way out has to be said here — today that is the browser setup flow
-    /// telling the server this machine has stopped listening, which is what stops the page going on to
-    /// offer decisions nobody will act on.
+    /// command needs to say on its way out has to be said here. The browser setup flow uses it to tell the
+    /// server this machine has stopped listening, which is what stops the page going on to offer decisions
+    /// nobody will act on.
     /// </summary>
     static void Interrupt() {
         FirstRunInterruptRelinquish.RunBeforeExit(ExitNoticeBudget);

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
@@ -155,11 +155,11 @@ public class BrowserFirstRunFlowTests {
 
         public int Arms { get; private set; }
 
-        public IFirstRunNotice Arm(Func<CancellationToken, Task> send) {
+        public IFirstRunNotice Arm(Func<string, CancellationToken, Task> send, Func<string?> interruptReason) {
             Arms++;
             _log.Add("arm");
 
-            var notice = new FirstRunNotice(send, onDispose: _ => _log.Add("disarm"));
+            var notice = new FirstRunNotice(send, interruptReason, onDispose: _ => _log.Add("disarm"));
 
             _interrupt = notice.RunBeforeExit;
 
@@ -188,8 +188,16 @@ public class BrowserFirstRunFlowTests {
 
         public List<(int Repos, int? Sessions)> Imports { get; } = [];
 
-        public void PollTick()  => Ticks++;
-        public void WaitEnded() => WaitEnds++;
+        /// <summary>Run when the wait ends, which is between the poll publishing its result and the leg
+        /// sending its own reason — the one window where an interrupt can claim with a result in view.</summary>
+        public Action? OnWaitEnded { get; set; }
+
+        public void PollTick() => Ticks++;
+
+        public void WaitEnded() {
+            WaitEnds++;
+            OnWaitEnded?.Invoke();
+        }
 
         public void PerformingAction(string capability) {
             log.Add("warn");
@@ -1746,14 +1754,48 @@ public class BrowserFirstRunFlowTests {
     public async Task An_interrupt_that_wins_the_claim_is_the_only_send() {
         var h = Build(new FakeKeys(canWatch: true, pressAfter: 2));
 
-        // On the last poll, before the leg has a result — so the interrupt sends `stopped` and the
-        // dismissal's own `handover` must not follow it.
+        // On a poll, before the leg has a result.
         h.Channel.OnPoll = () => h.Interrupts.Interrupt();
 
         var result = await Run(h);
 
         await Assert.That(result).IsTypeOf<FirstRunFlowResult.Dismissed>();
         await Assert.That(h.Channel.Relinquished).IsEquivalentTo([FirstRunRelinquishReasons.Stopped]);
+    }
+
+    /// <summary>
+    /// An interrupt winning the claim AFTER the leg published a dismissal must still say <c>stopped</c>.
+    /// Borrowing the leg's reason here tells someone their terminal took over at the moment that terminal
+    /// is killed — a dead end with no remedy stated, and the whole reason the two claimants carry their own
+    /// reasons rather than reading one shared field.
+    /// </summary>
+    [Test]
+    public async Task An_interrupt_after_a_dismissal_still_says_the_machine_stopped() {
+        var h = Build(new FakeKeys(canWatch: true, pressAfter: 2));
+
+        // Fires once the result is published and before the leg's own send — the window a shared reason
+        // leaves open.
+        h.Progress.OnWaitEnded = () => h.Interrupts.Interrupt();
+
+        var result = await Run(h);
+
+        await Assert.That(result).IsTypeOf<FirstRunFlowResult.Dismissed>();
+        await Assert.That(h.Channel.Relinquished).IsEquivalentTo([FirstRunRelinquishReasons.Stopped]);
+    }
+
+    /// <summary>And a flow that reached its payoff keeps it: the published result decides whether there is
+    /// anything to say at all, so a finished leg stays silent under an interrupt too.</summary>
+    [Test]
+    public async Task An_interrupt_after_a_finish_says_nothing() {
+        var h = Build();
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        h.Progress.OnWaitEnded = () => h.Interrupts.Interrupt();
+
+        var result = await Run(h);
+
+        await Assert.That(result).IsTypeOf<FirstRunFlowResult.Finished>();
+        await Assert.That(h.Channel.Relinquished).IsEmpty();
     }
 
     /// <summary>A leg that never reached a flow arms nothing: there is no id to name.</summary>

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
@@ -52,8 +52,12 @@ public class BrowserFirstRunFlowTests {
                 : outcome);
         }
 
+        /// <summary>Run on each poll, to model something happening to this process mid-wait.</summary>
+        public Action? OnPoll { get; set; }
+
         public Task<FirstRunPollOutcome> PollAsync(string serverUrl, string flowId, CancellationToken ct) {
             PollCount++;
+            OnPoll?.Invoke();
             log.Add("poll");
             if (clock is not null) PollTimes.Add(clock.GetUtcNow());
 
@@ -106,6 +110,26 @@ public class BrowserFirstRunFlowTests {
 
             return Task.FromResult(new FirstRunImportReportOutcome(
                 OutcomeStatuses.Count > 0 ? OutcomeStatuses.Dequeue() : 200));
+        }
+
+        public List<string> Relinquished { get; } = [];
+
+        /// <summary>Status per relinquish in turn; the last repeats. A non-2xx is how "the leg finishes
+        /// anyway" is driven.</summary>
+        public Queue<int> RelinquishStatuses { get; } = new();
+
+        /// <summary>Thrown on the next relinquish, to prove an unexpected fault does not escape the leg.</summary>
+        public Exception? RelinquishThrows { get; set; }
+
+        public Task<FirstRunRelinquishOutcome> RelinquishAsync(
+                string serverUrl, string flowId, string reason, CancellationToken ct) {
+            log.Add("relinquish");
+            Relinquished.Add(reason);
+
+            if (RelinquishThrows is { } boom) throw boom;
+
+            return Task.FromResult(new FirstRunRelinquishOutcome(
+                RelinquishStatuses.Count > 0 ? RelinquishStatuses.Dequeue() : 200));
         }
     }
 
@@ -1520,5 +1544,140 @@ public class BrowserFirstRunFlowTests {
         var result = await Run(h);
 
         await Assert.That(result).IsTypeOf<FirstRunFlowResult.Finished>();
+    }
+
+    // ---- saying the machine has gone ----
+
+    [Test]
+    public async Task A_finished_leg_relinquishes_nothing() {
+        // The load-bearing guard: the flow is over on its own terms and the browser is rendering the
+        // payoff, so telling it the machine has gone would replace that with a dead end.
+        var h = Build();
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        await Run(h);
+
+        await Assert.That(h.Channel.Relinquished).IsEmpty();
+    }
+
+    [Test]
+    public async Task An_expired_leg_relinquishes_nothing() {
+        // Already terminal server-side, and the store refuses every write past the lifetime — so the
+        // POST would be refused and the page already says the right thing.
+        var h = Build();
+        h.Channel.Polls.Enqueue(new(410, null));
+
+        await Run(h);
+
+        await Assert.That(h.Channel.Relinquished).IsEmpty();
+    }
+
+    /// <summary>The one exit where the terminal carries on, so the one where the page must not send
+    /// anybody back to <c>kcap setup</c>: the run they would restart is in flight.</summary>
+    [Test]
+    public async Task A_dismissed_leg_says_the_terminal_is_taking_over() {
+        var h = Build(new FakeKeys(canWatch: true, pressAfter: 2));
+
+        var result = await Run(h);
+
+        await Assert.That(result).IsTypeOf<FirstRunFlowResult.Dismissed>();
+        await Assert.That(h.Channel.Relinquished.Single()).IsEqualTo(FirstRunRelinquishReasons.Handover);
+    }
+
+    [Test]
+    public async Task An_abandoned_leg_says_nothing_is_left_running() {
+        var h = Build();
+
+        var result = await Run(h);
+
+        await Assert.That(result).IsTypeOf<FirstRunFlowResult.Abandoned>();
+        await Assert.That(h.Channel.Relinquished.Single()).IsEqualTo(FirstRunRelinquishReasons.Stopped);
+    }
+
+    [Test]
+    public async Task A_failed_leg_says_nothing_is_left_running() {
+        var h = Build();
+        h.Channel.Polls.Enqueue(new(200, Running()));
+        h.Channel.Polls.Enqueue(new(401, null));
+
+        var result = await Run(h);
+
+        await Assert.That(result).IsTypeOf<FirstRunFlowResult.Failed>();
+        await Assert.That(h.Channel.Relinquished.Single()).IsEqualTo(FirstRunRelinquishReasons.Stopped);
+    }
+
+    /// <summary>A leg that never reached a flow has nothing to relinquish, and no id to name.</summary>
+    [Test]
+    public async Task A_tenant_that_does_not_serve_the_flow_is_told_nothing() {
+        var h = Build();
+        h.Channel.Creates.Enqueue(new(404, null));
+
+        var result = await Run(h);
+
+        await Assert.That(result).IsTypeOf<FirstRunFlowResult.Unavailable>();
+        await Assert.That(h.Channel.Relinquished).IsEmpty();
+    }
+
+    /// <summary>It is the last thing the leg does, so a failure has nowhere to go: what it costs is the
+    /// browser falling back to the behaviour it had before the route existed.</summary>
+    [Test]
+    public async Task A_relinquish_the_server_refuses_does_not_change_how_the_leg_ended() {
+        var h = Build();
+        h.Channel.RelinquishStatuses.Enqueue(500);
+        h.Channel.Polls.Enqueue(new(200, Running()));
+        h.Channel.Polls.Enqueue(new(404, null));
+
+        var result = await Run(h);
+
+        await Assert.That(result).IsTypeOf<FirstRunFlowResult.Failed>();
+    }
+
+    [Test]
+    public async Task A_relinquish_that_throws_does_not_escape_the_leg() {
+        var h = Build();
+        h.Channel.RelinquishThrows = new InvalidOperationException("boom");
+
+        var result = await Run(h);
+
+        await Assert.That(result).IsTypeOf<FirstRunFlowResult.Abandoned>();
+    }
+
+    // ---- the interrupt path ----
+
+    /// <summary>
+    /// Ctrl+C reaches <c>Environment.Exit</c> from a signal handler, which runs no <c>finally</c> — so the
+    /// leg leaves a callback where the handler can find it, and takes it back when it ends.
+    /// </summary>
+    // Process-global state, so exclusive against the whole assembly rather than keyed: a concurrent test
+    // arming this would be indistinguishable from this one's own registration.
+    [Test]
+    [NotInParallel]
+    public async Task An_interrupt_during_the_leg_says_the_machine_stopped() {
+        var h = Build();
+
+        // Fired from inside a poll, which is the only way to observe the armed callback: the real trigger
+        // is a signal, and there is none to send a test host.
+        h.Channel.OnPoll = () => FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromSeconds(1));
+        h.Channel.Polls.Enqueue(new(200, Running()));
+        h.Channel.Polls.Enqueue(new(404, null));
+
+        await Run(h);
+
+        await Assert.That(h.Channel.Relinquished[0]).IsEqualTo(FirstRunRelinquishReasons.Stopped);
+    }
+
+    /// <summary>And it is taken back afterwards, or a later interrupt would POST against a leg that has
+    /// already ended — on a handover, restating a reason the browser has rendered.</summary>
+    [Test]
+    [NotInParallel]
+    public async Task Nothing_is_left_armed_once_the_leg_has_ended() {
+        var h = Build();
+        h.Channel.Polls.Enqueue(new(200, Done()));
+
+        await Run(h);
+
+        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromMilliseconds(50));
+
+        await Assert.That(h.Channel.Relinquished).IsEmpty();
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
@@ -133,6 +133,36 @@ public class BrowserFirstRunFlowTests {
         }
     }
 
+    /// <summary>Holds the leg's interrupt callback where a test can fire it, instead of the process-global
+    /// sink — which is what keeps this class out of assembly-wide exclusion.</summary>
+    sealed class FakeInterrupts : IFirstRunInterrupts {
+        Func<CancellationToken, Task>? _armed;
+
+        public int Arms    { get; private set; }
+        public int Disarms { get; private set; }
+
+        /// <summary>Whether something is armed right now. The whole point of the seam is that this is
+        /// false the moment the leg has a result.</summary>
+        public bool IsArmed => _armed is not null;
+
+        public IDisposable Arm(Func<CancellationToken, Task> relinquish) {
+            Arms++;
+            _armed = relinquish;
+
+            return new Handle(this);
+        }
+
+        /// <summary>Fires whatever is armed, as a signal handler would. A no-op when nothing is.</summary>
+        public Task FireAsync() => _armed?.Invoke(CancellationToken.None) ?? Task.CompletedTask;
+
+        sealed class Handle(FakeInterrupts owner) : IDisposable {
+            public void Dispose() {
+                owner.Disarms++;
+                owner._armed = null;
+            }
+        }
+    }
+
     sealed class RecordingProgress(Log log) : IFirstRunFlowProgress {
         public string? Url { get; private set; }
         public int Ticks    { get; private set; }
@@ -321,7 +351,8 @@ public class BrowserFirstRunFlowTests {
         List<string>        Opened,
         FakeKeys            Keys,
         FakeActions?        Actions,
-        FakeImportLane?     Importing);
+        FakeImportLane?     Importing,
+        FakeInterrupts      Interrupts);
 
     // No keyboard by default: the escape hatch is one test's subject, and left live it would read the
     // host's own console, where a stray keypress during a CI run would end an unrelated test's wait.
@@ -335,12 +366,13 @@ public class BrowserFirstRunFlowTests {
         var browser  = new RecordingBrowser();
         var actions  = capabilities is null ? null : new FakeActions(log, capabilities);
         var lane     = importing ? new FakeImportLane(log) : null;
+        var signals  = new FakeInterrupts();
 
         keys ??= new FakeKeys(canWatch: false);
 
         return new(
-            new BrowserFirstRunFlow(channel, progress, browser, clock, keys, actions, lane),
-            channel, progress, clock, log, browser.Urls, keys, actions, lane);
+            new BrowserFirstRunFlow(channel, progress, browser, clock, keys, actions, lane, signals),
+            channel, progress, clock, log, browser.Urls, keys, actions, lane, signals);
     }
 
     static readonly string[] PathShimOnly = [FirstRunMachineCapabilities.PathShim];
@@ -1646,18 +1678,14 @@ public class BrowserFirstRunFlowTests {
 
     /// <summary>
     /// Ctrl+C reaches <c>Environment.Exit</c> from a signal handler, which runs no <c>finally</c> — so the
-    /// leg leaves a callback where the handler can find it, and takes it back when it ends.
+    /// leg leaves a callback where the handler can find it.
     /// </summary>
-    // Process-global state, so exclusive against the whole assembly rather than keyed: a concurrent test
-    // arming this would be indistinguishable from this one's own registration.
     [Test]
-    [NotInParallel]
     public async Task An_interrupt_during_the_leg_says_the_machine_stopped() {
         var h = Build();
 
-        // Fired from inside a poll, which is the only way to observe the armed callback: the real trigger
-        // is a signal, and there is none to send a test host.
-        h.Channel.OnPoll = () => FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromSeconds(1));
+        // Fired from inside a poll, because that is when a real signal would arrive.
+        h.Channel.OnPoll = () => h.Interrupts.FireAsync().GetAwaiter().GetResult();
         h.Channel.Polls.Enqueue(new(200, Running()));
         h.Channel.Polls.Enqueue(new(404, null));
 
@@ -1666,18 +1694,41 @@ public class BrowserFirstRunFlowTests {
         await Assert.That(h.Channel.Relinquished[0]).IsEqualTo(FirstRunRelinquishReasons.Stopped);
     }
 
-    /// <summary>And it is taken back afterwards, or a later interrupt would POST against a leg that has
-    /// already ended — on a handover, restating a reason the browser has rendered.</summary>
+    /// <summary>
+    /// Disarmed the moment the leg has a result, and this is the guard that matters: the callback can only
+    /// ever say <c>stopped</c>, so left armed it would race the reason the result names — gambling
+    /// <c>handover</c> against <c>stopped</c> on a dismissal, and relinquishing at all on a finish.
+    /// </summary>
     [Test]
-    [NotInParallel]
-    public async Task Nothing_is_left_armed_once_the_leg_has_ended() {
-        var h = Build();
-        h.Channel.Polls.Enqueue(new(200, Done()));
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task Nothing_is_left_armed_once_the_leg_has_a_result(bool dismissed) {
+        var h = Build(dismissed ? new FakeKeys(canWatch: true, pressAfter: 2) : null);
+
+        if (!dismissed) h.Channel.Polls.Enqueue(new(200, Done()));
 
         await Run(h);
 
-        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromMilliseconds(50));
+        await Assert.That(h.Interrupts.IsArmed).IsFalse();
+        await Assert.That(h.Interrupts.Arms).IsEqualTo(1);
+        await Assert.That(h.Interrupts.Disarms).IsEqualTo(1);
 
-        await Assert.That(h.Channel.Relinquished).IsEmpty();
+        // Firing now sends nothing, so the reason on the wire is only ever the one the result named.
+        await h.Interrupts.FireAsync();
+
+        string[] expected = dismissed ? [FirstRunRelinquishReasons.Handover] : [];
+
+        await Assert.That(h.Channel.Relinquished).IsEquivalentTo(expected);
+    }
+
+    /// <summary>A leg that never reached a flow arms nothing: there is no id to name.</summary>
+    [Test]
+    public async Task A_leg_that_never_reached_a_flow_arms_nothing() {
+        var h = Build();
+        h.Channel.Creates.Enqueue(new(404, null));
+
+        await Run(h);
+
+        await Assert.That(h.Interrupts.Arms).IsEqualTo(0);
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
@@ -18,6 +18,11 @@ public class BrowserFirstRunFlowTests {
         public IReadOnlyList<string> Entries => _entries;
 
         public void Add(string entry) => _entries.Add(entry);
+
+        /// <summary>Whether <paramref name="first"/> was logged before <paramref name="second"/>. -1 for an
+        /// absent entry makes a missing one read as "before", so callers assert its presence too.</summary>
+        public bool Precedes(string first, string second) =>
+            _entries.IndexOf(first) < _entries.IndexOf(second);
     }
 
     sealed class FakeChannel(Log log, FakeTimeProvider? clock = null) : IFirstRunFlowChannel {
@@ -121,10 +126,14 @@ public class BrowserFirstRunFlowTests {
         /// <summary>Thrown on the next relinquish, to prove an unexpected fault does not escape the leg.</summary>
         public Exception? RelinquishThrows { get; set; }
 
+        /// <summary>Run on each relinquish, to model something happening at that exact moment.</summary>
+        public Action? OnRelinquish { get; set; }
+
         public Task<FirstRunRelinquishOutcome> RelinquishAsync(
                 string serverUrl, string flowId, string reason, CancellationToken ct) {
             log.Add("relinquish");
             Relinquished.Add(reason);
+            OnRelinquish?.Invoke();
 
             if (RelinquishThrows is { } boom) throw boom;
 
@@ -135,19 +144,18 @@ public class BrowserFirstRunFlowTests {
 
     /// <summary>Holds the leg's interrupt callback where a test can fire it, instead of the process-global
     /// sink — which is what keeps this class out of assembly-wide exclusion.</summary>
-    sealed class FakeInterrupts : IFirstRunInterrupts {
+    sealed class FakeInterrupts(Log log) : IFirstRunInterrupts {
+        readonly Log _log = log;
+
         Func<CancellationToken, Task>? _armed;
 
         public int Arms    { get; private set; }
         public int Disarms { get; private set; }
 
-        /// <summary>Whether something is armed right now. The whole point of the seam is that this is
-        /// false the moment the leg has a result.</summary>
-        public bool IsArmed => _armed is not null;
-
         public IDisposable Arm(Func<CancellationToken, Task> relinquish) {
             Arms++;
             _armed = relinquish;
+            _log.Add("arm");
 
             return new Handle(this);
         }
@@ -159,6 +167,7 @@ public class BrowserFirstRunFlowTests {
             public void Dispose() {
                 owner.Disarms++;
                 owner._armed = null;
+                owner._log.Add("disarm");
             }
         }
     }
@@ -366,7 +375,7 @@ public class BrowserFirstRunFlowTests {
         var browser  = new RecordingBrowser();
         var actions  = capabilities is null ? null : new FakeActions(log, capabilities);
         var lane     = importing ? new FakeImportLane(log) : null;
-        var signals  = new FakeInterrupts();
+        var signals  = new FakeInterrupts(log);
 
         keys ??= new FakeKeys(canWatch: false);
 
@@ -1695,27 +1704,44 @@ public class BrowserFirstRunFlowTests {
     }
 
     /// <summary>
-    /// Disarmed the moment the leg has a result, and this is the guard that matters: the callback can only
-    /// ever say <c>stopped</c>, so left armed it would race the reason the result names — gambling
+    /// Disarmed before anything the result decides, and this is the guard that matters: the callback can
+    /// only ever say <c>stopped</c>, so left armed it would race the reason the result names — gambling
     /// <c>handover</c> against <c>stopped</c> on a dismissal, and relinquishing at all on a finish.
+    ///
+    /// <para><b>Asserted as ORDERING, because nothing observable after the leg can tell the two shapes
+    /// apart:</b> an arm scoped to the whole method has also been disposed by then, so a test that only
+    /// looked afterwards would pass either way and prove nothing.</para>
     /// </summary>
     [Test]
     [Arguments(true)]
     [Arguments(false)]
-    public async Task Nothing_is_left_armed_once_the_leg_has_a_result(bool dismissed) {
+    public async Task The_arm_is_gone_before_the_result_is_acted_on(bool dismissed) {
         var h = Build(dismissed ? new FakeKeys(canWatch: true, pressAfter: 2) : null);
+
+        // Fires whatever is still armed at the moment the result's own reason is being sent. Left armed,
+        // that is a second POST saying the opposite thing.
+        //
+        // ONCE, or the second POST re-enters this hook and recurses until the stack goes — which aborts the
+        // run instead of failing an assertion, and an unreadable red is nearly as bad as a green.
+        var fired = false;
+
+        h.Channel.OnRelinquish = () => {
+            if (fired) return;
+
+            fired = true;
+
+            h.Interrupts.FireAsync().GetAwaiter().GetResult();
+        };
 
         if (!dismissed) h.Channel.Polls.Enqueue(new(200, Done()));
 
         await Run(h);
 
-        await Assert.That(h.Interrupts.IsArmed).IsFalse();
         await Assert.That(h.Interrupts.Arms).IsEqualTo(1);
         await Assert.That(h.Interrupts.Disarms).IsEqualTo(1);
+        await Assert.That(h.Log.Precedes("arm", "disarm")).IsTrue();
 
-        // Firing now sends nothing, so the reason on the wire is only ever the one the result named.
-        await h.Interrupts.FireAsync();
-
+        // Exactly the reason the result named, and nothing behind it.
         string[] expected = dismissed ? [FirstRunRelinquishReasons.Handover] : [];
 
         await Assert.That(h.Channel.Relinquished).IsEquivalentTo(expected);

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
@@ -142,34 +142,33 @@ public class BrowserFirstRunFlowTests {
         }
     }
 
-    /// <summary>Holds the leg's interrupt callback where a test can fire it, instead of the process-global
-    /// sink — which is what keeps this class out of assembly-wide exclusion.</summary>
+    /// <summary>
+    /// Stands in for the process-global sink, which is what keeps this class out of assembly-wide
+    /// exclusion. It hands out the REAL <see cref="FirstRunNotice"/>, so the claim arbitration under test
+    /// is the production one rather than a second implementation of it.
+    /// </summary>
     sealed class FakeInterrupts(Log log) : IFirstRunInterrupts {
         readonly Log _log = log;
 
-        Func<CancellationToken, Task>? _armed;
+        // The notice itself is the LEG's to dispose, so only its interrupt entry point is held here.
+        Action<TimeSpan>? _interrupt;
 
-        public int Arms    { get; private set; }
-        public int Disarms { get; private set; }
+        public int Arms { get; private set; }
 
-        public IDisposable Arm(Func<CancellationToken, Task> relinquish) {
+        public IFirstRunNotice Arm(Func<CancellationToken, Task> send) {
             Arms++;
-            _armed = relinquish;
             _log.Add("arm");
 
-            return new Handle(this);
+            var notice = new FirstRunNotice(send, onDispose: _ => _log.Add("disarm"));
+
+            _interrupt = notice.RunBeforeExit;
+
+            return notice;
         }
 
-        /// <summary>Fires whatever is armed, as a signal handler would. A no-op when nothing is.</summary>
-        public Task FireAsync() => _armed?.Invoke(CancellationToken.None) ?? Task.CompletedTask;
-
-        sealed class Handle(FakeInterrupts owner) : IDisposable {
-            public void Dispose() {
-                owner.Disarms++;
-                owner._armed = null;
-                owner._log.Add("disarm");
-            }
-        }
+        /// <summary>Fires the interrupt path, as a signal handler would.</summary>
+        public void Interrupt(TimeSpan? budget = null) =>
+            _interrupt?.Invoke(budget ?? TimeSpan.FromSeconds(5));
     }
 
     sealed class RecordingProgress(Log log) : IFirstRunFlowProgress {
@@ -1659,8 +1658,8 @@ public class BrowserFirstRunFlowTests {
         await Assert.That(h.Channel.Relinquished).IsEmpty();
     }
 
-    /// <summary>It is the last thing the leg does, so a failure has nowhere to go: what it costs is the
-    /// browser falling back to the behaviour it had before the route existed.</summary>
+    /// <summary>A refused best-effort relinquish leaves the leg's result unchanged, and the browser then
+    /// waits until the flow's own lifetime ends it.</summary>
     [Test]
     public async Task A_relinquish_the_server_refuses_does_not_change_how_the_leg_ended() {
         var h = Build();
@@ -1694,7 +1693,7 @@ public class BrowserFirstRunFlowTests {
         var h = Build();
 
         // Fired from inside a poll, because that is when a real signal would arrive.
-        h.Channel.OnPoll = () => h.Interrupts.FireAsync().GetAwaiter().GetResult();
+        h.Channel.OnPoll = () => h.Interrupts.Interrupt();
         h.Channel.Polls.Enqueue(new(200, Running()));
         h.Channel.Polls.Enqueue(new(404, null));
 
@@ -1704,25 +1703,21 @@ public class BrowserFirstRunFlowTests {
     }
 
     /// <summary>
-    /// Disarmed before anything the result decides, and this is the guard that matters: the callback can
-    /// only ever say <c>stopped</c>, so left armed it would race the reason the result names — gambling
-    /// <c>handover</c> against <c>stopped</c> on a dismissal, and relinquishing at all on a finish.
+    /// The claim is what stops the two paths contradicting each other. Ending a scope before the leg's own
+    /// send does NOT close it: an interrupt handler that read the callback first still runs it afterwards,
+    /// and the browser then shows whichever of two opposite remedies landed last.
     ///
-    /// <para><b>Asserted as ORDERING, because nothing observable after the leg can tell the two shapes
-    /// apart:</b> an arm scoped to the whole method has also been disposed by then, so a test that only
-    /// looked afterwards would pass either way and prove nothing.</para>
+    /// <para><b>The interrupt wins, and that is the honest outcome:</b> the process is being killed, so
+    /// nothing is carrying on however the poll happened to end.</para>
     /// </summary>
     [Test]
     [Arguments(true)]
     [Arguments(false)]
-    public async Task The_arm_is_gone_before_the_result_is_acted_on(bool dismissed) {
+    public async Task An_interrupt_racing_the_legs_own_send_produces_exactly_one(bool dismissed) {
         var h = Build(dismissed ? new FakeKeys(canWatch: true, pressAfter: 2) : null);
 
-        // Fires whatever is still armed at the moment the result's own reason is being sent. Left armed,
-        // that is a second POST saying the opposite thing.
-        //
-        // ONCE, or the second POST re-enters this hook and recurses until the stack goes — which aborts the
-        // run instead of failing an assertion, and an unreadable red is nearly as bad as a green.
+        // Fires at the moment the leg's own reason is being sent, which is the window a scope-based fix
+        // leaves open. ONCE, or the second send re-enters this hook and recurses until the stack goes.
         var fired = false;
 
         h.Channel.OnRelinquish = () => {
@@ -1730,21 +1725,35 @@ public class BrowserFirstRunFlowTests {
 
             fired = true;
 
-            h.Interrupts.FireAsync().GetAwaiter().GetResult();
+            h.Interrupts.Interrupt();
         };
 
         if (!dismissed) h.Channel.Polls.Enqueue(new(200, Done()));
 
         await Run(h);
 
-        await Assert.That(h.Interrupts.Arms).IsEqualTo(1);
-        await Assert.That(h.Interrupts.Disarms).IsEqualTo(1);
-        await Assert.That(h.Log.Precedes("arm", "disarm")).IsTrue();
-
-        // Exactly the reason the result named, and nothing behind it.
+        // Exactly one, and it is the reason the result named — never that reason plus its opposite.
         string[] expected = dismissed ? [FirstRunRelinquishReasons.Handover] : [];
 
         await Assert.That(h.Channel.Relinquished).IsEquivalentTo(expected);
+    }
+
+    /// <summary>
+    /// The other ordering: an interrupt gets there FIRST, so its reason is the one that stands and the
+    /// leg's own send is suppressed rather than appended.
+    /// </summary>
+    [Test]
+    public async Task An_interrupt_that_wins_the_claim_is_the_only_send() {
+        var h = Build(new FakeKeys(canWatch: true, pressAfter: 2));
+
+        // On the last poll, before the leg has a result — so the interrupt sends `stopped` and the
+        // dismissal's own `handover` must not follow it.
+        h.Channel.OnPoll = () => h.Interrupts.Interrupt();
+
+        var result = await Run(h);
+
+        await Assert.That(result).IsTypeOf<FirstRunFlowResult.Dismissed>();
+        await Assert.That(h.Channel.Relinquished).IsEquivalentTo([FirstRunRelinquishReasons.Stopped]);
     }
 
     /// <summary>A leg that never reached a flow arms nothing: there is no id to name.</summary>

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunFlowClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunFlowClientTests.cs
@@ -148,6 +148,48 @@ public class FirstRunFlowClientTests {
         await Assert.That(body.AsObject().ContainsKey("detail")).IsFalse();
     }
 
+    [Test]
+    public async Task RelinquishAsync_posts_the_reason_to_the_flow_s_relinquish_route() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath($"{PollPath}/relinquish").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithBody(StateBody("Pending")).WithHeader("Content-Type", "application/json"));
+
+        using var http = new HttpClient();
+
+        var outcome = await new FirstRunFlowClient(http).RelinquishAsync(
+            server.Urls[0], FlowId, FirstRunRelinquishReasons.Handover, CancellationToken.None);
+
+        await Assert.That(outcome.Recorded).IsTrue();
+
+        var body = JsonNode.Parse(
+            server.FindLogEntries(Request.Create().WithPath($"{PollPath}/relinquish").UsingPost())[0]
+                  .RequestMessage.Body!)!;
+
+        await Assert.That(body["reason"]!.GetValue<string>()).IsEqualTo("handover");
+
+        // The whole payload. There is nothing for a detail field to improve on a page whose only
+        // remaining job is to take affordances away.
+        await Assert.That(body.AsObject().Count).IsEqualTo(1);
+    }
+
+    // Never retried — it is the last thing the leg does — so the caller has to be able to tell that it
+    // did not land rather than assume it did.
+    [Test]
+    public async Task RelinquishAsync_reports_a_refusal_as_not_recorded() {
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath($"{PollPath}/relinquish").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(410));
+
+        using var http = new HttpClient();
+
+        var outcome = await new FirstRunFlowClient(http).RelinquishAsync(
+            server.Urls[0], FlowId, FirstRunRelinquishReasons.Stopped, CancellationToken.None);
+
+        await Assert.That(outcome.StatusCode).IsEqualTo(410);
+        await Assert.That(outcome.Recorded).IsFalse();
+    }
+
     // A report the server did not accept leaves the request outstanding, which is what makes the
     // loop's retry self-terminating.
     [Test]

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunInterruptRelinquishTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunInterruptRelinquishTests.cs
@@ -3,91 +3,158 @@ using Capacitor.Cli.Core.FirstRun;
 namespace Capacitor.Cli.Core.Tests.Unit.FirstRun;
 
 /// <summary>
-/// The process-global sink itself. Everything else reaches it through <see cref="IFirstRunInterrupts"/>,
-/// so this class is the only one that touches the static — which is why it is the only one that needs
-/// assembly-wide exclusion.
+/// The claim arbitration, and the process-global sink the CLI's signal handlers read. A leg reaches all of
+/// this through <see cref="IFirstRunInterrupts"/>, so this is the only class that touches the static —
+/// which is why it is the only one that needs assembly-wide exclusion.
 /// </summary>
 [NotInParallel]
 public class FirstRunInterruptRelinquishTests {
+    static readonly TimeSpan Budget = TimeSpan.FromSeconds(5);
+
     [Test]
-    public async Task An_armed_callback_runs_before_the_exit() {
+    public async Task An_armed_notice_is_sent_before_the_exit() {
         var sent = 0;
 
-        using var armed = FirstRunInterruptRelinquish.Arm(_ => { sent++; return Task.CompletedTask; });
+        using var notice = FirstRunInterruptRelinquish.Process.Arm(
+            _ => { sent++; return Task.CompletedTask; });
 
-        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromSeconds(1));
+        FirstRunInterruptRelinquish.RunBeforeExit(Budget);
 
         await Assert.That(sent).IsEqualTo(1);
     }
 
     [Test]
-    public async Task A_disarmed_callback_is_not_run() {
+    public async Task A_disposed_notice_is_not_sent() {
         var sent = 0;
 
-        FirstRunInterruptRelinquish.Arm(_ => { sent++; return Task.CompletedTask; }).Dispose();
+        FirstRunInterruptRelinquish.Process.Arm(_ => { sent++; return Task.CompletedTask; }).Dispose();
 
-        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromMilliseconds(50));
+        FirstRunInterruptRelinquish.RunBeforeExit(Budget);
 
         await Assert.That(sent).IsEqualTo(0);
     }
 
-    /// <summary>A handler going out of scope after a second leg armed must not take the second
+    /// <summary>A handle going out of scope after a second leg armed must not take the second
     /// registration with it.</summary>
     [Test]
     public async Task Disposing_an_older_handle_leaves_the_newer_registration() {
         var first  = 0;
         var second = 0;
 
-        var older = FirstRunInterruptRelinquish.Arm(_ => { first++; return Task.CompletedTask; });
-        using var newer = FirstRunInterruptRelinquish.Arm(_ => { second++; return Task.CompletedTask; });
+        var older = FirstRunInterruptRelinquish.Process.Arm(_ => { first++; return Task.CompletedTask; });
+        using var newer = FirstRunInterruptRelinquish.Process.Arm(
+            _ => { second++; return Task.CompletedTask; });
 
         older.Dispose();
 
-        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromSeconds(1));
+        FirstRunInterruptRelinquish.RunBeforeExit(Budget);
 
         await Assert.That(first).IsEqualTo(0);
         await Assert.That(second).IsEqualTo(1);
     }
 
-    /// <summary>It runs microseconds before an exit, so a throw has nowhere to go and must not become the
-    /// last thing the process does.</summary>
+    // ---- the claim ----
+
+    /// <summary>
+    /// The whole point of the claim. Two paths want to send, and their reasons give opposite remedies, so a
+    /// second send is a contradiction rather than a duplicate.
+    /// </summary>
     [Test]
-    public async Task A_callback_that_throws_is_swallowed() {
-        var ran = 0;
+    public async Task Only_the_first_claimant_sends() {
+        var sent = 0;
 
-        using var armed = FirstRunInterruptRelinquish.Arm(
-            _ => { ran++; throw new InvalidOperationException("boom"); });
+        using var notice = new FirstRunNotice(_ => { sent++; return Task.CompletedTask; });
 
-        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromSeconds(1));
+        await notice.SendAsync(CancellationToken.None);
+        notice.RunBeforeExit(Budget);
 
-        // Both halves: the callback was entered, and control came back to here rather than out of the
-        // signal handler.
-        await Assert.That(ran).IsEqualTo(1);
+        await Assert.That(sent).IsEqualTo(1);
     }
 
-    /// <summary>The budget is a ceiling on an exit the user already asked for, so a callback that hangs
-    /// must not hold the process.</summary>
+    /// <summary>And in the other order, or "the second one is suppressed" would pass on the strength of the
+    /// first path alone.</summary>
     [Test]
-    public async Task A_callback_that_hangs_is_bounded_by_the_budget() {
-        using var armed = FirstRunInterruptRelinquish.Arm(token => Task.Delay(Timeout.Infinite, token));
+    public async Task An_interrupt_that_claims_first_suppresses_the_legs_own_send() {
+        var sent = 0;
+
+        using var notice = new FirstRunNotice(_ => { sent++; return Task.CompletedTask; });
+
+        notice.RunBeforeExit(Budget);
+        await notice.SendAsync(CancellationToken.None);
+
+        await Assert.That(sent).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// The loser waits instead of exiting through the winner. Without it an interrupt arriving mid-POST
+    /// calls <c>Environment.Exit</c> and the notice is lost altogether — the failure a read-then-disarm
+    /// shape cannot avoid either way round.
+    /// </summary>
+    [Test]
+    public async Task An_interrupt_that_lost_the_claim_waits_for_the_send_to_finish() {
+        var release  = new TaskCompletionSource();
+        var finished = false;
+
+        using var notice = new FirstRunNotice(async _ => {
+            await release.Task;
+
+            finished = true;
+        });
+
+        // SendAsync claims synchronously before its first await, so by the time it hands back a Task the
+        // claim is taken and the interrupt below is deterministically the loser.
+        var sending = notice.SendAsync(CancellationToken.None);
+        var waiting = Task.Run(() => notice.RunBeforeExit(Budget));
+
+        release.SetResult();
+
+        await sending;
+        await waiting;
+
+        await Assert.That(finished).IsTrue();
+    }
+
+    /// <summary>The budget is a ceiling on an exit the user already asked for, so a send that hangs must
+    /// not hold the process.</summary>
+    [Test]
+    public async Task A_send_that_hangs_is_bounded_by_the_budget() {
+        using var notice = new FirstRunNotice(token => Task.Delay(Timeout.Infinite, token));
 
         var began = Environment.TickCount64;
 
-        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromMilliseconds(200));
+        notice.RunBeforeExit(TimeSpan.FromMilliseconds(200));
 
         // Generous against a loaded CI box; what it pins is that the wait is bounded at all.
         await Assert.That(Environment.TickCount64 - began).IsLessThan(5_000);
     }
 
+    /// <summary>It runs microseconds before an exit, so a throw has nowhere to go and must not become the
+    /// last thing the process does.</summary>
     [Test]
-    public async Task The_process_sink_arms_the_static() {
-        var sent = 0;
+    public async Task A_send_that_throws_is_swallowed() {
+        var ran = 0;
 
-        using var armed = FirstRunInterruptRelinquish.Process.Arm(
-            _ => { sent++; return Task.CompletedTask; });
+        using var notice = new FirstRunNotice(_ => { ran++; throw new InvalidOperationException("boom"); });
 
-        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromSeconds(1));
+        notice.RunBeforeExit(Budget);
 
-        await Assert.That(sent).IsEqualTo(1);
+        // Both halves: the send was entered, and control came back here rather than out of the handler.
+        await Assert.That(ran).IsEqualTo(1);
+    }
+
+    /// <summary>Disposing releases an interrupt waiting on a send that is never coming, so a leg that had
+    /// nothing to say does not cost the exit its whole budget.</summary>
+    [Test]
+    public async Task Disposing_releases_an_interrupt_waiting_on_a_send_that_never_comes() {
+        var notice = new FirstRunNotice(_ => Task.CompletedTask);
+
+        await notice.SendAsync(CancellationToken.None);
+        notice.Dispose();
+
+        var began = Environment.TickCount64;
+
+        notice.RunBeforeExit(TimeSpan.FromSeconds(30));
+
+        await Assert.That(Environment.TickCount64 - began).IsLessThan(5_000);
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunInterruptRelinquishTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunInterruptRelinquishTests.cs
@@ -1,0 +1,93 @@
+using Capacitor.Cli.Core.FirstRun;
+
+namespace Capacitor.Cli.Core.Tests.Unit.FirstRun;
+
+/// <summary>
+/// The process-global sink itself. Everything else reaches it through <see cref="IFirstRunInterrupts"/>,
+/// so this class is the only one that touches the static — which is why it is the only one that needs
+/// assembly-wide exclusion.
+/// </summary>
+[NotInParallel]
+public class FirstRunInterruptRelinquishTests {
+    [Test]
+    public async Task An_armed_callback_runs_before_the_exit() {
+        var sent = 0;
+
+        using var armed = FirstRunInterruptRelinquish.Arm(_ => { sent++; return Task.CompletedTask; });
+
+        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromSeconds(1));
+
+        await Assert.That(sent).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task A_disarmed_callback_is_not_run() {
+        var sent = 0;
+
+        FirstRunInterruptRelinquish.Arm(_ => { sent++; return Task.CompletedTask; }).Dispose();
+
+        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromMilliseconds(50));
+
+        await Assert.That(sent).IsEqualTo(0);
+    }
+
+    /// <summary>A handler going out of scope after a second leg armed must not take the second
+    /// registration with it.</summary>
+    [Test]
+    public async Task Disposing_an_older_handle_leaves_the_newer_registration() {
+        var first  = 0;
+        var second = 0;
+
+        var older = FirstRunInterruptRelinquish.Arm(_ => { first++; return Task.CompletedTask; });
+        using var newer = FirstRunInterruptRelinquish.Arm(_ => { second++; return Task.CompletedTask; });
+
+        older.Dispose();
+
+        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromSeconds(1));
+
+        await Assert.That(first).IsEqualTo(0);
+        await Assert.That(second).IsEqualTo(1);
+    }
+
+    /// <summary>It runs microseconds before an exit, so a throw has nowhere to go and must not become the
+    /// last thing the process does.</summary>
+    [Test]
+    public async Task A_callback_that_throws_is_swallowed() {
+        var ran = 0;
+
+        using var armed = FirstRunInterruptRelinquish.Arm(
+            _ => { ran++; throw new InvalidOperationException("boom"); });
+
+        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromSeconds(1));
+
+        // Both halves: the callback was entered, and control came back to here rather than out of the
+        // signal handler.
+        await Assert.That(ran).IsEqualTo(1);
+    }
+
+    /// <summary>The budget is a ceiling on an exit the user already asked for, so a callback that hangs
+    /// must not hold the process.</summary>
+    [Test]
+    public async Task A_callback_that_hangs_is_bounded_by_the_budget() {
+        using var armed = FirstRunInterruptRelinquish.Arm(token => Task.Delay(Timeout.Infinite, token));
+
+        var began = Environment.TickCount64;
+
+        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromMilliseconds(200));
+
+        // Generous against a loaded CI box; what it pins is that the wait is bounded at all.
+        await Assert.That(Environment.TickCount64 - began).IsLessThan(5_000);
+    }
+
+    [Test]
+    public async Task The_process_sink_arms_the_static() {
+        var sent = 0;
+
+        using var armed = FirstRunInterruptRelinquish.Process.Arm(
+            _ => { sent++; return Task.CompletedTask; });
+
+        FirstRunInterruptRelinquish.RunBeforeExit(TimeSpan.FromSeconds(1));
+
+        await Assert.That(sent).IsEqualTo(1);
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunInterruptRelinquishTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/FirstRunInterruptRelinquishTests.cs
@@ -11,12 +11,15 @@ namespace Capacitor.Cli.Core.Tests.Unit.FirstRun;
 public class FirstRunInterruptRelinquishTests {
     static readonly TimeSpan Budget = TimeSpan.FromSeconds(5);
 
+    const string Interrupted = "interrupt-reason";
+    const string FromTheLeg  = "leg-reason";
+
     [Test]
     public async Task An_armed_notice_is_sent_before_the_exit() {
         var sent = 0;
 
         using var notice = FirstRunInterruptRelinquish.Process.Arm(
-            _ => { sent++; return Task.CompletedTask; });
+            (_, _) => { sent++; return Task.CompletedTask; }, () => Interrupted);
 
         FirstRunInterruptRelinquish.RunBeforeExit(Budget);
 
@@ -27,7 +30,7 @@ public class FirstRunInterruptRelinquishTests {
     public async Task A_disposed_notice_is_not_sent() {
         var sent = 0;
 
-        FirstRunInterruptRelinquish.Process.Arm(_ => { sent++; return Task.CompletedTask; }).Dispose();
+        FirstRunInterruptRelinquish.Process.Arm((_, _) => { sent++; return Task.CompletedTask; }, () => Interrupted).Dispose();
 
         FirstRunInterruptRelinquish.RunBeforeExit(Budget);
 
@@ -41,9 +44,9 @@ public class FirstRunInterruptRelinquishTests {
         var first  = 0;
         var second = 0;
 
-        var older = FirstRunInterruptRelinquish.Process.Arm(_ => { first++; return Task.CompletedTask; });
+        var older = FirstRunInterruptRelinquish.Process.Arm((_, _) => { first++; return Task.CompletedTask; }, () => Interrupted);
         using var newer = FirstRunInterruptRelinquish.Process.Arm(
-            _ => { second++; return Task.CompletedTask; });
+            (_, _) => { second++; return Task.CompletedTask; }, () => Interrupted);
 
         older.Dispose();
 
@@ -63,9 +66,10 @@ public class FirstRunInterruptRelinquishTests {
     public async Task Only_the_first_claimant_sends() {
         var sent = 0;
 
-        using var notice = new FirstRunNotice(_ => { sent++; return Task.CompletedTask; });
+        using var notice = new FirstRunNotice(
+            (_, _) => { sent++; return Task.CompletedTask; }, () => Interrupted);
 
-        await notice.SendAsync(CancellationToken.None);
+        await notice.SendAsync(FromTheLeg, CancellationToken.None);
         notice.RunBeforeExit(Budget);
 
         await Assert.That(sent).IsEqualTo(1);
@@ -77,10 +81,11 @@ public class FirstRunInterruptRelinquishTests {
     public async Task An_interrupt_that_claims_first_suppresses_the_legs_own_send() {
         var sent = 0;
 
-        using var notice = new FirstRunNotice(_ => { sent++; return Task.CompletedTask; });
+        using var notice = new FirstRunNotice(
+            (_, _) => { sent++; return Task.CompletedTask; }, () => Interrupted);
 
         notice.RunBeforeExit(Budget);
-        await notice.SendAsync(CancellationToken.None);
+        await notice.SendAsync(FromTheLeg, CancellationToken.None);
 
         await Assert.That(sent).IsEqualTo(1);
     }
@@ -95,15 +100,17 @@ public class FirstRunInterruptRelinquishTests {
         var release  = new TaskCompletionSource();
         var finished = false;
 
-        using var notice = new FirstRunNotice(async _ => {
-            await release.Task;
+        using var notice = new FirstRunNotice(
+            async (_, _) => {
+                await release.Task;
 
-            finished = true;
-        });
+                finished = true;
+            },
+            () => Interrupted);
 
         // SendAsync claims synchronously before its first await, so by the time it hands back a Task the
         // claim is taken and the interrupt below is deterministically the loser.
-        var sending = notice.SendAsync(CancellationToken.None);
+        var sending = notice.SendAsync(FromTheLeg, CancellationToken.None);
         var waiting = Task.Run(() => notice.RunBeforeExit(Budget));
 
         release.SetResult();
@@ -114,11 +121,46 @@ public class FirstRunInterruptRelinquishTests {
         await Assert.That(finished).IsTrue();
     }
 
+    /// <summary>
+    /// Whoever claims sends its OWN reason. An interrupt borrowing the leg's could tell someone their
+    /// terminal had taken over as it died; the leg borrowing an interrupt's would understate a handover.
+    /// </summary>
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task The_claimant_supplies_the_reason(bool interrupted) {
+        var sent = new List<string>();
+
+        using var notice = new FirstRunNotice(
+            (reason, _) => { sent.Add(reason); return Task.CompletedTask; }, () => Interrupted);
+
+        if (interrupted) notice.RunBeforeExit(Budget);
+        else             await notice.SendAsync(FromTheLeg, CancellationToken.None);
+
+        await Assert.That(sent).IsEquivalentTo([interrupted ? Interrupted : FromTheLeg]);
+    }
+
+    /// <summary>A null reason claims without sending, which is how a result that must not be relinquished
+    /// shuts the interrupt out as well as itself.</summary>
+    [Test]
+    public async Task A_null_reason_claims_without_sending() {
+        var sent = 0;
+
+        using var notice = new FirstRunNotice(
+            (_, _) => { sent++; return Task.CompletedTask; }, () => Interrupted);
+
+        await notice.SendAsync(null, CancellationToken.None);
+        notice.RunBeforeExit(Budget);
+
+        await Assert.That(sent).IsEqualTo(0);
+    }
+
     /// <summary>The budget is a ceiling on an exit the user already asked for, so a send that hangs must
     /// not hold the process.</summary>
     [Test]
     public async Task A_send_that_hangs_is_bounded_by_the_budget() {
-        using var notice = new FirstRunNotice(token => Task.Delay(Timeout.Infinite, token));
+        using var notice = new FirstRunNotice(
+            (_, token) => Task.Delay(Timeout.Infinite, token), () => Interrupted);
 
         var began = Environment.TickCount64;
 
@@ -134,7 +176,8 @@ public class FirstRunInterruptRelinquishTests {
     public async Task A_send_that_throws_is_swallowed() {
         var ran = 0;
 
-        using var notice = new FirstRunNotice(_ => { ran++; throw new InvalidOperationException("boom"); });
+        using var notice = new FirstRunNotice(
+            (_, _) => { ran++; throw new InvalidOperationException("boom"); }, () => Interrupted);
 
         notice.RunBeforeExit(Budget);
 
@@ -146,9 +189,9 @@ public class FirstRunInterruptRelinquishTests {
     /// nothing to say does not cost the exit its whole budget.</summary>
     [Test]
     public async Task Disposing_releases_an_interrupt_waiting_on_a_send_that_never_comes() {
-        var notice = new FirstRunNotice(_ => Task.CompletedTask);
+        var notice = new FirstRunNotice((_, _) => Task.CompletedTask, () => Interrupted);
 
-        await notice.SendAsync(CancellationToken.None);
+        await notice.SendAsync(FromTheLeg, CancellationToken.None);
         notice.Dispose();
 
         var began = Environment.TickCount64;


### PR DESCRIPTION
AI-2343

## What & why

When the browser setup leg ends without finishing, the browser has no way to know: it keeps offering
decisions nothing will act on, and the PATH-fix button records a request that stays outstanding for ever
while the screen says it asked your machine. This adds `POST /api/first-run/flows/{id}/relinquish` to the
flow client and sends it from one place in `RunAsync`, keyed off the leg's result type — so a closed tab
and a failed leg are covered without a special case for the keypress.

Two reasons cross, because the browser renders opposite remedies for them. A dismissal is the only
handover: the terminal carries on with everything the browser settled, so it is the one exit where the
page must not send anyone back to `kcap setup`. `Abandoned` and `Failed` are `stopped`. `Finished` must
not send it at all, and that guard is the load-bearing one.

## Where to look

`FirstRunInterruptRelinquish` is a process-global static, which is what an interrupt needs: Ctrl+C,
SIGTERM, SIGHUP and the parent-liveness watchdog all reach `Environment.Exit` from a handler that runs no
`finally`, and the handlers are installed process-wide with nothing command-scoped to reach through. The
leg arms it for its own duration; `Disarm` compares before clearing so a second leg's registration is not
dropped by the first leg's handle going out of scope. Tests touching it carry bare `[NotInParallel]`.

## Verification

`BrowserFirstRunFlowTests` 86/86 and `FirstRunFlowClientTests` 32/32. `dotnet publish -c Release` clean
of IL2026/IL3050. Driven end to end against a live tenant: a flow relinquished under an open tab renders
the terminal page, and both reason tails were checked in the browser, including an unreadable token
falling back to `stopped`.
