### PR TITLE
Gate Kiro nudges behind a durable once-per-session claim

### DIFF
--- a/src/Capacitor.Cli/Commands/Harness/AntigravityHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/AntigravityHookCommand.cs
@@ -317,9 +317,9 @@ sealed class AntigravityHookCommand(ConfigRoot config, ProfileContext profiles, 
 
     /// <summary>
     /// Whether this PreInvocation is the conversation's first, read from the vendor's own
-    /// <c>invocationNum</c> counter — the one payload field that varies between callbacks. An absent,
-    /// non-numeric, or non-positive value reads as first: a payload without a usable counter cannot
-    /// distinguish callbacks, and emitting once too often beats never emitting.
+    /// <c>invocationNum</c> counter — the one payload field that varies between callbacks. Any value
+    /// at or below one reads as first, and so does an absent or non-numeric one: a payload without a
+    /// usable counter cannot distinguish callbacks, and emitting once too often beats never emitting.
     /// </summary>
     internal static bool IsFirstInvocation(JsonObject payload) =>
         payload["invocationNum"] is not JsonValue value

--- a/src/Capacitor.Cli/Commands/Harness/AntigravityHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/AntigravityHookCommand.cs
@@ -317,9 +317,9 @@ sealed class AntigravityHookCommand(ConfigRoot config, ProfileContext profiles, 
 
     /// <summary>
     /// Whether this PreInvocation is the conversation's first, read from the vendor's own
-    /// <c>invocationNum</c> counter — the one payload field that varies between callbacks. An absent
-    /// or non-numeric value reads as first: a payload without the counter cannot distinguish
-    /// callbacks, and emitting once too often beats never emitting.
+    /// <c>invocationNum</c> counter — the one payload field that varies between callbacks. An absent,
+    /// non-numeric, or non-positive value reads as first: a payload without a usable counter cannot
+    /// distinguish callbacks, and emitting once too often beats never emitting.
     /// </summary>
     internal static bool IsFirstInvocation(JsonObject payload) =>
         payload["invocationNum"] is not JsonValue value

--- a/src/Capacitor.Cli/Commands/Harness/KiroHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/KiroHookCommand.cs
@@ -44,6 +44,11 @@ sealed class KiroHookCommand(ConfigRoot config, ProfileContext profiles, HookClo
     /// killed, so an overrun costs the injection outright.</summary>
     static readonly TimeSpan Ceiling = TimeSpan.FromSeconds(5);
 
+    /// <summary>Bound on the nudge claim's store work. The fragment write never waits on the claim —
+    /// a still-pending claim defers the nudges to a post-flush append — so this caps only that
+    /// deferred wait.</summary>
+    static readonly TimeSpan NudgeClaimBudget = TimeSpan.FromMilliseconds(750);
+
     /// <summary>
     /// Writes the team-memory fragment as Kiro consumes it: raw text, no envelope.
     ///
@@ -237,6 +242,11 @@ sealed class KiroHookCommand(ConfigRoot config, ProfileContext profiles, HookClo
             // Remaining already reserves Safety — do not subtract it again.
             budget.Remaining);
 
+        // agentSpawn fires per prompt and Kiro persists appended stdout, so the nudges below are
+        // gated by a durable once-per-session claim — the payload carries no counter to key on.
+        // The claim overlaps the memory fetch; the write site consults it without waiting.
+        var nudgeClaim = NudgeLease.TryClaimAsync(config, clock.Time, HarnessId.Kiro, sessionId, NudgeClaimBudget);
+
         // Spawn-before-post: capture must start on Posted OR Spooled (auth lapse /
         // outage) — a doomed/delayed lifecycle POST must never withhold the watcher. On a real
         // failure PostOrSpoolAsync already logged to stderr; a lapse or transient outage instead
@@ -255,11 +265,32 @@ sealed class KiroHookCommand(ConfigRoot config, ProfileContext profiles, HookClo
         // a fragment sitting in a buffer when Kiro's hook timeout kills the process is a fragment
         // whose lease was spent for nothing.
         var fragment = await SessionStartMemoryHookSupport.AwaitBounded(memoryTask, budget);
-        var workItemsNudge = HarnessNudgeEmitter.Combine(
+        // Nothing may stand between the resolved fetch and the write below, so the claim is only
+        // consulted here, never waited for: a still-pending claim defers the nudges to a second
+        // append after the flush, where it IS awaited to completion — an abandoned-but-running
+        // claim could commit its record with nothing emitted and silence the nudges for the
+        // session. The emitters run at most once per firing: the harness nudge stamps a ledger.
+        string? ResolveNudges() => HarnessNudgeEmitter.Combine(
             WorkItemsNudgeEmitter.Resolve(HarnessId.Kiro, sessionId, activeProfile?.DisableWorkItemsNudge is true, home),
             HarnessNudgeEmitter.ResolveFragmentForHook(activeProfile?.DisableHarnessNudge is true, config, home));
+        var nudgeDecided = nudgeClaim.IsCompleted;
+        var workItemsNudge = nudgeDecided && await nudgeClaim ? ResolveNudges() : null;
         WriteAgentSpawnOutput(Console.Out, fragment, workItemsNudge);
         await Console.Out.FlushAsync();
+
+        // The deferred append: clipped to the remaining ceiling as well as the claim's own budget,
+        // because overrunning the ceiling discards even flushed output — the fragment, not just the
+        // nudge. A clipped-but-still-running claim can commit unemitted in that corner; one session
+        // without its nudge beats a discarded fragment. The nudge-only render's marker line is read
+        // only by the Pi/OpenCode capture scripts, so it is inert in Kiro context.
+        if (!nudgeDecided && budget.Remaining is { Ticks: > 0 } claimWait) {
+            var claimed = false;
+            try { claimed = await nudgeClaim.WaitAsync(claimWait); } catch (TimeoutException) { }
+            if (claimed) {
+                WriteAgentSpawnOutput(Console.Out, null, ResolveNudges());
+                await Console.Out.FlushAsync();
+            }
+        }
 
         // BOUNDED by what is left of the ceiling. Writing early is not sufficient on its own: Kiro
         // appends stdout only from a hook that COMPLETED, so an invocation killed at Kiro's timeout

--- a/src/Capacitor.Cli/NudgeLease.cs
+++ b/src/Capacitor.Cli/NudgeLease.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Harness;
+using Capacitor.Cli.SessionStartMemory;
+
+namespace Capacitor.Cli;
+
+/// <summary>
+/// Durable once-per-session claim for the SessionStart nudges on repeating start callbacks with no
+/// vendor counter to key on. False on a repeat, an unusable session id, or an unavailable store:
+/// the nudges land in a context channel the harness persists, so suppressing beats re-injecting.
+/// </summary>
+internal static class NudgeLease {
+    /// <summary>Store construction happens inside the failure boundary — an unusable store root
+    /// must suppress the nudge, never abort the hook.</summary>
+    public static async Task<bool> TryClaimAsync(
+            ConfigRoot config, TimeProvider time, HarnessId harness, string sessionId, TimeSpan budget) {
+        try {
+            return await TryClaimAsync(SessionStartMemoryLeaseStore.Create(config, time), harness, sessionId, budget);
+        } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
+            return false;
+        }
+    }
+
+    public static async Task<bool> TryClaimAsync(
+            SessionStartMemoryLeaseStore store, HarnessId harness, string sessionId, TimeSpan budget) {
+        try {
+            var key = SessionStartMemoryIdentity.CreateNudgeKey(harness, sessionId);
+            var started = Stopwatch.GetTimestamp();
+            var lease = await store.TryBeginAsync(key, budget);
+            if (lease is null) return false;
+            var remaining = budget - Stopwatch.GetElapsedTime(started);
+            if (remaining <= TimeSpan.Zero) return false;
+            // An uncompleted claim (a crash or exhausted budget between the two calls) expires with
+            // the lease, so a later prompt still emits — delayed, never duplicated.
+            return await store.CompleteAsync(lease, SessionStartMemoryDisposition.CompleteWithoutContext, remaining);
+        } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
+            return false;
+        }
+    }
+}

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryIdentity.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryIdentity.cs
@@ -19,6 +19,21 @@ internal static class SessionStartMemoryIdentity {
         return Convert.ToHexStringLower(SHA256.HashData(stream.ToArray()));
     }
 
+    /// <summary>
+    /// Key for the once-per-session nudge claim: the same identity inputs as <see cref="Create"/>
+    /// under a distinct domain byte, so a nudge claim can never collide with — or spend — the memory
+    /// lane's lease for the same session.
+    /// </summary>
+    public static string CreateNudgeKey(HarnessId harness, string sessionId) {
+        var normalized = NormalizeSessionId(harness, sessionId)
+            ?? throw new ArgumentException("A stable session identity is required.", nameof(sessionId));
+        using var stream = new MemoryStream();
+        stream.WriteByte(0x02);
+        WritePresent(stream, harness.VendorId);
+        WritePresent(stream, normalized);
+        return Convert.ToHexStringLower(SHA256.HashData(stream.ToArray()));
+    }
+
     public static string? NormalizeSessionId(HarnessId harness, string? value) {
         if (string.IsNullOrEmpty(value)) return null;
         if (harness is HarnessId.Cursor or HarnessId.Copilot or HarnessId.Antigravity)

--- a/test/Capacitor.Cli.Tests.Unit/Harness/Antigravity/AntigravitySessionStartMemoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Harness/Antigravity/AntigravitySessionStartMemoryTests.cs
@@ -259,9 +259,10 @@ public class AntigravitySessionStartMemoryTests {
         await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("""{"invocationNum":97}"""))).IsFalse();
     }
 
-    // Fail-open: a payload that cannot distinguish callbacks must still emit.
+    // Fail-open: a payload without a usable counter (missing, non-numeric, or non-positive)
+    // cannot distinguish callbacks and must still emit.
     [Test]
-    public async Task A_missing_or_non_numeric_counter_reads_as_the_first_invocation() {
+    public async Task A_missing_or_unusable_counter_reads_as_the_first_invocation() {
         await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("{}"))).IsTrue();
         await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("""{"invocationNum":"2"}"""))).IsTrue();
         await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("""{"invocationNum":0}"""))).IsTrue();

--- a/test/Capacitor.Cli.Tests.Unit/Harness/Antigravity/AntigravitySessionStartMemoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Harness/Antigravity/AntigravitySessionStartMemoryTests.cs
@@ -259,8 +259,8 @@ public class AntigravitySessionStartMemoryTests {
         await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("""{"invocationNum":97}"""))).IsFalse();
     }
 
-    // Fail-open: a payload without a usable counter (missing, non-numeric, or non-positive)
-    // cannot distinguish callbacks and must still emit.
+    // Fail-open: a payload whose counter cannot mark a later turn — missing, non-numeric, or below
+    // the genuine first value of one — must still emit.
     [Test]
     public async Task A_missing_or_unusable_counter_reads_as_the_first_invocation() {
         await Assert.That(AntigravityHookCommand.IsFirstInvocation(Payload("{}"))).IsTrue();

--- a/test/Capacitor.Cli.Tests.Unit/NudgeLeaseTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/NudgeLeaseTests.cs
@@ -1,0 +1,71 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.SessionStartMemory;
+using Capacitor.Cli.Core.Harness;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The once-per-session nudge claim for harnesses whose start callback repeats per prompt without a
+/// vendor counter to key on. What matters is the direction of failure: a repeat, an unusable id, or
+/// an unavailable store must refuse — the nudge lands in a context channel the harness persists, so
+/// one suppressed emission beats one per turn.
+/// </summary>
+public class NudgeLeaseTests {
+    static readonly TimeSpan Budget = TimeSpan.FromSeconds(2);
+
+    static SessionStartMemoryLeaseStore Store(TempDir root) => new(root.Path, TimeProvider.System);
+
+    [Test]
+    public async Task the_first_claim_wins_and_repeats_are_refused() {
+        using var root = new TempDir();
+        await Assert.That(await NudgeLease.TryClaimAsync(Store(root), HarnessId.Kiro, "kiro-session", Budget)).IsTrue();
+        await Assert.That(await NudgeLease.TryClaimAsync(Store(root), HarnessId.Kiro, "kiro-session", Budget)).IsFalse();
+    }
+
+    [Test]
+    public async Task distinct_sessions_claim_independently() {
+        using var root = new TempDir();
+        await Assert.That(await NudgeLease.TryClaimAsync(Store(root), HarnessId.Kiro, "session-a", Budget)).IsTrue();
+        await Assert.That(await NudgeLease.TryClaimAsync(Store(root), HarnessId.Kiro, "session-b", Budget)).IsTrue();
+    }
+
+    // Kiro session ids are GUIDs the identity normaliser canonicalises; two spellings of one session
+    // arriving across firings must not double-nudge.
+    [Test]
+    public async Task guid_spellings_collapse_to_one_claim() {
+        using var root = new TempDir();
+        await Assert.That(await NudgeLease.TryClaimAsync(
+            Store(root), HarnessId.Kiro, "6f9619ff-8b86-d011-b42d-00cf4fc964ff", Budget)).IsTrue();
+        await Assert.That(await NudgeLease.TryClaimAsync(
+            Store(root), HarnessId.Kiro, "6F9619FF8B86D011B42D00CF4FC964FF", Budget)).IsFalse();
+    }
+
+    // The claim lives in the shared store under its own key domain: claiming the nudge must never
+    // spend the memory lane's lease for the same session, or the index would stop injecting.
+    [Test]
+    public async Task the_nudge_claim_does_not_collide_with_the_memory_lease() {
+        using var root = new TempDir();
+        var store = Store(root);
+        await Assert.That(await NudgeLease.TryClaimAsync(store, HarnessId.Kiro, "kiro-session", Budget)).IsTrue();
+
+        var memoryKey = SessionStartMemoryIdentity.Create(HarnessId.Kiro, "kiro-session", null);
+        await Assert.That(await store.TryBeginAsync(memoryKey, Budget)).IsNotNull();
+    }
+
+    [Test]
+    public async Task an_unusable_session_id_never_claims() {
+        using var root = new TempDir();
+        await Assert.That(await NudgeLease.TryClaimAsync(Store(root), HarnessId.Kiro, "", Budget)).IsFalse();
+    }
+
+    // Store construction sits inside the claim's failure boundary: a config dir whose store root
+    // cannot be created must read as unclaimed, never throw out of a hook.
+    [Test]
+    public async Task an_uncreatable_store_root_reads_as_unclaimed() {
+        using var root = new TempDir();
+        var file = root.CreateFile("occupied");
+        var config = new ConfigRoot(Path.Combine(file, "under-a-file"));
+
+        await Assert.That(await NudgeLease.TryClaimAsync(config, TimeProvider.System, HarnessId.Kiro, "kiro-session", Budget)).IsFalse();
+    }
+}


### PR DESCRIPTION
AI-2354 — no GitHub-issue half: the Kiro repeat is tracked in Linear only.

## What & why

Kiro's agentSpawn fires on every prompt and appends hook stdout straight into agent context, yet the work-items and harness-setup nudges are resolved unconditionally — the accumulation #668 fixed for Antigravity, whose vendor counter Kiro's payload lacks. The gate is a durable once-per-session claim in the SessionStart memory store under a nudge-scoped key domain, so it survives per-prompt hook processes and is swept with the store's other records. Also aligns the Antigravity counter doc and pinning test with the actual <= 1 semantics.

## Where to look

The claim starts beside the memory fetch and is awaited only at the output site, so a wedged store cannot delay the fragment write. Its failure direction is refuse-to-emit — the opposite of Antigravity's counter fallback — because the store, unlike a vendor payload field, also guards every later turn.

## Verification

- NudgeLeaseTests + the foundation/Kiro/Antigravity memory classes: 65/65 pass.
- dotnet publish -c Release: no IL2026/IL3050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)