### PR TITLE
[AI-2280] Drop the stale Claude-Code-only qualifier from mcp workitems help

### DIFF
--- a/src/Capacitor.Cli.Core/Resources/help-usage.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-usage.txt
@@ -75,7 +75,7 @@ MCP servers (stdio):
   mcp sessions                       Search/inspect past sessions from agents
   mcp flows                          Start and manage review flows from agents
   mcp memory                         Team memory tools (search, get, save, update, rescope, archive)
-  mcp workitems                      Declare/list a session's work-item attachments (Claude Code only)
+  mcp workitems                      Declare/list a session's work-item attachments
   mcp analytics                      Governed SQL over org coding-agent analytics (schema + query)
 
 Plugin:


### PR DESCRIPTION
## What & why

`kcap --help` still marks `mcp workitems` as "(Claude Code only)", but the workitems MCP server registers on every supported harness — the qualifier tells non-Claude users the tool is unavailable to them when it is not. One line in the help resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)